### PR TITLE
[stdlib] Add method `UInt.__repr__()`

### DIFF
--- a/stdlib/src/builtin/uint.mojo
+++ b/stdlib/src/builtin/uint.mojo
@@ -19,7 +19,7 @@ These are Mojo built-ins, so you don't need to import them.
 @lldb_formatter_wrapping_type
 @value
 @register_passable("trivial")
-struct UInt:
+struct UInt(Stringable, Representable):
     """This type represents an unsigned integer.
 
     An unsigned integer is represents a positive integral number.
@@ -81,6 +81,21 @@ struct UInt:
         ```
 
         Returns:
-            The string representation of this Int.
+            The string representation of this UInt.
         """
         return str(UInt64(self))
+
+    @always_inline("nodebug")
+    fn __repr__(self) -> String:
+        """Convert this UInt to a string.
+
+        A small example.
+        ```mojo
+        var x = UInt(50)
+        var x_as_string = repr(x)  # x_as_string = "UInt(50)"
+        ```
+
+        Returns:
+            The string representation of this UInt.
+        """
+        return "UInt(" + str(self) + ")"

--- a/stdlib/test/builtin/test_uint.mojo
+++ b/stdlib/test/builtin/test_uint.mojo
@@ -29,5 +29,15 @@ def test_simple_uint():
     assert_equal(str(UInt(18446744073709551615)), "18446744073709551615")
 
 
+def test_uint_representation():
+    assert_equal(repr(UInt(32)), "UInt(32)")
+
+    assert_equal(repr(UInt(0)), "UInt(0)")
+    assert_equal(repr(UInt()), "UInt(0)")
+
+    assert_equal(repr(UInt(18446744073709551615)), "UInt(18446744073709551615)")
+
+
 def main():
     test_simple_uint()
+    test_uint_representation()


### PR DESCRIPTION
* https://github.com/modularml/mojo/issues/2919

I also added the Stringable trait, which was forgotten at the last PR.