### PR TITLE
[stdlib] add `Comparable` trait

### DIFF
--- a/stdlib/src/builtin/comparable.mojo
+++ b/stdlib/src/builtin/comparable.mojo
@@ -1,0 +1,60 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+
+trait Comparable(EqualityComparable):
+    """A type which can be compared with other instances of itself."""
+
+    fn __lt__(self, rhs: Self) -> Bool:
+        """Define whether `self` is less than `rhs`.
+
+        Args:
+            rhs: The right hand side of the comparison.
+
+        Returns:
+            True if `self` is less than `rhs`.
+        """
+        ...
+
+    fn __le__(self, rhs: Self) -> Bool:
+        """Define whether `self` is less than or equal to `rhs`.
+
+        Args:
+            rhs: The right hand side of the comparison.
+
+        Returns:
+            True if `self` is less than or equal to `rhs`.
+        """
+        ...
+
+    fn __gt__(self, rhs: Self) -> Bool:
+        """Define whether `self` is greater than `rhs`.
+
+        Args:
+            rhs: The right hand side of the comparison.
+
+        Returns:
+            True if `self` is greater than `rhs`.
+        """
+        ...
+
+    fn __ge__(self, rhs: Self) -> Bool:
+        """Define whether `self` is greater than or equal to `rhs`.
+
+        Args:
+            rhs: The right hand side of the comparison.
+
+        Returns:
+            True if `self` is greater than or equal to `rhs`.
+        """
+        ...

--- a/stdlib/src/builtin/float_literal.mojo
+++ b/stdlib/src/builtin/float_literal.mojo
@@ -30,7 +30,7 @@ struct FloatLiteral(
     Boolable,
     Ceilable,
     CeilDivable,
-    EqualityComparable,
+    Comparable,
     Floorable,
     Intable,
     Stringable,

--- a/stdlib/src/builtin/int.mojo
+++ b/stdlib/src/builtin/int.mojo
@@ -198,6 +198,7 @@ struct Int(
     Boolable,
     Ceilable,
     CeilDivable,
+    Comparable,
     Floorable,
     Formattable,
     Intable,

--- a/stdlib/src/builtin/int_literal.mojo
+++ b/stdlib/src/builtin/int_literal.mojo
@@ -23,7 +23,7 @@ struct IntLiteral(
     Boolable,
     Ceilable,
     CeilDivable,
-    EqualityComparable,
+    Comparable,
     Floorable,
     Intable,
     Roundable,

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -15,7 +15,7 @@
 from .dict import Dict, KeyElement, _DictEntryIter, _DictKeyIter
 
 
-struct Set[T: KeyElement](Sized, EqualityComparable, Hashable, Boolable):
+struct Set[T: KeyElement](Sized, Comparable, Hashable, Boolable):
     """A set data type.
 
     O(1) average-case amortized add, remove, and membership check.


### PR DESCRIPTION
adds a `Comparable` trait for comparison testing conformance.
explicitly conform `FloatLiteral`, `IntLiteral`, `Int`, and `Set`.