### PR TITLE
[stdlib] Add List constructor from Span

### DIFF
--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -24,6 +24,7 @@ from memory import UnsafePointer, Reference
 from memory.unsafe_pointer import move_pointee, move_from_pointee
 from sys.intrinsics import _type_is_eq
 from .optional import Optional
+from utils import Span
 
 # ===----------------------------------------------------------------------===#
 # List
@@ -126,6 +127,16 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         """
         self = Self(capacity=len(values))
         for value in values:
+            self.append(value[])
+
+    fn __init__(inout self, span: Span[T]):
+        """Constructs a list from the a Span of values.
+
+        Args:
+            span: The span of values to populate the list with.
+        """
+        self = Self(capacity=len(span))
+        for value in span:
             self.append(value[])
 
     fn __init__(

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -16,6 +16,7 @@ from collections import List
 
 from test_utils import CopyCounter, MoveCounter
 from testing import assert_equal, assert_false, assert_true, assert_raises
+from utils import Span
 
 
 def test_mojo_issue_698():
@@ -757,6 +758,14 @@ def test_list_contains():
     # y.append(List(1,2))
     # assert_equal(List(1,2) in y,True)
     # assert_equal(List(0,1) in y,False)
+
+
+def test_list_init_span():
+    var l = List[String]("a", "bb", "cc", "def")
+    var sp = Span(l)
+    var l2 = List[String](sp)
+    for i in range(len(l)):
+        assert_equal(l[i], l2[i])
 
 
 def main():


### PR DESCRIPTION
Being able to convert a Span to an owned value is useful, and List makes the most sense for this type. We could also consider a `to_list()` method on Span instead if that is a better fit.