### PR TITLE
[stdlib] Clean up `memory.unsafe`

### DIFF
--- a/stdlib/src/memory/__init__.mojo
+++ b/stdlib/src/memory/__init__.mojo
@@ -16,5 +16,5 @@ from .arc import Arc
 from .box import Box
 from .memory import memcmp, memcpy, memset, memset_zero, stack_allocation
 from .pointer import AddressSpace, Pointer
-from .unsafe import bitcast
+from .unsafe import bitcast, pack_bits
 from .unsafe_pointer import UnsafePointer

--- a/stdlib/src/utils/stringref.mojo
+++ b/stdlib/src/utils/stringref.mojo
@@ -17,7 +17,7 @@ from bit import count_trailing_zeros
 from builtin.dtype import _uint_type_of_width
 from collections.string import _atol, _isspace
 from hashlib._hasher import _HashableWithHasher, _Hasher
-from memory import UnsafePointer, memcmp, bitcast
+from memory import UnsafePointer, memcmp, pack_bits
 from memory.memory import _memcmp_impl_unconstrained
 from utils import StringSlice
 from sys.ffi import c_char
@@ -698,7 +698,7 @@ fn _memchr[
 
     for i in range(0, vectorized_end, bool_mask_width):
         var bool_mask = source.load[width=bool_mask_width](i) == first_needle
-        var mask = bitcast[_uint_type_of_width[bool_mask_width]()](bool_mask)
+        var mask = pack_bits(bool_mask)
         if mask:
             return source + int(i + count_trailing_zeros(mask))
 
@@ -742,7 +742,7 @@ fn _memmem[
         var eq_last = last_needle == last_block
 
         var bool_mask = eq_first & eq_last
-        var mask = bitcast[_uint_type_of_width[bool_mask_width]()](bool_mask)
+        var mask = pack_bits(bool_mask)
 
         while mask:
             var offset = int(i + count_trailing_zeros(mask))


### PR DESCRIPTION
- Make more things infer-only
- Remove unnecessary overload
- Rename the `bitcast` overload that performs the 'movemask' operation to `pack_mask`. This change is intended to prevent issues where the wrong overload might be selected, and since there is an implicit conversion from scalar to simd at return, the user won't get a type mismatch error to warn them about that. @JoeLoser, do you think this change is a good idea? The function in NumPy is called `packbits`, maybe that's a better name.