### PR TITLE
[tools] Add a docstring check to the CI pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,12 @@ repos:
         language: system
         files: '\.(mojo|🔥)$'
         stages: [commit]
+      - id: check-docstrings
+        name: check-docstrings
+        entry: python3 ./stdlib/scripts/check-docstrings.py
+        language: system
+        pass_filenames: false
+        stages: [commit]
       - id: check-license
         name: check-license
         entry: mojo stdlib/scripts/check-licenses.mojo


### PR DESCRIPTION
Split up from https://github.com/modularml/mojo/pull/2483 since Copybara
internally isn't managing the `.pre-commit-config.yaml` file.  So this PR just
updates the config file itself.