### PR TITLE
[docs] Force refetch the diagram image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ commonly fragmented AI deployment workflows. MAX accelerates time to market
 for the latest innovations by giving AI developers a single toolchain that
 unlocks full programmability, unparalleled performance, and seamless hardware portability.
 
-![](https://docs.modular.com/images/github/max-stack.png)
+![](https://docs.modular.com/images/github/max-stack.png?20240228)
 
 [See here to get started with MAX](https://docs.modular.com/max/get-started)
 and when you want to report issues or request features,


### PR DESCRIPTION
GitHub creates its own image cache so we need to force an update using a modified URL.
