### PR TITLE
[CI] Pin `magic` to 0.2.3 to avoid timeouts

### DIFF
--- a/.github/workflows/standard_library_tests_and_examples.yml
+++ b/.github/workflows/standard_library_tests_and_examples.yml
@@ -46,8 +46,13 @@ jobs:
       - name: Download Magic CLI
         run: |
           curl -ssL https://magic.modular.com/cfba4c92-2390-4b86-93de-04b2f47114d5 | bash
+
           # Add magic to PATH
           echo "$HOME/.modular/bin" >> $GITHUB_PATH
+
+          # Pin magic to older version to avoid HTTP timeouts and/or client certificate errors
+          # that manifest as a result of uv/python package solvers from Magic 0.3.0.
+          "$HOME/.modular/bin/magic" self-update --version 0.2.3
 
       - name: Install build tools (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/test_pre_commit.yml
+++ b/.github/workflows/test_pre_commit.yml
@@ -42,6 +42,10 @@ jobs:
           # Add magic to PATH
           echo "$HOME/.modular/bin" >> $GITHUB_PATH
 
+          # Pin magic to older version to avoid HTTP timeouts and/or client certificate errors
+          # that manifest as a result of uv/python package solvers from Magic 0.3.0.
+          "$HOME/.modular/bin/magic" self-update --version 0.2.3
+
       - name: Install pre-commit
         run: |
           pip install pre-commit


### PR DESCRIPTION
There's issues with HTTP timeouts/client certificate errors in the latest version of `magic` (0.3.0 at the time of writing) due to the uv/python package solver.  Workaround these to improve the stability of our CI by just downgrading `magic` to a known, previous version, `0.2.3`.