### PR TITLE
[stdlib] Remove obsolete `FIXME` 

### DIFF
--- a/stdlib/test/builtin/test_math.mojo
+++ b/stdlib/test/builtin/test_math.mojo
@@ -88,11 +88,9 @@ def test_round():
     assert_equal(2, round(1.5))
     assert_equal(2, round(2.0))
     assert_equal(1, round(1.4, 0))
-    # FIXME: round(2.5) is 2.0 (roundeven) but it's using roundhalfup
-    # Fix when the math library is open sourced
-    # assert_equal(2, round(2.5))
-    # assert_equal(1.5, round(1.5, 1))
-    # assert_equal(1.61, round(1.613, 2))
+    assert_equal(2, round(2.5))
+    assert_equal(1.5, round(1.5, 1))
+    assert_equal(1.61, round(1.613, 2))
 
     var lhs = SIMD[DType.float32, 4](1.1, 1.5, 1.9, 2.0)
     var expected = SIMD[DType.float32, 4](1.0, 2.0, 2.0, 2.0)


### PR DESCRIPTION
While working in the same file, I noticed that the workaround introduced in commit  [945a542](https://github.com/modularml/mojo/commit/945a542be74b81dfdb03b860ba38be4ac5228aa6) seems to resolve this issue. Additionally, the `TODO` in that commit a clearer direction.