### PR TITLE
[stdlib] Add __copyinit__ & __moveinit__ for InlineList

### DIFF
--- a/stdlib/src/collections/inline_list.mojo
+++ b/stdlib/src/collections/inline_list.mojo
@@ -72,7 +72,7 @@ struct _InlineListIter[
 
 
 # TODO: Provide a smarter default for the capacity.
-struct InlineList[ElementType: CollectionElement, capacity: Int = 16](Sized):
+struct InlineList[ElementType: CollectionElement, capacity: Int = 16](Sized, CollectionElement):
     """A list allocated on the stack with a maximum size known at compile time.
 
     It is backed by an `InlineArray` and an `Int` to represent the size.

--- a/stdlib/src/collections/inline_list.mojo
+++ b/stdlib/src/collections/inline_list.mojo
@@ -111,6 +111,26 @@ struct InlineList[ElementType: CollectionElement, capacity: Int = 16](Sized):
         for value in values:
             self.append(value[])
 
+    fn __copyinit__(inout self, existing: Self):
+        """Creates a deepcopy of the given list.
+
+        Args:
+            existing: The list to copy.
+        """
+
+        self = Self()
+        for i in range(len(existing)):
+            self.append(existing[i])
+
+    fn __moveinit__(inout self, owned existing: Self):
+        """Move data of an existing list into a new one.
+
+        Args:
+            existing: The existing list.
+        """
+        self._array = existing._array
+        self._size = existing._size
+
     @always_inline
     fn __len__(self) -> Int:
         """Returns the length of the list."""

--- a/stdlib/src/collections/inline_list.mojo
+++ b/stdlib/src/collections/inline_list.mojo
@@ -112,7 +112,7 @@ struct InlineList[ElementType: CollectionElement, capacity: Int = 16](Sized):
             self.append(value[])
 
     fn __copyinit__(inout self, existing: Self):
-        """Creates a deepcopy of the given list.
+        """Creates a copy of the given list.
 
         Args:
             existing: The list to copy.

--- a/stdlib/src/collections/inline_list.mojo
+++ b/stdlib/src/collections/inline_list.mojo
@@ -72,7 +72,9 @@ struct _InlineListIter[
 
 
 # TODO: Provide a smarter default for the capacity.
-struct InlineList[ElementType: CollectionElement, capacity: Int = 16](Sized, CollectionElement):
+struct InlineList[ElementType: CollectionElement, capacity: Int = 16](
+    Sized, CollectionElement
+):
     """A list allocated on the stack with a maximum size known at compile time.
 
     It is backed by an `InlineArray` and an `Int` to represent the size.

--- a/stdlib/test/collections/test_inline_list.mojo
+++ b/stdlib/test/collections/test_inline_list.mojo
@@ -164,6 +164,22 @@ def test_indexing():
     assert_equal(list[0], 0)
 
 
+def test_list_copy_constructor():
+    var vec = InlineList[Int](1, 2, 3)
+    var vec_copy = vec
+    assert_equal(vec_copy[0], 1)
+    assert_equal(vec_copy[1], 2)
+    assert_equal(vec_copy[2], 3)
+
+
+def test_list_move_constructor():
+    var vec = InlineList[Int](1, 2, 3)
+    var vec_move = vec^
+    assert_equal(vec_move[0], 1)
+    assert_equal(vec_move[1], 2)
+    assert_equal(vec_move[2], 3)
+
+
 def main():
     test_list()
     test_append_triggers_a_move()
@@ -175,3 +191,5 @@ def main():
     test_list_count()
     test_list_boolable()
     test_indexing()
+    test_list_copy_constructor()
+    test_list_move_constructor()


### PR DESCRIPTION
Do we need `__copyinit__` & `__moveinit__` for InlineList?