### PR TITLE
[stdlib] Use ownership ops in `Uninit` to remove pointer indirection.

### DIFF
--- a/stdlib/src/collections/inline_array.mojo
+++ b/stdlib/src/collections/inline_array.mojo
@@ -128,15 +128,11 @@ struct InlineArray[
             unsafe_assume_initialized: The array of `UnsafeMaybeUninitialized` elements.
         """
 
-        self._array = __mlir_op.`kgen.param.constant`[
-            _type = Self.type,
-            value = __mlir_attr[`#kgen.unknown : `, Self.type],
-        ]()
-
-        for i in range(Self.size):
-            unsafe_assume_initialized[i].unsafe_ptr().move_pointee_into(
-                self.unsafe_ptr() + i
-            )
+        self = (
+            UnsafePointer.address_of(unsafe_assume_initialized)
+            .bitcast[Self]()
+            .take_pointee()
+        )
 
     @always_inline
     fn __init__(inout self, fill: Self.ElementType):

--- a/stdlib/src/collections/inline_list.mojo
+++ b/stdlib/src/collections/inline_list.mojo
@@ -250,5 +250,5 @@ struct InlineList[ElementType: CollectionElementNew, capacity: Int = 16](Sized):
             value: The value to append.
         """
         debug_assert(self._size < capacity, "List is full.")
-        self._array[self._size].write(value^)
+        self._array[self._size] = value^
         self._size += 1

--- a/stdlib/test/collections/test_inline_array.mojo
+++ b/stdlib/test/collections/test_inline_array.mojo
@@ -154,9 +154,9 @@ def test_array_unsafe_assume_initialized_constructor_string():
     var maybe_uninitialized_arr = InlineArray[
         UnsafeMaybeUninitialized[String], 3
     ](unsafe_uninitialized=True)
-    maybe_uninitialized_arr[0].write("hello")
-    maybe_uninitialized_arr[1].write("mojo")
-    maybe_uninitialized_arr[2].write("world")
+    maybe_uninitialized_arr[0] = "hello"
+    maybe_uninitialized_arr[1] = "mojo"
+    maybe_uninitialized_arr[2] = "world"
 
     var initialized_arr = InlineArray[String, 3](
         unsafe_assume_initialized=maybe_uninitialized_arr^

--- a/stdlib/test/memory/test_maybe_uninitialized.mojo
+++ b/stdlib/test/memory/test_maybe_uninitialized.mojo
@@ -25,16 +25,11 @@ def test_maybe_uninitialized():
     var destructor_counter = List[Int]()
 
     var a = UnsafeMaybeUninitialized[ValueDestructorRecorder]()
-    a.write(
-        ValueDestructorRecorder(
-            42, UnsafePointer.address_of(destructor_counter)
-        )
+    a = ValueDestructorRecorder(
+        42, UnsafePointer.address_of(destructor_counter)
     )
 
     assert_equal(a.assume_initialized().value, 42)
-    assert_equal(len(destructor_counter), 0)
-
-    assert_equal(a.unsafe_ptr()[].value, 42)
     assert_equal(len(destructor_counter), 0)
 
     a.assume_initialized_destroy()
@@ -57,7 +52,7 @@ struct ImpossibleToDestroy:
 
 def test_write_does_not_trigger_destructor():
     var a = UnsafeMaybeUninitialized[ImpossibleToDestroy]()
-    a.write(ImpossibleToDestroy(42))
+    a = ImpossibleToDestroy(42)
 
     # Using the initializer should not trigger the destructor too.
     var b = UnsafeMaybeUninitialized[ImpossibleToDestroy](
@@ -86,17 +81,17 @@ def test_maybe_uninitialized_move_from_pointer():
 
     var b = UnsafeMaybeUninitialized[MoveCounter[Int]]()
     # b is uninitialized here.
-    b.move_from(UnsafePointer.address_of(a))
+    b = UnsafePointer.address_of(a).take_pointee()
     _ = a^
 
     # a is uninitialized now. Thankfully, we're working with trivial types
-    assert_equal(b.assume_initialized().move_count, 1)
+    assert_equal(b.assume_initialized().move_count, 2)
     b.assume_initialized_destroy()
 
 
 def test_maybe_uninitialized_copy():
     var a = UnsafeMaybeUninitialized[CopyCounter]()
-    a.write(CopyCounter())
+    a = CopyCounter()
     assert_equal(a.assume_initialized().copy_count, 0)
 
     var b = UnsafeMaybeUninitialized[CopyCounter]()


### PR DESCRIPTION
The ownership ops provide a more clear implementation than `pop.array`, and allows the pointer indirection to be removed.
This makes the inner field of `UnsafeMaybeUninitialized` just a `ElementType` instead of a `pop.array<...>`

Because we get an error when marking subobjects as destroyed, ~~i used a capturing function within the types destructor to make sure the underlying values destructor isn't called.~~ **edit**: I introduced two helper functions `_forget()` and `_uninit()`, which provide a very clear implementation.

I had to bump up the move counter check in one of the tests, because of how the implementation changed, but i'm pretty sure the actual move gets optimized away, even if the move counter doesn't.