### PR TITLE
[stdlib] Remove redundant `next_power_of_two()` from `math.mojo` and optimize existing function in `bit.mojo`

### DIFF
--- a/mojo/stdlib/benchmarks/bit/bench_bit.mojo
+++ b/mojo/stdlib/benchmarks/bit/bench_bit.mojo
@@ -1,0 +1,107 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License next_pwer_of_two_v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# RUN: %mojo-no-debug %s -t
+# NOTE: to test changes on the current branch using run-benchmarks.sh, remove
+# the -t flag. Remember to replace it again before pushing any code.
+
+from benchmark import Bench, BenchConfig, Bencher, BenchId, Unit, keep, run
+from bit import bit_width, count_leading_zeros
+from collections import Dict
+from random import random_ui64, seed
+from sys import bitwidthof
+
+
+# ===-----------------------------------------------------------------------===#
+# Benchmarks
+# ===-----------------------------------------------------------------------===#
+
+# ===-----------------------------------------------------------------------===#
+# next_power_of_two
+# ===-----------------------------------------------------------------------===#
+
+
+fn next_power_of_two_v1(val: Int) -> Int:
+    if val <= 1:
+        return 1
+
+    if val.is_power_of_two():
+        return val
+
+    return 1 << bit_width(val - 1)
+
+
+fn next_power_of_two_v2(val: Int) -> Int:
+    if val <= 1:
+        return 1
+
+    return 1 << (bitwidthof[Int]() - count_leading_zeros(val - 1))
+
+
+fn _build_list() -> List[Int]:
+    var values = List[Int](capacity=10_000)
+    for _ in range(10_000):
+        values.append(Int(random_ui64(0, 2 ^ 64 - 1)))
+    return values^
+
+
+var values = _build_list()
+
+
+@parameter
+fn bench_next_power_of_two_v1(mut b: Bencher) raises:
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        for _ in range(10_000):
+            for i in range(len(values)):
+                var result = next_power_of_two_v1(values.unsafe_get(i))
+                keep(result)
+
+    b.iter[call_fn]()
+
+
+@parameter
+fn bench_next_wer_of_two_v2(mut b: Bencher) raises:
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        for _ in range(10_000):
+            for i in range(len(values)):
+                var result = next_wer_of_two_v2(values.unsafe_get(i))
+                keep(result)
+
+    b.iter[call_fn]()
+
+
+# ===-----------------------------------------------------------------------===#
+# Benchmark Main
+# ===-----------------------------------------------------------------------===#
+def main():
+    seed()
+    var m = Bench(BenchConfig(num_repetitions=10))
+    m.bench_function[bench_next_power_of_two_v1](
+        BenchId("bench_next_power_of_two_v1")
+    )
+    m.bench_function[bench_next_power_of_two_v2](
+        BenchId("bench_next_power_of_two_v2")
+    )
+
+    results = Dict[String, (Float64, Int)]()
+    for info in m.info_vec:
+        n = info[].name
+        time = info[].result.mean("ms")
+        avg, amnt = results.get(n, (Float64(0), 0))
+        results[n] = ((avg * amnt + time) / (amnt + 1), amnt + 1)
+    print("")
+    for k_v in results.items():
+        print(k_v[].key, k_v[].value[0], sep=",")

--- a/mojo/stdlib/benchmarks/bit/bench_bit.mojo
+++ b/mojo/stdlib/benchmarks/bit/bench_bit.mojo
@@ -71,7 +71,7 @@ fn bench_next_power_of_two_v1(mut b: Bencher) raises:
 
 
 @parameter
-fn bench_next_wer_of_two_v2(mut b: Bencher) raises:
+fn bench_next_power_of_two_v2(mut b: Bencher) raises:
     @always_inline
     @parameter
     fn call_fn() raises:

--- a/mojo/stdlib/benchmarks/bit/bench_bit.mojo
+++ b/mojo/stdlib/benchmarks/bit/bench_bit.mojo
@@ -1,7 +1,7 @@
 # ===----------------------------------------------------------------------=== #
 # Copyright (c) 2025, Modular Inc. All rights reserved.
 #
