### PR TITLE
[stdlib] rename `variance` parameter to `std` (standard deviation) 

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -327,4 +327,4 @@ ctx.enqueue_function(compiled_func, grid_dim=1, block_dim=1)
 ### 🛠️ Fixed
 
 - [#3976](https://github.com/modular/max/issues/3976) The `variance` argument
-  in `random.randn_float64` and `random.randn` has been renamed to `standard_deviation`.
+  in `random.randn_float64` and `random.randn` has been renamed to `standard_deviation` so that values are drawn from the correct distribution.

--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -325,3 +325,6 @@ ctx.enqueue_function(compiled_func, grid_dim=1, block_dim=1)
   capacity constructor, or an `InlineArray`.
 
 ### 🛠️ Fixed
+
+- [#3976](https://github.com/modular/max/issues/3976) The `variance` argument
+  in `random.randn_float64` and `random.randn` has been renamed to `standard_deviation`.

--- a/mojo/stdlib/src/random/random.mojo
+++ b/mojo/stdlib/src/random/random.mojo
@@ -181,19 +181,17 @@ fn rand[
         return
 
 
-fn randn_float64(mean: Float64 = 0.0, variance: Float64 = 1.0) -> Float64:
-    """Returns a random double sampled from a Normal(mean, variance) distribution.
+fn randn_float64(mean: Float64 = 0.0, std: Float64 = 1.0) -> Float64:
+    """Returns a random double sampled from a Normal(mean, std) distribution.
 
     Args:
         mean: Normal distribution mean.
-        variance: Normal distribution variance.
+        std: Normal distribution standard deviation.
 
     Returns:
-        A random float64 sampled from Normal(mean, variance).
+        A random float64 sampled from Normal(mean, std).
     """
-    return external_call["KGEN_CompilerRT_NormalDouble", Float64](
-        mean, variance
-    )
+    return external_call["KGEN_CompilerRT_NormalDouble", Float64](mean, std)
 
 
 fn randn[
@@ -202,9 +200,9 @@ fn randn[
     ptr: UnsafePointer[Scalar[type]],
     size: Int,
     mean: Float64 = 0.0,
-    variance: Float64 = 1.0,
+    std: Float64 = 1.0,
 ):
-    """Fills memory with random values from a Normal(mean, variance) distribution.
+    """Fills memory with random values from a Normal(mean, std) distribution.
 
     Constraints:
         The type should be floating point.
@@ -216,11 +214,11 @@ fn randn[
         ptr: The pointer to the memory area to fill.
         size: The number of elements to fill.
         mean: Normal distribution mean.
-        variance: Normal distribution variance.
+        std: Normal distribution standard deviation.
     """
 
     for i in range(size):
-        ptr[i] = randn_float64(mean, variance).cast[type]()
+        ptr[i] = randn_float64(mean, std).cast[type]()
     return
 
 

--- a/mojo/stdlib/src/random/random.mojo
+++ b/mojo/stdlib/src/random/random.mojo
@@ -181,17 +181,21 @@ fn rand[
         return
 
 
-fn randn_float64(mean: Float64 = 0.0, std: Float64 = 1.0) -> Float64:
-    """Returns a random double sampled from a Normal(mean, std) distribution.
+fn randn_float64(
+    mean: Float64 = 0.0, standard_deviation: Float64 = 1.0
+) -> Float64:
+    """Returns a random double sampled from a Normal(mean, standard_deviation) distribution.
 
     Args:
         mean: Normal distribution mean.
-        std: Normal distribution standard deviation.
+        standard_deviation: Normal distribution standard deviation.
 
     Returns:
-        A random float64 sampled from Normal(mean, std).
+        A random float64 sampled from Normal(mean, standard_deviation).
     """
-    return external_call["KGEN_CompilerRT_NormalDouble", Float64](mean, std)
+    return external_call["KGEN_CompilerRT_NormalDouble", Float64](
+        mean, standard_deviation
+    )
 
 
 fn randn[
@@ -200,9 +204,9 @@ fn randn[
     ptr: UnsafePointer[Scalar[type]],
     size: Int,
     mean: Float64 = 0.0,
-    std: Float64 = 1.0,
+    standard_deviation: Float64 = 1.0,
 ):
-    """Fills memory with random values from a Normal(mean, std) distribution.
+    """Fills memory with random values from a Normal(mean, standard_deviation) distribution.
 
     Constraints:
         The type should be floating point.
@@ -214,11 +218,11 @@ fn randn[
         ptr: The pointer to the memory area to fill.
         size: The number of elements to fill.
         mean: Normal distribution mean.
-        std: Normal distribution standard deviation.
+        standard_deviation: Normal distribution standard deviation.
     """
 
     for i in range(size):
-        ptr[i] = randn_float64(mean, std).cast[type]()
+        ptr[i] = randn_float64(mean, standard_deviation).cast[type]()
     return
 
 

--- a/mojo/stdlib/test/random/test_random.mojo
+++ b/mojo/stdlib/test/random/test_random.mojo
@@ -68,9 +68,12 @@ def test_random():
             ),
         )
 
+
+def test_seed_normal():
+    seed(42)
     # verify `randn_float64` values are normally distributed
-    var samples = List[Float64]()
-    var num_samples = 1_000_000
+    var num_samples = 1000
+    var samples = List[Float64](capacity=num_samples)
     for _ in range(num_samples):
         samples.append(randn_float64(0, 2))
 
@@ -82,31 +85,32 @@ def test_random():
 
     var sum_sq: Float64 = 0.0
     for sample in samples:
-        sum_sq += (sample[] - mean) * (sample[] - mean)
+        sum_sq += (sample[] - mean) ** 2
 
     var variance = sum_sq / num_samples
 
     # Calculate absolute differences (errors)
-    var mean_error = mean if mean > 0 else -mean
-    var variance_error = variance - 4 if variance > 4 else 4 - variance
+    var mean_error = abs(mean)
+    var variance_error = abs(variance - 4)
 
-    var tolerance: Float64 = 0.01
+    var mean_tolerance: Float64 = 0.06  # SE_μ = σ / √n
     assert_true(
-        mean_error < tolerance,
+        mean_error < mean_tolerance,
         String(
             "Mean error ",
             mean_error,
             " is above the accepted tolerance ",
-            tolerance,
+            mean_tolerance,
         ),
     )
+    var variance_tolerance: Float64 = 0.57  # SE_S² = √(2 * σ^4 / (n - 1))
     assert_true(
-        variance_error < tolerance,
+        variance_error < variance_tolerance,
         String(
             "Variance error ",
             variance_error,
             " is above the accepted tolerance ",
-            tolerance,
+            variance_tolerance,
         ),
     )
 

--- a/mojo/stdlib/test/random/test_random.mojo
+++ b/mojo/stdlib/test/random/test_random.mojo
@@ -68,8 +68,47 @@ def test_random():
             ),
         )
 
