### PR TITLE
[mojo-stdlib] Add method `Dict.update()`

### DIFF
--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -638,6 +638,17 @@ struct Dict[K: KeyElement, V: CollectionElement](Sized, CollectionElement):
             0, 0, Reference(self)
         )
 
+    fn update(inout self, other: Self, /):
+        """Update the dictionary with the key/value pairs from other, overwriting existing keys.
+
+        The argument must be positional only.
+
+        Args:
+            other: The dictionary to update from.
+        """
+        for entry in other.items():
+            self[entry[].key] = entry[].value
+
     @staticmethod
     @always_inline
     fn _new_entries(reserved: Int) -> List[Optional[DictEntry[K, V]]]:

--- a/stdlib/test/collections/test_dict.mojo
+++ b/stdlib/test/collections/test_dict.mojo
@@ -192,6 +192,48 @@ def test_dict_copy_calls_copy_constructor():
     assert_equal(6, copy["a"].copy_count)
 
 
+def test_dict_update_nominal():
+    var orig = Dict[String, Int]()
+    orig["a"] = 1
+    orig["b"] = 2
+
+    var new = Dict[String, Int]()
+    new["b"] = 3
+    new["c"] = 4
+
+    orig.update(new)
+
+    assert_equal(orig["a"], 1)
+    assert_equal(orig["b"], 3)
+    assert_equal(orig["c"], 4)
+
+
+def test_dict_update_empty_origin():
+    var orig = Dict[String, Int]()
+    var new = Dict[String, Int]()
+    new["b"] = 3
+    new["c"] = 4
+
+    orig.update(new)
+
+    assert_equal(orig["b"], 3)
+    assert_equal(orig["c"], 4)
+
+
+def test_dict_update_empty_new():
+    var orig = Dict[String, Int]()
+    orig["a"] = 1
+    orig["b"] = 2
+
+    var new = Dict[String, Int]()
+
+    orig.update(new)
+
+    assert_equal(orig["a"], 1)
+    assert_equal(orig["b"], 2)
+    assert_equal(len(orig), 2)
+
+
 fn test[name: String, test_fn: fn () raises -> object]() raises:
     var name_val = name  # FIXME(#26974): Can't pass 'name' directly.
     print("Test", name_val, "...", end="")
@@ -223,3 +265,6 @@ def main():
         "test_dict_copy_calls_copy_constructor",
         test_dict_copy_calls_copy_constructor,
     ]()
+    test["test_dict_update_nominal", test_dict_update_nominal]()
+    test["test_dict_update_empty_origin", test_dict_update_empty_origin]()
+    test["test_dict_update_empty_new", test_dict_update_empty_new]()


### PR DESCRIPTION
Here is the python documentation about this method: https://docs.python.org/3/library/stdtypes.html#dict.update

There should be another overload: `fn update(self, **kwargs: V):` which we can't do yet since it would only work with keys that are strings and https://github.com/modularml/mojo/issues/1876 is not fixed yet.

This is why we force the argument to be positional-only. If we allowed it to be passed by keyword, it would break when we will intruduce the other overload of `Dict.update`.