-# Licensed under the Apache License next_pwer_of_two_v2.0 with LLVM Exceptions:
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
 # https://llvm.org/LICENSE.txt
 #
 # Unless required by applicable law or agreed to in writing, software

--- a/mojo/stdlib/benchmarks/bit/bench_bit.mojo
+++ b/mojo/stdlib/benchmarks/bit/bench_bit.mojo
@@ -77,7 +77,7 @@ fn bench_next_power_of_two_v2(mut b: Bencher) raises:
     fn call_fn() raises:
         for _ in range(10_000):
             for i in range(len(values)):
-                var result = next_wer_of_two_v2(values.unsafe_get(i))
+                var result = next_power_of_two_v2(values.unsafe_get(i))
                 keep(result)
 
     b.iter[call_fn]()

--- a/mojo/stdlib/src/bit/bit.mojo
+++ b/mojo/stdlib/src/bit/bit.mojo
@@ -375,18 +375,44 @@ fn next_power_of_two(val: Int) -> Int:
     """Computes the smallest power of 2 that is greater than or equal to the
     input value. Any integral value less than or equal to 1 will be ceiled to 1.
 
-    This operation is called `bit_ceil()` in C++.
+    Args:
+        val: The input value.
+
+    Returns:
+        The smallest power of 2 that is greater than or equal to the input
+        value.
+
+    Notes:
+        This operation is called `bit_ceil()` in C++.
+    """
+    var v = Scalar[DType.index](val)
+    return Int(
+        (v <= 1)
+        .select(1, 1 << (bitwidthof[Int]() - count_leading_zeros(v - 1)))
+        .__index__()
+    )
+
+
+fn next_power_of_two(val: UInt) -> UInt:
+    """Computes the smallest power of 2 that is greater than or equal to the
+    input value. Any integral value less than or equal to 1 will be ceiled to 1.
 
     Args:
         val: The input value.
 
     Returns:
-        The smallest power of 2 that is greater than or equal to the input value.
-    """
-    if val <= 1:
-        return 1
+        The smallest power of 2 that is greater than or equal to the input
+        value.
 
-    return 1 << (bitwidthof[Int]() - count_leading_zeros(val - 1))
+    Notes:
+        This operation is called `bit_ceil()` in C++.
+    """
+    var v = Scalar[DType.index](val)
+    return UInt(
+        (v == 0)
+        .select(1, 1 << (bitwidthof[Int]() - count_leading_zeros(v - 1)))
+        .__index__()
+    )
 
 
 @always_inline

--- a/mojo/stdlib/src/bit/bit.mojo
+++ b/mojo/stdlib/src/bit/bit.mojo
@@ -405,7 +405,7 @@ fn next_power_of_two(val: UInt) -> UInt:
     Notes:
         This operation is called `bit_ceil()` in C++.
     """
-    alias w = bitwidthof[Int]()
+    alias w = bitwidthof[UInt]()
     return UInt(select(val == 0, 1, 1 << (w - count_leading_zeros(val - 1))))
 
 

--- a/mojo/stdlib/src/bit/bit.mojo
+++ b/mojo/stdlib/src/bit/bit.mojo
@@ -386,8 +386,9 @@ fn next_power_of_two(val: Int) -> Int:
     Notes:
         This operation is called `bit_ceil()` in C++.
     """
-    alias w = bitwidthof[Int]()
-    return select(val <= 1, 1, 1 << (w - count_leading_zeros(val - 1)))
+    return select(
+        val <= 1, 1, 1 << (bitwidthof[Int]() - count_leading_zeros(val - 1))
+    )
 
 
 @always_inline
@@ -405,8 +406,9 @@ fn next_power_of_two(val: UInt) -> UInt:
     Notes:
         This operation is called `bit_ceil()` in C++.
     """
