### PR TITLE
[stdlib] Make `UInt` `Hashable` again

### DIFF
--- a/stdlib/src/builtin/uint.mojo
+++ b/stdlib/src/builtin/uint.mojo
@@ -17,6 +17,7 @@ These are Mojo built-ins, so you don't need to import them.
 
 from sys import bitwidthof
 from utils._visualizers import lldb_formatter_wrapping_type
+from builtin.hash import _hash_simd
 
 
 @lldb_formatter_wrapping_type
@@ -129,6 +130,17 @@ struct UInt(IntLike):
             The string representation of this UInt.
         """
         return "UInt(" + str(self) + ")"
+
+    fn __hash__(self) -> UInt:
+        """Hash the UInt using builtin hash.
+
+        Returns:
+            A 64-bit hash value. This value is _not_ suitable for cryptographic
+            uses. Its intended usage is for data structures. See the `hash`
+            builtin documentation for more details.
+        """
+        # TODO(MOCO-636): switch to DType.index
+        return _hash_simd(Scalar[DType.uint64](self))
 
     @always_inline("nodebug")
     fn __eq__(self, rhs: UInt) -> Bool:

--- a/stdlib/test/builtin/test_uint.mojo
+++ b/stdlib/test/builtin/test_uint.mojo
@@ -238,6 +238,12 @@ def test_pos():
     assert_equal(UInt(0).__pos__(), UInt(0))
 
 
+def test_hash():
+    assert_not_equal(UInt.__hash__(123), UInt.__hash__(456))
+    assert_equal(UInt.__hash__(123), UInt.__hash__(123))
+    assert_equal(UInt.__hash__(456), UInt.__hash__(456))
+
+
 def test_comptime():
     alias a: UInt = 32
     # Verify that count_trailing_zeros works at comptime.
@@ -268,4 +274,5 @@ def main():
     test_indexer()
     test_comparison()
     test_pos()
+    test_hash()
     test_comptime()


### PR DESCRIPTION
Redoing PR #3486 because I royally borked the rebase trying to resolve conflicts.

### Problem
Calling `hash` on a `UInt` value doesn't compile, e.g.

```mojo
def main():
    var x: UInt = 1234
    hash(x)
```

results in 

```
error: no matching function in call to 'hash'
    hash(u)
    ~~~~^~~
```

even though it does compile for `UInt8`, `UInt16`, `UInt32`, and `UInt64`. This means using `UInt` as a key to `Dict` doesn't compile either, for example

```mojo
from collections import Dict

def main():
    var d = Dict[UInt, String]()
```

results in

```
error: 'Dict' parameter #0 has 'KeyElement' type, but value has type 'AnyStruct[UInt]'
    var d = Dict[UInt, String]()
                 ^~~~
```

### Fix
This _does_ work for `Int8` through `Int64` as well as `Int` itself, so I essentially copied over the definition of `Int.__hash__` with the appropriate change to the underlying `DType` passed to `_hash_simd`, under the assumption it should work the same for `UInt`. Added a (very simple) test similar to that for `String.__hash__` too.

This seemed simple enough to go ahead and open a PR for, but it's my first contribution so if I need to open an issue first or am missing something obvious, please let me know!