### PR TITLE
[stdlib] Add `build` task in `pixi.toml` to build the stdlib

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,8 @@ channels = ["conda-forge", "https://conda.modular.com/max-nightly/"]
 platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 
 [tasks]
-tests ="./stdlib/scripts/run-tests.sh"
+build = "./stdlib/scripts/build-stdlib.sh"
+tests = "./stdlib/scripts/run-tests.sh"
 examples = "./examples/run-examples.sh"
 benchmarks = { cmd = ["./stdlib/scripts/run-benchmarks.sh"], env = { MODULAR_MOJO_NIGHTLY_IMPORT_PATH = "$CONDA_PREFIX/lib/mojo" } }
 


### PR DESCRIPTION
@jackos Maybe we could also update the contribution guide to use this?