### PR TITLE
[stdlib] Implement remaining int fns for `bit` module

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -297,6 +297,10 @@ future and `StringSlice.__len__` now does return the Unicode codepoints length.
   # Insert (2/3 of 1024) entries
   ```
 
+- `bit` module now supports `bit_reverse()`, `byte_swap()` and `pop_count()` for
+  `Int` type.
+  ([PR #3150](https://github.com/modularml/mojo/pull/3150) by [@LJ-9801](https://github.com/LJ-9801))
+
 ### 🦋 Changed
 
 - The pointer aliasing semantics of Mojo have changed. Initially, Mojo adopted a

--- a/stdlib/src/bit/bit.mojo
+++ b/stdlib/src/bit/bit.mojo
@@ -163,17 +163,10 @@ fn bit_reverse[
 fn byte_swap(val: Int) -> Int:
     """Byte-swaps an integer value with an even number of bytes.
 
-    Byte swap an integer value with an even number of bytes (positive multiple
-    of 16 bits). This is equivalent to `llvm.bswap` intrinsic that has the
-    following semantics:
-
-    The `llvm.bswap.i16` intrinsic returns an i16 value that has the high and
-    low byte of the input i16 swapped. Similarly, the `llvm.bswap.i32` intrinsic
-    returns an i32 value that has the four bytes of the input i32 swapped, so
-    that if the input bytes are numbered 0, 1, 2, 3 then the returned i32 will
-    have its bytes in 3, 2, 1, 0 order. The `llvm.bswap.i48`, `llvm.bswap.i64`
-    and other intrinsics extend this concept to additional even-byte lengths (6
-    bytes, 8 bytes and more, respectively).
+    Byte swap an integer value (8 bytes) with an even number of bytes (positive multiple
+    of 16 bits). This returns an integer value (8 bytes) that has its bytes swapped. For
+    example, if the input bytes are numbered 0, 1, 2, 3, 4, 5, 6, 7 then the returned
+    integer will have its bytes in 7, 6, 5, 4, 3, 2, 1, 0 order.
 
     Args:
         val: The input value.
@@ -191,16 +184,12 @@ fn byte_swap[
     """Byte-swaps a SIMD vector of integer values with an even number of bytes.
 
     Byte swap an integer value or vector of integer values with an even number
-    of bytes (positive multiple of 16 bits). This is equivalent to `llvm.bswap`
-    intrinsic that has the following semantics:
-
-    The `llvm.bswap.i16` intrinsic returns an i16 value that has the high and
-    low byte of the input i16 swapped. Similarly, the `llvm.bswap.i32` intrinsic
-    returns an i32 value that has the four bytes of the input i32 swapped, so
-    that if the input bytes are numbered 0, 1, 2, 3 then the returned i32 will
-    have its bytes in 3, 2, 1, 0 order. The `llvm.bswap.i48`, `llvm.bswap.i64`
-    and other intrinsics extend this concept to additional even-byte lengths (6
-    bytes, 8 bytes and more, respectively).
+    of bytes (positive multiple of 16 bits). For example, The Int16 returns an
+    Int16 value that has the high and low byte of the input Int16 swapped.
+    Similarly, Int32 returns an Int32 value that has the four bytes of the input Int32 swapped,
+    so that if the input bytes are numbered 0, 1, 2, 3 then the returned Int32 will
+    have its bytes in 3, 2, 1, 0 order. Int64 and other integer type extend this
+    concept to additional even-byte lengths (6 bytes, 8 bytes and more, respectively).
 
     Parameters:
         type: `dtype` used for the computation.

--- a/stdlib/src/bit/bit.mojo
+++ b/stdlib/src/bit/bit.mojo
@@ -113,7 +113,19 @@ fn count_trailing_zeros[
 # ===----------------------------------------------------------------------===#
 # bit_reverse
 # ===----------------------------------------------------------------------===#
-# TODO: implement bit_reverse for Int type
+
+
+@always_inline("nodebug")
+fn bit_reverse(val: Int) -> Int:
+    """Reverses the bitpattern of an integer value.
+
+    Args:
+        val: The input value.
+
+    Returns:
+        The input value with its bitpattern reversed.
+    """
+    return llvm_intrinsic["llvm.bitreverse", Int, has_side_effect=False](val)
 
 
 @always_inline("nodebug")
@@ -145,7 +157,31 @@ fn bit_reverse[
 # ===----------------------------------------------------------------------===#
 # byte_swap
 # ===----------------------------------------------------------------------===#
-# TODO: implement byte_swap for Int type
+
+
+@always_inline("nodebug")
+fn byte_swap(val: Int) -> Int:
+    """Byte-swaps an integer value with an even number of bytes.
+
+    Byte swap an integer value with an even number of bytes (positive multiple
+    of 16 bits). This is equivalent to `llvm.bswap` intrinsic that has the
+    following semantics:
+
+    The `llvm.bswap.i16` intrinsic returns an i16 value that has the high and
+    low byte of the input i16 swapped. Similarly, the `llvm.bswap.i32` intrinsic
+    returns an i32 value that has the four bytes of the input i32 swapped, so
+    that if the input bytes are numbered 0, 1, 2, 3 then the returned i32 will
+    have its bytes in 3, 2, 1, 0 order. The `llvm.bswap.i48`, `llvm.bswap.i64`
+    and other intrinsics extend this concept to additional even-byte lengths (6
+    bytes, 8 bytes and more, respectively).
+
+    Args:
+        val: The input value.
+
+    Returns:
+        The input value with its bytes swapped.
+    """
+    return llvm_intrinsic["llvm.bswap", Int, has_side_effect=False](val)
 
 
 @always_inline("nodebug")
@@ -190,7 +226,19 @@ fn byte_swap[
 # ===----------------------------------------------------------------------===#
 # pop_count
 # ===----------------------------------------------------------------------===#
-# TODO: implement pop_count for Int type
+
+
+@always_inline("nodebug")
+fn pop_count(val: Int) -> Int:
+    """Counts the number of bits set in an integer value.
+
+    Args:
+        val: The input value.
+
+    Returns:
+        The number of bits set in the input value.
+    """
+    return llvm_intrinsic["llvm.ctpop", Int, has_side_effect=False](val)
 
 
 @always_inline("nodebug")
@@ -222,7 +270,6 @@ fn pop_count[
 # ===----------------------------------------------------------------------===#
 # bit_not
 # ===----------------------------------------------------------------------===#
-# TODO: implement bit_not for Int type
 
 
 @always_inline("nodebug")

--- a/stdlib/test/bit/test_bit.mojo
+++ b/stdlib/test/bit/test_bit.mojo
@@ -124,9 +124,9 @@ def test_bit_reverse():
     assert_equal(bit_reverse(-(2**32)), 4294967295)
     assert_equal(bit_reverse(-1), -1)
     assert_equal(bit_reverse(0), 0)
-    assert_equal(bit_reverse(1), -9223372036854775808)
-    assert_equal(bit_reverse(2), 4611686018427387904)
-    assert_equal(bit_reverse(3), -4611686018427387904)
+    assert_equal(bit_reverse(1), -(2**63))
+    assert_equal(bit_reverse(2), 2**62)
+    assert_equal(bit_reverse(8), 2**60)
     assert_equal(bit_reverse(2**63), 1)
 
 

--- a/stdlib/test/bit/test_bit.mojo
+++ b/stdlib/test/bit/test_bit.mojo
@@ -120,6 +120,16 @@ def test_count_trailing_zeros_simd():
     )
 
 
+def test_bit_reverse():
+    assert_equal(bit_reverse(-(2**32)), 4294967295)
+    assert_equal(bit_reverse(-1), -1)
+    assert_equal(bit_reverse(0), 0)
+    assert_equal(bit_reverse(1), -9223372036854775808)
+    assert_equal(bit_reverse(2), 4611686018427387904)
+    assert_equal(bit_reverse(3), -4611686018427387904)
+    assert_equal(bit_reverse(2**63), 1)
+
+
 def test_bit_reverse_simd():
     alias simd_width = 4
     alias int8_t = DType.int8
@@ -148,6 +158,16 @@ def test_bit_reverse_simd():
             -1, 0, -9223372036854775808, 4611686018427387904
         ),
     )
+
+
+def test_byte_swap():
+    assert_equal(byte_swap(0x0000), 0x0000000000000000)
+    assert_equal(byte_swap(0x0102), 0x0201000000000000)
+    assert_equal(byte_swap(0x0201), 0x0102000000000000)
+    assert_equal(byte_swap(-0x0123456789ABCDEF), 0x1132547698BADCFE)
+    assert_equal(byte_swap(0x0000000001234567), 0x6745230100000000)
+    assert_equal(byte_swap(0x56789ABCDEF01234), 0x3412F0DEBC9A7856)
+    assert_equal(byte_swap(0x23456789ABCDEF01), 0x01EFCDAB89674523)
 
 
 def test_byte_swap_simd():
@@ -187,6 +207,17 @@ def test_byte_swap_simd():
             0x01EFCDAB89674523,
         ),
     )
+
+
+def test_pop_count():
+    assert_equal(pop_count(-111444444), 51)
+    assert_equal(pop_count(0), 0)
+    assert_equal(pop_count(1), 1)
+    assert_equal(pop_count(2), 1)
+    assert_equal(pop_count(3), 2)
+    assert_equal(pop_count(4), 1)
+    assert_equal(pop_count(5), 2)
+    assert_equal(pop_count(3000000), 10)
 
 
 def test_pop_count_simd():
@@ -473,7 +504,10 @@ def main():
     test_count_leading_zeros_simd()
     test_count_trailing_zeros()
     test_count_trailing_zeros_simd()
+    test_bit_reverse()
     test_bit_reverse_simd()
+    test_byte_swap()
     test_byte_swap_simd()
+    test_pop_count()
     test_pop_count_simd()
     test_bit_not_simd()


### PR DESCRIPTION
This PR implements the rest of the bit module with Int type #2862