### PR TITLE
[mojo-stdlib] Add new `ComparableCollectionElement` trait and `index(list, value, start, end)` function APIs

### DIFF
--- a/stdlib/src/builtin/value.mojo
+++ b/stdlib/src/builtin/value.mojo
@@ -122,6 +122,7 @@ trait StringableCollectionElement(CollectionElement, Stringable):
 
     pass
 
+
 trait ComparableCollectionElement(CollectionElement, EqualityComparable):
     """
     This trait is a temporary solution to enable comparison of
@@ -130,4 +131,5 @@ trait ComparableCollectionElement(CollectionElement, EqualityComparable):
     This approach will be revised with the introduction of conditional trait
     conformances.
     """
+
     pass

--- a/stdlib/src/builtin/value.mojo
+++ b/stdlib/src/builtin/value.mojo
@@ -121,3 +121,13 @@ trait StringableCollectionElement(CollectionElement, Stringable):
     """
 
     pass
+
+trait ComparableCollectionElement(CollectionElement, EqualityComparable):
+    """
+    This trait is a temporary solution to enable comparison of
+    collection elements as utilized in the `index` and `count` methods of
+    a list.
+    This approach will be revised with the introduction of conditional trait
+    conformances.
+    """
+    pass

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -452,16 +452,17 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         # TODO: Once the min() and max() functions are available in Mojo,
         # TODO: we can simplify the entire if-else block into a single line using the ternary operator:
         # var normalized_end = self.size if end is None else min(max(end, 0), self.size)
+        var normalized_end: Int
         if end is None:
-            var normalized_end = self.size
+            normalized_end = self.size
         else:
-            if end < 0:
-                var normalized_end = self.size + end
+            if end.value()[] < 0:
+                normalized_end = self.size + end.value()[]
             else:
-                if end > self.size:
-                    var normalized_end = self.size
+                if end.value()[] > self.size:
+                    normalized_end = self.size
                 else:
-                    var normalized_end = end
+                    normalized_end = end.value()[]
 
         if not self.size:
             raise "Cannot find index of a value in an empty list."

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -445,7 +445,19 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             ```
         """
         var normalized_start = (self.size + start) if start < 0 else start
-        var normalized_end = self.size if end is None else (self.size + end if end < 0 else (self.size if end > self.size else end))
+        # TODO: Once the min() and max() functions are available in Mojo,
+        # TODO: we can simplify the entire if-else block into a single line using the ternary operator:
+        # var normalized_end = self.size if end is None else min(max(end, 0), self.size)
+        if end is None:
+            var normalized_end = self.size
+        else:
+            if end < 0:
+                var normalized_end = self.size + end
+            else:
+                if end > self.size:
+                    var normalized_end = self.size
+                else:
+                    var normalized_end = end
 
         if not self.size: raise "Cannot find index of a value in an empty list."
         if normalized_start >= self.size: raise "Given 'start' parameter (" + String(normalized_start) + ") is out of range. List only has " + String(self.size) + " elements."

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -473,9 +473,6 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             ) + " elements."
 
         for i in range(normalized_start, normalized_end):
-            # Note: Implementing __contains__ with O(n) time complexity in future, indicating it relies on linear search,
-            # could degrade the performance of the List.index method if it were to replace the current implementation,
-            # as it would essentially perform the same loop twice.
             if self[i] == value:
                 return i
         raise "ValueError: Given element is not in list"

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -427,11 +427,19 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         Returns the index of the first occurrence of a value in a list, starting from the specified
         index (default 0). Raises an Error if the value is not found.
 
+        ```mojo
+        var my_list = List[Int](1, 2, 3)
+        print(__type_of(my_list).index(my_list, 2)) # Output: 1
+        ```
+
         Args:
             self: The list to search in.
             value: The value to search for.
             start: The starting index of the search (default 0).
             end: The ending index of the search (default None, which means the end of the list).
+
+        Parameters:
+            C: The type of the elements in the list. Must implement the `ComparableCollectionElement` trait.
 
         Returns:
             The index of the first occurrence of the value in the list.
@@ -439,14 +447,6 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         Raises:
             ValueError If the value is not found in the list.
 
