### PR TITLE
[stdlib] Removed SIMD.splat

### DIFF
--- a/docs/manual/parameters/index.ipynb
+++ b/docs/manual/parameters/index.ipynb
@@ -283,7 +283,7 @@
     "can call the `splat()` method like this:\n",
     "\n",
     "```mojo\n",
-    "GenericArray[Float64](8, 0)\n",
+    "GenericArray[Float64].splat(8, 0)\n",
     "```\n",
     "\n",
     "The method returns an instance of `GenericArray[Float64]`."

--- a/docs/manual/parameters/index.ipynb
+++ b/docs/manual/parameters/index.ipynb
@@ -261,6 +261,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -282,7 +283,7 @@
     "can call the `splat()` method like this:\n",
     "\n",
     "```mojo\n",
-    "GenericArray[Float64].splat(8, 0)\n",
+    "GenericArray[Float64](8, 0)\n",
     "```\n",
     "\n",
     "The method returns an instance of `GenericArray[Float64]`."

--- a/examples/notebooks/programming-manual.ipynb
+++ b/examples/notebooks/programming-manual.ipynb
@@ -1704,7 +1704,7 @@
         "var small_vec = SIMD[DType.float32, 4](1.0, 2.0, 3.0, 4.0)\n",
         "\n",
         "# Make a big vector containing 1.0 in float16 format.\n",
-        "var big_vec = SIMD[DType.float16, 32].splat(1.0)\n",
+        "var big_vec = SIMD[DType.float16, 32](1.0)\n",
         "\n",
         "# Do some math and convert the elements to float32.\n",
         "var bigger_vec = (big_vec+big_vec).cast[DType.float32]()\n",

--- a/stdlib/src/bit/bit.mojo
+++ b/stdlib/src/bit/bit.mojo
@@ -246,7 +246,7 @@ fn bit_not[
         NOT of the integer value at position `i` of the input value.
     """
     constrained[type.is_integral(), "must be integral"]()
-    var neg_one = SIMD[type, simd_width].splat(-1)
+    var neg_one = SIMD[type, simd_width](-1)
     return __mlir_op.`pop.xor`(val.value, neg_one.value)
 
 
@@ -402,7 +402,7 @@ fn bit_ceil[
     """
     constrained[type.is_integral(), "must be integral"]()
 
-    alias ones = SIMD[type, simd_width].splat(1)
+    alias ones = SIMD[type, simd_width](1)
 
     return (val > 1).select(1 << bit_width(val - ones), ones)
 
@@ -455,7 +455,7 @@ fn bit_floor[
     """
     constrained[type.is_integral(), "must be integral and unsigned"]()
 
-    alias zeros = SIMD[type, simd_width].splat(0)
+    alias zeros = SIMD[type, simd_width](0)
 
     return (val > 0).select(1 << (bit_width(val) - 1), zeros)
 

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -1440,13 +1440,13 @@ def test_reduce_bit_count():
     var int_iota8 = SIMD[DType.int32, 8](0, 1, 2, 3, 4, 5, 6, 7)
     assert_equal(int_iota8.reduce_bit_count(), 12)
 
-    var bool_true = Scalar[DType.bool].splat(True)
+    var bool_true = Scalar[DType.bool](True)
     assert_equal(bool_true.reduce_bit_count(), 1)
 
-    var bool_false = Scalar[DType.bool].splat(False)
+    var bool_false = Scalar[DType.bool](False)
     assert_equal(bool_false.reduce_bit_count(), 0)
 
-    var bool_true16 = SIMD[DType.bool, 16].splat(True)
+    var bool_true16 = SIMD[DType.bool, 16](True)
     assert_equal(bool_true16.reduce_bit_count(), 16)
 
 


### PR DESCRIPTION
Issue #2942,
I have removed the .splat method from SIMD. Please look into it, and let me know if there are any changes needed.