### PR TITLE
[stdlib] [NFC] Rename `String` `UnsafePointer` constructor args

### DIFF
--- a/stdlib/src/builtin/file.mojo
+++ b/stdlib/src/builtin/file.mojo
@@ -201,7 +201,7 @@ struct FileHandle:
         if err_msg:
             raise err_msg^.consume_as_error()
 
-        return String(buf, int(size_copy) + 1)
+        return String(ptr=buf, length=int(size_copy) + 1)
 
     fn read[
         type: DType

--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -146,7 +146,7 @@ fn chr(c: Int) -> String:
     #     p.free()
     #     return chr(0xFFFD)
     p[num_bytes] = 0
-    return String(ptr=p, len=num_bytes + 1)
+    return String(ptr=p, length=num_bytes + 1)
 
 
 # ===----------------------------------------------------------------------=== #
@@ -819,7 +819,7 @@ struct String(
         self = literal.__str__()
 
     @always_inline
-    fn __init__(inout self, ptr: UnsafePointer[UInt8], len: Int):
+    fn __init__(inout self, *, ptr: UnsafePointer[Byte], length: Int):
         """Creates a string from the buffer. Note that the string now owns
         the buffer.
 
@@ -827,14 +827,12 @@ struct String(
 
         Args:
             ptr: The pointer to the buffer.
-            len: The length of the buffer, including the null terminator.
+            length: The length of the buffer, including the null terminator.
         """
         # we don't know the capacity of ptr, but we'll assume it's the same or
         # larger than len
         self = Self(
-            Self._buffer_type(
-                unsafe_pointer=ptr.bitcast[UInt8](), size=len, capacity=len
-            )
+            Self._buffer_type(unsafe_pointer=ptr, size=length, capacity=length)
         )
 
     # ===------------------------------------------------------------------=== #
@@ -957,7 +955,7 @@ struct String(
             buff: The buffer. This should have an existing terminator.
         """
 
-        return String(buff, len(StringRef(ptr=buff)) + 1)
+        return String(ptr=buff, length=len(StringRef(ptr=buff)) + 1)
 
     @staticmethod
     fn _from_bytes(owned buff: Self._buffer_type) -> String:

--- a/stdlib/src/sys/info.mojo
+++ b/stdlib/src/sys/info.mojo
@@ -803,7 +803,7 @@ fn _macos_version() raises -> Tuple[Int, Int, Int]:
     if err:
         raise "Unable to query macOS version"
 
-    var osver = String(buf.steal_data(), buf_len)
+    var osver = String(ptr=buf.steal_data(), length=buf_len)
 
     var major = 0
     var minor = 0

--- a/stdlib/test/collections/test_string.mojo
+++ b/stdlib/test/collections/test_string.mojo
@@ -94,7 +94,7 @@ def test_constructors():
     ptr[1] = ord("b")
     ptr[2] = ord("c")
     ptr[3] = 0
-    var s3 = String(ptr, 4)
+    var s3 = String(ptr=ptr, length=4)
     assert_equal(s3, "abc")
 
 


### PR DESCRIPTION
Rename `String` `UnsafePointer` constructor args. Part of #3704