### PR TITLE
[stdlib] Make `Span[Byte]` to `String` ctor keyword only

### DIFF
--- a/mojo/stdlib/src/base64/base64.mojo
+++ b/mojo/stdlib/src/base64/base64.mojo
@@ -116,7 +116,7 @@ fn b64encode(input_bytes: Span[Byte, _]) -> String:
     """
     var result = List[UInt8, True]()
     b64encode(input_bytes, result)
-    return String(result)
+    return String(bytes=result)
 
 
 # ===-----------------------------------------------------------------------===#
@@ -200,7 +200,7 @@ fn b16encode(str: StringSlice) -> String:
         out.append(b16chars[Int(hi)])
         out.append(b16chars[Int(lo)])
 
-    return String(out)
+    return String(bytes=out)
 
 
 # ===-----------------------------------------------------------------------===#
@@ -244,4 +244,4 @@ fn b16decode(str: StringSlice) -> String:
         var lo = str[i + 1]
         p.append(decode(hi) << 4 | decode(lo))
 
-    return String(p)
+    return String(bytes=p)

--- a/mojo/stdlib/src/builtin/file.mojo
+++ b/mojo/stdlib/src/builtin/file.mojo
@@ -178,7 +178,7 @@ struct FileHandle(Writer):
         """
 
         var list = self.read_bytes(size)
-        return String(list)
+        return String(bytes=list)
 
     fn read_bytes(self, size: Int = -1) raises -> List[UInt8]:
         """Reads data from a file and sets the file handle seek position. If

--- a/mojo/stdlib/src/collections/string/string.mojo
+++ b/mojo/stdlib/src/collections/string/string.mojo
@@ -799,7 +799,7 @@ struct String(
             self._capacity_or_data.set_has_nul_terminator(True)
 
     @always_inline
-    fn __init__(out self, bytes: Span[UInt8, *_]):
+    fn __init__(out self, *, bytes: Span[Byte, *_]):
         """Construct a string by copying the data. This constructor is explicit
         because it can involve memory allocation.
 

--- a/mojo/stdlib/test/builtin/test_file.mojo
+++ b/mojo/stdlib/test/builtin/test_file.mojo
@@ -50,13 +50,13 @@ def test_file_read_bytes_multi():
     ) as f:
         var bytes1 = f.read_bytes(12)
         assert_equal(len(bytes1), 12, "12 bytes")
-        var string1 = String(bytes1)
+        var string1 = String(bytes=bytes1)
         assert_equal(len(string1), 12, "12 chars")
         assert_equal(string1, String("Lorem ipsum "))
 
         var bytes2 = f.read_bytes(6)
         assert_equal(len(bytes2), 6, "6 bytes")
-        var string2 = String(bytes2)
+        var string2 = String(bytes=bytes2)
         assert_equal(len(string2), 6, "6 chars")
         assert_equal(string2, "dolor ")
 

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -647,9 +647,9 @@ def test_split():
             "\x1c",
             "\x1d",
             "\x1e",
-            String(next_line),
-            String(unicode_line_sep),
-            String(unicode_paragraph_sep),
+            String(bytes=next_line),
+            String(bytes=unicode_line_sep),
+            String(bytes=unicode_paragraph_sep),
         )
     )
     var s = univ_sep_var + "hello" + univ_sep_var + "world" + univ_sep_var
@@ -807,7 +807,7 @@ def test_splitlines():
     var unicode_paragraph_sep = List[UInt8](0xE2, 0x80, 0xA9)
 
     for elt in List(next_line, unicode_line_sep, unicode_paragraph_sep):
-        u = String(elt[])
+        u = String(bytes=elt[])
         item = String().join("hello", u, "world", u, "mojo", u, "language", u)
         assert_equal(item.splitlines(), hello_mojo)
         assert_equal(
@@ -836,9 +836,9 @@ def test_isspace():
         String("\x1c"),
         String("\x1d"),
         String("\x1e"),
-        String(next_line),
-        String(unicode_line_sep),
-        String(unicode_paragraph_sep),
+        String(bytes=next_line),
+        String(bytes=unicode_line_sep),
+        String(bytes=unicode_paragraph_sep),
     )
 
     for i in univ_sep_var:

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -510,9 +510,9 @@ def test_split():
             "\x1c",
             "\x1d",
             "\x1e",
-            String(next_line),
-            String(unicode_line_sep),
-            String(unicode_paragraph_sep),
+            String(bytes=next_line),
+            String(bytes=unicode_line_sep),
+            String(bytes=unicode_paragraph_sep),
         )
     )
     var s = univ_sep_var + "hello" + univ_sep_var + "world" + univ_sep_var
@@ -623,9 +623,9 @@ def test_splitlines():
     )
 
     # test \x85 \u2028 \u2029
-    var next_line = String(List[UInt8](0xC2, 0x85))
-    var unicode_line_sep = String(List[UInt8](0xE2, 0x80, 0xA8))
-    var unicode_paragraph_sep = String(List[UInt8](0xE2, 0x80, 0xA9))
+    var next_line = String(bytes=List[UInt8](0xC2, 0x85))
+    var unicode_line_sep = String(bytes=List[UInt8](0xE2, 0x80, 0xA8))
+    var unicode_paragraph_sep = String(bytes=List[UInt8](0xE2, 0x80, 0xA9))
 
     for i in List(next_line, unicode_line_sep, unicode_paragraph_sep):
         u = i[]


### PR DESCRIPTION
So it doesn't get confused with the generic ctor which means `v.__str__()`