### PR TITLE
[max-examples] fix image_pipeline grayscale filter: set simd_width=1

### DIFF
--- a/examples/custom_ops/kernels/image_pipeline.mojo
+++ b/examples/custom_ops/kernels/image_pipeline.mojo
@@ -53,7 +53,7 @@ struct Grayscale:
 
             return gray_f32.clamp(0, 255).cast[DType.uint8]()
 
-        foreach[color_to_grayscale, target=target](img_out, ctx)
+        foreach[color_to_grayscale, target=target, simd_width=1](img_out, ctx)
 
 
 @register("brightness")


### PR DESCRIPTION
Followup on https://github.com/modular/max/pull/4432#issuecomment-2832943018 by @jackos 

It turns out the grayscale filter has the same issue as blur filter had.

Grayscale *only* output before the change:
![dogs_out_pre](https://github.com/user-attachments/assets/2a3f8d78-785b-461a-abe6-35b46710773e)

Grayscale only output after the simd_width=1:
![dogs_out](https://github.com/user-attachments/assets/244a72ef-97f7-45cc-8f07-63259b54be0c)

Overall I'd like to confirm that setting simd_width=1 is what should be done here.
Naively I would think grayscale is point-wise filter and should naturally support SIMD.
