### PR TITLE
[stdlib] Add simple `List.pop()` overload for last item

### DIFF
--- a/mojo/stdlib/stdlib/collections/list.mojo
+++ b/mojo/stdlib/stdlib/collections/list.mojo
@@ -808,7 +808,7 @@ struct List[T: ExplicitlyCopyable & Movable, hint_trivial_type: Bool = False](
         memcpy(self._unsafe_next_uninit_ptr(), value.unsafe_ptr(), len(value))
         self._len += len(value)
 
-    fn pop(mut self, i: Int = -1) -> T:
+    fn pop(mut self, i: Int) -> T:
         """Pops a value from the list at the given index.
 
         Args:
@@ -829,6 +829,17 @@ struct List[T: ExplicitlyCopyable & Movable, hint_trivial_type: Bool = False](
         self._len -= 1
 
         return ret_val^
+
+    fn pop(mut self) -> T:
+        """Pops a value from the end of the list.
+
+        Returns:
+            The popped value.
+        """
+
+        debug_assert(self._len > 0, "called .pop() on an empty List")
+        self._len -= 1
+        return (self._data + self._len).take_pointee()
 
     fn reserve(mut self, new_capacity: Int):
         """Reserves the requested capacity.


### PR DESCRIPTION
Add simple `List.pop()` overload for last item