### PR TITLE
[stdlib] Deque - don't use non-self out args

### DIFF
--- a/stdlib/src/collections/deque.mojo
+++ b/stdlib/src/collections/deque.mojo
@@ -794,7 +794,7 @@ struct Deque[ElementType: CollectionElement](
 
         return (self._data + self._head)[]
 
-    fn pop(mut self, out element: ElementType) raises:
+    fn pop(mut self) raises -> ElementType:
         """Removes and returns the element from the right side of the deque.
 
         Returns:
@@ -816,9 +816,9 @@ struct Deque[ElementType: CollectionElement](
         ):
             self._realloc(self._capacity >> 1)
 
-        return
+        return element
 
-    fn popleft(mut self, out element: ElementType) raises:
+    fn popleft(mut self) raises -> ElementType:
         """Removes and returns the element from the left side of the deque.
 
         Returns:
@@ -840,7 +840,7 @@ struct Deque[ElementType: CollectionElement](
         ):
             self._realloc(self._capacity >> 1)
 
-        return
+        return element
 
     fn reverse(mut self):
         """Reverses the elements of the deque in-place."""


### PR DESCRIPTION
As the original author of the Deque, I would like to propose to not use the `out` args instead of `-> ElementType as element` in `pop()` and `popleft()` methods.

The named return variable was just a simple convenience in these functions and not needed at all.

In general, having something in the args list of the function that you do not pass to the function at the call site looks weird (except for constructors). In my opinion, it makes the function signature just less clear to read and the return type of the function unnecessarily hidden inside the args list.

So, let's just use normal return statements here and have a clear function signatures.