### PR TITLE
[stdlib] Add `assert_is()` and `assert_is_not()` functions

### DIFF
--- a/stdlib/src/builtin/identifiable.mojo
+++ b/stdlib/src/builtin/identifiable.mojo
@@ -1,0 +1,52 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+
+trait Identifiable:
+    """The Identifiable trait denotes a type with an identity
+    which can be compared with other instances of itself.
+    """
+
+    fn __is__(self, rhs: Self) -> Bool:
+        """Define whether `self` has the same identity as `rhs`.
+
+        Args:
+            rhs: The right hand side of the comparison.
+
+        Returns:
+            True if `self` is `rhs`.
+        """
+        ...
+
+    fn __isnot__(self, rhs: Self) -> Bool:
+        """Define whether `self` has a different identity than `rhs`.
+
+        Args:
+            rhs: The right hand side of the comparison.
+
+        Returns:
+            True if `self` is not `rhs`.
+        """
+        ...
+
+
+trait StringableIdentifiable(Stringable, Identifiable):
+    """The StringableIdentifiable trait denotes a trait composition
+    of the `Stringable` and `Identifiable` traits.
+
+    This is useful to have as a named entity since Mojo does not
+    currently support anonymous trait compositions to constrain
+    on `Stringable & Identifiable` in the parameter.
+    """
+
+    pass

--- a/stdlib/src/testing/__init__.mojo
+++ b/stdlib/src/testing/__init__.mojo
@@ -20,4 +20,6 @@ from .testing import (
     assert_not_equal,
     assert_almost_equal,
     assert_raises,
+    assert_is,
+    assert_is_not,
 )

--- a/stdlib/src/testing/testing.mojo
+++ b/stdlib/src/testing/testing.mojo
@@ -133,7 +133,9 @@ fn assert_equal[T: Testable](lhs: T, rhs: T, msg: String = "") raises:
         An Error with the provided message if assert fails and `None` otherwise.
     """
     if lhs != rhs:
-        raise _assert_equal_error(str(lhs), str(rhs), msg, __call_location())
+        raise _assert_cmp_error["`left == right` comparison"](
+            str(lhs), str(rhs), msg, __call_location()
+        )
 
 
 # TODO: Remove the String and SIMD overloads once we have more powerful traits.
@@ -151,7 +153,9 @@ fn assert_equal(lhs: String, rhs: String, msg: String = "") raises:
         An Error with the provided message if assert fails and `None` otherwise.
     """
     if lhs != rhs:
-        raise _assert_equal_error(lhs, rhs, msg, __call_location())
+        raise _assert_cmp_error["`left == right` comparison"](
+            lhs, rhs, msg, __call_location()
+        )
 
 
 @always_inline
