### PR TITLE
[stdlib] [NFC] [proposal] Add `StringSlice` and `StaticString` to prelude

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -72,6 +72,9 @@ for i in range(iteration_range):
 - The `is_power_of_two(x)` function in the `bit` package is now a method on
   `Int`, `UInt` and `SIMD`.
 
+- The types `StringSlice` and `StaticString` are now part of the prelude, there
+  is no need to import them anymore.
+
 ### GPU changes
 
 - `debug_assert` in AMD GPU kernels now behaves the same as NVIDIA, printing the

--- a/mojo/stdlib/src/prelude/__init__.mojo
+++ b/mojo/stdlib/src/prelude/__init__.mojo
@@ -17,14 +17,14 @@
 from collections import KeyElement, List, Optional, InlineArray
 from collections.string import (
     Codepoint,
+    StaticString,
     String,
+    StringSlice,
     ascii,
     atof,
     atol,
     chr,
     ord,
-    StringSlice,
-    StaticString,
 )
 from hashlib.hash import Hashable, hash
 

--- a/mojo/stdlib/src/prelude/__init__.mojo
+++ b/mojo/stdlib/src/prelude/__init__.mojo
@@ -15,7 +15,17 @@
 """
 
 from collections import KeyElement, List, Optional, InlineArray
-from collections.string import Codepoint, String, ascii, atof, atol, chr, ord
+from collections.string import (
+    Codepoint,
+    String,
+    ascii,
+    atof,
+    atol,
+    chr,
+    ord,
+    StringSlice,
+    StaticString,
+)
 from hashlib.hash import Hashable, hash
 
 from builtin.anytype import AnyType, UnknownDestructibility


### PR DESCRIPTION
Add `StringSlice` and `StaticString` to prelude.

Since we are starting to use both these types pervasively, I think it makes sense to add them to the prelude. This will also help guide users towards using `StringSlice` more since it is best for read-only/in-place mutation operations.