### PR TITLE
[stdlib] Add `StringRef` constructor from `String`

### DIFF
--- a/stdlib/src/utils/stringref.mojo
+++ b/stdlib/src/utils/stringref.mojo
@@ -171,6 +171,18 @@ struct StringRef(
         return StringRef(ptr.bitcast[DType.int8](), len)
 
     @always_inline
+    fn __init__(str: String) -> StringRef:
+        """Construct a StringRef value given a string.
+
+        Args:
+            str: The input string.
+
+        Returns:
+            Constructed `StringRef` object.
+        """
+        return StringRef(str.unsafe_uint8_ptr(), len(str))
+
+    @always_inline
     fn unsafe_ptr(self) -> UnsafePointer[UInt8]:
         """Retrieves a pointer to the underlying memory.
 

--- a/stdlib/test/builtin/test_stringref.mojo
+++ b/stdlib/test/builtin/test_stringref.mojo
@@ -17,6 +17,15 @@ from testing import assert_equal, assert_true, assert_false, assert_raises
 from utils import StringRef
 
 
+def test_strref_string_constructor():
+    var s = String("abc")
+    var s_ref = StringRef(s)
+
+    assert_equal(s_ref, "abc")
+
+    _ = s
+
+
 def test_strref_from_start():
     var str = StringRef("Hello")
 
@@ -87,3 +96,4 @@ def main():
     test_comparison_operators()
     test_intable()
     test_indexing()
+    test_strref_string_constructor()


### PR DESCRIPTION
This PR adds a constructor for `StringRef` from `String`.

Current nightly version of stdlib supports constructing `StringRef` from `String` by getting the unsafe pointer:
```mojo
var s_ref = StringRef(s.unsafe_uint8_ptr())
```
Now the `StringRef` can be constructed from a `String`:
```mojo
var s_ref = StringRef(s)
```

However, not sure if this is done right, because this construction can be very unsafe as there are no lifetime guarantees in `StringRef`.