### PR TITLE
[stdlib] Replaced `Pointer` -> `UnsafePointer` in `python.mojo`

### DIFF
--- a/stdlib/src/python/python.mojo
+++ b/stdlib/src/python/python.mojo
@@ -22,7 +22,7 @@ from python import Python
 from sys import external_call, sizeof
 from sys.ffi import _get_global
 
-from memory import Pointer
+from memory import UnsafePointer
 
 from utils import StringRef
 
@@ -30,13 +30,13 @@ from ._cpython import CPython, Py_eval_input
 from .object import PythonObject
 
 
-fn _init_global(ignored: Pointer[NoneType]) -> Pointer[NoneType]:
-    var ptr = Pointer[CPython].alloc(1)
+fn _init_global(ignored: UnsafePointer[NoneType]) -> UnsafePointer[NoneType]:
+    var ptr = UnsafePointer[CPython].alloc(1)
     ptr[] = CPython()
     return ptr.bitcast[NoneType]()
 
 
-fn _destroy_global(python: Pointer[NoneType]):
+fn _destroy_global(python: UnsafePointer[NoneType]):
     var p = python.bitcast[CPython]()
     CPython.destroy(p[])
     python.free()
@@ -49,9 +49,9 @@ fn _get_global_python_itf() -> _PythonInterfaceImpl:
 
 
 struct _PythonInterfaceImpl:
-    var _cpython: Pointer[CPython]
+    var _cpython: UnsafePointer[CPython]
 
-    fn __init__(inout self, cpython: Pointer[CPython]):
+    fn __init__(inout self, cpython: UnsafePointer[CPython]):
         self._cpython = cpython
 
     fn __copyinit__(inout self, existing: Self):

--- a/stdlib/src/sys/ffi.mojo
+++ b/stdlib/src/sys/ffi.mojo
@@ -169,6 +169,19 @@ fn _get_global[
 
 
 @always_inline
+fn _get_global[
+    name: StringLiteral,
+    init_fn: fn (UnsafePointer[NoneType]) -> UnsafePointer[NoneType],
+    destroy_fn: fn (UnsafePointer[NoneType]) -> None,
+](
+    payload: UnsafePointer[NoneType] = UnsafePointer[NoneType]()
+) -> UnsafePointer[NoneType]:
+    return external_call[
+        "KGEN_CompilerRT_GetGlobalOrCreate", UnsafePointer[NoneType]
+    ](StringRef(name), payload, init_fn, destroy_fn)
+
+
+@always_inline
 fn _get_global_or_null[name: StringLiteral]() -> Pointer[NoneType]:
     return external_call["KGEN_CompilerRT_GetGlobalOrNull", Pointer[NoneType]](
         StringRef(name)


### PR DESCRIPTION
I added an overload of `_get_global` to work with `UnsafePointer`, I didn't remove the first overload to allow us to migrate progressively towards UnsafePointer. `_get_global` is used in quite a few other places, we'll do it step by step.