### PR TITLE
[stdlib] UTests for `IntLiteral`'s operators required by `Comparable`

### DIFF
--- a/stdlib/test/builtin/test_int_literal.mojo
+++ b/stdlib/test/builtin/test_int_literal.mojo
@@ -115,6 +115,38 @@ def test_bool():
     assert_false(IntLiteral.__as_bool__(0))
 
 
+def test_comparison():
+    assert_true(IntLiteral(5).__lt__(10))
+    assert_true(IntLiteral(-10).__lt__(-5))
+    assert_false(IntLiteral(0).__lt__(0))
+    assert_false(IntLiteral(10).__lt__(5))
+
+    assert_true(IntLiteral(5).__le__(10))
+    assert_true(IntLiteral(-10).__le__(-5))
+    assert_true(IntLiteral(0).__le__(0))
+    assert_false(IntLiteral(10).__le__(5))
+
+    assert_true(IntLiteral(5).__eq__(5))
+    assert_true(IntLiteral(0).__eq__(0))
+    assert_false(IntLiteral(0).__eq__(1))
+    assert_false(IntLiteral(5).__eq__(10))
+
+    assert_true(IntLiteral(5).__ne__(10))
+    assert_true(IntLiteral(0).__ne__(1))
+    assert_false(IntLiteral(5).__ne__(5))
+    assert_false(IntLiteral(0).__ne__(0))
+
+    assert_true(IntLiteral(10).__gt__(5))
+    assert_true(IntLiteral(-5).__gt__(-10))
+    assert_false(IntLiteral(0).__gt__(0))
+    assert_false(IntLiteral(5).__gt__(10))
+
+    assert_true(IntLiteral(10).__ge__(5))
+    assert_true(IntLiteral(5).__ge__(5))
+    assert_true(IntLiteral(-5).__ge__(-10))
+    assert_false(IntLiteral(5).__ge__(10))
+
+
 def main():
     test_add()
     test_sub()
@@ -129,3 +161,4 @@ def main():
     test_abs()
     test_indexer()
     test_bool()
+    test_comparison()


### PR DESCRIPTION
Testing the following dunder methods in `IntLiteral`: `__lt__`, `__le__`, `__eq__`, `__ne__`, `__gt__` and `__ge__`. Note that we test directly dunder methods to avoid any unintended implicit conversions possibly introduced trough operator syntax sugar.

Partially resolves #3145.