### PR TITLE
[stdlib] Rename `SIMD.value` to `SIMD._value`.

### DIFF
--- a/stdlib/src/bit/bit.mojo
+++ b/stdlib/src/bit/bit.mojo
@@ -283,7 +283,7 @@ fn bit_not[
     """
     constrained[type.is_integral(), "must be integral"]()
     var neg_one = SIMD[type, width](-1)
-    return __mlir_op.`pop.simd.xor`(val.value, neg_one.value)
+    return __mlir_op.`pop.simd.xor`(val._value, neg_one._value)
 
 
 # ===----------------------------------------------------------------------===#

--- a/stdlib/src/builtin/dtype.mojo
+++ b/stdlib/src/builtin/dtype.mojo
@@ -329,8 +329,8 @@ struct DType(
             return False
         return Bool(
             __mlir_op.`pop.cmp`[pred = __mlir_attr.`#pop<cmp_pred eq>`](
-                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsSigned.value),
-                UInt8(0).value,
+                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsSigned._value),
+                UInt8(0)._value,
             )
         )
 
@@ -347,8 +347,8 @@ struct DType(
             return False
         return Bool(
             __mlir_op.`pop.cmp`[pred = __mlir_attr.`#pop<cmp_pred ne>`](
-                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsSigned.value),
-                UInt8(0).value,
+                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsSigned._value),
+                UInt8(0)._value,
             )
         )
 
@@ -361,8 +361,8 @@ struct DType(
         """
         return Bool(
             __mlir_op.`pop.cmp`[pred = __mlir_attr.`#pop<cmp_pred ne>`](
-                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsInteger.value),
-                UInt8(0).value,
+                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsInteger._value),
+                UInt8(0)._value,
             )
         )
 
@@ -389,8 +389,8 @@ struct DType(
             return False
         return Bool(
             __mlir_op.`pop.cmp`[pred = __mlir_attr.`#pop<cmp_pred ne>`](
-                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsFloat.value),
-                UInt8(0).value,
+                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsFloat._value),
+                UInt8(0)._value,
             )
         )
 
