### PR TITLE
[stdlib] Do not copy elements when using `FileHandle.read_bytes()`

### DIFF
--- a/stdlib/src/builtin/file.mojo
+++ b/stdlib/src/builtin/file.mojo
@@ -33,8 +33,7 @@ with open("my_file.txt", "r") as f:
 
 from os import PathLike
 from sys import external_call
-
-from memory import AddressSpace, DTypePointer, Pointer
+from memory.unsafe import AddressSpace, DTypePointer, Pointer
 
 
 @register_passable
@@ -176,7 +175,7 @@ struct FileHandle:
         var err_msg = _OwnedStringRef()
 
         var buf = external_call[
-            "KGEN_CompilerRT_IO_FileReadBytes", Pointer[Int8]
+            "KGEN_CompilerRT_IO_FileReadBytes", AnyPointer[Int8]
         ](
             self.handle,
             Pointer.address_of(size_copy),
@@ -186,13 +185,8 @@ struct FileHandle:
         if err_msg:
             raise (err_msg^).consume_as_error()
 
-        var list = List[Int8](capacity=int(size_copy))
-
-        var list_ptr = Pointer[Int8].__from_index(int(list.data))
-
-        # Initialize the List elements and set the initialized size
-        memcpy(list_ptr, buf, int(size_copy))
-        list.size = int(size_copy)
+        # No-copy list initialization
+        var list = List[Int8](buf, int(size_copy), int(size_copy))
 
         return list
 

--- a/stdlib/src/builtin/file.mojo
+++ b/stdlib/src/builtin/file.mojo
@@ -33,7 +33,7 @@ with open("my_file.txt", "r") as f:
 
 from os import PathLike
 from sys import external_call
-from memory.unsafe import AddressSpace, DTypePointer, Pointer
+from memory import AddressSpace, DTypePointer, Pointer
 
 
 @register_passable
@@ -95,7 +95,7 @@ struct FileHandle:
 
         if err_msg:
             self.handle = DTypePointer[DType.invalid]()
-            raise (err_msg ^).consume_as_error()
+            raise (err_msg^).consume_as_error()
 
         self.handle = handle
 
@@ -118,7 +118,7 @@ struct FileHandle:
         )
 
         if err_msg:
-            raise (err_msg ^).consume_as_error()
+            raise (err_msg^).consume_as_error()
 
         self.handle = DTypePointer[DType.invalid]()
 
@@ -154,7 +154,7 @@ struct FileHandle:
         )
 
         if err_msg:
-            raise (err_msg ^).consume_as_error()
+            raise (err_msg^).consume_as_error()
 
         return String(buf, int(size_copy) + 1)
 
@@ -183,7 +183,7 @@ struct FileHandle:
         )
 
         if err_msg:
-            raise (err_msg ^).consume_as_error()
+            raise (err_msg^).consume_as_error()
 
         # No-copy list initialization
         var list = List[Int8](buf, int(size_copy), int(size_copy))
@@ -212,7 +212,7 @@ struct FileHandle:
         )
 
         if err_msg:
-            raise (err_msg ^).consume_as_error()
+            raise (err_msg^).consume_as_error()
 
         return pos
 
@@ -266,11 +266,11 @@ struct FileHandle:
         )
 
         if err_msg:
-            raise (err_msg ^).consume_as_error()
+            raise (err_msg^).consume_as_error()
 
     fn __enter__(owned self) -> Self:
         """The function to call when entering the context."""
-        return self ^
+        return self^
 
 
 fn open(path: String, mode: String) raises -> FileHandle:

--- a/stdlib/src/builtin/file.mojo
+++ b/stdlib/src/builtin/file.mojo
@@ -184,7 +184,7 @@ struct FileHandle:
 
         if err_msg:
             raise (err_msg^).consume_as_error()
-
+        
         # No-copy list initialization
         var list = List[Int8](buf, int(size_copy), int(size_copy))
 

--- a/stdlib/src/builtin/file.mojo
+++ b/stdlib/src/builtin/file.mojo
@@ -95,7 +95,7 @@ struct FileHandle:
 
         if err_msg:
             self.handle = DTypePointer[DType.invalid]()
