### PR TITLE
[stdlib] Add negative case for `String.split()`

### DIFF
--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -1545,7 +1545,7 @@ struct String(
         var items = 0
         var sep_len = sep.byte_length()
         if sep_len == 0:
-            raise Error("Seperator cannot be empty.")
+            raise Error("Separator cannot be empty.")
         if str_byte_len < 0:
             output.append("")
 

--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -1522,6 +1522,9 @@ struct String(
         Returns:
             A List of Strings containing the input split by the separator.
 
+        Raises:
+            If the separator is empty.
+
         Examples:
 
         ```mojo
@@ -1542,7 +1545,7 @@ struct String(
         var items = 0
         var sep_len = sep.byte_length()
         if sep_len == 0:
-            raise Error("ValueError: empty separator")
+            raise Error("Seperator cannot be empty.")
         if str_byte_len < 0:
             output.append("")
 

--- a/stdlib/test/collections/test_string.mojo
+++ b/stdlib/test/collections/test_string.mojo
@@ -819,6 +819,9 @@ def test_split():
     assert_equal(res6[3], "сит")
     assert_equal(res6[4], "амет")
 
+    with assert_raises(contains="Seperator cannot be empty."):
+        _ = String("1, 2, 3").split("")
+
 
 def test_splitlines():
     # Test with no line breaks

--- a/stdlib/test/collections/test_string.mojo
+++ b/stdlib/test/collections/test_string.mojo
@@ -819,7 +819,7 @@ def test_split():
     assert_equal(res6[3], "сит")
     assert_equal(res6[4], "амет")
 
-    with assert_raises(contains="Seperator cannot be empty."):
+    with assert_raises(contains="Separator cannot be empty."):
         _ = String("1, 2, 3").split("")
 
 


### PR DESCRIPTION
**Repurposed PR.** 

Originally addressed significant inefficiency in `String.split()`. It appears the issue was rather related to 5b026f4.