### PR TITLE
[stdlib][feature request] use `Tuple[K,V]` instead of `DictEntry[K,V]`

### DIFF
--- a/mojo/docs/manual/control-flow.mdx
+++ b/mojo/docs/manual/control-flow.mdx
@@ -314,7 +314,7 @@ Salem, Oregon
 
 The second approach to iterating over a Mojo `Dict` is to invoke its
 [`items()`](/mojo/stdlib/collections/dict/Dict#items) method, which produces a
-sequence of [`DictEntry`](/mojo/stdlib/collections/dict/DictEntry) objects.
+sequence of [`Tuple`](/mojo/stdlib/builtin/tuple/Tuple) objects.
 Within the loop body, you can then access the `key` and `value` fields of the
 entry.
 

--- a/mojo/stdlib/benchmarks/collections/bench_dict.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_dict.mojo
@@ -15,7 +15,6 @@
 # the -t flag. Remember to replace it again before pushing any code.
 
 from collections import Dict, Optional
-from collections.dict import DictEntry
 from math import ceil
 from random import *
 from sys import sizeof
@@ -103,7 +102,7 @@ fn bench_dict_lookup[size: Int](mut b: Bencher) raises:
 
 fn total_bytes_used(items: Dict[Int, Int]) -> Int:
     # the allocated memory by entries:
-    var entry_size = sizeof[Optional[DictEntry[Int, Int]]]()
+    var entry_size = sizeof[Optional[Tuple[Int, Int]]]()
     var amnt_bytes = items._entries.capacity * entry_size
     amnt_bytes += sizeof[Dict[Int, Int]]()
 

--- a/mojo/stdlib/src/builtin/object.mojo
+++ b/mojo/stdlib/src/builtin/object.mojo
@@ -618,7 +618,7 @@ struct _ObjectImpl(
         for entry in ptr[].impl[].items():
             if print_sep:
                 writer.write(", ")
-            writer.write("'", entry[].key, "' = ", object(entry[].value.copy()))
+            writer.write("'", entry[][0], "' = ", object(entry[][1].copy()))
             print_sep = True
         writer.write("}")
         return

--- a/mojo/stdlib/src/collections/counter.mojo
+++ b/mojo/stdlib/src/collections/counter.mojo
@@ -405,8 +405,8 @@ struct Counter[V: KeyElement](Sized, CollectionElement, Boolable):
         var result = Counter[V]()
         for item_ref in self.items():
             var item = item_ref[]
-            if item.value > 0:
-                result[item.key] = item.value
+            if item[1] > 0:
+                result[item[0]] = item[1]
         return result^
 
     fn __neg__(self) -> Self:
@@ -419,8 +419,8 @@ struct Counter[V: KeyElement](Sized, CollectionElement, Boolable):
         var result = Counter[V]()
         for item_ref in self.items():
             var item = item_ref[]
-            if item.value < 0:
-                result[item.key] = -item.value
+            if item[1] < 0:
+                result[item[0]] = -item[1]
         return result
 
     # ===------------------------------------------------------------------=== #
@@ -521,7 +521,7 @@ struct Counter[V: KeyElement](Sized, CollectionElement, Boolable):
             "KeyError" if the Counter is empty.
         """
         var item_ref = self._data.popitem()
-        return CountTuple[V](item_ref.key, item_ref.value)
+        return CountTuple[V](item_ref[0], item_ref[1])
 
     # Special methods for counter
 
@@ -549,7 +549,7 @@ struct Counter[V: KeyElement](Sized, CollectionElement, Boolable):
         var items: List[CountTuple[V]] = List[CountTuple[V]]()
         for item_ref in self._data.items():
             var item = item_ref[]
-            var t = CountTuple[V](item.key, item.value)
+            var t = CountTuple[V](item[0], item[1])
             items.append(t)
 
         @parameter
@@ -569,8 +569,8 @@ struct Counter[V: KeyElement](Sized, CollectionElement, Boolable):
         var elements: List[V] = List[V]()
         for item_ref in self._data.items():
             var item = item_ref[]
-            for _ in range(item.value):
-                elements.append(item.key)
+            for _ in range(item[1]):
+                elements.append(item[0])
         return elements
 
     fn update(mut self, other: Self):
@@ -582,7 +582,7 @@ struct Counter[V: KeyElement](Sized, CollectionElement, Boolable):
         """
         for item_ref in other.items():
             var item = item_ref[]
-            self._data[item.key] = self._data.get(item.key, 0) + item.value
+            self._data[item[0]] = self._data.get(item[0], 0) + item[1]
 
     fn subtract(mut self, other: Self):
         """Subtract count. Both inputs and outputs may be zero or negative.
@@ -592,7 +592,7 @@ struct Counter[V: KeyElement](Sized, CollectionElement, Boolable):
         """
         for item_ref in other.items():
             var item = item_ref[]
-            self[item.key] = self.get(item.key, 0) - item.value
+            self[item[0]] = self.get(item[0], 0) - item[1]
 
 
 struct CountTuple[V: KeyElement](

--- a/mojo/stdlib/src/python/python_object.mojo
+++ b/mojo/stdlib/src/python/python_object.mojo
@@ -526,7 +526,7 @@ struct PythonObject(
         self.py_object = cpython.PyDict_New()
         for entry in value.items():
             var result = cpython.PyDict_SetItem(
-                self.py_object, entry[].key.py_object, entry[].value.py_object
+                self.py_object, entry[][0].py_object, entry[][1].py_object
             )
 
     fn __copyinit__(out self, existing: Self):
@@ -1369,11 +1369,9 @@ struct PythonObject(
 
         var dict_obj = cpython.PyDict_New()
         for entry in kwargs.items():
-            var key = cpython.PyUnicode_DecodeUTF8(
-                entry[].key.as_string_slice()
-            )
+            var key = cpython.PyUnicode_DecodeUTF8(entry[][0].as_string_slice())
             var result = cpython.PyDict_SetItem(
-                dict_obj, key, entry[].value.py_object
+                dict_obj, key, entry[][1].py_object
             )
             if result != 0:
                 raise Error("internal error: PyDict_SetItem failed")

--- a/mojo/stdlib/test/builtin/test_reversed.mojo
+++ b/mojo/stdlib/test/builtin/test_reversed.mojo
@@ -57,8 +57,8 @@ def test_reversed_dict():
     keys = String("")
     check = 4
     for item in reversed(dict.items()):
-        keys += item[].key
-        assert_equal(item[].value, check)
+        keys += item[][0]
+        assert_equal(item[][1], check)
         check -= 1
 
     assert_equal(keys, "dcba")
@@ -91,8 +91,8 @@ def test_reversed_dict():
     keys = String("")
     check = 4
     for item in reversed(dict.items()):
-        keys += item[].key
-        assert_equal(item[].value, check)
+        keys += item[][0]
+        assert_equal(item[][1], check)
         check -= 2
 
     assert_equal(keys, "db")
@@ -108,8 +108,8 @@ def test_reversed_dict():
     keys = String("")
     check = 1
     for item in reversed(dict.items()):
-        keys += item[].key
-        assert_equal(item[].value, check)
+        keys += item[][0]
+        assert_equal(item[][1], check)
         check += 1
 
     assert_equal(keys, "acdb")
@@ -134,8 +134,8 @@ def test_reversed_dict():
     keys = String("")
     check = 0
     for item in reversed(empty_dict.items()):
-        keys += item[].key
-        check += item[].value
+        keys += item[][0]
+        check += item[][1]
 
     assert_equal(keys, "")
     assert_equal(check, 0)

--- a/mojo/stdlib/test/collections/test_counter.mojo
+++ b/mojo/stdlib/test/collections/test_counter.mojo
@@ -186,8 +186,8 @@ def test_iter_items():
     var keys = String("")
     var sum = 0
     for entry in c.items():
-        keys += entry[].key
-        sum += entry[].value
+        keys += entry[][0]
+        sum += entry[][1]
 
     assert_equal(keys, "ab")
     assert_equal(sum, 3)

--- a/mojo/stdlib/test/collections/test_dict.mojo
+++ b/mojo/stdlib/test/collections/test_dict.mojo
@@ -34,8 +34,8 @@ def test_dict_fromkeys():
     assert_equal(len(dict), len(expected_dict))
 
     for k_v in expected_dict.items():
-        var k = k_v[].key
-        var v = k_v[].value
+        var k = k_v[][0]
+        var v = k_v[][1]
         assert_true(k in dict)
         assert_equal(dict[k], v)
 
@@ -51,8 +51,8 @@ def test_dict_fromkeys_optional():
     assert_equal(len(dict), len(expected_dict))
 
     for k_v in expected_dict.items():
-        var k = k_v[].key
-        var v = k_v[].value
+        var k = k_v[][0]
+        var v = k_v[][1]
         assert_true(k in dict)
         assert_false(v)
 
@@ -226,8 +226,8 @@ def test_iter_items():
     var keys = String("")
     var sum = 0
     for entry in dict.items():
-        keys += entry[].key
-        sum += entry[].value
+        keys += entry[][0]
+        sum += entry[][1]
 
     assert_equal(keys, "ab")
     assert_equal(sum, 3)
@@ -503,8 +503,8 @@ def test_taking_owned_kwargs_dict(owned kwargs: OwnedKwargsDict[Int]):
     keys = String("")
     sum = 0
     for entry in kwargs.items():
-        keys += entry[].key
-        sum += entry[].value
+        keys += entry[][0]
+        sum += entry[][1]
     assert_equal(keys, "dessertsalad")
     assert_equal(sum, 19)
 
@@ -531,11 +531,11 @@ def test_dict_popitem():
     dict["b"] = 2
 
     var item = dict.popitem()
-    assert_equal(item.key, "b")
-    assert_equal(item.value, 2)
+    assert_equal(item[0], "b")
+    assert_equal(item[1], 2)
     item = dict.popitem()
-    assert_equal(item.key, "a")
-    assert_equal(item.value, 1)
+    assert_equal(item[0], "a")
+    assert_equal(item[1], 1)
     with assert_raises(contains="KeyError"):
         _ = dict.popitem()
 

--- a/mojo/stdlib/test/tempfile/test_tempfile.mojo
+++ b/mojo/stdlib/test/tempfile/test_tempfile.mojo
@@ -65,15 +65,15 @@ struct TempEnvWithCleanup:
 
     def __enter__(mut self):
         for key_value in self.vars_to_set.items():
-            var key = key_value[].key
-            var value = key_value[].value
+            var key = key_value[][0]
+            var value = key_value[][1]
             self._vars_back[key] = os.getenv(key)
             _ = os.setenv(key, value, overwrite=True)
 
     fn __exit__(mut self):
         for key_value in self.vars_to_set.items():
-            var key = key_value[].key
-            var value = key_value[].value
+            var key = key_value[][0]
+            var value = key_value[][1]
             _ = os.setenv(key, value, overwrite=True)
 
     def __exit__(mut self, error: Error) -> Bool:


### PR DESCRIPTION
Signed-off-by: Illia Sheshyn <187636533+illiasheshyn@users.noreply.github.com>

as per https://github.com/modular/max/issues/2554

Changes
- `Dict` type owns computed key hashes
- removes usages and doc mentions of `DictEntry` type
