### PR TITLE
[stdlib] Add the `gather` and `scatter` methods to `DTypePointer`

### DIFF
--- a/stdlib/src/memory/unsafe.mojo
+++ b/stdlib/src/memory/unsafe.mojo
@@ -1641,8 +1641,8 @@ struct DTypePointer[
             "alignment must be 0 or a power of two integer value",
         ]()
 
-        var pointer = offset.cast[DType.index]().fma(sizeof[type](), int(self))
-        return gather(pointer.cast[DType.address](), mask, default, alignment)
+        var base = offset.cast[DType.index]().fma(sizeof[type](), int(self))
+        return gather(base.cast[DType.address](), mask, default, alignment)
 
     @always_inline("nodebug")
     fn scatter[
@@ -1730,8 +1730,8 @@ struct DTypePointer[
             "alignment must be 0 or a power of two integer value",
         ]()
 
-        var pointer = offset.cast[DType.index]().fma(sizeof[type](), int(self))
-        scatter(val, pointer.cast[DType.address](), mask, alignment)
+        var base = offset.cast[DType.index]().fma(sizeof[type](), int(self))
+        scatter(val, base.cast[DType.address](), mask, alignment)
 
     @always_inline("nodebug")
     fn __int__(self) -> Int:

--- a/stdlib/src/memory/unsafe.mojo
+++ b/stdlib/src/memory/unsafe.mojo
@@ -1655,7 +1655,7 @@ struct DTypePointer[
         """Scatters values to memory based on offsets from the current pointer.
 
         This method performs a store operation, scattering each element from
-        the `val` SIMD vector at the memory address calculated by adding the
+        the `val` SIMD vector to the memory address calculated by adding the
         corresponding element from `offset` SIMD vector to the current pointer.
 
         If the same offset is targeted multiple times, the values are stored in
@@ -1695,7 +1695,7 @@ struct DTypePointer[
         """Scatters values to memory based on offsets from the current pointer.
 
         This method performs a conditional store operation, scattering each
-        element from the `val` SIMD vector at the memory address calculated by
+        element from the `val` SIMD vector to the memory address calculated by
         adding the corresponding element from `offset` SIMD vector to the
         current pointer. Storing is done according to the provided `mask` SIMD
         vector, which is used to prevent memory accesses to the masked-off

--- a/stdlib/src/memory/unsafe.mojo
+++ b/stdlib/src/memory/unsafe.mojo
@@ -1556,12 +1556,8 @@ struct DTypePointer[
 
     @always_inline("nodebug")
     fn gather[
-        offset_type: DType,
-        /,
-        *,
-        width: Int = 1,
-        alignment: Int = Self._default_alignment,
-    ](self, offset: SIMD[offset_type, width]) -> SIMD[type, width]:
+        *, width: Int = 1, alignment: Int = Self._default_alignment
+    ](self, offset: SIMD[_, width]) -> SIMD[type, width]:
         """Gathers a SIMD vector from offsets of the current pointer.
 
         This method loads from memory addresses calculated by appropriately
@@ -1569,10 +1565,9 @@ struct DTypePointer[
 
         Constraints:
             The offset type must be an integral type.
-            The alignment must be 0 or a power of two integer value.
+            The alignment must be a power of two integer value.
 
         Parameters:
-            offset_type: The type of the `offset` SIMD vector.
             width: The SIMD width.
             alignment: The minimal alignment of the address.
 
@@ -1590,14 +1585,10 @@ struct DTypePointer[
 
     @always_inline("nodebug")
     fn gather[
-        offset_type: DType,
-        /,
-        *,
-        width: Int = 1,
-        alignment: Int = Self._default_alignment,
+        *, width: Int = 1, alignment: Int = Self._default_alignment
     ](
         self,
-        offset: SIMD[offset_type, width],
+        offset: SIMD[_, width],
         mask: SIMD[DType.bool, width],
         default: SIMD[type, width],
     ) -> SIMD[type, width]:
@@ -1614,10 +1605,9 @@ struct DTypePointer[
 
         Constraints:
             The offset type must be an integral type.
-            The alignment must be 0 or a power of two integer value.
+            The alignment must be a power of two integer value.
 
         Parameters:
-            offset_type: The type of the `offset` SIMD vector.
             width: The SIMD width.
             alignment: The minimal alignment of the address.
 
@@ -1633,12 +1623,12 @@ struct DTypePointer[
             The SIMD vector containing the gathered values.
         """
         constrained[
-            offset_type.is_integral(),
+            offset.type.is_integral(),
             "offset type must be an integral type",
         ]()
         constrained[
-            (alignment == 0) | _is_power_of_2(alignment),
-            "alignment must be 0 or a power of two integer value",
+            _is_power_of_2(alignment),
+            "alignment must be a power of two integer value",
         ]()
 
         var base = offset.cast[DType.index]().fma(sizeof[type](), int(self))
@@ -1646,12 +1636,8 @@ struct DTypePointer[
 
     @always_inline("nodebug")
     fn scatter[
-        offset_type: DType,
-        /,
-        *,
-        width: Int = 1,
-        alignment: Int = Self._default_alignment,
-    ](self, offset: SIMD[offset_type, width], val: SIMD[type, width]):
+        *, width: Int = 1, alignment: Int = Self._default_alignment
+    ](self, offset: SIMD[_, width], val: SIMD[type, width]):
         """Scatters a SIMD vector into offsets of the current pointer.
 
         This method stores at memory addresses calculated by appropriately
@@ -1663,10 +1649,9 @@ struct DTypePointer[
 
         Constraints:
             The offset type must be an integral type.
-            The alignment must be 0 or a power of two integer value.
+            The alignment must be a power of two integer value.
 
         Parameters:
-            offset_type: The type of the `offset` SIMD vector.
             width: The SIMD width.
             alignment: The minimal alignment of the address.
 
@@ -1679,14 +1664,10 @@ struct DTypePointer[
 
     @always_inline("nodebug")
     fn scatter[
-        offset_type: DType,
-        /,
-        *,
-        width: Int = 1,
-        alignment: Int = Self._default_alignment,
+        *, width: Int = 1, alignment: Int = Self._default_alignment
     ](
         self,
-        offset: SIMD[offset_type, width],
+        offset: SIMD[_, width],
         val: SIMD[type, width],
         mask: SIMD[DType.bool, width],
     ):
@@ -1707,10 +1688,9 @@ struct DTypePointer[
 
         Constraints:
             The offset type must be an integral type.
-            The alignment must be 0 or a power of two integer value.
+            The alignment must be a power of two integer value.
 
         Parameters:
-            offset_type: The type of the `offset` SIMD vector.
             width: The SIMD width.
             alignment: The minimal alignment of the address.
 
@@ -1721,12 +1701,12 @@ struct DTypePointer[
                 element whether to store at memory or not.
         """
         constrained[
-            offset_type.is_integral(),
+            offset.type.is_integral(),
             "offset type must be an integral type",
         ]()
         constrained[
-            (alignment == 0) | _is_power_of_2(alignment),
-            "alignment must be 0 or a power of two integer value",
+            _is_power_of_2(alignment),
+            "alignment must be a power of two integer value",
         ]()
 
         var base = offset.cast[DType.index]().fma(sizeof[type](), int(self))

--- a/stdlib/src/memory/unsafe.mojo
+++ b/stdlib/src/memory/unsafe.mojo
@@ -1562,11 +1562,10 @@ struct DTypePointer[
         width: Int = 1,
         alignment: Int = Self._default_alignment,
     ](self, offset: SIMD[offset_type, width]) -> SIMD[type, width]:
-        """Gathers values based on offsets from the current pointer.
+        """Gathers a SIMD vector from offsets of the current pointer.
 
-        This method performs a load operation, gathering values from addresses
-        calculated by adding the specified `offset` SIMD vector to the current
-        pointer.
+        This method loads from memory addresses calculated by appropriately
+        shifting the current pointer according to the `offset` SIMD vector.
 
         Constraints:
             The offset type must be an integral type.
@@ -1578,11 +1577,10 @@ struct DTypePointer[
             alignment: The minimal alignment of the address.
 
         Args:
-            offset: A SIMD vector of offsets to be added to the current pointer
-                for the gather operation.
+            offset: The SIMD vector of offsets to gather from.
 
         Returns:
-            A SIMD vector containing the gathered values.
+            The SIMD vector containing the gathered values.
         """
         var mask = SIMD[DType.bool, width](True)
         var default = SIMD[type, width]()
@@ -1603,13 +1601,16 @@ struct DTypePointer[
         mask: SIMD[DType.bool, width],
         default: SIMD[type, width],
     ) -> SIMD[type, width]:
-        """Gathers values based on offsets from the current pointer.
+        """Gathers a SIMD vector from offsets of the current pointer.
 
-        This method performs a conditional load operation, gathering values
-        from addresses calculated by adding the specified `offset` SIMD vector
-        to the current pointer. For each element, if the corresponding mask
-        value is `True`, the method loads the value from memory; otherwise, it
-        uses the respective value from the `default` SIMD vector instead.
+        This method loads from memory addresses calculated by appropriately
+        shifting the current pointer according to the `offset` SIMD vector,
+        or takes from the `default` SIMD vector, depending on the values of
+        the `mask` SIMD vector.
+
+        If a mask element is `True`, the respective result element is given
+        by the current pointer and the `offset` SIMD vector; otherwise, the
+        result element is taken from the `default` SIMD vector.
 
         Constraints:
             The offset type must be an integral type.
@@ -1621,16 +1622,15 @@ struct DTypePointer[
             alignment: The minimal alignment of the address.
 
         Args:
-            offset: A SIMD vector of offsets to be added to the current pointer
-                for the gather operation.
-            mask: A SIMD vector of boolean values, indicating for each element
-                whether to load from memory or use the `default` SIMD vector.
-            default: A SIMD vector providing default values to be used where
-                the `mask` SIMD vector is `False`.
+            offset: The SIMD vector of offsets to gather from.
+            mask: The SIMD vector of boolean values, indicating for each
+                element whether to load from memory or to take from the
+                `default` SIMD vector.
+            default: The SIMD vector providing default values to be taken
+                where the `mask` SIMD vector is `False`.
 
         Returns:
-            A SIMD vector containing the gathered values or default values for
-            masked-off positions.
+            The SIMD vector containing the gathered values.
         """
         constrained[
             offset_type.is_integral(),
@@ -1652,15 +1652,14 @@ struct DTypePointer[
         width: Int = 1,
         alignment: Int = Self._default_alignment,
     ](self, offset: SIMD[offset_type, width], val: SIMD[type, width]):
-        """Scatters values to memory based on offsets from the current pointer.
+        """Scatters a SIMD vector into offsets of the current pointer.
 
-        This method performs a store operation, scattering each element from
-        the `val` SIMD vector to the memory address calculated by adding the
-        corresponding element from `offset` SIMD vector to the current pointer.
+        This method stores at memory addresses calculated by appropriately
+        shifting the current pointer according to the `offset` SIMD vector.
 
-        If the same offset is targeted multiple times, the values are stored in
-        the order they appear in the `val` SIMD vector, from the first to the
-        last element.
+        If the same offset is targeted multiple times, the values are stored
+        in the order they appear in the `val` SIMD vector, from the first to
+        the last element.
 
         Constraints:
             The offset type must be an integral type.
@@ -1672,9 +1671,8 @@ struct DTypePointer[
             alignment: The minimal alignment of the address.
 
         Args:
-            offset: A SIMD vector of offsets to be added to the current pointer
-                for the scatter operation.
-            val: A SIMD vector containing the values to be scattered.
+            offset: The SIMD vector of offsets to scatter into.
+            val: The SIMD vector containing the values to be scattered.
         """
         var mask = SIMD[DType.bool, width](True)
         self.scatter[width=width, alignment=alignment](offset, val, mask)
@@ -1692,18 +1690,20 @@ struct DTypePointer[
         val: SIMD[type, width],
         mask: SIMD[DType.bool, width],
     ):
-        """Scatters values to memory based on offsets from the current pointer.
+        """Scatters a SIMD vector into offsets of the current pointer.
 
-        This method performs a conditional store operation, scattering each
-        element from the `val` SIMD vector to the memory address calculated by
-        adding the corresponding element from `offset` SIMD vector to the
-        current pointer. Storing is done according to the provided `mask` SIMD
-        vector, which is used to prevent memory accesses to the masked-off
-        positions.
+        This method stores at memory addresses calculated by appropriately
+        shifting the current pointer according to the `offset` SIMD vector,
+        depending on the values of the `mask` SIMD vector.
 
-        If the same offset is targeted multiple times, the values are stored in
-        the order they appear in the `val` SIMD vector, from the first to the
-        last element, conditional on the `mask` SIMD vector.
+        If a mask element is `True`, the respective element in the `val` SIMD
+        vector is stored at the memory address defined by the current pointer
+        and the `offset` SIMD vector; otherwise, no action is taken for that
+        element in `val`.
+
+        If the same offset is targeted multiple times, the values are stored
+        in the order they appear in the `val` SIMD vector, from the first to
+        the last element.
 
         Constraints:
             The offset type must be an integral type.
@@ -1715,11 +1715,10 @@ struct DTypePointer[
             alignment: The minimal alignment of the address.
 
         Args:
-            offset: A SIMD vector of offsets to be added to the current pointer
-                for the scatter operation.
-            val: A SIMD vector containing the values to be scattered.
-            mask: A SIMD vector of boolean values, indicating for each element
-                whether to scatter the value to memory or not.
+            offset: The SIMD vector of offsets to scatter into.
+            val: The SIMD vector containing the values to be scattered.
+            mask: The SIMD vector of boolean values, indicating for each
+                element whether to store at memory or not.
         """
         constrained[
             offset_type.is_integral(),

--- a/stdlib/src/sys/intrinsics.mojo
+++ b/stdlib/src/sys/intrinsics.mojo
@@ -675,8 +675,8 @@ fn scatter[
     `mask` and the `value` operand must have the same number of vector
     elements.
 
-    The behavior of the _scatter is undefined if the op stores into
-    the same memory location more than once.
+    Scatter with overlapping addresses is guaranteed to be ordered from
+    least-significant to most-significant element.
 
     In general, for some vector %value, vector of pointers %base, and mask
     %mask instructions of the form:

--- a/stdlib/test/memory/test_memory.mojo
+++ b/stdlib/test/memory/test_memory.mojo
@@ -306,8 +306,8 @@ def test_dtypepointer_gather():
 
     @parameter
     def _test_gather[
-        offset_type: DType, width: Int
-    ](offset: SIMD[offset_type, width], desired: SIMD[ptr.type, width]):
+        width: Int
+    ](offset: SIMD[_, width], desired: SIMD[ptr.type, width]):
         var actual = ptr.gather(offset)
         assert_almost_equal(
             actual, desired, msg="_test_gather", atol=0.0, rtol=0.0
@@ -315,9 +315,9 @@ def test_dtypepointer_gather():
 
     @parameter
     def _test_masked_gather[
-        offset_type: DType, width: Int
+        width: Int
     ](
-        offset: SIMD[offset_type, width],
+        offset: SIMD[_, width],
         mask: SIMD[DType.bool, width],
         default: SIMD[ptr.type, width],
         desired: SIMD[ptr.type, width],
@@ -330,7 +330,7 @@ def test_dtypepointer_gather():
     var offset = SIMD[DType.int64, 8](3, 0, 2, 1, 2, 0, 3, 1)
     var desired = SIMD[ptr.type, 8](3.0, 0.0, 2.0, 1.0, 2.0, 0.0, 3.0, 1.0)
 
-    _test_gather[DType.uint16, 1](2, 2.0)
+    _test_gather[1](UInt16(2), 2.0)
     _test_gather(offset.cast[DType.uint32]().slice[2](), desired.slice[2]())
     _test_gather(offset.cast[DType.uint64]().slice[4](), desired.slice[4]())
 
@@ -338,8 +338,8 @@ def test_dtypepointer_gather():
     var default = SIMD[ptr.type, 8](-1.0)
     desired = SIMD[ptr.type, 8](-1.0, 0.0, 2.0, 1.0, 2.0, 0.0, -1.0, 1.0)
 
-    _test_masked_gather[DType.int16, 1](2, False, -1.0, -1.0)
-    _test_masked_gather[DType.int32, 1](2, True, -1.0, 2.0)
+    _test_masked_gather[1](Int16(2), False, -1.0, -1.0)
+    _test_masked_gather[1](Int32(2), True, -1.0, 2.0)
     _test_masked_gather(offset, mask, default, desired)
 
     ptr.free()
@@ -351,9 +351,9 @@ def test_dtypepointer_scatter():
 
     @parameter
     def _test_scatter[
-        offset_type: DType, width: Int
+        width: Int
     ](
-        offset: SIMD[offset_type, width],
+        offset: SIMD[_, width],
         val: SIMD[ptr.type, width],
         desired: SIMD[ptr.type, 4],
     ):
@@ -365,9 +365,9 @@ def test_dtypepointer_scatter():
 
     @parameter
     def _test_masked_scatter[
-        offset_type: DType, width: Int
+        width: Int
     ](
-        offset: SIMD[offset_type, width],
+        offset: SIMD[_, width],
         val: SIMD[ptr.type, width],
         mask: SIMD[DType.bool, width],
         desired: SIMD[ptr.type, 4],
@@ -378,9 +378,7 @@ def test_dtypepointer_scatter():
             actual, desired, msg="_test_masked_scatter", atol=0.0, rtol=0.0
         )
 
-    _test_scatter[DType.uint16, width=1](
-        2, 2.0, SIMD[ptr.type, 4](0.0, 0.0, 2.0, 0.0)
-    )
+    _test_scatter[1](UInt16(2), 2.0, SIMD[ptr.type, 4](0.0, 0.0, 2.0, 0.0))
     _test_scatter(  # Test with repeated offsets
         SIMD[DType.uint32, 4](1, 1, 1, 1),
         SIMD[ptr.type, 4](-1.0, 2.0, -2.0, 1.0),
@@ -394,11 +392,11 @@ def test_dtypepointer_scatter():
 
     ptr.store(0, SIMD[ptr.type, 4](0.0))
 
-    _test_masked_scatter[DType.int16, width=1](
-        2, 2.0, False, SIMD[ptr.type, 4](0.0, 0.0, 0.0, 0.0)
+    _test_masked_scatter[1](
+        Int16(2), 2.0, False, SIMD[ptr.type, 4](0.0, 0.0, 0.0, 0.0)
     )
-    _test_masked_scatter[DType.int32, width=1](
-        2, 2.0, True, SIMD[ptr.type, 4](0.0, 0.0, 2.0, 0.0)
+    _test_masked_scatter[1](
+        Int32(2), 2.0, True, SIMD[ptr.type, 4](0.0, 0.0, 2.0, 0.0)
     )
     _test_masked_scatter(  # Test with repeated offsets
         SIMD[DType.int64, 4](1, 1, 1, 1),

--- a/stdlib/test/memory/test_memory.mojo
+++ b/stdlib/test/memory/test_memory.mojo
@@ -17,7 +17,12 @@ from sys.info import sizeof
 from memory import memcmp, memcpy, memset_zero
 from memory.unsafe import DTypePointer, Pointer
 from utils._numerics import nan
-from testing import assert_equal, assert_not_equal, assert_true
+from testing import (
+    assert_almost_equal,
+    assert_equal,
+    assert_not_equal,
+    assert_true,
+)
 
 from utils.index import Index
 
@@ -295,6 +300,122 @@ def test_pointer_refitem_pair():
     ptr.free()
 
 
+def test_dtypepointer_gather():
+    var ptr = DTypePointer[DType.float32].alloc(4)
+    ptr.store(0, SIMD[ptr.type, 4](0.0, 1.0, 2.0, 3.0))
+
+    @parameter
+    def _test_gather[
+        offset_type: DType, width: Int
+    ](offset: SIMD[offset_type, width], desired: SIMD[ptr.type, width]):
+        var actual = ptr.gather(offset)
+        assert_almost_equal(
+            actual, desired, msg="_test_gather", atol=0.0, rtol=0.0
+        )
+
+    @parameter
+    def _test_masked_gather[
+        offset_type: DType, width: Int
+    ](
+        offset: SIMD[offset_type, width],
+        mask: SIMD[DType.bool, width],
+        default: SIMD[ptr.type, width],
+        desired: SIMD[ptr.type, width],
+    ):
+        var actual = ptr.gather(offset, mask, default)
+        assert_almost_equal(
+            actual, desired, msg="_test_masked_gather", atol=0.0, rtol=0.0
+        )
+
+    var offset = SIMD[DType.int64, 8](3, 0, 2, 1, 2, 0, 3, 1)
+    var desired = SIMD[ptr.type, 8](3.0, 0.0, 2.0, 1.0, 2.0, 0.0, 3.0, 1.0)
+
+    _test_gather[DType.uint16, 1](2, 2.0)
+    _test_gather(offset.cast[DType.uint32]().slice[2](), desired.slice[2]())
+    _test_gather(offset.cast[DType.uint64]().slice[4](), desired.slice[4]())
+
+    var mask = (offset >= 0) & (offset < 3)
+    var default = SIMD[ptr.type, 8](-1.0)
+    desired = SIMD[ptr.type, 8](-1.0, 0.0, 2.0, 1.0, 2.0, 0.0, -1.0, 1.0)
+
+    _test_masked_gather[DType.int16, 1](2, False, -1.0, -1.0)
+    _test_masked_gather[DType.int32, 1](2, True, -1.0, 2.0)
+    _test_masked_gather(offset, mask, default, desired)
+
+    ptr.free()
+
+
+def test_dtypepointer_scatter():
+    var ptr = DTypePointer[DType.float32].alloc(4)
+    ptr.store(0, SIMD[ptr.type, 4](0.0))
+
+    @parameter
+    def _test_scatter[
+        offset_type: DType, width: Int
+    ](
+        offset: SIMD[offset_type, width],
+        val: SIMD[ptr.type, width],
+        desired: SIMD[ptr.type, 4],
+    ):
+        ptr.scatter(offset, val)
+        var actual = ptr.load[width=4](0)
+        assert_almost_equal(
+            actual, desired, msg="_test_scatter", atol=0.0, rtol=0.0
+        )
+
+    @parameter
+    def _test_masked_scatter[
+        offset_type: DType, width: Int
+    ](
+        offset: SIMD[offset_type, width],
+        val: SIMD[ptr.type, width],
+        mask: SIMD[DType.bool, width],
+        desired: SIMD[ptr.type, 4],
+    ):
+        ptr.scatter(offset, val, mask)
+        var actual = ptr.load[width=4](0)
+        assert_almost_equal(
+            actual, desired, msg="_test_masked_scatter", atol=0.0, rtol=0.0
+        )
+
+    _test_scatter[DType.uint16, width=1](
+        2, 2.0, SIMD[ptr.type, 4](0.0, 0.0, 2.0, 0.0)
+    )
+    _test_scatter(  # Test with repeated offsets
+        SIMD[DType.uint32, 4](1, 1, 1, 1),
+        SIMD[ptr.type, 4](-1.0, 2.0, -2.0, 1.0),
+        SIMD[ptr.type, 4](0.0, 1.0, 2.0, 0.0),
+    )
+    _test_scatter(
+        SIMD[DType.uint64, 4](3, 2, 1, 0),
+        SIMD[ptr.type, 4](0.0, 1.0, 2.0, 3.0),
+        SIMD[ptr.type, 4](3.0, 2.0, 1.0, 0.0),
+    )
+
+    ptr.store(0, SIMD[ptr.type, 4](0.0))
+
+    _test_masked_scatter[DType.int16, width=1](
+        2, 2.0, False, SIMD[ptr.type, 4](0.0, 0.0, 0.0, 0.0)
+    )
+    _test_masked_scatter[DType.int32, width=1](
+        2, 2.0, True, SIMD[ptr.type, 4](0.0, 0.0, 2.0, 0.0)
+    )
+    _test_masked_scatter(  # Test with repeated offsets
+        SIMD[DType.int64, 4](1, 1, 1, 1),
+        SIMD[ptr.type, 4](-1.0, 2.0, -2.0, 1.0),
+        SIMD[DType.bool, 4](True, True, True, False),
+        SIMD[ptr.type, 4](0.0, -2.0, 2.0, 0.0),
+    )
+    _test_masked_scatter(
+        SIMD[DType.index, 4](3, 2, 1, 0),
+        SIMD[ptr.type, 4](0.0, 1.0, 2.0, 3.0),
+        SIMD[DType.bool, 4](True, False, True, True),
+        SIMD[ptr.type, 4](3.0, 2.0, 2.0, 0.0),
+    )
+
+    ptr.free()
+
+
 def main():
     test_memcpy()
     test_memcpy_dtype()
@@ -307,3 +428,6 @@ def main():
     test_pointer_refitem_string()
     test_pointer_refitem_pair()
     test_pointer_string()
+
+    test_dtypepointer_gather()
+    test_dtypepointer_scatter()


### PR DESCRIPTION
This PR introduces the `gather` and `scatter` methods to the `DTypePointer` struct, as outlined in feature request #1626.

**Key Changes:**
- Implemented the `gather` method for `DTypePointer`.
- Implemented the `scatter` method for `DTypePointer`.
- Added corresponding unit tests to validate the functionality of these methods.
- Updated the docstring in `sys.intrinsics.scatter` to align with the LLVM masked scatter intrinsic documentation [[link](https://llvm.org/docs/LangRef.html#llvm-masked-scatter-intrinsics)]. These changes better reflect the behavior of the scatter intrinsic with overlapping addresses.

**Naming Consideration:**
- While staying consistent with the corresponding LLVM intrinsics is important, it’s also crucial to focus on the primary audience of Mojo. If Mojo developers are primarily expected to have a comfort with Python, using `default` instead of `passthru` might reduce the learning curve and avoid confusion. For developers familiar with Python, `default` conveys the idea that an argument serves as a fallback or standard value when some condition fails. This naming choice aims to enhance clarity and accessibility, making the API more intuitive for our primary user base.

Aware that this feature had been assigned to a maintainer since January, I reached out through comments on the original feature request to ask about any progress and to express my willingness to contribute. In the absence of updates or responses, I proceeded with this implementation. _I am fully prepared to adjust or withdraw my contribution should there be existing work that overlaps with what is presented here_.

Thank you for considering this contribution.

Best regards,