### PR TITLE
[tools] Allow to choose the test files when using `run-tests.sh`

### DIFF
--- a/stdlib/docs/development.md
+++ b/stdlib/docs/development.md
@@ -66,13 +66,24 @@ We provide a simple Bash script to build the standard library package and
 `test_utils` package that is used by the test suite.
 
 Just run `./stdlib/scripts/run-tests.sh` which will produce the necessary
-`mojopkg` files inside your `build` directory, and then run `lit -sv
-stdlib/test`.
+`mojopkg` files inside your `build` directory, after this is done, the script will
+run all the tests automatically.
 
 ```bash
 ./stdlib/scripts/run-tests.sh
+```
 
-lit -sv stdlib/test
+If you wish to run the unit tests that are in a specific test file, you can do 
+so with 
+
+```bash
+./stdlib/scripts/run-tests.sh ./stdlib/test/utils/test_span.mojo 
+```
+
+You can do the same for a directory with
+
+```bash
+./stdlib/scripts/run-tests.sh ./stdlib/test/utils
 ```
 
 All the tests should pass on the `nightly` branch with the nightly Mojo

--- a/stdlib/scripts/run-tests.sh
+++ b/stdlib/scripts/run-tests.sh
@@ -27,4 +27,11 @@ echo "Packaging up the test_utils."
 TEST_UTILS_PATH="${REPO_ROOT}/stdlib/test/test_utils"
 mojo package "${TEST_UTILS_PATH}" -o "${BUILD_DIR}/test_utils.mojopkg"
 
-lit -sv "${REPO_ROOT}"/stdlib/test
+TEST_PATH="${REPO_ROOT}/stdlib/test"
+if [[ $# -gt 0 ]]; then
+  # If an argument is provided, use it as the specific test file or directory
+  TEST_PATH=$1
+fi
+
+# Run the tests
+lit -sv "${TEST_PATH}"


### PR DESCRIPTION
Also rectified a small mistake in the guide: unlike what was written previously, the contributors don't need to run `lit` after using the script `run-tests.sh`.