### PR TITLE
[stdlib] Add builtin `any()`/`all()` functions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -95,6 +95,20 @@ what we publish.
           return Self(trunc(re), trunc(im))
   ```
 
+- Add builtin `any()` and `all()` functions to check for truthy elements in a collection.
+  This also works to get the truthy value of a SIMD vector.
+  ([PR #2600](https://github.com/modularml/mojo/pull/2600) by [@helehex](https://github.com/helehex))
+  For example:
+
+  ```mojo
+    fn truthy_simd():
+        var vec = SIMD[DType.int32, 4](0, 1, 2, 3)
+        if any(vec):
+            print("any elements are truthy")
+        if all(vec):
+            print("all elements are truthy")
+  ```
+
 - Add an `InlinedArray` type that works on memory-only types.
   Compare with the existing `StaticTuple` type, which is conceptually an array
   type, but only worked on `AnyRegType`.

--- a/stdlib/src/builtin/bool.mojo
+++ b/stdlib/src/builtin/bool.mojo
@@ -17,6 +17,8 @@ These are Mojo built-ins, so you don't need to import them.
 
 from utils._visualizers import lldb_formatter_wrapping_type
 
+from collections import Set
+
 
 # ===----------------------------------------------------------------------=== #
 #  Boolable
@@ -355,3 +357,115 @@ fn bool[T: Boolable](value: T) -> Bool:
         The bool representation of the object.
     """
     return value.__bool__()
+
+
+# ===----------------------------------------------------------------------=== #
+#  any
+# ===----------------------------------------------------------------------=== #
+
+
+# TODO: Combine these into Iterators over Boolable elements
+
+
+fn any[T: BoolableCollectionElement](list: List[T]) -> Bool:
+    """Checks if **any** elements in the list are truthy.
+
+    Parameters:
+        T: The type of elements to check.
+
+    Args:
+        list: The list to check.
+
+    Returns:
+        Returns `True` if **any** elements in the list are truthy, `False` otherwise.
+    """
+    for item in list:
+        if item[]:
+            return True
+    return False
+
+
+fn any[T: BoolableKeyElement](set: Set[T]) -> Bool:
+    """Checks if **any** elements in the set are truthy.
+
+    Parameters:
+        T: The type of elements to check.
+
+    Args:
+        set: The set to check.
+
+    Returns:
+        Returns `True` if **any** elements in the set are truthy, `False` otherwise.
+    """
+    for item in set:
+        if item[]:
+            return True
+    return False
+
+
+fn any(value: SIMD) -> Bool:
+    """Checks if **any** elements in the simd vector are truthy.
+
+    Args:
+        value: The simd vector to check.
+
+    Returns:
+        Returns `True` if **any** elements in the simd vector are truthy, `False` otherwise.
+    """
+    return value._reduce_any()
+
+
+# ===----------------------------------------------------------------------=== #
+#  all
+# ===----------------------------------------------------------------------=== #
+
+
+# TODO: Combine these into Iterators over Boolable elements
+
+
+fn all[T: BoolableCollectionElement](list: List[T]) -> Bool:
+    """Checks if **all** elements in the list are truthy.
+
+    Parameters:
+        T: The type of elements to check.
+
+    Args:
+        list: The list to check.
+
+    Returns:
+        Returns `True` if **all** elements in the list are truthy, `False` otherwise.
+    """
+    for item in list:
+        if not item[]:
+            return False
+    return True
+
+
+fn all[T: BoolableKeyElement](set: Set[T]) -> Bool:
+    """Checks if **all** elements in the set are truthy.
+
+    Parameters:
+        T: The type of elements to check.
+
+    Args:
+        set: The set to check.
+
+    Returns:
+        Returns `True` if **all** elements in the set are truthy, `False` otherwise.
+    """
+    for item in set:
+        if not item[]:
+            return False
+    return True
+
+
+fn all(value: SIMD) -> Bool:
+    """Checks if **all** elements in the simd vector are truthy.
+
+    Args:
+        value: The simd vector to check.
+
+    Returns:
+        Returns `True` if **all** elements in the simd vector are truthy, `False` otherwise.
+    """
+    return value._reduce_all()

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2207,6 +2207,32 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
             "llvm.vector.reduce.or", Scalar[DType.bool], has_side_effect=False
         ](self)
 
+    @always_inline
+    fn _reduce_all(self) -> Bool:
+        """Returns `True` if **all** elements in this vector are non-zero.
+
+        Returns:
+            Returns `True` if **all** elements in this vector are non-zero, `False` otherwise.
+        """
+
+        @parameter
+        if type == DType.bool:
+            return self.reduce_and()
+        return self.cast[DType.bool]().reduce_and()
+
+    @always_inline
+    fn _reduce_any(self) -> Bool:
+        """Returns `True` if this vector contains **any** non-zero elements.
+
+        Returns:
+            `True` if this vector contains **any** non-zero elements, `False` otherwise.
+        """
+
+        @parameter
+        if type == DType.bool:
+            return self.reduce_or()
+        return self.cast[DType.bool]().reduce_or()
+
     # ===-------------------------------------------------------------------===#
     # select
     # ===-------------------------------------------------------------------===#

--- a/stdlib/src/builtin/value.mojo
+++ b/stdlib/src/builtin/value.mojo
@@ -179,3 +179,27 @@ trait RepresentableCollectionElement(CollectionElement, Representable):
     """
 
     pass
+
+
+trait BoolableCollectionElement(Boolable, CollectionElement):
+    """The BoolableCollectionElement trait denotes a trait composition
+    of the `Boolable` and `CollectionElement` traits.
+
+    This is useful to have as a named entity since Mojo does not
+    currently support anonymous trait compositions to constrain
+    on `Boolable & CollectionElement` in the parameter.
+    """
+
+    pass
+
+
+trait BoolableKeyElement(Boolable, KeyElement):
+    """The BoolableKeyElement trait denotes a trait composition
+    of the `Boolable` and `KeyElement` traits.
+
+    This is useful to have as a named entity since Mojo does not
+    currently support anonymous trait compositions to constrain
+    on `Boolable & KeyElement` in the parameter.
+    """
+
+    pass

--- a/stdlib/test/builtin/test_any_all.mojo
+++ b/stdlib/test/builtin/test_any_all.mojo
@@ -1,0 +1,160 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# RUN: %mojo %s
+
+from testing import assert_true, assert_false
+from collections.set import Set
+
+
+def test_list_any():
+    # List[Int]
+    assert_true(any(List(-1, 2)))
+    assert_true(any(List(-0, 2, 3)))
+    assert_true(any(List(-0, 0, 3)))
+    assert_false(any(List(0, 0, 0, 0)))
+    assert_false(any(List[Int]()))
+
+    # List[Float]
+    assert_true(any(List(-1.0, 2.0, 3.0)))
+    assert_true(any(List(-1.0, 0.0, 3.0)))
+    assert_true(any(List(-0.0, 2.0, 0.0)))
+    assert_false(any(List(0.0, 0.0, 0.0)))
+    assert_false(any(List[Float64]()))
+
+    # List[Bool]
+    assert_true(any(List(True)))
+    assert_true(any(List(True, True)))
+    assert_true(any(List(True, False)))
+    assert_true(any(List(False, True)))
+    assert_false(any(List(False, False)))
+    assert_false(any(List(False)))
+    assert_false(any(List[Bool]()))
+
+
+def test_list_all():
+    # List[Int]
+    assert_true(all(List(-1, 2, 3)))
+    assert_false(all(List(1, 2, 0)))
+    assert_false(all(List(1, 0, 0)))
+    assert_false(all(List(0, 0, 0)))
+    assert_true(all(List[Int]()))
+
+    # List[Float]
+    assert_true(all(List(-1.0, 2.0, 3.0, 4.0)))
+    assert_false(all(List(1.0, 0.0, 3.0)))
+    assert_false(all(List(0.0, 2.0, 0.0)))
+    assert_false(all(List(0.0, 0.0)))
+    assert_true(all(List[Float64]()))
+
+    # List[Bool]
+    assert_true(all(List(True)))
+    assert_true(all(List(True, True)))
+    assert_false(all(List(True, False)))
+    assert_false(all(List(False, True)))
+    assert_false(all(List(False, False)))
+    assert_false(all(List(False)))
+    assert_true(all(List[Bool]()))
+
+
+def test_set_any():
+    # Set[Int]
+    assert_true(any(Set(-1)))
+    assert_true(any(Set(-1, 0, 3)))
+    assert_false(any(Set(0)))
+    assert_false(any(Set[Int]()))
+
+    # Set[String]
+    assert_true(any(Set[String]("any")))
+    assert_true(any(Set[String]("bleep", "bloop")))
+    assert_true(any(Set[String]("", ":]")))
+    assert_false(any(Set[String]("")))
+    assert_false(any(Set[String]()))
+
+
+def test_set_all():
+    # Set[Int]
+    assert_true(all(Set(-1)))
+    assert_false(all(Set(0, 1, 3)))
+    assert_false(all(Set(0)))
+    assert_true(all(Set[Int]()))
+
+    # Set[String]
+    assert_true(all(Set[String]("all")))
+    assert_true(all(Set[String]("0", "1")))
+    assert_false(all(Set[String]("mojo", "")))
+    assert_false(all(Set[String]("")))
+    assert_true(all(Set[String]()))
+
+
+def test_simd_any():
+    @parameter
+    def _test_dtype[type: DType]():
+        assert_true(any(SIMD[type, 1](1)))
+        assert_false(any(SIMD[type, 1](0)))
+        assert_true(any(SIMD[type, 4](1, 2, 3, 4)))
+        assert_true(any(SIMD[type, 4](0, 2, 3, 4)))
+        assert_true(any(SIMD[type, 4](1, 2, 3, 0)))
+        assert_true(any(SIMD[type, 4](0, 2, 3, 0)))
+        assert_true(any(SIMD[type, 4](1, 0, 0, 4)))
+        assert_false(any(SIMD[type, 4](0, 0, 0, 0)))
+
+    _test_dtype[DType.bool]()
+    _test_dtype[DType.int8]()
+    _test_dtype[DType.int16]()
+    _test_dtype[DType.int32]()
+    _test_dtype[DType.int64]()
+    _test_dtype[DType.uint8]()
+    _test_dtype[DType.uint16]()
+    _test_dtype[DType.uint32]()
+    _test_dtype[DType.uint64]()
+    _test_dtype[DType.float16]()
+    _test_dtype[DType.float32]()
+    _test_dtype[DType.float64]()
+
+
+def test_simd_all():
+    @parameter
+    def _test_dtype[type: DType]():
+        assert_true(all(SIMD[type, 1](1)))
+        assert_false(all(SIMD[type, 1](0)))
+        assert_true(all(SIMD[type, 4](1, 2, 3, 4)))
+        assert_false(all(SIMD[type, 4](0, 2, 3, 4)))
+        assert_false(all(SIMD[type, 4](1, 2, 3, 0)))
+        assert_false(all(SIMD[type, 4](0, 2, 3, 0)))
+        assert_false(all(SIMD[type, 4](1, 0, 0, 4)))
+        assert_false(all(SIMD[type, 4](0, 0, 0, 0)))
+
+    _test_dtype[DType.bool]()
+    _test_dtype[DType.int8]()
+    _test_dtype[DType.int16]()
+    _test_dtype[DType.int32]()
+    _test_dtype[DType.int64]()
+    _test_dtype[DType.uint8]()
+    _test_dtype[DType.uint16]()
+    _test_dtype[DType.uint32]()
+    _test_dtype[DType.uint64]()
+    _test_dtype[DType.float16]()
+    _test_dtype[DType.float32]()
+    _test_dtype[DType.float64]()
+
+
+def main():
+    # any
+    test_list_any()
+    test_set_any()
+    test_simd_any()
+
+    # all
+    test_list_all()
+    test_set_all()
+    test_simd_all()


### PR DESCRIPTION
Adds builtin functions for testing if there are truthy elements in `List`, `Set`, `SIMD`.
Should change to check iterators eventually.

Also mentioned [here](https://github.com/modularml/mojo/pull/2502)