### PR TITLE
[stdlib] Fix large inline array fill initializations

### DIFF
--- a/mojo/stdlib/test/collections/test_inline_array.mojo
+++ b/mojo/stdlib/test/collections/test_inline_array.mojo
@@ -85,6 +85,9 @@ def test_array_int():
 
     var arr4 = InlineArray[UInt8, 1](42)
     assert_equal(arr4[0], 42)
+    var a = InlineArray[UInt8, 1000](10)
+    for i in range(1000):
+        assert_equal(a[i], 10)
 
 
 def test_array_str():


### PR DESCRIPTION
#4046 Broke EmberJSON due the indexing being improperly calculated causing a segfault when initializing large arrays.

https://github.com/bgreni/EmberJson/blob/main/emberjson/slow_float_parse.mojo#L247

Simply the logic and also avoid lots of unnecessary arithmetic by incrementing a simple pointer. I have also applied this approach to the variadic initialization constructor.

Also added a test for constructing a filled array larger than the default batch size.