### PR TITLE
[stdlib] Modify `String.__repr__` to handle multi-byte UTF-8 characters

### DIFF
--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -202,7 +202,6 @@ fn _repr_ascii(c: UInt8) -> String:
             return hex(uc, prefix=r"\x")
 
 
-# TODO: This is currently the same as repr, should change with unicode strings
 @always_inline
 fn ascii(value: String) -> String:
     """Get the ASCII representation of the object.
@@ -213,7 +212,19 @@ fn ascii(value: String) -> String:
     Returns:
         A string containing the ASCII representation of the object.
     """
-    return value.__repr__()
+    alias ord_squote = ord("'")
+    var result = String()
+    var use_dquote = False
+
+    for idx in range(len(value._buffer) - 1):
+        var char = value._buffer[idx]
+        result += _repr_ascii(char)
+        use_dquote = use_dquote or (char == ord_squote)
+
+    if use_dquote:
+        return '"' + result + '"'
+    else:
+        return "'" + result + "'"
 
 
 # ===----------------------------------------------------------------------=== #
@@ -1179,15 +1190,30 @@ struct String(
         Returns:
             A new representation of the string.
         """
-        alias ord_squote = ord("'")
         var result = String()
         var use_dquote = False
+        for s in self:
+            use_dquote = use_dquote or (s == "'")
 
-        for idx in range(len(self._buffer) - 1):
-            var char = self._buffer[idx]
-            result += _repr_ascii(char)
-            use_dquote = use_dquote or (char == ord_squote)
-
+            if s == '\\':
+                result += r"\\"
+            elif s == '\t':
+                result += r"\t"
+            elif s == '\n':
+                result += r"\n"
+            elif s == '\r':
+                result += r"\r"
+            else:
+                var codepoint = ord(s)
+                if isprintable(codepoint):
+                    result += s
+                elif codepoint < 0x10:
+                    result += hex(codepoint, prefix=r"\x0")
+                elif codepoint < 0x20 or codepoint == 0x7f:
+                    result += hex(codepoint, prefix=r"\x")
+                else: # multi-byte character
+                    result += s
+        
         if use_dquote:
             return '"' + result + '"'
         else:

--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -1195,13 +1195,13 @@ struct String(
         for s in self:
             use_dquote = use_dquote or (s == "'")
 
-            if s == '\\':
+            if s == "\\":
                 result += r"\\"
-            elif s == '\t':
+            elif s == "\t":
                 result += r"\t"
-            elif s == '\n':
+            elif s == "\n":
                 result += r"\n"
-            elif s == '\r':
+            elif s == "\r":
                 result += r"\r"
             else:
                 var codepoint = ord(s)
@@ -1209,11 +1209,11 @@ struct String(
                     result += s
                 elif codepoint < 0x10:
                     result += hex(codepoint, prefix=r"\x0")
-                elif codepoint < 0x20 or codepoint == 0x7f:
+                elif codepoint < 0x20 or codepoint == 0x7F:
                     result += hex(codepoint, prefix=r"\x")
-                else: # multi-byte character
+                else:  # multi-byte character
                     result += s
-        
+
         if use_dquote:
             return '"' + result + '"'
         else:

--- a/stdlib/test/collections/test_string.mojo
+++ b/stdlib/test/collections/test_string.mojo
@@ -65,9 +65,9 @@ def test_repr():
     assert_equal(String.__repr__("\x7f"), r"'\x7f'")
 
     # Multi-byte characters
-    assert_equal(String.__repr__("Örnsköldsvik"), "'Örnsköldsvik'") # 2-byte
-    assert_equal(String.__repr__("你好!"), "'你好!'") # 3-byte
-    assert_equal(String.__repr__("hello 🔥!"), "'hello 🔥!'") # 4-byte
+    assert_equal(String.__repr__("Örnsköldsvik"), "'Örnsköldsvik'")  # 2-byte
+    assert_equal(String.__repr__("你好!"), "'你好!'")  # 3-byte
+    assert_equal(String.__repr__("hello 🔥!"), "'hello 🔥!'")  # 4-byte
 
 
 def test_constructors():

--- a/stdlib/test/collections/test_string.mojo
+++ b/stdlib/test/collections/test_string.mojo
@@ -45,11 +45,14 @@ def test_stringable():
 
 
 def test_repr():
-    # Usual cases
+    # Standard single-byte characters
     assert_equal(String.__repr__("hello"), "'hello'")
     assert_equal(String.__repr__(str(0)), "'0'")
+    assert_equal(String.__repr__("A"), "'A'")
+    assert_equal(String.__repr__(" "), "' '")
+    assert_equal(String.__repr__("~"), "'~'")
 
-    # Escape cases
+    # Special single-byte characters
     assert_equal(String.__repr__("\0"), r"'\x00'")
     assert_equal(String.__repr__("\x06"), r"'\x06'")
     assert_equal(String.__repr__("\x09"), r"'\t'")
@@ -57,12 +60,14 @@ def test_repr():
     assert_equal(String.__repr__("\x0d"), r"'\r'")
     assert_equal(String.__repr__("\x0e"), r"'\x0e'")
     assert_equal(String.__repr__("\x1f"), r"'\x1f'")
-    assert_equal(String.__repr__(" "), "' '")
     assert_equal(String.__repr__("'"), '"\'"')
-    assert_equal(String.__repr__("A"), "'A'")
     assert_equal(String.__repr__("\\"), r"'\\'")
-    assert_equal(String.__repr__("~"), "'~'")
     assert_equal(String.__repr__("\x7f"), r"'\x7f'")
+
+    # Multi-byte characters
+    assert_equal(String.__repr__("Örnsköldsvik"), "'Örnsköldsvik'") # 2-byte
+    assert_equal(String.__repr__("你好!"), "'你好!'") # 3-byte
+    assert_equal(String.__repr__("hello 🔥!"), "'hello 🔥!'") # 4-byte
 
 
 def test_constructors():


### PR DESCRIPTION
This PR fixes #3456 by modifying `String.__repr__` to handle multi-byte UTF-8 characters. The original code iterated over the string's internal bytes buffer and handled each one individually, causing the multi-byte characters to get emitted separately.

I took advantage of `String.__iter__` since it already has the logic internally to slice the string up into its UTF-8 characters, but I do have another implementation that still iterates over the byte buffer and pulls out the characters directly, if that solution is preferred for whatever reason.

The old definition for the module function `string.ascii` used to just call `String.__repr__` directly, so I copied the old definition of `String.__repr__` to `string.ascii` so that it still works the same.