### PR TITLE
[stdlib] Make `String.split()` return `List[StringSlice]`

### DIFF
--- a/max/kernels/src/nvml/nvml.mojo
+++ b/max/kernels/src/nvml/nvml.mojo
@@ -12,6 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 """Implements wrappers around the NVIDIA Management Library (nvml)."""
 
+from collections.string.string_slice import _to_string_list
 from os import abort
 from pathlib import Path
 from sys.ffi import _get_dylib_function as _ffi_get_dylib_function
@@ -382,11 +383,10 @@ struct Device(Writable):
                 fn (UnsafePointer[c_char], UInt32) -> Result,
             ]()(driver_version_buffer, UInt32(max_length))
         )
-        var driver_version_list = String(
-            StaticString(unsafe_from_utf8_ptr=driver_version_buffer)
+        var driver_version_list = StaticString(
+            unsafe_from_utf8_ptr=driver_version_buffer
         ).split(".")
-        var driver_version = DriverVersion(driver_version_list)
-        return driver_version
+        return DriverVersion(to_string_list(driver_version_list))
 
     fn _max_clock(self, clock_type: ClockType) raises -> Int:
         var clock = UInt32()

--- a/max/kernels/src/nvml/nvml.mojo
+++ b/max/kernels/src/nvml/nvml.mojo
@@ -386,7 +386,7 @@ struct Device(Writable):
         var driver_version_list = StaticString(
             unsafe_from_utf8_ptr=driver_version_buffer
         ).split(".")
-        return DriverVersion(to_string_list(driver_version_list))
+        return DriverVersion(_to_string_list(driver_version_list))
 
     fn _max_clock(self, clock_type: ClockType) raises -> Int:
         var clock = UInt32()

--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -187,6 +187,8 @@ mutation.
 
 - Added support for NVIDIA GeForce RTX 3090.
 
+- `String.split()` now returns a `List[StringSlice]`.
+
 ### Tooling changes
 
 - Added support for GCC-style debug flags `-g0`, `-g1`, and `-g2` to match

--- a/mojo/stdlib/stdlib/builtin/string_literal.mojo
+++ b/mojo/stdlib/stdlib/builtin/string_literal.mojo
@@ -20,7 +20,6 @@ from collections.string.string_slice import CodepointSliceIter, StaticString
 from os import PathLike
 from sys.ffi import c_char
 from collections.string.format import _FormatCurlyEntry
-from collections.string.string_slice import _to_string_list
 
 from python import ConvertibleToPython, PythonObject
 
@@ -698,7 +697,7 @@ struct StringLiteral[value: __mlir_type.`!kgen.string`](
         var result = self
         return result.join(elems)
 
-    fn split(self, sep: StringSlice, maxsplit: Int = -1) -> List[String]:
+    fn split(self, sep: StringSlice, maxsplit: Int = -1) -> List[StaticString]:
         """Split the string by a separator.
 
         Args:
@@ -722,11 +721,11 @@ struct StringLiteral[value: __mlir_type.`!kgen.string`](
         _ = "123".split("") # ["", "1", "2", "3", ""]
         ```
         """
-        return _to_string_list(
-            self.as_string_slice().split(sep, maxsplit=maxsplit)
-        )
+        return self.as_string_slice().split(sep, maxsplit=maxsplit)
 
-    fn split(self, sep: NoneType = None, maxsplit: Int = -1) -> List[String]:
+    fn split(
+        self, sep: NoneType = None, maxsplit: Int = -1
+    ) -> List[StaticString]:
         """Split the string by every Whitespace separator.
 
         Args:
@@ -747,9 +746,9 @@ struct StringLiteral[value: __mlir_type.`!kgen.string`](
         # Splitting a string with leading, trailing, and middle whitespaces
         _ = "      hello    world     ".split() # ["hello", "world"]
         # Splitting adjacent universal newlines:
-        _ = "hello \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e\\x85\\u2028\\u2029world".split()  # ["hello", "world"]
+        _ = (
+            "hello \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e\\x85\\u2028\\u2029world"
+        ).split()  # ["hello", "world"]
         ```
         """
-        return _to_string_list(
-            self.as_string_slice().split(sep, maxsplit=maxsplit)
-        )
+        return self.as_string_slice().split(sep, maxsplit=maxsplit)

--- a/mojo/stdlib/stdlib/collections/string/string.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string.mojo
@@ -1366,7 +1366,9 @@ struct String(
         """
         return self.as_string_slice().isspace()
 
-    fn split(self, sep: StringSlice, maxsplit: Int = -1) -> List[String]:
+    fn split(
+        self, sep: StringSlice, maxsplit: Int = -1
+    ) -> List[StringSlice[__origin_of(self)]]:
         """Split the string by a separator.
 
         Args:
@@ -1390,11 +1392,11 @@ struct String(
         _ = "123".split("") # ["", "1", "2", "3", ""]
         ```
         """
-        return _to_string_list(
-            self.as_string_slice().split(sep, maxsplit=maxsplit)
-        )
+        return self.as_string_slice().split(sep, maxsplit=maxsplit)
 
-    fn split(self, sep: NoneType = None, maxsplit: Int = -1) -> List[String]:
+    fn split(
+        self, sep: NoneType = None, maxsplit: Int = -1
+    ) -> List[StringSlice[__origin_of(self)]]:
         """Split the string by every Whitespace separator.
 
         Args:
@@ -1418,9 +1420,7 @@ struct String(
         _ = "hello \\t\\n\\v\\f\\r\\x1c\\x1d\\x1e\\x85\\u2028\\u2029world".split()  # ["hello", "world"]
         ```
         """
-        return _to_string_list(
-            self.as_string_slice().split(sep, maxsplit=maxsplit)
-        )
+        return self.as_string_slice().split(sep, maxsplit=maxsplit)
 
     fn splitlines(self, keepends: Bool = False) -> List[String]:
         """Split the string at line boundaries. This corresponds to Python's

--- a/mojo/stdlib/stdlib/collections/string/string_slice.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string_slice.mojo
@@ -2332,7 +2332,7 @@ fn _to_string_list[
 
 
 @always_inline
-fn _to_string_list[O: Origin](items: List[StringSlice[O]]) -> List[String]:
+fn _to_string_list[O: Origin, //](items: List[StringSlice[O]]) -> List[String]:
     """Create a list of Strings **copying** the existing data.
 
     Parameters:
@@ -2357,7 +2357,7 @@ fn _to_string_list[O: Origin](items: List[StringSlice[O]]) -> List[String]:
 
 
 @always_inline
-fn _to_string_list[O: Origin](items: List[Span[Byte, O]]) -> List[String]:
+fn _to_string_list[O: Origin, //](items: List[Span[Byte, O]]) -> List[String]:
     """Create a list of Strings **copying** the existing data.
 
     Parameters:

--- a/mojo/stdlib/stdlib/os/path/path.mojo
+++ b/mojo/stdlib/stdlib/os/path/path.mojo
@@ -127,7 +127,7 @@ fn expanduser[PathLike: os.PathLike, //](path: PathLike) raises -> String:
     var path_split = fspath.split(os.sep, 1)
     # If there is a properly formatted separator, return expanded fspath.
     if len(path_split) == 2:
-        return os.path.join(userhome, path_split[1])
+        return os.path.join(userhome, String(path_split[1]))
     # Path was a single `~` character, return home path
     return userhome
 

--- a/mojo/stdlib/test/builtin/test_sort.mojo
+++ b/mojo/stdlib/test/builtin/test_sort.mojo
@@ -15,6 +15,7 @@ from pathlib import _dir_of_current_file
 from random import random_float64, random_si64, random_ui64, seed
 
 from builtin.sort import _quicksort, _small_sort, _SortWrapper
+from collections.string.string_slice import _to_string_list
 from testing import assert_equal, assert_false, assert_true
 
 
@@ -529,7 +530,7 @@ def test_sort_strings():
     var text = (
         _dir_of_current_file() / "test_file_dummy_input.txt"
     ).read_text()
-    var strings = text.split(" ")
+    var strings = _to_string_list(text.split(" "))
     sort(strings)
     assert_sorted_string(strings)
 

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -685,15 +685,6 @@ def test_split():
     alias S = StaticString
     alias L = List[StaticString]
 
-    # empty separators default to whitespace
-    var d = "hello world".split()
-    assert_true(len(d) == 2)
-    assert_true(d[0] == "hello")
-    assert_true(d[1] == "world")
-    d = "hello \t\n\n\v\fworld".split("\n")
-    assert_true(len(d) == 3)
-    assert_true(d[0] == "hello \t" and d[1] == "" and d[2] == "\v\fworld")
-
     # Should add all whitespace-like chars as one
     # test all unicode separators
     # 0 is to build a String with null terminator
@@ -717,108 +708,53 @@ def test_split():
         String(bytes=unicode_paragraph_sep),
     )
     var s = univ_sep_var + "hello" + univ_sep_var + "world" + univ_sep_var
-    d = s.split()
-    assert_true(len(d) == 2)
-    assert_true(d[0] == "hello" and d[1] == "world")
+    assert_equal(StringSlice(s).split(), L("hello", "world"))
 
     # should split into empty strings between separators
-    d = "1,,,3".split(",")
-    assert_true(len(d) == 4)
-    assert_true(d[0] == "1" and d[1] == "" and d[2] == "" and d[3] == "3")
-    d = ",,,".split(",")
-    assert_true(len(d) == 4)
-    assert_true(d[0] == "" and d[1] == "" and d[2] == "" and d[3] == "")
-    d = " a b ".split(" ")
-    assert_true(len(d) == 4)
-    assert_true(d[0] == "" and d[1] == "a" and d[2] == "b" and d[3] == "")
-    d = "abababaaba".split("aba")
-    assert_true(len(d) == 4)
-    assert_true(d[0] == "" and d[1] == "b" and d[2] == "" and d[3] == "")
+    assert_equal(S("1,,,3").split(","), L("1", "", "", "3"))
+    assert_equal(S(",,,").split(","), L("", "", "", ""))
+    assert_equal(S(" a b ").split(" "), L("", "a", "b", ""))
+    assert_equal(S("abababaaba").split("aba"), L("", "b", "", ""))
+    assert_true(len(S("").split()) == 0)
+    assert_true(len(S(" ").split()) == 0)
+    assert_true(len(S("").split(" ")) == 1)
+    assert_true(len(S(",").split(",")) == 2)
+    assert_true(len(S(" ").split(" ")) == 2)
+    assert_true(len(S("").split("")) == 2)
+    assert_true(len(S("  ").split(" ")) == 3)
+    assert_true(len(S("   ").split(" ")) == 4)
 
     # should split into maxsplit + 1 items
-    d = "1,2,3".split(",", 0)
-    assert_true(len(d) == 1)
-    assert_true(d[0] == "1,2,3")
-    d = "1,2,3".split(",", 1)
-    assert_true(len(d) == 2)
-    assert_true(d[0] == "1" and d[1] == "2,3")
-
-    assert_true(len(String().split()) == 0)
-    assert_true(len(" ".split()) == 0)
-    assert_true(len(String().split(" ")) == 1)
-    assert_true(len(" ".split(" ")) == 2)
-    assert_true(len(S("").split("")) == 2)
-    assert_true(len("  ".split(" ")) == 3)
-    assert_true(len("   ".split(" ")) == 4)
+    assert_equal(S("1,2,3").split(",", 0), L("1,2,3"))
+    assert_equal(S("1,2,3").split(",", 1), L("1", "2,3"))
 
     # Split in middle
-    var d1 = "n"
-    var in1 = "faang"
-    var res1 = in1.split(d1)
-    assert_equal(len(res1), 2)
-    assert_equal(res1[0], "faa")
-    assert_equal(res1[1], "g")
-
-    # Matches should be properly split in multiple case
-    var d2 = " "
-    var in2 = "modcon is coming soon"
-    var res2 = in2.split(d2)
-    assert_equal(len(res2), 4)
-    assert_equal(res2[0], "modcon")
-    assert_equal(res2[1], "is")
-    assert_equal(res2[2], "coming")
-    assert_equal(res2[3], "soon")
+    assert_equal(S("faang").split("n"), L("faa", "g"))
 
     # No match from the delimiter
-    var d3 = "x"
-    var in3 = "hello world"
-    var res3 = in3.split(d3)
-    assert_equal(len(res3), 1)
-    assert_equal(res3[0], "hello world")
+    assert_equal(S("hello world").split("x"), L("hello world"))
 
     # Multiple character delimiter
-    var d4 = "ll"
-    var in4 = "hello"
-    var res4 = in4.split(d4)
-    assert_equal(len(res4), 2)
-    assert_equal(res4[0], "he")
-    assert_equal(res4[1], "o")
+    assert_equal(S("hello").split("ll"), L("he", "o"))
 
-    # related to #2879
-    # TODO: replace string comparison when __eq__ is implemented for List
-    assert_equal(
-        "abbaaaabbba".split("a").__str__(),
-        "['', 'bb', '', '', '', 'bbb', '']",
-    )
-    assert_equal(
-        "abbaaaabbba".split("a", 8).__str__(),
-        "['', 'bb', '', '', '', 'bbb', '']",
-    )
-    assert_equal(
-        "abbaaaabbba".split("a", 5).__str__(),
-        "['', 'bb', '', '', '', 'bbba']",
-    )
-    assert_equal("aaa".split("a", 0).__str__(), "['aaa']")
-    assert_equal("a".split("a").__str__(), "['', '']")
-    assert_equal("1,2,3".split("3", 0).__str__(), "['1,2,3']")
-    assert_equal("1,2,3".split("3", 1).__str__(), "['1,2,', '']")
-    assert_equal("1,2,3,3".split("3", 2).__str__(), "['1,2,', ',', '']")
-    assert_equal("1,2,3,3,3".split("3", 2).__str__(), "['1,2,', ',', ',3']")
+    res = L("", "bb", "", "", "", "bbb", "")
+    assert_equal(S("abbaaaabbba").split("a"), res)
+    assert_equal(S("abbaaaabbba").split("a", 8), res)
+    s1 = S("abbaaaabbba").split("a", 5)
+    assert_equal(s1, L("", "bb", "", "", "", "bbba"))
+    assert_equal(S("aaa").split("a", 0), L("aaa"))
+    assert_equal(S("a").split("a"), L("", ""))
+    assert_equal(S("1,2,3").split("3", 0), L("1,2,3"))
+    assert_equal(S("1,2,3").split("3", 1), L("1,2,", ""))
+    assert_equal(S("1,2,3,3").split("3", 2), L("1,2,", ",", ""))
+    assert_equal(S("1,2,3,3,3").split("3", 2), L("1,2,", ",", ",3"))
 
-    var in5 = "Hello 🔥!"
-    var res5 = in5.split()
-    assert_equal(len(res5), 2)
-    assert_equal(res5[0], "Hello")
-    assert_equal(res5[1], "🔥!")
+    assert_equal(S("Hello 🔥!").split(), L("Hello", "🔥!"))
 
-    var in6 = "Лорем ипсум долор сит амет"
-    var res6 = in6.split(" ")
-    assert_equal(len(res6), 5)
-    assert_equal(res6[0], "Лорем")
-    assert_equal(res6[1], "ипсум")
-    assert_equal(res6[2], "долор")
-    assert_equal(res6[3], "сит")
-    assert_equal(res6[4], "амет")
+    s2 = S("Лорем ипсум долор сит амет").split(" ")
+    assert_equal(s2, L("Лорем", "ипсум", "долор", "сит", "амет"))
+    s3 = S("Лорем ипсум долор сит амет").split("м")
+    assert_equal(s3, L("Лоре", " ипсу", " долор сит а", "ет"))
 
     assert_equal(S("123").split(""), L("", "1", "2", "3", ""))
     assert_equal(S("").join(S("123").split("")), "123")


### PR DESCRIPTION
Make all split functions return `List[StringSlice]`. Part of #3528. Closes #3879. Closes MSTDL-590.