### PR TITLE
[stdlib] Add benchmarks for bitset

### DIFF
--- a/mojo/stdlib/benchmarks/collections/bench_bitset.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_bitset.mojo
@@ -1,0 +1,263 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# RUN: %mojo-no-debug %s -t
+# NOTE: to test changes on the current branch using run-benchmarks.sh, remove
+# the -t flag. Remember to replace it again before pushing any code.
+
+from collections import BitSet
+from math import ceil
+from random import *
+from sys import sizeof
+
+from benchmark import Bench, BenchConfig, Bencher, BenchId, Unit, keep, run
+from bit import next_power_of_two
+
+
+alias INIT_LOOP_SIZE: UInt = 1000000
+"""Bench loop size for BitSet init tests."""
+
+alias OP_LOOP_SIZE: UInt = 1000
+"""Bench loop size for BitSet operation tests."""
+
+
+@parameter
+fn bench_empty_bitset_init[size: Int](mut b: Bencher) raises:
+    @always_inline
+    @parameter
+    fn call_fn():
+        for _ in range(0, INIT_LOOP_SIZE):
+            var b = BitSet[size]()
+            keep(len(b))
+
+    b.iter[call_fn]()
+
+
+@parameter
+fn bench_bitset_init_from[width: Int](mut b: Bencher) raises:
+    var initial = SIMD[DType.bool, width](True)
+
+    @__copy_capture(initial)
+    @always_inline
+    @parameter
+    fn call_fn():
+        for _ in range(0, INIT_LOOP_SIZE):
+            var b = BitSet(initial)
+            keep(len(b))
+
+    b.iter[call_fn]()
+
+
+@parameter
+fn bench_bitset_set[size: Int](mut b: Bencher) raises:
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        var bitset = BitSet[size]()
+        for _ in range(0, OP_LOOP_SIZE):
+
+            @parameter
+            for i in range(0, bitset.size):
+                bitset.set(i)
+        keep(len(bitset))
+
+    b.iter[call_fn]()
+
+
+@parameter
+fn bench_bitset_clear[width: Int](mut b: Bencher) raises:
+    var initial = SIMD[DType.bool, width](True)
+
+    @__copy_capture(initial)
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        var bitset = BitSet[width](initial)
+        for _ in range(0, OP_LOOP_SIZE):
+
+            @parameter
+            for i in range(0, bitset.size):
+                bitset.clear(i)
+
+        keep(len(bitset))
+
+    b.iter[call_fn]()
+
+
+@parameter
+fn bench_bitset_toggle[width: Int](mut b: Bencher) raises:
+    var initial = SIMD[DType.bool, width](True)
+
+    @__copy_capture(initial)
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        var bitset = BitSet[width](initial)
+        for _ in range(0, OP_LOOP_SIZE):
+
+            @parameter
+            for i in range(0, bitset.size):
+                bitset.toggle(i)
+
+        keep(len(bitset))
+
+    b.iter[call_fn]()
+
+
+@parameter
+fn bench_bitset_test[width: Int](mut b: Bencher) raises:
+    var initial = SIMD[DType.bool, width](True)
+
+    @__copy_capture(initial)
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        var bitset = BitSet[width](initial)
+        for _ in range(0, OP_LOOP_SIZE):
+
+            @parameter
+            for i in range(0, bitset.size):
+                keep(bitset.test(i))
+
+    b.iter[call_fn]()
+
+
+@parameter
+fn bench_bitset_union[width: Int](mut b: Bencher) raises:
+    var lhs_init = SIMD[DType.bool, width](True)
+    var rhs_init = SIMD[DType.bool, width](False)
+
+    @__copy_capture(lhs_init)
+    @__copy_capture(rhs_init)
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        var lhs = BitSet[width](lhs_init)
+        var rhs = BitSet[width](rhs_init)
+
+        for _ in range(0, OP_LOOP_SIZE):
+            var new = lhs.union(rhs)
+            keep(len(new))
+
+    b.iter[call_fn]()
+
+
+@parameter
+fn bench_bitset_intersection[width: Int](mut b: Bencher) raises:
+    var lhs_init = SIMD[DType.bool, width](True)
+    var rhs_init = SIMD[DType.bool, width](False)
+
+    @__copy_capture(lhs_init)
+    @__copy_capture(rhs_init)
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        var lhs = BitSet[width](lhs_init)
+        var rhs = BitSet[width](rhs_init)
+
+        for _ in range(0, OP_LOOP_SIZE):
+            var new = lhs.intersection(rhs)
+            keep(len(new))
+
+    b.iter[call_fn]()
+
+
+@parameter
+fn bench_bitset_difference[width: Int](mut b: Bencher) raises:
+    var lhs_init = SIMD[DType.bool, width](True)
+    var rhs_init = SIMD[DType.bool, width](False)
+
+    @__copy_capture(lhs_init)
+    @__copy_capture(rhs_init)
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        var lhs = BitSet[width](lhs_init)
+        var rhs = BitSet[width](rhs_init)
+
+        for _ in range(0, OP_LOOP_SIZE):
+            var new = lhs.difference(rhs)
+            keep(len(new))
+
+    b.iter[call_fn]()
+
+
+def main():
+    seed()
+    alias widths = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512)
+    alias sizes = (10, 30, 50, 100, 1000, 10_000, 100_000, 1_000_000)
+    var m = Bench(BenchConfig(num_repetitions=1))
+
+    @parameter
+    for i in range(len(sizes)):
+        alias size = sizes[i]
+        m.bench_function[bench_empty_bitset_init[size]](
+            BenchId(String("bench_empty_bitset_init[", size, "]"))
+        )
+
+    @parameter
+    for width_idx in range(0, len(widths)):
+        alias width = widths[width_idx]
+        m.bench_function[bench_bitset_init_from[width]](
+            BenchId(String("bench_bitset_init_from[", width, "]"))
+        )
+
+    @parameter
+    for width_idx in range(0, len(widths)):
+        alias width = widths[width_idx]
+        m.bench_function[bench_bitset_set[width]](
+            BenchId(String("bench_bitset_set[", width, "]"))
+        )
+
+    @parameter
+    for width_idx in range(0, len(widths)):
+        alias width = widths[width_idx]
+        m.bench_function[bench_bitset_clear[width]](
+            BenchId(String("bench_bitset_clear[", width, "]"))
+        )
+
+    @parameter
+    for width_idx in range(0, len(widths)):
+        alias width = widths[width_idx]
+        m.bench_function[bench_bitset_clear[width]](
+            BenchId(String("bench_bitset_test[", width, "]"))
+        )
+
+    @parameter
+    for width_idx in range(0, len(widths)):
+        alias width = widths[width_idx]
+        m.bench_function[bench_bitset_clear[width]](
+            BenchId(String("bench_bitset_toggle[", width, "]"))
+        )
+
+    @parameter
+    for width_idx in range(0, len(widths)):
+        alias width = widths[width_idx]
+        m.bench_function[bench_bitset_clear[width]](
+            BenchId(String("bench_bitset_union[", width, "]"))
+        )
+
+    @parameter
+    for width_idx in range(0, len(widths)):
+        alias width = widths[width_idx]
+        m.bench_function[bench_bitset_clear[width]](
+            BenchId(String("bench_bitset_intersection[", width, "]"))
+        )
+
+    @parameter
+    for width_idx in range(0, len(widths)):
+        alias width = widths[width_idx]
+        m.bench_function[bench_bitset_clear[width]](
+            BenchId(String("bench_bitset_difference[", width, "]"))
+        )
+
+    m.dump_report()


