### PR TITLE
[stdlib] [NFC] Rename `StringSlice` `UnsafePointer` constructor args

### DIFF
--- a/stdlib/src/builtin/format_int.mojo
+++ b/stdlib/src/builtin/format_int.mojo
@@ -322,13 +322,12 @@ fn _try_write_int[
         # Construct a null-terminated buffer of single-byte char.
         var zero_buf = InlineArray[UInt8, 2](zero_char, 0)
 
+        # TODO(MSTDL-720):
+        #   Support printing non-null-terminated strings on GPU and switch
+        #   back to this code without a workaround.
+        # ptr=digit_chars_array,
         var zero = StringSlice[ImmutableAnyOrigin](
-            # TODO(MSTDL-720):
-            #   Support printing non-null-terminated strings on GPU and switch
-            #   back to this code without a workaround.
-            # unsafe_from_utf8_ptr=digit_chars_array,
-            unsafe_from_utf8_ptr=zero_buf.unsafe_ptr(),
-            len=1,
+            ptr=zero_buf.unsafe_ptr(), length=1
         )
         writer.write(zero)
 
@@ -404,10 +403,7 @@ fn _try_write_int[
 
     # SAFETY:
     #   Create a slice to only those bytes in `buf` that have been initialized.
-    var str_slice = StringSlice[__origin_of(buf)](
-        unsafe_from_utf8_ptr=buf_ptr,
-        len=len,
-    )
+    var str_slice = StringSlice[__origin_of(buf)](ptr=buf_ptr, length=len)
 
     writer.write(str_slice)
 

--- a/stdlib/src/builtin/string_literal.mojo
+++ b/stdlib/src/builtin/string_literal.mojo
@@ -444,9 +444,7 @@ struct StringLiteral(
         # FIXME(MSTDL-160):
         #   Enforce UTF-8 encoding in StringLiteral so this is actually
         #   guaranteed to be valid.
-        return StaticString(
-            unsafe_from_utf8_ptr=self.unsafe_ptr(), len=self.byte_length()
-        )
+        return StaticString(ptr=self.unsafe_ptr(), length=self.byte_length())
 
     @always_inline
     fn as_bytes(self) -> Span[Byte, StaticConstantOrigin]:

--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -1118,9 +1118,9 @@ struct String(
         var rhs_ptr = rhs.unsafe_ptr()
         alias S = StringSlice[ImmutableAnyOrigin]
         if lhs_len == 0:
-            return String(S(unsafe_from_utf8_ptr=rhs_ptr, len=rhs_len))
+            return String(S(ptr=rhs_ptr, length=rhs_len))
         elif rhs_len == 0:
-            return String(S(unsafe_from_utf8_ptr=lhs_ptr, len=lhs_len))
+            return String(S(ptr=lhs_ptr, length=lhs_len))
         var sum_len = lhs_len + rhs_len
         var buffer = Self._buffer_type(capacity=sum_len + 1)
         var ptr = buffer.unsafe_ptr()
@@ -1211,7 +1211,7 @@ struct String(
         var o_ptr = other.unsafe_ptr()
         if s_len == 0:
             alias S = StringSlice[ImmutableAnyOrigin]
-            self = String(S(unsafe_from_utf8_ptr=o_ptr, len=o_len))
+            self = String(S(ptr=o_ptr, length=o_len))
             return
         elif o_len == 0:
             return
@@ -2031,12 +2031,12 @@ struct String(
         """
         if end == -1:
             return StringSlice[__origin_of(self)](
-                unsafe_from_utf8_ptr=self.unsafe_ptr() + start,
-                len=self.byte_length() - start,
+                ptr=self.unsafe_ptr() + start,
+                length=self.byte_length() - start,
             ).startswith(prefix.as_string_slice())
 
         return StringSlice[__origin_of(self)](
-            unsafe_from_utf8_ptr=self.unsafe_ptr() + start, len=end - start
+            ptr=self.unsafe_ptr() + start, length=end - start
         ).startswith(prefix.as_string_slice())
 
     fn endswith(self, suffix: String, start: Int = 0, end: Int = -1) -> Bool:
@@ -2053,12 +2053,12 @@ struct String(
         """
         if end == -1:
             return StringSlice[__origin_of(self)](
-                unsafe_from_utf8_ptr=self.unsafe_ptr() + start,
-                len=self.byte_length() - start,
+                ptr=self.unsafe_ptr() + start,
+                length=self.byte_length() - start,
             ).endswith(suffix.as_string_slice())
 
         return StringSlice[__origin_of(self)](
-            unsafe_from_utf8_ptr=self.unsafe_ptr() + start, len=end - start
+            ptr=self.unsafe_ptr() + start, length=end - start
         ).endswith(suffix.as_string_slice())
 
     fn removeprefix(self, prefix: String, /) -> String:

--- a/stdlib/src/utils/string_slice.mojo
+++ b/stdlib/src/utils/string_slice.mojo
@@ -323,7 +323,7 @@ struct StringSlice[is_mutable: Bool, //, origin: Origin[is_mutable].type,](
         self = Self(unsafe_from_utf8=byte_slice)
 
     @always_inline
-    fn __init__(inout self, *, ptr: UnsafePointer[UInt8], length: Int):
+    fn __init__(inout self, *, ptr: UnsafePointer[Byte], length: Int):
         """Construct a `StringSlice` from a pointer to a sequence of UTF-8
         encoded bytes and a length.
 
@@ -337,7 +337,7 @@ struct StringSlice[is_mutable: Bool, //, origin: Origin[is_mutable].type,](
             - `ptr` must point to data that is live for the duration of
                 `origin`.
         """
-        self._slice = Span[Byte, origin](unsafe_ptr=ptr, length=length)
+        self._slice = Span[Byte, origin](unsafe_ptr=ptr, len=length)
 
     @always_inline
     fn __init__(inout self, *, other: Self):


### PR DESCRIPTION
Rename `StringSlice` `UnsafePointer` constructor args. Part of #3704