### PR TITLE
[stdlib] Make parameters of `min`/`max` explicit

### DIFF
--- a/mojo/stdlib/src/builtin/math.mojo
+++ b/mojo/stdlib/src/builtin/math.mojo
@@ -145,7 +145,7 @@ fn max(x: UInt, y: UInt, /) -> UInt:
 
 
 @always_inline("nodebug")
-fn max(x: SIMD, y: __type_of(x), /) -> __type_of(x):
+fn max[dtype: DType, //](x: SIMD[dtype, _], y: __type_of(x), /) -> __type_of(x):
     """Performs elementwise maximum of x and y.
 
     An element of the result SIMD vector will be the maximum of the
@@ -153,6 +153,9 @@ fn max(x: SIMD, y: __type_of(x), /) -> __type_of(x):
 
     Constraints:
         The type of the inputs must be numeric or boolean.
+
+    Parameters:
+            dtype: The data type of the SIMD vector.
 
     Args:
         x: First SIMD vector.
@@ -229,7 +232,7 @@ fn min(x: UInt, y: UInt, /) -> UInt:
 
 
 @always_inline("nodebug")
-fn min(x: SIMD, y: __type_of(x), /) -> __type_of(x):
+fn min[dtype: DType, //](x: SIMD[dtype, _], y: __type_of(x), /) -> __type_of(x):
     """Gets the elementwise minimum of x and y.
 
     An element of the result SIMD vector will be the minimum of the
@@ -237,6 +240,9 @@ fn min(x: SIMD, y: __type_of(x), /) -> __type_of(x):
 
     Constraints:
         The type of the inputs must be numeric or boolean.
+
+    Parameters:
+         dtype: The data type of the SIMD vector.
 
     Args:
         x: First SIMD vector.


### PR DESCRIPTION
This allows us to disambiguate and use them in higher-order functions like `f[min[dtype=...]]()`.

I introduced this change in #3901, but @latter inadvertently 'cleaned it up' in a subsequent commit.