### PR TITLE
[sdlib] Add `clamp` to math module

### DIFF
--- a/stdlib/src/builtin/_math.mojo
+++ b/stdlib/src/builtin/_math.mojo
@@ -197,3 +197,66 @@ trait Truncable:
     # associated types.
     fn __trunc__(self) -> Self:
         ...
+
+
+# ===----------------------------------------------------------------------=== #
+# clamp
+# ===----------------------------------------------------------------------=== #
+
+
+fn clamp(value: Int, lower: Int, upper: Int) -> Int:
+    """Clamp value to the range of [lower, upper].
+
+    If value is less lower, or greater than upper, it becomes the respective
+    value, else value is returned.
+
+    If lower > upper, then the two are swapped.
+
+    Args:
+        value: The integer to clamp.
+        lower: The lower bound of the range.
+        upper: Then upper bound of the range.
+
+    Returns:
+        A value in the range [lower, upper].
+    """
+    var lo = lower
+    var hi = upper
+    if lo > hi:
+        swap(lo, hi)
+    return max(lo, min(value, hi))
+
+
+fn clamp[
+    type: DType, size: Int, //
+](value: SIMD[type, size], lower: Scalar[type], upper: Scalar[type]) -> SIMD[
+    type, size
+]:
+    """Clamp values to the range of [lower, upper].
+
+    If value is less lower, or greater than upper, it becomes the respective
+    value, else value is returned.
+
+    If value is NAN, then upper is returned.
+
+    If lower > upper, then the two are swapped.
+
+    This is equivalent to `value.clamp(lower, upper)`
+
+    Parameters:
+        type: The dtype of the arguments.
+        size: The SIMD size of the arguments.
+
+    Args:
+        value: The value to clamp.
+        lower: The lower bound of the range.
+        upper: Then upper bound of the range.
+
+    Returns:
+        Values in the range [lower, upper].
+    """
+    var lo = lower
+    var hi = upper
+    if lo > hi:
+        swap(lo, hi)
+    return value.clamp(lo, hi)

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -652,8 +652,8 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         if stop_normalized < 0:
             stop_normalized += len(self)
 
-        start_normalized = _clip(start_normalized, 0, len(self))
-        stop_normalized = _clip(stop_normalized, 0, len(self))
+        start_normalized = clamp(start_normalized, 0, len(self))
+        stop_normalized = clamp(stop_normalized, 0, len(self))
 
         for i in range(start_normalized, stop_normalized):
             if self[i] == value:
@@ -838,7 +838,3 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
             The UnsafePointer to the underlying memory.
         """
         return self.data
-
-
-fn _clip(value: Int, start: Int, end: Int) -> Int:
-    return max(start, min(value, end))

--- a/stdlib/test/builtin/test_math.mojo
+++ b/stdlib/test/builtin/test_math.mojo
@@ -13,6 +13,7 @@
 # RUN: %mojo %s
 
 from testing import assert_equal
+from utils.numerics import nan
 
 
 def test_abs():
@@ -106,6 +107,29 @@ def test_pow():
     assert_equal(pow(I(0, 1, 2, 3), int(2)), I(0, 1, 4, 9))
 
 
+def test_clamp():
+    assert_equal(clamp(4, 5, 7), 5)
+    assert_equal(clamp(9, 5, 7), 7)
+    assert_equal(clamp(6, 5, 7), 6)
+
+    var lower = Int32(3)
+    var upper = Int32(9)
+    assert_equal(clamp(Int32(1), lower, upper), lower)
+    assert_equal(clamp(Int32(12), lower, upper), upper)
+    assert_equal(clamp(Int32(7), lower, upper), 7)
+    assert_equal(clamp(Int32(1), upper, lower), lower)
+
+    assert_equal(clamp(nan[DType.float64](), 1.3, 5.4), 5.4)
+
+    var value = SIMD[DType.int32, 4](4, 6, 65, 1)
+    assert_equal(
+        clamp(value, Int32(3), Int32(8)), SIMD[DType.int32, 4](4, 6, 8, 3)
+    )
+
+    assert_equal(clamp(2, 6, 4), 4)
+    assert_equal(clamp(9, 6, 4), 6)
+
+
 def main():
     test_abs()
     test_divmod()
@@ -113,3 +137,4 @@ def main():
     test_min()
     test_round()
     test_pow()
+    test_clamp()


### PR DESCRIPTION
- Add `clamp` to the math module
- Replace private `_clip` function in `List` with `clamp`