### PR TITLE
[stdlib] Move `hash.mojo` off `unroll`

### DIFF
--- a/stdlib/src/builtin/hash.mojo
+++ b/stdlib/src/builtin/hash.mojo
@@ -174,13 +174,12 @@ fn _hash_simd[type: DType, size: Int](data: SIMD[type, size]) -> Int:
     var final_data = bitcast[int_type, 1](hash_data[0]).cast[DType.uint64]()
 
     @parameter
-    fn hash_value[i: Int]():
+    for i in range(1, size):
         final_data = _ankerl_hash_update(
             final_data,
-            bitcast[int_type, 1](hash_data[i + 1]).cast[DType.uint64](),
+            bitcast[int_type, 1](hash_data[i]).cast[DType.uint64](),
         )
 
-    unroll[hash_value, size - 1]()
     return int(final_data)
 
 


### PR DESCRIPTION
As part of migrating off of `unroll` in favor of `@parameter for`, apply the use of `@parameter for` in `hash.mojo`.