### PR TITLE
[stdlib] Parameterize __getitem__ and __setitem__ in stdlib types

### DIFF
--- a/stdlib/src/builtin/bool.mojo
+++ b/stdlib/src/builtin/bool.mojo
@@ -59,7 +59,12 @@ trait Boolable:
 @value
 @register_passable("trivial")
 struct Bool(
-    Stringable, CollectionElement, Boolable, EqualityComparable, Intable
+    Stringable,
+    CollectionElement,
+    Boolable,
+    EqualityComparable,
+    Intable,
+    Indexer,
 ):
     """The primitive Bool scalar value used in Mojo."""
 
@@ -323,6 +328,15 @@ struct Bool(
             0 for -False and -1 for -True.
         """
         return __mlir_op.`index.casts`[_type = __mlir_type.index](self.value)
+
+    @always_inline("nodebug")
+    fn __index__(self) -> Int:
+        """Convert this Bool to an integer for indexing purposes
+
+        Returns:
+            Bool as Int
+        """
+        return self.__int__()
 
 
 # ===----------------------------------------------------------------------=== #

--- a/stdlib/src/builtin/builtin_list.mojo
+++ b/stdlib/src/builtin/builtin_list.mojo
@@ -146,16 +146,19 @@ struct VariadicList[type: AnyRegType](Sized):
         return __mlir_op.`pop.variadic.size`(self.value)
 
     @always_inline
-    fn __getitem__(self, index: Int) -> type:
+    fn __getitem__[indexer: Indexer](self, idx: indexer) -> type:
         """Gets a single element on the variadic list.
 
+        Parameters:
+            indexer: The type of the indexing value.
+
         Args:
-            index: The index of the element to access on the list.
+            idx: The index of the element to access on the list.
 
         Returns:
             The element on the list corresponding to the given index.
         """
-        return __mlir_op.`pop.variadic.get`(self.value, index.value)
+        return __mlir_op.`pop.variadic.get`(self.value, index(idx).value)
 
     @always_inline
     fn __iter__(self) -> Self.IterType:
@@ -358,18 +361,21 @@ struct VariadicListMem[
     # TODO: Fix for loops + _VariadicListIter to support a __nextref__ protocol
     # allowing us to get rid of this and make foreach iteration clean.
     @always_inline
-    fn __getitem__(self, index: Int) -> Self.reference_type:
+    fn __getitem__[indexer: Indexer](self, idx: indexer) -> Self.reference_type:
         """Gets a single element on the variadic list.
 
+        Parameters:
+            indexer: The type of the indexing value.
+
         Args:
-            index: The index of the element to access on the list.
+            idx: The index of the element to access on the list.
 
         Returns:
             A low-level pointer to the element on the list corresponding to the
             given index.
         """
         return Self.reference_type(
-            __mlir_op.`pop.variadic.get`(self.value, index.value)
+            __mlir_op.`pop.variadic.get`(self.value, index(idx).value)
         )
 
     @always_inline

--- a/stdlib/src/builtin/builtin_slice.mojo
+++ b/stdlib/src/builtin/builtin_slice.mojo
@@ -149,8 +149,11 @@ struct Slice(Sized, Stringable, EqualityComparable):
         return len(range(self.start, self.end, self.step))
 
     @always_inline
-    fn __getitem__(self, idx: Int) -> Int:
+    fn __getitem__[indexer: Indexer](self, idx: indexer) -> Int:
         """Get the slice index.
+
+        Parameters:
+            indexer: The type of the indexing value.
 
         Args:
             idx: The index.
@@ -158,7 +161,7 @@ struct Slice(Sized, Stringable, EqualityComparable):
         Returns:
             The slice index.
         """
-        return self.start + idx * self.step
+        return self.start + index(idx) * self.step
 
     @always_inline("nodebug")
     fn _has_end(self) -> Bool:

--- a/stdlib/src/builtin/int.mojo
+++ b/stdlib/src/builtin/int.mojo
@@ -205,6 +205,7 @@ struct Int(
     Roundable,
     Stringable,
     Truncable,
+    Indexer,
 ):
     """This type represents an integer value."""
 

--- a/stdlib/src/builtin/int_literal.mojo
+++ b/stdlib/src/builtin/int_literal.mojo
@@ -29,6 +29,7 @@ struct IntLiteral(
     Roundable,
     Stringable,
     Truncable,
+    Indexer,
 ):
     """This type represents a static integer literal value with
     infinite precision.  They can't be materialized at runtime and

--- a/stdlib/src/builtin/range.mojo
+++ b/stdlib/src/builtin/range.mojo
@@ -82,8 +82,8 @@ struct _ZeroStartingRange(Sized, ReversibleRange):
         return self.curr
 
     @always_inline("nodebug")
-    fn __getitem__(self, idx: Int) -> Int:
-        return idx
+    fn __getitem__[indexer: Indexer](self, idx: indexer) -> Int:
+        return index(idx)
 
     @always_inline("nodebug")
     fn __reversed__(self) -> _StridedRangeIterator:
@@ -113,8 +113,8 @@ struct _SequentialRange(Sized, ReversibleRange):
         return self.end - self.start if self.start < self.end else 0
 
     @always_inline("nodebug")
-    fn __getitem__(self, idx: Int) -> Int:
-        return self.start + idx
+    fn __getitem__[indexer: Indexer](self, idx: indexer) -> Int:
+        return self.start + index(idx)
 
     @always_inline("nodebug")
     fn __reversed__(self) -> _StridedRangeIterator:
@@ -185,8 +185,8 @@ struct _StridedRange(Sized, ReversibleRange):
         return _div_ceil_positive(abs(self.start - self.end), abs(self.step))
 
     @always_inline("nodebug")
-    fn __getitem__(self, idx: Int) -> Int:
-        return self.start + idx * self.step
+    fn __getitem__[indexer: Indexer](self, idx: indexer) -> Int:
+        return self.start + index(idx) * self.step
 
     @always_inline("nodebug")
     fn __reversed__(self) -> _StridedRangeIterator:

--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -798,8 +798,11 @@ struct String(
         """
         return len(self) > 0
 
-    fn __getitem__(self, idx: Int) -> String:
+    fn __getitem__[indexer: Indexer](self, idx: indexer) -> String:
         """Gets the character at the specified position.
+
+        Parameters:
+            indexer: The type of the indexing value.
 
         Args:
             idx: The index value.
@@ -807,12 +810,13 @@ struct String(
         Returns:
             A new string containing the character at the specified position.
         """
-        if idx < 0:
-            return self.__getitem__(len(self) + idx)
+        var index_val = index(idx)
+        if index_val < 0:
+            return self.__getitem__(len(self) + index_val)
 
-        debug_assert(0 <= idx < len(self), "index must be in range")
+        debug_assert(0 <= index_val < len(self), "index must be in range")
         var buf = Self._buffer_type(capacity=1)
-        buf.append(self._buffer[idx])
+        buf.append(self._buffer[index_val])
         buf.append(0)
         return String(buf^)
 

--- a/stdlib/src/builtin/value.mojo
+++ b/stdlib/src/builtin/value.mojo
@@ -203,3 +203,37 @@ trait BoolableKeyElement(Boolable, KeyElement):
     """
 
     pass
+
+
+trait Indexer:
+    """This trait denotes a type that can be used to index a container that
+    handles integral index values.
+
+    This solves the issue of being able to index data structures such as `List` with the various
+    integral types without being too broad and allowing types that should not be used such as float point
+    values.
+    """
+
+    fn __index__(self) -> Int:
+        """Return the index value
+
+        Returns:
+            The index value of the object
+        """
+        ...
+
+
+@always_inline("nodebug")
+fn index[indexer: Indexer](idx: indexer) -> Int:
+    """Returns the value of `__index__` for the given value.
+
+    Parameters:
+        indexer: The type of the given value.
+
+    Args:
+        idx: The value.
+
+    Returns:
+        An int respresenting the index value.
+    """
+    return idx.__index__()

--- a/stdlib/src/collections/inline_list.mojo
+++ b/stdlib/src/collections/inline_list.mojo
@@ -71,19 +71,22 @@ struct InlineList[ElementType: CollectionElement, capacity: Int = 16](Sized):
 
     @always_inline
     fn __refitem__[
-        IntableType: Intable,
-    ](self: Reference[Self, _, _], index: IntableType) -> Reference[
+        indexer: Indexer
+    ](self: Reference[Self, _, _], idx: indexer) -> Reference[
         Self.ElementType, self.is_mutable, self.lifetime
     ]:
         """Get a `Reference` to the element at the given index.
 
+        Parameters:
+            indexer: The inferred type of the indexer.
+
         Args:
-            index: The index of the item.
+            idx: The index of the item.
 
         Returns:
             A reference to the item at the given index.
         """
-        var i = int(index)
+        var i = index(idx)
         debug_assert(
             -self[]._size <= i < self[]._size, "Index must be within bounds."
         )

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -543,17 +543,24 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         self.capacity = 0
         return ptr
 
-    fn __setitem__(inout self, i: Int, owned value: T):
+    fn __setitem__[indexer: Indexer](inout self, i: indexer, owned value: T):
         """Sets a list element at the given index.
+
+        Parameters:
+            indexer: The type of the indexing value.
 
         Args:
             i: The index of the element.
             value: The value to assign.
         """
-        debug_assert(-self.size <= i < self.size, "index must be within bounds")
+        var normalized_idx = index(i)
 
-        var normalized_idx = i
-        if i < 0:
+        debug_assert(
+            -self.size <= normalized_idx < self.size,
+            "index must be within bounds",
+        )
+
+        if normalized_idx < 0:
             normalized_idx += len(self)
 
         destroy_pointee(self.data + normalized_idx)
@@ -603,10 +610,13 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         return res^
 
     @always_inline
-    fn __getitem__(self, i: Int) -> T:
+    fn __getitem__[indexer: Indexer](self, i: indexer) -> T:
         """Gets a copy of the list element at the given index.
 
         FIXME(lifetimes): This should return a reference, not a copy!
+
+        Parameters:
+            indexer: The type of the indexing value.
 
         Args:
             i: The index of the element.
@@ -614,10 +624,14 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         Returns:
             A copy of the element at the given index.
         """
-        debug_assert(-self.size <= i < self.size, "index must be within bounds")
+        var normalized_idx = index(i)
 
-        var normalized_idx = i
-        if i < 0:
+        debug_assert(
+            -self.size <= normalized_idx < self.size,
+            "index must be within bounds",
+        )
+
+        if normalized_idx < 0:
             normalized_idx += len(self)
 
         return (self.data + normalized_idx)[]
@@ -638,7 +652,8 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         if i < 0:
             normalized_idx += self[].size
 
-        return (self[].data + normalized_idx)[]
+        var offset_ptr = self[].data + normalized_idx
+        return offset_ptr[]
 
     fn __iter__(
         self: Reference[Self, _, _],

--- a/stdlib/src/collections/vector.mojo
+++ b/stdlib/src/collections/vector.mojo
@@ -181,8 +181,11 @@ struct InlinedFixedVector[
         return self.current_size
 
     @always_inline
-    fn __getitem__(self, i: Int) -> type:
+    fn __getitem__[indexer: Indexer](self, i: indexer) -> type:
         """Gets a vector element at the given index.
+
+        Parameters:
+            indexer: The type of the indexing value.
 
         Args:
             i: The index of the element.
@@ -190,12 +193,12 @@ struct InlinedFixedVector[
         Returns:
             The element at the given index.
         """
+        var normalized_idx = index(i)
         debug_assert(
-            -self.current_size <= i < self.current_size,
+            -self.current_size <= normalized_idx < self.current_size,
             "index must be within bounds",
         )
-        var normalized_idx = i
-        if i < 0:
+        if normalized_idx < 0:
             normalized_idx += len(self)
 
         if normalized_idx < Self.static_size:
@@ -204,20 +207,23 @@ struct InlinedFixedVector[
         return self.dynamic_data[normalized_idx - Self.static_size]
 
     @always_inline
-    fn __setitem__(inout self, i: Int, value: type):
+    fn __setitem__[indexer: Indexer](inout self, i: indexer, value: type):
         """Sets a vector element at the given index.
+
+        Parameters:
+            indexer: The type of the indexing value.
 
         Args:
             i: The index of the element.
             value: The value to assign.
         """
+        var normalized_idx = index(i)
         debug_assert(
-            -self.current_size <= i < self.current_size,
+            -self.current_size <= normalized_idx < self.current_size,
             "index must be within bounds",
         )
 
-        var normalized_idx = i
-        if i < 0:
+        if normalized_idx < 0:
             normalized_idx += len(self)
 
         if normalized_idx < Self.static_size:

--- a/stdlib/src/memory/unsafe.mojo
+++ b/stdlib/src/memory/unsafe.mojo
@@ -287,11 +287,11 @@ struct LegacyPointer[
         ](self.address)
 
     @always_inline("nodebug")
-    fn __refitem__[T: Intable](self, offset: T) -> Self._ref_type:
+    fn __refitem__[T: Indexer](self, offset: T) -> Self._ref_type:
         """Enable subscript syntax `ref[idx]` to access the element.
 
         Parameters:
-            T: The Intable type of the offset.
+            T: The Indexer type of the offset.
 
         Args:
             offset: The offset to load from.
@@ -299,7 +299,7 @@ struct LegacyPointer[
         Returns:
             The MLIR reference for the Mojo compiler to use.
         """
-        return (self + offset).__refitem__()
+        return (self + index(offset)).__refitem__()
 
     # ===------------------------------------------------------------------=== #
     # Load/Store
@@ -712,7 +712,7 @@ struct DTypePointer[
         return LegacyPointer.address_of(arg[])
 
     @always_inline("nodebug")
-    fn __getitem__[T: Intable](self, offset: T) -> Scalar[type]:
+    fn __getitem__[T: Indexer](self, offset: T) -> Scalar[type]:
         """Loads a single element (SIMD of size 1) from the pointer at the
         specified index.
 
@@ -725,20 +725,20 @@ struct DTypePointer[
         Returns:
             The loaded value.
         """
-        return self.load(offset)
+        return self.load(index(offset))
 
     @always_inline("nodebug")
-    fn __setitem__[T: Intable](self, offset: T, val: Scalar[type]):
+    fn __setitem__[T: Indexer](self, offset: T, val: Scalar[type]):
         """Stores a single element value at the given offset.
 
         Parameters:
-            T: The Intable type of the offset.
+            T: The type of the indexing value.
 
         Args:
             offset: The offset to store to.
             val: The value to store.
         """
-        return self.store(offset, val)
+        return self.store(index(offset), val)
 
     # ===------------------------------------------------------------------=== #
     # Comparisons

--- a/stdlib/src/python/object.mojo
+++ b/stdlib/src/python/object.mojo
@@ -101,7 +101,13 @@ struct _PyIter(Sized):
 
 @register_passable
 struct PythonObject(
-    Intable, Stringable, SizedRaising, Boolable, CollectionElement, KeyElement
+    Intable,
+    Stringable,
+    SizedRaising,
+    Boolable,
+    CollectionElement,
+    KeyElement,
+    Indexer,
 ):
     """A Python object."""
 

--- a/stdlib/src/utils/index.mojo
+++ b/stdlib/src/utils/index.mojo
@@ -335,11 +335,11 @@ struct StaticIntTuple[size: Int](Sized, Stringable, EqualityComparable):
         return size
 
     @always_inline("nodebug")
-    fn __getitem__[intable: Intable](self, index: intable) -> Int:
+    fn __getitem__[indexer: Indexer](self, index: indexer) -> Int:
         """Gets an element from the tuple by index.
 
         Parameters:
-            intable: The intable type.
+            indexer: The type of the indexing value.
 
         Args:
             index: The element index.
@@ -362,11 +362,11 @@ struct StaticIntTuple[size: Int](Sized, Stringable, EqualityComparable):
         self.data.__setitem__[index](val)
 
     @always_inline("nodebug")
-    fn __setitem__[intable: Intable](inout self, index: intable, val: Int):
+    fn __setitem__[indexer: Indexer](inout self, index: indexer, val: Int):
         """Sets an element in the tuple at the given index.
 
         Parameters:
-            intable: The intable type.
+            indexer: The type of the indexing value.
 
         Args:
             index: The element index.

--- a/stdlib/src/utils/inlined_string.mojo
+++ b/stdlib/src/utils/inlined_string.mojo
@@ -520,9 +520,12 @@ struct _ArrayMem[ElementType: AnyRegType, SIZE: Int](Sized):
         """
         return SIZE
 
-    fn __setitem__(inout self, index: Int, owned value: ElementType):
+    fn __setitem__[
+        indexer: Indexer
+    ](inout self, idx: indexer, owned value: ElementType):
         var ptr = __mlir_op.`pop.array.gep`(
-            UnsafePointer(Reference(self.storage._array)).address, index.value
+            UnsafePointer(Reference(self.storage._array)).address,
+            index(idx).value,
         )
         __mlir_op.`pop.store`(value, ptr)
 

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -197,19 +197,19 @@ struct StaticTuple[element_type: AnyRegType, size: Int](Sized):
         self = tmp
 
     @always_inline("nodebug")
-    fn __getitem__[intable: Intable](self, index: intable) -> Self.element_type:
+    fn __getitem__[indexer: Indexer](self, idx: indexer) -> Self.element_type:
         """Returns the value of the tuple at the given dynamic index.
 
         Parameters:
-            intable: The intable type.
+            indexer: The type of the indexing value.
 
         Args:
-            index: The index into the tuple.
+            idx: The index into the tuple.
 
         Returns:
             The value at the specified position.
         """
-        var offset = int(index)
+        var offset = index(idx)
         debug_assert(offset < size, "index must be within bounds")
         # Copy the array so we can get its address, because we can't take the
         # address of 'self' in a non-mutating method.
@@ -221,18 +221,18 @@ struct StaticTuple[element_type: AnyRegType, size: Int](Sized):
 
     @always_inline("nodebug")
     fn __setitem__[
-        intable: Intable
-    ](inout self, index: intable, val: Self.element_type):
+        indexer: Indexer
+    ](inout self, idx: indexer, val: Self.element_type):
         """Stores a single value into the tuple at the specified dynamic index.
 
         Parameters:
-            intable: The intable type.
+            indexer: The type of the indexing value.
 
         Args:
-            index: The index into the tuple.
+            idx: The index into the tuple.
             val: The value to store.
         """
-        var offset = int(index)
+        var offset = index(idx)
         debug_assert(offset < size, "index must be within bounds")
         var tmp = self
         var ptr = __mlir_op.`pop.array.gep`(

--- a/stdlib/src/utils/stringref.mojo
+++ b/stdlib/src/utils/stringref.mojo
@@ -257,8 +257,11 @@ struct StringRef(
         return not (self == rhs)
 
     @always_inline("nodebug")
-    fn __getitem__(self, idx: Int) -> StringRef:
+    fn __getitem__[indexer: Indexer](self, idx: indexer) -> StringRef:
         """Get the string value at the specified position.
+
+        Parameters:
+            indexer: The type of the indexing value.
 
         Args:
           idx: The index position.
@@ -266,7 +269,7 @@ struct StringRef(
         Returns:
           The character at the specified position.
         """
-        return StringRef {data: self.data + idx, length: 1}
+        return StringRef {data: self.data + index(idx), length: 1}
 
     fn __hash__(self) -> Int:
         """Hash the underlying buffer using builtin hash.

--- a/stdlib/test/builtin/test_list.mojo
+++ b/stdlib/test/builtin/test_list.mojo
@@ -27,6 +27,8 @@ fn test_variadic_list() raises:
         assert_equal(nums[2], 6)
 
         assert_equal(len(nums), 3)
+        assert_equal(nums[False], 5)
+        assert_equal(nums[Int16(2)], 6)
 
     check_list(5, 8, 6)
 

--- a/stdlib/test/builtin/test_slice.mojo
+++ b/stdlib/test/builtin/test_slice.mojo
@@ -82,9 +82,17 @@ def test_slice_stringable():
     assert_equal(s[:-1], "0:-1:1")
 
 
+def test_indexing():
+    var s = slice(1, 10)
+    assert_equal(s[True], 2)
+    assert_equal(s[UInt64(0)], 1)
+
+
 def main():
     test_none_end_folds()
     test_slicable()
     test_has_end()
 
     test_slice_stringable()
+
+    test_indexing()

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -279,6 +279,9 @@ fn test_string_indexing() raises:
 
     assert_equal("!jMolH", str[:-1:-2])
 
+    assert_equal(str[True], "e")
+    assert_equal(str[Int8(0)], "H")
+
 
 fn test_atol() raises:
     # base 10

--- a/stdlib/test/builtin/test_stringref.mojo
+++ b/stdlib/test/builtin/test_stringref.mojo
@@ -41,6 +41,13 @@ def test_intable():
         int(StringRef("hi"))
 
 
+def test_indexing():
+    a = StringRef("abc")
+    assert_equal(a[False], "a")
+    assert_equal(a[Int16(1)], "b")
+
+
 def main():
     test_strref_from_start()
     test_intable()
+    test_indexing()

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -719,6 +719,14 @@ def test_list_mult():
     assert_equal(len(List[Int](1, 2, 3) * 0), 0)
 
 
+def test_indexer():
+    var l = List[Int](1, 2, 3)
+    assert_equal(l[Int8(1)], 2)
+    assert_equal(l[UInt64(2)], 3)
+    assert_equal(l[False], 1)
+    assert_equal(l[True], 2)
+
+
 def main():
     test_mojo_issue_698()
     test_list()
@@ -746,3 +754,4 @@ def main():
     test_list_count()
     test_list_add()
     test_list_mult()
+    test_indexer()

--- a/stdlib/test/collections/test_vector.mojo
+++ b/stdlib/test/collections/test_vector.mojo
@@ -103,6 +103,11 @@ def test_inlined_fixed_vector_with_default():
     vector[5] = -2
     assert_equal(-2, vector[5])
 
+    # check we can index with non Int or IntLiteral
+    assert_equal(1, vector[Int16(1)])
+    assert_equal(1, vector[True])
+    assert_equal(1, vector[Scalar[DType.bool](True)])
+
     vector.clear()
     assert_equal(0, len(vector))
 

--- a/stdlib/test/utils/test_tuple.mojo
+++ b/stdlib/test/utils/test_tuple.mojo
@@ -34,6 +34,9 @@ def test_static_tuple():
     assert_equal(tup3[Int(0)], 1)
     assert_equal(tup3[Int64(0)], 1)
 
+    assert_equal(tup3[True], 2)
+    assert_equal(tup3[Int32(2)], 3)
+
 
 def test_static_int_tuple():
     assert_equal(str(StaticIntTuple[1](1)), "(1,)")


### PR DESCRIPTION
Fixes #2337

As mentioned in the referenced issue, the `__index__()` method allows types other than the base `Int` to be used when indexing containers without allowing inappropriate types that happen to implement `Intable` from being used (such as float point scalars).

Introduce the `Indexer` trait that requires the type to implement the `__index__()` method, and change all instances of `__getitem__` and `__setitem__` to accept any type that has the `Indexer` trait.