### PR TITLE
[stdlib] Add unit tests for the SIMD __rfloordiv__() method and constraint check on the element types

### DIFF
--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -671,6 +671,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         Returns:
             `floor(rhs / self)` value.
         """
+        constrained[type.is_numeric(), "the type must be numeric"]()
         return rhs // self
 
     @always_inline("nodebug")

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -223,6 +223,18 @@ def test_floordiv():
     assert_equal(Float32(99) // Float32(-2), -50)
 
 
+def test_rfloordiv():
+    alias I = SIMD[DType.int32, 4]
+    var i = I(2, 4, -2, -4)
+    assert_equal(i.__rfloordiv__(2), I(1, 0, -1, -1))
+    assert_equal(i.__rfloordiv__(Int32(2)), I(1, 0, -1, -1))
+
+    alias F = SIMD[DType.float32, 4]
+    var f = F(3, -4, 1, 5)
+    assert_equal(f.__rfloordiv__(3), F(1, -1, 3, 0))
+    assert_equal(f.__rfloordiv__(Float32(3)), F(1, -1, 3, 0))
+
+
 def test_mod():
     assert_equal(Int32(99) % Int32(1), 0)
     assert_equal(Int32(99) % Int32(3), 0)
@@ -873,6 +885,7 @@ def main():
     test_round()
     test_roundeven()
     test_floordiv()
+    test_rfloordiv()
     test_mod()
     test_rotate()
     test_shift()


### PR DESCRIPTION
The __rfloordiv__() method is already supported by Int and Object. This commit adds support for this method to the SIMD type.