### PR TITLE
[Stdlib] Speedup `Dict` in `_maybe_resize`

### DIFF
--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -894,8 +894,12 @@ struct Dict[K: KeyElement, V: CollectionElement](
     fn _insert(inout self, owned key: K, owned value: V):
         self._insert(DictEntry[K, V](key^, value^))
 
-    fn _insert(inout self, owned entry: DictEntry[K, V]):
-        self._maybe_resize()
+    fn _insert[
+        safe_context: Bool = False
+    ](inout self, owned entry: DictEntry[K, V]):
+        @parameter
+        if safe_context == False:
+            self._maybe_resize()
         var found: Bool
         var slot: Int
         var index: Int
@@ -965,7 +969,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
         for i in range(len(old_entries)):
             var entry = old_entries.__get_ref(i)
             if entry[]:
-                self._insert(entry[].unsafe_take())
+                self._insert[safe_context=True](entry[].unsafe_take())
 
     fn _compact(inout self):
         self._index = _DictIndex(self._reserved())


### PR DESCRIPTION
Hello, here is a PR to remove a small recursion,

In `_maybe_resize`, when overloaded, we double the capacity,
and when re-inserting the entries, `_insert` uses `_maybe_resize` again.

Theses two checks are performed: 
 - `_over_load_factor`
 - `_over_compact_factor`

(Before, they were using modulo, so it can explain the massive speedup we had)
 
We can grab a few performance by not doing thoses when resizing up :+1: 

&nbsp;

### ⏱️ Benchmark

🔥 1.29x on small dictionary growing from `1<<3` to `1<<9`

2368375 **PR**
32640

3059269
32640


```mojo
from time import now
def main():
    var dict_size = 1<<8
    var x = Dict[Int,Int]()
    var start = now()
    var stop = now()
    start = now()
    for n in range(dict_size):
        x = Dict[Int,Int]()
        for i in range(dict_size):
            x[i] = i
    stop = now()
    
    print(stop-start)
    var result = 0
    for i in range(len(x)):
        result+=x[i]
    print(result)
```

&nbsp;

Because we are re-inserting 'already compared' entries,
we could use `_find_empty_slot` to do the job faster!
(equality check for `K` is not necessary since they never the same)
(another PR later after tests)
