### PR TITLE
[mojo-stdlib] Add list.insert(index, value) API to stdlib

### DIFF
--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -185,6 +185,36 @@ struct List[T: CollectionElement](CollectionElement, Sized):
         self.size += 1
 
     @always_inline
+    fn insert(inout self, i: Int, owned value :T):
+        """Insert a value to the list at the given index.
+        `a.insert(len(a), value)` is equivalent to `a.append(value)`.
+
+        Args:
+            i: The index for the value.
+            value: The value to insert.
+        """
+        debug_assert(-self.size <= i <= self.size, "insert index out of range")
+        
+        var normalized_idx = i
+        if i < 0:
+            normalized_idx += len(self)
+
+        var earlier_idx = len(self)
+        var later_idx = len(self) - 1
+        self.append(value^)
+        
+        for _ in range(i, len(self) - 1): 
+            var earlier_ptr = self.data + earlier_idx
+            var later_ptr = self.data + later_idx
+
+            var tmp = earlier_ptr.take_value()
+            later_ptr.move_into(earlier_ptr)
+            later_ptr.emplace_value(tmp^)
+
+            earlier_idx -= 1
+            later_idx -= 1
+
+    @always_inline
     fn extend(inout self, owned other: List[T]):
         """Extends this list by consuming the elements of `other`.
 

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -185,7 +185,7 @@ struct List[T: CollectionElement](CollectionElement, Sized):
         self.size += 1
 
     @always_inline
-    fn insert(inout self, i: Int, owned value :T):
+    fn insert(inout self, i: Int, owned value: T):
         """Inserts a value to the list at the given index.
         `a.insert(len(a), value)` is equivalent to `a.append(value)`.
 
@@ -194,7 +194,7 @@ struct List[T: CollectionElement](CollectionElement, Sized):
             value: The value to insert.
         """
         debug_assert(i <= self.size, "insert index out of range")
-        
+
         var normalized_idx = i
         if i < 0:
             normalized_idx = _max(0, len(self) + i)
@@ -202,8 +202,8 @@ struct List[T: CollectionElement](CollectionElement, Sized):
         var earlier_idx = len(self)
         var later_idx = len(self) - 1
         self.append(value^)
-        
-        for _ in range(normalized_idx, len(self) - 1): 
+
+        for _ in range(normalized_idx, len(self) - 1):
             var earlier_ptr = self.data + earlier_idx
             var later_ptr = self.data + later_idx
 

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -186,24 +186,24 @@ struct List[T: CollectionElement](CollectionElement, Sized):
 
     @always_inline
     fn insert(inout self, i: Int, owned value :T):
-        """Insert a value to the list at the given index.
+        """Inserts a value to the list at the given index.
         `a.insert(len(a), value)` is equivalent to `a.append(value)`.
 
         Args:
             i: The index for the value.
             value: The value to insert.
         """
-        debug_assert(-self.size <= i <= self.size, "insert index out of range")
+        debug_assert(i <= self.size, "insert index out of range")
         
         var normalized_idx = i
         if i < 0:
-            normalized_idx += len(self)
+            normalized_idx = _max(0, len(self) + i)
 
         var earlier_idx = len(self)
         var later_idx = len(self) - 1
         self.append(value^)
         
-        for _ in range(i, len(self) - 1): 
+        for _ in range(normalized_idx, len(self) - 1): 
             var earlier_ptr = self.data + earlier_idx
             var later_ptr = self.data + later_idx
 

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -279,70 +279,67 @@ def test_list_reverse_move_count():
     # Keep vec alive until after we've done the last `vec.data + N` read.
     _ = vec^
 
+
 def test_list_insert():
     #
     # Test the list [1, 2, 3] created with insert
     #
 
-    vec = List[Int]()
-    vec.insert(len(vec), 1)
-    vec.insert(len(vec), 3)
-    vec.insert(1, 2)
+    v1 = List[Int]()
+    v1.insert(len(v1), 1)
+    v1.insert(len(v1), 3)
+    v1.insert(1, 2)
 
-    assert_equal(len(vec), 3)
-    assert_equal(vec[0], 1)
-    assert_equal(vec[1], 2)
-    assert_equal(vec[2], 3)
+    assert_equal(len(v1), 3)
+    assert_equal(v1[0], 1)
+    assert_equal(v1[1], 2)
+    assert_equal(v1[2], 3)
 
-    vec.clear()
-    
     #
     # Test the list [1, 2, 3, 4, 5] created with negative and positive index
     #
 
-    vec.insert(-1729, 2)
-    vec.insert(len(vec), 3)
-    vec.insert(len(vec), 5)
-    vec.insert(-1, 4)
-    vec.insert(-len(vec), 1)
+    v2 = List[Int]()
+    v2.insert(-1729, 2)
+    v2.insert(len(v2), 3)
+    v2.insert(len(v2), 5)
+    v2.insert(-1, 4)
+    v2.insert(-len(v2), 1)
 
