### PR TITLE
[CI] Format python with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
         name: mojo-format
         entry: mojo format
         language: system
-        files: '\.(mojo|🔥|py)$'
+        files: '\.(mojo|🔥)$'
         stages: [commit]
       - id: check-docstrings
         name: check-docstrings
@@ -24,3 +24,9 @@ repos:
     hooks:
     - id: markdownlint
       args: ['--config', 'stdlib/scripts/.markdownlint.yaml', '--fix']
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/examples/check_mod.py
+++ b/examples/check_mod.py
@@ -37,5 +37,5 @@ def install_if_missing(name: str):
             raise ImportError("python not on path" + FIX)
         subprocess.check_call([python, "-m", "pip", "install", name])
         return
-    except:
+    except subprocess.CalledProcessError:
         raise ImportError(f"{name} not found" + FIX)

--- a/examples/lit.cfg.py
+++ b/examples/lit.cfg.py
@@ -11,6 +11,8 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+# ruff: noqa
+
 import os
 from pathlib import Path
 
@@ -55,9 +57,9 @@ pre_built_packages_path = os.environ.get(
     / "mojo",
 )
 
-os.environ[
-    "MODULAR_MOJO_NIGHTLY_IMPORT_PATH"
-] = f"{build_root},{pre_built_packages_path}"
+os.environ["MODULAR_MOJO_NIGHTLY_IMPORT_PATH"] = (
+    f"{build_root},{pre_built_packages_path}"
+)
 
 # Pass through several environment variables
 # to the underlying subprocesses that run the tests.

--- a/examples/pymatmul.py
+++ b/examples/pymatmul.py
@@ -17,7 +17,7 @@ from timeit import timeit
 import check_mod
 
 check_mod.install_if_missing("numpy")
-import numpy as np
+import numpy as np  # noqa
 
 
 class PyMatrix:

--- a/examples/simple_interop.py
+++ b/examples/simple_interop.py
@@ -18,7 +18,7 @@
 import check_mod
 
 check_mod.install_if_missing("numpy")
-import numpy as np
+import numpy as np  # noqa
 
 
 def test_interop_func():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.ruff]
+line-length = 80

--- a/stdlib/benchmarks/lit.cfg.py
+++ b/stdlib/benchmarks/lit.cfg.py
@@ -11,6 +11,8 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+# ruff: noqa
+
 import os
 from pathlib import Path
 

--- a/stdlib/test/lit.cfg.py
+++ b/stdlib/test/lit.cfg.py
@@ -11,6 +11,8 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+# ruff: noqa
+
 import os
 import shutil
 from pathlib import Path


### PR DESCRIPTION
Ruff is a faster and more modern python formatter. This swaps out using
`mojo format` for python with ruff.
