### PR TITLE
[stdlib] Fix assert_equal[SIMD]() not raising if any elements are equal

### DIFF
--- a/stdlib/src/testing/testing.mojo
+++ b/stdlib/src/testing/testing.mojo
@@ -151,7 +151,9 @@ fn assert_equal[
     Raises:
         An Error with the provided message if assert fails and `None` otherwise.
     """
-    if lhs != rhs:
+    # `if lhs != rhs:` is not enough. `reduce_or()` must be used here, otherwise, if any of the elements are
+    # equal, the error is not triggered.
+    if (lhs != rhs).reduce_or():
         raise _assert_equal_error(str(lhs), str(rhs), msg=msg)
 
 

--- a/stdlib/test/testing/test_assertion.mojo
+++ b/stdlib/test/testing/test_assertion.mojo
@@ -43,6 +43,14 @@ def test_assert_not_equal_is_generic():
         assert_not_equal(DummyStruct(1), DummyStruct(1))
 
 
+def test_assert_equal_with_simd():
+    assert_equal(SIMD[DType.uint8, 2](1, 1), SIMD[DType.uint8, 2](1, 1))
+    
+    with assert_raises():
+        assert_equal(SIMD[DType.uint8, 2](1, 1), SIMD[DType.uint8, 2](1, 2))
+
+
 def main():
     test_assert_equal_is_generic()
     test_assert_not_equal_is_generic()
+    test_assert_equal_with_simd()

--- a/stdlib/test/testing/test_assertion.mojo
+++ b/stdlib/test/testing/test_assertion.mojo
@@ -45,7 +45,7 @@ def test_assert_not_equal_is_generic():
 
 def test_assert_equal_with_simd():
     assert_equal(SIMD[DType.uint8, 2](1, 1), SIMD[DType.uint8, 2](1, 1))
-    
+
     with assert_raises():
         assert_equal(SIMD[DType.uint8, 2](1, 1), SIMD[DType.uint8, 2](1, 2))
 


### PR DESCRIPTION
To reproduce the bug:
```mojo
with assert_raises():
    assert_equal(SIMD[DType.uint8, 2](1, 1), SIMD[DType.uint8, 2](1, 2))
```

This is because using `!=` returns `[False, True]` then, when using `.__bool__()` on this, since `__bool__()` is equivalent to a `reduce_and()`, it returns False, and the error is not triggered.

Long story short, doing `if a != b` doesn't do what one would expect. This bug is not present with `assert_not_equal()`