### PR TITLE
[stdlib] Temporary directory

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,9 @@ by [@jayzhan211](https://github.com/jayzhan211))
 
 - Added `C_char` type alias in `sys.ffi`.
 
+- Added `TemporaryDirectory` in module `tempfile`.
+  ([PR 2743](https://github.com/modularml/mojo/pull/2743) by [@artemiogr97](https://github.com/artemiogr97))
+
 ### 🦋 Changed
 
 - Continued transition to `UnsafePointer` and unsigned byte type for strings:

--- a/stdlib/src/tempfile/__init__.mojo
+++ b/stdlib/src/tempfile/__init__.mojo
@@ -12,4 +12,4 @@
 # ===----------------------------------------------------------------------=== #
 """Implements the tempfile package."""
 
-from .tempfile import gettempdir, mkdtemp
+from .tempfile import gettempdir, mkdtemp, TemporaryDirectory

--- a/stdlib/test/tempfile/test_tempfile.mojo
+++ b/stdlib/test/tempfile/test_tempfile.mojo
@@ -16,7 +16,7 @@ import os
 from os.path import exists
 from pathlib import Path
 from testing import assert_true, assert_false, assert_equal
-from tempfile import gettempdir, mkdtemp
+from tempfile import gettempdir, mkdtemp, TemporaryDirectory
 
 
 fn test_mkdtemp() raises:
@@ -161,6 +161,21 @@ fn test_gettempdir() raises:
     _clean_up_gettempdir_test()
 
 
+fn test_temporary_directory() raises -> None:
+    var tmp_dir: String = ""
+    with TemporaryDirectory() as tmp_dir:
+        assert_true(exists(tmp_dir), "Failed to create temp dir " + tmp_dir)
+    assert_false(exists(tmp_dir), "Failed to delete temp dir " + tmp_dir)
+
+    with TemporaryDirectory() as tmp_dir:
+        assert_true(exists(tmp_dir), "Failed to create temp dir " + tmp_dir)
+        _ = open(tmp_dir + "/test_file", "w")
+        os.mkdir(tmp_dir + "/test_dir")
+        _ = open(tmp_dir + "/test_dir/test_file2", "w")
+    assert_false(exists(tmp_dir), "Failed to delete temp dir " + tmp_dir)
+
+
 fn main() raises:
     test_mkdtemp()
     test_gettempdir()
+    test_temporary_directory()

--- a/stdlib/test/tempfile/test_tempfile.mojo
+++ b/stdlib/test/tempfile/test_tempfile.mojo
@@ -29,7 +29,7 @@ fn test_mkdtemp() raises:
 
     dir_name = mkdtemp(prefix="my_prefix", suffix="my_suffix")
     assert_true(exists(dir_name), "Failed to create temporary directory")
-    var name = dir_name.split("/")[-1]
+    var name = dir_name.split(os.sep)[-1]
     assert_true(name.startswith("my_prefix"))
     assert_true(name.endswith("my_suffix"))
 
@@ -39,7 +39,7 @@ fn test_mkdtemp() raises:
     dir_name = mkdtemp(dir=Path().__fspath__())
     assert_true(exists(dir_name), "Failed to create temporary directory")
     assert_true(
-        exists(Path() / dir_name.split("/")[-1]),
+        exists(Path() / dir_name.split(os.sep)[-1]),
         "Expected directory to be created in cwd",
     )
     os.rmdir(dir_name)
@@ -163,15 +163,17 @@ fn test_gettempdir() raises:
 
 fn test_temporary_directory() raises -> None:
     var tmp_dir: String = ""
-    with TemporaryDirectory() as tmp_dir:
+    with TemporaryDirectory(suffix="my_suffix", prefix="my_prefix") as tmp_dir:
         assert_true(exists(tmp_dir), "Failed to create temp dir " + tmp_dir)
+        assert_true(tmp_dir.endswith("my_suffix"))
+        assert_true(tmp_dir.split(os.sep)[-1].startswith("my_prefix"))
     assert_false(exists(tmp_dir), "Failed to delete temp dir " + tmp_dir)
 
     with TemporaryDirectory() as tmp_dir:
         assert_true(exists(tmp_dir), "Failed to create temp dir " + tmp_dir)
-        _ = open(tmp_dir + "/test_file", "w")
-        os.mkdir(tmp_dir + "/test_dir")
-        _ = open(tmp_dir + "/test_dir/test_file2", "w")
+        _ = open(Path(tmp_dir) / "test_file", "w")
+        os.mkdir(Path(tmp_dir) / "test_dir")
+        _ = open(Path(tmp_dir) / "test_dir" / "test_file2", "w")
     assert_false(exists(tmp_dir), "Failed to delete temp dir " + tmp_dir)
 
 


### PR DESCRIPTION
Implementation of `TemporaryDirectory`, a wrapper around `mkdtemp` that can be used as a context nanager.