### PR TITLE
[stdlib] Allow `is None` and `is not None` with `OptionalReg`

### DIFF
--- a/stdlib/src/collections/optional.mojo
+++ b/stdlib/src/collections/optional.mojo
@@ -312,6 +312,32 @@ struct OptionalReg[T: AnyRegType](Boolable):
         """
         return __mlir_op.`kgen.variant.take`[index = Int(0).value](self._value)
 
+    fn __is__(self, other: NoneType) -> Bool:
+        """Return `True` if the Optional has no value.
+
+        It allows you to use the following syntax: `if my_optional is None:`
+
+        Args:
+            other: The value to compare to (None).
+
+        Returns:
+            True if the Optional has no value and False otherwise.
+        """
+        return not self.__bool__()
+
+    fn __isnot__(self, other: NoneType) -> Bool:
+        """Return `True` if the Optional has a value.
+
+        It allows you to use the following syntax: `if my_optional is not None:`
+
+        Args:
+            other: The value to compare to (None).
+
+        Returns:
+            True if the Optional has a value and False otherwise.
+        """
+        return self.__bool__()
+
     fn __bool__(self) -> Bool:
         """Return true if the optional has a value.
 

--- a/stdlib/test/collections/test_optional.mojo
+++ b/stdlib/test/collections/test_optional.mojo
@@ -87,8 +87,26 @@ def test_optional_isnot():
     assert_false(a is not None)
 
 
+def test_optional_reg_is():
+    a = OptionalReg(1)
+    assert_false(a is None)
+
+    a = OptionalReg[Int](None)
+    assert_true(a is None)
+
+
+def test_optional_reg_isnot():
+    a = OptionalReg(1)
+    assert_true(a is not None)
+
+    a = OptionalReg[Int](None)
+    assert_false(a is not None)
+
+
 def main():
     test_basic()
     test_optional_reg_basic()
     test_optional_is()
     test_optional_isnot()
+    test_optional_reg_is()
+    test_optional_reg_isnot()


### PR DESCRIPTION
Follow-up on https://github.com/modularml/mojo/pull/2082
 
Do you think that we should recommend `if a is None` instead of `if a`? It will be closer to what Python's PEP8 recommends.
If so, I can change in another PR the examples in the documentation to show this syntax first.