### PR TITLE
[stdlib] Hristo/foundations for os process module

### DIFF
--- a/mojo/stdlib/src/builtin/file_descriptor.mojo
+++ b/mojo/stdlib/src/builtin/file_descriptor.mojo
@@ -90,11 +90,10 @@ struct FileDescriptor(Writer):
 
     @always_inline
     fn read_bytes(mut self, buffer: Span[mut=True, Byte]) raises -> UInt:
-        """
-        Read a number of bytes from the file.
+        """Read a number of bytes from the file into a buffer.
 
         Args:
-            buffer: Span[Byte] of length n where to store read bytes. n = number of bytes to read.
+            buffer: A `Span[Byte]` to read bytes into. Read up to `len(buffer)` number of bytes.
 
         Returns:
             Actual number of bytes read.
@@ -108,7 +107,7 @@ struct FileDescriptor(Writer):
 
         @parameter
         if os_is_macos() or os_is_linux():
-            read = external_call["read", c_ssize_t](
+            var read = external_call["read", c_ssize_t](
                 self.value, buffer.unsafe_ptr(), len(buffer)
             )
             if read < 0:

--- a/mojo/stdlib/src/builtin/file_descriptor.mojo
+++ b/mojo/stdlib/src/builtin/file_descriptor.mojo
@@ -89,7 +89,7 @@ struct FileDescriptor(Writer):
             )
 
     @always_inline
-    fn read_bytes(mut self, mut buffer: Span[Byte, _]) raises -> UInt:
+    fn read_bytes(mut self, buffer: Span[mut=True, Byte]) raises -> UInt:
         """
         Read a number of bytes from the file.
 

--- a/mojo/stdlib/src/builtin/file_descriptor.mojo
+++ b/mojo/stdlib/src/builtin/file_descriptor.mojo
@@ -98,6 +98,8 @@ struct FileDescriptor(Writer):
 
         Returns:
             Actual number of bytes read.
+        Notes:
+            [Reference](https://pubs.opengroup.org/onlinepubs/9799919799/functions/read.html).
         """
 
         constrained[

--- a/mojo/stdlib/src/builtin/file_descriptor.mojo
+++ b/mojo/stdlib/src/builtin/file_descriptor.mojo
@@ -30,6 +30,7 @@ from sys.info import is_amd_gpu, is_nvidia_gpu
 
 from builtin.io import _printf
 from builtin.os import abort
+from collections import List
 from memory import Span, UnsafePointer
 
 
@@ -88,9 +89,9 @@ struct FileDescriptor(Writer):
             )
 
     @always_inline
-    fn read_bytes(mut self, size: Int) raises -> Span[Byte, MutableAnyOrigin]:
+    fn read_bytes(mut self, size: Int) raises -> List[Byte]:
         """
-        Read a Span of bytes from the file.
+        Read a number of bytes from the file.
 
         Args:
             size: Number of bytes to read.
@@ -102,22 +103,20 @@ struct FileDescriptor(Writer):
         @parameter
         if is_nvidia_gpu():
             constrained[False, "Nvidia GPU read bytes not implemented"]()
-            return abort[Span[Byte, MutableAnyOrigin]]()
+            return abort[List[Byte]]()
         elif is_amd_gpu():
             constrained[False, "AMD GPU read bytes not implemented"]()
-            return abort[Span[Byte, MutableAnyOrigin]]()
+            return abort[List[Byte]]()
         elif os_is_macos() or os_is_linux():
-            var buf = UnsafePointer[UInt8].alloc(size)
-            read = external_call["read", Int](self.value, buf, size)
-
-            if read < 0:
-                buf.free()
-                raise Error("Failed to read bytes.")
-
-            return Span[Byte, MutableAnyOrigin](ptr=buf, length=size)
+            var list = List[Byte](capacity=size)
+            read = external_call["read", Int](
+                self.value, list.unsafe_ptr(), size
+            )
+            list.size = read
+            return list^
         else:
             constrained[False, "Unknown platform read bytes not implemented"]()
-            return abort[Span[Byte, MutableAnyOrigin]]()
+            return abort[List[Byte]]()
 
     fn write[*Ts: Writable](mut self, *args: *Ts):
         """Write a sequence of Writable arguments to the provided Writer.

--- a/mojo/stdlib/src/sys/_libc.mojo
+++ b/mojo/stdlib/src/sys/_libc.mojo
@@ -115,6 +115,7 @@ fn execvp(file: UnsafePointer[c_char], argv: UnsafePointer[c_str_ptr]) -> c_int:
 
 @always_inline
 fn vfork() -> c_int:
