### PR TITLE
[tools] Add markdownlint to the pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         files: '\.(mojo|🔥|py)$'
         stages: [commit]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.40.0
+    rev: v0.34.0
     hooks:
     - id: markdownlint
       args: ['--config', 'stdlib/scripts/.markdownlint.yaml', '--fix']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         files: '\.(mojo|🔥|py)$'
         stages: [commit]
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.34.0
+    rev: v0.40.0
     hooks:
     - id: markdownlint
       args: ['--config', 'stdlib/scripts/.markdownlint.yaml', '--fix']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,8 @@ repos:
         language: system
         files: '\.(mojo|🔥|py)$'
         stages: [commit]
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.40.0
+    hooks:
+    - id: markdownlint
+      args: ['--config', 'stdlib/scripts/.markdownlint.yaml', '--fix']

--- a/stdlib/docs/development.md
+++ b/stdlib/docs/development.md
@@ -142,7 +142,7 @@ standard library, test it, and raise a PR.
 
 First, follow everything in the [prerequisites](#prerequisites).
 
-__IMPORTANT__ We'll be in the `mojo/stdlib` folder for this tutorial, check and
+**IMPORTANT** We'll be in the `mojo/stdlib` folder for this tutorial, check and
 make sure you're in that location if anything goes wrong:
 `cd [path-to-repo]/stdlib`
 
@@ -263,7 +263,7 @@ ls **/*.mojo | entr sh -c "./scripts/build-stdlib.sh && mojo main.mojo"
 Now, every time you save a Mojo file, it packages the standard library and
 runs `main.mojo`.
 
-__Note__: you should stop `entr` while doing commits, otherwise you could have
+**Note**: you should stop `entr` while doing commits, otherwise you could have
 some issues, this is because some pre-commit hooks use mojo scripts
 and will try to load the standard library while it is being compiled by `entr`.
 

--- a/stdlib/docs/development.md
+++ b/stdlib/docs/development.md
@@ -263,7 +263,7 @@ ls **/*.mojo | entr sh -c "./scripts/build-stdlib.sh && mojo main.mojo"
 Now, every time you save a Mojo file, it packages the standard library and
 runs `main.mojo`.
 
-**Note**: you should stop `entr` while doing commits, otherwise you could have
+__Note__: you should stop `entr` while doing commits, otherwise you could have
 some issues, this is because some pre-commit hooks use mojo scripts
 and will try to load the standard library while it is being compiled by `entr`.
 

--- a/stdlib/scripts/.markdownlint.yaml
+++ b/stdlib/scripts/.markdownlint.yaml
@@ -38,6 +38,9 @@ no-inline-html: false
 # MD045: Images don't require alt text
 no-alt-text: false
 
+# MD050: Use **something** instead of __something__ for bold text
+strong-style: asterisk
+
 # MD051: Disable link checker because it false-flags custom anchors
 #        https://github.com/DavidAnson/markdownlint/issues/570
 link-fragments: false

--- a/stdlib/scripts/.markdownlint.yaml
+++ b/stdlib/scripts/.markdownlint.yaml
@@ -39,7 +39,9 @@ no-inline-html: false
 no-alt-text: false
 
 # MD050: Use **something** instead of __something__ for bold text
-strong-style: asterisk
+MD050:
+  # Strong style
+  style: "asterisk"
 
 # MD051: Disable link checker because it false-flags custom anchors
 #        https://github.com/DavidAnson/markdownlint/issues/570


### PR DESCRIPTION
Fix https://github.com/modularml/mojo/issues/2716

This pre-commit hook will also fix easy mistakes :) It also doesn't require any manual installation. It just works™

The CI will trigger an error if a markdown file does not conform to the rules of markdownlint

Example of pre-commit failure in the CI: https://github.com/modularml/mojo/actions/runs/9132279705/job/25113289498?pr=2663
