### PR TITLE
[stdlib] Ensure the type parameters match the return type in `SIMD` conditional constructors

### DIFF
--- a/mojo/stdlib/stdlib/benchmark/compiler.mojo
+++ b/mojo/stdlib/stdlib/benchmark/compiler.mojo
@@ -31,7 +31,7 @@ fn keep(val: Bool):
     Args:
       val: The value to not optimize away.
     """
-    keep(UInt8(val))
+    keep(Scalar[DType.bool](val).cast[DType.uint8]())
 
 
 @always_inline

--- a/mojo/stdlib/stdlib/builtin/simd.mojo
+++ b/mojo/stdlib/stdlib/builtin/simd.mojo
@@ -67,6 +67,7 @@ from sys import (
 )
 from sys._assembly import inlined_assembly
 from sys.info import _is_sm_9x_or_newer
+from sys.intrinsics import _type_is_eq
 
 from bit import byte_swap, pop_count
 from builtin._format_float import _write_float
@@ -473,6 +474,7 @@ struct SIMD[dtype: DType, size: Int](
         Args:
             value: The object to get the float point representation of.
         """
+        constrained[_type_is_eq[__type_of(self), Self]()]()
         self = value.__float__()
 
     @always_inline
@@ -488,6 +490,7 @@ struct SIMD[dtype: DType, size: Int](
         Raises:
             If the type does not have a float point representation.
         """
+        constrained[_type_is_eq[__type_of(self), Self]()]()
         self = value.__float__()
 
     # TODO(MSTDL-1587): Remove the dummy parameter.
@@ -560,6 +563,10 @@ struct SIMD[dtype: DType, size: Int](
         Args:
             value: The bool value.
         """
+        constrained[
+            _type_is_eq[__type_of(self), Self](),
+            "Target type doesn't support conversion from `Bool`",
+        ]()
         _simd_construction_checks[dtype, size]()
         var s = __mlir_op.`pop.cast_from_builtin`[
             _type = __mlir_type.`!pop.scalar<bool>`

--- a/mojo/stdlib/test/builtin/test_simd.mojo
+++ b/mojo/stdlib/test/builtin/test_simd.mojo
@@ -385,8 +385,8 @@ def test_truthy():
     @parameter
     fn test_dtype[dtype: DType]() raises:
         # Scalars of 0-values are false-y, 1-values are truth-y
-        assert_false(Scalar[dtype](False))
-        assert_true(Scalar[dtype](True))
+        assert_false(Scalar[dtype](0))
+        assert_true(Scalar[dtype](1))
 
     @parameter
     for i in range(dtypes.__len__()):


### PR DESCRIPTION
Unfortunately, we're forced to choose between allowing `Int32(True)` to have the type `Scalar[.bool]` or having it fail entirely.