### PR TITLE
[stdlib] [NFC] Rename `type: DType` parameters to `dtype` in `atomic.mojo`

### DIFF
--- a/mojo/stdlib/src/os/atomic.mojo
+++ b/mojo/stdlib/src/os/atomic.mojo
@@ -25,17 +25,17 @@ from builtin.dtype import _integral_type_of, _unsigned_integral_type_of
 from memory import UnsafePointer, bitcast
 
 
-struct Atomic[type: DType, *, scope: StringLiteral = ""]:
+struct Atomic[dtype: DType, *, scope: StringLiteral = ""]:
     """Represents a value with atomic operations.
 
     The class provides atomic `add` and `sub` methods for mutating the value.
 
     Parameters:
-        type: DType of the value.
+        dtype: DType of the value.
         scope: The memory synchronization scope.
     """
 
-    var value: Scalar[type]
+    var value: Scalar[dtype]
     """The atomic value.
 
     This is the underlying value of the atomic. Access to the value can only
@@ -44,16 +44,16 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
 
     @always_inline
     @implicit
-    fn __init__(out self, value: Scalar[type]):
+    fn __init__(out self, value: Scalar[dtype]):
         """Constructs a new atomic value.
 
         Args:
-            value: Initial value represented as `Scalar[type]` type.
+            value: Initial value represented as `Scalar[dtype]` type.
         """
         self.value = value
 
     @always_inline
-    fn load(self) -> Scalar[type]:
+    fn load(self) -> Scalar[dtype]:
         """Loads the current value from the atomic.
 
         Returns:
@@ -64,8 +64,8 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
     @staticmethod
     @always_inline
     fn _fetch_add(
-        ptr: UnsafePointer[Scalar[type], **_], rhs: Scalar[type]
-    ) -> Scalar[type]:
+        ptr: UnsafePointer[Scalar[dtype], **_], rhs: Scalar[dtype]
+    ) -> Scalar[dtype]:
         """Performs atomic in-place add.
 
         Atomically replaces the current value with the result of arithmetic
@@ -85,17 +85,19 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
             bin_op = __mlir_attr.`#pop<bin_op add>`,
             ordering = __mlir_attr.`#pop<atomic_ordering seq_cst>`,
             syncscope = scope.value,
-            _type = __mlir_type[`!pop.scalar<`, type.value, `>`],
+            _type = __mlir_type[`!pop.scalar<`, dtype.value, `>`],
         ](
-            ptr.bitcast[__mlir_type[`!pop.scalar<`, type.value, `>`]]().address,
+            ptr.bitcast[
+                __mlir_type[`!pop.scalar<`, dtype.value, `>`]
+            ]().address,
             rhs.value,
         )
 
     @staticmethod
     @always_inline
     fn _xchg(
-        ptr: UnsafePointer[Scalar[type], **_], value: Scalar[type]
-    ) -> Scalar[type]:
+        ptr: UnsafePointer[Scalar[dtype], **_], value: Scalar[dtype]
+    ) -> Scalar[dtype]:
         """Performs an atomic exchange.
         The operation is a read-modify-write operation. Memory
         is affected according to the value of order which is sequentially
@@ -111,15 +113,17 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
         return __mlir_op.`pop.atomic.rmw`[
             bin_op = __mlir_attr.`#pop<bin_op xchg>`,
             ordering = __mlir_attr.`#pop<atomic_ordering seq_cst>`,
-            _type = __mlir_type[`!pop.scalar<`, type.value, `>`],
+            _type = __mlir_type[`!pop.scalar<`, dtype.value, `>`],
         ](
-            ptr.bitcast[__mlir_type[`!pop.scalar<`, type.value, `>`]]().address,
+            ptr.bitcast[
+                __mlir_type[`!pop.scalar<`, dtype.value, `>`]
+            ]().address,
             value.value,
         )
 
     @staticmethod
     @always_inline
