### PR TITLE
[mojo-stdlib] Add `Bytes` struct, not public yet

### DIFF
--- a/stdlib/src/builtin/bytes.mojo
+++ b/stdlib/src/builtin/bytes.mojo
@@ -1,0 +1,110 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Defines the Bytes type.
+
+The Bytes type is the equalivalent of the bytes type in Python. It is an
+array of values between 0 and 255. It is used to represent binary data.
+
+This type cannot be used without imports yet because it's not ready for a wider audience.
+"""
+from collections import Optional
+
+
+struct Bytes(Sized, CollectionElement):
+    """A mutable sequence of bytes. Behaves like the python version.
+
+    Note that `some_bytes[i]` returns an UInt8.
+    some_bytes *= 2 modifies the sequence in-place. Same with +=.
+
+    Also `__setitem__` is available, meaning you can do `some_bytes[7] = 105` or
+    even `some_bytes[7] = some_other_bytes` (the latter must be only one byte long).
+
+    You can create bytes from a list of UInt8 values:
+    ```mojo
+    var some_bytes = Bytes(List[UInt8](1, 2, 3, 4))
+    print(some_bytes)
+    # b'\x01\x02\x03\x04'
+    ```
+
+    or you can create bytes, set to 0, by specifying the size:
+    ```mojo
+    var some_bytes = Bytes(4)
+    print(some_bytes)
+    # b'\x00\x00\x00\x00'
+    ```
+
+    An empty constructor means a sequence of 0 bytes.
+    ```mojo
+    var some_bytes = Bytes()
+    print(some_bytes)
+    # b''
+    ```
+    """
+
+    alias _storage_type = List[UInt8]
+
+    var _data: Self._storage_type
+
+    fn __init__(inout self, owned data: Self._storage_type, /):
+        """Creates a Bytes object from a list of UInt8 values.
+
+        Args:
+            data: The list of UInt8 values to create the Bytes object from. Positional-only.
+        """
+        self._data = data^
+
+    fn __init__(inout self, size: Int = 0, /):
+        """Creates a Bytes object of a given size, filled with 0s.
+
+        Args:
+            size: The size of the Bytes object. Defaults to 0.
+        """
+        self.__init__(size, capacity=size)
+
+    fn __init__(inout self, size: Int, /, *, capacity: Int):
+        """Creates a Bytes object of a given size, filled with 0s.
+
+        Args:
+            size: The size of the Bytes object. Defaults to 0.
+            capacity: The capacity of the underlying `List[UInt8]`.
+        """
+        self._data = Self._storage_type(capacity=capacity)
+        for i in range(size):
+            self._data.append(0)
+
+    fn __len__(self) -> Int:
+        """Returns the number of bytes present in the `Bytes` object."""
+        return len(self._data)
+
+    fn __getitem__(self, index: Int) -> UInt8:
+        """Returns the byte at the given index.
+
+        The returned value is an UInt8 (so in the range 0-255).
+        """
+        return self._data[index]
+
+    fn __setitem__(inout self, index: Int, value: UInt8):
+        """Sets the byte at the given index to the given value.
+
+        Args:
+            index: The index of the byte to set.
+            value: The value to set the byte to. Must be convertible to an
+                UInt8, for example an integer between 0 and 255 works.
+        """
+        self._data[index] = value
+
+    fn __copyinit__(inout self, existing: Self):
+        self._data = Self._storage_type(existing._data)
+
+    fn __moveinit__(inout self, owned existing: Self):
+        self._data = existing._data^

--- a/stdlib/test/builtin/test_bytes.mojo
+++ b/stdlib/test/builtin/test_bytes.mojo
@@ -1,0 +1,68 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# RUN: %mojo -debug-level full %s
+
+from testing import assert_equal
+
+
+def test_int_constructor():
+    some_bytes = Bytes(10)
+
+    assert_equal(len(some_bytes), 10)
+
+    for i in range(10):
+        assert_equal(some_bytes[i], 0)
+
+    assert_equal(some_bytes._data.capacity, 10)
+
+
+def test_int_constructor_with_capacity():
+    some_bytes = Bytes(10, capacity=20)
+
+    assert_equal(len(some_bytes), 10)
+
+    for i in range(10):
+        assert_equal(some_bytes[i], 0)
+
+    assert_equal(some_bytes._data.capacity, 20)
+
+
+def test_list_constructor():
+    some_bytes = Bytes(List[UInt8](10, 20, 30))
+
+    assert_equal(len(some_bytes), 3)
+
+    assert_equal(some_bytes[0], 10)
+    assert_equal(some_bytes[1], 20)
+    assert_equal(some_bytes[2], 30)
+
+
+def test_bytes_setitem():
+    some_bytes = Bytes(5)
+
+    some_bytes[0] = 100
+    some_bytes[2] = 102
+    some_bytes[4] = 104
+
+    assert_equal(some_bytes[0], 100)
+    assert_equal(some_bytes[1], 0)
+    assert_equal(some_bytes[2], 102)
+    assert_equal(some_bytes[3], 0)
+    assert_equal(some_bytes[4], 104)
+
+
+def main():
+    test_int_constructor()
+    test_int_constructor_with_capacity()
+    test_list_constructor()
+    test_bytes_setitem()


### PR DESCRIPTION
We add here a Bytes stuct, which is similar to python's `bytes`: https://docs.python.org/3/library/stdtypes.html#bytes-objects. One big difference is that it's mutable. 

We could also call it `BytesArray` since Python's `bytesarray` is like `bytes` but mutable: https://docs.python.org/3/library/stdtypes.html#bytearray-objects. 

I'm not sure we need the immutability for bytes in Mojo. So if we have only one of `bytes` and `bytesarray`, let's call it `Bytes`.

We can merge this PR without any additional features, they'll come later on. This struct should not be public and documented yet.

When more features are available for `Bytes`, we can start using it in `Path.read_bytes()` for example and make it public.