+    """[`vfork()`](https://pubs.opengroup.org/onlinepubs/009696799/functions/vfork.html)."""
     return external_call["vfork", c_int]()
 
 

--- a/mojo/stdlib/src/sys/_libc.mojo
+++ b/mojo/stdlib/src/sys/_libc.mojo
@@ -148,6 +148,9 @@ fn close(fd: c_int) -> c_int:
 
 @always_inline
 fn write(fd: c_int, buf: OpaquePointer, nbyte: c_size_t) -> c_int:
+    """[`write()`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/write.html)
+    — write to a file descriptor.
+    """
     return external_call["write", c_int](fd, buf, nbyte)
 
 

--- a/mojo/stdlib/src/sys/_libc.mojo
+++ b/mojo/stdlib/src/sys/_libc.mojo
@@ -131,6 +131,8 @@ struct SignalCodes:
 
 @always_inline
 fn kill(pid: c_int, sig: c_int) -> c_int:
+    """[`kill()`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/kill.html)
+    — send a signal to a process or group of processes."""
     return external_call["kill", c_int](pid, sig)
 
 

--- a/mojo/stdlib/src/sys/_libc.mojo
+++ b/mojo/stdlib/src/sys/_libc.mojo
@@ -144,6 +144,9 @@ fn pipe(fildes: UnsafePointer[c_int]) -> c_int:
 
 @always_inline
 fn close(fd: c_int) -> c_int:
+    """[`close()`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/close.html)
+    — close a file descriptor.
+    """
     return external_call["close", c_int](fd)
 
 

--- a/mojo/stdlib/src/sys/_libc.mojo
+++ b/mojo/stdlib/src/sys/_libc.mojo
@@ -174,6 +174,9 @@ struct FcntlFDFlags:
 
 @always_inline
 fn fcntl[*types: Intable](fd: c_int, cmd: c_int, *args: *types) -> c_int:
+    """[`fcntl()`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/fcntl.html)
+    — file control.
+    """
     return external_call["fcntl", c_int](fd, cmd, args)
 
 

--- a/mojo/stdlib/src/sys/_libc.mojo
+++ b/mojo/stdlib/src/sys/_libc.mojo
@@ -18,7 +18,7 @@ functionality in the rest of the Mojo standard library.
 """
 
 from sys import os_is_windows
-from sys.ffi import OpaquePointer, c_char, c_int, c_size_t, c_str_ptr
+from sys.ffi import OpaquePointer, c_char, c_int, c_size_t
 
 from memory import UnsafePointer
 
@@ -107,19 +107,23 @@ fn dup(oldfd: c_int) -> c_int:
 
 
 @always_inline
-fn execvp(file: UnsafePointer[c_char], argv: UnsafePointer[c_str_ptr]) -> c_int:
+fn execvp(
+    file: UnsafePointer[c_char], argv: UnsafePointer[UnsafePointer[c_char]]
+) -> c_int:
     """[`execvp`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/exec.html)
     — execute a file.
-    
+
     Args:
