### PR TITLE
[max] [NFC] Rename `type: DType` parameters to `dtype` in examples and tutorials

### DIFF
--- a/examples/mojo/mandelbrot.mojo
+++ b/examples/mojo/mandelbrot.mojo
@@ -36,13 +36,13 @@ alias min_y = -1.5
 alias max_y = 1.5
 
 
-struct Matrix[type: DType, rows: Int, cols: Int]:
-    var data: UnsafePointer[Scalar[type]]
+struct Matrix[dtype: DType, rows: Int, cols: Int]:
+    var data: UnsafePointer[Scalar[dtype]]
 
     fn __init__(out self):
-        self.data = UnsafePointer[Scalar[type]].alloc(rows * cols)
+        self.data = UnsafePointer[Scalar[dtype]].alloc(rows * cols)
 
-    fn store[nelts: Int](self, row: Int, col: Int, val: SIMD[type, nelts]):
+    fn store[nelts: Int](self, row: Int, col: Int, val: SIMD[dtype, nelts]):
         self.data.store(row * cols + col, val)
 
 

--- a/tutorials/max-graph-api/mnist.mojo
+++ b/tutorials/max-graph-api/mnist.mojo
@@ -35,10 +35,10 @@ def load_model_weights() -> PythonObject:
 
 @always_inline
 fn numpy_data_pointer[
-    type: DType
-](numpy_array: PythonObject) raises -> UnsafePointer[Scalar[type]]:
+    dtype: DType
+](numpy_array: PythonObject) raises -> UnsafePointer[Scalar[dtype]]:
     return numpy_array.__array_interface__["data"][0].unsafe_get_as_pointer[
-        type
+        dtype
     ]()
 
 
@@ -51,13 +51,13 @@ fn memcpy_from_numpy(array: PythonObject, tensor: Tensor) raises:
 
 
 @always_inline
-fn numpy_to_tensor[type: DType](array: PythonObject) raises -> Tensor[type]:
+fn numpy_to_tensor[dtype: DType](array: PythonObject) raises -> Tensor[dtype]:
     shape = List[Int]()
     array_shape = array.shape
     for dim in array_shape:
         shape.append(dim)
 
-    out = Tensor[type](shape)
+    out = Tensor[dtype](shape)
     memcpy_from_numpy(array, out)
     return out^
 


### PR DESCRIPTION
Rename `type: DType` parameters to `dtype` in examples and tutorials. Part of #4215