### PR TITLE
[stdlib] Use out param for __next__() in more iterators

### DIFF
--- a/stdlib/src/collections/deque.mojo
+++ b/stdlib/src/collections/deque.mojo
@@ -1016,14 +1016,14 @@ struct _DequeIter[
     fn __iter__(self) -> Self:
         return self
 
-    fn __next__(mut self) -> Pointer[ElementType, deque_lifetime]:
+    fn __next__(mut self, out p: Pointer[ElementType, deque_lifetime]):
         @parameter
         if forward:
+            p = Pointer.address_of(self.src[][self.index])
             self.index += 1
-            return Pointer.address_of(self.src[][self.index - 1])
         else:
             self.index -= 1
-            return Pointer.address_of(self.src[][self.index])
+            p = Pointer.address_of(self.src[][self.index])
 
     fn __len__(self) -> Int:
         @parameter

--- a/stdlib/src/collections/inline_list.mojo
+++ b/stdlib/src/collections/inline_list.mojo
@@ -53,16 +53,14 @@ struct _InlineListIter[
     fn __iter__(self) -> Self:
         return self
 
-    fn __next__(
-        mut self,
-    ) -> Pointer[T, __origin_of(self.src[][0])]:
+    fn __next__(mut self, out p: Pointer[T, __origin_of(self.src[][0])]):
         @parameter
         if forward:
+            p = Pointer.address_of(self.src[][self.index])
             self.index += 1
-            return Pointer.address_of(self.src[][self.index - 1])
         else:
             self.index -= 1
-            return Pointer.address_of(self.src[][self.index])
+            p = Pointer.address_of(self.src[][self.index])
 
     @always_inline
     fn __has_next__(self) -> Bool:

--- a/stdlib/src/memory/span.mojo
+++ b/stdlib/src/memory/span.mojo
@@ -68,16 +68,14 @@ struct _SpanIter[
         return self
 
     @always_inline
-    fn __next__(
-        mut self,
-    ) -> Pointer[T, origin]:
+    fn __next__(mut self, out p: Pointer[T, origin]):
         @parameter
         if forward:
+            p = Pointer.address_of(self.src[self.index])
             self.index += 1
-            return Pointer.address_of(self.src[self.index - 1])
         else:
             self.index -= 1
-            return Pointer.address_of(self.src[self.index])
+            p = Pointer.address_of(self.src[self.index])
 
     @always_inline
     fn __has_next__(self) -> Bool:


### PR DESCRIPTION
Apply the change from #3941 to other iterators where it applies.