### PR TITLE
[CI] Don't include the packaged stdlib in the import path

### DIFF
--- a/.github/workflows/standard_library_tests_and_examples.yml
+++ b/.github/workflows/standard_library_tests_and_examples.yml
@@ -66,3 +66,4 @@ jobs:
         run: |
           magic run --frozen tests
           magic run --frozen examples
+          magic run --frozen benchmarks

--- a/examples/mojo/lit.cfg.py
+++ b/examples/mojo/lit.cfg.py
@@ -46,8 +46,6 @@ config.test_source_root = Path(__file__).parent.resolve()
 # Substitute %mojo for just `mojo` itself.
 config.substitutions.insert(0, ("%mojo", "mojo"))
 
-os.environ["MODULAR_MOJO_MAX_IMPORT_PATH"] = str(build_root)
-
 # Pass through several environment variables
 # to the underlying subprocesses that run the tests.
 lit.llvm.initialize(lit_config, config)

--- a/examples/mojo/lit.cfg.py
+++ b/examples/mojo/lit.cfg.py
@@ -46,14 +46,7 @@ config.test_source_root = Path(__file__).parent.resolve()
 # Substitute %mojo for just `mojo` itself.
 config.substitutions.insert(0, ("%mojo", "mojo"))
 
-# MODULAR_HOME is at <package root>/share/max by default
-pre_built_packages_path = (
-    Path(os.environ["MODULAR_HOME"]).parent.parent / "lib" / "mojo"
-).resolve()
-
-os.environ[
-    "MODULAR_MOJO_MAX_IMPORT_PATH"
-] = f"{build_root},{pre_built_packages_path}"
+os.environ["MODULAR_MOJO_MAX_IMPORT_PATH"] = str(build_root)
 
 # Pass through several environment variables
 # to the underlying subprocesses that run the tests.

--- a/examples/mojo/run-examples.sh
+++ b/examples/mojo/run-examples.sh
@@ -15,11 +15,13 @@
 set -euo pipefail
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-REPO_ROOT="${SCRIPT_DIR}"/../../
+REPO_ROOT=$(realpath "${SCRIPT_DIR}/../..")
 EXAMPLES_DIR="${REPO_ROOT}"/examples/mojo
 
 BUILD_DIR="${REPO_ROOT}"/mojo/build
 mkdir -p "${BUILD_DIR}"
+
+source "${REPO_ROOT}"/mojo/stdlib/scripts/build-stdlib.sh
 
 # Run the examples using `lit`.
 lit -sv "${EXAMPLES_DIR}"

--- a/mojo/stdlib/benchmarks/lit.cfg.py
+++ b/mojo/stdlib/benchmarks/lit.cfg.py
@@ -42,31 +42,14 @@ else:
     # test_source_root: The root path where tests are located.
     config.test_source_root = Path(__file__).parent.resolve()
 
-    # This is important since `benchmark` is closed source
-    # still right now and is always used by the benchmarks.
-    # If running through `magic`, this will be preset,
-    # but is overridable by users.
-    # MODULAR_HOME is at <package root>/share/max by default
-    pre_built_packages_path = (
-        Path(os.environ["MODULAR_HOME"]).parent.parent / "lib" / "mojo"
-    ).resolve()
-
-    repo_root = Path(__file__).parent.parent.parent
-
     # The `run-tests.sh` script creates the build directory for you.
-    build_root = repo_root / "build"
+    build_root = Path(__file__).parent.parent.parent / "build"
 
     # The tests are executed inside this build directory to avoid
     # polluting the source tree.
     config.test_exec_root = (build_root / "stdlib" / "benchmarks").resolve()
 
-    # Add both the open source, locally built `stdlib.mojopkg`
-    # along with the closed source, pre-built packages shipped
-    # with the Mojo SDK to the appropriate environment variables.
-    # These environment variables are interpreted by the mojo parser
-    # when resolving imports.
-    joint_path = f"{build_root.resolve()},{pre_built_packages_path.resolve()}"
-    os.environ["MODULAR_MOJO_MAX_IMPORT_PATH"] = joint_path
+    os.environ["MODULAR_MOJO_MAX_IMPORT_PATH"] = str(build_root)
 
     # Pass through several environment variables
     # to the underlying subprocesses that run the tests.

--- a/mojo/stdlib/benchmarks/lit.cfg.py
+++ b/mojo/stdlib/benchmarks/lit.cfg.py
@@ -49,8 +49,6 @@ else:
     # polluting the source tree.
     config.test_exec_root = (build_root / "stdlib" / "benchmarks").resolve()
 
-    os.environ["MODULAR_MOJO_MAX_IMPORT_PATH"] = str(build_root)
-
     # Pass through several environment variables
     # to the underlying subprocesses that run the tests.
     lit.llvm.initialize(lit_config, config)

--- a/mojo/stdlib/scripts/build-stdlib.sh
+++ b/mojo/stdlib/scripts/build-stdlib.sh
@@ -26,4 +26,10 @@ STDLIB_PACKAGE_NAME="stdlib.mojopkg"
 FULL_STDLIB_PACKAGE_PATH="${BUILD_DIR}"/"${STDLIB_PACKAGE_NAME}"
 mojo package "${STDLIB_PATH}" -o "${FULL_STDLIB_PACKAGE_PATH}"
 
+# The `mojo` nightly compiler ships with its own `stdlib.mojopkg`. For the
+# open-source stdlib, we need to specify the paths to the just-built
+# `stdlib.mojopkg`. Otherwise, without this, the `mojo` compiler would
+# use its own `stdlib.mojopkg` it ships with which is not what we want.
+export MODULAR_MOJO_MAX_IMPORT_PATH=$BUILD_DIR
+
 echo Successfully created "${FULL_STDLIB_PACKAGE_PATH}"

--- a/mojo/stdlib/scripts/run-tests.sh
+++ b/mojo/stdlib/scripts/run-tests.sh
@@ -28,7 +28,6 @@ TEST_UTILS_PATH="${REPO_ROOT}/stdlib/test/test_utils"
 # This is needed to compile test_utils.mojopkg correctly, otherwise it
 # uses the stdlib that's given in the nightly, and will fail compilation
 # if some breaking changes are made.
-export MODULAR_MOJO_MAX_IMPORT_PATH=$BUILD_DIR
 mojo package "${TEST_UTILS_PATH}" -I ${BUILD_DIR} -o "${BUILD_DIR}/test_utils.mojopkg"
 
 TEST_PATH="${REPO_ROOT}/stdlib/test"

--- a/mojo/stdlib/test/lit.cfg.py
+++ b/mojo/stdlib/test/lit.cfg.py
@@ -83,14 +83,6 @@ else:
     config.substitutions.insert(0, ("%mojo-no-debug-no-assert", "mojo"))
     config.substitutions.insert(0, ("%mojo-no-debug", base_mojo_command))
 
-    # The `mojo` nightly compiler ships with its own `stdlib.mojopkg`. For the
-    # open-source stdlib, we need to specify the paths to the just-built
-    # `stdlib.mojopkg` and `test_utils.mojopkg`. Otherwise, without this, the
-    # `mojo` compiler would use its own `stdlib.mojopkg` it ships with which is not
-    # what we want. We override both the stable and nightly `mojo` import paths
-    # here to support both versions of the compiler.
-    os.environ["MODULAR_MOJO_MAX_IMPORT_PATH"] = str(build_root)
-
     # Pass through several environment variables
     # to the underlying subprocesses that run the tests.
     lit.llvm.initialize(lit_config, config)


### PR DESCRIPTION
With the `benchmark` package open-sourced, we no longer need to include the packaged stdlib when we run tests.