### PR TITLE
[stdlib] Add `repr` support for `List[RepresentableCollectionElement].

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -116,6 +116,15 @@ At /tmp/test.mojo:5:17: block: [1,0,0] thread: [1,0,0] Assert Error: x should be
 
 - The `type` parameter of `SIMD` has been renamed to `dtype`.
 
+- Add `repr` support for `List[T]` of `T: RepresentableCollectionElement`.
+  ([PR #4267](https://github.com/modular/max/pull/4267))
+  Example:
+
+  ```mojo
+    print(repr(List[UInt8](0, 1)))
+    # [SIMD[DType.uint8, 1](0), SIMD[DType.uint8, 1](1)]
+  ```
+
 ### Tooling changes
 
 ### ❌ Removed

--- a/mojo/stdlib/src/builtin/repr.mojo
+++ b/mojo/stdlib/src/builtin/repr.mojo
@@ -87,3 +87,19 @@ fn repr(value: None) -> String:
         The string representation of `None`.
     """
     return "None"
+
+
+fn repr[T: RepresentableCollectionElement](value: List[T]) -> String:
+    """Returns the string representation of a `List[T]`.
+
+    Args:
+        value: A `List` of elements `T`.
+
+    Parameters:
+        T: A type that implements `RepresentableCollectionElement`.
+
+    Returns:
+        The string representation of `List[T]`.
+    """
+    # TODO: remove when `List` can conform conditionally to `Representable`.
+    return value.__repr__()

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -905,6 +905,14 @@ def test_list_repr():
     assert_equal(empty.__repr__(), "[]")
 
 
+def test_list_repr_wrap():
+    assert_equal(repr(List("Hello", "World")), "['Hello', 'World']")
+    assert_equal(
+        repr(List[UInt8](0, 1)),
+        "[SIMD[DType.uint8, 1](0), SIMD[DType.uint8, 1](1)]",
+    )
+
+
 def test_list_fill_constructor():
     var l = List[Int32](length=10, fill=3)
     assert_equal(len(l), 10)
@@ -959,4 +967,5 @@ def main():
     test_list_dtor()
     test_destructor_trivial_elements()
     test_list_repr()
+    test_list_repr_wrap()
     test_list_fill_constructor()


### PR DESCRIPTION
Hello,
this adds an overload to `repr` to support it.

It is a workaround that has to be replaced one day,
but seem like something widely used by users !

```mojo
 print(repr(List[UInt8](0, 1)))
 # [SIMD[DType.uint8, 1](0), SIMD[DType.uint8, 1](1)]
```
Also work with `List[DType]` for metaprogramming:
```mojo
def main():
    x = List(DType.int8, DType.int16)
    print(repr(x))
    print(DType.int8 in x)
```

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
