### PR TITLE
[stdlib] Implicit conversion from `None` to `UnsafePointer`

### DIFF
--- a/stdlib/src/memory/unsafe_pointer.mojo
+++ b/stdlib/src/memory/unsafe_pointer.mojo
@@ -92,8 +92,12 @@ struct UnsafePointer[
     # ===-------------------------------------------------------------------===#
 
     @always_inline
-    fn __init__(inout self):
-        """Create a null pointer."""
+    fn __init__(inout self, none: NoneType = None):
+        """Create a null pointer.
+
+        Args:
+            none: Implicit conversion from `None`.
+        """
         self.address = __mlir_attr[`#interp.pointer<0> : `, Self._mlir_type]
 
     @always_inline

--- a/stdlib/test/memory/test_unsafepointer.mojo
+++ b/stdlib/test/memory/test_unsafepointer.mojo
@@ -225,12 +225,15 @@ def test_indexing():
 
 def test_bool():
     var nullptr = UnsafePointer[Int]()
+    var nullptr_none: UnsafePointer[Int] = None
     var ptr = UnsafePointer[Int].alloc(1)
 
     assert_true(ptr.__bool__())
     assert_false(nullptr.__bool__())
+    assert_false(nullptr_none.__bool__())
     assert_true(ptr.__as_bool__())
     assert_false(nullptr.__as_bool__())
+    assert_false(nullptr_none.__as_bool__())
 
     ptr.free()
 


### PR DESCRIPTION
None is sort of like null in other languages, so this is helpful as a consistent way to say a pointer is null, without having to write out the full type.