### PR TITLE
[stdlib] Add `split()` to `StringRef`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -172,6 +172,10 @@ what we publish.
       return a
   ```
 
+- `StringRef` now implements `split()` which can be used to split a
+  `StringRef` into a `List[StringRef]` by a delimiter.
+  ([PR #2705](https://github.com/modularml/mojo/pull/2705) by [@fknfilewalker](https://github.com/fknfilewalker))
+
 ### 🦋 Changed
 
 - More things have been removed from the auto-exported set of entities in the `prelude`

--- a/stdlib/src/utils/stringref.mojo
+++ b/stdlib/src/utils/stringref.mojo
@@ -574,6 +574,41 @@ struct StringRef(
             end -= 1
         return StringRef(ptr + start, end - start)
 
+    fn split(self, delimiter: StringRef) raises -> List[StringRef]:
+        """Split the StringRef by a delimiter.
+
+        Args:
+            delimiter: The StringRef to split on.
+
+        Returns:
+            A List of StringRefs containing the input split by the delimiter.
+
+        Raises:
+            Error if an empty delimiter is specified.
+        """
+        if not delimiter:
+            raise Error("empty delimiter not allowed to be passed to split.")
+
+        var output = List[StringRef]()
+        var ptr = self.unsafe_ptr()
+
+        var current_offset = 0
+        while True:
+            var loc = self.find(delimiter, current_offset)
+            # delimiter not found, so add the search slice from where we're currently at
+            if loc == -1:
+                output.append(
+                    StringRef(ptr + current_offset, len(self) - current_offset)
+                )
+                break
+
+            # We found a delimiter, so add the preceding string slice
+            output.append(StringRef(ptr + current_offset, loc - current_offset))
+
+            # Advance our search offset past the delimiter
+            current_offset = loc + len(delimiter)
+        return output
+
     fn startswith(
         self, prefix: StringRef, start: Int = 0, end: Int = -1
     ) -> Bool:

--- a/stdlib/test/utils/test_stringref.mojo
+++ b/stdlib/test/utils/test_stringref.mojo
@@ -128,8 +128,50 @@ def test_endswith():
     assert_true(ab.endswith("ab"))
 
 
+fn test_stringref_split() raises:
+    # Reject empty delimiters
+    with assert_raises(
+        contains="empty delimiter not allowed to be passed to split."
+    ):
+        _ = StringRef("hello").split("")
+
+    # Split in middle
+    var d1 = StringRef("n")
+    var in1 = StringRef("faang")
+    var res1 = in1.split(d1)
+    assert_equal(len(res1), 2)
+    assert_equal(res1[0], "faa")
+    assert_equal(res1[1], "g")
+
+    # Matches should be properly split in multiple case
+    var d2 = StringRef(" ")
+    var in2 = StringRef("modcon is coming soon")
+    var res2 = in2.split(d2)
+    assert_equal(len(res2), 4)
+    assert_equal(res2[0], "modcon")
+    assert_equal(res2[1], "is")
+    assert_equal(res2[2], "coming")
+    assert_equal(res2[3], "soon")
+
+    # No match from the delimiter
+    var d3 = StringRef("x")
+    var in3 = StringRef("hello world")
+    var res3 = in3.split(d3)
+    assert_equal(len(res3), 1)
+    assert_equal(res3[0], "hello world")
+
+    # Multiple character delimiter
+    var d4 = StringRef("ll")
+    var in4 = StringRef("hello")
+    var res4 = in4.split(d4)
+    assert_equal(len(res4), 2)
+    assert_equal(res4[0], "he")
+    assert_equal(res4[1], "o")
+
+
 def main():
     test_strref_from_start()
+    test_stringref_split()
     test_comparison_operators()
     test_intable()
     test_indexing()


### PR DESCRIPTION
This PR adds a `split()` function to `StringRef` and delegates `String.split()` to it