### PR TITLE
[stdlib] Fix example using `ListLiteral` in `python.mojo`

### DIFF
--- a/mojo/stdlib/src/python/python.mojo
+++ b/mojo/stdlib/src/python/python.mojo
@@ -219,8 +219,8 @@ struct Python:
         from python import Python
 
         # This is equivalent to Python's `import numpy as np`
-        var np = Python.import_module("numpy")
-        a = np.array([1, 2, 3])
+        np = Python.import_module("numpy")
+        a = np.array(Python.list(1, 2, 3))
         ```
 
         Args:


### PR DESCRIPTION
This has slightly higher priority than the other example fixes, as it could lead to new issues asking why things don't work.