### PR TITLE
[stdlib] Addition of a new constructor and reserve method to the String struct

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -232,6 +232,10 @@ what we publish.
 - Added `os.path.expandvars` to expand environment variables in a string.
   ([PR #3735](https://github.com/modularml/mojo/pull/3735) by [@thatstoasty](https://github.com/thatstoasty)).
 
+- Added a `reserve` method and new constructor to the `String` struct to
+  allocate additional capacity.
+  ([PR #3755](https://github.com/modularml/mojo/pull/3755) by [@thatstoasty](https://github.com/thatstoasty)).
+
 ### 🦋 Changed
 
 - More things have been removed from the auto-exported set of entities in the `prelude`

--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -766,6 +766,15 @@ struct String(
         """Construct an uninitialized string."""
         self._buffer = Self._buffer_type()
 
+    @always_inline
+    fn __init__(inout self, *, capacity: Int):
+        """Construct an uninitialized string with the given capacity.
+
+        Args:
+            capacity: The capacity of the string.
+        """
+        self._buffer = Self._buffer_type(capacity=capacity)
+
     fn __init__(inout self, *, other: Self):
         """Explicitly copy the provided value.
 
@@ -2295,6 +2304,18 @@ struct String(
         memcpy(buffer.unsafe_ptr().offset(start), self.unsafe_ptr(), len(self))
         var result = String(buffer)
         return result^
+
+    fn reserve(inout self, new_capacity: Int):
+        """Reserves the requested capacity.
+
+        Args:
+            new_capacity: The new capacity.
+
+        Notes:
+            If the current capacity is greater or equal, this is a no-op.
+            Otherwise, the storage is reallocated and the data is moved.
+        """
+        self._buffer.reserve(new_capacity)
 
 
 # ===----------------------------------------------------------------------=== #

--- a/stdlib/test/collections/test_string.mojo
+++ b/stdlib/test/collections/test_string.mojo
@@ -97,6 +97,10 @@ def test_constructors():
     var s3 = String(ptr, 4)
     assert_equal(s3, "abc")
 
+    # Construction with capacity
+    var s4 = String(capacity=1)
+    assert_equal(s4._buffer.capacity, 1)
+
 
 def test_copy():
     var s0 = String("find")
@@ -1573,6 +1577,13 @@ def test_slice_contains():
     assert_false(
         String("hello world").as_string_slice().__contains__("not-found")
     )
+
+
+def test_reserve():
+    var s = String()
+    assert_true(s._buffer.capacity == 0)
+    s.reserve(1)
+    assert_true(s._buffer.capacity == 1)
 
 
 def main():


### PR DESCRIPTION
Adds a public API for users to allocate capacity through String, instead of having to reach into the private internal `._buffer` attribute.

Satisfies: https://github.com/modularml/mojo/issues/3738