### PR TITLE
[stdlib] Refactor slice to use Optionals and fix negative step slices

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -465,6 +465,14 @@ what we publish.
 - Added `SIMD.__repr__` to get the verbose string representation of `SIMD` types.
 ([PR #2728](https://github.com/modularml/mojo/pull/2728) by [@bgreni](https://github.com/bgreni))
 
+- `Slice` now implements `indices()` to retrieve the `start`, `end`, and `step` values
+  as a tuple for a slice if applied to a container of a given length.
+  ([PR #2495](https://github.com/modularml/mojo/pull/2495) by [@bgreni](https://github.com/bgreni))
+  
+  ```mojo
+    slice(1, -1, 1).indices(5) # returns (1, 4, 1)
+  ```
+
 ### 🦋 Changed
 
 - Async function calls are no longer allowed to borrow non-trivial
@@ -570,6 +578,16 @@ what we publish.
   accepts a variadic list of integers. New overloads for a `List` or `Span`of
   integers are also added.
   ([PR #2777](https://github.com/modularml/mojo/pull/2777) by [@bgreni](https://github.com/bgreni))
+  
+- `Slice` now uses `OptionalReg[Int]` for `start` and `end` and implements
+  a constructor which accepts optional values. `Slice._has_end()` has also been removed
+  since a Slice with no end is now represented by an empty `Slice.end` option.
+  ([PR #2495](https://github.com/modularml/mojo/pull/2495) by [@bgreni](https://github.com/bgreni))
+
+  ```mojo
+    var s = Slice(1, None, 2)
+    print(s.start.value()) # must retrieve the value from the optional
+  ```
 
 ### ❌ Removed
 

--- a/stdlib/src/builtin/builtin_slice.mojo
+++ b/stdlib/src/builtin/builtin_slice.mojo
@@ -16,27 +16,14 @@ These are Mojo built-ins, so you don't need to import them.
 """
 
 from sys.intrinsics import _mlirtype_is_eq
+from collections import OptionalReg
 
 
 @always_inline("nodebug")
-fn _int_max_value() -> Int:
-    # FIXME: The `slice` type should have the concept of `None` indices, but the
-    # effect of a `None` end index is the same as a very large end index.
-    return int(Int32.MAX)
-
-
-@always_inline("nodebug")
-fn _default_or[T: AnyTrivialRegType](value: T, default: Int) -> Int:
-    # TODO: Handle `__index__` for other types when we have traits!
-    @parameter
-    if _mlirtype_is_eq[T, Int]():
-        return __mlir_op.`kgen.rebind`[_type=Int](value)
-    else:
-        __mlir_op.`kgen.param.assert`[
-            cond = (_mlirtype_is_eq[T, NoneType]()).__mlir_i1__(),
-            message = "expected Int or NoneType".value,
-        ]()
-        return default
+fn _compare_optional(x: OptionalReg[Int], y: OptionalReg[Int]) -> Bool:
+    if x and y:
+        return x.value() == y.value()
+    return not x and not y
 
 
 @register_passable("trivial")
@@ -55,9 +42,9 @@ struct Slice(Stringable, EqualityComparable):
     ```
     """
 
-    var start: Int
+    var start: OptionalReg[Int]
     """The starting index of the slice."""
-    var end: Int
+    var end: OptionalReg[Int]
     """The end index of the slice."""
     var step: Int
     """The step increment value of the slice."""
@@ -75,24 +62,26 @@ struct Slice(Stringable, EqualityComparable):
         self.step = 1
 
     @always_inline("nodebug")
-    fn __init__[
-        T0: AnyTrivialRegType, T1: AnyTrivialRegType, T2: AnyTrivialRegType
-    ](inout self, start: T0, end: T1, step: T2):
+    fn __init__(
+        inout self,
+        start: OptionalReg[Int],
+        end: OptionalReg[Int],
+        step: OptionalReg[Int],
+    ):
         """Construct slice given the start, end and step values.
-
-        Parameters:
-            T0: Type of the start value.
-            T1: Type of the end value.
-            T2: Type of the step value.
 
         Args:
             start: The start value.
             end: The end value.
             step: The step value.
         """
-        self.start = _default_or(start, 0)
-        self.end = _default_or(end, _int_max_value())
-        self.step = _default_or(step, 1)
+        self.start = start
+        self.end = end
+
+        if step and step.value() == 0:
+            abort("Cannot build slice with a step of 0")
+
+        self.step = step.value() if step else 1
 
     fn __str__(self) -> String:
         """Gets the string representation of the span.
@@ -100,10 +89,10 @@ struct Slice(Stringable, EqualityComparable):
         Returns:
             The string representation of the span.
         """
-        var res = str(self.start)
+        var res = str(self.start.value()) if self.start else ""
         res += ":"
-        if self._has_end():
-            res += str(self.end)
+        if self.end:
+            res += str(self.end.value()) if self.end else ""
         res += ":"
         res += str(self.step)
         return res
@@ -120,8 +109,8 @@ struct Slice(Stringable, EqualityComparable):
             corresponding values of the other slice and False otherwise.
         """
         return (
-            self.start == other.start
-            and self.end == other.end
+            _compare_optional(self.start, other.start)
+            and _compare_optional(self.end, other.end)
             and self.step == other.step
         )
 
@@ -148,7 +137,7 @@ struct Slice(Stringable, EqualityComparable):
             The length of the slice.
         """
 
-        return len(range(self.start, self.end, self.step))
+        return len(range(self.start.value(), self.end.value(), self.step))
 
     @always_inline
     fn __getitem__(self, idx: Int) -> Int:
@@ -160,11 +149,62 @@ struct Slice(Stringable, EqualityComparable):
         Returns:
             The slice index.
         """
-        return self.start + index(idx) * self.step
+        return self.start.value() + idx * self.step
 
-    @always_inline("nodebug")
-    fn _has_end(self) -> Bool:
-        return self.end != _int_max_value()
+    fn indices(self, src_len: Int) -> (Int, Int, Int):
+        """Returns a tuple of 3 intergers representing the start, end, and step
+           of the slice if applied to a container of the given length.
+
+        Uses the target container length to normalize negative, out of bounds, or None indices.
+
+        Negative indices are wrapped using the length of the container.
+        ```mojo
+        s = slice(0, -1, 1)
+        s.indices(5) # returns (0, 4, 1)
+        ```
+
+        None indices are defaulted to the start or the end of the container based
+        on whether `step` is positive or negative.
+        ```mojo
+        s = slice(None, None, 1)
+        s.indices(5) # returns (0, 5, 1)
+        ```
+
+        Out of bounds indices are clamped using the size of the container.
+        ```mojo
+        s = slice(20)
+        s.indices(5) # returns (0, 5, 1)
+        ```
+
+        Args:
+            src_len: The length of the target container.
+
+        Returns:
+            A tuple containing three integers for start, end, and step.
+        """
+        var start = self.start
+        var end = self.end
+        var positive_step = self.step > 0
+
+        if not start:
+            start = 0 if positive_step else src_len - 1
+        elif start.value() < 0:
+            start = start.value() + src_len
+            if start.value() < 0:
+                start = 0 if positive_step else -1
+        elif start.value() >= src_len:
+            start = src_len if positive_step else src_len - 1
+
+        if not end:
+            end = src_len if positive_step else -1
+        elif end.value() < 0:
+            end = end.value() + src_len
+            if end.value() < 0:
+                end = 0 if positive_step else -1
+        elif end.value() >= src_len:
+            end = src_len if positive_step else src_len - 1
+
+        return (start.value(), end.value(), self.step)
 
 
 @always_inline("nodebug")
@@ -194,17 +234,11 @@ fn slice(start: Int, end: Int) -> Slice:
     return Slice(start, end)
 
 
-# TODO(30496): Modernize the slice type
 @always_inline("nodebug")
-fn slice[
-    T0: AnyTrivialRegType, T1: AnyTrivialRegType, T2: AnyTrivialRegType
-](start: T0, end: T1, step: T2) -> Slice:
+fn slice(
+    start: OptionalReg[Int], end: OptionalReg[Int], step: OptionalReg[Int]
+) -> Slice:
     """Construct a Slice given the start, end and step values.
-
-    Parameters:
-        T0: Type of the start value.
-        T1: Type of the end value.
-        T2: Type of the step value.
 
     Args:
         start: The start value.

--- a/stdlib/src/builtin/range.mojo
+++ b/stdlib/src/builtin/range.mojo
@@ -179,9 +179,10 @@ struct _StridedRange(Sized, ReversibleRange, _StridedIterable):
 
     @always_inline("nodebug")
     fn __len__(self) -> Int:
-        # FIXME(#38392)
-        # if (self.step > 0) == (self.start > self.end):
-        #     return 0
+        if (self.step > 0 and self.start > self.end) or (
+            self.step < 0 and self.start < self.end
+        ):
+            return 0
         return _div_ceil_positive(abs(self.start - self.end), abs(self.step))
 
     @always_inline("nodebug")

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -708,26 +708,6 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         return ptr
 
     @always_inline
-    fn _adjust_span(self, span: Slice) -> Slice:
-        """Adjusts the span based on the list length."""
-        var adjusted_span = span
-
-        if adjusted_span.start < 0:
-            adjusted_span.start = len(self) + adjusted_span.start
-
-        if not adjusted_span._has_end():
-            adjusted_span.end = len(self)
-        elif adjusted_span.end < 0:
-            adjusted_span.end = len(self) + adjusted_span.end
-
-        if span.step < 0:
-            var tmp = adjusted_span.end
-            adjusted_span.end = adjusted_span.start - 1
-            adjusted_span.start = tmp - 1
-
-        return adjusted_span
-
-    @always_inline
     fn __getitem__(self, span: Slice) -> Self:
         """Gets the sequence of elements at the specified positions.
 
@@ -738,15 +718,18 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             A new list containing the list at the specified span.
         """
 
-        var adjusted_span = self._adjust_span(span)
-        var adjusted_span_len = adjusted_span.unsafe_indices()
+        var start: Int
+        var end: Int
+        var step: Int
+        start, end, step = span.indices(len(self))
+        var r = range(start, end, step)
 
-        if not adjusted_span_len:
+        if not len(r):
             return Self()
 
-        var res = Self(capacity=adjusted_span_len)
-        for i in range(adjusted_span_len):
-            res.append(self[adjusted_span[i]])
+        var res = Self(capacity=len(r))
+        for i in r:
+            res.append(self[i])
 
         return res^
 

--- a/stdlib/src/utils/span.mojo
+++ b/stdlib/src/utils/span.mojo
@@ -159,15 +159,17 @@ struct Span[
         Returns:
             A new span that points to the same data as the current span.
         """
-        var adjusted_span = self._adjust_span(slc)
+        var start: Int
+        var end: Int
+        var step: Int
+        start, end, step = slc.indices(len(self))
         debug_assert(
-            0 <= adjusted_span.start <= self._len
-            and 0 <= adjusted_span.end <= self._len,
-            "Slice must be within bounds.",
+            step != 1,
+            "Slice must be within bounds and step must be 1.",
         )
         var res = Self(
-            unsafe_ptr=(self._data + adjusted_span.start),
-            len=adjusted_span.unsafe_indices(),
+            unsafe_ptr=(self._data + start),
+            len=len(range(start, end, step)),
         )
 
         return res
@@ -197,26 +199,6 @@ struct Span[
     # ===------------------------------------------------------------------===#
     # Methods
     # ===------------------------------------------------------------------===#
-
-    @always_inline
-    fn _adjust_span(self, span: Slice) -> Slice:
-        """Adjusts the span based on the list length."""
-        var adjusted_span = span
-
-        if adjusted_span.start < 0:
-            adjusted_span.start = len(self) + adjusted_span.start
-
-        if not adjusted_span._has_end():
-            adjusted_span.end = len(self)
-        elif adjusted_span.end < 0:
-            adjusted_span.end = len(self) + adjusted_span.end
-
-        if span.step < 0:
-            var tmp = adjusted_span.end
-            adjusted_span.end = adjusted_span.start - 1
-            adjusted_span.start = tmp - 1
-
-        return adjusted_span
 
     fn unsafe_ptr(self) -> UnsafePointer[T]:
         """

--- a/stdlib/test/builtin/test_range.mojo
+++ b/stdlib/test/builtin/test_range.mojo
@@ -32,11 +32,11 @@ def test_range_len():
     assert_equal(range(0, 0).__len__(), 0, "len(range(0, 0))")
     assert_equal(range(10, 0).__len__(), 0, "len(range(10, 0))")
     assert_equal(range(0, 0, 1).__len__(), 0, "len(range(0, 0, 1))")
-    # FIXME(#38392)
-    # assert_equal(range(5, 10, -1).__len__(), 0, "len(range(5, 10, -1))")
-    # assert_equal(range(10, 5, 1).__len__(), 0, "len(range(10, 5, 1))")
-    # assert_equal(range(5, 10, -10).__len__(), 0, "len(range(5, 10, -10))")
-    # assert_equal(range(10, 5, 10).__len__(), 0, "len(range(10, 5, 10))")
+
+    assert_equal(range(5, 10, -1).__len__(), 0, "len(range(5, 10, -1))")
+    assert_equal(range(10, 5, 1).__len__(), 0, "len(range(10, 5, 1))")
+    assert_equal(range(5, 10, -10).__len__(), 0, "len(range(5, 10, -10))")
+    assert_equal(range(10, 5, 10).__len__(), 0, "len(range(10, 5, 10))")
     assert_equal(range(5, 10, 20).__len__(), 1, "len(range(5, 10, 20))")
     assert_equal(range(10, 5, -20).__len__(), 1, "len(range(10, 5, -20))")
 

--- a/stdlib/test/builtin/test_slice.mojo
+++ b/stdlib/test/builtin/test_slice.mojo
@@ -17,8 +17,8 @@ from testing import assert_equal, assert_false, assert_true
 
 def test_none_end_folds():
     alias all_def_slice = slice(0, None, 1)
-    assert_equal(all_def_slice.start, 0)
-    assert_equal(all_def_slice.end, int(Int32.MAX))
+    assert_equal(all_def_slice.start.value(), 0)
+    assert_true(all_def_slice.end is None)
     assert_equal(all_def_slice.step, 1)
 
 
@@ -62,11 +62,6 @@ def test_slicable():
     assert_equal(boring_slice.c, "foo")
 
 
-def test_has_end():
-    alias is_end = Slice(None, None, None)._has_end()
-    assert_false(is_end)
-
-
 struct SliceStringable:
     fn __init__(inout self):
         pass
@@ -79,7 +74,55 @@ def test_slice_stringable():
     var s = SliceStringable()
     assert_equal(s[2::-1], "2::-1")
     assert_equal(s[1:-1:2], "1:-1:2")
-    assert_equal(s[:-1], "0:-1:1")
+    assert_equal(s[:-1], ":-1:1")
+
+
+def test_slice_eq():
+    assert_equal(slice(1, 2, 3), slice(1, 2, 3))
+    assert_equal(slice(0, 1), slice(1))
+    assert_true(slice(2, 3) != slice(4, 5))
+    assert_equal(slice(1, None, 1), slice(1, None, None))
+
+
+def test_slice_adjust():
+    var start: Int
+    var end: Int
+    var step: Int
+    var s = slice(1, 10)
+    start, end, step = s.indices(9)
+    assert_equal(slice(start, end, step), slice(1, 9))
+    s = slice(1, None, 1)
+    start, end, step = s.indices(5)
+    assert_equal(slice(start, end, step), slice(1, 5))
+    s = slice(1, None, -1)
+    start, end, step = s.indices(5)
+    assert_equal(slice(start, end, step), slice(1, -1, -1))
+    s = slice(-1, None, 1)
+    start, end, step = s.indices(5)
+    assert_equal(slice(start, end, step), slice(4, 5, 1))
+    s = slice(None, 2, 1)
+    start, end, step = s.indices(5)
+    assert_equal(slice(start, end, step), slice(0, 2, 1))
+    s = slice(None, 2, -1)
+    start, end, step = s.indices(5)
+    assert_equal(slice(start, end, step), slice(4, 2, -1))
+    s = slice(0, -1, 1)
+    start, end, step = s.indices(5)
+    assert_equal(slice(start, end, step), slice(0, 4, 1))
+    s = slice(None, None, 1)
+    start, end, step = s.indices(5)
+    assert_equal(slice(start, end, step), slice(0, 5, 1))
+    s = slice(20)
+    start, end, step = s.indices(5)
+    assert_equal(slice(start, end, step), slice(0, 5, 1))
+    s = slice(10, -10, 1)
+    start, end, step = s.indices(5)
+    assert_equal(slice(start, end, step), slice(5, 0, 1))
+    assert_equal(len(range(start, end, step)), 0)
+    s = slice(-12, -10, -1)
+    start, end, step = s.indices(5)
+    assert_equal(slice(start, end, step), slice(-1, -1, -1))
+    assert_equal(len(range(start, end, step)), 0)
 
 
 def test_indexing():
@@ -92,6 +135,7 @@ def test_indexing():
 def main():
     test_none_end_folds()
     test_slicable()
-    test_has_end()
     test_slice_stringable()
     test_indexing()
+    test_slice_eq()
+    test_slice_adjust()

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -285,11 +285,19 @@ fn test_string_indexing() raises:
 
     assert_equal("!!ojoM olleH", str[::-1])
 
-    assert_equal("!!ojoM oll", str[2::-1])
+    assert_equal("leH", str[2::-1])
 
     assert_equal("!oo le", str[::-2])
 
-    assert_equal("!jMolH", str[:-1:-2])
+    assert_equal("", str[:-1:-2])
+    assert_equal("", str[-50::-1])
+    assert_equal("Hello Mojo!!", str[-50::])
+    assert_equal("!!ojoM olleH", str[:-50:-1])
+    assert_equal("Hello Mojo!!", str[:50:])
+    assert_equal("H", str[::50])
+    assert_equal("!", str[::-50])
+    assert_equal("!", str[50::-50])
+    assert_equal("H", str[-50::50])
 
 
 fn test_atol() raises:

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -671,6 +671,45 @@ def test_list_span():
     assert_equal(es[2], 3)
     assert_equal(len(es), 3)
 
+    assert_equal(vs[1:0:-1][0], 2)
+    assert_equal(vs[2:1:-1][0], 3)
+    es = vs[:0:-1]
+    assert_equal(es[0], 3)
+    assert_equal(es[1], 2)
+    assert_equal(vs[2::-1][0], 3)
+
+    assert_equal(len(vs[1:2:-1]), 0)
+
+    assert_equal(0, len(vs[:-1:-2]))
+    assert_equal(0, len(vs[-50::-1]))
+    es = vs[-50::]
+    assert_equal(3, len(es))
+    assert_equal(es[0], 1)
+    assert_equal(es[1], 2)
+    assert_equal(es[2], 3)
+    es = vs[:-50:-1]
+    assert_equal(3, len(es))
+    assert_equal(es[0], 3)
+    assert_equal(es[1], 2)
+    assert_equal(es[2], 1)
+    es = vs[:50:]
+    assert_equal(3, len(es))
+    assert_equal(es[0], 1)
+    assert_equal(es[1], 2)
+    assert_equal(es[2], 3)
+    es = vs[::50]
+    assert_equal(1, len(es))
+    assert_equal(es[0], 1)
+    es = vs[::-50]
+    assert_equal(1, len(es))
+    assert_equal(es[0], 3)
+    es = vs[50::-50]
+    assert_equal(1, len(es))
+    assert_equal(es[0], 3)
+    es = vs[-50::50]
+    assert_equal(1, len(es))
+    assert_equal(es[0], 1)
+
 
 def test_list_boolable():
     assert_true(List[Int](1))

--- a/stdlib/test/utils/test_span.mojo
+++ b/stdlib/test/utils/test_span.mojo
@@ -14,7 +14,7 @@
 
 from utils import InlineArray, Span
 from collections.list import List
-from testing import assert_equal
+from testing import assert_equal, assert_true
 
 
 def test_span_list_int():
@@ -118,9 +118,33 @@ def test_indexing():
     assert_equal(s[3], 4)
 
 
+def test_span_slice():
+    def compare(s: Span[Int], l: List[Int]) -> Bool:
+        if len(s) != len(l):
+            return False
+        for i in range(len(s)):
+            if s[i] != l[i]:
+                return False
+        return True
+
+    var l = List(1, 2, 3, 4, 5)
+    var s = Span(l)
+    var res = s[1:2]
+    assert_equal(res[0], 2)
+    res = s[1:-1:1]
+    assert_equal(res[0], 2)
+    assert_equal(res[1], 3)
+    assert_equal(res[2], 4)
+    # TODO: Fix Span slicing
+    # res = s[1::-1]
+    # assert_equal(res[0], 2)
+    # assert_equal(res[1], 1)
+
+
 def main():
     test_span_list_int()
     test_span_list_str()
     test_span_array_int()
     test_span_array_str()
     test_indexing()
+    test_span_slice()


### PR DESCRIPTION

- Use `Optional` for `Slice` `start` and `end`
- Fix negative step slice indexing
- Fix incorrect String unit tests
- Fix `_StridedRange` length with mismatched start and end indices

Fixes #2046
Fixes #1944
Fixes #2142