-    fn store(ptr: UnsafePointer[Scalar[type], **_], value: Scalar[type]):
+    fn store(ptr: UnsafePointer[Scalar[dtype], **_], value: Scalar[dtype]):
         """Performs atomic store.
         The operation is a read-modify-write operation. Memory
         is affected according to the value of order which is sequentially
@@ -132,14 +136,16 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
         _ = __mlir_op.`pop.atomic.rmw`[
             bin_op = __mlir_attr.`#pop<bin_op xchg>`,
             ordering = __mlir_attr.`#pop<atomic_ordering seq_cst>`,
-            _type = __mlir_type[`!pop.scalar<`, type.value, `>`],
+            _type = __mlir_type[`!pop.scalar<`, dtype.value, `>`],
         ](
-            ptr.bitcast[__mlir_type[`!pop.scalar<`, type.value, `>`]]().address,
+            ptr.bitcast[
+                __mlir_type[`!pop.scalar<`, dtype.value, `>`]
+            ]().address,
             value.value,
         )
 
     @always_inline
-    fn fetch_add(self, rhs: Scalar[type]) -> Scalar[type]:
+    fn fetch_add(self, rhs: Scalar[dtype]) -> Scalar[dtype]:
         """Performs atomic in-place add.
 
         Atomically replaces the current value with the result of arithmetic
@@ -158,7 +164,7 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
         return Self._fetch_add(value_addr, rhs)
 
     @always_inline
-    fn __iadd__(self, rhs: Scalar[type]):
+    fn __iadd__(self, rhs: Scalar[dtype]):
         """Performs atomic in-place add.
 
         Atomically replaces the current value with the result of arithmetic
@@ -173,7 +179,7 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
         _ = self.fetch_add(rhs)
 
     @always_inline
-    fn fetch_sub(self, rhs: Scalar[type]) -> Scalar[type]:
+    fn fetch_sub(self, rhs: Scalar[dtype]) -> Scalar[dtype]:
         """Performs atomic in-place sub.
 
         Atomically replaces the current value with the result of arithmetic
@@ -193,11 +199,11 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
             bin_op = __mlir_attr.`#pop<bin_op sub>`,
             ordering = __mlir_attr.`#pop<atomic_ordering seq_cst>`,
             syncscope = scope.value,
-            _type = __mlir_type[`!pop.scalar<`, type.value, `>`],
+            _type = __mlir_type[`!pop.scalar<`, dtype.value, `>`],
         ](value_addr.address, rhs.value)
 
     @always_inline
-    fn __isub__(self, rhs: Scalar[type]):
+    fn __isub__(self, rhs: Scalar[dtype]):
         """Performs atomic in-place sub.
 
         Atomically replaces the current value with the result of arithmetic
@@ -213,7 +219,7 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
 
     @always_inline
     fn compare_exchange_weak(
-        self, mut expected: Scalar[type], desired: Scalar[type]
+        self, mut expected: Scalar[dtype], desired: Scalar[dtype]
     ) -> Bool:
         """Atomically compares the self value with that of the expected value.
         If the values are equal, then the self value is replaced with the
@@ -227,10 +233,10 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
         Returns:
           True if self == expected and False otherwise.
         """
-        constrained[type.is_numeric(), "the input type must be arithmetic"]()
+        constrained[dtype.is_numeric(), "the input type must be arithmetic"]()
 
         @parameter
-        if type.is_integral():
+        if dtype.is_integral():
             return _compare_exchange_weak_integral_impl[scope=scope](
                 UnsafePointer.address_of(self.value), expected, desired
             )
@@ -239,7 +245,7 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
         # values to their integral representation and perform the atomic
         # operation on that.
 
-        alias integral_type = _integral_type_of[type]()
+        alias integral_type = _integral_type_of[dtype]()
         var value_integral_addr = UnsafePointer.address_of(self.value).bitcast[
             Scalar[integral_type]
         ]()
@@ -251,7 +257,7 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
 
     @staticmethod
     @always_inline
-    fn max(ptr: UnsafePointer[Scalar[type], **_], rhs: Scalar[type]):
+    fn max(ptr: UnsafePointer[Scalar[dtype], **_], rhs: Scalar[dtype]):
         """Performs atomic in-place max on the pointer.
 
         Atomically replaces the current value pointer to by `ptr` by the result
