### PR TITLE
[docs] Add constraint documentation for various `reduce`-like functions in simd.mojo

### DIFF
--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2006,6 +2006,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
             size_out: The width of the reduction.
 
         Constraints:
+            `size_out` must not exceed width of the vector.
             The element type of the vector must be integer or FP.
 
         Returns:
@@ -2063,6 +2064,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
             size_out: The width of the reduction.
 
         Constraints:
+            `size_out` must not exceed width of the vector.
             The element type of the vector must be integer or FP.
 
         Returns:
@@ -2119,6 +2121,9 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         Parameters:
             size_out: The width of the reduction.
 
+        Constraints:
+            `size_out` must not exceed width of the vector.
+
         Returns:
             The sum of all vector elements.
 
@@ -2141,6 +2146,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
             size_out: The width of the reduction.
 
         Constraints:
+            `size_out` must not exceed width of the vector.
             The element type of the vector must be integer or FP.
 
         Returns:


### PR DESCRIPTION
Fixes #2237 for `reduce`-like functions in simd.mojo:
- Adds documentation for constraint on value of `size_out` not exceeding width of input vector in `reduce_add`, `reduce_mul`, `reduce_max` and `reduce_min`.

Signed-off-by: Brian-M-J <brianmj02@gmail.com>