### PR TITLE
[stdlib] Fix string find method for non ASCII

### DIFF
--- a/stdlib/src/utils/string_slice.mojo
+++ b/stdlib/src/utils/string_slice.mojo
@@ -636,7 +636,7 @@ struct StringSlice[
             characters of the slice starting at start.
         """
 
-        var self_len = len(self)
+        var self_len = self.byte_length()
 
         var abs_start: Int
         if start < 0:
@@ -677,7 +677,7 @@ struct StringSlice[
         if not substr:
             return 0
 
-        if len(self) < len(substr) + start:
+        if self.byte_length() < substr.byte_length() + start:
             return -1
 
         # The substring to search within, offset from the beginning if `start`
@@ -686,9 +686,9 @@ struct StringSlice[
 
         var loc = stringref._memmem(
             haystack_str.unsafe_ptr(),
-            len(haystack_str),
+            haystack_str.byte_length(),
             substr.unsafe_ptr(),
-            len(substr),
+            substr.byte_length(),
         )
 
         if not loc:

--- a/stdlib/test/collections/test_string.mojo
+++ b/stdlib/test/collections/test_string.mojo
@@ -810,6 +810,15 @@ def test_split():
     assert_equal(res5[0], "Hello")
     assert_equal(res5[1], "🔥!")
 
+    var in6 = String("Лорем ипсум долор сит амет")
+    var res6 = in6.split(" ")
+    assert_equal(len(res6), 5)
+    assert_equal(res6[0], "Лорем")
+    assert_equal(res6[1], "ипсум")
+    assert_equal(res6[2], "долор")
+    assert_equal(res6[3], "сит")
+    assert_equal(res6[4], "амет")
+
 
 def test_splitlines():
     # Test with no line breaks


### PR DESCRIPTION
Fixes part of #3457, where we split on empty string