### PR TITLE
[Feature] Add checked arithmetic operations

### DIFF
--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -972,6 +972,97 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         self = self.__pow__(rhs)
 
     # ===-------------------------------------------------------------------===#
+    # Checked operations
+    # ===-------------------------------------------------------------------===#
+
+    @always_inline
+    fn add_with_overflow(self, rhs: Self) -> (Self, SIMD[DType.bool, size]):
+        """Computes `self + rhs` and a mask of which indices overflowed.
+
+        Args:
+            rhs: The rhs value.
+
+        Returns:
+            A tuple with the results of the operation and a mask for overflows. The first is a new vector whose element at position `i` is computed as
+            `self[i] + rhs[i]`. The second item is a vector of booleans where a `1` at position `i` represents `self[i] + rhs[i]` overflowed.
+        """
+        constrained[type.is_integral()]()
+
+        @parameter
+        if type.is_signed():
+            return llvm_intrinsic[
+                "llvm.sadd.with.overflow",
+                (Self, SIMD[DType.bool, size]),
+                Self,
+                Self,
+            ](self, rhs)
+        else:
+            return llvm_intrinsic[
+                "llvm.uadd.with.overflow",
+                (Self, SIMD[DType.bool, size]),
+                Self,
+                Self,
+            ](self, rhs)
+
+    @always_inline
+    fn sub_with_overflow(self, rhs: Self) -> (Self, SIMD[DType.bool, size]):
+        """Computes `self - rhs` and a mask of which indices overflowed.
+
+        Args:
+            rhs: The rhs value.
+
+        Returns:
+            A tuple with the results of the operation and a mask for overflows. The first is a new vector whose element at position `i` is computed as
+            `self[i] - rhs[i]`. The second item is a vector of booleans where a `1` at position `i` represents `self[i] - rhs[i]` overflowed.
+        """
+        constrained[type.is_integral()]()
+
+        @parameter
+        if type.is_signed():
+            return llvm_intrinsic[
+                "llvm.ssub.with.overflow",
+                (Self, SIMD[DType.bool, size]),
+                Self,
+                Self,
+            ](self, rhs)
+        else:
+            return llvm_intrinsic[
+                "llvm.usub.with.overflow",
+                (Self, SIMD[DType.bool, size]),
+                Self,
+                Self,
+            ](self, rhs)
+
+    @always_inline
+    fn mul_with_overflow(self, rhs: Self) -> (Self, SIMD[DType.bool, size]):
+        """Computes `self * rhs` and a mask of which indices overflowed.
+
+        Args:
+            rhs: The rhs value.
+
+        Returns:
+            A tuple with the results of the operation and a mask for overflows. The first is a new vector whose element at position `i` is computed as
+            `self[i] * rhs[i]`. The second item is a vector of booleans where a `1` at position `i` represents `self[i] * rhs[i]` overflowed.
+        """
+        constrained[type.is_integral()]()
+
+        @parameter
+        if type.is_signed():
+            return llvm_intrinsic[
+                "llvm.smul.with.overflow",
+                (Self, SIMD[DType.bool, size]),
+                Self,
+                Self,
+            ](self, rhs)
+        else:
+            return llvm_intrinsic[
+                "llvm.umul.with.overflow",
+                (Self, SIMD[DType.bool, size]),
+                Self,
+                Self,
+            ](self, rhs)
+
+    # ===-------------------------------------------------------------------===#
     # Reversed operations
     # ===-------------------------------------------------------------------===#
 

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -990,19 +990,27 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
 
         @parameter
         if type.is_signed():
