### PR TITLE
[mojo-stdlib] Create `InlineArray` type

### DIFF
--- a/stdlib/src/utils/__init__.mojo
+++ b/stdlib/src/utils/__init__.mojo
@@ -19,6 +19,6 @@ from .index import (
 )
 from .inlined_string import InlinedString
 from .loop import unroll
-from .static_tuple import StaticTuple
+from .static_tuple import StaticTuple, InlineArray
 from .stringref import StringRef
 from .variant import Variant

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -328,7 +328,11 @@ struct InlineArray[ElementType: CollectionElement, size: Int](Sized):
 
     @always_inline
     fn __init__(inout self, *, fill: Self.ElementType):
-        """Constructs an empty (undefined) array."""
+        """Constructs an empty array where each element is the supplied `fill`.
+
+        Args:
+            fill: The element to fill each index.
+        """
         _static_tuple_construction_checks[size]()
         self._array = __mlir_op.`kgen.undef`[_type = Self.type]()
 

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -387,15 +387,19 @@ struct InlineArray[ElementType: CollectionElement, size: Int](Sized):
 
     @always_inline("nodebug")
     fn __refitem__[
-        mutability: __mlir_type.i1, self_life: AnyLifetime[mutability].type
+        mutability: __mlir_type.i1,
+        self_life: AnyLifetime[mutability].type,
+        IntableType: Intable,
     ](
-        self: Reference[Self, mutability, self_life]._mlir_type, index: Int
+        self: Reference[Self, mutability, self_life]._mlir_type,
+        index: IntableType,
     ) -> Reference[Self.ElementType, mutability, self_life]:
         """Get a `Reference` to the element at the given index.
 
         Parameters:
             mutability: The inferred mutability of the reference.
             self_life: The inferred lifetime of the reference.
+            IntableType: The inferred type of an intable argument.
 
         Args:
             index: The index of the item.
@@ -403,9 +407,9 @@ struct InlineArray[ElementType: CollectionElement, size: Int](Sized):
         Returns:
             A reference to the item at the given index.
         """
