### PR TITLE
[stdlib] Use `UnsafePointer` in the `String` struct

### DIFF
--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -62,6 +62,15 @@ fn test_constructors() raises:
     assert_equal("abc", str(s2))
     assert_equal(3, len(s2))
 
+    # Construction from UnsafePointer
+    var ptr = UnsafePointer[Int8].alloc(4)
+    ptr[0] = ord("a")
+    ptr[1] = ord("b")
+    ptr[2] = ord("c")
+    ptr[3] = 0
+    var s3 = String(ptr, 4)
+    assert_equal(s3, "abc")
+
 
 fn test_copy() raises:
     var s0 = String("find")


### PR DESCRIPTION
Three things going on here:
* Added a String constructor from an `UnsafePointer`, this will help us phase out the `Pointer` constructor. Added corresponding test.
* Renamed Pointer -> LegacyPointer, for better information and it conveys the state of the code, better searchability too.
* Use DtypePointer instead of `LegacyPointer` when doing `memcpy`.

I'd appreciate a merge of the internal branch in nightly soon-ish otherwise it's a bit hard to guess what function has been changed or not internally. Especially the ones in _startup.mojo