### PR TITLE
[stdlib] Fix `String.removesuffix("")` removing entire string.

### DIFF
--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -2073,7 +2073,7 @@ struct String(
             `string[:-len(suffix)]` if the string ends with the suffix string,
             or a copy of the original string otherwise.
         """
-        if self.endswith(suffix):
+        if suffix and self.endswith(suffix):
             return self[: -len(suffix)]
         return self
 

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -1121,6 +1121,7 @@ fn test_endswith() raises:
 
 
 def test_removeprefix():
+    assert_equal(String("hello world").removeprefix(""), String("hello world"))
     assert_equal(String("hello world").removeprefix("hello"), " world")
     assert_equal(String("hello world").removeprefix("world"), "hello world")
     assert_equal(String("hello world").removeprefix("hello world"), "")
@@ -1128,6 +1129,7 @@ def test_removeprefix():
 
 
 def test_removesuffix():
+    assert_equal(String("hello world").removesuffix(""), String("hello world"))
     assert_equal(String("hello world").removesuffix("world"), "hello ")
     assert_equal(String("hello world").removesuffix("hello"), "hello world")
     assert_equal(String("hello world").removesuffix("hello world"), "")


### PR DESCRIPTION
A fix to #3117 