### PR TITLE
[stdlib] Implement `NamedTemporaryFile` in `tempfile` module

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -78,6 +78,9 @@ by [@jayzhan211](https://github.com/jayzhan211))
 - Added `TemporaryDirectory` in module `tempfile`.
   ([PR 2743](https://github.com/modularml/mojo/pull/2743) by [@artemiogr97](https://github.com/artemiogr97))
 
+- Added `NamedTemporaryFile` in module `tempfile`.
+  ([PR 2762](https://github.com/modularml/mojo/pull/2762) by [@artemiogr97](https://github.com/artemiogr97))
+
 - Added temporary `SliceNew` type with corrected behaviour from `Slice` to facilitate
   an incremental internal migration due to reliance on the old, incorrect behaviour.
   ([PR #2894](https://github.com/modularml/mojo/pull/2894) by [@bgreni](https://github.com/bgreni))

--- a/stdlib/src/tempfile/__init__.mojo
+++ b/stdlib/src/tempfile/__init__.mojo
@@ -12,4 +12,9 @@
 # ===----------------------------------------------------------------------=== #
 """Implements the tempfile package."""
 
-from .tempfile import gettempdir, mkdtemp, TemporaryDirectory
+from .tempfile import (
+    gettempdir,
+    mkdtemp,
+    TemporaryDirectory,
+    NamedTemporaryFile,
+)

--- a/stdlib/src/tempfile/tempfile.mojo
+++ b/stdlib/src/tempfile/tempfile.mojo
@@ -317,7 +317,7 @@ struct NamedTemporaryFile:
         """Moves constructor for the file handle.
 
         Args:
-          existing: The existing file handle.
+            existing: The existing file handle.
         """
         self._file_handle = existing._file_handle^
         self._delete = existing._delete
@@ -331,7 +331,7 @@ struct NamedTemporaryFile:
             size: Requested number of bytes to read.
 
         Returns:
-          The contents of the file.
+            The contents of the file.
         """
         return self._file_handle.read(size)
 
@@ -343,7 +343,7 @@ struct NamedTemporaryFile:
             size: Requested number of bytes to read.
 
         Returns:
-          The contents of the file.
+            The contents of the file.
         """
         return self._file_handle.read_bytes(size)
 
@@ -366,7 +366,7 @@ struct NamedTemporaryFile:
         """Write the data to the file.
 
         Args:
-          data: The data to write to the file.
+            data: The data to write to the file.
         """
         self._file_handle.write(data)
 

--- a/stdlib/src/tempfile/tempfile.mojo
+++ b/stdlib/src/tempfile/tempfile.mojo
@@ -239,3 +239,133 @@ struct TemporaryDirectory:
             return True
         except:
             return False
+
+
+struct NamedTemporaryFile:
+    """A handle to a temporary file."""
+
+    var _file_handle: FileHandle
+    """The underlying file handle."""
+    var _delete: Bool
+    """Whether the file is deleted on close."""
+    var name: String
+    """Name of the file."""
+
+    fn __init__(
+        inout self,
+        mode: String = "w",
+        suffix: String = "",
+        prefix: String = "tmp",
+        dir: Optional[String] = None,
+        delete: Bool = True,
+    ) raises:
+        """Create a named temporary file. Can be used as a context manager.
+        This is a wrapper around a `FileHandle`,
+        os.remove is called in close method if `delete` is True.
+
+        Args:
+            mode: The mode to open the file in (the mode can be "r" or "w").
+            suffix: Suffix to use for the file name.
+            prefix: Prefix to use for the file name.
+            dir: Directory in which the file will be created.
+            delete: Whether the file is deleted on close.
+        """
+        var final_dir = Path(dir.value()) if dir else Path(
+            _get_default_tempdir()
+        )
+
+        self._delete = delete
+
+        for _ in range(TMP_MAX):
+            var potential_name = final_dir / (
+                prefix + _get_random_name() + suffix
+            )
+            try:
+                if os.path.exists(potential_name) == False:
+                    # TODO for now this name could be relative,
+                    # python implementation expands the path,
+                    # but several functions are not yet implemented in mojo
+                    # i.e. abspath, normpath
+                    self.name = potential_name.__fspath__()
+                    self._file_handle = FileHandle(
+                        potential_name.__fspath__(), mode=mode
+                    )
+                    return
+            except:
+                continue
+        raise Error("Failed to create temporary file")
+
+    @always_inline
+    fn __del__(owned self):
+        """Closes the file handle."""
+        try:
+            self.close()
+        except:
+            pass
+
+    fn close(inout self) raises:
+        """Closes the file handle."""
+        self._file_handle.close()
+        if self._delete:
+            os.remove(self.name)
+
+    fn __moveinit__(inout self, owned existing: Self):
+        """Moves constructor for the file handle.
+
+        Args:
+          existing: The existing file handle.
+        """
+        self._file_handle = existing._file_handle^
+        self._delete = existing._delete
+        self.name = existing.name^
+
+    @always_inline
+    fn read(self, size: Int64 = -1) raises -> String:
+        """Reads the data from the file.
+
+        Args:
+            size: Requested number of bytes to read.
+
+        Returns:
+          The contents of the file.
+        """
+        return self._file_handle.read(size)
+
+    fn read_bytes(self, size: Int64 = -1) raises -> List[UInt8]:
+        """Read from file buffer until we have `size` characters or we hit EOF.
+        If `size` is negative or omitted, read until EOF.
+
+        Args:
+            size: Requested number of bytes to read.
+
+        Returns:
+          The contents of the file.
+        """
+        return self._file_handle.read_bytes(size)
+
+    fn seek(self, offset: UInt64) raises -> UInt64:
+        """Seeks to the given offset in the file.
+
+        Args:
+            offset: The byte offset to seek to from the start of the file.
+
+        Raises:
+            An error if this file handle is invalid, or if file seek returned a
+            failure.
+
+        Returns:
+            The resulting byte offset from the start of the file.
+        """
+        return self._file_handle.seek(offset)
+
+    fn write(self, data: String) raises:
+        """Write the data to the file.
+
+        Args:
+          data: The data to write to the file.
+        """
+        self._file_handle.write(data)
+
+    fn __enter__(owned self) -> Self:
+        """The function to call when entering the context."""
+        return self^

--- a/stdlib/src/tempfile/tempfile.mojo
+++ b/stdlib/src/tempfile/tempfile.mojo
@@ -282,19 +282,21 @@ struct NamedTemporaryFile:
             var potential_name = final_dir / (
                 prefix + _get_random_name() + suffix
             )
-            if not os.path.exists(potential_name):
+            if os.path.exists(potential_name):
+                continue
+            try:
                 # TODO for now this name could be relative,
                 # python implementation expands the path,
                 # but several functions are not yet implemented in mojo
                 # i.e. abspath, normpath
                 self.name = potential_name.__fspath__()
-                break
+                self._file_handle = FileHandle(
+                    potential_name.__fspath__(), mode=mode
+                )
+                return
+            except:
+                continue
         else:
-            raise Error("Failed to create temporary file")
-
-        try:
-            self._file_handle = FileHandle(self.name, mode=mode)
-        except:
             raise Error("Failed to create temporary file")
 
     @always_inline

--- a/stdlib/test/tempfile/test_tempfile.mojo
+++ b/stdlib/test/tempfile/test_tempfile.mojo
@@ -20,7 +20,7 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir, mkdtemp
 from testing import assert_equal, assert_false, assert_true
 
 
-fn test_mkdtemp() raises:
+def test_mkdtemp():
     var dir_name: String
 
     dir_name = mkdtemp()
@@ -62,7 +62,7 @@ struct TempEnvWithCleanup:
         self._vars_back = Dict[String, String]()
         self.clean_up_function = clean_up_function
 
-    fn __enter__(inout self) raises:
+    def __enter__(inout self):
         for key_value in self.vars_to_set.items():
             var key = key_value[].key
             var value = key_value[].value
@@ -75,7 +75,7 @@ struct TempEnvWithCleanup:
             var value = key_value[].value
             _ = os.setenv(key, value, overwrite=True)
 
-    fn __exit__(inout self, error: Error) raises -> Bool:
+    def __exit__(inout self, error: Error) -> Bool:
         self.__exit__()
         self.clean_up_function()
         return False
@@ -90,9 +90,9 @@ fn _clean_up_gettempdir_test() raises:
         os.rmdir(dir_with_writing_access)
 
 
-fn _set_up_gettempdir_test(
+def _set_up_gettempdir_test(
     dir_with_writing_access: Path, dir_without_writing_access: Path
-) raises:
+):
     os.mkdir(dir_with_writing_access, mode=0o700)
     try:
         os.mkdir(dir_without_writing_access, mode=0o100)
@@ -101,7 +101,7 @@ fn _set_up_gettempdir_test(
         raise Error("Failed to setup test")
 
 
-fn test_gettempdir() raises:
+def test_gettempdir():
     var non_existing_dir = Path() / "non_existing_dir"
     assert_false(
         exists(non_existing_dir),
@@ -162,7 +162,7 @@ fn test_gettempdir() raises:
     _clean_up_gettempdir_test()
 
 
-fn test_temporary_directory() raises -> None:
+def test_temporary_directory() -> None:
     var tmp_dir: String = ""
     with TemporaryDirectory(suffix="my_suffix", prefix="my_prefix") as tmp_dir:
         assert_true(exists(tmp_dir), "Failed to create temp dir " + tmp_dir)
@@ -178,7 +178,7 @@ fn test_temporary_directory() raises -> None:
     assert_false(exists(tmp_dir), "Failed to delete temp dir " + tmp_dir)
 
 
-fn test_named_temporary_file_deletion() raises:
+def test_named_temporary_file_deletion():
     var tmp_file: NamedTemporaryFile
     var file_path: String
 
@@ -214,7 +214,7 @@ fn test_named_temporary_file_deletion() raises:
     os.remove(file_path)
 
 
-fn test_named_temporary_file_write() raises:
+def test_named_temporary_file_write():
     var file_name: String
     var contents: String
 
@@ -228,7 +228,7 @@ fn test_named_temporary_file_write() raises:
     os.remove(file_name)
 
 
-fn main() raises:
+def main():
     test_mkdtemp()
     test_gettempdir()
     test_temporary_directory()

--- a/stdlib/test/tempfile/test_tempfile.mojo
+++ b/stdlib/test/tempfile/test_tempfile.mojo
@@ -180,34 +180,38 @@ fn test_temporary_directory() raises -> None:
 
 fn test_named_temporary_file_deletion() raises:
     var tmp_file: NamedTemporaryFile
-    var file_name: String
+    var file_path: String
 
     with NamedTemporaryFile(
-        prefix=String("my_prefix"), suffix=String("my_suffix")
+        prefix="my_prefix", suffix="my_suffix", dir=Path().__fspath__()
     ) as my_tmp_file:
-        file_name = my_tmp_file.name
-        assert_true(exists(file_name), "Failed to create file " + file_name)
-        assert_true(file_name.split("/")[-1].startswith(String("my_prefix")))
-    assert_false(exists(file_name), "Failed to delete file " + file_name)
+        file_path = my_tmp_file.name
+        var file_name = file_path.split(os.sep)[-1]
+        assert_true(exists(file_path), "Failed to create file " + file_path)
+        assert_true(file_name.startswith("my_prefix"))
+        assert_true(file_name.endswith("my_suffix"))
+        # TODO use os.path.split when it exists
+        assert_equal(file_path[: -len(file_name) - 1], Path().__fspath__())
+    assert_false(exists(file_path), "Failed to delete file " + file_path)
 
     with NamedTemporaryFile(delete=False) as my_tmp_file:
-        file_name = my_tmp_file.name
-        assert_true(exists(file_name), "Failed to create file " + file_name)
-    assert_true(exists(file_name), "File " + file_name + " should still exist")
-    os.remove(file_name)
+        file_path = my_tmp_file.name
+        assert_true(exists(file_path), "Failed to create file " + file_path)
+    assert_true(exists(file_path), "File " + file_path + " should still exist")
+    os.remove(file_path)
 
     tmp_file = NamedTemporaryFile()
-    file_name = tmp_file.name
-    assert_true(exists(file_name), "Failed to create file " + file_name)
+    file_path = tmp_file.name
+    assert_true(exists(file_path), "Failed to create file " + file_path)
     tmp_file.close()
-    assert_false(exists(file_name), "Failed to delete file " + file_name)
+    assert_false(exists(file_path), "Failed to delete file " + file_path)
 
     tmp_file = NamedTemporaryFile(delete=False)
-    file_name = tmp_file.name
-    assert_true(exists(file_name), "Failed to create file " + file_name)
+    file_path = tmp_file.name
+    assert_true(exists(file_path), "Failed to create file " + file_path)
     tmp_file.close()
-    assert_true(exists(file_name), "File " + file_name + " should still exist")
-    os.remove(file_name)
+    assert_true(exists(file_path), "File " + file_path + " should still exist")
+    os.remove(file_path)
 
 
 fn test_named_temporary_file_write() raises:


### PR DESCRIPTION
Implementation of `NamedTemporaryFile` a wrapper around a `FileHandle` that can be used as a context manager that is deleted after closing it if needed.