### PR TITLE
[stdlib] Cleanup sort module

### DIFF
--- a/stdlib/src/builtin/sort.mojo
+++ b/stdlib/src/builtin/sort.mojo
@@ -27,6 +27,7 @@ from sys import bitwidthof
 alias _cmp_fn_type = fn[type: AnyTrivialRegType] (type, type) capturing -> Bool
 
 
+@always_inline
 fn _insertion_sort[
     type: AnyTrivialRegType, cmp_fn: _cmp_fn_type
 ](array: Pointer[type], start: Int, end: Int):
@@ -46,6 +47,7 @@ fn _insertion_sort[
         array[j] = value
 
 
+@always_inline
 fn _insertion_sort[
     type: CollectionElement, cmp_fn: fn (type, type) capturing -> Bool
 ](array: UnsafePointer[type], start: Int, end: Int):
@@ -125,12 +127,14 @@ fn _partition[
     return right
 
 
+@always_inline
 fn _estimate_initial_height(size: Int) -> Int:
     # Compute the log2 of the size rounded upward.
     var log2 = int((bitwidthof[DType.index]() - 1) ^ countl_zero(size | 1))
     return max(2, log2)
 
 
+@always_inline
 fn _quicksort[
     type: AnyTrivialRegType, cmp_fn: _cmp_fn_type
 ](array: Pointer[type], size: Int):
@@ -177,6 +181,7 @@ fn _quicksort[
         stack.append(pivot)
 
 
+@always_inline
 fn _quicksort[
     type: CollectionElement, cmp_fn: fn (type, type) capturing -> Bool
 ](array: UnsafePointer[type], size: Int):
@@ -210,15 +215,16 @@ fn _quicksort[
 # ===----------------------------------------------------------------------===#
 # partition
 # ===----------------------------------------------------------------------===#
+@always_inline
 fn partition[
     type: AnyTrivialRegType, cmp_fn: _cmp_fn_type
 ](buff: Pointer[type], k: Int, size: Int):
-    """Partition the input vector inplace such that first k elements are the
+    """Partition the input buffer inplace such that first k elements are the
     largest (or smallest if cmp_fn is <= operator) elements.
     The ordering of the first k elements is undefined.
 
     Parameters:
-        type: DType of the underlying data.
+        type: Trivial reg type of the underlying data.
         cmp_fn: Comparison functor of type, type) capturing -> Bool type.
 
     Args:
@@ -248,9 +254,10 @@ fn partition[
 # ===----------------------------------------------------------------------===#
 
 
+@always_inline
 fn sort(inout buff: Pointer[Int], len: Int):
-    """Sort the vector inplace.
-    The function doesn't return anything, the vector is updated inplace.
+    """Sort the buffer inplace.
+    The function doesn't return anything, the buffer is updated inplace.
 
     Args:
         buff: Input buffer.
@@ -264,9 +271,10 @@ fn sort(inout buff: Pointer[Int], len: Int):
     _quicksort[Int, _less_than_equal](buff, len)
 
 
+@always_inline
 fn sort[type: DType](inout buff: Pointer[Scalar[type]], len: Int):
-    """Sort the vector inplace.
-    The function doesn't return anything, the vector is updated inplace.
+    """Sort the buffer inplace.
+    The function doesn't return anything, the buffer is updated inplace.
 
     Parameters:
         type: DType of the underlying data.
@@ -283,49 +291,70 @@ fn sort[type: DType](inout buff: Pointer[Scalar[type]], len: Int):
     _quicksort[Scalar[type], _less_than_equal](buff, len)
 
 
-fn sort(inout v: List[Int]):
-    """Sort the vector inplace.
-    The function doesn't return anything, the vector is updated inplace.
+@always_inline
+fn sort(inout list: List[Int]):
+    """Sort the list inplace.
+    The function doesn't return anything, the list is updated inplace.
 
     Args:
-        v: Input integer vector to sort.
+        list: Input integer list to sort.
     """
     # Downcast any pointer to register-passable pointer.
-    var ptr = rebind[Pointer[Int]](v.data)
-    sort(ptr, len(v))
+    var ptr = rebind[Pointer[Int]](list.data)
+    sort(ptr, len(list))
 
 
-fn sort[type: DType](inout v: List[Scalar[type]]):
-    """Sort the vector inplace.
-    The function doesn't return anything, the vector is updated inplace.
+@always_inline
+fn sort[type: DType](inout list: List[Scalar[type]]):
+    """Sort the list inplace.
+    The function doesn't return anything, the list is updated inplace.
 
     Parameters:
         type: DType of the underlying data.
 
     Args:
-        v: Input vector to sort.
+        list: Input vector to sort.
     """
 
-    var ptr = rebind[Pointer[Scalar[type]]](v.data)
-    sort[type](ptr, len(v))
+    var ptr = rebind[Pointer[Scalar[type]]](list.data)
+    sort[type](ptr, len(list))
 
 
+@always_inline
 fn sort[
     type: CollectionElement,
     cmp_fn: fn (type, type) capturing -> Bool,
-](inout v: List[type]):
-    """Sort the vector inplace.
-    The function doesn't return anything, the vector is updated inplace.
+](inout list: List[type]):
+    """Sort the list inplace.
+    The function doesn't return anything, the list is updated inplace.
 
     Parameters:
-        type: DType of the underlying data.
+        type: CollectionElement type of the underlying data.
         cmp_fn: The comparison function.
 
     Args:
-        v: Input vector to sort.
+        list: Input list to sort.
     """
 
-    _quicksort[type, cmp_fn](v.data, len(v))
+    _quicksort[type, cmp_fn](list.data, len(list))
+
+
+@always_inline
+fn sort[type: ComparableCollectionElement](inout list: List[type]):
+    """Sort list of the order comparable elements in-place.
+
+    Parameters:
+        type: The order comparable collection element type.
+
+    Args:
+        list: The list of the scalars which will be sorted in-place.
+    """
+
+    @parameter
+    fn _less_than_equal(a: type, b: type) -> Bool:
+        return a <= b
+
+    sort[type, _less_than_equal](list)
 
 
 # ===----------------------------------------------------------------------===#
@@ -395,91 +424,3 @@ fn _small_sort[
         _sort_partial_3[type, cmp_fn](array, 0, 2, 3)
         _sort_partial_3[type, cmp_fn](array, 1, 2, 3)
         return
-
-
-# ===----------------------------------------------------------------------=== #
-#  Comparable elements list sorting
-# ===----------------------------------------------------------------------=== #
-
-
-@always_inline
-fn insertion_sort[type: ComparableCollectionElement](inout list: List[type]):
-    """Sort list of the order comparable elements in-place with insertion sort algorithm.
-
-    Parameters:
-        type: The order comparable collection element type.
-
-    Args:
-        list: The list of the order comparable elements which will be sorted in-place.
-    """
-    for i in range(1, len(list)):
-        var key = list[i]
-        var j = i - 1
-        while j >= 0 and key < list[j]:
-            list[j + 1] = list[j]
-            j -= 1
-        list[j + 1] = key
-
-
-fn _quick_sort[
-    type: ComparableCollectionElement
-](inout list: List[type], low: Int, high: Int):
-    """Sort section of the list, between low and high, with quick sort algorithm in-place.
-
-    Parameters:
-        type: The order comparable collection element type.
-
-    Args:
-        list: The list of the order comparable elements which will be sorted in-place.
-        low: Int value identifying the lowest index of the list section to be sorted.
-        high: Int value identifying the highest index of the list section to be sorted.
-    """
-
-    @always_inline
-    @parameter
-    fn _partition(low: Int, high: Int) -> Int:
-        var pivot = list[high]
-        var i = low - 1
-        for j in range(low, high):
-            if list[j] <= pivot:
-                i += 1
-                list[j], list[i] = list[i], list[j]
-        list[i + 1], list[high] = list[high], list[i + 1]
-        return i + 1
-
-    if low < high:
-        var pi = _partition(low, high)
-        _quick_sort(list, low, pi - 1)
-        _quick_sort(list, pi + 1, high)
-
-
-@always_inline
-fn quick_sort[type: ComparableCollectionElement](inout list: List[type]):
-    """Sort list of the order comparable elements in-place with quick sort algorithm.
-
-    Parameters:
-        type: The order comparable collection element type.
-
-    Args:
-        list: The list of the order comparable elements which will be sorted in-place.
-    """
-    _quick_sort(list, 0, len(list) - 1)
-
-
-fn sort[
-    type: ComparableCollectionElement, slist_ub: Int = 64
-](inout list: List[type]):
-    """Sort list of the order comparable elements in-place. This function picks the best algorithm based on the list length.
-
-    Parameters:
-        type: The order comparable collection element type.
-        slist_ub: The upper bound for a list size which is considered small.
-
-    Args:
-        list: The list of the scalars which will be sorted in-place.
-    """
-    var count = len(list)
-    if count <= slist_ub:
-        insertion_sort(list)  # small lists are best sorted with insertion sort
-    else:
-        quick_sort(list)  # others are best sorted with quick sort

--- a/stdlib/src/builtin/sort.mojo
+++ b/stdlib/src/builtin/sort.mojo
@@ -215,7 +215,6 @@ fn _quicksort[
 # ===----------------------------------------------------------------------===#
 # partition
 # ===----------------------------------------------------------------------===#
-@always_inline
 fn partition[
     type: AnyTrivialRegType, cmp_fn: _cmp_fn_type
 ](buff: Pointer[type], k: Int, size: Int):
@@ -254,7 +253,6 @@ fn partition[
 # ===----------------------------------------------------------------------===#
 
 
-@always_inline
 fn sort(inout buff: Pointer[Int], len: Int):
     """Sort the buffer inplace.
     The function doesn't return anything, the buffer is updated inplace.
@@ -271,7 +269,6 @@ fn sort(inout buff: Pointer[Int], len: Int):
     _quicksort[Int, _less_than_equal](buff, len)
 
 
-@always_inline
 fn sort[type: DType](inout buff: Pointer[Scalar[type]], len: Int):
     """Sort the buffer inplace.
     The function doesn't return anything, the buffer is updated inplace.
@@ -291,7 +288,6 @@ fn sort[type: DType](inout buff: Pointer[Scalar[type]], len: Int):
     _quicksort[Scalar[type], _less_than_equal](buff, len)
 
 
-@always_inline
 fn sort(inout list: List[Int]):
     """Sort the list inplace.
     The function doesn't return anything, the list is updated inplace.
@@ -304,7 +300,6 @@ fn sort(inout list: List[Int]):
     sort(ptr, len(list))
 
 
-@always_inline
 fn sort[type: DType](inout list: List[Scalar[type]]):
     """Sort the list inplace.
     The function doesn't return anything, the list is updated inplace.
@@ -320,7 +315,6 @@ fn sort[type: DType](inout list: List[Scalar[type]]):
     sort[type](ptr, len(list))
 
 
-@always_inline
 fn sort[
     type: CollectionElement,
     cmp_fn: fn (type, type) capturing -> Bool,
@@ -339,7 +333,6 @@ fn sort[
     _quicksort[type, cmp_fn](list.data, len(list))
 
 
-@always_inline
 fn sort[type: ComparableCollectionElement](inout list: List[type]):
     """Sort list of the order comparable elements in-place.
 
@@ -354,7 +347,7 @@ fn sort[type: ComparableCollectionElement](inout list: List[type]):
     fn _less_than_equal(a: type, b: type) -> Bool:
         return a <= b
 
-    sort[type, _less_than_equal](list)
+    _quicksort[type, _less_than_equal](list.data, len(list))
 
 
 # ===----------------------------------------------------------------------===#

--- a/stdlib/test/builtin/test_sort.mojo
+++ b/stdlib/test/builtin/test_sort.mojo
@@ -595,11 +595,9 @@ def test_sort_comparamble_elements_list():
     assert_sorted(list)
 
 
-fn test_sort_empty_comparamble_elements_list() raises:
+fn test_sort_empty_comparable_elements_list() raises:
     var person_list = List[Person]()
     sort(person_list)
-    insertion_sort(person_list)
-    quick_sort(person_list)
     assert_true(len(person_list) == 0)
 
 
@@ -631,4 +629,4 @@ def main():
     test_sort_string_big_list()
     test_sort_strings()
     test_sort_comparamble_elements_list()
-    test_sort_empty_comparamble_elements_list()
+    test_sort_empty_comparable_elements_list()


### PR DESCRIPTION
Just a few renaming and removal of the Comparable elements list sorting section as it can be delegated to other sort function