### PR TITLE
Revert "[CI] Pin `magic` to 0.2.3 to avoid timeouts"

### DIFF
--- a/.github/workflows/standard_library_tests_and_examples.yml
+++ b/.github/workflows/standard_library_tests_and_examples.yml
@@ -46,13 +46,8 @@ jobs:
       - name: Download Magic CLI
         run: |
           curl -ssL https://magic.modular.com/cfba4c92-2390-4b86-93de-04b2f47114d5 | bash
-
           # Add magic to PATH
           echo "$HOME/.modular/bin" >> $GITHUB_PATH
-
-          # Pin magic to older version to avoid HTTP timeouts and/or client certificate errors
-          # that manifest as a result of uv/python package solvers from Magic 0.3.0.
-          "$HOME/.modular/bin/magic" self-update --version 0.2.3
 
       - name: Install build tools (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/test_pre_commit.yml
+++ b/.github/workflows/test_pre_commit.yml
@@ -42,10 +42,6 @@ jobs:
           # Add magic to PATH
           echo "$HOME/.modular/bin" >> $GITHUB_PATH
 
-          # Pin magic to older version to avoid HTTP timeouts and/or client certificate errors
-          # that manifest as a result of uv/python package solvers from Magic 0.3.0.
-          "$HOME/.modular/bin/magic" self-update --version 0.2.3
-
       - name: Install pre-commit
         run: |
           pip install pre-commit


### PR DESCRIPTION
This reverts commit 936018ed2980488cd0e10da9298279e01c563137.  The workaround is no longer necessary.