### PR TITLE
[stdlib] assertion overloads for `List`

### DIFF
--- a/stdlib/src/testing/testing.mojo
+++ b/stdlib/src/testing/testing.mojo
@@ -93,6 +93,15 @@ trait Testable(EqualityComparable, Stringable):
     pass
 
 
+trait TestableCollectionElement(
+    EqualityComparableCollectionElement,
+    RepresentableCollectionElement,
+):
+    """A trait for elements that can be tested in a collection."""
+
+    pass
+
+
 @always_inline
 fn assert_equal[
     T: Testable
@@ -124,7 +133,7 @@ fn assert_equal[
         )
 
 
-# TODO: Remove the String and SIMD overloads once we have more powerful traits.
+# TODO: Remove the String, SIMD and List overloads once we have more powerful traits.
 @always_inline
 fn assert_equal(
     lhs: String,
@@ -180,6 +189,39 @@ fn assert_equal[
     if any(lhs != rhs):
         raise _assert_cmp_error["`left == right` comparison"](
             str(lhs), str(rhs), msg=msg, loc=location.or_else(__call_location())
+        )
+
+
+@always_inline
+fn assert_equal[
+    T: TestableCollectionElement
+](
+    lhs: List[T],
+    rhs: List[T],
+    msg: String = "",
+    *,
+    location: Optional[_SourceLocation] = None,
+) raises:
+    """Asserts that two lists are equal.
+
+    Parameters:
+        T: A TestableCollectionElement type.
+
+    Args:
+        lhs: The left-hand side list.
+        rhs: The right-hand side list.
+        msg: The message to be printed if the assertion fails.
+        location: The location of the error (default to the `__call_location`).
+
+    Raises:
+        An Error with the provided message if assert fails and `None` otherwise.
+    """
+    if lhs != rhs:
+        raise _assert_cmp_error["`left == right` comparison"](
+            lhs.__str__(),
+            rhs.__str__(),
+            msg=msg,
+            loc=location.or_else(__call_location()),
         )
 
 
@@ -269,6 +311,39 @@ fn assert_not_equal[
     if all(lhs == rhs):
         raise _assert_cmp_error["`left != right` comparison"](
             str(lhs), str(rhs), msg=msg, loc=location.or_else(__call_location())
+        )
+
+
+@always_inline
+fn assert_not_equal[
+    T: TestableCollectionElement
+](
+    lhs: List[T],
+    rhs: List[T],
+    msg: String = "",
+    *,
+    location: Optional[_SourceLocation] = None,
+) raises:
+    """Asserts that two lists are not equal.
+
+    Parameters:
+        T: A TestableCollectionElement type.
+
+    Args:
+        lhs: The left-hand side list.
+        rhs: The right-hand side list.
+        msg: The message to be printed if the assertion fails.
+        location: The location of the error (default to the `__call_location`).
+
+    Raises:
+        An Error with the provided message if assert fails and `None` otherwise.
+    """
+    if lhs == rhs:
+        raise _assert_cmp_error["`left != right` comparison"](
+            lhs.__str__(),
+            rhs.__str__(),
+            msg=msg,
+            loc=location.or_else(__call_location()),
         )
 
 

--- a/stdlib/test/testing/test_assertion.mojo
+++ b/stdlib/test/testing/test_assertion.mojo
@@ -28,6 +28,28 @@ from builtin._location import _SourceLocation
 from python import PythonObject
 
 
+def test_assert_messages():
+    try:
+        assert_true(False)
+    except e:
+        assert_true("test_assertion.mojo:33:20: AssertionError:" in str(e))
+
+    try:
+        assert_false(True)
+    except e:
+        assert_true("test_assertion.mojo:38:21: AssertionError:" in str(e))
+
+    try:
+        assert_equal(1, 0)
+    except e:
+        assert_true("test_assertion.mojo:43:21: AssertionError:" in str(e))
+
+    try:
+        assert_not_equal(0, 0)
+    except e:
+        assert_true("test_assertion.mojo:48:25: AssertionError:" in str(e))
+
+
 @value
 struct DummyStruct:
     var value: Int
@@ -64,26 +86,30 @@ def test_assert_equal_with_simd():
         assert_equal(SIMD[DType.uint8, 2](1, 1), SIMD[DType.uint8, 2](1, 2))
 
 
-def test_assert_messages():
-    try:
-        assert_true(False)
-    except e:
-        assert_true("test_assertion.mojo:69:20: AssertionError:" in str(e))
+def test_assert_equal_with_list():
+    assert_equal(
+        List(String("This"), String("is"), String("Mojo")),
+        List(String("This"), String("is"), String("Mojo")),
+    )
 
-    try:
-        assert_false(True)
-    except e:
-        assert_true("test_assertion.mojo:74:21: AssertionError:" in str(e))
+    with assert_raises():
+        assert_equal(
+            List(String("This"), String("is"), String("Mojo")),
+            List(String("This"), String("is"), String("mojo")),
+        )
 
-    try:
-        assert_equal(1, 0)
-    except e:
-        assert_true("test_assertion.mojo:79:21: AssertionError:" in str(e))
 
-    try:
-        assert_not_equal(0, 0)
-    except e:
-        assert_true("test_assertion.mojo:84:25: AssertionError:" in str(e))
+def test_assert_not_equal_with_list():
+    assert_not_equal(
+        List(3, 2, 1),
+        List(3, 1, 0),
+    )
+
+    with assert_raises():
+        assert_not_equal(
+            List(3, 2, 1),
+            List(3, 2, 1),
+        )
 
 
 def test_assert_almost_equal():
@@ -215,6 +241,8 @@ def main():
     test_assert_equal_is_generic()
     test_assert_not_equal_is_generic()
     test_assert_equal_with_simd()
+    test_assert_equal_with_list()
+    test_assert_not_equal_with_list()
     test_assert_messages()
     test_assert_almost_equal()
     test_assert_is()


### PR DESCRIPTION
Add `assert_equal` and `assert_not_equal` overload for `List` comparisons, a nice-to-have in a few places. Most probably a temporary solution under the current trait system.