-        Type Parameters:
-            C: The type of the elements in the list. Must implement the `ComparableCollectionElement` trait.
-
-        Example:
-            ```mojo
-            var my_list = List[Int](1, 2, 3)
-            print(__type_of(my_list).index(my_list, 2))  # Output: 1
-            ```
         """
         var normalized_start = (self.size + start) if start < 0 else start
         # TODO: Once the min() and max() functions are available in Mojo,

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -416,6 +416,59 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             earlier_idx += 1
             later_idx -= 1
 
+    @always_inline
+    fn index(self, owned value: T, start: Int = 0) raises -> Int:
+        var normalized_start = self.size + start if start < 0 else start
+        var normalized_end = self.size
+    
+        if normalized_start >= self.size: raise "Given 'start' parameter is out of range"
+    
+        var ret_val: Int = -1
+        for i in range(normalized_start, normalized_end):
+            # Note: Implementing __contains__ with O(n) time complexity in future, indicating it relies on linear search,
+            # could degrade the performance of the List.index method if it were to replace the current implementation,
+            # as it would essentially perform the same loop twice.
+            if ((self.data + i).bitcast[T]()[]) == value:
+                ret_val = i
+                break
+        else:
+            pass
+            # TODO: Currently, attempting to raise a message, leads to a compiler error (#issue2188)
+            # TODO: Once this issue is resolved, the commented-out code below should be uncommented.
+            # TODO: And then the if statement below should get removed completely.
+            # Code:
+            # raise "Value does not exist in list"
+        if ret_val == -1:
+            raise "Value does not exist in list"
+        return ret_val
+
+    @always_inline
+    fn index(self, owned value: T, start: Int, end: Int) raises -> Int:
+        var normalized_start = (self.size + start) if start < 0 else start
+        var normalized_end = (self.size + end) if end < 0 else end
+    
+        if normalized_end > self.size: raise "Given 'end' parameter is out of range"
+        if normalized_start >= self.size: raise "Given 'start' parameter is out of range"
+    
+        var ret_val: Int = -1
+        for i in range(normalized_start, normalized_end):
+            # Note: Implementing __contains__ with O(n) time complexity in future, indicating it relies on linear search,
+            # could degrade the performance of the List.index method if it were to replace the current implementation,
+            # as it would essentially perform the same loop twice.
+            if ((self.data + i).bitcast[T]()[]) == value:
+                ret_val = i
+                break
+        else:
+            pass
+            # TODO: Currently, attempting to raise a message, leads to a compiler error (#issue2188)
+            # TODO: Once this issue is resolved, the commented-out code below should be uncommented.
+            # TODO: And then the if statement below should get removed completely.
+            # Code:
+            # raise "Value does not exist in list"
+        if ret_val == -1:
+            raise "Value does not exist in list"
+        return ret_val
+
     fn clear(inout self):
         """Clears the elements in the list."""
         for i in range(self.size):

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -416,8 +416,9 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             earlier_idx += 1
             later_idx -= 1
 
-    @always_inline
-    fn index(self, owned value: T, start: Int = 0) raises -> Int:
+    # TODO: Modify these to regular methods when issue 1876 is resolved
+    @staticmethod
+    fn index[C: ComparableCollectionElement](self: List[C], owned value: C, start: Int = 0) raises -> Int:
         """Returns the index of the first occurrence of a value in a list; raises Error if not found."""
         var normalized_start = self.size + start if start < 0 else start
         var normalized_end = self.size
@@ -430,15 +431,15 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             # Note: Implementing __contains__ with O(n) time complexity in future, indicating it relies on linear search,
             # could degrade the performance of the List.index method if it were to replace the current implementation,
             # as it would essentially perform the same loop twice.
-            if ((self.data + i).bitcast[T]()[]) == value:
+            if ((self.data + i).bitcast[C]()[]) == value:
                 ret_val = i
                 break
         else:
             raise "Value does not exist in the list."
         return ret_val
 
-    @always_inline
-    fn index(self, owned value: T, start: Int, end: Int) raises -> Int:
+    @staticmethod
+    fn index[C: ComparableCollectionElement](self: List[C], owned value: C, start: Int, end: Int) raises -> Int:
         """Returns the index of the first occurrence of a value in a list; raises Error if not found."""
         var normalized_start = (self.size + start) if start < 0 else start
         var normalized_end = (self.size + end) if end < 0 else (self.size if end > self.size else end)
@@ -451,7 +452,7 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             # Note: Implementing __contains__ with O(n) time complexity in future, indicating it relies on linear search,
             # could degrade the performance of the List.index method if it were to replace the current implementation,
             # as it would essentially perform the same loop twice.
-            if ((self.data + i).bitcast[T]()[]) == value:
+            if ((self.data + i).bitcast[C]()[]) == value:
                 ret_val = i
                 break
         else:

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -418,9 +418,13 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
 
     # TODO: Modify this to be regular method when issue 1876 is resolved
     @staticmethod
-    fn index[C: ComparableCollectionElement](self: List[C], owned value: C, start: Int = 0, end: Optional[Int] = None) raises -> Int:
+    fn index[
+        C: ComparableCollectionElement
+    ](
+        self: List[C], owned value: C, start: Int = 0, end: Optional[Int] = None
+    ) raises -> Int:
         """
-        Returns the index of the first occurrence of a value in a list, starting from the specified 
+        Returns the index of the first occurrence of a value in a list, starting from the specified
         index (default 0). Raises an Error if the value is not found.
 
         Args:
@@ -459,8 +463,14 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
                 else:
                     var normalized_end = end
 
-        if not self.size: raise "Cannot find index of a value in an empty list."
-        if normalized_start >= self.size: raise "Given 'start' parameter (" + String(normalized_start) + ") is out of range. List only has " + String(self.size) + " elements."
+        if not self.size:
+            raise "Cannot find index of a value in an empty list."
+        if normalized_start >= self.size:
+            raise "Given 'start' parameter (" + String(
+                normalized_start
+            ) + ") is out of range. List only has " + String(
+                self.size
+            ) + " elements."
 
         for i in range(normalized_start, normalized_end):
             # Note: Implementing __contains__ with O(n) time complexity in future, indicating it relies on linear search,

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -431,12 +431,9 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             # Note: Implementing __contains__ with O(n) time complexity in future, indicating it relies on linear search,
             # could degrade the performance of the List.index method if it were to replace the current implementation,
             # as it would essentially perform the same loop twice.
-            if ((self.data + i).bitcast[C]()[]) == value:
-                ret_val = i
-                break
-        else:
-            raise "Value does not exist in the list."
-        return ret_val
+            if self[i] == value:
+                return i
+        raise "ValueError: Given element is not in list"
 
     fn clear(inout self):
         """Clears the elements in the list."""

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -419,7 +419,31 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
     # TODO: Modify this to be regular method when issue 1876 is resolved
     @staticmethod
     fn index[C: ComparableCollectionElement](self: List[C], owned value: C, start: Int = 0, end: Optional[Int] = None) raises -> Int:
-        """Returns the index of the first occurrence of a value in a list; raises Error if not found."""
+        """
+        Returns the index of the first occurrence of a value in a list, starting from the specified 
+        index (default 0). Raises an Error if the value is not found.
+
+        Args:
+            self: The list to search in.
+            value: The value to search for.
+            start: The starting index of the search (default 0).
+            end: The ending index of the search (default None, which means the end of the list).
+
+        Returns:
+            The index of the first occurrence of the value in the list.
+
+        Raises:
+            ValueError If the value is not found in the list.
+
+        Type Parameters:
+            C: The type of the elements in the list. Must implement the `ComparableCollectionElement` trait.
+
+        Example:
+            ```mojo
+            var my_list = List[Int](1, 2, 3)
+            print(__type_of(my_list).index(my_list, 2))  # Output: 1
+            ```
+        """
         var normalized_start = (self.size + start) if start < 0 else start
         var normalized_end = self.size if end is None else (self.size + end if end < 0 else (self.size if end > self.size else end))
 

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -418,6 +418,7 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
 
     @always_inline
     fn index(self, owned value: T, start: Int = 0) raises -> Int:
+        """Returns the index of the first occurrence of a value in a list; raises ValueError if not found."""
         var normalized_start = self.size + start if start < 0 else start
         var normalized_end = self.size
     
@@ -444,6 +445,7 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
 
     @always_inline
     fn index(self, owned value: T, start: Int, end: Int) raises -> Int:
+        """Returns the index of the first occurrence of a value in a list; raises ValueError if not found."""
         var normalized_start = (self.size + start) if start < 0 else start
         var normalized_end = (self.size + end) if end < 0 else end
     

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -418,13 +418,14 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
 
     @always_inline
     fn index(self, owned value: T, start: Int = 0) raises -> Int:
-        """Returns the index of the first occurrence of a value in a list; raises ValueError if not found."""
+        """Returns the index of the first occurrence of a value in a list; raises Error if not found."""
         var normalized_start = self.size + start if start < 0 else start
         var normalized_end = self.size
