### PR TITLE
[stdlib] Add count() method for InlineList

### DIFF
--- a/stdlib/src/collections/inline_list.mojo
+++ b/stdlib/src/collections/inline_list.mojo
@@ -200,6 +200,34 @@ struct InlineList[ElementType: CollectionElement, capacity: Int = 16](Sized):
         return False
 
     @always_inline
+    fn count[C: ComparableCollectionElement](self: Self, value: C) -> Int:
+        """Counts the number of occurrences of a value in the list.
+
+        ```mojo
+        var my_list = InlineList[Int](1, 2, 3)
+        print(my_list.count(1))
+        ```
+        Parameters:
+            C: The type of the elements in the list. Must implement the
+              traits `EqualityComparable` and `CollectionElement`.
+
+        Args:
+            value: The value to count.
+
+        Returns:
+            The number of occurrences of the value in the list.
+        """
+        constrained[
+            _type_is_eq[ElementType, C](), "value type is not self.ElementType"
+        ]()
+
+        var count = 0
+        for elem in self:
+            if value == rebind[C](elem[]):
+                count += 1
+        return count
+
+    @always_inline
     fn __bool__(self) -> Bool:
         """Checks whether the list has any elements or not.
 

--- a/stdlib/test/collections/test_inline_list.mojo
+++ b/stdlib/test/collections/test_inline_list.mojo
@@ -138,6 +138,16 @@ def test_list_variadic_constructor():
     assert_equal(8, l[3])
 
 
+def test_list_count():
+    var list = InlineList[Int](1, 2, 3, 2, 5, 6, 7, 8, 9, 10)
+    assert_equal(1, list.count(1))
+    assert_equal(2, list.count(2))
+    assert_equal(0, list.count(4))
+
+    var list2 = InlineList[Int]()
+    assert_equal(0, list2.count(1))
+
+
 def test_list_boolable():
     assert_true(InlineList[Int](1))
     assert_false(InlineList[Int]())
@@ -162,5 +172,6 @@ def main():
     test_list_iter_mutable()
     test_list_contains()
     test_list_variadic_constructor()
+    test_list_count()
     test_list_boolable()
     test_indexing()


### PR DESCRIPTION
The PR adds count() method for InlineList

*count*
```mojo
var my_list = InlineList[Int](1, 2, 3)
print(my_list.count(1))
```