### PR TITLE
[stdlib] Add CollectionElementNew to a few structs, part 4

### DIFF
--- a/stdlib/src/builtin/object.mojo
+++ b/stdlib/src/builtin/object.mojo
@@ -35,7 +35,7 @@ struct _NoneMarker:
 
 
 @register_passable("trivial")
-struct _ImmutableString:
+struct _ImmutableString(CollectionElement, CollectionElementNew):
     """Python strings are immutable. This class is marked as trivially register
     passable because its memory will be managed by `_ObjectImpl`. It is a
     pointer and integer pair. Memory will be dynamically allocated.
@@ -51,6 +51,10 @@ struct _ImmutableString:
     fn __init__(inout self, data: UnsafePointer[UInt8], length: Int):
         self.data = data
         self.length = length
+
+    @always_inline
+    fn __init__(inout self, *, other: Self):
+        self = other
 
     @always_inline
     fn string_compare(self, rhs: _ImmutableString) -> Int:
@@ -233,7 +237,7 @@ struct _Function:
         )
 
 
-struct _ObjectImpl(CollectionElement, Stringable):
+struct _ObjectImpl(CollectionElement, CollectionElementNew, Stringable):
     """This class is the underlying implementation of the value of an `object`.
     It is a variant of primitive types and pointers to implementations of more
     complex types.
@@ -315,6 +319,10 @@ struct _ObjectImpl(CollectionElement, Stringable):
     @always_inline
     fn __init__(inout self, value: _RefCountedAttrsDictRef):
         self.value = Self.type(value)
+
+    @always_inline
+    fn __init__(inout self, *, other: Self):
+        self = other
 
     @always_inline
     fn __copyinit__(inout self, existing: Self):

--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -2350,7 +2350,7 @@ fn _calc_format_buffer_size[type: DType]() -> Int:
 
 
 @value
-struct _FormatCurlyEntry:
+struct _FormatCurlyEntry(CollectionElement, CollectionElementNew):
     """
     Internally used by the `format()` method.
 
@@ -2366,13 +2366,19 @@ struct _FormatCurlyEntry:
     var last_curly: Int
     """The index of an closing brace around a substitution field."""
 
-    var field: Variant[
+    alias _FieldVariantType = Variant[
         String,  # kwargs indexing (`{field_name}`)
         Int,  # args manual indexing (`{3}`)
         NoneType,  # args automatic indexing (`{}`)
         Bool,  # for escaped curlies ('{{')
     ]
+    var field: Self._FieldVariantType
     """Store the substitution field."""
+
+    fn __init__(inout self, *, other: Self):
+        self.first_curly = other.first_curly
+        self.last_curly = other.last_curly
+        self.field = Self._FieldVariantType(other=other.field)
 
     fn is_escaped_brace(ref [_]self) -> Bool:
         return self.field.isa[Bool]()

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -974,7 +974,9 @@ struct Dict[K: KeyElement, V: CollectionElement](
         self._n_entries = self.size
 
 
-struct OwnedKwargsDict[V: CollectionElement](Sized, CollectionElement):
+struct OwnedKwargsDict[V: CollectionElement](
+    Sized, CollectionElement, CollectionElementNew
+):
     """Container used to pass owned variadic keyword arguments to functions.
 
     This type mimics the interface of a dictionary with `String` keys, and
@@ -997,6 +999,14 @@ struct OwnedKwargsDict[V: CollectionElement](Sized, CollectionElement):
     fn __init__(inout self):
         """Initialize an empty keyword dictionary."""
         self._dict = Dict[Self.key_type, V]()
+
+    fn __init__(inout self, *, other: Self):
+        """Copy an existing keyword dictionary.
+
+        Args:
+            other: The existing keyword dictionary.
+        """
+        self._dict = other._dict
 
     fn __copyinit__(inout self, existing: Self):
         """Copy an existing keyword dictionary.

--- a/stdlib/src/collections/optional.mojo
+++ b/stdlib/src/collections/optional.mojo
@@ -36,8 +36,9 @@ from utils import Variant
 
 # TODO(27780): NoneType can't currently conform to traits
 @value
-struct _NoneType(CollectionElement):
-    pass
+struct _NoneType(CollectionElement, CollectionElementNew):
+    fn __init__(inout self, *, other: Self):
+        pass
 
 
 # ===----------------------------------------------------------------------===#


### PR DESCRIPTION
@ConnorGray for review

Adding the explicit copy constructor is needed for when collections will require all their elements to have an explicit copy constructor.

This PR contains the modification for `_ImmutableString`, `_ObjectImpl`, `_FormatCurlyEntry`, `OwnedKwargsDict` and `_NoneType`