### PR TITLE
[stdlib] Add `String.removeprefix` and `String.removesuffix`

### DIFF
--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -999,6 +999,47 @@ struct String(Sized, Stringable, IntableRaising, KeyElement, Boolable):
             return self._endswith_impl(suffix, start)
         return self[start:end]._endswith_impl(suffix)
 
+    fn removeprefix(self, prefix: String, /) -> String:
+        """If the string starts with the prefix string, return `string[len(prefix):]`.
+        Otherwise, return a copy of the original string.
+
+        ```mojo
+        print(String('TestHook').removeprefix('Test'))
+        # 'Hook'
+        print(String('BaseTestCase').removeprefix('Test'))
+        # 'BaseTestCase'
+        ```
+        Args:
+          prefix: The prefix to remove from the string.
+
+        Returns:
+          A new string with the prefix removed if it was present.
+        """
+        if self.startswith(prefix):
+            return self[len(prefix) :]
+        return self
+
+    fn removesuffix(self, suffix: String, /) -> String:
+        """If the string ends with the suffix string, return `string[:-len(suffix)]`.
+        Otherwise, return a copy of the original string.
+
+        ```mojo
+        print(String('TestHook').removesuffix('Hook'))
+        # 'Test'
+        print(String('BaseTestCase').removesuffix('Test'))
+        # 'BaseTestCase'
+        ```
+
+        Args:
+          suffix: The suffix to remove from the string.
+
+        Returns:
+          A new string with the suffix removed if it was present.
+        """
+        if self.endswith(suffix):
+            return self[: -len(suffix)]
+        return self
+
     @always_inline
     fn _endswith_impl(self, suffix: String, start: Int = 0) -> Bool:
         return self.rfind(suffix, start) + len(suffix) == len(self)

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -545,6 +545,20 @@ fn test_endswith() raises:
     assert_false(str.endswith("llo", 2, 3))
 
 
+def test_removeprefix():
+    assert_equal(String("hello world").removeprefix("hello"), " world")
+    assert_equal(String("hello world").removeprefix("world"), "hello world")
+    assert_equal(String("hello world").removeprefix("hello world"), "")
+    assert_equal(String("hello world").removeprefix("llo wor"), "hello world")
+
+
+def test_removesuffix():
+    assert_equal(String("hello world").removesuffix("world"), "hello ")
+    assert_equal(String("hello world").removesuffix("hello"), "hello world")
+    assert_equal(String("hello world").removesuffix("hello world"), "")
+    assert_equal(String("hello world").removesuffix("llo wor"), "hello world")
+
+
 def test_intable():
     assert_equal(int(String("123")), 123)
 
@@ -590,5 +604,7 @@ def main():
     test_hash()
     test_startswith()
     test_endswith()
+    test_removeprefix()
+    test_removesuffix()
     test_intable()
     test_string_mul()


### PR DESCRIPTION
Apologies since adding methods is not listed as "Changes we accept" in the readme. I had already implemented those methods in my own repo and it was very low effort to submit a first PR. Furthermore I believe adding those two methods is not controversial
and has a very low bikeshedding potential.

The two methods `removeprefix` and `removesuffix` are present in python. See the docs: 
* https://docs.python.org/3/library/stdtypes.html#str.removeprefix
* https://docs.python.org/3/library/stdtypes.html#str.removesuffix

Both were introduced in python 3.9.

The documentation was added, the argments were made positional-only like in CPython.

Unit tests were added in the corresponding module.

The docstrings were taken from the python documentation.