### PR TITLE
[stdlib] `List`'s `__getitem__()` uses `normalize_index()`

### DIFF
--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -20,6 +20,7 @@ from collections import List
 """
 
 
+from collections._index_normalization import normalize_index
 from memory import UnsafePointer, Reference
 from sys.intrinsics import _type_is_eq
 from .optional import Optional
@@ -739,14 +740,7 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         Returns:
             A copy of the element at the given index.
         """
-        var normalized_idx = idx
-        debug_assert(
-            -self.size <= normalized_idx < self.size,
-            "index must be within bounds",
-        )
-        if normalized_idx < 0:
-            normalized_idx += len(self)
-
+        var normalized_idx = normalize_index["List"](idx, self)
         return (self.data + normalized_idx)[]
 
     # TODO(30737): Replace __getitem__ with this, but lots of places use it


### PR DESCRIPTION
Using `normalize_index()` in `List`'s `__getitem__()` to reduce boilerplate bounds checking.

Note:
Initially opened #3024 but due to a bug was asked to open separate PRs for each method.