### PR TITLE
[stdlib] Implemented `.lower()` and `.upper()` methods to string literals

### DIFF
--- a/stdlib/src/builtin/string_literal.mojo
+++ b/stdlib/src/builtin/string_literal.mojo
@@ -405,3 +405,23 @@ struct StringLiteral(
             result += str(e[])
 
         return result
+
+    fn lower(self) -> String:
+        """Returns a copy of the string literal with all cased characters
+        converted to lowercase.
+
+        Returns:
+            A new string where cased letters have been converted to lowercase.
+        """
+
+        return str(self).lower()
+
+    fn upper(self) -> String:
+        """Returns a copy of the string literal with all cased characters
+        converted to uppercase.
+
+        Returns:
+            A new string where cased letters have been converted to uppercase.
+        """
+
+        return str(self).upper()

--- a/stdlib/test/builtin/test_string_literal.mojo
+++ b/stdlib/test/builtin/test_string_literal.mojo
@@ -167,6 +167,15 @@ def test_layout():
     assert_equal(ptr[5], 0)  # Verify NUL terminated
 
 
+def test_lower_upper():
+    assert_equal("hello".lower(), "hello")
+    assert_equal("HELLO".lower(), "hello")
+    assert_equal("Hello".lower(), "hello")
+    assert_equal("hello".upper(), "HELLO")
+    assert_equal("HELLO".upper(), "HELLO")
+    assert_equal("Hello".upper(), "HELLO")
+
+
 def test_repr():
     # Usual cases
     assert_equal(StringLiteral.__repr__("hello"), "'hello'")
@@ -200,4 +209,5 @@ def main():
     test_hash()
     test_intable()
     test_layout()
+    test_lower_upper()
     test_repr()


### PR DESCRIPTION
It was implemented in Strings but not for String literals, while in Python is supported:

```python
>>> "hello".upper()
'HELLO'
```