### PR TITLE
[stdlib] [NFC] Fix change `UnsafePointer` constructors to receive length as a `UInt`

### DIFF
--- a/stdlib/src/builtin/string_literal.mojo
+++ b/stdlib/src/builtin/string_literal.mojo
@@ -440,7 +440,7 @@ struct StringLiteral(
             An iterator over the string.
         """
         return _StringSliceIter[StaticConstantOrigin](
-            unsafe_pointer=self.unsafe_ptr(), length=self.byte_length()
+            ptr=self.unsafe_ptr(), length=self.byte_length()
         )
 
     fn __reversed__(self) -> _StringSliceIter[StaticConstantOrigin, False]:
@@ -450,7 +450,7 @@ struct StringLiteral(
             A reversed iterator over the string.
         """
         return _StringSliceIter[StaticConstantOrigin, False](
-            unsafe_pointer=self.unsafe_ptr(), length=self.byte_length()
+            ptr=self.unsafe_ptr(), length=self.byte_length()
         )
 
     fn __getitem__[IndexerType: Indexer](self, idx: IndexerType) -> String:

--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -178,7 +178,9 @@ struct List[T: CollectionElement, hint_trivial_type: Bool = False](
         for value in span:
             self.append(value[])
 
-    fn __init__(mut self, *, ptr: UnsafePointer[T], length: Int, capacity: Int):
+    fn __init__(
+        out self, *, ptr: UnsafePointer[T], length: UInt, capacity: UInt
+    ):
         """Constructs a list from a pointer, its length, and its capacity.
 
         Args:

--- a/stdlib/src/collections/string/string.mojo
+++ b/stdlib/src/collections/string/string.mojo
@@ -909,7 +909,7 @@ struct String(
         self = literal.__str__()
 
     @always_inline
-    fn __init__(out self, *, ptr: UnsafePointer[Byte], length: Int):
+    fn __init__(out self, *, ptr: UnsafePointer[Byte], length: UInt):
         """Creates a string from the buffer. Note that the string now owns
         the buffer.
 
@@ -919,7 +919,6 @@ struct String(
             ptr: The pointer to the buffer.
             length: The length of the buffer, including the null terminator.
         """
-        debug_assert(length > -1, "pointer length must be positive")
         # we don't know the capacity of ptr, but we'll assume it's the same or
         # larger than len
         self = Self(Self._buffer_type(ptr=ptr, length=length, capacity=length))

--- a/stdlib/src/collections/string/string.mojo
+++ b/stdlib/src/collections/string/string.mojo
@@ -919,6 +919,7 @@ struct String(
             ptr: The pointer to the buffer.
             length: The length of the buffer, including the null terminator.
         """
+        debug_assert(length > -1, "pointer length must be positive")
         # we don't know the capacity of ptr, but we'll assume it's the same or
         # larger than len
         self = Self(Self._buffer_type(ptr=ptr, length=length, capacity=length))
@@ -1344,7 +1345,7 @@ struct String(
             An iterator of references to the string elements.
         """
         return _StringSliceIter[__origin_of(self)](
-            unsafe_pointer=self.unsafe_ptr(), length=self.byte_length()
+            ptr=self.unsafe_ptr(), length=self.byte_length()
         )
 
     fn __reversed__(self) -> _StringSliceIter[__origin_of(self), False]:
@@ -1354,7 +1355,7 @@ struct String(
             A reversed iterator of references to the string elements.
         """
         return _StringSliceIter[__origin_of(self), forward=False](
-            unsafe_pointer=self.unsafe_ptr(), length=self.byte_length()
+            ptr=self.unsafe_ptr(), length=self.byte_length()
         )
 
     # ===------------------------------------------------------------------=== #

--- a/stdlib/src/collections/string/string_slice.mojo
+++ b/stdlib/src/collections/string/string_slice.mojo
@@ -183,7 +183,7 @@ struct _StringSliceIter[
     var ptr: UnsafePointer[Byte]
     var length: Int
 
-    fn __init__(mut self, *, ptr: UnsafePointer[Byte], length: UInt):
+    fn __init__(out self, *, ptr: UnsafePointer[Byte], length: UInt):
         self.index = 0 if forward else length
         self.ptr = ptr
         self.length = length

--- a/stdlib/src/collections/string/string_slice.mojo
+++ b/stdlib/src/collections/string/string_slice.mojo
@@ -183,8 +183,7 @@ struct _StringSliceIter[
     var ptr: UnsafePointer[Byte]
     var length: Int
 
-    fn __init__(mut self, *, ptr: UnsafePointer[Byte], length: Int):
-        debug_assert(length > -1, "pointer length must be positive")
+    fn __init__(mut self, *, ptr: UnsafePointer[Byte], length: UInt):
         self.index = 0 if forward else length
         self.ptr = ptr
         self.length = length
@@ -321,7 +320,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         self = Self(unsafe_from_utf8=byte_slice)
 
     @always_inline
-    fn __init__(out self, *, ptr: UnsafePointer[Byte], length: Int):
+    fn __init__(out self, *, ptr: UnsafePointer[Byte], length: UInt):
         """Construct a `StringSlice` from a pointer to a sequence of UTF-8
         encoded bytes and a length.
 
@@ -335,8 +334,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
             - `ptr` must point to data that is live for the duration of
                 `origin`.
         """
-        debug_assert(length > -1, "pointer length must be positive")
-        self._slice = Span[Byte, origin](ptr=ptr, length=length)
+        self = Self(unsafe_from_utf8=Span[Byte, origin](ptr=ptr, length=length))
 
     @always_inline
     fn copy(self) -> Self:

--- a/stdlib/src/collections/string/string_slice.mojo
+++ b/stdlib/src/collections/string/string_slice.mojo
@@ -183,9 +183,10 @@ struct _StringSliceIter[
     var ptr: UnsafePointer[Byte]
     var length: Int
 
-    fn __init__(mut self, *, unsafe_pointer: UnsafePointer[Byte], length: Int):
+    fn __init__(mut self, *, ptr: UnsafePointer[Byte], length: Int):
+        debug_assert(length > -1, "pointer length must be positive")
         self.index = 0 if forward else length
-        self.ptr = unsafe_pointer
+        self.ptr = ptr
         self.length = length
 
     fn __iter__(self) -> Self:
@@ -334,6 +335,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
             - `ptr` must point to data that is live for the duration of
                 `origin`.
         """
+        debug_assert(length > -1, "pointer length must be positive")
         self._slice = Span[Byte, origin](ptr=ptr, length=length)
 
     @always_inline
@@ -570,7 +572,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
             An iterator of references to the string elements.
         """
         return _StringSliceIter[origin](
-            unsafe_pointer=self.unsafe_ptr(), length=self.byte_length()
+            ptr=self.unsafe_ptr(), length=self.byte_length()
         )
 
     fn __reversed__(self) -> _StringSliceIter[origin, False]:
@@ -580,7 +582,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
             A reversed iterator of references to the string elements.
         """
         return _StringSliceIter[origin, forward=False](
-            unsafe_pointer=self.unsafe_ptr(), length=self.byte_length()
+            ptr=self.unsafe_ptr(), length=self.byte_length()
         )
 
     fn __getitem__[IndexerType: Indexer](self, idx: IndexerType) -> String:

--- a/stdlib/src/memory/span.mojo
+++ b/stdlib/src/memory/span.mojo
@@ -116,14 +116,13 @@ struct Span[
     # ===------------------------------------------------------------------===#
 
     @always_inline
-    fn __init__(out self, *, ptr: UnsafePointer[T], length: Int):
+    fn __init__(out self, *, ptr: UnsafePointer[T], length: UInt):
         """Unsafe construction from a pointer and length.
 
         Args:
             ptr: The underlying pointer of the span.
             length: The length of the view.
         """
-        debug_assert(length > -1, "pointer length must be positive")
         self._data = ptr
         self._len = length
 

--- a/stdlib/src/memory/span.mojo
+++ b/stdlib/src/memory/span.mojo
@@ -123,6 +123,7 @@ struct Span[
             ptr: The underlying pointer of the span.
             length: The length of the view.
         """
+        debug_assert(length > -1, "pointer length must be positive")
         self._data = ptr
         self._len = length
 


### PR DESCRIPTION
Fix change `UnsafePointer` constructors to receive length as a `UInt`