### PR TITLE
[mojo-stdlib] Add variadic initialiser, __iter__ and __contains__ to InlineList

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -229,6 +229,9 @@ what we publish.
 - `List()` now supports `__contains__`.
     ([PR #2667](https://github.com/modularml/mojo/pull/2667) by [@rd4com](https://github.com/rd4com/))
 
+- `InlineList()` now supports `__contains__`, `__iter__`.
+    ([PR #2703](https://github.com/modularml/mojo/pull/2703) by [@ChristopherLR](https://github.com/ChristopherLR))
+
 - `List` now has an `index` method that allows one to find the (first) location
   of an element in a `List` of `EqualityComparable` types. For example:
 

--- a/stdlib/src/collections/inline_list.mojo
+++ b/stdlib/src/collections/inline_list.mojo
@@ -20,10 +20,55 @@ from collections import InlineList
 """
 
 from utils import InlineArray
+from sys.intrinsics import _type_is_eq
+
 
 # ===----------------------------------------------------------------------===#
 # InlineList
 # ===----------------------------------------------------------------------===#
+@value
+struct _InlineListIter[
+    T: CollectionElement,
+    capacity: Int,
+    list_mutability: Bool,
+    list_lifetime: AnyLifetime[list_mutability].type,
+    forward: Bool = True,
+]:
+    """Iterator for InlineList.
+
+    Parameters:
+        T: The type of the elements in the list.
+        capacity: The maximum number of elements that the list can hold.
+        list_mutability: Whether the reference to the list is mutable.
+        list_lifetime: The lifetime of the List
+        forward: The iteration direction. `False` is backwards.
+    """
+
+    alias list_type = InlineList[T, capacity]
+
+    var index: Int
+    var src: Reference[Self.list_type, list_mutability, list_lifetime]
+
+    fn __iter__(self) -> Self:
+        return self
+
+    fn __next__(
+        inout self,
+    ) -> Reference[T, list_mutability, list_lifetime]:
+        @parameter
+        if forward:
+            self.index += 1
+            return self.src[].__refitem__(self.index - 1)
+        else:
+            self.index -= 1
+            return self.src[].__refitem__(self.index)
+
+    fn __len__(self) -> Int:
+        @parameter
+        if forward:
+            return len(self.src[]) - self.index
+        else:
+            return self.index
 
 
 # TODO: Provide a smarter default for the capacity.
@@ -52,6 +97,19 @@ struct InlineList[ElementType: CollectionElement, capacity: Int = 16](Sized):
             unsafe_uninitialized=True
         )
         self._size = 0
+
+    # TODO: Avoid copying elements in once owned varargs
+    # allow transfers.
+    fn __init__(inout self, *values: ElementType):
+        """Constructs a list from the given values.
+
+        Args:
+            values: The values to populate the list with.
+        """
+        debug_assert(len(values) < capacity, "List is full.")
+        self = Self()
+        for value in values:
+            self.append(value[])
 
     @always_inline
     fn __len__(self) -> Int:
@@ -98,3 +156,42 @@ struct InlineList[ElementType: CollectionElement, capacity: Int = 16](Sized):
         """Destroy all the elements in the list and free the memory."""
         for i in range(self._size):
             destroy_pointee(UnsafePointer(self._array[i]))
+
+    fn __iter__(
+        self: Reference[Self, _, _],
+    ) -> _InlineListIter[ElementType, capacity, self.is_mutable, self.lifetime]:
+        """Iterate over elements of the list, returning immutable references.
+
+        Returns:
+            An iterator of immutable references to the list elements.
+        """
+        return _InlineListIter(0, self)
+
+    @always_inline
+    fn __contains__[
+        C: ComparableCollectionElement
+    ](self: Self, value: C) -> Bool:
+        """Verify if a given value is present in the list.
+
+        ```mojo
+        var x = List[Int](1,2,3)
+        if 3 in x: print("x contains 3")
+        ```
+        Parameters:
+            C: The type of the elements in the list. Must implement the
+              traits `EqualityComparable` and `CollectionElement`.
+
+        Args:
+            value: The value to find.
+
+        Returns:
+            True if the value is contained in the list, False otherwise.
+        """
+
+        constrained[
+            _type_is_eq[ElementType, C](), "value type is not self.ElementType"
+        ]()
+        for i in self:
+            if value == rebind[C](i[]):
+                return True
+        return False

--- a/stdlib/src/collections/inline_list.mojo
+++ b/stdlib/src/collections/inline_list.mojo
@@ -174,7 +174,7 @@ struct InlineList[ElementType: CollectionElement, capacity: Int = 16](Sized):
         """Verify if a given value is present in the list.
 
         ```mojo
-        var x = List[Int](1,2,3)
+        var x = InlineList[Int](1,2,3)
         if 3 in x: print("x contains 3")
         ```
         Parameters:

--- a/stdlib/test/collections/test_inline_list.mojo
+++ b/stdlib/test/collections/test_inline_list.mojo
@@ -90,7 +90,59 @@ def test_destructor():
         assert_equal(destructor_counter[i], i)
 
 
+def test_list_iter():
+    var vs = InlineList[Int]()
+    vs.append(1)
+    vs.append(2)
+    vs.append(3)
+
+    # Borrow immutably
+    fn sum(vs: InlineList[Int]) -> Int:
+        var sum = 0
+        for v in vs:
+            sum += v[]
+        return sum
+
+    assert_equal(6, sum(vs))
+
+
+def test_list_iter_mutable():
+    var vs = InlineList[Int, 3](1, 2, 3)
+
+    for v in vs:
+        v[] += 1
+
+    var sum = 0
+    for v in vs:
+        sum += v[]
+
+    assert_equal(9, sum)
+
+
+def test_list_contains():
+    var x = InlineList[Int](1, 2, 3)
+    assert_false(0 in x)
+    assert_true(x.__contains__(1))
+    assert_false(x.__contains__(4))
+
+
+def test_list_variadic_constructor():
+    var l = InlineList[Int](2, 4, 6)
+    assert_equal(3, len(l))
+    assert_equal(2, l[0])
+    assert_equal(4, l[1])
+    assert_equal(6, l[2])
+
+    l.append(8)
+    assert_equal(4, len(l))
+    assert_equal(8, l[3])
+
+
 def main():
     test_list()
     test_append_triggers_a_move()
     test_destructor()
+    test_list_iter()
+    test_list_iter_mutable()
+    test_list_contains()
+    test_list_variadic_constructor()


### PR DESCRIPTION
This PR adds some features to InlineList ( related issue #2658 ) 

*Variadic initialiser*
```mojo
var x = InlineList[Int](1,2,3)
```

*iter*
```mojo
var x = InlineList[Int](1,2,3)
for i in x:
    print(i)
```

*contains*
```mojo
var x = InlineList[Int](1,2,3)
if 3 in x: print("ok")
```