### PR TITLE
[docs] Add section 'Dev Container' to the Mojo stdlib docs

### DIFF
--- a/stdlib/docs/development.md
+++ b/stdlib/docs/development.md
@@ -31,7 +31,7 @@ on how to use with [Github Codespaces](https://docs.github.com/en/codespaces/dev
 or [VS Code](https://code.visualstudio.com/docs/devcontainers/containers).
 
 If there is a problem with the Dev Container, please open an issue at
-<https://github.com/benz0li/mojo-dev-container/issues>.
+[here](https://github.com/benz0li/mojo-dev-container/issues).
 
 ## Building the standard library
 

--- a/stdlib/docs/development.md
+++ b/stdlib/docs/development.md
@@ -30,7 +30,7 @@ See [Mojo Dev Container &gt; Usage](https://github.com/benz0li/mojo-dev-containe
 on how to use with [Github Codespaces](https://docs.github.com/en/codespaces/developing-in-codespaces/creating-a-codespace-for-a-repository#creating-a-codespace-for-a-repository)
 or [VS Code](https://code.visualstudio.com/docs/devcontainers/containers).
 
-If there is a problem with the Dev Container, please open an issue at
+If there is a problem with the Dev Container, please open an issue
 [here](https://github.com/benz0li/mojo-dev-container/issues).
 
 ## Building the standard library

--- a/stdlib/docs/development.md
+++ b/stdlib/docs/development.md
@@ -17,6 +17,22 @@ And if you're using VS Code:
 - [Install the nightly VS Code
   extension](https://marketplace.visualstudio.com/items?itemName=modular-mojotools.vscode-mojo-nightly)
 
+### Dev Container
+
+There is an externally maintained
+[Mojo Dev Container](https://github.com/benz0li/mojo-dev-container) with all
+prerequisites installed.
+
+The Dev Container also includes the unit test dependencies `lit` and `FileCheck`
+(from LLVM) and has `pre-commit` already set up.
+
+See [Mojo Dev Container &gt; Usage](https://github.com/benz0li/mojo-dev-container#usage)
+on how to use with [Github Codespaces](https://docs.github.com/en/codespaces/developing-in-codespaces/creating-a-codespace-for-a-repository#creating-a-codespace-for-a-repository)
+or [VS Code](https://code.visualstudio.com/docs/devcontainers/containers).
+
+If there is a problem with the Dev Container, please open an issue at
+<https://github.com/benz0li/mojo-dev-container/issues>.
+
 ## Building the standard library
 
 To build the standard library, you can run the


### PR DESCRIPTION
Test online with GitHub Codespaces: https://codespaces.new/benz0li/mojo-dev-container?hide_repo_select=true&ref=main  

Parent image: `glcr.b-data.ch/mojo/base:nightly`  
👉 This image is being rebuilt [at the start of every 4th hour](https://cron.help/every-4-hours).