### PR TITLE
[stdlib] Allow `String()` to be created from `UInt8` ptr and list too

### DIFF
--- a/stdlib/src/builtin/file.mojo
+++ b/stdlib/src/builtin/file.mojo
@@ -189,7 +189,7 @@ struct FileHandle:
         var err_msg = _OwnedStringRef()
 
         var buf = external_call[
-            "KGEN_CompilerRT_IO_FileRead", UnsafePointer[Int8]
+            "KGEN_CompilerRT_IO_FileRead", UnsafePointer[UInt8]
         ](
             self.handle,
             UnsafePointer.address_of(size_copy),

--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -456,6 +456,7 @@ struct String(
     # Initializers
     # ===------------------------------------------------------------------===#
 
+    # TODO: Remove this method when #2317 is done
     @always_inline
     fn __init__(inout self, owned impl: Self._buffer_type):
         """Construct a string from a buffer of bytes.
@@ -505,11 +506,11 @@ struct String(
             impl[-1] == 0,
             "expected last element of String buffer to be null terminator",
         )
-        # we store the lenght and capacity beforehand as `steal_data()` will invalidated `impl`
-        var lenght = len(impl)
+        # we store the length and capacity beforehand as `steal_data()` will invalidated `impl`
+        var length = len(impl)
         var capacity = impl.capacity
         self._buffer = List[Int8](
-            impl.steal_data().bitcast[Int8](), size=lenght, capacity=capacity
+            impl.steal_data().bitcast[Int8](), size=length, capacity=capacity
         )
 
     @always_inline
@@ -553,6 +554,7 @@ struct String(
 
         self = str(value)
 
+    # TODO: Remove this method when #2317 is done
     @always_inline
     fn __init__(inout self, ptr: UnsafePointer[Int8], len: Int):
         """Creates a string from the buffer. Note that the string now owns
@@ -986,6 +988,7 @@ struct String(
         """
         pass
 
+    # TODO: Remove this method when #2317 is done
     fn _as_ptr(self) -> DTypePointer[DType.int8]:
         """Retrieves a pointer to the underlying memory.
 

--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -470,6 +470,11 @@ struct String(
         var hi = String(buf)
         ```
 
+        Note that you should use the constructor from `List[UInt8]` instead
+        as we are now storing the bytes as UInt8.
+
+        See https://github.com/modularml/mojo/issues/2317 for more information.
+
         Args:
             impl: The buffer.
         """
@@ -478,6 +483,34 @@ struct String(
             "expected last element of String buffer to be null terminator",
         )
         self._buffer = impl^
+
+    @always_inline
+    fn __init__(inout self, owned impl: List[UInt8]):
+        """Construct a string from a buffer of bytes.
+
+        The buffer must be terminated with a null byte:
+
+        ```mojo
+        var buf = List[UInt8]()
+        buf.append(ord('H'))
+        buf.append(ord('i'))
+        buf.append(0)
+        var hi = String(buf)
+        ```
+
+        Args:
+            impl: The buffer.
+        """
+        debug_assert(
+            impl[-1] == 0,
+            "expected last element of String buffer to be null terminator",
+        )
+        # we store the lenght and capacity beforehand as `steal_data()` will invalidated `impl`
+        var lenght = len(impl)
+        var capacity = impl.capacity
+        self._buffer = List[Int8](
+            impl.steal_data().bitcast[Int8](), size=lenght, capacity=capacity
+        )
 
     @always_inline
     fn __init__(inout self):
@@ -527,6 +560,11 @@ struct String(
 
         The buffer must be terminated with a null byte.
 
+        Note that you should use the constructor from `UnsafePointer[UInt8]` instead
+        as we are now storing the bytes as UInt8.
+
+        See https://github.com/modularml/mojo/issues/2317 for more information.
+
         Args:
             ptr: The pointer to the buffer.
             len: The length of the buffer, including the null terminator.
@@ -534,6 +572,23 @@ struct String(
         # we don't know the capacity of ptr, but we'll assume it's the same or
         # larger than len
         self = Self(Self._buffer_type(ptr, size=len, capacity=len))
+
+    @always_inline
+    fn __init__(inout self, ptr: UnsafePointer[UInt8], len: Int):
+        """Creates a string from the buffer. Note that the string now owns
+        the buffer.
+
+        The buffer must be terminated with a null byte.
+
+        Args:
+            ptr: The pointer to the buffer.
+            len: The length of the buffer, including the null terminator.
+        """
+        # we don't know the capacity of ptr, but we'll assume it's the same or
+        # larger than len
+        self = Self(
+            Self._buffer_type(ptr.bitcast[Int8](), size=len, capacity=len)
+        )
 
     @always_inline
     fn __init__(inout self, ptr: LegacyPointer[Int8], len: Int):
@@ -794,7 +849,11 @@ struct String(
         var total_len = self_len + other_len
         self._buffer.resize(total_len + 1, 0)
         # Copy the data alongside the terminator.
-        memcpy(self._as_ptr() + self_len, other._as_ptr(), other_len + 1)
+        memcpy(
+            self._as_uint8_ptr() + self_len,
+            other._as_uint8_ptr(),
+            other_len + 1,
+        )
 
     # ===------------------------------------------------------------------=== #
     # Methods
@@ -930,10 +989,25 @@ struct String(
     fn _as_ptr(self) -> DTypePointer[DType.int8]:
         """Retrieves a pointer to the underlying memory.
 
+        Note that you should use `_as_uint8_ptr()` if you need to access the
+        pointer as we are now storing the bytes as UInt8.
+
+        See https://github.com/modularml/mojo/issues/2317 for more information.
+
         Returns:
             The pointer to the underlying memory.
         """
         return rebind[DTypePointer[DType.int8]](self._buffer.data)
+
+    fn _as_uint8_ptr(self) -> DTypePointer[DType.uint8]:
+        """Retrieves a pointer to the underlying memory.
+
+        Returns:
+            The pointer to the underlying memory.
+        """
+        return rebind[DTypePointer[DType.uint8]](
+            self._buffer.data.bitcast[UInt8]()
+        )
 
     fn as_bytes(self) -> List[Int8]:
         """Retrieves the underlying byte sequence encoding the characters in

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -566,7 +566,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
             A string representation of the Dict.
         """
         var minimum_capacity = self._minimum_size_of_string_representation()
-        var result = String(List[Int8](capacity=minimum_capacity))
+        var result = String(List[UInt8](capacity=minimum_capacity))
         result += "{"
 
         var i = 0

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -596,7 +596,7 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             + len(self) * 3  # str(x) and ", "
             - 2  # remove the last ", "
         )
-        var result = String(List[Int8](capacity=minimum_capacity))
+        var result = String(List[UInt8](capacity=minimum_capacity))
         result += "["
         for i in range(len(self)):
             result += str(self[i])


### PR DESCRIPTION
This is related to https://github.com/modularml/mojo/issues/2317. 

It allows a graceful and slow migration to UInt8 as the primary byte type. This allows everyone to give whatever (Int8 or UInt8) to the String struct and it just works™

When everything uses Uint8, we can remove the old methods that work with Int8, and the migration will be complete.