### PR TITLE
[stdlib] Change Tuple.__contains__ to T:EqualityComparable instead of T:ComparableCollectionElement

### DIFF
--- a/stdlib/src/builtin/tuple.mojo
+++ b/stdlib/src/builtin/tuple.mojo
@@ -190,7 +190,7 @@ struct Tuple[*element_types: Movable](Sized, Movable):
         return rebind[T](self[i])
 
     @always_inline("nodebug")
-    fn __contains__[T: ComparableCollectionElement](self, value: T) -> Bool:
+    fn __contains__[T: EqualityComparable](self, value: T) -> Bool:
         """Verify if a given value is present in the tuple.
 
         ```mojo
@@ -203,7 +203,7 @@ struct Tuple[*element_types: Movable](Sized, Movable):
 
         Parameters:
             T: The type of the value argument. Must implement the
-              trait `ComparableCollectionElement`.
+              trait `EqualityComparable`.
 
         Returns:
             True if the value is contained in the tuple, False otherwise.


### PR DESCRIPTION
Hello,

`ComparableCollectionElement` requires many methods unused by `Tuple.__contains__`:

*1️⃣`__eq__`, 2️⃣`__ne__`, 3️⃣`__gt__`, 4️⃣`__ge__`, 5️⃣`__lt__`, 6️⃣`__le__`, `7️⃣__copyinit__`, `8️⃣__moveinit__`*.

&nbsp;

`Tuple.__contains__` only uses 1️⃣`__eq__` and  `EqualityComparable`  requires 1️⃣`__eq__`, 2️⃣`__ne__`.

&nbsp;

That way, users can easily create types ready for `Tuple.__contains__` if needed, for example:
```mojo
@value
struct MyStruct(EqualityComparable):
    alias A = MyStruct(True)
    alias B = MyStruct(False)
    var value:Bool
    fn __eq__(self,other:Self)->Bool: return self.value==other.value # ✅1️⃣
    fn __ne__(self,other:Self)->Bool: return not self==other # ✅2️⃣

fn SomeTuple()-> (MyStruct, Int):
    return (MyStruct.A,1)

fn main():
    if MyStruct.A in SomeTuple():
        print("A")
```

&nbsp;

#### Note
It is possible to create `EqualityComparableCollectionElement`, is it needed ?

&nbsp;