### PR TITLE
[stdlib] Add examples for `argv()`, `NamedTemporaryFile` and `assert_true`

### DIFF
--- a/stdlib/src/sys/arg.mojo
+++ b/stdlib/src/sys/arg.mojo
@@ -17,6 +17,16 @@ You can import these APIs from the `sys` package. For example:
 
 ```mojo
 from sys import argv
+def main():
+    arguments = argv()
+    print(
+        arguments[0], #app.mojo
+        arguments[1]  #Hello world!
+    )
+    for arg in arguments:
+        print(arg)
+# If the program is app.mojo:
+# mojo run app.mojo "Hello world!"
 ```
 """
 

--- a/stdlib/src/tempfile/tempfile.mojo
+++ b/stdlib/src/tempfile/tempfile.mojo
@@ -260,7 +260,25 @@ struct TemporaryDirectory:
 
 
 struct NamedTemporaryFile:
-    """A handle to a temporary file."""
+    """A handle to a temporary file.
+
+    Example:
+    ```mojo
+    from tempfile import NamedTemporaryFile
+    from pathlib import Path
+    def main():
+        var p: Path
+        with NamedTemporaryFile(mode="rw") as f:
+            p = f.name
+            f.write("Hello world!")
+            f.seek(0)
+            print(
+                f.read() == "Hello world!"
+            )
+        print(str(p), p.exists()) #Removed by default
+    ```
+    Note: `NamedTemporaryFile.__init__` document the arguments.
+    """
 
     var _file_handle: FileHandle
     """The underlying file handle."""

--- a/stdlib/src/testing/testing.mojo
+++ b/stdlib/src/testing/testing.mojo
@@ -16,6 +16,18 @@ You can import these APIs from the `testing` package. For example:
 
 ```mojo
 from testing import assert_true
+
+def main():
+    x = 1
+    y = 2
+    try:
+        assert_true(x==1)
+        assert_true(y==2)
+        assert_true((x+y)==3)
+        print("All assertions succeeded")
+    except e:
+        print("At least one assertion failed:")
+        print(e)
 ```
 """
 from collections import Optional


### PR DESCRIPTION
Hello, this commit adds a few examples:
- `argv` for app inputs
- `NamedTemporayFile` that uses `with` block
- `assert_true` in `try:`, `except:`