### PR TITLE
[stdlib] Fix `SIMD.__init__` for large int literals

### DIFF
--- a/mojo/stdlib/src/builtin/dtype.mojo
+++ b/mojo/stdlib/src/builtin/dtype.mojo
@@ -19,10 +19,10 @@ from collections import KeyElement
 from hashlib._hasher import _HashableWithHasher, _Hasher
 from sys import bitwidthof, os_is_windows, sizeof
 
-alias _mIsSigned = UInt8(1)
-alias _mIsInteger = UInt8(1 << 7)
-alias _mIsNotInteger = UInt8(~(1 << 7))
-alias _mIsFloat = UInt8(1 << 6)
+alias _mIsSigned = __mlir_attr.`#pop.simd<1> : !pop.scalar<ui8>`
+alias _mIsInteger = __mlir_attr.`#pop.simd<128> : !pop.scalar<ui8>`  # 1 << 7
+alias _mIsNotInteger = __mlir_attr.`#pop.simd<127> : !pop.scalar<ui8>`  # ~(1 << 7)
+alias _mIsFloat = __mlir_attr.`#pop.simd<64> : !pop.scalar<ui8>`  # 1 << 6
 
 
 @value
@@ -448,7 +448,7 @@ struct DType(
             return False
         return Bool(
             __mlir_op.`pop.cmp`[pred = __mlir_attr.`#pop<cmp_pred eq>`](
-                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsSigned.value),
+                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsSigned),
                 __mlir_attr.`#pop.simd<0> : !pop.scalar<ui8>`,
             )
         )
@@ -466,7 +466,7 @@ struct DType(
             return False
         return Bool(
             __mlir_op.`pop.cmp`[pred = __mlir_attr.`#pop<cmp_pred ne>`](
-                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsSigned.value),
+                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsSigned),
                 __mlir_attr.`#pop.simd<0> : !pop.scalar<ui8>`,
             )
         )
