### PR TITLE
[mojo-docs] Fix manual for  gpu basics

### DIFF
--- a/mojo/docs/manual/gpu/basics.mdx
+++ b/mojo/docs/manual/gpu/basics.mdx
@@ -330,7 +330,7 @@ e.g. tile with widths [2, 2] at index (0, 0) would be:
 [ 4 5 ]
 ```
 
-And index (1, 0) would be:
+And index (2, 0) would be:
 
 ```plaintext
 [ 2 3 ]

--- a/mojo/docs/manual/gpu/basics.mdx
+++ b/mojo/docs/manual/gpu/basics.mdx
@@ -726,7 +726,7 @@ see what happens!
 and initialize the numbers ordered sequentially. Copy the host buffer to the
 device.
 2. Create a in_tensor that wraps the host buffer, with the dimensions (8, 4)
-3. Create an host and device buffer for the output of `DType` `Int64`, with 8
+3. Create an host and device buffer for the output of `DType` `Float32`, with 8
 elements, don't forget to zero the values with `enqueue_memset()`.
 4. Launch a GPU kernel with 8 blocks and 4 threads that reduce sums the values,
 using your preferred method to write to the output buffer.


### PR DESCRIPTION
This PR provides a factual correction by fixing an incorrect index used in the manual.

```
Thread  |    0  1  2  3
-------------------------
block 0 | [  0  1  2  3 ]
block 1 | [  4  5  6  7 ]
block 2 | [  8  9 10 11 ]
block 3 | [ 12 13 14 15 ]

-- WRONG --
And index (1, 0) would be:
[ 2 3 ]
[ 6 7 ]

-- CORRECT  --
And index (2, 0) would be:
[ 2 3 ]
[ 6 7 ]
```

Additionally, I corrected the output buffer type for the final task, treating the solution code as the source of truth.
`DType Int64 -> DType Float32`
