### PR TITLE
[tools] Initial support for nix shell/develop

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1726755586,
+        "narHash": "sha256-PmUr/2GQGvFTIJ6/Tvsins7Q43KTMvMFhvG6oaYK+Wk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c04d5652cfa9742b1d519688f65d1bbccea9eb7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,81 @@
+{
+  description = "Magic development environment";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, flake-compat }:
+    let
+      linuxPkgs = nixpkgs.legacyPackages."x86_64-linux";
+      darwinPkgs = nixpkgs.legacyPackages."aarch64-darwin";
+      forAllSystems = function:
+        nixpkgs.lib.genAttrs [
+          "x86_64-linux"
+          "aarch64-darwin"
+        ] (system: function nixpkgs.legacyPackages.${system});
+      version = "0.3.0";
+      getBinary = system: {
+          "x86_64-linux" = "magic-x86_64-unknown-linux-musl";
+          "aarch64-darwin" = "magic-aarch64-apple-darwin";
+      }.${system} or (throw "unsupported system: ${system}");
+      fetchMagic = pkgs: binary: pkgs.stdenv.mkDerivation rec {
+          name = "magic";
+          src = pkgs.fetchurl {
+            url = "https://dl.modular.com/public/magic/raw/versions/${version}/${binary}";
+            sha256 = "sha256-wNweaK1TPqsVv9D1x7/m5kr1tryWfftzKCKDNdVBkOc=";
+          };
+
+          dontUnpack = true;
+
+          postInstall = ''
+            mkdir -p $out/bin
+            cp $src $out/bin/magic
+            chmod +x $out/bin/magic
+          '';
+        };
+      magicEnv = pkgs: magic: (pkgs.buildFHSEnv {
+        name = "magic-shell";
+        targetPkgs = pkgs: (with pkgs; [
+          libz
+          clang
+          lit
+          llvm
+          # Magic provides currently ncurses 6.5 on it's own but libtinfo is
+          # needed and in nixpkgs this does not seem to be provided separately
+          # https://github.com/NixOS/nixpkgs/issues/89769
+          ncurses
+        ]);
+        profile = ''
+          MODULAR_HOME=$HOME/.modular
+          BIN_DIR=$MODULAR_HOME/bin
+          MAGIC=$BIN_DIR/magic
+
+          if [ ! -e $MAGIC ]; then
+            mkdir -p $BIN_DIR
+            cp ${magic}/bin/magic $BIN_DIR/magic
+            echo 37e8aeee-7585-494b-83e4-59244188c2fe > "$MODULAR_HOME/webUserId"
+          fi
+
+          export PATH=$BIN_DIR:$PATH
+          # Seems to work but prints error 'complete: command not found' when 
+          # the shell is entered.
+          # Maybe related to https://github.com/NixOS/nix/issues/6091#issuecomment-1038247010
+          eval "$(magic completion --shell bash)"
+        '';
+        runScript = ''
+          magic shell
+        '';
+      }).env;
+    in
+    {
+      devShells = forAllSystems (pkgs: {
+        default = magicEnv pkgs (fetchMagic pkgs (getBinary pkgs.system));
+      });
+    };
+}
+

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+# To support non-flake-enabled nix instances.
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = lock.nodes.flake-compat.locked.url or
+      "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix
+


### PR DESCRIPTION
Nix shell/develop provides similar functionality to 'magic shell' but works with the Nix package manager (https://nixos.org/download/) and is generally used to manage an entire operating system.
Nix does not follow the FHS standard which means that magic does not work on systems using Nix out of the box and providing such a developer environment makes it easier for people using Nix to use and contribute to the software provided by Modular. On a system with a default Nix installation the shell can be entered by going to the mojo repository path and executing 'nix-shell'.
With flake support enabled it also works with 'nix develop'.

The Nix package manager is used in the NixOS Linux distribution and enables the configuration of the entire system declaratively in a functional language also called Nix.
But it can also be used on any other Linux distribution and macOS with the same guarantees as on NixOS with the exception that it uses the base system on the lowest layer in this case instead of it's own kernel.
With https://github.com/NixOS/nixpkgs there exists a repository for packaging software which is also a possible future path with the Modular products but currently I believe that it's not yet feasible.
I thought that the mojo repository is for now the best place to centralize the support for a Nix dev shell even though I realize that this is not something of high importance for Modular.

Nix might also be of interest because it could potentially also being used to build containers (https://nix.dev/tutorials/nixos/building-and-running-docker-images.html) and an increasing number of repositories provide a flake.nix file in the repository to package the current upstream version directly in comparison to the nixpkgs approach.

I know the chances are slim that this gets merged but I thought I will try.

I tested the shell on NixOS but was not able to test on macOS because I don't have access to it.

Anybody interested in trying it out can do so by installing the Nix package manager by following the instructions on https://nixos.org/download and running 'nix-shell' in the mojo repository directory with the nix files present.