### PR TITLE
[mojo-stdlib] Replace `register_passable` `__init__ -> Self` usages in `stdlib/src/os`

### DIFF
--- a/stdlib/src/os/_linux_aarch64.mojo
+++ b/stdlib/src/os/_linux_aarch64.mojo
@@ -49,26 +49,24 @@ struct _c_stat(Stringable):
     var st_birthtimespec: _CTimeSpec  # time of file creation(birth)
     var unused: StaticTuple[Int64, 2]  # RESERVED: DO NOT USE!
 
-    fn __init__() -> Self:
-        return Self {
-            st_dev: 0,
-            st_mode: 0,
-            st_nlink: 0,
-            st_ino: 0,
-            st_uid: 0,
-            st_gid: 0,
-            __pad0: 0,
-            st_rdev: 0,
-            st_size: 0,
-            st_blksize: 0,
-            __pad1: 0,
-            st_blocks: 0,
-            st_atimespec: _CTimeSpec(),
-            st_mtimespec: _CTimeSpec(),
-            st_ctimespec: _CTimeSpec(),
-            st_birthtimespec: _CTimeSpec(),
-            unused: StaticTuple[Int64, 2](0, 0),
-        }
+    fn __init__(inout self):
+        self.st_dev = 0
+        self.st_mode = 0
+        self.st_nlink = 0
+        self.st_ino = 0
+        self.st_uid = 0
+        self.st_gid = 0
+        self.__pad0 = 0
+        self.st_rdev = 0
+        self.st_size = 0
+        self.st_blksize = 0
+        self.__pad1 = 0
+        self.st_blocks = 0
+        self.st_atimespec = _CTimeSpec()
+        self.st_mtimespec = _CTimeSpec()
+        self.st_ctimespec = _CTimeSpec()
+        self.st_birthtimespec = _CTimeSpec()
+        self.unused = StaticTuple[Int64, 2](0, 0)
 
     fn __str__(self) -> String:
         var res = String("{\n")

--- a/stdlib/src/os/_linux_x86.mojo
+++ b/stdlib/src/os/_linux_x86.mojo
@@ -48,25 +48,23 @@ struct _c_stat(Stringable):
     var st_birthtimespec: _CTimeSpec  # time of file creation(birth)
     var unused: StaticTuple[Int64, 3]  # RESERVED: DO NOT USE!
 
-    fn __init__() -> Self:
-        return Self {
-            st_dev: 0,
-            st_mode: 0,
-            st_nlink: 0,
-            st_ino: 0,
-            st_uid: 0,
-            st_gid: 0,
-            __pad0: 0,
-            st_rdev: 0,
-            st_size: 0,
-            st_blksize: 0,
-            st_blocks: 0,
-            st_atimespec: _CTimeSpec(),
-            st_mtimespec: _CTimeSpec(),
-            st_ctimespec: _CTimeSpec(),
-            st_birthtimespec: _CTimeSpec(),
-            unused: StaticTuple[Int64, 3](0, 0, 0),
-        }
+    fn __init__(inout self):
+        self.st_dev = 0
+        self.st_mode = 0
+        self.st_nlink = 0
+        self.st_ino = 0
+        self.st_uid = 0
+        self.st_gid = 0
+        self.__pad0 = 0
+        self.st_rdev = 0
+        self.st_size = 0
+        self.st_blksize = 0
+        self.st_blocks = 0
+        self.st_atimespec = _CTimeSpec()
+        self.st_mtimespec = _CTimeSpec()
+        self.st_ctimespec = _CTimeSpec()
+        self.st_birthtimespec = _CTimeSpec()
+        self.unused = StaticTuple[Int64, 3](0, 0, 0)
 
     fn __str__(self) -> String:
         var res = String("{\n")

--- a/stdlib/src/os/_macos.mojo
+++ b/stdlib/src/os/_macos.mojo
@@ -51,27 +51,25 @@ struct _c_stat(Stringable):
     var st_lspare: Int32  # RESERVED: DO NOT USE!
     var st_qspare: StaticTuple[Int64, 2]  # RESERVED: DO NOT USE!
 
-    fn __init__() -> Self:
-        return Self {
-            st_dev: 0,
-            st_mode: 0,
-            st_nlink: 0,
-            st_ino: 0,
-            st_uid: 0,
-            st_gid: 0,
-            st_rdev: 0,
-            st_atimespec: _CTimeSpec(),
-            st_mtimespec: _CTimeSpec(),
-            st_ctimespec: _CTimeSpec(),
-            st_birthtimespec: _CTimeSpec(),
-            st_size: 0,
-            st_blocks: 0,
-            st_blksize: 0,
-            st_flags: 0,
-            st_gen: 0,
-            st_lspare: 0,
-            st_qspare: StaticTuple[Int64, 2](0, 0),
-        }
+    fn __init__(inout self):
+        self.st_dev = 0
+        self.st_mode = 0
+        self.st_nlink = 0
+        self.st_ino = 0
+        self.st_uid = 0
+        self.st_gid = 0
+        self.st_rdev = 0
+        self.st_atimespec = _CTimeSpec()
+        self.st_mtimespec = _CTimeSpec()
+        self.st_ctimespec = _CTimeSpec()
+        self.st_birthtimespec = _CTimeSpec()
+        self.st_size = 0
+        self.st_blocks = 0
+        self.st_blksize = 0
+        self.st_flags = 0
+        self.st_gen = 0
+        self.st_lspare = 0
+        self.st_qspare = StaticTuple[Int64, 2](0, 0)
 
     fn __str__(self) -> String:
         var res = String("{\n")


### PR DESCRIPTION
Replaces `register_passable __init__ -> Self` usages in `stdlib/src/os`. 4 of 6 PRs for https://github.com/modularml/mojo/issues/2037

- [x] Replace `/builtin` #2075
- [x] Replace `/collections` #2089
- [x] Replace `/memory` #2090
- [x] Replace `/os` #2091
- [ ] Replace `/utils`
- [ ] Replace misc