### PR TITLE
[Docs] use `self.cap` in heap allocated array example

### DIFF
--- a/mojo/docs/manual/functions.mdx
+++ b/mojo/docs/manual/functions.mdx
@@ -368,8 +368,13 @@ def greet(*names: String):
 Inside the function body, the variadic argument is available as an iterable list
 for ease of use. Currently there are some differences in handling the list
 depending on whether the arguments are register-passable types (such as `Int`)
-or memory-only types (such as `String`). TODO: We hope to remove these
-differences in the future.
+or memory-only types (such as `String`). 
+
+:::note TODO
+
+We hope to remove these differences in the future.
+
+:::
 
 Register-passable types, such as `Int`, are available as a
 [`VariadicList`](/mojo/stdlib/builtin/list_literal/VariadicList) type. As

--- a/mojo/docs/manual/lifecycle/life.mdx
+++ b/mojo/docs/manual/lifecycle/life.mdx
@@ -158,7 +158,7 @@ can happen when one of the following occurs:
 - You return a value of one type from a function that specifies a different
   return type.
 
-In both cases, implicit conversion is supported when the target type
+In all cases, implicit conversion is supported when the target type
 defines a constructor that meets the following criteria:
 
 - Is declared with the `@implicit` decorator.

--- a/mojo/docs/manual/lifecycle/life.mdx
+++ b/mojo/docs/manual/lifecycle/life.mdx
@@ -451,7 +451,7 @@ struct HeapArray:
     fn __init__(out self, size: Int, val: Int):
         self.size = size
         self.cap = size * 2
-        self.data = UnsafePointer[Int].alloc(self.size)
+        self.data = UnsafePointer[Int].alloc(self.cap)
         for i in range(self.size):
             (self.data + i).init_pointee_copy(val)
 


### PR DESCRIPTION
Just some minor neat-picks spotted as I was reading through [Life of a value](https://docs.modular.com/mojo/manual/lifecycle/life) page. The corresponding issue https://github.com/modular/max/issues/4127


**Changes**

- 3 cases of implicit conversion are now mentioned, replaces `both` with `all`
- uses `self.cap` to allocate memory (consistent with the previous `HeapArray` example on the same page)