### PR TITLE
[stdlib] Add `always_inline` to `Any(arg: SIMD)`, `All(arg: SIMD)`.

### DIFF
--- a/mojo/stdlib/src/builtin/bool.mojo
+++ b/mojo/stdlib/src/builtin/bool.mojo
@@ -607,6 +607,7 @@ fn any[T: BoolableKeyElement](set: Set[T]) -> Bool:
     return False
 
 
+@always_inline
 fn any(value: SIMD) -> Bool:
     """Checks if **any** element in the simd vector is truthy.
 
@@ -664,6 +665,7 @@ fn all[T: BoolableKeyElement](set: Set[T]) -> Bool:
     return True
 
 
+@always_inline
 fn all(value: SIMD) -> Bool:
     """Checks if **all** elements in the simd vector are truthy.
 


### PR DESCRIPTION
Hello,
this function is used in some `SIMD` methods,
(`__floordiv__`, `__ceildiv__`, `mod`, `_pow`)
and all `SIMD` things are inlined,
so just making a PR, but no idea if needed or not!

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
