### PR TITLE
[docs] add closing mojo code block in types page

### DIFF
--- a/docs/manual/types.ipynb
+++ b/docs/manual/types.ipynb
@@ -648,6 +648,7 @@
     "  ```mojo\n",
     "  # Doesn't work!\n",
     "  var list: List[Int] = [2, 3, 5]\n",
+    "  ```\n",
     "\n",
     "  But you can use variadic arguments to achieve the same thing:\n",
     "\n",


### PR DESCRIPTION
### Summary

The [types](https://docs.modular.com/mojo/manual/types) page displays a spurious **```mojo** starting code block annotation due to a missing closing block. This PR adds this.