### PR TITLE
[Stdlib] Add `Dict.__init__` overload with `power_of_two_initial_capacity`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -269,6 +269,20 @@ what we publish.
   # pw_gecos='System Administrator', pw_dir='/var/root', pw_shell='/bin/zsh')
   ```
 
+- Added `Dict.__init__` overload to specify initial capacity.
+  ([PR #3171](https://github.com/modularml/mojo/pull/3171) by [@rd4com](https://github.com/rd4com))
+
+  The capacity has to be a power of two and above or equal 8.
+
+  It allows for faster initialization by skipping incremental growth steps.
+
+  Example:
+
+  ```mojo
+  var dictionary = Dict[Int,Int](power_of_two_initial_capacity = 1024)
+  # Insert (2/3 of 1024) entries
+  ```
+
 ### 🦋 Changed
 
 - The pointer aliasing semantics of Mojo have changed. Initially, Mojo adopted a

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -34,6 +34,7 @@ See the `Dict` docs for more details.
 from builtin.value import StringableCollectionElement
 
 from .optional import Optional
+from bit import is_power_of_two
 
 
 trait KeyElement(CollectionElement, Hashable, EqualityComparable):
@@ -459,6 +460,11 @@ struct Dict[K: KeyElement, V: CollectionElement](
         ```
 
         """
+        debug_assert(
+            bit.is_power_of_two(power_of_two_initial_capacity)
+            and power_of_two_initial_capacity >= 8,
+            "power_of_two_initial_capacity need to be >=8 and a power of two",
+        )
         self.size = 0
         self._n_entries = 0
         self._entries = Self._new_entries(power_of_two_initial_capacity)

--- a/stdlib/src/collections/dict.mojo
+++ b/stdlib/src/collections/dict.mojo
@@ -444,6 +444,26 @@ struct Dict[K: KeyElement, V: CollectionElement](
         self._entries = Self._new_entries(Self._initial_reservation)
         self._index = _DictIndex(len(self._entries))
 
+    @always_inline
+    fn __init__(inout self, *, power_of_two_initial_capacity: Int):
+        """Initialize an empty dictiontary with a pre-reserved initial capacity.
+
+        Args:
+            power_of_two_initial_capacity: At least 8, has to be a power of two.
+
+        Example usage:
+
+        ```mojo
+        var x = Dict[Int,Int](power_of_two_initial_capacity = 1024)
+        # Insert (2/3 of 1024) entries without reallocation.
+        ```
+
+        """
+        self.size = 0
+        self._n_entries = 0
+        self._entries = Self._new_entries(power_of_two_initial_capacity)
+        self._index = _DictIndex(len(self._entries))
+
     # TODO: add @property when Mojo supports it to make
     # it possible to do `self._reserved`.
     @always_inline

--- a/stdlib/test/collections/test_dict.mojo
+++ b/stdlib/test/collections/test_dict.mojo
@@ -548,6 +548,19 @@ fn test_clear() raises:
     assert_equal(len(some_dict), 0)
 
 
+def test_init_inital_capacity():
+    var initial_capacity = 16
+    var x = Dict[Int, Int](power_of_two_initial_capacity=initial_capacity)
+    assert_equal(x._reserved(), initial_capacity)
+    for i in range(initial_capacity):
+        x[i] = i
+    for i in range(initial_capacity):
+        assert_equal(i, x[i])
+
+    var y = Dict[Int, Int](power_of_two_initial_capacity=64)
+    assert_equal(y._reserved(), 64)
+
+
 def main():
     test_dict()
     test_dict_fromkeys()
@@ -558,3 +571,4 @@ def main():
     test_bool_conversion()
     test_find_get()
     test_clear()
+    test_init_inital_capacity()


### PR DESCRIPTION
Hello, here is a new `__init__` that let user specify the initial reservation.

Skipping the un-necessary growth phases when the final size is known to be big.

&nbsp;

2.2x speedup on insertion, lookup should be faster aswel (during overcapacity).

1056082202       **PR**
35184367894528

2388001454
35184367894528

```mojo
from time import now
def main():
    var dict_size = 1<<23
    var start = now()
    var stop = now()
    start = now()
    x = Dict[Int,Int](power_of_two_initial_capacity = 1<<24)
    for i in range(dict_size):
        x[i] = i
    stop = now()
    
    print(stop-start)
    var result = 0
    for i in range(len(x)):
        result+=x[i]
    print(result)
```

We started with 24 and not 23 because the dict grows at 2/3 of capacity,
but reserving 23 is a huge speedup too.

&nbsp;

💡 Could this ameliorate variadic keyword arguments ?
If mojo knows there are 8 arguments passed,
maybe reserve 16 (and skip the dict growth phases).

&nbsp;

@gabrieldemarmiesse  suggested a `power_of_two` type in a PR,
thought about it too during this one ! :+1: 