### PR TITLE
[stdlib] [NFC] Fix missing dtypes in `normalize_index`

### DIFF
--- a/mojo/stdlib/src/collections/_index_normalization.mojo
+++ b/mojo/stdlib/src/collections/_index_normalization.mojo
@@ -45,6 +45,8 @@ fn normalize_index[
         or _type_is_eq[I, UInt16]()
         or _type_is_eq[I, UInt32]()
         or _type_is_eq[I, UInt64]()
+        or _type_is_eq[I, UInt128]()
+        or _type_is_eq[I, UInt256]()
     ):
         var i = UInt(index(idx))
         # TODO: Consider a way to construct the error message after the assert has failed


### PR DESCRIPTION
Fix missing dtypes in `normalize_index`