### PR TITLE
[stdlib] Add `String.isdigit`

### DIFF
--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -509,6 +509,18 @@ fn isdigit(c: UInt8) -> Bool:
     return ord_0 <= int(c) <= ord_9
 
 
+fn isdigit(c: String) -> Bool:
+    """Determines whether the given character is a digit [0-9].
+
+    Args:
+        c: The character to check.
+
+    Returns:
+        True if the character is a digit.
+    """
+    return isdigit(ord(c))
+
+
 # ===----------------------------------------------------------------------=== #
 # isupper
 # ===----------------------------------------------------------------------=== #
@@ -2133,6 +2145,17 @@ struct String(
             res += self[pos_in_self : len(self)]
 
         return res^
+
+    fn isdigit(self) -> Bool:
+        """Returns True if all characters in the string are digits.
+
+        Returns:
+            True if all characters are digits else False.
+        """
+        for c in self:
+            if not isdigit(c):
+                return False
+        return True
 
 
 # ===----------------------------------------------------------------------=== #

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -1308,6 +1308,18 @@ def test_format_args():
     )
 
 
+def test_isdigit():
+    assert_true(isdigit(ord("1")))
+    assert_true(isdigit("1"))
+    # TODO: What to do with multi-character strings?
+    # assert_false(isdigit("1gt"))
+    assert_false(isdigit(ord("g")))
+    assert_false(isdigit("g"))
+    assert_true(String("123").isdigit())
+    assert_false(String("asdg").isdigit())
+    assert_false(String("123asdg").isdigit())
+
+
 def main():
     test_constructors()
     test_copy()
@@ -1354,3 +1366,4 @@ def main():
     test_indexing()
     test_string_iter()
     test_format_args()
+    test_isdigit()


### PR DESCRIPTION
Partially addresses #2975

- Added convenience `String` overload `isdigit` function
- Add `isdigit` member to `String` that checks if all characters in a string are digits as python has