### PR TITLE
[stdlib] Implement `Writer` for `Span`

### DIFF
--- a/stdlib/src/builtin/sort.mojo
+++ b/stdlib/src/builtin/sort.mojo
@@ -213,7 +213,7 @@ fn _quicksort[
 
     # Work with an immutable span so we don't run into exclusivity problems with
     # the List[Span].
-    var imm_span = span.get_immutable()
+    var imm_span = span.for_read()
     alias ImmSpan = __type_of(imm_span)
 
     var stack = List[ImmSpan](capacity=_estimate_initial_height(size))
@@ -341,9 +341,7 @@ fn _stable_sort_impl[
         while j + merge_size < size:
             var span1 = span[j : j + merge_size]
             var span2 = span[j + merge_size : min(size, j + 2 * merge_size)]
-            _merge[cmp_fn](
-                span1.get_immutable(), span2.get_immutable(), temp_buff
-            )
+            _merge[cmp_fn](span1.for_read(), span2.for_read(), temp_buff)
             for i in range(merge_size + len(span2)):
                 span[j + i] = temp_buff[i]
             j += 2 * merge_size

--- a/stdlib/test/utils/test_span.mojo
+++ b/stdlib/test/utils/test_span.mojo
@@ -194,6 +194,16 @@ def test_ref():
     assert_true(s.as_ref() == Pointer.address_of(l.unsafe_ptr()[]))
 
 
+def test_write():
+    a = List[Byte](0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+    b = List[Byte](capacity=10)
+    b.size = 10
+    s1 = Span(a).for_read()
+    s2 = Span(b).for_write()
+    s2.write_bytes(s1)
+    assert_equal(a.__str__(), b.__str__())
+
+
 def main():
     test_span_list_int()
     test_span_list_str()
@@ -205,3 +215,4 @@ def main():
     test_bool()
     test_fill()
     test_ref()
+    test_write()


### PR DESCRIPTION
Implement `Writer` for `Span`. Related to [#3738 (comment)](https://github.com/modularml/mojo/issues/3738#issuecomment-2457894333)

This opens the door for using `Span` more often rather than `UnsafePointer`