### PR TITLE
[stdlib] Fix `Error.__repr__`

### DIFF
--- a/stdlib/src/builtin/error.mojo
+++ b/stdlib/src/builtin/error.mojo
@@ -26,7 +26,7 @@ from memory import memcmp, memcpy, UnsafePointer
 
 
 @register_passable
-struct Error(Stringable, Boolable):
+struct Error(Stringable, Boolable, Representable):
     """This type represents an Error."""
 
     var data: UnsafePointer[UInt8]
@@ -151,7 +151,7 @@ struct Error(Stringable, Boolable):
         Returns:
             A printable representation of the error message.
         """
-        return str(self)
+        return "Error(" + repr(self._message()) + ")"
 
     @always_inline
     fn _message(self) -> String:

--- a/stdlib/test/builtin/test_error.mojo
+++ b/stdlib/test/builtin/test_error.mojo
@@ -32,6 +32,7 @@ def test_from_and_to_string():
     assert_equal(str(error), "FOO")
 
     assert_equal(str(Error("bad")), "bad")
+    assert_equal(repr(Error("err")), "Error('err')")
 
 
 def main():


### PR DESCRIPTION
The current `Error.__repr__` implementation doesn't follow to the convention, so fix it to disambiguate it from a simple string.