### PR TITLE
[stdlib] Add `ListLiteral.__getitem__`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -292,6 +292,20 @@ what we publish.
   allows forming a runtime-constant StringLiteral from a compile-time-dynamic
   `Stringable` value.
 
+- Add a `__getitem__` dunder method to `ListLiteral`.
+  ([PR #3835](https://github.com/modularml/mojo/pull/3835) by [@rd4com](https://github.com/rd4com)).
+  
+  For example:
+  ```mojo
+  def main():
+      x = [0, 1.0, "two"]
+      print(
+          x[0] == 0,
+          x[1] == 1.0,
+          x[2] == "two"
+      )
+  ```
+
 ### 🦋 Changed
 
 - The `inout` and `borrowed` argument conventions have been renamed to the `mut`

--- a/stdlib/src/builtin/builtin_list.mojo
+++ b/stdlib/src/builtin/builtin_list.mojo
@@ -118,6 +118,33 @@ struct ListLiteral[*Ts: CollectionElement](Sized, CollectionElement):
         """
         return value in self.storage
 
+    @always_inline
+    fn __getitem__[
+        i: Int
+    ](ref self) -> ref [self.storage] __type_of(self.storage).element_types[
+        i.value
+    ]:
+        """Get a list element at the given index.
+
+        Parameters:
+            i: The element index.
+
+        Returns:
+            The element at the given index.
+
+        For example:
+        ```mojo
+        def main():
+            x = [0, 1.0, "two"]
+            print(
+                x[0] == 0,
+                x[1] == 1.0,
+                x[2] == "two"
+            )
+        ```.
+        """
+        return self.storage[i]
+
 
 # ===-----------------------------------------------------------------------===#
 # VariadicList / VariadicListMem

--- a/stdlib/test/builtin/test_list_literal.mojo
+++ b/stdlib/test/builtin/test_list_literal.mojo
@@ -12,7 +12,8 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo %s
 
-from testing import assert_equal, assert_false, assert_true
+from testing import assert_equal, assert_false, assert_true, assert_not_equal
+from sys.intrinsics import _type_is_eq
 
 
 def test_list():
@@ -66,7 +67,25 @@ def test_contains():
     assert_true("Mojo" not in h and String("Mojo") in h)
 
 
+def test_list_literal_dunder_getitem():
+    x = [0, True, 1.0, "two"]
+    assert_equal(x[0], 0)
+    assert_not_equal(x[0], 1)
+    assert_equal(x[1], True)
+    assert_not_equal(x[1], False)
+    assert_equal(x[2], 1.0)
+    assert_not_equal(x[2], 1.5)
+    assert_equal(x[3], "two")
+    assert_not_equal(x[3], "abc")
+
+    assert_true(_type_is_eq[__type_of(x[0]), Int]())
+    assert_true(_type_is_eq[__type_of(x[1]), Bool]())
+    assert_true(_type_is_eq[__type_of(x[2]), Float64]())
+    assert_true(_type_is_eq[__type_of(x[3]), StringLiteral]())
+
+
 def main():
     test_list()
     test_variadic_list()
     test_contains()
+    test_list_literal_dunder_getitem()


### PR DESCRIPTION
Hello,
just a small pr to add `__getitem__` to `ListLiteral` :+1: 

For example:
```mojo
def main():
    x = [0, 1.0, "two"]
    print(
        x[0] == 0,
        x[1] == 1.0,
        x[2] == "two"
    )
```

Does it needs the `@always_inline("nodebug")` like `Tuple` ?
