### PR TITLE
[stdlib] Mojo-Python slice interoperability

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -187,11 +187,18 @@ what we publish.
 - Support for multi-dimensional indexing for `PythonObject`
   ([PR #3583](https://github.com/modularml/mojo/pull/3583) by [@jjvraw](https://github.com/jjvraw)).
 
+- Support for multi-dimensional indexing and slicing for `PythonObject`
+  (PRs  [#3549](https://github.com/modularml/mojo/pull/3549),
+  [#3583](https://github.com/modularml/mojo/pull/3583) by [@jjvraw](https://github.com/jjvraw)).
+
     ```mojo
     var np = Python.import_module("numpy")
-    var a = np.array(PythonObject([1,2,3,1,2,3])).reshape(2,3)
+    var a = np.array(PythonObject([1,2,3,4,5,6])).reshape(2,3)
     print((a[0, 1])) # 2
-    ```
+    print((a[1][::-1])) # [6 5 4]
+   ```
+
+  Note, that the syntax, `a[1, ::-1]`, is currently not supported.
 
 - [`Arc`](/mojo/stdlib/memory/arc/Arc) now implements
   [`Identifiable`](/mojo/stdlib/builtin/identifiable/Identifiable), and can be

--- a/stdlib/test/python/test_python_object.mojo
+++ b/stdlib/test/python/test_python_object.mojo
@@ -517,6 +517,94 @@ def test_setitem_raises():
         d[[1, 2, 3]] = 5
 
 
+fn test_py_slice() raises:
+    var a = PythonObject([1, 2, 3, 4, 5])
+    assert_equal("[2, 3]", str(a[1:3]))
+    assert_equal("[1, 2, 3, 4, 5]", str(a[:]))
+    assert_equal("[1, 2, 3]", str(a[:3]))
+    assert_equal("[3, 4, 5]", str(a[2:]))
+    assert_equal("[1, 3, 5]", str(a[::2]))
+    assert_equal("[2, 4]", str(a[1::2]))
+    assert_equal("[4, 5]", str(a[-2:]))
+    assert_equal("[1, 2, 3]", str(a[:-2]))
+    assert_equal("[5, 4, 3, 2, 1]", str(a[::-1]))
+    assert_equal("[1, 2, 3, 4, 5]", str(a[-10:10]))  # out of bounds
+    assert_equal("[1, 2, 3, 4, 5]", str(a[::]))
+    assert_equal("[1, 2, 3, 4, 5]", str(a[:100]))
+    assert_equal("[]", str(a[5:]))
+    assert_equal("[5, 4, 3, 2]", str(a[:-5:-1]))
+
+    var b = Python.evaluate("[i for i in range(1000)]")
+    assert_equal("[0, 250, 500, 750]", str(b[::250]))
+    with assert_raises(contains="slice step cannot be zero"):
+        _ = b[::0]
+    # Negative cases such as `b[1.3:10]` or `b["1":10]` are handled by parser
+    # which would normally throw a TypeError in Python
+
+    var s = PythonObject("Hello, World!")
+    assert_equal("Hello", str(s[:5]))
+    assert_equal("World!", str(s[7:]))
+    assert_equal("!dlroW ,olleH", str(s[::-1]))
+    assert_equal("Hello, World!", str(s[:]))
+    assert_equal("Hlo ol!", str(s[::2]))
+    assert_equal("Hlo ol!", str(s[None:None:2]))
+
+    var t = PythonObject((1, 2, 3, 4, 5))
+    assert_equal("(2, 3, 4)", str(t[1:4]))
+    assert_equal("(4, 3, 2)", str(t[3:0:-1]))
+
+    var empty = PythonObject([])
+    assert_equal("[]", str(empty[:]))
+    assert_equal("[]", str(empty[1:2:3]))
+
+    var d = Python.dict()
+    d["a"] = 1
+    d["b"] = 2
+    with assert_raises(contains="slice(1, 3, None)"):
+        _ = d[1:3]
+
+    var custom = Python.evaluate(
+        "type('CustomSliceable', (), {'__getitem__': lambda self, key: key})()"
+    )
+    assert_equal("slice(1, 3, None)", str(custom[1:3]))
+
+    var i = PythonObject(1)
+    with assert_raises(contains="'int' object is not subscriptable"):
+        _ = i[0:1]
+
+    with_2d = Python.evaluate(
+        """type('With2D', (), {
+            '__init__': lambda self: setattr(self, 'data', [[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+            '__getitem__': lambda self, key: (
+                [row[key[1]] for row in self.data[key[0]]] if isinstance(key, tuple) and all(isinstance(k, slice) for k in key)
+                else (self.data[key[0]][key[1]] if isinstance(key, tuple)
+                else self.data[key])
+            )
+        })()"""
+    )
+    assert_equal("[1, 2]", str(with_2d[0, PythonObject(Slice(0, 2))]))
+    assert_equal("[1, 2]", str(with_2d[0][0:2]))
+
+    assert_equal("[4, 5, 6]", str(with_2d[PythonObject(Slice(0, 2)), 1]))
+    assert_equal("[4, 5, 6]", str(with_2d[0:2][1]))
+
+    assert_equal(
+        "[[1, 2, 3], [4, 5, 6]]", str(with_2d[PythonObject(Slice(0, 2))])
+    )
+    assert_equal("[[1, 2, 3], [4, 5, 6]]", str(with_2d[0:2]))
+    assert_equal("[[1, 3], [4, 6]]", str(with_2d[0:2, ::2]))
+
+    assert_equal(
+        "[6, 5, 4]", str(with_2d[1, PythonObject(Slice(None, None, -1))])
+    )
+    assert_equal("[6, 5, 4]", str(with_2d[1][::-1]))
+
+    assert_equal("[7, 9]", str(with_2d[2][::2]))
+
+    with assert_raises(contains="list index out of range"):
+        _ = with_2d[0:1][4]
+
+
 def main():
     # initializing Python instance calls init_python
     var python = Python()
@@ -533,3 +621,4 @@ def main():
     test_nested_object()
     test_getitem_raises()
     test_setitem_raises()
+    test_py_slice()


### PR DESCRIPTION
Leveraging Mojo's `Slice` for more natural interop between `PythonObject`s, enabling something like below:

```mojo
a = PythonObject([1, 2, 3, 4])
a_reversed = a[::-1]
```

- We leave C Python to handle slice parameters. 
- Negative cases such as `b[1.3:10]` or `b["1":10]` are handled by parser which would normally throw a `TypeError` in Python.