### PR TITLE
[stdlib] Remove `Formatter.write_str[StringLiteral]()` overload

### DIFF
--- a/stdlib/src/builtin/dtype.mojo
+++ b/stdlib/src/builtin/dtype.mojo
@@ -107,39 +107,39 @@ struct DType(
         """
 
         if self == DType.bool:
-            return writer.write_str["bool"]()
+            return writer.write_str("bool")
         if self == DType.int8:
-            return writer.write_str["int8"]()
+            return writer.write_str("int8")
         if self == DType.uint8:
-            return writer.write_str["uint8"]()
+            return writer.write_str("uint8")
         if self == DType.int16:
-            return writer.write_str["int16"]()
+            return writer.write_str("int16")
         if self == DType.uint16:
-            return writer.write_str["uint16"]()
+            return writer.write_str("uint16")
         if self == DType.int32:
-            return writer.write_str["int32"]()
+            return writer.write_str("int32")
         if self == DType.uint32:
-            return writer.write_str["uint32"]()
+            return writer.write_str("uint32")
         if self == DType.int64:
-            return writer.write_str["int64"]()
+            return writer.write_str("int64")
         if self == DType.uint64:
-            return writer.write_str["uint64"]()
+            return writer.write_str("uint64")
         if self == DType.index:
-            return writer.write_str["index"]()
+            return writer.write_str("index")
         if self == DType.bfloat16:
-            return writer.write_str["bfloat16"]()
+            return writer.write_str("bfloat16")
         if self == DType.float16:
-            return writer.write_str["float16"]()
+            return writer.write_str("float16")
         if self == DType.float32:
-            return writer.write_str["float32"]()
+            return writer.write_str("float32")
         if self == DType.tensor_float32:
-            return writer.write_str["tensor_float32"]()
+            return writer.write_str("tensor_float32")
         if self == DType.float64:
-            return writer.write_str["float64"]()
+            return writer.write_str("float64")
         if self == DType.invalid:
-            return writer.write_str["invalid"]()
+            return writer.write_str("invalid")
 
-        return writer.write_str["<<unknown>>"]()
+        return writer.write_str("<<unknown>>")
 
     @always_inline("nodebug")
     fn __repr__(self) -> String:

--- a/stdlib/src/builtin/format_int.mojo
+++ b/stdlib/src/builtin/format_int.mojo
@@ -304,7 +304,7 @@ fn _try_write_int[
 
     # Prefix a '-' if the original int was negative and make positive.
     if value < 0:
-        fmt.write_str["-"]()
+        fmt.write_str("-")
 
     # Add the custom number prefix, e.g. "0x" commonly used for hex numbers.
     # This comes *after* the minus sign, if present.

--- a/stdlib/src/builtin/simd.mojo
+++ b/stdlib/src/builtin/simd.mojo
@@ -1530,14 +1530,14 @@ struct SIMD[type: DType, size: Int](
         # Print an opening `[`.
         @parameter
         if size > 1:
-            writer.write_str["["]()
+            writer.write_str("[")
 
         # Print each element.
         for i in range(size):
             var element = self[i]
             # Print separators between each element.
             if i != 0:
-                writer.write_str[", "]()
+                writer.write_str(", ")
 
             @parameter
             if triple_is_nvidia_cuda():
@@ -1584,7 +1584,7 @@ struct SIMD[type: DType, size: Int](
         # Print a closing `]`.
         @parameter
         if size > 1:
-            writer.write_str["]"]()
+            writer.write_str("]")
 
     @always_inline
     fn _bits_to_float[dest_type: DType](self) -> SIMD[dest_type, size]:

--- a/stdlib/src/utils/_format.mojo
+++ b/stdlib/src/utils/_format.mojo
@@ -111,20 +111,6 @@ struct Formatter:
     # Methods
     # ===------------------------------------------------------------------=== #
 
-    # TODO(cleanup):
-    #   Remove this overload by defining a working
-    #   `StringSlice.__init__(StringLiteral)` implicit conversion.
-    @always_inline
-    fn write_str[literal: StringLiteral](inout self):
-        """
-        Write a string literal to this formatter.
-
-        Parameters:
-            literal: The string literal to write.
-        """
-        alias slc = literal.as_string_slice()
-        self.write_str(slc)
-
     # TODO: Constrain to only require an immutable StringSlice[..]`
     @always_inline
     fn write_str(inout self, str_slice: StringSlice[_]):

--- a/stdlib/src/utils/string_slice.mojo
+++ b/stdlib/src/utils/string_slice.mojo
@@ -323,19 +323,15 @@ struct StringSlice[
     # Initializers
     # ===------------------------------------------------------------------===#
 
-    fn __init__(inout self, literal: StringLiteral):
+    @always_inline
+    fn __init__(
+        inout self: StringSlice[ImmutableStaticLifetime], lit: StringLiteral
+    ):
         """Construct a new string slice from a string literal.
 
         Args:
-            literal: The literal to construct this string slice from.
+            lit: The literal to construct this string slice from.
         """
-
-        # Its not legal to try to mutate a StringLiteral. String literals are
-        # static data.
-        constrained[
-            not is_mutable, "cannot create mutable StringSlice of StringLiteral"
-        ]()
-
         # Since a StringLiteral has static lifetime, it will outlive
         # whatever arbitrary `lifetime` the user has specified they need this
         # slice to live for.
@@ -348,8 +344,8 @@ struct StringSlice[
         #     _is_valid_utf8(literal.unsafe_ptr(), literal._byte_length()),
         #     "StringLiteral doesn't have valid UTF-8 encoding",
         # )
-        self = StringSlice[lifetime](
-            unsafe_from_utf8_ptr=literal.unsafe_ptr(), len=literal.byte_length()
+        self = StringSlice[ImmutableStaticLifetime](
+            unsafe_from_utf8_ptr=lit.unsafe_ptr(), len=lit.byte_length()
         )
 
     @always_inline


### PR DESCRIPTION
Remove `Formatter.write_str[StringLiteral]()` overload in favor of `StringSlice` overload.

Change `StringSlice.__init__(StringLiteral)` to be conditional on `ImmutableStaticLifetime`.