### PR TITLE
[stdlib] Make `_memmem` function use Span

### DIFF
--- a/mojo/stdlib/benchmarks/collections/bench_string.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_string.mojo
@@ -228,6 +228,50 @@ fn bench_string_replace[
 
 
 # ===-----------------------------------------------------------------------===#
+# Benchmark string find single
+# ===-----------------------------------------------------------------------===#
+@parameter
+fn bench_string_find_single[
+    length: UInt = 0, filename: StaticString = "UN_charter_EN"
+](mut b: Bencher) raises:
+    var items = make_string[length](filename + ".txt")
+
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        # this is to help with instability when measuring small strings
+        for _ in range(10**6 // length):
+            var res = items.find("Z")  # something that probably won't be there
+            keep(res)
+
+    b.iter[call_fn]()
+    keep(Bool(items))
+
+
+# ===-----------------------------------------------------------------------===#
+# Benchmark string find multiple
+# ===-----------------------------------------------------------------------===#
+@parameter
+fn bench_string_find_multiple[
+    length: UInt = 0, filename: StaticString = "UN_charter_EN"
+](mut b: Bencher) raises:
+    var items = make_string[length](filename + ".txt")
+    var sequence = "ZZZZ"  # something that probably won't be there
+
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        # this is to help with instability when measuring small strings
+        for _ in range(10**6 // length):
+            var res = items.find(sequence)
+            keep(res)
+
+    b.iter[call_fn]()
+    keep(Bool(items))
+    keep(Bool(sequence))
+
+
+# ===-----------------------------------------------------------------------===#
 # Benchmark string _is_valid_utf8
 # ===-----------------------------------------------------------------------===#
 @parameter
@@ -391,6 +435,12 @@ def main():
             )
             m.bench_function[bench_string_replace[length, fname, old, new]](
                 BenchId(String("bench_string_replace", suffix))
+            )
+            m.bench_function[bench_string_find_single[length, fname]](
+                BenchId(String("bench_string_find_single", suffix))
+            )
+            m.bench_function[bench_string_find_multiple[length, fname]](
+                BenchId(String("bench_string_find_multiple", suffix))
             )
             m.bench_function[bench_string_is_valid_utf8[length, fname]](
                 BenchId(String("bench_string_is_valid_utf8", suffix))

--- a/mojo/stdlib/benchmarks/utils/bench_memmem.mojo
+++ b/mojo/stdlib/benchmarks/utils/bench_memmem.mojo
@@ -157,7 +157,12 @@ fn _memmem_baseline[
     if needle_len > haystack_len:
         return UnsafePointer[Scalar[dtype]]()
     if needle_len == 1:
-        return _memchr(haystack, needle[0], haystack_len)
+        return _memchr(
+            Span[Scalar[dtype], ImmutableAnyOrigin](
+                ptr=haystack.origin_cast[mut=False](), length=haystack_len
+            ),
+            needle[0],
+        )
 
     alias bool_mask_width = simdwidthof[DType.bool]()
     var first_needle = SIMD[dtype, bool_mask_width](needle[0])
@@ -213,12 +218,7 @@ fn bench_find_optimized(mut b: Bencher) raises:
     @always_inline
     @parameter
     fn call_fn():
-        _ = _memmem(
-            local_haystack.unsafe_ptr(),
-            len(local_haystack),
-            local_needle.unsafe_ptr(),
-            len(local_needle),
-        )
+        _ = _memmem(haystack.as_bytes(), needle.as_bytes())
 
     b.iter[call_fn]()
 

--- a/mojo/stdlib/stdlib/memory/span.mojo
+++ b/mojo/stdlib/stdlib/memory/span.mojo
@@ -100,14 +100,16 @@ struct Span[
     """The mutable version of the `Span`."""
     alias Immutable = Span[T, ImmutableOrigin.cast_from[origin]]
     """The immutable version of the `Span`."""
-    # Fields
-    var _data: UnsafePointer[
+    alias UnsafePointerType = UnsafePointer[
         T,
         mut=mut,
         origin=origin,
         address_space=address_space,
         alignment=alignment,
     ]
+    """The UnsafePointer type that corresponds to this `Span`."""
+    # Fields
+    var _data: Self.UnsafePointerType
     var _len: Int
 
     # ===------------------------------------------------------------------===#
@@ -135,18 +137,7 @@ struct Span[
         self = rebind[__type_of(self)](other)
 
     @always_inline("builtin")
-    fn __init__(
-        out self,
-        *,
-        ptr: UnsafePointer[
-            T,
-            address_space=address_space,
-            alignment=alignment,
-            mut=mut,
-            origin=origin, **_,
-        ],
-        length: UInt,
-    ):
+    fn __init__(out self, *, ptr: Self.UnsafePointerType, length: UInt):
         """Unsafe construction from a pointer and length.
 
         Args:


### PR DESCRIPTION
Make `_memmem` function use Span.

This is a split-off from PR #3548

### Benchmarks

Intel i7-7700HQ

  | old value (ms) | new value (ms) | markdown percentage
-- | -- | -- | --
bench_string_find_single[10] | 6.48115018378378 | 6.03484829081633 | 0.0689
bench_string_find_multiple[10] | 17.9806469444444 | 12.2977545454545 | 0.3161
bench_string_find_single[30] | 15.1792885822785 | 15.3715400655738 | -0.0127
bench_string_find_multiple[30] | 39.4704182068966 | 26.4202728913043 | 0.3306
bench_string_find_single[50] | 11.30529816 | 11.8535879 | -0.0485
bench_string_find_multiple[50] | 29.2628455208333 | 22.2432352727273 | 0.2399
bench_string_find_single[100] | 6.85366217142857 | 7.07481515 | -0.0323
bench_string_find_multiple[100] | 17.4309957391304 | 14.7496196790123 | 0.1538
bench_string_find_single[1000] | 21.1665719821429 | 34.3364576756757 | -0.6222
bench_string_find_multiple[1000] | 66.363384 | 55.7598185 | 0.1598
bench_string_find_single[10000] | 168.445427666667 | 173.191917857143 | -0.0282
bench_string_find_multiple[10000] | 508.217139666667 | 338.433613 | 0.3341
  |   | Average | 0.0716