### PR TITLE
[stdlib] Upgrade `Dict.__contains__` to use `get_ptr(k)`.

### DIFF
--- a/mojo/stdlib/benchmarks/collections/bench_dict.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_dict.mojo
@@ -97,6 +97,27 @@ fn bench_dict_lookup[size: Int](mut b: Bencher) raises:
 
 
 # ===-----------------------------------------------------------------------===#
+# Benchmark Dict __getitem__ K: trivial V:allocated
+# ===-----------------------------------------------------------------------===#
+@parameter
+fn bench_dict_getitem[size: Int](mut b: Bencher) raises:
+    """__getitem__ size new items."""
+    var items = Dict[Int, String]()
+    for i in range(size):
+        items[i] = String(i)
+
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        for key in range(size):
+            var res = Int(random.random_si64(0, size)) in items
+            keep(res)
+
+    b.iter[call_fn]()
+    keep(Bool(items))
+
+
+# ===-----------------------------------------------------------------------===#
 # Benchmark Dict Memory Footprint
 # ===-----------------------------------------------------------------------===#
 
@@ -139,6 +160,9 @@ def main():
         m.bench_function[bench_dict_lookup[size]](
             BenchId(String("bench_dict_lookup[", size, "]"))
         )
+    m.bench_function[bench_dict_getitem[1000]](
+        BenchId(String("bench_dict_getitem[1000]"))
+    )
 
     m.dump_report()
 

--- a/mojo/stdlib/src/collections/dict.mojo
+++ b/mojo/stdlib/src/collections/dict.mojo
@@ -629,7 +629,7 @@ struct Dict[K: KeyElement, V: CollectionElement](
         Returns:
             True if there key exists in the dictionary, False otherwise.
         """
-        return self.find(key).__bool__()
+        return self.get_ptr(key).__bool__()
 
     fn __iter__(ref self) -> _DictKeyIter[K, V, __origin_of(self)]:
         """Iterate over the dict's keys as immutable references.


### PR DESCRIPTION
Hello,

this upgrade that method that returns a `Bool`,
so that it does no `__copyinit__` on an entry value.

replaces:
- `find` (returns an `Optional` to an entry value) with:
- `get_ptr` (returns an `Optional` to a `Pointer` to an entry value)

We then return the result of `.__bool__()` on the `Optional` `Pointer`.

(speedup for `V` of types that allocates)

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
