### PR TITLE
[CI] Use MODULAR_HOME to determine package path

### DIFF
--- a/examples/mojo/lit.cfg.py
+++ b/examples/mojo/lit.cfg.py
@@ -46,17 +46,13 @@ config.test_source_root = Path(__file__).parent.resolve()
 # Substitute %mojo for just `mojo` itself.
 config.substitutions.insert(0, ("%mojo", "mojo"))
 
-pre_built_packages_path = os.environ.get(
-    "MODULAR_MOJO_IMPORT_PATH",
-    Path(os.environ["MODULAR_HOME"])
-    / "pkg"
-    / "packages.modular.com_nightly_mojo"
-    / "lib"
-    / "mojo",
-)
+# MODULAR_HOME is at <package root>/share/max by default
+pre_built_packages_path = (
+    Path(os.environ["MODULAR_HOME"]) / ".." / ".." / "lib" / "mojo"
+).resolve()
 
 os.environ[
-    "MODULAR_MOJO_IMPORT_PATH"
+    "MODULAR_MOJO_MAX_IMPORT_PATH"
 ] = f"{build_root},{pre_built_packages_path}"
 
 # Pass through several environment variables
@@ -65,7 +61,7 @@ lit.llvm.initialize(lit_config, config)
 lit.llvm.llvm_config.with_system_environment(
     [
         "MODULAR_HOME",
-        "MODULAR_MOJO_IMPORT_PATH",
+        "MODULAR_MOJO_MAX_IMPORT_PATH",
         "PATH",
     ]
 )

--- a/mojo/stdlib/benchmarks/lit.cfg.py
+++ b/mojo/stdlib/benchmarks/lit.cfg.py
@@ -42,13 +42,16 @@ else:
     # test_source_root: The root path where tests are located.
     config.test_source_root = Path(__file__).parent.resolve()
 
-    repo_root = Path(__file__).parent.parent.parent
-
     # This is important since `benchmark` is closed source
     # still right now and is always used by the benchmarks.
-    pre_built_packages_path = Path(
-        repo_root / ".magic" / "envs" / "default" / "lib" / "mojo"
-    )
+    # If running through `magic`, this will be preset,
+    # but is overridable by users.
+    # MODULAR_HOME is at <package root>/share/max by default
+    pre_built_packages_path = (
+        Path(os.environ["MODULAR_HOME"]) / ".." / ".." / "lib" / "mojo"
+    ).resolve()
+
+    repo_root = Path(__file__).parent.parent.parent
 
     # The `run-tests.sh` script creates the build directory for you.
     build_root = repo_root / "build"


### PR DESCRIPTION
Alternative to https://github.com/modular/max/pull/4196

This lets our CI scripts not assume we're using `magic`, so long as we pass `MODULAR_HOME` (which `magic` does automatically). Then the location of the packaged standard library is computed from that instead.

As an added bonus, finally get rid of `MODULAR_MOJO_IMPORT_PATH`, which didn't do anything. Now we're using `MODULAR_MOJO_MAX_IMPORT_PATH`, the canonical env var to override Mojo stdlib import paths.