### PR TITLE
[stdlib] Upgrade `Dict._find_index` to use `Pointer`.

### DIFF
--- a/mojo/stdlib/benchmarks/collections/bench_dict.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_dict.mojo
@@ -97,6 +97,32 @@ fn bench_dict_lookup[size: Int](mut b: Bencher) raises:
 
 
 # ===-----------------------------------------------------------------------===#
+# Benchmark Dict Lookup (types that allocated)
+# ===-----------------------------------------------------------------------===#
+@parameter
+fn bench_dict_lookup_types_that_allocates[size: Int](mut b: Bencher) raises:
+    """Lookup size items."""
+    dict = Dict[String, String]()
+    keys = List[String](capacity=size)
+    for i in range(size):
+        keys.append(String(i))
+    for i in range(size):
+        dict[keys[i]] = keys[i]
+
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        res = 0
+        for i in range(size):
+            res += len(dict[keys[i]])
+        keep(res)
+
+    b.iter[call_fn]()
+    keep(Bool(dict))
+    keep(Bool(keys))
+
+
+# ===-----------------------------------------------------------------------===#
 # Benchmark Dict Memory Footprint
 # ===-----------------------------------------------------------------------===#
 
@@ -138,6 +164,11 @@ def main():
         )
         m.bench_function[bench_dict_lookup[size]](
             BenchId(String("bench_dict_lookup[", size, "]"))
+        )
+        m.bench_function[bench_dict_lookup_types_that_allocates[size]](
+            BenchId(
+                String("bench_dict_lookup_types_that_allocates[", size, "]")
+            )
         )
 
     m.dump_report()

--- a/mojo/stdlib/benchmarks/collections/bench_dict.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_dict.mojo
@@ -102,8 +102,8 @@ fn bench_dict_lookup[size: Int](mut b: Bencher) raises:
 @parameter
 fn bench_dict_lookup_types_that_allocates[size: Int](mut b: Bencher) raises:
     """Lookup size items."""
-    dict = Dict[String, String]()
-    keys = List[String](capacity=size)
+    var dict = Dict[String, String]()
+    var keys = List[String](capacity=size)
     for i in range(size):
         keys.append(String(i))
     for i in range(size):
@@ -112,7 +112,7 @@ fn bench_dict_lookup_types_that_allocates[size: Int](mut b: Bencher) raises:
     @always_inline
     @parameter
     fn call_fn() raises:
-        res = 0
+        var res = 0
         for i in range(size):
             res += len(dict[keys[i]])
         keep(res)
@@ -165,11 +165,10 @@ def main():
         m.bench_function[bench_dict_lookup[size]](
             BenchId(String("bench_dict_lookup[", size, "]"))
         )
-        m.bench_function[bench_dict_lookup_types_that_allocates[size]](
-            BenchId(
-                String("bench_dict_lookup_types_that_allocates[", size, "]")
-            )
-        )
+
+    m.bench_function[bench_dict_lookup_types_that_allocates[256]](
+        BenchId(String("bench_dict_lookup_types_that_allocates[256]"))
+    )
 
     m.dump_report()
 

--- a/mojo/stdlib/src/collections/dict.mojo
+++ b/mojo/stdlib/src/collections/dict.mojo
@@ -1042,10 +1042,11 @@ struct Dict[K: KeyElement, V: CollectionElement](
             elif index == Self.REMOVED:
                 pass
             else:
-                var entry = self._entries[index]
-                debug_assert(entry.__bool__(), "entry in index must be full")
-                if hash == entry.value().hash and key == entry.value().key:
-                    return (True, slot, index)
+                var entry = Pointer.address_of(self._entries[index])
+                debug_assert(entry[].__bool__(), "entry in index must be full")
+                if hash == entry[].unsafe_value().hash:
+                    if K.__eq__(key, entry[].unsafe_value().key):
+                        return (True, slot, index)
             self._next_index_slot(slot, perturb)
 
     fn _over_load_factor(self) -> Bool:


### PR DESCRIPTION
Hello,
this pr upgrade the method to use `Pointer` to iterate `self._entries`. 
(removing a `__copyinit__` on `K` and `V`)

The method is used by almost all methods of `Dict`, 
that should be a great speedup with `K`,`V` that allocates.

(PR is a split of a previous PR :+1: )

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
