### PR TITLE
[stdlib] Implement `List.__str__()`

### DIFF
--- a/stdlib/src/builtin/str.mojo
+++ b/stdlib/src/builtin/str.mojo
@@ -18,6 +18,7 @@ These are Mojo built-ins, so you don't need to import them.
 # ===----------------------------------------------------------------------=== #
 # Stringable
 # ===----------------------------------------------------------------------=== #
+from ..collections.list import StringableCollectionElement
 
 
 trait Stringable:
@@ -169,3 +170,19 @@ fn str[T: StringableRaising](value: T) raises -> String:
         If there is an error when computing the string representation of the type.
     """
     return value.__str__()
+
+
+@always_inline
+fn str[T: StringableCollectionElement](value: List[T]) -> String:
+    """Get the string representation of a list of strings.
+
+    Parameters:
+        T: The type conforming to Stringable and a CollectionElement.
+
+    Args:
+        value: The object to get the string representation of.
+
+    Returns:
+        The string representation of the object.
+    """
+    return __type_of(value).__str__(value)

--- a/stdlib/src/builtin/str.mojo
+++ b/stdlib/src/builtin/str.mojo
@@ -18,7 +18,6 @@ These are Mojo built-ins, so you don't need to import them.
 # ===----------------------------------------------------------------------=== #
 # Stringable
 # ===----------------------------------------------------------------------=== #
-from ..collections.list import StringableCollectionElement
 
 
 trait Stringable:
@@ -170,19 +169,3 @@ fn str[T: StringableRaising](value: T) raises -> String:
         If there is an error when computing the string representation of the type.
     """
     return value.__str__()
-
-
-@always_inline
-fn str[T: StringableCollectionElement](value: List[T]) -> String:
-    """Get the string representation of a list of strings.
-
-    Parameters:
-        T: The type conforming to Stringable and a CollectionElement.
-
-    Args:
-        value: The object to get the string representation of.
-
-    Returns:
-        The string representation of the object.
-    """
-    return __type_of(value).__str__(value)

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -69,6 +69,10 @@ struct _ListIter[
         return len(self.src[]) - self.index
 
 
+trait StringableCollectionElement(Stringable, CollectionElement):
+    pass
+
+
 struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
     """The `List` type is a dynamically-allocated list.
 
@@ -537,3 +541,12 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             An iterator of immutable references to the list elements.
         """
         return _ListIter[T, mutability, self_life](0, Reference(self))
+
+    @staticmethod
+    fn __str__[U: StringableCollectionElement](self: List[U]) -> String:
+        var result = String("[")
+        for i in range(len(self)):
+            result += str(self[i])
+            if i < len(self) - 1:
+                result += ", "
+        return result + "]"

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -598,10 +598,18 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         Returns:
             A string representation of the list.
         """
-        # TODO: Use `String.join()` when it's working with List.
-        var result = String("[")
+        # we do a rough estimation of the number of chars that we'll see
+        # in the final string, we assume that str(x) will be at least one char.
+        var minimum_capacity = (
+            2  # '[' and ']'
+            + len(self) * 3  # str(x) and ", "
+            - 2  # remove the last ", "
+        )
+        var result = String(List[Int8](capacity=minimum_capacity))
+        result += "["
         for i in range(len(self)):
             result += str(self[i])
             if i < len(self) - 1:
                 result += ", "
-        return result + "]"
+        result += "]"
+        return result

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -575,6 +575,30 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
 
     @staticmethod
     fn __str__[U: StringableCollectionElement](self: List[U]) -> String:
+        """Returns a string representation of a list.
+
+        Note that since we can't condition methods on a trait yet,
+        the way to call this method is a bit special. Here is an example below:
+
+        ```mojo
+        var my_list = List[Int](1, 2, 3)
+        print(__type_of_(my_list).__str__(my_list))
+        ```
+
+        When the compiler supports conditional methods, then a simple `str(my_list)` will
+        be enough.
+
+        Args:
+            self: The list to represent as a string.
+
+        Parameters:
+            U: The type of the elements in the list. Must implement the
+              traits `Stringable` and `CollectionElement`.
+
+        Returns:
+            A string representation of the list.
+        """
+        # TODO: Use `String.join()` when it's working with List.
         var result = String("[")
         for i in range(len(self)):
             result += str(self[i])

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -575,7 +575,7 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
 
     @staticmethod
     fn __str__[U: StringableCollectionElement](self: List[U]) -> String:
-        """Returns a string representation of a list.
+        """Returns a string representation of a `List`.
 
         Note that since we can't condition methods on a trait yet,
         the way to call this method is a bit special. Here is an example below:

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -571,6 +571,19 @@ def test_constructor_from_other_list_through_pointer():
     assert_equal(some_list.capacity, capacity)
 
 
+def test_converting_list_to_string():
+    var my_list = List[Int](1, 2, 3)
+    assert_equal(str(my_list), "[1, 2, 3]")
+
+    var my_list2 = List[SIMD[DType.int8, 2]](
+        SIMD[DType.int8, 2](1, 2), SIMD[DType.int8, 2](3, 4)
+    )
+    assert_equal(str(my_list2), "[[1, 2], [3, 4]]")
+
+    var my_list3 = List[Float64](1.0, 2.0, 3.0)
+    assert_equal(str(my_list3), "[1.0, 2.0, 3.0]")
+
+
 def main():
     test_mojo_issue_698()
     test_list()
@@ -592,3 +605,4 @@ def main():
     test_list_span()
     test_constructor_from_pointer()
     test_constructor_from_other_list_through_pointer()
+    test_converting_list_to_string()

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -573,15 +573,15 @@ def test_constructor_from_other_list_through_pointer():
 
 def test_converting_list_to_string():
     var my_list = List[Int](1, 2, 3)
-    assert_equal(str(my_list), "[1, 2, 3]")
+    assert_equal(__type_of(my_list).__str__(my_list), "[1, 2, 3]")
 
     var my_list2 = List[SIMD[DType.int8, 2]](
         SIMD[DType.int8, 2](1, 2), SIMD[DType.int8, 2](3, 4)
     )
-    assert_equal(str(my_list2), "[[1, 2], [3, 4]]")
+    assert_equal(__type_of(my_list2).__str__(my_list2), "[[1, 2], [3, 4]]")
 
     var my_list3 = List[Float64](1.0, 2.0, 3.0)
-    assert_equal(str(my_list3), "[1.0, 2.0, 3.0]")
+    assert_equal(__type_of(my_list3).__str__(my_list3), "[1.0, 2.0, 3.0]")
 
 
 def main():


### PR DESCRIPTION
PR that can serve as a reference for https://github.com/modularml/mojo/pull/2190#issuecomment-2062101102

Note that it causes a bug that seems on the parser side. We get this:

```
RUN: at line 13: mojo /projects/open_source/mojo/stdlib/test/builtin/test_str.mojo
+ mojo /projects/open_source/mojo/stdlib/test/builtin/test_str.mojo
/projects/open_source/mojo/stdlib/test/builtin/test_str.mojo:18:5: error: cannot bind MLIR type 'None' to trait 'StringableCollectionElement'
def test_str_none():
    ^
/projects/open_source/mojo/stdlib/src/builtin/str.mojo:62:8: note: MLIR type cannot satisfy required trait function here
    fn __str__(self) -> String:
       ^
mojo: error: failed to parse the provided Mojo source module
```

So basically, making an overload to allow `str(List[...])` makes `str(List[Int](1, 2, 3))` return `"[1, 2, 3]"`, but breaks `str(None)`. I think the parser doesn't pick the right overload.

I'll try to make a small reproducer and open an issue to track the resolution