-    alias w = bitwidthof[UInt]()
-    return select(val == 0, 1, 1 << (w - count_leading_zeros(val - 1)))
+    return select(
+        val == 0, 1, 1 << (bitwidthof[UInt]() - count_leading_zeros(val - 1))
+    )
 
 
 @always_inline

--- a/mojo/stdlib/src/bit/bit.mojo
+++ b/mojo/stdlib/src/bit/bit.mojo
@@ -386,10 +386,7 @@ fn next_power_of_two(val: Int) -> Int:
     if val <= 1:
         return 1
 
-    if val.is_power_of_two():
-        return val
-
-    return 1 << bit_width(val - 1)
+    return 1 << (bitwidthof[Int]() - count_leading_zeros(val - 1))
 
 
 @always_inline

--- a/mojo/stdlib/src/bit/bit.mojo
+++ b/mojo/stdlib/src/bit/bit.mojo
@@ -387,7 +387,7 @@ fn next_power_of_two(val: Int) -> Int:
         This operation is called `bit_ceil()` in C++.
     """
     alias w = bitwidthof[Int]()
-    return Int(select(val <= 1, 1, 1 << (w - count_leading_zeros(val - 1))))
+    return select(val <= 1, 1, 1 << (w - count_leading_zeros(val - 1)))
 
 
 @always_inline
@@ -406,7 +406,7 @@ fn next_power_of_two(val: UInt) -> UInt:
         This operation is called `bit_ceil()` in C++.
     """
     alias w = bitwidthof[Int]()
-    return UInt(select(val == 0, 1, 1 << (w - count_leading_zeros(val - 1))))
+    return select(val == 0, 1, 1 << (w - count_leading_zeros(val - 1)))
 
 
 @always_inline

--- a/mojo/stdlib/src/bit/bit.mojo
+++ b/mojo/stdlib/src/bit/bit.mojo
@@ -393,6 +393,7 @@ fn next_power_of_two(val: Int) -> Int:
     )
 
 
+@always_inline
 fn next_power_of_two(val: UInt) -> UInt:
     """Computes the smallest power of 2 that is greater than or equal to the
     input value. Any integral value less than or equal to 1 will be ceiled to 1.

--- a/mojo/stdlib/src/bit/bit.mojo
+++ b/mojo/stdlib/src/bit/bit.mojo
@@ -21,6 +21,7 @@ from bit import count_leading_zeros
 
 from sys import llvm_intrinsic, sizeof
 from sys.info import bitwidthof
+from utils._select import _select_register_value as select
 
 # ===-----------------------------------------------------------------------===#
 # count_leading_zeros
@@ -385,12 +386,8 @@ fn next_power_of_two(val: Int) -> Int:
     Notes:
         This operation is called `bit_ceil()` in C++.
     """
-    var v = Scalar[DType.index](val)
-    return Int(
-        (v <= 1)
-        .select(1, 1 << (bitwidthof[Int]() - count_leading_zeros(v - 1)))
-        .__index__()
-    )
+    alias w = bitwidthof[Int]()
+    return Int(select(val <= 1, 1, 1 << (w - count_leading_zeros(val - 1))))
 
 
 @always_inline