-    
-        if normalized_start >= self.size: raise "Given 'start' parameter is out of range"
-    
-        var ret_val: Int = -1
+
+        if not self.size: raise "Cannot find index of a value in an empty list."
+        if normalized_start >= self.size: raise "Given 'start' parameter (" + String(normalized_start) + ") is out of range. List only has " + String(self.size) + " elements."
+
+        var ret_val: Int
         for i in range(normalized_start, normalized_end):
             # Note: Implementing __contains__ with O(n) time complexity in future, indicating it relies on linear search,
             # could degrade the performance of the List.index method if it were to replace the current implementation,
@@ -433,26 +434,19 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
                 ret_val = i
                 break
         else:
-            pass
-            # TODO: Currently, attempting to raise a message, leads to a compiler error (#issue2188)
-            # TODO: Once this issue is resolved, the commented-out code below should be uncommented.
-            # TODO: And then the if statement below should get removed completely.
-            # Code:
-            # raise "Value does not exist in list"
-        if ret_val == -1:
-            raise "Value does not exist in list"
+            raise "Value does not exist in the list."
         return ret_val
 
     @always_inline
     fn index(self, owned value: T, start: Int, end: Int) raises -> Int:
-        """Returns the index of the first occurrence of a value in a list; raises ValueError if not found."""
+        """Returns the index of the first occurrence of a value in a list; raises Error if not found."""
         var normalized_start = (self.size + start) if start < 0 else start
-        var normalized_end = (self.size + end) if end < 0 else end
-    
-        if normalized_end > self.size: raise "Given 'end' parameter is out of range"
-        if normalized_start >= self.size: raise "Given 'start' parameter is out of range"
-    
-        var ret_val: Int = -1
+        var normalized_end = (self.size + end) if end < 0 else (self.size if end > self.size else end)
+
+        if not self.size: raise "Cannot find index of a value in an empty list."
+        if normalized_start >= self.size: raise "Given 'start' parameter (" + String(normalized_start) + ") is out of range. List only has " + String(self.size) + " elements."
+
+        var ret_val: Int
         for i in range(normalized_start, normalized_end):
             # Note: Implementing __contains__ with O(n) time complexity in future, indicating it relies on linear search,
             # could degrade the performance of the List.index method if it were to replace the current implementation,
@@ -461,14 +455,7 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
                 ret_val = i
                 break
         else:
-            pass
-            # TODO: Currently, attempting to raise a message, leads to a compiler error (#issue2188)
-            # TODO: Once this issue is resolved, the commented-out code below should be uncommented.
-            # TODO: And then the if statement below should get removed completely.
-            # Code:
-            # raise "Value does not exist in list"
-        if ret_val == -1:
-            raise "Value does not exist in list"
+            raise "Value does not exist in the list."
         return ret_val
 
     fn clear(inout self):

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -23,7 +23,7 @@ from collections import List
 from builtin.value import StringableCollectionElement
 from memory import UnsafePointer, Reference
 from memory.unsafe_pointer import move_pointee, move_from_pointee
-
+from .optional import Optional
 
 # ===----------------------------------------------------------------------===#
 # Utilties
@@ -416,33 +416,12 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             earlier_idx += 1
             later_idx -= 1
 
-    # TODO: Modify these to regular methods when issue 1876 is resolved
+    # TODO: Modify this to be regular method when issue 1876 is resolved
     @staticmethod
-    fn index[C: ComparableCollectionElement](self: List[C], owned value: C, start: Int = 0) raises -> Int:
-        """Returns the index of the first occurrence of a value in a list; raises Error if not found."""
-        var normalized_start = self.size + start if start < 0 else start
-        var normalized_end = self.size
-
-        if not self.size: raise "Cannot find index of a value in an empty list."
-        if normalized_start >= self.size: raise "Given 'start' parameter (" + String(normalized_start) + ") is out of range. List only has " + String(self.size) + " elements."
-
-        var ret_val: Int
-        for i in range(normalized_start, normalized_end):
-            # Note: Implementing __contains__ with O(n) time complexity in future, indicating it relies on linear search,
-            # could degrade the performance of the List.index method if it were to replace the current implementation,
-            # as it would essentially perform the same loop twice.
-            if ((self.data + i).bitcast[C]()[]) == value:
-                ret_val = i
-                break
-        else:
-            raise "Value does not exist in the list."
-        return ret_val
-
-    @staticmethod
-    fn index[C: ComparableCollectionElement](self: List[C], owned value: C, start: Int, end: Int) raises -> Int:
+    fn index[C: ComparableCollectionElement](self: List[C], owned value: C, start: Int, end: Optional[Int] = None) raises -> Int:
         """Returns the index of the first occurrence of a value in a list; raises Error if not found."""
         var normalized_start = (self.size + start) if start < 0 else start
-        var normalized_end = (self.size + end) if end < 0 else (self.size if end > self.size else end)
+        var normalized_end = self.size if end is None else (self.size + end if end < 0 else (self.size if end > self.size else end))
 
         if not self.size: raise "Cannot find index of a value in an empty list."
         if normalized_start >= self.size: raise "Given 'start' parameter (" + String(normalized_start) + ") is out of range. List only has " + String(self.size) + " elements."

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -418,7 +418,7 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
 
     # TODO: Modify this to be regular method when issue 1876 is resolved
     @staticmethod
-    fn index[C: ComparableCollectionElement](self: List[C], owned value: C, start: Int, end: Optional[Int] = None) raises -> Int:
+    fn index[C: ComparableCollectionElement](self: List[C], owned value: C, start: Int = 0, end: Optional[Int] = None) raises -> Int:
         """Returns the index of the first occurrence of a value in a list; raises Error if not found."""
         var normalized_start = (self.size + start) if start < 0 else start
         var normalized_end = self.size if end is None else (self.size + end if end < 0 else (self.size if end > self.size else end))

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -426,7 +426,6 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         if not self.size: raise "Cannot find index of a value in an empty list."
         if normalized_start >= self.size: raise "Given 'start' parameter (" + String(normalized_start) + ") is out of range. List only has " + String(self.size) + " elements."
 
-        var ret_val: Int
         for i in range(normalized_start, normalized_end):
             # Note: Implementing __contains__ with O(n) time complexity in future, indicating it relies on linear search,
             # could degrade the performance of the List.index method if it were to replace the current implementation,

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -366,7 +366,7 @@ def test_list_index():
         __type_of(test_list_a).index(test_list_a, 30, start=3)
     with assert_raises(
         contains=(
-            "Given 'start' parameter (5) is out of range. List only have 5"
+            "Given 'start' parameter (5) is out of range. List only has 5"
             " elements."
         )
     ):
