### PR TITLE
[stdlib] Add `fill` method to `Span`

### DIFF
--- a/stdlib/src/utils/span.mojo
+++ b/stdlib/src/utils/span.mojo
@@ -241,3 +241,17 @@ struct Span[
         debug_assert(len(self) == len(other), "Spans must be of equal length")
         for i in range(len(self)):
             self[i] = other[i]
+
+    @always_inline
+    fn fill[lifetime: MutableLifetime](self: Span[T, lifetime], value: T):
+        """
+        Fill the memory that a span references with a given value.
+
+        Parameters:
+            lifetime: The inferred mutable lifetime of the data within the Span.
+
+        Args:
+            value: The value to assign to each element.
+        """
+        for element in self:
+            element[] = value

--- a/stdlib/test/utils/test_span.mojo
+++ b/stdlib/test/utils/test_span.mojo
@@ -154,6 +154,17 @@ def test_copy_from():
         assert_equal(s[i], s2[i])
 
 
+def test_fill():
+    var a = List[Int](0, 1, 2, 3, 4, 5, 6, 7, 8)
+    var s = Span(a)
+
+    s.fill(2)
+
+    for i in range(len(a)):
+        assert_equal(a[i], 2)
+        assert_equal(s[i], 2)
+
+
 def main():
     test_span_list_int()
     test_span_list_str()
@@ -161,3 +172,4 @@ def main():
     test_span_array_str()
     test_indexing()
     test_span_slice()
+    test_fill()


### PR DESCRIPTION
This PR tried to round out `Span` a little more by adding a `fill` method. Precedents are [std::fill](https://en.cppreference.com/w/cpp/algorithm/fill) and Rust's [slice fill](https://doc.rust-lang.org/std/primitive.slice.html#method.fill).