### PR TITLE
[stdlib] Add `Span.copy_from` method

### DIFF
--- a/stdlib/src/utils/span.mojo
+++ b/stdlib/src/utils/span.mojo
@@ -224,3 +224,20 @@ struct Span[
         """
 
         return self._data
+
+    @always_inline
+    fn copy_from[
+        lifetime: MutableLifetime, //
+    ](ref [_]self: Span[T, lifetime], ref [_]other: Span[T, _]):
+        """
+        Performs an element wise copy from all elements of `other` into all elements of `self`.
+
+        Parameters:
+            lifetime: The inferred mutable lifetime of the data within the Span.
+
+        Args:
+            other: The Span to copy all elements from.
+        """
+        debug_assert(len(self) == len(other), "Spans must be of equal length")
+        for i in range(len(self)):
+            self[i] = other[i]

--- a/stdlib/test/utils/test_span.mojo
+++ b/stdlib/test/utils/test_span.mojo
@@ -143,6 +143,17 @@ def test_span_slice():
     # assert_equal(res[1], 1)
 
 
+def test_copy_from():
+    var a = List[Int](0, 1, 2, 3)
+    var b = List[Int](4, 5, 6, 7, 8, 9, 10)
+    var s = Span(a)
+    var s2 = Span(b)
+    s.copy_from(s2[: len(a)])
+    for i in range(len(a)):
+        assert_equal(a[i], b[i])
+        assert_equal(s[i], s2[i])
+
+
 def main():
     test_span_list_int()
     test_span_list_str()


### PR DESCRIPTION
This PR adds a `copy_from` method to `Span`, which is meant to allow users to easily copy each element from one span to another.