### PR TITLE
[stdlib] Fix `StringSlice.replace`

### DIFF
--- a/mojo/docs/changelog-released.md
+++ b/mojo/docs/changelog-released.md
@@ -434,6 +434,9 @@ Special thanks to our community contributors:
 [@thatstoasty](https://github.com/thatstoasty), and
 [@winding-lines](https://github.com/winding-lines).
 
+- [#4492](https://github.com/modular/modular/issues/4488) - Fix `StringSlice.replace`
+  seg fault.
+
 ## v25.2 (2025-03-25)
 
 ### ✨ Highlights

--- a/mojo/stdlib/src/collections/string/string_slice.mojo
+++ b/mojo/stdlib/src/collections/string/string_slice.mojo
@@ -1121,7 +1121,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         var old_len = old.byte_length()
         var new_len = new.byte_length()
 
-        var res = String(capacity=self_len + (old_len - new_len) * occurrences)
+        var res = String(capacity=self_len + (new_len - old_len) * occurrences)
 
         for _ in range(occurrences):
             var curr_offset = Int(self_ptr) - Int(self_start)

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -966,6 +966,12 @@ def test_replace():
         StringSlice("hello world hello world").replace("world", "mojo"),
         "hello mojo hello mojo",
     )
+    assert_equal(
+        StringSlice("this is a test").replace(
+            "this", "abcdefghijklmnopqrstuvwxyz_abcdefghijklmnopqrstuvwxyz"
+        ),
+        "abcdefghijklmnopqrstuvwxyz_abcdefghijklmnopqrstuvwxyz is a test",
+    )
 
 
 def test_join():


### PR DESCRIPTION
Close #4488. Fix suggested by `@xtx` (@xtxtxtxtxtxtx) on Discord.