### PR TITLE
[stdlib] Introduce modular exponentation via `pow(Int, Int, Int)`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -350,6 +350,17 @@ future and `StringSlice.__len__` now does return the Unicode codepoints length.
   # "Mojo 'Mojo'"
   ```
 
+- Modular exponentation for is now supported via `math.pow(Int, Int, Int)`
+  ([PR #3307](https://github.com/modularml/mojo/pull/3307) by
+  [@jjvraw](https://github.com/jjvraw))
+
+  Example:
+
+  ```mojo
+  pow(2, 4, 5) # 1
+  pow(2, -1, 7) # 4
+  ```
+
 ### 🦋 Changed
 
 - The pointer aliasing semantics of Mojo have changed. Initially, Mojo adopted a

--- a/stdlib/src/builtin/math.mojo
+++ b/stdlib/src/builtin/math.mojo
@@ -309,6 +309,22 @@ fn pow(base: SIMD, exp: Int) -> __type_of(base):
     return base.__pow__(exp)
 
 
+fn pow(base: Int, exp: Int, mod: Int) -> Int:
+    """Compute modular exponentiation of an integer raised to a power, modulo
+    another integer.
+
+    Args:
+        base: The base integer.
+        exp: The exponent. Can be positive or negative.
+        mod: The modulus. Must be greater than 1.
+
+    Returns:
+        The result of `base` raised to `exp` power, modulo `mod`.
+
+    """
+    return base.__pow__(exp, mod)
+
+
 # ===----------------------------------------------------------------------=== #
 # round
 # ===----------------------------------------------------------------------=== #

--- a/stdlib/test/builtin/test_int.mojo
+++ b/stdlib/test/builtin/test_int.mojo
@@ -52,6 +52,49 @@ def test_pow():
     assert_equal(81, Int.__pow__(Int(3), Int(4)))
 
 
+def test_pow_mod():
+    assert_equal(1, Int.__pow__(Int(2), Int(4), Int(5)))
+    assert_equal(4, Int.__pow__(Int(2), Int(5), Int(7)))
+    assert_equal(6, Int.__pow__(Int(3), Int(3), Int(7)))
+    assert_equal(2, Int.__pow__(Int(2), Int(1000), Int(7)))
+    assert_equal(1, Int.__pow__(Int(10), Int(3), Int(3)))
+    assert_equal(1, Int.__pow__(Int(3), Int(5), Int(2)))
+
+    assert_equal(1, Int.__pow__(Int(5), Int(0), Int(7)))
+
+    assert_equal(4, Int.__pow__(Int(2), Int(-1), Int(7)))
+    assert_equal(2, Int.__pow__(Int(3), Int(-1), Int(5)))
+
+    assert_equal(0, Int.__pow__(Int(0), Int(5), Int(7)))
+    assert_equal(2, Int.__pow__(Int(100), Int(100), Int(7)))
+    assert_equal(6, Int.__pow__(Int(-2), Int(3), Int(7)))
+    assert_equal(1, Int.__pow__(Int(3), Int(2), Int(2)))
+    assert_equal(
+        598987215, Int.__pow__(Int(123456789), Int(123456789), Int(987654321))
+    )
+    assert_equal(1, Int.__pow__(Int(2), Int(10), Int(11)))
+
+    # TODO: Test negative cases when possible.
+
+
+def test_mod_inverse():
+    assert_equal(4, Int(3)._mod_inverse(11))
+    assert_equal(3, Int(5)._mod_inverse(14))
+
+    assert_equal(9, Int(-3)._mod_inverse(13))
+
+    assert_equal(521, Int(12345)._mod_inverse(1024))
+
+    assert_equal(3, Int(17)._mod_inverse(5))
+
+    assert_equal(1, Int(1)._mod_inverse(2))
+
+    assert_equal(3, Int(6)._mod_inverse(17))
+    assert_equal(1, Int(1)._mod_inverse(2))
+
+    # TODO: Test negative cases when possible.
+
+
 def test_ceil():
     assert_equal(Int.__ceil__(Int(5)), 5)
     assert_equal(Int.__ceil__(Int(0)), 0)
@@ -233,6 +276,8 @@ def main():
     test_sub()
     test_div()
     test_pow()
+    test_pow_mod()
+    test_mod_inverse()
     test_ceil()
     test_floor()
     test_round()

--- a/stdlib/test/builtin/test_math.mojo
+++ b/stdlib/test/builtin/test_math.mojo
@@ -114,6 +114,15 @@ def test_pow():
     assert_equal(pow(I(0, 1, 2, 3), int(2)), I(0, 1, 4, 9))
 
 
+def test_pow_mod():
+    assert_equal(1, pow(2, 4, 5))
+    assert_equal(2, pow(2, 1000, 7))
+    assert_equal(4, pow(2, -1, 7))
+    assert_equal(1, pow(5, 0, 7))
+
+    # TODO: Test negative cases when possible.
+
+
 def main():
     test_abs()
     test_divmod()
@@ -121,3 +130,4 @@ def main():
     test_min()
     test_round()
     test_pow()
+    test_pow_mod()


### PR DESCRIPTION
Partially addresses Issue #2867. 

This PR implements modular exponentiation, as suggested,
> Python's pow accepts a third mod argument to pow. We should do the same, and modify the Powable trait accordingly.

Since modulo arithmetic is defined for integers, I believe the implementation should be part of `Int`, as opposed to modifying `Powable`. Consequently, `pow(Int, Int, Int)` can wrap `Int.__pow__(Self, Self, Self)`.

Modular exponentiation uses the square-and-multiply algorithm. For negative exponents, it requires the calculation of a multiplicative inverse, which is performed using the extended Euclidean algorithm and implemented in `Int.mod_inverse`. 