### PR TITLE
[stdlib] Add `+`, `-`, `*`, `/` ops for `UInt`

### DIFF
--- a/stdlib/src/builtin/uint.mojo
+++ b/stdlib/src/builtin/uint.mojo
@@ -131,3 +131,50 @@ struct UInt(Stringable, Representable):
                 pred = __mlir_attr.`#index<cmp_predicate ne>`
             ](self.value, rhs.value)
         )
+
+    @always_inline("nodebug")
+    fn __add__(self, rhs: Self) -> Self:
+        """Return `self + rhs`.
+
+        Args:
+            rhs: The value to add.
+
+        Returns:
+            `self + rhs` value.
+        """
+        return __mlir_op.`index.add`(self.value, rhs.value)
+
+    @always_inline("nodebug")
+    fn __sub__(self, rhs: Self) -> Self:
+        """Return `self - rhs`.
+
+        Args:
+            rhs: The value to subtract.
+
+        Returns:
+            `self - rhs` value.
+        """
+        return __mlir_op.`index.sub`(self.value, rhs.value)
+
+    @always_inline("nodebug")
+    fn __mul__(self, rhs: Self) -> Self:
+        """Return `self * rhs`.
+
+        Args:
+            rhs: The value to multiply with.
+
+        Returns:
+            `self * rhs` value. An `UInt` value.
+        """
+        return __mlir_op.`index.mul`(self.value, rhs.value)
+
+    fn __truediv__(self, rhs: Self) -> Float64:
+        """Return the floating point division of `self` and `rhs`.
+
+        Args:
+            rhs: The value to divide on.
+
+        Returns:
+            `float(self)/float(rhs)` value. A `Float64` value.
+        """
+        return Float64(self) / Float64(rhs)

--- a/stdlib/test/builtin/test_uint.mojo
+++ b/stdlib/test/builtin/test_uint.mojo
@@ -12,7 +12,14 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo %s
 
-from testing import assert_equal, assert_false, assert_true, assert_not_equal
+from testing import (
+    assert_equal,
+    assert_false,
+    assert_true,
+    assert_not_equal,
+    assert_almost_equal,
+)
+from utils.numerics import isinf
 
 
 def test_simple_uint():
@@ -90,8 +97,69 @@ def test_inequality():
     )
 
 
+def test_uint_add():
+    assert_equal(UInt(32).__add__(UInt(32)), UInt(64))
+    assert_equal(UInt(0).__add__(UInt(0)), UInt(0))
+    assert_equal(UInt().__add__(UInt(0)), UInt(0))
+
+    assert_equal(UInt(3).__add__(UInt(2)), UInt(5))
+    assert_equal(UInt(3).__add__(UInt(0)), UInt(3))
+    assert_equal(UInt(154324).__add__(UInt(27435)), UInt(181759))
+
+
+def test_uint_sub():
+    assert_equal(UInt(21).__sub__(UInt(21)), UInt(0))
+    assert_equal(UInt(0).__sub__(UInt(0)), UInt(0))
+    assert_equal(UInt().__sub__(UInt(0)), UInt(0))
+
+    assert_equal(UInt(3).__sub__(UInt(2)), UInt(1))
+    assert_equal(UInt(3).__sub__(UInt(0)), UInt(3))
+    assert_equal(UInt(154324).__sub__(UInt(27435)), UInt(126889))
+
+
+def test_uint_mul():
+    assert_equal(UInt(21).__mul__(UInt(21)), UInt(441))
+    assert_equal(UInt(0).__mul__(UInt(0)), UInt(0))
+    assert_equal(UInt().__mul__(UInt(0)), UInt(0))
+
+    assert_equal(UInt(3).__mul__(UInt(2)), UInt(6))
+    assert_equal(UInt(3).__mul__(UInt(0)), UInt(0))
+    assert_equal(UInt(154324).__mul__(UInt(27435)), UInt(4233878940))
+
+
+def test_uint_truediv():
+    assert_equal(UInt(21).__truediv__(UInt(21)), Float64(1.0))
+    assert_equal(UInt(0).__truediv__(UInt(47)), Float64(0.0))
+    assert_equal(UInt().__truediv__(UInt(47)), Float64(0.0))
+
+    assert_almost_equal(UInt(3).__truediv__(UInt(2)), Float64(1.5))
+    assert_almost_equal(
+        UInt(1).__truediv__(UInt(3)), Float64(0.3333333333333333333)
+    )
+    assert_almost_equal(
+        UInt(154324).__truediv__(UInt(27435)), Float64(5.625077455804629)
+    )
+
+    assert_true(
+        isinf(UInt(3).__truediv__(UInt(0))),
+        msg="UInt(3).__truediv__(UInt(0)) is not infinite",
+    )
+    assert_true(
+        isinf(UInt(154324).__truediv__(UInt(0))),
+        msg="UInt(154324).__truediv__(UInt(0)) is not infinite",
+    )
+    assert_false(
+        isinf(UInt(0).__truediv__(UInt(0))),
+        msg="UInt(0).__truediv__(UInt(0)) should not be infinite",
+    )
+
+
 def main():
     test_simple_uint()
     test_uint_representation()
     test_equality()
     test_inequality()
+    test_uint_add()
+    test_uint_sub()
+    test_uint_mul()
+    test_uint_truediv()


### PR DESCRIPTION
Add simple arithmetic ops in UInt. Fixes the issue https://github.com/modularml/mojo/issues/3070.

https://mlir.llvm.org/docs/Dialects/IndexOps/ can be read for the description of the ops. All of those are the same for signed and unsigned variants.

Note that I wanted to add tests for very big numbers that can't be represented with an `Int`, like `2**64 - 10`, but I'm waiting for the PR https://github.com/modularml/mojo/pull/3015 