### PR TITLE
Revert "[mojo-stdlib] Replace `register_passable` `__init__ -> Self` usages in `stdlib/src/memory`"

### DIFF
--- a/stdlib/src/memory/anypointer.mojo
+++ b/stdlib/src/memory/anypointer.mojo
@@ -42,18 +42,27 @@ struct AnyPointer[T: Movable](
     """The underlying pointer."""
 
     @always_inline
-    fn __init__(inout self):
-        """Create a null pointer."""
-        self.value = __mlir_attr[`#interp.pointer<0> : `, Self.pointer_type]
+    fn __init__() -> Self:
+        """Create a null pointer.
+
+        Returns:
+            A null pointer.
+        """
+        return Self {
+            value: __mlir_attr[`#interp.pointer<0> : `, Self.pointer_type]
+        }
 
     @always_inline
-    fn __init__(inout self, value: Self.pointer_type):
+    fn __init__(value: Self.pointer_type) -> Self:
         """Create a pointer with the input value.
 
         Args:
             value: The input pointer to construct with.
+
+        Returns:
+            A null pointer.
         """
-        self.value = value
+        return Self {value: value}
 
     @staticmethod
     @always_inline


### PR DESCRIPTION
Reverts modularml/mojo#2090.  With this, we're seeing some increases in IR size and potential negative performance with this change, so internally, we'll want to dig into that before replacing it everywhere.  Reverting for now until we can do the investigation and then reapply.