### PR TITLE
[stdlib] Fix typo in inlined_assembly 9-arg function arguments

### DIFF
--- a/stdlib/src/sys/_assembly.mojo
+++ b/stdlib/src/sys/_assembly.mojo
@@ -612,7 +612,7 @@ fn inlined_assembly[
                 assembly = asm.value,
                 constraints = constraints.value,
                 hasSideEffects = __mlir_attr.unit,
-            ](arg0, arg1, arg2, arg3, arg3, arg5, arg6, arg7, arg8)
+            ](arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
         else:
             return __mlir_op.`pop.inline_asm`[
                 _type=result_type,


### PR DESCRIPTION
I discovered this copy-paste typo, arg3 repeated twice for 9 arg assembly generation, while poking around the stdlib. 

Unfortunately I don't know how to test this.
Tests passed both before and after this change, so I assume this code path is not tested on my setup