### PR TITLE
[stdlib] Make `StringRef` ctor from `UnsafePointer[Byte]` keyword only

### DIFF
--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -956,7 +956,7 @@ struct String(
             buff: The buffer. This should have an existing terminator.
         """
 
-        return String(buff, len(StringRef(buff)) + 1)
+        return String(buff, len(StringRef(ptr=buff)) + 1)
 
     @staticmethod
     fn _from_bytes(owned buff: Self._buffer_type) -> String:

--- a/stdlib/src/os/env.mojo
+++ b/stdlib/src/os/env.mojo
@@ -74,4 +74,4 @@ fn getenv(name: String, default: String = "") -> String:
     var ptr = external_call["getenv", UnsafePointer[UInt8]](name.unsafe_ptr())
     if not ptr:
         return default
-    return String(StringRef(ptr))
+    return String(StringRef(ptr=ptr))

--- a/stdlib/src/pathlib/path.mojo
+++ b/stdlib/src/pathlib/path.mojo
@@ -46,7 +46,7 @@ fn cwd() raises -> Path:
     if res == UnsafePointer[c_char]():
         raise Error("unable to query the current directory")
 
-    return String(StringRef(buf))
+    return String(StringRef(ptr=buf))
 
 
 @always_inline

--- a/stdlib/src/python/_cpython.mojo
+++ b/stdlib/src/python/_cpython.mojo
@@ -297,7 +297,7 @@ fn _py_get_version(lib: DLHandle) -> StringRef:
     var version_string = lib.get_function[fn () -> UnsafePointer[c_char]](
         "Py_GetVersion"
     )()
-    return StringRef(version_string)
+    return StringRef(ptr=version_string)
 
 
 fn _py_finalize(lib: DLHandle):

--- a/stdlib/src/utils/stringref.mojo
+++ b/stdlib/src/utils/stringref.mojo
@@ -112,7 +112,7 @@ struct StringRef(
         self.length = len
 
     @always_inline
-    fn __init__(inout self, ptr: UnsafePointer[UInt8]):
+    fn __init__(inout self, *, ptr: UnsafePointer[UInt8]):
         """Construct a StringRef value given a null-terminated string.
 
         Args:

--- a/stdlib/test/collections/test_string.mojo
+++ b/stdlib/test/collections/test_string.mojo
@@ -267,7 +267,7 @@ def test_stringref():
 
 def test_stringref_from_dtypepointer():
     var a = StringRef("AAA")
-    var b = StringRef(a.data)
+    var b = StringRef(ptr=a.data)
     assert_equal(3, len(a))
     assert_equal(3, len(b))
     assert_equal(a, b)


### PR DESCRIPTION
This issues was reported by `@aurelian`(@diocletiann) on Discord.
This prevents accidental `UnsafePointer[Byte]` to `String` implicit conversion through `String` ctor from `StringRef`.

@JoeLoser Should we make the constructor from pointer+length keyword only as well, following `String`?