### PR TITLE
[Scripts] Add override for compiler version checking

### DIFF
--- a/stdlib/scripts/build-stdlib.sh
+++ b/stdlib/scripts/build-stdlib.sh
@@ -22,12 +22,14 @@ mkdir -p "${BUILD_DIR}"
 ACTUAL_COMPILER_VERSION=$(mojo --version | tr " " "\n" | sed -n 2p)
 EXPECTED_COMPILER_VERSION=$(<"${REPO_ROOT}"/stdlib/COMPATIBLE_COMPILER_VERSION)
 
-if [ "${EXPECTED_COMPILER_VERSION}" != "${ACTUAL_COMPILER_VERSION}" ]; then
-  echo "Mismatch in compiler versions! Cannot build the standard library."
-  echo "Expected compiler version: ${EXPECTED_COMPILER_VERSION}"
-  echo "Current installed compiler version: ${ACTUAL_COMPILER_VERSION}"
-  echo "Please run modular update nightly/mojo to get the latest compiler."
-  exit 1
+if [ -z "${MOJO_OVERRIDE_COMPILER_VERSION_CHECK:-}" ]; then
+  if [ "${EXPECTED_COMPILER_VERSION}" != "${ACTUAL_COMPILER_VERSION}" ]; then
+    echo "Mismatch in compiler versions! Cannot build the standard library."
+    echo "Expected compiler version: ${EXPECTED_COMPILER_VERSION}"
+    echo "Current installed compiler version: ${ACTUAL_COMPILER_VERSION}"
+    echo "Please run modular update nightly/mojo to get the latest compiler."
+    exit 1
+  fi
 fi
 
 STDLIB_PATH="${REPO_ROOT}/stdlib/src"


### PR DESCRIPTION
Add an override ability for doing the compiler version checking.  This is opt-in based on the environment variable `MOJO_OVERRIDE_COMPILER_VERSION_CHECK`.  By default, we still do the compiler version checking.  Internally, this allows us to test to make sure the workflow upstream works for unreleased compilers that, by definition, would have a different compiler version than the one in the `COMPATIBLE_COMPILER_VERSION` file.