### PR TITLE
[stdlib] Make InlineArray variadic ctor assert msg more descriptive

### DIFF
--- a/mojo/stdlib/src/collections/inline_array.mojo
+++ b/mojo/stdlib/src/collections/inline_array.mojo
@@ -255,7 +255,13 @@ struct InlineArray[
             storage: The variadic list storage to construct from. Must match array size.
         """
 
-        debug_assert(len(storage) == size, "Elements must be of length size")
+        debug_assert(
+            len(storage) == size,
+            "Expected variadic list of length ",
+            size,
+            ", received ",
+            len(storage),
+        )
         _inline_array_construction_checks[size]()
         __mlir_op.`lit.ownership.mark_initialized`(__get_mvalue_as_litref(self))
 


### PR DESCRIPTION
Ran into this fairly unhelpful debug assert message when creating a larger lookup table with `InlineArray`. I've updated the message to include the expected, and actual size of the variadic list used to initialize it.