### PR TITLE
[stdlib] Make `DType` and `SIMD` work with `repr()`

### DIFF
--- a/stdlib/src/builtin/dtype.mojo
+++ b/stdlib/src/builtin/dtype.mojo
@@ -27,7 +27,7 @@ alias _mIsFloat = UInt8(1 << 6)
 
 @value
 @register_passable("trivial")
-struct DType(Stringable, KeyElement):
+struct DType(Stringable, Representable, KeyElement):
     """Represents DType and provides methods for working with it."""
 
     alias type = __mlir_type.`!kgen.dtype`
@@ -125,6 +125,15 @@ struct DType(Stringable, KeyElement):
         if self == DType.address:
             return "address"
         return "<<unknown>>"
+
+    @always_inline("nodebug")
+    fn __repr__(self) -> String:
+        """Gets the representation of the DType e.g. `"DType.float32"`.
+
+        Returns:
+            The representation of the dtype.
+        """
+        return "DType." + str(self)
 
     @always_inline("nodebug")
     fn get_value(self) -> __mlir_type.`!kgen.dtype`:

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -570,7 +570,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
 
         # Unsafe operations incoming, beware.
         # removing the null terminator
-        result._buffer.pop()
+        _ = result._buffer.pop()
         self._add_elements_as_str_to_buffer(result._buffer)
         # null terminator since we did unsafe operations
         result._buffer.append(0)

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -568,7 +568,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
             "SIMD[" + repr(self.element_type) + ", " + str(self.size) + "]("
         )
 
-        # Usafe operations incoming, beware.
+        # Unsafe operations incoming, beware.
         # removing the null terminator
         result._buffer.pop()
         self._add_elements_as_str_to_buffer(result._buffer)

--- a/stdlib/test/builtin/test_dtype.mojo
+++ b/stdlib/test/builtin/test_dtype.mojo
@@ -23,11 +23,11 @@ fn test_stringable() raises:
 
 
 fn test_representable() raises:
-    assert_equal("DType.float32", repr(DType.float32))
-    assert_equal("DType.int64", repr(DType.int64))
-    assert_equal("DType.bool", repr(DType.bool))
-    assert_equal("DType.address", repr(DType.address))
-    assert_equal("DType.index", repr(DType.index))
+    assert_equal(repr(DType.float32), "DType.float32")
+    assert_equal(repr(DType.int64), "DType.int64")
+    assert_equal(repr(DType.bool), "DType.bool")
+    assert_equal(repr(DType.address), "DType.address")
+    assert_equal(repr(DType.index), "DType.index")
 
 
 fn test_key_element() raises:

--- a/stdlib/test/builtin/test_dtype.mojo
+++ b/stdlib/test/builtin/test_dtype.mojo
@@ -22,6 +22,14 @@ fn test_stringable() raises:
     assert_equal("int64", str(DType.int64))
 
 
+fn test_representable() raises:
+    assert_equal("DType.float32", repr(DType.float32))
+    assert_equal("DType.int64", repr(DType.int64))
+    assert_equal("DType.bool", repr(DType.bool))
+    assert_equal("DType.address", repr(DType.address))
+    assert_equal("DType.index", repr(DType.index))
+
+
 fn test_key_element() raises:
     var set = Set[DType]()
     set.add(DType.bool)
@@ -33,4 +41,5 @@ fn test_key_element() raises:
 
 fn main() raises:
     test_stringable()
+    test_representable()
     test_key_element()

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -89,6 +89,60 @@ def test_convert_simd_to_string():
     )
 
 
+def test_simd_representation():
+    var a: SIMD[DType.float32, 2] = 5
+    assert_equal(repr(a), "SIMD[DType.float32, 2](5.0, 5.0)")
+
+    var b: SIMD[DType.float64, 4] = 6
+    assert_equal(repr(b), "SIMD[DType.float64, 4](6.0, 6.0, 6.0, 6.0)")
+
+    var c: SIMD[DType.index, 8] = 7
+    assert_equal(repr(c), "SIMD[DType.index, 8](7, 7, 7, 7, 7, 7, 7, 7)")
+
+    assert_equal(
+        repr(UInt64(-1)), "SIMD[DType.uint64, 1](18446744073709551615)"
+    )
+    assert_equal(
+        repr(Scalar[DType.address](22)), "SIMD[DType.address, 1](0x16)"
+    )
+    assert_equal(
+        repr(Scalar[DType.address](0xDEADBEAF)),
+        "SIMD[DType.address, 1](0xdeadbeaf)",
+    )
+
+    assert_equal(repr(UInt16(32768)), "SIMD[DType.uint16, 1](32768)")
+    assert_equal(repr(UInt16(65535)), "SIMD[DType.uint16, 1](65535)")
+    assert_equal(repr(Int16(-2)), "SIMD[DType.int16, 1](-2)")
+
+    assert_equal(
+        repr(UInt64(16646288086500911323)),
+        "SIMD[DType.uint64, 1](16646288086500911323)",
+    )
+
+    # https://github.com/modularml/mojo/issues/556
+    assert_equal(
+        repr(
+            SIMD[DType.uint64, 4](
+                0xA0761D6478BD642F,
+                0xE7037ED1A0B428DB,
+                0x8EBC6AF09C88C6E3,
+                0x589965CC75374CC3,
+            )
+        ),
+        (
+            "SIMD[DType.uint64, 4](11562461410679940143, 16646288086500911323,"
+            " 10285213230658275043, 6384245875588680899)"
+        ),
+    )
+
+    assert_equal(
+        repr(
+            SIMD[DType.int32, 4](-943274556, -875902520, -808530484, -741158448)
+        ),
+        "SIMD[DType.int32, 4](-943274556, -875902520, -808530484, -741158448)",
+    )
+
+
 def test_issue_20421():
     var a = DTypePointer[DType.uint8]().alloc(16 * 64, alignment=64)
     for i in range(16 * 64):
@@ -866,6 +920,7 @@ def main():
     test_cast()
     test_simd_variadic()
     test_convert_simd_to_string()
+    test_simd_representation()
     test_issue_20421()
     test_truthy()
     test_ceil()


### PR DESCRIPTION
I'll open issues for the TODO

I noticed that a `capacity` argument for String would be welcome and avoid having to create a list first.