@@ -439,15 +439,15 @@ struct DType(
             return int(
                 UInt8(
                     __mlir_op.`pop.shl`(
-                        UInt8(1).value,
+                        UInt8(1)._value,
                         __mlir_op.`pop.sub`(
                             __mlir_op.`pop.shr`(
                                 __mlir_op.`pop.simd.and`(
-                                    self._as_i8(), _mIsNotInteger.value
+                                    self._as_i8(), _mIsNotInteger._value
                                 ),
-                                UInt8(1).value,
+                                UInt8(1)._value,
                             ),
-                            UInt8(3).value,
+                            UInt8(3)._value,
                         ),
                     )
                 )

--- a/stdlib/src/builtin/file.mojo
+++ b/stdlib/src/builtin/file.mojo
@@ -466,7 +466,7 @@ struct FileHandle:
             "KGEN_CompilerRT_IO_GetFD",
             Int64,
         ](self.handle)
-        return Int(i64_res.value)
+        return Int(i64_res._value)
 
 
 fn open[

--- a/stdlib/src/builtin/io.mojo
+++ b/stdlib/src/builtin/io.mojo
@@ -260,7 +260,7 @@ fn _float_repr[
     # Using `%.17g` with decimal check is equivalent to CPython's fallback path
     # when its more complex dtoa library (forked from
     # https://github.com/dtolnay/dtoa) is not available.
-    var n = _snprintf[fmt](buffer, size, x.value)
+    var n = _snprintf[fmt](buffer, size, x._value)
     # If the buffer isn't big enough to add anything, then just return.
     if n + 2 >= size:
         return n

--- a/stdlib/src/builtin/math.mojo
+++ b/stdlib/src/builtin/math.mojo
@@ -192,7 +192,7 @@ fn max(x: SIMD, y: __type_of(x), /) -> __type_of(x):
         A SIMD vector containing the elementwise maximum of x and y.
     """
     constrained[x.type.is_numeric(), "the SIMD type must be numeric"]()
-    return __mlir_op.`pop.max`(x.value, y.value)
+    return __mlir_op.`pop.max`(x._value, y._value)
 
 
 # ===----------------------------------------------------------------------=== #
@@ -246,7 +246,7 @@ fn min(x: SIMD, y: __type_of(x), /) -> __type_of(x):
         A SIMD vector containing the elementwise minimum of x and y.
     """
     constrained[x.type.is_numeric(), "the SIMD type must be numeric"]()
-    return __mlir_op.`pop.min`(x.value, y.value)
+    return __mlir_op.`pop.min`(x._value, y._value)
 
 
 # ===----------------------------------------------------------------------=== #

--- a/stdlib/src/builtin/object.mojo
+++ b/stdlib/src/builtin/object.mojo
@@ -1802,10 +1802,10 @@ struct object(
     @always_inline
     fn _convert_index_to_int(i: object) raises -> Int:
         if i._value.is_bool():
-            return i._value.convert_bool_to_int().get_as_int().value
+            return i._value.convert_bool_to_int().get_as_int()._value
         elif not i._value.is_int():
             raise Error("TypeError: string indices must be integers")
-        return i._value.get_as_int().value
+        return i._value.get_as_int()._value
 
     @always_inline
     fn __getitem__(self, i: object) raises -> object:
@@ -1831,7 +1831,7 @@ struct object(
             var char = self._value.get_as_string().data[index]
             impl.data.init_pointee_move(char)
             return _ObjectImpl(impl)
-        return self._value.get_list_element(i._value.get_as_int().value)
+        return self._value.get_list_element(i._value.get_as_int()._value)
 
     @always_inline
     fn __getitem__(self, *index: object) raises -> object:

--- a/stdlib/src/hashlib/_ahash.mojo
+++ b/stdlib/src/hashlib/_ahash.mojo
@@ -35,10 +35,10 @@ fn _folded_multiply(lhs: UInt64, rhs: UInt64) -> UInt64:
         A value which is similar in its bitpattern to result of a folded multply.
     """
     l = __mlir_op.`pop.cast`[_type = __mlir_type.`!pop.scalar<ui128>`](
-        lhs.value
+        lhs._value
     )
     r = __mlir_op.`pop.cast`[_type = __mlir_type.`!pop.scalar<ui128>`](
-        rhs.value
+        rhs._value
     )
     m = __mlir_op.`pop.mul`(l, r)
     res = SIMD[DType.uint64, 2](

--- a/stdlib/src/memory/unsafe.mojo
+++ b/stdlib/src/memory/unsafe.mojo
@@ -61,7 +61,7 @@ fn bitcast[
         _type = __mlir_type[
             `!pop.simd<`, new_width.value, `, `, new_type.value, `>`
         ]
-    ](val.value)
+    ](val._value)
 
 
 @always_inline("nodebug")
@@ -118,4 +118,4 @@ fn bitcast[
 
     return __mlir_op.`pop.bitcast`[
         _type = __mlir_type[`!pop.scalar<`, new_type.value, `>`]
-    ](val.value)
+    ](val._value)

--- a/stdlib/src/os/atomic.mojo
+++ b/stdlib/src/os/atomic.mojo
@@ -84,7 +84,7 @@ struct Atomic[type: DType]:
             _type = __mlir_type[`!pop.scalar<`, type.value, `>`],
         ](
             ptr.bitcast[__mlir_type[`!pop.scalar<`, type.value, `>`]]().address,
-            rhs.value,
+            rhs._value,
         )
 
     @always_inline
@@ -137,12 +137,12 @@ struct Atomic[type: DType]:
         Returns:
             The original value before subtraction.
         """
-        var value_addr = UnsafePointer.address_of(self.value.value)
+        var value_addr = UnsafePointer.address_of(self.value._value)
         return __mlir_op.`pop.atomic.rmw`[
             bin_op = __mlir_attr.`#pop<bin_op sub>`,
             ordering = __mlir_attr.`#pop<atomic_ordering seq_cst>`,
             _type = __mlir_type[`!pop.scalar<`, type.value, `>`],
-        ](value_addr.address, rhs.value)
+        ](value_addr.address, rhs._value)
 
     @always_inline
     fn __isub__(inout self, rhs: Scalar[type]):
@@ -301,8 +301,8 @@ fn _compare_exchange_weak_integral_impl[
         value_addr.bitcast[
             __mlir_type[`!pop.scalar<`, type.value, `>`]
         ]().address,
-        expected.value,
-        desired.value,
+        expected._value,
+        desired._value,
     )
     var ok = Bool(
         __mlir_op.`kgen.struct.extract`[index = __mlir_attr.`1:index`](
@@ -323,7 +323,7 @@ fn _max_impl_base[
         bin_op = __mlir_attr.`#pop<bin_op max>`,
         ordering = __mlir_attr.`#pop<atomic_ordering seq_cst>`,
         _type = __mlir_type[`!pop.scalar<`, type.value, `>`],
-    ](value_addr.address, rhs.value)
+    ](value_addr.address, rhs._value)
 
 
 @always_inline
@@ -335,7 +335,7 @@ fn _min_impl_base[
         bin_op = __mlir_attr.`#pop<bin_op min>`,
         ordering = __mlir_attr.`#pop<atomic_ordering seq_cst>`,
         _type = __mlir_type[`!pop.scalar<`, type.value, `>`],
-    ](value_addr.address, rhs.value)
+    ](value_addr.address, rhs._value)
 
 
 @always_inline

--- a/stdlib/src/python/python_object.mojo
+++ b/stdlib/src/python/python_object.mojo
@@ -384,7 +384,7 @@ struct PythonObject(
         if dt is DType.bool:
             self.py_object = cpython.PyBool_FromLong(int(value))
         elif dt.is_integral():
-            int_val = value.cast[DType.index]().value
+            int_val = value.cast[DType.index]()._value
             self.py_object = cpython.PyLong_FromSsize_t(int_val)
         else:
             fp_val = value.cast[DType.float64]()

--- a/stdlib/src/utils/numerics.mojo
+++ b/stdlib/src/utils/numerics.mojo
@@ -568,7 +568,7 @@ fn isnan[
     alias quiet_nan_test: UInt32 = 0x0002
     return llvm_intrinsic[
         "llvm.is.fpclass", SIMD[DType.bool, simd_width], has_side_effect=False
-    ](val.value, (signaling_nan_test | quiet_nan_test))
+    ](val._value, (signaling_nan_test | quiet_nan_test))
 
 
 # ===----------------------------------------------------------------------=== #
@@ -887,7 +887,7 @@ fn isinf[
     alias negative_infinity_test: UInt32 = 0x0004
     alias positive_infinity_test: UInt32 = 0x0200
     return llvm_intrinsic["llvm.is.fpclass", SIMD[DType.bool, simd_width]](
-        val.value, (negative_infinity_test | positive_infinity_test)
+        val._value, (negative_infinity_test | positive_infinity_test)
     )
 
 
@@ -920,7 +920,7 @@ fn isfinite[
         return True
 
     return llvm_intrinsic["llvm.is.fpclass", SIMD[DType.bool, simd_width]](
-        val.value, UInt32(0x1F8)
+        val._value, UInt32(0x1F8)
     )
 
 


### PR DESCRIPTION
Use an alias for the underlying mlir type of the `_value`, to match the rest of the stdlib.