### PR TITLE
[mojo-stdlib] Used explicit str in `int_literal.mojo`

### DIFF
--- a/stdlib/src/builtin/int_literal.mojo
+++ b/stdlib/src/builtin/int_literal.mojo
@@ -84,7 +84,7 @@ struct IntLiteral(
         Returns:
             The value as a string.
         """
-        return self
+        return str(self)
 
     @always_inline("nodebug")
     fn __as_mlir_index(self) -> __mlir_type.index:


### PR DESCRIPTION
Changed for #2169 