### PR TITLE
[stdlib] Fix atol() when explicitly setting base 2, 8, and 16

### DIFF
--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -234,6 +234,20 @@ fn _atol(str_ref: StringRef, base: Int = 10) raises -> Int:
             start = pos
         break
 
+    if str_ref[start] == "0" and start + 1 < str_len:
+        if base == 2 and (
+            str_ref[start + 1] == "b" or str_ref[start + 1] == "B"
+        ):
+            start += 2
+        elif base == 8 and (
+            str_ref[start + 1] == "o" or str_ref[start + 1] == "O"
+        ):
+            start += 2
+        elif base == 16 and (
+            str_ref[start + 1] == "x" or str_ref[start + 1] == "X"
+        ):
+            start += 2
+
     alias ord_0 = ord("0")
     # FIXME:
     #   Change this to `alias` after fixing support for __refitem__ of alias.

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -306,7 +306,14 @@ fn test_atol() raises:
     assert_equal(10, atol("A", 16))
     assert_equal(15, atol("f ", 16))
     assert_equal(255, atol(" FF", 16))
+    assert_equal(255, atol(" 0xff ", 16))
+    assert_equal(255, atol(" 0Xff ", 16))
     assert_equal(18, atol("10010", 2))
+    assert_equal(18, atol("0b10010", 2))
+    assert_equal(18, atol("0B10010", 2))
+    assert_equal(10, atol("12", 8))
+    assert_equal(10, atol("0o12", 8))
+    assert_equal(10, atol("0O12", 8))
     assert_equal(35, atol("Z", 36))
 
     # Negative cases


### PR DESCRIPTION
Should atol() be fixed when explicitly setting base 2, 8, and 16?

```
atol(" 0xff ", 16)
atol(" 0o12 ", 8)
```