### PR TITLE
[stdlib] Fix Span slicing behaviour

### DIFF
--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -847,15 +847,14 @@ struct String(
         """
 
         # Calculate length in bytes
-        var length: Int = len(str_slice.as_bytes_slice())
+        var bytes = str_slice.as_bytes_slice()
+        var length: Int = len(bytes)
         var buffer = Self._buffer_type()
         # +1 for null terminator, initialized to 0
         buffer.resize(length + 1, 0)
-        memcpy(
-            dest=buffer.data,
-            src=str_slice.as_bytes_slice().unsafe_ptr(),
-            count=length,
-        )
+        for i in range(length):
+            buffer[i] = bytes[i]
+
         self = Self(buffer^)
 
     @always_inline

--- a/stdlib/test/utils/test_span.mojo
+++ b/stdlib/test/utils/test_span.mojo
@@ -121,26 +121,62 @@ def test_indexing():
 
 
 def test_span_slice():
-    def compare(s: Span[Int], l: List[Int]) -> Bool:
-        if len(s) != len(l):
-            return False
-        for i in range(len(s)):
-            if s[i] != l[i]:
-                return False
-        return True
-
     var l = List(1, 2, 3, 4, 5)
     var s = Span(l)
-    var res = s[1:2]
+    var res = s[Slice(1, 2)]
     assert_equal(res[0], 2)
-    res = s[1:-1:1]
+
+    res = s[Slice(1, -1, 1)]
     assert_equal(res[0], 2)
     assert_equal(res[1], 3)
     assert_equal(res[2], 4)
-    # TODO: Fix Span slicing
-    # res = s[1::-1]
-    # assert_equal(res[0], 2)
-    # assert_equal(res[1], 1)
+
+    res = s[1::-1]
+    assert_equal(res[0], 2)
+    assert_equal(res[1], 1)
+
+    res = s[1:6:2]
+    assert_equal(len(res), 2)
+    assert_equal(res[0], 2)
+    assert_equal(res[1], 4)
+
+    res = s[-1:-4:-1]
+    assert_equal(len(res), 3)
+    assert_equal(res[0], 5)
+    assert_equal(res[1], 4)
+    assert_equal(res[2], 3)
+
+    res = s[1:-1]
+    assert_equal(len(res), 3)
+    assert_equal(res[0], 2)
+    assert_equal(res[1], 3)
+    assert_equal(res[2], 4)
+
+    res = s[3:2]
+    assert_equal(len(res), 0)
+
+    var str_l = String("[1,2,3,4]")
+    var str_span = str_l.as_bytes_slice()
+    var sliced = str_span[1:-1]
+    assert_equal(len(sliced), 7)
+    assert_equal(chr(int(sliced[0])), "1")
+    assert_equal(chr(int(sliced[1])), ",")
+    assert_equal(chr(int(sliced[2])), "2")
+    assert_equal(chr(int(sliced[3])), ",")
+    assert_equal(chr(int(sliced[4])), "3")
+    assert_equal(chr(int(sliced[5])), ",")
+    assert_equal(chr(int(sliced[6])), "4")
+
+
+def test_span_iter():
+    var l = List(1, 2, 3, 4, 5)
+    var s = Span(l)
+    var it = s[1:6:2].__iter__()
+    assert_equal(len(it), 2)
+    var first = it.__next__()
+    assert_equal(first[], 2)
+    var second = it.__next__()
+    assert_equal(second[], 4)
 
 
 def main():
@@ -150,3 +186,4 @@ def main():
     test_span_array_str()
     test_indexing()
     test_span_slice()
+    test_span_iter()

--- a/stdlib/test/utils/test_string_slice.mojo
+++ b/stdlib/test/utils/test_string_slice.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo %s
 
-from testing import assert_equal
+from testing import assert_equal, assert_not_equal
 
 from utils import Span
 
@@ -86,7 +86,8 @@ fn test_string_byte_slice() raises:
     assert_equal(len(sub5), 0)
 
     # Empty slices still have a pointer value
-    assert_equal(int(sub5.unsafe_ptr()) - int(sub4.unsafe_ptr()), 2)
+    assert_not_equal(int(sub4.unsafe_ptr()), 0)
+    assert_not_equal(int(sub5.unsafe_ptr()), 0)
 
     # ----------------------------------
     # Test invalid slicing


### PR DESCRIPTION
- Allow more sophisticated slicing behaviour in `Span` by storing the currently active slice inside the span
- Alter `String` constructor from `StringSlice` to copy in a for loop instead of `memcpy` to correct behaviour when the 
  underlying `Span` has been sliced