### PR TITLE
[CI] Re-enable examples

### DIFF
--- a/.github/workflows/standard_library_tests_and_examples.yml
+++ b/.github/workflows/standard_library_tests_and_examples.yml
@@ -131,5 +131,4 @@ jobs:
       - name: Run standard library tests and examples
         run: |
           ./stdlib/scripts/run-tests.sh
-          # TODO: Examples are currently broken with latest nightly
-          # ./examples/run-examples.sh
+          ./examples/run-examples.sh


### PR DESCRIPTION
It was thought that the examples were breaking with the latest `nightly/mojo` release today.  However, that seemed to be an environmental problem.  They work fine on Ubuntu and macOS.