### PR TITLE
[tools] Add markdownlint to the pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,8 @@ repos:
         language: system
         files: '\.(mojo|🔥|py)$'
         stages: [commit]
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.40.0
+    hooks:
+    - id: markdownlint
+      args: ['--config', 'stdlib/scripts/.markdownlint.yaml', '--fix']


### PR DESCRIPTION
Split off from https://github.com/modularml/mojo/pull/2717 since Copybara isn't currently managing the
`.pre-commit-config.yaml` file.  The other changes from https://github.com/modularml/mojo/pull/2717 landed already in
https://github.com/modularml/mojo/commit/b6b01b4d5a4e81a00174330c92501669f04e5abe.