### PR TITLE
[mojo-stdlib] Make assert_equal more generic by using traits

### DIFF
--- a/stdlib/src/testing/testing.mojo
+++ b/stdlib/src/testing/testing.mojo
@@ -90,10 +90,15 @@ fn assert_false[
         raise Error("AssertionError: " + msg)
 
 
-# TODO: Collapse these two overloads for generic T that has the
-# Equality Comparable trait.
+trait Testable(EqualityComparable, Stringable):
+    """A trait that a struct should conform to if we do equality testing on it.
+    """
+
+    pass
+
+
 @always_inline
-fn assert_equal(lhs: Int, rhs: Int, msg: String = "") raises:
+fn assert_equal[T: Testable](lhs: T, rhs: T, msg: String = "") raises:
     """Asserts that the input values are equal. If it is not then an Error
     is raised.
 
@@ -109,6 +114,7 @@ fn assert_equal(lhs: Int, rhs: Int, msg: String = "") raises:
         raise _assert_equal_error(str(lhs), str(rhs), msg=msg)
 
 
+# TODO: Remove the String and SIMD overloads once we have more powerful traits.
 @always_inline
 fn assert_equal(lhs: String, rhs: String, msg: String = "") raises:
     """Asserts that the input values are equal. If it is not then an Error
@@ -150,7 +156,7 @@ fn assert_equal[
 
 
 @always_inline
-fn assert_not_equal(lhs: Int, rhs: Int, msg: String = "") raises:
+fn assert_not_equal[T: Testable](lhs: T, rhs: T, msg: String = "") raises:
     """Asserts that the input values are not equal. If it is not then an
     Error is raised.
 

--- a/stdlib/test/testing/test_assertion.mojo
+++ b/stdlib/test/testing/test_assertion.mojo
@@ -1,0 +1,48 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# RUN: %mojo -debug-level full %s
+
+from testing import assert_equal, assert_not_equal, assert_raises
+
+
+@value
+struct DummyStruct:
+    var value: Int
+
+    fn __eq__(self, other: Self) -> Bool:
+        return self.value == other.value
+
+    fn __ne__(self, other: Self) -> Bool:
+        return self.value != other.value
+
+    fn __str__(self) -> String:
+        return "Dummy"  # Can't be used for equality
+
+
+def test_assert_equal_is_generic():
+    assert_equal(DummyStruct(1), DummyStruct(1))
+
+    with assert_raises():
+        assert_equal(DummyStruct(1), DummyStruct(2))
+
+
+def test_assert_not_equal_is_generic():
+    assert_not_equal(DummyStruct(1), DummyStruct(2))
+
+    with assert_raises():
+        assert_not_equal(DummyStruct(1), DummyStruct(1))
+
+
+def main():
+    test_assert_equal_is_generic()
+    test_assert_not_equal_is_generic()


### PR DESCRIPTION
This should help write tests with new structs like `pathlib.Path`, `Bytes`, datetime, etc... 