### PR TITLE
[stdlib] Implement Python-like base64 encoding/decoding

### DIFF
--- a/stdlib/src/base64/base64.mojo
+++ b/stdlib/src/base64/base64.mojo
@@ -168,10 +168,10 @@ fn b64decode(
     var specials = _validate_altchars(altchars)
     base64_alphabet += specials
 
-    # Step 1: Remove ASCII whitespace from data
+    # Remove ASCII whitespace from data
     var encoded = _remove_whitespace(s)
 
-    # Step 3: Check for invalid characters
+    # Check for invalid characters
     var valid_chars = base64_alphabet + "="
     for char in encoded:
         if char not in valid_chars:
@@ -180,7 +180,7 @@ fn b64decode(
             else:
                 encoded = encoded.replace(char, "")
 
-    # Step 2: Validate padding and length
+    # Validate padding and length
     var length = encoded.byte_length()
     print("byte length =", length)
     if length % 4 != 0:

--- a/stdlib/test/base64/test_base64.mojo
+++ b/stdlib/test/base64/test_base64.mojo
@@ -14,7 +14,7 @@
 
 from base64 import b16decode, b16encode, b64decode, b64encode
 
-from testing import assert_equal
+from testing import assert_equal, assert_raises
 
 
 def test_b64encode():
@@ -32,6 +32,10 @@ def test_b64encode():
     )
 
     assert_equal(b64encode("ABCDEFabcdef"), "QUJDREVGYWJjZGVm")
+
+    assert_equal(
+        b64encode("Hello 🔥!!!", altchars=String("-_")), "SGVsbG8g8J-UpSEhIQ=="
+    )
 
 
 def test_b64decode():
@@ -51,6 +55,42 @@ def test_b64decode():
     )
 
     assert_equal(b64decode("QUJDREVGYWJjZGVm"), "ABCDEFabcdef")
+
+    assert_equal(
+        b64decode("SGVsbG8gTW9qbyEhIQ==", validate=True), "Hello Mojo!!!"
+    )
+
+    assert_equal(b64decode("SGVs bG8g\nTW9qbyE\thIQ\r=="), "Hello Mojo!!!")
+
+    assert_equal(
+        b64decode("SGVs bG8g\nTW9qbyE\thIQ\r==", validate=True), "Hello Mojo!!!"
+    )
+
+    assert_equal(b64decode("", validate=True), "")
+
+    assert_equal(
+        b64decode("SGVsbG8g8J-UpSEhIQ==", altchars=String("-_")), "Hello 🔥!!!"
+    )
+
+    assert_equal(
+        b64decode("SGVsbG8g8J-UpSEhIQ==", altchars=String("-_"), validate=True),
+        "Hello 🔥!!!",
+    )
+
+    with assert_raises():
+        b64decode("SGVsbG8gTW9qbyEhIQ=", validate=True)  # Length 19
+
+    with assert_raises():
+        b64decode("SGVsbG8gTW9qbyEhIQ===", validate=True)  # Length 21
+
+    with assert_raises():
+        b64decode("SGVsbG8gd29ybGQ")  # Length 15
+
+    with assert_raises():
+        b64decode("SGVsbG8gd29ybGQ@")  # Length 15
+
+    with assert_raises():
+        b64decode("SGVsbG8gd29ybGQ@", validate=True)  # Invalid character
 
 
 def test_b16encode():


### PR DESCRIPTION
This PR implements a few features to make Mojo's base64 encoding and decoding conform more closely to [Python's implementation](https://docs.python.org/3/library/base64.html#base64.b64encode):
- `b64decode` now ignores whitespace in the input, fixing #3446.
- Both `b64encode` and `b64decode` implement an optional `altchars` argument which allows the caller to substitute two characters for the default `+/`, useful for URL-safe encoding.
- `b64decode` implements an optional `validate` argument which, when `True`, will cause the function to raise an `Error` if the input contains any characters outside the alphabet. When `False` (the default), these characters are ignored like whitespace.
- `b64decode` now raises an `Error` if the input's length (after whitespace / invalid character removal) isn't divisible by 4.

Note about my comment about "leaky abstraction" in `b64encode`: I tried using `String.unsafe_ptr()` instead of `String._buffer` directly, since this was the function used for `StringLiteral` originally, but it does not return the correct underlying `UInt`s corresponding to the characters in the string. I ran into this issue switching from using a `StringLiteral` alias to `String` variable for the alphabet, since I need to modify the alphabet according to the `altchars` argument.

I'm not sure if this is a bug or just my misunderstanding `UnsafePointer`. Here is a small example that exhibits what I mean:

```mojo
def main():
    var l = "ABC"
    var lp = l.unsafe_ptr()
    print(lp[0])  # returns 65

    var s = String("ABC")
    var sp = s.unsafe_ptr()
    print(sp[0])  # returns 0
```

If this is a bug and I should open an issue for it, let me know.