### PR TITLE
[stdlib] Fix unsafe `String.write_bytes()`

### DIFF
--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -853,6 +853,9 @@ struct String(
             bytes: The byte span to write to this String. Must NOT be
                 null terminated.
         """
+        # TODO: maybe check byte by byte that there is no 0 ?
+        # need Span.count() to be faster
+        debug_assert(bytes[-1] != 0, "byte Span must not be null terminated")
         self._iadd[False](bytes)
 
     fn write[*Ts: Writable](inout self, *args: *Ts):

--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -847,14 +847,13 @@ struct String(
     # ===------------------------------------------------------------------=== #
 
     fn write_bytes(inout self, bytes: Span[Byte, _]):
-        """
-        Write a byte span to this String.
+        """Write a byte span to this String.
 
         Args:
             bytes: The byte span to write to this String. Must NOT be
-              null terminated.
+                null terminated.
         """
-        self._iadd[True](bytes)
+        self._iadd[False](bytes)
 
     fn write[*Ts: Writable](inout self, *args: *Ts):
         """Write a sequence of Writable arguments to the provided Writer.

--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -855,7 +855,10 @@ struct String(
         """
         # TODO: maybe check byte by byte that there is no 0 ?
         # need Span.count() to be faster
-        debug_assert(bytes[-1] != 0, "byte Span must not be null terminated")
+        if len(bytes) > 0:
+            debug_assert(
+                bytes[-1] != 0, "byte Span must not be null terminated"
+            )
         self._iadd[False](bytes)
 
     fn write[*Ts: Writable](inout self, *args: *Ts):

--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -853,12 +853,6 @@ struct String(
             bytes: The byte span to write to this String. Must NOT be
                 null terminated.
         """
-        # TODO: maybe check byte by byte that there is no 0 ?
-        # need Span.count() to be faster
-        if len(bytes) > 0:
-            debug_assert(
-                bytes[-1] != 0, "byte Span must not be null terminated"
-            )
         self._iadd[False](bytes)
 
     fn write[*Ts: Writable](inout self, *args: *Ts):


### PR DESCRIPTION
Fix an unsafe assumption that the span is null terminated.