### PR TITLE
[stdlib] Add equality methods to `Reference`.

### DIFF
--- a/stdlib/src/memory/reference.mojo
+++ b/stdlib/src/memory/reference.mojo
@@ -332,3 +332,31 @@ struct Reference[
             The MLIR reference for the Mojo compiler to use.
         """
         return __get_litref_as_mvalue(self.value)
+
+    @always_inline("nodebug")
+    fn __eq__(self, rhs: Reference[type, _, address_space]) -> Bool:
+        """Returns True if the two pointers are equal.
+
+        Args:
+            rhs: The value of the other pointer.
+
+        Returns:
+            True if the two pointers are equal and False otherwise.
+        """
+        return UnsafePointer(
+            __mlir_op.`lit.ref.to_pointer`(self.value)
+        ) == __mlir_op.`lit.ref.to_pointer`(rhs.value)
+
+    @always_inline("nodebug")
+    fn __ne__(self, rhs: Reference[type, _, address_space]) -> Bool:
+        """Returns True if the two pointers are not equal.
+
+        Args:
+            rhs: The value of the other pointer.
+
+        Returns:
+            True if the two pointers are not equal and False otherwise.
+        """
+        return UnsafePointer(
+            __mlir_op.`lit.ref.to_pointer`(self.value)
+        ) != __mlir_op.`lit.ref.to_pointer`(rhs.value)

--- a/stdlib/test/memory/test_reference.mojo
+++ b/stdlib/test/memory/test_reference.mojo
@@ -11,7 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo %s
-from testing import assert_equal
+from testing import assert_equal, assert_true
 
 
 def test_copy_reference_explicitly():
@@ -27,5 +27,15 @@ def test_copy_reference_explicitly():
     assert_equal(c[][0], 4)
 
 
+def test_equality():
+    var a = List[Int](1, 2, 3)
+    var b = List[Int](4, 5, 6)
+
+    assert_true(Reference(a) == Reference(a))
+    assert_true(Reference(b) == Reference(b))
+    assert_true(Reference(a) != Reference(b))
+
+
 def main():
     test_copy_reference_explicitly()
+    test_equality()


### PR DESCRIPTION
Does anyone know if there are any checks to take care of some equality/inequality cases at compile time? Like, by comparing the lifetimes.