### PR TITLE
[stdlib] Use autoderef in `Dict.__get_ref()`

### DIFF
--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -522,12 +522,12 @@ struct Dict[K: KeyElement, V: CollectionElement](
         Raises:
             "KeyError" if the key isn't present.
         """
-        return self._find_ref(key)[]
+        return self._find_ref(key)
 
     # TODO(MSTDL-452): rename to __getitem__ returning a reference
     fn __get_ref(
         ref [_]self: Self, key: K
-    ) raises -> Reference[V, __lifetime_of(self)]:
+    ) raises -> ref [__lifetime_of(self)] Self.V:
         """Retrieve a value out of the dictionary.
 
         Args:
@@ -692,14 +692,14 @@ struct Dict[K: KeyElement, V: CollectionElement](
             otherwise an empty Optional.
         """
         try:  # TODO(MOCO-604): push usage through
-            return self._find_ref(key)[]
+            return self._find_ref(key)
         except:
             return None
 
     # TODO(MOCO-604): Return Optional[Reference] instead of raising
     fn _find_ref(
         ref [_]self: Self, key: K
-    ) raises -> Reference[V, __lifetime_of(self)]:
+    ) raises -> ref [__lifetime_of(self)] Self.V:
         """Find a value in the dictionary by key.
 
         Args:
@@ -717,7 +717,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
         if found:
             var entry = self._entries.__get_ref(index)
             debug_assert(entry[].__bool__(), "entry in index must be full")
-            return Reference(entry[].value().value)
+            return entry[].value().value
         raise "KeyError"
 
     fn get(self, key: K) -> Optional[V]:

--- a/stdlib/test/collections/test_dict.mojo
+++ b/stdlib/test/collections/test_dict.mojo
@@ -66,6 +66,15 @@ def test_basic():
     assert_equal(2, dict["b"])
 
 
+def test_basic_no_copies():
+    var dict = Dict[String, Int]()
+    dict["a"] = 1
+    dict["b"] = 2
+
+    assert_equal(1, dict["a"])
+    assert_equal(2, dict["b"])
+
+
 def test_multiple_resizes():
     var dict = Dict[String, Int]()
     for i in range(20):
@@ -274,8 +283,8 @@ def test_dict_copy_calls_copy_constructor():
     # are coming from :)
     assert_equal(1, orig["a"].copy_count)
     assert_equal(2, copy["a"].copy_count)
-    assert_equal(0, orig.__get_ref("a")[].copy_count)
-    assert_equal(1, copy.__get_ref("a")[].copy_count)
+    assert_equal(0, orig.__get_ref("a").copy_count)
+    assert_equal(1, copy.__get_ref("a").copy_count)
 
 
 def test_dict_update_nominal():


### PR DESCRIPTION
We'll make `__getitem__` autoderef soon after the compiler understands that `my_dict["value"] = x` should call `__setitem__` and not `__getitem__`.