### PR TITLE
[stdlib] Infer mutability in Span

### DIFF
--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -1315,7 +1315,7 @@ struct String(
     @always_inline
     fn as_bytes_slice(
         self: Reference[Self, _, _]
-    ) -> Span[UInt8, self.is_mutable, self.lifetime]:
+    ) -> Span[UInt8, self.lifetime]:
         """
         Returns a contiguous slice of the bytes owned by this string.
 
@@ -1325,7 +1325,7 @@ struct String(
             A contiguous slice pointing to the bytes owned by this string.
         """
 
-        return Span[UInt8, self.is_mutable, self.lifetime](
+        return Span[UInt8, self.lifetime](
             unsafe_ptr=self[]._buffer.unsafe_ptr(),
             # Does NOT include the NUL terminator.
             len=self[]._byte_length(),

--- a/stdlib/src/builtin/string_literal.mojo
+++ b/stdlib/src/builtin/string_literal.mojo
@@ -267,7 +267,7 @@ struct StringLiteral(
         )
 
     @always_inline
-    fn as_bytes_slice(self) -> Span[UInt8, False, ImmutableStaticLifetime]:
+    fn as_bytes_slice(self) -> Span[UInt8, ImmutableStaticLifetime]:
         """
         Returns a contiguous slice of the bytes owned by this string.
 
@@ -277,7 +277,7 @@ struct StringLiteral(
 
         var ptr = self.unsafe_uint8_ptr()
 
-        return Span[UInt8, False, ImmutableStaticLifetime](
+        return Span[UInt8, ImmutableStaticLifetime](
             unsafe_ptr=ptr,
             len=self._byte_length(),
         )

--- a/stdlib/src/utils/inline_string.mojo
+++ b/stdlib/src/utils/inline_string.mojo
@@ -266,7 +266,7 @@ struct InlineString(Sized, Stringable, CollectionElement):
     @always_inline
     fn as_bytes_slice(
         self: Reference[Self, _, _]
-    ) -> Span[UInt8, self.is_mutable, self.lifetime]:
+    ) -> Span[UInt8, self.lifetime]:
         """
         Returns a contiguous slice of the bytes owned by this string.
 
@@ -276,7 +276,7 @@ struct InlineString(Sized, Stringable, CollectionElement):
             A contiguous slice pointing to the bytes owned by this string.
         """
 
-        return Span[UInt8, self.is_mutable, self.lifetime](
+        return Span[UInt8, self.lifetime](
             unsafe_ptr=self[].unsafe_ptr(),
             # Does NOT include the NUL terminator.
             len=len(self[]),
@@ -497,7 +497,7 @@ struct _FixedString[CAP: Int](
     @always_inline
     fn as_bytes_slice(
         self: Reference[Self, _, _]
-    ) -> Span[UInt8, self.is_mutable, self.lifetime]:
+    ) -> Span[UInt8, self.lifetime]:
         """
         Returns a contiguous slice of the bytes owned by this string.
 
@@ -507,7 +507,7 @@ struct _FixedString[CAP: Int](
             A contiguous slice pointing to the bytes owned by this string.
         """
 
-        return Span[UInt8, self.is_mutable, self.lifetime](
+        return Span[UInt8, self.lifetime](
             unsafe_ptr=self[].unsafe_ptr(),
             # Does NOT include the NUL terminator.
             len=self[].size,

--- a/stdlib/src/utils/span.mojo
+++ b/stdlib/src/utils/span.mojo
@@ -27,22 +27,22 @@ from sys.intrinsics import _type_is_eq
 
 @value
 struct _SpanIter[
+    is_mutable: Bool, //,
     T: CollectionElement,
-    is_mutable: Bool,
     lifetime: AnyLifetime[is_mutable].type,
     forward: Bool = True,
 ]:
     """Iterator for Span.
 
     Parameters:
-        T: The type of the elements in the span.
         is_mutable: Whether the reference to the span is mutable.
+        T: The type of the elements in the span.
         lifetime: The lifetime of the Span.
         forward: The iteration direction. `False` is backwards.
     """
 
     var index: Int
-    var src: Span[T, is_mutable, lifetime]
+    var src: Span[T, lifetime]
 
     @always_inline
     fn __iter__(self) -> Self:
@@ -71,15 +71,15 @@ struct _SpanIter[
 
 @value
 struct Span[
+    is_mutable: Bool, //,
     T: CollectionElement,
-    is_mutable: Bool,
     lifetime: AnyLifetime[is_mutable].type,
 ]:
     """A non owning view of contiguous data.
 
     Parameters:
-        T: The type of the elements in the span.
         is_mutable: Whether the span is mutable.
+        T: The type of the elements in the span.
         lifetime: The lifetime of the Span.
     """
 
@@ -182,7 +182,7 @@ struct Span[
         return res
 
     @always_inline
-    fn __iter__(self) -> _SpanIter[T, is_mutable, lifetime]:
+    fn __iter__(self) -> _SpanIter[T, lifetime]:
         """Get an iterator over the elements of the span.
 
         Returns:

--- a/stdlib/src/utils/string_slice.mojo
+++ b/stdlib/src/utils/string_slice.mojo
@@ -38,16 +38,14 @@ struct StringSlice[
         lifetime: The lifetime of the underlying string data.
     """
 
-    var _slice: Span[UInt8, is_mutable, lifetime]
+    var _slice: Span[UInt8, lifetime]
 
     # ===------------------------------------------------------------------===#
     # Initializers
     # ===------------------------------------------------------------------===#
 
     @always_inline
-    fn __init__(
-        inout self, *, owned unsafe_from_utf8: Span[UInt8, is_mutable, lifetime]
-    ):
+    fn __init__(inout self, *, owned unsafe_from_utf8: Span[UInt8, lifetime]):
         """
         Construct a new StringSlice from a sequence of UTF-8 encoded bytes.
 
@@ -75,7 +73,7 @@ struct StringSlice[
         """
         var strref = unsafe_from_utf8_strref
 
-        var byte_slice = Span[UInt8, is_mutable, lifetime](
+        var byte_slice = Span[UInt8, lifetime](
             unsafe_ptr=strref.unsafe_ptr(),
             len=len(strref),
         )
@@ -104,7 +102,7 @@ struct StringSlice[
               UTF-8.
             len: The number of bytes of encoded data.
         """
-        var byte_slice = Span[UInt8, is_mutable, lifetime](
+        var byte_slice = Span[UInt8, lifetime](
             unsafe_ptr=unsafe_from_utf8_ptr,
             len=len,
         )
@@ -123,7 +121,7 @@ struct StringSlice[
     # ===------------------------------------------------------------------===#
 
     @always_inline
-    fn as_bytes_slice(self) -> Span[UInt8, is_mutable, lifetime]:
+    fn as_bytes_slice(self) -> Span[UInt8, lifetime]:
         """
         Get the sequence of encoded bytes as a slice of the underlying string.
 


### PR DESCRIPTION
In the spirit of 6ba760d7d8c9c0c4e5a5b1a577f5dc4a02fef7b1, this PR simplifies `Span` to infer mutability.