### PR TITLE
[stdlib] Remove some `# CHECK` and refactor `test_print.mojo`

### DIFF
--- a/stdlib/test/builtin/test_bool.mojo
+++ b/stdlib/test/builtin/test_bool.mojo
@@ -29,6 +29,12 @@ def test_bool_none():
     assert_equal(bool(test), False)
 
 
+def test_bool_to_string():
+    assert_equal(str(True), "True")
+    assert_equal(str(False), "False")
+
+
 def main():
     test_bool_cast_to_int()
     test_bool_none()
+    test_bool_to_string()

--- a/stdlib/test/builtin/test_error.mojo
+++ b/stdlib/test/builtin/test_error.mojo
@@ -19,12 +19,21 @@ def raise_an_error():
     raise Error("MojoError: This is an error!")
 
 
-def main():
+def test_error_raising():
     try:
-        _ = raise_an_error()
+        raise_an_error()
     except e:
         assert_equal(str(e), "MojoError: This is an error!")
 
+
+def test_from_and_to_string():
     var myString: String = "FOO"
     var error = Error(myString)
     assert_equal(error, "FOO")
+
+    assert_equal(str(Error("bad")), "bad")
+
+
+def main():
+    test_error_raising()
+    test_from_and_to_string()

--- a/stdlib/test/builtin/test_print.mojo
+++ b/stdlib/test/builtin/test_print.mojo
@@ -22,48 +22,17 @@ from utils import StringRef, StaticIntTuple
 fn test_print():
     print("== test_print")
 
-    var a: SIMD[DType.float32, 2] = 5
-    var b: SIMD[DType.float64, 4] = 6
-    var c: SIMD[DType.index, 8] = 7
-
-    # CHECK: False
-    print(False)
-
-    # CHECK: True
-    print(True)
-
-    # CHECK: [5.0, 5.0]
-    print(a)
-
-    # CHECK: [6.0, 6.0, 6.0, 6.0]
-    print(b)
-
-    # CHECK: [7, 7, 7, 7, 7, 7, 7, 7]
-    print(c)
-
     # CHECK: Hello
     print("Hello")
 
     # CHECK: World
     print("World", flush=True)
 
-    # CHECK: 4294967295
-    print(UInt32(-1))
-
-    # CHECK: 184467440737095516
-    print(UInt64(-1))
-
-    # CHECK: 0x16
-    print(Scalar[DType.address](22))
-
-    # CHECK: 0xdeadbeaf
-    print(Scalar[DType.address](0xDEADBEAF))
-
     var hello: StringRef = "Hello,"
     var world: String = "world!"
     var f: Bool = False
-    # CHECK: > Hello, world! 42 True False [5.0, 5.0] [7, 7, 7, 7, 7, 7, 7, 7]
-    print(">", hello, world, 42, True, f, a, c)
+    # CHECK: > Hello, world! 42 True False
+    print(">", hello, world, 42, True, f)
 
     # CHECK: > 3.14000{{[0-9]+}} 99.90000{{[0-9]+}} -129.29018{{[0-9]+}} (1, 2, 3)
     var float32: Float32 = 99.9
@@ -85,33 +54,6 @@ fn test_print():
     # CHECK: Hello world
     print(String("Hello world"))
 
-    # CHECK: 32768
-    print((UInt16(32768)))
-    # CHECK: 65535
-    print((UInt16(65535)))
-    # CHECK: -2
-    print((Int16(-2)))
-
-    # CHECK: 16646288086500911323
-    print(UInt64(16646288086500911323))
-
-    # https://github.com/modularml/mojo/issues/556
-    # CHECK: [11562461410679940143, 16646288086500911323, 10285213230658275043, 6384245875588680899]
-    print(
-        SIMD[DType.uint64, 4](
-            0xA0761D6478BD642F,
-            0xE7037ED1A0B428DB,
-            0x8EBC6AF09C88C6E3,
-            0x589965CC75374CC3,
-        )
-    )
-
-    # CHECK: [-943274556, -875902520, -808530484, -741158448]
-    print(SIMD[DType.int32, 4](-943274556, -875902520, -808530484, -741158448))
-
-    # CHECK: bad
-    print(Error("bad"))
-
 
 # CHECK-LABEL: test_print_end
 fn test_print_end():
@@ -131,20 +73,7 @@ fn test_print_sep():
     print("a", 1, 2, sep="/", end="xx\n")
 
 
-# CHECK-LABEL: test_issue_20421
-fn test_issue_20421():
-    print("== test_issue_20421")
-    var a = DTypePointer[DType.uint8]().alloc(16 * 64, alignment=64)
-    for i in range(16 * 64):
-        a[i] = i & 255
-    var av16 = a.offset(128 + 64 + 4).bitcast[DType.int32]().load[width=4]()
-    # CHECK: [-943274556, -875902520, -808530484, -741158448]
-    print(av16)
-    a.free()
-
-
 fn main():
     test_print()
     test_print_end()
     test_print_sep()
-    test_issue_20421()


### PR DESCRIPTION
Related to #2024 

Some tests in `test_print.mojo` are not related to printing at all. It's more testing the string conversion. So I took the liberty of putting them in the right files. This also helped remove some `# CHECK` as removing those when testing the print() function is really hard.