@@ -409,7 +409,7 @@ def test_list_index():
         __type_of(test_list_a).index(test_list_a, 10, start=-4, end=-1)
     with assert_raises(
         contains=(
-            "Given 'start' parameter (5) is out of range. List only have 5"
+            "Given 'start' parameter (5) is out of range. List only has 5"
             " elements."
         )
     ):

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -15,7 +15,7 @@
 from collections import List
 
 from test_utils import CopyCounter, MoveCounter
-from testing import assert_equal, assert_false, assert_true
+from testing import assert_equal, assert_false, assert_true, assert_raises
 
 
 def test_mojo_issue_698():
@@ -348,6 +348,60 @@ def test_list_insert():
     for i in range(len(v4)):
         assert_equal(v4[i], i + 1)
 
+def test_list_index():
+    var test_list_a = List[Int](10,20,30,40,50)
+    
+    # Basic Functionality Tests
+    assert_equal(test_list_a.index(10), 0)  # Verify finding the first element's index.
+    assert_equal(test_list_a.index(30), 2)  # Verify finding the index of a middle element.
+    assert_equal(test_list_a.index(50), 4)  # Verify finding the last element's index.
+    with assert_raises():  # Verify error for a non-existent element.
+        _ = test_list_a.index(60)
+
+    # Tests With Start Parameter
+    assert_equal(test_list_a.index(30, start=1), 2)  # Verify search beginning from a specific start index.
+    assert_equal(test_list_a.index(30, start=-4), 2)  # Verify element search with a negative start index.
+    with assert_raises():  # Verify error when start is after element's index.
+        _ = test_list_a.index(30, start=3)
+
+    # Tests With Start and End Parameters
+    assert_equal(test_list_a.index(30, start=1, end=3), 2)  # Verify finding an element within a specified range.
+    assert_equal(test_list_a.index(30, start=-4, end=-2), 2)  # Verify search with negative start and end indices.
+    with assert_raises():  # Verify error when element is outside the range.
+        _ = test_list_a.index(30, start=1, end=2)
+    with assert_raises():  # Verify error with an invalid range (start > end).
+        _ = test_list_a.index(30, start=3, end=1)
+
+    # Edge Cases and Special Conditions
+    assert_equal(test_list_a.index(10, start=-5, end=-1), 0)  # Verify search covers the entire list with negative indices.
+    with assert_raises():  # Verify error when last element is excluded by end index.
+        _ = test_list_a.index(50, start=-5, end=-1)
+    with assert_raises():  # Verify error when search excludes the last item with -1 as end index.
+        _ = test_list_a.index(50, start=0, end=-1)
+    with assert_raises():  # Verify error when element is not within the negative indexed range.
+        _ = test_list_a.index(10, start=-4, end=-1) 
+
+
+    var test_list_b = List[Int](10, 20, 30, 20, 10)
+
+    # Test finding the first occurrence of an item
+    assert_equal(test_list_b.index(10), 0)  # Verify first occurrence of '10'.
+    assert_equal(test_list_b.index(20), 1)  # Verify first occurrence of '20'.
+
+    # Test skipping the first occurrence with a start parameter
+    assert_equal(test_list_b.index(20, start=2), 3)  # Skip first '20', find second.
+
+    # Test constraining search with start and end, excluding last occurrence
+    with assert_raises():  # '10' at end is excluded, expecting an error.
+        _ = test_list_b.index(10, start=1, end=4)
+
+    # Test search within a range that includes multiple occurrences
+    assert_equal(test_list_b.index(20, start=1, end=4), 1)  # Range includes two '20's, finds first in range.
+
+    # Verify error when constrained range excludes occurrences
+    with assert_raises():  # No '20' in the given range.
+        _ = test_list_b.index(20, start=4, end=5)
+
 
 def test_list_extend():
     #
@@ -600,6 +654,7 @@ def main():
     test_list_reverse()
     test_list_reverse_move_count()
     test_list_insert()
+    test_list_index()
     test_list_extend()
     test_list_extend_non_trivial()
     test_list_explicit_copy()

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -355,31 +355,32 @@ def test_list_index():
     assert_equal(test_list_a.index(10), 0)  # Verify finding the first element's index.
     assert_equal(test_list_a.index(30), 2)  # Verify finding the index of a middle element.
     assert_equal(test_list_a.index(50), 4)  # Verify finding the last element's index.
-    with assert_raises():  # Verify error for a non-existent element.
+    with assert_raises(contains="Value does not exist in the list."):  # Verify error for a non-existent element.
         _ = test_list_a.index(60)
 
     # Tests With Start Parameter
     assert_equal(test_list_a.index(30, start=1), 2)  # Verify search beginning from a specific start index.
     assert_equal(test_list_a.index(30, start=-4), 2)  # Verify element search with a negative start index.
-    with assert_raises():  # Verify error when start is after element's index.
+    with assert_raises(contains="Value does not exist in the list."):  # Verify error when start is after element's index.
         _ = test_list_a.index(30, start=3)
 
     # Tests With Start and End Parameters
     assert_equal(test_list_a.index(30, start=1, end=3), 2)  # Verify finding an element within a specified range.
     assert_equal(test_list_a.index(30, start=-4, end=-2), 2)  # Verify search with negative start and end indices.
-    with assert_raises():  # Verify error when element is outside the range.
+    with assert_raises(contains="Value does not exist in the list."):  # Verify error when element is outside the range.
         _ = test_list_a.index(30, start=1, end=2)
-    with assert_raises():  # Verify error with an invalid range (start > end).
+    with assert_raises(contains="Value does not exist in the list."):  # Verify error with an invalid range (start > end).
         _ = test_list_a.index(30, start=3, end=1)
 
     # Edge Cases and Special Conditions
     assert_equal(test_list_a.index(10, start=-5, end=-1), 0)  # Verify search covers the entire list with negative indices.
-    with assert_raises():  # Verify error when last element is excluded by end index.
+    assert_equal(test_list_a.index(10, start=0, end=50), 0)  # Verify acceptable out-of-range end value.
+    with assert_raises(contains="Value does not exist in the list."):  # Verify error when last element is excluded by end index.
         _ = test_list_a.index(50, start=-5, end=-1)
-    with assert_raises():  # Verify error when search excludes the last item with -1 as end index.
+    with assert_raises(contains="Value does not exist in the list."):  # Verify error when search excludes the last item with -1 as end index.
         _ = test_list_a.index(50, start=0, end=-1)
-    with assert_raises():  # Verify error when element is not within the negative indexed range.
-        _ = test_list_a.index(10, start=-4, end=-1) 
+    with assert_raises(contains="Value does not exist in the list."):  # Verify error when element is not within the negative indexed range.
+        _ = test_list_a.index(10, start=-4, end=-1)
 
 
     var test_list_b = List[Int](10, 20, 30, 20, 10)
