### PR TITLE
[stdlib] Remove SliceNew.__getitem__

### DIFF
--- a/stdlib/src/builtin/builtin_slice.mojo
+++ b/stdlib/src/builtin/builtin_slice.mojo
@@ -332,18 +332,6 @@ struct SliceNew(Stringable, EqualityComparable):
 
         return len(range(self.start.value(), self.end.value(), self.step))
 
-    @always_inline
-    fn __getitem__(self, idx: Int) -> Int:
-        """Get the slice index.
-
-        Args:
-            idx: The index.
-
-        Returns:
-            The slice index.
-        """
-        return self.start.value() + idx * self.step
-
     fn indices(self, src_len: Int) -> (Int, Int, Int):
         """Returns a tuple of 3 intergers representing the start, end, and step
            of the slice if applied to a container of the given length.


### PR DESCRIPTION
Fixes #2953

slice in python does not implement `__getitem__` and with the introduction of `indices()` it will also no longer be used when we've migrated to `SliceNew` in the stdlib containers. The current implementation is also incorrect when using negative indices anyways.