### PR TITLE
[stdlib] Speedup (~1.4x) on `PythonObject.__getitem__`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -172,6 +172,15 @@ what we publish.
       return a
   ```
 
+- Support for multi-dimensional indexing for `PythonObject`
+  ([PR #3583](https://github.com/modularml/mojo/pull/3583) by [@jjvraw](https://github.com/jjvraw)).
+
+    ```mojo
+    var np = Python.import_module("numpy")
+    var a = np.array(PythonObject([1,2,3,1,2,3])).reshape(2,3)
+    print((a[0, 1])) # 2
+    ```
+
 ### 🦋 Changed
 
 - More things have been removed from the auto-exported set of entities in the `prelude`

--- a/stdlib/src/python/_cpython.mojo
+++ b/stdlib/src/python/_cpython.mojo
@@ -1014,6 +1014,26 @@ struct CPython:
         self._inc_total_rc()
         return f(obj)
 
+    fn PyObject_GetItem(
+        inout self, obj: PyObjectPtr, key: PyObjectPtr
+    ) -> PyObjectPtr:
+        var r = self.lib.get_function[
+            fn (PyObjectPtr, PyObjectPtr) -> PyObjectPtr
+        ]("PyObject_GetItem")(obj, key)
+
+        self.log(
+            r._get_ptr_as_int(),
+            " NEWREF PyObject_GetItem, key:",
+            key._get_ptr_as_int(),
+            ", refcnt:",
+            self._Py_REFCNT(r),
+            ", parent obj:",
+            obj._get_ptr_as_int(),
+        )
+
+        self._inc_total_rc()
+        return r
+
     fn PyObject_GetAttrString(
         inout self,
         obj: PyObjectPtr,

--- a/stdlib/test/python/test_python_object.mojo
+++ b/stdlib/test/python/test_python_object.mojo
@@ -411,38 +411,46 @@ fn test_none() raises:
 
 fn test_getitem_raises() raises:
     var a = PythonObject(2)
-    with assert_raises(contains="'int' object has no attribute '__getitem__'"):
+    with assert_raises(contains="'int' object is not subscriptable"):
         _ = a[0]
+    with assert_raises(contains="'int' object is not subscriptable"):
+        _ = a[0, 0]
 
     var b = PythonObject(2.2)
-    with assert_raises(
-        contains="'float' object has no attribute '__getitem__'"
-    ):
+    with assert_raises(contains="'float' object is not subscriptable"):
         _ = b[0]
+    with assert_raises(contains="'float' object is not subscriptable"):
+        _ = b[0, 0]
 
     var c = PythonObject(True)
-    with assert_raises(contains="'bool' object has no attribute '__getitem__'"):
+    with assert_raises(contains="'bool' object is not subscriptable"):
         _ = c[0]
+    with assert_raises(contains="'bool' object is not subscriptable"):
+        _ = c[0, 0]
 
     var d = PythonObject(None)
-    with assert_raises(
-        contains="'NoneType' object has no attribute '__getitem__'"
-    ):
+    with assert_raises(contains="'NoneType' object is not subscriptable"):
         _ = d[0]
+    with assert_raises(contains="'NoneType' object is not subscriptable"):
+        _ = d[0, 0]
 
-    var with_get = Python.evaluate(
-        "type('WithGetItem', (), {'__getitem__': lambda self, key: f\"Key:"
-        ' {key}"})()'
+    with_get = Python.evaluate(
+        "type('WithGetItem', (), {'__getitem__': lambda self, key: f'Keys: {',"
+        " '.join(map(str, key))}' if isinstance(key, tuple) else f'Key:"
+        " {key}'})()"
     )
     assert_equal("Key: 0", str(with_get[0]))
+    assert_equal("Keys: 0, 0", str(with_get[0, 0]))
+    assert_equal("Keys: 0, 0, 0", str(with_get[0, 0, 0]))
 
     var without_get = Python.evaluate(
-        "type('WithOutGetItem', (), {'__str__': \"SomeString\"})()"
+        "type('WithOutGetItem', (), {'__str__': lambda self: \"SomeString\"})()"
     )
-    with assert_raises(
-        contains="'WithOutGetItem' object has no attribute '__getitem__'"
-    ):
+    with assert_raises(contains="'WithOutGetItem' object is not subscriptable"):
         _ = without_get[0]
+
+    with assert_raises(contains="'WithOutGetItem' object is not subscriptable"):
+        _ = without_get[0, 0]
 
     var with_get_exception = Python.evaluate(
         "type('WithGetItemException', (), {'__getitem__': lambda self, key: (_"

--- a/stdlib/test/python/test_python_object.mojo
+++ b/stdlib/test/python/test_python_object.mojo
@@ -435,9 +435,11 @@ fn test_getitem_raises() raises:
         _ = d[0, 0]
 
     with_get = Python.evaluate(
-        "type('WithGetItem', (), {'__getitem__': lambda self, key: f'Keys: {',"
-        " '.join(map(str, key))}' if isinstance(key, tuple) else f'Key:"
-        " {key}'})()"
+        """type('WithGetItem', (), {
+            '__getitem__': lambda self, key: 
+                'Keys: {0}'.format(", ".join(map(str, key))) if isinstance(key, tuple) 
+                else 'Key: {0}'.format(key)
+         })()"""
     )
     assert_equal("Key: 0", str(with_get[0]))
     assert_equal("Keys: 0, 0", str(with_get[0, 0]))

--- a/stdlib/test/python/test_python_object.mojo
+++ b/stdlib/test/python/test_python_object.mojo
@@ -460,6 +460,28 @@ fn test_getitem_raises() raises:
     with assert_raises(contains="Custom error"):
         _ = with_get_exception[1]
 
+    with_2d = Python.evaluate(
+        """type('With2D', (), {
+            '__init__': lambda self: setattr(self, 'data', [[1, 2, 3], [4, 5, 6]]),
+            '__getitem__': lambda self, key: (
+                self.data[key[0]][key[1]] if isinstance(key, tuple)
+                else self.data[key]
+            )
+        })()"""
+    )
+    assert_equal("[1, 2, 3]", str(with_2d[0]))
+    assert_equal(2, with_2d[0, 1])
+    assert_equal(6, with_2d[1, 2])
+
+    with assert_raises(contains="list index out of range"):
+        _ = with_2d[0, 4]
+
+    with assert_raises(contains="list index out of range"):
+        _ = with_2d[2, 0]
+
+    with assert_raises(contains="list index out of range"):
+        _ = with_2d[2]
+
 
 def main():
     # initializing Python instance calls init_python


### PR DESCRIPTION
Noticing consistent ~1.4x speedup for basic benchmarks on my machine (M1), example:

```mojo
for i in range(iterations):
    var idx_a = random_si64(0, 999)
    var idx_b = random_si64(0, 9999)
    var idx_c = random_si64(0, 99999)
        
    _ = a[idx_a]
    _ = b[idx_b]
    _ = c[idx_c]
```


This essentially free speedup comes from removing any overhead associated with `PyObject_GetAttr`, by using [`PyObject_GetItem`](https://docs.python.org/3/c-api/object.html#c.PyObject_GetItem) directly. Also noticed minimising the use of  `PythonObject` wrappers, and working directly with `PyObjectPtr` attributes contributed to the speedup as well.

In addition, multi-dimensional indexing into Python objects are now possible, such as below

```mojo
var np = Python.import_module("numpy")
var a = np.array(PythonObject([1,2,3,1,2,3])).reshape(2,3)
print((a[0, 1]))
```

Previously, this would raise an `expected 1 argument, got 2` exception.

Lastly, error messages are also now consistent to Python, for non-subscriptable objects (mentioned in #3557). 