### PR TITLE
[stdlib] `__contains__` for ListLiteral

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -297,6 +297,10 @@ future and `StringSlice.__len__` now does return the Unicode codepoints length.
   # Insert (2/3 of 1024) entries
   ```
 
+- `ListLiteral` now supports `__contains__`.
+  ([PR #3251](https://github.com/modularml/mojo/pull/3251) by
+  [@jjvraw](https://github.com/jjvraw))
+
 ### 🦋 Changed
 
 - The pointer aliasing semantics of Mojo have changed. Initially, Mojo adopted a

--- a/stdlib/src/builtin/builtin_list.mojo
+++ b/stdlib/src/builtin/builtin_list.mojo
@@ -17,6 +17,8 @@ These are Mojo built-ins, so you don't need to import them.
 
 from memory import Reference, UnsafePointer
 
+from sys.intrinsics import _type_is_eq
+
 # ===----------------------------------------------------------------------===#
 # ListLiteral
 # ===----------------------------------------------------------------------===#
@@ -74,6 +76,32 @@ struct ListLiteral[*Ts: Movable](Sized, Movable):
         """
         # FIXME: Rebinding to a different lifetime.
         return UnsafePointer.address_of(self.storage[i]).bitcast[T]()[]
+
+    @always_inline("nodebug")
+    fn __contains__[T: EqualityComparable](self, value: T) -> Bool:
+        """Determines if a given value exists in the ListLiteral.
+
+        Parameters:
+            T: The type of the value to search for. Must implement the
+              `EqualityComparable` trait.
+
+        Args:
+            value: The value to search for in the ListLiteral.
+
+        Returns:
+            True if the value is found in the ListLiteral, False otherwise.
+        """
+
+        @parameter
+        for i in range(len(VariadicList(Ts))):
+            if _type_is_eq[Ts[i], T]():
+                var elt_ptr = UnsafePointer.address_of(self.storage[i]).bitcast[
+                    T
+                ]()
+                if elt_ptr[] == value:
+                    return True
+
+        return False
 
 
 # ===----------------------------------------------------------------------===#

--- a/stdlib/test/builtin/test_list.mojo
+++ b/stdlib/test/builtin/test_list.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo %s
 
-from testing import assert_equal
+from testing import assert_equal, assert_true, assert_false
 
 
 fn test_list() raises:
@@ -39,7 +39,41 @@ fn test_repr_list() raises:
     assert_equal(empty.__repr__(), "[]")
 
 
+fn test_contains() raises:
+    # List
+    var l = List[String]("Hello", ",", "World", "!")
+    assert_true("Hello" in l)
+    assert_true(l.__contains__(String(",")))
+    assert_true("World" in l)
+    assert_true("!" in l)
+    assert_false("Mojo" in l)
+    assert_false(l.__contains__("hello"))
+    assert_false("" in l or l.__contains__(""))
+
+    # ListLiteral
+    var h = [1, False, String("Mojo")]
+    assert_true(1 in h)
+    assert_true(h.__contains__(1))
+    assert_false(True in h)
+    assert_false(h.__contains__(True))
+    assert_false(0 in h)
+    assert_true(False in h)
+    assert_false("Mojo" in h)
+    assert_true(String("Mojo") in h)
+    assert_false(String("") in h)
+    assert_false("" in h)
+
+    # TODO:
+    # Reevaluate the strict type checking behaviour in ListLiteral.__contains__.
+    # Consider aligning with the behavior with List.__contains__ when possible
+    # or a feasible workaround is identified.
+    # For instance, consider the following:
+    assert_true("Hello" in l and String("Hello") in l)
+    assert_true("Mojo" not in h and String("Mojo") in h)
+
+
 def main():
     test_list()
     test_variadic_list()
     test_repr_list()
+    test_contains()


### PR DESCRIPTION
An implementation of the `__contains__` function for `ListLiteral` as per issue #2658. 

The function parameterises the `EqualityComparable` trait, this maintains consistency with `Tuple.__contains__` behaviour (in nightly). 