### PR TITLE
[stdlib] Remove `String` constructor from `PythonObject`

### DIFF
--- a/stdlib/src/builtin/string.mojo
+++ b/stdlib/src/builtin/string.mojo
@@ -813,14 +813,6 @@ struct String(
             )
         )
 
-    fn __init__(inout self, obj: PythonObject):
-        """Creates a string from a python object.
-
-        Args:
-            obj: A python object.
-        """
-        self = str(obj)
-
     @always_inline
     fn __copyinit__(inout self, existing: Self):
         """Creates a deep copy of an existing string.

--- a/stdlib/test/builtin/test_string.mojo
+++ b/stdlib/test/builtin/test_string.mojo
@@ -93,11 +93,6 @@ def test_constructors():
     var s3 = String(ptr, 4)
     assert_equal(s3, "abc")
 
-    # Construction from PythonObject
-    var py = Python.evaluate("1 + 1")
-    var s4 = String(py)
-    assert_equal(s4, "2")
-
 
 def test_copy():
     var s0 = String("find")


### PR DESCRIPTION
It's removed to avoid implicit conversion from e.g. `Int` through `PythonObject`.