### PR TITLE
[stdlib] Add `CollectionElementNew` to a few structs, part 3

### DIFF
--- a/stdlib/src/pathlib/path.mojo
+++ b/stdlib/src/pathlib/path.mojo
@@ -60,7 +60,14 @@ fn _dir_of_current_file() raises -> Path:
     return Path(str(file_name)[0:i])
 
 
-struct Path(Stringable, Formattable, CollectionElement, PathLike, KeyElement):
+struct Path(
+    Stringable,
+    Formattable,
+    CollectionElement,
+    CollectionElementNew,
+    PathLike,
+    KeyElement,
+):
     """The Path object."""
 
     var path: String

--- a/stdlib/src/pathlib/path.mojo
+++ b/stdlib/src/pathlib/path.mojo
@@ -78,6 +78,14 @@ struct Path(Stringable, Formattable, CollectionElement, PathLike, KeyElement):
         """
         self.path = path
 
+    fn __init__(inout self, *, other: Self):
+        """Copy the object.
+
+        Args:
+            other: The value to copy.
+        """
+        self.path = String(other=other.path)
+
     fn __moveinit__(inout self, owned existing: Self):
         """Move data of an existing Path into a new one.
 

--- a/stdlib/src/python/object.mojo
+++ b/stdlib/src/python/object.mojo
@@ -119,6 +119,14 @@ struct PythonObject(
         """Initialize the object with a `None` value."""
         self.__init__(None)
 
+    fn __init__(inout self, *, other: Self):
+        """Copy the object.
+
+        Args:
+            other: The value to copy.
+        """
+        self = other
+
     fn __init__(inout self, ptr: PyObjectPtr):
         """Initialize the object with a `PyObjectPtr` value.
 

--- a/stdlib/src/sys/ffi.mojo
+++ b/stdlib/src/sys/ffi.mojo
@@ -78,6 +78,14 @@ struct DLHandle(CollectionElement, Boolable):
         else:
             self.handle = DTypePointer[DType.int8]()
 
+    fn __init__(inout self, *, other: Self):
+        """Copy the object.
+
+        Args:
+            other: The value to copy.
+        """
+        self = other
+
     fn check_symbol(self, name: String) -> Bool:
         """Check that the symbol exists in the dynamic library.
 

--- a/stdlib/src/sys/ffi.mojo
+++ b/stdlib/src/sys/ffi.mojo
@@ -44,7 +44,7 @@ alias DEFAULT_RTLD = RTLD.NOW | RTLD.GLOBAL
 
 @value
 @register_passable("trivial")
-struct DLHandle(CollectionElement, Boolable):
+struct DLHandle(CollectionElement, CollectionElementNew, Boolable):
     """Represents a dynamically linked library that can be loaded and unloaded.
 
     The library is loaded on initialization and unloaded by `close`.

--- a/stdlib/src/utils/inline_string.mojo
+++ b/stdlib/src/utils/inline_string.mojo
@@ -29,7 +29,7 @@ from utils._format import ToFormatter
 
 
 @value
-struct InlineString(Sized, Stringable, CollectionElement):
+struct InlineString(Sized, Stringable, CollectionElement, CollectionElementNew):
     """A string that performs small-string optimization to avoid heap allocations for short strings.
     """
 
@@ -302,7 +302,12 @@ struct InlineString(Sized, Stringable, CollectionElement):
 
 @value
 struct _FixedString[CAP: Int](
-    Sized, Stringable, Formattable, ToFormatter, CollectionElement
+    Sized,
+    Stringable,
+    Formattable,
+    ToFormatter,
+    CollectionElement,
+    CollectionElementNew,
 ):
     """A string with a fixed available capacity.
 

--- a/stdlib/src/utils/inline_string.mojo
+++ b/stdlib/src/utils/inline_string.mojo
@@ -89,6 +89,14 @@ struct InlineString(Sized, Stringable, CollectionElement):
         """
         self._storage = Self.Layout(heap_string^)
 
+    fn __init__(inout self, *, other: Self):
+        """Copy the object.
+
+        Args:
+            other: The value to copy.
+        """
+        self = other
+
     # ===------------------------------------------------------------------=== #
     # Operator dunders
     # ===------------------------------------------------------------------=== #
@@ -318,6 +326,14 @@ struct _FixedString[CAP: Int](
         """Constructs a new empty string."""
         self.buffer = InlineArray[UInt8, CAP](unsafe_uninitialized=True)
         self.size = 0
+
+    fn __init__(inout self, *, other: Self):
+        """Copy the object.
+
+        Args:
+            other: The value to copy.
+        """
+        self = other
 
     @always_inline
     fn __init__(inout self, literal: StringLiteral) raises:

--- a/stdlib/src/utils/stringref.mojo
+++ b/stdlib/src/utils/stringref.mojo
@@ -71,6 +71,18 @@ struct StringRef(
         return StringRef(UnsafePointer[UInt8](), 0)
 
     @always_inline
+    fn __init__(*, other: Self) -> Self:
+        """Copy the object.
+
+        Args:
+            other: The value to copy.
+
+        Returns:
+            Constructed `StringRef` object.
+        """
+        return Self(other.data, other.length)
+
+    @always_inline
     fn __init__(str: StringLiteral) -> Self:
         """Construct a StringRef value given a constant string.
 

--- a/stdlib/src/utils/stringref.mojo
+++ b/stdlib/src/utils/stringref.mojo
@@ -40,6 +40,7 @@ struct StringRef(
     Sized,
     IntableRaising,
     CollectionElement,
+    CollectionElementNew,
     Stringable,
     Formattable,
     Hashable,


### PR DESCRIPTION
@ConnorGray for review

As I worked on removing `CollectionElement`, I noticed that those structs needed the new trait in the migration.

Those are pretty trivial and the new constructor will soon be used left and right so there is no test, but if you believe that's needed, just ask.

This PR does not depend on part 3, it can be merged independently

This PR adds the explicit copy constructor to `StringRef`, `_FixedString`, `InlineString`, `DLHandle`, `PythonObject` and `Path`