### PR TITLE
[stdlib] Add equality methods to StringSlice

### DIFF
--- a/stdlib/src/utils/string_slice.mojo
+++ b/stdlib/src/utils/string_slice.mojo
@@ -218,13 +218,37 @@ struct StringSlice[
 
     @always_inline
     fn __ne__(self, rhs: StringSlice) -> Bool:
-        """Verify if span is not equal to another span.
+        """Verify if span is not equal to another string slice.
 
         Args:
-            rhs: The span to compare against.
+            rhs: The string slice to compare against.
 
         Returns:
-            True if the spans are not equal in length or contents, False otherwise.
+            True if the string slices are not equal in length or contents, False otherwise.
+        """
+        return not self == rhs
+
+    @always_inline
+    fn __ne__(self, rhs: String) -> Bool:
+        """Verify if span is not equal to another string slice.
+
+        Args:
+            rhs: The string slice to compare against.
+
+        Returns:
+            True if the string and slice are not equal in length or contents, False otherwise.
+        """
+        return not self == rhs
+
+    @always_inline
+    fn __ne__(self, rhs: StringLiteral) -> Bool:
+        """Verify if span is not equal to a literal.
+
+        Args:
+            rhs: The string literal to compare against.
+
+        Returns:
+            True if the slice is not equal to the literal in length or contents, False otherwise.
         """
         return not self == rhs
 

--- a/stdlib/src/utils/string_slice.mojo
+++ b/stdlib/src/utils/string_slice.mojo
@@ -163,6 +163,71 @@ struct StringSlice[
         """
         writer.write_str(str_slice=self)
 
+    fn __bool__(self) -> Bool:
+        """Check if a string slice is non-empty.
+
+        Returns:
+           True if a string slice is non-empty, False otherwise.
+        """
+        return len(self._slice) > 0
+
+    fn __eq__(self, rhs: StringSlice) -> Bool:
+        """Verify if a string slice is equal to another string slice.
+
+        Args:
+            rhs: The string slice to compare against.
+
+        Returns:
+            True if the string slices are equal in length and contain the same elements, False otherwise.
+        """
+        if not self and not rhs:
+            return True
+        if len(self) != len(rhs):
+            return False
+        # same pointer and length, so equal
+        if self._slice.unsafe_ptr() == rhs._slice.unsafe_ptr():
+            return True
+        for i in range(len(self)):
+            if self._slice[i] != rhs._slice.unsafe_ptr()[i]:
+                return False
+        return True
+
+    @always_inline
+    fn __eq__(self, rhs: String) -> Bool:
+        """Verify if a string slice is equal to a string.
+
+        Args:
+            rhs: The string to compare against.
+
+        Returns:
+            True if the string slice is equal to the input string in length and contain the same bytes, False otherwise.
+        """
+        return self == rhs.as_string_slice()
+
+    @always_inline
+    fn __eq__(self, rhs: StringLiteral) -> Bool:
+        """Verify if a string slice is equal to a literal.
+
+        Args:
+            rhs: The literal to compare against.
+
+        Returns:
+            True if the string slice is equal to the input literal in length and contain the same bytes, False otherwise.
+        """
+        return self == rhs.as_string_slice()
+
+    @always_inline
+    fn __ne__(self, rhs: StringSlice) -> Bool:
+        """Verify if span is not equal to another span.
+
+        Args:
+            rhs: The span to compare against.
+
+        Returns:
+            True if the spans are not equal in length or contents, False otherwise.
+        """
+        return not self == rhs
+
     # ===------------------------------------------------------------------===#
     # Methods
     # ===------------------------------------------------------------------===#

--- a/stdlib/test/utils/test_string_slice.mojo
+++ b/stdlib/test/utils/test_string_slice.mojo
@@ -155,16 +155,17 @@ fn test_slice_eq() raises:
 
     # eq
 
-    assert_true(str1.as_string_slice() == str1)
-    assert_true(str1.as_string_slice() == str2)
-    assert_true(str2.as_string_slice() == str2.as_string_slice())
-    assert_true(str1.as_string_slice() == str3)
+    assert_true(str1.as_string_slice().__eq__(str1))
+    assert_true(str1.as_string_slice().__eq__(str2))
+    assert_true(str2.as_string_slice().__eq__(str2.as_string_slice()))
+    assert_true(str1.as_string_slice().__eq__(str3))
 
     # ne
 
-    assert_true(str1.as_string_slice() != str4)
-    assert_true(str1.as_string_slice() != str5)
-    assert_true(str1.as_string_slice() != str6)
+    assert_true(str1.as_string_slice().__ne__(str4))
+    assert_true(str1.as_string_slice().__ne__(str5))
+    assert_true(str1.as_string_slice().__ne__(str5.as_string_slice()))
+    assert_true(str1.as_string_slice().__ne__(str6))
 
 
 fn test_slice_bool() raises:

--- a/stdlib/test/utils/test_string_slice.mojo
+++ b/stdlib/test/utils/test_string_slice.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo %s
 
-from testing import assert_equal, assert_true
+from testing import assert_equal, assert_true, assert_false
 
 from utils import Span
 
@@ -150,11 +150,21 @@ fn test_slice_eq() raises:
     var str2: String = "12345"
     var str3: StringLiteral = "12345"
     var str4: String = "abc"
+    var str5: String = "abcdef"
+    var str6: StringLiteral = "abcdef"
+
+    # eq
+
     assert_true(str1.as_string_slice() == str1)
     assert_true(str1.as_string_slice() == str2)
     assert_true(str2.as_string_slice() == str2.as_string_slice())
     assert_true(str1.as_string_slice() == str3)
-    assert_true(not str1.as_string_slice() == str4)
+
+    # ne
+
+    assert_true(str1.as_string_slice() != str4)
+    assert_true(str1.as_string_slice() != str5)
+    assert_true(str1.as_string_slice() != str6)
 
 
 fn test_slice_bool() raises:

--- a/stdlib/test/utils/test_string_slice.mojo
+++ b/stdlib/test/utils/test_string_slice.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo %s
 
-from testing import assert_equal
+from testing import assert_equal, assert_true
 
 from utils import Span
 
@@ -145,8 +145,29 @@ fn test_slice_len() raises:
     assert_equal(1, len(slice5))
 
 
+fn test_slice_eq() raises:
+    var str1: String = "12345"
+    var str2: String = "12345"
+    var str3: StringLiteral = "12345"
+    var str4: String = "abc"
+    assert_true(str1.as_string_slice() == str1)
+    assert_true(str1.as_string_slice() == str2)
+    assert_true(str2.as_string_slice() == str2.as_string_slice())
+    assert_true(str1.as_string_slice() == str3)
+    assert_true(not str1.as_string_slice() == str4)
+
+
+fn test_slice_bool() raises:
+    var str1: String = "abc"
+    assert_true(str1.as_string_slice().__bool__())
+    var str2: String = ""
+    assert_true(not str2.as_string_slice().__bool__())
+
+
 fn main() raises:
     test_string_literal_byte_slice()
     test_string_byte_slice()
     test_heap_string_from_string_slice()
     test_slice_len()
+    test_slice_eq()
+    test_slice_bool()


### PR DESCRIPTION
Now that [Span implements equality methods](https://github.com/modularml/mojo/pull/2698), it makes sense to do the same for StringSlice. Note that we can't just defer to `Span`'s equality method, since `SIMD.__eq__()` does not return a `Bool` (which is a discussion out of scope of this PR).