### PR TITLE
[docs] Add documentation for size constraint in reduce_add

### DIFF
--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2026,6 +2026,9 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         Parameters:
             size_out: The width of the reduction.
 
+        Constraints:
+            `size_out` must not exceed width of the vector.
+
         Returns:
             The sum of all vector elements.
 


### PR DESCRIPTION
Fixes #2237 for simd.mojo

- Adds documentation for the constraint on the value of `size_out` in `reduce_add`

Signed-off-by: Brian M Johnson <brianmj02@gmail.com>