@@ -266,12 +272,12 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
             ptr: The source pointer.
             rhs: Value to max.
         """
-        constrained[type.is_numeric(), "the input type must be arithmetic"]()
+        constrained[dtype.is_numeric(), "the input type must be arithmetic"]()
 
         _max_impl[scope=scope](ptr, rhs)
 
     @always_inline
-    fn max(self, rhs: Scalar[type]):
+    fn max(self, rhs: Scalar[dtype]):
         """Performs atomic in-place max.
 
         Atomically replaces the current value with the result of max of the
@@ -285,13 +291,13 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
         Args:
             rhs: Value to max.
         """
-        constrained[type.is_numeric(), "the input type must be arithmetic"]()
+        constrained[dtype.is_numeric(), "the input type must be arithmetic"]()
 
         Self.max(UnsafePointer.address_of(self.value), rhs)
 
     @staticmethod
     @always_inline
-    fn min(ptr: UnsafePointer[Scalar[type], **_], rhs: Scalar[type]):
+    fn min(ptr: UnsafePointer[Scalar[dtype], **_], rhs: Scalar[dtype]):
         """Performs atomic in-place min on the pointer.
 
         Atomically replaces the current value pointer to by `ptr` by the result
@@ -306,12 +312,12 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
             ptr: The source pointer.
             rhs: Value to min.
         """
-        constrained[type.is_numeric(), "the input type must be arithmetic"]()
+        constrained[dtype.is_numeric(), "the input type must be arithmetic"]()
 
         _min_impl[scope=scope](ptr, rhs)
 
     @always_inline
-    fn min(self, rhs: Scalar[type]):
+    fn min(self, rhs: Scalar[dtype]):
         """Performs atomic in-place min.
 
         Atomically replaces the current value with the result of min of the
