### PR TITLE
[stdlib] Make `Deque.__init__` explicit

### DIFF
--- a/mojo/stdlib/src/collections/deque.mojo
+++ b/mojo/stdlib/src/collections/deque.mojo
@@ -132,7 +132,6 @@ struct Deque[ElementType: CollectionElement](
         if elements is not None:
             self.extend(elements.value())
 
-    @implicit
     fn __init__(out self, owned *values: ElementType):
         """Constructs a deque from the given values.
 


### PR DESCRIPTION
Fixes a funny bug where `reversed(1)` returns `_DequeIter`.