### PR TITLE
[mojo-stdlib] Implement Corresponding Regular Methods for 4 Overloaded `Set` Operators

### DIFF
--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -310,7 +310,7 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
                 result.add(v[])
 
         return result^
-    
+
     fn difference(self, other: Self) -> Self:
         """Set difference.
 
@@ -326,7 +326,7 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
             if e[] not in other:
                 result.add(e[])
         return result^
-    
+
     fn update(inout self, other: Self):
         """In-place set update.
 
@@ -338,7 +338,7 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
         """
         for e in other:
             self.add(e[])
-    
+
     fn difference_update(inout self, other: Self):
         """In-place set difference update.
 
@@ -349,7 +349,7 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
             other: Another Set instance to compare with this one.
         """
         self.remove_all(other)
-    
+
     fn intersection_update(inout self, other: Self):
         """In-place set intersection update.
 


### PR DESCRIPTION
## Implement Corresponding Regular Methods for 4 Overloaded `Set` Operators

This pull request ensures that, alongside the existing functionality of overloaded operators for `Set`, their corresponding regular methods are also fully implemented as they are in Python.

The following methods have been introduced to correspond with their respective operators:

- `__sub__` (-): Now corresponds to `Set.difference()`
- `__isub__` (-=): Now corresponds to `Set.difference_update()`
- `__iand__` (&=): Now corresponds to `Set.intersection_update()`
- `__ior__` (|=): Now corresponds to `Set.update()`

Previously, these magic methods lacked their equivalent regular methods. This update rectifies that by ensuring that calls to the magic methods are properly linked to their corresponding regular methods.

Note: No changes are needed for the `test_set.mojo` file, as this update merely relocates the existing code for the overloaded operators to their respective regular functions without adding any new functionality that needs to be tested.