### PR TITLE
[stdlib] SIMD.shuffle with StaticIntTuple mask

### DIFF
--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -1468,13 +1468,10 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         @parameter
         fn _convert_variadic_to_pop_array[
             *mask: Int
-        ]() -> __mlir_type[
-            `!pop.array<`, variadic_len[mask]().value, `, `, Int, `>`
-        ]:
-            alias size = variadic_len[mask]()
+        ]() -> __mlir_type[`!pop.array<`, output_size.value, `, `, Int, `>`]:
             var array = __mlir_op.`kgen.undef`[
                 _type = __mlir_type[
-                    `!pop.array<`, variadic_len[mask]().value, `, `, Int, `>`
+                    `!pop.array<`, output_size.value, `, `, Int, `>`
                 ]
             ]()
 
@@ -1483,7 +1480,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
             fn fill[idx: Int]():
                 alias val = mask[idx]
                 constrained[
-                    0 <= val < 2 * size,
+                    0 <= val < 2 * output_size,
                     "invalid index in the shuffle operation",
                 ]()
                 var ptr = __mlir_op.`pop.array.gep`(
@@ -1491,7 +1488,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
                 )
                 __mlir_op.`pop.store`(val, ptr)
 
-            unroll[fill, size]()
+            unroll[fill, output_size]()
             return array
 
         alias length = variadic_len[mask]()

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -1768,92 +1768,17 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
 
         # Common cases will use shuffle which the compiler understands well.
         @parameter
-        if size == 1:
-            return self._shuffle_list[
-                0,
-                1,
-                output_size = 2 * size,
-            ](other)
-        elif size == 2:
-            return self._shuffle_list[
-                0,
-                1,
-                2,
-                3,
-                output_size = 2 * size,
-            ](other)
-        elif size == 4:
-            return self._shuffle_list[
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7,
-                output_size = 2 * size,
-            ](other)
-        elif size == 8:
-            return self._shuffle_list[
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                output_size = 2 * size,
-            ](other)
-        elif size == 16:
-            return self._shuffle_list[
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-                11,
-                12,
-                13,
-                14,
-                15,
-                16,
-                17,
-                18,
-                19,
-                20,
-                21,
-                22,
-                23,
-                24,
-                25,
-                26,
-                27,
-                28,
-                29,
-                30,
-                31,
-                output_size = 2 * size,
-            ](other)
+        fn build_indices() -> StaticIntTuple[2 * size]:
+            var indices = StaticIntTuple[2 * size]()
 
-        var res = SIMD[type, 2 * size]()
-        res = res.insert(self)
-        return res.insert[offset=size](other)
+            @parameter
+            fn _fill[i: Int]():
+                indices[i] = i
+
+            unroll[_fill, 2 * size]()
+            return indices
+
+        return self._shuffle_list[2 * size, build_indices()](other)
 
     @always_inline("nodebug")
     fn interleave(self, other: Self) -> SIMD[type, 2 * size]:

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -1524,21 +1524,14 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         """
 
         @parameter
-        fn _check_indices[mask: StaticIntTuple[output_size]]() -> Bool:
-            @parameter
-            fn _check[i: Int]():
-                constrained[
-                    0 <= mask[i] < 2 * size,
-                    "invalid index in the shuffle operation",
-                ]()
+        fn _check[i: Int]():
+            constrained[
+                0 <= mask[i] < 2 * size,
+                "invalid index in the shuffle operation",
+            ]()
 
-            unroll[_check, output_size]()
+        unroll[_check, output_size]()
 
-            return True
-
-        constrained[
-            _check_indices[mask](), "invalid index in the shuffle operation"
-        ]()
         return __mlir_op.`pop.simd.shuffle`[
             mask = mask.data.array,
             _type = __mlir_type[

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -1480,7 +1480,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
             fn fill[idx: Int]():
                 alias val = mask[idx]
                 constrained[
-                    0 <= val < 2 * output_size,
+                    0 <= val < 2 * size,
                     "invalid index in the shuffle operation",
                 ]()
                 var ptr = __mlir_op.`pop.array.gep`(

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -1759,7 +1759,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
             A new vector `self_0, self_1, ..., self_n, other_0, ..., other_n`.
         """
 
-        # Common cases will use shuffle which the compiler understands well.
+        @always_inline
         @parameter
         fn build_indices() -> StaticIntTuple[2 * size]:
             var indices = StaticIntTuple[2 * size]()

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -383,6 +383,43 @@ def test_shift():
     )
 
 
+def test_shuffle():
+    print("== test_shuffle")
+
+    alias dtype = DType.int32
+    alias width = 4
+
+    vec = SIMD[dtype, width](100, 101, 102, 103)
+
+    assert_equal(
+        vec.shuffle[3, 2, 1, 0](), SIMD[dtype, width](103, 102, 101, 100)
+    )
+    assert_equal(
+        vec.shuffle[0, 2, 4, 6](vec), SIMD[dtype, width](100, 102, 100, 102)
+    )
+
+    assert_equal(
+        vec._shuffle_list[7, 6, 5, 4, 3, 2, 1, 0, output_size = 2 * width](vec),
+        SIMD[dtype, 2 * width](103, 102, 101, 100, 103, 102, 101, 100),
+    )
+
+    assert_equal(
+        vec.shuffle[StaticIntTuple[width](3, 2, 1, 0)](),
+        SIMD[dtype, width](103, 102, 101, 100),
+    )
+    assert_equal(
+        vec.shuffle[StaticIntTuple[width](0, 2, 4, 6)](vec),
+        SIMD[dtype, width](100, 102, 100, 102),
+    )
+
+    assert_equal(
+        vec._shuffle_list[
+            2 * width, StaticIntTuple[2 * width](7, 6, 5, 4, 3, 2, 1, 0)
+        ](vec),
+        SIMD[dtype, 2 * width](103, 102, 101, 100, 103, 102, 101, 100),
+    )
+
+
 def test_insert():
     assert_equal(Int32(3).insert(Int32(4)), 4)
 
