### PR TITLE
[stdlib] Rename `uninitialized` -> `unsafe_uninitialized` in `InlineArray`

### DIFF
--- a/stdlib/src/builtin/hash.mojo
+++ b/stdlib/src/builtin/hash.mojo
@@ -288,7 +288,7 @@ fn hash(bytes: DTypePointer[DType.int8], n: Int) -> Int:
     # 3. Copy the tail data (smaller than the SIMD register) into
     #    a final hash state update vector that's stack-allocated.
     if r != 0:
-        var remaining = InlineArray[Int8, stride](uninitialized=True)
+        var remaining = InlineArray[Int8, stride](unsafe_uninitialized=True)
         var ptr = DTypePointer[DType.int8](
             UnsafePointer.address_of(remaining).bitcast[Int8]()
         )

--- a/stdlib/src/collections/inline_list.mojo
+++ b/stdlib/src/collections/inline_list.mojo
@@ -48,7 +48,9 @@ struct InlineList[ElementType: CollectionElement, capacity: Int = 16](Sized):
     @always_inline
     fn __init__(inout self):
         """This constructor creates an empty InlineList."""
-        self._array = InlineArray[ElementType, capacity](uninitialized=True)
+        self._array = InlineArray[ElementType, capacity](
+            unsafe_uninitialized=True
+        )
         self._size = 0
 
     @always_inline

--- a/stdlib/src/collections/vector.mojo
+++ b/stdlib/src/collections/vector.mojo
@@ -115,7 +115,7 @@ struct InlinedFixedVector[
         Args:
             capacity: The requested maximum capacity of the vector.
         """
-        self.static_data = Self.static_data_type(uninitialized=True)
+        self.static_data = Self.static_data_type(unsafe_uninitialized=True)
         self.dynamic_data = UnsafePointer[type]()
         if capacity > Self.static_size:
             self.dynamic_data = UnsafePointer[type].alloc(capacity - size)

--- a/stdlib/src/utils/static_tuple.mojo
+++ b/stdlib/src/utils/static_tuple.mojo
@@ -277,7 +277,7 @@ struct InlineArray[ElementType: CollectionElement, size: Int](Sized):
         self._array = __mlir_op.`kgen.undef`[_type = Self.type]()
 
     @always_inline
-    fn __init__(inout self, *, uninitialized: Bool):
+    fn __init__(inout self, *, unsafe_uninitialized: Bool):
         """Create an InlineArray with uninitialized memory.
 
         Note that this is highly unsafe and should be used with caution.
@@ -289,11 +289,11 @@ struct InlineArray[ElementType: CollectionElement, size: Int](Sized):
         it is possible with:
 
         ```mojo
-        var uninitialized_array = InlineArray[Int, 10](uninitialized=True)
+        var uninitialized_array = InlineArray[Int, 10](unsafe_uninitialized=True)
         ```
 
         Args:
-            uninitialized: A boolean to indicate if the array should be initialized.
+            unsafe_uninitialized: A boolean to indicate if the array should be initialized.
                 Always set to `True` (it's not actually used inside the constructor).
         """
         self._array = __mlir_op.`kgen.undef`[_type = Self.type]()


### PR DESCRIPTION
Unsafe methods should be explicit in the code. Uninitialized memory is highly unsafe (can't run destructor on it, etc) , thus it should have a name that reflects it.