### PR TITLE
[stdlib] Improve `InlineArray` Initialization

### DIFF
--- a/stdlib/src/builtin/format_int.mojo
+++ b/stdlib/src/builtin/format_int.mojo
@@ -341,7 +341,8 @@ fn _try_write_int[
     # TODO: use a dynamic size when #2194 is resolved
     alias CAPACITY: Int = 64 + 1  # +1 for storing NUL terminator.
 
-    var buf = InlineArray[UInt8, CAPACITY](unsafe_uninitialized=True)
+    var buf: InlineArray[UInt8, CAPACITY]
+    buf.__init__[False]()
 
     # Start the buf pointer at the end. We will write the least-significant
     # digits later in the buffer, and then decrement the pointer to move

--- a/stdlib/src/builtin/hash.mojo
+++ b/stdlib/src/builtin/hash.mojo
@@ -259,7 +259,8 @@ fn hash(bytes: UnsafePointer[UInt8], n: Int) -> UInt:
     # 3. Copy the tail data (smaller than the SIMD register) into
     #    a final hash state update vector that's stack-allocated.
     if r != 0:
-        var remaining = InlineArray[UInt8, stride](unsafe_uninitialized=True)
+        var remaining: InlineArray[UInt8, stride]
+        remaining.__init__[False]()
         var ptr = remaining.unsafe_ptr()
         memcpy(ptr, bytes + k * stride, r)
         memset_zero(ptr + r, stride - r)  # set the rest to 0

--- a/stdlib/src/builtin/value.mojo
+++ b/stdlib/src/builtin/value.mojo
@@ -209,6 +209,18 @@ trait CollectionElementNew(ExplicitlyCopyable, Movable):
     pass
 
 
+trait DefaultableCollectionElementNew(Defaultable, CollectionElementNew):
+    """The DefaultableCollectionElementNew trait denotes a trait composition
+    of the `Defaultable` and `CollectionElementNew` traits.
+
+    This is useful to have as a named entity since Mojo does not
+    currently support anonymous trait compositions to constrain
+    on `Defaultable & CollectionElementNew` in the parameter.
+    """
+
+    pass
+
+
 trait StringableCollectionElement(CollectionElement, Stringable):
     """The StringableCollectionElement trait denotes a trait composition
     of the `CollectionElement` and `Stringable` traits.

--- a/stdlib/src/collections/inline_list.mojo
+++ b/stdlib/src/collections/inline_list.mojo
@@ -98,9 +98,7 @@ struct InlineList[ElementType: CollectionElementNew, capacity: Int = 16](Sized):
     @always_inline
     fn __init__(inout self):
         """This constructor creates an empty InlineList."""
-        self._array = InlineArray[
-            UnsafeMaybeUninitialized[ElementType], capacity
-        ](unsafe_uninitialized=True)
+        self._array.__init__[False]()
         self._size = 0
 
     # TODO: Avoid copying elements in once owned varargs

--- a/stdlib/src/prelude/__init__.mojo
+++ b/stdlib/src/prelude/__init__.mojo
@@ -90,6 +90,7 @@ from builtin.value import (
     Defaultable,
     CollectionElement,
     CollectionElementNew,
+    DefaultableCollectionElementNew,
     StringableCollectionElement,
     EqualityComparableCollectionElement,
     ComparableCollectionElement,

--- a/stdlib/src/utils/inline_string.mojo
+++ b/stdlib/src/utils/inline_string.mojo
@@ -332,7 +332,7 @@ struct _FixedString[CAP: Int](
 
     fn __init__(inout self):
         """Constructs a new empty string."""
-        self.buffer = InlineArray[UInt8, CAP](unsafe_uninitialized=True)
+        self.buffer.__init__[False]()
         self.size = 0
 
     fn __init__(inout self, *, other: Self):

--- a/stdlib/test/collections/test_inline_array.mojo
+++ b/stdlib/test/collections/test_inline_array.mojo
@@ -150,9 +150,10 @@ def test_array_int_pointer():
 
 
 def test_array_unsafe_assume_initialized_constructor_string():
-    var maybe_uninitialized_arr = InlineArray[
+    var maybe_uninitialized_arr: InlineArray[
         UnsafeMaybeUninitialized[String], 3
-    ](unsafe_uninitialized=True)
+    ]
+    maybe_uninitialized_arr.__init__[False]()
     maybe_uninitialized_arr[0].write("hello")
     maybe_uninitialized_arr[1].write("mojo")
     maybe_uninitialized_arr[2].write("world")


### PR DESCRIPTION
Add `DefaultableCollectionElementNew` trait.
Add default initialization to `InlineArray`
Change to using a parameter to specify uninit data in `InlineArray`.
Moved explicit copy initializer to avoid bug causing the type to not conform to `ExplicitlyCopyable`.

It seems better to use a parameter for marking the data to be left uninitialized, and `self.__init__[False]()` captures the unsafeness well.
Also since we have a defaultable trait, you don't really have to worry about the default initializer anymore as long as your element types have a default initializer, or you want more control.