### PR TITLE
[stdlib] Resolve `../..` in `build-stdlib.sh`

### DIFF
--- a/stdlib/scripts/build-stdlib.sh
+++ b/stdlib/scripts/build-stdlib.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-REPO_ROOT="${SCRIPT_DIR}"/../..
+REPO_ROOT=$(realpath "${SCRIPT_DIR}/../..")
 BUILD_DIR="${REPO_ROOT}"/build
 mkdir -p "${BUILD_DIR}"
 


### PR DESCRIPTION
Prior to this patch, running `build-stdlib.sh` from the `modularml/mojo` repository root resulted in the following output:

```
$ ./stdlib/scripts/build-stdlib.sh
Packaging up the Standard Library.
Successfully created /Users/brian/src/mojo/stdlib/scripts/../../build/stdlib.mojopkg
```

With this patch, the printed path is simpler:

```
$ ./stdlib/scripts/build-stdlib.sh
Packaging up the Standard Library.
Successfully created /Users/brian/src/mojo/build/stdlib.mojopkg
```