### PR TITLE
[stdlib] `memcmp` refactor for string comparisons

### DIFF
--- a/stdlib/src/memory/memory.mojo
+++ b/stdlib/src/memory/memory.mojo
@@ -42,8 +42,9 @@ fn _align_down(value: Int, alignment: Int) -> Int:
 
 
 @always_inline
-fn _memcmp_impl(s1: DTypePointer, s2: __type_of(s1), count: Int) -> Int:
-    constrained[s1.type.is_integral(), "the input dtype must be integral"]()
+fn _memcmp_impl_unconstrained(
+    s1: DTypePointer, s2: __type_of(s1), count: Int
+) -> Int:
     alias simd_width = simdwidthof[s1.type]()
     if count < simd_width:
         for i in range(count):
@@ -85,6 +86,12 @@ fn _memcmp_impl(s1: DTypePointer, s2: __type_of(s1), count: Int) -> Int:
         )
         return -1 if s1i[index] < s2i[index] else 1
     return 0
+
+
+@always_inline
+fn _memcmp_impl(s1: DTypePointer, s2: __type_of(s1), count: Int) -> Int:
+    constrained[s1.type.is_integral(), "the input dtype must be integral"]()
+    return _memcmp_impl_unconstrained(s1, s2, count)
 
 
 @always_inline

--- a/stdlib/src/memory/memory.mojo
+++ b/stdlib/src/memory/memory.mojo
@@ -60,7 +60,9 @@ fn _memcmp_impl_unconstrained(
         has_side_effect=False,
     ]()
 
-    for i in range(0, count - simd_width, simd_width):
+    var last = count - simd_width
+
+    for i in range(0, last, simd_width):
         var s1i = s1.load[width=simd_width](i)
         var s2i = s2.load[width=simd_width](i)
         var diff = s1i != s2i
@@ -71,8 +73,6 @@ fn _memcmp_impl_unconstrained(
                 ).reduce_min()
             )
             return -1 if s1i[index] < s2i[index] else 1
-
-    var last = count - simd_width
 
     var s1i = s1.load[width=simd_width](last)
     var s2i = s2.load[width=simd_width](last)

--- a/stdlib/src/memory/memory.mojo
+++ b/stdlib/src/memory/memory.mojo
@@ -60,8 +60,7 @@ fn _memcmp_impl_unconstrained(
         has_side_effect=False,
     ]()
 
-    var vector_end_simd = _align_down(count, simd_width)
-    for i in range(0, vector_end_simd, simd_width):
+    for i in range(0, count - simd_width, simd_width):
         var s1i = s1.load[width=simd_width](i)
         var s2i = s2.load[width=simd_width](i)
         var diff = s1i != s2i
@@ -74,8 +73,6 @@ fn _memcmp_impl_unconstrained(
             return -1 if s1i[index] < s2i[index] else 1
 
     var last = count - simd_width
-    if last <= 0:
-        return 0
 
     var s1i = s1.load[width=simd_width](last)
     var s2i = s2.load[width=simd_width](last)


### PR DESCRIPTION
This is a follow-up to #2740.
Edit:
Refactored the `memcmp` implementation to give `StringRef` a `constrained`-less version for vectorized string comparisons that avoid an internal recursion bug.

Old:
`StringRef`'s local `_memcmp` is now vectorized, but without using `constrained` in an attempt to avoid indirect recursions.

`StringRef`'s `_memcmp` is pretty much identical to `memory.memcmp` now, but I've also replaced `_align_down(count, simd_width)` with `count - simd_width` (as the upper limit for the simd loop) because in cases where `count` is divisible by `simd_width` (and `count > simd_width`, e.g. `count = 64, simd_width = 32`), then the last simd comparison would be done twice (at the end of the loop and once after).