@@ -480,7 +480,7 @@ struct DType(
         """
         return Bool(
             __mlir_op.`pop.cmp`[pred = __mlir_attr.`#pop<cmp_pred ne>`](
-                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsInteger.value),
+                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsInteger),
                 __mlir_attr.`#pop.simd<0> : !pop.scalar<ui8>`,
             )
         )
@@ -508,7 +508,7 @@ struct DType(
             return False
         return Bool(
             __mlir_op.`pop.cmp`[pred = __mlir_attr.`#pop<cmp_pred ne>`](
-                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsFloat.value),
+                __mlir_op.`pop.simd.and`(self._as_i8(), _mIsFloat),
                 __mlir_attr.`#pop.simd<0> : !pop.scalar<ui8>`,
             )
         )
@@ -568,7 +568,7 @@ struct DType(
                         __mlir_op.`pop.sub`(
                             __mlir_op.`pop.shr`(
                                 __mlir_op.`pop.simd.and`(
-                                    self._as_i8(), _mIsNotInteger.value
+                                    self._as_i8(), _mIsNotInteger
                                 ),
                                 UInt8(1).value,
                             ),

--- a/mojo/stdlib/src/builtin/dtype.mojo
+++ b/mojo/stdlib/src/builtin/dtype.mojo
@@ -449,7 +449,7 @@ struct DType(
         return Bool(
             __mlir_op.`pop.cmp`[pred = __mlir_attr.`#pop<cmp_pred eq>`](
                 __mlir_op.`pop.simd.and`(self._as_i8(), _mIsSigned.value),
-                UInt8(0).value,
+                __mlir_attr.`#pop.simd<0> : !pop.scalar<ui8>`,
             )
         )
 
@@ -467,7 +467,7 @@ struct DType(
         return Bool(
             __mlir_op.`pop.cmp`[pred = __mlir_attr.`#pop<cmp_pred ne>`](
                 __mlir_op.`pop.simd.and`(self._as_i8(), _mIsSigned.value),
-                UInt8(0).value,
+                __mlir_attr.`#pop.simd<0> : !pop.scalar<ui8>`,
             )
         )
 
@@ -481,7 +481,7 @@ struct DType(
         return Bool(
             __mlir_op.`pop.cmp`[pred = __mlir_attr.`#pop<cmp_pred ne>`](
                 __mlir_op.`pop.simd.and`(self._as_i8(), _mIsInteger.value),
-                UInt8(0).value,
+                __mlir_attr.`#pop.simd<0> : !pop.scalar<ui8>`,
             )
         )
 
@@ -509,7 +509,7 @@ struct DType(
         return Bool(
             __mlir_op.`pop.cmp`[pred = __mlir_attr.`#pop<cmp_pred ne>`](
                 __mlir_op.`pop.simd.and`(self._as_i8(), _mIsFloat.value),
-                UInt8(0).value,
+                __mlir_attr.`#pop.simd<0> : !pop.scalar<ui8>`,
             )
         )
 

--- a/mojo/stdlib/src/builtin/simd.mojo
+++ b/mojo/stdlib/src/builtin/simd.mojo
@@ -475,7 +475,8 @@ struct SIMD[dtype: DType, size: Int](
             var val = __mlir_op.`pop.cast_from_builtin`[
                 _type = __mlir_type.`!pop.scalar<ui256>`
             ](ui256)
-            casted = __mlir_op.`pop.cast`[_type = Scalar[dtype]._mlir_type](val)
+            var casted = __mlir_op.`pop.cast`[_type = Scalar[dtype]._mlir_type](val)
+            self = Scalar[dtype](casted)
         else:
             var si256 = __mlir_attr[
                 `#pop<int_literal_convert<`, value.value, `, 0>> : si256`
@@ -483,8 +484,8 @@ struct SIMD[dtype: DType, size: Int](
             var val = __mlir_op.`pop.cast_from_builtin`[
                 _type = __mlir_type.`!pop.scalar<si256>`
             ](si256)
-            casted = __mlir_op.`pop.cast`[_type = Scalar[dtype]._mlir_type](val)
-        self = Scalar[dtype](casted)
+            var casted = __mlir_op.`pop.cast`[_type = Scalar[dtype]._mlir_type](val)
+            self = Scalar[dtype](casted)
 
     @always_inline("nodebug")
     @implicit

--- a/mojo/stdlib/src/builtin/simd.mojo
+++ b/mojo/stdlib/src/builtin/simd.mojo
@@ -467,13 +467,23 @@ struct SIMD[dtype: DType, size: Int](
         """
         _simd_construction_checks[dtype, size]()
 
-        var tn1 = __mlir_attr[
-            `#pop<int_literal_convert<`, value.value, `, 0>> : si128`
-        ]
-        var t0 = __mlir_op.`pop.cast_from_builtin`[
-            _type = __mlir_type.`!pop.scalar<si128>`
-        ](tn1)
-        var casted = __mlir_op.`pop.cast`[_type = Scalar[dtype]._mlir_type](t0)
+        @parameter
+        if dtype.is_unsigned():
+            var ui256 = __mlir_attr[
+                `#pop<int_literal_convert<`, value.value, `, 0>> : ui256`
+            ]
+            var val = __mlir_op.`pop.cast_from_builtin`[
+                _type = __mlir_type.`!pop.scalar<ui256>`
+            ](ui256)
+            casted = __mlir_op.`pop.cast`[_type = Scalar[dtype]._mlir_type](val)
+        else:
+            var si256 = __mlir_attr[
+                `#pop<int_literal_convert<`, value.value, `, 0>> : si256`
+            ]
+            var val = __mlir_op.`pop.cast_from_builtin`[
+                _type = __mlir_type.`!pop.scalar<si256>`
+            ](si256)
+            casted = __mlir_op.`pop.cast`[_type = Scalar[dtype]._mlir_type](val)
         self = Scalar[dtype](casted)
 
     @always_inline("nodebug")


### PR DESCRIPTION
Fix #4049. CC @lattner.

I don't know whether using wider types would cause performance issues.