### PR TITLE
[mojo-stdlib] Used explicit str in `float_literal.mojo`

### DIFF
--- a/stdlib/src/builtin/float_literal.mojo
+++ b/stdlib/src/builtin/float_literal.mojo
@@ -135,7 +135,7 @@ struct FloatLiteral(
         Returns:
             A string representation.
         """
-        return self
+        return str(self)
 
     @always_inline("nodebug")
     fn __int_literal__(self) -> IntLiteral:


### PR DESCRIPTION
Changed for #2169 