### PR TITLE
[stdlib] Save small move on `Variant.__copyinit__` ( `init_pointee_*`).

### DIFF
--- a/mojo/stdlib/src/utils/variant.mojo
+++ b/mojo/stdlib/src/utils/variant.mojo
@@ -142,7 +142,7 @@ struct Variant[*Ts: CollectionElement](
         for i in range(len(VariadicList(Ts))):
             alias T = Ts[i]
             if copy._get_discr() == i:
-                copy._get_ptr[T]().init_pointee_move(self._get_ptr[T]()[])
+                copy._get_ptr[T]().init_pointee_copy(self._get_ptr[T]()[])
                 return
 
     fn __copyinit__(out self, other: Self):

--- a/mojo/stdlib/test/utils/test_variant.mojo
+++ b/mojo/stdlib/test/utils/test_variant.mojo
@@ -87,17 +87,25 @@ def test_basic():
 
 
 def test_copy():
-    var v1 = TestVariant(MoveCopyCounter())
+    var v1 = TestVariant(MoveCopyCounter())  # initial move value in
+    assert_equal(v1[MoveCopyCounter].moved, 1)
     var v2 = v1
-    # didn't call copyinit
+
     assert_equal(v1[MoveCopyCounter].copied, 0)
     assert_equal(v2[MoveCopyCounter].copied, 1)
+    assert_equal(v1[MoveCopyCounter].moved, 1)  # same initial move value in
+    assert_equal(
+        v2[MoveCopyCounter].moved, 1
+    )  # carry the initial move value in
+
     # test that we didn't call the other copyinit too!
     assert_no_poison()
 
 
 def test_explicit_copy():
-    var v1 = TestVariant(MoveCopyCounter())
+    var v1 = TestVariant(MoveCopyCounter())  # initial move value in
+    assert_equal(v1[MoveCopyCounter].moved, 1)
+    assert_equal(v1[MoveCopyCounter].copied, 0)
 
     # Perform explicit copy
     var v2 = v1.copy()
@@ -105,17 +113,24 @@ def test_explicit_copy():
     # Test copy counts
     assert_equal(v1[MoveCopyCounter].copied, 0)
     assert_equal(v2[MoveCopyCounter].copied, 1)
+    assert_equal(v1[MoveCopyCounter].moved, 1)  # same initial move value in
+    assert_equal(
+        v2[MoveCopyCounter].moved, 1
+    )  # carry the initial move value in
 
     # test that we didn't call the other copyinit too!
     assert_no_poison()
 
 
 def test_move():
-    var v1 = TestVariant(MoveCopyCounter())
-    var v2 = v1
-    # didn't call moveinit
+    var v1 = TestVariant(MoveCopyCounter())  # initial move value in
     assert_equal(v1[MoveCopyCounter].moved, 1)
+
+    var v2 = v1^
+
     assert_equal(v2[MoveCopyCounter].moved, 2)
+    assert_equal(v2[MoveCopyCounter].copied, 0)
+
     # test that we didn't call the other moveinit too!
     assert_no_poison()
 


### PR DESCRIPTION
Hello,
this PR removes a small move on `Variant.__copyinit__`, (`UnsafePointer.init_pointee_*`),

It should also remove a move on `Optional`, `Dict._entries`,

and `struct` using `Variant` 🎉
