### PR TITLE
[stdlib] Change `FileHandle.read_bytes()` to not copy data

### DIFF
--- a/stdlib/src/builtin/file.mojo
+++ b/stdlib/src/builtin/file.mojo
@@ -188,12 +188,7 @@ struct FileHandle:
         if err_msg:
             raise (err_msg^).consume_as_error()
 
-        var list = List[Int8](capacity=int(size_copy))
-        var list_ptr = UnsafePointer[Int8](address=int(list.data))
-
-        # Initialize the List elements and set the initialized size
-        memcpy(list_ptr, buf, int(size_copy))
-        list.size = int(size_copy)
+        var list = List[Int8](buf, int(size_copy), int(size_copy))
 
         return list
 


### PR DESCRIPTION
Fixes https://github.com/modularml/mojo/issues/2051, allows FileHandle.read_bytes() to return List[Int8] without additional copies, depends on https://github.com/modularml/mojo/pull/2182.