### PR TITLE
[stdlib] Deque implementation: part 1 - life cycle methods

### DIFF
--- a/stdlib/src/collections/__init__.mojo
+++ b/stdlib/src/collections/__init__.mojo
@@ -13,6 +13,7 @@
 """Implements the collections package."""
 
 from .counter import Counter
+from .deque import Deque
 from .dict import Dict, KeyElement
 from .inline_array import InlineArray
 from .inline_list import InlineList

--- a/stdlib/src/collections/deque.mojo
+++ b/stdlib/src/collections/deque.mojo
@@ -336,14 +336,10 @@ struct Deque[ElementType: CollectionElement](
             (values.data + i).destroy_pointee()
 
         # move remaining elements from `values`
-        src = values.data + n_pop_values
+        src = values.data.bitcast[origin=__origin_of(values)]() + n_pop_values
         for i in range(n_move_values):
             (src + i).move_pointee_into(self._data + self._tail)
             self._tail = self._physical_index(self._tail + 1)
-
-        # mojo is too eager to destroy `values`
-        # TODO: remove this when mojo is fixed
-        _ = values.size
 
     @doc_private
     @always_inline

--- a/stdlib/src/collections/deque.mojo
+++ b/stdlib/src/collections/deque.mojo
@@ -22,7 +22,7 @@ from collections import Deque
 """
 
 from bit import bit_ceil
-from bit import bit_ceil
+from collections import Optional
 from documentation import doc_private
 from memory import UnsafePointer
 

--- a/stdlib/src/collections/deque.mojo
+++ b/stdlib/src/collections/deque.mojo
@@ -1,0 +1,313 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Defines the Deque type.
+
+You can import these APIs from the `collections` package.
+
+Examples:
+
+```mojo
+from collections import Deque
+```
+"""
+
+from bit import bit_ceil
+from collections import Optional
+from memory import UnsafePointer
+
+from builtin._documentation import doc_private
+
+# ===----------------------------------------------------------------------===#
+# Deque
+# ===----------------------------------------------------------------------===#
+
+
+struct Deque[ElementType: CollectionElement](
+    Movable, ExplicitlyCopyable, Sized, Boolable
+):
+    """Implements a double-ended queue.
+
+    It supports pushing and popping from both ends in O(1) time resizing the
+    underlying storage as needed.
+
+    Parameters:
+        ElementType: The type of the elements in the deque.
+            Must implement the trait `CollectionElement`.
+    """
+
+    # ===-------------------------------------------------------------------===#
+    # Aliases
+    # ===-------------------------------------------------------------------===#
+
+    alias default_capacity: Int = 64
+    """The default capacity of the deque: must be the power of 2."""
+
+    # ===-------------------------------------------------------------------===#
+    # Fields
+    # ===-------------------------------------------------------------------===#
+
+    var data: UnsafePointer[ElementType]
+    """The underlying storage for the deque."""
+
+    var head: Int
+    """The index of the head: points the first element of the deque."""
+
+    var tail: Int
+    """The index of the tail: points behind the last element of the deque."""
+
+    var capacity: Int
+    """The amount of elements that can fit in the deque without resizing it."""
+
+    var minlen: Int
+    """The minimum required capacity in the number of elements of the deque."""
+
+    var maxlen: Int
+    """The maximum allowed capacity in the number of elements of the deque."""
+
+    var shrink: Bool
+    """The flag defining if the deque storage is re-allocated to make it smaller when possible."""
+
+    # ===-------------------------------------------------------------------===#
+    # Life cycle methods
+    # ===-------------------------------------------------------------------===#
+
+    fn __init__(
+        inout self,
+        *,
+        owned elements: Optional[List[ElementType]] = None,
+        capacity: Int = self.default_capacity,
+        minlen: Int = self.default_capacity,
+        maxlen: Int = -1,
+        shrink: Bool = True,
+    ):
+        """Constructs a deque.
+
+        Args:
+            elements: The optional list of initial deque elements.
+            capacity: The initial capacity of the deque.
+            minlen: The minimum allowed capacity of the deque when shrinking.
+            maxlen: The maximum allowed capacity of the deque when growing.
+            shrink: Should storage be de-allocated when not needed.
+        """
+        if capacity <= 0:
+            deque_capacity = self.default_capacity
+        else:
+            deque_capacity = bit_ceil(capacity)
+
+        if minlen <= 0:
+            min_capacity = self.default_capacity
+        else:
+            min_capacity = bit_ceil(minlen)
+
+        if maxlen <= 0:
+            max_capacity = -1
+        else:
+            max_capacity = maxlen
+            deque_capacity = min(deque_capacity, bit_ceil(maxlen))
+
+        self.capacity = deque_capacity
+        self.data = UnsafePointer[ElementType].alloc(deque_capacity)
+        self.head = 0
+        self.tail = 0
+        self.minlen = min_capacity
+        self.maxlen = max_capacity
+        self.shrink = shrink
+
+        if elements is not None:
+            self.extend(elements.value())
+
+    fn __init__(inout self, owned *values: ElementType):
+        """Constructs a deque from the given values.
+
+        Args:
+            values: The values to populate the deque with.
+        """
+        self = Self(variadic_list=values^)
+
+    fn __init__(
+        inout self, *, owned variadic_list: VariadicListMem[ElementType, _]
+    ):
+        """Constructs a deque from the given values.
+
+        Args:
+            variadic_list: The values to populate the deque with.
+        """
+        args_length = len(variadic_list)
+
+        if args_length < self.default_capacity:
+            capacity = self.default_capacity
+        else:
+            capacity = args_length
+
+        self = Self(capacity=capacity)
+
+        for i in range(args_length):
+            src = UnsafePointer.address_of(variadic_list[i])
+            dst = self.data + i
+            src.move_pointee_into(dst)
+
+        # Mark the elements as unowned to avoid del'ing uninitialized objects.
+        variadic_list._is_owned = False
+
+        self.tail = args_length
+
+    fn __init__(inout self, other: Self):
+        """Creates a deepcopy of the given deque.
+
+        Args:
+            other: The deque to copy.
+        """
+        self = Self(
+            capacity=other.capacity,
+            minlen=other.minlen,
+            maxlen=other.maxlen,
+            shrink=other.shrink,
+        )
+        for i in range(len(other)):
+            offset = (other.head + i) & (other.capacity - 1)
+            (self.data + i).init_pointee_copy((other.data + offset)[])
+
+        self.tail = len(other)
+
+    fn __moveinit__(inout self, owned existing: Self):
+        """Moves data of an existing deque into a new one.
+
+        Args:
+            existing: The existing deque.
+        """
+        self.data = existing.data
+        self.capacity = existing.capacity
+        self.head = existing.head
+        self.tail = existing.tail
+        self.minlen = existing.minlen
+        self.maxlen = existing.maxlen
+        self.shrink = existing.shrink
+
+    fn __del__(owned self):
+        """Destroys all elements in the deque and free its memory."""
+        for i in range(len(self)):
+            offset = (self.head + i) & (self.capacity - 1)
+            (self.data + offset).destroy_pointee()
+        self.data.free()
+
+    # ===-------------------------------------------------------------------===#
+    # Trait implementations
+    # ===-------------------------------------------------------------------===#
+
+    @always_inline
+    fn __bool__(self) -> Bool:
+        """Checks whether the deque has any elements or not.
+
+        Returns:
+            `False` if the deque is empty, `True` if there is at least one element.
+        """
+        return self.head != self.tail
+
+    @always_inline
+    fn __len__(self) -> Int:
+        """Gets the number of elements in the deque.
+
+        Returns:
+            The number of elements in the deque.
+        """
+        return (self.tail - self.head) & (self.capacity - 1)
+
+    fn __getitem__(ref [_]self, idx: Int) -> ref [self] ElementType:
+        """Gets the deque element at the given index.
+
+        Args:
+            idx: The index of the element.
+
+        Returns:
+            A reference to the element at the given index.
+        """
+        normalized_idx = idx
+
+        debug_assert(
+            -len(self) <= normalized_idx < len(self),
+            "index: ",
+            normalized_idx,
+            " is out of bounds for `Deque` of size: ",
+            len(self),
+        )
+
+        if normalized_idx < 0:
+            normalized_idx += len(self)
+
+        offset = (self.head + normalized_idx) & (self.capacity - 1)
+        return (self.data + offset)[]
+
+    # ===-------------------------------------------------------------------===#
+    # Methods
+    # ===-------------------------------------------------------------------===#
+
+    fn append(inout self, owned value: ElementType):
+        """Appends a value to the right side of the deque.
+
+        Args:
+            value: The value to append.
+        """
+        if len(self) == self.maxlen:
+            (self.data + self.head).destroy_pointee()
+            self.head = (self.head + 1) & (self.capacity - 1)
+
+        (self.data + self.tail).init_pointee_move(value^)
+        self.tail = (self.tail + 1) & (self.capacity - 1)
+
+        if self.head == self.tail:
+            self._realloc(self.capacity << 1)
+
+    fn extend(inout self, owned values: List[ElementType]):
+        """Extends the right side of the deque by consuming elements of the list argument.
+
+        Args:
+            values: List whose elements will be added at the right side of the deque.
+        """
+        for value in values:
+            self.append(value[])
+
+    @doc_private
+    fn _realloc(inout self, new_capacity: Int):
+        """Relocates data to a new storage buffer.
+
+        Args:
+            new_capacity: The new capacity of the buffer.
+        """
+        deque_len = len(self) if self else self.capacity
+
+        tail_len = self.tail
+        head_len = self.capacity - self.head
+
+        if head_len > deque_len:
+            head_len = deque_len
+            tail_len = 0
+
+        new_data = UnsafePointer[ElementType].alloc(new_capacity)
+
+        src = self.data + self.head
+        dsc = new_data
+        for i in range(head_len):
+            (src + i).move_pointee_into(dsc + i)
+
+        src = self.data
+        dsc = new_data + head_len
+        for i in range(tail_len):
+            (src + i).move_pointee_into(dsc + i)
+
+        self.head = 0
+        self.tail = deque_len
+
+        if self.data:
+            self.data.free()
+        self.data = new_data
+        self.capacity = new_capacity

--- a/stdlib/src/collections/deque.mojo
+++ b/stdlib/src/collections/deque.mojo
@@ -178,7 +178,7 @@ struct Deque[ElementType: CollectionElement](
             shrink=other._shrink,
         )
         for i in range(len(other)):
-            offset = (other._head + i) & (other._capacity - 1)
+            offset = other._physical_index(other._head + i)
             (self._data + i).init_pointee_copy((other._data + offset)[])
 
         self._tail = len(other)

--- a/stdlib/src/collections/deque.mojo
+++ b/stdlib/src/collections/deque.mojo
@@ -22,7 +22,7 @@ from collections import Deque
 """
 
 from bit import bit_ceil
-from bit import bit_ceil, is_power_of_two
+from bit import bit_ceil
 from documentation import doc_private
 from memory import UnsafePointer
 
@@ -118,7 +118,7 @@ struct Deque[ElementType: CollectionElement](
         else:
             max_deque_len = maxlen
             max_deque_capacity = bit_ceil(maxlen)
-            if is_power_of_two(maxlen):
+            if max_deque_capacity == maxlen:
                 max_deque_capacity <<= 1
             deque_capacity = min(deque_capacity, max_deque_capacity)
 
@@ -284,20 +284,6 @@ struct Deque[ElementType: CollectionElement](
         len_values = len(values)
         len_total = len_self + len_values
 
-        new_capacity = self._capacity
-        if self._capacity <= len_total:
-            new_capacity = bit_ceil(len_total)
-            if is_power_of_two(len_total):
-                new_capacity <<= 1
-
-        max_capacity = new_capacity
-        if self._maxlen > 0:
-            max_capacity = bit_ceil(self._maxlen)
-            if is_power_of_two(self._maxlen):
-                max_capacity <<= 1
-
-        new_capacity = min(new_capacity, max_capacity)
-
         # number of elements to move into the final deque
         # first from `values` and then from `self`
         n_move_total = len_total
@@ -317,7 +303,10 @@ struct Deque[ElementType: CollectionElement](
             self._head = self._physical_index(self._head + 1)
 
         # move from `self` to new location if we have to re-allocate
-        if new_capacity > self._capacity:
+        if n_move_total >= self._capacity:
+            new_capacity = bit_ceil(n_move_total)
+            if new_capacity == n_move_total:
+                new_capacity <<= 1
             new_data = UnsafePointer[ElementType].alloc(new_capacity)
             for i in range(n_move_self):
                 offset = self._physical_index(self._head + i)

--- a/stdlib/src/collections/deque.mojo
+++ b/stdlib/src/collections/deque.mojo
@@ -319,13 +319,14 @@ struct Deque[ElementType: CollectionElement](
             self._tail = n_move_self
 
         # we will consume all elements of `values`
-        values.size = 0
+        values_data = values.steal_data()
+
         # pop excess elements from `values`
         for i in range(n_pop_values):
-            (values.data + i).destroy_pointee()
+            (values_data + i).destroy_pointee()
 
         # move remaining elements from `values`
-        src = values.data.bitcast[origin = __origin_of(values)]() + n_pop_values
+        src = values_data + n_pop_values
         for i in range(n_move_values):
             (src + i).move_pointee_into(self._data + self._tail)
             self._tail = self._physical_index(self._tail + 1)

--- a/stdlib/src/collections/deque.mojo
+++ b/stdlib/src/collections/deque.mojo
@@ -264,7 +264,8 @@ struct Deque[ElementType: CollectionElement](
         Args:
             value: The value to append.
         """
-        if len(self) == self._maxlen:
+        # checking for positive _maxlen first is important for speed
+        if self._maxlen > 0 and len(self) == self._maxlen:
             (self._data + self._head).destroy_pointee()
             self._head = self._physical_index(self._head + 1)
 

--- a/stdlib/src/collections/deque.mojo
+++ b/stdlib/src/collections/deque.mojo
@@ -23,9 +23,9 @@ from collections import Deque
 
 from bit import bit_ceil
 from bit import bit_ceil, is_power_of_two
+from documentation import doc_private
 from memory import UnsafePointer
 
-from builtin._documentation import doc_private
 
 # ===----------------------------------------------------------------------===#
 # Deque

--- a/stdlib/src/collections/deque.mojo
+++ b/stdlib/src/collections/deque.mojo
@@ -336,7 +336,7 @@ struct Deque[ElementType: CollectionElement](
             (values.data + i).destroy_pointee()
 
         # move remaining elements from `values`
-        src = values.data.bitcast[origin=__origin_of(values)]() + n_pop_values
+        src = values.data.bitcast[origin = __origin_of(values)]() + n_pop_values
         for i in range(n_move_values):
             (src + i).move_pointee_into(self._data + self._tail)
             self._tail = self._physical_index(self._tail + 1)

--- a/stdlib/test/collections/test_deque.mojo
+++ b/stdlib/test/collections/test_deque.mojo
@@ -24,113 +24,113 @@ from collections import Deque
 fn test_impl_init_default() raises:
     q = Deque[Int]()
 
-    assert_equal(q.capacity, q.default_capacity)
-    assert_equal(q.minlen, q.default_capacity)
-    assert_equal(q.maxlen, -1)
-    assert_equal(q.head, 0)
-    assert_equal(q.tail, 0)
-    assert_equal(q.shrink, True)
+    assert_equal(q._capacity, q.default_capacity)
+    assert_equal(q._min_capacity, q.default_capacity)
+    assert_equal(q._maxlen, -1)
+    assert_equal(q._head, 0)
+    assert_equal(q._tail, 0)
+    assert_equal(q._shrink, True)
 
 
 fn test_impl_init_capacity() raises:
     q = Deque[Int](capacity=-10)
-    assert_equal(q.capacity, q.default_capacity)
-    assert_equal(q.minlen, q.default_capacity)
+    assert_equal(q._capacity, q.default_capacity)
+    assert_equal(q._min_capacity, q.default_capacity)
 
     q = Deque[Int](capacity=0)
-    assert_equal(q.capacity, q.default_capacity)
-    assert_equal(q.minlen, q.default_capacity)
+    assert_equal(q._capacity, q.default_capacity)
+    assert_equal(q._min_capacity, q.default_capacity)
 
     q = Deque[Int](capacity=10)
-    assert_equal(q.capacity, 16)
-    assert_equal(q.minlen, q.default_capacity)
+    assert_equal(q._capacity, 16)
+    assert_equal(q._min_capacity, q.default_capacity)
 
     q = Deque[Int](capacity=100)
-    assert_equal(q.capacity, 128)
-    assert_equal(q.minlen, q.default_capacity)
+    assert_equal(q._capacity, 128)
+    assert_equal(q._min_capacity, q.default_capacity)
 
 
-fn test_impl_init_minlen() raises:
-    q = Deque[Int](minlen=-10)
-    assert_equal(q.minlen, q.default_capacity)
-    assert_equal(q.capacity, q.default_capacity)
+fn test_impl_init_min_capacity() raises:
+    q = Deque[Int](min_capacity=-10)
+    assert_equal(q._min_capacity, q.default_capacity)
+    assert_equal(q._capacity, q.default_capacity)
 
-    q = Deque[Int](minlen=0)
-    assert_equal(q.minlen, q.default_capacity)
-    assert_equal(q.capacity, q.default_capacity)
+    q = Deque[Int](min_capacity=0)
+    assert_equal(q._min_capacity, q.default_capacity)
+    assert_equal(q._capacity, q.default_capacity)
 
-    q = Deque[Int](minlen=10)
-    assert_equal(q.minlen, 16)
-    assert_equal(q.capacity, q.default_capacity)
+    q = Deque[Int](min_capacity=10)
+    assert_equal(q._min_capacity, 16)
+    assert_equal(q._capacity, q.default_capacity)
 
-    q = Deque[Int](minlen=100)
-    assert_equal(q.minlen, 128)
-    assert_equal(q.capacity, q.default_capacity)
+    q = Deque[Int](min_capacity=100)
+    assert_equal(q._min_capacity, 128)
+    assert_equal(q._capacity, q.default_capacity)
 
 
 fn test_impl_init_maxlen() raises:
     q = Deque[Int](maxlen=-10)
-    assert_equal(q.maxlen, -1)
-    assert_equal(q.capacity, q.default_capacity)
+    assert_equal(q._maxlen, -1)
+    assert_equal(q._capacity, q.default_capacity)
 
     q = Deque[Int](maxlen=0)
-    assert_equal(q.maxlen, -1)
-    assert_equal(q.capacity, q.default_capacity)
+    assert_equal(q._maxlen, -1)
+    assert_equal(q._capacity, q.default_capacity)
 
     q = Deque[Int](maxlen=10)
-    assert_equal(q.maxlen, 10)
-    assert_equal(q.capacity, 16)
+    assert_equal(q._maxlen, 10)
+    assert_equal(q._capacity, 16)
 
     q = Deque[Int](maxlen=100)
-    assert_equal(q.maxlen, 100)
-    assert_equal(q.capacity, q.default_capacity)
+    assert_equal(q._maxlen, 100)
+    assert_equal(q._capacity, q.default_capacity)
 
 
 fn test_impl_init_shrink() raises:
     q = Deque[Int](shrink=False)
-    assert_equal(q.shrink, False)
-    assert_equal(q.capacity, q.default_capacity)
+    assert_equal(q._shrink, False)
+    assert_equal(q._capacity, q.default_capacity)
 
 
 fn test_impl_init_list() raises:
     q = Deque(elements=List(0, 1, 2))
-    assert_equal(q.head, 0)
-    assert_equal(q.tail, 3)
-    assert_equal(q.capacity, q.default_capacity)
-    assert_equal((q.data + 0)[], 0)
-    assert_equal((q.data + 1)[], 1)
-    assert_equal((q.data + 2)[], 2)
+    assert_equal(q._head, 0)
+    assert_equal(q._tail, 3)
+    assert_equal(q._capacity, q.default_capacity)
+    assert_equal((q._data + 0)[], 0)
+    assert_equal((q._data + 1)[], 1)
+    assert_equal((q._data + 2)[], 2)
 
 
 fn test_impl_init_list_args() raises:
     q = Deque(elements=List(0, 1, 2), maxlen=2, capacity=10)
-    assert_equal(q.head, 1)
-    assert_equal(q.tail, 3)
-    assert_equal(q.capacity, 4)
-    assert_equal((q.data + 1)[], 1)
-    assert_equal((q.data + 2)[], 2)
+    assert_equal(q._head, 1)
+    assert_equal(q._tail, 3)
+    assert_equal(q._capacity, 4)
+    assert_equal((q._data + 1)[], 1)
+    assert_equal((q._data + 2)[], 2)
 
 
 fn test_impl_init_variadic() raises:
     q = Deque(0, 1, 2)
 
-    assert_equal(q.head, 0)
-    assert_equal(q.tail, 3)
-    assert_equal(q.capacity, q.default_capacity)
-    assert_equal((q.data + 0)[], 0)
-    assert_equal((q.data + 1)[], 1)
-    assert_equal((q.data + 2)[], 2)
+    assert_equal(q._head, 0)
+    assert_equal(q._tail, 3)
+    assert_equal(q._capacity, q.default_capacity)
+    assert_equal((q._data + 0)[], 0)
+    assert_equal((q._data + 1)[], 1)
+    assert_equal((q._data + 2)[], 2)
 
 
 fn test_impl_len() raises:
     q = Deque[Int]()
 
-    q.head = 0
-    q.tail = 10
+    q._head = 0
+    q._tail = 10
     assert_equal(len(q), 10)
 
-    q.head = q.default_capacity - 5
-    q.tail = 5
+    q._head = q.default_capacity - 5
+    q._tail = 5
     assert_equal(len(q), 10)
 
 
@@ -138,7 +138,7 @@ fn test_impl_bool() raises:
     q = Deque[Int]()
     assert_false(q)
 
-    q.tail = 1
+    q._tail = 1
     assert_true(q)
 
 
@@ -146,69 +146,69 @@ fn test_impl_append() raises:
     q = Deque[Int](capacity=2)
 
     q.append(0)
-    assert_equal(q.head, 0)
-    assert_equal(q.tail, 1)
-    assert_equal(q.capacity, 2)
-    assert_equal((q.data + 0)[], 0)
+    assert_equal(q._head, 0)
+    assert_equal(q._tail, 1)
+    assert_equal(q._capacity, 2)
+    assert_equal((q._data + 0)[], 0)
 
     q.append(1)
-    assert_equal(q.head, 0)
-    assert_equal(q.tail, 2)
-    assert_equal(q.capacity, 4)
-    assert_equal((q.data + 0)[], 0)
-    assert_equal((q.data + 1)[], 1)
+    assert_equal(q._head, 0)
+    assert_equal(q._tail, 2)
+    assert_equal(q._capacity, 4)
+    assert_equal((q._data + 0)[], 0)
+    assert_equal((q._data + 1)[], 1)
 
     q.append(2)
-    assert_equal(q.head, 0)
-    assert_equal(q.tail, 3)
-    assert_equal(q.capacity, 4)
-    assert_equal((q.data + 0)[], 0)
-    assert_equal((q.data + 1)[], 1)
-    assert_equal((q.data + 2)[], 2)
+    assert_equal(q._head, 0)
+    assert_equal(q._tail, 3)
+    assert_equal(q._capacity, 4)
+    assert_equal((q._data + 0)[], 0)
+    assert_equal((q._data + 1)[], 1)
+    assert_equal((q._data + 2)[], 2)
 
     # simulate popleft()
-    q.head += 1
+    q._head += 1
     q.append(3)
-    assert_equal(q.head, 1)
+    assert_equal(q._head, 1)
     # tail wrapped to the front
-    assert_equal(q.tail, 0)
-    assert_equal(q.capacity, 4)
-    assert_equal((q.data + 1)[], 1)
-    assert_equal((q.data + 2)[], 2)
-    assert_equal((q.data + 3)[], 3)
+    assert_equal(q._tail, 0)
+    assert_equal(q._capacity, 4)
+    assert_equal((q._data + 1)[], 1)
+    assert_equal((q._data + 2)[], 2)
+    assert_equal((q._data + 3)[], 3)
 
     q.append(4)
     # re-allocated buffer and moved all elements
-    assert_equal(q.head, 0)
-    assert_equal(q.tail, 4)
-    assert_equal(q.capacity, 8)
-    assert_equal((q.data + 0)[], 1)
-    assert_equal((q.data + 1)[], 2)
-    assert_equal((q.data + 2)[], 3)
-    assert_equal((q.data + 3)[], 4)
+    assert_equal(q._head, 0)
+    assert_equal(q._tail, 4)
+    assert_equal(q._capacity, 8)
+    assert_equal((q._data + 0)[], 1)
+    assert_equal((q._data + 1)[], 2)
+    assert_equal((q._data + 2)[], 3)
+    assert_equal((q._data + 3)[], 4)
 
 
 fn test_impl_append_with_maxlen() raises:
     q = Deque[Int](maxlen=3)
 
-    assert_equal(q.maxlen, 3)
-    assert_equal(q.capacity, 4)
+    assert_equal(q._maxlen, 3)
+    assert_equal(q._capacity, 4)
 
     q.append(0)
     q.append(1)
     q.append(2)
-    assert_equal(q.head, 0)
-    assert_equal(q.tail, 3)
+    assert_equal(q._head, 0)
+    assert_equal(q._tail, 3)
 
     q.append(3)
     # first popped the leftmost element
     # so there was no re-allocation of buffer
-    assert_equal(q.head, 1)
-    assert_equal(q.tail, 0)
-    assert_equal(q.capacity, 4)
-    assert_equal((q.data + 1)[], 1)
-    assert_equal((q.data + 2)[], 2)
-    assert_equal((q.data + 3)[], 3)
+    assert_equal(q._head, 1)
+    assert_equal(q._tail, 0)
+    assert_equal(q._capacity, 4)
+    assert_equal((q._data + 1)[], 1)
+    assert_equal((q._data + 2)[], 2)
+    assert_equal((q._data + 3)[], 3)
 
 
 fn test_impl_extend() raises:
@@ -216,28 +216,28 @@ fn test_impl_extend() raises:
     lst = List[Int](0, 1, 2)
 
     q.extend(lst)
-    assert_equal(q.head, 0)
-    assert_equal(q.tail, 3)
-    assert_equal(q.capacity, 4)
-    assert_equal((q.data + 0)[], 0)
-    assert_equal((q.data + 1)[], 1)
-    assert_equal((q.data + 2)[], 2)
+    assert_equal(q._head, 0)
+    assert_equal(q._tail, 3)
+    assert_equal(q._capacity, 4)
+    assert_equal((q._data + 0)[], 0)
+    assert_equal((q._data + 1)[], 1)
+    assert_equal((q._data + 2)[], 2)
 
     q.extend(lst)
     # re-allocated buffer after the first append
     # then poppedleft the first 2 elements
-    assert_equal(q.capacity, 8)
-    assert_equal(q.head, 2)
-    assert_equal(q.tail, 6)
-    assert_equal((q.data + 2)[], 2)
-    assert_equal((q.data + 3)[], 0)
-    assert_equal((q.data + 4)[], 1)
-    assert_equal((q.data + 5)[], 2)
+    assert_equal(q._capacity, 8)
+    assert_equal(q._head, 2)
+    assert_equal(q._tail, 6)
+    assert_equal((q._data + 2)[], 2)
+    assert_equal((q._data + 3)[], 0)
+    assert_equal((q._data + 4)[], 1)
+    assert_equal((q._data + 5)[], 2)
 
 
-# # ===----------------------------------------------------------------------===#
-# # API Interface tests
-# # ===----------------------------------------------------------------------===#
+# ===----------------------------------------------------------------------===#
+# API Interface tests
+# ===----------------------------------------------------------------------===#
 
 
 fn test_init_variadic_list() raises:
@@ -318,7 +318,7 @@ fn test_getitem() raises:
 def main():
     test_impl_init_default()
     test_impl_init_capacity()
-    test_impl_init_minlen()
+    test_impl_init_min_capacity()
     test_impl_init_maxlen()
     test_impl_init_shrink()
     test_impl_init_list()


### PR DESCRIPTION
This PR provides a first part of the Deque data type implementation as agreed in #2659.
It includes only the life cycle methods, some methods required by the life cycle methods, and related tests.
Looking forward to your comments for improvements.