### PR TITLE
[stdlib] Guard `SIMD.cast()` against equal types

### DIFF
--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -393,6 +393,10 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         """
 
         @parameter
+        if type == target:
+            return rebind[SIMD[target, size]](self)
+
+        @parameter
         if has_neon() and (type == DType.bfloat16 or target == DType.bfloat16):
             # BF16 support on neon systems is not supported.
             return _unchecked_zero[target, size]()


### PR DESCRIPTION
Checks if types are already equal when calling `SIMD.cast()`.
This avoids unnecessary code when generically casting simd vectors.

But, this could be used in place of rebind when you know the types are already equal.
if that's not what we want, then maybe we should constrain the types to be different, instead of doing this.