### PR TITLE
[stdlib] Fixed recursive calls to String.__getitem__ for negative idxs

### DIFF
--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -924,6 +924,9 @@ struct String(
 
     fn __getitem__[IndexerType: Indexer](self, idx: IndexerType) -> String:
         """Gets the character at the specified position.
+        
+        Parameters:
+            IndexerType: The inferred type of an indexer argument.
 
         Args:
             idx: The index value.

--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -924,7 +924,7 @@ struct String(
 
     fn __getitem__[IndexerType: Indexer](self, idx: IndexerType) -> String:
         """Gets the character at the specified position.
-        
+
         Parameters:
             IndexerType: The inferred type of an indexer argument.
 

--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -17,6 +17,7 @@ These are Mojo built-ins, so you don't need to import them.
 
 from bit import countl_zero
 from collections import List, KeyElement
+from collections._index_normalization import normalize_index
 from sys import llvm_intrinsic, bitwidthof
 from sys.ffi import C_char
 
@@ -921,7 +922,7 @@ struct String(
     # Operator dunders
     # ===------------------------------------------------------------------=== #
 
-    fn __getitem__(self, idx: Int) -> String:
+    fn __getitem__[IndexerType: Indexer](self, idx: IndexerType) -> String:
         """Gets the character at the specified position.
 
         Args:
@@ -930,13 +931,9 @@ struct String(
         Returns:
             A new string containing the character at the specified position.
         """
-        var index = idx
-        if idx < 0:
-            index = len(self) + index
-
-        debug_assert(0 <= index < len(self), "index must be in range")
+        var normalized_idx = normalize_index["String"](idx, self)
         var buf = Self._buffer_type(capacity=1)
-        buf.append(self._buffer[index])
+        buf.append(self._buffer[normalized_idx])
         buf.append(0)
         return String(buf^)
 

--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -930,12 +930,13 @@ struct String(
         Returns:
             A new string containing the character at the specified position.
         """
+        var index = idx
         if idx < 0:
-            return self.__getitem__(len(self) + idx)
+            index = len(self) + index
 
-        debug_assert(0 <= idx < len(self), "index must be in range")
+        debug_assert(0 <= index < len(self), "index must be in range")
         var buf = Self._buffer_type(capacity=1)
-        buf.append(self._buffer[idx])
+        buf.append(self._buffer[index])
         buf.append(0)
         return String(buf^)
 


### PR DESCRIPTION
Currently, `String.__getitem__(self, idx: Int)` has a behavior in which really large indices result in many recursive calls, causing the REPL to hang. Given,

```mojo
1> var s: String = "there"
2. print(s[-1000000000000000])
3.     

```

The REPL hangs. At the time of writing, it is still hanging after an hour.