### PR TITLE
[stdlib] Add min and max to Int

### DIFF
--- a/stdlib/src/builtin/int.mojo
+++ b/stdlib/src/builtin/int.mojo
@@ -1119,6 +1119,14 @@ struct Int(
             _format_scalar(writer, Int64(self))
 
     @always_inline("nodebug")
+    fn max(self, rhs: Self) -> Self:
+        return __mlir_op.`index.maxs`(self.value, rhs.value)
+
+    @always_inline("nodebug")
+    fn min(self, rhs: Self) -> Self:
+        return __mlir_op.`index.mins`(self.value, rhs.value)
+
+    @always_inline("nodebug")
     fn __mlir_index__(self) -> __mlir_type.index:
         """Convert to index.
 

--- a/stdlib/src/builtin/int.mojo
+++ b/stdlib/src/builtin/int.mojo
@@ -1119,12 +1119,28 @@ struct Int(
             _format_scalar(writer, Int64(self))
 
     @always_inline("nodebug")
-    fn max(self, rhs: Self) -> Self:
-        return __mlir_op.`index.maxs`(self.value, rhs.value)
+    fn max(self, other: Self) -> Self:
+        """Computes the maximum between the two Ints.
+
+        Args:
+            other: The other Int.
+
+        Returns:
+            A new Int with the maximum value of self and other.
+        """
+        return __mlir_op.`index.maxs`(self.value, other.value)
 
     @always_inline("nodebug")
-    fn min(self, rhs: Self) -> Self:
-        return __mlir_op.`index.mins`(self.value, rhs.value)
+    fn min(self, other: Self) -> Self:
+        """Computes the minimum between the two Ints.
+
+        Args:
+            other: The other Int.
+
+        Returns:
+            A new Int with the minimum value of self and other.
+        """
+        return __mlir_op.`index.mins`(self.value, other.value)
 
     @always_inline("nodebug")
     fn __mlir_index__(self) -> __mlir_type.index:

--- a/stdlib/test/builtin/test_int.mojo
+++ b/stdlib/test/builtin/test_int.mojo
@@ -227,6 +227,23 @@ def test_comparison():
     assert_false(Int(5).__ge__(Int(10)))
 
 
+def test_max():
+    assert_equal(Int(5).max(3), 5)
+    assert_equal(Int(3).max(5), 5)
+    var a: Int = 0
+    assert_equal(a.max(Int.MAX), Int.MAX)
+    assert_equal(Int(3).max(-5), 3)
+    assert_equal(Int(-3).max(5), 5)
+
+
+def test_min():
+    assert_equal(Int(5).min(3), 3)
+    assert_equal(Int(3).min(5), 3)
+    var a: Int = 0
+    assert_equal(a.min(Int.MAX), 0)
+    assert_equal(a.min(Int.MIN), Int.MIN)
+
+
 def main():
     test_properties()
     test_add()
@@ -248,3 +265,5 @@ def main():
     test_decimal_digit_count()
     test_comparison()
     test_int_uint()
+    test_max()
+    test_min()


### PR DESCRIPTION
Since `SIMD` already has a `min` and `max` function on it, it would make sense to add the same for `Int`. Also, since `Int` is basically just a thin wrapper around `__mlir_type.index`, it should probably reveal the rest of the `index` dialect ops eventually.