### PR TITLE
[stdlib] Micro-optimize string `splitlines` and `isnewline`

### DIFF
--- a/stdlib/benchmarks/collections/bench_string.mojo
+++ b/stdlib/benchmarks/collections/bench_string.mojo
@@ -225,7 +225,7 @@ fn bench_string_is_valid_utf8[
 # ===----------------------------------------------------------------------===#
 def main():
     seed()
-    var m = Bench(BenchConfig(num_repetitions=5))
+    var m = Bench(BenchConfig(num_repetitions=1))
     alias filenames = (
         "UN_charter_EN",
         "UN_charter_ES",

--- a/stdlib/src/utils/string_slice.mojo
+++ b/stdlib/src/utils/string_slice.mojo
@@ -27,7 +27,7 @@ from collections.string import _isspace, _atol, _atof
 from collections import List, Optional
 from memory import memcmp, UnsafePointer, memcpy
 from sys import simdwidthof, bitwidthof
-from sys.intrinsics import unlikely
+from sys.intrinsics import unlikely, likely
 from memory.memory import _memcmp_impl_unconstrained
 from utils.format import _CurlyEntryFormattable, _FormatCurlyEntry
 from ._utf8_validation import _is_valid_utf8
@@ -910,40 +910,22 @@ struct StringSlice[is_mutable: Bool, //, origin: Origin[is_mutable].type,](
                 listed above, otherwise False.
         """
 
-        fn _is_newline_char(s: StringSlice) -> Bool:
-            # sorry for readability, but this has less overhead than memcmp
-            # highly performance sensitive code, benchmark before touching
-            alias `\t` = UInt8(ord("\t"))
-            alias `\r` = UInt8(ord("\r"))
-            alias `\n` = UInt8(ord("\n"))
-            alias `\x1c` = UInt8(ord("\x1c"))
-            alias `\x1e` = UInt8(ord("\x1e"))
-            no_null_len = s.byte_length()
-            ptr = s.unsafe_ptr()
-            if no_null_len == 1:
-                v = ptr[0]
-                return `\t` <= v <= `\x1e` and not (`\r` < v < `\x1c`)
-            elif no_null_len == 2:
-                v0 = ptr[0]
-                v1 = ptr[1]
-                next_line = v0 == 0xC2 and v1 == 0x85  # next line: \x85
-                r_n = v0 == `\r` and v1 == `\n`
-                return next_line or r_n
-            elif no_null_len == 3:
-                # unicode line sep or paragraph sep: \u2028 , \u2029
-                v2 = ptr[2]
-                lastbyte = v2 == 0xA8 or v2 == 0xA9
-                return ptr[0] == 0xE2 and ptr[1] == 0x80 and lastbyte
-            return False
+        var ptr = self.unsafe_ptr()
+        var length = self.byte_length()
 
         @parameter
         if single_character:
-            return _is_newline_char(self)
+            return length != 0 and _is_newline_char[include_r_n=True](
+                ptr, 0, ptr[0], length
+            )
         else:
+            var offset = 0
             for s in self:
-                if not _is_newline_char(s):
+                var b_len = s.byte_length()
+                if not _is_newline_char(ptr, offset, ptr[offset], b_len):
                     return False
-            return self.byte_length() != 0
+                offset += b_len
+            return length != 0
 
     fn splitlines[
         O: ImmutableOrigin, //
@@ -963,54 +945,41 @@ struct StringSlice[is_mutable: Bool, //, origin: Origin[is_mutable].type,](
             A List of Strings containing the input split by line boundaries.
         """
 
+        # highly performance sensitive code, benchmark before touching
         alias `\r` = UInt8(ord("\r"))
         alias `\n` = UInt8(ord("\n"))
-        alias `\t` = UInt8(ord("\t"))
-        alias `\x1c` = UInt8(ord("\x1c"))
-        alias `\x1e` = UInt8(ord("\x1e"))
-        output = List[StringSlice[O]](capacity=128)  # guessing
-        ptr = self.unsafe_ptr()
-        length = self.byte_length()
-        offset = 0
 
-        @always_inline
-        @parameter
-        fn _is_newline_char(p: UnsafePointer[Byte], l: Int, b0: Byte) -> Bool:
-            # sorry for readability, but this has less overhead than memcmp
-            # highly performance sensitive code, benchmark before touching
-            if l == 1:
-                return `\t` <= b0 <= `\x1e` and not (`\r` < b0 < `\x1c`)
-            elif l == 2:
-                return b0 == 0xC2 and p[1] == 0x85  # next line: \x85
-            elif l == 3:
-                # unicode line sep or paragraph sep: \u2028 , \u2029
-                v2 = p[2]
-                lastbyte = v2 == 0xA8 or v2 == 0xA9
-                return b0 == 0xE2 and p[1] == 0x80 and lastbyte
-            return False
+        output = List[StringSlice[O]](capacity=128)  # guessing
+        var ptr = self.unsafe_ptr()
+        var length = self.byte_length()
+        var offset = 0
 
         while offset < length:
-            eol_start = offset
-            eol_length = 0
+            var eol_start = offset
+            var eol_length = 0
 
             while eol_start < length:
-                b0 = ptr[eol_start]
-                char_len = _utf8_first_byte_sequence_length(b0)
+                var b0 = ptr[eol_start]
+                var char_len = _utf8_first_byte_sequence_length(b0)
                 debug_assert(
                     eol_start + char_len <= length,
                     "corrupted sequence causing unsafe memory access",
                 )
-                isnewline = int(_is_newline_char(ptr + eol_start, char_len, b0))
-                char_end = isnewline * (eol_start + char_len)
-                next_idx = char_end * int(char_end < length)
-                is_r_n = b0 == `\r` and next_idx != 0 and ptr[next_idx] == `\n`
-                eol_length = isnewline * char_len + int(is_r_n)
-                if unlikely(isnewline == 1):
+                var isnewline = unlikely(
+                    _is_newline_char(ptr, eol_start, b0, char_len)
+                )
+                var char_end = int(isnewline) * (eol_start + char_len)
+                var next_idx = char_end * int(char_end < length)
+                var is_r_n = b0 == `\r` and next_idx != 0 and ptr[
+                    next_idx
+                ] == `\n`
+                eol_length = int(isnewline) * char_len + int(is_r_n)
+                if isnewline:
                     break
                 eol_start += char_len
 
-            str_len = eol_start - offset + int(keepends) * eol_length
-            s = StringSlice[O](ptr=ptr + offset, length=str_len)
+            var str_len = eol_start - offset + int(keepends) * eol_length
+            var s = StringSlice[O](ptr=ptr + offset, length=str_len)
             output.append(s)
             offset = eol_start + eol_length
 
@@ -1115,3 +1084,41 @@ fn _to_string_list[
         return len(v)
 
     return _to_string_list[items.T, len_fn, unsafe_ptr_fn](items)
+
+
+@always_inline
+fn _is_newline_char[
+    include_r_n: Bool = False
+](p: UnsafePointer[Byte], eol_start: Int, b0: Byte, char_len: Int) -> Bool:
+    """Returns the eol character length or 0.
+
+    Safety:
+        This assumes valid utf-8 is passed.
+    """
+    # highly performance sensitive code, benchmark before touching
+    alias `\r` = UInt8(ord("\r"))
+    alias `\n` = UInt8(ord("\n"))
+    alias `\t` = UInt8(ord("\t"))
+    alias `\x1c` = UInt8(ord("\x1c"))
+    alias `\x1e` = UInt8(ord("\x1e"))
+
+    # here it's actually faster to have branching due to the branch predictor
+    # "realizing" that the char_len == 1 path is often taken. Using the likely
+    # intrinsic is to make the machine code be ordered to optimize machine
+    # instruction fetching, which is an optimization for the CPU front-end.
+    if likely(char_len == 1):
+        return `\t` <= b0 <= `\x1e` and not (`\r` < b0 < `\x1c`)
+    elif char_len == 2:
+        var b1 = p[eol_start + 1]
+        var is_next_line = b0 == 0xC2 and b1 == 0x85  # unicode next line \x85
+
+        @parameter
+        if include_r_n:
+            return is_next_line or (b0 == `\r` and b1 == `\n`)
+        else:
+            return is_next_line
+    elif char_len == 3:  # unicode line sep or paragraph sep: \u2028 , \u2029
+        var b1 = p[eol_start + 1]
+        var b2 = p[eol_start + 2]
+        return b0 == 0xE2 and b1 == 0x80 and (b2 == 0xA8 or b2 == 0xA9)
+    return False

--- a/stdlib/src/utils/string_slice.mojo
+++ b/stdlib/src/utils/string_slice.mojo
@@ -1090,7 +1090,7 @@ fn _to_string_list[
 fn _is_newline_char[
     include_r_n: Bool = False
 ](p: UnsafePointer[Byte], eol_start: Int, b0: Byte, char_len: Int) -> Bool:
-    """Returns the eol character length or 0.
+    """Returns whether the char is a newline char.
 
     Safety:
         This assumes valid utf-8 is passed.

--- a/stdlib/test/python/my_module.py
+++ b/stdlib/test/python/my_module.py
@@ -25,7 +25,8 @@ class Foo:
 
 class AbstractPerson(ABC):
     @abstractmethod
-    def method(self): ...
+    def method(self):
+        ...
 
 
 def my_function(name):


### PR DESCRIPTION
## Micro-optimize string `splitlines` and `isnewline`.

Benchmark results:

CPU: Intel® Core™ i7-7700HQ

improvement metric: markdown percentage improvement (`(old_value - new_value) / old_value`)

Average improvement: 1.2% . Many of the discrepancies are likely because of runtime (nano-second scale) pipelining (and other) differences during testing. The most robust estimates are the biggest tests which show around 4.2% improvement.

|Name                          | old_value (ms)           | new_value (ms)      | improvement|
|:-----------------------------|---------------------:|----------------:|------:|
|`bench_string_splitlines[10]` | 0.000100497059839818 | 0.00010261460376 | -2.11% |
|`bench_string_splitlines[30]` | 0.000171998352418428 | 0.000174028055158599 | -1.18% |
|`bench_string_splitlines[50]` | 0.000264958575880379 | 0.000251598931395228 | 5.04% |
|`bench_string_splitlines[100]` | 0.000417350538881514 | 0.000415764808815687 | 0.38% |
|`bench_string_splitlines[1000]` | 0.00320600819966129 | 0.00322517645847026 | -0.60% |
|`bench_string_splitlines[10000]` | 0.0302790238107332 | 0.0305872863513719 | -1.02% |
|`bench_string_splitlines[100000]` | 0.319274428592796 | 0.304513179279761 | 4.62% |
|`bench_string_splitlines[1000000]` | 3.24098357344348 | 3.10220707742267 | 4.28% |
