### PR TITLE
[docs] Prevent unwanted Latex interpretation in `Path` docs

### DIFF
--- a/stdlib/src/pathlib/path.mojo
+++ b/stdlib/src/pathlib/path.mojo
@@ -264,7 +264,7 @@ struct Path(
         return os.path.exists(self)
 
     fn expanduser(self) raises -> Path:
-        """Expands a prefixed `~` with $HOME on posix or $USERPROFILE on
+        """Expands a prefixed `~` with `$HOME` on posix or `$USERPROFILE` on
         windows. If environment variables are not set or the `path` is not
         prefixed with `~`, returns the `path` unmodified.
 
@@ -275,7 +275,7 @@ struct Path(
 
     @staticmethod
     fn home() raises -> Path:
-        """Returns $HOME on posix or $USERPROFILE on windows. If environment
+        """Returns `$HOME` on posix or `$USERPROFILE` on windows. If environment
         variables are not set it returns `~`.
 
         Returns:

--- a/stdlib/test/python/my_module.py
+++ b/stdlib/test/python/my_module.py
@@ -25,7 +25,8 @@ class Foo:
 
 class AbstractPerson(ABC):
     @abstractmethod
-    def method(self): ...
+    def method(self):
+        ...
 
 
 def my_function(name):


### PR DESCRIPTION
As title, see [docs](https://docs.modular.com/mojo/stdlib/pathlib/path/Path#home).