### PR TITLE
[stdlib] Upgrade `Slice.__str__` to new out convention `(+capacity=16)`.

### DIFF
--- a/mojo/stdlib/src/builtin/builtin_slice.mojo
+++ b/mojo/stdlib/src/builtin/builtin_slice.mojo
@@ -95,15 +95,14 @@ struct Slice(
     # ===-------------------------------------------------------------------===#
 
     @no_inline
-    fn __str__(self) -> String:
+    fn __str__(self, out ret: String):
         """Gets the string representation of the span.
 
         Returns:
             The string representation of the span.
         """
-        var output = String()
-        self.write_to(output)
-        return output
+        ret = String(capacity=16)
+        self.write_to(ret)
 
     @no_inline
     fn __repr__(self) -> String:


### PR DESCRIPTION
Hello, small PR to upgrade,
this also removes a move on the way,
it is quite nice how the two methods work together like this!

Small capacity of 16 (might be enough),
that way, it won't realloc too many times while building the return.

It should be possible to calculate an optimized capacity,
but that seem like a good base line:

```mojo
slice(1, 2, 3)
```

We might need to adjust the capacity, if `None` step is used a lot!

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
