### PR TITLE
[stdlib] Make `Prefetch*` flag types explicitly constructible from `Int`

### DIFF
--- a/mojo/stdlib/src/sys/intrinsics.mojo
+++ b/mojo/stdlib/src/sys/intrinsics.mojo
@@ -298,7 +298,6 @@ struct PrefetchLocality:
     """Extremely local locality (keep in cache)."""
 
     @always_inline("nodebug")
-    @implicit
     fn __init__(out self, value: Int):
         """Constructs a prefetch locality option.
 
@@ -321,7 +320,6 @@ struct PrefetchRW:
     """Write prefetch."""
 
     @always_inline("nodebug")
-    @implicit
     fn __init__(out self, value: Int):
         """Constructs a prefetch read-write option.
 
@@ -345,7 +343,6 @@ struct PrefetchCache:
     """The data prefetching option."""
 
     @always_inline("nodebug")
-    @implicit
     fn __init__(out self, value: Int):
         """Constructs a prefetch option.
 


### PR DESCRIPTION
So they behave more like enums.