@@ -420,43 +457,6 @@ def test_join():
     assert_equal(
         vec.join(vec),
         SIMD[DType.int32, 8](100, 101, 102, 103, 100, 101, 102, 103),
-    )
-
-
-def test_shuffle():
-    print("== test_shuffle")
-
-    alias dtype = DType.int32
-    alias width = 4
-
-    vec = SIMD[dtype, width](100, 101, 102, 103)
-
-    assert_equal(
-        vec.shuffle[3, 2, 1, 0](), SIMD[dtype, width](103, 102, 101, 100)
-    )
-    assert_equal(
-        vec.shuffle[0, 2, 4, 6](vec), SIMD[dtype, width](100, 102, 100, 102)
-    )
-
-    assert_equal(
-        vec._shuffle_list[7, 6, 5, 4, 3, 2, 1, 0, output_size = 2 * width](vec),
-        SIMD[dtype, 2 * width](103, 102, 101, 100, 103, 102, 101, 100),
-    )
-
-    assert_equal(
-        vec.shuffle[StaticIntTuple[width](3, 2, 1, 0)](),
-        SIMD[dtype, width](103, 102, 101, 100),
-    )
-    assert_equal(
-        vec.shuffle[StaticIntTuple[width](0, 2, 4, 6)](vec),
-        SIMD[dtype, width](100, 102, 100, 102),
-    )
-
-    assert_equal(
-        vec._shuffle_list[
-            2 * width, StaticIntTuple[2 * width](7, 6, 5, 4, 3, 2, 1, 0)
-        ](vec),
-        SIMD[dtype, 2 * width](103, 102, 101, 100, 103, 102, 101, 100),
     )
 
 
@@ -794,9 +794,9 @@ def main():
     test_mod()
     test_rotate()
     test_shift()
+    test_shuffle()
     test_insert()
     test_join()
-    test_shuffle()
     test_interleave()
     test_deinterleave()
     test_address()

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -413,6 +413,37 @@ def test_insert():
     )
 
 
+def test_join():
+    print("== test_join")
+    vec = SIMD[DType.int32, 4](100, 101, 102, 103)
+
+    assert_equal(
+        vec.join(vec),
+        SIMD[DType.int32, 8](100, 101, 102, 103, 100, 101, 102, 103),
+    )
+
+
+def test_shuffle():
+    print("== test_shuffle")
+
+    alias dtype = DType.int32
+    alias width = 4
+
+    vec = SIMD[dtype, width](100, 101, 102, 103)
+
+    assert_equal(
+        vec.shuffle[3, 2, 1, 0](), SIMD[dtype, width](103, 102, 101, 100)
+    )
+    assert_equal(
+        vec.shuffle[0, 2, 4, 6](vec), SIMD[dtype, width](100, 102, 100, 102)
+    )
+
+    assert_equal(
+        vec._shuffle_list[7, 6, 5, 4, 3, 2, 1, 0, output_size = 2 * width](vec),
+        SIMD[dtype, 2 * width](103, 102, 101, 100, 103, 102, 101, 100),
+    )
+
+
 def test_interleave():
     assert_equal(Int32(0).interleave(Int32(1)), SIMD[DType.index, 2](0, 1))
 
@@ -748,6 +779,8 @@ def main():
     test_rotate()
     test_shift()
     test_insert()
+    test_join()
+    test_shuffle()
     test_interleave()
     test_deinterleave()
     test_address()

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -384,8 +384,6 @@ def test_shift():
 
 
 def test_shuffle():
-    print("== test_shuffle")
-
     alias dtype = DType.int32
     alias width = 4
 
@@ -451,7 +449,6 @@ def test_insert():
 
 
 def test_join():
-    print("== test_join")
     vec = SIMD[DType.int32, 4](100, 101, 102, 103)
 
     assert_equal(

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -443,6 +443,22 @@ def test_shuffle():
         SIMD[dtype, 2 * width](103, 102, 101, 100, 103, 102, 101, 100),
     )
 
+    assert_equal(
+        vec.shuffle[StaticIntTuple[width](3, 2, 1, 0)](),
+        SIMD[dtype, width](103, 102, 101, 100),
+    )
+    assert_equal(
+        vec.shuffle[StaticIntTuple[width](0, 2, 4, 6)](vec),
+        SIMD[dtype, width](100, 102, 100, 102),
+    )
+
+    assert_equal(
+        vec._shuffle_list[
+            2 * width, StaticIntTuple[2 * width](7, 6, 5, 4, 3, 2, 1, 0)
+        ](vec),
+        SIMD[dtype, 2 * width](103, 102, 101, 100, 103, 102, 101, 100),
+    )
+
 
 def test_interleave():
     assert_equal(Int32(0).interleave(Int32(1)), SIMD[DType.index, 2](0, 1))


### PR DESCRIPTION
Implement #2293.  New overloads for `SIMD.shuffle()` like this: 
```
fn shuffle[mask: StaticIntTuple[size]](self) -> Self:
```
additionally:
- added tests for `SIMD.join()` and `SIMD.shuffle()`
- simplified `join` implementation and always use shuffle rather than 2 inserts when mask size > 32
- cleaned up doc strings about shuffle output length
- minor refactor of original `_shuffle_list` to use `output_size` parameter rather than calculate `len(mask)` many times

As I mentioned in the issue, this can be nicer when inferred parameters are implemented but I guess that is true of most things.