### PR TITLE
[stdlib] [NFC] Fix revert python format with ruff inside stdlib folder

### DIFF
--- a/stdlib/test/python/my_module.py
+++ b/stdlib/test/python/my_module.py
@@ -25,7 +25,8 @@ class Foo:
 
 class AbstractPerson(ABC):
     @abstractmethod
-    def method(self): ...
+    def method(self):
+        ...
 
 
 def my_function(name):


### PR DESCRIPTION
Revert d6fdf0cac5a987c030f5bc4da0f0bd9ba0ff112e , which used ruff formatter that is not the same as the mojo black formatter fork (I assume that's what was forked). It was making the public CI fail.

CC @keith