### PR TITLE
[stdlib] Add three __delitem__ method overloads for List

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -470,6 +470,19 @@ what we publish.
 - Added `SIMD.__repr__` to get the verbose string representation of `SIMD` types.
 ([PR #2728](https://github.com/modularml/mojo/pull/2728) by [@bgreni](https://github.com/bgreni))
 
+- `List` now has a `__delitem__` method.
+  ([PR #2704](https://github.com/modularml/mojo/pull/2704) by [@rd4com](https://github.com/rd4com))
+
+  It provides a way to delete one or multiple(in a batch) elements by index:
+  - Even if provided twice, it won't delete two times the same index.
+  - The order of removal is reverse of sorted provided indexes.
+
+  ```mojo
+  x = List[Int](0,10,20,30,40)
+  x.__delitem__(0,4)
+  for i in x: print(i[]) #10,20,30
+  ```
+
 ### 🦋 Changed
 
 - `Coroutine` now requires a lifetime parameter. This parameter is set

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -858,6 +858,73 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         """
         return self.data
 
+    @always_inline
+    fn __delitem__(inout self, owned positions: List[Int]):
+        """
+        Remove one or multiples elements at specific positions in a list.
+        Order of removal is reverse of sorted positions.
+        Will only remove once, any position specified multiple times.
+
+        *Example:*
+        ```mojo
+        var x = List(0,10,20,30,40)
+        x.__delitem__(List(0,1,4))
+        for i in x: print(i[]) #20,30
+        ```
+
+        Args:
+            positions: The positions of the elements to delete from the list.
+
+        """
+        var tmp = Set[Int]()
+        sort(positions)
+        for e in reversed(positions):
+            if e[] not in tmp and e[] < len(self):
+                _ = self.pop(e[])
+                tmp.add(e[])
+
+    @always_inline
+    fn __delitem__(inout self, *positions: Int):
+        """
+        Remove one or multiples elements at specific positions in a list.
+        Positions are specified as arguments separated by ```,```.
+        Will only remove once, any position specified multiple times.
+        Order of removal is reverse of sorted arguments.
+
+        *Example:*
+        ```mojo
+        var x = List(0,10,20,30,40)
+        x.__delitem__(0,1,4)
+        for i in x: print(i[]) #20,30
+        ```
+
+        Args:
+            positions: The positions of the elements to delete from the list.
+
+        """
+        var indexes_as_list = List[Int]()
+        for i in positions:
+            indexes_as_list.append(i)
+        self.__delitem__(indexes_as_list^)
+
+    @always_inline
+    fn __delitem__(inout self, position: Int):
+        """
+        Remove one element at specific position in a list.
+
+        *Example:*
+        ```mojo
+        var x = List(0,10,20,30,40)
+        x.__delitem__(2)
+        for i in x: print(i[]) #0,10,30,40
+        ```
+
+        Args:
+            position: The position of the element to delete from the list.
+
+        """
+        _ = self.pop(position)
+
 
 fn _clip(value: Int, start: Int, end: Int) -> Int:
     return max(start, min(value, end))

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -807,6 +807,45 @@ def test_indexing():
     assert_equal(l[2], 3)
 
 
+def test_list_delitem():
+    var x = List[Int](0, 10, 20, 30, 40)
+    x.__delitem__(0, 4)
+    assert_equal(len(x), 3)
+    assert_equal(x[0], 10)
+    assert_equal(x[1], 20)
+    assert_equal(x[2], 30)
+
+    x = List[Int](0, 10, 20, 30, 40)
+    x.__delitem__(List(0, 4))
+    assert_equal(len(x), 3)
+    assert_equal(x[0], 10)
+    assert_equal(x[1], 20)
+    assert_equal(x[2], 30)
+
+    x = List[Int](0, 10, 20, 30, 40)
+    var orig_len = len(x)
+    x.__delitem__(99, 100)
+    assert_equal(len(x), orig_len)
+    for i in range(orig_len):
+        assert_equal(x[i], i * 10)
+
+    x = List[Int](0, 10, 20, 30, 40)
+    orig_len = len(x)
+    x.__delitem__(List(99, 100))
+    assert_equal(len(x), orig_len)
+    for i in range(orig_len):
+        assert_equal(x[i], i * 10)
+
+    x = List[Int](0, 10, 20, 30, 40)
+    assert_equal(len(x), 5)
+    x.__delitem__(2)
+    assert_equal(len(x), 4)
+    assert_equal(x[0], 0)
+    assert_equal(x[1], 10)
+    assert_equal(x[2], 30)
+    assert_equal(x[3], 40)
+
+
 def main():
     test_mojo_issue_698()
     test_list()
@@ -837,3 +876,4 @@ def main():
     test_list_mult()
     test_list_contains()
     test_indexing()
+    test_list_delitem()


### PR DESCRIPTION
This PR includes three `__delitem__` method overloads for `List`:
- `fn __delitem__(inout self, position: Int)`
- `fn __delitem__(inout self, *positions: Int)`
- `fn __delitem__(inout self, owned positions: List[Int])`

The implementation ensure that an index will not be deleted twice, 
even if provided multiple times.
The order of removal is the reverse of sorted indexes.

&nbsp;

Example:
```mojo
  x = List[Int](0,10,20,30,40)
  x.__delitem__(0,4)
  for i in x: print(i[]) #10,20,30
  ```
&nbsp;

@rparolin proposed using `__delitem__` directly instead of `del_batch_of_indexes`

#### Suggestion for the future:

```del my_list[0,1,4,5]```

