### PR TITLE
[stdlib] [NFC] Fix docstrings for `string.strip()` function family

### DIFF
--- a/stdlib/src/builtin/string_literal.mojo
+++ b/stdlib/src/builtin/string_literal.mojo
@@ -889,8 +889,9 @@ struct StringLiteral(
         return str(self).islower()
 
     fn strip(self) -> String:
-        """Return a copy of the string literal with leading and trailing whitespaces
-        removed.
+        """Return a copy of the string literal with leading and trailing
+        whitespaces removed. This only takes ASCII whitespace into account:
+        `" \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e"`.
 
         Returns:
             A string with no leading or trailing whitespaces.
@@ -922,7 +923,9 @@ struct StringLiteral(
         return str(self).rstrip(chars)
 
     fn rstrip(self) -> String:
-        """Return a copy of the string with trailing whitespaces removed.
+        """Return a copy of the string with trailing whitespaces removed. This
+        only takes ASCII whitespace into account:
+        `" \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e"`.
 
         Returns:
             A copy of the string with no trailing whitespaces.
@@ -941,7 +944,9 @@ struct StringLiteral(
         return str(self).lstrip(chars)
 
     fn lstrip(self) -> String:
-        """Return a copy of the string with leading whitespaces removed.
+        """Return a copy of the string with leading whitespaces removed. This
+        only takes ASCII whitespace into account:
+        `" \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e"`.
 
         Returns:
             A copy of the string with no leading whitespaces.

--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -1919,6 +1919,7 @@ struct String(
         """Return a copy of the string with leading and trailing characters
         removed.
 
+
         Args:
             chars: A set of characters to be removed. Defaults to whitespace.
 
@@ -1930,7 +1931,8 @@ struct String(
 
     fn strip(self) -> StringSlice[__origin_of(self)]:
         """Return a copy of the string with leading and trailing whitespaces
-        removed.
+        removed. This only takes ASCII whitespace into account:
+        `" \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e"`.
 
         Returns:
             A copy of the string with no leading or trailing whitespaces.
@@ -1950,7 +1952,9 @@ struct String(
         return self.as_string_slice().rstrip(chars)
 
     fn rstrip(self) -> StringSlice[__origin_of(self)]:
-        """Return a copy of the string with trailing whitespaces removed.
+        """Return a copy of the string with trailing whitespaces removed. This
+        only takes ASCII whitespace into account:
+        `" \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e"`.
 
         Returns:
             A copy of the string with no trailing whitespaces.
@@ -1970,7 +1974,9 @@ struct String(
         return self.as_string_slice().lstrip(chars)
 
     fn lstrip(self) -> StringSlice[__origin_of(self)]:
-        """Return a copy of the string with leading whitespaces removed.
+        """Return a copy of the string with leading whitespaces removed. This
+        only takes ASCII whitespace into account:
+        `" \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e"`.
 
         Returns:
             A copy of the string with no leading whitespaces.

--- a/stdlib/src/collections/string.mojo
+++ b/stdlib/src/collections/string.mojo
@@ -1919,7 +1919,6 @@ struct String(
         """Return a copy of the string with leading and trailing characters
         removed.
 
-
         Args:
             chars: A set of characters to be removed. Defaults to whitespace.
 

--- a/stdlib/src/utils/string_slice.mojo
+++ b/stdlib/src/utils/string_slice.mojo
@@ -638,7 +638,8 @@ struct StringSlice[is_mutable: Bool, //, origin: Origin[is_mutable]](
     @always_inline
     fn strip(self) -> Self:
         """Return a copy of the string with leading and trailing whitespaces
-        removed.
+        removed. This only takes ASCII whitespace into account:
+        `" \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e"`.
 
         Returns:
             A copy of the string with no leading or trailing whitespaces.
@@ -678,7 +679,9 @@ struct StringSlice[is_mutable: Bool, //, origin: Origin[is_mutable]](
 
     @always_inline
     fn rstrip(self) -> Self:
-        """Return a copy of the string with trailing whitespaces removed.
+        """Return a copy of the string with trailing whitespaces removed. This
+        only takes ASCII whitespace into account:
+        `" \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e"`.
 
         Returns:
             A copy of the string with no trailing whitespaces.
@@ -726,7 +729,9 @@ struct StringSlice[is_mutable: Bool, //, origin: Origin[is_mutable]](
 
     @always_inline
     fn lstrip(self) -> Self:
-        """Return a copy of the string with leading whitespaces removed.
+        """Return a copy of the string with leading whitespaces removed. This
+        only takes ASCII whitespace into account:
+        `" \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e"`.
 
         Returns:
             A copy of the string with no leading whitespaces.

--- a/stdlib/test/python/my_module.py
+++ b/stdlib/test/python/my_module.py
@@ -25,7 +25,8 @@ class Foo:
 
 class AbstractPerson(ABC):
     @abstractmethod
-    def method(self): ...
+    def method(self):
+        ...
 
 
 def my_function(name):


### PR DESCRIPTION
Fix docstrings for `string.strip()` function family.

Was deleted in b0094d3d9dfc6e38154393862098c22a0c1dec89. @lsh I really don't want that documentation deleted, this is very often not included and caused me quite a couple of headaches in finding the correct information and backward compatibility reasons for using those characters. And we should be explicit that this method does not yet support full Python spaces until we can run the methods with `.isspace()` at compile time.