### PR TITLE
[stdlib] Support creating nested python objects using list literals

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,27 @@ what we publish.
 
 ### ⭐️ New
 
+- Creating nested `PythonObject` from a list or tuple of python objects is
+  possible now:
+
+  ```mojo
+  var np = Python.import_module("numpy")
+  var a = np.array([1, 2, 3])
+  var b = np.array([4, 5, 6])
+  var arrays = PythonObject([a, b])
+  assert_equal(len(arrays), 2)
+  ```
+
+  Also allowing more convenient call syntax:
+
+  ```mojo
+  var stacked = np.hstack((a, b))
+  assert_equal(str(stacked), "[1 2 3 4 5 6]")
+  ```
+
+  ([PR 3264#](https://github.com/modularml/mojo/pull/3264) by
+  [@kszucs](https://github.com/kszucs))
+
 - `List[T]` values are now equality comparable with `==` and `!=` when `T` is
   equality comparable.
   ([PR 3195#](https://github.com/modularml/mojo/pull/3195) by

--- a/stdlib/src/python/object.mojo
+++ b/stdlib/src/python/object.mojo
@@ -255,7 +255,9 @@ struct PythonObject(
             var obj: PythonObject
 
             @parameter
-            if _type_is_eq[T, Int]():
+            if _type_is_eq[T, PythonObject]():
+                obj = value.get[i, PythonObject]()
+            elif _type_is_eq[T, Int]():
                 obj = PythonObject(value.get[i, Int]())
             elif _type_is_eq[T, Float64]():
                 obj = PythonObject(value.get[i, Float64]())
@@ -268,8 +270,9 @@ struct PythonObject(
             else:
                 obj = PythonObject(0)
                 constrained[
-                    False, "cannot convert nested list element to object"
+                    False, "cannot convert list element to python object"
                 ]()
+
             cpython.Py_IncRef(obj.py_object)
             _ = cpython.PyList_SetItem(self.py_object, i, obj.py_object)
 
@@ -295,7 +298,9 @@ struct PythonObject(
             var obj: PythonObject
 
             @parameter
-            if _type_is_eq[T, Int]():
+            if _type_is_eq[T, PythonObject]():
+                obj = value.get[i, PythonObject]()
+            elif _type_is_eq[T, Int]():
                 obj = PythonObject(value.get[i, Int]())
             elif _type_is_eq[T, Float64]():
                 obj = PythonObject(value.get[i, Float64]())
@@ -308,8 +313,9 @@ struct PythonObject(
             else:
                 obj = PythonObject(0)
                 constrained[
-                    False, "cannot convert nested list element to object"
+                    False, "cannot convert list element to python object"
                 ]()
+
             cpython.Py_IncRef(obj.py_object)
             _ = cpython.PyTuple_SetItem(self.py_object, i, obj.py_object)
 

--- a/stdlib/test/python/test_python_object.mojo
+++ b/stdlib/test/python/test_python_object.mojo
@@ -339,6 +339,16 @@ def test_is():
     assert_true(l1 is not l2)
 
 
+def test_nested_object():
+    var a = PythonObject([1, 2, 3])
+    var b = PythonObject([4, 5, 6])
+    var nested_list = PythonObject([a, b])
+    var nested_tuple = PythonObject((a, b))
+
+    assert_equal(str(nested_list), "[[1, 2, 3], [4, 5, 6]]")
+    assert_equal(str(nested_tuple), "([1, 2, 3], [4, 5, 6])")
+
+
 fn test_iter() raises:
     var list_obj: PythonObject = ["apple", "orange", "banana"]
     var i = 0
@@ -411,3 +421,4 @@ def main():
     test_setitem()
     test_dict()
     test_none()
+    test_nested_object()


### PR DESCRIPTION
Previously creating python objects from list literals was not possible making the python experience less convenient. Noticed this while I wanted to create a pyarrow schema from mojo. Instead of the following:

```mojo
    var pa = Python.import_module("pyarrow")
    var int_field = pa.field("int_field", pa.int32())
    var string_field = pa.field("string_field", pa.string())
    var schema = pa.schema([int_field, string_field])
```

I had to append the fields to an empty schema:

```mojo
    var schema = pa.schema([])
    schema = schema.append(some_int)
    schema = schema.append(some_string)
```

This change allows creating a `PythonObject` from both `ListLiteral`s and `Tuple`s containing `PythonObject` values.