### PR TITLE
[stdlib] Add `String.unsafe_ptr_mut[is_unique_mut_ref]()` parameter and rename internal fns

### DIFF
--- a/mojo/stdlib/stdlib/collections/string/codepoint.mojo
+++ b/mojo/stdlib/stdlib/collections/string/codepoint.mojo
@@ -310,7 +310,9 @@ struct Codepoint(Copyable, EqualityComparable, Intable, Movable, Stringable):
         """
         var char_len = self.utf8_byte_length()
         var result = String(unsafe_uninit_length=char_len)
-        _ = self.unsafe_write_utf8(result.unsafe_ptr_mut())
+        _ = self.unsafe_write_utf8(
+            result.unsafe_ptr_mut[is_unique_mut_ref=True]()
+        )
         return result
 
     # ===-------------------------------------------------------------------===#

--- a/mojo/stdlib/stdlib/collections/string/string_slice.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string_slice.mojo
@@ -718,7 +718,11 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         """
         var len = self.byte_length()
         var result = String(unsafe_uninit_length=len)
-        memcpy(result.unsafe_ptr_mut(), self.unsafe_ptr(), len)
+        memcpy(
+            result.unsafe_ptr_mut[is_unique_mut_ref=True](),
+            self.unsafe_ptr(),
+            len,
+        )
         return result^
 
     fn __repr__(self) -> String:

--- a/mojo/stdlib/stdlib/sys/info.mojo
+++ b/mojo/stdlib/stdlib/sys/info.mojo
@@ -1026,7 +1026,7 @@ fn _macos_version() raises -> Tuple[Int, Int, Int]:
 
     var err = external_call["sysctlbyname", Int32](
         "kern.osproductversion".unsafe_cstr_ptr(),
-        osver.unsafe_ptr(),
+        osver.unsafe_ptr_mut[is_unique_mut_ref=True](),
         Pointer(to=buf_len),
         OpaquePointer(),
         Int(0),

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -1476,20 +1476,25 @@ def test_reserve():
 def test_uninit_ctor():
     var hello_len = len("hello")
     var s = String(unsafe_uninit_length=hello_len)
-    memcpy(s.unsafe_ptr(), StaticString("hello").unsafe_ptr(), hello_len)
+    var hello = StaticString("hello").unsafe_ptr()
+    memcpy(s.unsafe_ptr_mut[is_unique_mut_ref=True](), hello, hello_len)
     assert_equal(s, "hello")
 
     # Resize with uninitialized memory.
     var s2 = String()
     s2.resize(unsafe_uninit_length=hello_len)
-    memcpy(s2.unsafe_ptr_mut(), StaticString("hello").unsafe_ptr(), hello_len)
+    memcpy(s2.unsafe_ptr_mut[is_unique_mut_ref=True](), hello, hello_len)
     assert_equal(s2, "hello")
     assert_equal(s2._capacity_or_data.is_inline(), True)
 
     var s3 = String()
     var long: StaticString = "hellohellohellohellohellohellohellohellohellohel"
     s3.resize(unsafe_uninit_length=len(long))
-    memcpy(s3.unsafe_ptr_mut(), long.unsafe_ptr(), len(long))
+    memcpy(
+        s3.unsafe_ptr_mut[is_unique_mut_ref=True](),
+        long.unsafe_ptr(),
+        len(long),
+    )
     assert_equal(s3, long)
     assert_equal(s3._capacity_or_data.is_inline(), False)
 


### PR DESCRIPTION
Add `String.unsafe_ptr_mut[is_unique_mut_ref]()` parameter and rename internal fns.

The parameter determines whether the variable is a unique mutable reference to the `String`, avoiding a potential realloc branch. This is useful because this function is called in hot paths where the memory was already previously reserved.

CC: @soraros 