### PR TITLE
[stdlib] Add back a safer filehandle read function

### DIFF
--- a/mojo/stdlib/src/builtin/file.mojo
+++ b/mojo/stdlib/src/builtin/file.mojo
@@ -185,6 +185,12 @@ struct FileHandle(Writer):
     ](self, buffer: Span[Scalar[dtype], origin]) raises -> Int:
         """Read data from the file into the Span.
 
+        This will read n bytes from the file into the input Span where
+        `0 <= n <= len(buffer)`.
+
+        0 is returned when the file is at EOF, or a 0-sized buffer is
+        passed in.
+
         Parameters:
             dtype: The type that the data will be represented as.
             origin: The origin of the passed in Span.

--- a/mojo/stdlib/src/builtin/file.mojo
+++ b/mojo/stdlib/src/builtin/file.mojo
@@ -182,7 +182,7 @@ struct FileHandle(Writer):
 
     fn read[
         dtype: DType, origin: Origin[True]
-    ](self, buffer: Span[Scalar[dtype], origin]) raises -> Int64:
+    ](self, buffer: Span[Scalar[dtype], origin]) raises -> Int:
         """Read data from the file into the Span.
 
         Parameters:
@@ -229,7 +229,6 @@ struct FileHandle(Writer):
         var twelvth_element = ptr2[1]
         print(eleventh_element, twelvth_element)
         ```
-        .
         """
 
         if not self.handle:
@@ -237,9 +236,7 @@ struct FileHandle(Writer):
 
         var err_msg = _OwnedStringRef()
 
-        var bytes_read = external_call[
-            "KGEN_CompilerRT_IO_FileReadToAddress", Int64
-        ](
+        var bytes_read = external_call["KGEN_CompilerRT_IO_FileReadBytes", Int](
             self.handle,
             buffer.unsafe_ptr(),
             len(buffer) * sizeof[dtype](),

--- a/mojo/stdlib/src/builtin/file.mojo
+++ b/mojo/stdlib/src/builtin/file.mojo
@@ -180,6 +180,77 @@ struct FileHandle(Writer):
         var list = self.read_bytes(size)
         return String(bytes=list)
 
+    fn read[
+        dtype: DType, origin: Origin[True]
+    ](self, buffer: Span[Scalar[dtype], origin]) raises -> Int64:
+        """Read data from the file into the Span.
+
+        Parameters:
+            dtype: The type that the data will be represented as.
+            origin: The origin of the passed in Span.
+
+        Args:
+            buffer: The mutable Span to read data into.
+
+        Returns:
+            The total amount of data that was read in bytes.
+
+        Raises:
+            An error if this file handle is invalid, or if the file read
+            returned a failure.
+
+        Examples:
+
+        ```mojo
+        import os
+        from sys.info import sizeof
+
+        alias file_name = "/tmp/example.txt"
+        var file = open(file_name, "r")
+
+        # Allocate and load 8 elements
+        var ptr = UnsafePointer[Float32].alloc(8)
+        var buffer = InlineArray[Float32, size=8](fill=0)
+        var bytes = file.read(buffer)
+        print("bytes read", bytes)
+
+        var first_element = ptr[0]
+        print(first_element)
+
+        # Skip 2 elements
+        _ = file.seek(2 * sizeof[DType.float32](), os.SEEK_CUR)
+
+        # Allocate and load 8 more elements from file handle seek position
+        var ptr2 = UnsafePointer[Float32].alloc(8)
+        var buffer2 = InlineArray[Float32, size=8](fill=0)
+        var bytes2 = file.read(buffer2)
+
+        var eleventh_element = ptr2[0]
+        var twelvth_element = ptr2[1]
+        print(eleventh_element, twelvth_element)
+        ```
+        .
+        """
+
+        if not self.handle:
+            raise Error("invalid file handle")
+
+        var err_msg = _OwnedStringRef()
+
+        var bytes_read = external_call[
+            "KGEN_CompilerRT_IO_FileReadToAddress", Int64
+        ](
+            self.handle,
+            buffer.unsafe_ptr(),
+            len(buffer) * sizeof[dtype](),
+            Pointer(to=err_msg),
+        )
+
+        if err_msg:
+            raise (err_msg^).consume_as_error()
+
+        return bytes_read
+
     fn read_bytes(self, size: Int = -1) raises -> List[UInt8]:
         """Reads data from a file and sets the file handle seek position. If
         size is left as default of -1, it will read to the end of the file.

--- a/mojo/stdlib/test/builtin/test_file.mojo
+++ b/mojo/stdlib/test/builtin/test_file.mojo
@@ -99,6 +99,42 @@ def test_file_read_context():
         )
 
 
+def test_file_read_to_address():
+    with open(
+        _dir_of_current_file() / "test_file_dummy_input.txt",
+        "r",
+    ) as f:
+        var buffer = InlineArray[UInt8, size=1000](fill=0)
+        assert_equal(f.read(buffer), 954)
+        assert_equal(buffer[0], 76)  # L
+        assert_equal(buffer[1], 111)  # o
+        assert_equal(buffer[2], 114)  # r
+        assert_equal(buffer[3], 101)  # e
+        assert_equal(buffer[4], 109)  # m
+        assert_equal(buffer[5], 32)  # <space>
+        assert_equal(buffer[56], 10)  # <LF>
+
+    with open(
+        _dir_of_current_file() / "test_file_dummy_input.txt",
+        "r",
+    ) as f:
+        var buffer = InlineArray[UInt8, size=1000](fill=0)
+        assert_equal(f.read(buffer), 954)
+
+    with open(
+        _dir_of_current_file() / "test_file_dummy_input.txt",
+        "r",
+    ) as f:
+        var buffer_30 = InlineArray[UInt8, size=30](fill=0)
+        var buffer_1 = InlineArray[UInt8, size=1](fill=0)
+        var buffer_2 = InlineArray[UInt8, size=2](fill=0)
+        var buffer_100 = InlineArray[UInt8, size=100](fill=0)
+        assert_equal(f.read(buffer_30), 30)
+        assert_equal(f.read(buffer_1), 1)
+        assert_equal(f.read(buffer_2), 2)
+        assert_equal(f.read(buffer_100), 100)
+
+
 def test_file_seek():
     import os
 


### PR DESCRIPTION
`FileHandle.read` was removed in 716cd45 for safety. This adds a safer mechanism for reading that has a known size, unlike the previous `read` method that could take a size of `-1` to attempt to read the whole file into a pointer.

If I'm missing the point with why the original was removed, feel free to close this!

To Reviewer:
I switch from `KGEN_CompilerRT_IO_FileReadToAddress` to `KGEN_CompilerRT_IO_FileReadBytes` to match the other read functions. However, I don't know for sure that is safe without seeing the docs for those. Tests pass but I wanted to point that out in case it's an issue.
