### PR TITLE
[CI] polish: Improve job name shown in UI for readability

### DIFF
--- a/.github/workflows/check_pr_target.yml
+++ b/.github/workflows/check_pr_target.yml
@@ -9,7 +9,9 @@ permissions:
   pull-requests: read
 
 jobs:
-  check-pr:
+  check-pr-target:
+    name: Check PR target branch
+
     runs-on: ubuntu-latest
 
     defaults:

--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -9,11 +9,14 @@ on:
     types: [opened, edited, reopened, synchronize, ready_for_review]
 
 jobs:
-  pr-lint:
+  check-pr-title:
+    name: Check PR title format
+
     permissions:
       pull-requests: write
 
     runs-on: ubuntu-latest
+
     steps:
       - uses: morrisoncole/pr-lint-action@51f3cfabaf5d46f94e54524214e45685f0401b2a
         if: github.actor != 'dependabot[bot]'


### PR DESCRIPTION
Previously these jobs were called just "check-pr" and "pr-lint" based on the raw job name, which aren't very descriptive names.