### PR TITLE
[stdlib] Fix `startswith()` and `endswith()`

### DIFF
--- a/stdlib/src/builtin/string_literal.mojo
+++ b/stdlib/src/builtin/string_literal.mojo
@@ -827,33 +827,37 @@ struct StringLiteral(
         """
         return str(self).center(width, fillchar)
 
-    fn startswith(self, prefix: String, start: Int = 0, end: Int = -1) -> Bool:
-        """Checks if the string literal starts with the specified prefix between start
-        and end positions. Returns True if found and False otherwise.
+    fn startswith(
+        self, prefix: StringSlice, start: Int = 0, end: Int = -1
+    ) -> Bool:
+        """Checks if the string literal starts with the specified prefix between
+        start and end positions. Returns True if found and False otherwise.
 
         Args:
-          prefix: The prefix to check.
-          start: The start offset from which to check.
-          end: The end offset from which to check.
+            prefix: The prefix to check.
+            start: The start offset from which to check.
+            end: The end offset from which to check.
 
         Returns:
-          True if the self[start:end] is prefixed by the input prefix.
+            True if the `self[start:end]` is prefixed by the input prefix.
         """
-        return str(self).startswith(prefix, start, end)
+        return self.as_string_slice().startswith(prefix, start, end)
 
-    fn endswith(self, suffix: String, start: Int = 0, end: Int = -1) -> Bool:
-        """Checks if the string literal end with the specified suffix between start
-        and end positions. Returns True if found and False otherwise.
+    fn endswith(
+        self, suffix: StringSlice, start: Int = 0, end: Int = -1
+    ) -> Bool:
+        """Checks if the string literal end with the specified suffix between
+        start and end positions. Returns True if found and False otherwise.
 
         Args:
-          suffix: The suffix to check.
-          start: The start offset from which to check.
-          end: The end offset from which to check.
+            suffix: The suffix to check.
+            start: The start offset from which to check.
+            end: The end offset from which to check.
 
         Returns:
-          True if the self[start:end] is suffixed by the input suffix.
+            True if the `self[start:end]` is suffixed by the input suffix.
         """
-        return str(self).endswith(suffix, start, end)
+        return self.as_string_slice().endswith(suffix, start, end)
 
     fn isdigit(self) -> Bool:
         """Returns True if all characters in the string literal are digits.

--- a/stdlib/src/collections/string/string.mojo
+++ b/stdlib/src/collections/string/string.mojo
@@ -2054,50 +2054,36 @@ struct String(
         return to_uppercase(self)
 
     fn startswith(
-        ref self, prefix: String, start: Int = 0, end: Int = -1
+        self, prefix: StringSlice, start: Int = 0, end: Int = -1
     ) -> Bool:
         """Checks if the string starts with the specified prefix between start
         and end positions. Returns True if found and False otherwise.
 
         Args:
-          prefix: The prefix to check.
-          start: The start offset from which to check.
-          end: The end offset from which to check.
+            prefix: The prefix to check.
+            start: The start offset from which to check.
+            end: The end offset from which to check.
 
         Returns:
-          True if the self[start:end] is prefixed by the input prefix.
+            True if the `self[start:end]` is prefixed by the input prefix.
         """
-        if end == -1:
-            return StringSlice[__origin_of(self)](
-                ptr=self.unsafe_ptr() + start,
-                length=self.byte_length() - start,
-            ).startswith(prefix.as_string_slice())
+        return self.as_string_slice().startswith(prefix, start, end)
 
-        return StringSlice[__origin_of(self)](
-            ptr=self.unsafe_ptr() + start, length=end - start
-        ).startswith(prefix.as_string_slice())
-
-    fn endswith(self, suffix: String, start: Int = 0, end: Int = -1) -> Bool:
+    fn endswith(
+        self, suffix: StringSlice, start: Int = 0, end: Int = -1
+    ) -> Bool:
         """Checks if the string end with the specified suffix between start
         and end positions. Returns True if found and False otherwise.
 
         Args:
-          suffix: The suffix to check.
-          start: The start offset from which to check.
-          end: The end offset from which to check.
+            suffix: The suffix to check.
+            start: The start offset from which to check.
+            end: The end offset from which to check.
 
         Returns:
-          True if the self[start:end] is suffixed by the input suffix.
+            True if the `self[start:end]` is suffixed by the input suffix.
         """
-        if end == -1:
-            return StringSlice[__origin_of(self)](
-                ptr=self.unsafe_ptr() + start,
-                length=self.byte_length() - start,
-            ).endswith(suffix.as_string_slice())
-
-        return StringSlice[__origin_of(self)](
-            ptr=self.unsafe_ptr() + start, length=end - start
-        ).endswith(suffix.as_string_slice())
+        return self.as_string_slice().endswith(suffix, start, end)
 
     fn removeprefix(self, prefix: String, /) -> String:
         """Returns a new string with the prefix removed if it was present.

--- a/stdlib/src/collections/string/string_slice.mojo
+++ b/stdlib/src/collections/string/string_slice.mojo
@@ -855,7 +855,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         """
         if end == -1:
             return self.find(prefix, start) == start
-        return StringSlice[origin](
+        return Self(
             ptr=self.unsafe_ptr() + start, length=end - start
         ).startswith(prefix)
 
@@ -873,13 +873,17 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         Returns:
             True if the `self[start:end]` is suffixed by the input suffix.
         """
-        if len(suffix) > len(self):
+        var o_len = suffix.byte_length()
+        if o_len > self.byte_length():
             return False
         if end == -1:
-            return self.rfind(suffix, start) + len(suffix) == len(self)
-        return StringSlice[origin](
-            ptr=self.unsafe_ptr() + start, length=end - start
-        ).endswith(suffix)
+            return (
+                self.rfind(suffix, start) + o_len
+                == self.byte_length()
+            )
+        return Self(ptr=self.unsafe_ptr() + start, length=end - start).endswith(
+            suffix
+        )
 
     fn _from_start(self, start: Int) -> Self:
         """Gets the `StringSlice` pointing to the substring after the specified

--- a/stdlib/src/collections/string/string_slice.mojo
+++ b/stdlib/src/collections/string/string_slice.mojo
@@ -849,6 +849,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         """
         if end == -1:
             return self.find(prefix, start) == start
+        # FIXME: use normalize_index
         return Self(
             ptr=self.unsafe_ptr() + start, length=end - start
         ).startswith(prefix)
@@ -872,6 +873,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
             return False
         if end == -1:
             return self.rfind(suffix, start) + o_len == self.byte_length()
+        # FIXME: use normalize_index
         return Self(ptr=self.unsafe_ptr() + start, length=end - start).endswith(
             suffix
         )
@@ -888,6 +890,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
             A `StringSlice` borrowed from the current string containing the
             characters of the slice starting at start.
         """
+        # FIXME: use normalize_index
 
         var self_len = self.byte_length()
 

--- a/stdlib/src/collections/string/string_slice.mojo
+++ b/stdlib/src/collections/string/string_slice.mojo
@@ -277,11 +277,6 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         #   StringLiteral is guaranteed to use UTF-8 encoding.
         # FIXME(MSTDL-160):
         #   Ensure StringLiteral _actually_ always uses UTF-8 encoding.
-        # FIXME: this gets practically stuck at compile time
-        # debug_assert(
-        #     _is_valid_utf8(lit.as_bytes()),
-        #     "StringLiteral doesn't have valid UTF-8 encoding",
-        # )
         self = StaticString(unsafe_from_utf8=lit.as_bytes())
 
     @always_inline
@@ -294,7 +289,10 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         Safety:
             `unsafe_from_utf8` MUST be valid UTF-8 encoded data.
         """
-
+        # FIXME(#3706): can't run at compile time
+        # debug_assert(
+        #     _is_valid_utf8(value.as_bytes()), "value is not valid utf8"
+        # )
         self._slice = unsafe_from_utf8
 
     fn __init__(out self, *, unsafe_from_utf8_strref: StringRef):
@@ -357,10 +355,6 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         Args:
             value: The string value.
         """
-
-        debug_assert(
-            _is_valid_utf8(value.as_bytes()), "value is not valid utf8"
-        )
         self = StringSlice[O](unsafe_from_utf8=value.as_bytes())
 
     # ===-------------------------------------------------------------------===#
@@ -877,10 +871,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         if o_len > self.byte_length():
             return False
         if end == -1:
-            return (
-                self.rfind(suffix, start) + o_len
-                == self.byte_length()
-            )
+            return self.rfind(suffix, start) + o_len == self.byte_length()
         return Self(ptr=self.unsafe_ptr() + start, length=end - start).endswith(
             suffix
         )


### PR DESCRIPTION
Fix `startswith()` and `endswith()`

Closes  #3903
Solves the current CI failure with `check_licences.mojo` passing a `StringSlice` to `String.startswith()`