### PR TITLE
[stdlib] [proposal] Add `DBuffer` type

### DIFF
--- a/stdlib/src/collections/dbuffer.mojo
+++ b/stdlib/src/collections/dbuffer.mojo
@@ -191,6 +191,9 @@ struct DBuffer[
         Args:
             list: The list to which the DBuffer refers.
 
+        Returns:
+            The owned DBuffer with the data.
+
         Examples:
 
         ```mojo

--- a/stdlib/src/collections/dbuffer.mojo
+++ b/stdlib/src/collections/dbuffer.mojo
@@ -1,0 +1,477 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Defines the DBuffer type."""
+
+
+from builtin.builtin_list import _lit_mut_cast
+from collections import InlineArray, List
+from memory import UnsafePointer
+from sys.info import bitwidthof
+from utils import Span
+
+
+@value
+struct _DBufferIter[
+    is_mutable: Bool, //,
+    T: CollectionElement,
+    origin: Origin[is_mutable].type,
+    forward: Bool = True,
+]:
+    """Iterator for DBuffer.
+
+    Parameters:
+        is_mutable: Whether the reference to the DBuffer is mutable.
+        T: The type of the elements in the DBuffer.
+        origin: The origin of the DBuffer.
+        forward: The iteration direction. `False` is backwards.
+    """
+
+    var index: Int
+    var src: DBuffer[T, origin]
+
+    @always_inline
+    fn __iter__(self) -> Self:
+        return self
+
+    @always_inline
+    fn __next__(inout self) -> ref [origin] T:
+        @parameter
+        if forward:
+            self.index += 1
+            return self.src[self.index - 1]
+        else:
+            self.index -= 1
+            return self.src[self.index]
+
+    @always_inline
+    fn __has_next__(self) -> Bool:
+        return self.__len__() > 0
+
+    @always_inline
+    fn __len__(self) -> Int:
+        @parameter
+        if forward:
+            return len(self.src) - self.index
+        else:
+            return self.index
+
+
+# TODO: decide whether DBuffer will be the entrypoint API for Python-like bytes
+# alias Bytes = DBuffer[Byte, _]
+# """A buffer of bytes."""
+
+
+struct DBuffer[
+    is_mutable: Bool, //,
+    T: CollectionElement,
+    origin: Origin[is_mutable].type,
+](CollectionElementNew):
+    """A potentially owning view of contiguous data.
+
+    Parameters:
+        is_mutable: Whether the DBuffer is mutable.
+        T: The type of the elements in the DBuffer.
+        origin: The origin of the DBuffer.
+
+    Examples:
+
+    ```mojo
+    %# from collections.dbuffer import DBuffer
+    fn parse(
+        owned buf: DBuffer[Byte], encoding: String = "utf-8"
+    ) raises -> String:
+        if encoding == "utf-16":
+            ...
+        elif encoding == "utf-8":
+            debug_assert(
+                len(buf) > 0 and buf[-1] == 0,
+                "parser expects null terminated data"
+            )
+            return String(ptr=buf.steal_data(), length=len(buf))
+        else:
+            raise Error("Unsupported encoding")
+
+    fn main() raises:
+        l1 = List[Byte](ord("h"), ord("i"), 0)
+        # l1 gets implicitly built into a DBuffer that doesn't own the data.
+        # Since the DBuffer doesn't own the data, the method steal_data()
+        # makes a copy of the data to pass as owned to the String constructor
+        print(parse(l1)) # hi
+        # Passing an owned DBuffer makes the .steal_data() inside the parse
+        # method not allocate
+        print(parse(DBuffer[origin=MutableAnyOrigin].own(l1^))) # hi
+        # the compiler won't let you use l1 beyond this point
+    ```
+    """
+
+    alias _intwidth = bitwidthof[Int]()
+    alias _shift = Self._intwidth - 1
+    alias _len_mask = 0x7F_FF if Self._intwidth == 32 else 0x7F_FF_FF_FF
+    alias _max_length = 2**Self._shift
+    var _data: UnsafePointer[T]
+    var _len: UInt
+
+    # ===------------------------------------------------------------------===#
+    # Life cycle methods
+    # ===------------------------------------------------------------------===#
+
+    @always_inline
+    fn __init__(
+        out self,
+        *,
+        ptr: UnsafePointer[T],
+        length: UInt,
+        self_is_owner: Bool = False,
+        is_stack_alloc: Bool = False,
+    ):
+        """Unsafe construction from a pointer and length.
+
+        Args:
+            ptr: The underlying pointer of the DBuffer.
+            length: The length of the view.
+            self_is_owner: Whether the DBuffer instance is the owner of the
+                data.
+            is_stack_alloc: Whether the pointer is a stack allocation.
+
+        Notes:
+            If `is_stack_alloc` is True, then the `is_owner` bit is set to
+            False.
+        """
+
+        debug_assert(
+            length <= Self._max_length, "length must be <= ", Self._max_length
+        )
+        self._data = ptr
+        self._len = length | (
+            UInt(self_is_owner and not is_stack_alloc) << Self._shift
+        )
+
+    @always_inline
+    fn __init__(out self, *, other: Self):
+        """Explicitly construct a deep copy of the provided DBuffer.
+
+        Args:
+            other: The DBuffer to copy.
+        """
+
+        var o_len = len(other)
+        var buf = UnsafePointer[T].alloc(o_len)
+        for i in range(o_len):
+            buf[i] = other._data[i]
+        self = Self(ptr=buf, length=o_len, self_is_owner=True)
+
+    @always_inline
+    @implicit
+    fn __init__(out self, ref [origin]list: List[T, *_]):
+        """Construct a DBuffer from a List.
+
+        Args:
+            list: The list to which the DBuffer refers.
+        """
+        self = Self(ptr=list.unsafe_ptr(), length=len(list))
+
+    # TODO: this needs some sort of "SelfOrigin" which binds it to the
+    # variable that holds it
+    # TODO: this can potentially be abstracted over a `Stealable` trait
+    @always_inline
+    @staticmethod
+    fn own(owned list: List[T, *_]) -> Self:
+        """Construct a DBuffer from an owned List.
+
+        Args:
+            list: The list to which the DBuffer refers.
+
+        Examples:
+
+        ```mojo
+        %# from collections.dbuffer import DBuffer
+        l1 = List[Int](1, 2, 3, 4, 5, 6, 7)
+        s1 = DBuffer[origin=MutableAnyOrigin].own(l1^)
+        ```
+        """
+        var l_len = len(list)  # to avoid steal_data() which sets it to 0
+        return Self(ptr=list.steal_data(), length=l_len, self_is_owner=True)
+
+    @always_inline
+    @implicit
+    fn __init__[
+        size: Int, //
+    ](inout self, ref [origin]array: InlineArray[T, size]):
+        """Construct a DBuffer from an InlineArray.
+
+        Parameters:
+            size: The size of the InlineArray.
+
+        Args:
+            array: The array to which the DBuffer refers.
+        """
+        self = Self(
+            ptr=UnsafePointer.address_of(array).bitcast[T](), length=UInt(size)
+        )
+
+    @always_inline
+    @implicit
+    fn __init__(out self, span: Span[T, origin]):
+        """Construct a DBuffer from a Span.
+
+        Args:
+            span: The span from which to construct a DBuffer.
+        """
+        self = Self(ptr=span.unsafe_ptr(), length=len(span))
+
+    fn __moveinit__(out self, owned existing: Self):
+        """Move data of an existing DBuffer into a new one.
+
+        Args:
+            existing: The existing DBuffer.
+        """
+        self._data = existing._data
+        self._len = existing._len
+
+    fn __copyinit__(out self, existing: Self):
+        """Creates a shallow non-owning copy of the given DBuffer.
+
+        Args:
+            existing: The DBuffer to copy.
+        """
+        self = Self(ptr=existing.unsafe_ptr(), length=len(existing))
+
+    fn __del__(owned self):
+        """If self.is_owner(), destroy all elements in the DBuffer and free its
+        memory."""
+
+        if self.is_owner():
+            for i in range(len(self)):
+                (self._data + i).destroy_pointee()
+            self._data.free()
+
+    # ===------------------------------------------------------------------===#
+    # Operator dunders
+    # ===------------------------------------------------------------------===#
+
+    @always_inline
+    fn __getitem__(self, idx: Int) -> ref [origin] T:
+        """Get a reference to an element in the DBuffer.
+
+        Args:
+            idx: The index of the value to return.
+
+        Returns:
+            An element reference.
+        """
+
+        # TODO: use normalize_index
+        debug_assert(
+            -len(self) <= int(idx) < len(self), "index must be within bounds"
+        )
+        var offset = idx
+        if offset < 0:
+            offset += len(self)
+        return self._data[offset]
+
+    @always_inline
+    fn __getitem__(self, slc: Slice) -> Self:
+        """Get a new DBuffer from a slice of the current DBuffer.
+
+        Args:
+            slc: The slice specifying the range of the new subslice.
+
+        Returns:
+            A new DBuffer that points to the same data as the current DBuffer.
+
+        Notes:
+            If the step is not 1, this allocates a new buffer which owns the
+            data.
+        """
+
+        start, end, step = slc.indices(len(self))
+
+        if step == 1:
+            return Self(ptr=self._data + start, length=end - start)
+
+        var new_len = len(range(start, end, step))
+        var buf = UnsafePointer[T].alloc(new_len)
+        var i = 0
+        # TODO: DType branch using memcpy
+
+        if step < 0:
+            while start > end:
+                buf[i] = self._data[start]
+                start += step
+                i += 1
+            return Self(ptr=buf, length=new_len, self_is_owner=True)
+
+        while start < end:
+            buf[i] = self._data[start]
+            start += step
+            i += 1
+        return Self(ptr=buf, length=new_len, self_is_owner=True)
+
+    @always_inline
+    fn __iter__(self) -> _DBufferIter[T, origin]:
+        """Get an iterator over the elements of the DBuffer.
+
+        Returns:
+            An iterator over the elements of the DBuffer.
+        """
+        return _DBufferIter(0, self)
+
+    # ===------------------------------------------------------------------===#
+    # Trait implementations
+    # ===------------------------------------------------------------------===#
+
+    @always_inline
+    fn __len__(self) -> Int:
+        """Returns the length of the DBuffer. This is a known constant value.
+
+        Returns:
+            The size of the DBuffer.
+        """
+        return int(self._len) & Self._len_mask
+
+    fn __bool__(self) -> Bool:
+        """Check if a DBuffer is non-empty.
+
+        Returns:
+            True if a DBuffer is non-empty, False otherwise.
+        """
+        return len(self) > 0
+
+    # This decorator informs the compiler that indirect address spaces are not
+    # dereferenced by the method.
+    # TODO: replace with a safe model that checks the body of the method for
+    # accesses to the origin.
+    @__unsafe_disable_nested_origin_exclusivity
+    fn __eq__[
+        T: EqualityComparableCollectionElement, //
+    ](self: DBuffer[T, origin], rhs: DBuffer[T]) -> Bool:
+        """Verify if DBuffer is equal to another DBuffer.
+
+        Parameters:
+            T: The type of the elements in the DBuffer. Must implement the
+                traits `EqualityComparable` and `CollectionElement`.
+
+        Args:
+            rhs: The DBuffer to compare against.
+
+        Returns:
+            True if the DBuffers are equal in length and contain the same
+            elements, False otherwise.
+        """
+        # both empty
+        if not self and not rhs:
+            return True
+        if len(self) != len(rhs):
+            return False
+        # same pointer and length, so equal
+        if self.unsafe_ptr() == rhs.unsafe_ptr():
+            return True
+
+        # TODO: DType branch using memcmp
+        for i in range(len(self)):
+            if self[i] != rhs[i]:
+                return False
+        return True
+
+    @always_inline
+    fn __ne__[
+        T: EqualityComparableCollectionElement, //
+    ](self: DBuffer[T, origin], rhs: DBuffer[T]) -> Bool:
+        """Verify if DBuffer is not equal to another DBuffer.
+
+        Parameters:
+            T: The type of the elements in the DBuffer. Must implement the
+              traits `EqualityComparable` and `CollectionElement`.
+
+        Args:
+            rhs: The DBuffer to compare against.
+
+        Returns:
+            True if the DBuffers are not equal in length or contents, False
+            otherwise.
+        """
+        return not self == rhs
+
+    # ===------------------------------------------------------------------===#
+    # Methods
+    # ===------------------------------------------------------------------===#
+
+    @always_inline("nodebug")
+    fn unsafe_ptr(self) -> UnsafePointer[T]:
+        """Gets a pointer to the first element of this DBuffer.
+
+        Returns:
+            A pointer pointing at the first element of this DBuffer.
+        """
+        return self._data
+
+    @always_inline("nodebug")
+    fn is_owner(self) -> Bool:
+        """Whether the DBuffer is the owner of the data.
+
+        Returns:
+            Whether the DBuffer is the owner of the data.
+
+        Notes:
+            If the pointer is stack allocated, this will always return False.
+        """
+        return bool(self._len >> Self._shift)
+
+    fn steal_data(inout self) -> UnsafePointer[T]:
+        """Take ownership of the underlying pointer from the DBuffer if
+        `self.is_owner()`, otherwise create a deep copy.
+
+        Returns:
+            The underlying data if `self.is_owner()`, otherwise a deep copy.
+
+        Notes:
+            The DBuffer will still work as a non owning reference to the data.
+            In the case that the DBuffer's pointer was stack allocated, this
+            will copy the data to a new pointer in the heap.
+        """
+
+        if self.is_owner():
+            self._len &= Self._len_mask
+            return self.unsafe_ptr()
+
+        var s_len = len(self)
+        var buf = UnsafePointer[T].alloc(s_len)
+        # TODO: DType branch using memcpy
+        for i in range(s_len):
+            (buf + i).init_pointee_copy(self[i])
+        return buf
+
+    fn get_immutable(self) -> DBuffer[T, _lit_mut_cast[origin, False].result]:
+        """Return an immutable version of this DBuffer.
+
+        Returns:
+            A DBuffer covering the same elements, but without mutability.
+        """
+        return DBuffer[T, _lit_mut_cast[origin, False].result](
+            ptr=self.unsafe_ptr(), length=len(self)
+        )
+
+    fn fill[origin: MutableOrigin, //](self: DBuffer[T, origin], value: T):
+        """Fill the memory that a DBuffer references with a given value.
+
+        Parameters:
+            origin: The inferred mutable origin of the data within the DBuffer.
+
+        Args:
+            value: The value to assign to each element.
+        """
+
+        var ptr = self.unsafe_ptr()
+        # TODO: DType branch using memset
+        for i in range(len(self)):
+            ptr[i] = value

--- a/stdlib/src/collections/dbuffer.mojo
+++ b/stdlib/src/collections/dbuffer.mojo
@@ -112,6 +112,7 @@ struct DBuffer[
         print(parse(DBuffer[origin=MutableAnyOrigin].own(l1^))) # hi
         # the compiler won't let you use l1 beyond this point
     ```
+    .
     """
 
     alias _intwidth = bitwidthof[Int]()
@@ -201,6 +202,7 @@ struct DBuffer[
         l1 = List[Int](1, 2, 3, 4, 5, 6, 7)
         s1 = DBuffer[origin=MutableAnyOrigin].own(l1^)
         ```
+        .
         """
         var l_len = len(list)  # to avoid steal_data() which sets it to 0
         return Self(ptr=list.steal_data(), length=l_len, self_is_owner=True)

--- a/stdlib/test/collections/test_dbuffer.mojo
+++ b/stdlib/test/collections/test_dbuffer.mojo
@@ -1,0 +1,243 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# RUN: %mojo %s
+
+from collections import InlineArray, List
+from testing import assert_equal, assert_true
+
+from collections.dbuffer import DBuffer
+
+
+def test_dbuffer_list_init_trivial():
+    # test taking ownership
+    var l1 = List[Int](1, 2, 3, 4, 5, 6, 7)
+    var l1_copy = List(other=l1)
+    var s1 = DBuffer[origin=MutableAnyOrigin].own(l1^)
+    assert_true(s1.is_owner())
+    assert_equal(len(s1), len(l1_copy))
+    for i in range(len(s1)):
+        assert_equal(l1_copy[i], s1[i])
+    # subslice
+    var slice_1 = s1[2:]
+    assert_true(not slice_1.is_owner())
+    assert_equal(slice_1[0], l1_copy[2])
+    assert_equal(slice_1[1], l1_copy[3])
+    assert_equal(slice_1[2], l1_copy[4])
+    assert_equal(slice_1[3], l1_copy[5])
+    assert_equal(s1[-1], l1_copy[-1])
+
+    # test non owning Buffer
+    var l2 = List[Int](1, 2, 3, 4, 5, 6, 7)
+    var s2 = DBuffer(l2)
+    assert_true(not s2.is_owner())
+    assert_equal(len(s2), len(l2))
+    for i in range(len(s2)):
+        assert_equal(l2[i], s2[i])
+    # subslice
+    var slice_2 = s2[2:]
+    assert_true(not slice_2.is_owner())
+    assert_equal(slice_2[0], l2[2])
+    assert_equal(slice_2[1], l2[3])
+    assert_equal(slice_2[2], l2[4])
+    assert_equal(slice_2[3], l2[5])
+    assert_equal(s2[-1], l2[-1])
+
+    # Test mutation
+    s2[0] = 9
+    assert_equal(s2[0], 9)
+    assert_equal(l2[0], 9)
+
+    s2[-1] = 0
+    assert_equal(s2[-1], 0)
+    assert_equal(l2[-1], 0)
+
+
+def test_dbuffer_list_init_memory():
+    # test taking ownership
+    var l1 = List[String]("a", "b", "c", "d", "e", "f", "g")
+    var l1_copy = List(other=l1)
+    var s1 = DBuffer[origin=MutableAnyOrigin].own(l1^)
+    assert_true(s1.is_owner())
+    assert_equal(len(s1), len(l1_copy))
+    for i in range(len(s1)):
+        assert_equal(l1_copy[i], s1[i])
+    # subslice
+    var slice_1 = s1[2:]
+    assert_true(not slice_1.is_owner())
+    assert_equal(slice_1[0], l1_copy[2])
+    assert_equal(slice_1[1], l1_copy[3])
+    assert_equal(slice_1[2], l1_copy[4])
+    assert_equal(slice_1[3], l1_copy[5])
+
+    # test non owning Buffer
+    var l2 = List[String]("a", "b", "c", "d", "e", "f", "g")
+    var s2 = DBuffer(l2)
+    assert_true(not s2.is_owner())
+    assert_equal(len(s2), len(l2))
+    for i in range(len(s2)):
+        assert_equal(l2[i], s2[i])
+    # subslice
+    var slice_2 = s2[2:]
+    assert_true(not slice_2.is_owner())
+    assert_equal(slice_2[0], l2[2])
+    assert_equal(slice_2[1], l2[3])
+    assert_equal(slice_2[2], l2[4])
+    assert_equal(slice_2[3], l2[5])
+
+    # Test mutation
+    s2[0] = "h"
+    assert_equal(s2[0], "h")
+    assert_equal(l2[0], "h")
+
+    s2[-1] = "i"
+    assert_equal(s2[-1], "i")
+    assert_equal(l2[-1], "i")
+
+
+def test_dbuffer_array_int():
+    var l = InlineArray[Int, 7](1, 2, 3, 4, 5, 6, 7)
+    var s = DBuffer[Int](array=l)
+    assert_equal(len(s), len(l))
+    for i in range(len(s)):
+        assert_equal(l[i], s[i])
+    # subslice
+    var s2 = s[2:]
+    assert_equal(s2[0], l[2])
+    assert_equal(s2[1], l[3])
+    assert_equal(s2[2], l[4])
+    assert_equal(s2[3], l[5])
+
+    # Test mutation
+    s[0] = 9
+    assert_equal(s[0], 9)
+    assert_equal(l[0], 9)
+
+    s[-1] = 0
+    assert_equal(s[-1], 0)
+    assert_equal(l[-1], 0)
+
+
+def test_dbuffer_array_str():
+    var l = InlineArray[String, 7]("a", "b", "c", "d", "e", "f", "g")
+    var s = DBuffer[String](array=l)
+    assert_true(not s.is_owner())
+    assert_equal(len(s), len(l))
+    for i in range(len(s)):
+        assert_equal(l[i], s[i])
+    # subslice
+    var s2 = s[2:]
+    assert_equal(s2[0], l[2])
+    assert_equal(s2[1], l[3])
+    assert_equal(s2[2], l[4])
+    assert_equal(s2[3], l[5])
+
+    # Test mutation
+    s[0] = "h"
+    assert_equal(s[0], "h")
+    assert_equal(l[0], "h")
+
+    s[-1] = "i"
+    assert_equal(s[-1], "i")
+    assert_equal(l[-1], "i")
+
+
+def test_indexing():
+    var l = InlineArray[Int, 7](1, 2, 3, 4, 5, 6, 7)
+    var s = DBuffer[Int](array=l)
+    assert_equal(s[True], 2)
+    assert_equal(s[int(0)], 1)
+    assert_equal(s[3], 4)
+
+
+def test_dbuffer_slice():
+    def compare(s: DBuffer[Int], l: List[Int]) -> Bool:
+        if len(s) != len(l):
+            return False
+        for i in range(len(s)):
+            if s[i] != l[i]:
+                return False
+        return True
+
+    var l = List(1, 2, 3, 4, 5)
+    var s = DBuffer(l)
+    var res = s[1:2]
+    assert_equal(res[0], 2)
+    res = s[1:-1:1]
+    assert_equal(res[0], 2)
+    assert_equal(res[1], 3)
+    assert_equal(res[2], 4)
+    # Test slicing with negative step
+    res = s[1::-1]
+    assert_equal(res[0], 2)
+    assert_equal(res[1], 1)
+    res = s[2:1:-1]
+    assert_equal(res[0], 3)
+    assert_equal(len(res), 1)
+    res = s[5:1:-2]
+    assert_equal(res[0], 5)
+    assert_equal(res[1], 3)
+
+
+def test_bool():
+    var l = InlineArray[String, 7]("a", "b", "c", "d", "e", "f", "g")
+    var s = DBuffer[String](l)
+    assert_true(s)
+    assert_true(not s[0:0])
+
+
+def test_equality():
+    var l = InlineArray[String, 7]("a", "b", "c", "d", "e", "f", "g")
+    var l2 = List[String]("a", "b", "c", "d", "e", "f", "g")
+    var sp = DBuffer[String](l)
+    var sp2 = DBuffer[String](l)
+    var sp3 = DBuffer(l2)
+    # same pointer
+    assert_true(sp == sp2)
+    # different pointer
+    assert_true(sp == sp3)
+    # different length
+    assert_true(sp != sp3[:-1])
+    # empty
+    assert_true(sp[0:0] == sp3[0:0])
+
+
+def test_fill():
+    var l1 = List[Int](0, 1, 2, 3, 4, 5, 6, 7, 8)
+    var s1 = DBuffer(l1)
+
+    s1.fill(2)
+
+    for i in range(len(l1)):
+        assert_equal(l1[i], 2)
+        assert_equal(s1[i], 2)
+
+    var l2 = List[String]("a", "b", "c", "d", "e", "f", "g")
+    var s2 = DBuffer(l2)
+
+    s2.fill("hi")
+
+    for i in range(len(s2)):
+        assert_equal(l2[i], "hi")
+        assert_equal(s2[i], "hi")
+
+
+def main():
+    test_dbuffer_list_init_trivial()
+    test_dbuffer_list_init_memory()
+    test_dbuffer_array_int()
+    test_dbuffer_array_str()
+    test_indexing()
+    test_dbuffer_slice()
+    test_bool()
+    test_equality()
+    test_fill()


### PR DESCRIPTION
# Add `DBuffer` type
Closes #3797

This is a proof of concept and a potential approach to add  the type. Another suggested approach was using `Variant[List[T], Span[T]]` but because of complications with the current origin system and the amount of branching that `Variant` introduces, the current approach is to just use 1 bit from the `_len` field to store an ownership flag.

This can potentially become a more generic version of Python's `bytes`/`bytearray`. Many APIs will benefit from being able to dynamically take ownership of data instead of copying, while also allowing mutable or immutable `Span`s as an input. This also allows abstracting over `InlineArray` by using `DBuffer`'s constructor. Any stack allocated pointer can also be used.

This type can also be potentially phagocytized by `List`, becoming it's underlying mechanism to signal ownership. And as such allow shallow copies of `List` in its `__copyinit__` and deep copies in its `List(other=other_list)` constructor. This is an alternative that seems very compelling to me since it will give "free" (at the cost of the flag handling) performance improvements to many programs. One thing that holds this back is the current clunkyness of parametrized origins.

```mojo
struct DBuffer[
    is_mutable: Bool, //,
    T: CollectionElement,
    origin: Origin[is_mutable].type,
](CollectionElementNew):
    """A potentially owning view of contiguous data.

    Parameters:
        is_mutable: Whether the DBuffer is mutable.
        T: The type of the elements in the DBuffer.
        origin: The origin of the DBuffer.

    Examples:

    ```mojo
    %# from collections.dbuffer import DBuffer
    fn parse(
        owned buf: DBuffer[Byte], encoding: String = "utf-8"
    ) raises -> String:
        if encoding == "utf-16":
            ...
        elif encoding == "utf-8":
            debug_assert(
                len(buf) > 0 and buf[-1] == 0,
                "parser expects null terminated data"
            )
            return String(ptr=buf.steal_data(), length=len(buf))
        else:
            raise Error("Unsupported encoding")

    fn main() raises:
        l1 = List[Byte](ord("h"), ord("i"), 0)
        # l1 gets implicitly built into a DBuffer that doesn't own the data.
        # Since the DBuffer doesn't own the data, the method steal_data()
        # makes a copy of the data to pass as owned to the String constructor
        print(parse(l1)) # hi
        # Passing an owned DBuffer makes the .steal_data() inside the parse
        # method not allocate
        print(parse(DBuffer[origin=MutableAnyOrigin].own(l1^))) # hi
        # the compiler won't let you use l1 beyond this point
    ```
    """

    alias _intwidth = bitwidthof[Int]()
    alias _shift = Self._intwidth - 1
    alias _len_mask = 0x7F_FF if Self._intwidth == 32 else 0x7F_FF_FF_FF
    alias _max_length = 2**Self._shift
    var _data: UnsafePointer[T]
    var _len: UInt

    ...
```

PS: I wanted to name this type `Buffer`, but a `Buffer` type already exists