### PR TITLE
[stdlib] Fix TODO in `/io.mojo`.

### DIFF
--- a/stdlib/src/builtin/io.mojo
+++ b/stdlib/src/builtin/io.mojo
@@ -316,9 +316,10 @@ fn _put(x: DType, file: FileDescriptor = stdout):
     _put(str(x).as_string_slice(), file=file)
 
 
-# TODO: Constrain to `StringSlice[False, _]`
 @no_inline
-fn _put(x: StringSlice, file: FileDescriptor = stdout):
+fn _put[
+    lif: AnyLifetime[False].type, //
+](x: StringSlice[lif], file: FileDescriptor = stdout):
     # Avoid printing "(null)" for an empty/default constructed `String`
     var str_len = x.byte_length()
 


### PR DESCRIPTION
Maybe there's an internal reason this couldn't be done, but i'll open it so it can at least be tracked.