### PR TITLE
[stdlib] Remove some usage of `LegacyPointer` in tests and StringRef

### DIFF
--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -537,7 +537,7 @@ struct String(Sized, Stringable, IntableRaising, KeyElement, Boolable):
         var adjusted_span = self._adjust_span(span)
         if adjusted_span.step == 1:
             return StringRef(
-                (self._buffer.data + span.start).value,
+                self._buffer.data + span.start,
                 len(adjusted_span),
             )
 

--- a/stdlib/src/utils/stringref.mojo
+++ b/stdlib/src/utils/stringref.mojo
@@ -16,7 +16,7 @@
 
 from builtin.dtype import _uint_type_of_width
 from builtin.string import _atol
-from memory import DTypePointer, LegacyPointer, UnsafePointer
+from memory import DTypePointer, UnsafePointer
 
 # ===----------------------------------------------------------------------=== #
 # Utilities
@@ -89,23 +89,6 @@ struct StringRef(
             A new string.
         """
         return self
-
-    @always_inline
-    fn __init__(ptr: LegacyPointer[Int8], len: Int) -> StringRef:
-        """Construct a StringRef value given a (potentially non-0 terminated
-        string).
-
-        The constructor takes a raw pointer and a length.
-
-        Args:
-            ptr: UnsafePointer to the string.
-            len: The length of the string.
-
-        Returns:
-            Constructed `StringRef` object.
-        """
-
-        return Self {data: ptr, length: len}
 
     @always_inline
     fn __init__(ptr: DTypePointer[DType.int8], len: Int) -> StringRef:

--- a/stdlib/test/memory/test_arc.mojo
+++ b/stdlib/test/memory/test_arc.mojo
@@ -27,15 +27,15 @@ def test_basic():
 
 @value
 struct ObservableDel(CollectionElement):
-    var target: Pointer[Bool]
+    var target: UnsafePointer[Bool]
 
     fn __del__(owned self):
-        self.target.store(True)
+        initialize_pointee(self.target, True)
 
 
 def test_deleter_not_called_until_no_references():
     var deleted = False
-    var p = Arc(ObservableDel(Pointer.address_of(deleted)))
+    var p = Arc(ObservableDel(UnsafePointer.address_of(deleted)))
     var p2 = p
     _ = p^
     assert_false(deleted)

--- a/stdlib/test/python/test_ownership.mojo
+++ b/stdlib/test/python/test_ownership.mojo
@@ -15,7 +15,6 @@
 
 from sys import env_get_string
 
-from memory import Pointer
 from python._cpython import CPython, PyObjectPtr
 from python import PythonObject, Python
 

--- a/stdlib/test/python/test_python_object.mojo
+++ b/stdlib/test/python/test_python_object.mojo
@@ -13,7 +13,6 @@
 # XFAIL: asan && !system-darwin
 # RUN: %mojo-no-debug %s
 
-from memory import Pointer
 from python._cpython import CPython, PyObjectPtr
 
 from python import PythonObject, Python

--- a/stdlib/test/sys/test_windows_target.mojo
+++ b/stdlib/test/sys/test_windows_target.mojo
@@ -25,7 +25,6 @@ from os._windows import (
 )
 from sys import external_call, os_is_linux, os_is_macos, os_is_windows
 
-from memory import Pointer
 from testing import assert_false, assert_true, assert_equal
 
 


### PR DESCRIPTION
We continue to remove the LegacyPointer