### PR TITLE
[stdlib] Remove `StringRef` starts and endswith

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,4 +29,7 @@ what we publish.
 
 ### ❌ Removed
 
+- `StringRef` is being deprecated. Use `StringSlice` instead.
+  - removed `StringRef.startswith()` and `StringRef.endswith()`
+
 ### 🛠️ Fixed

--- a/stdlib/src/utils/stringref.mojo
+++ b/stdlib/src/utils/stringref.mojo
@@ -650,46 +650,6 @@ struct StringRef(
             current_offset = loc + len(delimiter)
         return output
 
-    fn startswith(
-        self, prefix: StringRef, start: Int = 0, end: Int = -1
-    ) -> Bool:
-        """Checks if the StringRef starts with the specified prefix between start
-        and end positions. Returns True if found and False otherwise.
-
-        Args:
-          prefix: The prefix to check.
-          start: The start offset from which to check.
-          end: The end offset from which to check.
-
-        Returns:
-          True if the self[start:end] is prefixed by the input prefix.
-        """
-        if end == -1:
-            return self.find(prefix, start) == start
-        return StringRef(self.unsafe_ptr() + start, end - start).startswith(
-            prefix
-        )
-
-    fn endswith(self, suffix: StringRef, start: Int = 0, end: Int = -1) -> Bool:
-        """Checks if the StringRef end with the specified suffix between start
-        and end positions. Returns True if found and False otherwise.
-
-        Args:
-          suffix: The suffix to check.
-          start: The start offset from which to check.
-          end: The end offset from which to check.
-
-        Returns:
-          True if the self[start:end] is suffixed by the input suffix.
-        """
-        if len(suffix) > len(self):
-            return False
-        if end == -1:
-            return self.rfind(suffix, start) + len(suffix) == len(self)
-        return StringRef(self.unsafe_ptr() + start, end - start).endswith(
-            suffix
-        )
-
 
 # ===-----------------------------------------------------------------------===#
 # Utilities

--- a/stdlib/test/utils/test_string_slice.mojo
+++ b/stdlib/test/utils/test_string_slice.mojo
@@ -584,6 +584,46 @@ def test_strip():
     assert_true(comp_str4_stripped == "\n mississippimississippi \n")
 
 
+def test_startswith():
+    var empty = StringSlice("")
+    assert_true(empty.startswith(""))
+    assert_false(empty.startswith("a"))
+    assert_false(empty.startswith("ab"))
+
+    var a = StringSlice("a")
+    assert_true(a.startswith(""))
+    assert_true(a.startswith("a"))
+    assert_false(a.startswith("ab"))
+
+    var ab = StringSlice("ab")
+    assert_true(ab.startswith(""))
+    assert_true(ab.startswith("a"))
+    assert_false(ab.startswith("b"))
+    assert_true(ab.startswith("b", start=1))
+    assert_true(ab.startswith("a", end=1))
+    assert_true(ab.startswith("ab"))
+
+
+def test_endswith():
+    var empty = StringSlice("")
+    assert_true(empty.endswith(""))
+    assert_false(empty.endswith("a"))
+    assert_false(empty.endswith("ab"))
+
+    var a = StringSlice("a")
+    assert_true(a.endswith(""))
+    assert_true(a.endswith("a"))
+    assert_false(a.endswith("ab"))
+
+    var ab = StringSlice("ab")
+    assert_true(ab.endswith(""))
+    assert_false(ab.endswith("a"))
+    assert_true(ab.endswith("b"))
+    assert_true(ab.endswith("b", start=1))
+    assert_true(ab.endswith("a", end=1))
+    assert_true(ab.endswith("ab"))
+
+
 def main():
     test_string_literal_byte_span()
     test_string_byte_span()
@@ -605,3 +645,5 @@ def main():
     test_rstrip()
     test_lstrip()
     test_strip()
+    test_startswith()
+    test_endswith()

--- a/stdlib/test/utils/test_stringref.mojo
+++ b/stdlib/test/utils/test_stringref.mojo
@@ -108,26 +108,6 @@ def test_find():
     assert_equal(StringRef("").find("abc"), -1)
 
 
-def test_endswith():
-    var empty = StringRef("")
-    assert_true(empty.endswith(""))
-    assert_false(empty.endswith("a"))
-    assert_false(empty.endswith("ab"))
-
-    var a = StringRef("a")
-    assert_true(a.endswith(""))
-    assert_true(a.endswith("a"))
-    assert_false(a.endswith("ab"))
-
-    var ab = StringRef("ab")
-    assert_true(ab.endswith(""))
-    assert_false(ab.endswith("a"))
-    assert_true(ab.endswith("b"))
-    assert_true(ab.endswith("b", start=1))
-    assert_true(ab.endswith("a", end=1))
-    assert_true(ab.endswith("ab"))
-
-
 fn test_stringref_split() raises:
     # Reject empty delimiters
     with assert_raises(
@@ -195,5 +175,4 @@ def main():
     test_intable()
     test_indexing()
     test_find()
-    test_endswith()
     test_str_and_ref()


### PR DESCRIPTION
Remove `StringRef` starts and endswith

We already have this in `StringSlice`