### PR TITLE
[stdlib] Integrate `hint_trivial_type` in `List.__copyinit__`

### DIFF
--- a/stdlib/benchmarks/collections/bench_list.mojo
+++ b/stdlib/benchmarks/collections/bench_list.mojo
@@ -1,0 +1,88 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2024, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# RUN: %mojo-no-debug %s -t
+# NOTE: to test changes on the current branch using run-benchmarks.sh, remove
+# the -t flag. Remember to replace it again before pushing any code.
+
+from benchmark import Bench, BenchConfig, Bencher, BenchId, Unit, keep, run
+from memory import UnsafePointer
+from random import seed
+from collections import List
+from collections import Dict
+from time import now
+
+
+def benchmark_list_hint_trivial_type_int[length: Int, iterations: Int]() -> Int:
+    var start = now()
+    var stop = now()
+    alias size = length
+
+    var items = List[Int, True]()
+    for i in range(size):
+        items.append(i)
+
+    start = now()
+    for iter in range(iterations):
+        var items2 = items
+        keep(items2.data)
+    stop = now()
+    keep(items.data)
+    return stop - start
+
+
+def benchmark_string_copyinit__[length: Int, iterations: Int]() -> Int:
+    var start = now()
+    var stop = now()
+
+    var x: String = ""
+    for l in range(length):
+        x += str(l)[0]
+
+    start = now()
+    for iter in range(iterations):
+        var y: String
+        String.__copyinit__(y, x)
+        keep(y._buffer.data)
+    stop = now()
+    keep(x._buffer.data)
+    return stop - start
+
+
+def main():
+    seed()
+
+    alias iterations = 1 << 10
+
+    alias result_type = Dict[String, Int]
+    var results = Dict[String, result_type]()
+    results["list_hint_trivial_type"] = result_type()
+    results["string_copyinit"] = result_type()
+
+    alias lengths = (1, 2, 4, 8, 16, 32, 128, 256, 512, 1024, 2048, 4096)
+
+    @parameter
+    for i in range(len(lengths)):
+        alias length = lengths.get[i, Int]()
+        results["list_hint_trivial_type"][
+            str(length)
+        ] = benchmark_list_hint_trivial_type_int[length, iterations]()
+        results["string_copyinit"][str(length)] = benchmark_string_copyinit__[
+            length, iterations
+        ]()
+
+    print("iterations: ", iterations)
+    for benchmark in results:
+        print(benchmark[])
+        for result in results[benchmark[]]:
+            print("\t", result[], "\t", results[benchmark[]][result[]])
+        print()

