### PR TITLE
[stdlib] Revert the deletion of `StringLiteral` comptime `__mul__`

### DIFF
--- a/mojo/stdlib/src/builtin/string_literal.mojo
+++ b/mojo/stdlib/src/builtin/string_literal.mojo
@@ -189,6 +189,34 @@ struct StringLiteral(
         """
         self = self + rhs
 
+    @always_inline("nodebug")
+    fn __mul__(self, n: IntLiteral) -> StringLiteral:
+        """Concatenates the string literal `n` times. Can only be evaluated at
+        compile time using the `alias` keyword, which will write the result into
+        the binary.
+
+        Args:
+            n : The number of times to concatenate the string literal.
+
+        Returns:
+            The string concatenated `n` times.
+
+        Examples:
+
+        ```mojo
+        alias concat = "mojo" * 3
+        print(concat) # mojomojomojo
+        ```
+        .
+        """
+
+        var concat = ""
+
+        for _ in range(Int(n)):
+            concat += self
+
+        return concat
+
     fn __mul__(self, n: Int) -> String:
         """Concatenates the string `n` times.
 

--- a/mojo/stdlib/test/builtin/test_string_literal.mojo
+++ b/mojo/stdlib/test/builtin/test_string_literal.mojo
@@ -28,6 +28,7 @@ from builtin.string_literal import (
     _compress,
     _decompress,
 )
+from sys.intrinsics import _type_is_eq
 
 
 def test_add():
@@ -60,9 +61,17 @@ def test_mul():
     assert_equal(static_concat_1, static_concat_2)
     assert_equal("mojomojomojo", static_concat_0)
     assert_equal(static_concat_0, String("mojo") * 3)
-    var dynamic_concat = "mojo" * 3
-    assert_equal("mojomojomojo", dynamic_concat)
-    assert_equal(static_concat_0, dynamic_concat)
+    assert_true(_type_is_eq[__type_of(static_concat_0), StringLiteral]())
+    assert_true(_type_is_eq[__type_of(static_concat_1), String]())
+    assert_true(_type_is_eq[__type_of(static_concat_2), String]())
+    var dynamic_concat_0 = "mojo" * 3
+    var dynamic_concat_1 = "mojo" * `3`
+    var dynamic_concat_2 = "mojo" * `u3`
+    assert_equal("mojomojomojo", dynamic_concat_0)
+    assert_equal(static_concat_0, dynamic_concat_0)
+    assert_true(_type_is_eq[__type_of(dynamic_concat_0), StringLiteral]())
+    assert_true(_type_is_eq[__type_of(dynamic_concat_1), String]())
+    assert_true(_type_is_eq[__type_of(dynamic_concat_2), String]())
 
 
 def test_equality():


### PR DESCRIPTION
Revert the deletion of `StringLiteral` comptime `__mul__`. As stated in [this comment](https://github.com/modular/max/commit/4a83bf01c3853cbedecaa2e5d90ffbd3acd1f247#r152875958) for commit 4a83bf01c3853cbedecaa2e5d90ffbd3acd1f247, there does exist a need for that method.

Even if we make `StringLiteral` be non-materializable in the future, the multiplication by a compile time known variable should not allocate on the heap and can remain in parameter space, and then be embedded into the binary. Unless I'm wrong on how `String` builds its values from a `StringLiteral` (which AFAIK is allocating on the heap), I think this will have an impact on compile time.

If we do have a mechanism in the future where we can differentiate on compile time known `Int` vs runtime `Int`, then I guess we could delete this method. If I'm wrong on wanting to revert this, I'd like to know. I'd rather this surface to be talked about than remain in obscurity.