### PR TITLE
[mojo-stdlib] Allow `my_optional is None` and `my_optional is not None`

### DIFF
--- a/stdlib/src/collections/optional.mojo
+++ b/stdlib/src/collections/optional.mojo
@@ -147,6 +147,32 @@ struct Optional[T: CollectionElement](CollectionElement, Boolable):
             return self._value.get[T]()[]
         return default
 
+    fn __is__(self, other: NoneType) -> Bool:
+        """Return `True` if the Optional has no value.
+
+        It allows you to use the following syntax: `if my_optional is None:`
+
+        Args:
+            other: The value to compare to (None).
+
+        Returns:
+            True if the Optional has no value and False otherwise.
+        """
+        return not self.__bool__()
+
+    fn __isnot__(self, other: NoneType) -> Bool:
+        """Return `True` if the Optional has a value.
+
+        It allows you to use the following syntax: `if my_optional is not None:`
+
+        Args:
+            other: The value to compare to (None).
+
+        Returns:
+            True if the Optional has a value and False otherwise.
+        """
+        return self.__bool__()
+
     fn __bool__(self) -> Bool:
         """Return true if the Optional has a value.
 

--- a/stdlib/test/collections/test_optional.mojo
+++ b/stdlib/test/collections/test_optional.mojo
@@ -71,6 +71,24 @@ def test_optional_reg_basic():
     assert_true(True and val)
 
 
+def test_optional_is():
+    a = Optional(1)
+    assert_false(a is None)
+
+    a = Optional[Int](None)
+    assert_true(a is None)
+
+
+def test_optional_isnot():
+    a = Optional(1)
+    assert_true(a is not None)
+
+    a = Optional[Int](None)
+    assert_false(a is not None)
+
+
 def main():
     test_basic()
     test_optional_reg_basic()
+    test_optional_is()
+    test_optional_isnot()


### PR DESCRIPTION
Just as the title says, it's a very common idiom in python, is even recommended by PEP8: https://peps.python.org/pep-0008/#programming-recommendations

> Comparisons to singletons like None should always be done with is or is not, never the equality operators.
Also, beware of writing if x when you really mean if x is not None – e.g. when testing whether a variable or argument that defaults to None was set to some other value. The other value might have a type (such as a container) that could be false in a boolean context!

While the warning does not apply to Mojo, Python users are quite used to it and it's a small quality of life improvement which is inexpensive to support.

We could also add the same methods to the `Bool` struct if the maintainers agree.