### PR TITLE
[stdlib] Add split overloads

### DIFF
--- a/mojo/stdlib/stdlib/builtin/string_literal.mojo
+++ b/mojo/stdlib/stdlib/builtin/string_literal.mojo
@@ -697,13 +697,12 @@ struct StringLiteral[value: __mlir_type.`!kgen.string`](
         var result = self
         return result.join(elems)
 
-    fn split(self, sep: StringSlice, maxsplit: Int = -1) -> List[StaticString]:
+    @always_inline
+    fn split(self, sep: StringSlice) -> List[StaticString]:
         """Split the string by a separator.
 
         Args:
             sep: The string to split on.
-            maxsplit: The maximum amount of items to split from String.
-                Defaults to unlimited.
 
         Returns:
             A List of Strings containing the input split by the separator.
@@ -712,26 +711,46 @@ struct StringLiteral[value: __mlir_type.`!kgen.string`](
 
         ```mojo
         # Splitting a space
-        _ = "hello world".split(" ") # ["hello", "world"]
+        _ = StringSlice("hello world").split(" ") # ["hello", "world"]
         # Splitting adjacent separators
-        _ = "hello,,world".split(",") # ["hello", "", "world"]
-        # Splitting with maxsplit
-        _ = "1,2,3".split(",", 1) # ['1', '2,3']
+        _ = StringSlice("hello,,world").split(",") # ["hello", "", "world"]
+        # Splitting with starting or ending separators
+        _ = StringSlice(",1,2,3,").split(",") # ['', '1', '2', '3', '']
         # Splitting with an empty separator
-        _ = "123".split("") # ["", "1", "2", "3", ""]
+        _ = StringSlice("123").split("") # ['', '1', '2', '3', '']
+        ```
+        """
+        return self.as_string_slice().split(sep)
+
+    @always_inline
+    fn split(self, sep: StringSlice, maxsplit: Int) -> List[StaticString]:
+        """Split the string by a separator.
+
+        Args:
+            sep: The string to split on.
+            maxsplit: The maximum amount of items to split from String.
+
+        Returns:
+            A List of Strings containing the input split by the separator.
+
+        Examples:
+        ```mojo
+        # Splitting with maxsplit
+        _ = StringSlice("1,2,3").split(",", maxsplit=1) # ['1', '2,3']
+        # Splitting with starting or ending separators
+        _ = StringSlice(",1,2,3,").split(",", maxsplit=1) # ['', '1,2,3,']
+        # Splitting with an empty separator
+        _ = StringSlice("123").split("", maxsplit=1) # ['', '123']
         ```
         """
         return self.as_string_slice().split(sep, maxsplit=maxsplit)
 
-    fn split(
-        self, sep: NoneType = None, maxsplit: Int = -1
-    ) -> List[StaticString]:
+    @always_inline
+    fn split(self, sep: NoneType = None) -> List[StaticString]:
         """Split the string by every Whitespace separator.
 
         Args:
             sep: None.
-            maxsplit: The maximum amount of items to split from String. Defaults
-                to unlimited.
 
         Returns:
             A List of Strings containing the input split by the separator.
@@ -740,15 +759,36 @@ struct StringLiteral[value: __mlir_type.`!kgen.string`](
 
         ```mojo
         # Splitting an empty string or filled with whitespaces
-        _ = "      ".split() # []
-        _ = "".split() # []
+        _ = StringSlice("      ").split() # []
+        _ = StringSlice("").split() # []
 
         # Splitting a string with leading, trailing, and middle whitespaces
-        _ = "      hello    world     ".split() # ["hello", "world"]
+        _ = StringSlice("      hello    world     ").split() # ["hello", "world"]
         # Splitting adjacent universal newlines:
-        _ = (
+        _ = StringSlice(
             "hello \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e\\x85\\u2028\\u2029world"
         ).split()  # ["hello", "world"]
+        ```
+        """
+        return self.as_string_slice().split(sep)
+
+    @always_inline
+    fn split(
+        self, sep: NoneType = None, *, maxsplit: Int
+    ) -> List[StaticString]:
+        """Split the string by every Whitespace separator.
+
+        Args:
+            sep: None.
+            maxsplit: The maximum amount of items to split from String.
+
+        Returns:
+            A List of Strings containing the input split by the separator.
+
+        Examples:
+        ```mojo
+        # Splitting with maxsplit
+        _ = StringSlice("1     2  3").split(maxsplit=1) # ['1', '2  3']
         ```
         """
         return self.as_string_slice().split(sep, maxsplit=maxsplit)

--- a/mojo/stdlib/stdlib/collections/string/string.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string.mojo
@@ -1366,15 +1366,12 @@ struct String(
         """
         return self.as_string_slice().isspace()
 
-    fn split(
-        self, sep: StringSlice, maxsplit: Int = -1
-    ) -> List[StringSlice[__origin_of(self)]]:
+    @always_inline
+    fn split(self, sep: StringSlice) -> List[StringSlice[__origin_of(self)]]:
         """Split the string by a separator.
 
         Args:
             sep: The string to split on.
-            maxsplit: The maximum amount of items to split from String.
-                Defaults to unlimited.
 
         Returns:
             A List of Strings containing the input split by the separator.
@@ -1383,26 +1380,50 @@ struct String(
 
         ```mojo
         # Splitting a space
-        _ = "hello world".split(" ") # ["hello", "world"]
+        _ = StringSlice("hello world").split(" ") # ["hello", "world"]
         # Splitting adjacent separators
-        _ = "hello,,world".split(",") # ["hello", "", "world"]
-        # Splitting with maxsplit
-        _ = "1,2,3".split(",", 1) # ['1', '2,3']
+        _ = StringSlice("hello,,world").split(",") # ["hello", "", "world"]
+        # Splitting with starting or ending separators
+        _ = StringSlice(",1,2,3,").split(",") # ['', '1', '2', '3', '']
         # Splitting with an empty separator
-        _ = "123".split("") # ["", "1", "2", "3", ""]
+        _ = StringSlice("123").split("") # ['', '1', '2', '3', '']
+        ```
+        """
+        return self.as_string_slice().split(sep)
+
+    @always_inline
+    fn split(
+        self, sep: StringSlice, maxsplit: Int
+    ) -> List[StringSlice[__origin_of(self)]]:
+        """Split the string by a separator.
+
+        Args:
+            sep: The string to split on.
+            maxsplit: The maximum amount of items to split from String.
+
+        Returns:
+            A List of Strings containing the input split by the separator.
+
+        Examples:
+        ```mojo
+        # Splitting with maxsplit
+        _ = StringSlice("1,2,3").split(",", maxsplit=1) # ['1', '2,3']
+        # Splitting with starting or ending separators
+        _ = StringSlice(",1,2,3,").split(",", maxsplit=1) # ['', '1,2,3,']
+        # Splitting with an empty separator
+        _ = StringSlice("123").split("", maxsplit=1) # ['', '123']
         ```
         """
         return self.as_string_slice().split(sep, maxsplit=maxsplit)
 
+    @always_inline
     fn split(
-        self, sep: NoneType = None, maxsplit: Int = -1
+        self, sep: NoneType = None
     ) -> List[StringSlice[__origin_of(self)]]:
         """Split the string by every Whitespace separator.
 
         Args:
             sep: None.
-            maxsplit: The maximum amount of items to split from String. Defaults
-                to unlimited.
 
         Returns:
             A List of Strings containing the input split by the separator.
@@ -1411,13 +1432,36 @@ struct String(
 
         ```mojo
         # Splitting an empty string or filled with whitespaces
-        _ = "      ".split() # []
-        _ = "".split() # []
+        _ = StringSlice("      ").split() # []
+        _ = StringSlice("").split() # []
 
         # Splitting a string with leading, trailing, and middle whitespaces
-        _ = "      hello    world     ".split() # ["hello", "world"]
+        _ = StringSlice("      hello    world     ").split() # ["hello", "world"]
         # Splitting adjacent universal newlines:
-        _ = "hello \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e\\x85\\u2028\\u2029world".split()  # ["hello", "world"]
+        _ = StringSlice(
+            "hello \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e\\x85\\u2028\\u2029world"
+        ).split()  # ["hello", "world"]
+        ```
+        """
+        return self.as_string_slice().split(sep)
+
+    @always_inline
+    fn split(
+        self, sep: NoneType = None, *, maxsplit: Int
+    ) -> List[StringSlice[__origin_of(self)]]:
+        """Split the string by every Whitespace separator.
+
+        Args:
+            sep: None.
+            maxsplit: The maximum amount of items to split from String.
+
+        Returns:
+            A List of Strings containing the input split by the separator.
+
+        Examples:
+        ```mojo
+        # Splitting with maxsplit
+        _ = StringSlice("1     2  3").split(maxsplit=1) # ['1', '2  3']
         ```
         """
         return self.as_string_slice().split(sep, maxsplit=maxsplit)

--- a/mojo/stdlib/stdlib/collections/string/string_slice.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string_slice.mojo
@@ -1891,15 +1891,12 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
                     return False
             return self.byte_length() != 0
 
-    fn split(
-        self, sep: StringSlice, maxsplit: Int = -1
-    ) -> List[Self.Immutable]:
+    @always_inline
+    fn split(self, sep: StringSlice) -> List[Self.Immutable]:
         """Split the string by a separator.
 
         Args:
             sep: The string to split on.
-            maxsplit: The maximum amount of items to split from String.
-                Defaults to unlimited.
 
         Returns:
             A List of Strings containing the input split by the separator.
@@ -1911,23 +1908,43 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         _ = StringSlice("hello world").split(" ") # ["hello", "world"]
         # Splitting adjacent separators
         _ = StringSlice("hello,,world").split(",") # ["hello", "", "world"]
-        # Splitting with maxsplit
-        _ = StringSlice("1,2,3").split(",", 1) # ['1', '2,3']
+        # Splitting with starting or ending separators
+        _ = StringSlice(",1,2,3,").split(",") # ['', '1', '2', '3', '']
         # Splitting with an empty separator
-        _ = StringSlice("123").split("") # ["", "1", "2", "3", ""]
+        _ = StringSlice("123").split("") # ['', '1', '2', '3', '']
+        ```
+        """
+        return _split[has_maxsplit=False](self.get_immutable(), sep, -1)
+
+    @always_inline
+    fn split(self, sep: StringSlice, maxsplit: Int) -> List[Self.Immutable]:
+        """Split the string by a separator.
+
+        Args:
+            sep: The string to split on.
+            maxsplit: The maximum amount of items to split from String.
+
+        Returns:
+            A List of Strings containing the input split by the separator.
+
+        Examples:
+        ```mojo
+        # Splitting with maxsplit
+        _ = StringSlice("1,2,3").split(",", maxsplit=1) # ['1', '2,3']
+        # Splitting with starting or ending separators
+        _ = StringSlice(",1,2,3,").split(",", maxsplit=1) # ['', '1,2,3,']
+        # Splitting with an empty separator
+        _ = StringSlice("123").split("", maxsplit=1) # ['', '123']
         ```
         """
         return _split[has_maxsplit=True](self.get_immutable(), sep, maxsplit)
 
-    fn split(
-        self, sep: NoneType = None, maxsplit: Int = -1
-    ) -> List[Self.Immutable]:
+    @always_inline
+    fn split(self, sep: NoneType = None) -> List[Self.Immutable]:
         """Split the string by every Whitespace separator.
 
         Args:
             sep: None.
-            maxsplit: The maximum amount of items to split from String. Defaults
-                to unlimited.
 
         Returns:
             A List of Strings containing the input split by the separator.
@@ -1945,6 +1962,27 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         _ = StringSlice(
             "hello \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e\\x85\\u2028\\u2029world"
         ).split()  # ["hello", "world"]
+        ```
+        """
+        return _split[has_maxsplit=False](self.get_immutable(), sep, -1)
+
+    @always_inline
+    fn split(
+        self, sep: NoneType = None, *, maxsplit: Int
+    ) -> List[Self.Immutable]:
+        """Split the string by every Whitespace separator.
+
+        Args:
+            sep: None.
+            maxsplit: The maximum amount of items to split from String.
+
+        Returns:
+            A List of Strings containing the input split by the separator.
+
+        Examples:
+        ```mojo
+        # Splitting with maxsplit
+        _ = StringSlice("1     2  3").split(maxsplit=1) # ['1', '2  3']
         ```
         """
         return _split[has_maxsplit=True](self.get_immutable(), sep, maxsplit)


### PR DESCRIPTION
Add all split overloads with examples. Part of #3528

cc: @ConnorGray 
