### PR TITLE
[stdlib] Fix `String.split()` implementations

### DIFF
--- a/mojo/stdlib/benchmarks/collections/bench_string.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_string.mojo
@@ -17,6 +17,7 @@
 
 from collections.string import String
 from collections.string._utf8 import _is_valid_utf8
+from collections.string.string_slice import _split
 from memory import stack_allocation
 from os import abort
 from pathlib import _dir_of_current_file
@@ -106,18 +107,20 @@ fn bench_string_split[
     filename: StaticString = "UN_charter_EN",
     sequence: Optional[StaticString] = None,
 ](mut b: Bencher) raises:
-    var items = make_string[length](filename + ".txt")
+    var items = (
+        make_string[length](filename + ".txt").as_string_slice().get_immutable()
+    )
 
     @always_inline
     @parameter
     fn call_fn() raises:
-        var res: List[String]
+        var res: List[__type_of(items)]
 
         @parameter
         if sequence:
-            res = items.split(sequence.value())
+            res = _split[has_maxsplit=False](items, sequence.value(), -1)
         else:
-            res = items.split()
+            res = _split[has_maxsplit=False](items, None, -1)
         keep(res.data)
 
     b.iter[call_fn]()

--- a/mojo/stdlib/stdlib/collections/string/string.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string.mojo
@@ -1321,8 +1321,7 @@ struct String(
         """
         return self.as_string_slice().isspace()
 
-    # TODO(MSTDL-590): String.split() should return `StringSlice`s.
-    fn split(self, sep: StringSlice, maxsplit: Int = -1) raises -> List[String]:
+    fn split(self, sep: StringSlice, maxsplit: Int = -1) -> List[String]:
         """Split the string by a separator.
 
         Args:
@@ -1333,9 +1332,6 @@ struct String(
         Returns:
             A List of Strings containing the input split by the separator.
 
-        Raises:
-            If the separator is empty.
-
         Examples:
 
         ```mojo
@@ -1345,6 +1341,8 @@ struct String(
         _ = String("hello,,world").split(",") # ["hello", "", "world"]
         # Splitting with maxsplit
         _ = String("1,2,3").split(",", 1) # ['1', '2,3']
+        # Splitting with an empty separator
+        _ = StringSlice("123").split("") # ["", "1", "2", "3", ""]
         ```
         .
         """

--- a/mojo/stdlib/stdlib/collections/string/string_slice.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string_slice.mojo
@@ -1161,139 +1161,6 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
             res.append_byte(self_ptr[i])
         return res^
 
-    fn split(
-        self, sep: StringSlice, maxsplit: Int = -1
-    ) raises -> List[Self.Immutable]:
-        """Split the string by a separator.
-
-        Args:
-            sep: The string to split on.
-            maxsplit: The maximum amount of items to split from String.
-                Defaults to unlimited.
-
-        Returns:
-            A List of Strings containing the input split by the separator.
-
-        Raises:
-            If the separator is empty.
-
-        Examples:
-
-        ```mojo
-        # Splitting a space
-        _ = StringSlice("hello world").split(" ") # ["hello", "world"]
-        # Splitting adjacent separators
-        _ = StringSlice("hello,,world").split(",") # ["hello", "", "world"]
-        # Splitting with maxsplit
-        _ = StringSlice("1,2,3").split(",", 1) # ['1', '2,3']
-        ```
-        """
-        var output = List[Self.Immutable]()
-
-        var str_byte_len = self.byte_length() - 1
-        var lhs = 0
-        var items = 0
-        var sep_len = sep.byte_length()
-        if sep_len == 0:
-            raise Error("Separator cannot be empty.")
-        if str_byte_len < 0:
-            output.append(rebind[Self.Immutable](StaticString("")))
-
-        while lhs <= str_byte_len:
-            var rhs = self.find(sep, lhs)
-            if rhs == -1:
-                output.append(rebind[Self.Immutable](self[lhs:]))
-                break
-
-            if maxsplit > -1:
-                if items == maxsplit:
-                    output.append(rebind[Self.Immutable](self[lhs:]))
-                    break
-                items += 1
-
-            output.append(rebind[Self.Immutable](self[lhs:rhs]))
-            lhs = rhs + sep_len
-
-        if self.endswith(sep) and (len(output) <= maxsplit or maxsplit == -1):
-            output.append(rebind[Self.Immutable](StaticString("")))
-
-        return output^
-
-    fn split(
-        self, sep: NoneType = None, maxsplit: Int = -1
-    ) -> List[Self.Immutable]:
-        """Split the string by every Whitespace separator.
-
-        Args:
-            sep: None.
-            maxsplit: The maximum amount of items to split from String. Defaults
-                to unlimited.
-
-        Returns:
-            A List of Strings containing the input split by the separator.
-
-        Examples:
-
-        ```mojo
-        # Splitting an empty string or filled with whitespaces
-        _ = StringSlice("      ").split() # []
-        _ = StringSlice("").split() # []
-
-        # Splitting a string with leading, trailing, and middle whitespaces
-        _ = StringSlice("      hello    world     ").split() # ["hello", "world"]
-        # Splitting adjacent universal newlines:
-        _ = StringSlice(
-            "hello \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e\\x85\\u2028\\u2029world"
-        ).split()  # ["hello", "world"]
-        ```
-        """
-
-        return self._split_whitespace()
-
-    fn _split_whitespace(self, maxsplit: Int = -1) -> List[Self.Immutable]:
-        fn num_bytes(b: UInt8) -> Int:
-            var flipped = ~b
-            return Int(count_leading_zeros(flipped) + (flipped >> 7))
-
-        var output = List[Self.Immutable]()
-        var str_byte_len = self.byte_length() - 1
-        var lhs = 0
-        var items = 0
-        while lhs <= str_byte_len:
-            # Python adds all "whitespace chars" as one separator if no
-            # separator was specified.
-            for s in self[lhs:].codepoint_slices():
-                if not s.isspace():
-                    break
-                lhs += s.byte_length()
-            # If it went until the end of the String, then it should be sliced
-            # up until the original start of the whitespace which was already
-            # appended.
-            if lhs - 1 == str_byte_len:
-                break
-            elif lhs == str_byte_len:
-                # If the last char is not whitespace
-                output.append(rebind[Self.Immutable](self[str_byte_len:]))
-                break
-            var rhs = lhs + num_bytes(self.unsafe_ptr()[lhs])
-            for s in self[
-                lhs + num_bytes(self.unsafe_ptr()[lhs]) :
-            ].codepoint_slices():
-                if s.isspace():
-                    break
-                rhs += s.byte_length()
-
-            if maxsplit > -1:
-                if items == maxsplit:
-                    output.append(rebind[Self.Immutable](self[lhs:]))
-                    break
-                items += 1
-
-            output.append(rebind[Self.Immutable](self[lhs:rhs]))
-            lhs = rhs
-
-        return output^
-
     @always_inline
     fn strip(self, chars: StringSlice) -> Self:
         """Return a copy of the string with leading and trailing characters
@@ -1910,12 +1777,16 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
 
         return Int(loc) - Int(self.unsafe_ptr())
 
-    fn isspace(self) -> Bool:
+    fn isspace[single_character: Bool = False](self) -> Bool:
         """Determines whether every character in the given StringSlice is a
         python whitespace String. This corresponds to Python's
         [universal separators](
         https://docs.python.org/3/library/stdtypes.html#str.splitlines):
          `" \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e\\x85\\u2028\\u2029"`.
+
+        Parameters:
+            single_character: Whether to evaluate the stringslice as a single
+                unicode character (avoids overhead when already iterating).
 
         Returns:
             True if the whole StringSlice is made up of whitespace characters
@@ -1926,7 +1797,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         Check if a string contains only whitespace:
 
         ```mojo
-        from testing import assert_true, assert_false
+        %# from testing import assert_true, assert_false
 
         # An empty string is not considered to contain only whitespace chars:
         assert_false(StringSlice("").isspace())
@@ -1940,14 +1811,110 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         ```
         """
 
-        if self.byte_length() == 0:
+        fn _is_space_char(s: StringSlice) -> Bool:
+            # sorry for readability, but this has less overhead than memcmp
+            # highly performance sensitive code, benchmark before touching
+            alias ` ` = UInt8(ord(" "))
+            alias `\t` = UInt8(ord("\t"))
+            alias `\n` = UInt8(ord("\n"))
+            alias `\r` = UInt8(ord("\r"))
+            alias `\f` = UInt8(ord("\f"))
+            alias `\v` = UInt8(ord("\v"))
+            alias `\x1c` = UInt8(ord("\x1c"))
+            alias `\x1d` = UInt8(ord("\x1d"))
+            alias `\x1e` = UInt8(ord("\x1e"))
+
+            var no_null_len = s.byte_length()
+            var ptr = s.unsafe_ptr()
+            if likely(no_null_len == 1):
+                var c = ptr[0]
+                return (
+                    c == ` `
+                    or c == `\t`
+                    or c == `\n`
+                    or c == `\r`
+                    or c == `\f`
+                    or c == `\v`
+                    or c == `\x1c`
+                    or c == `\x1d`
+                    or c == `\x1e`
+                )
+            elif no_null_len == 2:
+                return ptr[0] == 0xC2 and ptr[1] == 0x85  # next_line: \x85
+            elif no_null_len == 3:
+                # unicode line sep or paragraph sep: \u2028 , \u2029
+                var last_byte = ptr[2] == 0xA8 or ptr[2] == 0xA9
+                return ptr[0] == 0xE2 and ptr[1] == 0x80 and last_byte
             return False
 
-        for s in self.codepoints():
-            if not s.is_python_space():
-                return False
+        @parameter
+        if single_character:
+            return _is_space_char(self)
+        else:
+            for s in self.codepoint_slices():
+                if not _is_space_char(s):
+                    return False
+            return self.byte_length() != 0
 
-        return True
+    fn split(
+        self, sep: StringSlice, maxsplit: Int = -1
+    ) -> List[Self.Immutable]:
+        """Split the string by a separator.
+
+        Args:
+            sep: The string to split on.
+            maxsplit: The maximum amount of items to split from String.
+                Defaults to unlimited.
+
+        Returns:
+            A List of Strings containing the input split by the separator.
+
+        Examples:
+
+        ```mojo
+        # Splitting a space
+        _ = StringSlice("hello world").split(" ") # ["hello", "world"]
+        # Splitting adjacent separators
+        _ = StringSlice("hello,,world").split(",") # ["hello", "", "world"]
+        # Splitting with maxsplit
+        _ = StringSlice("1,2,3").split(",", 1) # ['1', '2,3']
+        # Splitting with an empty separator
+        _ = StringSlice("123").split("") # ["", "1", "2", "3", ""]
+        ```
+        .
+        """
+        return _split[has_maxsplit=True](self.get_immutable(), sep, maxsplit)
+
+    fn split(
+        self, sep: NoneType = None, maxsplit: Int = -1
+    ) -> List[Self.Immutable]:
+        """Split the string by every Whitespace separator.
+
+        Args:
+            sep: None.
+            maxsplit: The maximum amount of items to split from String. Defaults
+                to unlimited.
+
+        Returns:
+            A List of Strings containing the input split by the separator.
+
+        Examples:
+
+        ```mojo
+        # Splitting an empty string or filled with whitespaces
+        _ = StringSlice("      ").split() # []
+        _ = StringSlice("").split() # []
+
+        # Splitting a string with leading, trailing, and middle whitespaces
+        _ = StringSlice("      hello    world     ").split() # ["hello", "world"]
+        # Splitting adjacent universal newlines:
+        _ = StringSlice(
+            "hello \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e\\x85\\u2028\\u2029world"
+        ).split()  # ["hello", "world"]
+        ```
+        .
+        """
+        return _split[has_maxsplit=True](self.get_immutable(), sep, maxsplit)
 
     fn isnewline[single_character: Bool = False](self) -> Bool:
         """Determines whether every character in the given StringSlice is a
@@ -2297,10 +2264,10 @@ fn get_static_string[
 
 
 fn _to_string_list[
-    O: ImmutableOrigin, //,
+    O: Origin, //,
     T: Copyable & Movable,  # TODO(MOCO-1446): Make `T` parameter inferred
     len_fn: fn (T) -> Int,
-    unsafe_ptr_fn: fn (T) -> UnsafePointer[Byte, mut=False, origin=O],
+    unsafe_ptr_fn: fn (T) -> UnsafePointer[Byte, mut = O.mut, origin=O],
 ](items: List[T]) -> List[String]:
     var i_len = len(items)
 
@@ -2315,9 +2282,7 @@ fn _to_string_list[
 
 
 @always_inline
-fn _to_string_list[
-    O: ImmutableOrigin, //
-](items: List[StringSlice[O]]) -> List[String]:
+fn _to_string_list[O: Origin](items: List[StringSlice[O]]) -> List[String]:
     """Create a list of Strings **copying** the existing data.
 
     Parameters:
@@ -2332,7 +2297,7 @@ fn _to_string_list[
 
     fn unsafe_ptr_fn(
         v: StringSlice[O],
-    ) -> UnsafePointer[Byte, mut=False, origin=O]:
+    ) -> UnsafePointer[Byte, mut = O.mut, origin=O]:
         return v.unsafe_ptr()
 
     fn len_fn(v: StringSlice[O]) -> Int:
@@ -2342,9 +2307,7 @@ fn _to_string_list[
 
 
 @always_inline
-fn _to_string_list[
-    O: ImmutableOrigin, //
-](items: List[Span[Byte, O]]) -> List[String]:
+fn _to_string_list[O: Origin](items: List[Span[Byte, O]]) -> List[String]:
     """Create a list of Strings **copying** the existing data.
 
     Parameters:
@@ -2359,7 +2322,7 @@ fn _to_string_list[
 
     fn unsafe_ptr_fn(
         v: Span[Byte, O]
-    ) -> UnsafePointer[Byte, mut=False, origin=O]:
+    ) -> UnsafePointer[Byte, mut = O.mut, origin=O]:
         return v.unsafe_ptr()
 
     fn len_fn(v: Span[Byte, O]) -> Int:
@@ -2557,3 +2520,105 @@ fn _memrmem[
         if memcmp(haystack + i + 1, needle + 1, needle_len - 1) == 0:
             return haystack + i
     return UnsafePointer[Scalar[dtype]]()
+
+
+fn _split[
+    has_maxsplit: Bool
+](
+    src_str: StringSlice,
+    sep: StringSlice,
+    maxsplit: Int,
+    out output: List[__type_of(src_str).Immutable],
+):
+    alias S = __type_of(src_str).Immutable
+    var ptr = src_str.unsafe_ptr().origin_cast[mut=False]()
+    var sep_len = sep.byte_length()
+    if sep_len == 0:
+        var iterator = src_str.codepoint_slices()
+        var i_len = len(iterator) + 2
+        output = __type_of(output)(capacity=i_len)
+        output.append(S(ptr=ptr, length=0))
+        for s in iterator:
+            output.append(s)
+        output.append(S(ptr=ptr + i_len - 1, length=0))
+        return
+
+    alias prealloc = 32  # guessing, Python's implementation uses 12
+    var amnt = prealloc
+
+    @parameter
+    if has_maxsplit:
+        amnt = maxsplit + 1 if maxsplit < prealloc else prealloc
+    output = __type_of(output)(capacity=amnt)
+    var str_byte_len = src_str.byte_length()
+    var lhs = 0
+    var rhs: Int
+    var items = 0
+    # var str_span = src_str.as_bytes() # FIXME: solve #3526 with #3548
+    # var sep_span = sep.as_bytes() # FIXME: solve #3526 with #3548
+
+    while lhs <= str_byte_len:
+        # FIXME(#3526): use str_span and sep_span
+        rhs = src_str.find(sep, lhs)
+        # if not found go to the end
+        rhs += -Int(rhs == -1) & (str_byte_len + 1)
+
+        @parameter
+        if has_maxsplit:
+            rhs += -Int(items == maxsplit) & (str_byte_len - rhs)
+            items += 1
+
+        output.append(S(ptr=ptr + lhs, length=rhs - lhs))
+        lhs = rhs + sep_len
+
+
+fn _split[
+    has_maxsplit: Bool
+](
+    src_str: StringSlice,
+    sep: NoneType,
+    maxsplit: Int,
+    out output: List[__type_of(src_str).Immutable],
+):
+    alias S = __type_of(src_str).Immutable
+    alias prealloc = 32  # guessing, Python's implementation uses 12
+    var amnt = prealloc
+
+    @parameter
+    if has_maxsplit:
+        amnt = maxsplit + 1 if maxsplit < prealloc else prealloc
+    output = __type_of(output)(capacity=amnt)
+    var str_byte_len = src_str.byte_length()
+    var lhs = 0
+    var rhs: Int
+    var items = 0
+    var ptr = src_str.unsafe_ptr().origin_cast[mut=False]()
+
+    @always_inline("nodebug")
+    fn _build_slice(p: __type_of(ptr), start: Int, end: Int) -> S:
+        return S(ptr=p + start, length=end - start)
+
+    while lhs <= str_byte_len:
+        # Python adds all "whitespace chars" as one separator
+        # if no separator was specified
+        for s in _build_slice(ptr, lhs, str_byte_len).codepoint_slices():
+            if not s.isspace[single_character=True]():
+                break
+            lhs += s.byte_length()
+        # if it went until the end of the String, then it should be sliced
+        # until the start of the whitespace which was already appended
+        if lhs == str_byte_len:
+            break
+        rhs = lhs + _utf8_first_byte_sequence_length(ptr[lhs])
+        for s in _build_slice(ptr, rhs, str_byte_len).codepoint_slices():
+            if s.isspace[single_character=True]():
+                break
+            rhs += s.byte_length()
+
+        @parameter
+        if has_maxsplit:
+            rhs += -Int(items == maxsplit) & (str_byte_len - rhs)
+            items += 1
+
+        output.append(S(ptr=ptr + lhs, length=rhs - lhs))
+        lhs = rhs

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -679,6 +679,9 @@ def test_rfind():
 
 
 def test_split():
+    alias S = StaticString
+    alias L = List[StaticString]
+
     # empty separators default to whitespace
     var d = String("hello world").split()
     assert_true(len(d) == 2)
@@ -741,11 +744,9 @@ def test_split():
     assert_true(len(String(" ").split()) == 0)
     assert_true(len(String().split(" ")) == 1)
     assert_true(len(String(" ").split(" ")) == 2)
+    assert_true(len(S("").split("")) == 2)
     assert_true(len(String("  ").split(" ")) == 3)
     assert_true(len(String("   ").split(" ")) == 4)
-
-    with assert_raises():
-        _ = String().split("")
 
     # Split in middle
     var d1 = String("n")
@@ -818,8 +819,10 @@ def test_split():
     assert_equal(res6[3], "сит")
     assert_equal(res6[4], "амет")
 
-    with assert_raises(contains="Separator cannot be empty."):
-        _ = String("1, 2, 3").split("")
+    assert_equal(S("123").split(""), L("", "1", "2", "3", ""))
+    assert_equal(S("").join(S("123").split("")), "123")
+    assert_equal(S(",1,2,3,").split(","), S("123").split(""))
+    assert_equal(S(",").join(S("123").split("")), ",1,2,3,")
 
 
 def test_splitlines():

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -526,17 +526,13 @@ def test_split():
     assert_true(len(S("").split(" ")) == 1)
     assert_true(len(S(",").split(",")) == 2)
     assert_true(len(S(" ").split(" ")) == 2)
-    # assert_true(len(S("").split("")) == 2) # TODO(#3528)
+    assert_true(len(S("").split("")) == 2)
     assert_true(len(S("  ").split(" ")) == 3)
     assert_true(len(S("   ").split(" ")) == 4)
 
     # should split into maxsplit + 1 items
     assert_equal(S("1,2,3").split(",", 0), L("1,2,3"))
     assert_equal(S("1,2,3").split(",", 1), L("1", "2,3"))
-
-    # TODO(#3528): delete this test
-    with assert_raises():
-        _ = S("").split("")
 
     # Split in middle
     assert_equal(S("faang").split("n"), L("faa", "g"))
@@ -566,11 +562,10 @@ def test_split():
     s3 = S("Лорем ипсум долор сит амет").split("м")
     assert_equal(s3, L("Лоре", " ипсу", " долор сит а", "ет"))
 
-    # TODO(#3528)
-    # assert_equal(S("123").split(""), L("", "1", "2", "3", ""))
-    # assert_equal(S("").join(S("123").split("")), "123")
-    # assert_equal(S(",1,2,3,").split(","), S("123").split(""))
-    # assert_equal(S(",").join(S("123").split("")), ",1,2,3,")
+    assert_equal(S("123").split(""), L("", "1", "2", "3", ""))
+    assert_equal(S("").join(S("123").split("")), "123")
+    assert_equal(S(",1,2,3,").split(","), S("123").split(""))
+    assert_equal(S(",").join(S("123").split("")), ",1,2,3,")
 
 
 def test_splitlines():


### PR DESCRIPTION
#### Main issue

Fix `String.split()` implementations to use a generic implementation and without assuming that indexing is by byte offset. Some important optimizations were added by parametrizing and avoiding slicing with numeric tricks.

#### Changes in behavior

This PR changes `split("")` behavior to be non-raising and return the separated unicode characters analogous to when the whole string has the separator at start, end, and in between every character. Closes #3635

#### Benchmark results:

CPU: Intel® Core™ i7-7700HQ

improvement metric: markdown percentage improvement (`(old_value - new_value) / old_value`)

Average improvement for split with a sequence: 91.2486% . In orders of magnitude, this is a 11x improvement
Average improvement for split on any whitespace: 99.9975% . In orders of magnitude, this is a 40k x improvement


|Name                          | old_value (ms)           | new_value (ms)      | improvement|
|:-----------------------------|---------------------:|----------------:|------:|
|`bench_string_split[1000000]` | 5.6970877871796 | 0.503624904955618 | 0.912486298354641|
|`bench_string_split_none[1000000]` | 147157.6808882 | 3.78480079182398 | 0.999975287456096|