@@ -174,7 +178,9 @@ fn assert_equal[
         An Error with the provided message if assert fails and `None` otherwise.
     """
     if any(lhs != rhs):
-        raise _assert_equal_error(str(lhs), str(rhs), msg, __call_location())
+        raise _assert_cmp_error["`left == right` comparison"](
+            str(lhs), str(rhs), msg, __call_location()
+        )
 
 
 @always_inline
@@ -194,7 +200,7 @@ fn assert_not_equal[T: Testable](lhs: T, rhs: T, msg: String = "") raises:
         An Error with the provided message if assert fails and `None` otherwise.
     """
     if lhs == rhs:
-        raise _assert_not_equal_error(
+        raise _assert_cmp_error["`left != right` comparison"](
             str(lhs), str(rhs), msg, __call_location()
         )
 
@@ -213,7 +219,9 @@ fn assert_not_equal(lhs: String, rhs: String, msg: String = "") raises:
         An Error with the provided message if assert fails and `None` otherwise.
     """
     if lhs == rhs:
-        raise _assert_not_equal_error(lhs, rhs, msg, __call_location())
+        raise _assert_cmp_error["`left != right` comparison"](
+            lhs, rhs, msg, __call_location()
+        )
 
 
 @always_inline
@@ -236,7 +244,7 @@ fn assert_not_equal[
         An Error with the provided message if assert fails and `None` otherwise.
     """
     if all(lhs == rhs):
-        raise _assert_not_equal_error(
+        raise _assert_cmp_error["`left != right` comparison"](
             str(lhs), str(rhs), msg, __call_location()
         )
 
@@ -302,29 +310,64 @@ fn assert_almost_equal[
         raise _assert_error(err, __call_location())
 
 
-fn _assert_equal_error(
-    lhs: String, rhs: String, msg: String, loc: _SourceLocation
-) -> String:
-    var err = (
-        "`left == right` comparison failed:\n   left: "
-        + lhs
-        + "\n  right: "
-        + rhs
-    )
-    if msg:
-        err += "\n  reason: " + msg
-    return _assert_error(err, loc)
+@always_inline
+fn assert_is[
+    T: StringableIdentifiable
+](lhs: T, rhs: T, msg: String = "") raises:
+    """Asserts that the input values have the same identity. If they do not
+    then an Error is raised.
+
+    Parameters:
+        T: A StringableIdentifiable type.
+
+    Args:
+        lhs: The lhs of the `is` statement.
+        rhs: The rhs of the `is` statement.
+        msg: The message to be printed if the assertion fails.
+
+    Raises:
+        An Error with the provided message if assert fails and `None` otherwise.
+    """
+    if lhs is not rhs:
+        raise _assert_cmp_error["`left is right` identification"](
+            str(lhs),
+            str(rhs),
+            msg,
+            __call_location(),
+        )
 
 
-fn _assert_not_equal_error(
-    lhs: String, rhs: String, msg: String, loc: _SourceLocation
-) -> String:
-    var err = (
-        "`left != right` comparison failed:\n   left: "
-        + lhs
-        + "\n  right: "
-        + rhs
-    )
+@always_inline
+fn assert_is_not[
+    T: StringableIdentifiable
+](lhs: T, rhs: T, msg: String = "") raises:
+    """Asserts that the input values have different identities. If they do not
+    then an Error is raised.
+
+    Parameters:
+        T: A StringableIdentifiable type.
+
+    Args:
+        lhs: The lhs of the `is not` statement.
+        rhs: The rhs of the `is not` statement.
+        msg: The message to be printed if the assertion fails.
+
+    Raises:
+        An Error with the provided message if assert fails and `None` otherwise.
+    """
+    if lhs is rhs:
+        raise _assert_cmp_error["`left is not right` identification"](
+            str(lhs),
+            str(rhs),
+            msg,
+            __call_location(),
+        )
+
+
+fn _assert_cmp_error[
+    cmp: String
+](lhs: String, rhs: String, msg: String, loc: _SourceLocation) -> String:
+    var err = (cmp + " failed:\n   left: " + lhs + "\n  right: " + rhs)
     if msg:
         err += "\n  reason: " + msg
     return _assert_error(err, loc)

--- a/stdlib/test/testing/test_assertion.mojo
+++ b/stdlib/test/testing/test_assertion.mojo
@@ -19,6 +19,8 @@ from testing import (
     assert_not_equal,
     assert_raises,
     assert_true,
+    assert_is,
+    assert_is_not,
 )
 
 from utils.numerics import inf, nan
@@ -63,22 +65,22 @@ def test_assert_messages():
     try:
         assert_true(False)
     except e:
-        assert_true("test_assertion.mojo:64:20: AssertionError:" in str(e))
+        assert_true("test_assertion.mojo:66:20: AssertionError:" in str(e))
 
     try:
         assert_false(True)
     except e:
-        assert_true("test_assertion.mojo:69:21: AssertionError:" in str(e))
+        assert_true("test_assertion.mojo:71:21: AssertionError:" in str(e))
 
     try:
         assert_equal(1, 0)
     except e:
-        assert_true("test_assertion.mojo:74:21: AssertionError:" in str(e))
+        assert_true("test_assertion.mojo:76:21: AssertionError:" in str(e))
 
     try:
         assert_not_equal(0, 0)
     except e:
-        assert_true("test_assertion.mojo:79:25: AssertionError:" in str(e))
+        assert_true("test_assertion.mojo:81:25: AssertionError:" in str(e))
 
 
 def test_assert_almost_equal():
@@ -181,9 +183,23 @@ def test_assert_almost_equal():
     )
 
 
+def test_assert_is():
+    var a = PythonObject("mojo")
+    var b = a
+    assert_is(a, b)
+
+
+def test_assert_is_not():
+    var a = PythonObject("mojo")
+    var b = PythonObject("mojo")
+    assert_is_not(a, b)
+
+
 def main():
     test_assert_equal_is_generic()
     test_assert_not_equal_is_generic()
     test_assert_equal_with_simd()
     test_assert_messages()
     test_assert_almost_equal()
+    test_assert_is()
+    test_assert_is_not()


### PR DESCRIPTION
Adds functions for asserting identity comparisons, along with some helper traits to make it possible.
Having the address information in the error message isn't always helpful, but sometimes it is.