### PR TITLE
[stdlib] Fix accidental use of `assert_true` in tests

### DIFF
--- a/stdlib/test/builtin/test_slice.mojo
+++ b/stdlib/test/builtin/test_slice.mojo
@@ -18,7 +18,7 @@ from testing import assert_equal, assert_false, assert_true
 def test_none_end_folds():
     alias all_def_slice = slice(0, None, 1)
     assert_equal(all_def_slice.start, 0)
-    assert_true(all_def_slice.end, Int.MAX)
+    assert_equal(all_def_slice.end, int(Int32.MAX))
     assert_equal(all_def_slice.step, 1)
 
 

--- a/stdlib/test/python/test_python_object.mojo
+++ b/stdlib/test/python/test_python_object.mojo
@@ -26,11 +26,11 @@ def test_dunder_methods(inout python: Python):
 
     # __add__
     var c = a + b
-    assert_true(c, 44)
+    assert_equal(c, 44)
 
     # __add__
     c = a + 100
-    assert_true(c, 134)
+    assert_equal(c, 134)
 
     # __iadd__
     c += 100


### PR DESCRIPTION
Found when trying to remove `String` constructor from `Stringable`. Implicit conversion is just, evil.

@JoeLoser Shall we make the `msg` argument keyword only in the mean time to prevent this from happening? 