### PR TITLE
[Docs] correct output, fix indent in Heterogeneous variadic arguments

### DIFF
--- a/docs/manual/functions.ipynb
+++ b/docs/manual/functions.ipynb
@@ -516,23 +516,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Bob0\n"
+      "Bob\n"
      ]
     }
    ],
    "source": [
-    "  fn print_string(s: String):\n",
+    "fn print_string(s: String):\n",
     "    print(s, end=\"\")\n",
     "\n",
-    "  fn print_many[T: Stringable, *Ts: Stringable](first: T, *rest: *Ts):\n",
-    "      print_string(str(first))\n",
+    "fn print_many[T: Stringable, *Ts: Stringable](first: T, *rest: *Ts):\n",
+    "    print_string(str(first))\n",
     "\n",
-    "      @parameter\n",
-    "      fn print_elt[T: Stringable](a: T):\n",
-    "          print_string(\" \")\n",
-    "          print_string(a)\n",
-    "      rest.each[print_elt]()\n",
-    "  print_many(\"Bob\")"
+    "    @parameter\n",
+    "    fn print_elt[T: Stringable](a: T):\n",
+    "        print_string(\" \")\n",
+    "        print_string(a)\n",
+    "    rest.each[print_elt]()\n",
+    "print_many(\"Bob\")"
    ]
   },
   {


### PR DESCRIPTION
The current [Heterogeneous variadic arguments](https://docs.modular.com/mojo/manual/functions#heterogeneous-variadic-arguments) (see screenshot) - last example has wrong output (`Bob0` should be `Bob`), and indentation of the example code is also off (had to edit after copying into Mojo playground)

<img width="838" alt="Screenshot 2024-05-12 at 9 31 51 AM" src="https://github.com/modularml/mojo/assets/8209263/9ea82a34-9ac4-4414-b391-9d8b7f31357f">
