### PR TITLE
[stdlib] Remove unnecessary arguments and overloads in print()

### DIFF
--- a/stdlib/src/builtin/io.mojo
+++ b/stdlib/src/builtin/io.mojo
@@ -374,7 +374,7 @@ fn print[
         Ts: The elements types.
 
     Args:
-        values: The remaining elements.
+        values: The elements to print.
         sep: The separator used between elements.
         end: The String to write after printing the elements.
         flush: If set to true, then the stream is forcibly flushed.

--- a/stdlib/src/builtin/io.mojo
+++ b/stdlib/src/builtin/io.mojo
@@ -379,17 +379,16 @@ fn print[
         end: The String to write after printing the elements.
         flush: If set to true, then the stream is forcibly flushed.
     """
-    alias number_of_values = values.__len__()
 
     @parameter
-    fn print_with_separator[i: Int]():
-        _put(values.get_element[i]()[])
+    fn print_with_separator[i: Int, T: Stringable](value: T):
+        _put(value)
 
         @parameter
-        if i < number_of_values - 1:
+        if i < values.__len__() - 1:
             _put(sep)
 
-    unroll[print_with_separator, number_of_values]()
+    values.each_idx[print_with_separator]()
 
     _put(end)
     if flush:

--- a/stdlib/src/builtin/io.mojo
+++ b/stdlib/src/builtin/io.mojo
@@ -359,27 +359,10 @@ fn _put(x: DType):
 
 
 @no_inline
-fn print(
-    *, sep: StringLiteral = " ", end: StringLiteral = "\n", flush: Bool = False
-):
-    """Prints the end value.
-
-    Args:
-        sep: The separator used between elements.
-        end: The String to write after printing the elements.
-        flush: If set to true, then the stream is forcibly flushed.
-    """
-    _put(end)
-    if flush:
-        _flush()
-
-
-@no_inline
 fn print[
-    T: Stringable, *Ts: Stringable
+    *Ts: Stringable
 ](
-    first: T,
-    *rest: *Ts,
+    *values: *Ts,
     sep: StringLiteral = " ",
     end: StringLiteral = "\n",
     flush: Bool = False,
@@ -388,24 +371,25 @@ fn print[
     and followed by `end`.
 
     Parameters:
-        T: The first element type.
-        Ts: The remaining element types.
+        Ts: The elements types.
 
     Args:
-        first: The first element.
-        rest: The remaining elements.
+        values: The remaining elements.
         sep: The separator used between elements.
         end: The String to write after printing the elements.
         flush: If set to true, then the stream is forcibly flushed.
     """
-    _put(str(first))
+    alias number_of_values = values.__len__()
 
     @parameter
-    fn print_elt[T: Stringable](a: T):
-        _put(sep)
-        _put(a)
+    fn print_with_separator[i: Int]():
+        _put(values.get_element[i]()[])
 
-    rest.each[print_elt]()
+        @parameter
+        if i < number_of_values - 1:
+            _put(sep)
+
+    unroll[print_with_separator, number_of_values]()
 
     _put(end)
     if flush:


### PR DESCRIPTION
The print function was using overloads and `rest.each` to be able to generate all the `_put` call necessary at compile time. It's possible to do the same thing without overloads and also with less arguments. This will increase maintainability and make the signature easily understandable in the docs.


I would suggest that we merge this simplification PR before merging https://github.com/modularml/mojo/pull/2457 which adds support for the `file` argument in print(). Or we could rebase https://github.com/modularml/mojo/pull/2457 on top of this PR too.
