### PR TITLE
[stdlib] Use `ValueDestructorRecorder` in `test_inline_list.mojo`

### DIFF
--- a/stdlib/test/test_utils/types.mojo
+++ b/stdlib/test/test_utils/types.mojo
@@ -109,9 +109,13 @@ struct MoveCounter[T: CollectionElementNew](
 
 
 @value
-struct ValueDestructorRecorder:
+struct ValueDestructorRecorder(ExplicitlyCopyable):
     var value: Int
     var destructor_counter: UnsafePointer[List[Int]]
+
+    fn __init__(inout self, *, other: Self):
+        self.value = other.value
+        self.destructor_counter = other.destructor_counter
 
     fn __del__(owned self):
         self.destructor_counter[].append(self.value)


### PR DESCRIPTION
This PR is a small piece of #2965 . I'm trying to make #2965 smaller to make it easier to work on.

In itself, this PR is a refactoring. The goal is to unify the "destructor counters" that are present in the unit tests and use only the one in `stdlib/test/test_utils/types.mojo`. The goal of those structs is to record the number of `__del__` call being made to make sure the lifecycle of elements in a collection is correct. To make it usable with `InlineList`, I had to add the explicit copy constructor.

@ConnorGray  since you already did a review of #2965 