### PR TITLE
[stdlib] Make Bool struct Intable

### DIFF
--- a/stdlib/src/builtin/bool.mojo
+++ b/stdlib/src/builtin/bool.mojo
@@ -46,7 +46,9 @@ trait Boolable:
 @lldb_formatter_wrapping_type
 @value
 @register_passable("trivial")
-struct Bool(Stringable, CollectionElement, Boolable, EqualityComparable):
+struct Bool(
+    Stringable, CollectionElement, Boolable, EqualityComparable, Intable
+):
     """The primitive Bool scalar value used in Mojo."""
 
     var value: __mlir_type.`!pop.scalar<bool>`
@@ -245,3 +247,16 @@ struct Bool(Stringable, CollectionElement, Boolable, EqualityComparable):
             `value ^ self`.
         """
         return value ^ self
+
+    @always_inline("nodebug")
+    fn __int__(self) -> Int:
+        """Convert this Bool to an integer.
+
+        Returns:
+            1 if the Bool is True, 0 otherwise.
+        """
+        return Int(
+            __mlir_op.`pop.cast`[_type = __mlir_type.`!pop.scalar<index>`](
+                self.value
+            )
+        )

--- a/stdlib/test/builtin/test_bool.mojo
+++ b/stdlib/test/builtin/test_bool.mojo
@@ -1,0 +1,27 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# RUN: %mojo -debug-level full %s
+
+from testing import assert_equal
+
+
+def test_bool_cast_to_int():
+    assert_equal(False.__int__(), 0)
+    assert_equal(True.__int__(), 1)
+
+    assert_equal(int(False), 0)
+    assert_equal(int(True), 1)
+
+
+def main():
+    test_bool_cast_to_int()


### PR DESCRIPTION
Fix #2168  As the title says. I don't know if this implementation will give us the maximum amount of performance, (I don't know if I should have used MLIR directly) but it can always be improved later if needed.

Technically, in Python, a bool is an alias for 0 and 1, so a bool is an int. But I guess that doing `int(my_bool)` is close enough.
