### PR TITLE
[stdlib] Fix string split by whitespace

### DIFF
--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -1585,6 +1585,10 @@ struct String(
         .
         """
 
+        fn num_bytes(b: UInt8) -> Int:
+            var flipped = ~b
+            return int(count_leading_zeros(flipped) + (b >> 7))
+
         var output = List[String]()
         var str_byte_len = self.byte_length() - 1
         var lhs = 0
@@ -1606,8 +1610,8 @@ struct String(
                 # if the last char is not whitespace
                 output.append(self[str_byte_len])
                 break
-            rhs = lhs + 1
-            for s in self[lhs + 1 :]:
+            rhs = lhs + num_bytes(self.unsafe_ptr()[lhs])
+            for s in self[lhs + num_bytes(self.unsafe_ptr()[lhs]) :]:
                 if str(s).isspace():  # TODO: with StringSlice.isspace()
                     break
                 rhs += s.byte_length()

--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -1587,7 +1587,7 @@ struct String(
 
         fn num_bytes(b: UInt8) -> Int:
             var flipped = ~b
-            return int(count_leading_zeros(flipped) + (b >> 7))
+            return int(count_leading_zeros(flipped) + (flipped >> 7))
 
         var output = List[String]()
         var str_byte_len = self.byte_length() - 1

--- a/stdlib/test/collections/test_string.mojo
+++ b/stdlib/test/collections/test_string.mojo
@@ -804,6 +804,12 @@ def test_split():
         String("1,2,3,3,3").split("3", 2).__str__(), "['1,2,', ',', ',3']"
     )
 
+    var in5 = String("Hello 🔥!")
+    var res5 = in5.split()
+    assert_equal(len(res5), 2)
+    assert_equal(res5[0], "Hello")
+    assert_equal(res5[1], "🔥!")
+
 
 def test_splitlines():
     # Test with no line breaks


### PR DESCRIPTION
Fixes one case in the bug report #3457 where string is split by white space