### PR TITLE
[docs] Fix docstring in `swap.mojo`

### DIFF
--- a/stdlib/src/builtin/swap.mojo
+++ b/stdlib/src/builtin/swap.mojo
@@ -21,7 +21,7 @@ fn swap[T: Movable](inout lhs: T, inout rhs: T):
     """Swaps the two given arguments.
 
     Parameters:
-       T: Constrained to Copyable types.
+       T: Constrained to Movable types.
 
     Args:
         lhs: Argument value swapped with rhs.


### PR DESCRIPTION
The code says that `T` is constrained to Movable types, so the docstring should also reflect this. It only uses the `^` operator in its body.