### PR TITLE
[stdlib] Make `StringSlice.from_utf8` a constructor

### DIFF
--- a/mojo/stdlib/src/collections/string/string_slice.mojo
+++ b/mojo/stdlib/src/collections/string/string_slice.mojo
@@ -473,6 +473,25 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         #   Ensure StringLiteral _actually_ always uses UTF-8 encoding.
         self = StaticString(unsafe_from_utf8=lit.as_bytes())
 
+    fn __init__(out self, *, from_utf8: Span[Byte, origin]) raises:
+        """Construct a new `StringSlice` from a buffer containing UTF-8 encoded
+        data.
+
+        Args:
+            from_utf8: A span of bytes containing UTF-8 encoded data.
+
+        Returns:
+            A new validated `StringSlice` pointing to the provided buffer.
+
+        Raises:
+            An exception is raised if the provided buffer byte values do not
+            form valid UTF-8 encoded codepoints.
+        """
+        if not _is_valid_utf8(from_utf8):
+            raise Error("StringSlice: buffer is not valid UTF-8")
+
+        return Self(unsafe_from_utf8=from_utf8)
+
     @always_inline("builtin")
     fn __init__(out self, *, unsafe_from_utf8: Span[Byte, origin]):
         """Construct a new `StringSlice` from a sequence of UTF-8 encoded bytes.
@@ -571,33 +590,6 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
             value: The string value.
         """
         self = StringSlice[O](unsafe_from_utf8=value.as_bytes())
-
-    # ===-------------------------------------------------------------------===#
-    # Factory methods
-    # ===-------------------------------------------------------------------===#
-
-    # TODO: Change to `__init__(out self, *, from_utf8: Span[..])` once ambiguity
-    #   with existing `unsafe_from_utf8` overload is fixed. Would require
-    #   signature comparision to take into account required named arguments.
-    @staticmethod
-    fn from_utf8(from_utf8: Span[Byte, origin]) raises -> StringSlice[origin]:
-        """Construct a new `StringSlice` from a buffer containing UTF-8 encoded
-        data.
-
-        Args:
-            from_utf8: A span of bytes containing UTF-8 encoded data.
-
-        Returns:
-            A new validated `StringSlice` pointing to the provided buffer.
-
-        Raises:
-            An exception is raised if the provided buffer byte values do not
-            form valid UTF-8 encoded codepoints.
-        """
-        if not _is_valid_utf8(from_utf8):
-            raise Error("StringSlice: buffer is not valid UTF-8")
-
-        return StringSlice[origin](unsafe_from_utf8=from_utf8)
 
     # ===------------------------------------------------------------------===#
     # Trait implementations

--- a/mojo/stdlib/test/collections/string/test_utf8.mojo
+++ b/mojo/stdlib/test/collections/string/test_utf8.mojo
@@ -184,11 +184,11 @@ def test_bad_utf8_sequences():
 
 def test_stringslice_from_utf8():
     for sequence in GOOD_SEQUENCES:
-        _ = StringSlice.from_utf8(Span(sequence[]))
+        _ = StringSlice(from_utf8=Span(sequence[]))
 
     for sequence in BAD_SEQUENCES:
         with assert_raises(contains="buffer is not valid UTF-8"):
-            _ = StringSlice.from_utf8(Span(sequence[]))
+            _ = StringSlice(from_utf8=Span(sequence[]))
 
 
 def test_combination_good_utf8_sequences():


### PR DESCRIPTION
Blocked by #4270.