### PR TITLE
[stdlib] Fix example in `/floatable.mojo`

### DIFF
--- a/stdlib/src/builtin/floatable.mojo
+++ b/stdlib/src/builtin/floatable.mojo
@@ -69,8 +69,10 @@ trait FloatableRaising:
     For example:
 
     ```mojo
+    from stdlib.utils import Variant
+
     @value
-    struct MaybeFloat(FloatableRasing):
+    struct MaybeFloat(FloatableRaising):
         var value: Variant[Float64, NoneType]
 
         fn __float__(self) raises -> Float64:

--- a/stdlib/src/builtin/floatable.mojo
+++ b/stdlib/src/builtin/floatable.mojo
@@ -69,7 +69,7 @@ trait FloatableRaising:
     For example:
 
     ```mojo
-    from stdlib.utils import Variant
+    from utils import Variant
 
     @value
     struct MaybeFloat(FloatableRaising):


### PR DESCRIPTION
Not sure if I should import `Variant` and use it unqualified.