### PR TITLE
[stdlib] Add `sqrt(FloatLiteral) -> FloatLiteral` overload.

### DIFF
--- a/stdlib/src/builtin/float_literal.mojo
+++ b/stdlib/src/builtin/float_literal.mojo
@@ -16,6 +16,7 @@ These are Mojo built-ins, so you don't need to import them.
 """
 
 from builtin._math import Ceilable, CeilDivable, Floorable, Truncable
+from math.solver import newtons_method
 
 # ===----------------------------------------------------------------------===#
 # FloatLiteral
@@ -324,6 +325,37 @@ struct FloatLiteral(
         elif ndigits < 0:
             result *= Self(multiplier)
         return result
+
+    @always_inline
+    fn __sqrt__(self) -> Self:
+        """Returns the square root of `self`.
+
+        Returns:
+            The square root of `self`.
+        """
+        if self == 0.0:
+            return 0.0
+        return 1.0 / self.__recip_sqrt__()
+
+    @always_inline
+    fn __recip_sqrt__(self) -> Self:
+        """Returns the reciprocal square root of `self`.
+
+        Returns:
+            The reciprocal square root of `self`.
+        """
+
+        @parameter
+        fn func(value: Self) -> Self:
+            return 1.0 / (value * value)
+
+        @parameter
+        fn deriv(value: Self) -> Self:
+            return -2.0 / (value * value * value)
+
+        return newtons_method[func, deriv, 8, 1e-8, 1e-8](
+            2.0 / (self + 1.0), self
+        )
 
     # ===------------------------------------------------------------------===#
     # Arithmetic Operators

--- a/stdlib/src/math/math.mojo
+++ b/stdlib/src/math/math.mojo
@@ -38,6 +38,7 @@ from utils.numerics import FPUtils, isnan, nan
 from utils.static_tuple import StaticTuple
 
 from .polynomial import polynomial_evaluate
+from .solver import newtons_method
 
 # ===----------------------------------------------------------------------=== #
 # floor
@@ -203,6 +204,19 @@ fn sqrt(x: Int) -> Int:
 
 
 @always_inline
+fn sqrt(x: FloatLiteral) -> FloatLiteral:
+    """Performs square root on a FloatLiteral.
+
+    Args:
+        x: The FloatLiteral value to perform square root on.
+
+    Returns:
+        The square root of x.
+    """
+    return x.__sqrt__()
+
+
+@always_inline
 fn _sqrt_nvvm(x: SIMD) -> __type_of(x):
     constrained[
         x.type in (DType.float32, DType.float64), "must be f32 or f64 type"
@@ -265,6 +279,19 @@ fn sqrt[
 # ===----------------------------------------------------------------------=== #
 # rsqrt
 # ===----------------------------------------------------------------------=== #
+
+
+@always_inline
+fn isqrt(x: FloatLiteral) -> FloatLiteral:
+    """Performs reciprocal square root on a FloatLiteral.
+
+    Args:
+        x: The FloatLiteral to perform reciprocal square root on.
+
+    Returns:
+        The reciprocal square root of x.
+    """
+    return x.__recip_sqrt__()
 
 
 @always_inline

--- a/stdlib/src/math/solver.mojo
+++ b/stdlib/src/math/solver.mojo
@@ -1,0 +1,65 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Defines equation solving utilities."""
+
+
+fn newtons_method[
+    func: fn (FloatLiteral) capturing -> FloatLiteral,
+    deriv: fn (FloatLiteral) capturing -> FloatLiteral,
+    iters: Int = 8,
+    atol: FloatLiteral = FloatLiteral.nan,
+    epsilon: FloatLiteral = FloatLiteral.nan,
+](x0: FloatLiteral, y_offset: FloatLiteral = 0) -> FloatLiteral:
+    """Implements newtons method for solving trancendental equations.
+
+    Converges on the roots of the input function `f` using it's derivative `fp`.
+    If `tolerance` and `epsilon` are left undefined, only iterations will be used, and may return non-convergent results.
+
+    Parameters:
+        func: The function to find the solutions to.
+        deriv: The first derivative of f (not calculated automatically).
+        iters: The number of iterations to perform.
+        atol: If provided, results within the tolerance will be considered solved.
+        epsilon: If provided, the calculation will return `nan` for values that explode.
+
+    Args:
+        x0: The initial guess of the solution. Determines which solution is found, and how fast it converges.
+        y_offset: A vertical offset applied to the input function `f`. Use for solving the inverse of `f`, for values other than 0.
+
+    Returns:
+        The converged value, or `nan` if no solution was found.
+    """
+
+    var x1: FloatLiteral = x0
+
+    for _ in range(iters):
+        var yp: FloatLiteral = deriv(x1)
+
+        @parameter
+        if epsilon == epsilon:
+            if abs(yp) <= epsilon:
+                return FloatLiteral.nan
+
+        var x2: FloatLiteral = x1 - (func(x1) - y_offset) / yp
+
+        @parameter
+        if atol == atol:
+            if abs(x2 - x1) <= atol:
+                return x2
+
+        x1 = x2
+
+    @parameter
+    if atol == atol or epsilon == epsilon:
+        return FloatLiteral.nan
+    return x1

--- a/stdlib/test/builtin/test_float_literal.mojo
+++ b/stdlib/test/builtin/test_float_literal.mojo
@@ -212,6 +212,17 @@ def test_comparison():
     assert_false(FloatLiteral.__ge__(4.4, 10.4))
 
 
+def test_sqrt():
+    assert_almost_equal(
+        FloatLiteral.__sqrt__(-1.0), FloatLiteral.nan, equal_nan=True
+    )
+    assert_almost_equal(FloatLiteral.__sqrt__(0.0), 0.0)
+    assert_almost_equal(FloatLiteral.__sqrt__(0.25), 0.5)
+    assert_almost_equal(FloatLiteral.__sqrt__(1.0), 1.0)
+    assert_almost_equal(FloatLiteral.__sqrt__(2.0), 1.4142135623_7309504880)
+    assert_almost_equal(FloatLiteral.__sqrt__(4.0), 2.0)
+
+
 def main():
     test_ceil()
     test_floor()
@@ -226,3 +237,4 @@ def main():
     test_is_special_value()
     test_abs()
     test_comparison()
+    test_sqrt()


### PR DESCRIPTION
Add `FloatLiteral.__sqrt__()`
Add `FloatLiteral.__recip_sqrt__()`
Add Newtons method for solving it.

I hope this doesn't explode anyone's compile times, but since i did #3381 I figured I should add this as well.