### PR TITLE
[Docs] Clarify the rounding in the builtin math module.

### DIFF
--- a/stdlib/src/builtin/math.mojo
+++ b/stdlib/src/builtin/math.mojo
@@ -414,6 +414,6 @@ fn round(number: FloatLiteral, ndigits: Int) -> FloatLiteral:
         ndigits: The number of digits to round to.
 
     Returns:
-        The rounded value of the object.
+        The rounded value of the object. Positive ndigits to the right of the decimal, negative ndigits to the left.
     """
     return number.__round__(ndigits)


### PR DESCRIPTION
This addresses: [https://github.com/modularml/mojo/issues/3183](https://github.com/modularml/mojo/issues/3183).

Previously, it was unclear how the math module rounded for negative numbers, this clears things up.