### PR TITLE
[stdlib] Add `CollectionElementNew` to a few structs, part 2

### DIFF
--- a/stdlib/src/memory/arc.mojo
+++ b/stdlib/src/memory/arc.mojo
@@ -70,7 +70,7 @@ struct _ArcInner[T: Movable]:
 
 
 @register_passable
-struct Arc[T: Movable](CollectionElement):
+struct Arc[T: Movable](CollectionElement, CollectionElementNew):
     """Atomic reference-counted pointer.
 
     This smart pointer owns an instance of `T` indirectly managed on the heap.
@@ -100,6 +100,15 @@ struct Arc[T: Movable](CollectionElement):
         __get_address_as_uninit_lvalue(self._inner.address) = Self._inner_type(
             value^
         )
+
+    fn __init__(inout self, *, other: Self):
+        """Copy the object.
+
+        Args:
+            other: The value to copy.
+        """
+        other._inner[].add_ref()
+        self._inner = other._inner
 
     fn __copyinit__(inout self, existing: Self):
         """Copy an existing reference. Increment the refcount to the object.

--- a/stdlib/src/memory/unsafe.mojo
+++ b/stdlib/src/memory/unsafe.mojo
@@ -140,7 +140,14 @@ alias Pointer = LegacyPointer
 @register_passable("trivial")
 struct LegacyPointer[
     type: AnyTrivialRegType, address_space: AddressSpace = AddressSpace.GENERIC
-](Boolable, CollectionElement, Intable, Stringable, EqualityComparable):
+](
+    Boolable,
+    CollectionElement,
+    CollectionElementNew,
+    Intable,
+    Stringable,
+    EqualityComparable,
+):
     """Defines a LegacyPointer struct that contains the address of a register passable
     type.
 
@@ -166,6 +173,17 @@ struct LegacyPointer[
             Constructed LegacyPointer object.
         """
         return __mlir_attr[`#interp.pointer<0> : `, Self._mlir_type]
+
+    fn __init__(*, other: Self) -> Self:
+        """Copy the object.
+
+        Args:
+            other: The value to copy.
+
+        Returns:
+            Constructed LegacyPointer object.
+        """
+        return other
 
     @always_inline("nodebug")
     fn __init__(address: Self._mlir_type) -> Self:
@@ -568,6 +586,14 @@ struct DTypePointer[
         """Constructs a null `DTypePointer` from the given type."""
 
         self.address = Self._pointer_type()
+
+    fn __init__(inout self, *, other: Self):
+        """Copy the object.
+
+        Args:
+            other: The value to copy.
+        """
+        self = other
 
     @always_inline("nodebug")
     fn __init__(

--- a/stdlib/src/memory/unsafe_pointer.mojo
+++ b/stdlib/src/memory/unsafe_pointer.mojo
@@ -34,6 +34,7 @@ struct UnsafePointer[
 ](
     Boolable,
     CollectionElement,
+    CollectionElementNew,
     Stringable,
     Formattable,
     Intable,
@@ -99,6 +100,18 @@ struct UnsafePointer[
                 Scalar[DType.index](address).value
             )
         }
+
+    @always_inline
+    fn __init__(*, other: Self) -> Self:
+        """Copy the object.
+
+        Args:
+            other: The value to copy.
+
+        Returns:
+            A copy of the object.
+        """
+        return Self {address: other.address}
 
     # ===-------------------------------------------------------------------===#
     # Factory methods

--- a/stdlib/test/memory/test_arc.mojo
+++ b/stdlib/test/memory/test_arc.mojo
@@ -48,6 +48,22 @@ def test_deleter_not_called_until_no_references():
     assert_true(deleted)
 
 
+def test_deleter_not_called_until_no_references_explicit_copy():
+    var deleted = False
+    var p = Arc(ObservableDel(UnsafePointer.address_of(deleted)))
+    var p2 = Arc(other=p)
+    _ = p^
+    assert_false(deleted)
+
+    var vec = List[Arc[ObservableDel]]()
+    vec.append(Arc(other=p2)^)
+    _ = p2^
+    assert_false(deleted)
+    _ = vec^
+    assert_true(deleted)
+
+
 def main():
     test_basic()
     test_deleter_not_called_until_no_references()
+    test_deleter_not_called_until_no_references_explicit_copy()

--- a/stdlib/test/memory/test_memory.mojo
+++ b/stdlib/test/memory/test_memory.mojo
@@ -330,6 +330,14 @@ def test_dtypepointer_string():
     ptr.free()
 
 
+def test_pointer_explicit_copy():
+    var ptr = Pointer[Int].alloc(1)
+    ptr[] = 42
+    var copy = Pointer(other=ptr)
+    assert_equal(copy[], 42)
+    ptr.free()
+
+
 def test_pointer_refitem():
     var ptr = Pointer[Int].alloc(1)
     ptr[] = 42
@@ -534,6 +542,7 @@ def main():
     test_memcpy_unsafe_pointer()
     test_memset()
 
+    test_pointer_explicit_copy()
     test_dtypepointer_string()
     test_pointer_refitem()
     test_pointer_refitem_string()

--- a/stdlib/test/memory/test_unsafepointer.mojo
+++ b/stdlib/test/memory/test_unsafepointer.mojo
@@ -115,6 +115,14 @@ def test_address_of():
     _ = local
 
 
+def test_explicit_copy_of_pointer_address():
+    var local = 1
+    var ptr = UnsafePointer[Int].address_of(local)
+    var copy = UnsafePointer(other=ptr)
+    assert_equal(int(ptr), int(copy))
+    _ = local
+
+
 def test_bitcast():
     var local = 1
     var ptr = UnsafePointer[Int].address_of(local)
@@ -226,6 +234,7 @@ def main():
     test_unsafepointer_move_pointee_move_count()
     test_unsafepointer_initialize_pointee_explicit_copy()
 
+    test_explicit_copy_of_pointer_address()
     test_bitcast()
     test_unsafepointer_string()
     test_eq()


### PR DESCRIPTION
@ConnorGray for the review

That should make the final transition of our collections to CollectionElementNew easier. I can see that the trait was needed for those structs. See the global PR here: https://github.com/modularml/mojo/pull/3134

This PR does not depend on part 1, it can be merged independently

This PR adds the explicit copy constructor to `Arc`, `UnsafePointer`, `DTypePointer` and `LegacyPointer`