### PR TITLE
[stdlib] Fix `PythonObject` creation from large `UInt64` values

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -161,6 +161,9 @@ previously compiler would throw error "cannot fold operation".
 
 ### 🛠️ Fixed
 
+- [#3510](https://github.com/modular/max/issues/3510) - `PythonObject` doesn't
+  handle large `UInt64` correctly.
+
 - [#3847](https://github.com/modular/max/issues/3847) - Count leading zeros
   can't be used on SIMD at compile time.
 

--- a/mojo/stdlib/src/python/python_object.mojo
+++ b/mojo/stdlib/src/python/python_object.mojo
@@ -383,16 +383,19 @@ struct PythonObject(
         Args:
             value: The scalar value.
         """
-        cpython = _get_global_python_itf().cpython()
+        var cpython = _get_global_python_itf().cpython()
 
         @parameter
         if dtype is DType.bool:
             self.py_object = cpython.PyBool_FromLong(Int(value))
+        elif dtype.is_unsigned():
+            var uint_val = value.cast[DType.index]().value
+            self.py_object = cpython.PyLong_FromSize_t(uint_val)
         elif dtype.is_integral():
-            int_val = value.cast[DType.index]().value
+            var int_val = value.cast[DType.index]().value
             self.py_object = cpython.PyLong_FromSsize_t(int_val)
         else:
-            fp_val = value.cast[DType.float64]()
+            var fp_val = value.cast[DType.float64]()
             self.py_object = cpython.PyFloat_FromDouble(fp_val)
 
     @implicit

--- a/mojo/stdlib/test/python/test_python_object.mojo
+++ b/mojo/stdlib/test/python/test_python_object.mojo
@@ -255,6 +255,12 @@ def test_dunder_methods(mut python: Python):
     assert_equal(c, -35)
 
 
+def test_num_conversion() -> None:
+    alias n = UInt64(0xFEDC_BA09_8765_4321)
+    alias n_str = String(n)
+    assert_equal(n_str, String(PythonObject(n)))
+
+
 def test_bool_conversion() -> None:
     var x: PythonObject = 1
     assert_true(x == 0 or x == 1)
@@ -592,6 +598,7 @@ def main():
     var python = Python()
 
     test_dunder_methods(python)
+    test_num_conversion()
     test_bool_conversion()
     test_string_conversions()
     test_len()


### PR DESCRIPTION
Fix #3510