### PR TITLE
[stdlib] Add `has_fma` function to `sys` package

### DIFF
--- a/stdlib/src/sys/__init__.mojo
+++ b/stdlib/src/sys/__init__.mojo
@@ -22,6 +22,7 @@ from .info import (
     has_avx,
     has_avx2,
     has_avx512f,
+    has_fma,
     has_intel_amx,
     has_neon,
     has_neon_int8_dotprod,

--- a/stdlib/src/sys/info.mojo
+++ b/stdlib/src/sys/info.mojo
@@ -108,6 +108,22 @@ fn has_avx512f() -> Bool:
 
 
 @always_inline("nodebug")
+fn has_fma() -> Bool:
+    """Returns True if the host system has FMA (Fused Multiply-Add) support,
+    otherwise returns False.
+
+    Returns:
+        True if the host system has FMA support, otherwise returns False.
+    """
+    return __mlir_attr[
+        `#kgen.param.expr<target_has_feature,`,
+        _current_target(),
+        `, "fma" : !kgen.string`,
+        `> : i1`,
+    ]
+
+
+@always_inline("nodebug")
 fn has_vnni() -> Bool:
     """Returns True if the host system has avx512_vnni, otherwise returns False.
 

--- a/stdlib/test/sys/test_targetinfo.mojo
+++ b/stdlib/test/sys/test_targetinfo.mojo
@@ -12,8 +12,18 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo %s
 
-from sys.info import (
+from sys import (
     alignof,
+    has_avx,
+    has_avx2,
+    has_avx512f,
+    has_fma,
+    has_intel_amx,
+    has_neon,
+    has_neon_int8_dotprod,
+    has_neon_int8_matmul,
+    has_sse4,
+    has_vnni,
     num_logical_cores,
     num_performance_cores,
     num_physical_cores,
@@ -53,7 +63,22 @@ fn test_cores() raises:
     assert_true(num_performance_cores() > 0)
 
 
+fn test_target_has_feature():
+    # Ensures target feature check functions exist and return a boolable value.
+    var has_feature: Bool = has_avx()
+    has_feature = has_avx2()
+    has_feature = has_avx512f()
+    has_feature = has_fma()
+    has_feature = has_intel_amx()
+    has_feature = has_neon()
+    has_feature = has_neon_int8_dotprod()
+    has_feature = has_neon_int8_matmul()
+    has_feature = has_sse4()
+    has_feature = has_vnni()
+
+
 def main():
     test_sizeof()
     test_alignof()
     test_cores()
+    test_target_has_feature()


### PR DESCRIPTION
This PR adds a new function `has_fma` to the `sys` package. This function checks if the host system supports Fused Multiply-Add (FMA) instructions.

**Justification**:

The `has_fma` function is important for developers implementing math functions. Numerical algorithms can adopt different strategies depending on whether the target architecture supports FMA or not. For example, the implementation of the `log10` function in the LLVM libc library considers the presence of FMA support.

**Note on Unit Testing:**

~~I have not added a unit test for this function because I am unsure how to implement it. I searched for unit tests for similar functions, such as `has_avx`, but could not find any. If anyone has suggestions on how to write a unit test for this function, they are welcome.~~

As suggested by @laszlokindrat [here](https://github.com/modularml/mojo/pull/3306#issuecomment-2254066284), I added a basic test for this function to ensures it exists and returns a boolable value. This test prevents accidental deletion or changes but does not validate the correctness of the `has_fma` output. If anyone has suggestions on how to write a better test for this function, they are welcome.

**Replacement**

This PR replaces PR #3306.