@@ -326,7 +332,7 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
             rhs: Value to min.
         """
 
-        constrained[type.is_numeric(), "the input type must be arithmetic"]()
+        constrained[dtype.is_numeric(), "the input type must be arithmetic"]()
 
         Self.min(UnsafePointer.address_of(self.value), rhs)
 
@@ -338,13 +344,13 @@ struct Atomic[type: DType, *, scope: StringLiteral = ""]:
 
 @always_inline
 fn _compare_exchange_weak_integral_impl[
-    type: DType, //, *, scope: StringLiteral
+    dtype: DType, //, *, scope: StringLiteral
 ](
-    value_addr: UnsafePointer[Scalar[type], **_],
-    mut expected: Scalar[type],
-    desired: Scalar[type],
+    value_addr: UnsafePointer[Scalar[dtype], **_],
+    mut expected: Scalar[dtype],
+    desired: Scalar[dtype],
 ) -> Bool:
-    constrained[type.is_integral(), "the input type must be integral"]()
+    constrained[dtype.is_integral(), "the input type must be integral"]()
     var cmpxchg_res = __mlir_op.`pop.atomic.cmpxchg`[
         bin_op = __mlir_attr.`#pop<bin_op sub>`,
         failure_ordering = __mlir_attr.`#pop<atomic_ordering seq_cst>`,
@@ -352,7 +358,7 @@ fn _compare_exchange_weak_integral_impl[
         syncscope = scope.value,
     ](
         value_addr.bitcast[
-            __mlir_type[`!pop.scalar<`, type.value, `>`]
+            __mlir_type[`!pop.scalar<`, dtype.value, `>`]
         ]().address,
         expected.value,
         desired.value,
@@ -369,38 +375,42 @@ fn _compare_exchange_weak_integral_impl[
 
 @always_inline
 fn _max_impl_base[
-    type: DType, //, *, scope: StringLiteral
-](ptr: UnsafePointer[Scalar[type], **_], rhs: Scalar[type]):
-    var value_addr = ptr.bitcast[__mlir_type[`!pop.scalar<`, type.value, `>`]]()
+    dtype: DType, //, *, scope: StringLiteral
+](ptr: UnsafePointer[Scalar[dtype], **_], rhs: Scalar[dtype]):
+    var value_addr = ptr.bitcast[
+        __mlir_type[`!pop.scalar<`, dtype.value, `>`]
+    ]()
     _ = __mlir_op.`pop.atomic.rmw`[
         bin_op = __mlir_attr.`#pop<bin_op max>`,
         ordering = __mlir_attr.`#pop<atomic_ordering seq_cst>`,
         syncscope = scope.value,
-        _type = __mlir_type[`!pop.scalar<`, type.value, `>`],
+        _type = __mlir_type[`!pop.scalar<`, dtype.value, `>`],
     ](value_addr.address, rhs.value)
 
 
 @always_inline
 fn _min_impl_base[
-    type: DType, //, *, scope: StringLiteral
-](ptr: UnsafePointer[Scalar[type], **_], rhs: Scalar[type]):
-    var value_addr = ptr.bitcast[__mlir_type[`!pop.scalar<`, type.value, `>`]]()
+    dtype: DType, //, *, scope: StringLiteral
+](ptr: UnsafePointer[Scalar[dtype], **_], rhs: Scalar[dtype]):
+    var value_addr = ptr.bitcast[
+        __mlir_type[`!pop.scalar<`, dtype.value, `>`]
+    ]()
     _ = __mlir_op.`pop.atomic.rmw`[
         bin_op = __mlir_attr.`#pop<bin_op min>`,
         ordering = __mlir_attr.`#pop<atomic_ordering seq_cst>`,
         syncscope = scope.value,
-        _type = __mlir_type[`!pop.scalar<`, type.value, `>`],
+        _type = __mlir_type[`!pop.scalar<`, dtype.value, `>`],
     ](value_addr.address, rhs.value)
 
 
 @always_inline
 fn _max_impl[
-    type: DType, //, *, scope: StringLiteral
-](ptr: UnsafePointer[Scalar[type], **_], rhs: Scalar[type]):
+    dtype: DType, //, *, scope: StringLiteral
+](ptr: UnsafePointer[Scalar[dtype], **_], rhs: Scalar[dtype]):
     @parameter
-    if is_nvidia_gpu() and type.is_floating_point():
-        alias integral_type = _integral_type_of[type]()
-        alias unsigned_integral_type = _unsigned_integral_type_of[type]()
+    if is_nvidia_gpu() and dtype.is_floating_point():
+        alias integral_type = _integral_type_of[dtype]()
+        alias unsigned_integral_type = _unsigned_integral_type_of[dtype]()
         if rhs >= 0:
             _max_impl_base[scope=scope](
                 ptr.bitcast[Scalar[integral_type]](),
@@ -418,12 +428,12 @@ fn _max_impl[
 
 @always_inline
 fn _min_impl[
-    type: DType, //, *, scope: StringLiteral
-](ptr: UnsafePointer[Scalar[type], **_], rhs: Scalar[type]):
+    dtype: DType, //, *, scope: StringLiteral
+](ptr: UnsafePointer[Scalar[dtype], **_], rhs: Scalar[dtype]):
     @parameter
-    if is_nvidia_gpu() and type.is_floating_point():
-        alias integral_type = _integral_type_of[type]()
-        alias unsigned_integral_type = _unsigned_integral_type_of[type]()
+    if is_nvidia_gpu() and dtype.is_floating_point():
+        alias integral_type = _integral_type_of[dtype]()
+        alias unsigned_integral_type = _unsigned_integral_type_of[dtype]()
         if rhs >= 0:
             _min_impl_base[scope=scope](
                 ptr.bitcast[Scalar[integral_type]](),


### PR DESCRIPTION
Rename `type: DType` parameters to `dtype` in `atomic.mojo`. Part of #4215