### PR TITLE
[stdlib] Fix invalid code point check

### DIFF
--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -95,7 +95,9 @@ fn chr(c: Int) -> String:
 
     @always_inline
     fn _utf8_len(val: Int) -> Int:
-        debug_assert(val > 0x10FFFF, "Value is not a valid Unicode code point")
+        debug_assert(
+            0 <= val <= 0x10FFFF, "Value is not a valid Unicode code point"
+        )
         alias sizes = SIMD[DType.int32, 4](
             0, 0b1111_111, 0b1111_1111_111, 0b1111_1111_1111_1111
         )


### PR DESCRIPTION
Related to https://github.com/modularml/mojo/issues/2687

See https://stackoverflow.com/questions/27415935/does-unicode-have-a-defined-maximum-number-of-code-points for the correct range. You can also use Python's `chr` function to make sure the range is correct