@@ -392,14 +393,14 @@ def test_list_index():
     assert_equal(test_list_b.index(20, start=2), 3)  # Skip first '20', find second.
 
     # Test constraining search with start and end, excluding last occurrence
-    with assert_raises():  # '10' at end is excluded, expecting an error.
+    with assert_raises(contains="Value does not exist in the list."):  # '10' at end is excluded, expecting an error.
         _ = test_list_b.index(10, start=1, end=4)
 
     # Test search within a range that includes multiple occurrences
     assert_equal(test_list_b.index(20, start=1, end=4), 1)  # Range includes two '20's, finds first in range.
 
     # Verify error when constrained range excludes occurrences
-    with assert_raises():  # No '20' in the given range.
+    with assert_raises(contains="Value does not exist in the list."):  # No '20' in the given range.
         _ = test_list_b.index(20, start=4, end=5)
 
 

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -352,38 +352,38 @@ def test_list_index():
     var test_list_a = List[Int](10,20,30,40,50)
     
     # Basic Functionality Tests
-    assert_equal(__type_of(test_list_a).index(test_list_a, 10), 0)  # Verify finding the first element's index.
-    assert_equal(__type_of(test_list_a).index(test_list_a, 30), 2)  # Verify finding the index of a middle element.
-    assert_equal(__type_of(test_list_a).index(test_list_a, 50), 4)  # Verify finding the last element's index.
-    with assert_raises(contains="Value does not exist in the list."):  # Verify error for a non-existent element.
+    assert_equal(__type_of(test_list_a).index(test_list_a, 10), 0)
+    assert_equal(__type_of(test_list_a).index(test_list_a, 30), 2)
+    assert_equal(__type_of(test_list_a).index(test_list_a, 50), 4)
+    with assert_raises(contains="Value does not exist in the list."):
         _ = __type_of(test_list_a).index(test_list_a, 60)
 
     # Tests With Start Parameter
-    assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=1), 2)  # Verify search beginning from a specific start index.
-    assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=-4), 2)  # Verify element search with a negative start index.
-    with assert_raises(contains="Value does not exist in the list."):  # Verify error when start is after element's index.
+    assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=1), 2)
+    assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=-4), 2)
+    with assert_raises(contains="Value does not exist in the list."):
         _ = __type_of(test_list_a).index(test_list_a, 30, start=3)
-    with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):  # Verify error when start is out of range.
+    with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):
         _ = __type_of(test_list_a).index(test_list_a, 30, start=5)
 
     # Tests With Start and End Parameters
-    assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=1, end=3), 2)  # Verify finding an element within a specified range.
-    assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=-4, end=-2), 2)  # Verify search with negative start and end indices.
-    with assert_raises(contains="Value does not exist in the list."):  # Verify error when element is outside the range.
+    assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=1, end=3), 2)
+    assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=-4, end=-2), 2)
+    with assert_raises(contains="Value does not exist in the list."):
         _ = __type_of(test_list_a).index(test_list_a, 30, start=1, end=2)
-    with assert_raises(contains="Value does not exist in the list."):  # Verify error with an invalid range (start > end).
+    with assert_raises(contains="Value does not exist in the list."):
         _ = __type_of(test_list_a).index(test_list_a, 30, start=3, end=1)
 
     # Edge Cases and Special Conditions
-    assert_equal(__type_of(test_list_a).index(test_list_a, 10, start=-5, end=-1), 0)  # Verify search covers the entire list with negative indices.
-    assert_equal(__type_of(test_list_a).index(test_list_a, 10, start=0, end=50), 0)  # Verify acceptable out-of-range end value.
-    with assert_raises(contains="Value does not exist in the list."):  # Verify error when last element is excluded by end index.
+    assert_equal(__type_of(test_list_a).index(test_list_a, 10, start=-5, end=-1), 0)
+    assert_equal(__type_of(test_list_a).index(test_list_a, 10, start=0, end=50), 0)
+    with assert_raises(contains="Value does not exist in the list."):
         _ = __type_of(test_list_a).index(test_list_a, 50, start=-5, end=-1)
-    with assert_raises(contains="Value does not exist in the list."):  # Verify error when search excludes the last item with -1 as end index.
+    with assert_raises(contains="Value does not exist in the list."):
         _ = __type_of(test_list_a).index(test_list_a, 50, start=0, end=-1)
-    with assert_raises(contains="Value does not exist in the list."):  # Verify error when element is not within the negative indexed range.
+    with assert_raises(contains="Value does not exist in the list."):
         _ = __type_of(test_list_a).index(test_list_a, 10, start=-4, end=-1)
-    with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):  # Verify error when start value is out-of-range.
+    with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):
         _ = __type_of(test_list_a).index(test_list_a, 10, start=5, end=50)
     
     # Verify error when list is empty.
@@ -394,21 +394,21 @@ def test_list_index():
     var test_list_b = List[Int](10, 20, 30, 20, 10)
 
     # Test finding the first occurrence of an item
-    assert_equal(__type_of(test_list_b).index(test_list_b, 10), 0)  # Verify first occurrence of '10'.
-    assert_equal(__type_of(test_list_b).index(test_list_b, 20), 1)  # Verify first occurrence of '20'.
+    assert_equal(__type_of(test_list_b).index(test_list_b, 10), 0)
+    assert_equal(__type_of(test_list_b).index(test_list_b, 20), 1)
 
     # Test skipping the first occurrence with a start parameter
-    assert_equal(__type_of(test_list_b).index(test_list_b, 20, start=2), 3)  # Skip first '20', find second.
+    assert_equal(__type_of(test_list_b).index(test_list_b, 20, start=2), 3)
 
     # Test constraining search with start and end, excluding last occurrence
-    with assert_raises(contains="Value does not exist in the list."):  # '10' at end is excluded, expecting an error.
+    with assert_raises(contains="Value does not exist in the list."):
         _ = __type_of(test_list_b).index(test_list_b, 10, start=1, end=4)
 
     # Test search within a range that includes multiple occurrences
-    assert_equal(__type_of(test_list_b).index(test_list_b, 20, start=1, end=4), 1)  # Range includes two '20's, finds first in range.
+    assert_equal(__type_of(test_list_b).index(test_list_b, 20, start=1, end=4), 1)
 
     # Verify error when constrained range excludes occurrences
