### PR TITLE
[stdlib] Add `reversed`

### DIFF
--- a/stdlib/src/builtin/reversed.mojo
+++ b/stdlib/src/builtin/reversed.mojo
@@ -1,0 +1,96 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Provides the `reversed` function for reverse iteration over collections.
+
+These are Mojo built-ins, so you don't need to import them.
+"""
+
+from .range import _StridedRangeIterator
+
+from collections.list import _ListIter
+
+# ===----------------------------------------------------------------------=== #
+#  Reversible
+# ===----------------------------------------------------------------------=== #
+
+
+trait ReversibleRange:
+    """
+    The `ReversibleRange` trait describes a range that can be reversed.
+
+    Any type that conforms to `ReversibleRange` works with the builtin
+    [`reversed()`](/mojo/stdlib/builtin/reversed.html) functions.
+
+    The `ReversibleRange` trait requires the type to define the `__reversed__()`
+    method.
+
+    **Note**: iterators are currently non-raising.
+    """
+
+    # TODO: general `Reversible` trait that returns an iterator.
+    # iterators currently check __len__() instead of raising an exception
+    # so there is no ReversibleRaising trait yet.
+
+    fn __reversed__(self) -> _StridedRangeIterator:
+        """Get a reversed iterator for the type.
+
+        **Note**: iterators are currently non-raising.
+
+        Returns:
+            The reversed iterator of the type.
+        """
+        ...
+
+
+# ===----------------------------------------------------------------------=== #
+#  reversed
+# ===----------------------------------------------------------------------=== #
+
+
+fn reversed[T: ReversibleRange](value: T) -> _StridedRangeIterator:
+    """Get a reversed iterator of the input range.
+
+    **Note**: iterators are currently non-raising.
+
+    Parameters:
+        T: The type conforming to ReversibleRange.
+
+    Args:
+        value: The range to get the reversed iterator of.
+
+    Returns:
+        The reversed iterator of the range.
+    """
+    return value.__reversed__()
+
+
+fn reversed[
+    mutability: __mlir_type.`i1`,
+    self_life: AnyLifetime[mutability].type,
+    T: CollectionElement,
+](
+    value: Reference[List[T], mutability, self_life]._mlir_type,
+) -> _ListIter[
+    T, mutability, self_life, False
+]:
+    """Get a reversed iterator of the input list.
+
+    **Note**: iterators are currently non-raising.
+
+    Args:
+        value: The list to get the reversed iterator of.
+
+    Returns:
+        The reversed iterator of the list.
+    """
+    return Reference(value)[].__reversed__[mutability, self_life]()

--- a/stdlib/test/builtin/test_range.mojo
+++ b/stdlib/test/builtin/test_range.mojo
@@ -15,25 +15,104 @@
 from testing import assert_equal
 
 
-fn test_range_len() raises:
-    assert_equal(range(0).__len__(), 0)
-    assert_equal(range(-1).__len__(), 0)
-    assert_equal(range(10).__len__(), 10)
-    assert_equal(range(0, 10).__len__(), 10)
-    assert_equal(range(5, 10).__len__(), 5)
-    assert_equal(range(10, 0, -1).__len__(), 10)
-    assert_equal(range(0, 10, 2).__len__(), 5)
-    assert_equal(range(38, -13, -23).__len__(), 3)
+def test_range_len():
+    # Usual cases
+    assert_equal(range(10).__len__(), 10, "len(range(10))")
+    assert_equal(range(0, 10).__len__(), 10, "len(range(0, 10))")
+    assert_equal(range(5, 10).__len__(), 5, "len(range(5, 10))")
+    assert_equal(range(10, 0, -1).__len__(), 10, "len(range(10, 0, -1))")
+    assert_equal(range(0, 10, 2).__len__(), 5, "len(range(0, 10, 2))")
+    assert_equal(range(38, -13, -23).__len__(), 3, "len(range(38, -13, -23))")
+
+    # Edge cases
+    assert_equal(range(0).__len__(), 0, "len(range(0))")
+    assert_equal(range(-10).__len__(), 0, "len(range(-10))")
+    assert_equal(range(0, 0).__len__(), 0, "len(range(0, 0))")
+    assert_equal(range(10, 0).__len__(), 0, "len(range(10, 0))")
+    assert_equal(range(0, 0, 1).__len__(), 0, "len(range(0, 0, 1))")
+    assert_equal(range(5, 10, -1).__len__(), 0, "len(range(5, 10, -1))")
+    assert_equal(range(10, 5, 1).__len__(), 0, "len(range(10, 5, 1))")
+    assert_equal(range(5, 10, -10).__len__(), 0, "len(range(5, 10, -10))")
+    assert_equal(range(10, 5, 10).__len__(), 0, "len(range(10, 5, 10))")
+    assert_equal(range(5, 10, 20).__len__(), 1, "len(range(5, 10, 20))")
+    assert_equal(range(10, 5, -20).__len__(), 1, "len(range(10, 5, -20))")
 
 
-fn test_range_getitem() raises:
-    assert_equal(range(10)[5], 5)
-    assert_equal(range(0, 10)[3], 3)
-    assert_equal(range(5, 10)[3], 8)
-    assert_equal(range(10, 0, -1)[2], 8)
-    assert_equal(range(0, 10, 2)[4], 8)
+def test_range_getitem():
+    # Usual cases
+    assert_equal(range(10)[3], 3, "range(10)[3]")
+    assert_equal(range(0, 10)[3], 3, "range(0, 10)[3]")
+    assert_equal(range(5, 10)[3], 8, "range(5, 10)[3]")
+    assert_equal(range(5, 10)[4], 9, "range(5, 10)[4]")
+    assert_equal(range(10, 0, -1)[2], 8, "range(10, 0, -1)[2]")
+    assert_equal(range(0, 10, 2)[4], 8, "range(0, 10, 2)[4]")
+    assert_equal(range(38, -13, -23)[1], 15, "range(38, -13, -23)[1]")
+
+
+def test_range_reversed():
+    # Zero starting
+    assert_equal(
+        range(10).__reversed__().start, 9, "range(10).__reversed__().start"
+    )
+    assert_equal(
+        range(10).__reversed__().end, -1, "range(10).__reversed__().end"
+    )
+    assert_equal(
+        range(10).__reversed__().step, -1, "range(10).__reversed__().step"
+    )
+    # Sequential
+    assert_equal(
+        range(5, 10).__reversed__().start, 9, "range(5,10).__reversed__().start"
+    )
+    assert_equal(
+        range(5, 10).__reversed__().end, 4, "range(5,10).__reversed__().end"
+    )
+    assert_equal(
+        range(5, 10).__reversed__().step, -1, "range(5,10).__reversed__().step"
+    )
+    # Strided
+    assert_equal(
+        range(38, -13, -23).__reversed__().start,
+        -8,
+        "range(38, -13, -23).__reversed__().start",
+    )
+    assert_equal(
+        range(38, -13, -23).__reversed__().end,
+        61,
+        "range(38, -13, -23).__reversed__().end",
+    )
+    assert_equal(
+        range(38, -13, -23).__reversed__().step,
+        23,
+        "range(38, -13, -23).__reversed__().step",
+    )
+
+    # Test a reversed range's sum and length compared to the original
+    @parameter
+    fn test_sum_reversed(start: Int, end: Int, step: Int) raises:
+        var forward = range(start, end, step)
+        var iforward = forward.__iter__()
+        var ibackward = forward.__reversed__()
+        var backward = range(ibackward.start, ibackward.end, ibackward.step)
+        assert_equal(
+            forward.__len__(), backward.__len__(), "len(forward), len(backward)"
+        )
+        var forward_sum = 0
+        var backward_sum = 0
+        for i in range(len(forward)):
+            forward_sum += iforward.__next__()
+            backward_sum += ibackward.__next__()
+        assert_equal(forward_sum, backward_sum, "forward_sum, backward_sum")
+
+    # Test using loops and reversed
+    for end in range(10, 13):
+        test_sum_reversed(1, end, 3)
+
+    for end in range(10, 13).__reversed__():
+        test_sum_reversed(20, end, -3)
 
 
 def main():
     test_range_len()
     test_range_getitem()
+    test_range_reversed()

--- a/stdlib/test/builtin/test_reversed.mojo
+++ b/stdlib/test/builtin/test_reversed.mojo
@@ -1,0 +1,28 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# RUN: %mojo -debug-level full %s
+
+from testing import assert_equal
+
+
+def test_reversed_list():
+    var list = List[Int](1, 2, 3, 4, 5, 6)
+    var check: Int = 6
+
+    for item in reversed(list):
+        assert_equal(item[], check, "item[], check")
+        check -= 1
+
+
+def main():
+    test_reversed_list()


### PR DESCRIPTION
Adds an initial implementation of `reversed()`, for getting a reversed iterator of a range or list.

This isn't meant to be final, since iterators are not fully worked out yet, but it works for now.

Changes:
- Added submodule `/builtin/reversed.mojo` 
- Added function `reversed()`
- Added trait `ReversibleRange`
- Implemented `ReversibleRange` for ranges
- Added method `__reversed__()` in `List`
- Changed `_ListIter` to allow for backwards iteration
- Added tests for ranges and reversed list iterator
- Fixed original ranges with negative size not passing the new tests
