### PR TITLE
[stdlib] Change `StringSlice.__getitem__` to return a `StringSlice`

### DIFF
--- a/mojo/stdlib/src/collections/string/string_slice.mojo
+++ b/mojo/stdlib/src/collections/string/string_slice.mojo
@@ -49,6 +49,7 @@ Example:
 """
 
 from collections import List, Optional
+from collections._index_normalization import normalize_index
 from collections.string._unicode import (
     is_lowercase,
     is_uppercase,
@@ -963,7 +964,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         """
         return CodepointSliceIter[origin, forward=False](self)
 
-    fn __getitem__[I: Indexer](self, idx: I) -> String:
+    fn __getitem__[I: Indexer](self, idx: I) -> Self.Immutable:
         """Gets the character at the specified position.
 
         Parameters:
@@ -975,11 +976,9 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         Returns:
             A new string containing the character at the specified position.
         """
-        # TODO(#933): implement this for unicode when we support llvm intrinsic evaluation at compile time
-        var buf = String._buffer_type(capacity=1)
-        buf.append(self._slice[idx])
-        buf.append(0)
-        return String(buf^)
+        # TODO(#3526): implement this for unicode
+        var i = normalize_index["StringSlice"](idx, len(self))
+        return Self.Immutable(ptr=self.unsafe_ptr() + i, length=1)
 
     fn __contains__(self, substr: StringSlice) -> Bool:
         """Returns True if the substring is contained within the current string.

--- a/mojo/stdlib/src/os/path/path.mojo
+++ b/mojo/stdlib/src/os/path/path.mojo
@@ -476,7 +476,7 @@ fn _split_extension(
         # skip all leading dots
         var file_start = head_end + 1
         while file_start < file_end:
-            if path[file_start].as_string_slice() != extension_sep:
+            if path[file_start] != extension_sep:
                 return String(path[:file_end]), String(path[file_end:])
             file_start += 1
 


### PR DESCRIPTION
Had to do some black magic to get this to work. But we totally needed to stop allocating so much for such cases.