-    with assert_raises(contains="Value does not exist in the list."):  # No '20' in the given range.
+    with assert_raises(contains="Value does not exist in the list."):
         _ = __type_of(test_list_b).index(test_list_b, 20, start=4, end=5)
 
 

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -352,64 +352,64 @@ def test_list_index():
     var test_list_a = List[Int](10,20,30,40,50)
     
     # Basic Functionality Tests
-    assert_equal(test_list_a.index(10), 0)  # Verify finding the first element's index.
-    assert_equal(test_list_a.index(30), 2)  # Verify finding the index of a middle element.
-    assert_equal(test_list_a.index(50), 4)  # Verify finding the last element's index.
+    assert_equal(__type_of(test_list_a).index(test_list_a, 10), 0)  # Verify finding the first element's index.
+    assert_equal(__type_of(test_list_a).index(test_list_a, 30), 2)  # Verify finding the index of a middle element.
+    assert_equal(__type_of(test_list_a).index(test_list_a, 50), 4)  # Verify finding the last element's index.
     with assert_raises(contains="Value does not exist in the list."):  # Verify error for a non-existent element.
-        _ = test_list_a.index(60)
+        _ = __type_of(test_list_a).index(test_list_a, 60)
 
     # Tests With Start Parameter
-    assert_equal(test_list_a.index(30, start=1), 2)  # Verify search beginning from a specific start index.
-    assert_equal(test_list_a.index(30, start=-4), 2)  # Verify element search with a negative start index.
+    assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=1), 2)  # Verify search beginning from a specific start index.
+    assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=-4), 2)  # Verify element search with a negative start index.
     with assert_raises(contains="Value does not exist in the list."):  # Verify error when start is after element's index.
-        _ = test_list_a.index(30, start=3)
+        _ = __type_of(test_list_a).index(test_list_a, 30, start=3)
     with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):  # Verify error when start is out of range.
-        _ = test_list_a.index(30, start=5)
+        _ = __type_of(test_list_a).index(test_list_a, 30, start=5)
 
     # Tests With Start and End Parameters
-    assert_equal(test_list_a.index(30, start=1, end=3), 2)  # Verify finding an element within a specified range.
-    assert_equal(test_list_a.index(30, start=-4, end=-2), 2)  # Verify search with negative start and end indices.
+    assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=1, end=3), 2)  # Verify finding an element within a specified range.
+    assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=-4, end=-2), 2)  # Verify search with negative start and end indices.
     with assert_raises(contains="Value does not exist in the list."):  # Verify error when element is outside the range.
-        _ = test_list_a.index(30, start=1, end=2)
+        _ = __type_of(test_list_a).index(test_list_a, 30, start=1, end=2)
     with assert_raises(contains="Value does not exist in the list."):  # Verify error with an invalid range (start > end).
-        _ = test_list_a.index(30, start=3, end=1)
+        _ = __type_of(test_list_a).index(test_list_a, 30, start=3, end=1)
 
     # Edge Cases and Special Conditions
-    assert_equal(test_list_a.index(10, start=-5, end=-1), 0)  # Verify search covers the entire list with negative indices.
-    assert_equal(test_list_a.index(10, start=0, end=50), 0)  # Verify acceptable out-of-range end value.
+    assert_equal(__type_of(test_list_a).index(test_list_a, 10, start=-5, end=-1), 0)  # Verify search covers the entire list with negative indices.
+    assert_equal(__type_of(test_list_a).index(test_list_a, 10, start=0, end=50), 0)  # Verify acceptable out-of-range end value.
     with assert_raises(contains="Value does not exist in the list."):  # Verify error when last element is excluded by end index.
-        _ = test_list_a.index(50, start=-5, end=-1)
+        _ = __type_of(test_list_a).index(test_list_a, 50, start=-5, end=-1)
     with assert_raises(contains="Value does not exist in the list."):  # Verify error when search excludes the last item with -1 as end index.
-        _ = test_list_a.index(50, start=0, end=-1)
+        _ = __type_of(test_list_a).index(test_list_a, 50, start=0, end=-1)
     with assert_raises(contains="Value does not exist in the list."):  # Verify error when element is not within the negative indexed range.
-        _ = test_list_a.index(10, start=-4, end=-1)
+        _ = __type_of(test_list_a).index(test_list_a, 10, start=-4, end=-1)
     with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):  # Verify error when start value is out-of-range.
-        _ = test_list_a.index(10, start=5, end=50)
+        _ = __type_of(test_list_a).index(test_list_a, 10, start=5, end=50)
     
     # Verify error when list is empty.
     with assert_raises(contains="Cannot find index of a value in an empty list."):
-        _ = List[Int]().index(10)
+        _ = __type_of(List[Int]()).index(List[Int](), 10)
 
 
     var test_list_b = List[Int](10, 20, 30, 20, 10)
 
     # Test finding the first occurrence of an item
-    assert_equal(test_list_b.index(10), 0)  # Verify first occurrence of '10'.
-    assert_equal(test_list_b.index(20), 1)  # Verify first occurrence of '20'.
+    assert_equal(__type_of(test_list_b).index(test_list_b, 10), 0)  # Verify first occurrence of '10'.
+    assert_equal(__type_of(test_list_b).index(test_list_b, 20), 1)  # Verify first occurrence of '20'.
 
     # Test skipping the first occurrence with a start parameter
-    assert_equal(test_list_b.index(20, start=2), 3)  # Skip first '20', find second.
+    assert_equal(__type_of(test_list_b).index(test_list_b, 20, start=2), 3)  # Skip first '20', find second.
 
     # Test constraining search with start and end, excluding last occurrence
     with assert_raises(contains="Value does not exist in the list."):  # '10' at end is excluded, expecting an error.
-        _ = test_list_b.index(10, start=1, end=4)
+        _ = __type_of(test_list_b).index(test_list_b, 10, start=1, end=4)
 
     # Test search within a range that includes multiple occurrences
-    assert_equal(test_list_b.index(20, start=1, end=4), 1)  # Range includes two '20's, finds first in range.
+    assert_equal(__type_of(test_list_b).index(test_list_b, 20, start=1, end=4), 1)  # Range includes two '20's, finds first in range.
 
     # Verify error when constrained range excludes occurrences
     with assert_raises(contains="Value does not exist in the list."):  # No '20' in the given range.
-        _ = test_list_b.index(20, start=4, end=5)
+        _ = __type_of(test_list_b).index(test_list_b, 20, start=4, end=5)
 
 
 def test_list_extend():

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -356,47 +356,47 @@ def test_list_index():
     assert_equal(__type_of(test_list_a).index(test_list_a, 30), 2)
     assert_equal(__type_of(test_list_a).index(test_list_a, 50), 4)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        _ = __type_of(test_list_a).index(test_list_a, 60)
