### PR TITLE
[stdlib] Add `math.next_multiple_of()` and fix `String` impl

### DIFF
--- a/mojo/stdlib/stdlib/collections/string/string.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string.mojo
@@ -90,6 +90,7 @@ from sys.info import is_32bit
 from sys.ffi import c_char
 
 from bit import count_leading_zeros
+from math import next_multiple_of
 from memory import memcpy, memset, memcmp
 from python import PythonObject, ConvertibleFromPython, ConvertibleToPython
 
@@ -204,8 +205,9 @@ struct String(
                 __get_mvalue_as_litref(self)
             )
         else:
-            self._capacity_or_data = (capacity + 7) >> 3
-            self._ptr_or_data = Self._alloc(self._capacity_or_data << 3)
+            var mul = next_multiple_of[8](capacity)
+            self._capacity_or_data = mul >> 3
+            self._ptr_or_data = Self._alloc(mul)
             self._len_or_data = 0
             self._set_ref_counted()
 

--- a/mojo/stdlib/stdlib/math/__init__.mojo
+++ b/mojo/stdlib/stdlib/math/__init__.mojo
@@ -68,6 +68,7 @@ from .math import (
     modf,
     recip,
     remainder,
+    next_multiple_of,
     scalb,
     sin,
     sinh,

--- a/mojo/stdlib/stdlib/math/math.mojo
+++ b/mojo/stdlib/stdlib/math/math.mojo
@@ -1330,8 +1330,39 @@ fn align_down(value: UInt, alignment: UInt) -> UInt:
 
 
 # ===----------------------------------------------------------------------=== #
-# align_up
+# next_multiple_of
 # ===----------------------------------------------------------------------=== #
+
+
+@always_inline
+fn next_multiple_of[multiple_of: UInt](value: UInt) -> UInt:
+    """Returns the closest multiple of `multiple_of` that is greater than or
+    equal to value.
+
+    Parameters:
+        multiple_of: Value to round up to.
+
+    Args:
+        value: The value to round up.
+
+    Returns:
+        Closest multiple of `multiple_of` that is greater than or equal to the
+        input value.
+
+    Notes:
+        Zero is a multiple of every number. If value is zero, then the
+        rounded number will be zero.
+    """
+    constrained[multiple_of != 0, "multiple_of must be > 0"]()
+
+    @parameter
+    if multiple_of == 1:
+        return value
+    elif multiple_of.is_power_of_two():
+        alias offset = multiple_of - 1
+        return (value + offset) & ~offset
+    else:
+        return ceildiv(value, multiple_of) * multiple_of
 
 
 @always_inline

--- a/mojo/stdlib/test/math/test_math.mojo
+++ b/mojo/stdlib/test/math/test_math.mojo
@@ -31,6 +31,7 @@ from math import (
     lcm,
     log,
     log2,
+    next_multiple_of,
     sin,
     sqrt,
     trunc,
@@ -525,6 +526,23 @@ def test_ceildiv():
     assert_equal(ceildiv(UInt32(5), UInt32(2)), ceildiv(5, 2))
 
 
+def test_next_multiple_of():
+    for i in range(8):
+        assert_equal(next_multiple_of[1](i), i)
+
+    alias multiples = (2, 3, 4, 5, 8, 16, 17, 18, 19, 32, 64, 65, 99, 100, 128)
+
+    @parameter
+    for i in range(len(multiples)):
+        for j in range(8):
+            # zero is a multiple of everything
+            assert_equal(next_multiple_of[multiples[i]](0), 0)
+            for k in range(j * multiples[i] + 1, (j + 1) * multiples[i] + 1):
+                assert_equal(
+                    next_multiple_of[multiples[i]](k), (j + 1) * multiples[i]
+                )
+
+
 def test_align_down():
     assert_equal(align_down(1, 7), 0)
     assert_equal(align_down(548, -7), 553)
@@ -641,3 +659,4 @@ def main():
     test_align_up()
     test_clamp()
     test_atanh()
+    test_next_multiple_of()


### PR DESCRIPTION
Spin off from #4388.

This is useful to centralize the implementation and avoid bugs.

It is a compile time version of `align_up` where the multiple is a parameter.