-        debug_assert(-size <= index < size, "Index must be within bounds.")
-        var normalized_idx = index
-        if index < 0:
+        debug_assert(-size <= int(index) < size, "Index must be within bounds.")
+        var normalized_idx = int(index)
+        if normalized_idx < 0:
             normalized_idx += size
 
         return Reference(self)[]._get_reference_unsafe[mutability, self_life](
@@ -416,7 +420,8 @@ struct InlineArray[ElementType: CollectionElement, size: Int](Sized):
     fn __refitem__[
         mutability: __mlir_type.i1,
         self_life: AnyLifetime[mutability].type,
-        index: Int,
+        IntableType: Intable,
+        index: IntableType,
     ](self: Reference[Self, mutability, self_life]._mlir_type) -> Reference[
         Self.ElementType, mutability, self_life
     ]:
@@ -425,17 +430,19 @@ struct InlineArray[ElementType: CollectionElement, size: Int](Sized):
         Parameters:
             mutability: The inferred mutability of the reference.
             self_life: The inferred lifetime of the reference.
+            IntableType: The inferred type of an intable argument.
             index: The index of the item.
 
         Returns:
             A reference to the item at the given index.
         """
-        constrained[-size <= index < size, "Index must be within bounds."]()
+        alias i = int(index)
+        constrained[-size <= i < size, "Index must be within bounds."]()
 
-        var normalized_idx = index
+        var normalized_idx = i
 
         @parameter
-        if index < 0:
+        if i < 0:
             normalized_idx += size
 
         return Reference(self)[]._get_reference_unsafe[mutability, self_life](

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -368,6 +368,7 @@ struct Array[ElementType: CollectionElement, size: Int](Sized):
         """
         return size
 
+    @always_inline("nodebug")
     fn __refitem__[
         mutability: __mlir_type.i1, self_life: AnyLifetime[mutability].type
     ](
@@ -381,6 +382,7 @@ struct Array[ElementType: CollectionElement, size: Int](Sized):
             UnsafePointer(ptr)[]
         )
 
+    @always_inline("nodebug")
     fn __refitem__[
         mutability: __mlir_type.i1,
         self_life: AnyLifetime[mutability].type,

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -306,6 +306,11 @@ struct StaticTuple[element_type: AnyRegType, size: Int](Sized):
         self = tmp
 
 
+# ===----------------------------------------------------------------------===#
+# Array
+# ===----------------------------------------------------------------------===#
+
+
 @value
 struct Array[ElementType: CollectionElement, size: Int](Sized):
     """A statically sized array type which contains elements of homogeneous types.

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -392,6 +392,26 @@ struct Array[ElementType: CollectionElement, size: Int](Sized):
             Reference(Reference(self)[].array).get_legacy_pointer().address,
             index.value,
         )
+<<<<<<< HEAD
         return Reference[Self.ElementType, mutability, self_life](
             UnsafePointer(ptr)[]
+=======
+        return AnyPointer(ptr).__refitem__()
+
+    # TODO: make generic over mutability
+    fn __refitem__[
+        self_life: MutLifetime, index: Int
+    ](
+        self: Reference[Self, __mlir_attr.`1: i1`, self_life].mlir_ref_type,
+    ) -> Reference[Self.ElementType, __mlir_attr.`1: i1`, self_life]:
+        constrained[-index < index < size, "index must be within bounds"]()
+        var normalized_idx = index
+
+        if index < 0:
+            normalized_idx += Reference(self)[].size
+
+        var ptr = __mlir_op.`pop.array.gep`(
+            Pointer.address_of(Reference(self)[].array).address,
+            normalized_idx.value,
+>>>>>>> eb7c04c (debug_assert -> constrained)
         )

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -262,8 +262,21 @@ struct InlineArray[ElementType: CollectionElement, size: Int](Sized):
     var _array: Self.type
     """The underlying storage for the array."""
 
+    # This constructor will always cause a compile time error if used.
+    # It is used to steer users away from uninitialized memory.
     @always_inline
-    fn __init__(inout self, *, fill: Self.ElementType):
+    fn __init__(inout self):
+        constrained[
+            False,
+            (
+                "Initialize with either a variadic list of arguments or a"
+                " default fill element."
+            ),
+        ]()
+        self._array = __mlir_op.`kgen.undef`[_type = Self.type]()
+
+    @always_inline
+    fn __init__(inout self, fill: Self.ElementType):
         """Constructs an empty array where each element is the supplied `fill`.
 
         Args:

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -131,9 +131,7 @@ fn _set_array_elem_mem[
 @always_inline
 fn _create_array_mem[
     size: Int, type: CollectionElement
-](lst: VariadicList[type]) -> __mlir_type[
-    `!pop.array<`, size.value, `, `, type, `>`
-]:
+](*lst: type) -> __mlir_type[`!pop.array<`, size.value, `, `, type, `>`]:
     """Sets the array element at position `index` with the value `val`.
 
     Parameters:

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -368,6 +368,11 @@ struct Array[ElementType: CollectionElement, size: Int](Sized):
         """
         return size
 
+<<<<<<< HEAD
+=======
+    # TODO: make generic over mutability
+    @always_inline
+>>>>>>> 5f73890 (always_inline)
     fn __refitem__[
         mutability: __mlir_type.i1, self_life: AnyLifetime[mutability].type
     ](
@@ -399,6 +404,7 @@ struct Array[ElementType: CollectionElement, size: Int](Sized):
         return AnyPointer(ptr).__refitem__()
 
     # TODO: make generic over mutability
+    @always_inline
     fn __refitem__[
         self_life: MutLifetime, index: Int
     ](

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -323,14 +323,14 @@ struct InlineArray[ElementType: CollectionElement, size: Int](Sized):
     alias type = __mlir_type[
         `!pop.array<`, size.value, `, `, Self.ElementType, `>`
     ]
-    var array: Self.type
+    var _array: Self.type
     """The underlying storage for the array."""
 
     @always_inline
     fn __init__(inout self, *, fill: Self.ElementType):
         """Constructs an empty (undefined) array."""
         _static_tuple_construction_checks[size]()
-        self.array = __mlir_op.`kgen.undef`[_type = Self.type]()
+        self._array = __mlir_op.`kgen.undef`[_type = Self.type]()
 
         @unroll
         for i in range(size):
@@ -346,7 +346,7 @@ struct InlineArray[ElementType: CollectionElement, size: Int](Sized):
         """
         debug_assert(len(elems) == size, "Elements must be of length size")
         _static_tuple_construction_checks[size]()
-        self.array = __mlir_op.`kgen.undef`[_type = Self.type]()
+        self._array = __mlir_op.`kgen.undef`[_type = Self.type]()
 
         @unroll
         for i in range(size):
@@ -374,7 +374,7 @@ struct InlineArray[ElementType: CollectionElement, size: Int](Sized):
         Users should opt for `__refitem__` instead of this method.
         """
         var ptr = __mlir_op.`pop.array.gep`(
-            Reference(Reference(self)[].array).get_legacy_pointer().address,
+            Reference(Reference(self)[]._array).get_legacy_pointer().address,
             index.value,
         )
         return Reference[Self.ElementType, mutability, self_life](

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -368,11 +368,6 @@ struct Array[ElementType: CollectionElement, size: Int](Sized):
         """
         return size
 
-<<<<<<< HEAD
-=======
-    # TODO: make generic over mutability
-    @always_inline
->>>>>>> 5f73890 (always_inline)
     fn __refitem__[
         mutability: __mlir_type.i1, self_life: AnyLifetime[mutability].type
     ](
@@ -397,27 +392,6 @@ struct Array[ElementType: CollectionElement, size: Int](Sized):
             Reference(Reference(self)[].array).get_legacy_pointer().address,
             index.value,
         )
-<<<<<<< HEAD
         return Reference[Self.ElementType, mutability, self_life](
             UnsafePointer(ptr)[]
-=======
-        return AnyPointer(ptr).__refitem__()
-
-    # TODO: make generic over mutability
-    @always_inline
-    fn __refitem__[
-        self_life: MutLifetime, index: Int
-    ](
-        self: Reference[Self, __mlir_attr.`1: i1`, self_life].mlir_ref_type,
-    ) -> Reference[Self.ElementType, __mlir_attr.`1: i1`, self_life]:
-        constrained[-index < index < size, "index must be within bounds"]()
-        var normalized_idx = index
-
-        if index < 0:
-            normalized_idx += Reference(self)[].size
-
-        var ptr = __mlir_op.`pop.array.gep`(
-            Pointer.address_of(Reference(self)[].array).address,
-            normalized_idx.value,
->>>>>>> eb7c04c (debug_assert -> constrained)
         )

--- a/stdlib/test/utils/test_tuple.mojo
+++ b/stdlib/test/utils/test_tuple.mojo
@@ -121,6 +121,9 @@ def test_array_int():
     assert_equal(arr2[1], 5)
     assert_equal(arr2[2], 5)
 
+    var arr3 = InlineArray[Int, 1](5)
+    assert_equal(arr2[0], 5)
+
 
 def test_array_str():
     var arr = InlineArray[String, 3]("hi", "hello", "hey")
@@ -157,6 +160,10 @@ def test_array_str():
     assert_equal(arr2[0], "hi")
     assert_equal(arr2[1], "hi")
     assert_equal(arr2[2], "hi")
+
+    # size 1 array to prevent regressions in the constructors
+    var arr3 = InlineArray[String, 1]("hi")
+    assert_equal(arr3[0], "hi")
 
 
 def main():

--- a/stdlib/test/utils/test_tuple.mojo
+++ b/stdlib/test/utils/test_tuple.mojo
@@ -116,7 +116,7 @@ def test_array_str():
     assert_equal(arr[1], "hello")
     assert_equal(arr[2], "hey")
 
-    # Test mutating a tuple through its __setitem__
+    # Test mutating a tuple through its __refitem__
     arr[0] = "howdy"
     arr[1] = "morning"
     arr[2] = "wazzup"

--- a/stdlib/test/utils/test_tuple.mojo
+++ b/stdlib/test/utils/test_tuple.mojo
@@ -15,7 +15,7 @@
 from testing import assert_equal, assert_false, assert_true
 
 from utils import StaticTuple, StaticIntTuple
-from utils.static_tuple import Array
+from utils.static_tuple import InlineArray
 
 
 def test_static_tuple():
@@ -82,9 +82,7 @@ def test_tuple_literal():
 
 
 def test_array_int():
-    var arr = Array[Int, 3](0, 0, 0)
-    for i in range(len(arr)):
-        print(arr[i])
+    var arr = InlineArray[Int, 3](0, 0, 0)
 
     assert_equal(arr[0], 0)
     assert_equal(arr[1], 0)
@@ -98,6 +96,10 @@ def test_array_int():
     assert_equal(arr[1], 2)
     assert_equal(arr[2], 3)
 
+    # test negative indexing
+    assert_equal(arr[-1], 3)
+    assert_equal(arr[-2], 2)
+
     var copy = arr
     assert_equal(arr[0], copy[0])
     assert_equal(arr[1], copy[1])
@@ -110,13 +112,13 @@ def test_array_int():
 
 
 def test_array_str():
-    var arr = Array[String, 3]("hi", "hello", "hey")
+    var arr = InlineArray[String, 3]("hi", "hello", "hey")
 
     assert_equal(arr[0], "hi")
     assert_equal(arr[1], "hello")
     assert_equal(arr[2], "hey")
 
-    # Test mutating a tuple through its __refitem__
+    # Test mutating an array through its __refitem__
     arr[0] = "howdy"
     arr[1] = "morning"
     arr[2] = "wazzup"
@@ -125,12 +127,9 @@ def test_array_str():
     assert_equal(arr[1], "morning")
     assert_equal(arr[2], "wazzup")
 
-    var ptr = arr.as_ptr()
-    ptr[0] = "good morning"
-    ptr[1] = "good evening"
-
-    assert_equal(arr[0], "good morning")
-    assert_equal(arr[1], "good evening")
+    # test negative indexing
+    assert_equal(arr[-1], "wazzup")
+    assert_equal(arr[-2], "morning")
 
     var copy = arr
     assert_equal(arr[0], copy[0])

--- a/stdlib/test/utils/test_tuple.mojo
+++ b/stdlib/test/utils/test_tuple.mojo
@@ -100,6 +100,12 @@ def test_array_int():
     assert_equal(arr[-1], 3)
     assert_equal(arr[-2], 2)
 
+    # test negative indexing with dynamic index
+    var i = -1
+    assert_equal(arr[i], 3)
+    i -= 1
+    assert_equal(arr[i], 2)
+
     var copy = arr
     assert_equal(arr[0], copy[0])
     assert_equal(arr[1], copy[1])

--- a/stdlib/test/utils/test_tuple.mojo
+++ b/stdlib/test/utils/test_tuple.mojo
@@ -115,6 +115,12 @@ def test_array_int():
     assert_equal(copy[1], move[1])
     assert_equal(copy[2], move[2])
 
+    # fill element initializer
+    var arr2 = InlineArray[Int, 3](5)
+    assert_equal(arr2[0], 5)
+    assert_equal(arr2[1], 5)
+    assert_equal(arr2[2], 5)
+
 
 def test_array_str():
     var arr = InlineArray[String, 3]("hi", "hello", "hey")
@@ -145,6 +151,12 @@ def test_array_str():
     assert_equal(copy[0], move[0])
     assert_equal(copy[1], move[1])
     assert_equal(copy[2], move[2])
+
+    # fill element initializer
+    var arr2 = InlineArray[String, 3]("hi")
+    assert_equal(arr2[0], "hi")
+    assert_equal(arr2[1], "hi")
+    assert_equal(arr2[2], "hi")
 
 
 def main():

--- a/stdlib/test/utils/test_tuple.mojo
+++ b/stdlib/test/utils/test_tuple.mojo
@@ -15,6 +15,7 @@
 from testing import assert_equal, assert_false, assert_true
 
 from utils import StaticTuple, StaticIntTuple
+from utils.static_tuple import Array
 
 
 def test_static_tuple():
@@ -80,7 +81,64 @@ def test_tuple_literal():
     assert_equal(len(()), 0)
 
 
+def test_array_int():
+    var arr = Array[Int, 3](0, 0, 0)
+    for i in range(len(arr)):
+        print(arr[i])
+
+    assert_equal(arr[0], 0)
+    assert_equal(arr[1], 0)
+    assert_equal(arr[2], 0)
+
+    arr[0] = 1
+    arr[1] = 2
+    arr[2] = 3
+
+    assert_equal(arr[0], 1)
+    assert_equal(arr[1], 2)
+    assert_equal(arr[2], 3)
+
+    var copy = arr
+    assert_equal(arr[0], copy[0])
+    assert_equal(arr[1], copy[1])
+    assert_equal(arr[2], copy[2])
+
+    var move = arr^
+    assert_equal(copy[0], move[0])
+    assert_equal(copy[1], move[1])
+    assert_equal(copy[2], move[2])
+
+
+def test_array_str():
+    var arr = Array[String, 3]("hi", "hello", "hey")
+
+    assert_equal(arr[0], "hi")
+    assert_equal(arr[1], "hello")
+    assert_equal(arr[2], "hey")
+
+    # Test mutating a tuple through its __setitem__
+    arr[0] = "howdy"
+    arr[1] = "morning"
+    arr[2] = "wazzup"
+
+    assert_equal(arr[0], "howdy")
+    assert_equal(arr[1], "morning")
+    assert_equal(arr[2], "wazzup")
+
+    var copy = arr
+    assert_equal(arr[0], copy[0])
+    assert_equal(arr[1], copy[1])
+    assert_equal(arr[2], copy[2])
+
+    var move = arr^
+    assert_equal(copy[0], move[0])
+    assert_equal(copy[1], move[1])
+    assert_equal(copy[2], move[2])
+
+
 def main():
     test_static_tuple()
     test_static_int_tuple()
     test_tuple_literal()
+    test_array_int()
+    test_array_str()

--- a/stdlib/test/utils/test_tuple.mojo
+++ b/stdlib/test/utils/test_tuple.mojo
@@ -125,6 +125,13 @@ def test_array_str():
     assert_equal(arr[1], "morning")
     assert_equal(arr[2], "wazzup")
 
+    var ptr = arr.as_ptr()
+    ptr[0] = "good morning"
+    ptr[1] = "good evening"
+
+    assert_equal(arr[0], "good morning")
+    assert_equal(arr[1], "good evening")
+
     var copy = arr
     assert_equal(arr[0], copy[0])
     assert_equal(arr[1], copy[1])

--- a/stdlib/test/utils/test_tuple.mojo
+++ b/stdlib/test/utils/test_tuple.mojo
@@ -14,8 +14,7 @@
 
 from testing import assert_equal, assert_false, assert_true
 
-from utils import StaticTuple, StaticIntTuple
-from utils.static_tuple import InlineArray
+from utils import StaticTuple, StaticIntTuple, InlineArray
 
 
 def test_static_tuple():


### PR DESCRIPTION
This PR creates an `InlineArray` type that takes any `CollectionElement` rather than just `AnyRegType`. See also [this thread](https://discord.com/channels/1087530497313357884/1228515158234501231) on Discord.