### PR TITLE
[stdlib] Fix `Int.MIN` error

### DIFF
--- a/stdlib/src/builtin/dtype.mojo
+++ b/stdlib/src/builtin/dtype.mojo
@@ -334,6 +334,24 @@ struct DType(Stringable, KeyElement):
         return self.isa[DType.index]()
 
     @always_inline("nodebug")
+    fn is_index32(self) -> Bool:
+        """Checks if this DType is Index and 32 bit.
+
+        Returns:
+            True if this DType is Index and 32 bit, False otherwise.
+        """
+        return self.is_index() and (self.sizeof() == DType.int32.sizeof())
+
+    @always_inline("nodebug")
+    fn is_index64(self) -> Bool:
+        """Checks if this DType is Index and 64 bit.
+
+        Returns:
+            True if this DType is Index and 64 bit, False otherwise.
+        """
+        return self.is_index() and (self.sizeof() == DType.int64.sizeof())
+
+    @always_inline("nodebug")
     fn is_address(self) -> Bool:
         """Checks if this DType is Address.
 

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -105,6 +105,11 @@ fn _unchecked_zero[type: DType, size: Int]() -> SIMD[type, size]:
     }
 
 
+# ===------------------------------------------------------------------------===#
+# SIMD
+# ===------------------------------------------------------------------------===#
+
+
 @lldb_formatter_wrapping_type
 @register_passable("trivial")
 struct SIMD[type: DType, size: Int = simdwidthof[type]()](
@@ -2465,11 +2470,6 @@ fn _neginf[type: DType]() -> Scalar[type]:
 # ===----------------------------------------------------------------------===#
 
 
-@always_inline("nodebug")
-fn _is_32_bit_system() -> Bool:
-    return sizeof[DType.index]() == sizeof[DType.int32]()
-
-
 @always_inline
 fn _max_finite[type: DType]() -> Scalar[type]:
     """Returns the maximum finite value of type.
@@ -2491,13 +2491,13 @@ fn _max_finite[type: DType]() -> Scalar[type]:
         return 32767
     elif type == DType.uint16:
         return 65535
-    elif type == DType.int32 or (type == DType.index and _is_32_bit_system()):
+    elif type == DType.int32 or type.is_index32():
         return 2147483647
     elif type == DType.uint32:
         return 4294967295
-    elif type == DType.int64 or (
-        type == DType.index and not _is_32_bit_system()
-    ):
+    elif type == DType.float32:
+        return 3.40282346638528859812e38
+    elif type == DType.int64 or type.is_index64():
         return 9223372036854775807
     elif type == DType.uint64:
         return 18446744073709551615
@@ -2538,11 +2538,9 @@ fn _min_finite[type: DType]() -> Scalar[type]:
         return -128
     elif type == DType.int16:
         return -32768
-    elif type == DType.int32 or (type == DType.index and _is_32_bit_system()):
+    elif type == DType.int32 or type.is_index32():
         return -2147483648
-    elif type == DType.int64 or (
-        type == DType.index and not _is_32_bit_system()
-    ):
+    elif type == DType.int64 or type.is_index64():
         return -9223372036854775808
     elif type.is_floating_point():
         return -_max_finite[type]()

--- a/stdlib/src/sys/info.mojo
+++ b/stdlib/src/sys/info.mojo
@@ -447,6 +447,32 @@ fn is_big_endian[
 
 
 @always_inline("nodebug")
+fn is_32bit[target: __mlir_type.`!kgen.target` = _current_target()]() -> Bool:
+    """Returns True if the maximum integral value is 32 bit.
+
+    Parameters:
+        target: The target architecture.
+
+    Returns:
+        True if the maximum integral value is 32 bit, False otherwise.
+    """
+    return sizeof[DType.index, target]() == sizeof[DType.int32, target]()
+
+
+@always_inline("nodebug")
+fn is_64bit[target: __mlir_type.`!kgen.target` = _current_target()]() -> Bool:
+    """Returns True if the maximum integral value is 64 bit.
+
+    Parameters:
+        target: The target architecture.
+
+    Returns:
+        True if the maximum integral value is 64 bit, False otherwise.
+    """
+    return sizeof[DType.index, target]() == sizeof[DType.int64, target]()
+
+
+@always_inline("nodebug")
 fn simdbitwidth[
     target: __mlir_type.`!kgen.target` = _current_target()
 ]() -> Int:

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -403,6 +403,24 @@ def test_extract():
     )
 
 
+def test_limits():
+    @parameter
+    fn test_integral_overflow[type: DType]() raises:
+        var max_value = Scalar[type].MAX
+        var min_value = Scalar[type].MIN
+        assert_equal(max_value + 1, min_value)
+
+    test_integral_overflow[DType.index]()
+    test_integral_overflow[DType.int8]()
+    test_integral_overflow[DType.uint8]()
+    test_integral_overflow[DType.int16]()
+    test_integral_overflow[DType.uint16]()
+    test_integral_overflow[DType.int32]()
+    test_integral_overflow[DType.uint32]()
+    test_integral_overflow[DType.int64]()
+    test_integral_overflow[DType.uint64]()
+
+
 def main():
     test_cast()
     test_simd_variadic()
@@ -416,3 +434,4 @@ def main():
     test_deinterleave()
     test_address()
     test_extract()
+    test_limits()


### PR DESCRIPTION
Fixes the compilation error you get when using `Int.MIN`