### PR TITLE
[stdlib] [NFC] Rename `type: DType` parameters to `dtype` in `numerics.mojo` and `index.mojo`

### DIFF
--- a/mojo/stdlib/src/math/math.mojo
+++ b/mojo/stdlib/src/math/math.mojo
@@ -1062,12 +1062,14 @@ fn isclose[
 
 
 # TODO: Remove this when `iota` works at compile-time
-fn _compile_time_iota[type: DType, simd_width: Int]() -> SIMD[type, simd_width]:
+fn _compile_time_iota[
+    dtype: DType, simd_width: Int
+]() -> SIMD[dtype, simd_width]:
     constrained[
-        type.is_integral(),
+        dtype.is_integral(),
         "_compile_time_iota can only be used with integer types.",
     ]()
-    var a = SIMD[type, simd_width](0)
+    var a = SIMD[dtype, simd_width](0)
     for i in range(simd_width):
         a[i] = i
     return a
@@ -1134,11 +1136,11 @@ fn iota[
         buff.store(i, i + offset)
 
 
-fn iota[type: DType, //](mut v: List[Scalar[type], *_], offset: Int = 0):
+fn iota[dtype: DType, //](mut v: List[Scalar[dtype], *_], offset: Int = 0):
     """Fill a list with consecutive numbers starting from the specified offset.
 
     Parameters:
-        type: DType of the underlying data.
+        dtype: DType of the underlying data.
 
     Args:
         v: The list to fill with numbers.

--- a/mojo/stdlib/src/math/math.mojo
+++ b/mojo/stdlib/src/math/math.mojo
@@ -1062,14 +1062,12 @@ fn isclose[
 
 
 # TODO: Remove this when `iota` works at compile-time
-fn _compile_time_iota[
-    dtype: DType, simd_width: Int
-]() -> SIMD[dtype, simd_width]:
+fn _compile_time_iota[type: DType, simd_width: Int]() -> SIMD[type, simd_width]:
     constrained[
-        dtype.is_integral(),
+        type.is_integral(),
         "_compile_time_iota can only be used with integer types.",
     ]()
-    var a = SIMD[dtype, simd_width](0)
+    var a = SIMD[type, simd_width](0)
     for i in range(simd_width):
         a[i] = i
     return a
@@ -1136,11 +1134,11 @@ fn iota[
         buff.store(i, i + offset)
 
 
-fn iota[dtype: DType, //](mut v: List[Scalar[dtype], *_], offset: Int = 0):
+fn iota[type: DType, //](mut v: List[Scalar[type], *_], offset: Int = 0):
     """Fill a list with consecutive numbers starting from the specified offset.
 
     Parameters:
-        dtype: DType of the underlying data.
+        type: DType of the underlying data.
 
     Args:
         v: The list to fill with numbers.

--- a/mojo/stdlib/src/utils/index.mojo
+++ b/mojo/stdlib/src/utils/index.mojo
@@ -56,7 +56,7 @@ fn _reduce_and_fn(a: Bool, b: Bool) -> Bool:
 
 @always_inline
 fn _int_tuple_binary_apply[
-    binary_fn: fn[type: DType] (Scalar[type], Scalar[type]) -> Scalar[type],
+    binary_fn: fn[dtype: DType] (Scalar[dtype], Scalar[dtype]) -> Scalar[dtype],
 ](a: IndexList, b: __type_of(a)) -> __type_of(a):
     """Applies a given element binary function to each pair of corresponding
     elements in two tuples.
@@ -87,7 +87,7 @@ fn _int_tuple_binary_apply[
 
 @always_inline
 fn _int_tuple_compare[
-    comp_fn: fn[type: DType] (Scalar[type], Scalar[type]) -> Bool,
+    comp_fn: fn[dtype: DType] (Scalar[dtype], Scalar[dtype]) -> Bool,
 ](a: IndexList, b: __type_of(a)) -> StaticTuple[Bool, a.size]:
     """Applies a given element compare function to each pair of corresponding
     elements in two tuples and produces a tuple of Bools containing result.
@@ -160,8 +160,8 @@ fn _type_of_width[bitwidth: Int, unsigned: Bool]() -> DType:
         return _int_type_of_width[bitwidth]()
 
 
-fn _is_unsigned[type: DType]() -> Bool:
-    return type in (DType.uint8, DType.uint16, DType.uint32, DType.uint64)
+fn _is_unsigned[dtype: DType]() -> Bool:
+    return dtype in (DType.uint8, DType.uint16, DType.uint32, DType.uint64)
 
 
 @value
@@ -494,8 +494,8 @@ struct IndexList[
 
         @always_inline
         fn apply_fn[
-            type: DType
-        ](a: Scalar[type], b: Scalar[type]) -> Scalar[type]:
+            dtype: DType
+        ](a: Scalar[dtype], b: Scalar[dtype]) -> Scalar[dtype]:
             return a + b
 
         return _int_tuple_binary_apply[apply_fn](self, rhs)
@@ -513,8 +513,8 @@ struct IndexList[
 
         @always_inline
         fn apply_fn[
-            type: DType
-        ](a: Scalar[type], b: Scalar[type]) -> Scalar[type]:
+            dtype: DType
+        ](a: Scalar[dtype], b: Scalar[dtype]) -> Scalar[dtype]:
             return a - b
 
         return _int_tuple_binary_apply[apply_fn](self, rhs)
@@ -532,8 +532,8 @@ struct IndexList[
 
         @always_inline
         fn apply_fn[
-            type: DType
-        ](a: Scalar[type], b: Scalar[type]) -> Scalar[type]:
+            dtype: DType
+        ](a: Scalar[dtype], b: Scalar[dtype]) -> Scalar[dtype]:
             return a * b
 
         return _int_tuple_binary_apply[apply_fn](self, rhs)
@@ -551,8 +551,8 @@ struct IndexList[
 
         @always_inline
         fn apply_fn[
-            type: DType
-        ](a: Scalar[type], b: Scalar[type]) -> Scalar[type]:
+            dtype: DType
+        ](a: Scalar[dtype], b: Scalar[dtype]) -> Scalar[dtype]:
             return a // b
 
         return _int_tuple_binary_apply[apply_fn](self, rhs)
@@ -582,8 +582,8 @@ struct IndexList[
 
         @always_inline
         fn apply_fn[
-            type: DType
-        ](a: Scalar[type], b: Scalar[type]) -> Scalar[type]:
+            dtype: DType
+        ](a: Scalar[dtype], b: Scalar[dtype]) -> Scalar[dtype]:
             return a % b
 
         return _int_tuple_binary_apply[apply_fn](self, rhs)
@@ -602,7 +602,7 @@ struct IndexList[
         """
 
         @always_inline
-        fn apply_fn[type: DType](a: Scalar[type], b: Scalar[type]) -> Bool:
+        fn apply_fn[dtype: DType](a: Scalar[dtype], b: Scalar[dtype]) -> Bool:
             return a == b
 
         return _bool_tuple_reduce[_reduce_and_fn](
@@ -641,7 +641,7 @@ struct IndexList[
         """
 
         @always_inline
-        fn apply_fn[type: DType](a: Scalar[type], b: Scalar[type]) -> Bool:
+        fn apply_fn[dtype: DType](a: Scalar[dtype], b: Scalar[dtype]) -> Bool:
             return a < b
 
         return _bool_tuple_reduce[_reduce_and_fn](
@@ -665,7 +665,7 @@ struct IndexList[
         """
 
         @always_inline
-        fn apply_fn[type: DType](a: Scalar[type], b: Scalar[type]) -> Bool:
+        fn apply_fn[dtype: DType](a: Scalar[dtype], b: Scalar[dtype]) -> Bool:
             return a <= b
 
         return _bool_tuple_reduce[_reduce_and_fn](
@@ -689,7 +689,7 @@ struct IndexList[
         """
 
         @always_inline
-        fn apply_fn[type: DType](a: Scalar[type], b: Scalar[type]) -> Bool:
+        fn apply_fn[dtype: DType](a: Scalar[dtype], b: Scalar[dtype]) -> Bool:
             return a > b
 
         return _bool_tuple_reduce[_reduce_and_fn](
@@ -713,7 +713,7 @@ struct IndexList[
         """
 
         @always_inline
-        fn apply_fn[type: DType](a: Scalar[type], b: Scalar[type]) -> Bool:
+        fn apply_fn[dtype: DType](a: Scalar[dtype], b: Scalar[dtype]) -> Bool:
             return a >= b
 
         return _bool_tuple_reduce[_reduce_and_fn](
@@ -764,24 +764,24 @@ struct IndexList[
 
     @always_inline
     fn cast[
-        type: DType
+        dtype: DType
     ](
         self,
         out result: IndexList[
             size,
-            element_bitwidth = bitwidthof[type](),
-            unsigned = _is_unsigned[type](),
+            element_bitwidth = bitwidthof[dtype](),
+            unsigned = _is_unsigned[dtype](),
         ],
     ):
         """Casts to the target DType.
 
         Parameters:
-            type: The type to cast towards.
+            dtype: The dtype to cast towards.
 
         Returns:
             The list casted to the target type.
         """
-        constrained[type.is_integral(), "the target type must be integral"]()
+        constrained[dtype.is_integral(), "the target type must be integral"]()
 
         var res = __type_of(result)()
 

--- a/mojo/stdlib/src/utils/numerics.mojo
+++ b/mojo/stdlib/src/utils/numerics.mojo
@@ -32,30 +32,30 @@ from memory import UnsafePointer, bitcast
 # ===----------------------------------------------------------------------=== #
 
 
-fn _constrain_fp_type[type: DType]():
+fn _constrain_fp_type[dtype: DType]():
     constrained[
-        type.is_floating_point(), "dtype must be a floating point type"
+        dtype.is_floating_point(), "dtype must be a floating point type"
     ]()
 
 
 struct FPUtils[
-    type: DType, *, _constraint: NoneType = _constrain_fp_type[type]()
+    dtype: DType, *, _constraint: NoneType = _constrain_fp_type[dtype]()
 ]:
     """Collection of utility functions for working with FP values.
 
     Constraints:
-        The type is floating point.
+        The dtype is floating point.
 
     Parameters:
-        type: The concrete FP dtype (FP32/FP64/etc).
+        dtype: The concrete FP dtype (FP32/FP64/etc).
         _constraint: Implements the constraint. Do not pass explicitly.
     """
 
-    alias integral_type = _integral_type_of[type]()
-    """The equivalent integer type of the float type."""
+    alias integral_type = _integral_type_of[dtype]()
+    """The equivalent integer dtype of the float type."""
 
-    alias uint_type = _uint_type_of[type]()
-    """The equivalent uint type of the float type."""
+    alias uint_type = _uint_type_of[dtype]()
+    """The equivalent uint dtype of the float type."""
 
     @staticmethod
     @always_inline("nodebug")
@@ -66,12 +66,12 @@ struct FPUtils[
             The mantissa width.
         """
 
-        return bitwidthof[type]() - Self.exponent_width() - 1
+        return bitwidthof[dtype]() - Self.exponent_width() - 1
 
     @staticmethod
     @always_inline("nodebug")
     fn max_exponent() -> Int:
-        """Returns the max exponent of a floating point type without accounting
+        """Returns the max exponent of a floating point dtype without accounting
         for inf representations. This is not
         the maximum representable exponent, which is generally equal to
         the exponent_bias.
@@ -81,16 +81,16 @@ struct FPUtils[
         """
 
         @parameter
-        if type in (DType.float8_e4m3, DType.float8_e4m3fnuz):
+        if dtype in (DType.float8_e4m3, DType.float8_e4m3fnuz):
             return 7
-        elif type is DType.float8_e4m3fn:
+        elif dtype is DType.float8_e4m3fn:
             return 8
-        elif type in (DType.float8_e5m2, DType.float8_e5m2fnuz, DType.float16):
+        elif dtype in (DType.float8_e5m2, DType.float8_e5m2fnuz, DType.float16):
             return 16
-        elif type in (DType.bfloat16, DType.float32):
+        elif dtype in (DType.bfloat16, DType.float32):
             return 128
         else:
-            constrained[type is DType.float64, "unsupported float type"]()
+            constrained[dtype is DType.float64, "unsupported float type"]()
             return 1024
 
     @staticmethod
@@ -103,18 +103,18 @@ struct FPUtils[
         """
 
         @parameter
-        if type in (
+        if dtype in (
             DType.float8_e4m3,
             DType.float8_e4m3fn,
             DType.float8_e4m3fnuz,
         ):
             return 4
-        elif type in (DType.float8_e5m2, DType.float8_e5m2fnuz, DType.float16):
+        elif dtype in (DType.float8_e5m2, DType.float8_e5m2fnuz, DType.float16):
             return 5
-        elif type in (DType.float32, DType.bfloat16):
+        elif dtype in (DType.float32, DType.bfloat16):
             return 8
         else:
-            constrained[type is DType.float64, "unsupported float type"]()
+            constrained[dtype is DType.float64, "unsupported float type"]()
             return 11
 
     @staticmethod
@@ -137,7 +137,7 @@ struct FPUtils[
         """
 
         @parameter
-        if type in (DType.float8_e4m3fnuz, DType.float8_e5m2fnuz):
+        if dtype in (DType.float8_e4m3fnuz, DType.float8_e5m2fnuz):
             return Self.max_exponent()
         else:
             return Self.max_exponent() - 1
@@ -200,7 +200,7 @@ struct FPUtils[
 
     @staticmethod
     @always_inline
-    fn bitcast_to_integer(value: Scalar[type]) -> Int:
+    fn bitcast_to_integer(value: Scalar[dtype]) -> Int:
         """Bitcasts the floating-point value to an integer.
 
         Args:
@@ -213,7 +213,7 @@ struct FPUtils[
 
     @staticmethod
     @always_inline
-    fn bitcast_to_uint(value: Scalar[type]) -> Scalar[Self.uint_type]:
+    fn bitcast_to_uint(value: Scalar[dtype]) -> Scalar[Self.uint_type]:
         """Bitcasts the floating-point value to an integer.
 
         Args:
@@ -226,7 +226,7 @@ struct FPUtils[
 
     @staticmethod
     @always_inline
-    fn bitcast_from_integer(value: Int) -> Scalar[type]:
+    fn bitcast_from_integer(value: Int) -> Scalar[dtype]:
         """Bitcasts the floating-point value from an integer.
 
         Args:
@@ -235,11 +235,11 @@ struct FPUtils[
         Returns:
             An floating-point representation of the Int.
         """
-        return bitcast[type, 1](SIMD[Self.integral_type, 1](value))
+        return bitcast[dtype, 1](SIMD[Self.integral_type, 1](value))
 
     @staticmethod
     @always_inline
-    fn get_sign(value: Scalar[type]) -> Bool:
+    fn get_sign(value: Scalar[dtype]) -> Bool:
         """Returns the sign of the floating point value.
 
         Args:
@@ -252,7 +252,7 @@ struct FPUtils[
 
     @staticmethod
     @always_inline
-    fn set_sign(value: Scalar[type], sign: Bool) -> Scalar[type]:
+    fn set_sign(value: Scalar[dtype], sign: Bool) -> Scalar[dtype]:
         """Sets the sign of the floating point value.
 
         Args:
@@ -271,7 +271,7 @@ struct FPUtils[
 
     @staticmethod
     @always_inline
-    fn get_exponent(value: Scalar[type]) -> Int:
+    fn get_exponent(value: Scalar[dtype]) -> Int:
         """Returns the exponent bits of the floating-point value.
 
         Args:
@@ -286,7 +286,7 @@ struct FPUtils[
 
     @staticmethod
     @always_inline
-    fn get_exponent_biased(value: Scalar[type]) -> Int:
+    fn get_exponent_biased(value: Scalar[dtype]) -> Int:
         """Returns the biased exponent of the floating-point value as an Int,
         this is how the value is stored before subtracting the exponent bias.
 
@@ -303,7 +303,7 @@ struct FPUtils[
 
     @staticmethod
     @always_inline
-    fn set_exponent(value: Scalar[type], exponent: Int) -> Scalar[type]:
+    fn set_exponent(value: Scalar[dtype], exponent: Int) -> Scalar[dtype]:
         """Sets the exponent bits of the floating-point value.
 
         Args:
@@ -320,7 +320,7 @@ struct FPUtils[
 
     @staticmethod
     @always_inline
-    fn get_mantissa(value: Scalar[type]) -> Int:
+    fn get_mantissa(value: Scalar[dtype]) -> Int:
         """Gets the mantissa bits of the floating-point value.
 
         Args:
@@ -333,7 +333,7 @@ struct FPUtils[
 
     @staticmethod
     @always_inline
-    fn get_mantissa_uint(value: Scalar[type]) -> Scalar[Self.uint_type]:
+    fn get_mantissa_uint(value: Scalar[dtype]) -> Scalar[Self.uint_type]:
         """Gets the mantissa bits of the floating-point value.
 
         Args:
@@ -346,7 +346,7 @@ struct FPUtils[
 
     @staticmethod
     @always_inline
-    fn set_mantissa(value: Scalar[type], mantissa: Int) -> Scalar[type]:
+    fn set_mantissa(value: Scalar[dtype], mantissa: Int) -> Scalar[dtype]:
         """Sets the mantissa bits of the floating-point value.
 
         Args:
@@ -363,7 +363,7 @@ struct FPUtils[
 
     @staticmethod
     @always_inline
-    fn pack(sign: Bool, exponent: Int, mantissa: Int) -> Scalar[type]:
+    fn pack(sign: Bool, exponent: Int, mantissa: Int) -> Scalar[dtype]:
         """Construct a floating-point value from its constituent sign, exponent,
         and mantissa.
 
@@ -375,7 +375,7 @@ struct FPUtils[
         Returns:
             Returns the floating-point value.
         """
-        var res: Scalar[type] = 0
+        var res: Scalar[dtype] = 0
         res = Self.set_sign(res, sign)
         res = Self.set_exponent(res, exponent)
         res = Self.set_mantissa(res, mantissa)
@@ -494,29 +494,29 @@ struct FlushDenormals:
 
 
 @always_inline("nodebug")
-fn nan[type: DType]() -> Scalar[type]:
+fn nan[dtype: DType]() -> Scalar[dtype]:
     """Gets a NaN value for the given dtype.
 
     Constraints:
         Can only be used for FP dtypes.
 
     Parameters:
-        type: The value dtype.
+        dtype: The value dtype.
 
     Returns:
         The NaN value of the given dtype.
     """
 
     @parameter
-    if type is DType.float8_e5m2:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    if dtype is DType.float8_e5m2:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f8e5m2>`],
                 value = __mlir_attr[`#pop.simd<"nan"> : !pop.scalar<f8e5m2>`],
             ]()
         )
-    elif type is DType.float8_e5m2fnuz:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float8_e5m2fnuz:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f8e5m2fnuz>`],
                 value = __mlir_attr[
@@ -524,15 +524,15 @@ fn nan[type: DType]() -> Scalar[type]:
                 ],
             ]()
         )
-    elif type is DType.float8_e4m3fn:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float8_e4m3fn:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f8e4m3>`],
                 value = __mlir_attr[`#pop.simd<"nan"> : !pop.scalar<f8e4m3>`],
             ]()
         )
-    elif type is DType.float8_e4m3fnuz:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float8_e4m3fnuz:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f8e4m3fnuz>`],
                 value = __mlir_attr[
@@ -540,29 +540,29 @@ fn nan[type: DType]() -> Scalar[type]:
                 ],
             ]()
         )
-    elif type is DType.float16:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float16:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f16>`],
                 value = __mlir_attr[`#pop.simd<"nan"> : !pop.scalar<f16>`],
             ]()
         )
-    elif type is DType.bfloat16:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.bfloat16:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<bf16>`],
                 value = __mlir_attr[`#pop.simd<"nan"> : !pop.scalar<bf16>`],
             ]()
         )
-    elif type is DType.float32:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float32:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f32>`],
                 value = __mlir_attr[`#pop.simd<"nan"> : !pop.scalar<f32>`],
             ]()
         )
-    elif type is DType.float64:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float64:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f64>`],
                 value = __mlir_attr[`#pop.simd<"nan"> : !pop.scalar<f64>`],
@@ -580,12 +580,12 @@ fn nan[type: DType]() -> Scalar[type]:
 
 @always_inline("nodebug")
 fn isnan[
-    type: DType, simd_width: Int
-](val: SIMD[type, simd_width]) -> SIMD[DType.bool, simd_width]:
+    dtype: DType, simd_width: Int
+](val: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
     """Checks if the value is Not a Number (NaN).
 
     Parameters:
-        type: The value dtype.
+        dtype: The value dtype.
         simd_width: The width of the SIMD vector.
 
     Args:
@@ -596,25 +596,25 @@ fn isnan[
     """
 
     @parameter
-    if not type.is_floating_point() or type in (
+    if not dtype.is_floating_point() or dtype in (
         DType.float8_e4m3fnuz,
         DType.float8_e5m2fnuz,
     ):
         return False
 
-    alias int_dtype = _integral_type_of[type]()
+    alias int_dtype = _integral_type_of[dtype]()
 
     @parameter
-    if type is DType.float8_e4m3fn:
+    if dtype is DType.float8_e4m3fn:
         return (bitcast[int_dtype, simd_width](val) & 0x7F) == 0x7F
-    elif type is DType.float8_e5m2:
-        # For the float8_e5m2 type NaN is limited to 0x7F and 0xFF values.
+    elif dtype is DType.float8_e5m2:
+        # For the float8_e5m2 dtype NaN is limited to 0x7F and 0xFF values.
         # 7D, 7E, 7F are positive NaNs; FD, FE, FF are negative NaNs.
         return (bitcast[int_dtype, simd_width](val) & 0x7F) > 0x7C
-    elif type is DType.float16:
+    elif dtype is DType.float16:
         var ival = bitcast[int_dtype, simd_width](val)
         return (ival & 0x7C00) == 0x7C00 and (ival & 0x03FF) != 0
-    elif type is DType.bfloat16:
+    elif dtype is DType.bfloat16:
         alias x7FFF = SIMD[int_dtype, simd_width](0x7FFF)
         alias x7F80 = SIMD[int_dtype, simd_width](0x7F80)
         return bitcast[int_dtype, simd_width](val) & x7FFF > x7F80
@@ -632,29 +632,29 @@ fn isnan[
 
 
 @always_inline("nodebug")
-fn inf[type: DType]() -> Scalar[type]:
+fn inf[dtype: DType]() -> Scalar[dtype]:
     """Gets a +inf value for the given dtype.
 
     Constraints:
         Can only be used for FP dtypes.
 
     Parameters:
-        type: The value dtype.
+        dtype: The value dtype.
 
     Returns:
         The +inf value of the given dtype.
     """
 
     @parameter
-    if type is DType.float8_e5m2:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    if dtype is DType.float8_e5m2:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f8e5m2>`],
                 value = __mlir_attr[`#pop.simd<"inf"> : !pop.scalar<f8e5m2>`],
             ]()
         )
-    elif type is DType.float8_e5m2fnuz:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float8_e5m2fnuz:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f8e5m2fnuz>`],
                 value = __mlir_attr[
@@ -662,15 +662,15 @@ fn inf[type: DType]() -> Scalar[type]:
                 ],
             ]()
         )
-    elif type is DType.float8_e4m3fn:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float8_e4m3fn:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f8e4m3>`],
                 value = __mlir_attr[`#pop.simd<"inf"> : !pop.scalar<f8e4m3>`],
             ]()
         )
-    elif type is DType.float8_e4m3fnuz:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float8_e4m3fnuz:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f8e4m3fnuz>`],
                 value = __mlir_attr[
@@ -678,29 +678,29 @@ fn inf[type: DType]() -> Scalar[type]:
                 ],
             ]()
         )
-    elif type is DType.float16:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float16:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f16>`],
                 value = __mlir_attr[`#pop.simd<"inf"> : !pop.scalar<f16>`],
             ]()
         )
-    elif type is DType.bfloat16:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.bfloat16:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<bf16>`],
                 value = __mlir_attr[`#pop.simd<"inf"> : !pop.scalar<bf16>`],
             ]()
         )
-    elif type is DType.float32:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float32:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f32>`],
                 value = __mlir_attr[`#pop.simd<"inf"> : !pop.scalar<f32>`],
             ]()
         )
-    elif type is DType.float64:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float64:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f64>`],
                 value = __mlir_attr[`#pop.simd<"inf"> : !pop.scalar<f64>`],
@@ -717,29 +717,29 @@ fn inf[type: DType]() -> Scalar[type]:
 
 
 @always_inline("nodebug")
-fn neg_inf[type: DType]() -> Scalar[type]:
+fn neg_inf[dtype: DType]() -> Scalar[dtype]:
     """Gets a -inf value for the given dtype.
 
     Constraints:
         Can only be used for FP dtypes.
 
     Parameters:
-        type: The value dtype.
+        dtype: The value dtype.
 
     Returns:
         The -inf value of the given dtype.
     """
 
     @parameter
-    if type is DType.float8_e5m2:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    if dtype is DType.float8_e5m2:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f8e5m2>`],
                 value = __mlir_attr[`#pop.simd<"-inf"> : !pop.scalar<f8e5m2>`],
             ]()
         )
-    elif type is DType.float8_e5m2fnuz:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float8_e5m2fnuz:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f8e5m2fnuz>`],
                 value = __mlir_attr[
@@ -747,15 +747,15 @@ fn neg_inf[type: DType]() -> Scalar[type]:
                 ],
             ]()
         )
-    elif type is DType.float8_e4m3fn:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float8_e4m3fn:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f8e4m3>`],
                 value = __mlir_attr[`#pop.simd<"-inf"> : !pop.scalar<f8e4m3>`],
             ]()
         )
-    elif type is DType.float8_e4m3fnuz:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float8_e4m3fnuz:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f8e4m3fnuz>`],
                 value = __mlir_attr[
@@ -763,29 +763,29 @@ fn neg_inf[type: DType]() -> Scalar[type]:
                 ],
             ]()
         )
-    elif type is DType.float16:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float16:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f16>`],
                 value = __mlir_attr[`#pop.simd<"-inf"> : !pop.scalar<f16>`],
             ]()
         )
-    elif type is DType.bfloat16:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.bfloat16:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<bf16>`],
                 value = __mlir_attr[`#pop.simd<"-inf"> : !pop.scalar<bf16>`],
             ]()
         )
-    elif type is DType.float32:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float32:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f32>`],
                 value = __mlir_attr[`#pop.simd<"-inf"> : !pop.scalar<f32>`],
             ]()
         )
-    elif type is DType.float64:
-        return rebind[__mlir_type[`!pop.scalar<`, type.value, `>`]](
+    elif dtype is DType.float64:
+        return rebind[__mlir_type[`!pop.scalar<`, dtype.value, `>`]](
             __mlir_op.`kgen.param.constant`[
                 _type = __mlir_type[`!pop.scalar<f64>`],
                 value = __mlir_attr[`#pop.simd<"-inf"> : !pop.scalar<f64>`],
@@ -802,11 +802,11 @@ fn neg_inf[type: DType]() -> Scalar[type]:
 
 
 @always_inline
-fn max_finite[type: DType]() -> Scalar[type]:
+fn max_finite[dtype: DType]() -> Scalar[dtype]:
     """Returns the maximum finite value of type.
 
     Parameters:
-        type: The value dtype.
+        dtype: The value dtype.
 
     Returns:
         The maximum representable value of the type. Does not include infinity
@@ -814,42 +814,42 @@ fn max_finite[type: DType]() -> Scalar[type]:
     """
 
     @parameter
-    if type is DType.int8:
+    if dtype is DType.int8:
         return 127
-    elif type is DType.uint8:
+    elif dtype is DType.uint8:
         return 255
-    elif type is DType.int16:
+    elif dtype is DType.int16:
         return 32767
-    elif type is DType.uint16:
+    elif dtype is DType.uint16:
         return 65535
-    elif type is DType.int32 or (
-        type is DType.index and bitwidthof[DType.index]() == 32
+    elif dtype is DType.int32 or (
+        dtype is DType.index and bitwidthof[DType.index]() == 32
     ):
         return 2147483647
-    elif type is DType.uint32:
+    elif dtype is DType.uint32:
         return 4294967295
-    elif type is DType.int64 or (
-        type is DType.index and bitwidthof[DType.index]() == 64
+    elif dtype is DType.int64 or (
+        dtype is DType.index and bitwidthof[DType.index]() == 64
     ):
         return 9223372036854775807
-    elif type is DType.uint64:
+    elif dtype is DType.uint64:
         return 18446744073709551615
-    elif type is DType.float8_e4m3fn:
+    elif dtype is DType.float8_e4m3fn:
         return 448
-    elif type is DType.float8_e4m3fnuz:
+    elif dtype is DType.float8_e4m3fnuz:
         return 240
-    elif type in (DType.float8_e5m2, DType.float8_e5m2fnuz):
+    elif dtype in (DType.float8_e5m2, DType.float8_e5m2fnuz):
         return 57344
-    elif type is DType.float16:
+    elif dtype is DType.float16:
         return 65504
-    elif type is DType.bfloat16:
+    elif dtype is DType.bfloat16:
         return 3.38953139e38
-    elif type is DType.float32:
+    elif dtype is DType.float32:
         return 3.40282346638528859812e38
-    elif type is DType.float64:
+    elif dtype is DType.float64:
         return 1.79769313486231570815e308
-    elif type is DType.bool:
-        return rebind[Scalar[type]](Scalar(True))
+    elif dtype is DType.bool:
+        return rebind[Scalar[dtype]](Scalar(True))
     else:
         constrained[False, "max_finite() called on unsupported type"]()
         return 0
@@ -861,11 +861,11 @@ fn max_finite[type: DType]() -> Scalar[type]:
 
 
 @always_inline
-fn min_finite[type: DType]() -> Scalar[type]:
+fn min_finite[dtype: DType]() -> Scalar[dtype]:
     """Returns the minimum (lowest) finite value of type.
 
     Parameters:
-        type: The value dtype.
+        dtype: The value dtype.
 
     Returns:
         The minimum representable value of the type. Does not include negative
@@ -873,24 +873,24 @@ fn min_finite[type: DType]() -> Scalar[type]:
     """
 
     @parameter
-    if type.is_unsigned():
+    if dtype.is_unsigned():
         return 0
-    elif type is DType.int8:
+    elif dtype is DType.int8:
         return -128
-    elif type is DType.int16:
+    elif dtype is DType.int16:
         return -32768
-    elif type is DType.int32 or (
-        type is DType.index and bitwidthof[DType.index]() == 32
+    elif dtype is DType.int32 or (
+        dtype is DType.index and bitwidthof[DType.index]() == 32
     ):
         return -2147483648
-    elif type is DType.int64 or (
-        type is DType.index and bitwidthof[DType.index]() == 64
+    elif dtype is DType.int64 or (
+        dtype is DType.index and bitwidthof[DType.index]() == 64
     ):
         return -9223372036854775808
-    elif type.is_floating_point():
-        return -max_finite[type]()
-    elif type is DType.bool:
-        return rebind[Scalar[type]](Scalar(False))
+    elif dtype.is_floating_point():
+        return -max_finite[dtype]()
+    elif dtype is DType.bool:
+        return rebind[Scalar[dtype]](Scalar(False))
     else:
         constrained[False, "min_finite() called on unsupported type"]()
         return 0
@@ -902,11 +902,11 @@ fn min_finite[type: DType]() -> Scalar[type]:
 
 
 @always_inline("nodebug")
-fn max_or_inf[type: DType]() -> Scalar[type]:
+fn max_or_inf[dtype: DType]() -> Scalar[dtype]:
     """Returns the maximum (potentially infinite) value of type.
 
     Parameters:
-        type: The value dtype.
+        dtype: The value dtype.
 
     Returns:
         The maximum representable value of the type. Can include infinity for
@@ -914,10 +914,10 @@ fn max_or_inf[type: DType]() -> Scalar[type]:
     """
 
     @parameter
-    if type.is_floating_point():
-        return inf[type]()
+    if dtype.is_floating_point():
+        return inf[dtype]()
     else:
-        return max_finite[type]()
+        return max_finite[dtype]()
 
 
 # ===----------------------------------------------------------------------=== #
@@ -926,11 +926,11 @@ fn max_or_inf[type: DType]() -> Scalar[type]:
 
 
 @always_inline("nodebug")
-fn min_or_neg_inf[type: DType]() -> Scalar[type]:
+fn min_or_neg_inf[dtype: DType]() -> Scalar[dtype]:
     """Returns the minimum (potentially negative infinite) value of type.
 
     Parameters:
-        type: The value dtype.
+        dtype: The value dtype.
 
     Returns:
         The minimum representable value of the type. Can include negative
@@ -938,10 +938,10 @@ fn min_or_neg_inf[type: DType]() -> Scalar[type]:
     """
 
     @parameter
-    if type.is_floating_point():
-        return neg_inf[type]()
+    if dtype.is_floating_point():
+        return neg_inf[dtype]()
     else:
-        return min_finite[type]()
+        return min_finite[dtype]()
 
 
 # ===----------------------------------------------------------------------=== #
@@ -951,14 +951,14 @@ fn min_or_neg_inf[type: DType]() -> Scalar[type]:
 
 @always_inline("nodebug")
 fn isinf[
-    type: DType, simd_width: Int
-](val: SIMD[type, simd_width]) -> SIMD[DType.bool, simd_width]:
+    dtype: DType, simd_width: Int
+](val: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
     """Checks if the value is infinite.
 
     This is always False for non-FP data types.
 
     Parameters:
-        type: The value dtype.
+        dtype: The value dtype.
         simd_width: The width of the SIMD vector.
 
     Args:
@@ -969,14 +969,14 @@ fn isinf[
     """
 
     @parameter
-    if not type.is_floating_point() or type in (
+    if not dtype.is_floating_point() or dtype in (
         DType.float8_e4m3fnuz,
         DType.float8_e5m2fnuz,
     ):
         return False
-    elif type is DType.float8_e5m2:
+    elif dtype is DType.float8_e5m2:
         # For the float8_e5m2 both 7C and FC are infinity.
-        alias int_dtype = _integral_type_of[type]()
+        alias int_dtype = _integral_type_of[dtype]()
         return (bitcast[int_dtype, simd_width](val) & 0x7F) == 0x7C
 
     alias negative_infinity_test: UInt32 = 0x0004
@@ -993,14 +993,14 @@ fn isinf[
 
 @always_inline("nodebug")
 fn isfinite[
-    type: DType, simd_width: Int
-](val: SIMD[type, simd_width]) -> SIMD[DType.bool, simd_width]:
+    dtype: DType, simd_width: Int
+](val: SIMD[dtype, simd_width]) -> SIMD[DType.bool, simd_width]:
     """Checks if the value is not infinite.
 
     This is always True for non-FP data types.
 
     Parameters:
-        type: The value dtype.
+        dtype: The value dtype.
         simd_width: The width of the SIMD vector.
 
     Args:
@@ -1011,7 +1011,7 @@ fn isfinite[
     """
 
     @parameter
-    if not type.is_floating_point():
+    if not dtype.is_floating_point():
         return True
 
     return llvm_intrinsic["llvm.is.fpclass", SIMD[DType.bool, simd_width]](
@@ -1026,39 +1026,40 @@ fn isfinite[
 
 @always_inline
 fn get_accum_type[
-    type: DType, *, preferred_accum_type: DType = DType.float32
+    dtype: DType, *, preferred_accum_type: DType = DType.float32
 ]() -> DType:
-    """Returns the recommended type for accumulation operations.
+    """Returns the recommended dtype for accumulation operations.
 
-    Half precision and float8 types can introduce numerical error if they are used
-    in reduction/accumulation operations. This method returns a higher precision
-    type to use for accumulation if a half precision types is provided,
-    otherwise it returns the original type.
+    Half precision and float8 types can introduce numerical error if they are
+    used in reduction/accumulation operations. This method returns a higher
+    precision dtype to use for accumulation if a half precision types is
+    provided, otherwise it returns the original dtype.
 
     The rules are as follows:
-        - If the type is a float8 type, return a float16 type.
-        - If the type is a bfloat16 precision type, return a float32 type.
-        - If the type is a float16 precision type, return a float32 type if the
-          preferred_accum_type is float32, otherwise return a float16 type.
+        - If the dtype is a float8 type, return a float16 type.
+        - If the dtype is a bfloat16 precision type, return a float32 type.
+        - If the dtype is a float16 precision type, return a float32 dtype if
+            the preferred_accum_type is float32, otherwise return a float16
+            type.
         - Otherwise, return the original type.
 
     Parameters:
-        type: The type of some accumulation operation.
-        preferred_accum_type: The preferred type for accumulation.
+        dtype: The dtype of some accumulation operation.
+        preferred_accum_type: The preferred dtype for accumulation.
 
     Returns:
-        DType.float32 if type is a half-precision float, type otherwise.
+        DType.float32 if dtype is a half-precision float, dtype otherwise.
     """
 
     @parameter
-    if type.is_float8():
+    if dtype.is_float8():
         if preferred_accum_type is DType.float32:
             return preferred_accum_type
         else:
             return DType.float16
-    elif type is DType.bfloat16:
+    elif dtype is DType.bfloat16:
         return DType.float32
-    elif type is DType.float16:
+    elif dtype is DType.float16:
         # fp16 accumulation can be done in fp16 or fp32. Use fp16 by default for better
         # performance and use fp32 only when it's specified via preferred type.
         @parameter
@@ -1067,7 +1068,7 @@ fn get_accum_type[
         else:
             return DType.float16
     else:
-        return type
+        return dtype
 
 
 # ===----------------------------------------------------------------------=== #
@@ -1076,17 +1077,17 @@ fn get_accum_type[
 
 
 fn nextafter[
-    type: DType, simd_width: Int
-](arg0: SIMD[type, simd_width], arg1: SIMD[type, simd_width]) -> SIMD[
-    type, simd_width
+    dtype: DType, simd_width: Int
+](arg0: SIMD[dtype, simd_width], arg1: SIMD[dtype, simd_width]) -> SIMD[
+    dtype, simd_width
 ]:
     """Computes next representable value of `arg0` in the direction of `arg1`.
 
     Constraints:
-        The element type of the input must be a floating-point type.
+        The element dtype of the input must be a floating-point type.
 
     Parameters:
-        type: The `dtype` of the input and output SIMD vector.
+        dtype: The `dtype` of the input and output SIMD vector.
         simd_width: The width of the input and output SIMD vector.
 
     Args:
@@ -1115,12 +1116,14 @@ fn nextafter[
             arg0, arg1
         )
 
-    constrained[type.is_floating_point(), "input type must be floating point"]()
+    constrained[
+        dtype.is_floating_point(), "input dtype must be floating point"
+    ]()
 
     @parameter
-    if type is DType.float64:
-        return _simd_apply[_float64_dispatch, type, simd_width](arg0, arg1)
-    return _simd_apply[_float32_dispatch, type, simd_width](arg0, arg1)
+    if dtype is DType.float64:
+        return _simd_apply[_float64_dispatch, dtype, simd_width](arg0, arg1)
+    return _simd_apply[_float32_dispatch, dtype, simd_width](arg0, arg1)
 
 
 # ===----------------------------------------------------------------------=== #
@@ -1130,16 +1133,16 @@ fn nextafter[
 
 @always_inline("nodebug")
 fn ulp[
-    type: DType, simd_width: Int
-](x: SIMD[type, simd_width]) -> SIMD[type, simd_width]:
+    dtype: DType, simd_width: Int
+](x: SIMD[dtype, simd_width]) -> SIMD[dtype, simd_width]:
     """Computes the ULP (units of last place) or (units of least precision) of
     the number.
 
     Constraints:
-        The element type of the inpiut must be a floating-point type.
+        The element dtype of the inpiut must be a floating-point type.
 
     Parameters:
-        type: The `dtype` of the input and output SIMD vector.
+        dtype: The `dtype` of the input and output SIMD vector.
         simd_width: The width of the input and output SIMD vector.
 
     Args:
@@ -1149,9 +1152,9 @@ fn ulp[
         The ULP of x.
     """
 
-    constrained[type.is_floating_point(), "the type must be floating point"]()
+    constrained[dtype.is_floating_point(), "the dtype must be floating point"]()
 
-    alias inf_val = SIMD[type, simd_width](inf[type]())
+    alias inf_val = SIMD[dtype, simd_width](inf[dtype]())
 
     var nan_mask = isnan(x)
     var xabs = abs(x)

--- a/mojo/stdlib/test/builtin/test_any_all.mojo
+++ b/mojo/stdlib/test/builtin/test_any_all.mojo
@@ -99,15 +99,15 @@ def test_set_all():
 
 def test_simd_any():
     @parameter
-    def _test_dtype[type: DType]():
-        assert_true(any(SIMD[type, 1](1)))
-        assert_false(any(SIMD[type, 1](0)))
-        assert_true(any(SIMD[type, 4](1, 2, 3, 4)))
-        assert_true(any(SIMD[type, 4](0, 2, 3, 4)))
-        assert_true(any(SIMD[type, 4](1, 2, 3, 0)))
-        assert_true(any(SIMD[type, 4](0, 2, 3, 0)))
-        assert_true(any(SIMD[type, 4](1, 0, 0, 4)))
-        assert_false(any(SIMD[type, 4](0, 0, 0, 0)))
+    def _test_dtype[dtype: DType]():
+        assert_true(any(SIMD[dtype, 1](1)))
+        assert_false(any(SIMD[dtype, 1](0)))
+        assert_true(any(SIMD[dtype, 4](1, 2, 3, 4)))
+        assert_true(any(SIMD[dtype, 4](0, 2, 3, 4)))
+        assert_true(any(SIMD[dtype, 4](1, 2, 3, 0)))
+        assert_true(any(SIMD[dtype, 4](0, 2, 3, 0)))
+        assert_true(any(SIMD[dtype, 4](1, 0, 0, 4)))
+        assert_false(any(SIMD[dtype, 4](0, 0, 0, 0)))
 
     _test_dtype[DType.bool]()
     _test_dtype[DType.int8]()
@@ -125,15 +125,15 @@ def test_simd_any():
 
 def test_simd_all():
     @parameter
-    def _test_dtype[type: DType]():
-        assert_true(all(SIMD[type, 1](1)))
-        assert_false(all(SIMD[type, 1](0)))
-        assert_true(all(SIMD[type, 4](1, 2, 3, 4)))
-        assert_false(all(SIMD[type, 4](0, 2, 3, 4)))
-        assert_false(all(SIMD[type, 4](1, 2, 3, 0)))
-        assert_false(all(SIMD[type, 4](0, 2, 3, 0)))
-        assert_false(all(SIMD[type, 4](1, 0, 0, 4)))
-        assert_false(all(SIMD[type, 4](0, 0, 0, 0)))
+    def _test_dtype[dtype: DType]():
+        assert_true(all(SIMD[dtype, 1](1)))
+        assert_false(all(SIMD[dtype, 1](0)))
+        assert_true(all(SIMD[dtype, 4](1, 2, 3, 4)))
+        assert_false(all(SIMD[dtype, 4](0, 2, 3, 4)))
+        assert_false(all(SIMD[dtype, 4](1, 2, 3, 0)))
+        assert_false(all(SIMD[dtype, 4](0, 2, 3, 0)))
+        assert_false(all(SIMD[dtype, 4](1, 0, 0, 4)))
+        assert_false(all(SIMD[dtype, 4](0, 0, 0, 0)))
 
     _test_dtype[DType.bool]()
     _test_dtype[DType.int8]()

--- a/mojo/stdlib/test/utils/test_numerics.mojo
+++ b/mojo/stdlib/test/utils/test_numerics.mojo
@@ -139,17 +139,19 @@ def test_isnan():
     assert_true(isnan(nan[DType.float64]()))
 
 
-fn overflow_int[type: DType]() -> Bool:
-    constrained[type.is_integral(), "comparison only valid on integral types"]()
-    return max_finite[type]() + 1 < max_finite[type]()
-
-
-fn overflow_fp[type: DType]() -> Bool:
+fn overflow_int[dtype: DType]() -> Bool:
     constrained[
-        type.is_floating_point(),
+        dtype.is_integral(), "comparison only valid on integral types"
+    ]()
+    return max_finite[dtype]() + 1 < max_finite[dtype]()
+
+
+fn overflow_fp[dtype: DType]() -> Bool:
+    constrained[
+        dtype.is_floating_point(),
         "comparison only valid on floating point types",
     ]()
-    return max_finite[type]() + 1 == max_finite[type]()
+    return max_finite[dtype]() + 1 == max_finite[dtype]()
 
 
 def test_max_finite():
@@ -171,17 +173,19 @@ def test_max_finite():
     assert_true(overflow_fp[DType.float64]())
 
 
-fn underflow_int[type: DType]() -> Bool:
-    constrained[type.is_integral(), "comparison only valid on integral types"]()
-    return min_finite[type]() - 1 > min_finite[type]()
-
-
-fn underflow_fp[type: DType]() -> Bool:
+fn underflow_int[dtype: DType]() -> Bool:
     constrained[
-        type.is_floating_point(),
+        dtype.is_integral(), "comparison only valid on integral types"
+    ]()
+    return min_finite[dtype]() - 1 > min_finite[dtype]()
+
+
+fn underflow_fp[dtype: DType]() -> Bool:
+    constrained[
+        dtype.is_floating_point(),
         "comparison only valid on floating point types",
     ]()
-    return min_finite[type]() - 1 == min_finite[type]()
+    return min_finite[dtype]() - 1 == min_finite[dtype]()
 
 
 def test_min_finite():


### PR DESCRIPTION
Rename `type: DType` parameters to `dtype` in `numerics.mojo` and `index.mojo`. Part of #4215