### PR TITLE
[stdlib] Refactor `memset()` to be generic for all trivial types

### DIFF
--- a/mojo/stdlib/test/memory/test_memory.mojo
+++ b/mojo/stdlib/test/memory/test_memory.mojo
@@ -20,6 +20,7 @@ from memory import (
     memcpy,
     memset,
     memset_zero,
+    stack_allocation,
 )
 from testing import (
     assert_almost_equal,
@@ -258,40 +259,38 @@ def test_memcmp_extensive():
 
 def test_memset():
     var pair = Pair(1, 2)
-
     var ptr = UnsafePointer(to=pair)
-    memset_zero(ptr, 1)
+    memset(ptr.bitcast[UInt64](), 0, 1)
+    assert_equal(pair.lo, 0)
+    assert_equal(pair.hi, 2)
 
+    pair = Pair(1, 2)
+    memset_zero(ptr, 1)
     assert_equal(pair.lo, 0)
     assert_equal(pair.hi, 0)
 
-    pair.lo = 1
-    pair.hi = 2
-    memset_zero(ptr, 1)
+    fn test_dtype[D: DType]() raises:
+        var buf1 = stack_allocation[2, Scalar[D]]()
+        memset(buf1, 5, 2)
+        assert_equal(buf1.load(0), 5)
+        assert_equal(buf1.load(1), 5)
+        var buf2 = UnsafePointer[Scalar[D]].alloc(2)
+        memset(buf2, 5, 2)
+        assert_equal(buf2.load(0), 5)
+        assert_equal(buf2.load(1), 5)
+        buf2.free()
 
-    assert_equal(pair.lo, 0)
-    assert_equal(pair.hi, 0)
-
-    var buf0 = UnsafePointer[Int32].alloc(2)
-    memset(buf0, 1, 2)
-    assert_equal(buf0.load(0), 16843009)
-    memset(buf0, -1, 2)
-    assert_equal(buf0.load(0), -1)
-    buf0.free()
-
-    var buf1 = UnsafePointer[Int8].alloc(2)
-    memset(buf1, 5, 2)
-    assert_equal(buf1.load(0), 5)
-    buf1.free()
-
-    var buf3 = UnsafePointer[Int32].alloc(2)
-    memset(buf3, 1, 2)
-    memset_zero[count=2](buf3)
-    assert_equal(buf3.load(0), 0)
-    assert_equal(buf3.load(1), 0)
-    buf3.free()
-
-    _ = pair
+    test_dtype[DType.uint8]()
+    test_dtype[DType.uint16]()
+    test_dtype[DType.uint32]()
+    test_dtype[DType.uint64]()
+    test_dtype[DType.int8]()
+    test_dtype[DType.int16]()
+    test_dtype[DType.int32]()
+    test_dtype[DType.int64]()
+    test_dtype[DType.float16]()
+    test_dtype[DType.float32]()
+    test_dtype[DType.float64]()
 
 
 def test_pointer_string():


### PR DESCRIPTION
Refactor `memset` to be generic over scalars and trivial types to be filled with scalar values of the same bitwidth.