### PR TITLE
[stdlib] add `SIMD.Mask` alias

### DIFF
--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -144,6 +144,8 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         size: The size of the SIMD vector.
     """
 
+    alias Mask = SIMD[DType.bool, size]
+
     alias element_type = type
     var value: __mlir_type[`!pop.simd<`, size.value, `, `, type.value, `>`]
     """The underlying storage for the vector."""
@@ -582,10 +584,9 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
 
         @parameter
         if type == DType.bool:
-            return (
-                rebind[SIMD[DType.bool, size]](self)
-                & rebind[SIMD[DType.bool, size]](rhs)
-            ).cast[type]()
+            return (rebind[Self.Mask](self) & rebind[Self.Mask](rhs)).cast[
+                type
+            ]()
 
         constrained[type.is_numeric(), "the SIMD type must be numeric"]()
         return __mlir_op.`pop.mul`(self.value, rhs.value)
@@ -714,7 +715,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         return _pow(self, rhs)
 
     @always_inline("nodebug")
-    fn __lt__(self, rhs: Self) -> SIMD[DType.bool, size]:
+    fn __lt__(self, rhs: Self) -> Self.Mask:
         """Compares two SIMD vectors using less-than comparison.
 
         Args:
@@ -731,7 +732,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         )
 
     @always_inline("nodebug")
-    fn __le__(self, rhs: Self) -> SIMD[DType.bool, size]:
+    fn __le__(self, rhs: Self) -> Self.Mask:
         """Compares two SIMD vectors using less-than-or-equal comparison.
 
         Args:
@@ -748,7 +749,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         )
 
     @always_inline("nodebug")
-    fn __eq__(self, rhs: Self) -> SIMD[DType.bool, size]:
+    fn __eq__(self, rhs: Self) -> Self.Mask:
         """Compares two SIMD vectors using equal-to comparison.
 
         Args:
@@ -771,7 +772,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         )
 
     @always_inline("nodebug")
-    fn __ne__(self, rhs: Self) -> SIMD[DType.bool, size]:
+    fn __ne__(self, rhs: Self) -> Self.Mask:
         """Compares two SIMD vectors using not-equal comparison.
 
         Args:
@@ -794,7 +795,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         )
 
     @always_inline("nodebug")
-    fn __gt__(self, rhs: Self) -> SIMD[DType.bool, size]:
+    fn __gt__(self, rhs: Self) -> Self.Mask:
         """Compares two SIMD vectors using greater-than comparison.
 
         Args:
@@ -811,7 +812,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         )
 
     @always_inline("nodebug")
-    fn __ge__(self, rhs: Self) -> SIMD[DType.bool, size]:
+    fn __ge__(self, rhs: Self) -> Self.Mask:
         """Compares two SIMD vectors using greater-than-or-equal comparison.
 
         Args:
@@ -1084,7 +1085,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
     # ===-------------------------------------------------------------------===#
 
     @always_inline
-    fn add_with_overflow(self, rhs: Self) -> (Self, SIMD[DType.bool, size]):
+    fn add_with_overflow(self, rhs: Self) -> (Self, Self.Mask):
         """Computes `self + rhs` and a mask of which indices overflowed.
 
         Args:
@@ -1100,7 +1101,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         if type.is_signed():
             var result = llvm_intrinsic[
                 "llvm.sadd.with.overflow",
-                _RegisterPackType[Self, SIMD[DType.bool, size]],
+                _RegisterPackType[Self, Self.Mask],
                 Self,
                 Self,
             ](self, rhs)
@@ -1108,14 +1109,14 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         else:
             var result = llvm_intrinsic[
                 "llvm.uadd.with.overflow",
-                _RegisterPackType[Self, SIMD[DType.bool, size]],
+                _RegisterPackType[Self, Self.Mask],
                 Self,
                 Self,
             ](self, rhs)
             return (result[0], result[1])
 
     @always_inline
-    fn sub_with_overflow(self, rhs: Self) -> (Self, SIMD[DType.bool, size]):
+    fn sub_with_overflow(self, rhs: Self) -> (Self, Self.Mask):
         """Computes `self - rhs` and a mask of which indices overflowed.
 
         Args:
@@ -1131,7 +1132,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         if type.is_signed():
             var result = llvm_intrinsic[
                 "llvm.ssub.with.overflow",
-                _RegisterPackType[Self, SIMD[DType.bool, size]],
+                _RegisterPackType[Self, Self.Mask],
                 Self,
                 Self,
             ](self, rhs)
@@ -1139,14 +1140,14 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         else:
             var result = llvm_intrinsic[
                 "llvm.usub.with.overflow",
-                _RegisterPackType[Self, SIMD[DType.bool, size]],
+                _RegisterPackType[Self, Self.Mask],
                 Self,
                 Self,
             ](self, rhs)
             return (result[0], result[1])
 
     @always_inline
-    fn mul_with_overflow(self, rhs: Self) -> (Self, SIMD[DType.bool, size]):
+    fn mul_with_overflow(self, rhs: Self) -> (Self, Self.Mask):
         """Computes `self * rhs` and a mask of which indices overflowed.
 
         Args:
@@ -1162,7 +1163,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         if type.is_signed():
             var result = llvm_intrinsic[
                 "llvm.smul.with.overflow",
-                _RegisterPackType[Self, SIMD[DType.bool, size]],
+                _RegisterPackType[Self, Self.Mask],
                 Self,
                 Self,
             ](self, rhs)
@@ -1170,7 +1171,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         else:
             var result = llvm_intrinsic[
                 "llvm.umul.with.overflow",
-                _RegisterPackType[Self, SIMD[DType.bool, size]],
+                _RegisterPackType[Self, Self.Mask],
                 Self,
                 Self,
             ](self, rhs)
@@ -2216,7 +2217,7 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         """
         constrained[type.is_bool(), "the simd dtype must be bool"]()
         return __mlir_op.`pop.simd.select`(
-            rebind[SIMD[DType.bool, size]](self).value,
+            rebind[Self.Mask](self).value,
             true_case.value,
             false_case.value,
         )


### PR DESCRIPTION
adds an alias for a boolean simd vector, and applies it throughout the `simd.mojo` file.