### PR TITLE
[stdlib] Fix inconsistency with `UnsafePointer[SIMD[bool]]`

### DIFF
--- a/stdlib/src/memory/unsafe_pointer.mojo
+++ b/stdlib/src/memory/unsafe_pointer.mojo
@@ -479,6 +479,23 @@ struct UnsafePointer[
             "both volatile and invariant cannot be set at the same time",
         ]()
 
+        # bool load unpacks bits differently depending on the width.
+        # This causes issues when doing stores and loads of different widths.
+        # Cast between uint8 to keep a consistent representation in memory.
+        # TODO: decide how/whether to pack SIMD[bool] bits in memory
+        @parameter
+        if type == DType.bool:
+            return (
+                self.bitcast[UInt8]()
+                .load[
+                    width=width,
+                    alignment=alignment,
+                    volatile=volatile,
+                    invariant=invariant,
+                ]()
+                .cast[type]()
+            )
+
         @parameter
         if is_nvidia_gpu() and sizeof[type]() == 1 and alignment == 1:
             # LLVM lowering to PTX incorrectly vectorizes loads for 1-byte types
@@ -784,6 +801,17 @@ struct UnsafePointer[
         constrained[
             alignment > 0, "alignment must be a positive integer value"
         ]()
+
+        # bool store packs bits differently depending on the width.
+        # This causes issues when doing stores and loads of different widths.
+        # Cast between uint8 to keep a consistent representation in memory.
+        # TODO: decide how/whether to pack SIMD[bool] bits in memory
+        @parameter
+        if type == DType.bool:
+            self.bitcast[UInt8]()._store[
+                alignment=alignment, volatile=volatile
+            ](val.cast[DType.uint8]())
+            return
 
         @parameter
         if volatile:


### PR DESCRIPTION
Fixes #2813 and #3229
This was originally fixed with `DTypePointer`, but regressed after it got removed.
I'm still curious about whether original behavior is intended or not, and what we want to do about the inconsistency (if anything).

`SIMD[bool]` does seem to be packed in memory, and I'm guessing that just carries over to `pop.store`/`pop.load`:
```mojo
var a = SIMD[DType.bool, 4](True)
var ptr = UnsafePointer.address_of(a)
print(ptr.bitcast[UInt8]().load())
# prints 15
```
Because of that, this fix may have unwanted consequences.

The solution in this PR is the same as before: it forces simd bools to be represented as bytes when doing stores/loads.
Doing it this way keeps simd bools consistent with the other dtypes when doing stores/loads of varying widths.

Maybe there's a way we could pack bools in a width-independent way, but i cant see that working with pointer offset.
we might want to have a separate method, or a parameter which keeps the original behavior.

Another thing i noticed, `bitwidthof[SIMD[DType.bool, 4]]()` returns `32`, so I'm really not sure what's intended here.