+        __type_of(test_list_a).index(test_list_a, 60)
 
     # Tests With Start Parameter
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=1), 2)
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=-4), 2)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        _ = __type_of(test_list_a).index(test_list_a, 30, start=3)
+        __type_of(test_list_a).index(test_list_a, 30, start=3)
     with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):
-        _ = __type_of(test_list_a).index(test_list_a, 30, start=5)
+        __type_of(test_list_a).index(test_list_a, 30, start=5)
 
     # Tests With Start and End Parameters
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=1, end=3), 2)
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=-4, end=-2), 2)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        _ = __type_of(test_list_a).index(test_list_a, 30, start=1, end=2)
+        __type_of(test_list_a).index(test_list_a, 30, start=1, end=2)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        _ = __type_of(test_list_a).index(test_list_a, 30, start=3, end=1)
+        __type_of(test_list_a).index(test_list_a, 30, start=3, end=1)
 
     # Tests With End Parameter Only
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, end=3), 2)
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, end=-2), 2)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        _ = __type_of(test_list_a).index(test_list_a, 30, end=1)
+        __type_of(test_list_a).index(test_list_a, 30, end=1)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        _ = __type_of(test_list_a).index(test_list_a, 30, end=2)
+        __type_of(test_list_a).index(test_list_a, 30, end=2)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        _ = __type_of(test_list_a).index(test_list_a, 60, end=50)
+        __type_of(test_list_a).index(test_list_a, 60, end=50)
 
     # Edge Cases and Special Conditions
     assert_equal(__type_of(test_list_a).index(test_list_a, 10, start=-5, end=-1), 0)
     assert_equal(__type_of(test_list_a).index(test_list_a, 10, start=0, end=50), 0)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        _ = __type_of(test_list_a).index(test_list_a, 50, start=-5, end=-1)
+        __type_of(test_list_a).index(test_list_a, 50, start=-5, end=-1)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        _ = __type_of(test_list_a).index(test_list_a, 50, start=0, end=-1)
+        __type_of(test_list_a).index(test_list_a, 50, start=0, end=-1)
     with assert_raises(contains="ValueError: Given element is not in list"):
-        _ = __type_of(test_list_a).index(test_list_a, 10, start=-4, end=-1)
+        __type_of(test_list_a).index(test_list_a, 10, start=-4, end=-1)
     with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):
-        _ = __type_of(test_list_a).index(test_list_a, 10, start=5, end=50)
+        __type_of(test_list_a).index(test_list_a, 10, start=5, end=50)
     with assert_raises(contains="Cannot find index of a value in an empty list."):
-        _ = __type_of(List[Int]()).index(List[Int](), 10)
+        __type_of(List[Int]()).index(List[Int](), 10)
 
 
     var test_list_b = List[Int](10, 20, 30, 20, 10)

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -355,13 +355,13 @@ def test_list_index():
     assert_equal(__type_of(test_list_a).index(test_list_a, 10), 0)
     assert_equal(__type_of(test_list_a).index(test_list_a, 30), 2)
     assert_equal(__type_of(test_list_a).index(test_list_a, 50), 4)
-    with assert_raises(contains="Value does not exist in the list."):
+    with assert_raises(contains="ValueError: Given element is not in list"):
         _ = __type_of(test_list_a).index(test_list_a, 60)
 
     # Tests With Start Parameter
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=1), 2)
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=-4), 2)
-    with assert_raises(contains="Value does not exist in the list."):
+    with assert_raises(contains="ValueError: Given element is not in list"):
         _ = __type_of(test_list_a).index(test_list_a, 30, start=3)
     with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):
         _ = __type_of(test_list_a).index(test_list_a, 30, start=5)
@@ -369,19 +369,19 @@ def test_list_index():
     # Tests With Start and End Parameters
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=1, end=3), 2)
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=-4, end=-2), 2)
-    with assert_raises(contains="Value does not exist in the list."):
+    with assert_raises(contains="ValueError: Given element is not in list"):
         _ = __type_of(test_list_a).index(test_list_a, 30, start=1, end=2)
-    with assert_raises(contains="Value does not exist in the list."):
+    with assert_raises(contains="ValueError: Given element is not in list"):
         _ = __type_of(test_list_a).index(test_list_a, 30, start=3, end=1)
 
     # Edge Cases and Special Conditions
     assert_equal(__type_of(test_list_a).index(test_list_a, 10, start=-5, end=-1), 0)
     assert_equal(__type_of(test_list_a).index(test_list_a, 10, start=0, end=50), 0)
-    with assert_raises(contains="Value does not exist in the list."):
+    with assert_raises(contains="ValueError: Given element is not in list"):
         _ = __type_of(test_list_a).index(test_list_a, 50, start=-5, end=-1)
-    with assert_raises(contains="Value does not exist in the list."):
+    with assert_raises(contains="ValueError: Given element is not in list"):
         _ = __type_of(test_list_a).index(test_list_a, 50, start=0, end=-1)
-    with assert_raises(contains="Value does not exist in the list."):
+    with assert_raises(contains="ValueError: Given element is not in list"):
         _ = __type_of(test_list_a).index(test_list_a, 10, start=-4, end=-1)
     with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):
         _ = __type_of(test_list_a).index(test_list_a, 10, start=5, end=50)
@@ -401,14 +401,14 @@ def test_list_index():
     assert_equal(__type_of(test_list_b).index(test_list_b, 20, start=2), 3)
 
     # Test constraining search with start and end, excluding last occurrence
-    with assert_raises(contains="Value does not exist in the list."):
+    with assert_raises(contains="ValueError: Given element is not in list"):
         _ = __type_of(test_list_b).index(test_list_b, 10, start=1, end=4)
 
     # Test search within a range that includes multiple occurrences
     assert_equal(__type_of(test_list_b).index(test_list_b, 20, start=1, end=4), 1)
 
     # Verify error when constrained range excludes occurrences
-    with assert_raises(contains="Value does not exist in the list."):
+    with assert_raises(contains="ValueError: Given element is not in list"):
         _ = __type_of(test_list_b).index(test_list_b, 20, start=4, end=5)
 
 

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -363,6 +363,8 @@ def test_list_index():
     assert_equal(test_list_a.index(30, start=-4), 2)  # Verify element search with a negative start index.
     with assert_raises(contains="Value does not exist in the list."):  # Verify error when start is after element's index.
         _ = test_list_a.index(30, start=3)
+    with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):  # Verify error when start is out of range.
+        _ = test_list_a.index(30, start=5)
 
     # Tests With Start and End Parameters
     assert_equal(test_list_a.index(30, start=1, end=3), 2)  # Verify finding an element within a specified range.
