### PR TITLE
[stdlib] Add test for `InlineArray` (`sizeof[T]` by `capacity`).

### DIFF
--- a/mojo/stdlib/test/collections/test_inline_array.mojo
+++ b/mojo/stdlib/test/collections/test_inline_array.mojo
@@ -226,22 +226,17 @@ fn test_unsafe_ptr() raises:
         assert_equal(arr[i], ptr[i])
 
 
-def test_sizeof_array[
-    current_type: CollectionElement, capacity: Int
-](fill_value: current_type):
+def test_sizeof_array[current_type: CollectionElement, capacity: Int]():
     """Testing if `sizeof` the array equals capacity * `sizeof` current_type.
-
-    Args:
-        fill_value: The value to initialize the array with.
 
     Parameters:
         current_type: The type of the elements of the `InlineList`.
         capacity: The capacity of the `InlineList`.
     """
     alias size_of_current_type = sizeof[current_type]()
-    var arr = InlineArray[current_type, capacity](fill=fill_value)
     assert_equal(
-        sizeof[__type_of(arr._array)](), capacity * size_of_current_type
+        sizeof[InlineArray[current_type, capacity]](),
+        capacity * size_of_current_type,
     )
 
 
@@ -254,4 +249,4 @@ def main():
     test_array_contains()
     test_inline_array_runs_destructors()
     test_unsafe_ptr()
-    test_sizeof_array[Int, capacity=32](fill_value=0)
+    test_sizeof_array[Int, capacity=32]()

--- a/mojo/stdlib/test/collections/test_inline_array.mojo
+++ b/mojo/stdlib/test/collections/test_inline_array.mojo
@@ -18,6 +18,7 @@ from memory import UnsafePointer
 from memory.maybe_uninitialized import UnsafeMaybeUninitialized
 from test_utils import DelRecorder
 from testing import assert_equal, assert_false, assert_true
+from sys.info import sizeof
 
 
 def test_array_unsafe_get():
@@ -225,6 +226,25 @@ fn test_unsafe_ptr() raises:
         assert_equal(arr[i], ptr[i])
 
 
+def test_sizeof_array[
+    current_type: CollectionElement, capacity: Int
+](fill_value: current_type):
+    """Testing if `sizeof` the array equals capacity * `sizeof` current_type.
+
+    Args:
+        fill_value: The value to initialize the array with.
+
+    Parameters:
+        current_type: The type of the elements of the `InlineList`.
+        capacity: The capacity of the `InlineList`.
+    """
+    alias size_of_current_type = sizeof[current_type]()
+    var arr = InlineArray[current_type, capacity](fill=fill_value)
+    assert_equal(
+        sizeof[__type_of(arr._array)](), capacity * size_of_current_type
+    )
+
+
 def main():
     test_array_unsafe_get()
     test_array_int()
@@ -234,3 +254,4 @@ def main():
     test_array_contains()
     test_inline_array_runs_destructors()
     test_unsafe_ptr()
+    test_sizeof_array[Int, capacity=32](fill_value=0)


### PR DESCRIPTION
Hello,
this PR adds a small test for `InlineArray`:

```mojo
(sizeof[ElementType]() * capacity) == sizeof[self._array]()
```