### PR TITLE
[mojo-stdlib] Refactor tests to use `assert_*` functions whenever possible

### DIFF
--- a/stdlib/test/base64/test_base64.mojo
+++ b/stdlib/test/base64/test_base64.mojo
@@ -15,6 +15,7 @@
 from base64 import b64encode
 from testing import assert_equal
 
+
 def test_b64encode():
     assert_equal(b64encode("a"), "YQ==")
 
@@ -27,7 +28,7 @@ def test_b64encode():
     assert_equal(
         b64encode("the quick brown fox jumps over the lazy dog"),
         "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw==",
-    ) 
+    )
 
     assert_equal(b64encode("ABCDEFabcdef"), "QUJDREVGYWJjZGVm")
 

--- a/stdlib/test/base64/test_base64.mojo
+++ b/stdlib/test/base64/test_base64.mojo
@@ -10,33 +10,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
 
 from base64 import b64encode
+from testing import assert_equal
+
+def test_b64encode():
+    assert_equal(b64encode("a"), "YQ==")
+
+    assert_equal(b64encode("fo"), "Zm8=")
+
+    assert_equal(b64encode("Hello Mojo!!!"), "SGVsbG8gTW9qbyEhIQ==")
+
+    assert_equal(b64encode("Hello 🔥!!!"), "SGVsbG8g8J+UpSEhIQ==")
+
+    assert_equal(
+        b64encode("the quick brown fox jumps over the lazy dog"),
+        "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw==",
+    ) 
+
+    assert_equal(b64encode("ABCDEFabcdef"), "QUJDREVGYWJjZGVm")
 
 
-# CHECK-LABEL: test_b64encode
-fn test_b64encode():
-    print("== test_b64encode")
-
-    # CHECK: YQ==
-    print(b64encode("a"))
-
-    # CHECK: Zm8=
-    print(b64encode("fo"))
-
-    # CHECK: SGVsbG8gTW9qbyEhIQ==
-    print(b64encode("Hello Mojo!!!"))
-
-    # CHECK: SGVsbG8g8J+UpSEhIQ==
-    print(b64encode("Hello 🔥!!!"))
-
-    # CHECK: dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw==
-    print(b64encode("the quick brown fox jumps over the lazy dog"))
-
-    # CHECK: QUJDREVGYWJjZGVm
-    print(b64encode("ABCDEFabcdef"))
-
-
-fn main():
+def main():
     test_b64encode()

--- a/stdlib/test/builtin/test_error.mojo
+++ b/stdlib/test/builtin/test_error.mojo
@@ -10,23 +10,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
+
+from testing import assert_equal
 
 
 def raise_an_error():
     raise Error("MojoError: This is an error!")
 
 
-fn main():
-    # CHECK: == test_error
-    print("== test_error")
+def main():
     try:
         _ = raise_an_error()
     except e:
-        # CHECK: MojoError: This is an error!
-        print(e)
+        assert_equal(str(e), "MojoError: This is an error!")
 
     var myString: String = "FOO"
     var error = Error(myString)
-    # CHECK: FOO
-    print(error)
+    assert_equal(error, "FOO")

