### PR TITLE
[stdlib] Add `SIMD.count` for `Scalar` rhs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -289,9 +289,9 @@ future and `StringSlice.__len__` now does return the Unicode codepoints length.
   Example usage:
 
   ```mojo
-  var B = SIMD[DType.int64, 4](1)
-  B[0] = 0
-  print(B.count(1)) # 3
+  var vector_of_four_int64 = SIMD[DType.int64, 4](1)
+  vector_of_four_int64[0] = 0
+  print(vector_of_four_int64.count(1)) # 3
   ```
 
 ### 🦋 Changed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -283,6 +283,17 @@ future and `StringSlice.__len__` now does return the Unicode codepoints length.
   # pw_gecos='System Administrator', pw_dir='/var/root', pw_shell='/bin/zsh')
   ```
 
+- Added `SIMD.count` method for `Scalar` rhs.
+  ([PR #3179](https://github.com/modularml/mojo/pull/3179) by [@rd4com](https://github.com/rd4com))
+
+  Example usage:
+
+  ```mojo
+  var B = SIMD[DType.int64, 4](1)
+  B[0] = 0
+  print(B.count(1)) # 3
+  ```
+
 ### 🦋 Changed
 
 - The pointer aliasing semantics of Mojo have changed. Initially, Mojo adopted a

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -289,9 +289,7 @@ future and `StringSlice.__len__` now does return the Unicode codepoints length.
   Example usage:
 
   ```mojo
-  var vector_of_four_int64 = SIMD[DType.int64, 4](1)
-  vector_of_four_int64[0] = 0
-  print(vector_of_four_int64.count(1)) # 3
+  print(SIMD[DType.uint8, 4](1, 1, 1, 0).count(1)) # 3
   ```
 
 ### 🦋 Changed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -284,7 +284,8 @@ future and `StringSlice.__len__` now does return the Unicode codepoints length.
   ```
 
 - Added `SIMD.count` method for `Scalar` rhs.
