### PR TITLE
[stdlib] improve pack_bits constraint error message

### DIFF
--- a/mojo/stdlib/src/memory/unsafe.mojo
+++ b/mojo/stdlib/src/memory/unsafe.mojo
@@ -134,8 +134,9 @@ fn pack_bits[
         width == bitwidthof[Scalar[new_type]](),
         (
             "the width of the bool vector must be the same as the bitwidth of"
-            " the target type"
+            " the target type. "
         ),
+        "Scalar bool (width=1) is not supported." if width == 1 else "",
     ]()
 
     return __mlir_op.`pop.bitcast`[_type = Scalar[new_type]._mlir_type](


### PR DESCRIPTION
`pack_bits` can't convert a SIMD[DType.bool, 1] vector into a valid integral type. This adds an explicity error message when this function is called with a scalar.


Create the error:
```python
    alias c = SIMD[DType.bool, 1](1)
    assert_equal(pack_bits(c), 1)
```

New error message:

```
note: constraint failed: the width of the bool vector must be the same as the bitwidth of the target type. Scalar bool (width=1) is not supported.
```

Related:
- https://github.com/modular/modular/issues/4503
- https://forum.modular.com/t/pack-bits-inside-of-vectorize-fails-constraint-check/1384/3

cc @soraros 