### PR TITLE
[stdlib] Complete most of the remaining methods of `Set`

### DIFF
--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -463,3 +463,24 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
                 return False
 
         return True
+
+    fn symmetric_difference(self, other: Self) -> Self:
+        """Returns the symmetric difference of two sets.
+        
+        Args:
+            other: The set to find the symmetric difference with.
+
+        Returns:
+            A new set containing the symmetric difference of the two sets.
+        """
+        var result = Set[T]()
+        
+        for element in self:
+            if element[] not in other:
+                result.add(element[])
+        
+        for element in other:
+            if element[] not in self:
+                result.add(element[])
+        
+        return result ^

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -262,6 +262,17 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
         """
         return self <= other and self != other
 
+    fn __xor__(self, other: Self) -> Self:
+        """Overloads the ^ operator for sets. Works like as `symmetric_difference` method.
+        
+        Args:
+            other: The set to find the symmetric difference with.
+
+        Returns:
+            A new set containing the symmetric difference of the two sets.
+        """
+        return self.symmetric_difference(other)
+
     fn __iter__[
         mutability: __mlir_type.i1, self_life: AnyLifetime[mutability].type
     ](

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -495,3 +495,11 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
                 result.add(element[])
         
         return result ^
+
+    fn symmetric_difference_update(inout self, other: Self):
+        """Updates the set with the symmetric difference of itself and another set.
+        
+        Args:
+            other: The set to find the symmetric difference with.
+        """
+        self = self.symmetric_difference(other)

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -368,3 +368,21 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
                 self.remove(o[])
             except:
                 pass
+
+    fn issubset(self, other: Self) -> Bool:
+        """Check if this set is a subset of another set.
+
+        Args:
+            other: Another Set instance to check against.
+
+        Returns:
+            True if this set is a subset of the `other` set, False otherwise.
+        """
+        if len(self) > len(other):
+            return False
+
+        for element in self:
+            if element[] not in other:
+                return False
+
+        return True

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -229,6 +229,17 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
         """
         return self.issubset(other)
 
