### PR TITLE
[stdlib] Support for negative indexes in `List._reverse(start)` method

### DIFF
--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -380,18 +380,12 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         Args:
             start: A non-negative integer indicating the position after which to reverse elements.
         """
+        var start_idx = start if start >= 0 else len(self) + start
 
-        # TODO(polish): Support a negative slice-like start position here that
-        #               counts from the end.
-        debug_assert(
-            start >= 0,
-            "List reverse start position must be non-negative",
-        )
-
-        var earlier_idx = start
+        var earlier_idx = start_idx
         var later_idx = len(self) - 1
 
-        var effective_len = len(self) - start
+        var effective_len = len(self) - start_idx
         var half_len = effective_len // 2
 
         for _ in range(half_len):

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -369,18 +369,22 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
 
     fn reverse(inout self):
         """Reverses the elements of the list."""
-
-        self._reverse()
+        try:
+            self._reverse()
+        except:
+            return  # With the start argument being zero, this should never raise.
 
     # This method is private to avoid exposing the non-Pythonic `start` argument.
     @always_inline
-    fn _reverse(inout self, start: Int = 0):
+    fn _reverse(inout self, start: Int = 0) raises:
         """Reverses the elements of the list at positions after `start`.
 
         Args:
-            start: A non-negative integer indicating the position after which to reverse elements.
+            start: An integer indicating the position after which to reverse elements.
         """
         var start_idx = start if start >= 0 else len(self) + start
+        if start_idx < 0 or start_idx > len(self):
+            raise "IndexError: start index out of range."
 
         var earlier_idx = start_idx
         var later_idx = len(self) - 1

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -222,6 +222,22 @@ def test_list_reverse():
     assert_equal(vec[4], 3)
 
     #
+    # Test reversing the list [1, 2, 3] with negative indexes
+    #
+
+    vec = List[Int]()
+    vec.append(1)
+    vec.append(2)
+    vec.append(3)
+
+    vec._reverse(start=-2)
+
+    assert_equal(len(vec), 3)
+    assert_equal(vec[0], 1)
+    assert_equal(vec[1], 3)
+    assert_equal(vec[2], 2)
+
+    #
     # Test edge case of reversing the list [1, 2, 3] but starting after the
     # last element.
     #

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -238,6 +238,19 @@ def test_list_reverse():
     assert_equal(vec[2], 2)
 
     #
+    # Test reversing the list [1, 2] with out of bounds indexes
+    #
+    vec = List[Int]()
+    vec.append(1)
+    vec.append(2)
+
+    with assert_raises(contains="IndexError"):
+        vec._reverse(start=-3)
+
+    with assert_raises(contains="IndexError"):
+        vec._reverse(start=3)
+
+    #
     # Test edge case of reversing the list [1, 2, 3] but starting after the
     # last element.
     #


### PR DESCRIPTION
## Changes

* The `_reverse(start)` private method in the `collections.List` struct does not support negative indexes. 
* Check out-of-bound indexes in the `List._reverse()` method
* Tests

## Ref

Fixes #2496