### PR TITLE
[stdlib] Add `expect` intrinsic

### DIFF
--- a/stdlib/src/sys/intrinsics.mojo
+++ b/stdlib/src/sys/intrinsics.mojo
@@ -1505,6 +1505,34 @@ struct _RegisterPackType[*a: AnyTrivialRegType]:
 
 
 # ===----------------------------------------------------------------------=== #
+# expect
+# ===----------------------------------------------------------------------=== #
+
+
+@always_inline("nodebug")
+fn expect[T: AnyTrivialRegType, //, expected_val: T](val: T) -> T:
+    """Provides information about expected (the most probable) value of `val`,
+    which can be used by optimizers.
+
+    Constraints:
+        Only work with integer types.
+
+    Parameters:
+        T: The type of the input value.
+        expected_val: The expected value of `val`.
+
+    Args:
+        val: The input value.
+
+    Returns:
+        The input value.
+    """
+    return llvm_intrinsic["llvm.expect", T, has_side_effect=False](
+        val, expected_val
+    )
+
+
+# ===----------------------------------------------------------------------=== #
 # likely
 # ===----------------------------------------------------------------------=== #
 
@@ -1515,12 +1543,12 @@ fn likely(val: Bool) -> Bool:
     `True`. This information can be used by optimizers.
 
     Args:
-      val: The input value which is likely to be `True` most of the time.
+        val: The input value which is likely to be `True` most of the time.
 
     Returns:
-      The input value.
+        The input value.
     """
-    return llvm_intrinsic["llvm.expect", Bool](val, True)
+    return expect[True](val)
 
 
 # ===----------------------------------------------------------------------=== #
@@ -1534,12 +1562,12 @@ fn unlikely(val: Bool) -> Bool:
     `False`. This information can be used by optimizers.
 
     Args:
-      val: The input value which is likely to be `False` most of the time.
+        val: The input value which is likely to be `False` most of the time.
 
     Returns:
-      The input value.
+        The input value.
     """
-    return llvm_intrinsic["llvm.expect", Bool](val, False)
+    return expect[False](val)
 
 
 # ===----------------------------------------------------------------------=== #


### PR DESCRIPTION
- Add `llvm.expect` intrinsic to stdlib
- Refector `likely` and `unlikely` intrinsics to use `expect`
- Mark `likely` and `unlikely` intrinsics as side-effect free