### PR TITLE
[CI] Add timeouts to workflows

### DIFF
--- a/.github/workflows/check_pr_target.yml
+++ b/.github/workflows/check_pr_target.yml
@@ -13,6 +13,7 @@ jobs:
     name: Check PR target branch
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     defaults:
       run:

--- a/.github/workflows/check_pr_title.yml
+++ b/.github/workflows/check_pr_title.yml
@@ -16,6 +16,7 @@ jobs:
       pull-requests: write
 
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: morrisoncole/pr-lint-action@51f3cfabaf5d46f94e54524214e45685f0401b2a

--- a/.github/workflows/standard_library_tests_and_examples.yml
+++ b/.github/workflows/standard_library_tests_and_examples.yml
@@ -29,6 +29,7 @@ jobs:
         os: ["ubuntu-latest", "macos-14"]
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     defaults:
       run:


### PR DESCRIPTION
On Ubuntu tests, we're seeing some non-deterministic timeouts due to a code bug (either in compiler or library) from a recent `nightly` release.  Instead of relying on the default GitHub timeout of 6 hours for all of our workflows, add a sensible timeout for each of our jobs, so they end early rather than spinning for many hours.