### PR TITLE
[stdlib] Support reverse for Dict keys

### DIFF
--- a/stdlib/src/builtin/reversed.mojo
+++ b/stdlib/src/builtin/reversed.mojo
@@ -106,14 +106,14 @@ fn reversed[
 ](
     value: Reference[Dict[K, V], mutability, self_life]._mlir_type,
 ) -> _DictKeyIter[K, V, mutability, self_life, False]:
-    """Get a reversed iterator of the input list.
+    """Get a reversed iterator of the input dict.
 
     **Note**: iterators are currently non-raising.
 
     Args:
-        value: The list to get the reversed iterator of.
+        value: The dict to get the reversed iterator of.
 
     Returns:
-        The reversed iterator of the list.
+        The reversed iterator of the dict.
     """
     return Reference(value)[].__reversed__[mutability, self_life]()

--- a/stdlib/src/builtin/reversed.mojo
+++ b/stdlib/src/builtin/reversed.mojo
@@ -19,6 +19,8 @@ from .range import _StridedRangeIterator
 
 from collections.list import _ListIter
 
+from collections.dict import _DictKeyIter
+
 # ===----------------------------------------------------------------------=== #
 #  Reversible
 # ===----------------------------------------------------------------------=== #
@@ -83,6 +85,27 @@ fn reversed[
 ) -> _ListIter[
     T, mutability, self_life, False
 ]:
+    """Get a reversed iterator of the input list.
+
+    **Note**: iterators are currently non-raising.
+
+    Args:
+        value: The list to get the reversed iterator of.
+
+    Returns:
+        The reversed iterator of the list.
+    """
+    return Reference(value)[].__reversed__[mutability, self_life]()
+
+
+fn reversed[
+    mutability: __mlir_type.`i1`,
+    self_life: AnyLifetime[mutability].type,
+    K: KeyElement,
+    V: CollectionElement,
+](
+    value: Reference[Dict[K, V], mutability, self_life]._mlir_type,
+) -> _DictKeyIter[K, V, mutability, self_life, False]:
     """Get a reversed iterator of the input list.
 
     **Note**: iterators are currently non-raising.

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -80,6 +80,7 @@ struct _DictEntryIter[
     @always_inline
     fn __next__(inout self) -> Self.ref_type:
         while True:
+
             @parameter
             if forward:
                 debug_assert(

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -785,10 +785,10 @@ struct Dict[K: KeyElement, V: CollectionElement](
     ) -> _DictKeyIter[
         K, V, mutability, self_life, False
     ]:
-        """Iterate backwards over the list, returning immutable references.
+        """Iterate backwards over the dict keys, returning immutable references.
 
         Returns:
-            A reversed iterator of immutable references to the list elements.
+            A reversed iterator of immutable references to the dict keys.
         """
         var ref = Reference(self)
         return _DictKeyIter(

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -80,6 +80,7 @@ struct _DictEntryIter[
     @always_inline
     fn __next__(inout self) -> Self.ref_type:
         while True:
+            @parameter
             if forward:
                 debug_assert(
                     self.index < self.src[]._reserved, "dict iter bounds"
@@ -93,6 +94,7 @@ struct _DictEntryIter[
                     Self.imm_dict_lifetime,
                 ](self.index)
 
+                @parameter
                 if forward:
                     self.index += 1
                 else:
@@ -103,6 +105,7 @@ struct _DictEntryIter[
                 # unsafe reference lifetime casting.
                 return opt_entry_ref.unsafe_bitcast[DictEntry[K, V]]()
 
+            @parameter
             if forward:
                 self.index += 1
             else:

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -51,6 +51,7 @@ struct _DictEntryIter[
     V: CollectionElement,
     dict_mutability: __mlir_type.`i1`,
     dict_lifetime: AnyLifetime[dict_mutability].type,
+    forward: Bool = True,
 ]:
     """Iterator over immutable DictEntry references.
 
@@ -59,6 +60,7 @@ struct _DictEntryIter[
         V: The value type of the elements in the dictionary.
         dict_mutability: Whether the reference to the dictionary is mutable.
         dict_lifetime: The lifetime of the List
+        forward: The iteration direction. `False` is backwards.
     """
 
     alias imm_dict_lifetime = __mlir_attr[
@@ -78,18 +80,33 @@ struct _DictEntryIter[
     @always_inline
     fn __next__(inout self) -> Self.ref_type:
         while True:
-            debug_assert(self.index < self.src[]._reserved, "dict iter bounds")
+            if forward:
+                debug_assert(
+                    self.index < self.src[]._reserved, "dict iter bounds"
+                )
+            else:
+                debug_assert(self.index >= 0, "dict iter bounds")
+
             if self.src[]._entries.__get_ref(self.index)[]:
                 var opt_entry_ref = self.src[]._entries.__get_ref[
                     __mlir_attr.`0: i1`,
                     Self.imm_dict_lifetime,
                 ](self.index)
-                self.index += 1
+
+                if forward:
+                    self.index += 1
+                else:
+                    self.index -= 1
+
                 self.seen += 1
                 # Super unsafe, but otherwise we have to do a bunch of super
                 # unsafe reference lifetime casting.
                 return opt_entry_ref.unsafe_bitcast[DictEntry[K, V]]()
-            self.index += 1
+
+            if forward:
+                self.index += 1
+            else:
+                self.index -= 1
 
     fn __len__(self) -> Int:
         return len(self.src[]) - self.seen
@@ -101,6 +118,7 @@ struct _DictKeyIter[
     V: CollectionElement,
     dict_mutability: __mlir_type.`i1`,
     dict_lifetime: AnyLifetime[dict_mutability].type,
+    forward: Bool = True,
 ]:
     """Iterator over immutable Dict key references.
 
@@ -109,6 +127,7 @@ struct _DictKeyIter[
         V: The value type of the elements in the dictionary.
         dict_mutability: Whether the reference to the vector is mutable.
         dict_lifetime: The lifetime of the List
+        forward: The iteration direction. `False` is backwards.
     """
 
     alias imm_dict_lifetime = __mlir_attr[
@@ -116,7 +135,9 @@ struct _DictKeyIter[
     ]
     alias ref_type = Reference[K, __mlir_attr.`0: i1`, Self.imm_dict_lifetime]
 
-    alias dict_entry_iter = _DictEntryIter[K, V, dict_mutability, dict_lifetime]
+    alias dict_entry_iter = _DictEntryIter[
+        K, V, dict_mutability, dict_lifetime, forward
+    ]
 
     var iter: Self.dict_entry_iter
 
@@ -756,6 +777,25 @@ struct Dict[K: KeyElement, V: CollectionElement](
                 self._entries[right] = None
 
         self._n_entries = self.size
+
+    fn __reversed__[
+        mutability: __mlir_type.`i1`, self_life: AnyLifetime[mutability].type
+    ](
+        self: Reference[Self, mutability, self_life]._mlir_type,
+    ) -> _DictKeyIter[
+        K, V, mutability, self_life, False
+    ]:
+        """Iterate backwards over the list, returning immutable references.
+
+        Returns:
+            A reversed iterator of immutable references to the list elements.
+        """
+        var ref = Reference(self)
+        return _DictKeyIter(
+            _DictEntryIter[K, V, mutability, self_life, False](
+                ref[]._reserved, 0, ref
+            )
+        )
 
 
 struct OwnedKwargsDict[V: CollectionElement](Sized, CollectionElement):

--- a/stdlib/test/builtin/test_reversed.mojo
+++ b/stdlib/test/builtin/test_reversed.mojo
@@ -24,5 +24,62 @@ def test_reversed_list():
         check -= 1
 
 
+def test_reversed_dict():
+    var dict = Dict[String, Int]()
+    dict["a"] = 1
+    dict["b"] = 2
+    dict["c"] = 3
+    dict["d"] = 4
+    dict["a"] = 5
+
+    var keys = String("")
+    for key in reversed(dict):
+        keys += key[]
+
+    assert_equal(keys, "dcba")
+
+    # Order preserved
+
+    _ = dict.pop("a")
+    _ = dict.pop("c")
+
+    keys = String("")
+    for key in dict:
+        keys += key[]
+
+    assert_equal(keys, "bd")
+
+    keys = String("")
+    for key in reversed(dict):
+        keys += key[]
+
+    assert_equal(keys, "db")
+
+    # Empty dict is iterable
+
+    _ = dict.pop("b")
+    _ = dict.pop("d")
+
+    keys = String("")
+    for key in reversed(dict):
+        keys += key[]
+
+    assert_equal(keys, "")
+
+    # Refill dict
+
+    dict["d"] = 4
+    dict["a"] = 1
+    dict["b"] = 2
+    dict["e"] = 3
+
+    keys = String("")
+    for key in reversed(dict):
+        keys += key[]
+
+    assert_equal(keys, "ebad")
+
+
 def main():
+    test_reversed_dict()
     test_reversed_list()


### PR DESCRIPTION
Part of #2325 

The behavior is align with Python, only keys is iterated

> reversed(d)
Return a reverse iterator over the keys of the dictionary. This is a shortcut for reversed(d.keys()).

I plan to support `d.values()` and `d.items()` in follow up PR too!