-            raise (err_msg^).consume_as_error()
+            raise (err_msg ^).consume_as_error()
 
         self.handle = handle
 
@@ -118,7 +118,7 @@ struct FileHandle:
         )
 
         if err_msg:
-            raise (err_msg^).consume_as_error()
+            raise (err_msg ^).consume_as_error()
 
         self.handle = DTypePointer[DType.invalid]()
 
@@ -154,7 +154,7 @@ struct FileHandle:
         )
 
         if err_msg:
-            raise (err_msg^).consume_as_error()
+            raise (err_msg ^).consume_as_error()
 
         return String(buf, int(size_copy) + 1)
 
@@ -183,8 +183,8 @@ struct FileHandle:
         )
 
         if err_msg:
-            raise (err_msg^).consume_as_error()
-        
+            raise (err_msg ^).consume_as_error()
+
         # No-copy list initialization
         var list = List[Int8](buf, int(size_copy), int(size_copy))
 
@@ -212,7 +212,7 @@ struct FileHandle:
         )
 
         if err_msg:
-            raise (err_msg^).consume_as_error()
+            raise (err_msg ^).consume_as_error()
 
         return pos
 
@@ -266,11 +266,11 @@ struct FileHandle:
         )
 
         if err_msg:
-            raise (err_msg^).consume_as_error()
+            raise (err_msg ^).consume_as_error()
 
     fn __enter__(owned self) -> Self:
         """The function to call when entering the context."""
-        return self^
+        return self ^
 
 
 fn open(path: String, mode: String) raises -> FileHandle:

--- a/stdlib/src/builtin/object.mojo
+++ b/stdlib/src/builtin/object.mojo
@@ -144,7 +144,7 @@ struct _RefCountedAttrsDict:
     fn get(self, key: StringLiteral) raises -> _ObjectImpl:
         var iter = self.impl[].find(key)
         if iter:
