### PR TITLE
[stdlib] Fix allow implicit casting `MutableOrigin` -> `ImmutableOrigin` for `Span` and `StringSlice`

### DIFF
--- a/mojo/stdlib/src/builtin/sort.mojo
+++ b/mojo/stdlib/src/builtin/sort.mojo
@@ -216,11 +216,10 @@ fn _quicksort[
 
     # Work with an immutable span so we don't run into exclusivity problems with
     # the List[Span].
-    var imm_span = span.get_immutable()
-    alias ImmSpan = __type_of(imm_span)
+    alias ImmSpan = span.Immutable
 
     var stack = List[ImmSpan](capacity=_estimate_initial_height(size))
-    stack.append(imm_span)
+    stack.append(span)
     while len(stack) > 0:
         var imm_interval = stack.pop()
         var ptr = imm_interval.unsafe_ptr()
@@ -342,9 +341,7 @@ fn _stable_sort_impl[
         while j + merge_size < size:
             var span1 = span[j : j + merge_size]
             var span2 = span[j + merge_size : min(size, j + 2 * merge_size)]
-            _merge[cmp_fn](
-                span1.get_immutable(), span2.get_immutable(), temp_buff
-            )
+            _merge[cmp_fn](span1, span2, temp_buff)
             for i in range(merge_size + len(span2)):
                 span[j + i] = temp_buff[i]
             j += 2 * merge_size

--- a/mojo/stdlib/src/builtin/type_aliases.mojo
+++ b/mojo/stdlib/src/builtin/type_aliases.mojo
@@ -95,17 +95,15 @@ struct Origin[is_mutable: Bool]:
     # Life cycle methods
     # ===-------------------------------------------------------------------===#
 
-    # NOTE:
-    #   Needs to be @implicit convertible for the time being so that
-    #   `__origin_of(..)` can implicilty convert to `Origin` in use cases like:
-    #       Span[Byte, __origin_of(self)]
+    @doc_private
     @implicit
     @always_inline("builtin")
     fn __init__(out self, mlir_origin: Self._mlir_type):
         """Initialize an Origin from a raw MLIR `!lit.origin` value.
 
         Args:
-            mlir_origin: The raw MLIR origin value."""
+            mlir_origin: The raw MLIR origin value.
+        """
         self._mlir_origin = mlir_origin
 
 

--- a/mojo/stdlib/src/os/path/path.mojo
+++ b/mojo/stdlib/src/os/path/path.mojo
@@ -565,7 +565,7 @@ fn expandvars[PathLike: os.PathLike, //](path: PathLike) -> String:
         The expanded path.
     """
     var path_str = path.__fspath__()
-    var bytes = path_str.as_bytes().get_immutable()
+    var bytes = path_str.as_bytes()
     var buf = String()
 
     # Byte scanning should be fine, ${} is ASCII.


### PR DESCRIPTION
Fix allow implicit casting `MutableOrigin` -> `ImmutableOrigin` for `Span` and `StringSlice` by adding implicit constructors