### PR TITLE
[stdlib] Modify SIMD's tests to directly invoke __rmod__

### DIFF
--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -235,10 +235,6 @@ def test_mod():
     assert_equal(UInt32(99) % UInt32(1), 0)
     assert_equal(UInt32(99) % UInt32(3), 0)
 
-    assert_equal(Int(4) % Int32(3), 1)
-    assert_equal(
-        Int(78) % SIMD[DType.int32, 2](78, 78), SIMD[DType.int32, 2](0, 0)
-    )
     assert_equal(
         SIMD[DType.int32, 2](7, 7) % Int(4), SIMD[DType.int32, 2](3, 3)
     )
@@ -300,6 +296,19 @@ def test_mod():
             0.0,
         ),
     )
+
+
+def test_rmod():
+    assert_equal(Int32(3).__rmod__(Int(4)), 1)
+
+    alias I = SIMD[DType.int32, 2]
+    var i = I(78, 78)
+    assert_equal(i.__rmod__(Int(78)), I(0, 0))
+
+    alias F = SIMD[DType.float32, 4]
+    var f = F(3, -4, 1, 5)
+    assert_equal(f.__rmod__(3), F(0, -1, 0, 3))
+    assert_equal(f.__rmod__(Float32(3)), F(0, -1, 0, 3))
 
 
 def test_rotate():
@@ -874,6 +883,7 @@ def main():
     test_roundeven()
     test_floordiv()
     test_mod()
+    test_rmod()
     test_rotate()
     test_shift()
     test_shuffle()


### PR DESCRIPTION
The unit tests for the SIMD's ` __rmod__` have been modified to directly invoke the dunder function. This change ensures that the tests invoke the magic function, and prevents any interference from conversion rules. Additionally, a new test has been introduced for a SIMD of floating-point type, and all `__rmod__` tests have been consolidated into their own test function for better organization.