### PR TITLE
[stdlib] fix: set constraint in `rotate_bits_*` function to bit size

### DIFF
--- a/stdlib/src/bit/bit.mojo
+++ b/stdlib/src/bit/bit.mojo
@@ -520,8 +520,8 @@ fn rotate_bits_left[shift: Int](x: Int) -> Int:
         The input rotated to the left by `shift` elements (with wrap-around).
     """
     constrained[
-        shift >= -sizeof[Int]() and shift < sizeof[Int](),
-        "Constraints: -sizeof[Int]() <= shift < sizeof[Int]()",
+        shift >= -bitwidthof[Int]() and shift < bitwidthof[Int](),
+        "Constraints: -bitwidthof[Int]() <= shift < bitwidthof[Int]()",
     ]()
 
     @parameter
@@ -598,8 +598,8 @@ fn rotate_bits_right[shift: Int](x: Int) -> Int:
         The input rotated to the right by `shift` elements (with wrap-around).
     """
     constrained[
-        shift >= -sizeof[Int]() and shift < sizeof[Int](),
-        "Constraints: -sizeof[Int]() <= shift < sizeof[Int]()",
+        shift >= -bitwidthof[Int]() and shift < bitwidthof[Int](),
+        "Constraints: -bitwidthof[Int]() <= shift < bitwidthof[Int]()",
     ]()
 
     @parameter

--- a/stdlib/test/bit/test_bit.mojo
+++ b/stdlib/test/bit/test_bit.mojo
@@ -447,10 +447,14 @@ def test_rotate_bits_int():
     assert_equal(rotate_bits_left[0](104), 104)
     assert_equal(rotate_bits_left[2](104), 416)
     assert_equal(rotate_bits_left[-2](104), 26)
+    assert_equal(rotate_bits_left[8](104), 26624)
+    assert_equal(rotate_bits_left[-8](104), 7493989779944505344)
 
     assert_equal(rotate_bits_right[0](104), 104)
     assert_equal(rotate_bits_right[2](104), 26)
     assert_equal(rotate_bits_right[-2](104), 416)
+    assert_equal(rotate_bits_right[8](104), 7493989779944505344)
+    assert_equal(rotate_bits_right[-8](104), 26624)
 
 
 def test_rotate_bits_simd():


### PR DESCRIPTION
Set constraint to bit size instead of byte size in `rotate_bits_left` and `rotate_bits_right`

Fixes: #3538