### PR TITLE
[stdlib] Integrate `PyObject_SetItem` for speedup and error handling

### DIFF
--- a/stdlib/src/python/_cpython.mojo
+++ b/stdlib/src/python/_cpython.mojo
@@ -1009,6 +1009,26 @@ struct CPython:
         self._inc_total_rc()
         return r
 
+    fn PyObject_SetItem(
+        inout self, obj: PyObjectPtr, key: PyObjectPtr, value: PyObjectPtr
+    ) -> Int:
+        var r = self.lib.get_function[
+            fn (PyObjectPtr, PyObjectPtr, PyObjectPtr) -> Int
+        ]("PyObject_SetItem")(obj, key, value)
+
+        self.log(
+            "PyObject_SetItem result:",
+            r,
+            ", key:",
+            key._get_ptr_as_int(),
+            ", value:",
+            value._get_ptr_as_int(),
+            ", parent obj:",
+            obj._get_ptr_as_int(),
+        )
+
+        return r
+
     fn PyObject_GetAttrString(
         inout self,
         obj: PyObjectPtr,

--- a/stdlib/src/python/_cpython.mojo
+++ b/stdlib/src/python/_cpython.mojo
@@ -1011,9 +1011,9 @@ struct CPython:
 
     fn PyObject_SetItem(
         inout self, obj: PyObjectPtr, key: PyObjectPtr, value: PyObjectPtr
-    ) -> Int:
+    ) -> c_int:
         var r = self.lib.get_function[
-            fn (PyObjectPtr, PyObjectPtr, PyObjectPtr) -> Int
+            fn (PyObjectPtr, PyObjectPtr, PyObjectPtr) -> c_int 
         ]("PyObject_SetItem")(obj, key, value)
 
         self.log(

--- a/stdlib/src/python/_cpython.mojo
+++ b/stdlib/src/python/_cpython.mojo
@@ -1009,11 +1009,13 @@ struct CPython:
         self._inc_total_rc()
         return r
 
+    # int PyObject_SetItem(PyObject *o, PyObject *key, PyObject *v)
+    # ref: https://docs.python.org/3/c-api/object.html#c.PyObject_SetItem
     fn PyObject_SetItem(
         inout self, obj: PyObjectPtr, key: PyObjectPtr, value: PyObjectPtr
     ) -> c_int:
         var r = self.lib.get_function[
-            fn (PyObjectPtr, PyObjectPtr, PyObjectPtr) -> c_int 
+            fn (PyObjectPtr, PyObjectPtr, PyObjectPtr) -> c_int
         ]("PyObject_SetItem")(obj, key, value)
 
         self.log(

--- a/stdlib/src/python/python_object.mojo
+++ b/stdlib/src/python/python_object.mojo
@@ -724,29 +724,30 @@ struct PythonObject(
             args: The key or keys to set on this object.
             value: The value to set.
         """
-        var size = len(args)
-
         var cpython = _get_global_python_itf().cpython()
-        var tuple_obj = cpython.PyTuple_New(size + 1)
-        for i in range(size):
-            var arg_value = args[i].py_object
-            cpython.Py_IncRef(arg_value)
-            var result = cpython.PyTuple_SetItem(tuple_obj, i, arg_value)
-            if result != 0:
-                raise Error("internal error: PyTuple_SetItem failed")
+        var size = len(args)
+        var key_obj: PyObjectPtr
 
+        if size == 1:
+            key_obj = args[0].py_object
+        else:
+            key_obj = cpython.PyTuple_New(size)
+            for i in range(size):
+                var arg_value = args[i].py_object
+                cpython.Py_IncRef(arg_value)
+                var result = cpython.PyTuple_SetItem(key_obj, i, arg_value)
+                if result != 0:
+                    raise Error("internal error: PyTuple_SetItem failed")
+
+        cpython.Py_IncRef(key_obj)
         cpython.Py_IncRef(value.py_object)
-        var result2 = cpython.PyTuple_SetItem(tuple_obj, size, value.py_object)
-        if result2 != 0:
-            raise Error("internal error: PyTuple_SetItem failed")
-
-        var callable_obj = cpython.PyObject_GetAttrString(
-            self.py_object, "__setitem__"
+        var result = cpython.PyObject_SetItem(
+            self.py_object, key_obj, value.py_object
         )
-        var result = cpython.PyObject_CallObject(callable_obj, tuple_obj)
-        cpython.Py_DecRef(callable_obj)
-        cpython.Py_DecRef(tuple_obj)
-        Python.throw_python_exception_if_error_state(cpython)
+        if result != 0:
+            Python.throw_python_exception_if_error_state(cpython)
+        cpython.Py_DecRef(key_obj)
+        cpython.Py_DecRef(value.py_object)
 
     fn _call_zero_arg_method(
         self, method_name: StringRef

--- a/stdlib/test/python/test_python_object.mojo
+++ b/stdlib/test/python/test_python_object.mojo
@@ -485,6 +485,38 @@ fn test_getitem_raises() raises:
         _ = with_2d[2]
 
 
+def test_setitem_raises():
+    t = Python.evaluate("(1,2,3)")
+    with assert_raises(
+        contains="'tuple' object does not support item assignment"
+    ):
+        t[0] = 0
+
+    lst = Python.evaluate("[1, 2, 3]")
+    with assert_raises(contains="list assignment index out of range"):
+        lst[10] = 4
+
+    s = Python.evaluate('"hello"')
+    with assert_raises(
+        contains="'str' object does not support item assignment"
+    ):
+        s[3] = "xy"
+
+    custom = Python.evaluate(
+        """type('Custom', (), {
+        '__init__': lambda self: None,
+    })()"""
+    )
+    with assert_raises(
+        contains="'Custom' object does not support item assignment"
+    ):
+        custom[0] = 0
+
+    d = Python.evaluate("{}")
+    with assert_raises(contains="unhashable type: 'list'"):
+        d[[1, 2, 3]] = 5
+
+
 def main():
     # initializing Python instance calls init_python
     var python = Python()
@@ -500,3 +532,4 @@ def main():
     test_none()
     test_nested_object()
     test_getitem_raises()
+    test_setitem_raises()


### PR DESCRIPTION
Following the trend of:
- #3549 
- #3583 

Again, noticing ~1.4x speedup on basic benchmarks:
```mojo
for _ in range(iterations):
    var idx_a = random_si64(0, 999)
    var idx_b = random_si64(0, 9999)
    var idx_c = random_si64(0, 99999)
    
    a[idx_a] = idx_a
    b[idx_b] = idx_b
    c[idx_c] = idx_c 
```

and improved error handling, preventing crashes.