### PR TITLE
[mojo-stdlib] Fix `len` for unary `range` with negative `end` value

### DIFF
--- a/stdlib/src/builtin/range.mojo
+++ b/stdlib/src/builtin/range.mojo
@@ -48,6 +48,11 @@ fn _abs(x: Int) -> Int:
     return x if x > 0 else -x
 
 
+@always_inline
+fn _max(a: Int, b: Int) -> Int:
+    return a if a > b else b
+
+
 # ===----------------------------------------------------------------------=== #
 # Range
 # ===----------------------------------------------------------------------=== #
@@ -60,8 +65,8 @@ struct _ZeroStartingRange(Sized):
 
     @always_inline("nodebug")
     fn __init__(inout self, end: Int):
-        self.curr = end
-        self.end = end
+        self.curr = _max(0, end)
+        self.end = self.curr
 
     @always_inline("nodebug")
     fn __iter__(self) -> Self:

--- a/stdlib/test/builtin/test_range.mojo
+++ b/stdlib/test/builtin/test_range.mojo
@@ -16,6 +16,8 @@ from testing import assert_equal
 
 
 fn test_range_len() raises:
+    assert_equal(range(0).__len__(), 0)
+    assert_equal(range(-1).__len__(), 0)
     assert_equal(range(10).__len__(), 10)
     assert_equal(range(0, 10).__len__(), 10)
     assert_equal(range(5, 10).__len__(), 5)


### PR DESCRIPTION
I think we could simply `_ZeroStartingRange` and use `_SequentialRange`.