### PR TITLE
[stdlib] Make atomics sharable

### DIFF
--- a/stdlib/src/os/atomic.mojo
+++ b/stdlib/src/os/atomic.mojo
@@ -53,7 +53,7 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
         self.value = value
 
     @always_inline
-    fn load(mut self) -> Scalar[type]:
+    fn load(self) -> Scalar[type]:
         """Loads the current value from the atomic.
 
         Returns:
@@ -139,7 +139,7 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
         )
 
     @always_inline
-    fn fetch_add(mut self, rhs: Scalar[type]) -> Scalar[type]:
+    fn fetch_add(self, rhs: Scalar[type]) -> Scalar[type]:
         """Performs atomic in-place add.
 
         Atomically replaces the current value with the result of arithmetic
@@ -158,7 +158,7 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
         return Self._fetch_add(value_addr, rhs)
 
     @always_inline
-    fn __iadd__(mut self, rhs: Scalar[type]):
+    fn __iadd__(self, rhs: Scalar[type]):
         """Performs atomic in-place add.
 
         Atomically replaces the current value with the result of arithmetic
@@ -173,7 +173,7 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
         _ = self.fetch_add(rhs)
 
     @always_inline
-    fn fetch_sub(mut self, rhs: Scalar[type]) -> Scalar[type]:
+    fn fetch_sub(self, rhs: Scalar[type]) -> Scalar[type]:
         """Performs atomic in-place sub.
 
         Atomically replaces the current value with the result of arithmetic
@@ -197,7 +197,7 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
         ](value_addr.address, rhs.value)
 
     @always_inline
-    fn __isub__(mut self, rhs: Scalar[type]):
+    fn __isub__(self, rhs: Scalar[type]):
         """Performs atomic in-place sub.
 
         Atomically replaces the current value with the result of arithmetic
@@ -213,7 +213,7 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
 
     @always_inline
     fn compare_exchange_weak(
-        mut self, mut expected: Scalar[type], desired: Scalar[type]
+        self, mut expected: Scalar[type], desired: Scalar[type]
     ) -> Bool:
         """Atomically compares the self value with that of the expected value.
         If the values are equal, then the self value is replaced with the
@@ -271,7 +271,7 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
         _max_impl[scope=scope](ptr, rhs)
 
     @always_inline
-    fn max(mut self, rhs: Scalar[type]):
+    fn max(self, rhs: Scalar[type]):
         """Performs atomic in-place max.
 
         Atomically replaces the current value with the result of max of the
@@ -311,7 +311,7 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
         _min_impl[scope=scope](ptr, rhs)
 
     @always_inline
-    fn min(mut self, rhs: Scalar[type]):
+    fn min(self, rhs: Scalar[type]):
         """Performs atomic in-place min.
 
         Atomically replaces the current value with the result of min of the


### PR DESCRIPTION
Prior to this, most atomic operations required a mutable reference, which meant you had statically guarenteed mutual exclusion, which means you don't need atomics. This fixes those operations to only require an immutable reference, allowing them to be used in multiple threads.