### PR TITLE
[stdlib] SIMD conformance to EqualityComparable

### DIFF
--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -146,6 +146,7 @@ struct SIMD[type: DType, size: Int](
     CeilDivable,
     CollectionElement,
     CollectionElementNew,
+    EqualityComparable,
     Floorable,
     Formattable,
     Hashable,
@@ -717,6 +718,26 @@ struct SIMD[type: DType, size: Int](
                 self.value, rhs.value
             )
 
+    # TODO there may be a better way to do this:
+    # the [overload_1: None = None] parameter is to give this overload lower precedence,
+    # while still conforming to EqualityComparable
+    @always_inline("nodebug")
+    fn __eq__[overload_1: None = None](self, rhs: Self) -> Bool:
+        """Compares two SIMD vectors using all-equal-to comparison.
+
+        This overload allows EqualityComparable conformance.
+
+        Parameters:
+            overload_1: Ignore this parameter, used to set the overload precedence.
+
+        Args:
+            rhs: The rhs of the operation.
+
+        Returns:
+            True if all lanes are equal, False otherwise.
+        """
+        return all(self == rhs)
+
     @always_inline("nodebug")
     fn __ne__(self, rhs: Self) -> Self._Mask:
         """Compares two SIMD vectors using not-equal comparison.
@@ -741,6 +762,26 @@ struct SIMD[type: DType, size: Int](
             return __mlir_op.`pop.cmp`[pred = __mlir_attr.`#pop<cmp_pred ne>`](
                 self.value, rhs.value
             )
+
+    # TODO there may be a better way to do this:
+    # the [overload_1: None = None] parameter is to give this overload lower precedence,
+    # while still conforming to EqualityComparable
+    @always_inline("nodebug")
+    fn __ne__[overload_1: None = None](self, rhs: Self) -> Bool:
+        """Compares two SIMD vectors using any-not-equal comparison.
+
+        This overload allows EqualityComparable conformance.
+
+        Parameters:
+            overload_1: Ignore this parameter, used to set the overload precedence.
+
+        Args:
+            rhs: The rhs of the operation.
+
+        Returns:
+            True if any lanes are not equal, False otherwise.
+        """
+        return any(self != rhs)
 
     @always_inline("nodebug")
     fn __gt__(self, rhs: Self) -> Self._Mask:

--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -680,6 +680,7 @@ struct String(
     Stringable,
     Representable,
     IntableRaising,
+    EqualityComparable,
     KeyElement,
     Comparable,
     Boolable,

--- a/stdlib/src/testing/testing.mojo
+++ b/stdlib/src/testing/testing.mojo
@@ -86,7 +86,7 @@ fn assert_false[
         raise _assert_error(msg, location.or_else(__call_location()))
 
 
-trait Testable(EqualityComparable, Stringable):
+trait EqualityTestable(EqualityComparable, Stringable):
     """A trait that a struct should conform to if we do equality testing on it.
     """
 
@@ -95,7 +95,7 @@ trait Testable(EqualityComparable, Stringable):
 
 @always_inline
 fn assert_equal[
-    T: Testable
+    T: EqualityTestable
 ](
     lhs: T,
     rhs: T,
@@ -124,36 +124,9 @@ fn assert_equal[
         )
 
 
-# TODO: Remove the String and SIMD overloads once we have more powerful traits.
-@always_inline
-fn assert_equal(
-    lhs: String,
-    rhs: String,
-    msg: String = "",
-    *,
-    location: Optional[_SourceLocation] = None,
-) raises:
-    """Asserts that the input values are equal. If it is not then an Error
-    is raised.
-
-    Args:
-        lhs: The lhs of the equality.
-        rhs: The rhs of the equality.
-        msg: The message to be printed if the assertion fails.
-        location: The location of the error (default to the `__call_location`).
-
-    Raises:
-        An Error with the provided message if assert fails and `None` otherwise.
-    """
-    if lhs != rhs:
-        raise _assert_cmp_error["`left == right` comparison"](
-            lhs, rhs, msg=msg, loc=location.or_else(__call_location())
-        )
-
-
 @always_inline
 fn assert_not_equal[
-    T: Testable
+    T: EqualityTestable
 ](
     lhs: T,
     rhs: T,
@@ -179,32 +152,6 @@ fn assert_not_equal[
     if lhs == rhs:
         raise _assert_cmp_error["`left != right` comparison"](
             str(lhs), str(rhs), msg=msg, loc=location.or_else(__call_location())
-        )
-
-
-@always_inline
-fn assert_not_equal(
-    lhs: String,
-    rhs: String,
-    msg: String = "",
-    *,
-    location: Optional[_SourceLocation] = None,
-) raises:
-    """Asserts that the input values are not equal. If it is not then an
-    an Error is raised.
-
-    Args:
-        lhs: The lhs of the inequality.
-        rhs: The rhs of the inequality.
-        msg: The message to be printed if the assertion fails.
-        location: The location of the error (default to the `__call_location`).
-
-    Raises:
-        An Error with the provided message if assert fails and `None` otherwise.
-    """
-    if lhs == rhs:
-        raise _assert_cmp_error["`left != right` comparison"](
-            lhs, rhs, msg=msg, loc=location.or_else(__call_location())
         )
 
 

--- a/stdlib/src/testing/testing.mojo
+++ b/stdlib/src/testing/testing.mojo
@@ -152,38 +152,6 @@ fn assert_equal(
 
 
 @always_inline
-fn assert_equal[
-    type: DType, size: Int
-](
-    lhs: SIMD[type, size],
-    rhs: SIMD[type, size],
-    msg: String = "",
-    *,
-    location: Optional[_SourceLocation] = None,
-) raises:
-    """Asserts that the input values are equal. If it is not then an
-    Error is raised.
-
-    Parameters:
-        type: The dtype of the left- and right-hand-side SIMD vectors.
-        size: The width of the left- and right-hand-side SIMD vectors.
-
-    Args:
-        lhs: The lhs of the equality.
-        rhs: The rhs of the equality.
-        msg: The message to be printed if the assertion fails.
-        location: The location of the error (default to the `__call_location`).
-
-    Raises:
-        An Error with the provided message if assert fails and `None` otherwise.
-    """
-    if any(lhs != rhs):
-        raise _assert_cmp_error["`left == right` comparison"](
-            str(lhs), str(rhs), msg=msg, loc=location.or_else(__call_location())
-        )
-
-
-@always_inline
 fn assert_not_equal[
     T: Testable
 ](
@@ -237,38 +205,6 @@ fn assert_not_equal(
     if lhs == rhs:
         raise _assert_cmp_error["`left != right` comparison"](
             lhs, rhs, msg=msg, loc=location.or_else(__call_location())
-        )
-
-
-@always_inline
-fn assert_not_equal[
-    type: DType, size: Int
-](
-    lhs: SIMD[type, size],
-    rhs: SIMD[type, size],
-    msg: String = "",
-    *,
-    location: Optional[_SourceLocation] = None,
-) raises:
-    """Asserts that the input values are not equal. If it is not then an
-    Error is raised.
-
-    Parameters:
-        type: The dtype of the left- and right-hand-side SIMD vectors.
-        size: The width of the left- and right-hand-side SIMD vectors.
-
-    Args:
-        lhs: The lhs of the inequality.
-        rhs: The rhs of the inequality.
-        msg: The message to be printed if the assertion fails.
-        location: The location of the error (default to the `__call_location`).
-
-    Raises:
-        An Error with the provided message if assert fails and `None` otherwise.
-    """
-    if all(lhs == rhs):
-        raise _assert_cmp_error["`left != right` comparison"](
-            str(lhs), str(rhs), msg=msg, loc=location.or_else(__call_location())
         )
 
 

--- a/stdlib/src/utils/string_slice.mojo
+++ b/stdlib/src/utils/string_slice.mojo
@@ -302,7 +302,7 @@ struct _StringSliceIter[
 struct StringSlice[
     is_mutable: Bool, //,
     lifetime: AnyLifetime[is_mutable].type,
-](Stringable, Sized, Formattable):
+](Stringable, Sized, Formattable, EqualityComparable):
     """
     A non-owning view to encoded string data.
 
@@ -458,8 +458,25 @@ struct StringSlice[
         """
         return len(self._slice) > 0
 
-    fn __eq__(self, rhs: StringSlice) -> Bool:
+    fn __eq__(self, rhs: Self) -> Bool:
         """Verify if a string slice is equal to another string slice.
+
+        Args:
+            rhs: The string slice to compare against.
+
+        Returns:
+            True if the string slices are equal in length and contain the same elements, False otherwise.
+        """
+        return self.__eq__[rhs_lifetime=lifetime](rhs)
+
+    fn __eq__[
+        rhs_mutability: Bool, //, rhs_lifetime: AnyLifetime[rhs_mutability].type
+    ](self, rhs: StringSlice[rhs_lifetime]) -> Bool:
+        """Verify if a string slice is equal to another string slice.
+
+        Parameters:
+            rhs_mutability: The mutability of the string slice to compare against.
+            rhs_lifetime: The lifetime of the string slice to compare against.
 
         Args:
             rhs: The string slice to compare against.
@@ -503,9 +520,25 @@ struct StringSlice[
         """
         return self == rhs.as_string_slice()
 
-    @always_inline
-    fn __ne__(self, rhs: StringSlice) -> Bool:
+    fn __ne__(self, rhs: Self) -> Bool:
         """Verify if span is not equal to another string slice.
+
+        Args:
+            rhs: The string slice to compare against.
+
+        Returns:
+            True if the string slices are not equal in length or contents, False otherwise.
+        """
+        return self.__ne__[rhs_lifetime=lifetime](rhs)
+
+    fn __ne__[
+        rhs_mutability: Bool, //, rhs_lifetime: AnyLifetime[rhs_mutability].type
+    ](self, rhs: StringSlice[rhs_lifetime]) -> Bool:
+        """Verify if span is not equal to another string slice.
+
+        Parameters:
+            rhs_mutability: The mutability of the string slice to compare against.
+            rhs_lifetime: The lifetime of the string slice to compare against.
 
         Args:
             rhs: The string slice to compare against.

--- a/stdlib/test/builtin/test_dtype.mojo
+++ b/stdlib/test/builtin/test_dtype.mojo
@@ -23,8 +23,8 @@ fn test_equality() raises:
 
 
 fn test_stringable() raises:
-    assert_equal("float32", str(DType.float32))
-    assert_equal("int64", str(DType.int64))
+    assert_equal(str(DType.float32), "float32")
+    assert_equal(str(DType.int64), "int64")
 
 
 fn test_representable() raises:

--- a/stdlib/test/builtin/test_math.mojo
+++ b/stdlib/test/builtin/test_math.mojo
@@ -81,16 +81,16 @@ def test_max():
 
 
 def test_round():
-    assert_equal(0.0, round(0.0))
-    assert_equal(1.0, round(1.0))
-    assert_equal(1.0, round(1.1))
-    assert_equal(1.0, round(1.4))
-    assert_equal(2.0, round(1.5))
-    assert_equal(2.0, round(2.0))
-    assert_equal(1.0, round(1.4, 0))
-    assert_equal(2.0, round(2.5))
-    assert_equal(1.5, round(1.5, 1))
-    assert_equal(1.61, round(1.613, 2))
+    assert_equal(round(0.0), 0)
+    assert_equal(round(1.0), 1)
+    assert_equal(round(1.1), 1)
+    assert_equal(round(1.4), 1)
+    assert_equal(round(1.5), 2)
+    assert_equal(round(2.0), 2)
+    assert_equal(round(1.4, 0), 1)
+    assert_equal(round(2.5), 2)
+    assert_equal(round(1.5, 1), 1.5)
+    assert_equal(round(1.613, 2), 1.61)
 
     var lhs = SIMD[DType.float32, 4](1.1, 1.5, 1.9, 2.0)
     var expected = SIMD[DType.float32, 4](1.0, 2.0, 2.0, 2.0)

--- a/stdlib/test/builtin/test_math.mojo
+++ b/stdlib/test/builtin/test_math.mojo
@@ -81,14 +81,14 @@ def test_max():
 
 
 def test_round():
-    assert_equal(0, round(0.0))
-    assert_equal(1, round(1.0))
-    assert_equal(1, round(1.1))
-    assert_equal(1, round(1.4))
-    assert_equal(2, round(1.5))
-    assert_equal(2, round(2.0))
-    assert_equal(1, round(1.4, 0))
-    assert_equal(2, round(2.5))
+    assert_equal(0.0, round(0.0))
+    assert_equal(1.0, round(1.0))
+    assert_equal(1.0, round(1.1))
+    assert_equal(1.0, round(1.4))
+    assert_equal(2.0, round(1.5))
+    assert_equal(2.0, round(2.0))
+    assert_equal(1.0, round(1.4, 0))
+    assert_equal(2.0, round(2.5))
     assert_equal(1.5, round(1.5, 1))
     assert_equal(1.61, round(1.613, 2))
 

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -974,6 +974,29 @@ def test_abs():
     )
 
 
+def test_equatable():
+    var s1 = SIMD[DType.int32, 2](1, 2)
+    var s2 = SIMD[DType.int32, 2](1, 6)
+    var s3 = SIMD[DType.int32, 2](6, 2)
+    var s4 = SIMD[DType.int32, 2](6, 6)
+
+    assert_equal(s1 == s1, SIMD[DType.bool, 2](True, True))
+    assert_equal(s1 != s1, SIMD[DType.bool, 2](False, False))
+    assert_equal(s1, s1)
+
+    assert_equal(s1 == s2, SIMD[DType.bool, 2](True, False))
+    assert_equal(s1 != s2, SIMD[DType.bool, 2](False, True))
+    assert_not_equal(s1, s2)
+
+    assert_equal(s1 == s3, SIMD[DType.bool, 2](False, True))
+    assert_equal(s1 != s3, SIMD[DType.bool, 2](True, False))
+    assert_not_equal(s1, s3)
+
+    assert_equal(s1 == s4, SIMD[DType.bool, 2](False, False))
+    assert_equal(s1 != s4, SIMD[DType.bool, 2](True, True))
+    assert_not_equal(s1, s4)
+
+
 def test_clamp():
     alias F = SIMD[DType.float32, 4]
     var f = F(-10.5, -5.0, 5.0, 10.0)
@@ -994,22 +1017,20 @@ def test_indexing():
 def test_reduce():
     @parameter
     def test_dtype[type: DType]():
-        alias X8 = SIMD[type, 8]
-        alias X4 = SIMD[type, 4]
-        alias X2 = SIMD[type, 2]
-        alias X1 = SIMD[type, 1]
-        var x8: X8
-        var x4: X4
-        var x2: X2
-        var x1: X1
+        var x8: SIMD[type, 8]
+        var x4: SIMD[type, 4]
+        var x2: SIMD[type, 2]
+        var x1: SIMD[type, 1]
 
         @parameter
         if type.is_numeric():
             # reduce_add
-            x8 = X8(0, 1, 2, 3, 4, 5, 6, 7)
-            x4 = X4(4, 6, 8, 10)
-            x2 = X2(12, 16)
-            x1 = X1(int(28))  # TODO: fix MOCO-697 and use X1(28) instead
+            x8 = SIMD[type, 8](0, 1, 2, 3, 4, 5, 6, 7)
+            x4 = SIMD[type, 4](4, 6, 8, 10)
+            x2 = SIMD[type, 2](12, 16)
+            x1 = SIMD[type, 1](
+                int(28)
+            )  # TODO: fix MOCO-697 and use SIMD[type, 1](28) instead
             assert_equal(x8.reduce_add(), x1)
             assert_equal(x4.reduce_add(), x1)
             assert_equal(x2.reduce_add(), x1)
@@ -1020,13 +1041,15 @@ def test_reduce():
             assert_equal(x8.reduce_add[4](), x4)
             assert_equal(x4.reduce_add[4](), x4)
             assert_equal(x8.reduce_add[8](), x8)
-            assert_equal(X2(6, 3).reduce_add(), 9)
+            assert_equal(SIMD[type, 2](6, 3).reduce_add(), 9)
 
             # reduce_mul
-            x8 = X8(0, 1, 2, 3, 4, 5, 6, 7)
-            x4 = X4(0, 5, 12, 21)
-            x2 = X2(0, 105)
-            x1 = X1(int(0))  # TODO: fix MOCO-697 and use X1(0) instead
+            x8 = SIMD[type, 8](0, 1, 2, 3, 4, 5, 6, 7)
+            x4 = SIMD[type, 4](0, 5, 12, 21)
+            x2 = SIMD[type, 2](0, 105)
+            x1 = SIMD[type, 1](
+                int(0)
+            )  # TODO: fix MOCO-697 and use SIMD[type, 1](0) instead
             assert_equal(x8.reduce_mul(), x1)
             assert_equal(x4.reduce_mul(), x1)
             assert_equal(x2.reduce_mul(), x1)
@@ -1037,13 +1060,15 @@ def test_reduce():
             assert_equal(x8.reduce_mul[4](), x4)
             assert_equal(x4.reduce_mul[4](), x4)
             assert_equal(x8.reduce_mul[8](), x8)
-            assert_equal(X2(6, 3).reduce_mul(), 18)
+            assert_equal(SIMD[type, 2](6, 3).reduce_mul(), 18)
 
             # reduce_min
-            x8 = X8(0, 1, 2, 3, 4, 5, 6, 7)
-            x4 = X4(0, 1, 2, 3)
-            x2 = X2(0, 1)
-            x1 = X1(int(0))  # TODO: fix MOCO-697 and use X1(0) instead
+            x8 = SIMD[type, 8](0, 1, 2, 3, 4, 5, 6, 7)
+            x4 = SIMD[type, 4](0, 1, 2, 3)
+            x2 = SIMD[type, 2](0, 1)
+            x1 = SIMD[type, 1](
+                int(0)
+            )  # TODO: fix MOCO-697 and use SIMD[type, 1](0) instead
             assert_equal(x8.reduce_min(), x1)
             assert_equal(x4.reduce_min(), x1)
             assert_equal(x2.reduce_min(), x1)
@@ -1054,13 +1079,15 @@ def test_reduce():
             assert_equal(x8.reduce_min[4](), x4)
             assert_equal(x4.reduce_min[4](), x4)
             assert_equal(x8.reduce_min[8](), x8)
-            assert_equal(X2(6, 3).reduce_min(), 3)
+            assert_equal(SIMD[type, 2](6, 3).reduce_min(), 3)
 
             # reduce_max
-            x8 = X8(0, 1, 2, 3, 4, 5, 6, 7)
-            x4 = X4(4, 5, 6, 7)
-            x2 = X2(6, 7)
-            x1 = X1(int(7))  # TODO: fix MOCO-697 and use X1(7) instead
+            x8 = SIMD[type, 8](0, 1, 2, 3, 4, 5, 6, 7)
+            x4 = SIMD[type, 4](4, 5, 6, 7)
+            x2 = SIMD[type, 2](6, 7)
+            x1 = SIMD[type, 1](
+                int(7)
+            )  # TODO: fix MOCO-697 and use SIMD[type, 1](7) instead
             assert_equal(x8.reduce_max(), x1)
             assert_equal(x4.reduce_max(), x1)
             assert_equal(x2.reduce_max(), x1)
@@ -1071,15 +1098,17 @@ def test_reduce():
             assert_equal(x8.reduce_max[4](), x4)
             assert_equal(x4.reduce_max[4](), x4)
             assert_equal(x8.reduce_max[8](), x8)
-            assert_equal(X2(6, 3).reduce_max(), 6)
+            assert_equal(SIMD[type, 2](6, 3).reduce_max(), 6)
 
         @parameter
         if type.is_signed():
             # reduce_add
-            x8 = X8(0, -1, 2, -3, 4, -5, 6, -7)
-            x4 = X4(4, -6, 8, -10)
-            x2 = X2(12, -16)
-            x1 = X1(int(-4))  # TODO: fix MOCO-697 and use X1(-4) instead
+            x8 = SIMD[type, 8](0, -1, 2, -3, 4, -5, 6, -7)
+            x4 = SIMD[type, 4](4, -6, 8, -10)
+            x2 = SIMD[type, 2](12, -16)
+            x1 = SIMD[type, 1](
+                int(-4)
+            )  # TODO: fix MOCO-697 and use SIMD[type, 1](-4) instead
             assert_equal(x8.reduce_add(), x1)
             assert_equal(x4.reduce_add(), x1)
             assert_equal(x2.reduce_add(), x1)
@@ -1090,13 +1119,15 @@ def test_reduce():
             assert_equal(x8.reduce_add[4](), x4)
             assert_equal(x4.reduce_add[4](), x4)
             assert_equal(x8.reduce_add[8](), x8)
-            assert_equal(X2(6, -3).reduce_add(), 3)
+            assert_equal(SIMD[type, 2](6, -3).reduce_add(), 3)
 
             # reduce_mul
-            x8 = X8(0, -1, 2, -3, 4, -5, 6, -7)
-            x4 = X4(0, 5, 12, 21)
-            x2 = X2(0, 105)
-            x1 = X1(int(0))  # TODO: fix MOCO-697 and use X1(0) instead
+            x8 = SIMD[type, 8](0, -1, 2, -3, 4, -5, 6, -7)
+            x4 = SIMD[type, 4](0, 5, 12, 21)
+            x2 = SIMD[type, 2](0, 105)
+            x1 = SIMD[type, 1](
+                int(0)
+            )  # TODO: fix MOCO-697 and use SIMD[type, 1](0) instead
             assert_equal(x8.reduce_mul(), x1)
             assert_equal(x4.reduce_mul(), x1)
             assert_equal(x2.reduce_mul(), x1)
@@ -1107,13 +1138,15 @@ def test_reduce():
             assert_equal(x8.reduce_mul[4](), x4)
             assert_equal(x4.reduce_mul[4](), x4)
             assert_equal(x8.reduce_mul[8](), x8)
-            assert_equal(X2(6, -3).reduce_mul(), -18)
+            assert_equal(SIMD[type, 2](6, -3).reduce_mul(), -18)
 
             # reduce_min
-            x8 = X8(0, -1, 2, -3, 4, -5, 6, -7)
-            x4 = X4(0, -5, 2, -7)
-            x2 = X2(0, -7)
-            x1 = X1(int(-7))  # TODO: fix MOCO-697 and use X1(-7) instead
+            x8 = SIMD[type, 8](0, -1, 2, -3, 4, -5, 6, -7)
+            x4 = SIMD[type, 4](0, -5, 2, -7)
+            x2 = SIMD[type, 2](0, -7)
+            x1 = SIMD[type, 1](
+                int(-7)
+            )  # TODO: fix MOCO-697 and use SIMD[type, 1](-7) instead
             assert_equal(x8.reduce_min(), x1)
             assert_equal(x4.reduce_min(), x1)
             assert_equal(x2.reduce_min(), x1)
@@ -1124,13 +1157,15 @@ def test_reduce():
             assert_equal(x8.reduce_min[4](), x4)
             assert_equal(x4.reduce_min[4](), x4)
             assert_equal(x8.reduce_min[8](), x8)
-            assert_equal(X2(6, -3).reduce_min(), -3)
+            assert_equal(SIMD[type, 2](6, -3).reduce_min(), -3)
 
             # reduce_max
-            x8 = X8(0, -1, 2, -3, 4, -5, 6, -7)
-            x4 = X4(4, -1, 6, -3)
-            x2 = X2(6, -1)
-            x1 = X1(int(6))  # TODO: fix MOCO-697 and use X1(6) instead
+            x8 = SIMD[type, 8](0, -1, 2, -3, 4, -5, 6, -7)
+            x4 = SIMD[type, 4](4, -1, 6, -3)
+            x2 = SIMD[type, 2](6, -1)
+            x1 = SIMD[type, 1](
+                int(6)
+            )  # TODO: fix MOCO-697 and use SIMD[type, 1](6) instead
             assert_equal(x8.reduce_max(), x1)
             assert_equal(x4.reduce_max(), x1)
             assert_equal(x2.reduce_max(), x1)
@@ -1141,7 +1176,7 @@ def test_reduce():
             assert_equal(x8.reduce_max[4](), x4)
             assert_equal(x4.reduce_max[4](), x4)
             assert_equal(x8.reduce_max[8](), x8)
-            assert_equal(X2(6, -3).reduce_max(), 6)
+            assert_equal(SIMD[type, 2](6, -3).reduce_max(), 6)
 
         @parameter
         if type is DType.bool:
@@ -1186,10 +1221,12 @@ def test_reduce():
         @parameter
         if type.is_integral():
             # reduce_and
-            x8 = X8(0, 1, 2, 3, 4, 5, 6, 7)
-            x4 = X4(0, 1, 2, 3)
-            x2 = X2(0, 1)
-            x1 = X1(int(0))  # TODO: fix MOCO-697 and use X1(0) instead
+            x8 = SIMD[type, 8](0, 1, 2, 3, 4, 5, 6, 7)
+            x4 = SIMD[type, 4](0, 1, 2, 3)
+            x2 = SIMD[type, 2](0, 1)
+            x1 = SIMD[type, 1](
+                int(0)
+            )  # TODO: fix MOCO-697 and use SIMD[type, 1](0) instead
             assert_equal(x8.reduce_and(), x1)
             assert_equal(x4.reduce_and(), x1)
             assert_equal(x2.reduce_and(), x1)
@@ -1200,13 +1237,15 @@ def test_reduce():
             assert_equal(x8.reduce_and[4](), x4)
             assert_equal(x4.reduce_and[4](), x4)
             assert_equal(x8.reduce_and[8](), x8)
-            assert_equal(X2(6, 3).reduce_and(), 2)
+            assert_equal(SIMD[type, 2](6, 3).reduce_and(), 2)
 
             # reduce_or
-            x8 = X8(0, 1, 2, 3, 4, 5, 6, 7)
-            x4 = X4(4, 5, 6, 7)
-            x2 = X2(6, 7)
-            x1 = X1(int(7))  # TODO: fix MOCO-697 and use X1(7) instead
+            x8 = SIMD[type, 8](0, 1, 2, 3, 4, 5, 6, 7)
+            x4 = SIMD[type, 4](4, 5, 6, 7)
+            x2 = SIMD[type, 2](6, 7)
+            x1 = SIMD[type, 1](
+                int(7)
+            )  # TODO: fix MOCO-697 and use SIMD[type, 1](7) instead
             assert_equal(x8.reduce_or(), x1)
             assert_equal(x4.reduce_or(), x1)
             assert_equal(x2.reduce_or(), x1)
@@ -1217,7 +1256,7 @@ def test_reduce():
             assert_equal(x8.reduce_or[4](), x4)
             assert_equal(x4.reduce_or[4](), x4)
             assert_equal(x8.reduce_or[8](), x8)
-            assert_equal(X2(6, 3).reduce_or(), 7)
+            assert_equal(SIMD[type, 2](6, 3).reduce_or(), 7)
 
     test_dtype[DType.bool]()
     test_dtype[DType.int8]()
@@ -1710,3 +1749,4 @@ def main():
     test_contains()
     test_comparison()
     # TODO: add tests for __and__, __or__, anc comparison operators
+    test_equatable()

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -505,7 +505,7 @@ def test_atof():
     assert_equal(1.0, atof(String("001.")))
     assert_equal(+5.0, atof(String(" +005.")))
     assert_equal(13.0, atof(String(" 013.f  ")))
-    assert_equal(-89, atof(String("-89")))
+    assert_equal(-89.0, atof(String("-89")))
     assert_equal(-0.3, atof(String(" -0.3")))
     assert_equal(-69e3, atof(String(" -69E+3  ")))
     assert_equal(123.2e1, atof(String(" 123.2E1  ")))

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -38,10 +38,10 @@ struct AString(Stringable):
 
 
 def test_stringable():
-    assert_equal("hello", str("hello"))
-    assert_equal("0", str(0))
-    assert_equal("AAA", str(StringRef("AAA")))
-    assert_equal("a string", str(AString()))
+    assert_equal(str("hello"), "hello")
+    assert_equal(str(0), "0")
+    assert_equal(str(StringRef("AAA")), "AAA")
+    assert_equal(str(AString()), "a string")
 
 
 def test_repr():
@@ -72,17 +72,17 @@ def test_constructors():
 
     # Construction from Int
     var s0 = str(0)
-    assert_equal("0", str(0))
-    assert_equal(1, len(s0))
+    assert_equal(str(0), "0")
+    assert_equal(len(s0), 1)
 
     var s1 = str(123)
-    assert_equal("123", str(123))
-    assert_equal(3, len(s1))
+    assert_equal(str(123), "123")
+    assert_equal(len(s1), 3)
 
     # Construction from StringLiteral
     var s2 = String("abc")
-    assert_equal("abc", str(s2))
-    assert_equal(3, len(s2))
+    assert_equal(str(s2), "abc")
+    assert_equal(len(s2), 3)
 
     # Construction from UnsafePointer
     var ptr = UnsafePointer[UInt8].alloc(4)
@@ -103,8 +103,8 @@ def test_copy():
     var s0 = String("find")
     var s1 = str(s0)
     s1._buffer[3] = ord("e")
-    assert_equal("find", s0)
-    assert_equal("fine", s1)
+    assert_equal(s0, "find")
+    assert_equal(s1, "fine")
 
 
 def test_equality_operators():
@@ -172,31 +172,31 @@ def test_add():
     var s1 = String("123")
     var s2 = String("abc")
     var s3 = s1 + s2
-    assert_equal("123abc", s3)
+    assert_equal(s3, "123abc")
 
     var s4 = String("x")
     var s5 = s4.join(1, 2, 3)
-    assert_equal("1x2x3", s5)
+    assert_equal(s5, "1x2x3")
 
     var s6 = s4.join(s1, s2)
-    assert_equal("123xabc", s6)
+    assert_equal(s6, "123xabc")
 
     var s7 = String()
-    assert_equal("abc", s2 + s7)
+    assert_equal(s2 + s7, "abc")
 
-    assert_equal("abcdef", s2 + "def")
-    assert_equal("123abc", "123" + s2)
+    assert_equal(s2 + "def", "abcdef")
+    assert_equal("123" + s2, "123abc")
 
     var s8 = String("abc is ")
     var s9 = AString()
-    assert_equal("abc is a string", str(s8) + str(s9))
+    assert_equal(str(s8) + str(s9), "abc is a string")
 
 
 def test_string_join():
     var sep = String(",")
     var s0 = String("abc")
     var s1 = sep.join(s0, s0, s0, s0)
-    assert_equal("abc,abc,abc,abc", s1)
+    assert_equal(s1, "abc,abc,abc,abc")
 
     assert_equal(sep.join(1, 2, 3), "1,2,3")
 
@@ -306,39 +306,39 @@ def test_ord():
 
 
 def test_chr():
-    assert_equal("A", chr(65))
-    assert_equal("a", chr(97))
-    assert_equal("!", chr(33))
-    assert_equal("α", chr(945))
-    assert_equal("➿", chr(10175))
-    assert_equal("🔥", chr(128293))
+    assert_equal(chr(65), "A")
+    assert_equal(chr(97), "a")
+    assert_equal(chr(33), "!")
+    assert_equal(chr(945), "α")
+    assert_equal(chr(10175), "➿")
+    assert_equal(chr(128293), "🔥")
 
 
 def test_string_indexing():
     var str = String("Hello Mojo!!")
 
-    assert_equal("H", str[0])
-    assert_equal("!", str[-1])
-    assert_equal("H", str[-len(str)])
-    assert_equal("llo Mojo!!", str[2:])
-    assert_equal("lo Mojo!", str[3:-1:1])
-    assert_equal("lo Moj", str[3:-3])
+    assert_equal(str[0], "H")
+    assert_equal(str[-1], "!")
+    assert_equal(str[-len(str)], "H")
+    assert_equal(str[2:], "llo Mojo!!")
+    assert_equal(str[3:-1:1], "lo Mojo!")
+    assert_equal(str[3:-3], "lo Moj")
 
-    assert_equal("!!ojoM olleH", str[::-1])
+    assert_equal(str[::-1], "!!ojoM olleH")
 
-    assert_equal("leH", str[2::-1])
+    assert_equal(str[2::-1], "leH")
 
-    assert_equal("!oo le", str[::-2])
+    assert_equal(str[::-2], "!oo le")
 
-    assert_equal("", str[:-1:-2])
-    assert_equal("", str[-50::-1])
-    assert_equal("Hello Mojo!!", str[-50::])
-    assert_equal("!!ojoM olleH", str[:-50:-1])
-    assert_equal("Hello Mojo!!", str[:50:])
-    assert_equal("H", str[::50])
-    assert_equal("!", str[::-50])
-    assert_equal("!", str[50::-50])
-    assert_equal("H", str[-50::50])
+    assert_equal(str[:-1:-2], "")
+    assert_equal(str[-50::-1], "")
+    assert_equal(str[-50::], "Hello Mojo!!")
+    assert_equal(str[:-50:-1], "!!ojoM olleH")
+    assert_equal(str[:50:], "Hello Mojo!!")
+    assert_equal(str[::50], "H")
+    assert_equal(str[::-50], "!")
+    assert_equal(str[50::-50], "!")
+    assert_equal(str[-50::50], "H")
 
 
 def test_atol():
@@ -637,21 +637,21 @@ def test_count():
 def test_replace():
     # Replace empty
     var s1 = String("abc")
-    assert_equal("xaxbxc", s1.replace("", "x"))
-    assert_equal("->a->b->c", s1.replace("", "->"))
+    assert_equal(s1.replace("", "x"), "xaxbxc")
+    assert_equal(s1.replace("", "->"), "->a->b->c")
 
     var s2 = String("Hello Python")
-    assert_equal("Hello Mojo", s2.replace("Python", "Mojo"))
-    assert_equal("HELLo Python", s2.replace("Hell", "HELL"))
-    assert_equal("Hello Python", s2.replace("HELL", "xxx"))
-    assert_equal("HellP oython", s2.replace("o P", "P o"))
-    assert_equal("Hello Pything", s2.replace("thon", "thing"))
-    assert_equal("He||o Python", s2.replace("ll", "||"))
-    assert_equal("He--o Python", s2.replace("l", "-"))
-    assert_equal("He-x--x-o Python", s2.replace("l", "-x-"))
+    assert_equal(s2.replace("Python", "Mojo"), "Hello Mojo")
+    assert_equal(s2.replace("Hell", "HELL"), "HELLo Python")
+    assert_equal(s2.replace("HELL", "xxx"), "Hello Python")
+    assert_equal(s2.replace("o P", "P o"), "HellP oython")
+    assert_equal(s2.replace("thon", "thing"), "Hello Pything")
+    assert_equal(s2.replace("ll", "||"), "He||o Python")
+    assert_equal(s2.replace("l", "-"), "He--o Python")
+    assert_equal(s2.replace("l", "-x-"), "He-x--x-o Python")
 
     var s3 = String("a   complex  test case  with some  spaces")
-    assert_equal("a  complex test case with some spaces", s3.replace("  ", " "))
+    assert_equal(s3.replace("  ", " "), "a  complex test case with some spaces")
 
 
 def test_rfind():
@@ -1280,15 +1280,15 @@ def test_string_iter():
     for item in vs:
         idx += 1
         if idx == 0:
-            assert_equal("m", item)
+            assert_equal(str(item), "m")
         elif idx == 1:
-            assert_equal("o", item)
+            assert_equal(str(item), "o")
         elif idx == 2:
-            assert_equal("j", item)
+            assert_equal(str(item), "j")
         elif idx == 3:
-            assert_equal("o", item)
+            assert_equal(str(item), "o")
         elif idx == 4:
-            assert_equal("🔥", item)
+            assert_equal(str(item), "🔥")
     assert_equal(4, idx)
 
     var items = List[String](

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -560,15 +560,15 @@ def test_no_extra_copies_with_sugared_set_by_field():
     child_list.append(CopyCountedStruct("World"))
 
     # No copies here.  Constructing with List[CopyCountedStruct](CopyCountedStruct("Hello")) is a copy.
-    assert_equal(0, child_list[0].counter.copy_count)
-    assert_equal(0, child_list[1].counter.copy_count)
+    assert_equal(child_list[0].counter.copy_count, 0)
+    assert_equal(child_list[1].counter.copy_count, 0)
     list.append(child_list^)
 
     list[0][1].value = "Mojo"
-    assert_equal("Mojo", list[0][1].value)
+    assert_equal(list[0][1].value, "Mojo")
 
-    assert_equal(0, list[0][0].counter.copy_count)
-    assert_equal(0, list[0][1].counter.copy_count)
+    assert_equal(list[0][0].counter.copy_count, 0)
+    assert_equal(list[0][1].counter.copy_count, 0)
 
 
 # Ensure correct behavior of __copyinit__

--- a/stdlib/test/os/path/test_dirname.mojo
+++ b/stdlib/test/os/path/test_dirname.mojo
@@ -21,59 +21,59 @@ from testing import assert_equal
 
 fn main() raises:
     # Root directories
-    assert_equal("/", dirname("/"))
+    assert_equal(dirname("/"), "/")
 
     # Empty strings
-    assert_equal("", dirname(""))
+    assert_equal(dirname(""), "")
 
     # Current directory (matching behavior of python, doesn't resolve `..` etc.)
-    assert_equal("", dirname("."))
+    assert_equal(dirname("."), "")
 
     # Parent directory
-    assert_equal("", dirname(".."))
+    assert_equal(dirname(".."), "")
 
     # Absolute paths
-    assert_equal("/", dirname("/file"))
-    assert_equal("/dir", dirname("/dir/file"))
-    assert_equal("/dir/subdir", dirname("/dir/subdir/file"))
+    assert_equal(dirname("/file"), "/")
+    assert_equal(dirname("/dir/file"), "/dir")
+    assert_equal(dirname("/dir/subdir/file"), "/dir/subdir")
 
     # Relative paths
-    assert_equal("dir", dirname("dir/file"))
-    assert_equal("dir/subdir", dirname("dir/subdir/file"))
-    assert_equal("", dirname("file"))
+    assert_equal(dirname("dir/file"), "dir")
+    assert_equal(dirname("dir/subdir/file"), "dir/subdir")
+    assert_equal(dirname("file"), "")
 
     # Trailing slashes
-    assert_equal("/path/to", dirname("/path/to/"))
-    assert_equal("/path/to/dir", dirname("/path/to/dir/"))
+    assert_equal(dirname("/path/to/"), "/path/to")
+    assert_equal(dirname("/path/to/dir/"), "/path/to/dir")
 
     # Multiple slashes
-    assert_equal("/path/to", dirname("/path/to//file"))
-    assert_equal("/path", dirname("/path//to"))
+    assert_equal(dirname("/path/to//file"), "/path/to")
+    assert_equal(dirname("/path//to"), "/path")
 
     # Paths with spaces
-    assert_equal("/path to", dirname("/path to/file"))
-    assert_equal("/path to/dir", dirname("/path to/dir/file"))
+    assert_equal(dirname("/path to/file"), "/path to")
+    assert_equal(dirname("/path to/dir/file"), "/path to/dir")
 
     # Paths with special characters
-    assert_equal("/path-to", dirname("/path-to/file"))
-    assert_equal("/path_to/dir", dirname("/path_to/dir/file"))
+    assert_equal(dirname("/path-to/file"), "/path-to")
+    assert_equal(dirname("/path_to/dir/file"), "/path_to/dir")
 
     # Paths with dots
-    assert_equal("/path/./to", dirname("/path/./to/file"))
-    assert_equal("/path/../to", dirname("/path/../to/file"))
+    assert_equal(dirname("/path/./to/file"), "/path/./to")
+    assert_equal(dirname("/path/../to/file"), "/path/../to")
 
     # Paths with double dots
-    assert_equal("/path/..", dirname("/path/../file"))
-    assert_equal("/path/to/..", dirname("/path/to/../file"))
+    assert_equal(dirname("/path/../file"), "/path/..")
+    assert_equal(dirname("/path/to/../file"), "/path/to/..")
 
     # Root and relative mixed
-    assert_equal("/dir/.", dirname("/dir/./file"))
-    assert_equal("/dir/subdir/..", dirname("/dir/subdir/../file"))
+    assert_equal(dirname("/dir/./file"), "/dir/.")
+    assert_equal(dirname("/dir/subdir/../file"), "/dir/subdir/..")
 
     # Edge cases
-    assert_equal("/.", dirname("/./file"))
-    assert_equal("/..", dirname("/../file"))
+    assert_equal(dirname("/./file"), "/.")
+    assert_equal(dirname("/../file"), "/..")
 
     # Unix hidden files
-    assert_equal("/path/to", dirname("/path/to/.hiddenfile"))
-    assert_equal("/path/to/dir", dirname("/path/to/dir/.hiddenfile"))
+    assert_equal(dirname("/path/to/.hiddenfile"), "/path/to")
+    assert_equal(dirname("/path/to/dir/.hiddenfile"), "/path/to/dir")

--- a/stdlib/test/os/path/test_expanduser.mojo
+++ b/stdlib/test/os/path/test_expanduser.mojo
@@ -58,13 +58,13 @@ fn main() raises:
     assert_equal(join(user_path, "folder/"), expanduser("~/folder/"))
 
     # Path without user home directory
-    assert_equal("/usr/bin", expanduser("/usr/bin"))
+    assert_equal(expanduser("/usr/bin"), "/usr/bin")
 
     # Relative path
-    assert_equal("../folder", expanduser("../folder"))
+    assert_equal(expanduser("../folder"), "../folder")
 
     # Empty string
-    assert_equal("", expanduser(""))
+    assert_equal(expanduser(""), "")
 
     # Path with multiple tildes
     assert_equal(join(user_path, "~folder"), expanduser("~/~folder"))
@@ -73,7 +73,7 @@ fn main() raises:
     set_home("")
     if os_is_windows():
         # Don't expand on windows if home isn't set
-        assert_equal("~/folder", expanduser("~/folder"))
+        assert_equal(expanduser("~/folder"), "~/folder")
     else:
         # Test fallback to `/etc/passwd` works on linux
         alias folder = "~/folder"

--- a/stdlib/test/os/path/test_join.mojo
+++ b/stdlib/test/os/path/test_join.mojo
@@ -22,26 +22,26 @@ from testing import assert_equal
 
 fn main() raises:
     # TODO uncomment lines using Path when unpacking is supported
-    assert_equal("path/to/file", join("path", "to", "file"))
+    assert_equal(join("path", "to", "file"), "path/to/file")
     # assert_equal("path/to/file", join(Path("path"), Path("to"), Path("file")))
-    assert_equal("path/to/file", join("path", "to/file"))
+    assert_equal(join("path", "to/file"), "path/to/file")
     # assert_equal("path/to/file", join(Path("path"), Path("to/file")))
-    assert_equal("path/to/file", join("path/to", "file"))
+    assert_equal(join("path/to", "file"), "path/to/file")
     # assert_equal("path/to/file", join(Path("path/to"), Path("file")))
-    assert_equal("path/to/file", join("path/", "to/", "file"))
+    assert_equal(join("path/", "to/", "file"), "path/to/file")
 
-    assert_equal("path/", join("path", ""))
+    assert_equal(join("path", ""), "path/")
     # assert_equal("path/", join(Path("path"), Path("")))
-    assert_equal("path", join("path"))
+    assert_equal(join("path"), "path")
     # assert_equal("path", join(Path("path")))
-    assert_equal("", join(""))
-    assert_equal("path", join("", "path"))
+    assert_equal(join(""), "")
+    assert_equal(join("", "path"), "path")
 
-    assert_equal("/path/to/file", join("ignored", "/path/to", "file"))
+    assert_equal(join("ignored", "/path/to", "file"), "/path/to/file")
     # assert_equal("/path/to/file", join(Path("ignored"), Path("/path/to/file")))
     assert_equal(
-        "/absolute/path",
         join("ignored", "/ignored/absolute/path", "/absolute", "path"),
+        "/absolute/path",
     )
     # assert_equal(
     #     "/path/to/file",

--- a/stdlib/test/tempfile/test_tempfile.mojo
+++ b/stdlib/test/tempfile/test_tempfile.mojo
@@ -227,7 +227,7 @@ def test_named_temporary_file_write():
 
     with open(file_name, "r") as my_file:
         contents = my_file.read()
-    assert_equal("hello world", contents)
+    assert_equal(contents, "hello world")
     os.remove(file_name)
 
 

--- a/stdlib/test/utils/test_variant.mojo
+++ b/stdlib/test/utils/test_variant.mojo
@@ -95,7 +95,7 @@ def test_basic():
 
     # get
     assert_equal(4, i[Int])
-    assert_equal("4", s[String])
+    assert_equal(s[String], "4")
     # we don't test what happens when you `get` the wrong type.
     # have fun!
 
@@ -103,7 +103,7 @@ def test_basic():
     i.set[String]("i")
     assert_false(i.isa[Int]())
     assert_true(i.isa[String]())
-    assert_equal("i", i[String])
+    assert_equal(i[String], "i")
 
 
 def test_copy():


### PR DESCRIPTION
This allows `SIMD` to conform to `EqualityComparable`, without losing any of the original behavior.

It uses the 4th overload resolution rule to give the new methods lower precedence, while still conforming to `EqualityComparable`