### PR TITLE
[stdlib] Fix wrong debug_assert condition in `InlineList`

### DIFF
--- a/stdlib/src/collections/inline_list.mojo
+++ b/stdlib/src/collections/inline_list.mojo
@@ -106,7 +106,7 @@ struct InlineList[ElementType: CollectionElement, capacity: Int = 16](Sized):
         Args:
             values: The values to populate the list with.
         """
-        debug_assert(len(values) < capacity, "List is full.")
+        debug_assert(len(values) <= capacity, "List is full.")
         self = Self()
         for value in values:
             self.append(value[])


### PR DESCRIPTION
If the InlineList is of capacity N, then it's possible to initialize it with N values. It's the same as a regular List.

Related to https://github.com/modularml/mojo/issues/2687