### PR TITLE
[docs] Update remaining occurrences of `Reference` type to `Pointer`

### DIFF
--- a/mojo/docs/manual/control-flow.mdx
+++ b/mojo/docs/manual/control-flow.mdx
@@ -251,7 +251,7 @@ information on Mojo collection types.
 :::caution TODO
 
 Iterating over Mojo native collections currently assigns the loop index variable
-a [`Reference`](/mojo/stdlib/memory/reference/Reference) to each item, not the
+a [`Pointer`](/mojo/stdlib/memory/pointer/Pointer) to each item, not the
 item itself. You can access the item using the dereference operator, `[]`, as
 shown in the examples below. This may change in a future version of Mojo.
 

--- a/mojo/docs/manual/control-flow.mdx
+++ b/mojo/docs/manual/control-flow.mdx
@@ -336,7 +336,7 @@ collection types shown above in that it's implemented as a
 [generator](https://en.wikipedia.org/wiki/Generator_\(computer_programming\)),
 producing each value as needed rather than materializing the entire sequence
 in memory. Additionally, each value assigned to the loop index variable is
-simply the `Int` value rather than a `Reference` to the value, so you should
+simply the `Int` value rather than a `Pointer` to the value, so you should
 not use the dereference operator on it within the loop. For example:
 
 ```mojo
@@ -459,7 +459,7 @@ cat
 :::note TODO
 
 Iterating over a Mojo collection currently assigns the loop index variable a
-`Reference` to each element, which then requires you to use the dereference
+`Pointer` to each element, which then requires you to use the dereference
 operator within the loop body. In contrast, iterating over a Python collection
 assigns a `PythonObject` wrapper for the element, which does *not* require you
 to use the dereference operator.

--- a/mojo/docs/manual/functions.mdx
+++ b/mojo/docs/manual/functions.mdx
@@ -387,13 +387,13 @@ fn sum(*values: Int) -> Int:
 Memory-only types, such as `String`, are available as a
 [`VariadicListMem`](/mojo/stdlib/builtin/list_literal/VariadicListMem).
 Iterating over this list directly with a `for..in` loop currently produces a
-[`Pointer`](/mojo/stdlib/memory/pointer/Pointer) for each value instead
+[`Pointer`](/mojo/stdlib/memory/pointer/Pointer) to each value instead
 of the value itself. You must add an empty subscript operator `[]` to
-dereference the reference and retrieve the value:
+dereference the pointer and retrieve the value:
 
 ```mojo
 def make_worldly(mut *strs: String):
-    # Requires extra [] to dereference the reference for now.
+    # Requires extra [] to dereference the pointer for now.
     for i in strs:
         i[] += " world"
 

--- a/mojo/docs/manual/functions.mdx
+++ b/mojo/docs/manual/functions.mdx
@@ -387,7 +387,7 @@ fn sum(*values: Int) -> Int:
 Memory-only types, such as `String`, are available as a
 [`VariadicListMem`](/mojo/stdlib/builtin/list_literal/VariadicListMem).
 Iterating over this list directly with a `for..in` loop currently produces a
-[`Reference`](/mojo/stdlib/memory/reference/Reference) for each value instead
+[`Pointer`](/mojo/stdlib/memory/pointer/Pointer) for each value instead
 of the value itself. You must add an empty subscript operator `[]` to
 dereference the reference and retrieve the value:
 

--- a/mojo/docs/manual/types.mdx
+++ b/mojo/docs/manual/types.mdx
@@ -621,7 +621,7 @@ There are some notable limitations when using `List`:
   they're a [`Stringable`](/mojo/stdlib/builtin/str/Stringable) type.
 
 * Iterating a `List` currently returns a
-  [`Reference`](/mojo/stdlib/memory/reference/Reference) to each item, not the
+  [`Pointer`](/mojo/stdlib/memory/pointer/Pointer) to each item, not the
   item itself. You can access the item using the dereference operator, `[]`:
 
 ```mojo


### PR DESCRIPTION
*Changes*

updates remaining occurrences of the `Reference` type to `Pointer` as per:
> The `Reference` type has been renamed to [`Pointer`](/mojo/stdlib/memory/pointer/Pointer): a memory safe complement to `UnsafePointer`. This change is motivated by the fact that `Pointer` is assignable and requires an explicit dereference with `ptr[]`. Renaming to `Pointer` clarifies that "references" means `ref` arguments and results, and gives us a model that is more similar to what the C++ community would expect.