### PR TITLE
[mojo-stdlib] Used explicit str in `test_simd.mojo`

### DIFF
--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -520,7 +520,9 @@ def test_join():
 
 
 def test_interleave():
-    assert_equal(Int32(0).interleave(Int32(1)), SIMD[DType.index, 2](0, 1))
+    assert_equal(
+        str(Int32(0).interleave(Int32(1))), str(SIMD[DType.index, 2](0, 1))
+    )
 
     assert_equal(
         SIMD[DType.index, 2](0, 2).interleave(SIMD[DType.index, 2](1, 3)),


### PR DESCRIPTION
Changed for #2169 