### PR DESCRIPTION
Add benchmarks for `BitSet`.

The purpose in adding these is to help guide development of bitset, not to serve as standalone benchmarks. I've included the bench outputs here to at least serve as a single reference point for the other bitset prs that are currently up. I'll rerun as those get merged in and compare.

Current timings based off of 2e27f9b3e on an M1 MBP.

------------------------------------------------------------------
| name                             | met (ms)            | iters |
| ------ | --- | -- |
| bench_empty_bitset_init[10]      | 0.3137454164484023  | 3818  |
| bench_empty_bitset_init[30]      | 0.3147054794520548  | 3796  |
| bench_empty_bitset_init[50]      | 0.31733936058700213 | 3816  |
| bench_empty_bitset_init[100]     | 0.3147194320273468  | 3803  |
| bench_empty_bitset_init[1000]    | 0.3162380575349697  | 3789  |
| bench_empty_bitset_init[10000]   | 0.3174175013178703  | 3794  |
| bench_empty_bitset_init[100000]  | 0.3166993848622626  | 3739  |
| bench_empty_bitset_init[1000000] | 0.3127266093302059  | 3837  |
| bench_bitset_init_from[1]        | 92.40361538461539   | 13    |
| bench_bitset_init_from[2]        | 195.24616666666668  | 6     |
| bench_bitset_init_from[4]        | 394.479             | 3     |
| bench_bitset_init_from[8]        | 778.9265            | 2     |
| bench_bitset_init_from[16]       | 1604.823            | 2     |
| bench_bitset_init_from[32]       | 3188.3455           | 2     |
| bench_bitset_init_from[64]       | 6369.6285           | 2     |
| bench_bitset_init_from[128]      | 12924.6475          | 2     |
| bench_bitset_init_from[256]      | 25792.409           | 2     |
| bench_bitset_init_from[512]      | 52162.211           | 2     |
| bench_bitset_set[1]              | 0.09288640000000001 | 10000 |
| bench_bitset_set[2]              | 0.19437959514170042 | 6175  |
| bench_bitset_set[4]              | 0.3865228081527014  | 3091  |
| bench_bitset_set[8]              | 0.7862140533506832  | 1537  |
| bench_bitset_set[16]             | 1.5802437086092715  | 755   |
| bench_bitset_set[32]             | 3.193368146214099   | 383   |
| bench_bitset_set[64]             | 6.403657894736842   | 190   |
| bench_bitset_set[128]            | 12.819159574468085  | 94    |
| bench_bitset_set[256]            | 26.070978260869566  | 46    |
| bench_bitset_set[512]            | 51.793173913043475  | 23    |
| bench_bitset_clear[1]            | 0.0937863           | 10000 |
| bench_bitset_clear[2]            | 0.19217412855772306 | 6254  |
| bench_bitset_clear[4]            | 0.38930873786407766 | 3090  |
| bench_bitset_clear[8]            | 0.782059093893631   | 1523  |
| bench_bitset_clear[16]           | 1.6211915455746366  | 757   |
| bench_bitset_clear[32]           | 3.2325710455764076  | 373   |
| bench_bitset_clear[64]           | 6.46921505376344    | 186   |
| bench_bitset_clear[128]          | 13.161175824175823  | 91    |
| bench_bitset_clear[256]          | 26.21597777777778   | 45    |
| bench_bitset_clear[512]          | 52.39481818181818   | 22    |
| bench_bitset_test[1]             | 0.0939003           | 10000 |
| bench_bitset_test[2]             | 0.1917836164470551  | 6299  |
| bench_bitset_test[4]             | 0.3876852628184457  | 3101  |
| bench_bitset_test[8]             | 0.7742248711340206  | 1552  |
| bench_bitset_test[16]            | 1.618086956521739   | 759   |
| bench_bitset_test[32]            | 3.3586378378378376  | 370   |
| bench_bitset_test[64]            | 6.471157608695652   | 184   |
| bench_bitset_test[128]           | 13.159277777777778  | 90    |
| bench_bitset_test[256]           | 26.589222222222226  | 45    |
| bench_bitset_test[512]           | 52.490590909090905  | 22    |
| bench_bitset_toggle[1]           | 0.0939792           | 10000 |
| bench_bitset_toggle[2]           | 0.1949778353017311  | 6181  |
| bench_bitset_toggle[4]           | 0.38948717115946735 | 3079  |
| bench_bitset_toggle[8]           | 0.7863961038961038  | 1540  |
| bench_bitset_toggle[16]          | 1.6149608636977058  | 741   |
| bench_bitset_toggle[32]          | 3.243853260869565   | 368   |
| bench_bitset_toggle[64]          | 6.506016393442623   | 183   |
| bench_bitset_toggle[128]         | 13.216955555555556  | 90    |
| bench_bitset_toggle[256]         | 26.383377777777778  | 45    |
| bench_bitset_toggle[512]         | 52.659              | 22    |
| bench_bitset_union[1]            | 0.0938492           | 10000 |
| bench_bitset_union[2]            | 0.19289979322411324 | 6287  |
| bench_bitset_union[4]            | 0.3841317829457364  | 3096  |
| bench_bitset_union[8]            | 0.7819645436638214  | 1523  |
| bench_bitset_union[16]           | 1.5929152317880795  | 755   |
| bench_bitset_union[32]           | 3.2263104395604394  | 364   |
| bench_bitset_union[64]           | 6.480563829787234   | 188   |
| bench_bitset_union[128]          | 13.149230769230769  | 91    |
| bench_bitset_union[256]          | 26.32593333333333   | 45    |
| bench_bitset_union[512]          | 52.688863636363635  | 22    |
| bench_bitset_intersection[1]     | 0.0945391           | 10000 |
| bench_bitset_intersection[2]     | 0.19355660218671153 | 5945  |
| bench_bitset_intersection[4]     | 0.40231776315789475 | 3040  |
| bench_bitset_intersection[8]     | 0.7703072482360488  | 1559  |
| bench_bitset_intersection[16]    | 1.5836618037135277  | 754   |
| bench_bitset_intersection[32]    | 3.178752659574468   | 376   |
| bench_bitset_intersection[64]    | 6.494090395480225   | 177   |
| bench_bitset_intersection[128]   | 13.275899999999998  | 90    |
| bench_bitset_intersection[256]   | 26.26086666666667   | 45    |
| bench_bitset_intersection[512]   | 52.1735652173913    | 23    |
| bench_bitset_difference[1]       | 0.09362430000000001 | 10000 |
| bench_bitset_difference[2]       | 0.19301860982980754 | 6287  |
| bench_bitset_difference[4]       | 0.3881313586606568  | 3106  |
| bench_bitset_difference[8]       | 0.7792233766233766  | 1540  |
| bench_bitset_difference[16]      | 1.6201122994652406  | 748   |
| bench_bitset_difference[32]      | 3.231536            | 375   |
| bench_bitset_difference[64]      | 6.489616216216216   | 185   |
| bench_bitset_difference[128]     | 13.2722             | 90    |
| bench_bitset_difference[256]     | 26.35375555555556   | 45    |
| bench_bitset_difference[512]     | 52.414086956521736  | 23    |




Related to:
- https://github.com/modular/modular/pull/4522
- https://github.com/modular/modular/pull/4511