### PR TITLE
[stdlib] Add explicit `False` to `llvm.memcpy` call

### DIFF
--- a/mojo/stdlib/src/memory/memory.mojo
+++ b/mojo/stdlib/src/memory/memory.mojo
@@ -268,6 +268,7 @@ fn memcpy[
             dest.bitcast[Byte]().origin_cast[origin=MutableAnyOrigin](),
             src.bitcast[Byte]().origin_cast[origin=MutableAnyOrigin](),
             n,
+            False,
         )
     else:
         _memcpy_impl(


### PR DESCRIPTION
Updated the compile-time `llvm.memcpy` call to include `False` for the is_volatile argument. This makes the code cleaner and more explicit.

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
