### PR TITLE
[stdlib] Fix `SIMD[..., u128/s128]` construction from `UInt`

### DIFF
--- a/mojo/stdlib/stdlib/builtin/simd.mojo
+++ b/mojo/stdlib/stdlib/builtin/simd.mojo
@@ -431,7 +431,13 @@ struct SIMD[dtype: DType, size: Int](
         Args:
             value: The input value.
         """
-        self = Self(value.value)
+
+        @parameter
+        if bitwidthof[dtype]() > bitwidthof[DType.index]():
+            alias dt = _unsigned_integral_type_of[DType.index]()
+            self = Self(bitcast[dt](Scalar[DType.index](value)))
+        else:
+            self = Self(value.value)
 
     @always_inline("nodebug")
     @implicit

--- a/mojo/stdlib/test/builtin/test_simd.mojo
+++ b/mojo/stdlib/test/builtin/test_simd.mojo
@@ -106,6 +106,15 @@ def test_cast_init():
     )
 
 
+def test_init_from_index():
+    alias a = UInt.MAX
+    alias a_str = String(a)
+    assert_equal(a_str, String(UInt128(a)))
+    assert_equal(a_str, String(Int128(a)))
+    assert_equal(a_str, String(UInt256(a)))
+    assert_equal(a_str, String(Int256(a)))
+
+
 def test_simd_variadic():
     assert_equal(String(SIMD[DType.index, 4](52, 12, 43, 5)), "[52, 12, 43, 5]")
 
@@ -1997,6 +2006,7 @@ def main():
     test_from_bytes_as_bytes()
     test_iadd()
     test_indexing()
+    test_init_from_index()
     test_insert()
     test_interleave()
     test_issue_1625()


### PR DESCRIPTION
Close #4338.