### PR TITLE
[stdlib] Change `os.env` functions to use `StringSlice`

### DIFF
--- a/mojo/stdlib/src/os/env.mojo
+++ b/mojo/stdlib/src/os/env.mojo
@@ -51,7 +51,7 @@ fn setenv(
     var status = external_call["setenv", Int32](
         name.unsafe_ptr().bitcast[c_char](),
         value.unsafe_ptr().bitcast[c_char](),
-        Int32(1 if overwrite else 0),
+        Int32(overwrite),
     )
     return status == 0
 

--- a/mojo/stdlib/src/os/env.mojo
+++ b/mojo/stdlib/src/os/env.mojo
@@ -21,7 +21,7 @@ from os import setenv
 
 
 from sys import external_call, os_is_linux, os_is_macos, os_is_windows
-from sys.ffi import c_int
+from sys.ffi import c_int, c_char
 
 from memory import UnsafePointer
 
@@ -49,8 +49,8 @@ fn setenv(
         return False
 
     var status = external_call["setenv", Int32](
-        name.unsafe_ptr().bitcast[c_int](),
-        value.unsafe_ptr().bitcast[c_int](),
+        name.unsafe_ptr().bitcast[c_char](),
+        value.unsafe_ptr().bitcast[c_char](),
         Int32(1 if overwrite else 0),
     )
     return status == 0
@@ -70,7 +70,7 @@ fn unsetenv(name: StringSlice) -> Bool:
     ]()
 
     return (
-        external_call["unsetenv", c_int](name.unsafe_ptr().bitcast[c_int]())
+        external_call["unsetenv", c_int](name.unsafe_ptr().bitcast[c_char]())
         == 0
     )
 
@@ -104,7 +104,7 @@ fn getenv[
         return String(default)
 
     var ptr = external_call["getenv", UnsafePointer[UInt8]](
-        name.unsafe_ptr().bitcast[c_int]()
+        name.unsafe_ptr().bitcast[c_char]()
     )
     if not ptr:
         return String(default)

--- a/mojo/stdlib/src/os/env.mojo
+++ b/mojo/stdlib/src/os/env.mojo
@@ -44,8 +44,9 @@ fn setenv(
     Constraints:
         The function only works on macOS or Linux and returns False otherwise.
     """
-    alias os_is_supported = os_is_linux() or os_is_macos()
-    if not os_is_supported:
+
+    @parameter
+    if not (os_is_linux() or os_is_macos()):
         return False
 
     var status = external_call["setenv", Int32](
@@ -98,9 +99,9 @@ fn getenv[
         The function only works on macOS or Linux and returns an empty string
         otherwise.
     """
-    alias os_is_supported = os_is_linux() or os_is_macos()
 
-    if not os_is_supported:
+    @parameter
+    if not (os_is_linux() or os_is_macos()):
         return String(default)
 
     var ptr = external_call["getenv", UnsafePointer[UInt8]](


### PR DESCRIPTION
Change `os.env` functions to use `StringSlice`