### PR TITLE
[docs] Add all env. vars. used to pass mojo lib. search paths to tutorial

### DIFF
--- a/stdlib/docs/development.md
+++ b/stdlib/docs/development.md
@@ -262,11 +262,14 @@ def main():
     print(all_paths.__str__())
 ```
 
-We also need to set the following environment variable that tells Mojo to
+We also need to set the following environment variables that tells Mojo to
 prioritize imports from the standard library we just built, over the one that
 ships with Mojo:
 
 ```bash
+MODULAR_MOJO_IMPORT_PATH=../build \
+MODULAR_MOJO_MAX_IMPORT_PATH=../build \
+MODULAR_MOJO_MAX_NIGHTLY_IMPORT_PATH=../build \
 MODULAR_MOJO_NIGHTLY_IMPORT_PATH=../build mojo main.mojo
 ```
 
@@ -288,6 +291,9 @@ you can get with `sudo apt install entr` on Linux, or `brew install entr` on
 macOS. Now run:
 
 ```bash
+export MODULAR_MOJO_IMPORT_PATH=../build
+export MODULAR_MOJO_MAX_IMPORT_PATH=../build
+export MODULAR_MOJO_MAX_NIGHTLY_IMPORT_PATH=../build
 export MODULAR_MOJO_NIGHTLY_IMPORT_PATH=../build
 
 ls **/*.mojo | entr sh -c "./scripts/build-stdlib.sh && mojo main.mojo"


### PR DESCRIPTION
The env. var. shown in the tutorial section of the development document for the Stdlib is (at least in some cases) insufficient to point `mojo` to a newly build stdlib.mjpkg. This adds all the same variable that are passed in the `lit` config to hopefully get all edge cases covered and make getting stared easier.

Issue mentiones on Modular Discord:
https://discord.com/channels/1087530497313357884/1151418092052815884/1295522197275934824
https://discord.com/channels/1087530497313357884/1282843332690575444/1282845603017130127