### PR TITLE
[stdlib] Make `NoneType` Formattable, Stringable and Representable.

### DIFF
--- a/stdlib/src/builtin/none.mojo
+++ b/stdlib/src/builtin/none.mojo
@@ -18,7 +18,13 @@ These are Mojo built-ins, so you don't need to import them.
 
 @value
 @register_passable("trivial")
-struct NoneType(CollectionElement):
+struct NoneType(
+    CollectionElement,
+    CollectionElementNew,
+    Formattable,
+    Representable,
+    Stringable,
+):
     """Represents the absence of a value."""
 
     alias _mlir_type = __mlir_type.`!kgen.none`
@@ -26,10 +32,12 @@ struct NoneType(CollectionElement):
 
     var _value: Self._mlir_type
 
+    @always_inline
     fn __init__(inout self):
         """Construct an instance of the `None` type."""
         self._value = None
 
+    @always_inline
     fn __init__(inout self, *, other: Self):
         """Explicit copy constructor.
 
@@ -37,3 +45,30 @@ struct NoneType(CollectionElement):
             other: Another `NoneType` instance to copy.
         """
         self._value = None
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns the string representation of `None`.
+
+        Returns:
+            `"None"`.
+        """
+        return "None"
+
+    @no_inline
+    fn __repr__(self) -> String:
+        """Returns the string representation of `None`.
+
+        Returns:
+            `"None"`.
+        """
+        return "None"
+
+    @no_inline
+    fn format_to(self, inout writer: Formatter):
+        """Write `None` to a formatter stream.
+
+        Args:
+            writer: The formatter to write to.
+        """
+        writer.write("None")

--- a/stdlib/test/builtin/test_none.mojo
+++ b/stdlib/test/builtin/test_none.mojo
@@ -12,9 +12,26 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo %s
 
+from testing import assert_equal
+
 
 def main():
+    test_str()
+    test_repr()
+    test_format_to()
     test_type_from_none()
+
+
+def test_str():
+    assert_equal(NoneType().__str__(), "None")
+
+
+def test_repr():
+    assert_equal(NoneType().__str__(), "None")
+
+
+def test_format_to():
+    assert_equal(String.format_sequence(NoneType()), "None")
 
 
 struct FromNone:


### PR DESCRIPTION
Since currently, you can't do `str(NoneType())`