### PR TITLE
[stdlib] Add `_SplitlinesIter`

### DIFF
--- a/mojo/stdlib/benchmarks/collections/bench_string.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_string.mojo
@@ -160,7 +160,7 @@ fn bench_string_splitlines[
     @always_inline
     @parameter
     fn call_fn() raises:
-        for _ in range(1_000_000 // length):
+        for _ in range(10**6 // length):
             var res = items.splitlines()
             keep(res.unsafe_ptr())
 
@@ -457,4 +457,14 @@ def main():
         BenchId(String("bench_string_join_long"))
     )
 
-    print(m)
+    # NOTE: do not replace this for print(m). This averages all the results for
+    # the different languages and runs that these benchmarks evaluate.
+    results = Dict[String, (Float64, Int)]()
+    for info in m.info_vec:
+        n = info.name
+        time = info.result.mean("ms")
+        avg, amnt = results.get(n, (Float64(0), 0))
+        results[n] = ((avg * amnt + time) / (amnt + 1), amnt + 1)
+    print("")
+    for k_v in results.items():
+        print(k_v.key, k_v.value[0], sep=",")


### PR DESCRIPTION
Add `_SplitlinesIter`

This allows lazy iteration over generic line boundaries.

### Benchmark results

CPU: Intel® Core™ i7-7700HQ

|  | old value (ms) | new value (ms) | percentage | magnitude|
|-- | -- | -- | -- | --|
|bench_string_splitlines[10] | 6.832 | 7.279 | -0.065 | 0.939|
|bench_string_splitlines[30] | 5.169 | 5.336 | -0.032 | 0.969|
|bench_string_splitlines[50] | 4.991 | 4.850 | 0.028 | 1.029|
|bench_string_splitlines[100] | 4.855 | 4.709 | 0.030 | 1.031|
|bench_string_splitlines[1000] | 4.353 | 4.708 | -0.081 | 0.925|
|bench_string_splitlines[10000] | 4.273 | 4.254 | 0.004 | 1.004|
|bench_string_splitlines[100000] | 4.289 | 4.327 | -0.009 | 0.991|
|bench_string_splitlines[1000000] | 4.261 | 4.242 | 0.004 | 1.004|
| average  | -  | -  | -0.015 | 0.986

Interpretation:

I had to undo some of the performance gains from  #4683 which stored the previous starting byte in a variable. It allowed the algorithm to just compare from two variables instead of dereferencing a pointer.

But since this is a left to right iterator, it can't store a variable and continue on to the next loop, it would have to call `__next__` recursively. This means the previous byte would have to be stored as a struct variable, and the `__has_next__` method would've had to check the edge-case where a sequence ends with `\r\n`; and that hits performance worse than dereferencing the next byte.

IMO this performance hit is worth the ability to give users the power of lazy iteration, like running the algorithm x times instead of for the whole string when not necessary.
