### PR TITLE
[stdlib] Add `__rmod__` for `SIMD`

### DIFF
--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -692,6 +692,19 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
             return mod + mask.select(rhs, Self(0))
 
     @always_inline("nodebug")
+    fn __rmod__(self, value: Self) -> Self:
+        """Returns `value mod self`.
+
+        Args:
+            value: The other value.
+
+        Returns:
+            `value mod self`.
+        """
+        constrained[type.is_numeric(), "the type must be numeric"]()
+        return value % self
+
+    @always_inline("nodebug")
     fn __pow__(self, rhs: Int) -> Self:
         """Computes the vector raised to the power of the input integer value.
 

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -131,6 +131,14 @@ def test_mod():
     assert_equal(UInt32(99) % UInt32(1), 0)
     assert_equal(UInt32(99) % UInt32(3), 0)
 
+    assert_equal(Int(4) % Int32(3), 1)
+    assert_equal(
+        Int(78) % SIMD[DType.int32, 2](78, 78), SIMD[DType.int32, 2](0, 0)
+    )
+    assert_equal(
+        SIMD[DType.int32, 2](7, 7) % Int(4), SIMD[DType.int32, 2](3, 3)
+    )
+
     var a = SIMD[DType.float32, 16](
         3.1,
         3.1,


### PR DESCRIPTION
Add __rmod__ for SIMD types to allow expressions with an `Int` on the lhs

Fixes #1482