### PR TITLE
[mojo-stdlib] Used explicit str in `inlined_string.mojo`

### DIFF
--- a/stdlib/src/utils/inlined_string.mojo
+++ b/stdlib/src/utils/inlined_string.mojo
@@ -302,7 +302,7 @@ struct _FixedString[CAP: Int](
                 "String literal (len="
                 + str(len(literal))
                 + ") is longer than FixedString capacity ("
-                + CAP
+                + str(CAP)
                 + ")"
             )
 


### PR DESCRIPTION
Changed for #2169 