### PR TITLE
[stdlib] Make `ListLiteral` subscriptable, and remove `get[i, T]()`.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -75,4 +75,6 @@ a different threshold or to `0` to disable the warning.
 
 ### ❌ Removed
 
+- Removed `ListLiteral.get[i, T]()`. `ListLiteral` is now subscriptable.
+
 ### 🛠️ Fixed

--- a/stdlib/src/builtin/builtin_list.mojo
+++ b/stdlib/src/builtin/builtin_list.mojo
@@ -91,10 +91,13 @@ struct ListLiteral[*Ts: CollectionElement](Sized, CollectionElement):
     # Methods
     # ===-------------------------------------------------------------------===#
 
-    # FIXME: This should have a getitem like Tuple does, not a "get" method.
     @always_inline
-    fn get[i: Int, T: CollectionElement](self) -> ref [self.storage] T:
+    fn unsafe_get[i: Int, T: CollectionElement](self) -> ref [self.storage] T:
         """Get a list element at the given index.
+
+        Users should consider using `__getitem__` instead of this method as it is
+        unsafe. If type T does not match the actual type at index i, this will
+        result in undefined behavior.
 
         Parameters:
             i: The element index.
@@ -108,6 +111,18 @@ struct ListLiteral[*Ts: CollectionElement](Sized, CollectionElement):
     # ===-------------------------------------------------------------------===#
     # Operator dunders
     # ===-------------------------------------------------------------------===#
+
+    @always_inline
+    fn __getitem__[idx: Int](ref self) -> ref [self.storage] Ts[idx.value]:
+        """Get a reference to an element in the list.
+
+        Parameters:
+            idx: The element to return.
+
+        Returns:
+            A reference to the specified element.
+        """
+        return rebind[Ts[idx.value]](self.storage[idx])
 
     @always_inline
     fn __contains__[

--- a/stdlib/src/builtin/builtin_list.mojo
+++ b/stdlib/src/builtin/builtin_list.mojo
@@ -113,7 +113,7 @@ struct ListLiteral[*Ts: CollectionElement](Sized, CollectionElement):
     # ===-------------------------------------------------------------------===#
 
     @always_inline
-    fn __getitem__[idx: Int](ref self) -> ref [self.storage] Ts[idx.value]:
+    fn __getitem__[idx: Int](ref self) -> ref [self.storage] Ts[idx]:
         """Get a reference to an element in the list.
 
         Parameters:
