### PR TITLE
[stdlib] Replace `Pointer` by `UnsafePointer` in `stdlib/src/builtin/object.mojo`

### DIFF
--- a/stdlib/src/builtin/object.mojo
+++ b/stdlib/src/builtin/object.mojo
@@ -20,9 +20,9 @@ from os import Atomic
 from sys.intrinsics import _type_is_eq
 
 
-from memory import memcmp, memcpy, DTypePointer, Pointer
+from memory import memcmp, memcpy, DTypePointer
 from memory._arc import Arc
-from memory.unsafe import LegacyPointer
+from memory.unsafe_pointer import move_from_pointee
 
 
 from utils import StringRef, unroll
@@ -58,15 +58,11 @@ struct _ImmutableString:
     pointer and integer pair. Memory will be dynamically allocated.
     """
 
-    var data: LegacyPointer[Int8]
+    var data: UnsafePointer[Int8]
     """The pointer to the beginning of the string contents. It is not
     null-terminated."""
     var length: Int
     """The length of the string."""
-
-    @always_inline
-    fn __init__(data: LegacyPointer[Int8], length: Int) -> Self:
-        return Self {data: data.address, length: length}
 
     @always_inline
     fn __init__(data: UnsafePointer[Int8], length: Int) -> Self:
@@ -1270,7 +1266,7 @@ struct object(IntableRaising, Boolable, Stringable):
                 UnsafePointer[Int8].alloc(length), length
             )
             memcpy(impl.data, lhsStr.data, lhsStr.length)
-            memcpy(impl.data.offset(lhsStr.length), rhsStr.data, rhsStr.length)
+            memcpy(impl.data + lhsStr.length, rhsStr.data, rhsStr.length)
             var result = object()
             result._value = impl
             return result
@@ -1743,8 +1739,9 @@ struct object(IntableRaising, Boolable, Stringable):
         var index = Self._convert_index_to_int(i)
         if self._value.is_str():
             var impl = _ImmutableString(UnsafePointer[Int8].alloc(1), 1)
-            impl.data.store(
-                self._value.get_as_string().data.offset(index).load()
+            initialize_pointee(
+                impl.data,
+                move_from_pointee(self._value.get_as_string().data + index),
             )
             return _ObjectImpl(impl)
         return self._value.get_list_element(i._value.get_as_int().value)

--- a/stdlib/src/python/_cpython.mojo
+++ b/stdlib/src/python/_cpython.mojo
@@ -15,7 +15,7 @@ from os import getenv
 from sys import external_call
 from sys.ffi import DLHandle
 
-from memory import DTypePointer
+from memory import DTypePointer, LegacyPointer
 
 from utils import StringRef, StaticIntTuple
 


### PR DESCRIPTION
Builtins imports behave in a weird way, I had to import LegacyPointer in `stdlib/src/python/_cpython.mojo`, I have no explanation for this. I just import what the compiler asks me to import :p

See https://discord.com/channels/1087530497313357884/1224434323193594059/1231287603462930452