### PR TITLE
[stdlib] Prevent crash for non-subscriptable `PythonObject`s

### DIFF
--- a/stdlib/src/python/python_object.mojo
+++ b/stdlib/src/python/python_object.mojo
@@ -697,8 +697,8 @@ struct PythonObject(
         Returns:
             The value corresponding to the given key for this object.
         """
-        var size = len(args)
         var cpython = _get_global_python_itf().cpython()
+        var size = len(args)
         var tuple_obj = cpython.PyTuple_New(size)
         for i in range(size):
             var arg_value = args[i].py_object
@@ -710,6 +710,9 @@ struct PythonObject(
         var callable_obj = cpython.PyObject_GetAttrString(
             self.py_object, "__getitem__"
         )
+        if callable_obj.is_null():
+            cpython.Py_DecRef(tuple_obj)
+            Python.throw_python_exception_if_error_state(cpython)
         var result = cpython.PyObject_CallObject(callable_obj, tuple_obj)
         cpython.Py_DecRef(callable_obj)
         cpython.Py_DecRef(tuple_obj)

--- a/stdlib/test/python/test_python_object.mojo
+++ b/stdlib/test/python/test_python_object.mojo
@@ -409,6 +409,50 @@ fn test_none() raises:
     assert_true(n is None)
 
 
+fn test_getitem_raises() raises:
+    var a = PythonObject(2)
+    with assert_raises(contains="'int' object has no attribute '__getitem__'"):
+        _ = a[0]
+
+    var b = PythonObject(2.2)
+    with assert_raises(
+        contains="'float' object has no attribute '__getitem__'"
+    ):
+        _ = b[0]
+
+    var c = PythonObject(True)
+    with assert_raises(contains="'bool' object has no attribute '__getitem__'"):
+        _ = c[0]
+
+    var d = PythonObject(None)
+    with assert_raises(
+        contains="'NoneType' object has no attribute '__getitem__'"
+    ):
+        _ = d[0]
+
+    var with_get = Python.evaluate(
+        "type('WithGetItem', (), {'__getitem__': lambda self, key: f\"Key:"
+        ' {key}"})()'
+    )
+    assert_equal("Key: 0", str(with_get[0]))
+
+    var without_get = Python.evaluate(
+        "type('WithOutGetItem', (), {'__str__': \"SomeString\"})()"
+    )
+    with assert_raises(
+        contains="'WithOutGetItem' object has no attribute '__getitem__'"
+    ):
+        _ = without_get[0]
+
+    var with_get_exception = Python.evaluate(
+        "type('WithGetItemException', (), {'__getitem__': lambda self, key: (_"
+        ' for _ in ()).throw(ValueError("Custom error")),})()'
+    )
+
+    with assert_raises(contains="Custom error"):
+        _ = with_get_exception[1]
+
+
 def main():
     # initializing Python instance calls init_python
     var python = Python()
@@ -423,3 +467,4 @@ def main():
     test_dict()
     test_none()
     test_nested_object()
+    test_getitem_raises()

--- a/stdlib/test/python/test_python_object.mojo
+++ b/stdlib/test/python/test_python_object.mojo
@@ -437,7 +437,7 @@ fn test_getitem_raises() raises:
     assert_equal("Key: 0", str(with_get[0]))
 
     var without_get = Python.evaluate(
-        "type('WithOutGetItem', (), {'__str__': \"SomeString\"})()"
+        "type('WithOutGetItem', (), {'__str__': lambda self: \"SomeString\"})()"
     )
     with assert_raises(
         contains="'WithOutGetItem' object has no attribute '__getitem__'"


### PR DESCRIPTION
Add a null check for `callable_obj` in `PythonObject.__getitem__` method to prevent crashes for non-subscriptable objects. 

**NOTE:**
This results in a different error than Python's `'<object>' is not subscriptable`:
- We raise an `AttributeError` at method lookup, while Python raises a `TypeError`.
    - Due to call of `PyObject_GetAttrString` as apposed to `PyObect_GetItem`

We may want to consider handling for non-variadic arguments, leveraging [`PyObject_GetItem`](https://docs.python.org/3/c-api/object.html#c.PyObject_GetItem). It's part of the stable ABI and may improve Python interop, perhaps some performance gain aswell.
