### PR TITLE
[stdlib] Add examples for `env_get_int` and `sizeof`

### DIFF
--- a/stdlib/src/sys/info.mojo
+++ b/stdlib/src/sys/info.mojo
@@ -565,6 +565,22 @@ fn sizeof[
 
     Returns:
         The size of the type in bytes.
+
+    Example:
+    ```mojo
+    from sys.info import sizeof
+    def main():
+        print(
+            sizeof[UInt8]() == 1,
+            sizeof[UInt16]() == 2,
+            sizeof[Int32]() == 4,
+            sizeof[Float64]() == 8,
+            sizeof[
+                SIMD[DType.uint8, 4]
+            ]() == 4,
+        )
+    ```
+    Note: `align_of` is in same module.
     """
     alias mlir_type = __mlir_attr[
         `#kgen.param.expr<rebind, #kgen.type<!kgen.paramref<`,

--- a/stdlib/src/sys/param_env.mojo
+++ b/stdlib/src/sys/param_env.mojo
@@ -76,6 +76,27 @@ fn env_get_int[name: StringLiteral, default: Int]() -> Int:
 
     Returns:
         An integer parameter value.
+
+    Example:
+    ```mojo
+    from sys.param_env import env_get_int
+
+    def main():
+        alias number = env_get_int[
+            "favorite_number",
+            1 # Default value
+        ]()
+        parametrized[number]()
+
+    fn parametrized[num: Int]():
+        print(num)
+    ```
+
+    If the program is `app.mojo`:
+    - `mojo run -D favorite_number=2 app.mojo`
+    - `mojo run -D app.mojo`
+
+    Note: useful for parametrizing SIMD vector sizes.
     """
 
     @parameter

--- a/stdlib/src/sys/param_env.mojo
+++ b/stdlib/src/sys/param_env.mojo
@@ -96,7 +96,7 @@ fn env_get_int[name: StringLiteral, default: Int]() -> Int:
     - `mojo run -D favorite_number=2 app.mojo`
     - `mojo run -D app.mojo`
 
-    Note: useful for parametrizing SIMD vector sizes.
+    Note: useful for parameterizing SIMD vector sizes.
     """
 
     @parameter


### PR DESCRIPTION
Hello, this commit adds a few examples:
- `env_get_int` for parametrizing
- `sizeof` for sizes

