### PR TITLE
[stdlib] [NFC] Reorganize UTF-8 utils

### DIFF
--- a/mojo/stdlib/src/collections/string/string_slice.mojo
+++ b/mojo/stdlib/src/collections/string/string_slice.mojo
@@ -23,7 +23,13 @@ from collections.string import StringSlice
 
 from collections import List, Optional
 from collections.string.format import _CurlyEntryFormattable, _FormatCurlyEntry
-from collections.string._utf8_validation import _is_valid_utf8
+from collections.string._utf8 import (
+    _is_valid_utf8,
+    _count_utf8_continuation_bytes,
+    _utf8_first_byte_sequence_length,
+    _utf8_byte_type,
+    _is_newline_char_utf8,
+)
 from collections.string._unicode import (
     is_lowercase,
     is_uppercase,
@@ -1794,14 +1800,14 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
 
         @parameter
         if single_character:
-            return length != 0 and _is_newline_char[include_r_n=True](
+            return length != 0 and _is_newline_char_utf8[include_r_n=True](
                 ptr, 0, ptr[0], length
             )
         else:
             var offset = 0
             for s in self.codepoint_slices():
                 var b_len = s.byte_length()
-                if not _is_newline_char(ptr, offset, ptr[offset], b_len):
+                if not _is_newline_char_utf8(ptr, offset, ptr[offset], b_len):
                     return False
                 offset += b_len
             return length != 0
@@ -1845,7 +1851,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
                     "corrupted sequence causing unsafe memory access",
                 )
                 var isnewline = unlikely(
-                    _is_newline_char(ptr, eol_start, b0, char_len)
+                    _is_newline_char_utf8(ptr, eol_start, b0, char_len)
                 )
                 var char_end = Int(isnewline) * (eol_start + char_len)
                 var next_idx = char_end * Int(char_end < length)
@@ -2092,44 +2098,6 @@ fn _to_string_list[
 
 
 @always_inline
-fn _is_newline_char[
-    include_r_n: Bool = False
-](p: UnsafePointer[Byte], eol_start: Int, b0: Byte, char_len: Int) -> Bool:
-    """Returns whether the char is a newline char.
-
-    Safety:
-        This assumes valid utf-8 is passed.
-    """
-    # highly performance sensitive code, benchmark before touching
-    alias `\r` = UInt8(ord("\r"))
-    alias `\n` = UInt8(ord("\n"))
-    alias `\t` = UInt8(ord("\t"))
-    alias `\x1c` = UInt8(ord("\x1c"))
-    alias `\x1e` = UInt8(ord("\x1e"))
-
-    # here it's actually faster to have branching due to the branch predictor
-    # "realizing" that the char_len == 1 path is often taken. Using the likely
-    # intrinsic is to make the machine code be ordered to optimize machine
-    # instruction fetching, which is an optimization for the CPU front-end.
-    if likely(char_len == 1):
-        return `\t` <= b0 <= `\x1e` and not (`\r` < b0 < `\x1c`)
-    elif char_len == 2:
-        var b1 = p[eol_start + 1]
-        var is_next_line = b0 == 0xC2 and b1 == 0x85  # unicode next line \x85
-
-        @parameter
-        if include_r_n:
-            return is_next_line or (b0 == `\r` and b1 == `\n`)
-        else:
-            return is_next_line
-    elif char_len == 3:  # unicode line sep or paragraph sep: \u2028 , \u2029
-        var b1 = p[eol_start + 1]
-        var b2 = p[eol_start + 2]
-        return b0 == 0xE2 and b1 == 0x80 and (b2 == 0xA8 or b2 == 0xA9)
-    return False
-
-
-@always_inline
 fn _unsafe_strlen(owned ptr: UnsafePointer[Byte]) -> Int:
     """
     Get the length of a null-terminated string from a pointer.
@@ -2281,68 +2249,6 @@ fn _memmem_impl[
             return haystack + i
 
     return UnsafePointer[Scalar[type]]()
-
-
-@always_inline
-fn _is_utf8_continuation_byte[
-    w: Int
-](vec: SIMD[DType.uint8, w]) -> SIMD[DType.bool, w]:
-    return vec.cast[DType.int8]() < -(0b1000_0000 >> 1)
-
-
-fn _count_utf8_continuation_bytes(str_slice: StringSlice) -> Int:
-    alias sizes = (256, 128, 64, 32, 16, 8)
-    var ptr = str_slice.unsafe_ptr()
-    var num_bytes = str_slice.byte_length()
-    var amnt: Int = 0
-    var processed = 0
-
-    @parameter
-    for i in range(len(sizes)):
-        alias s = sizes[i]
-
-        @parameter
-        if simdwidthof[DType.uint8]() >= s:
-            var rest = num_bytes - processed
-            for _ in range(rest // s):
-                var vec = (ptr + processed).load[width=s]()
-                var comp = _is_utf8_continuation_byte(vec)
-                amnt += Int(comp.cast[DType.uint8]().reduce_add())
-                processed += s
-
-    for i in range(num_bytes - processed):
-        amnt += Int(_is_utf8_continuation_byte(ptr[processed + i]))
-
-    return amnt
-
-
-@always_inline
-fn _utf8_first_byte_sequence_length(b: Byte) -> Int:
-    """Get the length of the sequence starting with given byte. Do note that
-    this does not work correctly if given a continuation byte."""
-
-    debug_assert(
-        not _is_utf8_continuation_byte(b),
-        "Function does not work correctly if given a continuation byte.",
-    )
-    return Int(count_leading_zeros(~b) | (b < 0b1000_0000).cast[DType.uint8]())
-
-
-fn _utf8_byte_type(b: SIMD[DType.uint8, _], /) -> __type_of(b):
-    """UTF-8 byte type.
-
-    Returns:
-        The byte type.
-
-    Notes:
-
-        - 0 -> ASCII byte.
-        - 1 -> continuation byte.
-        - 2 -> start of 2 byte long sequence.
-        - 3 -> start of 3 byte long sequence.
-        - 4 -> start of 4 byte long sequence.
-    """
-    return count_leading_zeros(~b)
 
 
 @always_inline

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -12,11 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo %s
 
-from collections.string._utf8_validation import _is_valid_utf8
-from collections.string.string_slice import (
-    StringSlice,
-    _count_utf8_continuation_bytes,
-)
+from collections.string.string_slice import StringSlice
 from sys.info import alignof, sizeof
 
 from memory import Span, UnsafePointer
@@ -419,89 +415,6 @@ def test_slice_repr():
     assert_equal(StringSlice.__repr__("hello 🔥!"), "'hello 🔥!'")  # 4-byte
 
 
-fn test_utf8_validation() raises:
-    var text = """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
-    varius tellus quis tincidunt dictum. Donec eros orci, ultricies ac metus non
-    , rutrum faucibus neque. Nunc ultricies turpis ut lacus consequat dapibus.
-    Nulla nec risus a purus volutpat blandit. Donec sit amet massa velit. Aenean
-    fermentum libero eu pharetra placerat. Sed id molestie tellus. Fusce
-    sollicitudin a purus ac placerat.
-    Lorem Ipsum，也称乱数假文或者哑元文本， 是印刷及排版领域所常用的虚拟文字
-    由于曾经一台匿名的打印机刻意打乱了一盒印刷字体从而造出一本字体样品书，Lorem
-    Ipsum从西元15世纪起就被作为此领域的标准文本使用。它不仅延续了五个世纪，
-    还通过了电子排版的挑战，其雏形却依然保存至今。在1960年代，”Leatraset”公司发布了印刷着
-    Lorem Ipsum段落的纸张，从而广泛普及了它的使用。最近，计算机桌面出版软件
-    למה אנו משתמשים בזה?
-    זוהי עובדה מבוססת שדעתו של הקורא תהיה מוסחת על ידי טקטס קריא כאשר הוא יביט בפריסתו. המטרה בשימוש
-     ב- Lorem Ipsum הוא שיש לו פחות או יותר תפוצה של אותיות, בניגוד למלל ' יסוי
-    יסוי  יסוי', ונותן חזות קריאה יותר.הרבה הוצאות מחשבים ועורכי דפי אינטרנט משתמשים כיום ב-
-    Lorem Ipsum כטקסט ברירת המחדל שלהם, וחיפוש של 'lorem ipsum' יחשוף אתרים רבים בראשית
-    דרכם.גרסאות רבות נוצרו במהלך השנים, לעתים בשגגה
-    Lorem Ipsum е едноставен модел на текст кој се користел во печатарската
-    индустрија.
-    Lorem Ipsum - це текст-"риба", що використовується в друкарстві та дизайні.
-    Lorem Ipsum คือ เนื้อหาจำลองแบบเรียบๆ ที่ใช้กันในธุรกิจงานพิมพ์หรืองานเรียงพิมพ์
-    มันได้กลายมาเป็นเนื้อหาจำลองมาตรฐานของธุรกิจดังกล่าวมาตั้งแต่ศตวรรษที่
-    Lorem ipsum" في أي محرك بحث ستظهر العديد
-     من المواقع الحديثة العهد في نتائج البحث. على مدى السنين
-     ظهرت نسخ جديدة ومختلفة من نص لوريم إيبسوم، أحياناً عن طريق
-     الصدفة، وأحياناً عن عمد كإدخال بعض العبارات الفكاهية إليها.
-    """
-    assert_true(_is_valid_utf8(text.as_bytes()))
-    assert_true(_is_valid_utf8(text.as_bytes()))
-
-    var positive = List[List[UInt8]](
-        List[UInt8](0x0),
-        List[UInt8](0x00),
-        List[UInt8](0x66),
-        List[UInt8](0x7F),
-        List[UInt8](0x00, 0x7F),
-        List[UInt8](0x7F, 0x00),
-        List[UInt8](0xC2, 0x80),
-        List[UInt8](0xDF, 0xBF),
-        List[UInt8](0xE0, 0xA0, 0x80),
-        List[UInt8](0xE0, 0xA0, 0xBF),
-        List[UInt8](0xED, 0x9F, 0x80),
-        List[UInt8](0xEF, 0x80, 0xBF),
-        List[UInt8](0xF0, 0x90, 0xBF, 0x80),
-        List[UInt8](0xF2, 0x81, 0xBE, 0x99),
-        List[UInt8](0xF4, 0x8F, 0x88, 0xAA),
-    )
-    for item in positive:
-        assert_true(_is_valid_utf8(Span(item[])))
-        assert_true(_is_valid_utf8(Span(item[])))
-    var negative = List[List[UInt8]](
-        List[UInt8](0x80),
-        List[UInt8](0xBF),
-        List[UInt8](0xC0, 0x80),
-        List[UInt8](0xC1, 0x00),
-        List[UInt8](0xC2, 0x7F),
-        List[UInt8](0xDF, 0xC0),
-        List[UInt8](0xE0, 0x9F, 0x80),
-        List[UInt8](0xE0, 0xC2, 0x80),
-        List[UInt8](0xED, 0xA0, 0x80),
-        List[UInt8](0xED, 0x7F, 0x80),
-        List[UInt8](0xEF, 0x80, 0x00),
-        List[UInt8](0xF0, 0x8F, 0x80, 0x80),
-        List[UInt8](0xF0, 0xEE, 0x80, 0x80),
-        List[UInt8](0xF2, 0x90, 0x91, 0x7F),
-        List[UInt8](0xF4, 0x90, 0x88, 0xAA),
-        List[UInt8](0xF4, 0x00, 0xBF, 0xBF),
-        List[UInt8](
-            0xC2, 0x80, 0x00, 0x00, 0xE1, 0x80, 0x80, 0x00, 0xC2, 0xC2, 0x80
-        ),
-        List[UInt8](0x00, 0xC2, 0xC2, 0x80, 0x00, 0x00, 0xE1, 0x80, 0x80),
-        List[UInt8](0x00, 0x00, 0x00, 0xF1, 0x80, 0x00),
-        List[UInt8](0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF1),
-        List[UInt8](0x00, 0x00, 0x00, 0x00, 0xF1, 0x00, 0x80, 0x80),
-        List[UInt8](0x00, 0x00, 0xF1, 0x80, 0xC2, 0x80, 0x00),
-        List[UInt8](0x00, 0x00, 0xF0, 0x80, 0x80, 0x80),
-    )
-    for item in negative:
-        assert_false(_is_valid_utf8(Span(item[])))
-        assert_false(_is_valid_utf8(Span(item[])))
-
-
 def test_find():
     haystack = String("abcdefg").as_string_slice()
     haystack_with_special_chars = String("abcdefg@#$").as_string_slice()
@@ -604,141 +517,6 @@ def test_is_codepoint_boundary():
     assert_true(empty.is_codepoint_boundary(0))
     # Also tests that positions greater then the length don't raise/abort.
     assert_false(empty.is_codepoint_boundary(1))
-
-
-alias GOOD_SEQUENCES = List[String](
-    "a",
-    "\xc3\xb1",
-    "\xe2\x82\xa1",
-    "\xf0\x90\x8c\xbc",
-    "안녕하세요, 세상",
-    "\xc2\x80",
-    "\xf0\x90\x80\x80",
-    "\xee\x80\x80",
-    "very very very long string 🔥🔥🔥",
-)
-
-
-# TODO: later on, don't use String because
-# it will likely refuse non-utf8 data.
-alias BAD_SEQUENCES = List[String](
-    "\xc3\x28",  # continuation bytes does not start with 10xx
-    "\xa0\xa1",  # first byte is continuation byte
-    "\xe2\x28\xa1",  # second byte should be continuation byte
-    "\xe2\x82\x28",  # third byte should be continuation byte
-    "\xf0\x28\x8c\xbc",  # second byte should be continuation byte
-    "\xf0\x90\x28\xbc",  # third byte should be continuation byte
-    "\xf0\x28\x8c\x28",  # fourth byte should be continuation byte
-    "\xc0\x9f",  # overlong, could be just one byte
-    "\xf5\xff\xff\xff",  # missing continuation bytes
-    "\xed\xa0\x81",  # UTF-16 surrogate pair
-    "\xf8\x90\x80\x80\x80",  # 5 bytes is too long
-    "123456789012345\xed",  # Continuation bytes are missing
-    "123456789012345\xf1",  # Continuation bytes are missing
-    "123456789012345\xc2",  # Continuation bytes are missing
-    "\xC2\x7F",  # second byte is not continuation byte
-    "\xce",  # Continuation byte missing
-    "\xce\xba\xe1",  # two continuation bytes missing
-    "\xce\xba\xe1\xbd",  # One continuation byte missing
-    "\xce\xba\xe1\xbd\xb9\xcf",  # fifth byte should be continuation byte
-    "\xce\xba\xe1\xbd\xb9\xcf\x83\xce",  # missing continuation byte
-    "\xce\xba\xe1\xbd\xb9\xcf\x83\xce\xbc\xce",  # missing continuation byte
-    "\xdf",  # missing continuation byte
-    "\xef\xbf",  # missing continuation byte
-)
-
-
-fn validate_utf8(slice: StringSlice) -> Bool:
-    return _is_valid_utf8(slice.as_bytes())
-
-
-def test_good_utf8_sequences():
-    for sequence in GOOD_SEQUENCES:
-        assert_true(validate_utf8(sequence[]))
-
-
-def test_bad_utf8_sequences():
-    for sequence in BAD_SEQUENCES:
-        assert_false(validate_utf8(sequence[]))
-
-
-def test_stringslice_from_utf8():
-    for sequence in GOOD_SEQUENCES:
-        var bytes = sequence[].as_bytes()
-        _ = StringSlice.from_utf8(bytes)
-
-    for sequence in BAD_SEQUENCES:
-        with assert_raises(contains="buffer is not valid UTF-8"):
-            var bytes = sequence[].as_bytes()
-            _ = StringSlice.from_utf8(bytes)
-
-
-def test_combination_good_utf8_sequences():
-    # any combination of good sequences should be good
-    for i in range(0, len(GOOD_SEQUENCES)):
-        for j in range(i, len(GOOD_SEQUENCES)):
-            var sequence = GOOD_SEQUENCES[i] + GOOD_SEQUENCES[j]
-            assert_true(validate_utf8(sequence))
-
-
-def test_combination_bad_utf8_sequences():
-    # any combination of bad sequences should be bad
-    for i in range(0, len(BAD_SEQUENCES)):
-        for j in range(i, len(BAD_SEQUENCES)):
-            var sequence = BAD_SEQUENCES[i] + BAD_SEQUENCES[j]
-            assert_false(validate_utf8(sequence))
-
-
-def test_combination_good_bad_utf8_sequences():
-    # any combination of good and bad sequences should be bad
-    for i in range(0, len(GOOD_SEQUENCES)):
-        for j in range(0, len(BAD_SEQUENCES)):
-            var sequence = GOOD_SEQUENCES[i] + BAD_SEQUENCES[j]
-            assert_false(validate_utf8(sequence))
-
-
-def test_combination_10_good_utf8_sequences():
-    # any 10 combination of good sequences should be good
-    for i in range(0, len(GOOD_SEQUENCES)):
-        for j in range(i, len(GOOD_SEQUENCES)):
-            var sequence = GOOD_SEQUENCES[i] * 10 + GOOD_SEQUENCES[j] * 10
-            assert_true(validate_utf8(sequence))
-
-
-def test_combination_10_good_10_bad_utf8_sequences():
-    # any 10 combination of good and bad sequences should be bad
-    for i in range(0, len(GOOD_SEQUENCES)):
-        for j in range(0, len(BAD_SEQUENCES)):
-            var sequence = GOOD_SEQUENCES[i] * 10 + BAD_SEQUENCES[j] * 10
-            assert_false(validate_utf8(sequence))
-
-
-def test_count_utf8_continuation_bytes():
-    alias c = UInt8(0b1000_0000)
-    alias b1 = UInt8(0b0100_0000)
-    alias b2 = UInt8(0b1100_0000)
-    alias b3 = UInt8(0b1110_0000)
-    alias b4 = UInt8(0b1111_0000)
-
-    def _test(amnt: Int, items: List[UInt8]):
-        var p = items.unsafe_ptr()
-        var span = Span[Byte, StaticConstantOrigin](ptr=p, length=len(items))
-        var str_slice = StringSlice(unsafe_from_utf8=span)
-        assert_equal(amnt, _count_utf8_continuation_bytes(str_slice))
-
-    _test(5, List[UInt8](c, c, c, c, c))
-    _test(2, List[UInt8](b2, c, b2, c, b1))
-    _test(2, List[UInt8](b2, c, b1, b2, c))
-    _test(2, List[UInt8](b2, c, b2, c, b1))
-    _test(2, List[UInt8](b2, c, b1, b2, c))
-    _test(2, List[UInt8](b1, b2, c, b2, c))
-    _test(2, List[UInt8](b3, c, c, b1, b1))
-    _test(2, List[UInt8](b1, b1, b3, c, c))
-    _test(2, List[UInt8](b1, b3, c, c, b1))
-    _test(3, List[UInt8](b1, b4, c, c, c))
-    _test(3, List[UInt8](b4, c, c, c, b1))
-    _test(3, List[UInt8](b3, c, c, b2, c))
-    _test(3, List[UInt8](b2, c, b3, c, c))
 
 
 def test_split():
@@ -1282,19 +1060,9 @@ def main():
     test_slice_eq()
     test_slice_bool()
     test_slice_repr()
-    test_utf8_validation()
     test_find()
     test_find_compile_time()
     test_is_codepoint_boundary()
-    test_good_utf8_sequences()
-    test_bad_utf8_sequences()
-    test_stringslice_from_utf8()
-    test_combination_good_utf8_sequences()
-    test_combination_bad_utf8_sequences()
-    test_combination_good_bad_utf8_sequences()
-    test_combination_10_good_utf8_sequences()
-    test_combination_10_good_10_bad_utf8_sequences()
-    test_count_utf8_continuation_bytes()
     test_split()
     test_splitlines()
     test_rstrip()

--- a/mojo/stdlib/test/collections/string/test_utf8.mojo
+++ b/mojo/stdlib/test/collections/string/test_utf8.mojo
@@ -1,0 +1,272 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# RUN: %mojo %s
+
+from collections.string._utf8 import (
+    _is_valid_utf8,
+    _count_utf8_continuation_bytes,
+)
+from collections.string.string_slice import StringSlice
+from sys.info import alignof, sizeof
+
+from memory import Span, UnsafePointer
+from testing import assert_equal, assert_false, assert_raises, assert_true
+
+# ===----------------------------------------------------------------------=== #
+# Reusable testing data
+# ===----------------------------------------------------------------------=== #
+
+alias GOOD_SEQUENCES = List[List[Byte]](
+    List("a".as_bytes()),
+    List("\xc3\xb1".as_bytes()),
+    List("\xe2\x82\xa1".as_bytes()),
+    List("\xf0\x90\x8c\xbc".as_bytes()),
+    List("안녕하세요, 세상".as_bytes()),
+    List("\xc2\x80".as_bytes()),
+    List("\xf0\x90\x80\x80".as_bytes()),
+    List("\xee\x80\x80".as_bytes()),
+    List("very very very long string 🔥🔥🔥".as_bytes()),
+)
+
+
+alias BAD_SEQUENCES = List[List[Byte]](
+    List[Byte](0xC3, 0x28),  # continuation bytes does not start with 10xx
+    List[Byte](0xA0, 0xA1),  # first byte is continuation byte
+    List[Byte](0xE2, 0x28, 0xA1),  # second byte should be continuation byte
+    List[Byte](0xE2, 0x82, 0x28),  # third byte should be continuation byte
+    List[Byte](
+        0xF0, 0x28, 0x8C, 0xBC
+    ),  # second byte should be continuation byte
+    List[Byte](
+        0xF0, 0x90, 0x28, 0xBC
+    ),  # third byte should be continuation byte
+    List[Byte](
+        0xF0, 0x28, 0x8C, 0x28
+    ),  # fourth byte should be continuation byte
+    List[Byte](0xC0, 0x9F),  # overlong, could be just one byte
+    List[Byte](0xF5, 0xFF, 0xFF, 0xFF),  # missing continuation bytes
+    List[Byte](0xED, 0xA0, 0x81),  # UTF-16 surrogate pair
+    List[Byte](0xF8, 0x90, 0x80, 0x80, 0x80),  # 5 bytes is too long
+    List("123456789012345".as_bytes())
+    + List[Byte](0xED),  # Continuation bytes are missing
+    List("123456789012345".as_bytes())
+    + List[Byte](0xF1),  # Continuation bytes are missing
+    List("123456789012345".as_bytes())
+    + List[Byte](0xC2),  # Continuation bytes are missing
+    List[Byte](0xC2, 0x7F),  # second byte is not continuation byte
+    List[Byte](0xCE),  # Continuation byte missing
+    List[Byte](0xCE, 0xBA, 0xE1),  # two continuation bytes missing
+    List[Byte](0xCE, 0xBA, 0xE1, 0xBD),  # One continuation byte missing
+    List[Byte](
+        0xCE, 0xBA, 0xE1, 0xBD, 0xB9, 0xCF
+    ),  # fifth byte should be continuation byte
+    List[Byte](
+        0xCE, 0xBA, 0xE1, 0xBD, 0xB9, 0xCF, 0x83, 0xCE
+    ),  # missing continuation byte
+    List[Byte](
+        0xCE, 0xBA, 0xE1, 0xBD, 0xB9, 0xCF, 0x83, 0xCE, 0xBC, 0xCE
+    ),  # missing continuation byte
+    List[Byte](0xDF),  # missing continuation byte
+    List[Byte](0xEF, 0xBF),  # missing continuation byte
+)
+
+# ===----------------------------------------------------------------------=== #
+# Tests
+# ===----------------------------------------------------------------------=== #
+
+
+fn test_utf8_validation() raises:
+    var text = """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam
+    varius tellus quis tincidunt dictum. Donec eros orci, ultricies ac metus non
+    , rutrum faucibus neque. Nunc ultricies turpis ut lacus consequat dapibus.
+    Nulla nec risus a purus volutpat blandit. Donec sit amet massa velit. Aenean
+    fermentum libero eu pharetra placerat. Sed id molestie tellus. Fusce
+    sollicitudin a purus ac placerat.
+    Lorem Ipsum，也称乱数假文或者哑元文本， 是印刷及排版领域所常用的虚拟文字
+    由于曾经一台匿名的打印机刻意打乱了一盒印刷字体从而造出一本字体样品书，Lorem
+    Ipsum从西元15世纪起就被作为此领域的标准文本使用。它不仅延续了五个世纪，
+    还通过了电子排版的挑战，其雏形却依然保存至今。在1960年代，”Leatraset”公司发布了印刷着
+    Lorem Ipsum段落的纸张，从而广泛普及了它的使用。最近，计算机桌面出版软件
+    למה אנו משתמשים בזה?
+    זוהי עובדה מבוססת שדעתו של הקורא תהיה מוסחת על ידי טקטס קריא כאשר הוא יביט בפריסתו. המטרה בשימוש
+     ב- Lorem Ipsum הוא שיש לו פחות או יותר תפוצה של אותיות, בניגוד למלל ' יסוי
+    יסוי  יסוי', ונותן חזות קריאה יותר.הרבה הוצאות מחשבים ועורכי דפי אינטרנט משתמשים כיום ב-
+    Lorem Ipsum כטקסט ברירת המחדל שלהם, וחיפוש של 'lorem ipsum' יחשוף אתרים רבים בראשית
+    דרכם.גרסאות רבות נוצרו במהלך השנים, לעתים בשגגה
+    Lorem Ipsum е едноставен модел на текст кој се користел во печатарската
+    индустрија.
+    Lorem Ipsum - це текст-"риба", що використовується в друкарстві та дизайні.
+    Lorem Ipsum คือ เนื้อหาจำลองแบบเรียบๆ ที่ใช้กันในธุรกิจงานพิมพ์หรืองานเรียงพิมพ์
+    มันได้กลายมาเป็นเนื้อหาจำลองมาตรฐานของธุรกิจดังกล่าวมาตั้งแต่ศตวรรษที่
+    Lorem ipsum" في أي محرك بحث ستظهر العديد
+     من المواقع الحديثة العهد في نتائج البحث. على مدى السنين
+     ظهرت نسخ جديدة ومختلفة من نص لوريم إيبسوم، أحياناً عن طريق
+     الصدفة، وأحياناً عن عمد كإدخال بعض العبارات الفكاهية إليها.
+    """
+    assert_true(_is_valid_utf8(text.as_bytes()))
+    assert_true(_is_valid_utf8(text.as_bytes()))
+
+    var positive = List[List[UInt8]](
+        List[UInt8](0x0),
+        List[UInt8](0x00),
+        List[UInt8](0x66),
+        List[UInt8](0x7F),
+        List[UInt8](0x00, 0x7F),
+        List[UInt8](0x7F, 0x00),
+        List[UInt8](0xC2, 0x80),
+        List[UInt8](0xDF, 0xBF),
+        List[UInt8](0xE0, 0xA0, 0x80),
+        List[UInt8](0xE0, 0xA0, 0xBF),
+        List[UInt8](0xED, 0x9F, 0x80),
+        List[UInt8](0xEF, 0x80, 0xBF),
+        List[UInt8](0xF0, 0x90, 0xBF, 0x80),
+        List[UInt8](0xF2, 0x81, 0xBE, 0x99),
+        List[UInt8](0xF4, 0x8F, 0x88, 0xAA),
+    )
+    for item in positive:
+        assert_true(_is_valid_utf8(Span(item[])))
+        assert_true(_is_valid_utf8(Span(item[])))
+    var negative = List[List[UInt8]](
+        List[UInt8](0x80),
+        List[UInt8](0xBF),
+        List[UInt8](0xC0, 0x80),
+        List[UInt8](0xC1, 0x00),
+        List[UInt8](0xC2, 0x7F),
+        List[UInt8](0xDF, 0xC0),
+        List[UInt8](0xE0, 0x9F, 0x80),
+        List[UInt8](0xE0, 0xC2, 0x80),
+        List[UInt8](0xED, 0xA0, 0x80),
+        List[UInt8](0xED, 0x7F, 0x80),
+        List[UInt8](0xEF, 0x80, 0x00),
+        List[UInt8](0xF0, 0x8F, 0x80, 0x80),
+        List[UInt8](0xF0, 0xEE, 0x80, 0x80),
+        List[UInt8](0xF2, 0x90, 0x91, 0x7F),
+        List[UInt8](0xF4, 0x90, 0x88, 0xAA),
+        List[UInt8](0xF4, 0x00, 0xBF, 0xBF),
+        List[UInt8](
+            0xC2, 0x80, 0x00, 0x00, 0xE1, 0x80, 0x80, 0x00, 0xC2, 0xC2, 0x80
+        ),
+        List[UInt8](0x00, 0xC2, 0xC2, 0x80, 0x00, 0x00, 0xE1, 0x80, 0x80),
+        List[UInt8](0x00, 0x00, 0x00, 0xF1, 0x80, 0x00),
+        List[UInt8](0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF1),
+        List[UInt8](0x00, 0x00, 0x00, 0x00, 0xF1, 0x00, 0x80, 0x80),
+        List[UInt8](0x00, 0x00, 0xF1, 0x80, 0xC2, 0x80, 0x00),
+        List[UInt8](0x00, 0x00, 0xF0, 0x80, 0x80, 0x80),
+    )
+    for item in negative:
+        assert_false(_is_valid_utf8(Span(item[])))
+        assert_false(_is_valid_utf8(Span(item[])))
+
+
+fn validate_utf8(span: Span[Byte]) -> Bool:
+    return _is_valid_utf8(span)
+
+
+def test_good_utf8_sequences():
+    for sequence in GOOD_SEQUENCES:
+        assert_true(validate_utf8(sequence[]))
+
+
+def test_bad_utf8_sequences():
+    for sequence in BAD_SEQUENCES:
+        assert_false(validate_utf8(Span(sequence[])))
+
+
+def test_stringslice_from_utf8():
+    for sequence in GOOD_SEQUENCES:
+        _ = StringSlice.from_utf8(Span(sequence[]))
+
+    for sequence in BAD_SEQUENCES:
+        with assert_raises(contains="buffer is not valid UTF-8"):
+            _ = StringSlice.from_utf8(Span(sequence[]))
+
+
+def test_combination_good_utf8_sequences():
+    # any combination of good sequences should be good
+    for i in range(0, len(GOOD_SEQUENCES)):
+        for j in range(i, len(GOOD_SEQUENCES)):
+            var sequence = GOOD_SEQUENCES[i] + GOOD_SEQUENCES[j]
+            assert_true(validate_utf8(Span(sequence)))
+
+
+def test_combination_bad_utf8_sequences():
+    # any combination of bad sequences should be bad
+    for i in range(0, len(BAD_SEQUENCES)):
+        for j in range(i, len(BAD_SEQUENCES)):
+            var sequence = BAD_SEQUENCES[i] + BAD_SEQUENCES[j]
+            assert_false(validate_utf8(Span(sequence)))
+
+
+def test_combination_good_bad_utf8_sequences():
+    # any combination of good and bad sequences should be bad
+    for i in range(0, len(GOOD_SEQUENCES)):
+        for j in range(0, len(BAD_SEQUENCES)):
+            var sequence = GOOD_SEQUENCES[i] + BAD_SEQUENCES[j]
+            assert_false(validate_utf8(Span(sequence)))
+
+
+def test_combination_10_good_utf8_sequences():
+    # any 10 combination of good sequences should be good
+    for i in range(0, len(GOOD_SEQUENCES)):
+        for j in range(i, len(GOOD_SEQUENCES)):
+            var sequence = GOOD_SEQUENCES[i] * 10 + GOOD_SEQUENCES[j] * 10
+            assert_true(validate_utf8(Span(sequence)))
+
+
+def test_combination_10_good_10_bad_utf8_sequences():
+    # any 10 combination of good and bad sequences should be bad
+    for i in range(0, len(GOOD_SEQUENCES)):
+        for j in range(0, len(BAD_SEQUENCES)):
+            var sequence = GOOD_SEQUENCES[i] * 10 + BAD_SEQUENCES[j] * 10
+            assert_false(validate_utf8(Span(sequence)))
+
+
+def test_count_utf8_continuation_bytes():
+    alias c = UInt8(0b1000_0000)
+    alias b1 = UInt8(0b0100_0000)
+    alias b2 = UInt8(0b1100_0000)
+    alias b3 = UInt8(0b1110_0000)
+    alias b4 = UInt8(0b1111_0000)
+
+    def _test(amnt: Int, items: List[UInt8]):
+        var p = items.unsafe_ptr()
+        var span = Span[Byte, StaticConstantOrigin](ptr=p, length=len(items))
+        var str_slice = StringSlice(unsafe_from_utf8=span)
+        assert_equal(amnt, _count_utf8_continuation_bytes(str_slice))
+
+    _test(5, List[UInt8](c, c, c, c, c))
+    _test(2, List[UInt8](b2, c, b2, c, b1))
+    _test(2, List[UInt8](b2, c, b1, b2, c))
+    _test(2, List[UInt8](b2, c, b2, c, b1))
+    _test(2, List[UInt8](b2, c, b1, b2, c))
+    _test(2, List[UInt8](b1, b2, c, b2, c))
+    _test(2, List[UInt8](b3, c, c, b1, b1))
+    _test(2, List[UInt8](b1, b1, b3, c, c))
+    _test(2, List[UInt8](b1, b3, c, c, b1))
+    _test(3, List[UInt8](b1, b4, c, c, c))
+    _test(3, List[UInt8](b4, c, c, c, b1))
+    _test(3, List[UInt8](b3, c, c, b2, c))
+    _test(3, List[UInt8](b2, c, b3, c, c))
+
+
+def main():
+    test_utf8_validation()
+    test_good_utf8_sequences()
+    test_bad_utf8_sequences()
+    test_stringslice_from_utf8()
+    test_combination_good_utf8_sequences()
+    test_combination_bad_utf8_sequences()
+    test_combination_good_bad_utf8_sequences()
+    test_combination_10_good_utf8_sequences()
+    test_combination_10_good_10_bad_utf8_sequences()
+    test_count_utf8_continuation_bytes()


### PR DESCRIPTION
Reorganize UTF-8 utils into their own files and tests. It is bloating `string_slice.mojo` and `test_string_slice.mojo`, and in the case that  #3988 gets accepted we will need to build similar infrastructure for UTF-16 and UTF-32.