### PR TITLE
[stdlib] Constrain `simd.bool()` to `size == 1`

### DIFF
--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -348,17 +348,22 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
 
     @always_inline("nodebug")
     fn __bool__(self) -> Bool:
-        """Converts the SIMD vector into a boolean scalar value.
+        """Converts the SIMD scalar into a boolean value.
+
+        Constraints:
+            The size of the SIMD vector must be 1.
 
         Returns:
-            True if all the elements in the SIMD vector are non-zero and False
-            otherwise.
+            True if the SIMD scalar is non-zero and False otherwise.
         """
-
-        @parameter
-        if Self.element_type == DType.bool:
-            return self.reduce_and()
-        return (self != 0).reduce_and()
+        constrained[
+            size == 1,
+            (
+                "The truth value of a SIMD vector with more than one element is"
+                " ambiguous. Use the builtin `all()` or `any() functions.`"
+            ),
+        ]()
+        return rebind[Scalar[DType.bool]](self.cast[DType.bool]()).value
 
     @staticmethod
     @always_inline("nodebug")
@@ -609,7 +614,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         """
         constrained[type.is_numeric(), "the type must be numeric"]()
 
-        if rhs == 0:
+        if (rhs == 0).reduce_and():
             # this should raise an exception.
             return 0
 
@@ -621,7 +626,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         elif type.is_unsigned():
             return div
         else:
-            if self > 0 and rhs > 0:
+            if ((self > 0) & (rhs > 0)).reduce_and():
                 return div
 
             var mod = self - div * rhs
@@ -657,7 +662,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         """
         constrained[type.is_numeric(), "the type must be numeric"]()
 
-        if rhs == 0:
+        if (rhs == 0).reduce_and():
             # this should raise an exception.
             return 0
 
@@ -1470,7 +1475,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
             `self << rhs`.
         """
         constrained[type.is_integral(), "must be an integral type"]()
-        debug_assert(rhs >= 0, "unhandled negative value")
+        debug_assert((rhs >= 0).reduce_and(), "unhandled negative value")
         return __mlir_op.`pop.shl`(self.value, rhs.value)
 
     @always_inline("nodebug")
@@ -1487,7 +1492,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
             `self >> rhs`.
         """
         constrained[type.is_integral(), "must be an integral type"]()
-        debug_assert(rhs >= 0, "unhandled negative value")
+        debug_assert((rhs >= 0).reduce_and(), "unhandled negative value")
         return __mlir_op.`pop.shr`(self.value, rhs.value)
 
     @always_inline("nodebug")
@@ -2436,7 +2441,7 @@ fn _pow[
     @parameter
     if rhs_type.is_floating_point() and lhs_type == rhs_type:
         var rhs_quotient = rhs.__floor__()
-        if rhs >= 0 and rhs_quotient == rhs:
+        if ((rhs >= 0) & (rhs_quotient == rhs)).reduce_and():
             return _pow(lhs, rhs_quotient.cast[_integral_type_of[rhs_type]()]())
 
         var result = SIMD[lhs_type, simd_width]()
@@ -2450,9 +2455,9 @@ fn _pow[
         return result
     elif rhs_type.is_integral():
         # Common cases
-        if rhs == 2:
+        if (rhs == 2).reduce_and():
             return lhs * lhs
-        if rhs == 3:
+        if (rhs == 3).reduce_and():
             return lhs * lhs * lhs
 
         var result = SIMD[lhs_type, simd_width]()

--- a/stdlib/src/testing/testing.mojo
+++ b/stdlib/src/testing/testing.mojo
@@ -235,7 +235,7 @@ fn assert_not_equal[
     Raises:
         An Error with the provided message if assert fails and `None` otherwise.
     """
-    if lhs == rhs:
+    if (lhs == rhs).reduce_and():
         raise _assert_not_equal_error(
             str(lhs), str(rhs), msg, __call_location()
         )

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -125,14 +125,6 @@ def test_truthy():
         assert_false(Scalar[type](False).__bool__())
         assert_true(Scalar[type](True).__bool__())
 
-        # # SIMD vectors are truth-y if _all_ values are truth-y
-        assert_true(SIMD[type, 2](True, True).__bool__())
-
-        # # SIMD vectors are false-y if _any_ values are false-y
-        assert_false(SIMD[type, 2](False, True).__bool__())
-        assert_false(SIMD[type, 2](True, False).__bool__())
-        assert_false(SIMD[type, 2](False, False).__bool__())
-
     @parameter
     fn test_dtype_unrolled[i: Int]() raises:
         alias type = dtypes.get[i, DType]()


### PR DESCRIPTION
Use explicit `reduce_or()`/`reduce_and()` instead
see https://github.com/modularml/mojo/pull/2412