-    var random_normal = randn_float64(0, 1)
-    # it's quite hard to verify that the values returned are forming a normal distribution
+    # verify `randn_float64` values are normally distributed
+    var samples = List[Float64]()
+    var num_samples = 1_000_000
+    for _ in range(num_samples):
+        samples.append(randn_float64(0, 2))
+
+    var sum: Float64 = 0.0
+    for sample in samples:
+        sum += sample[]
+
+    var mean: Float64 = sum / num_samples
+
+    var sum_sq: Float64 = 0.0
+    for sample in samples:
+        sum_sq += (sample[] - mean) * (sample[] - mean)
+
+    var variance = sum_sq / num_samples
+
+    # Calculate absolute differences (errors)
+    var mean_error = mean if mean > 0 else -mean
+    var variance_error = variance - 4 if variance > 4 else 4 - variance
+
+    var tolerance: Float64 = 0.01
+    assert_true(
+        mean_error < tolerance,
+        String(
+            "Mean error ",
+            mean_error,
+            " is above the accepted tolerance ",
+            tolerance,
+        ),
+    )
+    assert_true(
+        variance_error < tolerance,
+        String(
+            "Variance error ",
+            variance_error,
+            " is above the accepted tolerance ",
+            tolerance,
+        ),
+    )
 
 
 def test_seed():


### PR DESCRIPTION

addresses the following [issue](https://github.com/modular/max/issues/3976) regarding the argument name in `randn_float64()` as well as `randn`. 

The choice to go with standard deviation over variance was made based on the existing `random.gauss` function from Python's standard library and numpy's `random.normal` which both take mean and standard deviation.

Things to consider
 - the new argument name could arguably be more descriptive.
 - the added test does increase the testing time by 2-3 seconds on my machine.


Changes
- renames the argument for `randn_float64()` and `randn`
- extends the corresponding unit tests