### PR TITLE
[stdlib] Rename `py_object` to `py_object_ptr`

### DIFF
--- a/mojo/stdlib/stdlib/collections/string/string_slice.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string_slice.mojo
@@ -864,7 +864,9 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
             An error if the conversion failed.
         """
         var cpython = Python().cpython()
-        self = cpython.PyUnicode_AsUTF8AndSize(unsafe_borrowed_obj.py_object)
+        self = cpython.PyUnicode_AsUTF8AndSize(
+            unsafe_borrowed_obj.py_object_ptr
+        )
         if not self.unsafe_ptr():
             raise cpython.get_error()
 

--- a/mojo/stdlib/stdlib/python/_bindings.mojo
+++ b/mojo/stdlib/stdlib/python/_bindings.mojo
@@ -1455,7 +1455,7 @@ fn check_arguments_arity(
 fn _get_type_name(obj: PythonObject) raises -> String:
     var cpython = Python().cpython()
 
-    var actual_type = cpython.Py_TYPE(obj.unsafe_as_py_object_ptr())
+    var actual_type = cpython.Py_TYPE(obj.unsafe_py_object_ptr())
     var actual_type_name = PythonObject(
         from_owned_ptr=cpython.PyType_GetName(actual_type)
     )
@@ -1474,9 +1474,9 @@ fn check_argument_type[
     instance of the Mojo `T` type.
     """
 
-    var opt: Optional[UnsafePointer[T]] = obj.py_object.try_cast_to_mojo_value[
-        T
-    ](type_name_id)
+    var opt: Optional[
+        UnsafePointer[T]
+    ] = obj.py_object_ptr.try_cast_to_mojo_value[T](type_name_id)
 
     if not opt:
         raise Error(

--- a/mojo/stdlib/stdlib/python/_cpython.mojo
+++ b/mojo/stdlib/stdlib/python/_cpython.mojo
@@ -1649,13 +1649,13 @@ struct CPython(Copyable, Movable):
         return self.lib.call["PyObject_Hash", Py_hash_t](obj)
 
     fn PyObject_GetIter(
-        self, traversable_py_object: PyObjectPtr
+        self, traversable_py_object_ptr: PyObjectPtr
     ) -> PyObjectPtr:
         """[Reference](
         https://docs.python.org/3/c-api/object.html#c.PyObject_GetIter).
         """
         var iterator = self.lib.call["PyObject_GetIter", PyObjectPtr](
-            traversable_py_object
+            traversable_py_object_ptr
         )
 
         self.log(
@@ -1663,9 +1663,9 @@ struct CPython(Copyable, Movable):
             " NEWREF PyObject_GetIter, refcnt:",
             self._Py_REFCNT(iterator),
             "referencing ",
-            traversable_py_object._get_ptr_as_int(),
+            traversable_py_object_ptr._get_ptr_as_int(),
             "refcnt of traversable: ",
-            self._Py_REFCNT(traversable_py_object),
+            self._Py_REFCNT(traversable_py_object_ptr),
         )
 
         self._inc_total_rc()
@@ -1876,17 +1876,17 @@ struct CPython(Copyable, Movable):
         self._inc_total_rc()
         return r
 
-    fn PyLong_AsSsize_t(self, py_object: PyObjectPtr) -> c_ssize_t:
+    fn PyLong_AsSsize_t(self, py_object_ptr: PyObjectPtr) -> c_ssize_t:
         """[Reference](
         https://docs.python.org/3/c-api/long.html#c.PyLong_AsSsize_t).
         """
-        return self.lib.call["PyLong_AsSsize_t", c_ssize_t](py_object)
+        return self.lib.call["PyLong_AsSsize_t", c_ssize_t](py_object_ptr)
 
-    fn PyNumber_Long(self, py_object: PyObjectPtr) -> PyObjectPtr:
+    fn PyNumber_Long(self, py_object_ptr: PyObjectPtr) -> PyObjectPtr:
         """[Reference](
         https://docs.python.org/3/c-api/number.html#c.PyNumber_Long).
         """
-        return self.lib.call["PyNumber_Long", PyObjectPtr](py_object)
+        return self.lib.call["PyNumber_Long", PyObjectPtr](py_object_ptr)
 
     # ===-------------------------------------------------------------------===#
     # Floating-Point Objects
@@ -1910,11 +1910,11 @@ struct CPython(Copyable, Movable):
         self._inc_total_rc()
         return r
 
-    fn PyFloat_AsDouble(self, py_object: PyObjectPtr) -> Float64:
+    fn PyFloat_AsDouble(self, py_object_ptr: PyObjectPtr) -> Float64:
         """[Reference](
         https://docs.python.org/3/c-api/float.html#c.PyFloat_AsDouble).
         """
-        return self.lib.call["PyFloat_AsDouble", Float64](py_object)
+        return self.lib.call["PyFloat_AsDouble", Float64](py_object_ptr)
 
     # ===-------------------------------------------------------------------===#
     # Unicode Objects
@@ -1969,8 +1969,8 @@ struct CPython(Copyable, Movable):
         return py_slice
 
     fn PyUnicode_AsUTF8AndSize(
-        self, py_object: PyObjectPtr
-    ) -> StringSlice[__origin_of(py_object.unsized_obj_ptr.origin)]:
+        self, py_object_ptr: PyObjectPtr
+    ) -> StringSlice[__origin_of(py_object_ptr.unsized_obj_ptr.origin)]:
         """[Reference](
         https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_AsUTF8AndSize).
         """
