### PR TITLE
[stdlib] Avoid copy when fetching a value using Dict.get_ptr

### DIFF
--- a/mojo/stdlib/src/collections/dict.mojo
+++ b/mojo/stdlib/src/collections/dict.mojo
@@ -1039,9 +1039,9 @@ struct Dict[K: KeyElement, V: CollectionElement](
             elif index == Self.REMOVED:
                 pass
             else:
-                var entry = self._entries[index]
-                debug_assert(entry.__bool__(), "entry in index must be full")
-                if hash == entry.value().hash and key == entry.value().key:
+                var entry = Pointer(to=self._entries[index])
+                debug_assert(entry[].__bool__(), "entry in index must be full")
+                if hash == entry[].value().hash and key == entry[].value().key:
                     return (True, slot, index)
             self._next_index_slot(slot, perturb)
 

--- a/mojo/stdlib/test/collections/test_dict.mojo
+++ b/mojo/stdlib/test/collections/test_dict.mojo
@@ -15,7 +15,8 @@
 from collections import Dict, KeyElement, Optional
 from collections.dict import OwnedKwargsDict
 
-from test_utils import CopyCounter
+from test_utils import CopyCounter, AbortOnCopy
+from os import abort
 from testing import assert_equal, assert_false, assert_raises, assert_true
 
 
@@ -619,6 +620,13 @@ def test_compile_time_dict():
         assert_equal(val, i)
 
 
+def test_get_ptr():
+    var d = Dict[Int, AbortOnCopy]()
+    d[1] = AbortOnCopy()
+    assert_true(d.get_ptr(1))
+    assert_false(d.get_ptr(5))
+
+
 def main():
     test_dict()
     test_dict_fromkeys()
@@ -633,3 +641,4 @@ def main():
     test_init_initial_capacity()
     test_dict_setdefault()
     test_compile_time_dict()
+    test_get_ptr()

--- a/mojo/stdlib/test/test_utils/__init__.mojo
+++ b/mojo/stdlib/test/test_utils/__init__.mojo
@@ -13,6 +13,7 @@
 
 from .test_utils import libm_call
 from .types import (
+    AbortOnCopy,
     AbortOnDel,
     CopyCountedStruct,
     CopyCounter,

--- a/mojo/stdlib/test/test_utils/types.mojo
+++ b/mojo/stdlib/test/test_utils/types.mojo
@@ -24,6 +24,7 @@
 * `ObservableDel`
 * `DelRecorder`
 * `AbortOnDel`
+* `AbortOnCopy`
 """
 
 from os import abort
@@ -332,3 +333,18 @@ struct CopyCountedStruct(CollectionElement):
     fn __init__(out self, value: String):
         self.counter = CopyCounter()
         self.value = value
+
+
+# ===----------------------------------------------------------------------=== #
+# AbortOnCopy
+# ===----------------------------------------------------------------------=== #
+
+
+@value
+struct AbortOnCopy(Copyable, ExplicitlyCopyable):
+    fn __copyinit__(out self, other: Self):
+        abort("We should never implicitly copy AbortOnCopy")
+
+    fn copy(self) -> Self:
+        abort("We should never explicitly copy AbortOnCopy")
+        return self


### PR DESCRIPTION
Discord member reported an unexpected copy and move when using `Dict.get_ptr()`. 

https://discord.com/channels/1087530497313357884/1151418092052815884/1362569663422402630

I'm not sure about the source of the move, but I was able to eliminate the copy.