### PR TITLE
[tools] Add environment variable for Mojo Dev Container

### DIFF
--- a/mojo/stdlib/benchmarks/lit.cfg.py
+++ b/mojo/stdlib/benchmarks/lit.cfg.py
@@ -47,7 +47,10 @@ else:
     # This is important since `benchmark` is closed source
     # still right now and is always used by the benchmarks.
     pre_built_packages_path = Path(
-        repo_root / ".magic" / "envs" / "default" / "lib" / "mojo"
+        os.environ.get(
+            "MODULAR_MOJO_PREBUILT_PACKAGES_PATH",
+            repo_root / ".magic" / "envs" / "default" / "lib" / "mojo",
+        )
     )
 
     # The `run-tests.sh` script creates the build directory for you.


### PR DESCRIPTION
Due to https://github.com/modular/max/commit/974872977e3138f72c48161094c2c35f6a979699, `MODULAR_MOJO_NIGHTLY_IMPORT_PATH=/opt/modular/lib/mojo ./stdlib/scripts/run-benchmarks.sh` does not work anymore.