### PR TITLE
[stdlib] `InlineArray` -> fix example, add `debug_assert`.

### DIFF
--- a/mojo/stdlib/src/collections/inline_array.mojo
+++ b/mojo/stdlib/src/collections/inline_array.mojo
@@ -217,7 +217,7 @@ struct InlineArray[
             ptr.init_pointee_copy(fill)
             ptr += 1
         debug_assert(
-            Int(ptr) == (Int(self.unsafe_ptr().offset(size))),
+            ptr == self.unsafe_ptr().offset(size),
             "error during initialization, please create a bug report",
         )
 

--- a/mojo/stdlib/src/collections/inline_array.mojo
+++ b/mojo/stdlib/src/collections/inline_array.mojo
@@ -218,7 +218,7 @@ struct InlineArray[
             ptr += 1
         debug_assert(
             ptr == self.unsafe_ptr().offset(size),
-            "error during initialization, please create a bug report",
+            "error during `InlineArray` initialization, please file a bug report.",
         )
 
     @always_inline

--- a/mojo/stdlib/src/collections/inline_array.mojo
+++ b/mojo/stdlib/src/collections/inline_array.mojo
@@ -179,12 +179,13 @@ struct InlineArray[
             fill: The element value to fill each index with.
 
         Example:
+
             ```mojo
             var filled = InlineArray[Int, 5](fill=42)  # [42, 42, 42, 42, 42]
 
             # For large arrays, consider adjusting batch_size to balance
             # compile time and runtime performance:
-            var large = InlineArray[Int, 10000, batch_size=32](fill=0)
+            var large = InlineArray[Int, 10000].__init__[batch_size=32](fill=0)
             ```
 
         Notes:
@@ -215,6 +216,10 @@ struct InlineArray[
         for _ in range(unroll_end, size):
             ptr.init_pointee_copy(fill)
             ptr += 1
+        debug_assert(
+            Int(ptr) == (Int(self.unsafe_ptr().offset(size))),
+            "error during initialization, please create a bug report",
+        )
 
     @always_inline
     @implicit


### PR DESCRIPTION
Hello, small pr to help with fix #4171.

This adds a `debug_assert` to test that all values are initialized,
and also correct the doc example.

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