-  ([PR #3179](https://github.com/modularml/mojo/pull/3179) by [@rd4com](https://github.com/rd4com))
+  ([PR #3179](https://github.com/modularml/mojo/pull/3179)
+  by [@rd4com](https://github.com/rd4com))
 
   Example usage:
 

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2161,7 +2161,7 @@ struct SIMD[type: DType, size: Int](
     fn count(self, value: Scalar[type]) -> Int:
         """Counts the number of occurrences of a value in the vector.
 
-        Example:
+        Examples:
 
         ```mojo
         print(SIMD[DType.uint8, 4](1, 1, 1, 0).count(1)) # 3

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2161,10 +2161,9 @@ struct SIMD[type: DType, size: Int](
     fn count(self, value: Scalar[type]) -> Int:
         """Counts the number of occurrences of a value in the vector.
 
-        Examples:
+        Example:
 
         ```mojo
-        var thirty_two_uint8 = SIMD[DType.uint8, 32](1)
         print(SIMD[DType.uint8, 4](1, 1, 1, 0).count(1)) # 3
         ```
 

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2158,6 +2158,30 @@ struct SIMD[type: DType, size: Int](
         constrained[type.is_numeric(), "the SIMD type must be numeric"]()
         return __mlir_op.`pop.max`(self.value, other.value)
 
+    fn count(self, value: Scalar[type]) -> Int:
+        """Count the occurences the value in the vector.
+
+        Example usage:
+
+        ```mojo
+        var thirty_two_uint8 = SIMD[DType.uint8, 32](1)
+        thirty_two_uint8[0] = 0
+        print(thirty_two_uint8.count(1)) # 31
+        ```
+
+        Args:
+            value: The value.
+
+        Returns:
+            The amount of time the value occurs in the vector.
+        """
+
+        @parameter
+        if self.size > 255:
+            constrained[False, "size > 255"]()
+            # adding 256 occurences of a value would wrap to 0
+        return (self == value).cast[DType.uint8]().reduce_add().__int__()
+
     # ===------------------------------------------------------------------=== #
     # Reduce operations
     # ===------------------------------------------------------------------=== #

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2178,7 +2178,7 @@ struct SIMD[type: DType, size: Int](
 
         constrained[self.size < 256, "size must be less than 256"]()
         # adding 256 occurences of a value would wrap to 0
-        return (self == value).cast[DType.uint8]().reduce_add().__int__()
+        return int((self == value).cast[DType.uint8]().reduce_add())
 
     # ===------------------------------------------------------------------=== #
     # Reduce operations

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2165,7 +2165,6 @@ struct SIMD[type: DType, size: Int](
 
         ```mojo
         var thirty_two_uint8 = SIMD[DType.uint8, 32](1)
-        thirty_two_uint8[0] = 0
         print(SIMD[DType.uint8, 4](1, 1, 1, 0).count(1)) # 3
         ```
 

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2176,9 +2176,8 @@ struct SIMD[type: DType, size: Int](
             The number of occurrences of the value in the vector.
         """
 
-        @parameter
         constrained[self.size < 256, "size must be less than 256"]()
-            # adding 256 occurences of a value would wrap to 0
+        # adding 256 occurences of a value would wrap to 0
         return (self == value).cast[DType.uint8]().reduce_add().__int__()
 
     # ===------------------------------------------------------------------=== #

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2159,7 +2159,7 @@ struct SIMD[type: DType, size: Int](
         return __mlir_op.`pop.max`(self.value, other.value)
 
     fn count(self, value: Scalar[type]) -> Int:
-        """Count the occurences the value in the vector.
+        """Counts the number of occurrences of a value in the vector.
 
         Example usage:
 

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2174,8 +2174,9 @@ struct SIMD[type: DType, size: Int](
             The number of occurrences of the value in the vector.
         """
 
-        constrained[self.size < 256, "size must be less than 256"]()
-        # adding 256 occurences of a value would wrap to 0
+        @parameter
+        if size > 255:
+            return int((self == value).cast[DType.uint16]().reduce_add())
         return int((self == value).cast[DType.uint8]().reduce_add())
 
     # ===------------------------------------------------------------------=== #

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2161,7 +2161,7 @@ struct SIMD[type: DType, size: Int](
     fn count(self, value: Scalar[type]) -> Int:
         """Counts the number of occurrences of a value in the vector.
 
-        Example usage:
+        Examples:
 
         ```mojo
         var thirty_two_uint8 = SIMD[DType.uint8, 32](1)

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2177,8 +2177,7 @@ struct SIMD[type: DType, size: Int](
         """
 
         @parameter
-        if self.size > 255:
-            constrained[False, "size > 255"]()
+        constrained[self.size < 256, "size must be less than 256"]()
             # adding 256 occurences of a value would wrap to 0
         return (self == value).cast[DType.uint8]().reduce_add().__int__()
 

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2166,7 +2166,7 @@ struct SIMD[type: DType, size: Int](
         ```mojo
         var thirty_two_uint8 = SIMD[DType.uint8, 32](1)
         thirty_two_uint8[0] = 0
-        print(thirty_two_uint8.count(1)) # 31
+        print(SIMD[DType.uint8, 4](1, 1, 1, 0).count(1)) # 3
         ```
 
         Args:

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -2173,7 +2173,7 @@ struct SIMD[type: DType, size: Int](
             value: The value.
 
         Returns:
-            The amount of time the value occurs in the vector.
+            The number of occurrences of the value in the vector.
         """
 
         @parameter

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -1547,40 +1547,40 @@ def test_contains():
 
 
 def test_count():
-    var A = SIMD[DType.uint8, 32](1)
-    assert_equal(A.count(1), 32)
-    A[31] = 0
-    assert_equal(A.count(1), 31)
+    var a = SIMD[DType.uint8, 32](1)
+    assert_equal(a.count(1), 32)
+    a[31] = 0
+    assert_equal(a.count(1), 31)
 
-    var B = SIMD[DType.bool, 32](True)
-    assert_equal(B.count(True), 32)
-    B[0] = False
-    assert_equal(B.count(True), 31)
+    var b = SIMD[DType.bool, 32](True)
+    assert_equal(b.count(True), 32)
+    b[0] = False
+    assert_equal(b.count(True), 31)
 
     for i in range(32):
-        B[I] = i % 2
+        b[i] = i % 2
 
-    assert_equal(B.count(True), 16)
-    assert_equal(B.count(False), 16)
+    assert_equal(b.count(True), 16)
+    assert_equal(b.count(False), 16)
 
-    var C = B.cast[DType.uint16]()
-    assert_equal(C.count(1), 16)
-    assert_equal(C.count(0), 16)
+    var c = b.cast[DType.uint16]()
+    assert_equal(c.count(1), 16)
+    assert_equal(c.count(0), 16)
 
-    var D = B.cast[DType.float32]()
-    assert_equal(D.count(1.0), 16)
-    assert_equal(D.count(0.0), 16)
-    assert_equal(D.count(1.5), 0)
+    var d = b.cast[DType.float32]()
+    assert_equal(d.count(1.0), 16)
+    assert_equal(d.count(0.0), 16)
+    assert_equal(d.count(1.5), 0)
 
-    var E = SIMD[DType.int64, 4](100, 200, 300, 100)
-    assert_equal(E.count(100), 2)
-    assert_equal(E.count(200), 1)
-    assert_equal(E.count(150), 0)
+    var e = SIMD[DType.int64, 4](100, 200, 300, 100)
+    assert_equal(e.count(100), 2)
+    assert_equal(e.count(200), 1)
+    assert_equal(e.count(150), 0)
 
-    E = E * -1
-    assert_equal(E.count(-100), 2)
-    assert_equal(E.count(-200), 1)
-    assert_equal(E.count(-150), 0)
+    e = e * -1
+    assert_equal(e.count(-100), 2)
+    assert_equal(e.count(-200), 1)
+    assert_equal(e.count(-150), 0)
 
 
 def main():

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -1558,10 +1558,7 @@ def test_count():
     assert_equal(B.count(True), 31)
 
     for i in range(32):
-        if i % 2 == 0:
-            B[i] = False
-        else:
-            B[i] = True
+        B[I] = i % 2
 
     assert_equal(B.count(True), 16)
     assert_equal(B.count(False), 16)

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -1582,6 +1582,23 @@ def test_count():
     assert_equal(e.count(-200), 1)
     assert_equal(e.count(-150), 0)
 
+    # SIMD vector size >= 256 :
+    var f = SIMD[DType.uint8, 256](1)
+    assert_equal(f.count(1), 256)
+    f[0] = 0
+    assert_equal(f.count(1), 255)
+
+    var g = SIMD[DType.uint8, 256](0)
+    assert_equal(g.count(1), 0)
+    assert_equal(g.count(0), 256)
+    g[0] = 1
+    assert_equal(g.count(1), 1)
+    assert_equal(g.count(0), 255)
+
+    var h = SIMD[DType.uint8, 512](1)
+    assert_equal(h.count(1), 512)
+    h[0] = 0
+    assert_equal(h.count(1), 511)
 
 def main():
     test_abs()

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -1600,6 +1600,7 @@ def test_count():
     h[0] = 0
     assert_equal(h.count(1), 511)
 
+
 def main():
     test_abs()
     test_add()

--- a/stdlib/test/builtin/test_simd.mojo
+++ b/stdlib/test/builtin/test_simd.mojo
@@ -1546,6 +1546,46 @@ def test_contains():
     assert_false(0 in y or 5 in y)
 
 
+def test_count():
+    var A = SIMD[DType.uint8, 32](1)
+    assert_equal(A.count(1), 32)
+    A[31] = 0
+    assert_equal(A.count(1), 31)
+
+    var B = SIMD[DType.bool, 32](True)
+    assert_equal(B.count(True), 32)
+    B[0] = False
+    assert_equal(B.count(True), 31)
+
+    for i in range(32):
+        if i % 2 == 0:
+            B[i] = False
+        else:
+            B[i] = True
+
+    assert_equal(B.count(True), 16)
+    assert_equal(B.count(False), 16)
+
+    var C = B.cast[DType.uint16]()
+    assert_equal(C.count(1), 16)
+    assert_equal(C.count(0), 16)
+
+    var D = B.cast[DType.float32]()
+    assert_equal(D.count(1.0), 16)
+    assert_equal(D.count(0.0), 16)
+    assert_equal(D.count(1.5), 0)
+
+    var E = SIMD[DType.int64, 4](100, 200, 300, 100)
+    assert_equal(E.count(100), 2)
+    assert_equal(E.count(200), 1)
+    assert_equal(E.count(150), 0)
+
+    E = E * -1
+    assert_equal(E.count(-100), 2)
+    assert_equal(E.count(-200), 1)
+    assert_equal(E.count(-150), 0)
+
+
 def main():
     test_abs()
     test_add()
@@ -1595,4 +1635,5 @@ def main():
     test_modf()
     test_split()
     test_contains()
+    test_count()
     # TODO: add tests for __and__, __or__, anc comparison operators


### PR DESCRIPTION
Hello,

here is a method that do a `SIMD` count:

```mojo
var B = SIMD[DType.bool, 32](True)
assert_equal(B.count(True), 32)

for i in range(32):
    if i%2 == 0:
        B[i] = False
    else:
        B[i] = True

assert_equal(B.count(True), 16)
assert_equal(B.count(False), 16)
```
The implementation looks like this:
```mojo
(self == value).cast[DType.uint8]().reduce_add().__int__()
```
And we do a `@parameter if` check to make sure `self.size` is below `256` :+1: 