### PR TITLE
[stdlib] Added `unreachable` alternative to `contrained[False]`

### DIFF
--- a/stdlib/src/builtin/constrained.mojo
+++ b/stdlib/src/builtin/constrained.mojo
@@ -33,3 +33,15 @@ fn constrained[cond: Bool, msg: StringLiteral = "param assertion failed"]():
         cond = cond.__mlir_i1__(), message = msg.value
     ]()
     return
+
+@always_inline("nodebug")
+fn unreachable[msg: StringLiteral = "unreachable code"]():
+    """Compile time checks for unreachable code.
+
+    Parameters:
+        msg: The message to display on failure.
+    """
+    __mlir_op.`kgen.param.assert`[
+        cond = __mlir_attr.`0: i1`, message = msg.value
+    ]()
+    return

--- a/stdlib/src/builtin/constrained.mojo
+++ b/stdlib/src/builtin/constrained.mojo
@@ -34,6 +34,7 @@ fn constrained[cond: Bool, msg: StringLiteral = "param assertion failed"]():
     ]()
     return
 
+
 @always_inline("nodebug")
 fn unreachable[msg: StringLiteral = "unreachable code"]():
     """Compile time checks for unreachable code.


### PR DESCRIPTION
As mentioned in #2547, there should realistically be an `unreachable` function, to indicate when a segment of code can never be reached. 

For example
```mojo
fn one_or_two[value: Int]() -> Int:
    if value == 1:
        return 1
    elif value == 2:
        return 2
    unreachable()
```

The above code demonstrates a great use case, where the alternative now would be:

```mojo
fn one_or_two[value: Int]() -> Int:
    contrained[value == 1 or value == 2]()
    if value == 1:
        return 1
    return 2
```

This is problematic in my opinion as it creates two issues:
1. You are now checking `value == 1` two separate times, the only way to avoid this is creating an unnecessary variable.
2. You are reducing readability and harming code structure by leading with the entire body of a conditional.

More information and further suggestions found at https://github.com/modularml/mojo/issues/2547 

Signed-off-by: Benny Nottonson <bennynottonson@gmail.com>