### PR TITLE
[stdlib] Add `sqrt(IntLiteral) -> IntLiteral`.

### DIFF
--- a/stdlib/src/builtin/int_literal.mojo
+++ b/stdlib/src/builtin/int_literal.mojo
@@ -248,6 +248,23 @@ struct IntLiteral(
     # TODO: implement __pow__
 
     @always_inline("nodebug")
+    fn __sqrt__(self) -> Self:
+        """Return the square root of `self`, rounded down if necessary. Negative values return themselves.
+
+        Returns:
+            The square root of `self`.
+        """
+        # TODO: Benchmark and improve. This is using a basic babylonian method.
+        if self < 2:
+            return self
+        var res: IntLiteral = self
+        var nex: IntLiteral = 1
+        while res > nex:
+            res = (res + nex) // 2
+            nex = self // res
+        return res
+
+    @always_inline("nodebug")
     fn __floordiv__(self, rhs: Self) -> Self:
         """Return `self // rhs`.
 

--- a/stdlib/src/math/math.mojo
+++ b/stdlib/src/math/math.mojo
@@ -177,6 +177,19 @@ fn trunc[T: Truncable, //](value: T) -> T:
 
 
 @always_inline
+fn sqrt(x: IntLiteral) -> IntLiteral:
+    """Performs square root on an IntLiteral, rounded down if necessary. Negative values return themselves.
+
+    Args:
+        x: The IntLiteral value to perform square root on.
+
+    Returns:
+        The square root of x.
+    """
+    return x.__sqrt__()
+
+
+@always_inline
 fn sqrt(x: Int) -> Int:
     """Performs square root on an integer.
 

--- a/stdlib/test/builtin/test_int_literal.mojo
+++ b/stdlib/test/builtin/test_int_literal.mojo
@@ -147,6 +147,23 @@ def test_comparison():
     assert_false((5).__ge__(10))
 
 
+def test_sqrt():
+    assert_equal(IntLiteral.__sqrt__(-2), -2)
+    assert_equal(IntLiteral.__sqrt__(-1), -1)
+    assert_equal(IntLiteral.__sqrt__(0), 0)
+    assert_equal(IntLiteral.__sqrt__(1), 1)
+    assert_equal(IntLiteral.__sqrt__(2), 1)
+    assert_equal(IntLiteral.__sqrt__(3), 1)
+    assert_equal(IntLiteral.__sqrt__(4), 2)
+    assert_equal(IntLiteral.__sqrt__(5), 2)
+    assert_equal(IntLiteral.__sqrt__(8), 2)
+    assert_equal(IntLiteral.__sqrt__(9), 3)
+    assert_equal(IntLiteral.__sqrt__(15), 3)
+    assert_equal(IntLiteral.__sqrt__(16), 4)
+    assert_equal(IntLiteral.__sqrt__(99), 9)
+    assert_equal(IntLiteral.__sqrt__(100), 10)
+
+
 def main():
     test_add()
     test_sub()
@@ -162,3 +179,4 @@ def main():
     test_indexer()
     test_bool()
     test_comparison()
+    test_sqrt()


### PR DESCRIPTION
I know there are better methods, but it would be nice to have something.
I'm not sure there's a nice way to track compile time benchmarks in the stdlib right now, so that might have to wait.