@@ -381,6 +383,12 @@ def test_list_index():
         _ = test_list_a.index(50, start=0, end=-1)
     with assert_raises(contains="Value does not exist in the list."):  # Verify error when element is not within the negative indexed range.
         _ = test_list_a.index(10, start=-4, end=-1)
+    with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):  # Verify error when start value is out-of-range.
+        _ = test_list_a.index(10, start=5, end=50)
+    
+    # Verify error when list is empty.
+    with assert_raises(contains="Cannot find index of a value in an empty list."):
+        _ = List[Int]().index(10)
 
 
     var test_list_b = List[Int](10, 20, 30, 20, 10)

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -348,9 +348,10 @@ def test_list_insert():
     for i in range(len(v4)):
         assert_equal(v4[i], i + 1)
 
+
 def test_list_index():
-    var test_list_a = List[Int](10,20,30,40,50)
-    
+    var test_list_a = List[Int](10, 20, 30, 40, 50)
+
     # Basic Functionality Tests
     assert_equal(__type_of(test_list_a).index(test_list_a, 10), 0)
     assert_equal(__type_of(test_list_a).index(test_list_a, 30), 2)
@@ -363,12 +364,21 @@ def test_list_index():
     assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=-4), 2)
     with assert_raises(contains="ValueError: Given element is not in list"):
         __type_of(test_list_a).index(test_list_a, 30, start=3)
-    with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):
+    with assert_raises(
+        contains=(
+            "Given 'start' parameter (5) is out of range. List only have 5"
+            " elements."
+        )
+    ):
         __type_of(test_list_a).index(test_list_a, 30, start=5)
 
     # Tests With Start and End Parameters
-    assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=1, end=3), 2)
-    assert_equal(__type_of(test_list_a).index(test_list_a, 30, start=-4, end=-2), 2)
+    assert_equal(
+        __type_of(test_list_a).index(test_list_a, 30, start=1, end=3), 2
+    )
+    assert_equal(
+        __type_of(test_list_a).index(test_list_a, 30, start=-4, end=-2), 2
+    )
     with assert_raises(contains="ValueError: Given element is not in list"):
         __type_of(test_list_a).index(test_list_a, 30, start=1, end=2)
     with assert_raises(contains="ValueError: Given element is not in list"):
@@ -385,19 +395,29 @@ def test_list_index():
         __type_of(test_list_a).index(test_list_a, 60, end=50)
 
     # Edge Cases and Special Conditions
-    assert_equal(__type_of(test_list_a).index(test_list_a, 10, start=-5, end=-1), 0)
-    assert_equal(__type_of(test_list_a).index(test_list_a, 10, start=0, end=50), 0)
+    assert_equal(
+        __type_of(test_list_a).index(test_list_a, 10, start=-5, end=-1), 0
+    )
+    assert_equal(
+        __type_of(test_list_a).index(test_list_a, 10, start=0, end=50), 0
+    )
     with assert_raises(contains="ValueError: Given element is not in list"):
         __type_of(test_list_a).index(test_list_a, 50, start=-5, end=-1)
     with assert_raises(contains="ValueError: Given element is not in list"):
         __type_of(test_list_a).index(test_list_a, 50, start=0, end=-1)
     with assert_raises(contains="ValueError: Given element is not in list"):
         __type_of(test_list_a).index(test_list_a, 10, start=-4, end=-1)
-    with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):
+    with assert_raises(
+        contains=(
+            "Given 'start' parameter (5) is out of range. List only have 5"
+            " elements."
+        )
+    ):
         __type_of(test_list_a).index(test_list_a, 10, start=5, end=50)
-    with assert_raises(contains="Cannot find index of a value in an empty list."):
+    with assert_raises(
+        contains="Cannot find index of a value in an empty list."
+    ):
         __type_of(List[Int]()).index(List[Int](), 10)
-
 
     var test_list_b = List[Int](10, 20, 30, 20, 10)
 
@@ -413,7 +433,9 @@ def test_list_index():
         _ = __type_of(test_list_b).index(test_list_b, 10, start=1, end=4)
 
     # Test search within a range that includes multiple occurrences
-    assert_equal(__type_of(test_list_b).index(test_list_b, 20, start=1, end=4), 1)
+    assert_equal(
+        __type_of(test_list_b).index(test_list_b, 20, start=1, end=4), 1
+    )
 
     # Verify error when constrained range excludes occurrences
     with assert_raises(contains="ValueError: Given element is not in list"):

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -374,6 +374,16 @@ def test_list_index():
     with assert_raises(contains="ValueError: Given element is not in list"):
         _ = __type_of(test_list_a).index(test_list_a, 30, start=3, end=1)
 
+    # Tests With End Parameter Only
+    assert_equal(__type_of(test_list_a).index(test_list_a, 30, end=3), 2)
+    assert_equal(__type_of(test_list_a).index(test_list_a, 30, end=-2), 2)
+    with assert_raises(contains="ValueError: Given element is not in list"):
+        _ = __type_of(test_list_a).index(test_list_a, 30, end=1)
+    with assert_raises(contains="ValueError: Given element is not in list"):
+        _ = __type_of(test_list_a).index(test_list_a, 30, end=2)
+    with assert_raises(contains="ValueError: Given element is not in list"):
+        _ = __type_of(test_list_a).index(test_list_a, 60, end=50)
+
     # Edge Cases and Special Conditions
     assert_equal(__type_of(test_list_a).index(test_list_a, 10, start=-5, end=-1), 0)
     assert_equal(__type_of(test_list_a).index(test_list_a, 10, start=0, end=50), 0)
@@ -385,8 +395,6 @@ def test_list_index():
         _ = __type_of(test_list_a).index(test_list_a, 10, start=-4, end=-1)
     with assert_raises(contains="Given 'start' parameter (5) is out of range. List only have 5 elements."):
         _ = __type_of(test_list_a).index(test_list_a, 10, start=5, end=50)
-    
-    # Verify error when list is empty.
     with assert_raises(contains="Cannot find index of a value in an empty list."):
         _ = __type_of(List[Int]()).index(List[Int](), 10)
 


### PR DESCRIPTION
This pull request introduces the new `index` method to the `collections.List` struct within mojo-stdlib, mirroring the exact functionality found in Python's list, as detailed [here](https://docs.python.org/3/tutorial/datastructures.html).

This also allows for the specification of start and end parameters when searching for an item's index within a list, with both parameters accepting positive and negative numbers.

Also comprehensive suite of unit tests included meticulously designed to cover a wide range of scenarios for the `index` method's application.