### PR TITLE
[Docs] Updates parameters doc with typo fix.

### DIFF
--- a/docs/manual/parameters/index.ipynb
+++ b/docs/manual/parameters/index.ipynb
@@ -1261,7 +1261,7 @@
    "source": [
     "The `eat()` function takes a `Fudge` struct with the first parameter (`sugar`)\n",
     "bound to the value 5. The second and third parameters, `cream` and `chocolate`\n",
-    "are.\n",
+    "are unbound.\n",
     "\n",
     "The unbound `cream` and `chocolate` parameters become implicit input parameters\n",
     "on the `eat` function. In practice, this is roughly equivalent to writing:"


### PR DESCRIPTION
Missed a word in a paragraph about bound and unbound parameters.