### PR TITLE
[stdlib] Implement gcd for two or more values

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -525,6 +525,15 @@ by [@jayzhan211](https://github.com/jayzhan211))
   method. This makes it explicit that this implementation does not check if the
   slice bounds are concrete or within any given object's length.
 
+- `gcd` is now more pythonic and accepts a `List`, `Span` and `VariadicList` to
+  compute the gcd of many elements.
+  ([PR #2777](https://github.com/modularml/mojo/pull/2777) by [@bgreni](https://github.com/bgreni))
+
+```mojo
+  gcd(2, 4, 6, 8, 16) # returns 2
+  gcd(List(2, 4, 6, 8, 16))
+```
+
 ### ❌ Removed
 
 - The `@unroll` decorator has been deprecated and removed. The decorator was

--- a/stdlib/src/builtin/_math.mojo
+++ b/stdlib/src/builtin/_math.mojo
@@ -195,3 +195,76 @@ trait Truncable:
     # associated types.
     fn __trunc__(self) -> Self:
         ...
+
+
+# ===----------------------------------------------------------------------=== #
+# gcd
+# ===----------------------------------------------------------------------=== #
+
+
+fn gcd(owned m: Int, owned n: Int, /) -> Int:
+    """Compute the greatest common divisor of two integers.
+
+    Args:
+        m: The first integer.
+        n: The second integrer.
+
+    Returns:
+        The greatest common divisor of the two integers.
+    """
+    while n:
+        m, n = n, m % n
+    return abs(m)
+
+
+fn gcd(s: Span[Int]) -> Int:
+    """Computes the greatest common divisor of a collection of integers.
+
+    Args:
+        s: A span containing a collection of integers.
+
+    Returns:
+        The greatest common divisor of all the integers in the span.
+    """
+    if len(s) == 0:
+        return 0
+    var result = s[0]
+    for item in s[1:]:
+        result = gcd(item[], result)
+        if result == 1:
+            return result
+    return result
+
+
+@always_inline
+fn gcd(l: List[Int]) -> Int:
+    """Computes the greatest common divisor of a collection of integers.
+
+    Args:
+        l: A list containing a collection of integers.
+
+    Returns:
+        The greatest common divisor of all the integers in the list.
+    """
+    return gcd(Span(l))
+
+
+@always_inline
+fn gcd(*values: Int) -> Int:
+    """Computes the greatest common divisor of a collection of integers.
+
+    Args:
+        values: A variadic list containing a collection of integers.
+
+    Returns:
+        The greatest common divisor of all the integers in the list.
+    """
+    # TODO: Deduplicate when we can create a Span from VariadicList
+    if len(values) == 0:
+        return 0
+    var result = values[0]
+    for i in range(1, len(values)):
+        result = gcd(values[i], result)
+        if result == 1:
+            return result
+    return result

--- a/stdlib/test/builtin/test_math.mojo
+++ b/stdlib/test/builtin/test_math.mojo
@@ -84,6 +84,26 @@ def test_pow():
     assert_equal(pow(I(0, 1, 2, 3), int(2)), I(0, 1, 4, 9))
 
 
+def test_gcd():
+    var l = List(2, 4, 6, 8, 16)
+    var il = InlineArray[Int, 5](4, 16, 2, 8, 6)
+    assert_equal(gcd(Span(il)), 2)
+    assert_equal(gcd(2, 4, 6, 8, 16), 2)
+    assert_equal(gcd(l), 2)
+    assert_equal(gcd(88, 24), 8)
+    assert_equal(gcd(0, 0), 0)
+    assert_equal(gcd(1, 0), 1)
+    assert_equal(gcd(-2, 4), 2)
+    assert_equal(gcd(-2, -4), 2)
+    assert_equal(gcd(24826148, 45296490), 526)
+    assert_equal(gcd(0, 9), 9)
+    assert_equal(gcd(4, 4), 4)
+    assert_equal(gcd(8), 8)
+    assert_equal(gcd(), 0)
+    assert_equal(gcd(List[Int]()), 0)
+    assert_equal(gcd(List(16)), 16)
+
+
 def main():
     test_abs()
     test_divmod()
@@ -91,3 +111,4 @@ def main():
     test_min()
     test_round()
     test_pow()
+    test_gcd()


### PR DESCRIPTION
The `gcd` implementation in Python accepts a variadic list of integers. The existing mojo implementation lives in the closed source part of the stdlib and I see the comment mentioning that the open source module cannot depend on the closed source one so I've written a simple one here.

Since mojo does not support unpacking a `List` into a `VariadicList` I've also included a couple overloads to support the `List` and `Span` types as well.

The existing `gcd` implementation also does not have matching behaviour when negative integers are used.