### PR TITLE
[stdlib] Add more safeguards in the `String` constructors

### DIFF
--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -687,6 +687,8 @@ struct String(
         Args:
             impl: The buffer.
         """
+        if len(impl) == 0:
+            impl.append(0)
         debug_assert(
             impl[-1] == 0,
             "expected last element of String buffer to be null terminator",
@@ -704,6 +706,7 @@ struct String(
     fn __init__(inout self):
         """Construct an uninitialized string."""
         self._buffer = Self._buffer_type()
+        self._buffer.append(0)
 
     @always_inline
     fn __init__(inout self, str: StringRef):
@@ -783,8 +786,10 @@ struct String(
         """
         # we don't know the capacity of ptr, but we'll assume it's the same or
         # larger than len
-        self._buffer = Self._buffer_type(
-            unsafe_pointer=ptr.bitcast[UInt8](), size=len, capacity=len
+        self = Self(
+            Self._buffer_type(
+                unsafe_pointer=ptr.bitcast[UInt8](), size=len, capacity=len
+            )
         )
 
     @always_inline
@@ -798,9 +803,13 @@ struct String(
             ptr: The pointer to the buffer.
             len: The length of the buffer, including the null terminator.
         """
-        self._buffer = Self._buffer_type()
-        self._buffer.data = UnsafePointer(ptr.address)
-        self._buffer.size = len
+        self = Self(
+            Self._buffer_type(
+                unsafe_pointer=UnsafePointer(ptr.address),
+                size=len,
+                capacity=len,
+            )
+        )
 
     @always_inline
     fn __init__(inout self, ptr: DTypePointer[DType.uint8], len: Int):

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -899,6 +899,23 @@ def test_string_mul():
     assert_equal(String("ab") * 5, "ababababab")
 
 
+def test_empty_string():
+    assert_equal(str(String()), String())
+    assert_equal(str(String()), String(""))
+    assert_equal(str(String()), str(String("")))
+    assert_equal(str(String()), "")
+    assert_equal(str(String()), str(""))
+    assert_equal(len(String()), 0)
+
+    assert_equal(String(), String(List[UInt8]()))
+
+    # useful for functions which assume the pointer is valid and null-terminated
+    assert_equal(len(String(List[UInt8]())._buffer), 1)
+    assert_true(String().unsafe_uint8_ptr())
+    assert_true(String(List[UInt8]()).unsafe_uint8_ptr())
+    assert_equal(String()._buffer[0], 0)
+
+
 def main():
     test_constructors()
     test_copy()
@@ -941,3 +958,4 @@ def main():
     test_removesuffix()
     test_intable()
     test_string_mul()
+    test_empty_string()


### PR DESCRIPTION
Related to https://github.com/modularml/mojo/issues/2687

Fix https://github.com/modularml/mojo/issues/2392

Also related to https://github.com/modularml/mojo/issues/2678

### Description of the problem:

![sddefault](https://github.com/modularml/mojo/assets/12891691/40552dc4-7972-4019-82ba-1b2bbff953ab)


EDIT: Please note that now, an empty string will allocate one byte on the heap for the null terminator. This will degrade the performance of some programs, the tradeoff is more safety. This performance penalty will go away with SSO, as the null terminator will be on the stack, which I hope can be implemented soon-ish when https://github.com/modularml/mojo/issues/2637 is fixed