### PR TITLE
[stdlib] [NFC] Rename `type: DType` parameters to `dtype` in `testing.mojo`

### DIFF
--- a/mojo/stdlib/src/testing/testing.mojo
+++ b/mojo/stdlib/src/testing/testing.mojo
@@ -179,10 +179,10 @@ fn assert_equal(
 
 @always_inline
 fn assert_equal[
-    type: DType, size: Int
+    dtype: DType, size: Int
 ](
-    lhs: SIMD[type, size],
-    rhs: SIMD[type, size],
+    lhs: SIMD[dtype, size],
+    rhs: SIMD[dtype, size],
     msg: String = "",
     *,
     location: Optional[_SourceLocation] = None,
@@ -191,7 +191,7 @@ fn assert_equal[
     Error is raised.
 
     Parameters:
-        type: The dtype of the left- and right-hand-side SIMD vectors.
+        dtype: The dtype of the left- and right-hand-side SIMD vectors.
         size: The width of the left- and right-hand-side SIMD vectors.
 
     Args:
@@ -388,10 +388,10 @@ fn assert_not_equal(
 
 @always_inline
 fn assert_not_equal[
-    type: DType, size: Int
+    dtype: DType, size: Int
 ](
-    lhs: SIMD[type, size],
-    rhs: SIMD[type, size],
+    lhs: SIMD[dtype, size],
+    rhs: SIMD[dtype, size],
     msg: String = "",
     *,
     location: Optional[_SourceLocation] = None,
@@ -400,7 +400,7 @@ fn assert_not_equal[
     Error is raised.
 
     Parameters:
-        type: The dtype of the left- and right-hand-side SIMD vectors.
+        dtype: The dtype of the left- and right-hand-side SIMD vectors.
         size: The width of the left- and right-hand-side SIMD vectors.
 
     Args:
@@ -456,10 +456,10 @@ fn assert_not_equal[
 
 @always_inline
 fn assert_almost_equal[
-    type: DType, size: Int
+    dtype: DType, size: Int
 ](
-    lhs: SIMD[type, size],
-    rhs: SIMD[type, size],
+    lhs: SIMD[dtype, size],
+    rhs: SIMD[dtype, size],
     msg: String = "",
     *,
     atol: Float64 = 1e-08,
@@ -479,7 +479,7 @@ fn assert_almost_equal[
         The type must be boolean, integral, or floating-point.
 
     Parameters:
-        type: The dtype of the left- and right-hand-side SIMD vectors.
+        dtype: The dtype of the left- and right-hand-side SIMD vectors.
         size: The width of the left- and right-hand-side SIMD vectors.
 
     Args:
@@ -495,7 +495,7 @@ fn assert_almost_equal[
         An Error with the provided message if assert fails and `None` otherwise.
     """
     constrained[
-        type is DType.bool or type.is_integral() or type.is_floating_point(),
+        dtype is DType.bool or dtype.is_integral() or dtype.is_floating_point(),
         "type must be boolean, integral, or floating-point",
     ]()
 
@@ -507,7 +507,7 @@ fn assert_almost_equal[
         var err = String(lhs, " is not close to ", rhs)
 
         @parameter
-        if type.is_integral() or type.is_floating_point():
+        if dtype.is_integral() or dtype.is_floating_point():
             err += String(" with a diff of ", abs(lhs - rhs))
 
         if msg:

--- a/mojo/stdlib/test/test_utils/test_utils.mojo
+++ b/mojo/stdlib/test/test_utils/test_utils.mojo
@@ -18,8 +18,11 @@ from builtin.simd import _simd_apply
 
 @always_inline
 fn libm_call[
-    type: DType, simd_width: Int, fn_fp32: StringLiteral, fn_fp64: StringLiteral
-](arg: SIMD[type, simd_width]) -> SIMD[type, simd_width]:
+    dtype: DType,
+    simd_width: Int,
+    fn_fp32: StringLiteral,
+    fn_fp64: StringLiteral,
+](arg: SIMD[dtype, simd_width]) -> SIMD[dtype, simd_width]:
     @always_inline("nodebug")
     @parameter
     fn _float32_dispatch[
@@ -34,11 +37,13 @@ fn libm_call[
     ](arg: SIMD[input_type, 1]) -> SIMD[result_type, 1]:
         return external_call[fn_fp64, SIMD[result_type, 1]](arg)
 
-    constrained[type.is_floating_point(), "input type must be floating point"]()
+    constrained[
+        dtype.is_floating_point(), "input dtype must be floating point"
+    ]()
 
     @parameter
-    if type is DType.float64:
-        return _simd_apply[_float64_dispatch, type, simd_width](arg)
+    if dtype is DType.float64:
+        return _simd_apply[_float64_dispatch, dtype, simd_width](arg)
     return _simd_apply[_float32_dispatch, DType.float32, simd_width](
         arg.cast[DType.float32]()
-    ).cast[type]()
+    ).cast[dtype]()

--- a/mojo/stdlib/test/testing/test_assertion.mojo
+++ b/mojo/stdlib/test/testing/test_assertion.mojo
@@ -122,10 +122,10 @@ def test_assert_almost_equal():
 
     @parameter
     def _should_succeed[
-        type: DType, size: Int
+        dtype: DType, size: Int
     ](
-        lhs: SIMD[type, size],
-        rhs: SIMD[type, size],
+        lhs: SIMD[dtype, size],
+        rhs: SIMD[dtype, size],
         *,
         atol: Float64 = 0,
         rtol: Float64 = 0,
@@ -159,10 +159,10 @@ def test_assert_almost_equal():
 
     @parameter
     def _should_fail[
-        type: DType, size: Int
+        dtype: DType, size: Int
     ](
-        lhs: SIMD[type, size],
-        rhs: SIMD[type, size],
+        lhs: SIMD[dtype, size],
+        rhs: SIMD[dtype, size],
         *,
         atol: Float64 = 0,
         rtol: Float64 = 0,


### PR DESCRIPTION
Rename `type: DType` parameters to `dtype` in `testing.mojo`. Part of #4215