### PR TITLE
[stdlib] Add `Dict.get(key) -> Optional[T]` and  `Dict.get(key, default) -> T` methods

### DIFF
--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -612,6 +612,18 @@ struct Dict[K: KeyElement, V: CollectionElement](
             return ev.value()[].value
         return None
 
+    fn get(self, key: K) -> Optional[V]:
+        """Get a value from the dictionary by key.
+
+        Args:
+            key: The key to search for in the dictionary.
+
+        Returns:
+            An optional value containing a copy of the value if it was present,
+            otherwise an empty Optional.
+        """
+        return self.find(key)
+
     fn pop(inout self, key: K, owned default: Optional[V] = None) raises -> V:
         """Remove a value from the dictionary by key.
 

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -632,8 +632,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
             default: Default value to return.
 
         Returns:
-            An optional value containing a copy of the value if it was present,
-            otherwise an empty Optional.
+            A copy of the value if it was present, otherwise default.
         """
         return self.find(key).or_else(default)
 

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -624,6 +624,19 @@ struct Dict[K: KeyElement, V: CollectionElement](
         """
         return self.find(key)
 
+    fn get(self, key: K, default: V) -> V:
+        """Get a value from the dictionary by key.
+
+        Args:
+            key: The key to search for in the dictionary.
+            default: Default value to return.
+
+        Returns:
+            An optional value containing a copy of the value if it was present,
+            otherwise an empty Optional.
+        """
+        return self.find(key).or_else(default)
+
     fn pop(inout self, key: K, owned default: Optional[V] = None) raises -> V:
         """Remove a value from the dictionary by key.
 

--- a/stdlib/test/collections/test_dict.mojo
+++ b/stdlib/test/collections/test_dict.mojo
@@ -394,9 +394,19 @@ def test_owned_kwargs_dict():
     test_taking_owned_kwargs_dict(owned_kwargs^)
 
 
+def test_find_get():
+    var some_dict = Dict[String, Int]()
+    some_dict["key"] = 1
+    assert_equal(some_dict.find("key").take(), 1)
+    assert_equal(some_dict.get("key").take(), 1)
+    assert_equal(some_dict.find("not_key").or_else(0), 0)
+    assert_equal(some_dict.get("not_key", 0), 0)
+
+
 def main():
     test_dict()
     test_dict_string_representation_string_int()
     test_dict_string_representation_int_int()
     test_owned_kwargs_dict()
     test_bool_conversion()
+    test_find_get()


### PR DESCRIPTION
added both functions to keep compatibility with python
```
fn get(self, key: K) -> Optional[V]:
    ...

fn get(self, key: K, default: V) -> V:
    ...
```