### PR TITLE
[stdlib] Remove FileCheck relics

### DIFF
--- a/stdlib/test/builtin/test_file.mojo
+++ b/stdlib/test/builtin/test_file.mojo
@@ -129,7 +129,7 @@ def test_file_seek():
         pos = f.seek(-16, os.SEEK_END)
         assert_equal(pos, 938)
 
-        print(f.read(6))
+        f.read(6)
 
         # Seek from current possition, skip the space
         pos = f.seek(1, os.SEEK_CUR)
@@ -195,10 +195,7 @@ struct Word:
         return word
 
 
-# CHECK-LABEL: test_file_read_to_dtype_pointer
 def test_file_read_to_dtype_pointer():
-    print("== test_file_read_to_dtype_pointer")
-
     var f = open(Path(CURRENT_DIR) / "test_file_dummy_input.txt", "r")
 
     var ptr = DTypePointer[DType.int8].alloc(8)

--- a/stdlib/test/builtin/test_list.mojo
+++ b/stdlib/test/builtin/test_list.mojo
@@ -21,14 +21,14 @@ fn test_list() raises:
 
 fn test_variadic_list() raises:
     @parameter
-    fn print_list(*nums: Int) raises:
+    fn check_list(*nums: Int) raises:
         assert_equal(nums[0], 5)
         assert_equal(nums[1], 8)
         assert_equal(nums[2], 6)
 
         assert_equal(len(nums), 3)
 
-    print_list(5, 8, 6)
+    check_list(5, 8, 6)
 
 
 def main():

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -558,7 +558,7 @@ fn test_upper() raises:
 
 
 fn test_isspace() raises:
-    print("checking true cases")
+    # checking true cases
     assert_true(isspace(ord(" ")))
     assert_true(isspace(ord("\n")))
     assert_true(isspace(ord("\t")))
@@ -566,7 +566,7 @@ fn test_isspace() raises:
     assert_true(isspace(ord("\v")))
     assert_true(isspace(ord("\f")))
 
-    print("Checking false cases")
+    # Checking false cases
     assert_false(isspace(ord("a")))
     assert_false(isspace(ord("u")))
     assert_false(isspace(ord("s")))
@@ -612,7 +612,6 @@ fn test_lstrip() raises:
 
 
 fn test_strip() raises:
-    print("start strip")
     var empty_string = String("")
     assert_true(empty_string.strip() == "")
 

--- a/stdlib/test/collections/test_optional.mojo
+++ b/stdlib/test/collections/test_optional.mojo
@@ -61,8 +61,6 @@ def test_basic():
 
 
 def test_optional_reg_basic():
-    print("== test_optional_reg_basic")
-
     var val: OptionalReg[Int] = None
     assert_false(val.__bool__())
 

--- a/stdlib/test/memory/test_memory.mojo
+++ b/stdlib/test/memory/test_memory.mojo
@@ -36,7 +36,6 @@ struct Pair:
 
 
 def test_memcpy():
-    print("== test_memcpy")
     var pair1 = Pair(1, 2)
     var pair2 = Pair(0, 0)
 
@@ -89,7 +88,6 @@ def test_memcpy():
 
 
 def test_memcpy_dtype():
-    print("== test_memcpy_dtype")
     var a = DTypePointer[DType.int32].alloc(4)
     var b = DTypePointer[DType.int32].alloc(4)
     for i in range(4):
@@ -113,7 +111,6 @@ def test_memcpy_dtype():
 
 
 def test_memcmp():
-    print("== test_memcmp")
     var pair1 = Pair(1, 2)
     var pair2 = Pair(1, 2)
 
@@ -235,7 +232,6 @@ def test_memcmp_extensive():
 
 
 def test_memset():
-    print("== test_memset")
     var pair = Pair(1, 2)
 
     var ptr = Pointer.address_of(pair)

--- a/stdlib/test/os/test_getenv_setenv.mojo
+++ b/stdlib/test/os/test_getenv_setenv.mojo
@@ -19,8 +19,6 @@ from testing import assert_equal
 
 
 def test_getenv():
-    print("== test_getenv")
-
     assert_equal(getenv("TEST_MYVAR"), "MyValue")
 
     assert_equal(getenv("TEST_MYVAR", "DefaultValue"), "MyValue")
@@ -30,8 +28,6 @@ def test_getenv():
 
 # CHECK-OK-LABEL: test_setenv
 def test_setenv():
-    print("== test_setenv")
-
     assert_equal(setenv("NEW_VAR", "FOO", True), True)
     assert_equal(getenv("NEW_VAR"), "FOO")
 

--- a/stdlib/test/pathlib/test_pathlib.mojo
+++ b/stdlib/test/pathlib/test_pathlib.mojo
@@ -23,15 +23,10 @@ alias TEMP_FILE = env_get_string["TEMP_FILE"]()
 
 
 def test_cwd():
-    print("== test_cwd")
-
-    # CHECK-NOT: unable to query the current directory
     assert_true(str(cwd()).startswith("/"))
 
 
 def test_path():
-    print("== test_path")
-
     assert_true(str(Path() / "some" / "dir").endswith("/some/dir"))
 
     assert_equal(str(Path("/foo") / "bar" / "jar"), "/foo/bar/jar")
@@ -46,21 +41,17 @@ def test_path():
 
 
 def test_path_exists():
-    print("== test_path_exists")
-
     assert_true(Path(__source_location().file_name).exists(), "does not exist")
 
     assert_false((Path() / "this_path_does_not_exist.mojo").exists(), "exists")
 
 
 def test_path_isdir():
-    print("== test_path_isdir")
     assert_true(Path().is_dir())
     assert_false((Path() / "this_path_does_not_exist").is_dir())
 
 
 def test_path_isfile():
-    print("== test_path_isfile")
     assert_true(Path(__source_location().file_name).is_file())
     assert_false(Path("this/file/does/not/exist").is_file())
 

--- a/stdlib/test/utils/test_tuple.mojo
+++ b/stdlib/test/utils/test_tuple.mojo
@@ -18,8 +18,6 @@ from utils import StaticTuple, StaticIntTuple, InlineArray
 
 
 def test_static_tuple():
-    print("== test_static_tuple")
-
     var tup1 = StaticTuple[Int, 1](1)
     assert_equal(tup1[0], 1)
 
@@ -38,7 +36,6 @@ def test_static_tuple():
 
 
 def test_static_int_tuple():
-    print("== test_static_int_tuple")
     assert_equal(str(StaticIntTuple[1](1)), "(1,)")
 
     assert_equal(str(StaticIntTuple[3](2)), "(2, 2, 2)")
@@ -75,7 +72,6 @@ def test_static_int_tuple():
 
 
 def test_tuple_literal():
-    print("== test_tuple_literal\n")
     assert_equal(len((1, 2, (3, 4), 5)), 4)
     assert_equal(len(()), 0)
 


### PR DESCRIPTION
There are a lot of prints in the unit tests related to FileCheck. I removed the prints when FileCheck was not used.