@@ -408,12 +405,8 @@ fn next_power_of_two(val: UInt) -> UInt:
     Notes:
         This operation is called `bit_ceil()` in C++.
     """
-    var v = Scalar[DType.index](val)
-    return UInt(
-        (v == 0)
-        .select(1, 1 << (bitwidthof[Int]() - count_leading_zeros(v - 1)))
-        .__index__()
-    )
+    alias w = bitwidthof[Int]()
+    return UInt(select(val == 0, 1, 1 << (w - count_leading_zeros(val - 1))))
 
 
 @always_inline

--- a/mojo/stdlib/src/math/__init__.mojo
+++ b/mojo/stdlib/src/math/__init__.mojo
@@ -66,7 +66,6 @@ from .math import (
     log10,
     logb,
     modf,
-    next_power_of_two,
     recip,
     remainder,
     scalb,

--- a/mojo/stdlib/src/math/math.mojo
+++ b/mojo/stdlib/src/math/math.mojo
@@ -34,7 +34,7 @@ from sys._assembly import inlined_assembly
 from sys.ffi import _external_call_const
 from sys.info import _current_arch
 
-from bit import count_trailing_zeros, count_leading_zeros, next_power_of_two
+from bit import count_trailing_zeros, count_leading_zeros
 from builtin.dtype import _integral_type_of
 from builtin.simd import _modf, _simd_apply
 from memory import Span, UnsafePointer

--- a/mojo/stdlib/src/math/math.mojo
+++ b/mojo/stdlib/src/math/math.mojo
@@ -34,7 +34,7 @@ from sys._assembly import inlined_assembly
 from sys.ffi import _external_call_const
 from sys.info import _current_arch
 
-from bit import count_trailing_zeros, count_leading_zeros
+from bit import count_trailing_zeros, count_leading_zeros, next_power_of_two
 from builtin.dtype import _integral_type_of
 from builtin.simd import _modf, _simd_apply
 from memory import Span, UnsafePointer
@@ -2355,26 +2355,6 @@ fn clamp(
         upper_bound.
     """
     return val.clamp(lower_bound, upper_bound)
-
-
-# ===----------------------------------------------------------------------=== #
-# next_power_of_two
-# ===----------------------------------------------------------------------=== #
-
-
-fn next_power_of_two(n: Int) -> Int:
-    """Computes the next power of two greater than or equal to the input.
-
-    Args:
-        n: The input value.
-
-    Returns:
-        The next power of two greater than or equal to the input.
-    """
-    if n <= 1:
-        return 1
-
-    return 1 << (bitwidthof[Int]() - count_leading_zeros(n - 1))
 
 
 # ===----------------------------------------------------------------------=== #

--- a/mojo/stdlib/src/utils/_select.mojo
+++ b/mojo/stdlib/src/utils/_select.mojo
@@ -17,11 +17,7 @@ fn _select_register_value[
     T: AnyTrivialRegType
 ](condition: Bool, lhs: T, rhs: T) -> T:
     """Choose one value based on a condition, without IR-level branching.
-        Use this over normal `if` branches to reduce the size of the generated IR.
-
-        This should not be used pervasively in general code. It should only be
-        used in very low level libraries where IR size/compile time matters because it
-        flattens if statements early in the compiler pipeline.
+    Use this over normal `if` branches to reduce the size of the generated IR.
 
     Parameters:
         T: The type of the lhs and rhs.
@@ -33,5 +29,10 @@ fn _select_register_value[
 
     Returns:
         The value selected based on the condition.
+
+    Notes:
+        This should not be used pervasively in general code. It should only be
+        used in very low level libraries where IR size/compile time matters
+        because it flattens if statements early in the compiler pipeline.
     """
     return __mlir_op.`pop.select`(condition.value, lhs, rhs)

--- a/mojo/stdlib/src/utils/_select.mojo
+++ b/mojo/stdlib/src/utils/_select.mojo
@@ -17,7 +17,10 @@ fn _select_register_value[
     T: AnyTrivialRegType
 ](condition: Bool, lhs: T, rhs: T) -> T:
     """Choose one value based on a condition, without IR-level branching.
-    Use this over normal `if` branches to reduce the size of the generated IR.
+        Use this over normal `if` branches to reduce the size of the generated IR.
+        This should not be used pervasively in general code. It should only be
+        used in very low level libraries where IR size/compile time matters because it
+        flattens if statements early in the compiler pipeline.
 
     Parameters:
         T: The type of the lhs and rhs.
@@ -29,10 +32,5 @@ fn _select_register_value[
 
     Returns:
         The value selected based on the condition.
-
-    Notes:
-        This should not be used pervasively in general code. It should only be
-        used in very low level libraries where IR size/compile time matters
-        because it flattens if statements early in the compiler pipeline.
     """
     return __mlir_op.`pop.select`(condition.value, lhs, rhs)

