### PR TITLE
[docs] Addressed typo in Stringable documentation. Issue #4274

### DIFF
--- a/mojo/stdlib/src/builtin/str.mojo
+++ b/mojo/stdlib/src/builtin/str.mojo
@@ -59,7 +59,7 @@ trait Stringable:
     trait, instead.
 
     About the difference between `__repr__()` and `__str__()`:
-    The method `__repr__` compute the compute the "official" string representation of an object
+    The method `__repr__` computes the "official" string representation of an object
     while `__str__` computes the "informal" or nicely printable string representation of an object.
 
     This method differs from `__repr__()` in that there is no expectation that `__str__()`


### PR DESCRIPTION
This pull request addresses issue #4274 concerning the `Stringable` trait in `max/mojo/stdlib/src/builtin/str.mojo`.
