### PR TITLE
[stdlib] List __getitem__ returns auto-dereferenced ref

### DIFF
--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -64,10 +64,10 @@ struct _ListIter[
         @parameter
         if forward:
             self.index += 1
-            return self.src[].__get_ref(self.index - 1)[]
+            return self.src[][self.index - 1]
         else:
             self.index -= 1
-            return self.src[].__get_ref(self.index)[]
+            return self.src[][self.index]
 
     fn __len__(self) -> Int:
         @parameter
@@ -722,10 +722,11 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         return res^
 
     @always_inline
-    fn __getitem__(self, idx: Int) -> T:
+    fn __getitem__(
+        self: Reference[Self, _, _], idx: Int
+    ) -> ref [self.lifetime] T:
         """Gets a copy of the list element at the given index.
 
-        FIXME(lifetimes): This should return a reference, not a copy!
 
         Args:
             idx: The index of the element.
@@ -735,13 +736,13 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         """
         var normalized_idx = idx
         debug_assert(
-            -self.size <= normalized_idx < self.size,
+            -self[].size <= normalized_idx < self[].size,
             "index must be within bounds",
         )
         if normalized_idx < 0:
-            normalized_idx += len(self)
+            normalized_idx += len(self[])
 
-        return (self.data + normalized_idx)[]
+        return (self[].data + normalized_idx)[]
 
     # TODO(30737): Replace __getitem__ with this, but lots of places use it
     fn __get_ref(

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -722,9 +722,7 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         return res^
 
     @always_inline
-    fn __getitem__(
-        self: Reference[Self, _, _], idx: Int
-    ) -> ref [self.lifetime] T:
+    fn __getitem__(ref [_]self, idx: Int) -> ref [__lifetime_of(self)] T:
         """Gets the list element at the given index.
 
 
@@ -736,13 +734,13 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         """
         var normalized_idx = idx
         debug_assert(
-            -self[].size <= normalized_idx < self[].size,
+            -self.size <= normalized_idx < self.size,
             "index must be within bounds",
         )
         if normalized_idx < 0:
-            normalized_idx += len(self[])
+            normalized_idx += len(self)
 
-        return (self[].data + normalized_idx)[]
+        return (self.data + normalized_idx)[]
 
     # TODO(30737): Replace __getitem__ with this, but lots of places use it
     fn __get_ref(

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -725,14 +725,14 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
     fn __getitem__(
         self: Reference[Self, _, _], idx: Int
     ) -> ref [self.lifetime] T:
-        """Gets a copy of the list element at the given index.
+        """Gets the list element at the given index.
 
 
         Args:
             idx: The index of the element.
 
         Returns:
-            A copy of the element at the given index.
+            The element at the given index.
         """
         var normalized_idx = idx
         debug_assert(

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -522,7 +522,8 @@ def test_2d_dynamic_list():
     assert_equal(2, list.capacity)
 
 
-def test_list_explicit_copy():
+# TODO(30737): remove this test along with other __get_ref() uses.
+def test_list_explicit_copy_using_get_ref():
     var list = List[CopyCounter]()
     list.append(CopyCounter())
     var list_copy = List(list)
@@ -537,6 +538,51 @@ def test_list_explicit_copy():
     assert_equal(len(l2), len(l2_copy))
     for i in range(len(l2)):
         assert_equal(l2[i], l2_copy[i])
+
+
+def test_list_explicit_copy():
+    var list = List[CopyCounter]()
+    list.append(CopyCounter())
+    var list_copy = List(list)
+    assert_equal(0, list[0].copy_count)
+    assert_equal(1, list_copy[0].copy_count)
+
+    var l2 = List[Int]()
+    for i in range(10):
+        l2.append(i)
+
+    var l2_copy = List(l2)
+    assert_equal(len(l2), len(l2_copy))
+    for i in range(len(l2)):
+        assert_equal(l2[i], l2_copy[i])
+
+
+@value
+struct CopyCountedStruct(CollectionElement):
+    var counter: CopyCounter
+    var value: String
+
+    fn __init__(inout self, value: String):
+        self.counter = CopyCounter()
+        self.value = value
+
+
+def test_no_extra_copies_with_sugared_set_by_field():
+    var list = List[List[CopyCountedStruct]](capacity=1)
+    var child_list = List[CopyCountedStruct](capacity=2)
+    child_list.append(CopyCountedStruct("Hello"))
+    child_list.append(CopyCountedStruct("World"))
+
+    # No copies here.  Contructing with List[CopyCountedStruct](CopyCountedStruct("Hello")) is a copy.
+    assert_equal(0, child_list[0].counter.copy_count)
+    assert_equal(0, child_list[1].counter.copy_count)
+    list.append(child_list^)
+
+    list[0][1].value = "Mojo"
+    assert_equal("Mojo", list[0][1].value)
+
+    assert_equal(0, list[0][0].counter.copy_count)
+    assert_equal(0, list[0][1].counter.copy_count)
 
 
 # Ensure correct behavior of __copyinit__
@@ -802,7 +848,9 @@ def main():
     test_list_index()
     test_list_extend()
     test_list_extend_non_trivial()
+    test_list_explicit_copy_using_get_ref()
     test_list_explicit_copy()
+    test_no_extra_copies_with_sugared_set_by_field()
     test_list_copy_constructor()
     test_2d_dynamic_list()
     test_list_iter()


### PR DESCRIPTION
With this, `List.__getitem__()` no longer makes copies when returning a value.  I also added a test to show that setting an individual field using sugared `my_list[0].value = 1` no longer produces extra copies.  Passing that test is why `__getitem__` receives a `Reference[Self, ...]` argument rather than just `self`.

I removed uses of `__get_ref` in `list.mojo` and `test_list.mojo` other than leaving one test to show that `__get_ref` was still functioning correctly until it is removed.  I left usage of `List.__get_ref` in other modules untouched. From a few quick efforts to eliminate `__get_ref` it was leading to some lifetime casting decisions that seemed complex and numerous enough they should be handled separately.

This supersedes #2544 which I will close. It should close #2432 and #2540 as `__refitem__` and it related difficulties are no longer relevant.