@@ -1978,8 +1978,8 @@ struct CPython(Copyable, Movable):
         var length = Int(0)
         var ptr = self.lib.call[
             "PyUnicode_AsUTF8AndSize", UnsafePointer[c_char]
-        ](py_object, UnsafePointer(to=length)).bitcast[UInt8]()
-        return StringSlice[__origin_of(py_object.unsized_obj_ptr.origin)](
+        ](py_object_ptr, UnsafePointer(to=length)).bitcast[UInt8]()
+        return StringSlice[__origin_of(py_object_ptr.unsized_obj_ptr.origin)](
             ptr=ptr, length=length
         )
 

--- a/mojo/stdlib/test/python/test_python_cpython.mojo
+++ b/mojo/stdlib/test/python/test_python_cpython.mojo
@@ -24,13 +24,13 @@ def test_PyObject_HasAttrString(mut python: Python):
 
     var the_object = PythonObject(0)
     var result = cpython_env.PyObject_HasAttrString(
-        the_object.py_object, "__contains__"
+        the_object.py_object_ptr, "__contains__"
     )
     assert_equal(0, result)
 
     the_object = Python.list(1, 2, 3)
     result = cpython_env.PyObject_HasAttrString(
-        the_object.py_object, "__contains__"
+        the_object.py_object_ptr, "__contains__"
     )
     assert_equal(1, result)
     _ = the_object
@@ -46,7 +46,7 @@ def test_PyCapsule(mut python: Python):
     # Not a PyCapsule, a NULL pointer is expected.
     var the_object = PythonObject(0)
     var result = cpython_env.PyCapsule_GetPointer(
-        the_object.py_object, "some_name"
+        the_object.py_object_ptr, "some_name"
     )
     var expected_none = UnsafePointer[NoneType]()
     assert_equal(expected_none, result)


### PR DESCRIPTION
Apologies if this _needs discussion_. However, while working in these files, It seems odd to have an attribute of  `PythonObject` named `python_object` that stores a `PyObjectPtr`.

```mojo
struct PythonObject(...):
    var py_object: PyObjectPtr # rename py_object_ptr
    
...
 
     fn unsafe_as_py_object_ptr(self) -> PyObjectPtr:
        """Get the underlying PyObject pointer.

        Returns:
            The underlying PyObject pointer.

        Safety:
            Use-after-free: The caller must take care that `self` outlives the
            usage of the pointer returned by this function.
        """
        return self.py_object
```

This will cause conflicts with 
- #3549 
