### PR TITLE
[stdlib] Enable equality comparisons for `List[T] == List[T]`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,11 @@ what we publish.
 
 ### ⭐️ New
 
+- `List[T]` values are now equality comparable with `==` and `!=` when `T` is
+  equality comparable.
+  ([PR 3195#](https://github.com/modularml/mojo/pull/3195) by
+  [@kszucs](https://github.com/kszucs))
+
 - `__setitem__` now works with variadic argument lists such as:
 
   ```mojo

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -197,6 +197,62 @@ struct List[T: CollectionElement](
     # Operator dunders
     # ===-------------------------------------------------------------------===#
 
+    fn __eq__[
+        U: EqualityComparableCollectionElement
+    ](self: List[U], other: List[U]) -> Bool:
+        """Checks if two lists are equal.
+
+        Examples:
+        ```mojo
+        var x = List[Int](1, 2, 3)
+        var y = List[Int](1, 2, 3)
+        if x == y: print("x and y are equal")
+        ```
+
+        Parameters:
+            U: The type of the elements in the list. Must implement the
+               traits `EqualityComparable` and `CollectionElement`.
+
+        Args:
+            other: The list to compare with.
+
+        Returns:
+            True if the lists are equal, False otherwise.
+        """
+        if len(self) != len(other):
+            return False
+        var index = 0
+        for i in self:
+            if i[] != other[index]:
+                return False
+            index += 1
+        return True
+
+    fn __ne__[
+        U: EqualityComparableCollectionElement
+    ](self: List[U], other: List[U]) -> Bool:
+        """Checks if two lists are not equal.
+
+        Examples:
+
+        ```mojo
+        var x = List[Int](1, 2, 3)
+        var y = List[Int](1, 2, 4)
+        if x != y: print("x and y are not equal")
+        ```
+
+        Parameters:
+            U: The type of the elements in the list. Must implement the
+               traits `EqualityComparable` and `CollectionElement`.
+
+        Args:
+            other: The list to compare with.
+
+        Returns:
+            True if the lists are not equal, False otherwise.
+        """
+        return not (self == other)
+
     fn __contains__[
         U: ComparableCollectionElement
     ](self: List[U], value: U) -> Bool:

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -816,6 +816,29 @@ def test_list_contains():
     # assert_equal(List(0,1) in y,False)
 
 
+def test_list_eq_ne():
+    var l1 = List[Int](1, 2, 3)
+    var l2 = List[Int](1, 2, 3)
+    assert_true(l1 == l2)
+    assert_false(l1 != l2)
+
+    var l3 = List[Int](1, 2, 3, 4)
+    assert_false(l1 == l3)
+    assert_true(l1 != l3)
+
+    var l4 = List[Int]()
+    var l5 = List[Int]()
+    assert_true(l4 == l5)
+    assert_true(l1 != l4)
+
+    var l6 = List[String]("a", "b", "c")
+    var l7 = List[String]("a", "b", "c")
+    var l8 = List[String]("a", "b")
+    assert_true(l6 == l7)
+    assert_false(l6 != l7)
+    assert_false(l6 == l8)
+
+
 def test_list_init_span():
     var l = List[String]("a", "bb", "cc", "def")
     var sp = Span(l)


### PR DESCRIPTION
Noticed that this feature has been missing, so I implemented `List.__eq__` and `List.__ne__`. 

