### PR TITLE
[stdlib] [NFC] Rename `type: DType` parameters to `dtype` in `bit.mojo`

### DIFF
--- a/mojo/stdlib/src/bit/bit.mojo
+++ b/mojo/stdlib/src/bit/bit.mojo
@@ -42,12 +42,12 @@ fn count_leading_zeros(val: Int) -> Int:
 
 @always_inline("nodebug")
 fn count_leading_zeros[
-    type: DType, width: Int, //
-](val: SIMD[type, width]) -> SIMD[type, width]:
+    dtype: DType, width: Int, //
+](val: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Counts the per-element number of leading zeros in a SIMD vector.
 
     Parameters:
-        type: `DType` used for the computation.
+        dtype: `DType` used for the computation.
         width: SIMD width used for the computation.
 
     Constraints:
@@ -60,7 +60,7 @@ fn count_leading_zeros[
         A SIMD value where the element at position `i` contains the number of
         leading zeros at position `i` of the input value.
     """
-    constrained[type.is_integral(), "must be integral"]()
+    constrained[dtype.is_integral(), "must be integral"]()
     return llvm_intrinsic["llvm.ctlz", __type_of(val), has_side_effect=False](
         val, False
     )
@@ -88,12 +88,12 @@ fn count_trailing_zeros(val: Int) -> Int:
 
 @always_inline("nodebug")
 fn count_trailing_zeros[
-    type: DType, width: Int, //
-](val: SIMD[type, width]) -> SIMD[type, width]:
+    dtype: DType, width: Int, //
+](val: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Counts the per-element number of trailing zeros in a SIMD vector.
 
     Parameters:
-        type: `dtype` used for the computation.
+        dtype: `dtype` used for the computation.
         width: SIMD width used for the computation.
 
     Constraints:
@@ -106,7 +106,7 @@ fn count_trailing_zeros[
         A SIMD value where the element at position `i` contains the number of
         trailing zeros at position `i` of the input value.
     """
-    constrained[type.is_integral(), "must be integral"]()
+    constrained[dtype.is_integral(), "must be integral"]()
     return llvm_intrinsic[
         "llvm.cttz", __type_of(val.value), has_side_effect=False
     ](val.value, False.value)
@@ -132,12 +132,12 @@ fn bit_reverse(val: Int) -> Int:
 
 @always_inline("nodebug")
 fn bit_reverse[
-    type: DType, width: Int, //
-](val: SIMD[type, width]) -> SIMD[type, width]:
+    dtype: DType, width: Int, //
+](val: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Element-wise reverses the bitpattern of a SIMD vector of integer values.
 
     Parameters:
-        type: `dtype` used for the computation.
+        dtype: `dtype` used for the computation.
         width: SIMD width used for the computation.
 
     Args:
@@ -150,7 +150,7 @@ fn bit_reverse[
         A SIMD value where the element at position `i` has a reversed bitpattern
         of an integer value of the element at position `i` of the input value.
     """
-    constrained[type.is_integral(), "must be integral"]()
+    constrained[dtype.is_integral(), "must be integral"]()
     return llvm_intrinsic[
         "llvm.bitreverse", __type_of(val), has_side_effect=False
     ](val)
@@ -181,8 +181,8 @@ fn byte_swap(val: Int) -> Int:
 
 @always_inline("nodebug")
 fn byte_swap[
-    type: DType, width: Int, //
-](val: SIMD[type, width]) -> SIMD[type, width]:
+    dtype: DType, width: Int, //
+](val: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Byte-swaps a SIMD vector of integer values with an even number of bytes.
 
     Byte swap an integer value or vector of integer values with an even number
@@ -194,7 +194,7 @@ fn byte_swap[
     concept to additional even-byte lengths (6 bytes, 8 bytes and more, respectively).
 
     Parameters:
-        type: `dtype` used for the computation.
+        dtype: `dtype` used for the computation.
         width: SIMD width used for the computation.
 
     Constraints:
@@ -208,7 +208,7 @@ fn byte_swap[
         A SIMD value where the element at position `i` is the value of the
         element at position `i` of the input value with its bytes swapped.
     """
-    constrained[type.is_integral(), "must be integral"]()
+    constrained[dtype.is_integral(), "must be integral"]()
     return llvm_intrinsic["llvm.bswap", __type_of(val), has_side_effect=False](
         val
     )
@@ -234,12 +234,12 @@ fn pop_count(val: Int) -> Int:
 
 @always_inline("nodebug")
 fn pop_count[
-    type: DType, width: Int, //
-](val: SIMD[type, width]) -> SIMD[type, width]:
+    dtype: DType, width: Int, //
+](val: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Counts the number of bits set in a SIMD vector of integer values.
 
     Parameters:
-        type: `dtype` used for the computation.
+        dtype: `dtype` used for the computation.
         width: SIMD width used for the computation.
 
     Constraints:
@@ -252,7 +252,7 @@ fn pop_count[
         A SIMD value where the element at position `i` contains the number of
         bits set in the element at position `i` of the input value.
     """
-    constrained[type.is_integral(), "must be integral"]()
+    constrained[dtype.is_integral(), "must be integral"]()
     return llvm_intrinsic["llvm.ctpop", __type_of(val), has_side_effect=False](
         val
     )
@@ -265,12 +265,12 @@ fn pop_count[
 
 @always_inline
 fn bit_not[
-    type: DType, width: Int, //
-](val: SIMD[type, width]) -> SIMD[type, width]:
+    dtype: DType, width: Int, //
+](val: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Performs a bitwise NOT operation on an SIMD vector of integer values.
 
     Parameters:
-        type: `dtype` used for the computation.
+        dtype: `dtype` used for the computation.
         width: SIMD width used for the computation.
 
     Constraints:
@@ -283,8 +283,8 @@ fn bit_not[
         A SIMD value where the element at position `i` is computed as a bitwise
         NOT of the integer value at position `i` of the input value.
     """
-    constrained[type.is_integral(), "must be integral"]()
-    var neg_one = SIMD[type, width](-1)
+    constrained[dtype.is_integral(), "must be integral"]()
+    var neg_one = SIMD[dtype, width](-1)
     return __mlir_op.`pop.simd.xor`(val.value, neg_one.value)
 
 
@@ -310,13 +310,13 @@ fn bit_width(val: Int) -> Int:
 
 @always_inline
 fn bit_width[
-    type: DType, width: Int, //
-](val: SIMD[type, width]) -> SIMD[type, width]:
+    dtype: DType, width: Int, //
+](val: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Computes the minimum number of bits required to represent the SIMD vector
     of integer values.
 
     Parameters:
-        type: `dtype` used for the computation.
+        dtype: `dtype` used for the computation.
         width: SIMD width used for the computation.
 
     Constraints:
@@ -331,12 +331,12 @@ fn bit_width[
         value.
     """
 
-    constrained[type.is_integral(), "must be integral"]()
+    constrained[dtype.is_integral(), "must be integral"]()
 
-    alias bitwidth = bitwidthof[type]()
+    alias bitwidth = bitwidthof[dtype]()
 
     @parameter
-    if type.is_unsigned():
+    if dtype.is_unsigned():
         return bitwidth - count_leading_zeros(val)
     else:
         var leading_zero_pos = count_leading_zeros(val)
@@ -397,8 +397,8 @@ fn next_power_of_two(val: Int) -> Int:
 
 @always_inline
 fn next_power_of_two[
-    type: DType, width: Int, //
-](val: SIMD[type, width]) -> SIMD[type, width]:
+    dtype: DType, width: Int, //
+](val: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Computes the smallest power of 2 that is greater than or equal to the
     input value for each element of a SIMD vector. Any integral value less than
     or equal to 1 will be ceiled to 1.
@@ -406,7 +406,7 @@ fn next_power_of_two[
     This operation is called `bit_ceil()` in C++.
 
     Parameters:
-        type: `dtype` used for the computation.
+        dtype: `dtype` used for the computation.
         width: SIMD width used for the computation.
 
     Constraints:
@@ -420,9 +420,9 @@ fn next_power_of_two[
         that is greater than or equal to the integer at position `i` of the input
         value.
     """
-    constrained[type.is_integral(), "must be integral"]()
+    constrained[dtype.is_integral(), "must be integral"]()
 
-    alias ones = SIMD[type, width](1)
+    alias ones = SIMD[dtype, width](1)
 
     return (val > 1).select(1 << bit_width(val - ones), ones)
 
@@ -454,8 +454,8 @@ fn prev_power_of_two(val: Int) -> Int:
 
 @always_inline
 fn prev_power_of_two[
-    type: DType, width: Int, //
-](val: SIMD[type, width]) -> SIMD[type, width]:
+    dtype: DType, width: Int, //
+](val: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Computes the largest power of 2 that is less than or equal to the input
     value for each element of a SIMD vector. Any integral value less than or
     equal to 0 will be floored to 0.
@@ -463,7 +463,7 @@ fn prev_power_of_two[
     This operation is called `bit_floor()` in C++.
 
     Parameters:
-        type: `dtype` used for the computation.
+        dtype: `dtype` used for the computation.
         width: SIMD width used for the computation.
 
     Constraints:
@@ -477,9 +477,9 @@ fn prev_power_of_two[
         that is less than or equal to the integer at position `i` of the input
         value.
     """
-    constrained[type.is_integral(), "must be integral and unsigned"]()
+    constrained[dtype.is_integral(), "must be integral and unsigned"]()
 
-    alias zeros = SIMD[type, width](0)
+    alias zeros = SIMD[dtype, width](0)
 
     return (val > 0).select(1 << (bit_width(val) - 1), zeros)
 
@@ -524,10 +524,10 @@ fn rotate_bits_left[shift: Int](x: Int) -> Int:
 
 
 fn rotate_bits_left[
-    type: DType,
+    dtype: DType,
     width: Int, //,
     shift: Int,
-](x: SIMD[type, width]) -> SIMD[type, width]:
+](x: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Shifts bits to the left by `shift` positions (with wrap-around) for each
     element of a SIMD vector.
 
@@ -535,7 +535,7 @@ fn rotate_bits_left[
         `0 <= shift < size`
 
     Parameters:
-        type: The `dtype` of the input and output SIMD vector.
+        dtype: The `dtype` of the input and output SIMD vector.
               Constraints: must be integral and unsigned.
         width: The width of the input and output SIMD vector.
         shift: The number of positions by which to shift left the bits for each
@@ -549,7 +549,7 @@ fn rotate_bits_left[
         bits (with wrap-around).
     """
 
-    constrained[type.is_unsigned(), "Only unsigned types can be rotated."]()
+    constrained[dtype.is_unsigned(), "Only unsigned types can be rotated."]()
 
     @parameter
     if shift == 0:
@@ -558,7 +558,7 @@ fn rotate_bits_left[
         return rotate_bits_right[-shift](x)
     else:
         return llvm_intrinsic["llvm.fshl", __type_of(x), has_side_effect=False](
-            x, x, SIMD[type, width](shift)
+            x, x, SIMD[dtype, width](shift)
         )
 
 
@@ -602,10 +602,10 @@ fn rotate_bits_right[shift: Int](x: Int) -> Int:
 
 
 fn rotate_bits_right[
-    type: DType,
+    dtype: DType,
     width: Int, //,
     shift: Int,
-](x: SIMD[type, width]) -> SIMD[type, width]:
+](x: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Shifts bits to the right by `shift` positions (with wrap-around) for each
     element of a SIMD vector.
 
@@ -613,7 +613,7 @@ fn rotate_bits_right[
         `0 <= shift < size`
 
     Parameters:
-        type: The `dtype` of the input and output SIMD vector.
+        dtype: The `dtype` of the input and output SIMD vector.
               Constraints: must be integral and unsigned.
         width: The width of the input and output SIMD vector.
         shift: The number of positions by which to shift right the bits for each
@@ -627,7 +627,7 @@ fn rotate_bits_right[
         bits (with wrap-around).
     """
 
-    constrained[type.is_unsigned(), "Only unsigned types can be rotated."]()
+    constrained[dtype.is_unsigned(), "Only unsigned types can be rotated."]()
 
     @parameter
     if shift == 0:
@@ -636,5 +636,5 @@ fn rotate_bits_right[
         return rotate_bits_left[-shift](x)
     else:
         return llvm_intrinsic["llvm.fshr", __type_of(x), has_side_effect=False](
-            x, x, SIMD[type, width](shift)
+            x, x, SIMD[dtype, width](shift)
         )

--- a/mojo/stdlib/test/bit/test_bit.mojo
+++ b/mojo/stdlib/test/bit/test_bit.mojo
@@ -419,38 +419,38 @@ def test_rotate_bits_int():
 
 def test_rotate_bits_simd():
     alias simd_width = 1
-    alias type = DType.uint8
+    alias dtype = DType.uint8
 
     assert_equal(rotate_bits_left[0](UInt64(104)), 104)
-    assert_equal(rotate_bits_left[0](SIMD[type, simd_width](104)), 104)
+    assert_equal(rotate_bits_left[0](SIMD[dtype, simd_width](104)), 104)
     assert_equal(
-        rotate_bits_left[2](SIMD[type, 2](104)), SIMD[type, 2](161, 161)
+        rotate_bits_left[2](SIMD[dtype, 2](104)), SIMD[dtype, 2](161, 161)
     )
 
-    assert_equal(rotate_bits_left[2](Scalar[type](104)), 161)
-    assert_equal(rotate_bits_left[11](Scalar[type](15)), 120)
-    assert_equal(rotate_bits_left[0](Scalar[type](96)), 96)
-    assert_equal(rotate_bits_left[1](Scalar[type](96)), 192)
-    assert_equal(rotate_bits_left[2](Scalar[type](96)), 129)
-    assert_equal(rotate_bits_left[3](Scalar[type](96)), 3)
-    assert_equal(rotate_bits_left[4](Scalar[type](96)), 6)
-    assert_equal(rotate_bits_left[5](Scalar[type](96)), 12)
+    assert_equal(rotate_bits_left[2](Scalar[dtype](104)), 161)
+    assert_equal(rotate_bits_left[11](Scalar[dtype](15)), 120)
+    assert_equal(rotate_bits_left[0](Scalar[dtype](96)), 96)
+    assert_equal(rotate_bits_left[1](Scalar[dtype](96)), 192)
+    assert_equal(rotate_bits_left[2](Scalar[dtype](96)), 129)
+    assert_equal(rotate_bits_left[3](Scalar[dtype](96)), 3)
+    assert_equal(rotate_bits_left[4](Scalar[dtype](96)), 6)
+    assert_equal(rotate_bits_left[5](Scalar[dtype](96)), 12)
 
     assert_equal(rotate_bits_right[0](UInt64(104)), 104)
-    assert_equal(rotate_bits_right[0](SIMD[type, simd_width](104)), 104)
+    assert_equal(rotate_bits_right[0](SIMD[dtype, simd_width](104)), 104)
     assert_equal(
-        rotate_bits_right[2](SIMD[type, 2](104)), SIMD[type, 2](26, 26)
+        rotate_bits_right[2](SIMD[dtype, 2](104)), SIMD[dtype, 2](26, 26)
     )
 
-    assert_equal(rotate_bits_right[2](Scalar[type](104)), 26)
-    assert_equal(rotate_bits_right[11](Scalar[type](15)), 225)
-    assert_equal(rotate_bits_right[0](Scalar[type](96)), 96)
-    assert_equal(rotate_bits_right[1](Scalar[type](96)), 48)
-    assert_equal(rotate_bits_right[2](Scalar[type](96)), 24)
-    assert_equal(rotate_bits_right[3](Scalar[type](96)), 12)
-    assert_equal(rotate_bits_right[4](Scalar[type](96)), 6)
-    assert_equal(rotate_bits_right[5](Scalar[type](96)), 3)
-    assert_equal(rotate_bits_right[6](Scalar[type](96)), 129)
+    assert_equal(rotate_bits_right[2](Scalar[dtype](104)), 26)
+    assert_equal(rotate_bits_right[11](Scalar[dtype](15)), 225)
+    assert_equal(rotate_bits_right[0](Scalar[dtype](96)), 96)
+    assert_equal(rotate_bits_right[1](Scalar[dtype](96)), 48)
+    assert_equal(rotate_bits_right[2](Scalar[dtype](96)), 24)
+    assert_equal(rotate_bits_right[3](Scalar[dtype](96)), 12)
+    assert_equal(rotate_bits_right[4](Scalar[dtype](96)), 6)
+    assert_equal(rotate_bits_right[5](Scalar[dtype](96)), 3)
+    assert_equal(rotate_bits_right[6](Scalar[dtype](96)), 129)
 
 
 fn _log2_floor(n: Int) -> Int:


### PR DESCRIPTION
Rename `type: DType` parameters to `dtype` in `bit.mojo`. Part of #4215