### PR TITLE
[stdlib] Constrain SIMD width to be an integer power of 2 in `UnsafePointer.load()`

### DIFF
--- a/mojo/stdlib/src/memory/unsafe_pointer.mojo
+++ b/mojo/stdlib/src/memory/unsafe_pointer.mojo
@@ -31,6 +31,7 @@ from sys.intrinsics import (
 
 from bit import is_power_of_two
 from memory.memory import _free, _malloc
+from builtin.simd import _simd_construction_checks
 
 # ===----------------------------------------------------------------------=== #
 # UnsafePointer
@@ -501,9 +502,7 @@ struct UnsafePointer[
         Returns:
             The loaded value.
         """
-        constrained[
-            is_power_of_two(width), "width must be a power of 2 integer value"
-        ]()
+        _simd_construction_checks[type, width]()
         constrained[
             alignment > 0, "alignment must be a positive integer value"
         ]()

--- a/mojo/stdlib/src/memory/unsafe_pointer.mojo
+++ b/mojo/stdlib/src/memory/unsafe_pointer.mojo
@@ -501,7 +501,9 @@ struct UnsafePointer[
         Returns:
             The loaded value.
         """
-        constrained[width > 0, "width must be a positive integer value"]()
+        constrained[
+            is_power_of_two(width), "width must be a power of 2 integer value"
+        ]()
         constrained[
             alignment > 0, "alignment must be a positive integer value"
         ]()


### PR DESCRIPTION
### Description
`UnsafePointer.load()` currently only constrains `SIMD` load widths to be a positive integer, and since loading bypasses `_simd_construction_checks()`, the `SIMD` vector can have a non-power of 2 size.

### Example
```mojo
from memory import UnsafePointer

fn main():
    var ptr = UnsafePointer[UInt8].alloc(3)
    ptr[0] = 1
    ptr[1] = 2
    ptr[2] = 3

    var simd = ptr.load[width = 3]()
    print(simd)
    
    # Output:
    # [1, 2, 3] <- SIMD size == 3
```

### Solution
Use `_simd_construction_checks()` in `UnsafePointer.load()`.