### PR TITLE
[stdlib] Introduce non owning collection type

### DIFF
--- a/stdlib/src/utils/__init__.mojo
+++ b/stdlib/src/utils/__init__.mojo
@@ -19,6 +19,7 @@ from .index import (
 )
 from .inlined_string import InlinedString
 from .loop import unroll
+from .span import Span
 from .static_tuple import StaticTuple, InlineArray
 from .stringref import StringRef
 from .variant import Variant

--- a/stdlib/src/utils/span.mojo
+++ b/stdlib/src/utils/span.mojo
@@ -111,6 +111,9 @@ struct Span[
     ](inout self, array: Reference[InlineArray[T, size], is_mutable, lifetime]):
         """Construct a Span from an InlineArray.
 
+        Parameters:
+            size: The size of the InlineArray.
+
         Args:
             array: The array to which the span refers.
         """
@@ -195,13 +198,16 @@ struct Span[
         ref[] = value
 
     @always_inline
-    fn __getitem__(self, span: Slice) -> Self:
+    fn __getitem__(self, slice: Slice) -> Self:
         """Get a new span from a slice of the current span.
+
+        Args:
+            slice: The slice specifying the range of the new subslice.
 
         Returns:
             A new span that points to the same data as the current span.
         """
-        var adjusted_span = self._adjust_span(span)
+        var adjusted_span = self._adjust_span(slice)
         debug_assert(
             0 <= adjusted_span.start < self._len
             and 0 <= adjusted_span.end < self._len,

--- a/stdlib/src/utils/span.mojo
+++ b/stdlib/src/utils/span.mojo
@@ -1,0 +1,181 @@
+from . import InlineArray
+
+
+@value
+struct _SpanIter[
+    T: CollectionElement,
+    is_mutable: __mlir_type.`i1`,
+    lifetime: AnyLifetime[is_mutable].type,
+    forward: Bool = True,
+]:
+    """Iterator for Span.
+
+    Parameters:
+        T: The type of the elements in the span.
+        is_mutable: Whether the reference to the span is mutable.
+        lifetime: The lifetime of the Span.
+        forward: The iteration direction. `False` is backwards.
+    """
+
+    var index: Int
+    var src: Span[T, is_mutable, lifetime]
+
+    @always_inline
+    fn __iter__(self) -> Self:
+        return self
+
+    @always_inline
+    fn __next__(
+        inout self,
+    ) -> Reference[T, is_mutable, lifetime]:
+        @parameter
+        if forward:
+            self.index += 1
+            return self.src._refitem__(self.index - 1)
+        else:
+            self.index -= 1
+            return self.src._refitem__(self.index)
+
+    @always_inline
+    fn __len__(self) -> Int:
+        @parameter
+        if forward:
+            return len(self.src) - self.index
+        else:
+            return self.index
+
+
+@value
+struct Span[
+    T: CollectionElement,
+    is_mutable: __mlir_type.i1,
+    lifetime: AnyLifetime[is_mutable].type,
+]:
+    """A non owning view of contiguous data.
+
+    Parameters:
+        T: The type of the elements in the span.
+        is_mutable: Whether the span is mutable.
+        lifetime: The lifetime of the Span.
+    """
+
+    var data: UnsafePointer[T]
+    var len: Int
+
+    @always_inline
+    fn __init__(inout self, *, data: UnsafePointer[T], len: Int):
+        """Unsafe construction from a pointer and length.
+
+        Args:
+            data: The underlying pointer of the span.
+            len: The length of the view.
+        """
+        self.data = data
+        self.len = len
+
+    @always_inline
+    fn __init__(inout self, list: Reference[List[T], is_mutable, lifetime]):
+        """Construct a Span from a List.
+
+        Args:
+            list: The list to which the span refers.
+        """
+        self.data = list[].data
+        self.len = len(list[])
+
+    @always_inline
+    fn __init__[
+        size: Int
+    ](inout self, array: Reference[InlineArray[T, size], is_mutable, lifetime]):
+        """Construct a Span from an InlineArray.
+
+        Args:
+            array: The array to which the span refers.
+        """
+        self.data = UnsafePointer(array).bitcast[T]()
+        self.len = size
+
+    @always_inline
+    fn __len__(self) -> Int:
+        """Returns the length of the span. This is a known constant value.
+
+        Returns:
+            The size of the span.
+        """
+        return self.len
+
+    @always_inline
+    fn _refitem__[
+        intable: Intable
+    ](self, index: intable) -> Reference[T, is_mutable, lifetime]:
+        debug_assert(
+            -self.len <= int(index) < self.len, "index must be within bounds"
+        )
+
+        var offset = int(index)
+        if offset < 0:
+            offset += len(self)
+        return (self.data + offset)[]
+
+    @always_inline
+    fn _adjust_span(self, span: Slice) -> Slice:
+        """Adjusts the span based on the list length."""
+        var adjusted_span = span
+
+        if adjusted_span.start < 0:
+            adjusted_span.start = len(self) + adjusted_span.start
+
+        if not adjusted_span._has_end():
+            adjusted_span.end = len(self)
+        elif adjusted_span.end < 0:
+            adjusted_span.end = len(self) + adjusted_span.end
+
+        if span.step < 0:
+            var tmp = adjusted_span.end
+            adjusted_span.end = adjusted_span.start - 1
+            adjusted_span.start = tmp - 1
+
+        return adjusted_span
+
+    @always_inline
+    fn __getitem__[IntableType: Intable](self, index: IntableType) -> T:
+        """Get a `Reference` to the element at the given index.
+
+        Parameters:
+            IntableType: The inferred type of an intable argument.
+
+        Args:
+            index: The index of the item.
+
+        Returns:
+            A reference to the item at the given index.
+        """
+        # note that self._refitem__ is already bounds checking
+        return self._refitem__(index)[]
+
+    @always_inline
+    fn __getitem__(self, span: Slice) -> Self:
+        """Get a new span from a slice of the current span.
+
+        Returns:
+            A new span that points to the same data as the current span.
+        """
+        var adjusted_span = self._adjust_span(span)
+        debug_assert(
+            0 <= adjusted_span.start < self.len and 0 <= adjusted_span.end,
+            "Slice must be within bounds.",
+        )
+        var res = Self(
+            data=(self.data + adjusted_span.start), len=len(adjusted_span)
+        )
+
+        return res
+
+    @always_inline
+    fn __iter__(self) -> _SpanIter[T, is_mutable, lifetime]:
+        """Get an iterator over the elements of the span.
+
+        Returns:
+            An iterator over the elements of the span.
+        """
+        return _SpanIter(0, self)

--- a/stdlib/src/utils/span.mojo
+++ b/stdlib/src/utils/span.mojo
@@ -1,3 +1,25 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Implements the Span type.
+
+You can import these APIs from the `utils.span` module. For example:
+
+```mojo
+from utils import Span
+```
+"""
+
 from . import InlineArray
 
 

--- a/stdlib/src/utils/span.mojo
+++ b/stdlib/src/utils/span.mojo
@@ -176,6 +176,25 @@ struct Span[
         return self._refitem__(index)[]
 
     @always_inline
+    fn __setitem__[
+        IntableType: Intable
+    ](inout self, index: IntableType, value: T):
+        """Get a `Reference` to the element at the given index.
+
+        Parameters:
+            IntableType: The inferred type of an intable argument.
+
+        Args:
+            index: The index of the item.
+            value: The value to set at the given index.
+        """
+        # note that self._refitem__ is already bounds checking
+        var ref = Reference[T, __mlir_attr.`1: i1`, __lifetime_of(self)](
+            UnsafePointer(self._refitem__(index))[]
+        )
+        ref[] = value
+
+    @always_inline
     fn __getitem__(self, span: Slice) -> Self:
         """Get a new span from a slice of the current span.
 

--- a/stdlib/test/utils/test_span.mojo
+++ b/stdlib/test/utils/test_span.mojo
@@ -31,6 +31,15 @@ def test_span_list_int():
     assert_equal(s2[3], l[5])
     assert_equal(s[-1], l[-1])
 
+    # Test mutation
+    s[0] = 9
+    assert_equal(s[0], 9)
+    assert_equal(l[0], 9)
+
+    s[-1] = 0
+    assert_equal(s[-1], 0)
+    assert_equal(l[-1], 0)
+
 
 def test_span_list_str():
     var l = List[String]("a", "b", "c", "d", "e", "f", "g")
@@ -44,6 +53,15 @@ def test_span_list_str():
     assert_equal(s2[1], l[3])
     assert_equal(s2[2], l[4])
     assert_equal(s2[3], l[5])
+
+    # Test mutation
+    s[0] = "h"
+    assert_equal(s[0], "h")
+    assert_equal(l[0], "h")
+
+    s[-1] = "i"
+    assert_equal(s[-1], "i")
+    assert_equal(l[-1], "i")
 
 
 def test_span_array_int():
@@ -59,6 +77,15 @@ def test_span_array_int():
     assert_equal(s2[2], l[4])
     assert_equal(s2[3], l[5])
 
+    # Test mutation
+    s[0] = 9
+    assert_equal(s[0], 9)
+    assert_equal(l[0], 9)
+
+    s[-1] = 0
+    assert_equal(s[-1], 0)
+    assert_equal(l[-1], 0)
+
 
 def test_span_array_str():
     var l = InlineArray[String, 7]("a", "b", "c", "d", "e", "f", "g")
@@ -72,6 +99,15 @@ def test_span_array_str():
     assert_equal(s2[1], l[3])
     assert_equal(s2[2], l[4])
     assert_equal(s2[3], l[5])
+
+    # Test mutation
+    s[0] = "h"
+    assert_equal(s[0], "h")
+    assert_equal(l[0], "h")
+
+    s[-1] = "i"
+    assert_equal(s[-1], "i")
+    assert_equal(l[-1], "i")
 
 
 def main():

--- a/stdlib/test/utils/test_span.mojo
+++ b/stdlib/test/utils/test_span.mojo
@@ -1,0 +1,81 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# RUN: %mojo %s
+
+from utils import InlineArray, Span
+from collections.list import List
+from testing import *
+
+
+def test_span_list_int():
+    var l = List[Int](1, 2, 3, 4, 5, 6, 7)
+    var s = Span(l)
+    assert_equal(len(s), len(l))
+    for i in range(len(s)):
+        assert_equal(l[i], s[i])
+    # subslice
+    var s2 = s[2:]
+    assert_equal(s2[0], l[2])
+    assert_equal(s2[1], l[3])
+    assert_equal(s2[2], l[4])
+    assert_equal(s2[3], l[5])
+    assert_equal(s[-1], l[-1])
+
+
+def test_span_list_str():
+    var l = List[String]("a", "b", "c", "d", "e", "f", "g")
+    var s = Span(l)
+    assert_equal(len(s), len(l))
+    for i in range(len(s)):
+        assert_equal(l[i], s[i])
+    # subslice
+    var s2 = s[2:]
+    assert_equal(s2[0], l[2])
+    assert_equal(s2[1], l[3])
+    assert_equal(s2[2], l[4])
+    assert_equal(s2[3], l[5])
+
+
+def test_span_array_int():
+    var l = InlineArray[Int, 7](1, 2, 3, 4, 5, 6, 7)
+    var s = Span(l)
+    assert_equal(len(s), len(l))
+    for i in range(len(s)):
+        assert_equal(l[i], s[i])
+    # subslice
+    var s2 = s[2:]
+    assert_equal(s2[0], l[2])
+    assert_equal(s2[1], l[3])
+    assert_equal(s2[2], l[4])
+    assert_equal(s2[3], l[5])
+
+
+def test_span_array_str():
+    var l = InlineArray[String, 7]("a", "b", "c", "d", "e", "f", "g")
+    var s = Span(l)
+    assert_equal(len(s), len(l))
+    for i in range(len(s)):
+        assert_equal(l[i], s[i])
+    # subslice
+    var s2 = s[2:]
+    assert_equal(s2[0], l[2])
+    assert_equal(s2[1], l[3])
+    assert_equal(s2[2], l[4])
+    assert_equal(s2[3], l[5])
+
+
+def main():
+    test_span_list_int()
+    test_span_list_str()
+    test_span_array_int()
+    test_span_array_str()


### PR DESCRIPTION
This PR introduces a non owning collection type for contiguous arrays of `CollectionElement`. With this type, we will be able to tie together the array types in the standard library, and reduce necessary copies in some places.

### Motivation

The pointer & length data structure is common across most mainstream programming languages at this point ([Zig](https://ziglang.org/documentation/master/#Slices), [Rust](https://doc.rust-lang.org/std/primitive.slice.html), [C++](https://en.cppreference.com/w/cpp/container/span)). In order to mirror APIs developers are used to with the performance characteristic they expect, this type will be required.

Notably, it now allows functions that can work on `List` _or_ `Array` without an overload:
```mojo
fn copy[
    T: CollectionElement, lifetime: MutLifetime
](owned dst: Span[T, __mlir_attr.`1: i1`, lifetime], src: Span[T, _, _],):
    for i in range(len(src)):
        dst[i] = src[i]


fn main():
    var l = List[Int](1, 2, 3)
    var a = InlineArray[Int, 3](4, 5, 6)
    copy(Span(l), Span(a))
    for i in l:
        print(i[])
```
This code keeps the `List` and `InlineArray` alive long enough for the copy to work, which is not true for `Buffer` or `DTypePointer`.

This type will be especially necessary for traits such as `Read` and `Write`, which will want to take a `Span` as the relevant buffer, since taking a `List` or `Array` is use case dependent for such functions.

Another motivation for this change is to reduce unnecessary copies on methods such as slicing a `List`, which currently allocates a new list. Ideally, we would just return a `Span` without making a copy. The same could be said for `String.as_bytes()`, which does not need to allocate a `List`.

**Note about naming**

I'm using the name `Span` to mirror C++'s `std::span<T>`. Rust, Go, and Zig call this type a `slice`, but that term has an overloaded meaning in Python. It's also nice that it's short as a name. Similarly, Mojo already has the `Buffer` type. I'm open to other options if `Span` is not the right fit.