### PR TITLE
[stdlib] Fix out of bounds access in `List.index()`

### DIFF
--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -508,18 +508,24 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         Raises:
             ValueError: If the value is not found in the list.
         """
-        var size = self[].size
-        var normalized_start = max(size + start, 0) if start < 0 else start
+        var start_normalized = start
 
-        @parameter
-        fn normalized_stop() -> Int:
-            if stop is None:
-                return size
-            else:
-                var end = stop.value()[]
-                return end if end > 0 else min(end + size, size)
+        var stop_normalized: Int
+        if stop is None:
+            # Default end
+            stop_normalized = len(self[])
+        else:
+            stop_normalized = stop.value()[]
 
-        for i in range(normalized_start, normalized_stop()):
+        if start_normalized < 0:
+            start_normalized += len(self[])
+        if stop_normalized < 0:
+            stop_normalized += len(self[])
+
+        start_normalized = _clip(start_normalized, 0, len(self[]))
+        stop_normalized = _clip(stop_normalized, 0, len(self[]))
+
+        for i in range(start_normalized, stop_normalized):
             if self[][i] == value:
                 return i
         raise "ValueError: Given element is not in list"
@@ -790,3 +796,7 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             if i[] == rebind[T2](value):
                 return True
         return False
+
+
+fn _clip(value: Int, start: Int, end: Int) -> Int:
+    return max(start, min(value, end))

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -391,6 +391,7 @@ def test_list_index():
     # Tests With Start Parameter
     assert_equal(test_list_a.index(30, start=1), 2)
     assert_equal(test_list_a.index(30, start=-4), 2)
+    assert_equal(test_list_a.index(30, start=-1000), 2)
     with assert_raises(contains="ValueError: Given element is not in list"):
         _ = test_list_a.index(30, start=3)
     with assert_raises(contains="ValueError: Given element is not in list"):
@@ -399,6 +400,7 @@ def test_list_index():
     # Tests With Start and End Parameters
     assert_equal(test_list_a.index(30, start=1, stop=3), 2)
     assert_equal(test_list_a.index(30, start=-4, stop=-2), 2)
+    assert_equal(test_list_a.index(30, start=-1000, stop=1000), 2)
     with assert_raises(contains="ValueError: Given element is not in list"):
         _ = test_list_a.index(30, start=1, stop=2)
     with assert_raises(contains="ValueError: Given element is not in list"):
@@ -407,6 +409,7 @@ def test_list_index():
     # Tests With End Parameter Only
     assert_equal(test_list_a.index(30, stop=3), 2)
     assert_equal(test_list_a.index(30, stop=-2), 2)
+    assert_equal(test_list_a.index(30, stop=1000), 2)
     with assert_raises(contains="ValueError: Given element is not in list"):
         _ = test_list_a.index(30, stop=1)
     with assert_raises(contains="ValueError: Given element is not in list"):

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -431,6 +431,13 @@ def test_list_index():
     with assert_raises(contains="ValueError: Given element is not in list"):
         _ = List[Int]().index(10)
 
+    # Test empty slice
+    with assert_raises(contains="ValueError: Given element is not in list"):
+        _ = test_list_a.index(10, start=1, stop=1)
+    # Test empty slice with 0 start and end
+    with assert_raises(contains="ValueError: Given element is not in list"):
+        _ = test_list_a.index(10, start=0, stop=0)
+
     var test_list_b = List[Int](10, 20, 30, 20, 10)
 
     # Test finding the first occurrence of an item


### PR DESCRIPTION
Related to https://github.com/modularml/mojo/issues/2687

There were multiple bugs related to clipping there.

Long story short, the behavior of `list.index()` in python is this one: given a `start` and `end`, python will look for the element in `my_list[start:end]` and report the result, (`start` is added to the result to give the index with respect to the original list).

You can take a look at the description of the `index` method here: https://docs.python.org/3/tutorial/datastructures.html#more-on-lists

Since there is slicing semantics applied to `start` and `end`, we should do multiple things:
1) default to the start and the end of the list
2) normalize negative values by doing `+ len(my_list)`
3) clip both start and end between `0` and `len(my_list)`

The last step wasn't done correctly. Especially for the `stop` argument where the clipping was applied only when negative values were found (this caused the out of bounds bug in the tests).
Effectively 

```mojo
return end if end > 0 else min(end + size, size)
```
 is equivalent to 
```mojo
return end if end > 0 else end + size
```
since the min is applied only when `end <= 0`. So `end + size <= size`

This test can cause some flakyness in our CI: `test_list_a.index(10, start=5, stop=50)` for a list of size 6.
The stop was positive, so it was never clipped, thus too many values (out of bounds) were tried, causing some to match, sometimes.

Another bug was that because of this condition, `end = 0` means "check until the end of the list" while in python, with the slicing semantics, `end = 0` means "do nothing" (empty slice).

### TL;DR
Multiple clipping bugs. Slicing semantics applied to `start` and `stop` now like in Python. No more flakyness in our CI. No more out of bounds access. Corresponding tests added.