### PR TITLE
[stdlib] mark dict entry as destroyed in `Dict.pop()`

### DIFF
--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -216,6 +216,15 @@ struct DictEntry[K: KeyElement, V: CollectionElement](
         self.key = other.key
         self.value = other.value
 
+    fn reap_value(owned self) -> V:
+        """Take the value from an owned entry.
+
+        Returns:
+            The value of the entry.
+        """
+        __mlir_op.`lit.ownership.mark_destroyed`(__get_mvalue_as_litref(self))
+        return self.value^
+
 
 alias _EMPTY = -1
 alias _REMOVED = -2
@@ -813,7 +822,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
             var entry_value = entry[].unsafe_take()
             entry[] = None
             self.size -= 1
-            return entry_value.value^
+            return entry_value^.reap_value()
         raise "KeyError"
 
     fn popitem(inout self) raises -> DictEntry[K, V]:

--- a/stdlib/test/collections/test_dict.mojo
+++ b/stdlib/test/collections/test_dict.mojo
@@ -538,6 +538,21 @@ def test_dict_popitem():
         _ = dict.popitem()
 
 
+def test_pop_string_values():
+    var dict = Dict[String, String]()
+    dict["mojo"] = "lang"
+    dict["max"] = "engine"
+    dict["a"] = ""
+    dict[""] = "a"
+
+    assert_equal(dict.pop("mojo"), "lang")
+    assert_equal(dict.pop("max"), "engine")
+    assert_equal(dict.pop("a"), "")
+    assert_equal(dict.pop(""), "a")
+    with assert_raises(contains="KeyError"):
+        _ = dict.pop("absent")
+
+
 fn test_clear() raises:
     var some_dict = Dict[String, Int]()
     some_dict["key"] = 1
@@ -594,6 +609,7 @@ def main():
     test_owned_kwargs_dict()
     test_bool_conversion()
     test_find_get()
+    test_pop_string_values()
     test_clear()
     test_init_initial_capacity()
     test_dict_setdefault()


### PR DESCRIPTION
see [#2756](https://github.com/modularml/mojo/issues/2756)
this is an attempt to fix errors that sometimes arise when using the pop method. I'm not sure this is the best way, so feedback is much appreciated