### PR TITLE
[stdlib] [NFC] Rename `type: DType` parameters to `dtype` in `sort.mojo`

### DIFF
--- a/mojo/stdlib/benchmarks/builtin/bench_sort.mojo
+++ b/mojo/stdlib/benchmarks/builtin/bench_sort.mojo
@@ -46,10 +46,10 @@ fn randomize_list[
 
 
 @always_inline
-fn insertion_sort[type: DType](mut list: List[Scalar[type]]):
+fn insertion_sort[dtype: DType](mut list: List[Scalar[dtype]]):
     @parameter
     fn _less_than(
-        lhs: _SortWrapper[Scalar[type]], rhs: _SortWrapper[Scalar[type]]
+        lhs: _SortWrapper[Scalar[dtype]], rhs: _SortWrapper[Scalar[dtype]]
     ) -> Bool:
         return lhs.data < rhs.data
 
@@ -57,21 +57,21 @@ fn insertion_sort[type: DType](mut list: List[Scalar[type]]):
 
 
 @always_inline
-fn small_sort[size: Int, type: DType](mut list: List[Scalar[type]]):
+fn small_sort[size: Int, dtype: DType](mut list: List[Scalar[dtype]]):
     @parameter
     fn _less_than(
-        lhs: _SortWrapper[Scalar[type]], rhs: _SortWrapper[Scalar[type]]
+        lhs: _SortWrapper[Scalar[dtype]], rhs: _SortWrapper[Scalar[dtype]]
     ) -> Bool:
         return lhs.data < rhs.data
 
-    _small_sort[size, Scalar[type], _less_than](list.data)
+    _small_sort[size, Scalar[dtype], _less_than](list.data)
 
 
 @always_inline
-fn heap_sort[type: DType](mut list: List[Scalar[type]]):
+fn heap_sort[dtype: DType](mut list: List[Scalar[dtype]]):
     @parameter
     fn _less_than(
-        lhs: _SortWrapper[Scalar[type]], rhs: _SortWrapper[Scalar[type]]
+        lhs: _SortWrapper[Scalar[dtype]], rhs: _SortWrapper[Scalar[dtype]]
     ) -> Bool:
         return lhs.data < rhs.data
 
@@ -83,7 +83,7 @@ fn heap_sort[type: DType](mut list: List[Scalar[type]]):
 # ===-----------------------------------------------------------------------===#
 
 
-fn bench_tiny_list_sort[type: DType](mut m: Bench) raises:
+fn bench_tiny_list_sort[dtype: DType](mut m: Bench) raises:
     alias small_list_size = 5
 
     @parameter
@@ -92,8 +92,10 @@ fn bench_tiny_list_sort[type: DType](mut m: Bench) raises:
         @parameter
         fn bench_sort_list(mut b: Bencher) raises:
             seed(1)
-            var ptr = UnsafePointer[Scalar[type]].alloc(count)
-            var list = List[Scalar[type]](ptr=ptr, length=count, capacity=count)
+            var ptr = UnsafePointer[Scalar[dtype]].alloc(count)
+            var list = List[Scalar[dtype]](
+                ptr=ptr, length=count, capacity=count
+            )
 
             @always_inline
             @parameter
@@ -111,8 +113,10 @@ fn bench_tiny_list_sort[type: DType](mut m: Bench) raises:
         @parameter
         fn bench_small_sort(mut b: Bencher) raises:
             seed(1)
-            var ptr = UnsafePointer[Scalar[type]].alloc(count)
-            var list = List[Scalar[type]](ptr=ptr, length=count, capacity=count)
+            var ptr = UnsafePointer[Scalar[dtype]].alloc(count)
+            var list = List[Scalar[dtype]](
+                ptr=ptr, length=count, capacity=count
+            )
 
             @always_inline
             @parameter
@@ -130,8 +134,10 @@ fn bench_tiny_list_sort[type: DType](mut m: Bench) raises:
         @parameter
         fn bench_insertion_sort(mut b: Bencher) raises:
             seed(1)
-            var ptr = UnsafePointer[Scalar[type]].alloc(count)
-            var list = List[Scalar[type]](ptr=ptr, length=count, capacity=count)
+            var ptr = UnsafePointer[Scalar[dtype]].alloc(count)
+            var list = List[Scalar[dtype]](
+                ptr=ptr, length=count, capacity=count
+            )
 
             @always_inline
             @parameter
@@ -162,12 +168,12 @@ fn bench_tiny_list_sort[type: DType](mut m: Bench) raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn bench_small_list_sort[type: DType](mut m: Bench, count: Int) raises:
+fn bench_small_list_sort[dtype: DType](mut m: Bench, count: Int) raises:
     @parameter
     fn bench_sort_list(mut b: Bencher) raises:
         seed(1)
-        var ptr = UnsafePointer[Scalar[type]].alloc(count)
-        var list = List[Scalar[type]](ptr=ptr, length=count, capacity=count)
+        var ptr = UnsafePointer[Scalar[dtype]].alloc(count)
+        var list = List[Scalar[dtype]](ptr=ptr, length=count, capacity=count)
 
         @always_inline
         @parameter
@@ -185,8 +191,8 @@ fn bench_small_list_sort[type: DType](mut m: Bench, count: Int) raises:
     @parameter
     fn bench_insertion_sort(mut b: Bencher) raises:
         seed(1)
-        var ptr = UnsafePointer[Scalar[type]].alloc(count)
-        var list = List[Scalar[type]](ptr=ptr, length=count, capacity=count)
+        var ptr = UnsafePointer[Scalar[dtype]].alloc(count)
+        var list = List[Scalar[dtype]](ptr=ptr, length=count, capacity=count)
 
         @always_inline
         @parameter
@@ -214,12 +220,12 @@ fn bench_small_list_sort[type: DType](mut m: Bench, count: Int) raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn bench_large_list_sort[type: DType](mut m: Bench, count: Int) raises:
+fn bench_large_list_sort[dtype: DType](mut m: Bench, count: Int) raises:
     @parameter
     fn bench_sort_list(mut b: Bencher) raises:
         seed(1)
-        var ptr = UnsafePointer[Scalar[type]].alloc(count)
-        var list = List[Scalar[type]](ptr=ptr, length=count, capacity=count)
+        var ptr = UnsafePointer[Scalar[dtype]].alloc(count)
+        var list = List[Scalar[dtype]](ptr=ptr, length=count, capacity=count)
 
         @always_inline
         @parameter
@@ -237,8 +243,8 @@ fn bench_large_list_sort[type: DType](mut m: Bench, count: Int) raises:
     @parameter
     fn bench_heap_sort(mut b: Bencher) raises:
         seed(1)
-        var ptr = UnsafePointer[Scalar[type]].alloc(count)
-        var list = List[Scalar[type]](ptr=ptr, length=count, capacity=count)
+        var ptr = UnsafePointer[Scalar[dtype]].alloc(count)
+        var list = List[Scalar[dtype]](ptr=ptr, length=count, capacity=count)
 
         @always_inline
         @parameter
@@ -338,19 +344,19 @@ def main():
     @parameter
     for i in range(len(dtypes)):
         alias type = dtypes[i]
-        bench_tiny_list_sort[type](m)
+        bench_tiny_list_sort[dtype](m)
 
     @parameter
     for i in range(len(dtypes)):
         alias type = dtypes[i]
         for count in small_counts:
-            bench_small_list_sort[type](m, count[])
+            bench_small_list_sort[dtype](m, count[])
 
     @parameter
     for i in range(len(dtypes)):
         alias type = dtypes[i]
         for count in large_counts:
-            bench_large_list_sort[type](m, count[])
+            bench_large_list_sort[dtype](m, count[])
 
     for count in large_counts:
         for delta in deltas:

--- a/mojo/stdlib/src/builtin/sort.mojo
+++ b/mojo/stdlib/src/builtin/sort.mojo
@@ -30,11 +30,11 @@ alias insertion_sort_threshold = 32
 
 
 @value
-struct _SortWrapper[type: CollectionElement](CollectionElement):
-    var data: type
+struct _SortWrapper[dtype: CollectionElement](CollectionElement):
+    var data: dtype
 
     @implicit
-    fn __init__(out self, data: type):
+    fn __init__(out self, data: dtype):
         self.data = data
 
     fn __init__(out self, *, other: Self):
@@ -43,10 +43,10 @@ struct _SortWrapper[type: CollectionElement](CollectionElement):
 
 @always_inline
 fn _insertion_sort[
-    type: CollectionElement,
+    dtype: CollectionElement,
     origin: MutableOrigin, //,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](span: Span[type, origin]):
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](span: Span[dtype, origin]):
     """Sort the array[start:end] slice"""
     var array = span.unsafe_ptr().origin_cast[origin=MutableAnyOrigin]()
     var size = len(span)
@@ -68,10 +68,10 @@ fn _insertion_sort[
 # put everything thats "<" to the left of pivot
 @always_inline
 fn _quicksort_partition_right[
-    type: CollectionElement,
+    dtype: CollectionElement,
     origin: MutableOrigin, //,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](span: Span[type, origin]) -> Int:
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](span: Span[dtype, origin]) -> Int:
     var array = span.unsafe_ptr().origin_cast[origin=MutableAnyOrigin]()
     var size = len(span)
 
@@ -97,10 +97,10 @@ fn _quicksort_partition_right[
 # put everything thats "<=" to the left of pivot
 @always_inline
 fn _quicksort_partition_left[
-    type: CollectionElement,
+    dtype: CollectionElement,
     origin: MutableOrigin, //,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](span: Span[type, origin]) -> Int:
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](span: Span[dtype, origin]) -> Int:
     var array = span.unsafe_ptr().origin_cast[origin=MutableAnyOrigin]()
     var size = len(span)
 
@@ -123,10 +123,10 @@ fn _quicksort_partition_left[
 
 
 fn _heap_sort_fix_down[
-    type: CollectionElement,
+    dtype: CollectionElement,
     origin: MutableOrigin, //,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](span: Span[type, origin], idx: Int):
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](span: Span[dtype, origin], idx: Int):
     var array = span.unsafe_ptr().origin_cast[origin=MutableAnyOrigin]()
     var size = len(span)
     var i = idx
@@ -144,10 +144,10 @@ fn _heap_sort_fix_down[
 
 @always_inline
 fn _heap_sort[
-    type: CollectionElement,
+    dtype: CollectionElement,
     origin: MutableOrigin, //,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](span: Span[type, origin]):
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](span: Span[dtype, origin]):
     var array = span.unsafe_ptr().origin_cast[origin=MutableAnyOrigin]()
     var size = len(span)
     # heapify
@@ -173,42 +173,42 @@ fn _estimate_initial_height(size: Int) -> Int:
 
 @always_inline
 fn _delegate_small_sort[
-    type: CollectionElement,
+    dtype: CollectionElement,
     origin: MutableOrigin, //,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](span: Span[type, origin]):
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](span: Span[dtype, origin]):
     var array = span.unsafe_ptr().origin_cast[origin=MutableAnyOrigin]()
     var size = len(span)
     if size == 2:
-        _small_sort[2, type, cmp_fn](array)
+        _small_sort[2, dtype, cmp_fn](array)
 
         return
     if size == 3:
-        _small_sort[3, type, cmp_fn](array)
+        _small_sort[3, dtype, cmp_fn](array)
         return
 
     if size == 4:
-        _small_sort[4, type, cmp_fn](array)
+        _small_sort[4, dtype, cmp_fn](array)
         return
 
     if size == 5:
-        _small_sort[5, type, cmp_fn](array)
+        _small_sort[5, dtype, cmp_fn](array)
         return
 
 
 # FIXME (MSTDL-808): Using _Pair over Span results in 1-3% improvement
 # @value
-# struct _Pair[type: AnyType]:
-#     var ptr: UnsafePointer[type]
+# struct _Pair[dtype: AnyType]:
+#     var ptr: UnsafePointer[dtype]
 #     var len: Int
 
 
 @always_inline
 fn _quicksort[
-    type: CollectionElement,
+    dtype: CollectionElement,
     origin: MutableOrigin, //,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](span: Span[type, origin]):
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](span: Span[dtype, origin]):
     var array = span.unsafe_ptr().origin_cast[origin=MutableAnyOrigin]()
     var size = len(span)
     if size == 0:
@@ -225,7 +225,7 @@ fn _quicksort[
         var imm_interval = stack.pop()
         var ptr = imm_interval.unsafe_ptr()
         var len = len(imm_interval)
-        var interval = Span[type, origin](ptr=ptr, length=len)
+        var interval = Span[dtype, origin](ptr=ptr, length=len)
 
         if len <= 5:
             _delegate_small_sort[cmp_fn](interval)
@@ -236,7 +236,7 @@ fn _quicksort[
             continue
 
         # pick median of 3 as pivot
-        _sort3[type, cmp_fn](ptr, len >> 1, 0, len - 1)
+        _sort3[dtype, cmp_fn](ptr, len >> 1, 0, len - 1)
 
         # if ptr[-1] == pivot_value, then everything in between will
         # be the same, so no need to recurse that interval
@@ -264,14 +264,14 @@ fn _quicksort[
 
 
 fn _merge[
-    type: CollectionElement,
+    dtype: CollectionElement,
     span_origin: ImmutableOrigin,
     result_origin: MutableOrigin, //,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
 ](
-    span1: Span[type, span_origin],
-    span2: Span[type, span_origin],
-    result: Span[type, result_origin],
+    span1: Span[dtype, span_origin],
+    span2: Span[dtype, span_origin],
+    result: Span[dtype, result_origin],
 ):
     """Merge span1 and span2 into result using the given cmp_fn. The function
     will crash if result is not large enough to hold both span1 and span2.
@@ -279,7 +279,7 @@ fn _merge[
     Note that if result contains data previously, its destructor will not be called.
 
     Parameters:
-        type: Type of the spans.
+        dtype: Type of the spans.
         span_origin: Origin of the input spans.
         result_origin: Origin of the result Span.
         cmp_fn: Comparison functor of (type, type) capturing [_] -> Bool type.
@@ -322,11 +322,11 @@ fn _merge[
 
 
 fn _stable_sort_impl[
-    type: CollectionElement,
+    dtype: CollectionElement,
     span_life: MutableOrigin,
     tmp_life: MutableOrigin, //,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](span: Span[type, span_life], temp_buff: Span[type, tmp_life]):
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](span: Span[dtype, span_life], temp_buff: Span[dtype, tmp_life]):
     var size = len(span)
     if size <= 1:
         return
@@ -352,12 +352,12 @@ fn _stable_sort_impl[
 
 
 fn _stable_sort[
-    type: CollectionElement,
+    dtype: CollectionElement,
     origin: MutableOrigin, //,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](span: Span[type, origin]):
-    var temp_buff = UnsafePointer[type].alloc(len(span))
-    var temp_buff_span = Span[type, __origin_of(temp_buff)](
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](span: Span[dtype, origin]):
+    var temp_buff = UnsafePointer[dtype].alloc(len(span))
+    var temp_buff_span = Span[dtype, __origin_of(temp_buff)](
         ptr=temp_buff, length=len(span)
     )
     _stable_sort_impl[cmp_fn](span, temp_buff_span)
@@ -371,10 +371,10 @@ fn _stable_sort[
 
 @always_inline
 fn _partition[
-    type: CollectionElement,
+    dtype: CollectionElement,
     origin: MutableOrigin, //,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](span: Span[type, origin]) -> Int:
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](span: Span[dtype, origin]) -> Int:
     var size = len(span)
     if size <= 1:
         return 0
@@ -404,10 +404,10 @@ fn _partition[
 
 
 fn _partition[
-    type: CollectionElement,
+    dtype: CollectionElement,
     origin: MutableOrigin, //,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](owned span: Span[type, origin], owned k: Int):
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](owned span: Span[dtype, origin], owned k: Int):
     while True:
         var pivot = _partition[cmp_fn](span)
         if pivot == k:
@@ -422,18 +422,18 @@ fn _partition[
 
 
 fn partition[
-    type: CollectionElement,
+    dtype: CollectionElement,
     origin: MutableOrigin, //,
-    cmp_fn: fn (type, type) capturing [_] -> Bool,
-](span: Span[type, origin], k: Int):
+    cmp_fn: fn (dtype, dtype) capturing [_] -> Bool,
+](span: Span[dtype, origin], k: Int):
     """Partition the input buffer inplace such that first k elements are the
     largest (or smallest if cmp_fn is < operator) elements.
     The ordering of the first k elements is undefined.
 
     Parameters:
-        type: Type of the underlying data.
+        dtype: Type of the underlying data.
         origin: Origin of span.
-        cmp_fn: Comparison functor of (type, type) capturing [_] -> Bool type.
+        cmp_fn: Comparison functor of (dtype, dtype) capturing [_] -> Bool type.
 
     Args:
         span: Input buffer.
@@ -441,7 +441,7 @@ fn partition[
     """
 
     @parameter
-    fn _cmp_fn(lhs: _SortWrapper[type], rhs: _SortWrapper[type]) -> Bool:
+    fn _cmp_fn(lhs: _SortWrapper[dtype], rhs: _SortWrapper[dtype]) -> Bool:
         return cmp_fn(lhs.data, rhs.data)
 
     _partition[_cmp_fn](span, k)
@@ -472,16 +472,16 @@ fn partition[
 
 
 fn partition[
-    type: DType,
+    dtype: DType,
     origin: MutableOrigin, //,
-    cmp_fn: fn (Scalar[type], Scalar[type]) capturing [_] -> Bool,
-](span: Span[Scalar[type], origin], k: Int):
+    cmp_fn: fn (Scalar[dtype], Scalar[dtype]) capturing [_] -> Bool,
+](span: Span[Scalar[dtype], origin], k: Int):
     """Partition the input buffer inplace such that first k elements are the
     largest (or smallest if cmp_fn is < operator) elements.
     The ordering of the first k elements is undefined.
 
     Parameters:
-        type: DType of the underlying data.
+        dtype: DType of the underlying data.
         origin: Origin of span.
         cmp_fn: Comparison functor of (type, type) capturing [_] -> Bool type.
 
@@ -492,7 +492,7 @@ fn partition[
 
     @parameter
     fn _cmp_fn(
-        lhs: _SortWrapper[Scalar[type]], rhs: _SortWrapper[Scalar[type]]
+        lhs: _SortWrapper[Scalar[dtype]], rhs: _SortWrapper[Scalar[dtype]]
     ) -> Bool:
         return cmp_fn(lhs.data, rhs.data)
 
@@ -506,12 +506,12 @@ fn partition[
 
 # Junction from public to private API
 fn _sort[
-    type: CollectionElement,
+    dtype: CollectionElement,
     origin: MutableOrigin, //,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
     *,
     stable: Bool = False,
-](span: Span[type, origin]):
+](span: Span[dtype, origin]):
     if len(span) <= 5:
         _delegate_small_sort[cmp_fn](span)
         return
@@ -527,22 +527,22 @@ fn _sort[
         _quicksort[cmp_fn](span)
 
 
-# TODO (MSTDL-766): The Int and Scalar[type] overload should be remove
+# TODO (MSTDL-766): The Int and Scalar[dtype] overload should be remove
 # (same for partition)
 # Eventually we want a sort that takes a Span and one that takes a List with
 # optional cmp_fn.
 fn sort[
-    type: CollectionElement,
+    dtype: CollectionElement,
     origin: MutableOrigin, //,
-    cmp_fn: fn (type, type) capturing [_] -> Bool,
+    cmp_fn: fn (dtype, dtype) capturing [_] -> Bool,
     *,
     stable: Bool = False,
-](span: Span[type, origin]):
+](span: Span[dtype, origin]):
     """Sort the list inplace.
     The function doesn't return anything, the list is updated inplace.
 
     Parameters:
-        type: CollectionElement type of the underlying data.
+        dtype: CollectionElement type of the underlying data.
         origin: Origin of span.
         cmp_fn: The comparison function.
         stable: Whether the sort should be stable.
@@ -552,7 +552,7 @@ fn sort[
     """
 
     @parameter
-    fn _cmp_fn(lhs: _SortWrapper[type], rhs: _SortWrapper[type]) -> Bool:
+    fn _cmp_fn(lhs: _SortWrapper[dtype], rhs: _SortWrapper[dtype]) -> Bool:
         return cmp_fn(lhs.data, rhs.data)
 
     _sort[_cmp_fn, stable=stable](span)
@@ -584,17 +584,17 @@ fn sort[
 
 
 fn sort[
-    type: DType,
+    dtype: DType,
     origin: MutableOrigin, //,
-    cmp_fn: fn (Scalar[type], Scalar[type]) capturing [_] -> Bool,
+    cmp_fn: fn (Scalar[dtype], Scalar[dtype]) capturing [_] -> Bool,
     *,
     stable: Bool = False,
-](span: Span[Scalar[type], origin]):
+](span: Span[Scalar[dtype], origin]):
     """Sort the list inplace.
     The function doesn't return anything, the list is updated inplace.
 
     Parameters:
-        type: DType type of the underlying data.
+        dtype: DType type of the underlying data.
         origin: Origin of span.
         cmp_fn: The comparison function.
         stable: Whether the sort should be stable.
@@ -605,7 +605,7 @@ fn sort[
 
     @parameter
     fn _cmp_fn(
-        lhs: _SortWrapper[Scalar[type]], rhs: _SortWrapper[Scalar[type]]
+        lhs: _SortWrapper[Scalar[dtype]], rhs: _SortWrapper[Scalar[dtype]]
     ) -> Bool:
         return cmp_fn(lhs.data, rhs.data)
 
@@ -636,16 +636,16 @@ fn sort[
 
 
 fn sort[
-    type: DType,
+    dtype: DType,
     origin: MutableOrigin, //,
     *,
     stable: Bool = False,
-](span: Span[Scalar[type], origin]):
+](span: Span[Scalar[dtype], origin]):
     """Sort the list inplace.
     The function doesn't return anything, the list is updated inplace.
 
     Parameters:
-        type: CollectionElement type of the underlying data.
+        dtype: CollectionElement type of the underlying data.
         origin: Origin of span.
         stable: Whether the sort should be stable.
 
@@ -654,22 +654,22 @@ fn sort[
     """
 
     @parameter
-    fn _cmp_fn(lhs: Scalar[type], rhs: Scalar[type]) -> Bool:
+    fn _cmp_fn(lhs: Scalar[dtype], rhs: Scalar[dtype]) -> Bool:
         return lhs < rhs
 
     sort[_cmp_fn, stable=stable](span)
 
 
 fn sort[
-    type: ComparableCollectionElement,
+    dtype: ComparableCollectionElement,
     origin: MutableOrigin, //,
     *,
     stable: Bool = False,
-](span: Span[type, origin]):
+](span: Span[dtype, origin]):
     """Sort list of the order comparable elements in-place.
 
     Parameters:
-        type: The order comparable collection element type.
+        dtype: The order comparable collection element type.
         origin: Origin of span.
         stable: Whether the sort should be stable.
 
@@ -678,7 +678,7 @@ fn sort[
     """
 
     @parameter
-    fn _cmp_fn(a: type, b: type) -> Bool:
+    fn _cmp_fn(a: dtype, b: dtype) -> Bool:
         return a < b
 
     sort[_cmp_fn, stable=stable](span)
@@ -691,9 +691,9 @@ fn sort[
 
 @always_inline
 fn _sort2[
-    type: CollectionElement,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](array: UnsafePointer[type], offset0: Int, offset1: Int):
+    dtype: CollectionElement,
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](array: UnsafePointer[dtype], offset0: Int, offset1: Int):
     var a = array[offset0]
     var b = array[offset1]
     if not cmp_fn(a, b):
@@ -703,19 +703,19 @@ fn _sort2[
 
 @always_inline
 fn _sort3[
-    type: CollectionElement,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](array: UnsafePointer[type], offset0: Int, offset1: Int, offset2: Int):
-    _sort2[type, cmp_fn](array, offset0, offset1)
-    _sort2[type, cmp_fn](array, offset1, offset2)
-    _sort2[type, cmp_fn](array, offset0, offset1)
+    dtype: CollectionElement,
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](array: UnsafePointer[dtype], offset0: Int, offset1: Int, offset2: Int):
+    _sort2[dtype, cmp_fn](array, offset0, offset1)
+    _sort2[dtype, cmp_fn](array, offset1, offset2)
+    _sort2[dtype, cmp_fn](array, offset0, offset1)
 
 
 @always_inline
 fn _sort_partial_3[
-    type: CollectionElement,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](array: UnsafePointer[type], offset0: Int, offset1: Int, offset2: Int):
+    dtype: CollectionElement,
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](array: UnsafePointer[dtype], offset0: Int, offset1: Int, offset2: Int):
     var a = array[offset0]
     var b = array[offset1]
     var c = array[offset2]
@@ -733,35 +733,35 @@ fn _sort_partial_3[
 @always_inline
 fn _small_sort[
     n: Int,
-    type: CollectionElement,
-    cmp_fn: fn (_SortWrapper[type], _SortWrapper[type]) capturing [_] -> Bool,
-](array: UnsafePointer[type]):
+    dtype: CollectionElement,
+    cmp_fn: fn (_SortWrapper[dtype], _SortWrapper[dtype]) capturing [_] -> Bool,
+](array: UnsafePointer[dtype]):
     @parameter
     if n == 2:
-        _sort2[type, cmp_fn](array, 0, 1)
+        _sort2[dtype, cmp_fn](array, 0, 1)
         return
 
     @parameter
     if n == 3:
-        _sort2[type, cmp_fn](array, 1, 2)
-        _sort_partial_3[type, cmp_fn](array, 0, 1, 2)
+        _sort2[dtype, cmp_fn](array, 1, 2)
+        _sort_partial_3[dtype, cmp_fn](array, 0, 1, 2)
         return
 
     @parameter
     if n == 4:
-        _sort2[type, cmp_fn](array, 0, 2)
-        _sort2[type, cmp_fn](array, 1, 3)
-        _sort2[type, cmp_fn](array, 0, 1)
-        _sort2[type, cmp_fn](array, 2, 3)
-        _sort2[type, cmp_fn](array, 1, 2)
+        _sort2[dtype, cmp_fn](array, 0, 2)
+        _sort2[dtype, cmp_fn](array, 1, 3)
+        _sort2[dtype, cmp_fn](array, 0, 1)
+        _sort2[dtype, cmp_fn](array, 2, 3)
+        _sort2[dtype, cmp_fn](array, 1, 2)
         return
 
     @parameter
     if n == 5:
-        _sort2[type, cmp_fn](array, 0, 1)
-        _sort2[type, cmp_fn](array, 3, 4)
-        _sort_partial_3[type, cmp_fn](array, 2, 3, 4)
-        _sort2[type, cmp_fn](array, 1, 4)
-        _sort_partial_3[type, cmp_fn](array, 0, 2, 3)
-        _sort_partial_3[type, cmp_fn](array, 1, 2, 3)
+        _sort2[dtype, cmp_fn](array, 0, 1)
+        _sort2[dtype, cmp_fn](array, 3, 4)
+        _sort_partial_3[dtype, cmp_fn](array, 2, 3, 4)
+        _sort2[dtype, cmp_fn](array, 1, 4)
+        _sort_partial_3[dtype, cmp_fn](array, 0, 2, 3)
+        _sort_partial_3[dtype, cmp_fn](array, 1, 2, 3)
         return

--- a/mojo/stdlib/test/builtin/test_sort.mojo
+++ b/mojo/stdlib/test/builtin/test_sort.mojo
@@ -53,9 +53,7 @@ fn assert_sorted_string(mut list: List[String]) raises:
         )
 
 
-fn assert_sorted[
-    type: ComparableCollectionElement
-](mut list: List[type]) raises:
+fn assert_sorted[T: ComparableCollectionElement](mut list: List[T]) raises:
     for i in range(1, len(list)):
         assert_true(list[i] >= list[i - 1], String("error at index: ", i))
 


### PR DESCRIPTION
Change `type: DType` parameters to `dtype` in sort.mojo. Part of #4215