--- a/mojo/stdlib/src/utils/_select.mojo
+++ b/mojo/stdlib/src/utils/_select.mojo
@@ -18,6 +18,7 @@ fn _select_register_value[
 ](condition: Bool, lhs: T, rhs: T) -> T:
     """Choose one value based on a condition, without IR-level branching.
         Use this over normal `if` branches to reduce the size of the generated IR.
+
         This should not be used pervasively in general code. It should only be
         used in very low level libraries where IR size/compile time matters because it
         flattens if statements early in the compiler pipeline.

--- a/mojo/stdlib/test/bit/test_bit.mojo
+++ b/mojo/stdlib/test/bit/test_bit.mojo
@@ -314,6 +314,7 @@ def test_bit_width_simd():
 
 
 def test_next_power_of_two():
+    # test for Int
     assert_equal(next_power_of_two(Int(-(2**59))), 1)
     assert_equal(next_power_of_two(Int(-2)), 1)
     assert_equal(next_power_of_two(Int(-1)), 1)
@@ -322,7 +323,7 @@ def test_next_power_of_two():
     assert_equal(next_power_of_two(Int(2)), 2)
     assert_equal(next_power_of_two(Int(4)), 4)
     assert_equal(next_power_of_two(Int(5)), 8)
-    assert_equal(next_power_of_two(2**59 - 3), 2**59)
+    assert_equal(next_power_of_two(Int(2**59 - 3)), 2**59)
 
     # test for UInt
     assert_equal(next_power_of_two(UInt(0)), 1)

--- a/mojo/stdlib/test/bit/test_bit.mojo
+++ b/mojo/stdlib/test/bit/test_bit.mojo
@@ -314,13 +314,23 @@ def test_bit_width_simd():
 
 
 def test_next_power_of_two():
-    assert_equal(next_power_of_two(-(2**59)), 1)
-    assert_equal(next_power_of_two(-2), 1)
-    assert_equal(next_power_of_two(1), 1)
-    assert_equal(next_power_of_two(2), 2)
-    assert_equal(next_power_of_two(4), 4)
-    assert_equal(next_power_of_two(5), 8)
+    assert_equal(next_power_of_two(Int(-(2**59))), 1)
+    assert_equal(next_power_of_two(Int(-2)), 1)
+    assert_equal(next_power_of_two(Int(-1)), 1)
+    assert_equal(next_power_of_two(Int(0)), 1)
+    assert_equal(next_power_of_two(Int(1)), 1)
+    assert_equal(next_power_of_two(Int(2)), 2)
+    assert_equal(next_power_of_two(Int(4)), 4)
+    assert_equal(next_power_of_two(Int(5)), 8)
     assert_equal(next_power_of_two(2**59 - 3), 2**59)
+
+    # test for UInt
+    assert_equal(next_power_of_two(UInt(0)), 1)
+    assert_equal(next_power_of_two(UInt(1)), 1)
+    assert_equal(next_power_of_two(UInt(2)), 2)
+    assert_equal(next_power_of_two(UInt(4)), 4)
+    assert_equal(next_power_of_two(UInt(5)), 8)
+    assert_equal(next_power_of_two(UInt(2**59 - 3)), 2**59)
 
 
 def test_next_power_of_two_simd():


### PR DESCRIPTION
Optimization of `next_power_of_two`

### Benchmark results
CPU: i7 7th gen
Measured in miliseconds to do 100 million calculations
```text
bench_next_power_of_two_int_v1,204.92954861666666
bench_next_power_of_two_int_v2,117.86505349666666
bench_next_power_of_two_int_v3,111.60907072111111
bench_next_power_of_two_int_v4,105.20949030055556
bench_next_power_of_two_uint_v1,89.40362252435895
bench_next_power_of_two_uint_v2,82.5889815992857
bench_next_power_of_two_uint_v3,85.60044429065934
bench_next_power_of_two_uint_v4,108.61543930999999
```

I decided to go for `..._int_v3` and `..._uint_v2` (which use `SIMD[bool].select`) since they are the most stable in performance between executions, even though the `..._int_v4` and `..._uint_v1` have sometimes given better results.