### PR TITLE
[stdlib] Make `Slice` step `Optional`

### DIFF
--- a/stdlib/src/builtin/builtin_slice.mojo
+++ b/stdlib/src/builtin/builtin_slice.mojo
@@ -45,7 +45,7 @@ struct Slice(
     """The starting index of the slice."""
     var end: Optional[Int]
     """The end index of the slice."""
-    var step: Int
+    var step: Optional[Int]
     """The step increment value of the slice."""
 
     # ===-------------------------------------------------------------------===#
@@ -62,7 +62,7 @@ struct Slice(
         """
         self.start = start
         self.end = end
-        self.step = 1
+        self.step = None
 
     @always_inline
     fn __init__(
@@ -80,7 +80,7 @@ struct Slice(
         """
         self.start = start
         self.end = end
-        self.step = step.or_else(1)
+        self.step = step
 
     fn __init__(inout self, *, other: Self):
         """Creates a deep copy of the Slice.
@@ -135,7 +135,7 @@ struct Slice(
         writer.write(", ")
         write_optional(self.end)
         writer.write(", ")
-        writer.write(repr(self.step))
+        write_optional(self.step)
         writer.write(")")
 
     @always_inline
@@ -200,7 +200,7 @@ struct Slice(
         Returns:
             A tuple containing three integers for start, end, and step.
         """
-        var step = self.step
+        var step = self.step.or_else(1)
 
         var start = self.start
         var end = self.end

--- a/stdlib/test/builtin/test_slice.mojo
+++ b/stdlib/test/builtin/test_slice.mojo
@@ -19,7 +19,7 @@ def test_none_end_folds():
     var all_def_slice = slice(0, None, 1)
     assert_equal(all_def_slice.start.value(), 0)
     assert_true(all_def_slice.end is None)
-    assert_equal(all_def_slice.step, 1)
+    assert_equal(all_def_slice.step.value(), 1)
 
 
 # This requires parameter inference of StartT.
@@ -74,11 +74,11 @@ def test_slice_stringable():
     var s = SliceStringable()
     assert_equal(s[2::-1], "slice(2, None, -1)")
     assert_equal(s[1:-1:2], "slice(1, -1, 2)")
-    assert_equal(s[:-1], "slice(None, -1, 1)")
-    assert_equal(s[::], "slice(None, None, 1)")
+    assert_equal(s[:-1], "slice(None, -1, None)")
+    assert_equal(s[::], "slice(None, None, None)")
     assert_equal(s[::4], "slice(None, None, 4)")
     assert_equal(repr(slice(None, 2, 3)), "slice(None, 2, 3)")
-    assert_equal(repr(slice(10)), "slice(None, 10, 1)")
+    assert_equal(repr(slice(10)), "slice(None, 10, None)")
 
 
 def test_slice_eq():


### PR DESCRIPTION
Follow up from https://github.com/modularml/mojo/pull/3064#issuecomment-2195753384

Make `step` member of `Slice` `Optional` in order to better match the behaviour/semantics of the Python slice.