### PR TITLE
[stdlib] Fix make `math.iota(buff: UnsafePointer)` generic over the origin

### DIFF
--- a/mojo/stdlib/src/math/math.mojo
+++ b/mojo/stdlib/src/math/math.mojo
@@ -1147,7 +1147,7 @@ fn iota[
 
 fn iota[
     dtype: DType
-](buff: UnsafePointer[Scalar[dtype]], len: Int, offset: Int = 0):
+](buff: UnsafePointer[Scalar[dtype], mut=True, **_], len: Int, offset: Int = 0):
     """Fill the buffer with numbers ranging from offset to offset + len - 1,
     spaced by 1.
 


### PR DESCRIPTION
Part of #4396