--- a/stdlib/test/builtin/test_int_literal.mojo
+++ b/stdlib/test/builtin/test_int_literal.mojo
@@ -10,79 +10,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
+
+from testing import assert_equal
 
 
-# CHECK-LABEL: test_int
-fn test_int():
-    print("== test_int")
-    # CHECK: 3
-    print(3)
-    # CHECK: 6
-    print(3 + 3)
-
-    # CHECK: 3
-    print(4 - 1)
-    # CHECK: 5
-    print(6 - 1)
+fn test_int() raises:
+    assert_equal(3, 3)
+    assert_equal(3 + 3, 6)
+    assert_equal(4 - 1, 3)
+    assert_equal(6 - 1, 5)
 
 
-# CHECK-LABEL: test_floordiv
-fn test_floordiv():
-    print("== test_floordiv")
-
-    # CHECK: 1
-    print(2 // 2)
-
-    # CHECK: 0
-    print(2 // 3)
-
-    # CHECK: -1
-    print(2 // -2)
-
-    # CHECK: -50
-    print(99 // -2)
+fn test_floordiv() raises:
+    assert_equal(2 // 2, 1)
+    assert_equal(2 // 3, 0)
+    assert_equal(2 // -2, -1)
+    assert_equal(99 // -2, -50)
 
 
-# CHECK-LABEL: test_mod
-fn test_mod():
-    print("== test_mod")
-
-    # CHECK: 0
-    print(99 % 1)
-    # CHECK: 0
-    print(99 % 3)
-    # CHECK: -1
-    print(99 % -2)
-    # CHECK: 3
-    print(99 % 8)
-    # CHECK: -5
-    print(99 % -8)
-    # CHECK: 0
-    print(2 % -1)
-    # CHECK: 0
-    print(2 % -2)
-    # CHECK: -1
-    print(3 % -2)
-    # CHECK: 1
-    print(-3 % 2)
+fn test_mod() raises:
+    assert_equal(99 % 1, 0)
+    assert_equal(99 % 3, 0)
+    assert_equal(99 % -2, -1)
+    assert_equal(99 % 8, 3)
+    assert_equal(99 % -8, -5)
+    assert_equal(2 % -1, 0)
+    assert_equal(2 % -2, 0)
+    assert_equal(3 % -2, -1)
+    assert_equal(-3 % 2, 1)
 
 
-# CHECK-LABEL: test_bit_width
-fn test_bit_width():
-    print("== test_bit_width")
-
-    # CHECK: 1
-    print((0)._bit_width())
-    # CHECK: 1
-    print((-1)._bit_width())
-    # CHECK: 9
-    print((255)._bit_width())
-    # CHECK: 9
-    print((-256)._bit_width())
+fn test_bit_width() raises:
+    assert_equal((0)._bit_width(), 1)
+    assert_equal((-1)._bit_width(), 1)
+    assert_equal((255)._bit_width(), 9)
+    assert_equal((-256)._bit_width(), 9)
 
 
-fn main():
+def main():
     test_int()
     test_floordiv()
     test_mod()

--- a/stdlib/test/builtin/test_issue_1004.mojo
+++ b/stdlib/test/builtin/test_issue_1004.mojo
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
 # Test for https://github.com/modularml/mojo/issues/1004
 
 from testing import assert_equal
@@ -24,6 +24,4 @@ def main():
     try:
         foo("Hello")
     except e:
-        # CHECK: Failed on: Hello
-        print(e)
         assert_equal(str(e), "Failed on: Hello")

--- a/stdlib/test/builtin/test_list.mojo
+++ b/stdlib/test/builtin/test_list.mojo
@@ -10,34 +10,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
+
+from testing import assert_equal
 
 
-# CHECK-LABEL: test_list
-fn test_list():
-    print("== test_list")
-    # CHECK: 4
-    print(len([1, 2.0, 3.14, [-1, -2]]))
+fn test_list() raises:
+    assert_equal(len([1, 2.0, 3.14, [-1, -2]]), 4)
 
 
-# CHECK-LABEL: test_variadic_list
-fn test_variadic_list():
-    print("== test_variadic_list")
-
+fn test_variadic_list() raises:
     @parameter
-    fn print_list(*nums: Int):
-        # CHECK: 5
-        # CHECK: 8
-        # CHECK: 6
-        for num in nums:
-            print(num)
+    fn print_list(*nums: Int) raises:
+        assert_equal(nums[0], 5)
+        assert_equal(nums[1], 8)
+        assert_equal(nums[2], 6)
 
-        # CHECK: 3
-        print(len(nums))
+        assert_equal(len(nums), 3)
 
     print_list(5, 8, 6)
 
 
-fn main():
+def main():
     test_list()
     test_variadic_list()

--- a/stdlib/test/builtin/test_range.mojo
+++ b/stdlib/test/builtin/test_range.mojo
@@ -10,52 +10,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
+
+from testing import assert_equal
 
 
-# CHECK-LABEL: test_range_len
-fn test_range_len():
-    print("== test_range_len")
-
-    # CHECK: 10
-    print(range(10).__len__())
-
-    # CHECK: 10
-    print(range(0, 10).__len__())
-
-    # CHECK: 5
-    print(range(5, 10).__len__())
-
-    # CHECK: 10
-    print(range(10, 0, -1).__len__())
-
-    # CHECK: 5
-    print(range(0, 10, 2).__len__())
-
-    # CHECK: 3
-    print(range(38, -13, -23).__len__())
+fn test_range_len() raises:
+    assert_equal(range(10).__len__(), 10)
+    assert_equal(range(0, 10).__len__(), 10)
+    assert_equal(range(5, 10).__len__(), 5)
+    assert_equal(range(10, 0, -1).__len__(), 10)
+    assert_equal(range(0, 10, 2).__len__(), 5)
+    assert_equal(range(38, -13, -23).__len__(), 3)
 
 
-# CHECK-LABEL: test_range_getitem
-fn test_range_getitem():
-    print("== test_range_getitem")
-
-    # CHECK: 5
-    print(range(10)[5])
-
-    # CHECK: 3
-    print(range(0, 10)[3])
-
-    # CHECK: 8
-    print(range(5, 10)[3])
-
-    # CHECK: 8
-    print(range(10, 0, -1)[2])
-
-    # CHECK: 8
-    print(range(0, 10, 2)[4])
+fn test_range_getitem() raises:
+    assert_equal(range(10)[5], 5)
+    assert_equal(range(0, 10)[3], 3)
+    assert_equal(range(5, 10)[3], 8)
+    assert_equal(range(10, 0, -1)[2], 8)
+    assert_equal(range(0, 10, 2)[4], 8)
 
 
-fn main():
+def main():
     test_range_len()
     test_range_getitem()

--- a/stdlib/test/os/test_atomic.mojo
+++ b/stdlib/test/os/test_atomic.mojo
@@ -10,82 +10,58 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
 
 from os.atomic import Atomic
 from testing import assert_equal
 
 
-# CHECK-LABEL: test_atomic
-fn test_atomic():
-    print("== test_atomic")
-
+fn test_atomic() raises:
     var atom: Atomic[DType.index] = 3
 
-    # CHECK: 3
-    print(atom.value)
+    assert_equal(atom.value, 3)
 
     atom += 4
-
-    # CHECK: 7
-    print(atom.value)
+    assert_equal(atom.value, 7)
 
     atom -= 4
+    assert_equal(atom.value, 3)
 
-    # CHECK: 3
-    print(atom.value)
-
-    # CHECK: 3
     atom.max(0)
-    print(atom.value)
+    assert_equal(atom.value, 3)
 
-    # CHECK: 42
     atom.max(42)
-    print(atom.value)
+    assert_equal(atom.value, 42)
 
-    # CHECK: 3
     atom.min(3)
-    print(atom.value)
+    assert_equal(atom.value, 3)
 
-    # CHECK: 0
     atom.min(0)
-    print(atom.value)
+    assert_equal(atom.value, 0)
 
 
-# CHECK-LABEL: test_atomic_floating_point
-fn test_atomic_floating_point():
-    print("== test_atomic_floating_point")
-
+fn test_atomic_floating_point() raises:
     var atom: Atomic[DType.float32] = Float32(3.0)
 
-    # CHECK: 3.0
-    print(atom.value)
+    assert_equal(atom.value, 3.0)
 
     atom += 4
-
-    # CHECK: 7.0
-    print(atom.value)
+    assert_equal(atom.value, 7.0)
 
     atom -= 4
+    assert_equal(atom.value, 3.0)
 
-    # CHECK: 3.0
-    print(atom.value)
-
-    # CHECK: 3.0
     atom.max(0)
-    print(atom.value)
+    assert_equal(atom.value, 3.0)
 
-    # CHECK: 42.0
     atom.max(42)
-    print(atom.value)
+    assert_equal(atom.value, 42.0)
 
-    # CHECK: 3.0
     atom.min(3)
-    print(atom.value)
+    assert_equal(atom.value, 3.0)
 
-    # CHECK: 0.0
     atom.min(0)
-    print(atom.value)
+    assert_equal(atom.value, 0.0)
 
 
 def test_atomic_move_constructor():

--- a/stdlib/test/python/test_ownership.mojo
+++ b/stdlib/test/python/test_ownership.mojo
@@ -25,78 +25,58 @@ from testing import assert_equal
 alias TEST_DIR = env_get_string["TEST_DIR"]()
 
 
-fn test_import(inout python: Python) raises -> String:
-    try:
-        Python.add_to_path(TEST_DIR)
-        var my_module: PythonObject = Python.import_module("my_module")
-        var py_string = my_module.my_function("Hello")
-        var str = String(python.__str__(py_string))
-        return str
-    except e:
-        return str(e)
+fn test_import(inout python: Python) raises:
+    Python.add_to_path(TEST_DIR)
+    var my_module: PythonObject = Python.import_module("my_module")
+    var py_string = my_module.my_function("Hello")
+    var str = String(python.__str__(py_string))
+    assert_equal(str, "Formatting the string from Lit with Python: Hello")
 
 
-fn test_list(inout python: Python) raises -> String:
-    try:
-        var b: PythonObject = Python.import_module("builtins")
-        var my_list = PythonObject([1, 2.34, "False"])
-        var py_string = str(my_list)
-        return String(python.__str__(py_string))
-    except e:
-        return str(e)
+fn test_list(inout python: Python) raises:
+    var b: PythonObject = Python.import_module("builtins")
+    var my_list = PythonObject([1, 2.34, "False"])
+    var py_string = str(my_list)
+    assert_equal(py_string, "[1, 2.34, 'False']")
 
 
-fn test_tuple(inout python: Python) raises -> String:
-    try:
-        var b: PythonObject = Python.import_module("builtins")
-        var my_tuple = PythonObject((1, 2.34, "False"))
-        var py_string = str(my_tuple)
-        return String(python.__str__(py_string))
-    except e:
-        return str(e)
+fn test_tuple(inout python: Python) raises:
+    var b: PythonObject = Python.import_module("builtins")
+    var my_tuple = PythonObject((1, 2.34, "False"))
+    var py_string = str(my_tuple)
+    assert_equal(py_string, "(1, 2.34, 'False')")
 
 
-fn test_call_ownership(inout python: Python) raises -> String:
+fn test_call_ownership(inout python: Python) raises:
     var obj: PythonObject = [1, "5"]
     var py_string = str(obj)
     var string = python.__str__(py_string)
-    return String(string)
+    assert_equal(string, "[1, '5']")
 
 
-fn test_getitem_ownership(inout python: Python) raises -> String:
-    try:
-        var obj: PythonObject = [1, "5"]
-        var py_string = str(obj[1])
-        var string = python.__str__(py_string)
-        return String(string)
-    except e:
-        return str(e)
+fn test_getitem_ownership(inout python: Python) raises:
+    var obj: PythonObject = [1, "5"]
+    var py_string = str(obj[1])
+    var string = python.__str__(py_string)
+    assert_equal(string, "5")
 
 
-fn test_getattr_ownership(inout python: Python) raises -> String:
-    try:
-        Python.add_to_path(TEST_DIR)
-        var my_module: PythonObject = Python.import_module("my_module")
-        var obj = my_module.Foo(4)
-        var py_string = str(obj.bar)
-        var string = python.__str__(py_string)
-        return String(string)
-    except e:
-        return str(e)
+fn test_getattr_ownership(inout python: Python) raises:
+    Python.add_to_path(TEST_DIR)
+    var my_module: PythonObject = Python.import_module("my_module")
+    var obj = my_module.Foo(4)
+    var py_string = str(obj.bar)
+    var string = python.__str__(py_string)
+    assert_equal(string, "4")
 
 
 def main():
     # initializing Python instance calls init_python
     var python = Python()
 
-    assert_equal(test_list(python), "[1, 2.34, 'False']")
-
-    assert_equal(test_tuple(python), "(1, 2.34, 'False')")
-
-    assert_equal(test_call_ownership(python), "[1, '5']")
-
-    assert_equal(test_getitem_ownership(python), "5")
-
-    assert_equal(test_getattr_ownership(python), "4")
-
-    assert_equal(test_import(python), "Formatting the string from Lit with Python: Hello")
+    test_list(python)
+    test_tuple(python)
+    test_call_ownership(python)
+    test_getitem_ownership(python)
+    test_getattr_ownership(python)
+    test_import(python)

--- a/stdlib/test/python/test_ownership.mojo
+++ b/stdlib/test/python/test_ownership.mojo
@@ -11,7 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 # XFAIL: asan && !system-darwin
-# RUN: %mojo -D TEST_DIR=%S %s | FileCheck %s
+# RUN: %mojo -D TEST_DIR=%S %s
 
 from sys.param_env import env_get_string
 
@@ -19,6 +19,8 @@ from memory.unsafe import Pointer
 from python._cpython import CPython, PyObjectPtr
 from python.object import PythonObject
 from python.python import Python
+
+from testing import assert_equal
 
 alias TEST_DIR = env_get_string["TEST_DIR"]()
 
@@ -87,20 +89,14 @@ def main():
     # initializing Python instance calls init_python
     var python = Python()
 
-    # CHECK: [1, 2.34, 'False']
-    print(test_list(python))
+    assert_equal(test_list(python), "[1, 2.34, 'False']")
 
-    # CHECK: (1, 2.34, 'False')
-    print(test_tuple(python))
+    assert_equal(test_tuple(python), "(1, 2.34, 'False')")
 
-    # CHECK: [1, '5']
-    print(test_call_ownership(python))
+    assert_equal(test_call_ownership(python), "[1, '5']")
 
-    # CHECK: 5
-    print(test_getitem_ownership(python))
+    assert_equal(test_getitem_ownership(python), "5")
 
-    # CHECK: 4
-    print(test_getattr_ownership(python))
+    assert_equal(test_getattr_ownership(python), "4")
 
-    # CHECK: Formatting the string from Lit with Python: Hello
-    print(test_import(python))
+    assert_equal(test_import(python), "Formatting the string from Lit with Python: Hello")

--- a/stdlib/test/python/test_python_error_handling.mojo
+++ b/stdlib/test/python/test_python_error_handling.mojo
@@ -51,7 +51,9 @@ fn test_python_exception_getitem() raises:
 
 
 fn test_python_exception_call() raises:
-    with assert_raises(contains="Can't instantiate abstract class AbstractPerson"):
+    with assert_raises(
+        contains="Can't instantiate abstract class AbstractPerson"
+    ):
         Python.add_to_path(TEST_DIR)
         var my_module: PythonObject = Python.import_module("my_module")
         if my_module:

--- a/stdlib/test/python/test_python_error_handling.mojo
+++ b/stdlib/test/python/test_python_error_handling.mojo
@@ -11,13 +11,15 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 # XFAIL: asan && !system-darwin
-# RUN: %mojo -D TEST_DIR=%S %s | FileCheck %s
+# RUN: %mojo -D TEST_DIR=%S %s
 
 from sys.param_env import env_get_string
 
 from python import Python
 from python._cpython import CPython, PyObjectPtr
 from python.object import PythonObject
+
+from testing import assert_equal, assert_raises
 
 alias TEST_DIR = env_get_string["TEST_DIR"]()
 
@@ -26,7 +28,7 @@ fn test_python_exception_import() raises:
     try:
         var sys = Python.import_module("my_uninstalled_module")
     except e:
-        print(e)
+        assert_equal(str(e), "No module named 'my_uninstalled_module'")
 
 
 fn test_python_exception_getattr() raises:
@@ -37,7 +39,7 @@ fn test_python_exception_getattr() raises:
             var person = my_module.Person()
             var expec_fail = person.undefined()
     except e:
-        print(e)
+        assert_equal(str(e), "'Person' object has no attribute 'undefined'")
 
 
 fn test_python_exception_getitem() raises:
@@ -45,25 +47,19 @@ fn test_python_exception_getitem() raises:
         var list = PythonObject([1, 2, 3])
         var should_fail = list[13]
     except e:
-        print(e)
+        assert_equal(str(e), "list index out of range")
 
 
 fn test_python_exception_call() raises:
-    try:
+    with assert_raises(contains="Can't instantiate abstract class AbstractPerson"):
         Python.add_to_path(TEST_DIR)
         var my_module: PythonObject = Python.import_module("my_module")
         if my_module:
             var person = my_module.AbstractPerson()
-    except e:
-        print(e)
 
 
 def main():
-    # CHECK: No module named 'my_uninstalled_module'
     test_python_exception_import()
-    # CHECK: 'Person' object has no attribute 'undefined'
     test_python_exception_getattr()
-    # CHECK: list index out of range
     test_python_exception_getitem()
-    # CHECK: Can't instantiate abstract class AbstractPerson
     test_python_exception_call()

--- a/stdlib/test/python/test_python_info.mojo
+++ b/stdlib/test/python/test_python_info.mojo
@@ -11,24 +11,23 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 # XFAIL: asan && !system-darwin
-# RUN: %mojo %s | FileCheck %s
+# RUN: %mojo %s
 
 
 from python._cpython import PythonVersion
 from python import Python
 
+from testing import assert_equal
 
-fn test_python_version(inout python: Python):
+
+fn test_python_version(inout python: Python) raises:
     var version = "3.10.8 (main, Nov 24 2022, 08:08:27) [Clang 14.0.6 ]"
     var pythonVersion = PythonVersion(version)
-    # CHECK: 3
-    print(pythonVersion.major)
-    # CHECK: 10
-    print(pythonVersion.minor)
-    # CHECK: 8
-    print(pythonVersion.patch)
+    assert_equal(pythonVersion.major, 3)
+    assert_equal(pythonVersion.minor, 10)
+    assert_equal(pythonVersion.patch, 8)
 
 
-fn main():
+def main():
     var python = Python()
     test_python_version(python)

--- a/stdlib/test/python/test_python_interop.mojo
+++ b/stdlib/test/python/test_python_interop.mojo
@@ -69,7 +69,10 @@ def main():
 
     assert_equal(
         test_call(python),
-        "carrot ('bread', 'rice') fruit=pear {'protein': 'fish', 'cake': 'yes'}",
+        (
+            "carrot ('bread', 'rice') fruit=pear {'protein': 'fish', 'cake':"
+            " 'yes'}"
+        ),
     )
 
     var obj: PythonObject = [1, 2.4, True, "False"]

--- a/stdlib/test/python/test_python_interop.mojo
+++ b/stdlib/test/python/test_python_interop.mojo
@@ -11,13 +11,15 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 # XFAIL: asan && !system-darwin
-# RUN: %mojo -D TEST_DIR=%S %s | FileCheck %s
+# RUN: %mojo -D TEST_DIR=%S %s
 
 from sys.param_env import env_get_string
 
 from python._cpython import CPython, PyObjectPtr
 from python.object import PythonObject
 from python.python import Python, _get_global_python_itf
+
+from testing import assert_equal
 
 alias TEST_DIR = env_get_string["TEST_DIR"]()
 
@@ -63,23 +65,20 @@ fn test_call(inout python: Python) -> String:
 
 def main():
     var python = Python()
-    # CHECK: orange
-    print(test_local_import(python))
+    assert_equal(test_local_import(python), "orange")
 
-    # CHECK: carrot ('bread', 'rice') fruit=pear {'protein': 'fish', 'cake': 'yes'}
-    print(test_call(python))
+    assert_equal(
+        test_call(python),
+        "carrot ('bread', 'rice') fruit=pear {'protein': 'fish', 'cake': 'yes'}",
+    )
 
-    # CHECK: [1, 2.4, True, 'False']
     var obj: PythonObject = [1, 2.4, True, "False"]
-    print(obj)
+    assert_equal(str(obj), "[1, 2.4, True, 'False']")
 
-    # CHECK: (1, 2.4, True, 'False')
     obj = (1, 2.4, True, "False")
-    print(obj)
+    assert_equal(str(obj), "(1, 2.4, True, 'False')")
 
-    # CHECK: None
     obj = None
-    print(obj)
+    assert_equal(str(obj), "None")
 
-    # CHECK: ab
-    print(test_execute_python_string(python))
+    assert_equal(test_execute_python_string(python), "ab")

--- a/stdlib/test/python/test_python_object.mojo
+++ b/stdlib/test/python/test_python_object.mojo
@@ -17,337 +17,267 @@ from memory.unsafe import Pointer
 from python._cpython import CPython, PyObjectPtr
 from python.object import PythonObject
 from python.python import Python
-from testing import assert_false, assert_raises, assert_true
+from testing import assert_false, assert_raises, assert_true, assert_equal
 
 from utils import StringRef
 
 
-# CHECK-LABEL: test_dunder_methods
 fn test_dunder_methods(inout python: Python):
-    print("=== test_dunder_methods ===")
     try:
         var a = PythonObject(34)
         var b = PythonObject(10)
 
         # __add__
-        # CHECK-NEXT: 44
         var c = a + b
-        print(c)
+        assert_true(c, 44)
 
         # __add__
-        # CHECK-NEXT: 134
         c = a + 100
-        print(c)
+        assert_true(c, 134)
 
         # __iadd__
-        # CHECK-NEXT: 234
         c += 100
-        print(c)
+        assert_equal(c, 234)
 
         # __radd__
-        # CHECK-NEXT: 134
         c = 100 + a
-        print(c)
+        assert_equal(c, 134)
 
         # __sub__
-        # CHECK-NEXT: 24
         c = a - b
-        print(c)
+        assert_equal(c, 24)
 
         # __isub__
-        # CHECK-NEXT: -76
         c -= 100
-        print(c)
+        assert_equal(c, -76)
 
         # __sub__
-        # CHECK-NEXT: -66
         c = a - 100
-        print(c)
+        assert_equal(c, -66)
 
         # __rsub__
-        # CHECK-NEXT: 66
         c = 100 - a
-        print(c)
+        assert_equal(c, 66)
 
         # __mul__
-        # CHECK-NEXT: 340
         c = a * b
-        print(c)
+        assert_equal(c, 340)
 
         # __imul__
-        # CHECK-NEXT: 3400
         c *= 10
-        print(c)
+        assert_equal(c, 3400)
 
         # __mul__
-        # CHECK-NEXT: 340
         c = a * 10
-        print(c)
+        assert_equal(c, 340)
 
         # __rmul__
-        # CHECK-NEXT: 340
         c = 34 * b
-        print(c)
+        assert_equal(c, 340)
 
         # __floordiv__
-        # CHECK-NEXT: 3
         c = a // b
-        print(c)
+        assert_equal(c, 3)
 
         # __ifloordiv__
-        # CHECK-NEXT: 1
         c //= 2
-        print(c)
+        assert_equal(c, 1)
 
         # __floordiv__
-        # CHECK-NEXT: 3
         c = a // 10
-        print(c)
+        assert_equal(c, 3)
 
         # __rfloordiv__
-        # CHECK-NEXT: 3
         c = 34 // b
-        print(c)
+        assert_equal(c, 3)
 
         # __truediv__
-        # CHECK-NEXT: 3.4
         c = a / b
-        print(c)
+        assert_equal(c, 3.4)
 
         # __itruediv__
-        # CHECK-NEXT: 1.7
         c /= 2
-        print(c)
+        assert_equal(c, 1.7)
 
         # __truediv__
-        # CHECK-NEXT: 3.4
         c = a / 10
-        print(c)
+        assert_equal(c, 3.4)
 
         # __rtruediv__
-        # CHECK-NEXT: 3.4
         c = 34 / b
-        print(c)
+        assert_equal(c, 3.4)
 
         # __mod__
-        # CHECK-NEXT: 4
         c = a % b
-        print(c)
+        assert_equal(c, 4)
 
         # __imod__
-        # CHECK-NEXT: 1
         c %= 3
-        print(c)
+        assert_equal(c, 1)
 
         # __mod__
-        # CHECK-NEXT: 4
         c = a % 10
-        print(c)
+        assert_equal(c, 4)
 
         # __rmod__
-        # CHECK-NEXT: 4
         c = 34 % b
-        print(c)
+        assert_equal(c, 4)
 
         # __xor__
-        # CHECK-NEXT: 40
         c = a ^ b
-        print(c)
+        assert_equal(c, 40)
 
         # __ixor__
-        # CHECK-NEXT: 39
         c ^= 15
-        print(c)
+        assert_equal(c, 39)
 
         # __xor__
-        # CHECK-NEXT: 40
         c = a ^ 10
-        print(c)
+        assert_equal(c, 40)
 
         # __rxor__
-        # CHECK-NEXT: 40
         c = 34 ^ b
-        print(c)
+        assert_equal(c, 40)
 
         # __or__
-        # CHECK-NEXT: 42
         c = a | b
-        print(c)
+        assert_equal(c, 42)
 
         # __ior__
-        # CHECK-NEXT: 43
         c |= 9
-        print(c)
+        assert_equal(c, 43)
 
         # __or__
-        # CHECK-NEXT: 42
         c = a | 10
-        print(c)
+        assert_equal(c, 42)
 
         # __ror__
-        # CHECK-NEXT: 42
         c = 34 | b
-        print(c)
+        assert_equal(c, 42)
 
         # __and__
-        # CHECK-NEXT: 2
         c = a & b
-        print(c)
+        assert_equal(c, 2)
 
         # __iand__
-        # CHECK-NEXT: 2
         c &= 6
-        print(c)
+        assert_equal(c, 2)
 
         # __and__
-        # CHECK-NEXT: 2
         c = a & 10
-        print(c)
+        assert_equal(c, 2)
 
         # __rand__
-        # CHECK-NEXT: 2
         c = 34 & b
-        print(c)
+        assert_equal(c, 2)
 
         # __rshift__
         var d = PythonObject(2)
-        # CHECK-NEXT: 8
         c = a >> d
-        print(c)
+        assert_equal(c, 8)
 
         # __irshift__
-        # CHECK-NEXT: 2
         c >>= 2
-        print(c)
+        assert_equal(c, 2)
 
         # __rshift__
-        # CHECK-NEXT: 8
         c = a >> 2
-        print(c)
+        assert_equal(c, 8)
 
         # __rrshift__
-        # CHECK-NEXT: 8
         c = 34 >> d
-        print(c)
+        assert_equal(c, 8)
 
         # __lshift__
-        # CHECK-NEXT: 136
         c = a << d
-        print(c)
+        assert_equal(c, 136)
 
         # __ilshift__
-        # CHECK-NEXT: 272
         c <<= 1
-        print(c)
+        assert_equal(c, 272)
 
         # __lshift__
-        # CHECK-NEXT: 136
         c = a << 2
-        print(c)
+        assert_equal(c, 136)
 
         # __rlshift__
-        # CHECK-NEXT: 136
         c = 34 << d
-        print(c)
+        assert_equal(c, 136)
 
         # __pow__
-        # CHECK-NEXT: 1156
         c = a**d
-        print(c)
+        assert_equal(c, 1156)
 
         # __ipow__
-        # CHECK-NEXT: 81
         c = 3
         c **= 4
-        print(c)
+        assert_equal(c, 81)
 
         # __pow__
-        # CHECK-NEXT: 1156
         c = a**2
-        print(c)
+        assert_equal(c, 1156)
 
         # __rpow__
-        # CHECK-NEXT: 1156
         c = 34**d
-        print(c)
+        assert_equal(c, 1156)
 
         # __lt__
-        # CHECK-NEXT: False
         c = a < b
-        print(c)
+        assert_false(c)
 
         # __le__
-        # CHECK-NEXT: False
         c = a <= b
-        print(c)
+        assert_false(c)
 
         # __gt__
-        # CHECK-NEXT: True
         c = a > b
-        print(c)
+        assert_true(c)
 
         # __ge__
-        # CHECK-NEXT: True
         c = a >= b
-        print(c)
+        assert_true(c)
 
         # __eq__
-        # CHECK-NEXT: False
         c = a == b
-        print(c)
+        assert_false(c)
 
         # __ne__
-        # CHECK-NEXT: True
         c = a != b
-        print(c)
+        assert_true(c)
 
         # __pos__
-        # CHECK-NEXT: 34
         c = +a
-        print(c)
+        assert_equal(c, 34)
 
         # __neg__
-        # CHECK-NEXT: -34
         c = -a
-        print(c)
+        assert_equal(c, -34)
 
         # __invert__
-        # CHECK-NEXT: -35
         c = ~a
-        print(c)
+        assert_equal(c, -35)
     except e:
         pass
 
 
-# CHECK-LABEL: test_bool_conversion
 def test_bool_conversion() -> None:
-    print("=== test_bool_conversion ===")
     var x: PythonObject = 1
-    # CHECK: test_bool: True
-    print("test_bool:", x == 0 or x == 1)
+    assert_true(x == 0 or x == 1)
 
 
-# CHECK-LABEL: test_string_conversions
-fn test_string_conversions() -> None:
-    print("=== test_string_conversions ===")
-
-    # CHECK-LABEL: test_string_literal
+fn test_string_conversions() raises -> None:
     fn test_string_literal() -> None:
-        print("=== test_string_literal ===")
         try:
             var mojo_str: StringLiteral = "mojo"
             var py_str = PythonObject(mojo_str)
             var py_capitalized = py_str.capitalize()
             var py = Python()
             var mojo_capitalized = py.__str__(py_capitalized)
-            # CHECK: Mojo
-            print(mojo_capitalized)
+            assert_equal(mojo_capitalized, "Mojo")
         except e:
             print("Error occurred")
 
-    # CHECK-LABEL: test_string_ref
     fn test_string_ref() -> None:
-        print("=== test_string_ref ===")
         try:
             var mojo_str: StringLiteral = "mojo"
             var mojo_strref = StringRef(mojo_str)
@@ -355,14 +285,11 @@ fn test_string_conversions() -> None:
             var py_capitalized = py_str.capitalize()
             var py = Python()
             var mojo_capitalized = py.__str__(py_capitalized)
-            # CHECK: Mojo
-            print(mojo_capitalized)
+            assert_equal(mojo_capitalized, "Mojo")
         except e:
             print("Error occurred")
 
-    # CHECK-LABEL: test_string
     fn test_string() -> None:
-        print("=== test_string ===")
         try:
             var mo_str = String("mo")
             var jo_str = String("jo")
@@ -371,19 +298,15 @@ fn test_string_conversions() -> None:
             var py_capitalized = py_str.capitalize()
             var py = Python()
             var mojo_capitalized = py.__str__(py_capitalized)
-            # CHECK: Mojo
-            print(mojo_capitalized)
+            assert_equal(mojo_capitalized, "Mojo")
         except e:
             print("Error occurred")
 
-    # CHECK-LABEL: test_type_object
-    fn test_type_object() -> None:
-        print("=== test_type_object ===")
+    fn test_type_object() raises -> None:
         var py = Python()
         var py_float = PythonObject(3.14)
         var type_obj = py.type(py_float)
-        # CHECK: <class 'float'>
-        print(type_obj)
+        assert_equal(str(type_obj), "<class 'float'>")
 
     test_string_literal()
     test_string_ref()
@@ -391,20 +314,15 @@ fn test_string_conversions() -> None:
     test_type_object()
 
 
-# CHECK-LABEL: test_len
 def test_len():
-    print("=== test_len ===")
     var empty_list = Python.evaluate("[]")
-    # CHECK: 0
-    print(len(empty_list))
+    assert_equal(len(empty_list), 0)
 
     var l1 = Python.evaluate("[1,2,3]")
-    # CHECK: 3
-    print(len(l1))
+    assert_equal(len(l1), 3)
 
     var l2 = Python.evaluate("[42,42.0]")
-    # CHECK: 2
-    print(len(l2))
+    assert_equal(len(l2), 2)
 
 
 # CHECK-LABEL: test_is

--- a/stdlib/test/python/test_python_to_mojo.mojo
+++ b/stdlib/test/python/test_python_to_mojo.mojo
@@ -15,14 +15,16 @@
 from python.object import PythonObject
 from python.python import Python
 
+from testing import assert_equal
+
 
 fn test_string_to_python_to_mojo(inout python: Python) raises:
     var py_string = PythonObject("mojo")
     var py_string_capitalized = py_string.capitalize()
 
-    # CHECK: Mojo
     var cap_mojo_string = str(py_string_capitalized)
-    print(cap_mojo_string)
+    assert_equal(cap_mojo_string, "Mojo")
+
 
 fn test_range() raises:
     var array_size: PythonObject = 2

--- a/stdlib/test/sys/test_intrinsics.mojo
+++ b/stdlib/test/sys/test_intrinsics.mojo
@@ -21,21 +21,19 @@ from sys.intrinsics import (
 )
 
 from memory.unsafe import DTypePointer
+from testing import assert_equal
 
 
-# CHECK-LABEL: test_strided_load
-fn test_strided_load():
-    print("== test_strided_load")
-
+fn test_strided_load() raises:
     alias size = 16
     var vector = DTypePointer[DType.float32]().alloc(size)
 
     for i in range(size):
         vector[i] = i
 
-    # CHECK: [0.0, 4.0, 8.0, 12.0]
     var s = strided_load[DType.float32, 4](vector, 4)
-    print(s)
+    assert_equal(s, SIMD[DType.float32, 4](0, 4, 8, 12))
+
     vector.free()
 
 
@@ -61,6 +59,6 @@ fn test_strided_store():
     vector.free()
 
 
-fn main():
+def main():
     test_strided_load()
     test_strided_store()

--- a/stdlib/test/sys/test_macos_target.mojo
+++ b/stdlib/test/sys/test_macos_target.mojo
@@ -15,7 +15,7 @@
 #
 # ===----------------------------------------------------------------------=== #
 # REQUIRES: darwin
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
 
 
 from sys.info import (
@@ -25,30 +25,23 @@ from sys.info import (
     os_is_macos,
     os_is_windows,
 )
+from testing import assert_true, assert_false
 
 
-# CHECK-LABEL: test_os_query
-fn test_os_query():
-    print("== test_os_query")
+fn test_os_query() raises:
+    assert_true(os_is_macos())
 
-    # CHECK: True
-    print(os_is_macos())
+    assert_false(os_is_linux())
 
-    # CHECK: False
-    print(os_is_linux())
-
-    # CHECK: False
-    print(os_is_windows())
+    assert_false(os_is_windows())
 
     # The mac systems are either arm64 or intel, so they are always little
     # endian at the moment.
 
-    # CHECK: True
-    print(is_little_endian())
+    assert_true(is_little_endian())
 
-    # CHECK: False
-    print(is_big_endian())
+    assert_false(is_big_endian())
 
 
-fn main():
+def main():
     test_os_query()

--- a/stdlib/test/sys/test_targetinfo.mojo
+++ b/stdlib/test/sys/test_targetinfo.mojo
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
 
 from sys.info import (
     alignof,
@@ -19,58 +19,40 @@ from sys.info import (
     num_physical_cores,
     sizeof,
 )
+from testing import assert_equal, assert_true
 
 
-# CHECK-LABEL: test_sizeof
-fn test_sizeof():
-    print("== test_sizeof")
+fn test_sizeof() raises:
+    assert_equal(sizeof[__mlir_type.i16](), 2)
 
-    # CHECK: 2
-    print(sizeof[__mlir_type.i16]())
+    assert_equal(sizeof[__mlir_type.ui16](), 2)
 
-    # CHECK: 2
-    print(sizeof[__mlir_type.ui16]())
+    assert_equal(sizeof[DType.int16](), 2)
 
-    # CHECK: 2
-    print(sizeof[DType.int16]())
+    assert_equal(sizeof[DType.uint16](), 2)
 
-    # CHECK: 2
-    print(sizeof[DType.uint16]())
-
-    # CHECK: 4
-    print(sizeof[SIMD[DType.int16, 2]]())
+    assert_equal(sizeof[SIMD[DType.int16, 2]](), 4)
 
 
-# CHECK-LABEL: test_alignof
-fn test_alignof():
-    print("== test_alignof")
+fn test_alignof() raises:
+    assert_true(alignof[__mlir_type.i16]() > 0)
 
-    # CHECK: True
-    print(alignof[__mlir_type.i16]() > 0)
+    assert_true(alignof[__mlir_type.ui16]() > 0)
 
-    # CHECK: True
-    print(alignof[__mlir_type.ui16]() > 0)
+    assert_true(alignof[DType.int16]() > 0)
 
-    # CHECK: True
-    print(alignof[DType.int16]() > 0)
+    assert_true(alignof[DType.uint16]() > 0)
 
-    # CHECK: True
-    print(alignof[DType.uint16]() > 0)
-
-    # CHECK: True
-    print(alignof[SIMD[DType.int16, 2]]() > 0)
+    assert_true(alignof[SIMD[DType.int16, 2]]() > 0)
 
 
-fn test_cores():
-    # CHECK: True
-    print(num_logical_cores() > 0)
-    # CHECK: True
-    print(num_physical_cores() > 0)
-    # CHECK: True
-    print(num_performance_cores() > 0)
+fn test_cores() raises:
+    assert_true(num_logical_cores() > 0)
+    assert_true(num_physical_cores() > 0)
+    assert_true(num_performance_cores() > 0)
 
 
-fn main():
+def main():
     test_sizeof()
     test_alignof()
     test_cores()

--- a/stdlib/test/time/test_time.mojo
+++ b/stdlib/test/time/test_time.mojo
@@ -10,10 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
 
 from sys.info import os_is_windows
 from time import now, sleep, time_function
+from testing import assert_true
 
 
 @always_inline
@@ -46,42 +47,30 @@ fn time_capturing_function(iters: Int) -> Int:
     return time_function[time_fn]()
 
 
-# CHECK-LABEL: test_time
-fn test_time():
-    print("== test_time")
-
+fn test_time() raises:
     alias ns_per_sec = 1_000_000_000
 
-    # CHECK: True
-    print(now() > 0)
+    assert_true(now() > 0)
 
     var t1 = time_function[time_me]()
-    # CHECK: True
-    print(t1 > 1 * ns_per_sec)
-    # CHECK: True
-    print(t1 < 10 * ns_per_sec)
+    assert_true(t1 > 1 * ns_per_sec)
+    assert_true(t1 < 10 * ns_per_sec)
 
     var t2 = time_templated_function[DType.float32]()
-    # CHECK: True
-    print(t2 > 1 * ns_per_sec)
-    # CHECK: True
-    print(t2 < 10 * ns_per_sec)
+    assert_true(t2 > 1 * ns_per_sec)
+    assert_true(t2 < 10 * ns_per_sec)
 
     var t3 = time_capturing_function(42)
-    # CHECK: True
-    print(t3 > 1 * ns_per_sec)
-    # CHECK: True
-    print(t3 < 10 * ns_per_sec)
+    assert_true(t3 > 1 * ns_per_sec)
+    assert_true(t3 < 10 * ns_per_sec)
 
     # test now() directly since time_function doesn't use now on windows
     var t4 = now()
     time_me()
     var t5 = now()
-    # CHECK: True
-    print((t5 - t4) > 1 * ns_per_sec)
-    # CHECK: True
-    print((t5 - t4) < 10 * ns_per_sec)
+    assert_true((t5 - t4) > 1 * ns_per_sec)
+    assert_true((t5 - t4) < 10 * ns_per_sec)
 
 
-fn main():
+def main():
     test_time()

--- a/stdlib/test/utils/issue_13632.mojo
+++ b/stdlib/test/utils/issue_13632.mojo
@@ -10,9 +10,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
 
 from collections import List
+from testing import assert_equal
 
 
 fn sum_items(data: List[Int8]) -> Int:
@@ -26,7 +27,6 @@ fn make_abcd_vector() -> List[Int8]:
     return List[Int8](97, 98, 99, 100)
 
 
-fn main():
+def main():
     var vec = make_abcd_vector()
-    # CHECK: 394
-    print(sum_items(vec))
+    assert_equal(sum_items(vec), 394)

--- a/stdlib/test/utils/test_numerics.mojo
+++ b/stdlib/test/utils/test_numerics.mojo
@@ -10,62 +10,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
 
 from utils._numerics import FPUtils
+from testing import assert_equal, assert_true, assert_false
 
 alias FPU64 = FPUtils[DType.float64]
 
 
-# CHECK-LABEL: test_numerics
-fn test_numerics():
-    print("== test_numerics")
+fn test_numerics() raises:
+    assert_equal(FPUtils[DType.float32].mantissa_width(), 23)
 
-    # CHECK: 23
-    print(FPUtils[DType.float32].mantissa_width())
+    assert_equal(FPUtils[DType.float64].mantissa_width(), 52)
 
-    # CHECK: 52
-    print(FPUtils[DType.float64].mantissa_width())
+    assert_equal(FPUtils[DType.float32].exponent_bias(), 127)
 
-    # CHECK: 127
-    print(FPUtils[DType.float32].exponent_bias())
+    assert_equal(FPUtils[DType.float64].exponent_bias(), 1023)
 
-    # CHECK: 1023
-    print(FPUtils[DType.float64].exponent_bias())
-
-    # CHECK: 2
-    print(FPU64.get_exponent(FPU64.set_exponent(1, 2)))
-    # CHECK-NEXT: 3
-    print(FPU64.get_mantissa(FPU64.set_mantissa(1, 3)))
-    # CHECK-NEXT: 4
-    print(FPU64.get_exponent(FPU64.set_exponent(-1, 4)))
-    # CHECK-NEXT: 5
-    print(FPU64.get_mantissa(FPU64.set_mantissa(-1, 5)))
-    # CHECK-NEXT: True
-    print(FPU64.get_sign(FPU64.set_sign(0, True)))
-    # CHECK-NEXT: False
-    print(FPU64.get_sign(FPU64.set_sign(0, False)))
-    # CHECK-NEXT: True
-    print(FPU64.get_sign(FPU64.set_sign(-0, True)))
-    # CHECK-NEXT: False
-    print(FPU64.get_sign(FPU64.set_sign(-0, False)))
-    # CHECK-NEXT: False
-    print(FPU64.get_sign(1))
-    # CHECK-NEXT: True
-    print(FPU64.get_sign(-1))
-    # CHECK-NEXT: False
-    print(FPU64.get_sign(FPU64.pack(False, 6, 12)))
-    # CHECK-NEXT: 6
-    print(FPU64.get_exponent(FPU64.pack(False, 6, 12)))
-    # CHECK-NEXT: 12
-    print(FPU64.get_mantissa(FPU64.pack(False, 6, 12)))
-    # CHECK-NEXT: True
-    print(FPU64.get_sign(FPU64.pack(True, 6, 12)))
-    # CHECK-NEXT: 6
-    print(FPU64.get_exponent(FPU64.pack(True, 6, 12)))
-    # CHECK-NEXT: 12
-    print(FPU64.get_mantissa(FPU64.pack(True, 6, 12)))
+    assert_equal(FPU64.get_exponent(FPU64.set_exponent(1, 2)), 2)
+    assert_equal(FPU64.get_mantissa(FPU64.set_mantissa(1, 3)), 3)
+    assert_equal(FPU64.get_exponent(FPU64.set_exponent(-1, 4)), 4)
+    assert_equal(FPU64.get_mantissa(FPU64.set_mantissa(-1, 5)), 5)
+    assert_true(FPU64.get_sign(FPU64.set_sign(0, True)))
+    assert_false(FPU64.get_sign(FPU64.set_sign(0, False)))
+    assert_true(FPU64.get_sign(FPU64.set_sign(-0, True)))
+    assert_false(FPU64.get_sign(FPU64.set_sign(-0, False)))
+    assert_false(FPU64.get_sign(1))
+    assert_true(FPU64.get_sign(-1))
+    assert_false(FPU64.get_sign(FPU64.pack(False, 6, 12)))
+    assert_equal(FPU64.get_exponent(FPU64.pack(False, 6, 12)), 6)
+    assert_equal(FPU64.get_mantissa(FPU64.pack(False, 6, 12)), 12)
+    assert_true(FPU64.get_sign(FPU64.pack(True, 6, 12)))
+    assert_equal(FPU64.get_exponent(FPU64.pack(True, 6, 12)), 6)
+    assert_equal(FPU64.get_mantissa(FPU64.pack(True, 6, 12)), 12)
 
 
-fn main():
+def main():
     test_numerics()


### PR DESCRIPTION
# Description

This PR ports a subset of tests using `FileCheck` to use `testing.assert_*` functions (#2024)

Below is a list of files still using `FileCheck` (`git grep -l '| FileCheck'`) as of 8bf9e6c5b4693f2d666c14f2260f11a33f7fb955, and the highlighted files are the ones I've tackled:

```diff
examples/deviceinfo.mojo
"examples/hello.\360\237\224\245"
examples/mandelbrot.mojo
examples/reduce.mojo
stdlib/docs/development.md
- stdlib/test/base64/test_base64.mojo
stdlib/test/builtin/test_bfloat16.mojo
stdlib/test/builtin/test_debug_assert-error.mojo
stdlib/test/builtin/test_debug_assert-mojo-enable-assertions.mojo
stdlib/test/builtin/test_debug_assert.mojo
stdlib/test/builtin/test_debug_assert_warning.mojo
- stdlib/test/builtin/test_error.mojo
stdlib/test/builtin/test_file.mojo
- stdlib/test/builtin/test_int_literal.mojo
- stdlib/test/builtin/test_issue_1004.mojo
- stdlib/test/builtin/test_list.mojo
stdlib/test/builtin/test_object.mojo
stdlib/test/builtin/test_print.mojo
stdlib/test/builtin/test_print_long_string.mojo
- stdlib/test/builtin/test_range.mojo
stdlib/test/builtin/test_simd.mojo
stdlib/test/builtin/test_slice.mojo
stdlib/test/memory/test_anypointer.mojo
stdlib/test/memory/test_bitcast.mojo
- stdlib/test/os/test_atomic.mojo
stdlib/test/os/test_no_trap.mojo
stdlib/test/os/test_trap.mojo
stdlib/test/os/test_trap_stringable.mojo
- stdlib/test/python/test_ownership.mojo
- stdlib/test/python/test_python_error_handling.mojo
- stdlib/test/python/test_python_info.mojo
- stdlib/test/python/test_python_interop.mojo
- stdlib/test/python/test_python_object.mojo
- stdlib/test/python/test_python_to_mojo.mojo
stdlib/test/random/test_random.mojo
stdlib/test/sys/test_aarch64_target.mojo
stdlib/test/sys/test_build_info_debug.mojo
stdlib/test/sys/test_has_intel_amx.mojo
- stdlib/test/sys/test_intrinsics.mojo
stdlib/test/sys/test_linux_target.mojo
- stdlib/test/sys/test_macos_target.mojo
stdlib/test/sys/test_paramenv.mojo
- stdlib/test/sys/test_targetinfo.mojo
stdlib/test/sys/test_windows_target.mojo
stdlib/test/testing/test_assert_raises_basic.mojo
stdlib/test/testing/test_assert_raises_no_error.mojo
stdlib/test/testing/test_assert_raises_no_match.mojo
- stdlib/test/time/test_time.mojo
- stdlib/test/utils/issue_13632.mojo
- stdlib/test/utils/test_numerics.mojo
stdlib/test/utils/test_unroll.mojo
```