### PR TITLE
[stdlib] [NFC] Fix `_select_register_value` docstrings

### DIFF
--- a/mojo/stdlib/src/utils/_select.mojo
+++ b/mojo/stdlib/src/utils/_select.mojo
@@ -17,11 +17,7 @@ fn _select_register_value[
     T: AnyTrivialRegType
 ](condition: Bool, lhs: T, rhs: T) -> T:
     """Choose one value based on a condition, without IR-level branching.
-        Use this over normal `if` branches to reduce the size of the generated IR.
-
-        This should not be used pervasively in general code. It should only be
-        used in very low level libraries where IR size/compile time matters because it
-        flattens if statements early in the compiler pipeline.
+    Use this over normal `if` branches to reduce the size of the generated IR.
 
     Parameters:
         T: The type of the lhs and rhs.
@@ -33,5 +29,10 @@ fn _select_register_value[
 
     Returns:
         The value selected based on the condition.
+
+    Notes:
+        This should not be used pervasively in general code. It should only be
+        used in very low level libraries where IR size/compile time matters
+        because it flattens if statements early in the compiler pipeline.
     """
     return __mlir_op.`pop.select`(condition.value, lhs, rhs)


### PR DESCRIPTION
Split off from #4278 due to [Abdul's request](https://github.com/modular/max/pull/4278#discussion_r2029660939)