### PR TITLE
[stdlib] Ensure `not` in `PATH` for Linux builds

### DIFF
--- a/stdlib/scripts/install-build-tools-linux.sh
+++ b/stdlib/scripts/install-build-tools-linux.sh
@@ -28,5 +28,6 @@ sudo update-alternatives --install /usr/bin/lld lld /usr/bin/lld-$LLVM_VERSION 1
 sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-$LLVM_VERSION 100
 sudo update-alternatives --install /usr/bin/lldb lldb /usr/bin/lldb-$LLVM_VERSION 100
 sudo update-alternatives --install /usr/bin/FileCheck FileCheck /usr/bin/FileCheck-$LLVM_VERSION 100
+sudo update-alternatives --install /usr/bin/not not /usr/bin/not-$LLVM_VERSION 100
 
 python3 -m pip install lit


### PR DESCRIPTION
Recently, the `not` tool was upgraded to be required and was only installed on our macOS CI.  Set the alternative for `not` in the Linux build scripts too to make the Ubuntu builds run the tests that require the `not` tool.