### PR TITLE
[mojo-stdlib] Replace `register_passable` `__init__ -> Self` usages in `stdlib/src/utils`

### DIFF
--- a/stdlib/src/utils/index.mojo
+++ b/stdlib/src/utils/index.mojo
@@ -192,35 +192,25 @@ struct StaticIntTuple[size: Int](Sized, Stringable, EqualityComparable):
 
     @always_inline
     fn __init__(inout self):
-        """Constructs a static int tuple of the given size.
-
-        Returns:
-            The constructed tuple.
-        """
+        """Constructs a static int tuple of the given size."""
         self = 0
 
     @always_inline
-    fn __init__(value: __mlir_type.index) -> Self:
+    fn __init__(inout self, value: __mlir_type.index):
         """Constructs a sized 1 static int tuple of given the element value.
 
         Args:
             value: The initial value.
-
-        Returns:
-            The constructed tuple.
         """
         constrained[size == 1]()
-        return Int(value)
+        self = Int(value)
 
     @always_inline
-    fn __init__(elems: Tuple[Int, Int]) -> Self:
+    fn __init__(inout self, elems: Tuple[Int, Int]):
         """Constructs a static int tuple given a tuple of integers.
 
         Args:
             elems: The tuple to copy from.
-
-        Returns:
-            The constructed tuple.
         """
 
         var num_elements = len(elems)
@@ -238,17 +228,14 @@ struct StaticIntTuple[size: Int](Sized, Stringable, EqualityComparable):
 
         unroll[fill, 2]()
 
-        return tup
+        self = tup
 
     @always_inline
-    fn __init__(elems: Tuple[Int, Int, Int]) -> Self:
+    fn __init__(inout self, elems: Tuple[Int, Int, Int]):
         """Constructs a static int tuple given a tuple of integers.
 
         Args:
             elems: The tuple to copy from.
-
-        Returns:
-            The constructed tuple.
         """
 
         var num_elements = len(elems)
@@ -266,17 +253,14 @@ struct StaticIntTuple[size: Int](Sized, Stringable, EqualityComparable):
 
         unroll[fill, 3]()
 
-        return tup
+        self = tup
 
     @always_inline
-    fn __init__(elems: Tuple[Int, Int, Int, Int]) -> Self:
+    fn __init__(inout self, elems: Tuple[Int, Int, Int, Int]):
         """Constructs a static int tuple given a tuple of integers.
 
         Args:
             elems: The tuple to copy from.
-
-        Returns:
-            The constructed tuple.
         """
 
         var num_elements = len(elems)
@@ -294,17 +278,14 @@ struct StaticIntTuple[size: Int](Sized, Stringable, EqualityComparable):
 
         unroll[fill, 4]()
 
-        return tup
+        self = tup
 
     @always_inline
-    fn __init__(*elems: Int) -> Self:
+    fn __init__(inout self, *elems: Int):
         """Constructs a static int tuple given a set of arguments.
 
         Args:
             elems: The elements to construct the tuple.
-
-        Returns:
-            The constructed tuple.
         """
 
         var num_elements = len(elems)
@@ -320,37 +301,29 @@ struct StaticIntTuple[size: Int](Sized, Stringable, EqualityComparable):
         for idx in range(size):
             tup[idx] = elems[idx]
 
-        return tup
+        self = tup
 
     @always_inline
-    fn __init__(elem: Int) -> Self:
+    fn __init__(inout self, elem: Int):
         """Constructs a static int tuple given a set of arguments.
 
         Args:
             elem: The elem to splat into the tuple.
-
-        Returns:
-            The constructed tuple.
         """
 
-        return StaticIntTuple[size] {
-            data: __mlir_op.`pop.array.repeat`[
-                _type = __mlir_type[`!pop.array<`, size.value, `, `, Int, `>`]
-            ](elem)
-        }
+        self.data = __mlir_op.`pop.array.repeat`[
+            _type = __mlir_type[`!pop.array<`, size.value, `, `, Int, `>`]
+        ](elem)
 
     @always_inline
