### PR TITLE
[mojo-stdlib] Used explicit str in `_location.mojo`

### DIFF
--- a/stdlib/src/builtin/_location.mojo
+++ b/stdlib/src/builtin/_location.mojo
@@ -35,7 +35,7 @@ struct _SourceLocation(Stringable):
         Args:
             msg: The message to attach the prefix to.
         """
-        return "At " + str(self) + ": " + msg
+        return "At " + str(self) + ": " + str(msg)
 
 
 @always_inline("nodebug")


### PR DESCRIPTION
Changed for #2169 