### PR TITLE
[stdlib] Simplify iterator logic in `dict.mojo`

### DIFF
--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -85,22 +85,16 @@ struct _DictEntryIter[
     fn __next__(inout self) -> Reference[DictEntry[K, V], Self.dict_lifetime]:
         while True:
             var opt_entry_ref = self.src[]._entries.__get_ref(self.index)
-            if opt_entry_ref[]:
-
-                @parameter
-                if forward:
-                    self.index += 1
-                else:
-                    self.index -= 1
-
-                self.seen += 1
-                return opt_entry_ref[].value()
 
             @parameter
             if forward:
                 self.index += 1
             else:
                 self.index -= 1
+
+            if opt_entry_ref[]:
+                self.seen += 1
+                return opt_entry_ref[].value()
 
     fn __len__(self) -> Int:
         return len(self.src[]) - self.seen


### PR DESCRIPTION
There is no need to increment or decrement the index in both branches of the if. We just need to do it once, before the if statement, since `self.index` is not used afterwards.

It also makes it easier to understand the purpose of the if statement.