### PR TITLE
[mojo-stdlib] Fix base64 encode for non ASCII chars

### DIFF
--- a/stdlib/src/base64/base64.mojo
+++ b/stdlib/src/base64/base64.mojo
@@ -47,7 +47,7 @@ fn b64encode(str: String) -> String:
     @parameter
     @always_inline
     fn s(idx: Int) -> Int:
-        return int(str._buffer[idx])
+        return int(str._as_ptr().bitcast[DType.uint8]()[idx])
 
     # This algorithm is based on https://arxiv.org/abs/1704.00605
     var end = length - (length % 3)

--- a/stdlib/test/base64/test_base64.mojo
+++ b/stdlib/test/base64/test_base64.mojo
@@ -28,6 +28,9 @@ fn test_b64encode():
     # CHECK: SGVsbG8gTW9qbyEhIQ==
     print(b64encode("Hello Mojo!!!"))
 
+    # CHECK: SGVsbG8g8J+UpSEhIQ==
+    print(b64encode("Hello 🔥!!!"))
+
     # CHECK: dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw==
     print(b64encode("the quick brown fox jumps over the lazy dog"))
 


### PR DESCRIPTION
This change fixes following bug: https://github.com/modularml/mojo/issues/1630
