### PR TITLE
[stdlib] Add the trait `CollectionElementNew` to `List`

### DIFF
--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -77,7 +77,9 @@ struct _ListIter[
             return self.index
 
 
-struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
+struct List[T: CollectionElement](
+    CollectionElement, CollectionElementNew, Sized, Boolable
+):
     """The `List` type is a dynamically-allocated list.
 
     It supports pushing and popping from the back resizing the underlying
@@ -105,14 +107,14 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         self.size = 0
         self.capacity = 0
 
-    fn __init__(inout self, existing: Self):
+    fn __init__(inout self, *, other: Self):
         """Creates a deep copy of the given list.
 
         Args:
-            existing: The list to copy.
+            other: The list to copy.
         """
-        self.__init__(capacity=existing.capacity)
-        for e in existing:
+        self.__init__(capacity=other.capacity)
+        for e in other:
             self.append(e[])
 
     fn __init__(inout self, *, capacity: Int):
@@ -237,7 +239,7 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         # avoid the copy since it would be cleared immediately anyways
         if x == 0:
             return Self()
-        var result = List(self)
+        var result = List(other=self)
         result.__mul(x)
         return result^
 
@@ -260,7 +262,7 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         Returns:
             The newly created list.
         """
-        var result = List(self)
+        var result = List(other=self)
         result.extend(other^)
         return result^
 
@@ -455,7 +457,7 @@ struct List[T: CollectionElement](CollectionElement, Sized, Boolable):
         if x == 0:
             self.clear()
             return
-        var orig = List(self)
+        var orig = List(other=self)
         self.reserve(len(self) * x)
         for i in range(x - 1):
             self.extend(orig)

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -526,7 +526,7 @@ def test_2d_dynamic_list():
 def test_list_explicit_copy_using_get_ref():
     var list = List[CopyCounter]()
     list.append(CopyCounter())
-    var list_copy = List(list)
+    var list_copy = List(other=list)
     assert_equal(0, list.__get_ref(0)[].copy_count)
     assert_equal(1, list_copy.__get_ref(0)[].copy_count)
 
@@ -534,7 +534,7 @@ def test_list_explicit_copy_using_get_ref():
     for i in range(10):
         l2.append(i)
 
-    var l2_copy = List(l2)
+    var l2_copy = List(other=l2)
     assert_equal(len(l2), len(l2_copy))
     for i in range(len(l2)):
         assert_equal(l2[i], l2_copy[i])
@@ -543,7 +543,7 @@ def test_list_explicit_copy_using_get_ref():
 def test_list_explicit_copy():
     var list = List[CopyCounter]()
     list.append(CopyCounter())
-    var list_copy = List(list)
+    var list_copy = List(other=list)
     assert_equal(0, list[0].copy_count)
     assert_equal(1, list_copy[0].copy_count)
 
@@ -551,7 +551,7 @@ def test_list_explicit_copy():
     for i in range(10):
         l2.append(i)
 
-    var l2_copy = List(l2)
+    var l2_copy = List(other=l2)
     assert_equal(len(l2), len(l2_copy))
     for i in range(len(l2)):
         assert_equal(l2[i], l2_copy[i])


### PR DESCRIPTION
@ConnorGray for review

At first I wanted to make a second constructor but it was not possible because of this bug:
* https://github.com/modularml/mojo/issues/3137

so in the end, I replaced the existing one. Hopefully end users won't get too many surprises with that, as it can change the type of the result when doing things like `List(List[Int]())` since it uses then the constructor with variadic arguments.