### PR TITLE
[stdlib] handle escape characters with `repr()`

### DIFF
--- a/stdlib/src/builtin/hex.mojo
+++ b/stdlib/src/builtin/hex.mojo
@@ -23,7 +23,7 @@ alias _DEFAULT_DIGIT_CHARS = "0123456789abcdefghijklmnopqrstuvwxyz"
 
 
 @always_inline
-fn hex[T: Intable](value: T) -> String:
+fn hex[T: Intable](value: T, prefix: StringLiteral = "0x") -> String:
     """Returns the hex string representation of the given integer.
 
     The hexadecimal representation is a base-16 encoding of the integer value.
@@ -36,13 +36,14 @@ fn hex[T: Intable](value: T) -> String:
 
     Args:
         value: The integer value to format.
+        prefix: The prefix of the formatted int.
 
     Returns:
         A string containing the hex representation of the given integer.
     """
 
     try:
-        return _format_int(int(value), 16, prefix="0x")
+        return _format_int(int(value), 16, prefix=prefix)
     except e:
         # This should not be reachable as _format_int only throws if we pass
         # incompatible radix and custom digit chars, which we aren't doing

--- a/stdlib/src/builtin/string_literal.mojo
+++ b/stdlib/src/builtin/string_literal.mojo
@@ -34,6 +34,7 @@ struct StringLiteral(
     Sized,
     IntableRaising,
     Stringable,
+    Representable,
     KeyElement,
     Boolable,
     Formattable,
@@ -143,6 +144,16 @@ struct StringLiteral(
             A new string.
         """
         return self
+
+    fn __repr__(self) -> String:
+        """Return a representation of the `StringLiteral` instance.
+
+        You don't need to call this method directly, use `repr("...")` instead.
+
+        Returns:
+            A new representation of the string.
+        """
+        return self.__str__().__repr__()
 
     fn format_to(self, inout writer: Formatter):
         """

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -41,10 +41,24 @@ fn test_stringable() raises:
 
 
 fn test_representable() raises:
+    # Usual cases
     assert_equal(repr(String("hello")), "'hello'")
     assert_equal(repr(str(0)), "'0'")
-    # TODO: Add more complex cases with "'", escape characters, etc
-    # and make String.__repr__ more robust to handle those cases.
+
+    # Escape cases
+    assert_equal(repr(String("\0")), r"'\x00'")
+    assert_equal(repr(String("\x06")), r"'\x06'")
+    assert_equal(repr(String("\x09")), r"'\t'")
+    assert_equal(repr(String("\n")), r"'\n'")
+    assert_equal(repr(String("\x0d")), r"'\r'")
+    assert_equal(repr(String("\x0e")), r"'\x0e'")
+    assert_equal(repr(String("\x1f")), r"'\x1f'")
+    assert_equal(repr(String(" ")), "' '")
+    assert_equal(repr(String("'")), '"\'"')
+    assert_equal(repr(String("A")), "'A'")
+    assert_equal(repr(String("\\")), r"'\\'")
+    assert_equal(repr(String("~")), "'~'")
+    assert_equal(repr(String("\x7f")), r"'\x7f'")
 
 
 fn test_constructors() raises:

--- a/stdlib/test/builtin/test_string_literal.mojo
+++ b/stdlib/test/builtin/test_string_literal.mojo
@@ -94,6 +94,26 @@ def test_intable():
         _ = int("hi")
 
 
+fn test_representable() raises:
+    # Usual cases
+    assert_equal(repr("hello"), "'hello'")
+
+    # Escape cases
+    assert_equal(repr("\0"), r"'\x00'")
+    assert_equal(repr("\x06"), r"'\x06'")
+    assert_equal(repr("\x09"), r"'\t'")
+    assert_equal(repr("\n"), r"'\n'")
+    assert_equal(repr("\x0d"), r"'\r'")
+    assert_equal(repr("\x0e"), r"'\x0e'")
+    assert_equal(repr("\x1f"), r"'\x1f'")
+    assert_equal(repr(" "), "' '")
+    assert_equal(repr("'"), '"\'"')
+    assert_equal(repr("A"), "'A'")
+    assert_equal(repr("\\"), r"'\\'")
+    assert_equal(repr("~"), "'~'")
+    assert_equal(repr("\x7f"), r"'\x7f'")
+
+
 def main():
     test_basics()
     test_contains()
@@ -101,3 +121,4 @@ def main():
     test_rfind()
     test_hash()
     test_intable()
+    test_representable()


### PR DESCRIPTION
guarantees a printable representation of the string when using `repr()`