-        argv: The c_str_ptr array must be terminated with a NULL pointer.
+        file: NULL terminated UnsafePointer[c_char] (C string), containing path to executable.
+        argv: The UnsafePointer[c_char] array must be terminated with a NULL pointer.
     """
     return external_call["execvp", c_int](file, argv)
 
 
 @always_inline
 fn vfork() -> c_int:
-    """[`vfork()`](https://pubs.opengroup.org/onlinepubs/009696799/functions/vfork.html)."""
+    """[`vfork()`](https://pubs.opengroup.org/onlinepubs/009696799/functions/vfork.html).
+    """
     return external_call["vfork", c_int]()
 
 
@@ -142,7 +146,8 @@ fn kill(pid: c_int, sig: c_int) -> c_int:
 
 @always_inline
 fn pipe(fildes: UnsafePointer[c_int]) -> c_int:
-    """[`pipe()`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/pipe.html) — create an interprocess channel."""
+    """[`pipe()`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/pipe.html) — create an interprocess channel.
+    """
     return external_call["pipe", c_int](fildes)
 
 

--- a/mojo/stdlib/src/sys/_libc.mojo
+++ b/mojo/stdlib/src/sys/_libc.mojo
@@ -108,7 +108,11 @@ fn dup(oldfd: c_int) -> c_int:
 
 @always_inline
 fn execvp(file: UnsafePointer[c_char], argv: UnsafePointer[c_str_ptr]) -> c_int:
-    """`execvp` expects that the c_str_ptr array is terminated with a NULL pointer.
+    """[`execvp`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/exec.html)
+    — execute a file.
+    
+    Args:
+        argv: The c_str_ptr array must be terminated with a NULL pointer.
     """
     return external_call["execvp", c_int](file, argv)
 

--- a/mojo/stdlib/src/sys/_libc.mojo
+++ b/mojo/stdlib/src/sys/_libc.mojo
@@ -18,7 +18,7 @@ functionality in the rest of the Mojo standard library.
 """
 
 from sys import os_is_windows
-from sys.ffi import OpaquePointer, c_char, c_int, c_size_t
+from sys.ffi import OpaquePointer, c_char, c_int, c_size_t, c_str_ptr
 
 from memory import UnsafePointer
 
@@ -104,6 +104,67 @@ fn dup(oldfd: c_int) -> c_int:
     alias name = "_dup" if os_is_windows() else "dup"
 
     return external_call[name, c_int](oldfd)
+
+
+@always_inline
+fn execvp(file: UnsafePointer[c_char], argv: UnsafePointer[c_str_ptr]) -> c_int:
+    """`execvp` expects that the c_str_ptr array is terminated with a NULL pointer.
+    """
+    return external_call["execvp", c_int](file, argv)
+
+
+@always_inline
+fn vfork() -> c_int:
+    return external_call["vfork", c_int]()
+
+
+struct SignalCodes:
+    alias HUP = 1  # (hang up)
+    alias INT = 2  # (interrupt)
+    alias QUIT = 3  # (quit)
+    alias ABRT = 6  # (abort)
+    alias KILL = 9  # (non-catchable, non-ignorable kill)
+    alias ALRM = 14  # (alarm clock)
+    alias TERM = 15  # (software termination signal)
+
+
+@always_inline
+fn kill(pid: c_int, sig: c_int) -> c_int:
+    return external_call["kill", c_int](pid, sig)
+
+
+@always_inline
+fn pipe(fildes: UnsafePointer[c_int]) -> c_int:
+    return external_call["pipe", c_int](fildes)
+
+
+@always_inline
+fn close(fd: c_int) -> c_int:
+    return external_call["close", c_int](fd)
+
+
+@always_inline
+fn write(fd: c_int, buf: OpaquePointer, nbyte: c_size_t) -> c_int:
+    return external_call["write", c_int](fd, buf, nbyte)
+
+
+# ===-----------------------------------------------------------------------===#
+# fcntl.h - Control over file descriptors
+# ===-----------------------------------------------------------------------===#
+
+
+struct FcntlCommands:
+    alias F_GETFD: c_int = 1
+    alias F_SETFD: c_int = 2
+
+
+struct FcntlFDFlags:
+    alias FD_CLOEXEC: c_int = 1
+
+
+@always_inline
+fn fcntl[*types: Intable](fd: c_int, cmd: c_int, *args: *types) -> c_int:
+    return external_call["fcntl", c_int](fd, cmd, args)
 
 
 # ===-----------------------------------------------------------------------===#

--- a/mojo/stdlib/src/sys/_libc.mojo
+++ b/mojo/stdlib/src/sys/_libc.mojo
@@ -138,6 +138,7 @@ fn kill(pid: c_int, sig: c_int) -> c_int:
 
 @always_inline
 fn pipe(fildes: UnsafePointer[c_int]) -> c_int:
+    """[`pipe()`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/pipe.html) — create an interprocess channel."""
     return external_call["pipe", c_int](fildes)
 
 

--- a/mojo/stdlib/src/sys/ffi.mojo
+++ b/mojo/stdlib/src/sys/ffi.mojo
@@ -71,9 +71,6 @@ alias c_float = Float32
 alias c_double = Float64
 """C `double` type."""
 
-alias c_str_ptr = UnsafePointer[c_char]
-"""C `*char` type"""
-
 alias OpaquePointer = UnsafePointer[NoneType]
 """An opaque pointer, equivalent to the C `void*` type."""
 

--- a/mojo/stdlib/src/sys/ffi.mojo
+++ b/mojo/stdlib/src/sys/ffi.mojo
@@ -71,6 +71,9 @@ alias c_float = Float32
 alias c_double = Float64
 """C `double` type."""
 
+alias c_str_ptr = UnsafePointer[c_char]
+"""C `*char` type"""
+
 alias OpaquePointer = UnsafePointer[NoneType]
 """An opaque pointer, equivalent to the C `void*` type."""
 


### PR DESCRIPTION
Sets up the foundation for implementing the `os/process` module [PR with process module changes](https://github.com/modular/mojo/pull/3998)
  - Add `read_bytes` capability to `FileDecscriptor`
  - Add file descriptor controls function to Libc. bindings
  - Adds vfork, execvp, kill system call utils. to Mojos cLib binds
