### PR TITLE
[stdlib] Add small string optimization to the `String` struct

### DIFF
--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -405,7 +405,7 @@ struct InlineArray[ElementType: CollectionElement, size: Int](Sized):
 
         return self[]._get_reference_unsafe(normalized_idx)
 
-    fn get_storage_unsafe_pointer(self) -> UnsafePointer[ElementType]:
+    fn unsafe_ptr(self) -> UnsafePointer[ElementType]:
         """Get an `UnsafePointer` to the underlying storage of the array.
 
         Returns:

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -404,3 +404,11 @@ struct InlineArray[ElementType: CollectionElement, size: Int](Sized):
             normalized_idx += size
 
         return self[]._get_reference_unsafe(normalized_idx)
+
+    fn get_storage_unsafe_pointer(self) -> UnsafePointer[ElementType]:
+        """Get an `UnsafePointer` to the underlying storage of the array.
+
+        Returns:
+            An `UnsafePointer` to the underlying storage.
+        """
+        return UnsafePointer(self._array).bitcast[ElementType]()


### PR DESCRIPTION
Fix part of https://github.com/modularml/mojo/issues/2467

This PR will stay in draft as it's too big to be merged at once, I'll split it further into multiple PRs. I also have some cleanup to do and some benchmarking. But it can give the general idea of how it works.

In a nutshell:
* I created a type `_InlineBytesList` which is like `InlineArray` but specialized in `Int8` and has a size and capacity (list-like)
* I created a type `_BytesListWithSmallSizeOptimization` which has the interface of a List, but can fall back to stack allocated memory  with `_InlineBytesList` for small sizes.
* Replaced `List[Int8]` in `String` by `_BytesListWithSmallSizeOptimization`. Adapt a few lines here and there.

The tests are passing locally. I'm open to feedback as I work on the cleanup+split.


### Benchmark
See  https://github.com/modularml/mojo/issues/2467#issuecomment-2106263163