+    fn __ge__(self, other: Self) -> Bool:
+        """Overloads the >= operator for sets. Works like as `issuperset` method.
+        
+        Args:
+            other: Another Set instance to check against.
+
+        Returns:
+            True if this set is a superset of the `other` set, False otherwise.
+        """
+        return self.issuperset(other)
+
     fn __iter__[
         mutability: __mlir_type.i1, self_life: AnyLifetime[mutability].type
     ](

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -412,3 +412,21 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
                 return False
 
         return True
+
+    fn issuperset(self, other: Self) -> Bool:
+        """Check if this set is a superset of another set.
+
+        Args:
+            other: Another Set instance to check against.
+
+        Returns:
+            True if this set is a superset of the `other` set, False otherwise.
+        """
+        if len(self) < len(other):
+            return False
+
+        for element in other:
+            if element[] not in self:
+                return False
+
+        return True

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -218,6 +218,17 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
         """
         self.difference_update(other)
 
+    fn __le__(self, other: Self) -> Bool:
+        """Overloads the <= operator for sets. Works like as `issubset` method.
+
+        Args:
+            other: Another Set instance to check against.
+
+        Returns:
+            True if this set is a subset of the `other` set, False otherwise.
+        """
+        return self.issubset(other)
+
     fn __iter__[
         mutability: __mlir_type.i1, self_life: AnyLifetime[mutability].type
     ](

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -273,6 +273,16 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
         """
         return self.symmetric_difference(other)
 
+    fn __ixor__(inout self, other: Self):
+        """Overloads the ^= operator. Works like as `symmetric_difference_update` method.
+        
+        Updates the set with the symmetric difference of itself and another set.
+
+        Args:
+            other: The set to find the symmetric difference with.
+        """
+        self.symmetric_difference_update(other)
+
     fn __iter__[
         mutability: __mlir_type.i1, self_life: AnyLifetime[mutability].type
     ](

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -251,6 +251,17 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
         """
         return self >= other and self != other
 
+    fn __lt__(self, other: Self) -> Bool:
+        """Overloads the < operator for strict subset comparison of sets.
+
+        Args:
+            other: The set to compare against for the strict subset relationship.
+
+        Returns:
+            True if the set is a strict subset of the `other` set, False otherwise.
+        """
+        return self <= other and self != other
+
     fn __iter__[
         mutability: __mlir_type.i1, self_life: AnyLifetime[mutability].type
     ](

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -397,3 +397,18 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
                 return False
 
         return True
+
+    fn isdisjoint(self, other: Self) -> Bool:
+        """Check if this set is disjoint with another set.
+
+        Args:
+            other: Another Set instance to check against.
+
+        Returns:
+            True if this set is disjoint with the `other` set, False otherwise.
+        """
+        for element in self:
+            if element[] in other:
+                return False
+
+        return True

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -231,7 +231,7 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
 
     fn __ge__(self, other: Self) -> Bool:
         """Overloads the >= operator for sets. Works like as `issuperset` method.
-        
+
         Args:
             other: Another Set instance to check against.
 
@@ -264,7 +264,7 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
 
     fn __xor__(self, other: Self) -> Self:
         """Overloads the ^ operator for sets. Works like as `symmetric_difference` method.
-        
+
         Args:
             other: The set to find the symmetric difference with.
 
@@ -275,7 +275,7 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
 
     fn __ixor__(inout self, other: Self):
         """Overloads the ^= operator. Works like as `symmetric_difference_update` method.
-        
+
         Updates the set with the symmetric difference of itself and another set.
 
         Args:
@@ -487,7 +487,7 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
 
     fn symmetric_difference(self, other: Self) -> Self:
         """Returns the symmetric difference of two sets.
-        
+
         Args:
             other: The set to find the symmetric difference with.
 
@@ -495,20 +495,20 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
             A new set containing the symmetric difference of the two sets.
         """
         var result = Set[T]()
-        
+
         for element in self:
             if element[] not in other:
                 result.add(element[])
-        
+
         for element in other:
             if element[] not in self:
                 result.add(element[])
-        
-        return result ^
+
+        return result^
 
     fn symmetric_difference_update(inout self, other: Self):
         """Updates the set with the symmetric difference of itself and another set.
-        
+
         Args:
             other: The set to find the symmetric difference with.
         """
@@ -533,7 +533,7 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
         """
         for _ in range(len(self)):
             var a = self.pop()
-        
+
         #! This code below (without using range function) won't pass tests
         #! It leaves set with one remaining item. Is this a bug?
         # for _ in self:

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -524,3 +524,17 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
             self._data.pop(value)
         except:
             pass
+
+    fn clear(inout self) raises:
+        """Removes all elements from the set.
+
+        This method modifies the set in-place, removing all of its elements.
+        After calling this method, the set will be empty.
+        """
+        for _ in range(len(self)):
+            var a = self.pop()
+        
+        #! This code below (without using range function) won't pass tests
+        #! It leaves set with one remaining item. Is this a bug?
+        # for _ in self:
+        #     var a = self.pop()

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -341,17 +341,6 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
         for e in other:
             self.add(e[])
 
-    fn difference_update(inout self, other: Self):
-        """In-place set difference update.
-
-        Updates the set by removing all elements found in the `other` set,
-        effectively keeping only elements that are unique to this set.
-
-        Args:
-            other: Another Set instance to compare with this one.
-        """
-        self.remove_all(other)
-
     fn intersection_update(inout self, other: Self):
         """In-place set intersection update.
 
@@ -363,12 +352,13 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
         """
         # Possible to do this without an extra allocation, but need to be
         # careful about concurrent iteration + mutation
-        self.remove_all(self - other)
+        self.difference_update(self - other)
 
-    fn remove_all(inout self, other: Self):
+    fn difference_update(inout self, other: Self):
         """In-place set subtraction.
 
-        Updates the set to remove any elements from the `other` set.
+        Updates the set by removing all elements found in the `other` set,
+        effectively keeping only elements that are unique to this set.
 
         Args:
             other: Another Set instance to subtract from this one.

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -240,6 +240,17 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
         """
         return self.issuperset(other)
 
+    fn __gt__(self, other: Self) -> Bool:
+        """Overloads the > operator for strict superset comparison of sets.
+
+        Args:
+            other: The set to compare against for the strict superset relationship.
+
+        Returns:
+            True if the set is a strict superset of the `other` set, False otherwise.
+        """
+        return self >= other and self != other
+
     fn __iter__[
         mutability: __mlir_type.i1, self_life: AnyLifetime[mutability].type
     ](

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -513,3 +513,14 @@ struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
             other: The set to find the symmetric difference with.
         """
         self = self.symmetric_difference(other)
+
+    fn discard(inout self, value: T):
+        """Remove a value from the set if it exists. Pass otherwise.
+
+        Args:
+            value: The element to remove from the set.
+        """
+        try:
+            self._data.pop(value)
+        except:
+            pass

--- a/stdlib/test/collections/test_set.mojo
+++ b/stdlib/test/collections/test_set.mojo
@@ -286,6 +286,31 @@ def test_disjoint():
     assert_false(Set[Int](1, 2, 3).isdisjoint(Set[Int](3)))
     assert_true(Set[Int](1, 2, 3).isdisjoint(Set[Int](4)))
 
+def test_issuperset():
+    assert_true(Set[Int](1, 2, 3).issuperset(Set[Int]()))
+    assert_true(Set[Int](1, 2, 3) >= Set[Int]())
+
+    assert_true(Set[Int](1, 2, 3).issuperset(Set[Int](1, 2, 3)))
+    assert_true(Set[Int](1, 2, 3) >= Set[Int](1, 2, 3))
+
+    assert_true(Set[Int](1, 2, 3, 4).issuperset(Set[Int](2, 3)))
+    assert_true(Set[Int](1, 2, 3, 4) >= Set[Int](2, 3))
+
+    assert_false(Set[Int](2, 3).issuperset(Set[Int](1, 2, 3, 4)))
+    assert_false(Set[Int](2, 3) >= Set[Int](1, 2, 3, 4))
+
+    assert_false(Set[Int](1, 2, 3).issuperset(Set[Int](4, 5, 6)))
+    assert_false(Set[Int](1, 2, 3) >= Set[Int](4, 5, 6))
+
+    assert_false(Set[Int]().issuperset(Set[Int](1, 2, 3)))
+    assert_false(Set[Int]() >= Set[Int](1, 2, 3))
+
+    assert_false(Set[Int](1, 2, 3).issuperset(Set[Int](1, 2, 3, 4)))
+    assert_false(Set[Int](1, 2, 3) >= Set[Int](1, 2, 3, 4))
+
+    assert_true(Set[Int]().issuperset(Set[Int]()))
+    assert_true(Set[Int]() >= Set[Int]())
+
 fn test[name: String, test_fn: fn () raises -> object]() raises:
     var name_val = name  # FIXME(#26974): Can't pass 'name' directly.
     print("Test", name_val, "...", end="")
@@ -313,3 +338,4 @@ def main():
     test["test_pop_insertion_order", test_pop_insertion_order]()
     test["test_issubset", test_issubset]()
     test["test_disjoint", test_disjoint]()
+    test["test_issuperset", test_issuperset]()

--- a/stdlib/test/collections/test_set.mojo
+++ b/stdlib/test/collections/test_set.mojo
@@ -254,6 +254,27 @@ def test_pop_insertion_order():
     with assert_raises():
         s.pop()  # pop from empty set raises
 
+def test_issubset():
+    assert_true(Set[Int]().issubset(Set[Int](1, 2, 3)))
+    assert_true(Set[Int]() <= Set[Int](1, 2, 3))
+
+    assert_true(Set[Int](1, 2, 3).issubset(Set[Int](1, 2, 3)))
+    assert_true(Set[Int](1, 2, 3) <= Set[Int](1, 2, 3))
+
+    assert_true(Set[Int](2, 3).issubset(Set[Int](1, 2, 3, 4)))
+    assert_true(Set[Int](2, 3) <= Set[Int](1, 2, 3, 4))
+
+    assert_false(Set[Int](1, 2, 3, 4).issubset(Set[Int](2, 3)))
+    assert_false(Set[Int](1, 2, 3, 4) <= Set[Int](2, 3))
+
+    assert_false(Set[Int](1, 2, 3, 4, 5).issubset(Set[Int](2, 3)))
+    assert_false(Set[Int](1, 2, 3, 4, 5) <= Set[Int](2, 3))
+
+    assert_true(Set[Int]().issubset(Set[Int]()))
+    assert_true(Set[Int]() <= Set[Int]())
+
+    assert_false(Set[Int](1, 2, 3).issubset(Set[Int](4, 5, 6)))
+    assert_false(Set[Int](1, 2, 3) <= Set[Int](4, 5, 6))
 
 fn test[name: String, test_fn: fn () raises -> object]() raises:
     var name_val = name  # FIXME(#26974): Can't pass 'name' directly.

--- a/stdlib/test/collections/test_set.mojo
+++ b/stdlib/test/collections/test_set.mojo
@@ -276,6 +276,16 @@ def test_issubset():
     assert_false(Set[Int](1, 2, 3).issubset(Set[Int](4, 5, 6)))
     assert_false(Set[Int](1, 2, 3) <= Set[Int](4, 5, 6))
 
+def test_disjoint():
+    assert_true(Set[Int]().isdisjoint(Set[Int]()))
+    assert_false(Set[Int](1, 2, 3).isdisjoint(Set[Int](1, 2, 3)))
+    assert_true(Set[Int](1, 2, 3).isdisjoint(Set[Int](4, 5, 6)))
+    assert_false(Set[Int](1, 2, 3).isdisjoint(Set[Int](3, 4, 5)))
+    assert_true(Set[Int]().isdisjoint(Set[Int](1, 2, 3)))
+    assert_true(Set[Int](1, 2, 3).isdisjoint(Set[Int]()))
+    assert_false(Set[Int](1, 2, 3).isdisjoint(Set[Int](3)))
+    assert_true(Set[Int](1, 2, 3).isdisjoint(Set[Int](4)))
+
 fn test[name: String, test_fn: fn () raises -> object]() raises:
     var name_val = name  # FIXME(#26974): Can't pass 'name' directly.
     print("Test", name_val, "...", end="")
@@ -301,3 +311,5 @@ def main():
     test["test_add", test_add]()
     test["test_remove", test_remove]()
     test["test_pop_insertion_order", test_pop_insertion_order]()
+    test["test_issubset", test_issubset]()
+    test["test_disjoint", test_disjoint]()

--- a/stdlib/test/collections/test_set.mojo
+++ b/stdlib/test/collections/test_set.mojo
@@ -254,6 +254,7 @@ def test_pop_insertion_order():
     with assert_raises():
         s.pop()  # pop from empty set raises
 
+
 def test_issubset():
     assert_true(Set[Int]().issubset(Set[Int](1, 2, 3)))
     assert_true(Set[Int]() <= Set[Int](1, 2, 3))
@@ -276,6 +277,7 @@ def test_issubset():
     assert_false(Set[Int](1, 2, 3).issubset(Set[Int](4, 5, 6)))
     assert_false(Set[Int](1, 2, 3) <= Set[Int](4, 5, 6))
 
+
 def test_disjoint():
     assert_true(Set[Int]().isdisjoint(Set[Int]()))
     assert_false(Set[Int](1, 2, 3).isdisjoint(Set[Int](1, 2, 3)))
@@ -285,6 +287,7 @@ def test_disjoint():
     assert_true(Set[Int](1, 2, 3).isdisjoint(Set[Int]()))
     assert_false(Set[Int](1, 2, 3).isdisjoint(Set[Int](3)))
     assert_true(Set[Int](1, 2, 3).isdisjoint(Set[Int](4)))
+
 
 def test_issuperset():
     assert_true(Set[Int](1, 2, 3).issuperset(Set[Int]()))
@@ -311,12 +314,14 @@ def test_issuperset():
     assert_true(Set[Int]().issuperset(Set[Int]()))
     assert_true(Set[Int]() >= Set[Int]())
 
+
 def test_greaterthan():
     assert_true(Set[Int](1, 2, 3, 4) > Set[Int](2, 3))
     assert_false(Set[Int](2, 3) > Set[Int](1, 2, 3, 4))
     assert_false(Set[Int](1, 2, 3) > Set[Int](1, 2, 3))
     assert_false(Set[Int]() > Set[Int]())
     assert_true(Set[Int](1, 2, 3) > Set[Int]())
+
 
 def test_lessthan():
     assert_true(Set[Int](2, 3) < Set[Int](1, 2, 3, 4))
@@ -325,24 +330,40 @@ def test_lessthan():
     assert_false(Set[Int]() < Set[Int]())
     assert_true(Set[Int]() < Set[Int](1, 2, 3))
 
+
 def test_symmetric_difference():
-    assert_true(Set[Int](1, 4) == Set[Int](1, 2, 3).symmetric_difference(Set[Int](2, 3, 4)))
+    assert_true(
+        Set[Int](1, 4)
+        == Set[Int](1, 2, 3).symmetric_difference(Set[Int](2, 3, 4))
+    )
     assert_true(Set[Int](1, 4) == Set[Int](1, 2, 3) ^ Set[Int](2, 3, 4))
 
-    assert_true(Set[Int](1, 2, 3, 4, 5, 6) == Set[Int](1, 2, 3).symmetric_difference(Set[Int](4, 5, 6)))
-    assert_true(Set[Int](1, 2, 3, 4, 5, 6) == Set[Int](1, 2, 3) ^ Set[Int](4, 5, 6))
+    assert_true(
+        Set[Int](1, 2, 3, 4, 5, 6)
+        == Set[Int](1, 2, 3).symmetric_difference(Set[Int](4, 5, 6))
+    )
+    assert_true(
+        Set[Int](1, 2, 3, 4, 5, 6) == Set[Int](1, 2, 3) ^ Set[Int](4, 5, 6)
+    )
 
-    assert_true(Set[Int](1, 2, 3) == Set[Int](1, 2, 3).symmetric_difference(Set[Int]()))
+    assert_true(
+        Set[Int](1, 2, 3) == Set[Int](1, 2, 3).symmetric_difference(Set[Int]())
+    )
     assert_true(Set[Int](1, 2, 3) == Set[Int](1, 2, 3) ^ Set[Int]())
 
-    assert_true(Set[Int](1, 2, 3) == Set[Int]().symmetric_difference(Set[Int](1, 2, 3)))
+    assert_true(
+        Set[Int](1, 2, 3) == Set[Int]().symmetric_difference(Set[Int](1, 2, 3))
+    )
     assert_true(Set[Int](1, 2, 3) == Set[Int]() ^ Set[Int](1, 2, 3))
 
     assert_true(Set[Int]() == Set[Int]().symmetric_difference(Set[Int]()))
     assert_true(Set[Int]() == Set[Int]() ^ Set[Int]())
 
-    assert_true(Set[Int]() == Set[Int](1, 2, 3).symmetric_difference(Set[Int](1, 2, 3)))
+    assert_true(
+        Set[Int]() == Set[Int](1, 2, 3).symmetric_difference(Set[Int](1, 2, 3))
+    )
     assert_true(Set[Int]() == Set[Int](1, 2, 3) ^ Set[Int](1, 2, 3))
+
 
 def test_symmetric_difference_update():
     # Test case 1
@@ -411,6 +432,7 @@ def test_symmetric_difference_update():
     set11 ^= set12
     assert_true(Set[Int]() == set11)
 
+
 def test_discard():
     set1 = Set[Int](1, 2, 3)
     set1.discard(2)
@@ -435,30 +457,32 @@ def test_discard():
     set5.discard(3)
     assert_true(set5 == Set[Int]())
 
+
 def test_clear():
     set1 = Set[Int](1, 2, 3)
     set1.clear()
     assert_true(set1 == Set[Int]())
-    
+
     set2 = Set[Int]()
     set2.clear()
     assert_true(set2 == Set[Int]())
-    
+
     set3 = Set[Int](1, 2, 3)
     set3.clear()
     set3.add(4)
     set3.add(5)
     assert_true(set3 == Set[Int](4, 5))
-    
+
     set4 = Set[Int](1, 2, 3)
     set4.clear()
     set4.clear()
     set4.clear()
     assert_true(set4 == Set[Int]())
-    
+
     set5 = Set[Int](1, 2, 3)
     set5.clear()
     assert_true(len(set5) == 0)
+
 
 fn test[name: String, test_fn: fn () raises -> object]() raises:
     var name_val = name  # FIXME(#26974): Can't pass 'name' directly.

--- a/stdlib/test/collections/test_set.mojo
+++ b/stdlib/test/collections/test_set.mojo
@@ -344,6 +344,73 @@ def test_symmetric_difference():
     assert_true(Set[Int]() == Set[Int](1, 2, 3).symmetric_difference(Set[Int](1, 2, 3)))
     assert_true(Set[Int]() == Set[Int](1, 2, 3) ^ Set[Int](1, 2, 3))
 
+def test_symmetric_difference_update():
+    # Test case 1
+    set1 = Set[Int](1, 2, 3)
+    set2 = Set[Int](2, 3, 4)
+    set1.symmetric_difference_update(set2)
+    assert_true(Set[Int](1, 4) == set1)
+
+    set1 = Set[Int](1, 2, 3)
+    set2 = Set[Int](2, 3, 4)
+    set1 ^= set2
+    assert_true(Set[Int](1, 4) == set1)
+
+    # Test case 2
+    set3 = Set[Int](1, 2, 3)
+    set4 = Set[Int](4, 5, 6)
+    set3.symmetric_difference_update(set4)
+    assert_true(Set[Int](1, 2, 3, 4, 5, 6) == set3)
+
+    set3 = Set[Int](1, 2, 3)
+    set4 = Set[Int](4, 5, 6)
+    set3 ^= set4
+    assert_true(Set[Int](1, 2, 3, 4, 5, 6) == set3)
+
+    # Test case 3
+    set5 = Set[Int](1, 2, 3)
+    set6 = Set[Int]()
+    set5.symmetric_difference_update(set6)
+    assert_true(Set[Int](1, 2, 3) == set5)
+
+    set5 = Set[Int](1, 2, 3)
+    set6 = Set[Int]()
+    set5 ^= set6
+    assert_true(Set[Int](1, 2, 3) == set5)
+
+    # Test case 4
+    set7 = Set[Int]()
+    set8 = Set[Int](1, 2, 3)
+    set7.symmetric_difference_update(set8)
+    assert_true(Set[Int](1, 2, 3) == set7)
+
+    set7 = Set[Int]()
+    set8 = Set[Int](1, 2, 3)
+    set7 ^= set8
+    assert_true(Set[Int](1, 2, 3) == set7)
+
+    # Test case 5
+    set9 = Set[Int]()
+    set10 = Set[Int]()
+    set9.symmetric_difference_update(set10)
+    assert_true(Set[Int]() == set9)
+
+    set9 = Set[Int]()
+    set10 = Set[Int]()
+    set9 ^= set10
+    assert_true(Set[Int]() == set9)
+
+    # Test case 6
+    set11 = Set[Int](1, 2, 3)
+    set12 = Set[Int](1, 2, 3)
+    set11.symmetric_difference_update(set12)
+    assert_true(Set[Int]() == set11)
+
+    set11 = Set[Int](1, 2, 3)
+    set12 = Set[Int](1, 2, 3)
+    set11 ^= set12
+    assert_true(Set[Int]() == set11)
+
 fn test[name: String, test_fn: fn () raises -> object]() raises:
     var name_val = name  # FIXME(#26974): Can't pass 'name' directly.
     print("Test", name_val, "...", end="")

--- a/stdlib/test/collections/test_set.mojo
+++ b/stdlib/test/collections/test_set.mojo
@@ -325,6 +325,25 @@ def test_lessthan():
     assert_false(Set[Int]() < Set[Int]())
     assert_true(Set[Int]() < Set[Int](1, 2, 3))
 
+def test_symmetric_difference():
+    assert_true(Set[Int](1, 4) == Set[Int](1, 2, 3).symmetric_difference(Set[Int](2, 3, 4)))
+    assert_true(Set[Int](1, 4) == Set[Int](1, 2, 3) ^ Set[Int](2, 3, 4))
+
+    assert_true(Set[Int](1, 2, 3, 4, 5, 6) == Set[Int](1, 2, 3).symmetric_difference(Set[Int](4, 5, 6)))
+    assert_true(Set[Int](1, 2, 3, 4, 5, 6) == Set[Int](1, 2, 3) ^ Set[Int](4, 5, 6))
+
+    assert_true(Set[Int](1, 2, 3) == Set[Int](1, 2, 3).symmetric_difference(Set[Int]()))
+    assert_true(Set[Int](1, 2, 3) == Set[Int](1, 2, 3) ^ Set[Int]())
+
+    assert_true(Set[Int](1, 2, 3) == Set[Int]().symmetric_difference(Set[Int](1, 2, 3)))
+    assert_true(Set[Int](1, 2, 3) == Set[Int]() ^ Set[Int](1, 2, 3))
+
+    assert_true(Set[Int]() == Set[Int]().symmetric_difference(Set[Int]()))
+    assert_true(Set[Int]() == Set[Int]() ^ Set[Int]())
+
+    assert_true(Set[Int]() == Set[Int](1, 2, 3).symmetric_difference(Set[Int](1, 2, 3)))
+    assert_true(Set[Int]() == Set[Int](1, 2, 3) ^ Set[Int](1, 2, 3))
+
 fn test[name: String, test_fn: fn () raises -> object]() raises:
     var name_val = name  # FIXME(#26974): Can't pass 'name' directly.
     print("Test", name_val, "...", end="")
@@ -355,3 +374,4 @@ def main():
     test["test_issuperset", test_issuperset]()
     test["test_greaterthan", test_greaterthan]()
     test["test_lessthan", test_lessthan]()
+    test["test_symmetric_difference", test_symmetric_difference]()

--- a/stdlib/test/collections/test_set.mojo
+++ b/stdlib/test/collections/test_set.mojo
@@ -311,6 +311,13 @@ def test_issuperset():
     assert_true(Set[Int]().issuperset(Set[Int]()))
     assert_true(Set[Int]() >= Set[Int]())
 
+def test_greaterthan():
+    assert_true(Set[Int](1, 2, 3, 4) > Set[Int](2, 3))
+    assert_false(Set[Int](2, 3) > Set[Int](1, 2, 3, 4))
+    assert_false(Set[Int](1, 2, 3) > Set[Int](1, 2, 3))
+    assert_false(Set[Int]() > Set[Int]())
+    assert_true(Set[Int](1, 2, 3) > Set[Int]())
+
 fn test[name: String, test_fn: fn () raises -> object]() raises:
     var name_val = name  # FIXME(#26974): Can't pass 'name' directly.
     print("Test", name_val, "...", end="")
@@ -339,3 +346,4 @@ def main():
     test["test_issubset", test_issubset]()
     test["test_disjoint", test_disjoint]()
     test["test_issuperset", test_issuperset]()
+    test["test_greaterthan", test_greaterthan]()

--- a/stdlib/test/collections/test_set.mojo
+++ b/stdlib/test/collections/test_set.mojo
@@ -442,3 +442,4 @@ def main():
     test["test_greaterthan", test_greaterthan]()
     test["test_lessthan", test_lessthan]()
     test["test_symmetric_difference", test_symmetric_difference]()
+    test["test_symmetric_difference_update", test_symmetric_difference_update]()

--- a/stdlib/test/collections/test_set.mojo
+++ b/stdlib/test/collections/test_set.mojo
@@ -155,21 +155,21 @@ def test_subtract():
     assert_equal(s2 - Set[Int](3, 4), Set[Int](1, 2))
 
 
-def test_remove_all():
+def test_difference_update():
     var x = Set[Int]()
-    x.remove_all(Set[Int]())
+    x.difference_update(Set[Int]())
     assert_equal(x, Set[Int]())
 
     x = Set[Int](1, 2, 3)
-    x.remove_all(Set[Int](1, 2, 3))
+    x.difference_update(Set[Int](1, 2, 3))
     assert_equal(x, Set[Int]())
 
     x = Set[Int](1, 2, 3)
-    x.remove_all(Set[Int]())
+    x.difference_update(Set[Int]())
     assert_equal(x, Set[Int](1, 2, 3))
 
     x = Set[Int](1, 2, 3)
-    x.remove_all(Set[Int](3, 4))
+    x.difference_update(Set[Int](3, 4))
     assert_equal(x, Set[Int](1, 2))
 
     x = Set[Int]()

--- a/stdlib/test/collections/test_set.mojo
+++ b/stdlib/test/collections/test_set.mojo
@@ -411,6 +411,30 @@ def test_symmetric_difference_update():
     set11 ^= set12
     assert_true(Set[Int]() == set11)
 
+def test_discard():
+    set1 = Set[Int](1, 2, 3)
+    set1.discard(2)
+    assert_true(set1 == Set[Int](1, 3))
+
+    set2 = Set[Int](1, 2, 3)
+    set2.discard(4)
+    assert_true(set2 == Set[Int](1, 2, 3))
+
+    set3 = Set[Int]()
+    set3.discard(1)
+    assert_true(set3 == Set[Int]())
+
+    set4 = Set[Int](1, 2, 3, 4, 5)
+    set4.discard(2)
+    set4.discard(4)
+    assert_true(set4 == Set[Int](1, 3, 5))
+
+    set5 = Set[Int](1, 2, 3)
+    set5.discard(1)
+    set5.discard(2)
+    set5.discard(3)
+    assert_true(set5 == Set[Int]())
+
 fn test[name: String, test_fn: fn () raises -> object]() raises:
     var name_val = name  # FIXME(#26974): Can't pass 'name' directly.
     print("Test", name_val, "...", end="")

--- a/stdlib/test/collections/test_set.mojo
+++ b/stdlib/test/collections/test_set.mojo
@@ -492,4 +492,5 @@ def main():
     test["test_lessthan", test_lessthan]()
     test["test_symmetric_difference", test_symmetric_difference]()
     test["test_symmetric_difference_update", test_symmetric_difference_update]()
+    test["test_discard", test_discard]()
     test["test_clear", test_clear]()

--- a/stdlib/test/collections/test_set.mojo
+++ b/stdlib/test/collections/test_set.mojo
@@ -306,7 +306,7 @@ def main():
     test["test_intersection", test_intersection]()
     test["test_union", test_union]()
     test["test_subtract", test_subtract]()
-    test["test_remove_all", test_remove_all]()
+    test["test_difference_update", test_difference_update]()
     test["test_iter", test_iter]()
     test["test_add", test_add]()
     test["test_remove", test_remove]()

--- a/stdlib/test/collections/test_set.mojo
+++ b/stdlib/test/collections/test_set.mojo
@@ -435,6 +435,31 @@ def test_discard():
     set5.discard(3)
     assert_true(set5 == Set[Int]())
 
+def test_clear():
+    set1 = Set[Int](1, 2, 3)
+    set1.clear()
+    assert_true(set1 == Set[Int]())
+    
+    set2 = Set[Int]()
+    set2.clear()
+    assert_true(set2 == Set[Int]())
+    
+    set3 = Set[Int](1, 2, 3)
+    set3.clear()
+    set3.add(4)
+    set3.add(5)
+    assert_true(set3 == Set[Int](4, 5))
+    
+    set4 = Set[Int](1, 2, 3)
+    set4.clear()
+    set4.clear()
+    set4.clear()
+    assert_true(set4 == Set[Int]())
+    
+    set5 = Set[Int](1, 2, 3)
+    set5.clear()
+    assert_true(len(set5) == 0)
+
 fn test[name: String, test_fn: fn () raises -> object]() raises:
     var name_val = name  # FIXME(#26974): Can't pass 'name' directly.
     print("Test", name_val, "...", end="")
@@ -467,3 +492,4 @@ def main():
     test["test_lessthan", test_lessthan]()
     test["test_symmetric_difference", test_symmetric_difference]()
     test["test_symmetric_difference_update", test_symmetric_difference_update]()
+    test["test_clear", test_clear]()

--- a/stdlib/test/collections/test_set.mojo
+++ b/stdlib/test/collections/test_set.mojo
@@ -318,6 +318,13 @@ def test_greaterthan():
     assert_false(Set[Int]() > Set[Int]())
     assert_true(Set[Int](1, 2, 3) > Set[Int]())
 
+def test_lessthan():
+    assert_true(Set[Int](2, 3) < Set[Int](1, 2, 3, 4))
+    assert_false(Set[Int](1, 2, 3, 4) < Set[Int](2, 3))
+    assert_false(Set[Int](1, 2, 3) < Set[Int](1, 2, 3))
+    assert_false(Set[Int]() < Set[Int]())
+    assert_true(Set[Int]() < Set[Int](1, 2, 3))
+
 fn test[name: String, test_fn: fn () raises -> object]() raises:
     var name_val = name  # FIXME(#26974): Can't pass 'name' directly.
     print("Test", name_val, "...", end="")
@@ -347,3 +354,4 @@ def main():
     test["test_disjoint", test_disjoint]()
     test["test_issuperset", test_issuperset]()
     test["test_greaterthan", test_greaterthan]()
+    test["test_lessthan", test_lessthan]()


### PR DESCRIPTION
I've been working on this for a while and I believe this PR is a big step toward reaching the point that our collection datatypes are almost identical to Python. Long story short, First, let me introduce you to the new methods and operators that are being implemented with this PR:

## Methods
1- `issubset`
2- `isdisjoint`
3- `issuperset`
4- `symmetric_difference`
5- `symmetric_difference_update`
6- `discard`
7- `clear`

## Operators
1- `__le__`
2- `__lt__`
3- `__ge__`
4- `__gt__`
5- `__xor__`
6- `__ixor__`

## Renamed methods
- `remove_all` renamed to `difference_update`

## The EDGE CASES:
The methods are designed to replicate the same functionality we get from them in Python. So, This PR assures that we have no methods/operators left that are not coded yet. Cool, right? But there are still some points that must be considered. I list them below:

1- The only method not implemented yet is `copy`. I haven't implemented this because of the differences between Python and Mojo and the related concepts of shallow/deep copy. Any suggestion is welcomed.

2- I have observed `pop` method has slightly different functionality than the Pythonic version. In Python, `pop` method works by randomly deleting an item, which is not what we have in Mojo's sets. We can keep the current functionality and also add the Pythonic one.  They can be declared all in one single method but a default argument can determine if the user wants the random poping or the other.

3- In Python, some of the methods that accept another set (e.g. `union`), work with variadic arguments which means you can pass more than one set/collection to them. The newly added and the previously implemented methods do not still support such a thing. I'm deciding whether to add them here.