-            return llvm_intrinsic[
+            var result = llvm_intrinsic[
                 "llvm.sadd.with.overflow",
-                (Self, SIMD[DType.bool, size]),
+                _RegisterPackType[Self, SIMD[DType.bool, size]],
                 Self,
                 Self,
             ](self, rhs)
+            return (
+                result.get[0, Self](),
+                result.get[1, SIMD[DType.bool, size]](),
+            )
         else:
-            return llvm_intrinsic[
+            var result = llvm_intrinsic[
                 "llvm.uadd.with.overflow",
-                (Self, SIMD[DType.bool, size]),
+                _RegisterPackType[Self, SIMD[DType.bool, size]],
                 Self,
                 Self,
             ](self, rhs)
+            return (
+                result.get[0, Self](),
+                result.get[1, SIMD[DType.bool, size]](),
+            )
 
     @always_inline
     fn sub_with_overflow(self, rhs: Self) -> (Self, SIMD[DType.bool, size]):
@@ -1019,19 +1027,27 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
 
         @parameter
         if type.is_signed():
-            return llvm_intrinsic[
+            var result = llvm_intrinsic[
                 "llvm.ssub.with.overflow",
-                (Self, SIMD[DType.bool, size]),
+                _RegisterPackType[Self, SIMD[DType.bool, size]],
                 Self,
                 Self,
             ](self, rhs)
+            return (
+                result.get[0, Self](),
+                result.get[1, SIMD[DType.bool, size]](),
+            )
         else:
-            return llvm_intrinsic[
+            var result = llvm_intrinsic[
                 "llvm.usub.with.overflow",
-                (Self, SIMD[DType.bool, size]),
+                _RegisterPackType[Self, SIMD[DType.bool, size]],
                 Self,
                 Self,
             ](self, rhs)
+            return (
+                result.get[0, Self](),
+                result.get[1, SIMD[DType.bool, size]](),
+            )
 
     @always_inline
     fn mul_with_overflow(self, rhs: Self) -> (Self, SIMD[DType.bool, size]):
@@ -1048,19 +1064,27 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
 
         @parameter
         if type.is_signed():
-            return llvm_intrinsic[
+            var result = llvm_intrinsic[
                 "llvm.smul.with.overflow",
-                (Self, SIMD[DType.bool, size]),
+                _RegisterPackType[Self, SIMD[DType.bool, size]],
                 Self,
                 Self,
             ](self, rhs)
+            return (
+                result.get[0, Self](),
+                result.get[1, SIMD[DType.bool, size]](),
+            )
         else:
-            return llvm_intrinsic[
+            var result = llvm_intrinsic[
                 "llvm.umul.with.overflow",
-                (Self, SIMD[DType.bool, size]),
+                _RegisterPackType[Self, SIMD[DType.bool, size]],
                 Self,
                 Self,
             ](self, rhs)
+            return (
+                result.get[0, Self](),
+                result.get[1, SIMD[DType.bool, size]](),
+            )
 
     # ===-------------------------------------------------------------------===#
     # Reversed operations

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -419,7 +419,8 @@ def test_limits():
     test_integral_overflow[DType.uint32]()
     test_integral_overflow[DType.int64]()
     test_integral_overflow[DType.uint64]()
-    
+
+
 def test_add_with_overflow():
     # TODO: replace all the aliases with math.limit.max_finite()
     # and math.limit.min_finite()
@@ -468,8 +469,12 @@ def test_add_with_overflow():
     value_u32x4, overflowed_u32x4 = SIMD[DType.uint32, 4](
         1, uint32_max, 1, uint32_max
     ).add_with_overflow(SIMD[DType.uint32, 4](0, 1, 0, 1))
-    assert_equal(value_u32x4, SIMD[DType.uint32, 4](1, uint32_min, 1, uint32_min))
-    assert_equal(overflowed_u32x4, SIMD[DType.bool, 4](False, True, False, True))
+    assert_equal(
+        value_u32x4, SIMD[DType.uint32, 4](1, uint32_min, 1, uint32_min)
+    )
+    assert_equal(
+        overflowed_u32x4, SIMD[DType.bool, 4](False, True, False, True)
+    )
 
     alias int32_min = -2147483648
     alias int32_max = 2147483647
@@ -485,7 +490,9 @@ def test_add_with_overflow():
         1, int32_max, 1, int32_max
     ).add_with_overflow(SIMD[DType.int32, 4](0, 1, 0, 1))
     assert_equal(value_i32x4, SIMD[DType.int32, 4](1, int32_min, 1, int32_min))
-    assert_equal(overflowed_i32x4, SIMD[DType.bool, 4](False, True, False, True))
+    assert_equal(
+        overflowed_i32x4, SIMD[DType.bool, 4](False, True, False, True)
+    )
 
 
 def test_sub_with_overflow():
@@ -536,8 +543,12 @@ def test_sub_with_overflow():
     value_u32x4, overflowed_u32x4 = SIMD[DType.uint32, 4](
         1, uint32_min, 1, uint32_min
     ).sub_with_overflow(SIMD[DType.uint32, 4](0, 1, 0, 1))
-    assert_equal(value_u32x4, SIMD[DType.uint32, 4](1, uint32_max, 1, uint32_max))
-    assert_equal(overflowed_u32x4, SIMD[DType.bool, 4](False, True, False, True))
+    assert_equal(
+        value_u32x4, SIMD[DType.uint32, 4](1, uint32_max, 1, uint32_max)
+    )
+    assert_equal(
+        overflowed_u32x4, SIMD[DType.bool, 4](False, True, False, True)
+    )
 
     alias int32_min = -2147483648
     alias int32_max = 2147483647
@@ -553,7 +564,9 @@ def test_sub_with_overflow():
         1, int32_min, 1, int32_min
     ).sub_with_overflow(SIMD[DType.int32, 4](0, 1, 0, 1))
     assert_equal(value_i32x4, SIMD[DType.int32, 4](1, int32_max, 1, int32_max))
-    assert_equal(overflowed_i32x4, SIMD[DType.bool, 4](False, True, False, True))
+    assert_equal(
+        overflowed_i32x4, SIMD[DType.bool, 4](False, True, False, True)
+    )
 
 
 def test_mul_with_overflow():
@@ -573,7 +586,9 @@ def test_mul_with_overflow():
     value_u8x4, overflowed_u8x4 = SIMD[DType.uint8, 4](
         1, uint8_max, 1, uint8_max
     ).mul_with_overflow(SIMD[DType.uint8, 4](0, 2, 0, 2))
-    assert_equal(value_u8x4, SIMD[DType.uint8, 4](0, uint8_max_x2, 0, uint8_max_x2))
+    assert_equal(
+        value_u8x4, SIMD[DType.uint8, 4](0, uint8_max_x2, 0, uint8_max_x2)
+    )
     assert_equal(overflowed_u8x4, SIMD[DType.bool, 4](False, True, False, True))
 
     alias int8_min = -128
@@ -590,7 +605,9 @@ def test_mul_with_overflow():
     value_i8x4, overflowed_i8x4 = SIMD[DType.int8, 4](
         1, int8_max, 1, int8_max
     ).mul_with_overflow(SIMD[DType.int8, 4](0, 2, 0, 2))
-    assert_equal(value_i8x4, SIMD[DType.int8, 4](0, int8_max_x2, 0, int8_max_x2))
+    assert_equal(
+        value_i8x4, SIMD[DType.int8, 4](0, int8_max_x2, 0, int8_max_x2)
+    )
     assert_equal(overflowed_i8x4, SIMD[DType.bool, 4](False, True, False, True))
 
     alias uint32_min = 0
@@ -607,8 +624,12 @@ def test_mul_with_overflow():
     value_u32x4, overflowed_u32x4 = SIMD[DType.uint32, 4](
         1, uint32_max, 1, uint32_max
     ).mul_with_overflow(SIMD[DType.uint32, 4](0, 2, 0, 2))
-    assert_equal(value_u32x4, SIMD[DType.uint32, 4](0, uint32_max_x2, 0, uint32_max_x2))
-    assert_equal(overflowed_u32x4, SIMD[DType.bool, 4](False, True, False, True))
+    assert_equal(
+        value_u32x4, SIMD[DType.uint32, 4](0, uint32_max_x2, 0, uint32_max_x2)
+    )
+    assert_equal(
+        overflowed_u32x4, SIMD[DType.bool, 4](False, True, False, True)
+    )
 
     alias int32_min = -2147483648
     alias int32_max = 2147483647
@@ -624,8 +645,12 @@ def test_mul_with_overflow():
     value_i32x4, overflowed_i32x4 = SIMD[DType.int32, 4](
         1, int32_max, 1, int32_max
     ).mul_with_overflow(SIMD[DType.int32, 4](0, 2, 0, 2))
-    assert_equal(value_i32x4, SIMD[DType.int32, 4](0, int32_max_x2, 0, int32_max_x2))
-    assert_equal(overflowed_i32x4, SIMD[DType.bool, 4](False, True, False, True))
+    assert_equal(
+        value_i32x4, SIMD[DType.int32, 4](0, int32_max_x2, 0, int32_max_x2)
+    )
+    assert_equal(
+        overflowed_i32x4, SIMD[DType.bool, 4](False, True, False, True)
+    )
 
 
 def main():

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -419,6 +419,213 @@ def test_limits():
     test_integral_overflow[DType.uint32]()
     test_integral_overflow[DType.int64]()
     test_integral_overflow[DType.uint64]()
+    
+def test_add_with_overflow():
+    # TODO: replace all the aliases with math.limit.max_finite()
+    # and math.limit.min_finite()
+    alias uint8_min = 0
+    alias uint8_max = 255
+    var value_u8: UInt8
+    var overflowed_u8: Scalar[DType.bool]
+    value_u8, overflowed_u8 = UInt8(uint8_max).add_with_overflow(1)
+    assert_equal(value_u8, uint8_min)
+    assert_equal(overflowed_u8, True)
+
+    var value_u8x4: SIMD[DType.uint8, 4]
+    var overflowed_u8x4: SIMD[DType.bool, 4]
+    value_u8x4, overflowed_u8x4 = SIMD[DType.uint8, 4](
+        1, uint8_max, 1, uint8_max
+    ).add_with_overflow(SIMD[DType.uint8, 4](0, 1, 0, 1))
+    assert_equal(value_u8x4, SIMD[DType.uint8, 4](1, uint8_min, 1, uint8_min))
+    assert_equal(overflowed_u8x4, SIMD[DType.bool, 4](False, True, False, True))
+
+    alias int8_min = -128
+    alias int8_max = 127
+    var value_i8: Int8
+    var overflowed_i8: Scalar[DType.bool]
+    value_i8, overflowed_i8 = Int8(int8_max).add_with_overflow(1)
+    assert_equal(value_i8, int8_min)
+    assert_equal(overflowed_i8, True)
+
+    var value_i8x4: SIMD[DType.int8, 4]
+    var overflowed_i8x4: SIMD[DType.bool, 4]
+    value_i8x4, overflowed_i8x4 = SIMD[DType.int8, 4](
+        1, int8_max, 1, int8_max
+    ).add_with_overflow(SIMD[DType.int8, 4](0, 1, 0, 1))
+    assert_equal(value_i8x4, SIMD[DType.int8, 4](1, int8_min, 1, int8_min))
+    assert_equal(overflowed_i8x4, SIMD[DType.bool, 4](False, True, False, True))
+
+    alias uint32_min = 0
+    alias uint32_max = 4294967295
+    var value_u32: UInt32
+    var overflowed_u32: Scalar[DType.bool]
+    value_u32, overflowed_u32 = UInt32(uint32_max).add_with_overflow(1)
+    assert_equal(value_u32, uint32_min)
+    assert_equal(overflowed_u32, True)
+
+    var value_u32x4: SIMD[DType.uint32, 4]
+    var overflowed_u32x4: SIMD[DType.bool, 4]
+    value_u32x4, overflowed_u32x4 = SIMD[DType.uint32, 4](
+        1, uint32_max, 1, uint32_max
+    ).add_with_overflow(SIMD[DType.uint32, 4](0, 1, 0, 1))
+    assert_equal(value_u32x4, SIMD[DType.uint32, 4](1, uint32_min, 1, uint32_min))
+    assert_equal(overflowed_u32x4, SIMD[DType.bool, 4](False, True, False, True))
+
+    alias int32_min = -2147483648
+    alias int32_max = 2147483647
+    var value_i32: Int32
+    var overflowed_i32: Scalar[DType.bool]
+    value_i32, overflowed_i32 = Int32(int32_max).add_with_overflow(1)
+    assert_equal(value_i32, int32_min)
+    assert_equal(overflowed_i32, True)
+
+    var value_i32x4: SIMD[DType.int32, 4]
+    var overflowed_i32x4: SIMD[DType.bool, 4]
+    value_i32x4, overflowed_i32x4 = SIMD[DType.int32, 4](
+        1, int32_max, 1, int32_max
+    ).add_with_overflow(SIMD[DType.int32, 4](0, 1, 0, 1))
+    assert_equal(value_i32x4, SIMD[DType.int32, 4](1, int32_min, 1, int32_min))
+    assert_equal(overflowed_i32x4, SIMD[DType.bool, 4](False, True, False, True))
+
+
+def test_sub_with_overflow():
+    # TODO: replace all the aliases with math.limit.max_finite()
+    # and math.limit.min_finite()
+    alias uint8_min = 0
+    alias uint8_max = 255
+    var value_u8: UInt8
+    var overflowed_u8: Scalar[DType.bool]
+    value_u8, overflowed_u8 = UInt8(uint8_min).sub_with_overflow(1)
+    assert_equal(value_u8, uint8_max)
+    assert_equal(overflowed_u8, True)
+
+    var value_u8x4: SIMD[DType.uint8, 4]
+    var overflowed_u8x4: SIMD[DType.bool, 4]
+    value_u8x4, overflowed_u8x4 = SIMD[DType.uint8, 4](
+        1, uint8_min, 1, uint8_min
+    ).sub_with_overflow(SIMD[DType.uint8, 4](0, 1, 0, 1))
+    assert_equal(value_u8x4, SIMD[DType.uint8, 4](1, uint8_max, 1, uint8_max))
+    assert_equal(overflowed_u8x4, SIMD[DType.bool, 4](False, True, False, True))
+
+    alias int8_min = -128
+    alias int8_max = 127
+    var value_i8: Int8
+    var overflowed_i8: Scalar[DType.bool]
+    value_i8, overflowed_i8 = Int8(int8_min).sub_with_overflow(1)
+    assert_equal(value_i8, int8_max)
+    assert_equal(overflowed_i8, True)
+
+    var value_i8x4: SIMD[DType.int8, 4]
+    var overflowed_i8x4: SIMD[DType.bool, 4]
+    value_i8x4, overflowed_i8x4 = SIMD[DType.int8, 4](
+        1, int8_min, 1, int8_min
+    ).sub_with_overflow(SIMD[DType.int8, 4](0, 1, 0, 1))
+    assert_equal(value_i8x4, SIMD[DType.int8, 4](1, int8_max, 1, int8_max))
+    assert_equal(overflowed_i8x4, SIMD[DType.bool, 4](False, True, False, True))
+
+    alias uint32_min = 0
+    alias uint32_max = 4294967295
+    var value_u32: UInt32
+    var overflowed_u32: Scalar[DType.bool]
+    value_u32, overflowed_u32 = UInt32(uint32_min).sub_with_overflow(1)
+    assert_equal(value_u32, uint32_max)
+    assert_equal(overflowed_u32, True)
+
+    var value_u32x4: SIMD[DType.uint32, 4]
+    var overflowed_u32x4: SIMD[DType.bool, 4]
+    value_u32x4, overflowed_u32x4 = SIMD[DType.uint32, 4](
+        1, uint32_min, 1, uint32_min
+    ).sub_with_overflow(SIMD[DType.uint32, 4](0, 1, 0, 1))
+    assert_equal(value_u32x4, SIMD[DType.uint32, 4](1, uint32_max, 1, uint32_max))
+    assert_equal(overflowed_u32x4, SIMD[DType.bool, 4](False, True, False, True))
+
+    alias int32_min = -2147483648
+    alias int32_max = 2147483647
+    var value_i32: Int32
+    var overflowed_i32: Scalar[DType.bool]
+    value_i32, overflowed_i32 = Int32(int32_min).sub_with_overflow(1)
+    assert_equal(value_i32, int32_max)
+    assert_equal(overflowed_i32, True)
+
+    var value_i32x4: SIMD[DType.int32, 4]
+    var overflowed_i32x4: SIMD[DType.bool, 4]
+    value_i32x4, overflowed_i32x4 = SIMD[DType.int32, 4](
+        1, int32_min, 1, int32_min
+    ).sub_with_overflow(SIMD[DType.int32, 4](0, 1, 0, 1))
+    assert_equal(value_i32x4, SIMD[DType.int32, 4](1, int32_max, 1, int32_max))
+    assert_equal(overflowed_i32x4, SIMD[DType.bool, 4](False, True, False, True))
+
+
+def test_mul_with_overflow():
+    # TODO: replace all the aliases with math.limit.max_finite()
+    # and math.limit.min_finite()
+    alias uint8_min = 0
+    alias uint8_max = 255
+    alias uint8_max_x2 = 254
+    var value_u8: UInt8
+    var overflowed_u8: Scalar[DType.bool]
+    value_u8, overflowed_u8 = UInt8(uint8_max).mul_with_overflow(2)
+    assert_equal(value_u8, uint8_max_x2)
+    assert_equal(overflowed_u8, True)
+
+    var value_u8x4: SIMD[DType.uint8, 4]
+    var overflowed_u8x4: SIMD[DType.bool, 4]
+    value_u8x4, overflowed_u8x4 = SIMD[DType.uint8, 4](
+        1, uint8_max, 1, uint8_max
+    ).mul_with_overflow(SIMD[DType.uint8, 4](0, 2, 0, 2))
+    assert_equal(value_u8x4, SIMD[DType.uint8, 4](0, uint8_max_x2, 0, uint8_max_x2))
+    assert_equal(overflowed_u8x4, SIMD[DType.bool, 4](False, True, False, True))
+
+    alias int8_min = -128
+    alias int8_max = 127
+    alias int8_max_x2 = -2
+    var value_i8: Int8
+    var overflowed_i8: Scalar[DType.bool]
+    value_i8, overflowed_i8 = Int8(int8_max).mul_with_overflow(2)
+    assert_equal(value_i8, int8_max_x2)
+    assert_equal(overflowed_i8, True)
+
+    var value_i8x4: SIMD[DType.int8, 4]
+    var overflowed_i8x4: SIMD[DType.bool, 4]
+    value_i8x4, overflowed_i8x4 = SIMD[DType.int8, 4](
+        1, int8_max, 1, int8_max
+    ).mul_with_overflow(SIMD[DType.int8, 4](0, 2, 0, 2))
+    assert_equal(value_i8x4, SIMD[DType.int8, 4](0, int8_max_x2, 0, int8_max_x2))
+    assert_equal(overflowed_i8x4, SIMD[DType.bool, 4](False, True, False, True))
+
+    alias uint32_min = 0
+    alias uint32_max = 4294967295
+    alias uint32_max_x2 = 4294967294
+    var value_u32: UInt32
+    var overflowed_u32: Scalar[DType.bool]
+    value_u32, overflowed_u32 = UInt32(uint32_max).mul_with_overflow(2)
+    assert_equal(value_u32, uint32_max_x2)
+    assert_equal(overflowed_u32, True)
+
+    var value_u32x4: SIMD[DType.uint32, 4]
+    var overflowed_u32x4: SIMD[DType.bool, 4]
+    value_u32x4, overflowed_u32x4 = SIMD[DType.uint32, 4](
+        1, uint32_max, 1, uint32_max
+    ).mul_with_overflow(SIMD[DType.uint32, 4](0, 2, 0, 2))
+    assert_equal(value_u32x4, SIMD[DType.uint32, 4](0, uint32_max_x2, 0, uint32_max_x2))
+    assert_equal(overflowed_u32x4, SIMD[DType.bool, 4](False, True, False, True))
+
+    alias int32_min = -2147483648
+    alias int32_max = 2147483647
+    alias int32_max_x2 = -2
+    var value_i32: Int32
+    var overflowed_i32: Scalar[DType.bool]
+    value_i32, overflowed_i32 = Int32(int32_max).mul_with_overflow(2)
+    assert_equal(value_i32, int32_max_x2)
+    assert_equal(overflowed_i32, True)
+
+    var value_i32x4: SIMD[DType.int32, 4]
+    var overflowed_i32x4: SIMD[DType.bool, 4]
+    value_i32x4, overflowed_i32x4 = SIMD[DType.int32, 4](
+        1, int32_max, 1, int32_max
+    ).mul_with_overflow(SIMD[DType.int32, 4](0, 2, 0, 2))
+    assert_equal(value_i32x4, SIMD[DType.int32, 4](0, int32_max_x2, 0, int32_max_x2))
+    assert_equal(overflowed_i32x4, SIMD[DType.bool, 4](False, True, False, True))
 
 
 def main():
@@ -435,3 +642,6 @@ def main():
     test_address()
     test_extract()
     test_limits()
+    test_add_with_overflow()
+    test_sub_with_overflow()
+    test_mul_with_overflow()


### PR DESCRIPTION
This PR adds a wrapper around the [LLVM family of arithmetic operations with overflow](https://llvm.org/docs/LangRef.html#arithmetic-with-overflow-intrinsics). This low level primitive opens up the door for higher level checked arithmetic operations that return optionals (or raise) on overflow instead.