### PR TITLE
[stdlib] Fix: Add null terminator to the buffer inside `__str__` method

### DIFF
--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -627,7 +627,9 @@ struct Dict[K: KeyElement, V: CollectionElement](
             A string representation of the Dict.
         """
         var minimum_capacity = self._minimum_size_of_string_representation()
-        var result = String(List[UInt8](capacity=minimum_capacity))
+        var string_buffer = List[UInt8](capacity=minimum_capacity)
+        string_buffer.append(0)  # Null terminator
+        var result = String(string_buffer^)
         result += "{"
 
         var i = 0

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -719,7 +719,9 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             + len(self) * 3  # str(x) and ", "
             - 2  # remove the last ", "
         )
-        var result = String(List[UInt8](capacity=minimum_capacity))
+        var string_buffer = List[UInt8](capacity=minimum_capacity)
+        string_buffer.append(0)  # Null terminator
+        var result = String(string_buffer^)
         result += "["
         for i in range(len(self)):
             result += repr(self[i])


### PR DESCRIPTION
String really has a hard time working without this null terminator and I feel this PR is a step towards fixing https://github.com/modularml/mojo/issues/2687 without requirering controversial changes like the ones in https://github.com/modularml/mojo/pull/2691.