### PR TITLE
[stdlib] Simplify `SIMD.reduce_op` functions

### DIFF
--- a/mojo/stdlib/stdlib/algorithm/_gpu/reduction.mojo
+++ b/mojo/stdlib/stdlib/algorithm/_gpu/reduction.mojo
@@ -155,15 +155,7 @@ fn block_reduce[
 
     @parameter
     for i in range(num_reductions):
-
-        @always_inline
-        @parameter
-        fn reduce_wrapper[
-            type: DType, width: Int
-        ](lhs: SIMD[type, width], rhs: SIMD[type, width]) -> SIMD[type, width]:
-            return reduce_fn[type, width, i](lhs, rhs)
-
-        result[i] = result_packed[i].reduce[reduce_wrapper]()
+        result[i] = result_packed[i].reduce[reduce_fn[type, reduction_idx=i]]()
 
     return result
 

--- a/mojo/stdlib/stdlib/algorithm/reduction.mojo
+++ b/mojo/stdlib/stdlib/algorithm/reduction.mojo
@@ -819,18 +819,8 @@ fn _reduce_along_inner_dimension[
 
         @parameter
         for i in range(num_reductions):
-
-            @always_inline
-            @parameter
-            fn simd_reduce_wrapper[
-                type: DType, width: Int
-            ](lhs: SIMD[type, width], rhs: SIMD[type, width]) -> SIMD[
-                type, width
-            ]:
-                return reduce_function[type, width, i](lhs, rhs)
-
             out_acc_tup[i] = in_acc_tup[i].reduce[
-                simd_reduce_wrapper, out_width
+                reduce_function[init_type, reduction_idx=i], out_width
             ]()
 
         return out_acc_tup


### PR DESCRIPTION
- Simplify the signature of `reduce` since it's doesn't have to be generic over `type`
- Introduced a `reduce` overload for non-capturing functions
- Simplify `SIMD.reduce_op` functions using `SIMD.op` methods directly