### PR TITLE
[stdlib] Make `String.splitlines()` return `List[StringSlice]`

### DIFF
--- a/mojo/stdlib/benchmarks/collections/string/bench_atof.mojo
+++ b/mojo/stdlib/benchmarks/collections/string/bench_atof.mojo
@@ -26,9 +26,9 @@ from pathlib import _dir_of_current_file
 # Benchmarks
 # ===-----------------------------------------------------------------------===#
 @parameter
-fn bench_parsing_all_floats_in_file(
-    mut b: Bencher, items_to_parse: List[String]
-) raises:
+fn bench_parsing_all_floats_in_file[
+    origin: Origin
+](mut b: Bencher, items_to_parse: List[StringSlice[origin]]) raises:
     @always_inline
     @parameter
     fn call_fn() raises:
@@ -53,13 +53,13 @@ fn main() raises:
     for i in range(len(files)):
         alias filename = files[i]
         var file_path = _dir_of_current_file() / "data" / (filename + ".txt")
-
         var items_to_parse = file_path.read_text().splitlines()
         var nb_of_bytes = 0
         for item2 in items_to_parse:
             nb_of_bytes += len(item2)
 
-        bench.bench_with_input[List[String], bench_parsing_all_floats_in_file](
+        alias S = __type_of(items_to_parse)
+        bench.bench_with_input[S, bench_parsing_all_floats_in_file[S.T.origin]](
             BenchId("atof", filename),
             items_to_parse,
             ThroughputMeasure(BenchMetric.elements, len(items_to_parse)),

--- a/mojo/stdlib/stdlib/collections/string/string.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string.mojo
@@ -1444,10 +1444,12 @@ struct String(
         """
         return self.as_string_slice().split(sep, maxsplit=maxsplit)
 
-    fn splitlines(self, keepends: Bool = False) -> List[String]:
+    fn splitlines(
+        self, keepends: Bool = False
+    ) -> List[StringSlice[__origin_of(self)]]:
         """Split the string at line boundaries. This corresponds to Python's
         [universal newlines:](
-            https://docs.python.org/3/library/stdtypes.html#str.splitlines)
+        https://docs.python.org/3/library/stdtypes.html#str.splitlines)
         `"\\r\\n"` and `"\\t\\n\\v\\f\\r\\x1c\\x1d\\x1e\\x85\\u2028\\u2029"`.
 
         Args:
@@ -1456,7 +1458,7 @@ struct String(
         Returns:
             A List of Strings containing the input split by line boundaries.
         """
-        return _to_string_list(self.as_string_slice().splitlines(keepends))
+        return self.as_string_slice().splitlines(keepends)
 
     fn replace(self, old: StringSlice, new: StringSlice) -> String:
         """Return a copy of the string with all occurrences of substring `old`

--- a/mojo/stdlib/stdlib/testing/testing.mojo
+++ b/mojo/stdlib/stdlib/testing/testing.mojo
@@ -200,8 +200,7 @@ fn assert_equal[
 #   compared, then drop this overload.
 @always_inline
 fn assert_equal[
-    O1: ImmutableOrigin,
-    O2: ImmutableOrigin,
+    O1: Origin, O2: Origin
 ](
     lhs: List[StringSlice[O1]],
     rhs: List[StringSlice[O2]],

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -26,6 +26,7 @@ from testing import (
     assert_raises,
     assert_true,
 )
+from collections.string.string_slice import _to_string_list
 
 
 @fieldwise_init
@@ -687,7 +688,6 @@ def test_split():
 
     # Should add all whitespace-like chars as one
     # test all unicode separators
-    # 0 is to build a String with null terminator
     var next_line = List[UInt8](0xC2, 0x85)
     var unicode_line_sep = List[UInt8](0xE2, 0x80, 0xA8)
     var unicode_paragraph_sep = List[UInt8](0xE2, 0x80, 0xA9)
@@ -763,17 +763,19 @@ def test_split():
 
 
 def test_splitlines():
-    alias L = List[String]
+    alias S = String
+    alias L = List[StaticString]
+
     # Test with no line breaks
-    assert_equal(String("hello world").splitlines(), L("hello world"))
+    assert_equal(S("hello world").splitlines(), L("hello world"))
 
     # Test with line breaks
-    assert_equal(String("hello\nworld").splitlines(), L("hello", "world"))
-    assert_equal(String("hello\rworld").splitlines(), L("hello", "world"))
-    assert_equal(String("hello\r\nworld").splitlines(), L("hello", "world"))
+    assert_equal(S("hello\nworld").splitlines(), L("hello", "world"))
+    assert_equal(S("hello\rworld").splitlines(), L("hello", "world"))
+    assert_equal(S("hello\r\nworld").splitlines(), L("hello", "world"))
 
     # Test with multiple different line breaks
-    s1 = "hello\nworld\r\nmojo\rlanguage\r\n"
+    s1 = S("hello\nworld\r\nmojo\rlanguage\r\n")
     hello_mojo = L("hello", "world", "mojo", "language")
     assert_equal(s1.splitlines(), hello_mojo)
     assert_equal(
@@ -782,9 +784,9 @@ def test_splitlines():
     )
 
     # Test with an empty string
-    assert_equal(String().splitlines(), L())
+    assert_equal(S("").splitlines(), L())
     # test \v \f \x1c \x1d
-    s2 = "hello\vworld\fmojo\x1clanguage\x1d"
+    s2 = S("hello\vworld\fmojo\x1clanguage\x1d")
     assert_equal(s2.splitlines(), hello_mojo)
     assert_equal(
         s2.splitlines(keepends=True),
@@ -792,7 +794,7 @@ def test_splitlines():
     )
 
     # test \x1c \x1d \x1e
-    s3 = "hello\x1cworld\x1dmojo\x1elanguage\x1e"
+    s3 = S("hello\x1cworld\x1dmojo\x1elanguage\x1e")
     assert_equal(s3.splitlines(), hello_mojo)
     assert_equal(
         s3.splitlines(keepends=True),
@@ -800,17 +802,18 @@ def test_splitlines():
     )
 
     # test \x85 \u2028 \u2029
-    var next_line = List[UInt8](0xC2, 0x85)
-    var unicode_line_sep = List[UInt8](0xE2, 0x80, 0xA8)
-    var unicode_paragraph_sep = List[UInt8](0xE2, 0x80, 0xA9)
+    var next_line = String(bytes=List[UInt8](0xC2, 0x85))
+    var unicode_line_sep = String(bytes=List[UInt8](0xE2, 0x80, 0xA8))
+    var unicode_paragraph_sep = String(bytes=List[UInt8](0xE2, 0x80, 0xA9))
 
-    for elt in [next_line, unicode_line_sep, unicode_paragraph_sep]:
-        u = String(bytes=elt)
-        item = String().join("hello", u, "world", u, "mojo", u, "language", u)
+    for u in [next_line, unicode_line_sep, unicode_paragraph_sep]:
+        item = StaticString("").join(
+            "hello", u, "world", u, "mojo", u, "language", u
+        )
         assert_equal(item.splitlines(), hello_mojo)
         assert_equal(
-            item.splitlines(keepends=True),
-            L("hello" + u, "world" + u, "mojo" + u, "language" + u),
+            _to_string_list(item.splitlines(keepends=True)),
+            List("hello" + u, "world" + u, "mojo" + u, "language" + u),
         )
 
 
@@ -818,7 +821,6 @@ def test_isspace():
     assert_false(String().isspace())
 
     # test all utf8 and unicode separators
-    # 0 is to build a String with null terminator
     var next_line = List[UInt8](0xC2, 0x85)
     var unicode_line_sep = List[UInt8](0xE2, 0x80, 0xA8)
     var unicode_paragraph_sep = List[UInt8](0xE2, 0x80, 0xA9)

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -11,7 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from collections.string.string_slice import get_static_string
+from collections.string.string_slice import get_static_string, _to_string_list
 from sys.info import size_of
 
 from testing import assert_equal, assert_false, assert_true
@@ -487,7 +487,6 @@ def test_split():
 
     # Should add all whitespace-like chars as one
     # test all unicode separators
-    # 0 is to build a String with null terminator
     var next_line = List[UInt8](0xC2, 0x85)
     var unicode_line_sep = List[UInt8](0xE2, 0x80, 0xA8)
     var unicode_paragraph_sep = List[UInt8](0xE2, 0x80, 0xA9)
@@ -563,16 +562,8 @@ def test_split():
 
 
 def test_splitlines():
-    alias S = StringSlice[StaticConstantOrigin]
-    alias L = List[StringSlice[StaticConstantOrigin]]
-
-    # FIXME: remove once we can compare Lists of different element types
-    fn _assert_equal[
-        O1: ImmutableOrigin
-    ](l1: List[StringSlice[O1]], l2: List[String]) raises:
-        assert_equal(len(l1), len(l2))
-        for i in range(len(l1)):
-            assert_equal(String(l1[i]), l2[i])
+    alias S = StaticString
+    alias L = List[StaticString]
 
     # Test with no line breaks
     assert_equal(S("hello world").splitlines(), L("hello world"))
@@ -614,12 +605,15 @@ def test_splitlines():
     var unicode_line_sep = String(bytes=List[UInt8](0xE2, 0x80, 0xA8))
     var unicode_paragraph_sep = String(bytes=List[UInt8](0xE2, 0x80, 0xA9))
 
-    for u in [next_line, unicode_line_sep, unicode_paragraph_sep]:
-        item = String().join("hello", u, "world", u, "mojo", u, "language", u)
-        s = StringSlice(item)
-        assert_equal(s.splitlines(), hello_mojo)
-        items = ["hello" + u, "world" + u, "mojo" + u, "language" + u]
-        _assert_equal(s.splitlines(keepends=True), items)
+    for ref u in [next_line, unicode_line_sep, unicode_paragraph_sep]:
+        item = StaticString("").join(
+            "hello", u, "world", u, "mojo", u, "language", u
+        )
+        assert_equal(item.splitlines(), hello_mojo)
+        assert_equal(
+            _to_string_list(item.splitlines(keepends=True)),
+            List("hello" + u, "world" + u, "mojo" + u, "language" + u),
+        )
 
 
 def test_rstrip():


### PR DESCRIPTION
Make `String.splitlines()` return `List[StringSlice]`.

part of #3879.

personal note: I'd like to just delete the tests for `String` since IMO they are redundant now that they just wrap `StringSlice.splitlines()`