### PR TITLE
[docs] Fix FileHandle seek Argument Order in Example

### DIFF
--- a/docs/changelog-released.md
+++ b/docs/changelog-released.md
@@ -1148,14 +1148,14 @@ Special thanks to our community contributors:
   ```mojo
   var f = open("/tmp/example.txt")
   # Skip 32 bytes
-  f.seek(os.SEEK_CUR, 32)
+  f.seek(32, os.SEEK_CUR)
   ```
 
   Or `os.SEEK_END` to offset from the end of file:
 
   ```mojo
   # Start from 32 bytes before the end of the file
-  f.seek(os.SEEK_END, -32)
+  f.seek(-32, os.SEEK_END)
   ```
 
 - [`FileHandle.read()`](/mojo/stdlib/builtin/file/FileHandle#read) can now

--- a/stdlib/src/builtin/file.mojo
+++ b/stdlib/src/builtin/file.mojo
@@ -377,7 +377,7 @@ struct FileHandle:
         ```mojo
         import os
         var f = open("/tmp/example.txt", "r")
-        f.seek(os.SEEK_CUR, 32)
+        f.seek(32, os.SEEK_CUR)
         ```
 
         Start from 32 bytes from the end of the file:
@@ -385,7 +385,7 @@ struct FileHandle:
         ```mojo
         import os
         var f = open("/tmp/example.txt", "r")
-        f.seek(os.SEEK_END, -32)
+        f.seek(-32, os.SEEK_END)
         ```
         .
         """


### PR DESCRIPTION
The example codeblocks for FileHandle seek swap the order of the offset and whence positional arguments