### PR TITLE
[stdlib] fix:  license check ci

### DIFF
--- a/stdlib/scripts/check_licenses.mojo
+++ b/stdlib/scripts/check_licenses.mojo
@@ -17,11 +17,13 @@ from pathlib import Path
 # We can't check much more than this at the moment, because the license year
 # changes and the language is not mature enough to do regex yet.
 var LICENSE = String(
-    """
+    String(
+        """
 # ===----------------------------------------------------------------------=== #
 # Copyright (c)
 """
-).strip()
+    ).strip()
+)
 
 
 def main():


### PR DESCRIPTION
Is currently failing: https://github.com/modularml/mojo/actions/runs/12663247169/job/35289501487#step:5:50
Possibly due to https://github.com/modularml/mojo/commit/4903cf9fbc979646aab2e6b7c181004bfa3623f3