### PR TITLE
[stdlib] Add trait `Boolable` to `Dict` and `List`

### DIFF
--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -303,7 +303,9 @@ struct _DictIndex:
         self.data.free()
 
 
-struct Dict[K: KeyElement, V: CollectionElement](Sized, CollectionElement):
+struct Dict[K: KeyElement, V: CollectionElement](
+    Sized, CollectionElement, Boolable
+):
     """A container that stores key-value pairs.
 
     The key type and value type must be specified statically, unlike a Python
@@ -504,6 +506,14 @@ struct Dict[K: KeyElement, V: CollectionElement](Sized, CollectionElement):
     fn __len__(self) -> Int:
         """The number of elements currenly stored in the dictionary."""
         return self.size
+
+    fn __bool__(self) -> Bool:
+        """Check if the dictionary is empty or not.
+
+        Returns:
+            `False` if the dictionary is empty, `True` if there is at least one element.
+        """
+        return len(self).__bool__()
 
     fn find(self, key: K) -> Optional[V]:
         """Find a value in the dictionary by key.

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -69,7 +69,7 @@ struct _ListIter[
         return len(self.src[]) - self.index
 
 
-struct List[T: CollectionElement](CollectionElement, Sized):
+struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
     """The `List` type is a dynamically-allocated list.
 
     It supports pushing and popping from the back resizing the underlying
@@ -173,6 +173,14 @@ struct List[T: CollectionElement](CollectionElement, Sized):
             The number of elements in the list.
         """
         return self.size
+
+    fn __bool__(self) -> Bool:
+        """Checks if the list is empty.
+
+        Returns:
+            `False` if the list is empty, `True` if there is at least one element.
+        """
+        return len(self).__bool__()
 
     @always_inline
     fn _realloc(inout self, new_capacity: Int):

--- a/stdlib/test/collections/test_dict.mojo
+++ b/stdlib/test/collections/test_dict.mojo
@@ -41,6 +41,19 @@ def test_multiple_resizes():
     assert_equal(20, dict["key19"])
 
 
+def test_bool_conversion():
+    var dict = Dict[String, Int]()
+    assert_false(dict)
+    dict["a"] = 1
+    assert_true(dict)
+    dict["b"] = 2
+    assert_true(dict)
+    dict.pop("a")
+    assert_true(dict)
+    dict.pop("b")
+    assert_false(dict)
+
+
 def test_big_dict():
     var dict = Dict[String, Int]()
     for i in range(2000):
@@ -322,3 +335,4 @@ def test_owned_kwargs_dict():
 def main():
     test_dict()
     test_owned_kwargs_dict()
+    test_bool_conversion()

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -15,7 +15,7 @@
 from collections import List
 
 from test_utils import CopyCounter, MoveCounter
-from testing import assert_equal
+from testing import assert_equal, assert_false, assert_true
 
 
 def test_mojo_issue_698():
@@ -66,6 +66,13 @@ def test_list_clear():
 
     assert_equal(len(list), 0)
     assert_equal(list.capacity, 3)
+
+
+def test_list_to_bool_conversion():
+    assert_false(List[String]())
+    assert_true(List[String]("a"))
+    assert_true(List[String]("", "a"))
+    assert_true(List[String](""))
 
 
 def test_list_pop():
@@ -568,6 +575,7 @@ def main():
     test_mojo_issue_698()
     test_list()
     test_list_clear()
+    test_list_to_bool_conversion()
     test_list_pop()
     test_list_variadic_constructor()
     test_list_resize()


### PR DESCRIPTION
This allows a very common pattern that's available in python:

```mojo
error_messages = List[String]()
for ... in ...:
    if ...:
        error_messages.append("some new error")

if error_messages:
    print("There were errors!!!")
    ....
    sys.exit(1)

```