### PR TITLE
[stdlib] [NFC] Remove expanduser tests with empty `HOME`

### DIFF
--- a/mojo/stdlib/test/os/path/test_expanduser.mojo
+++ b/mojo/stdlib/test/os/path/test_expanduser.mojo
@@ -69,21 +69,4 @@ fn main() raises:
     # Path with multiple tildes
     assert_equal(join(user_path, "~folder"), expanduser("~/~folder"))
 
-    # Tests with empty "HOME" and "USERPROFILE"
-    set_home("")
-    if os_is_windows():
-        # Don't expand on windows if home isn't set
-        assert_equal("~/folder", expanduser("~/folder"))
-    else:
-        # Test fallback to `/etc/passwd` works on linux
-        alias folder = "~/folder"
-        assert_true(len(expanduser(folder)) > len(folder))
-
-        # Test expanding user name on Unix
-        assert_true(expanduser("~root") != "~root")
-
-        # Test path is returned unchanged on missing user
-        var missing_user = "~asdfasdzvxewr/user"
-        assert_equal(expanduser(missing_user), missing_user)
-
     set_home(original_home)

--- a/mojo/stdlib/test/pathlib/test_pathlib.mojo
+++ b/mojo/stdlib/test/pathlib/test_pathlib.mojo
@@ -144,14 +144,6 @@ def test_home():
     assert_equal(user_path, Path.home())
     # Match Python behavior allowing `home()` to overwrite existing path.
     assert_equal(user_path, Path("test").home())
-    # Tests with empty "HOME" and "USERPROFILE"
-    set_home(Path(""))
-    if os_is_windows():
-        # Don't expand on windows if home isn't set
-        assert_equal(Path("~"), Path.home())
-    else:
-        # Test fallback to `/etc/passwd` works on linux
-        assert_true(len(Path.home().path) > 1)
 
     # Ensure other tests in this process aren't broken by changing the home dir.
     set_home(original_home)


### PR DESCRIPTION
This is a flaky test that I don't know how it didn't get caught before. In Ubuntu 22.04 this works fine (returns `/etc/passwd`), in 24.04 it doesn't (returns `/`). MacOS defaults to `User/runner` instead of the empty string. We shouldn't be concerned with and chase after default OS behavior in this test.
