### PR TITLE
[stdlib] Add compile time branch for llvm expect intrinsic

### DIFF
--- a/mojo/stdlib/stdlib/collections/string/codepoint.mojo
+++ b/mojo/stdlib/stdlib/collections/string/codepoint.mojo
@@ -521,9 +521,7 @@ struct Codepoint(
 
         @parameter
         if optimize_ascii:
-            # FIXME(#933): can't run LLVM intrinsic at compile time
-            # if likely(num_bytes == 1):
-            if num_bytes == 1:
+            if likely(num_bytes == 1):
                 ptr[0] = UInt8(c)
                 return 1
             var shift = 6 * (num_bytes - 1)

--- a/mojo/stdlib/stdlib/sys/intrinsics.mojo
+++ b/mojo/stdlib/stdlib/sys/intrinsics.mojo
@@ -21,6 +21,7 @@ from sys import PrefetchLocality
 
 import math
 from collections.string.string_slice import _get_kgen_string
+from sys import is_compile_time
 from sys.info import _is_sm_9x_or_newer, is_gpu
 
 from memory import AddressSpace, UnsafePointer
@@ -816,9 +817,6 @@ fn expect[T: AnyTrivialRegType, //, expected_val: T](val: T) -> T:
     """Provides information about expected (the most probable) value of `val`,
     which can be used by optimizers.
 
-    Constraints:
-        Only work with integer types.
-
     Parameters:
         T: The type of the input value.
         expected_val: The expected value of `val`.
@@ -828,7 +826,12 @@ fn expect[T: AnyTrivialRegType, //, expected_val: T](val: T) -> T:
 
     Returns:
         The input value.
+
+    Notes:
+        Only works with integer/boolean types.
     """
+    if is_compile_time():
+        return val
     return llvm_intrinsic["llvm.expect", T, has_side_effect=False](
         val, expected_val
     )


### PR DESCRIPTION
Add compile time branch for llvm expect intrinsic. This is needed to run optimized code at compile time.