--- a/stdlib/benchmarks/collections/bench_list.mojo
+++ b/stdlib/benchmarks/collections/bench_list.mojo
@@ -68,14 +68,12 @@ fn bench_list_copyinit[
 
 
 def main():
-    seed()
-
     var m = Bench(
         BenchConfig(
             num_repetitions=1,
             max_runtime_secs=0.5,
             min_runtime_secs=0.25,
-            min_warmuptime_secs=0,  # 0.25
+            min_warmuptime_secs=0,  #FIXME: adjust the values
         )
     )
     alias lengths = (1, 2, 4, 8, 16, 32, 128, 256, 512, 1024, 2048, 4096)

--- a/stdlib/benchmarks/collections/bench_list.mojo
+++ b/stdlib/benchmarks/collections/bench_list.mojo
@@ -73,7 +73,7 @@ def main():
             num_repetitions=1,
             max_runtime_secs=0.5,
             min_runtime_secs=0.25,
-            min_warmuptime_secs=0,  #FIXME: adjust the values
+            min_warmuptime_secs=0,  # FIXME: adjust the values
         )
     )
     alias lengths = (1, 2, 4, 8, 16, 32, 128, 256, 512, 1024, 2048, 4096)

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -206,8 +206,14 @@ struct List[T: CollectionElement, hint_trivial_type: Bool = False](
             existing: The list to copy.
         """
         self = Self(capacity=existing.capacity)
-        for i in range(len(existing)):
-            self.append(existing[i])
+
+        @parameter
+        if hint_trivial_type:
+            memcpy(self.data, existing.data, len(existing))
+            self.size = existing.size
+        else:
+            for i in range(len(existing)):
+                self.append(existing[i])
 
     fn __del__(owned self):
         """Destroy all elements in the list and free its memory."""

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -936,7 +936,7 @@ def test_list_repr():
     assert_equal(empty.__repr__(), "[]")
 
 
-def test_copyinit_trivial_types[dt: DType, hint_trivial_type:Bool]():
+def test_copyinit_trivial_types[dt: DType, hint_trivial_type: Bool]():
     alias sizes = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512)
     assert_equal(len(sizes), 10)
     var test_current_size = 1

--- a/stdlib/test/collections/test_list.mojo
+++ b/stdlib/test/collections/test_list.mojo
@@ -18,6 +18,7 @@ from sys.info import sizeof
 from memory import UnsafePointer, Span
 from test_utils import CopyCounter, MoveCounter
 from testing import assert_equal, assert_false, assert_raises, assert_true
+from testing import assert_not_equal
 
 
 def test_mojo_issue_698():
@@ -935,6 +936,48 @@ def test_list_repr():
     assert_equal(empty.__repr__(), "[]")
 
 
+def test_copyinit_trivial_types[dt: DType, hint_trivial_type:Bool]():
+    alias sizes = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512)
+    assert_equal(len(sizes), 10)
+    var test_current_size = 1
+
+    @parameter
+    for sizes_index in range(len(sizes)):
+        alias current_size = sizes.get[sizes_index, Int]()
+        x = List[Scalar[dt], hint_trivial_type]()
+        for i in range(current_size):
+            x.append(i)
+        y = x
+        assert_equal(test_current_size, current_size)
+        assert_equal(len(y), current_size)
+        assert_not_equal(int(x.data), int(y.data))
+        for i in range(current_size):
+            assert_equal(i, x[i])
+            assert_equal(y[i], x[i])
+        test_current_size *= 2
+    assert_equal(test_current_size, 1024)
+
+
+def test_copyinit_trivial_types_dtypes():
+    alias dtypes = (
+        DType.int64,
+        DType.int32,
+        DType.float64,
+        DType.float32,
+        DType.uint8,
+        DType.int8,
+        DType.bool,
+    )
+    var test_index_dtype = 0
+
+    @parameter
+    for index_dtype in range(len(dtypes)):
+        test_copyinit_trivial_types[dtypes.get[index_dtype, DType](), True]()
+        test_copyinit_trivial_types[dtypes.get[index_dtype, DType](), False]()
+        test_index_dtype += 1
+    assert_equal(test_index_dtype, 7)
+
+
 # ===-------------------------------------------------------------------===#
 # main
 # ===-------------------------------------------------------------------===#
@@ -974,3 +1017,4 @@ def main():
     test_list_dtor()
     test_destructor_trivial_elements()
     test_list_repr()
+    test_copyinit_trivial_types_dtypes()

--- a/stdlib/test/collections/test_string.mojo
+++ b/stdlib/test/collections/test_string.mojo
@@ -1593,6 +1593,26 @@ def test_reserve():
     assert_equal(s._buffer.capacity, 1)
 
 
+def test_copyinit():
+    alias sizes = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512)
+    assert_equal(len(sizes), 10)
+    var test_current_size = 1
+
+    @parameter
+    for sizes_index in range(len(sizes)):
+        alias current_size = sizes.get[sizes_index, Int]()
+        x = String("")
+        for i in range(current_size):
+            x += str(i)[0]
+        y = x
+        assert_equal(x._buffer, y._buffer)
+        assert_equal(test_current_size, current_size)
+        assert_equal(len(y), current_size)
+        assert_not_equal(int(x._buffer.data), int(y._buffer.data))
+        test_current_size *= 2
+    assert_equal(test_current_size, 1024)
+
+
 def main():
     test_constructors()
     test_copy()
@@ -1649,3 +1669,4 @@ def main():
     test_center()
     test_float_conversion()
     test_slice_contains()
+    test_copyinit()


### PR DESCRIPTION
Hello, 
`List.__copyinit__ ` needed to implement `@parameter if hint_trivial_type`,
so here is a PR :+1: !

Because `String.__copyinit__` does `List.__copyinit__`,
and that it's buffer uses `hint_trivial_type`,
there is a nice speedup from it!

:partying_face:  nice speedup for:
  - `List[_, hint_trivial_type=True].__copyinit__ `
  - `String.__copyinit__` (57x, increase with length)
	(`var buffer: List[UInt8, hint_trivial_type=True]`)
  - `fn(**kwargs)` should be faster too !
	(see PR #3133, because it currently does `__copyinit__` of `DictEntry[K,V]`)
	(`_find_slot` just need to use `Pointer` :+1: )
  - More types that uses `hint_trivial_type=True` ?

I need to learn the `Benchmark`, but here is a simple one (`benchmarks/collections/bench_list`)
(please somebody help try to convert it to `Benchmark`)

Is it possible to check if it is faster or that the benchmark is good ?

The benchmark for `Int` is less than for `UInt8`, is it a bug ?
- (`4512122÷720588 = 6.2x`) for size `4096`
- (`5425619÷102102 = 53x`) for size `4096`


#### results PR:

```
iterations:  1024
list_hint_trivial_type
	 1		33281
	 2		43820
	 4		41106
	 8		28076
	 16		26829
	 32		27688
	 128	35084
	 256	46950
	 512	73477
	 1024	115724
	 2048	339350
	 4096	720588

string_copyinit
	 1		26295
	 2		28299
	 4		39899
	 8		40835
	 16		32544
	 32		27912
	 128	30006
	 256	31930
	 512	32685
	 1024	39246
	 2048	59733
	 4096	102102
```

#### results currently:

```
iterations:  1024
list_hint_trivial_type
	 1		43318
	 2		29643
	 4		30210
	 8		32667
	 16		42152
	 32		58145
	 128	157062
	 256	325332
	 512	534089
	 1024	1036117
	 2048	2079208
	 4096	4512122

string_copyinit
	 1		28839
	 2 	 	30548
	 4 	 	33308
	 8 	 	37221
	 16		47267
	 32		67287
	 128	190275
	 256	347621
	 512 	714950
	 1024 	1327402
	 2048 	2785542
	 4096	5425619
```