### PR TITLE
[stdlib] Add `Floatable` trait

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -391,6 +391,19 @@ future and `StringSlice.__len__` now does return the Unicode codepoints length.
   var dictionary = Dict[Int,Int](power_of_two_initial_capacity = 1024)
   # Insert (2/3 of 1024) entries
   ```
+  
+- Add the `Floatable` and `FloatableRaising` traits to denote types that can
+  be converted to a `Float64` value using the builtin `float` function.
+  - Make `SIMD` and `FloatLiteral` conform to the `Floatable` trait.
+
+  ```mojo
+  fn foo[F: Floatable](v: F):
+    ...
+
+  var f = float(Int32(45))
+  ```
+  
+  ([PR #3163](https://github.com/modularml/mojo/pull/3163) by [@bgreni](https://github.com/bgreni))
 
 - `ListLiteral` now supports `__contains__`.
   ([PR #3251](https://github.com/modularml/mojo/pull/3251) by

--- a/stdlib/src/builtin/bool.mojo
+++ b/stdlib/src/builtin/bool.mojo
@@ -108,6 +108,7 @@ struct Bool(
     Representable,
     Stringable,
     Formattable,
+    Floatable,
 ):
     """The primitive Bool scalar value used in Mojo."""
 
@@ -247,6 +248,15 @@ struct Bool(
             1 if the Bool is True, 0 otherwise.
         """
         return _select_register_value(self.value, Int(1), Int(0))
+
+    @always_inline("nodebug")
+    fn __float__(self) -> Float64:
+        """Convert this Bool to a float.
+
+        Returns:
+            1.0 if True else 0.0 otherwise.
+        """
+        return _select_register_value(self.value, Float64(1.0), Float64(0.0))
 
     @always_inline("nodebug")
     fn __index__(self) -> Int:

--- a/stdlib/src/builtin/float_literal.mojo
+++ b/stdlib/src/builtin/float_literal.mojo
@@ -36,6 +36,7 @@ struct FloatLiteral(
     Roundable,
     Stringable,
     Truncable,
+    Floatable,
 ):
     """Mojo floating point literal type."""
 
@@ -147,6 +148,15 @@ struct FloatLiteral(
             The value as an integer.
         """
         return self.__int_literal__().__int__()
+
+    @always_inline("nodebug")
+    fn __float__(self) -> Float64:
+        """Converts the FloatLiteral to a concrete Float64.
+
+        Returns:
+            The Float value.
+        """
+        return Float64(self)
 
     # ===------------------------------------------------------------------===#
     # Unary Operators

--- a/stdlib/src/builtin/floatable.mojo
+++ b/stdlib/src/builtin/floatable.mojo
@@ -1,0 +1,151 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Implements the `Floatable` and `FloatableRaising` traits.
+
+These are Mojo built-ins, so you don't need to import them.
+"""
+
+
+trait Floatable:
+    """The `Floatable` trait describes a type that can be converted to a Float.
+
+    Any type that conforms to `Floatable` works with the built-in `float`
+    function.
+
+    This trait requires the type to implement the `__float__()` method.
+
+    For example:
+
+    ```mojo
+    @value
+    struct Foo(Floatable):
+        var i: Float64
+
+        fn __float__(self) -> Float64:
+            return self.i
+    ```
+
+    A `Foo` can now be converted to a `Float64` using `float`:
+
+    ```mojo
+    var f = float(Foo(5.5))
+    ```
+
+    **Note:** If the `__float__()` method can raise an error, use
+    the [`FloatableRaising`](/mojo/stdlib/builtin/floatable/floatableraising)
+    trait instead.
+    """
+
+    fn __float__(self) -> Float64:
+        """Get the float point representation of the value.
+
+        Returns:
+            The float point representation of the value.
+        """
+        ...
+
+
+trait FloatableRaising:
+    """The `FloatableRaising` trait describes a type that can be converted to a
+    Float, but the conversion might raise an error (e.g.: a string).
+
+    Any type that conforms to `FloatableRaising` works with the built-in `float`
+    function.
+
+    This trait requires the type to implement the `__float__()` method, which
+    can raise an error.
+
+    For example:
+
+    ```mojo
+    @value
+    struct MaybeFloat(FloatableRasing):
+        var value: Variant[Float64, NoneType]
+
+        fn __float__(self) raises -> Float64:
+            if self.value.isa[NoneType]():
+                raise "Float expected"
+            return self.value[Float64]
+    ```
+
+    A `MaybeFloat` can now be converted to `Float64` using `float`:
+
+    ```mojo
+    try:
+        print(float(MaybeFloat(4.6)))
+    except:
+        print("error occured")
+    ```
+    """
+
+    fn __float__(self) raises -> Float64:
+        """Get the float point representation of the value.
+
+        Returns:
+            The float point representation of the value.
+
+        Raises:
+            If the type does not have a float point representation.
+        """
+        ...
+
+
+@always_inline
+fn float[T: Floatable](value: T, /) -> Float64:
+    """Get the Float representation of the value.
+
+    Parameters:
+        T: The Floatable type.
+
+    Args:
+        value: The object to get the float point representation of.
+
+    Returns:
+        The float point representation of the value.
+    """
+    return value.__float__()
+
+
+@always_inline
+fn float[T: FloatableRaising](value: T, /) raises -> Float64:
+    """Get the Float representation of the value.
+
+    Parameters:
+        T: The Floatable type.
+
+    Args:
+        value: The object to get the float point representation of.
+
+    Returns:
+        The float point representation of the value.
+
+    Raises:
+        If the type does not have a float point representation.
+    """
+    return value.__float__()
+
+
+# TODO: Int can't conform to Floatable at the moment due to circular
+#       dependency with SIMD.
+@always_inline
+fn float(value: Int, /) -> Float64:
+    """Get the Float representation of the Int.
+
+    Args:
+        value: The Int to get the float point representation of.
+
+    Returns:
+        The float point representation of the Int.
+    """
+    return Float64(value)

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -166,6 +166,7 @@ struct SIMD[type: DType, size: Int](
     CeilDivable,
     CollectionElement,
     CollectionElementNew,
+    Floatable,
     Floorable,
     Formattable,
     Hashable,
@@ -1344,6 +1345,21 @@ struct SIMD[type: DType, size: Int](
             return __mlir_op.`pop.cast`[
                 _type = __mlir_type.`!pop.scalar<index>`
             ](rebind[Scalar[type]](self).value)
+
+    @always_inline("nodebug")
+    fn __float__(self) -> Float64:
+        """Casts the value to a float.
+
+        Constraints:
+            The size of the SIMD vector must be 1.
+
+        Returns:
+            The value as a float.
+        """
+        constrained[size == 1, "expected a scalar type"]()
+        return __mlir_op.`pop.cast`[_type = __mlir_type.`!pop.scalar<f64>`](
+            rebind[Scalar[type]](self).value
+        )
 
     @no_inline
     fn __str__(self) -> String:

--- a/stdlib/src/builtin/string_literal.mojo
+++ b/stdlib/src/builtin/string_literal.mojo
@@ -42,6 +42,7 @@ struct StringLiteral(
     Representable,
     Sized,
     Stringable,
+    FloatableRaising,
 ):
     """This type represents a string literal.
 
@@ -213,6 +214,16 @@ struct StringLiteral(
             An integer value that represents the string, or otherwise raises.
         """
         return _atol(self)
+
+    fn __float__(self) raises -> Float64:
+        """Parses the string as a float point number and returns that value.
+
+        If the string cannot be parsed as a float, an error is raised.
+
+        Returns:
+            A float value that represents the string, or otherwise raises.
+        """
+        return atof(self)
 
     @no_inline
     fn __str__(self) -> String:

--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -687,6 +687,7 @@ struct String(
     Formattable,
     ToFormatter,
     CollectionElementNew,
+    FloatableRaising,
 ):
     """Represents a mutable string."""
 
@@ -1941,6 +1942,16 @@ struct String(
             An integer value that represents the string, or otherwise raises.
         """
         return atol(self)
+
+    fn __float__(self) raises -> Float64:
+        """Parses the string as a float point number and returns that value.
+
+        If the string cannot be parsed as a float, an error is raised.
+
+        Returns:
+            A float value that represents the string, or otherwise raises.
+        """
+        return atof(self)
 
     fn __mul__(self, n: Int) -> String:
         """Concatenates the string `n` times.

--- a/stdlib/src/prelude/__init__.mojo
+++ b/stdlib/src/prelude/__init__.mojo
@@ -34,6 +34,7 @@ from builtin.error import Error
 from builtin.file import open, FileHandle
 from builtin.file_descriptor import FileDescriptor
 from builtin.float_literal import FloatLiteral
+from builtin.floatable import Floatable, FloatableRaising, float
 from builtin.format_int import bin, hex, oct
 from builtin.hash import hash, Hashable
 from builtin.identifiable import Identifiable, StringableIdentifiable

--- a/stdlib/test/builtin/test_bool.mojo
+++ b/stdlib/test/builtin/test_bool.mojo
@@ -149,6 +149,11 @@ def test_comparisons():
     assert_true(True <= True)
 
 
+def test_float_conversion():
+    assert_equal((True).__float__(), 1.0)
+    assert_equal((False).__float__(), 0.0)
+
+
 def main():
     test_default()
     test_bool_cast_to_int()
@@ -160,3 +165,4 @@ def main():
     test_neg()
     test_indexer()
     test_comparisons()
+    test_float_conversion()

--- a/stdlib/test/builtin/test_float_literal.mojo
+++ b/stdlib/test/builtin/test_float_literal.mojo
@@ -278,6 +278,11 @@ def test_comparison():
     assert_false(FloatLiteral.__ge__(nan, neg_zero))
 
 
+def test_float_conversion():
+    assert_equal((4.5).__float__(), 4.5)
+    assert_equal((0.0).__float__(), 0.0)
+
+
 def main():
     test_ceil()
     test_floor()
@@ -292,3 +297,4 @@ def main():
     test_is_special_value()
     test_abs()
     test_comparison()
+    test_float_conversion()

--- a/stdlib/test/builtin/test_int.mojo
+++ b/stdlib/test/builtin/test_int.mojo
@@ -227,6 +227,10 @@ def test_comparison():
     assert_false(Int(5).__ge__(Int(10)))
 
 
+def test_float_conversion():
+    assert_equal(float(Int(45)), Float64(45))
+
+
 def main():
     test_properties()
     test_add()
@@ -248,3 +252,4 @@ def main():
     test_decimal_digit_count()
     test_comparison()
     test_int_uint()
+    test_float_conversion()

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -1662,6 +1662,12 @@ def test_comparison():
         test_dtype[DType.bfloat16]()
 
 
+def test_float_conversion():
+    assert_almost_equal(float(Int32(45)), 45.0)
+    assert_almost_equal(float(Float32(34.32)), 34.32)
+    assert_almost_equal(float(UInt64(36)), 36.0)
+
+
 def main():
     test_abs()
     test_add()
@@ -1709,4 +1715,5 @@ def main():
     test_split()
     test_contains()
     test_comparison()
+    test_float_conversion()
     # TODO: add tests for __and__, __or__, anc comparison operators

--- a/stdlib/test/builtin/test_string_literal.mojo
+++ b/stdlib/test/builtin/test_string_literal.mojo
@@ -187,6 +187,13 @@ def test_repr():
     assert_equal(StringLiteral.__repr__("\x7f"), r"'\x7f'")
 
 
+def test_float_conversion():
+    assert_equal(("4.5").__float__(), 4.5)
+    assert_equal(float("4.5"), 4.5)
+    with assert_raises():
+        _ = ("not a float").__float__()
+
+
 def main():
     test_add()
     test_equality()
@@ -201,3 +208,4 @@ def main():
     test_intable()
     test_layout()
     test_repr()
+    test_float_conversion()

--- a/stdlib/test/collections/test_string.mojo
+++ b/stdlib/test/collections/test_string.mojo
@@ -1580,6 +1580,15 @@ def test_center():
     assert_equal(String("hello").center(8, "*"), "*hello**")
 
 
+def test_float_conversion():
+    # This is basically just a wrapper around atof which is
+    # more throughouly tested above
+    assert_equal(String("4.5").__float__(), 4.5)
+    assert_equal(float(String("4.5")), 4.5)
+    with assert_raises():
+        _ = float(String("not a float"))
+
+
 def main():
     test_constructors()
     test_copy()
@@ -1633,3 +1642,4 @@ def main():
     test_rjust()
     test_ljust()
     test_center()
+    test_float_conversion()


### PR DESCRIPTION
Begins #3157

Add `Floatable` and `FloatableRaising` traits to allow casting compliant types to `Float64`.