### PR TITLE
[stdlib] Remove FileCheck from `test_file.mojo`

### DIFF
--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -358,6 +358,10 @@ struct String(Sized, Stringable, IntableRaising, KeyElement, Boolable):
         Args:
             impl: The buffer.
         """
+        debug_assert(
+            impl[-1] == 0,
+            "expected last element of String buffer to be null terminator",
+        )
         self._buffer = impl^
 
     @always_inline

--- a/stdlib/test/builtin/test_file.mojo
+++ b/stdlib/test/builtin/test_file.mojo
@@ -10,119 +10,110 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-# RUN: %mojo -D CURRENT_DIR=%S -D TEMP_FILE_DIR=%T -debug-level full %s | FileCheck %s
+# RUN: %mojo -D CURRENT_DIR=%S -D TEMP_FILE_DIR=%T -debug-level full %s
 
 
 from pathlib import Path
 from sys.info import os_is_windows
 from sys.param_env import env_get_string
 
-from testing import assert_equal
+from testing import assert_equal, assert_true
 
 alias CURRENT_DIR = env_get_string["CURRENT_DIR"]()
 alias TEMP_FILE_DIR = env_get_string["TEMP_FILE_DIR"]()
 
 
-# CHECK-LABEL: test_file_read
 def test_file_read():
-    print("== test_file_read")
-
-    # CHECK: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
     var f = open(
         Path(CURRENT_DIR) / "test_file_dummy_input.txt",
         "r",
     )
-    print(f.read())
+    assert_true(
+        f.read().startswith(
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+        )
+    )
     f.close()
 
 
-# CHECK-LABEL: test_file_read_multi
 def test_file_read_multi():
-    print("== test_file_read_multi")
-
     var f = open(
         (Path(CURRENT_DIR) / "test_file_dummy_input.txt"),
         "r",
     )
 
-    # CHECK: Lorem ipsum
-    print(f.read(12))
-
-    # CHECK: dolor
-    print(f.read(6))
-
-    # CHECK: sit amet, consectetur adipiscing elit.
-    print(f.read())
+    assert_equal(f.read(12), "Lorem ipsum ")
+    assert_equal(f.read(6), "dolor ")
+    assert_true(f.read().startswith("sit amet, consectetur adipiscing elit."))
 
     f.close()
 
 
-# CHECK-LABEL: test_file_read_bytes_multi
 def test_file_read_bytes_multi():
-    print("== test_file_read_bytes_multi")
-
     var f = open(
         Path(CURRENT_DIR) / "test_file_dummy_input.txt",
         "r",
     )
 
-    # CHECK: Lorem ipsum
     var bytes1 = f.read_bytes(12)
-    print(String(bytes1))
+    assert_equal(len(bytes1), 12, "12 bytes")
+    # we add the null terminator
+    bytes1.append(0)
+    var string1 = String(bytes1)
+    assert_equal(len(string1), 12, "12 chars")
+    assert_equal(string1, String("Lorem ipsum "))
 
-    # CHECK: dolor
     var bytes2 = f.read_bytes(6)
-    print(String(bytes2))
+    assert_equal(len(bytes2), 6, "6 bytes")
+    # we add the null terminator
+    bytes2.append(0)
+    var string2 = String(bytes2)
+    assert_equal(len(string2), 6, "6 chars")
+    assert_equal(string2, "dolor ")
 
     # Read where N is greater than the number of bytes in the file.
     var s: String = f.read(1e9)
 
-    # CHECK: 936
-    print(len(s))
-
-    # CHECK: sit amet, consectetur adipiscing elit.
-    print(s)
+    assert_equal(len(s), 936)
+    assert_true(s.startswith("sit amet, consectetur adipiscing elit."))
 
     f.close()
 
 
-# CHECK-LABEL: test_file_read_path
 def test_file_read_path():
-    print("== test_file_read_path")
-
     var file_path = Path(CURRENT_DIR) / "test_file_dummy_input.txt"
 
-    # CHECK: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
     var f = open(file_path, "r")
-    print(f.read())
+    assert_true(
+        f.read().startswith(
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+        )
+    )
     f.close()
 
 
-# CHECK-LABEL: test_file_path_direct_read
 def test_file_path_direct_read():
-    print("== test_file_path_direct_read")
-
     var file_path = Path(CURRENT_DIR) / "test_file_dummy_input.txt"
-    # CHECK: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-    print(file_path.read_text())
+    assert_true(
+        file_path.read_text().startswith(
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+        )
+    )
 
 
-# CHECK-LABEL: test_file_read_context
 def test_file_read_context():
-    print("== test_file_read_context")
-
-    # CHECK: Lorem ipsum dolor sit amet, consectetur adipiscing elit.
     with open(
         Path(CURRENT_DIR) / "test_file_dummy_input.txt",
         "r",
     ) as f:
-        print(f.read())
+        assert_true(
+            f.read().startswith(
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+            )
+        )
 
 
-# CHECK-LABEL: test_file_seek
 def test_file_seek():
-    print("== test_file_seek")
-
     with open(
         Path(CURRENT_DIR) / "test_file_dummy_input.txt",
         "r",
@@ -140,43 +131,35 @@ def test_file_seek():
             assert_equal(str(e)[: len(expected_msg)], expected_msg)
 
 
-# CHECK-LABEL: test_file_open_nodir
 def test_file_open_nodir():
-    print("== test_file_open_nodir")
     var f = open(Path("test_file_open_nodir"), "w")
     f.close()
 
 
-# CHECK-LABEL: test_file_write
 def test_file_write():
-    print("== test_file_write")
-
+    var content = "The quick brown fox jumps over the lazy dog"
     var TEMP_FILE = Path(TEMP_FILE_DIR) / "test_file_write"
     var f = open(TEMP_FILE, "w")
-    f.write("The quick brown fox jumps over the lazy dog")
+    f.write(content)
     f.close()
 
-    # CHECK: The quick brown fox jumps over the lazy dog
     var read_file = open(TEMP_FILE, "r")
-    print(read_file.read())
+    assert_equal(read_file.read(), content)
     read_file.close()
 
 
-# CHECK-LABEL: test_file_write_again
 def test_file_write_again():
-    print("== test_file_write_again")
-
+    var unexpected_content = "foo bar baz"
+    var expected_content = "foo bar"
     var TEMP_FILE = Path(TEMP_FILE_DIR) / "test_file_write_again"
     with open(TEMP_FILE, "w") as f:
-        f.write("foo bar baz")
+        f.write(unexpected_content)
 
     with open(TEMP_FILE, "w") as f:
-        f.write("foo bar")
+        f.write(expected_content)
 
-    # CHECK: foo bar
-    # CHECK-NOT: baz
     var read_file = open(TEMP_FILE, "r")
-    print(read_file.read())
+    assert_equal(read_file.read(), expected_content)
     read_file.close()
 
 


### PR DESCRIPTION
Related to https://github.com/modularml/mojo/issues/2024

I had some issues concerning the conversion `List[Int8]` -> `String`, the null terminator was missing, so I added a check concerning this.