### PR TITLE
[CI] Fix benchmarks, clean up environment variables

### DIFF
--- a/mojo/pixi.toml
+++ b/mojo/pixi.toml
@@ -8,7 +8,7 @@ platforms = ["linux-64", "linux-aarch64", "osx-arm64"]
 build = "./stdlib/scripts/build-stdlib.sh"
 tests = "./stdlib/scripts/run-tests.sh"
 examples = "../examples/mojo/run-examples.sh"
-benchmarks = { cmd = ["./stdlib/scripts/run-benchmarks.sh"], env = { MODULAR_MOJO_IMPORT_PATH = "$CONDA_PREFIX/lib/mojo" } }
+benchmarks = "./stdlib/scripts/run-benchmarks.sh"
 
 [dependencies]
 python = ">=3.9,<3.13"

--- a/mojo/stdlib/benchmarks/lit.cfg.py
+++ b/mojo/stdlib/benchmarks/lit.cfg.py
@@ -47,10 +47,7 @@ else:
     # This is important since `benchmark` is closed source
     # still right now and is always used by the benchmarks.
     pre_built_packages_path = Path(
-        os.environ.get(
-            "MODULAR_MOJO_IMPORT_PATH",
-            repo_root / ".magic" / "envs" / "default" / "lib" / "mojo",
-        )
+        repo_root / ".magic" / "envs" / "default" / "lib" / "mojo"
     )
 
     # The `run-tests.sh` script creates the build directory for you.
@@ -66,7 +63,6 @@ else:
     # These environment variables are interpreted by the mojo parser
     # when resolving imports.
     joint_path = f"{build_root.resolve()},{pre_built_packages_path.resolve()}"
-    os.environ["MODULAR_MOJO_IMPORT_PATH"] = joint_path
     os.environ["MODULAR_MOJO_MAX_IMPORT_PATH"] = joint_path
 
     # Pass through several environment variables
@@ -75,7 +71,7 @@ else:
     lit.llvm.llvm_config.with_system_environment(
         [
             "MODULAR_HOME",
-            "MODULAR_MOJO_IMPORT_PATH",
+            "MODULAR_MOJO_MAX_IMPORT_PATH",
             "PATH",
         ]
     )

--- a/mojo/stdlib/docs/development.md
+++ b/mojo/stdlib/docs/development.md
@@ -267,7 +267,7 @@ prioritize imports from the standard library we just built, over the one that
 ships with Mojo:
 
 ```bash
-MODULAR_MOJO_IMPORT_PATH=../build mojo main.mojo
+MODULAR_MOJO_MAX_IMPORT_PATH=../build mojo main.mojo
 ```
 
 Which now outputs:
@@ -288,7 +288,7 @@ you can get with `sudo apt install entr` on Linux, or `brew install entr` on
 macOS. Now run:
 
 ```bash
-export MODULAR_MOJO_IMPORT_PATH=../build
+export MODULAR_MOJO_MAX_IMPORT_PATH=../build
 
 ls **/*.mojo | entr sh -c "./scripts/build-stdlib.sh && mojo main.mojo"
 ```

--- a/mojo/stdlib/scripts/run-tests.sh
+++ b/mojo/stdlib/scripts/run-tests.sh
@@ -28,7 +28,7 @@ TEST_UTILS_PATH="${REPO_ROOT}/stdlib/test/test_utils"
 # This is needed to compile test_utils.mojopkg correctly, otherwise it
 # uses the stdlib that's given in the nightly, and will fail compilation
 # if some breaking changes are made.
-export MODULAR_MOJO_IMPORT_PATH=$BUILD_DIR
+export MODULAR_MOJO_MAX_IMPORT_PATH=$BUILD_DIR
 mojo package "${TEST_UTILS_PATH}" -I ${BUILD_DIR} -o "${BUILD_DIR}/test_utils.mojopkg"
 
 TEST_PATH="${REPO_ROOT}/stdlib/test"

--- a/mojo/stdlib/test/lit.cfg.py
+++ b/mojo/stdlib/test/lit.cfg.py
@@ -89,10 +89,7 @@ else:
     # `mojo` compiler would use its own `stdlib.mojopkg` it ships with which is not
     # what we want. We override both the stable and nightly `mojo` import paths
     # here to support both versions of the compiler.
-    os.environ["MODULAR_MOJO_IMPORT_PATH"] = str(build_root)
-    os.environ["MODULAR_MOJO_NIGHTLY_IMPORT_PATH"] = str(build_root)
     os.environ["MODULAR_MOJO_MAX_IMPORT_PATH"] = str(build_root)
-    os.environ["MODULAR_MOJO_MAX_NIGHTLY_IMPORT_PATH"] = str(build_root)
 
     # Pass through several environment variables
     # to the underlying subprocesses that run the tests.
@@ -100,9 +97,6 @@ else:
     lit.llvm.llvm_config.with_system_environment(
         [
             "MODULAR_HOME",
-            "MODULAR_MOJO_IMPORT_PATH",
-            "MODULAR_MOJO_NIGHTLY_IMPORT_PATH",
             "MODULAR_MOJO_MAX_IMPORT_PATH",
-            "MODULAR_MOJO_MAX_NIGHTLY_IMPORT_PATH",
         ]
     )


### PR DESCRIPTION
This is a series of small changes:
1. I replaced all of the import path environment variables being passed with `MODULAR_MOJO_MAX_IMPORT_PATH`. The others don't actually resolve to anything in Mojo, so they were just noise. I deduplicated them where applicable. I left the ones in the examples directory alone, for some reason they broke things.
2. I removed the env var in the top level pixi file, shouldn't be needed anymore
3. When looking for the precompiled package root, unconditionally look in the `.magic` folder. This is one of the key changes that I think fixes it

@martinvuyk - I tested this on your branch (https://github.com/modular/max/pull/3528) and got this:
```
******************** TEST 'Mojo Standard Library Benchmarks :: collections/bench_string.mojo' FAILED ********************
Exit Code: 1

Command Output (stderr):
--
RUN: at line 13: mojo /home/alextrotta/Documents/martin/mojo/mojo/stdlib/benchmarks/collections/bench_string.mojo -t
+ mojo /home/alextrotta/Documents/martin/mojo/mojo/stdlib/benchmarks/collections/bench_string.mojo -t
/home/alextrotta/Documents/martin/mojo/mojo/stdlib/benchmarks/collections/bench_string.mojo:117:30: error: cannot implicitly convert 'List[StringSlice[(muttoimm items)]]' value to 'List[StringSlice[items]]'
            res = items.split(sequence.value())
                  ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
/home/alextrotta/Documents/martin/mojo/mojo/stdlib/benchmarks/collections/bench_string.mojo:119:30: error: cannot implicitly convert 'List[StringSlice[(muttoimm items)]]' value to 'List[StringSlice[items]]'
            res = items.split()
                  ~~~~~~~~~~~^~
mojo: error: failed to parse the provided Mojo source module

--
```
but I think this is due to your change, so you just need to update the benchmarking script.