### PR TITLE
[stdlib] Simplify `Int.__floordiv__()` by using MLIR `index.floordivs`

### DIFF
--- a/stdlib/src/builtin/int.mojo
+++ b/stdlib/src/builtin/int.mojo
@@ -546,16 +546,7 @@ struct Int(
         Returns:
             `floor(self/rhs)` value.
         """
-        if rhs == 0:
-            # this should raise an exception.
-            return 0
-        var div: Int = self._positive_div(rhs)
-        if self > 0 and rhs > 0:
-            return div
-        var mod = self - div * rhs
-        if ((rhs < 0) ^ (self < 0)) and mod:
-            return div - 1
-        return div
+        return __mlir_op.`index.floordivs`(self.value, rhs.value)
 
     @always_inline("nodebug")
     fn __mod__(self, rhs: Int) -> Int:

--- a/stdlib/test/builtin/test_int.mojo
+++ b/stdlib/test/builtin/test_int.mojo
@@ -81,8 +81,12 @@ def test_floordiv():
     assert_equal(1, Int(2) // Int(2))
     assert_equal(0, Int(2) // Int(3))
     assert_equal(-1, Int(2) // Int(-2))
+    assert_equal(-1, Int(1) // Int(-2))
+    assert_equal(-1, Int(1) // Int(-3))
     assert_equal(-50, Int(99) // Int(-2))
     assert_equal(-1, Int(-1) // Int(10))
+    assert_equal(-1, Int(-1) // Int(2))
+    assert_equal(2, Int(-10) // Int(-5))
 
 
 def test_mod():


### PR DESCRIPTION
Also added other unit tests to make sure the behavior didn't change.

MMMhhh actually it's 2x slower XD I think we can close this PR. Still this is very strange but I guess the codegen is not very good for this MLIR op.

I wonder if that's something that can be fixed upstream either in LLVM or MLIR?