### PR TITLE
[stdlib] Consolidate range structs and fix length calculation

### DIFF
--- a/stdlib/src/builtin/reversed.mojo
+++ b/stdlib/src/builtin/reversed.mojo
@@ -15,7 +15,7 @@
 These are Mojo built-ins, so you don't need to import them.
 """
 
-from .range import _StridedRange
+from .range import _Range
 
 from collections.list import _ListIter
 
@@ -43,7 +43,7 @@ trait ReversibleRange:
     # iterators currently check __len__() instead of raising an exception
     # so there is no ReversibleRaising trait yet.
 
-    fn __reversed__(self) -> _StridedRange:
+    fn __reversed__(self) -> _Range:
         """Get a reversed iterator for the type.
 
         **Note**: iterators are currently non-raising.
@@ -59,7 +59,7 @@ trait ReversibleRange:
 # ===----------------------------------------------------------------------=== #
 
 
-fn reversed[T: ReversibleRange](value: T) -> _StridedRange:
+fn reversed[T: ReversibleRange](value: T) -> _Range:
     """Get a reversed iterator of the input range.
 
     **Note**: iterators are currently non-raising.

--- a/stdlib/test/builtin/test_range.mojo
+++ b/stdlib/test/builtin/test_range.mojo
@@ -30,7 +30,6 @@ def test_range_len():
     assert_equal(range(0, 0).__len__(), 0, "len(range(0, 0))")
     assert_equal(range(10, 0).__len__(), 0, "len(range(10, 0))")
     assert_equal(range(0, 0, 1).__len__(), 0, "len(range(0, 0, 1))")
-
     assert_equal(range(5, 10, -1).__len__(), 0, "len(range(5, 10, -1))")
     assert_equal(range(10, 5, 1).__len__(), 0, "len(range(10, 5, 1))")
     assert_equal(range(5, 10, -10).__len__(), 0, "len(range(5, 10, -10))")
@@ -118,6 +117,11 @@ def test_indexing():
     assert_equal(r[True], 1)
     assert_equal(r[int(4)], 4)
     assert_equal(r[3], 3)
+
+    assert_equal(range(10)[-1], 9)
+    assert_equal(range(10)[-2], 8)
+    assert_equal(range(1, 10)[-1], 9)
+    assert_equal(range(1, 10, 4)[-1], 9)
 
 
 def main():

--- a/stdlib/test/builtin/test_slice.mojo
+++ b/stdlib/test/builtin/test_slice.mojo
@@ -84,7 +84,7 @@ def test_slice_eq():
     assert_equal(slice(1, None, 1), slice(1, None, None))
 
 
-def test_slice_adjust():
+def test_slice_indices():
     var start: Int
     var end: Int
     var step: Int
@@ -143,4 +143,4 @@ def main():
     test_slice_stringable()
     test_indexing()
     test_slice_eq()
-    test_slice_adjust()
+    test_slice_indices()


### PR DESCRIPTION
Having three different range structs is unnecessary and makes it difficult to do something like write a function that accepts a range as an argument since `range` will currently return 3 different types depending on which override you happen to use.

- Remove `_ZeroStartingRange` and `_SequentialRange` as everything can be done with `_StridedRange`
- Rename `_StridedRange` to `_Range`
- Apply index normalization to `_Range.__getitem__`
- Fix `_Range` length when start index is after end index.