-            return iter.value()
+            return iter.value()[]
         raise Error(
             "AttributeError: Object does not have an attribute of name '"
             + key

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -480,7 +480,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
         """
         var value = self.find(key)
         if value:
-            return value.value()
+            return value.value()[]
         raise "KeyError"
 
     fn __setitem__(inout self, key: K, value: V):
@@ -533,7 +533,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
         if found:
             var ev = self._entries.__get_ref(index)[]
             debug_assert(ev.__bool__(), "entry in index must be full")
-            return ev.value().value
+            return ev.value()[].value
         return None
 
     fn pop(inout self, key: K, owned default: Optional[V] = None) raises -> V:
@@ -563,9 +563,9 @@ struct Dict[K: KeyElement, V: CollectionElement](
             self._entries[index] = None
             self.size -= 1
             debug_assert(entry.__bool__(), "entry in index must be full")
-            return entry.value().value
+            return entry.value()[].value
         elif default:
-            return default.value()
+            return default.value()[]
         raise "KeyError"
 
     fn __iter__[
@@ -720,14 +720,14 @@ struct Dict[K: KeyElement, V: CollectionElement](
             else:
                 var ev = self._entries.__get_ref(index)[]
                 debug_assert(ev.__bool__(), "entry in index must be full")
-                var entry = ev.value()
+                var entry = ev.value()[]
                 if hash == entry.hash and key == entry.key:
                     return (True, slot, index)
             self._next_index_slot(slot, perturb)
 
         debug_assert(insert_slot.__bool__(), "never found a slot")
         debug_assert(insert_index.__bool__(), "slot populated but not index!!")
-        return (False, insert_slot.value(), insert_index.value())
+        return (False, insert_slot.value()[], insert_index.value()[])
 
     fn _over_load_factor(self) -> Bool:
         return 3 * self.size > 2 * self._reserved
@@ -750,7 +750,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
         for i in range(len(old_entries)):
             var entry = old_entries.__get_ref(i)[]
             if entry:
-                self._insert(entry.value())
+                self._insert(entry.value()[])
 
     fn _compact(inout self):
         self._index = _DictIndex(self._reserved)
@@ -761,7 +761,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
                 debug_assert(right < self._reserved, "Invalid dict state")
             var entry = self._entries.__get_ref(right)[]
             debug_assert(entry.__bool__(), "Logic error")
-            var slot = self._find_empty_index(entry.value().hash)
+            var slot = self._find_empty_index(entry.value()[].hash)
             self._set_index(slot, left)
             if left != right:
                 self._entries[left] = entry

--- a/stdlib/src/collections/optional.mojo
+++ b/stdlib/src/collections/optional.mojo
@@ -21,9 +21,9 @@ from collections import Optional
 var a = Optional(1)
 var b = Optional[Int](None)
 if a:
-    print(a.value())  # prints 1
+    print(a.value()[])  # prints 1
 if b:  # bool(b) is False, so no print
-    print(b.value())
+    print(b.value()[])
 var c = a.or_else(2)
 var d = b.or_else(2)
 print(c)  # prints 1
@@ -61,9 +61,9 @@ struct Optional[T: CollectionElement](CollectionElement, Boolable):
     var a = Optional(1)
     var b = Optional[Int](None)
     if a:
-        print(a.value())  # prints 1
+        print(a.value()[])  # prints 1
     if b:  # bool(b) is False, so no print
-        print(b.value())
+        print(b.value()[])
     var c = a.or_else(2)
     var d = b.or_else(2)
     print(c)  # prints 1
@@ -100,11 +100,12 @@ struct Optional[T: CollectionElement](CollectionElement, Boolable):
         self = Self()
 
     @always_inline
-    fn value(self) -> T:
-        """Unsafely retrieve the value out of the Optional.
-
-        This function currently creates a copy. Once we have lifetimes
-        we'll be able to have it return a reference.
+    fn value[
+        mutability: __mlir_type.`i1`, self_life: AnyLifetime[mutability].type
+    ](self: Reference[Self, mutability, self_life].mlir_ref_type) -> Reference[
+        T, mutability, self_life
+    ]:
+        """Unsafely retrieve a reference to the value of the Optional.
 
         This doesn't check to see if the optional contains a value.
         If you call this without first verifying the optional with __bool__()
@@ -112,10 +113,14 @@ struct Optional[T: CollectionElement](CollectionElement, Boolable):
         value (for instance with `or_else`), you'll get garbage unsafe data out.
 
         Returns:
-            The contained data of the option as a T value.
+            A reference to the contained data of the option as a Reference[T].
         """
-        debug_assert(self.__bool__(), ".value() on empty Optional")
-        return self._value.get[T]()[]
+        debug_assert(Reference(self)[].__bool__(), ".value() on empty Optional")
+        alias RefType = Reference[T, mutability, self_life]
+        var ptr = Reference(self)[]._value._get_ptr[T]().value
+        return __mlir_op.`lit.ref.from_pointer`[_type = RefType.mlir_ref_type](
+            ptr
+        )
 
     fn take(owned self) -> T:
         """Unsafely move the value out of the Optional.

--- a/stdlib/src/testing/testing.mojo
+++ b/stdlib/src/testing/testing.mojo
@@ -151,7 +151,9 @@ fn assert_equal[
     Raises:
         An Error with the provided message if assert fails and `None` otherwise.
     """
-    if lhs != rhs:
+    # `if lhs != rhs:` is not enough. `reduce_or()` must be used here, otherwise, if any of the elements are
+    # equal, the error is not triggered.
+    if (lhs != rhs).reduce_or():
         raise _assert_equal_error(str(lhs), str(rhs), msg=msg)
 
 

--- a/stdlib/src/testing/testing.mojo
+++ b/stdlib/src/testing/testing.mojo
@@ -331,5 +331,7 @@ struct assert_raises:
             Error: If the error raised doesn't match the expected error to raise.
         """
         if self.message_contains:
-            return self.message_contains.value() in str(error)
+            return self.message_contains.value[
+                __mlir_attr.`0: i1`, __lifetime_of(self)
+            ]()[] in str(error)
         return True

--- a/stdlib/test/builtin/test_file.mojo
+++ b/stdlib/test/builtin/test_file.mojo
@@ -65,22 +65,16 @@ def test_file_read_bytes_multi():
         "r",
     )
 
-    # CHECK: Lorem ipsum
     var bytes1 = f.read_bytes(12)
     assert_equal(bytes1, "Lorem ipsum")
-    print(String(bytes1))
 
-    # CHECK: dolor
     var bytes2 = f.read_bytes(6)
     assert_equal(String(bytes2).strip(), "dolor")
-    print(String(bytes2))
 
     # Read where N is greater than the number of bytes in the file.
     var s: String = f.read(1e9)
 
-    # CHECK: 936
     assert_equal(len(s), 936)
-    print(len(s))
 
     # CHECK: sit amet, consectetur adipiscing elit.
     print(s)

--- a/stdlib/test/builtin/test_file.mojo
+++ b/stdlib/test/builtin/test_file.mojo
@@ -67,16 +67,19 @@ def test_file_read_bytes_multi():
 
     # CHECK: Lorem ipsum
     var bytes1 = f.read_bytes(12)
+    assert_equal(bytes1, "Lorem ipsum")
     print(String(bytes1))
 
     # CHECK: dolor
     var bytes2 = f.read_bytes(6)
+    assert_equal(String(bytes2).strip(), "dolor")
     print(String(bytes2))
 
     # Read where N is greater than the number of bytes in the file.
     var s: String = f.read(1e9)
 
     # CHECK: 936
+    assert_equal(len(s), 936)
     print(len(s))
 
     # CHECK: sit amet, consectetur adipiscing elit.

--- a/stdlib/test/collections/test_dict.mojo
+++ b/stdlib/test/collections/test_dict.mojo
@@ -202,8 +202,8 @@ def test_dict_copy_calls_copy_constructor():
     var copy = Dict(orig)
     # I _may_ have thoughts about where our performance issues
     # are coming from :)
-    assert_equal(5, orig["a"].copy_count)
-    assert_equal(6, copy["a"].copy_count)
+    assert_equal(4, orig["a"].copy_count)
+    assert_equal(5, copy["a"].copy_count)
 
 
 def test_dict_update_nominal():

--- a/stdlib/test/collections/test_optional.mojo
+++ b/stdlib/test/collections/test_optional.mojo
@@ -37,7 +37,7 @@ def test_basic():
     assert_true(b or True)
     assert_false(b or False)
 
-    assert_equal(1, a.value())
+    assert_equal(1, a.value()[])
 
     # Test invert operator
     assert_false(~a)
@@ -51,6 +51,13 @@ def test_basic():
     assert_equal(2, b1)
 
     assert_equal(1, (a^).take())
+
+    # TODO: this currently only checks for mutable references.
+    # We may want to come back and add an immutable test once
+    # there are the language features to do so.
+    var a2 = Optional(1)
+    a2.value()[] = 2
+    assert_equal(a2.value()[], 2)
 
 
 def test_optional_reg_basic():

--- a/stdlib/test/memory/test_bitcast.mojo
+++ b/stdlib/test/memory/test_bitcast.mojo
@@ -10,21 +10,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
 
 from memory import bitcast
+from testing import assert_equal
 
 
-# CHECK-LABEL: test_bitcast
-fn test_bitcast():
-    print("== test_bitcast")
+def test_bitcast():
+    assert_equal(
+        bitcast[DType.int8, 8](SIMD[DType.int16, 4](1, 2, 3, 4)),
+        SIMD[DType.int8, 8](1, 0, 2, 0, 3, 0, 4, 0),
+    )
 
-    # CHECK: [1, 0, 2, 0, 3, 0, 4, 0]
-    print(bitcast[DType.int8, 8](SIMD[DType.int16, 4](1, 2, 3, 4)))
+    assert_equal(
+        bitcast[DType.int32, 1](SIMD[DType.int8, 4](0xFF, 0x00, 0xFF, 0x55)),
+        Int32(1442775295),
+    )
 
-    # CHECK: 1442775295
-    print(bitcast[DType.int32, 1](SIMD[DType.int8, 4](0xFF, 0x00, 0xFF, 0x55)))
 
-
-fn main():
+def main():
     test_bitcast()

--- a/stdlib/test/sys/test_build_info_debug.mojo
+++ b/stdlib/test/sys/test_build_info_debug.mojo
@@ -11,20 +11,15 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 # REQUIRES: is_debug
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
 
 from sys._build import is_debug_build, is_release_build
+from testing import assert_true, assert_false
 
 
-# CHECK-OK-LABEL: test_is_debug
 fn test_is_debug():
-    print("== test_is_debug")
-
-    # CHECK: True
-    print(is_debug_build())
-
-    # CHECK: False
-    print(is_release_build())
+    assert_true(is_debug_build())
+    assert_false(is_release_build())
 
 
 fn main():

--- a/stdlib/test/sys/test_has_intel_amx.mojo
+++ b/stdlib/test/sys/test_has_intel_amx.mojo
@@ -16,23 +16,17 @@
 # ===----------------------------------------------------------------------=== #
 # REQUIRES: linux
 # REQUIRES: amx_tile
-# RUN: %mojo -debug-level full %s | FileCheck %s
-
+# RUN: %mojo -debug-level full %s
 
 from sys import has_intel_amx, os_is_linux
-
+from testing import assert_false, assert_true
 from LinAlg.intel_amx import init_intel_amx
 
 
-# CHECK-LABEL: test_has_intel_amx
 fn test_has_intel_amx():
-    print("== test_intel_amx_amx")
-    # CHECK: True
-    print(os_is_linux())
-    # CHECK: True
-    print(has_intel_amx())
-    # CHECK: True
-    print(init_intel_amx())
+    assert_true(os_is_linux())
+    assert_true(has_intel_amx())
+    assert_true(init_intel_amx())
 
 
 fn main():

--- a/stdlib/test/sys/test_intrinsics.mojo
+++ b/stdlib/test/sys/test_intrinsics.mojo
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -debug-level full %s | FileCheck %s
+# RUN: %mojo -debug-level full %s
 
 from sys import (
     compressed_store,
@@ -38,8 +38,7 @@ fn test_strided_load() raises:
     vector.free()
 
 
-# CHECK-LABEL: test_strided_store
-fn test_strided_store():
+fn test_strided_store() raises:
     print("== test_strided_store")
 
     alias size = 8
@@ -47,16 +46,15 @@ fn test_strided_store():
     memset_zero(vector, size)
 
     strided_store(SIMD[DType.float32, 4](99, 12, 23, 56), vector, 2)
-    # CHECK: 99.0
-    # CHECK: 0.0
-    # CHECK: 12.0
-    # CHECK: 0.0
-    # CHECK: 23.0
-    # CHECK: 0.0
-    # CHECK: 56.0
-    # CHECK: 0.0
-    for i in range(size):
-        print(vector[i])
+    assert_equal(vector[0], 99.0)
+    assert_equal(vector[1], 0.0)
+    assert_equal(vector[2], 12.0)
+    assert_equal(vector[3], 0.0)
+    assert_equal(vector[4], 23.0)
+    assert_equal(vector[5], 0.0)
+    assert_equal(vector[6], 56.0)
+    assert_equal(vector[7], 0.0)
+
     vector.free()
 
 

--- a/stdlib/test/sys/test_paramenv.mojo
+++ b/stdlib/test/sys/test_paramenv.mojo
@@ -10,27 +10,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -D bar=99 -D baz=hello %s | FileCheck %s
-# RUN: %mojo -D bar=99 -D baz=hello -D foo=11 %s | FileCheck %s --check-prefix=FOO
+# RUN: %mojo -D bar=99 -D baz=hello -D foo=11 %s
 
 from sys import env_get_int, env_get_string, is_defined
+from testing import assert_equal, assert_true, assert_false
 
 
-fn main():
-    # CHECK-LABEL: === test_env
-    print("=== test_env")
+def test_is_defined():
+    assert_true(is_defined["bar"]())
+    assert_true(is_defined["foo"]())
+    assert_true(is_defined["baz"]())
+    assert_false(is_defined["boo"]())
 
-    # CHECK: is_defined(foo) False
-    print("is_defined(foo)", is_defined["foo"]())
-    # CHECK: is_defined(bar) True
-    print("is_defined(bar)", is_defined["bar"]())
-    # CHECK: env_get_int(bar) 99
-    print("env_get_int(bar)", env_get_int["bar"]())
-    # CHECK: env_get_string(baz) hello
-    print("env_get_string(baz)", env_get_string["baz"]())
 
-    # CHECK: env_get_int_or(foo, 42) 42
-    # FOO: env_get_int_or(foo, 42) 11
-    print("env_get_int_or(foo, 42)", env_get_int["foo", 42]())
-    # CHECK: env_get_int_or(bar, 42) 99
-    print("env_get_int_or(bar, 42)", env_get_int["bar", 42]())
+def test_get_string():
+    assert_equal(env_get_string["baz"](), "hello")
+
+
+def test_env_get_int():
+    assert_equal(env_get_int["bar"](), 99)
+    assert_equal(env_get_int["foo", 42](), 11)
+    assert_equal(env_get_int["bar", 42](), 99)
+    assert_equal(env_get_int["boo", 42](), 42)
+
+
+def main():
+    test_is_defined()
+    test_get_string()
+    test_env_get_int()

--- a/stdlib/test/sys/test_windows_target.mojo
+++ b/stdlib/test/sys/test_windows_target.mojo
@@ -15,7 +15,7 @@
 #
 # ===----------------------------------------------------------------------=== #
 # REQUIRES: windows
-# RUN: mojo.exe %s | FileCheck %s
+# RUN: mojo.exe %s
 
 
 from os._windows import (
@@ -26,49 +26,33 @@ from os._windows import (
 from sys import external_call, os_is_linux, os_is_macos, os_is_windows
 
 from memory import Pointer
+from testing import assert_false, assert_true, assert_equal
 
 
-# CHECK-LABEL: test_os_query
-fn test_os_query():
-    print("== test_os_query\n")
-
-    # CHECK: False
-    print(os_is_macos())
-
-    # CHECK: False
-    print(os_is_linux())
-
-    # CHECK: True
-    print(os_is_windows())
+def test_os_query():
+    assert_false(os_is_macos())
+    assert_false(os_is_linux())
+    assert_true(os_is_windows())
 
 
-# CHECK-LABEL: test_last_error
-fn test_last_error():
-    print("== test_last_error\n")
-
+def test_last_error():
     reset_last_error()
 
-    # CHECK: 0
-    print(get_last_error_code())
+    assert_equal(get_last_error_code(), 0)
 
-    # CHECK: True
-    print(last_operation_succeeded())
+    assert_true(last_operation_succeeded())
 
     # GetProcessId takes the handle to a process and returns its id. If the
     # handle is null this will fail and returns an invalid handle error (error
     # code 6).
     var succeeded = external_call["GetProcessId", Int](Pointer[Int].get_null())
 
-    # CHECK: 0
-    print(succeeded)
+    assert_equal(succeeded, 0)
 
-    # CHECK: False
-    print(last_operation_succeeded())
-
-    # CHECK: 6
-    print(get_last_error_code())
+    assert_false(last_operation_succeeded())
+    assert_equal(get_last_error_code(), 6)
 
 
-fn main():
+def main():
     test_os_query()
     test_last_error()

--- a/stdlib/test/testing/test_assertion.mojo
+++ b/stdlib/test/testing/test_assertion.mojo
@@ -43,6 +43,14 @@ def test_assert_not_equal_is_generic():
         assert_not_equal(DummyStruct(1), DummyStruct(1))
 
 
+def test_assert_equal_with_simd():
+    assert_equal(SIMD[DType.uint8, 2](1, 1), SIMD[DType.uint8, 2](1, 1))
+
+    with assert_raises():
+        assert_equal(SIMD[DType.uint8, 2](1, 1), SIMD[DType.uint8, 2](1, 2))
+
+
 def main():
     test_assert_equal_is_generic()
     test_assert_not_equal_is_generic()
+    test_assert_equal_with_simd()


### PR DESCRIPTION
Fixes #2051, allows `FileHandle.read_bytes()` to return `List[Int8]` without additional copies, depends on #2182.
