### PR TITLE
[stdlib] Fix draft for 2756 (not to merge), changes DictEntry.value:V to DictEntry.value: Optional[V] 

### DIFF
--- a/stdlib/src/builtin/object.mojo
+++ b/stdlib/src/builtin/object.mojo
@@ -575,7 +575,7 @@ struct _ObjectImpl(CollectionElement, Stringable):
                 "'"
                 + str(entry[].key)
                 + "' = "
-                + str(object(entry[].value.copy()))
+                + str(object(entry[].value.value()[].copy()))
             )
             print_sep = True
         res += "}"

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -682,7 +682,9 @@ struct Dict[K: KeyElement, V: CollectionElement](
 
         var i = 0
         for key_value in self.items():
-            result += repr(key_value[].key) + ": " + repr(key_value[].value.value()[])
+            result += (
+                repr(key_value[].key) + ": " + repr(key_value[].value.value()[])
+            )
             if i < len(self) - 1:
                 result += ", "
             i += 1

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -793,11 +793,9 @@ struct Dict[K: KeyElement, V: CollectionElement](
             self._set_index(slot, Self.REMOVED)
             var entry = self._entries.__get_ref(index)
             debug_assert(entry[].__bool__(), "entry in index must be full")
-            var entry_value = entry[].unsafe_take()
-
+            var ret_val = entry[].value()[].value.unsafe_take()
             entry[] = None
             self.size -= 1
-            var ret_val = entry_value.value.unsafe_take()
             return ret_val^
         elif default:
             return default.value()[]

--- a/stdlib/src/python/object.mojo
+++ b/stdlib/src/python/object.mojo
@@ -308,7 +308,9 @@ struct PythonObject(
         self.py_object = cpython.PyDict_New()
         for entry in value.items():
             var result = cpython.PyDict_SetItem(
-                self.py_object, entry[].key.py_object, entry[].value.value()[].py_object
+                self.py_object,
+                entry[].key.py_object,
+                entry[].value.value()[].py_object,
             )
 
     fn __copyinit__(inout self, existing: Self):

--- a/stdlib/src/python/object.mojo
+++ b/stdlib/src/python/object.mojo
@@ -308,7 +308,7 @@ struct PythonObject(
         self.py_object = cpython.PyDict_New()
         for entry in value.items():
             var result = cpython.PyDict_SetItem(
-                self.py_object, entry[].key.py_object, entry[].value.py_object
+                self.py_object, entry[].key.py_object, entry[].value.value()[].py_object
             )
 
     fn __copyinit__(inout self, existing: Self):
@@ -1101,7 +1101,7 @@ struct PythonObject(
         for entry in kwargs.items():
             var key = cpython.toPython(entry[].key._strref_dangerous())
             var result = cpython.PyDict_SetItem(
-                dict_obj, key, entry[].value.py_object
+                dict_obj, key, entry[].value.value()[].py_object
             )
             if result != 0:
                 raise Error("internal error: PyDict_SetItem failed")

--- a/stdlib/test/builtin/test_reversed.mojo
+++ b/stdlib/test/builtin/test_reversed.mojo
@@ -47,7 +47,7 @@ def test_reversed_dict():
     check = 4
     for item in reversed(dict.items()):
         keys += item[].key
-        assert_equal(item[].value, check)
+        assert_equal(item[].value.value()[], check)
         check -= 1
 
     assert_equal(keys, "dcba")
@@ -81,7 +81,7 @@ def test_reversed_dict():
     check = 4
     for item in reversed(dict.items()):
         keys += item[].key
-        assert_equal(item[].value, check)
+        assert_equal(item[].value.value()[], check)
         check -= 2
 
     assert_equal(keys, "db")
@@ -98,7 +98,7 @@ def test_reversed_dict():
     check = 1
     for item in reversed(dict.items()):
         keys += item[].key
-        assert_equal(item[].value, check)
+        assert_equal(item[].value.value()[], check)
         check += 1
 
     assert_equal(keys, "acdb")
@@ -124,7 +124,7 @@ def test_reversed_dict():
     check = 0
     for item in reversed(empty_dict.items()):
         keys += item[].key
-        check += item[].value
+        check += item[].value.value()[]
 
     assert_equal(keys, "")
     assert_equal(check, 0)

--- a/stdlib/test/collections/test_dict.mojo
+++ b/stdlib/test/collections/test_dict.mojo
@@ -36,7 +36,7 @@ def test_dict_fromkeys():
 
     for k_v in expected_dict.items():
         var k = k_v[].key
-        var v = k_v[].value
+        var v = k_v[].value.value()[]
         assert_true(k in dict)
         assert_equal(dict[k], v)
 
@@ -53,7 +53,7 @@ def test_dict_fromkeys_optional():
 
     for k_v in expected_dict.items():
         var k = k_v[].key
-        var v = k_v[].value
+        var v = k_v[].value.value()[]
         assert_true(k in dict)
         assert_false(v)
 
@@ -219,7 +219,7 @@ def test_iter_items():
     var sum = 0
     for entry in dict.items():
         keys += entry[].key
-        sum += entry[].value
+        sum += entry[].value.value()[]
 
     assert_equal(keys, "ab")
     assert_equal(sum, 3)
@@ -491,7 +491,7 @@ def test_taking_owned_kwargs_dict(owned kwargs: OwnedKwargsDict[Int]):
     sum = 0
     for entry in kwargs.items():
         keys += entry[].key
-        sum += entry[].value
+        sum += entry[].value.value()[]
     assert_equal(keys, "dessertsalad")
     assert_equal(sum, 19)
 
@@ -523,6 +523,18 @@ fn test_clear() raises:
     some_dict.clear()
     assert_equal(len(some_dict), 0)
 
+def issue_2756():
+    var context = Dict[String, String]()
+    context["a"] = "b"
+    print(context.pop("a"))
+
+    var context_assert = Dict[String, String]()
+    context_assert["a"] = "b"
+    assert_equal(context_assert.pop("a"),"b")
+
+    var context2 = Dict[String, StringLiteral]()
+    context2["a"] = "b"
+    assert_equal(context2.pop("a"),"b")
 
 def main():
     test_dict()
@@ -534,3 +546,4 @@ def main():
     test_bool_conversion()
     test_find_get()
     test_clear()
+    issue_2756()

--- a/stdlib/test/collections/test_dict.mojo
+++ b/stdlib/test/collections/test_dict.mojo
@@ -523,6 +523,7 @@ fn test_clear() raises:
     some_dict.clear()
     assert_equal(len(some_dict), 0)
 
+
 def issue_2756():
     var context = Dict[String, String]()
     context["a"] = "b"
@@ -530,11 +531,12 @@ def issue_2756():
 
     var context_assert = Dict[String, String]()
     context_assert["a"] = "b"
-    assert_equal(context_assert.pop("a"),"b")
+    assert_equal(context_assert.pop("a"), "b")
 
     var context2 = Dict[String, StringLiteral]()
     context2["a"] = "b"
-    assert_equal(context2.pop("a"),"b")
+    assert_equal(context2.pop("a"), "b")
+
 
 def main():
     test_dict()


### PR DESCRIPTION
Hello,

This PR is just to help designing a solution for https://github.com/modularml/mojo/issues/2756 ,

It also makes the `Dict.pop` return the `DictEntry.value` as an owned value by moving the value.

But making it an `Optional could affect the performance, and add complexity to the Dict.

(See feature request https://github.com/modularml/mojo/issues/2822 for another approach)

 &nbsp;

The good part is that is seem to fix the https://github.com/modularml/mojo/issues/2756, so at least we know what could be the problem.

This PR is quite a design change, but it can be used by staff to see if it fixes some bugs

I don't recommend this solution that adds an Optional, but could be wrong !

Hope it is useful 👍