-    assert_equal(len(vec), 5)
-    assert_equal(vec[0], 1)
-    assert_equal(vec[1], 2)
-    assert_equal(vec[2], 3)
-    assert_equal(vec[3], 4)
-    assert_equal(vec[4], 5) 
-
-    vec.clear()
-
+    assert_equal(len(v2), 5)
+    assert_equal(v2[0], 1)
+    assert_equal(v2[1], 2)
+    assert_equal(v2[2], 3)
+    assert_equal(v2[3], 4)
+    assert_equal(v2[4], 5)
 
     #
     # Test the list [1, 2, 3, 4] created with negative index
     #
 
-    vec.insert(-11, 4)
-    vec.insert(-13, 3)
-    vec.insert(-17, 2)
-    vec.insert(-19, 1)
+    v3 = List[Int]()
+    v3.insert(-11, 4)
+    v3.insert(-13, 3)
+    v3.insert(-17, 2)
+    v3.insert(-19, 1)
 
-    assert_equal(len(vec), 4)
-    assert_equal(vec[0], 1)
-    assert_equal(vec[1], 2)
-    assert_equal(vec[2], 3)
-    assert_equal(vec[3], 4)
-    
-    vec.clear()
-    
-    # 
+    assert_equal(len(v3), 4)
+    assert_equal(v3[0], 1)
+    assert_equal(v3[1], 2)
+    assert_equal(v3[2], 3)
+    assert_equal(v3[3], 4)
+
+    #
     # Test the list [1, 2, 3, 4, 5, 6, 7, 8] created with insert
     #
- 
-    for i in range(4):
-        vec.insert(0, 4 - i)
-        vec.insert(len(vec), 4 + i + 1)
 
-    for i in range(len(vec)):
-        assert_equal(vec[i], i + 1)
+    v4 = List[Int]()
+    for i in range(4):
+        v4.insert(0, 4 - i)
+        v4.insert(len(v4), 4 + i + 1)
+
+    for i in range(len(v4)):
+        assert_equal(v4[i], i + 1)
 
 
 def test_list_extend():

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -296,6 +296,43 @@ def test_list_insert():
 
     vec.clear()
     
+    #
+    # Test the list [1, 2, 3, 4, 5] created with negative and positive index
+    #
+
+    vec.insert(-1729, 2)
+    vec.insert(len(vec), 3)
+    vec.insert(len(vec), 5)
+    vec.insert(-1, 4)
+    vec.insert(-len(vec), 1)
+
+    assert_equal(len(vec), 5)
+    assert_equal(vec[0], 1)
+    assert_equal(vec[1], 2)
+    assert_equal(vec[2], 3)
+    assert_equal(vec[3], 4)
+    assert_equal(vec[4], 5) 
+
+    vec.clear()
+
+
+    #
+    # Test the list [1, 2, 3, 4] created with negative index
+    #
+
+    vec.insert(-11, 4)
+    vec.insert(-13, 3)
+    vec.insert(-17, 2)
+    vec.insert(-19, 1)
+
+    assert_equal(len(vec), 4)
+    assert_equal(vec[0], 1)
+    assert_equal(vec[1], 2)
+    assert_equal(vec[2], 3)
+    assert_equal(vec[3], 4)
+    
+    vec.clear()
+    
     # 
     # Test the list [1, 2, 3, 4, 5, 6, 7, 8] created with insert
     #

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -279,6 +279,34 @@ def test_list_reverse_move_count():
     # Keep vec alive until after we've done the last `vec.data + N` read.
     _ = vec^
 
+def test_list_insert():
+    #
+    # Test the list [1, 2, 3] created with insert
+    #
+
+    vec = List[Int]()
+    vec.insert(len(vec), 1)
+    vec.insert(len(vec), 3)
+    vec.insert(1, 2)
+
+    assert_equal(len(vec), 3)
+    assert_equal(vec[0], 1)
+    assert_equal(vec[1], 2)
+    assert_equal(vec[2], 3)
+
+    vec.clear()
+    
+    # 
+    # Test the list [1, 2, 3, 4, 5, 6, 7, 8] created with insert
+    #
+ 
+    for i in range(4):
+        vec.insert(0, 4 - i)
+        vec.insert(len(vec), 4 + i + 1)
+
+    for i in range(len(vec)):
+        assert_equal(vec[i], i + 1)
+
 
 def test_list_extend():
     #
@@ -480,6 +508,7 @@ def main():
     test_list_resize()
     test_list_reverse()
     test_list_reverse_move_count()
+    test_list_insert()
     test_list_extend()
     test_list_extend_non_trivial()
     test_list_explicit_copy()


### PR DESCRIPTION
This pr serves to add `list.insert(index, value)` API to the stdlib as requested by issue https://github.com/modularml/mojo/issues/2134.

This API should handle the same functionality as the [python `list.insert`](https://docs.python.org/3/tutorial/datastructures.html) and adds tests for the same.