@@ -122,7 +122,7 @@ struct ListLiteral[*Ts: CollectionElement](Sized, CollectionElement):
         Returns:
             A reference to the specified element.
         """
-        return rebind[Ts[idx.value]](self.storage[idx])
+        return rebind[Ts[idx]](self.storage[idx])
 
     @always_inline
     fn __contains__[

--- a/stdlib/src/builtin/builtin_list.mojo
+++ b/stdlib/src/builtin/builtin_list.mojo
@@ -88,27 +88,6 @@ struct ListLiteral[*Ts: CollectionElement](Sized, CollectionElement):
         return len(self.storage)
 
     # ===-------------------------------------------------------------------===#
-    # Methods
-    # ===-------------------------------------------------------------------===#
-
-    @always_inline
-    fn unsafe_get[i: Int, T: CollectionElement](self) -> ref [self.storage] T:
-        """Get a list element at the given index.
-
-        Users should consider using `__getitem__` instead of this method as it is
-        unsafe. If type T does not match the actual type at index i, this will
-        result in undefined behavior.
-
-        Parameters:
-            i: The element index.
-            T: The element type.
-
-        Returns:
-            The element at the given index.
-        """
-        return rebind[T](self.storage[i])
-
-    # ===-------------------------------------------------------------------===#
     # Operator dunders
     # ===-------------------------------------------------------------------===#
 

--- a/stdlib/src/builtin/object.mojo
+++ b/stdlib/src/builtin/object.mojo
@@ -854,13 +854,13 @@ struct object(
 
             @parameter
             if _type_is_eq[T, Int]():
-                self._append(value.unsafe_get[i, Int]())
+                self._append(rebind[Int](value[i]))
             elif _type_is_eq[T, Float64]():
-                self._append(value.unsafe_get[i, Float64]())
+                self._append(rebind[Float64](value[i]))
             elif _type_is_eq[T, Bool]():
-                self._append(value.unsafe_get[i, Bool]())
+                self._append(rebind[Bool](value[i]))
             elif _type_is_eq[T, StringLiteral]():
-                self._append(value.unsafe_get[i, StringLiteral]())
+                self._append(rebind[StringLiteral](value[i]))
             else:
                 constrained[
                     False, "cannot convert nested list element to object"

--- a/stdlib/src/builtin/object.mojo
+++ b/stdlib/src/builtin/object.mojo
@@ -854,13 +854,13 @@ struct object(
 
             @parameter
             if _type_is_eq[T, Int]():
-                self._append(value.get[i, Int]())
+                self._append(value.unsafe_get[i, Int]())
             elif _type_is_eq[T, Float64]():
-                self._append(value.get[i, Float64]())
+                self._append(value.unsafe_get[i, Float64]())
             elif _type_is_eq[T, Bool]():
-                self._append(value.get[i, Bool]())
+                self._append(value.unsafe_get[i, Bool]())
             elif _type_is_eq[T, StringLiteral]():
-                self._append(value.get[i, StringLiteral]())
+                self._append(value.unsafe_get[i, StringLiteral]())
             else:
                 constrained[
                     False, "cannot convert nested list element to object"

--- a/stdlib/src/python/python_object.mojo
+++ b/stdlib/src/python/python_object.mojo
@@ -446,15 +446,15 @@ struct PythonObject(
 
             @parameter
             if _type_is_eq[T, PythonObject]():
-                obj = value.unsafe_get[i, PythonObject]()
+                obj = rebind[PythonObject](value[i]).copy()
             elif _type_is_eq[T, Int]():
-                obj = PythonObject(value.unsafe_get[i, Int]())
+                obj = PythonObject(rebind[Int](value[i]))
             elif _type_is_eq[T, Float64]():
-                obj = PythonObject(value.unsafe_get[i, Float64]())
+                obj = PythonObject(rebind[Float64](value[i]))
             elif _type_is_eq[T, Bool]():
-                obj = PythonObject(value.unsafe_get[i, Bool]())
+                obj = PythonObject(rebind[Bool](value[i]))
             elif _type_is_eq[T, StringLiteral]():
-                obj = PythonObject(value.unsafe_get[i, StringLiteral]())
+                obj = PythonObject(rebind[StringLiteral](value[i]))
             else:
                 obj = PythonObject(0)
                 constrained[

--- a/stdlib/src/python/python_object.mojo
+++ b/stdlib/src/python/python_object.mojo
@@ -446,15 +446,15 @@ struct PythonObject(
 
             @parameter
             if _type_is_eq[T, PythonObject]():
-                obj = value.get[i, PythonObject]()
+                obj = value.unsafe_get[i, PythonObject]()
             elif _type_is_eq[T, Int]():
-                obj = PythonObject(value.get[i, Int]())
+                obj = PythonObject(value.unsafe_get[i, Int]())
             elif _type_is_eq[T, Float64]():
-                obj = PythonObject(value.get[i, Float64]())
+                obj = PythonObject(value.unsafe_get[i, Float64]())
             elif _type_is_eq[T, Bool]():
-                obj = PythonObject(value.get[i, Bool]())
+                obj = PythonObject(value.unsafe_get[i, Bool]())
             elif _type_is_eq[T, StringLiteral]():
-                obj = PythonObject(value.get[i, StringLiteral]())
+                obj = PythonObject(value.unsafe_get[i, StringLiteral]())
             else:
                 obj = PythonObject(0)
                 constrained[


### PR DESCRIPTION
Prevent crashes similar to that seen with `Tuple.get` (#3935). Also addressing #319, introducing `__getitem__` by forwarding `Tuple.__getitem__`.