### PR TITLE
[stdlib] Apply Indexer trait to stdlib containers

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -251,7 +251,9 @@ what we publish.
 - Added the `Indexer` trait to denote types that implement the `__index__()`
   method which allow these types to be accepted in common `__getitem__` and
   `__setitem__` implementations, as well as allow a new builtin `index` function
-  to be called on them. For example:
+  to be called on them. Most stdlib containers are now able to be indexed by
+  any type that implements `Indexer`.
+  For example:
 
   ```mojo
   @value

--- a/stdlib/src/builtin/builtin_list.mojo
+++ b/stdlib/src/builtin/builtin_list.mojo
@@ -146,16 +146,19 @@ struct VariadicList[type: AnyRegType](Sized):
         return __mlir_op.`pop.variadic.size`(self.value)
 
     @always_inline
-    fn __getitem__(self, index: Int) -> type:
+    fn __getitem__[IndexerType: Indexer](self, idx: IndexerType) -> type:
         """Gets a single element on the variadic list.
 
+        Parameters:
+            IndexerType: The type of the indexer.
+
         Args:
-            index: The index of the element to access on the list.
+            idx: The index of the element to access on the list.
 
         Returns:
             The element on the list corresponding to the given index.
         """
-        return __mlir_op.`pop.variadic.get`(self.value, index.value)
+        return __mlir_op.`pop.variadic.get`(self.value, index(idx).value)
 
     @always_inline
     fn __iter__(self) -> Self.IterType:
@@ -358,24 +361,29 @@ struct VariadicListMem[
     # TODO: Fix for loops + _VariadicListIter to support a __nextref__ protocol
     # allowing us to get rid of this and make foreach iteration clean.
     @always_inline
-    fn __getitem__(self, index: Int) -> Self.reference_type:
+    fn __getitem__[
+        IndexerType: Indexer
+    ](self, idx: IndexerType) -> Self.reference_type:
         """Gets a single element on the variadic list.
 
+        Parameters:
+            IndexerType: The type of the indexer.
+
         Args:
-            index: The index of the element to access on the list.
+            idx: The index of the element to access on the list.
 
         Returns:
             A low-level pointer to the element on the list corresponding to the
             given index.
         """
         return Self.reference_type(
-            __mlir_op.`pop.variadic.get`(self.value, index.value)
+            __mlir_op.`pop.variadic.get`(self.value, index(idx).value)
         )
 
     @always_inline
-    fn __refitem__(
-        self, index: Int
-    ) -> Reference[
+    fn __refitem__[
+        IndexerType: Indexer
+    ](self, idx: IndexerType) -> Reference[
         element_type,
         Bool {value: elt_is_mutable},
         _lit_lifetime_union[
@@ -391,14 +399,17 @@ struct VariadicListMem[
     ]:
         """Gets a single element on the variadic list.
 
+        Parameters:
+            IndexerType: The type of the indexer.
+
         Args:
-            index: The index of the element to access on the list.
+            idx: The index of the element to access on the list.
 
         Returns:
             A low-level pointer to the element on the list corresponding to the
             given index.
         """
-        return __mlir_op.`pop.variadic.get`(self.value, index.value)
+        return __mlir_op.`pop.variadic.get`(self.value, index(idx).value)
 
     fn __iter__(
         self,

--- a/stdlib/src/builtin/builtin_slice.mojo
+++ b/stdlib/src/builtin/builtin_slice.mojo
@@ -149,8 +149,11 @@ struct Slice(Sized, Stringable, EqualityComparable):
         return len(range(self.start, self.end, self.step))
 
     @always_inline
-    fn __getitem__(self, idx: Int) -> Int:
+    fn __getitem__[IndexerType: Indexer](self, idx: IndexerType) -> Int:
         """Get the slice index.
+
+        Parameters:
+            IndexerType: The type of the indexer.
 
         Args:
             idx: The index.
@@ -158,7 +161,7 @@ struct Slice(Sized, Stringable, EqualityComparable):
         Returns:
             The slice index.
         """
-        return self.start + idx * self.step
+        return self.start + index(idx) * self.step
 
     @always_inline("nodebug")
     fn _has_end(self) -> Bool:

--- a/stdlib/src/builtin/range.mojo
+++ b/stdlib/src/builtin/range.mojo
@@ -85,8 +85,8 @@ struct _ZeroStartingRange(Sized, ReversibleRange, _IntIterable):
         return self.curr
 
     @always_inline("nodebug")
-    fn __getitem__(self, idx: Int) -> Int:
-        return idx
+    fn __getitem__[IndexerType: Indexer](self, idx: IndexerType) -> Int:
+        return index(idx)
 
     @always_inline("nodebug")
     fn __reversed__(self) -> _StridedRange:
@@ -116,8 +116,8 @@ struct _SequentialRange(Sized, ReversibleRange, _IntIterable):
         return self.end - self.start if self.start < self.end else 0
 
     @always_inline("nodebug")
-    fn __getitem__(self, idx: Int) -> Int:
-        return self.start + idx
+    fn __getitem__[IndexerType: Indexer](self, idx: IndexerType) -> Int:
+        return self.start + index(idx)
 
     @always_inline("nodebug")
     fn __reversed__(self) -> _StridedRange:
@@ -184,8 +184,8 @@ struct _StridedRange(Sized, ReversibleRange, _StridedIterable):
         return _div_ceil_positive(abs(self.start - self.end), abs(self.step))
 
     @always_inline("nodebug")
-    fn __getitem__(self, idx: Int) -> Int:
-        return self.start + idx * self.step
+    fn __getitem__[IndexerType: Indexer](self, idx: IndexerType) -> Int:
+        return self.start + index(idx) * self.step
 
     @always_inline("nodebug")
     fn __reversed__(self) -> _StridedRange:

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -1748,8 +1748,13 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
     # ===-------------------------------------------------------------------===#
 
     @always_inline("nodebug")
-    fn __getitem__(self, idx: Int) -> Scalar[type]:
+    fn __getitem__[
+        IndexerType: Indexer
+    ](self, idx: IndexerType) -> Scalar[type]:
         """Gets an element from the vector.
+
+        Parameters:
+            IndexerType: The type of the indexer.
 
         Args:
             idx: The element index.
@@ -1759,32 +1764,44 @@ struct SIMD[type: DType, size: Int = simdwidthof[type]()](
         """
         return __mlir_op.`pop.simd.extractelement`[
             _type = __mlir_type[`!pop.scalar<`, type.value, `>`]
-        ](self.value, idx.value)
+        ](self.value, index(idx).value)
 
     @always_inline("nodebug")
-    fn __setitem__(inout self, idx: Int, val: Scalar[type]):
+    fn __setitem__[
+        IndexerType: Indexer
+    ](inout self, idx: IndexerType, val: Scalar[type]):
         """Sets an element in the vector.
+
+        Parameters:
+            IndexerType: The type of the indexer.
 
         Args:
             idx: The index to set.
             val: The value to set.
         """
         self.value = __mlir_op.`pop.simd.insertelement`(
-            self.value, val.value, idx.value
+            self.value, val.value, index(idx).value
         )
 
     @always_inline("nodebug")
-    fn __setitem__(
-        inout self, idx: Int, val: __mlir_type[`!pop.scalar<`, type.value, `>`]
+    fn __setitem__[
+        IndexerType: Indexer
+    ](
+        inout self,
+        idx: IndexerType,
+        val: __mlir_type[`!pop.scalar<`, type.value, `>`],
     ):
         """Sets an element in the vector.
+
+        Parameters:
+            IndexerType: The type of the indexer.
 
         Args:
             idx: The index to set.
             val: The value to set.
         """
         self.value = __mlir_op.`pop.simd.insertelement`(
-            self.value, val, idx.value
+            self.value, val, index(idx).value
         )
 
     fn __hash__(self) -> Int:

--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -805,15 +805,19 @@ struct String(
         """
         return len(self) > 0
 
-    fn __getitem__(self, idx: Int) -> String:
+    fn __getitem__[IndexerType: Indexer](self, i: IndexerType) -> String:
         """Gets the character at the specified position.
 
+        Parameters:
+            IndexerType: The type of the indexer.
+
         Args:
-            idx: The index value.
+            i: The index value.
 
         Returns:
             A new string containing the character at the specified position.
         """
+        var idx = index(i)
         if idx < 0:
             return self.__getitem__(len(self) + idx)
 

--- a/stdlib/src/collections/inline_list.mojo
+++ b/stdlib/src/collections/inline_list.mojo
@@ -71,19 +71,22 @@ struct InlineList[ElementType: CollectionElement, capacity: Int = 16](Sized):
 
     @always_inline
     fn __refitem__[
-        IntableType: Intable,
-    ](self: Reference[Self, _, _], index: IntableType) -> Reference[
+        IndexerType: Indexer,
+    ](self: Reference[Self, _, _], idx: IndexerType) -> Reference[
         Self.ElementType, self.is_mutable, self.lifetime
     ]:
         """Get a `Reference` to the element at the given index.
 
+        Parameters:
+            IndexerType: The type of the indexer.
+
         Args:
-            index: The index of the item.
+            idx: The index of the item.
 
         Returns:
             A reference to the item at the given index.
         """
-        var i = int(index)
+        var i = index(idx)
         debug_assert(
             -self[]._size <= i < self[]._size, "Index must be within bounds."
         )

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -542,17 +542,25 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         self.capacity = 0
         return ptr
 
-    fn __setitem__(inout self, i: Int, owned value: T):
+    fn __setitem__[
+        IndexerType: Indexer
+    ](inout self, i: IndexerType, owned value: T):
         """Sets a list element at the given index.
+
+        Parameters:
+            IndexerType: The type of the indexer.
 
         Args:
             i: The index of the element.
             value: The value to assign.
         """
-        debug_assert(-self.size <= i < self.size, "index must be within bounds")
+        var normalized_idx = index(i)
+        debug_assert(
+            -self.size <= normalized_idx < self.size,
+            "index must be within bounds",
+        )
 
-        var normalized_idx = i
-        if i < 0:
+        if normalized_idx < 0:
             normalized_idx += len(self)
 
         destroy_pointee(self.data + normalized_idx)
@@ -602,10 +610,13 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         return res^
 
     @always_inline
-    fn __getitem__(self, i: Int) -> T:
+    fn __getitem__[IndexerType: Indexer](self, i: IndexerType) -> T:
         """Gets a copy of the list element at the given index.
 
         FIXME(lifetimes): This should return a reference, not a copy!
+
+        Parameters:
+            IndexerType: The type of the indexer.
 
         Args:
             i: The index of the element.
@@ -613,10 +624,12 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         Returns:
             A copy of the element at the given index.
         """
-        debug_assert(-self.size <= i < self.size, "index must be within bounds")
-
-        var normalized_idx = i
-        if i < 0:
+        var normalized_idx = index(i)
+        debug_assert(
+            -self.size <= normalized_idx < self.size,
+            "index must be within bounds",
+        )
+        if normalized_idx < 0:
             normalized_idx += len(self)
 
         return (self.data + normalized_idx)[]

--- a/stdlib/src/collections/vector.mojo
+++ b/stdlib/src/collections/vector.mojo
@@ -181,8 +181,11 @@ struct InlinedFixedVector[
         return self.current_size
 
     @always_inline
-    fn __getitem__(self, i: Int) -> type:
+    fn __getitem__[IndexerType: Indexer](self, i: IndexerType) -> type:
         """Gets a vector element at the given index.
+
+        Parameters:
+            IndexerType: The type of the indexer.
 
         Args:
             i: The index of the element.
@@ -190,12 +193,13 @@ struct InlinedFixedVector[
         Returns:
             The element at the given index.
         """
+        var normalized_idx = index(i)
         debug_assert(
-            -self.current_size <= i < self.current_size,
+            -self.current_size <= normalized_idx < self.current_size,
             "index must be within bounds",
         )
-        var normalized_idx = i
-        if i < 0:
+
+        if normalized_idx < 0:
             normalized_idx += len(self)
 
         if normalized_idx < Self.static_size:
@@ -204,20 +208,24 @@ struct InlinedFixedVector[
         return self.dynamic_data[normalized_idx - Self.static_size]
 
     @always_inline
-    fn __setitem__(inout self, i: Int, value: type):
+    fn __setitem__[
+        IndexerType: Indexer
+    ](inout self, i: IndexerType, value: type):
         """Sets a vector element at the given index.
+
+        Parameters:
+            IndexerType: The type of the indexer.
 
         Args:
             i: The index of the element.
             value: The value to assign.
         """
+        var normalized_idx = index(i)
         debug_assert(
-            -self.current_size <= i < self.current_size,
+            -self.current_size <= normalized_idx < self.current_size,
             "index must be within bounds",
         )
-
-        var normalized_idx = i
-        if i < 0:
+        if normalized_idx < 0:
             normalized_idx += len(self)
 
         if normalized_idx < Self.static_size:

--- a/stdlib/src/memory/unsafe.mojo
+++ b/stdlib/src/memory/unsafe.mojo
@@ -287,11 +287,13 @@ struct LegacyPointer[
         ](self.address)
 
     @always_inline("nodebug")
-    fn __refitem__[T: Intable](self, offset: T) -> Self._ref_type:
+    fn __refitem__[
+        IndexerType: Indexer
+    ](self, offset: IndexerType) -> Self._ref_type:
         """Enable subscript syntax `ref[idx]` to access the element.
 
         Parameters:
-            T: The Intable type of the offset.
+            IndexerType: The type of the indexer..
 
         Args:
             offset: The offset to load from.
@@ -299,7 +301,7 @@ struct LegacyPointer[
         Returns:
             The MLIR reference for the Mojo compiler to use.
         """
-        return (self + offset).__refitem__()
+        return (self + index(offset)).__refitem__()
 
     # ===------------------------------------------------------------------=== #
     # Load/Store
@@ -712,12 +714,14 @@ struct DTypePointer[
         return LegacyPointer.address_of(arg[])
 
     @always_inline("nodebug")
-    fn __getitem__[T: Intable](self, offset: T) -> Scalar[type]:
+    fn __getitem__[
+        IndexerType: Indexer
+    ](self, offset: IndexerType) -> Scalar[type]:
         """Loads a single element (SIMD of size 1) from the pointer at the
         specified index.
 
         Parameters:
-            T: The Intable type of the offset.
+            IndexerType: The type of the indexer.
 
         Args:
             offset: The offset to load from.
@@ -725,20 +729,22 @@ struct DTypePointer[
         Returns:
             The loaded value.
         """
-        return self.load(offset)
+        return self.load(index(offset))
 
     @always_inline("nodebug")
-    fn __setitem__[T: Intable](self, offset: T, val: Scalar[type]):
+    fn __setitem__[
+        IndexerType: Indexer
+    ](self, offset: IndexerType, val: Scalar[type]):
         """Stores a single element value at the given offset.
 
         Parameters:
-            T: The Intable type of the offset.
+            IndexerType: The type of the indexer.
 
         Args:
             offset: The offset to store to.
             val: The value to store.
         """
-        return self.store(offset, val)
+        return self.store(index(offset), val)
 
     # ===------------------------------------------------------------------=== #
     # Comparisons

--- a/stdlib/src/memory/unsafe_pointer.mojo
+++ b/stdlib/src/memory/unsafe_pointer.mojo
@@ -362,8 +362,13 @@ struct UnsafePointer[
         ](self.address)
 
     @always_inline
-    fn __refitem__(self, offset: Int) -> Self._ref_type:
+    fn __refitem__[
+        IndexerType: Indexer
+    ](self, offset: IndexerType) -> Self._ref_type:
         """Return a reference to the underlying data, offset by the offset index.
+
+        Parameters:
+            IndexerType: The type of the indexer.
 
         Args:
             offset: The offset index.
@@ -371,7 +376,7 @@ struct UnsafePointer[
         Returns:
             An offset reference.
         """
-        return (self + offset).__refitem__()
+        return (self + index(offset)).__refitem__()
 
 
 # ===----------------------------------------------------------------------=== #

--- a/stdlib/src/utils/index.mojo
+++ b/stdlib/src/utils/index.mojo
@@ -335,19 +335,19 @@ struct StaticIntTuple[size: Int](Sized, Stringable, EqualityComparable):
         return size
 
     @always_inline("nodebug")
-    fn __getitem__[intable: Intable](self, index: intable) -> Int:
+    fn __getitem__[IndexerType: Indexer](self, idx: IndexerType) -> Int:
         """Gets an element from the tuple by index.
 
         Parameters:
-            intable: The intable type.
+            IndexerType: The type of the indexer.
 
         Args:
-            index: The element index.
+            idx: The element index.
 
         Returns:
             The tuple element value.
         """
-        return self.data[index]
+        return self.data[index(idx)]
 
     @always_inline("nodebug")
     fn __setitem__[index: Int](inout self, val: Int):
@@ -362,17 +362,19 @@ struct StaticIntTuple[size: Int](Sized, Stringable, EqualityComparable):
         self.data.__setitem__[index](val)
 
     @always_inline("nodebug")
-    fn __setitem__[intable: Intable](inout self, index: intable, val: Int):
+    fn __setitem__[
+        IndexerType: Indexer
+    ](inout self, idx: IndexerType, val: Int):
         """Sets an element in the tuple at the given index.
 
         Parameters:
-            intable: The intable type.
+            IndexerType: The type of the indexer.
 
         Args:
-            index: The element index.
+            idx: The element index.
             val: The value to store.
         """
-        self.data[index] = val
+        self.data[index(idx)] = val
 
     @always_inline("nodebug")
     fn as_tuple(self) -> StaticTuple[Int, size]:

--- a/stdlib/src/utils/span.mojo
+++ b/stdlib/src/utils/span.mojo
@@ -176,38 +176,38 @@ struct Span[
 
     @always_inline
     fn __getitem__[
-        IntableType: Intable
-    ](self, index: IntableType) -> Reference[T, is_mutable, lifetime]:
+        IndexerType: Indexer
+    ](self, idx: IndexerType) -> Reference[T, is_mutable, lifetime]:
         """Get a `Reference` to the element at the given index.
 
         Parameters:
-            IntableType: The inferred type of an intable argument.
+            IndexerType: The type of the indexer.
 
         Args:
-            index: The index of the item.
+            idx: The index of the item.
 
         Returns:
             A reference to the item at the given index.
         """
         # note that self._refitem__ is already bounds checking
-        return self._refitem__(index)
+        return self._refitem__(index(idx))
 
     @always_inline
     fn __setitem__[
-        IntableType: Intable
-    ](inout self, index: IntableType, value: T):
+        IndexerType: Indexer
+    ](inout self, idx: IndexerType, value: T):
         """Get a `Reference` to the element at the given index.
 
         Parameters:
-            IntableType: The inferred type of an intable argument.
+            IndexerType: The type of the indexer.
 
         Args:
-            index: The index of the item.
+            idx: The index of the item.
             value: The value to set at the given index.
         """
         # note that self._refitem__ is already bounds checking
         var ref = Reference[T, __mlir_attr.`1: i1`, __lifetime_of(self)](
-            UnsafePointer(self._refitem__(index))[]
+            UnsafePointer(self._refitem__(index(idx)))[]
         )
         ref[] = value
 

--- a/stdlib/src/utils/stringref.mojo
+++ b/stdlib/src/utils/stringref.mojo
@@ -317,8 +317,11 @@ struct StringRef(
         return not (self < rhs)
 
     @always_inline("nodebug")
-    fn __getitem__(self, idx: Int) -> StringRef:
+    fn __getitem__[IndexerType: Indexer](self, idx: IndexerType) -> StringRef:
         """Get the string value at the specified position.
+
+        Parameters:
+            IndexerType: The type of the indexer.
 
         Args:
           idx: The index position.
@@ -326,7 +329,7 @@ struct StringRef(
         Returns:
           The character at the specified position.
         """
-        return StringRef {data: self.data + idx, length: 1}
+        return StringRef {data: self.data + index(idx), length: 1}
 
     fn __hash__(self) -> Int:
         """Hash the underlying buffer using builtin hash.

--- a/stdlib/test/builtin/test_list.mojo
+++ b/stdlib/test/builtin/test_list.mojo
@@ -25,6 +25,8 @@ fn test_variadic_list() raises:
         assert_equal(nums[0], 5)
         assert_equal(nums[1], 8)
         assert_equal(nums[2], 6)
+        assert_equal(nums[True], 8)
+        assert_equal(nums[Int32(0)], 5)
 
         assert_equal(len(nums), 3)
 

--- a/stdlib/test/builtin/test_range.mojo
+++ b/stdlib/test/builtin/test_range.mojo
@@ -115,7 +115,15 @@ def test_range_reversed():
         test_sum_reversed(20, end, -3)
 
 
+def test_indexing():
+    var r = range(10)
+    assert_equal(r[True], 1)
+    assert_equal(r[Int8(4)], 4)
+    assert_equal(r[3], 3)
+
+
 def main():
     test_range_len()
     test_range_getitem()
     test_range_reversed()
+    test_indexing()

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -1016,6 +1016,13 @@ def test_indexer():
     assert_equal(0, Scalar[DType.bool](False).__index__())
 
 
+def test_indexing():
+    var s = SIMD[DType.int32, 4](1, 2, 3, 4)
+    assert_equal(s[False], 1)
+    assert_equal(s[Int32(2)], 3)
+    assert_equal(s[3], 4)
+
+
 def main():
     test_cast()
     test_simd_variadic()
@@ -1052,3 +1059,4 @@ def main():
     test_abs()
     test_min_max_clamp()
     test_indexer()
+    test_indexing()

--- a/stdlib/test/builtin/test_slice.mojo
+++ b/stdlib/test/builtin/test_slice.mojo
@@ -82,9 +82,16 @@ def test_slice_stringable():
     assert_equal(s[:-1], "0:-1:1")
 
 
+def test_indexing():
+    var s = slice(1, 10)
+    assert_equal(s[True], 2)
+    assert_equal(s[UInt64(0)], 1)
+    assert_equal(s[2], 3)
+
+
 def main():
     test_none_end_folds()
     test_slicable()
     test_has_end()
-
     test_slice_stringable()
+    test_indexing()

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -839,6 +839,13 @@ def test_string_mul():
     assert_equal(String("ab") * 5, "ababababab")
 
 
+def test_indexing():
+    a = String("abc")
+    assert_equal(a[False], "a")
+    assert_equal(a[Int16(1)], "b")
+    assert_equal(a[2], "c")
+
+
 def main():
     test_constructors()
     test_copy()
@@ -882,3 +889,4 @@ def main():
     test_removesuffix()
     test_intable()
     test_string_mul()
+    test_indexing()

--- a/stdlib/test/builtin/test_stringref.mojo
+++ b/stdlib/test/builtin/test_stringref.mojo
@@ -75,7 +75,15 @@ def test_intable():
         _ = int(StringRef("hi"))
 
 
+def test_indexing():
+    a = StringRef("abc")
+    assert_equal(a[False], "a")
+    assert_equal(a[Int16(1)], "b")
+    assert_equal(a[0], "a")
+
+
 def main():
     test_strref_from_start()
     test_comparison_operators()
     test_intable()
+    test_indexing()

--- a/stdlib/test/collections/test_inline_list.mojo
+++ b/stdlib/test/collections/test_inline_list.mojo
@@ -90,7 +90,19 @@ def test_destructor():
         assert_equal(destructor_counter[i], i)
 
 
+def test_indexing():
+    var list = InlineList[Int]()
+
+    for i in range(5):
+        list.append(i)
+
+    assert_equal(list[True], 1)
+    assert_equal(list[Int32(4)], 4)
+    assert_equal(list[0], 0)
+
+
 def main():
     test_list()
     test_append_triggers_a_move()
     test_destructor()
+    test_indexing()

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -759,6 +759,15 @@ def test_list_contains():
     # assert_equal(List(0,1) in y,False)
 
 
+def test_indexing():
+    var l = List[Int](1, 2, 3)
+    assert_equal(l[Int8(1)], 2)
+    assert_equal(l[UInt64(2)], 3)
+    assert_equal(l[False], 1)
+    assert_equal(l[True], 2)
+    assert_equal(l[2], 3)
+
+
 def main():
     test_mojo_issue_698()
     test_list()
@@ -787,3 +796,4 @@ def main():
     test_list_add()
     test_list_mult()
     test_list_contains()
+    test_indexing()

--- a/stdlib/test/collections/test_vector.mojo
+++ b/stdlib/test/collections/test_vector.mojo
@@ -109,6 +109,17 @@ def test_inlined_fixed_vector_with_default():
     vector._del_old()
 
 
+def test_indexing():
+    var vector = InlinedFixedVector[Int](10)
+    for i in range(5):
+        vector.append(i)
+    assert_equal(1, vector[Int16(1)])
+    assert_equal(1, vector[True])
+    assert_equal(1, vector[Scalar[DType.bool](True)])
+    assert_equal(2, vector[2])
+
+
 def main():
     test_inlined_fixed_vector()
     test_inlined_fixed_vector_with_default()
+    test_indexing()

--- a/stdlib/test/memory/test_memory.mojo
+++ b/stdlib/test/memory/test_memory.mojo
@@ -508,6 +508,16 @@ def test_memcpy_unsafe_pointer():
     assert_equal(list_a[9], 5)
 
 
+def test_indexing():
+    var ptr = DTypePointer[DType.float32].alloc(4)
+    for i in range(4):
+        ptr[i] = i
+
+    assert_equal(ptr[True], 1)
+    assert_equal(ptr[Int32(2)], 2)
+    assert_equal(ptr[1], 1)
+
+
 def main():
     test_memcpy()
     test_memcpy_dtype()
@@ -526,3 +536,4 @@ def main():
 
     test_dtypepointer_gather()
     test_dtypepointer_scatter()
+    test_indexing()

--- a/stdlib/test/memory/test_unsafepointer.mojo
+++ b/stdlib/test/memory/test_unsafepointer.mojo
@@ -158,6 +158,16 @@ def test_unsafepointer_address_space():
     p2.free()
 
 
+def test_indexing():
+    var ptr = UnsafePointer[Int].alloc(4)
+    for i in range(4):
+        ptr[i] = i
+
+    assert_equal(ptr[False], 0)
+    assert_equal(ptr[Int32(1)], 1)
+    assert_equal(ptr[3], 3)
+
+
 def main():
     test_address_of()
 
@@ -173,3 +183,4 @@ def main():
     test_comparisons()
 
     test_unsafepointer_address_space()
+    test_indexing()

--- a/stdlib/test/utils/test_span.mojo
+++ b/stdlib/test/utils/test_span.mojo
@@ -110,8 +110,17 @@ def test_span_array_str():
     assert_equal(l[-1], "i")
 
 
+def test_indexing():
+    var l = InlineArray[Int, 7](1, 2, 3, 4, 5, 6, 7)
+    var s = Span(l)
+    assert_equal(s[True][], 2)
+    assert_equal(s[Int32(0)][], 1)
+    assert_equal(s[3][], 4)
+
+
 def main():
     test_span_list_int()
     test_span_list_str()
     test_span_array_int()
     test_span_array_str()
+    test_indexing()


### PR DESCRIPTION
The second half of #2384

I have intentionally omitted `static_tuple.mojo` to avoid conflicting with #2677