### PR TITLE
[stdlib] Remove unnecessary declaration

### DIFF
--- a/stdlib/src/base64/base64.mojo
+++ b/stdlib/src/base64/base64.mojo
@@ -60,15 +60,14 @@ fn b64encode(str: String) -> String:
         out.append(b64chars.load(((si_1 * 4) % 64) + si_2 // 64))
         out.append(b64chars.load(si_2 % 64))
 
-    var i = end
-    if i < length:
-        var si = s(i)
+    if end < length:
+        var si = s(end)
         out.append(b64chars.load(si // 4))
-        if i == length - 1:
+        if end == length - 1:
             out.append(b64chars.load((si * 16) % 64))
             out.append(ord("="))
-        elif i == length - 2:
-            var si_1 = s(i + 1)
+        elif end == length - 2:
+            var si_1 = s(end + 1)
             out.append(b64chars.load(((si * 16) % 64) + si_1 // 16))
             out.append(b64chars.load((si_1 * 4) % 64))
         out.append(ord("="))


### PR DESCRIPTION
`i` was an unnecessary and unclear declaration that could be substituted for `end`. This is not a behavioral change.

Reasoning:
- `i` was set to be equivalent to `end`, but was never used in a way in which it could not simply be substituted for `end`.
- `i` is not descriptive, and `end` does a better job describing it's purpose. `i` didn't have a comment either, also making it less descriptive than `end`.
- `var i` was used almost immediately after a different `i` was used as a counter in a for loop, and it could be confusing to use two variables with different purposes and the same name immediately after one another.
- Removing this declaration could result in a small performance improvement because an assignment is removed, but at the very least the code is simpler without this declaration.