### PR TITLE
[stdlib] Fix `UnsafePointer` origins in `codepoint.mojo`

### DIFF
--- a/mojo/stdlib/src/collections/string/codepoint.mojo
+++ b/mojo/stdlib/src/collections/string/codepoint.mojo
@@ -315,7 +315,7 @@ struct Codepoint(
         """
         var char_len = self.utf8_byte_length()
         var result = String(unsafe_uninit_length=char_len)
-        _ = self.unsafe_write_utf8(result.unsafe_ptr())
+        _ = self.unsafe_write_utf8(result.unsafe_ptr_mut())
         return result
 
     # ===-------------------------------------------------------------------===#
@@ -482,7 +482,7 @@ struct Codepoint(
     @always_inline
     fn unsafe_write_utf8[
         optimize_ascii: Bool = True
-    ](self, ptr: UnsafePointer[Byte]) -> UInt:
+    ](self, ptr: UnsafePointer[Byte, mut=True, **_]) -> UInt:
         """Shift unicode to utf8 representation.
 
         Parameters:


### PR DESCRIPTION
Part of #4396