### PR TITLE
[stdlib] Rename `InlinedFixedVector` to `Vector`

### DIFF
--- a/stdlib/src/collections/__init__.mojo
+++ b/stdlib/src/collections/__init__.mojo
@@ -17,7 +17,4 @@ from .inline_list import InlineList
 from .list import List
 from .optional import Optional, OptionalReg
 from .set import Set
-from .vector import (
-    CollectionElement,
-    InlinedFixedVector,
-)
+from .vector import CollectionElement, Vector

--- a/stdlib/src/collections/vector.mojo
+++ b/stdlib/src/collections/vector.mojo
@@ -10,12 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-"""Defines InlinedFixedVector.
+"""Defines Vector.
 
 You can import these APIs from the `collections` package. For example:
 
 ```mojo
-from collections.vector import InlinedFixedVector
+from collections.vector import Vector
 ```
 """
 
@@ -48,7 +48,7 @@ struct _VecIter[
 
 
 # ===----------------------------------------------------------------------===#
-# InlinedFixedVector
+# Vector
 # ===----------------------------------------------------------------------===#
 
 
@@ -61,20 +61,18 @@ fn _calculate_fixed_vector_default_size[type: AnyRegType]() -> Int:
     if sizeof_type >= 256:
         return 0
 
-    alias prefered_inline_bytes = prefered_bytecount - sizeof[
-        InlinedFixedVector[type, 0]
-    ]()
+    alias prefered_inline_bytes = prefered_bytecount - sizeof[Vector[type, 0]]()
     alias num_elements = prefered_inline_bytes // sizeof_type
     return num_elements or 1
 
 
-struct InlinedFixedVector[
+struct Vector[
     type: AnyRegType, size: Int = _calculate_fixed_vector_default_size[type]()
 ](Sized):
     """A dynamically-allocated vector with small-vector optimization and a fixed
     maximum capacity.
 
-    The `InlinedFixedVector` does not resize or implement bounds checks. It is
+    The `Vector` does not resize or implement bounds checks. It is
     initialized with both a small-vector size (specified at compile time) and a
     maximum capacity (specified at runtime).
 
@@ -108,7 +106,7 @@ struct InlinedFixedVector[
 
     @always_inline
     fn __init__(inout self, capacity: Int):
-        """Constructs `InlinedFixedVector` with the given capacity.
+        """Constructs `Vector` with the given capacity.
 
         The dynamically allocated portion is `capacity - size`.
 
@@ -129,7 +127,7 @@ struct InlinedFixedVector[
         """Creates a shallow copy (doesn't copy the underlying elements).
 
         Args:
-            existing: The `InlinedFixedVector` to copy.
+            existing: The `Vector` to copy.
         """
         self.static_data = existing.static_data
         self.dynamic_data = existing.dynamic_data

--- a/stdlib/test/collections/test_vector.mojo
+++ b/stdlib/test/collections/test_vector.mojo
@@ -12,14 +12,14 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo %s
 
-from collections.vector import InlinedFixedVector
+from collections.vector import Vector
 
 from test_utils import MoveCounter
 from testing import assert_equal
 
 
 def test_inlined_fixed_vector():
-    var vector = InlinedFixedVector[Int, 5](10)
+    var vector = Vector[Int, 5](10)
 
     for i in range(5):
         vector.append(i)
@@ -73,12 +73,12 @@ def test_inlined_fixed_vector():
     vector.clear()
     assert_equal(0, len(vector))
 
-    # Free the memory since we manage it ourselves in `InlinedFixedVector` for now.
+    # Free the memory since we manage it ourselves in `Vector` for now.
     vector._del_old()
 
 
 def test_inlined_fixed_vector_with_default():
-    var vector = InlinedFixedVector[Int](10)
+    var vector = Vector[Int](10)
 
     for i in range(5):
         vector.append(i)
@@ -110,7 +110,7 @@ def test_inlined_fixed_vector_with_default():
 
 
 def test_indexing():
-    var vector = InlinedFixedVector[Int](10)
+    var vector = Vector[Int](10)
     for i in range(5):
         vector.append(i)
     assert_equal(1, vector[Int16(1)])


### PR DESCRIPTION
First stage to renaming `InlinedFixedVector` to `Vector` as per issue #2773