### PR TITLE
[stdlib] Fix sqrt loop range and rewrite to prevent overflow

### DIFF
--- a/mojo/stdlib/src/math/math.mojo
+++ b/mojo/stdlib/src/math/math.mojo
@@ -191,10 +191,10 @@ fn sqrt(x: Int) -> Int:
     var r2 = 0
 
     @parameter
-    for p in range(bitwidthof[Int]() // 4, -1, -1):
-        var tr2 = r2 + (r << (p + 1)) + (1 << (p + p))
-        if tr2 <= x:
-            r2 = tr2
+    for p in reversed(range(bitwidthof[Int]() // 2)):
+        var dr2 = (r << (p + 1)) + (1 << (p + p))
+        if r2 <= x - dr2:
+            r2 += dr2
             r |= 1 << p
 
     return r

--- a/mojo/stdlib/test/math/test_math.mojo
+++ b/mojo/stdlib/test/math/test_math.mojo
@@ -184,6 +184,14 @@ alias F64x4 = SIMD[DType.float64, 4]
 
 
 def test_sqrt():
+    assert_equal(sqrt(-1), 0)
+    assert_equal(sqrt(0), 0)
+    assert_equal(sqrt(1), 1)
+    assert_equal(sqrt(2**34 - 1), 2**17 - 1)
+    assert_equal(sqrt(2**34), 2**17)
+    assert_equal(sqrt(10**16), 10**8)
+    assert_equal(sqrt(Int.MAX), 3037000499)
+
     var i = SIMD[DType.index, 4](0, 1, 2, 3)
     assert_equal(sqrt(i**2), i)
     assert_equal(sqrt(64), 8)

--- a/mojo/stdlib/test/math/test_math.mojo
+++ b/mojo/stdlib/test/math/test_math.mojo
@@ -187,6 +187,8 @@ def test_sqrt():
     assert_equal(sqrt(-1), 0)
     assert_equal(sqrt(0), 0)
     assert_equal(sqrt(1), 1)
+    assert_equal(sqrt(63), 7)
+    assert_equal(sqrt(64), 8)
     assert_equal(sqrt(2**34 - 1), 2**17 - 1)
     assert_equal(sqrt(2**34), 2**17)
     assert_equal(sqrt(10**16), 10**8)
@@ -194,8 +196,6 @@ def test_sqrt():
 
     var i = SIMD[DType.index, 4](0, 1, 2, 3)
     assert_equal(sqrt(i**2), i)
-    assert_equal(sqrt(64), 8)
-    assert_equal(sqrt(63), 7)
 
     var f32x4 = 0.5 * F32x4(0.0, 1.0, 2.0, 3.0)
 


### PR DESCRIPTION
Fix https://github.com/modular/max/issues/4352

This PR fixes a bug in the `sqrt` function in the standard library.

### Summary of the problem
The loop previously started at `bitwidthof[Int]() // 4`, which was too small to handle larger integer inputs. This resulted in incorrect square root values in some cases.

### Changes made
- Corrected the loop range to start from `((bitwidthof[Int]() - 1) // 2)` to fully cover the bit width of `Int`.
- Rewrote the condition to avoid intermediate overflow by reformulating the check:
  ```mojo
  if r2 <= x - (r << (p + 1)) - (1 << (2 * p)):
