### PR TITLE
[stdlib] Fix wrong slice check in span

### DIFF
--- a/stdlib/src/utils/span.mojo
+++ b/stdlib/src/utils/span.mojo
@@ -223,8 +223,8 @@ struct Span[
         """
         var adjusted_span = self._adjust_span(slice)
         debug_assert(
-            0 <= adjusted_span.start < self._len
-            and 0 <= adjusted_span.end < self._len,
+            0 <= adjusted_span.start <= self._len
+            and 0 <= adjusted_span.end <= self._len,
             "Slice must be within bounds.",
         )
         var res = Self(


### PR DESCRIPTION
Fix part of https://github.com/modularml/mojo/issues/2687 

both the start and the end of span can be `len(original_string)`, that's not an issue. In the case where the start is equal to the lenght of th string, it just gives an empty span. This is similar to the slicing `my_string[:0]` which also gives an empty span.