-    fn __init__(values: VariadicList[Int]) -> Self:
+    fn __init__(inout self, values: VariadicList[Int]):
         """Creates a tuple constant using the specified values.
 
         Args:
             values: The list of values.
-
-        Returns:
-            A tuple with the values filled in.
         """
         constrained[size > 0]()
-        return Self {data: values}
+        self.data = values
 
     @always_inline("nodebug")
     fn __len__(self) -> Int:

--- a/stdlib/src/utils/index.mojo
+++ b/stdlib/src/utils/index.mojo
@@ -203,7 +203,7 @@ struct StaticIntTuple[size: Int](Sized, Stringable, EqualityComparable):
             value: The initial value.
         """
         constrained[size == 1]()
-        self = Int(value)
+        self = value
 
     @always_inline
     fn __init__(inout self, elems: Tuple[Int, Int]):

--- a/stdlib/src/utils/index.mojo
+++ b/stdlib/src/utils/index.mojo
@@ -191,13 +191,13 @@ struct StaticIntTuple[size: Int](Sized, Stringable, EqualityComparable):
     """The underlying storage of the tuple value."""
 
     @always_inline
-    fn __init__() -> Self:
+    fn __init__(inout self):
         """Constructs a static int tuple of the given size.
 
         Returns:
             The constructed tuple.
         """
-        return 0
+        self = 0
 
     @always_inline
     fn __init__(value: __mlir_type.index) -> Self:

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -132,30 +132,24 @@ struct StaticTuple[element_type: AnyRegType, size: Int](Sized):
         self.array = __mlir_op.`kgen.undef`[_type = Self.type]()
 
     @always_inline
-    fn __init__(*elems: Self.element_type) -> Self:
+    fn __init__(inout self, *elems: Self.element_type):
         """Constructs a static tuple given a set of arguments.
 
         Args:
             elems: The element types.
-
-        Returns:
-            The tuple.
         """
         _static_tuple_construction_checks[size]()
-        return Self {array: _create_array[size](elems)}
+        self.array = _create_array[size](elems)
 
     @always_inline
-    fn __init__(values: VariadicList[Self.element_type]) -> Self:
+    fn __init__(inout self, values: VariadicList[Self.element_type]):
         """Creates a tuple constant using the specified values.
 
         Args:
             values: The list of values.
-
-        Returns:
-            A tuple with the values filled in.
         """
         _static_tuple_construction_checks[size]()
-        return Self {array: _create_array[size, Self.element_type](values)}
+        self.array = _create_array[size, Self.element_type](values)
 
     @always_inline("nodebug")
     fn __len__(self) -> Int:

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -126,14 +126,10 @@ struct StaticTuple[element_type: AnyRegType, size: Int](Sized):
     """The underlying storage for the static tuple."""
 
     @always_inline
-    fn __init__() -> Self:
-        """Constructs an empty (undefined) tuple.
-
-        Returns:
-            The tuple.
-        """
+    fn __init__(inout self):
+        """Constructs an empty (undefined) tuple."""
         _static_tuple_construction_checks[size]()
-        return Self {array: __mlir_op.`kgen.undef`[_type = Self.type]()}
+        self.array = __mlir_op.`kgen.undef`[_type = Self.type]()
 
     @always_inline
     fn __init__(*elems: Self.element_type) -> Self:


### PR DESCRIPTION
Replaces `register_passable __init__ -> Self` usages in `stdlib/src/utils`. 5 of 6 PRs for https://github.com/modularml/mojo/issues/2037

- [x] Replace `/builtin` #2075
- [x] Replace `/collections` #2089
- [x] Replace `/memory` #2090
- [x] Replace `/os` #2091
- [x] Replace `/utils` #2092
- [ ] Replace misc