### PR TITLE
[stdlib] Make `UInt` `Formattable`

### DIFF
--- a/stdlib/src/builtin/uint.mojo
+++ b/stdlib/src/builtin/uint.mojo
@@ -19,7 +19,7 @@ These are Mojo built-ins, so you don't need to import them.
 @lldb_formatter_wrapping_type
 @value
 @register_passable("trivial")
-struct UInt(Comparable, Representable, Stringable):
+struct UInt(Comparable, Representable, Stringable, Formattable):
     """This type represents an unsigned integer.
 
     An unsigned integer is represents a positive integral number.
@@ -745,3 +745,16 @@ struct UInt(Comparable, Representable, Stringable):
             The self value.
         """
         return self
+
+    # ===-------------------------------------------------------------------===#
+    # Methods
+    # ===-------------------------------------------------------------------===#
+
+    fn format_to(self, inout writer: Formatter):
+        """
+        Formats this unsigned integer to the provided formatter.
+
+        Args:
+            writer: The formatter to write to.
+        """
+        writer.write(str(self))

--- a/stdlib/test/builtin/test_uint.mojo
+++ b/stdlib/test/builtin/test_uint.mojo
@@ -204,6 +204,11 @@ def test_string_conversion():
     assert_equal(UInt(100).__str__(), "100")
     assert_equal(UInt(-100).__str__(), "18446744073709551516")
 
+    var out = String()
+    var writer = out._unsafe_to_formatter()
+    UInt(32).format_to(writer)
+    assert_equal(out, "32")
+
 
 def test_int_representation():
     assert_equal(UInt(3).__repr__(), "UInt(3)")


### PR DESCRIPTION
Make `UInt` conform to the `Formattable` trait.