### PR TITLE
[stdlib] Add `List.__init__[multiple_of: UInt](capacity=)` functionality for power of two multiples

### DIFF
--- a/mojo/stdlib/src/collections/list.mojo
+++ b/mojo/stdlib/src/collections/list.mojo
@@ -124,18 +124,38 @@ struct List[T: CollectionElement, hint_trivial_type: Bool = False](
             copy.append(e[])
         return copy^
 
-    fn __init__(out self, *, capacity: Int):
+    fn __init__[*, multiple_of: UInt = 1](out self, *, capacity: UInt):
         """Constructs a list with the given capacity.
+
+        Parameters:
+            multiple_of: The power of two multiple to round the capacity up to.
 
         Args:
             capacity: The requested capacity of the list.
+
+        Notes:
+            Zero is a multiple of every number. If capacity is zero, then the
+            rounded number will be zero.
         """
+        constrained[
+            multiple_of.is_power_of_two(),
+            "multiple_of value must be a power of two",
+        ]()
+        var rounded: UInt
+
+        @parameter
+        if multiple_of > 1:
+            alias offset = multiple_of - 1
+            rounded = (capacity + offset) & ~offset
+        else:
+            rounded = capacity
+
         if capacity:
-            self.data = UnsafePointer[T].alloc(capacity)
+            self.data = UnsafePointer[T].alloc(rounded)
         else:
             self.data = UnsafePointer[T]()
         self._len = 0
-        self.capacity = capacity
+        self.capacity = rounded
 
     fn __init__(out self, *, length: UInt, fill: T):
         """Constructs a list with the given capacity.

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -905,6 +905,31 @@ def test_uninit_ctor():
     assert_equal(list2[1], "world")
 
 
+def test_list_capacity_ctor():
+    for i in range(8):
+        assert_equal(List[Byte](capacity=i).capacity, i)
+
+    alias multiples = (2, 4, 8, 16, 32, 64, 128)
+
+    @parameter
+    for i in range(len(multiples)):
+        for j in range(8):
+            # zero is a multiple of everything
+            assert_equal(
+                List[Byte]
+                .__init__[multiple_of = multiples[i]](capacity=0)
+                .capacity,
+                0,
+            )
+            for k in range(j * multiples[i] + 1, (j + 1) * multiples[i] + 1):
+                assert_equal(
+                    List[Byte]
+                    .__init__[multiple_of = multiples[i]](capacity=k)
+                    .capacity,
+                    (j + 1) * multiples[i],
+                )
+
+
 # ===-------------------------------------------------------------------===#
 # main
 # ===-------------------------------------------------------------------===#
@@ -945,3 +970,4 @@ def main():
     test_list_repr()
     test_list_fill_constructor()
     test_uninit_ctor()
+    test_list_capacity_ctor()


### PR DESCRIPTION
This is a fast version for power of two multiples. In the future another version for other numbers could be added if necessary.