### PR TITLE
[stdlib] Improve type refinement for `pack_bits`

### DIFF
--- a/mojo/stdlib/src/memory/unsafe.mojo
+++ b/mojo/stdlib/src/memory/unsafe.mojo
@@ -84,16 +84,19 @@ fn bitcast[
     ](val.value)
 
 
-@always_inline("nodebug")
+@always_inline("builtin")
 fn _uint(n: Int) -> DType:
-    if n == 8:
-        return DType.uint8
-    elif n == 16:
-        return DType.uint16
-    elif n == 32:
-        return DType.uint32
-    else:
-        return DType.uint64
+    # fmt: off
+    return (
+        DType.uint8 if n == 8
+        else DType.uint16 if n == 16
+        else DType.uint32 if n == 32
+        else DType.uint64 if n == 64
+        else DType.uint128 if n == 128
+        else DType.uint256 if n == 256
+        else DType.invalid
+    )
+    # fmt: on
 
 
 @always_inline("nodebug")

--- a/mojo/stdlib/test/memory/test_bitcast.mojo
+++ b/mojo/stdlib/test/memory/test_bitcast.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo %s
 
-from memory import bitcast
+from memory import bitcast, pack_bits
 from testing import assert_equal
 
 
@@ -28,5 +28,11 @@ def test_bitcast():
     )
 
 
+def test_pack_bits():
+    alias b = SIMD[DType.bool, 8](1, 1, 1, 0, 1, 0, 1, 1)
+    assert_equal(pack_bits(b), UInt8(0b1101_0111))
+
+
 def main():
     test_bitcast()
+    test_pack_bits()


### PR DESCRIPTION
So the following works without `rebind`:
```mojo
var v: UInt8 = pack_bits(SIMD[DType.bool, 8](1))
```

`_uint` gets inlined even when `n` isn't concrete, cluttering tooltips and types.  
Can call-by-value be triggered only when `n` is concrete?

CC @lattner since it's related to `@always_inline("builtin")`.