### PR TITLE
[stdlib] `write_to(writer, ...)` -> `writer.write(...)`

### DIFF
--- a/stdlib/src/builtin/io.mojo
+++ b/stdlib/src/builtin/io.mojo
@@ -29,7 +29,7 @@ from builtin.file_descriptor import FileDescriptor
 from memory import UnsafePointer
 
 from utils import StringRef, StaticString, StringSlice
-from utils._format import Formattable, Formatter, write_to
+from utils._format import Formattable, Formatter
 
 # ===----------------------------------------------------------------------=== #
 #  _file_handle

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -25,7 +25,6 @@ from sys.intrinsics import _type_is_eq
 from memory import Reference, UnsafePointer
 
 from utils import Span
-from utils._format import write_to
 
 from .optional import Optional
 
@@ -419,7 +418,7 @@ struct List[T: CollectionElement](
 
         ```mojo
         var my_list = List[Int](1, 2, 3)
-        print(my_list.__repr__(my_list))
+        print(my_list.__repr__())
         ```
 
         When the compiler supports conditional methods, then a simple `repr(my_list)` will

--- a/stdlib/src/collections/optional.mojo
+++ b/stdlib/src/collections/optional.mojo
@@ -285,9 +285,9 @@ struct Optional[T: CollectionElement](
         """
         var output = String()
         var writer = output._unsafe_to_formatter()
-        write_to(writer, "Optional(")
+        writer.write("Optional(")
         self.format_to(writer)
-        write_to(writer, ")")
+        writer.write(")")
         return output
 
     fn format_to[
@@ -303,9 +303,9 @@ struct Optional[T: CollectionElement](
             writer: The formatter to write to.
         """
         if self:
-            write_to(writer, repr(self.value()))
+            writer.write(repr(self.value()))
         else:
-            write_to(writer, "None")
+            writer.write("None")
 
     # ===-------------------------------------------------------------------===#
     # Methods

--- a/stdlib/src/collections/set.mojo
+++ b/stdlib/src/collections/set.mojo
@@ -340,14 +340,14 @@ struct Set[T: KeyElement](Sized, Comparable, Hashable, Boolable):
         Args:
             writer: The formatter to write to.
         """
-        write_to(writer, "{")
+        writer.write("{")
         var written = 0
         for item in self:
-            write_to(writer, repr(item[]))
+            writer.write(repr(item[]))
             if written < len(self) - 1:
-                write_to(writer, ", ")
+                writer.write(", ")
             written += 1
-        write_to(writer, "}")
+        writer.write("}")
 
     # ===-------------------------------------------------------------------===#
     # Methods

--- a/stdlib/src/utils/_format.mojo
+++ b/stdlib/src/utils/_format.mojo
@@ -184,16 +184,3 @@ struct Formatter:
             _put(strref)
 
         return Formatter(write_to_stdout, UnsafePointer[NoneType]())
-
-
-# TODO: Use Formatter.write instead.
-fn write_to[*Ts: Formattable](inout writer: Formatter, *args: *Ts):
-    """
-    Write a sequence of formattable arguments to the provided formatter.
-    """
-
-    @parameter
-    fn write_arg[T: Formattable](arg: T):
-        arg.format_to(writer)
-
-    args.each[write_arg]()

--- a/stdlib/test/utils/test_format.mojo
+++ b/stdlib/test/utils/test_format.mojo
@@ -14,7 +14,7 @@
 
 from testing import assert_equal
 
-from utils._format import Formattable, Formatter, write_to
+from utils._format import Formattable, Formatter
 from utils.inline_string import _FixedString
 
 
@@ -35,7 +35,7 @@ struct Point(Formattable, Stringable):
 
     @no_inline
     fn format_to(self, inout writer: Formatter):
-        write_to(writer, "Point(", self.x, ", ", self.y, ")")
+        writer.write("Point(", self.x, ", ", self.y, ")")
 
     @no_inline
     fn __str__(self) -> String:
@@ -52,11 +52,11 @@ fn test_formatter_of_string() raises:
     assert_equal(s1, "Point(2, 7)")
 
     #
-    # Test write_to(String, ..)
+    # Test fmt.write(String, ..)
     #
     var s2 = String()
     var s2_fmt = Formatter(s2)
-    write_to(s2_fmt, Point(3, 8))
+    s2_fmt.write(Point(3, 8))
     assert_equal(s2, "Point(3, 8)")
 
 
@@ -78,7 +78,7 @@ fn test_stringable_based_on_format() raises:
 fn test_formatter_of_fixed_string() raises:
     var s1 = _FixedString[100]()
     var s1_fmt = Formatter(s1)
-    write_to(s1_fmt, "Hello, World!")
+    s1_fmt.write("Hello, World!")
     assert_equal(str(s1), "Hello, World!")
 
 

--- a/stdlib/test/utils/test_format_to_stdout.mojo
+++ b/stdlib/test/utils/test_format_to_stdout.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo -debug-level full %s
 
-from utils._format import Formattable, Formatter, write_to
+from utils._format import Formattable, Formatter
 
 
 fn main() raises:
@@ -25,7 +25,7 @@ struct Point(Formattable):
     var y: Int
 
     fn format_to(self, inout writer: Formatter):
-        write_to(writer, "Point(", self.x, ", ", self.y, ")")
+        writer.write("Point(", self.x, ", ", self.y, ")")
 
 
 # CHECK-LABEL: test_write_to_stdout
@@ -35,8 +35,8 @@ fn test_write_to_stdout():
     var stdout = Formatter.stdout()
 
     # CHECK: Hello, World!
-    write_to(stdout, "Hello, World!")
+    stdout.write("Hello, World!")
 
     # CHECK: point = Point(1, 1)
     var point = Point(1, 1)
-    write_to(stdout, "point = ", point)
+    stdout.write("point = ", point)


### PR DESCRIPTION
use `writer.write(...)` instead of `write_to(writer, ...)`