### PR TITLE
[stdlib] Use named output for _ListIter __next__() method

### DIFF
--- a/stdlib/src/collections/list.mojo
+++ b/stdlib/src/collections/list.mojo
@@ -60,16 +60,14 @@ struct _ListIter[
     fn __iter__(self) -> Self:
         return self
 
-    fn __next__(
-        mut self,
-    ) -> Pointer[T, list_origin]:
+    fn __next__(mut self, out p: Pointer[T, list_origin]):
         @parameter
         if forward:
+            p = Pointer.address_of(self.src[][self.index])
             self.index += 1
-            return Pointer.address_of(self.src[][self.index - 1])
         else:
             self.index -= 1
-            return Pointer.address_of(self.src[][self.index])
+            p = Pointer.address_of(self.src[][self.index])
 
     @always_inline
     fn __has_next__(self) -> Bool:


### PR DESCRIPTION
- Add a trivial optimization to use a named output for the `__next__()` method in `_ListIter` to save a subtraction operation on every iteration