### PR TITLE
[stdlib] Let write methods receive `StringSlice`s

### DIFF
--- a/mojo/stdlib/std/builtin/variadics.mojo
+++ b/mojo/stdlib/std/builtin/variadics.mojo
@@ -1168,17 +1168,13 @@ struct VariadicPack[
         return __mlir_op.`kgen.pack.load`(self.get_as_kgen_pack())
 
     def _write_to[
-        O1: ImmutOrigin,
-        O2: ImmutOrigin,
-        O3: ImmutOrigin,
-        *,
-        is_repr: Bool = False,
+        is_repr: Bool = False
     ](
         self: VariadicPack[_, Writable, ...],
         mut writer: Some[Writer],
-        start: StringSlice[O1] = StaticString(""),
-        end: StringSlice[O2] = StaticString(""),
-        sep: StringSlice[O3] = StaticString(", "),
+        start: StringSlice = "",
+        end: StringSlice = "",
+        sep: StringSlice = ", ",
     ):
         """Writes a sequence of writable values from a pack to a writer with
         delimiters.
@@ -1188,9 +1184,6 @@ struct VariadicPack[
         enclosed by start and end delimiters.
 
         Parameters:
-            O1: The origin of the open `StringSlice`.
-            O2: The origin of the close `StringSlice`.
-            O3: The origin of the separator `StringSlice`.
             is_repr: Whether to use repr formatting for elements.
 
         Args:
@@ -1220,11 +1213,7 @@ struct VariadicPack[
         Args:
             writer: The object to write to.
         """
-        self._write_to(
-            writer,
-            start=StaticString("("),
-            end=StaticString(")"),
-        )
+        self._write_to(writer, start="(", end=")")
 
     @no_inline
     def write_repr_to(
@@ -1235,11 +1224,7 @@ struct VariadicPack[
         Args:
             writer: The object to write to.
         """
-        self._write_to[is_repr=True](
-            writer,
-            start=StaticString("("),
-            end=StaticString(")"),
-        )
+        self._write_to[is_repr=True](writer, start="(", end=")")
 
 
 # ===-----------------------------------------------------------------------===#

--- a/mojo/stdlib/std/collections/string/string.mojo
+++ b/mojo/stdlib/std/collections/string/string.mojo
@@ -161,9 +161,9 @@ struct String(
     var text = "Hello"
 
     # String properties and indexing
-    print(len(text))     # 5
-    print(text[1])       # e
-    print(text[-1])      # o
+    print(text.byte_length())     # 5
+    print(text[byte=1])       # e
+    print(text[byte=-1])      # o
 
     # In-place concatenation
     text += " World"
@@ -401,6 +401,7 @@ struct String(
         Examples:
 
         ```mojo
+        %# from std.testing import assert_equal
         # Valid UTF-8 sequence
         var fire_emoji_bytes = [Byte(0xF0), 0x9F, 0x94, 0xA5]
         var fire_emoji = String(from_utf8_lossy=fire_emoji_bytes)
@@ -444,18 +445,18 @@ struct String(
     # register pressure.
 
     def __init__[
-        *Ts: Writable,
-    ](out self, *args: *Ts, sep: StaticString = "", end: StaticString = ""):
+        *Ts: Writable
+    ](out self, *args: *Ts, sep: StringSlice = "", end: StringSlice = ""):
         """
         Construct a string by concatenating a sequence of Writable arguments.
+
+        Parameters:
+            Ts: Types of the provided argument sequence.
 
         Args:
             args: A sequence of Writable arguments.
             sep: The separator used between elements.
             end: The String to write after printing the elements.
-
-        Parameters:
-            Ts: Types of the provided argument sequence.
 
         Examples:
 
@@ -479,16 +480,12 @@ struct String(
             args._write_to(buffer, end=end, sep=sep)
             buffer.flush()
 
-    # TODO(MOCO-1791): Default arguments and param inference aren't powerful
-    # to declare sep/end as StringSlice.
     @staticmethod
-    def __init__[
-        *Ts: Writable,
-    ](
+    def __init__(
         out self,
-        args: VariadicPack[_, Writable, *Ts],
-        sep: StaticString = "",
-        end: StaticString = "",
+        args: VariadicPack[_, Writable, ...],
+        sep: StringSlice = "",
+        end: StringSlice = "",
     ):
         """
         Construct a string by passing a variadic pack.
@@ -498,20 +495,17 @@ struct String(
             sep: The separator used between elements.
             end: The String to write after printing the elements.
 
-        Parameters:
-            Ts: Types of the provided argument sequence.
-
         Examples:
 
         ```mojo
+        %# from std.testing import assert_equal
         def variadic_pack_to_string[
             *Ts: Writable,
         ](*args: *Ts) -> String:
             return String(args)
 
         string = variadic_pack_to_string(1, ", ", 2.0, ", ", "three")
-        %# from testing import assert_equal
-        %# assert_equal(string, "1, 2.0, three")
+        assert_equal(string, "1, 2.0, three")
         ```
         """
         comptime length = args.__len__()
@@ -529,17 +523,17 @@ struct String(
 
     @staticmethod
     def write[
-        *Ts: Writable,
-    ](*args: *Ts, sep: StaticString = "", end: StaticString = "") -> Self:
+        *Ts: Writable
+    ](*args: *Ts, sep: StringSlice = "", end: StringSlice = "") -> Self:
         """Construct a string by concatenating a sequence of Writable arguments.
+
+        Parameters:
+            Ts: Types of the provided argument sequence.
 
         Args:
             args: A sequence of Writable arguments.
             sep: The separator used between elements.
             end: The String to write after printing the elements.
-
-        Parameters:
-            Ts: Types of the provided argument sequence.
 
         Returns:
             A string formed by formatting the argument sequence.
@@ -1076,8 +1070,7 @@ struct String(
     # ===------------------------------------------------------------------=== #
 
     def write_to(self, mut writer: Some[Writer]):
-        """
-        Formats this string to the provided Writer.
+        """Formats this string to the provided Writer.
 
         Args:
             writer: The object to write to.
@@ -1334,7 +1327,7 @@ struct String(
             Query the length of a string, in bytes and Unicode codepoints:
 
             ```mojo
-            %# from testing import assert_equal
+            %# from std.testing import assert_equal
 
             var s = StringSlice("ನಮಸ್ಕಾರ")
             assert_equal(s.count_codepoints(), 7)
@@ -1345,7 +1338,7 @@ struct String(
             Unicode codepoint length:
 
             ```mojo
-            %# from testing import assert_equal
+            %# from std.testing import assert_equal
 
             var s = StringSlice("abc")
             assert_equal(s.count_codepoints(), 3)
@@ -1356,7 +1349,7 @@ struct String(
             the length in Unicode codepoints, not grapheme clusters:
 
             ```mojo
-            %# from testing import assert_equal
+            %# from std.testing import assert_equal
 
             var s = StringSlice("á")
             assert_equal(s.count_codepoints(), 2)
@@ -1945,9 +1938,9 @@ struct String(
 
         ```mojo
         var s = String("hello")
-        print(s.center(10))        # "  hello   "
-        print(s.center(11, "*"))   # "***hello***"
-        print(s.center(3))         # "hello" (no padding)
+        print(s.ascii_center(10))        # "  hello   "
+        print(s.ascii_center(11, "*"))   # "***hello***"
+        print(s.ascii_center(3))         # "hello" (no padding)
         ```
         """
         return StringSlice(self).ascii_center(width, fillchar)

--- a/mojo/stdlib/std/collections/string/string_slice.mojo
+++ b/mojo/stdlib/std/collections/string/string_slice.mojo
@@ -2464,8 +2464,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
         if len(elems) == 0:
             return String()
 
-        var sep = StringSlice(ptr=self.unsafe_ptr(), length=self.byte_length())
-        var total_bytes = _TotalWritableBytes(elems, sep=sep).size
+        var total_bytes = _TotalWritableBytes(elems, sep=self).size
         var result = String(capacity=total_bytes)
 
         if result._is_inline():

--- a/mojo/stdlib/std/format/_utils.mojo
+++ b/mojo/stdlib/std/format/_utils.mojo
@@ -40,7 +40,9 @@ def constrained_conforms_to_writable[*Ts: AnyType, Parent: AnyType]():
         ]()
 
 
-struct _SequenceWriter[W: Writer, origin: MutOrigin](Movable, Writer):
+struct _SequenceWriter[W: Writer, origin: MutOrigin, sep_origin: ImmutOrigin](
+    Movable, Writer
+):
     """A writer that handles sequences of elements with separators.
 
     This writer ensures separators are only inserted between elements, even
@@ -50,9 +52,13 @@ struct _SequenceWriter[W: Writer, origin: MutOrigin](Movable, Writer):
     var writer: Pointer[Self.W, Self.origin]
     var is_first_element: Bool
     var at_element_start: Bool
-    var sep: StaticString
+    var sep: StringSlice[Self.sep_origin]
 
-    def __init__(out self, ref[Self.origin] writer: Self.W, sep: StaticString):
+    def __init__(
+        out self,
+        ref[Self.origin] writer: Self.W,
+        sep: StringSlice[Self.sep_origin],
+    ):
         self.writer = Pointer(to=writer)
         self.is_first_element = True
         self.at_element_start = True
@@ -85,9 +91,9 @@ def write_sequence_to[
     W: Writer, ElementFn: fn[T: Writer](mut T) raises StopIteration capturing
 ](
     mut writer: W,
-    start: StaticString = "[",
-    end: StaticString = "]",
-    sep: StaticString = ", ",
+    start: StringSlice = "[",
+    end: StringSlice = "]",
+    sep: StringSlice = ", ",
 ):
     """Writes a sequence of elements to a writer using a callback function.
 
@@ -130,9 +136,9 @@ def write_sequence_to[
 ](
     mut writer: Some[Writer],
     *args: *Ts,
-    start: StaticString,
-    end: StaticString,
-    sep: StaticString = ", ",
+    start: StringSlice,
+    end: StringSlice,
+    sep: StringSlice = ", ",
 ):
     """Writes a sequence of writable values to a writer with delimiters.
 
@@ -159,9 +165,9 @@ def write_sequence_to[
     ElementFn: fn[i: Int](mut Some[Writer]) capturing,
 ](
     mut writer: Some[Writer],
-    open: StaticString = "[",
-    close: StaticString = "]",
-    sep: StaticString = ", ",
+    open: StringSlice = "[",
+    close: StringSlice = "]",
+    sep: StringSlice = ", ",
 ):
     """Writes a compile-time sized sequence of elements using an indexed callback.
 
@@ -574,16 +580,15 @@ def _hex_digits_to_hex_chars(
     %# from std.memory import memset_zero
     %# from std.testing import assert_equal
     %# from std.utils import StringSlice
-    %# from std.io.write import _hex_digits_to_hex_chars
-    items: List[Byte] = [0, 0, 0, 0, 0, 0, 0, 0, 0]
-    comptime S = StringSlice[origin_of(items)]
-    ptr = items.unsafe_ptr()
+    %# from std.format._utils import _hex_digits_to_hex_chars
+    var items: List[Byte] = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+    var ptr = items.unsafe_ptr()
     ptr.store(_hex_digits_to_hex_chars(UInt32(ord("🔥"))))
-    assert_equal("0001f525", S(ptr=ptr, length=8))
+    assert_equal("0001f525", StringSlice(ptr=ptr, length=8))
     ptr.store(_hex_digits_to_hex_chars(UInt16(ord("你"))))
-    assert_equal("4f60", S(ptr=ptr, length=4))
+    assert_equal("4f60", StringSlice(ptr=ptr, length=4))
     ptr.store(_hex_digits_to_hex_chars(UInt8(ord("Ö"))))
-    assert_equal("d6", S(ptr=ptr, length=2))
+    assert_equal("d6", StringSlice(ptr=ptr, length=2))
     ```
     """
     comptime size = size_of[decimal.dtype]()
@@ -601,10 +606,10 @@ def _write_hex[
     Examples:
 
     ```mojo
-    %# from memory import memset_zero
-    %# from testing import assert_equal
-    %# from utils import StringSlice
-    %# from io.write import _write_hex
+    %# from std.memory import memset_zero
+    %# from std.testing import assert_equal
+    %# from std.utils import StringSlice
+    %# from std.format._utils import _write_hex
     var s = String()
     _write_hex[amnt_hex_bytes=8](s, ord("🔥"))
     assert_equal("\\U0001f525", s)

--- a/mojo/stdlib/std/io/io.mojo
+++ b/mojo/stdlib/std/io/io.mojo
@@ -351,8 +351,8 @@ def print[
     *Ts: Writable
 ](
     *values: *Ts,
-    sep: StaticString = " ",
-    end: StaticString = "\n",
+    sep: StringSlice = " ",
+    end: StringSlice = "\n",
     flush: Bool = False,
     var file: FileDescriptor = stdout,
 ):

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -1487,6 +1487,10 @@ def test_variadic_ctors() raises:
 
     var s2 = String.write("message", 42, 42.2, True, sep=", ")
     assert_equal(s2, "message, 42, 42.2, True")
+    s2 = String.write(
+        "message", 42, 42.2, True, sep=String(", "), end=String("!")
+    )
+    assert_equal(s2, "message, 42, 42.2, True!")
 
     def forward_variadic_pack[
         *Ts: Writable,


### PR DESCRIPTION
This removes the unsafe building of a `StaticString` from a `String` and modifies several writer methods to receive `StringSlice`s with a default of `StaticString()` by making use of a default origin of `origin: ImmutableOrigin = StaticConstantOrigin` and rebinding it to the `StringSlice[origin]`

Closes MOCO-1791