### PR TITLE
[mojo-stdlib] Replace `register_passable` `__init__ -> Self` usages in `stdlib/src/collections`

### DIFF
--- a/stdlib/src/collections/optional.mojo
+++ b/stdlib/src/collections/optional.mojo
@@ -243,13 +243,9 @@ struct OptionalReg[T: AnyRegType](Boolable):
     alias _type = __mlir_type[`!kgen.variant<`, T, `, i1>`]
     var _value: Self._type
 
-    fn __init__() -> Self:
-        """Create an optional without a value.
-
-        Returns:
-            The optional.
-        """
-        return Self(None)
+    fn __init__(inout self):
+        """Create an optional with a value of None."""
+        self = Self(None)
 
     fn __init__(value: T) -> Self:
         """Create an optional with a value.


### PR DESCRIPTION
Replaces `register_passable __init__ -> Self` usages in `stdlib/src/collections`. 2 of 6 PRs for https://github.com/modularml/mojo/issues/2037

- [x] Replace `/builtin` #2075
- [x] Replace `/collections` #2089
- [ ] Replace `/memory`
- [ ] Replace `/os`
- [ ] Replace `/utils`
- [ ] Replace misc