### PR TITLE
[stdlib] [CI] Fix public CI pre-commit

### DIFF
--- a/.github/workflows/test_pre_commit.yml
+++ b/.github/workflows/test_pre_commit.yml
@@ -48,5 +48,6 @@ jobs:
           pre-commit install
       
       - name: Run pre-commit
-        run: magic run pre-commit run --all-files
+        working-directory: mojo
+        run: magic run pre-commit run --files ./stdlib
 


### PR DESCRIPTION
Missing manifest path and files to run for pre-commit

cc: @patrickdoc 
