### PR TITLE
[stdlib] Clean up `bitcast` and `pack_bits`

### DIFF
--- a/mojo/stdlib/stdlib/builtin/dtype.mojo
+++ b/mojo/stdlib/stdlib/builtin/dtype.mojo
@@ -59,6 +59,10 @@ struct DType(
     """Represents an integral type whose bitwidth is the maximum integral value
     on the system."""
 
+    alias _uint1 = DType(__mlir_attr.`#kgen.dtype.constant<ui1> : !kgen.dtype`)
+    alias _uint2 = DType(__mlir_attr.`#kgen.dtype.constant<ui2> : !kgen.dtype`)
+    alias _uint4 = DType(__mlir_attr.`#kgen.dtype.constant<ui4> : !kgen.dtype`)
+
     alias uint8 = DType(__mlir_attr.`#kgen.dtype.constant<ui8> : !kgen.dtype`)
     """Represents an unsigned integer type whose bitwidth is 8."""
     alias int8 = DType(__mlir_attr.`#kgen.dtype.constant<si8> : !kgen.dtype`)

--- a/mojo/stdlib/stdlib/builtin/simd.mojo
+++ b/mojo/stdlib/stdlib/builtin/simd.mojo
@@ -1845,6 +1845,15 @@ struct SIMD[dtype: DType, size: Int](
         elif target is DType.bfloat16 and not _has_native_bf16_support():
             return rebind[Target](_f32_to_bfloat16(self.cast[DType.float32]()))
 
+        @parameter
+        if dtype in (DType._uint1, DType._uint2, DType._uint4):
+            # `pop.cast` doesn't support some conversions from `ui1`, `ui2`, or `ui4`
+            var uint = __mlir_op.`pop.cast`[
+                _type = SIMD[DType.index, size]._mlir_type,
+                fast = __mlir_attr.unit,
+            ](self.value)
+            return SIMD[DType.index, size](uint).cast[target]()
+
         return __mlir_op.`pop.cast`[
             _type = Target._mlir_type, fast = __mlir_attr.unit
         ](self.value)

--- a/mojo/stdlib/stdlib/builtin/simd.mojo
+++ b/mojo/stdlib/stdlib/builtin/simd.mojo
@@ -1849,10 +1849,10 @@ struct SIMD[dtype: DType, size: Int](
         if dtype in (DType._uint1, DType._uint2, DType._uint4):
             # `pop.cast` doesn't support some conversions from `ui1`, `ui2`, or `ui4`
             var uint = __mlir_op.`pop.cast`[
-                _type = SIMD[DType.index, size]._mlir_type,
+                _type = SIMD[DType.uint32, size]._mlir_type,
                 fast = __mlir_attr.unit,
             ](self.value)
-            return SIMD[DType.index, size](uint).cast[target]()
+            return SIMD[DType.uint32, size](uint).cast[target]()
 
         return __mlir_op.`pop.cast`[
             _type = Target._mlir_type, fast = __mlir_attr.unit

--- a/mojo/stdlib/stdlib/gpu/warp.mojo
+++ b/mojo/stdlib/stdlib/gpu/warp.mojo
@@ -82,9 +82,7 @@ fn _shuffle[
             "llvm.nvvm.shfl.sync." + mnemonic + ".i32", Scalar[type]
         ](Int32(mask), val, offset, WIDTH_MASK)
     elif type in (DType.int64, DType.uint64):
-        var val_bitcast = bitcast[
-            new_type = DType.uint32, new_width = simd_width * 2
-        ](val)
+        var val_bitcast = bitcast[DType.uint32, simd_width * 2](val)
         var val_half1, val_half2 = val_bitcast.deinterleave()
         var shuffle1 = _shuffle[mnemonic, WIDTH_MASK=WIDTH_MASK](
             mask, val_half1, offset
@@ -145,9 +143,7 @@ fn _shuffle_amd_helper[
         var val_splatted = SIMD[type, 2](rebind[Scalar[type]](val))
         return _shuffle_amd_helper(dst_lane, val_splatted)[0]
     elif bitwidthof[type]() == 64:
-        var val_bitcast = bitcast[
-            new_type = DType.uint32, new_width = simd_width * 2
-        ](val)
+        var val_bitcast = bitcast[DType.uint32, simd_width * 2](val)
         var val_half1, val_half2 = val_bitcast.deinterleave()
         var shuffle1 = _shuffle_amd_helper(dst_lane, val_half1)
         var shuffle2 = _shuffle_amd_helper(dst_lane, val_half2)

--- a/mojo/stdlib/stdlib/memory/unsafe.mojo
+++ b/mojo/stdlib/stdlib/memory/unsafe.mojo
@@ -28,11 +28,11 @@ from sys import bitwidthof
 
 @always_inline("nodebug")
 fn bitcast[
+    src_dtype: DType,
+    src_width: Int, //,
     dtype: DType,
-    width: Int, //,
-    new_type: DType,
-    new_width: Int = width,
-](val: SIMD[dtype, width]) -> SIMD[new_type, new_width]:
+    width: Int = src_width,
+](val: SIMD[src_dtype, src_width]) -> SIMD[dtype, width]:
     """Bitcasts a SIMD value to another SIMD value.
 
     For a discussion of byte order, see
@@ -47,19 +47,19 @@ fn bitcast[
     ```mojo
     from memory import bitcast
 
-    one = SIMD[DType.uint32, 1](4631)
-    many = bitcast[DType.uint8, 4](one)
-    print(one, many) # 4631 [23, 18, 0, 0]
+    u32 = SIMD[DType.uint32, 1](4631)
+    u8x4 = bitcast[DType.uint8, 4](u32)
+    print(u32, u8x4) # 4631 [23, 18, 0, 0]
     ```
 
     Constraints:
         The bitwidth of the two types must be the same.
 
     Parameters:
-        dtype: The source type.
-        width: The source width.
-        new_type: The target type.
-        new_width: The target width.
+        src_dtype: The source type.
+        src_width: The source width.
+        dtype: The target type.
+        width: The target width.
 
     Args:
         val: The source value.
@@ -69,39 +69,64 @@ fn bitcast[
         source SIMD value.
     """
     constrained[
-        bitwidthof[SIMD[dtype, width]]()
-        == bitwidthof[SIMD[new_type, new_width]](),
+        bitwidthof[SIMD[dtype, width]]() == bitwidthof[__type_of(val)](),
         "the source and destination types must have the same bitwidth",
     ]()
 
     @parameter
-    if new_type == dtype:
-        return rebind[SIMD[new_type, new_width]](val)
-    return __mlir_op.`pop.bitcast`[
-        _type = SIMD[new_type, new_width]._mlir_type
-    ](val.value)
+    if dtype == src_dtype:
+        return rebind[SIMD[dtype, width]](val)
+    return __mlir_op.`pop.bitcast`[_type = SIMD[dtype, width]._mlir_type](
+        val.value
+    )
+
+
+alias _uint1 = DType(__mlir_attr.`#kgen.dtype.constant<ui1> : !kgen.dtype`)
+alias _uint2 = DType(__mlir_attr.`#kgen.dtype.constant<ui2> : !kgen.dtype`)
+alias _uint4 = DType(__mlir_attr.`#kgen.dtype.constant<ui4> : !kgen.dtype`)
 
 
 @always_inline("builtin")
 fn _uint(n: Int) -> DType:
     # fmt: off
     return (
-        DType.uint8 if n == 8
-        else DType.uint16 if n == 16
-        else DType.uint32 if n == 32
-        else DType.uint64 if n == 64
-        else DType.uint128 if n == 128
-        else DType.uint256 if n == 256
-        else DType.invalid
+        _uint1 if n == 1 else
+        _uint2 if n == 2 else
+        _uint4 if n == 4 else
+        DType.uint8 if n == 8 else
+        DType.uint16 if n == 16 else
+        DType.uint32 if n == 32 else
+        DType.uint64 if n == 64 else
+        DType.uint128 if n == 128 else
+        DType.uint256 if n == 256 else
+        DType.invalid
+    )
+    # fmt: on
+
+
+fn _llvm_bitwidth(dtype: DType) -> Int:
+    # fmt: off
+    return (
+        1 if dtype is _uint1 else
+        2 if dtype is _uint2 else
+        4 if dtype is _uint4 else
+        8 if dtype is DType.uint8 else
+        16 if dtype is DType.uint16 else
+        32 if dtype is DType.uint32 else
+        64 if dtype is DType.uint64 else
+        128 if dtype is DType.uint128 else
+        256 if dtype is DType.uint256 else
+        -1
     )
     # fmt: on
 
 
 @always_inline("nodebug")
 fn pack_bits[
-    width: Int, //,
-    new_type: DType = _uint(width),
-](val: SIMD[DType.bool, width]) -> Scalar[new_type]:
+    src_width: Int, //,
+    dtype: DType = _uint(src_width),
+    width: Int = 1,
+](val: SIMD[DType.bool, src_width]) -> SIMD[dtype, width]:
     """Packs a SIMD vector of `bool` values into an integer.
 
     Examples:
@@ -111,18 +136,19 @@ fn pack_bits[
     ```mojo
     from memory import pack_bits
 
-    flags = SIMD[DType.bool, 8](1, 1, 0, 1, 0, 0, 0, 0)
-    i = pack_bits[DType.uint8](flags)
-    print(flags, i) # [True, True, False, True, False, False, False, False] 11
+    bits = SIMD[DType.bool, 8](1, 1, 0, 1, 0, 0, 0, 0)
+    u8 = pack_bits[DType.uint8](bits)
+    print(bits, u8) # [True, True, False, True, False, False, False, False] 11
     ```
 
     Constraints:
-        The width of the bool vector must be the same as the bitwidth of the
-        target type.
+        The logical bitwidth of the bool vector must be the same as the bitwidth of the
+        target type. The target type must be a unsigned type.
 
     Parameters:
-        width: The source width.
-        new_type: The target type.
+        src_width: The source width.
+        dtype: The target type.
+        width: The target width.
 
     Args:
         val: The source value.
@@ -131,14 +157,13 @@ fn pack_bits[
         A new integer scalar which has the same bitwidth as the bool vector.
     """
     constrained[
-        width == bitwidthof[Scalar[new_type]](),
+        dtype.is_unsigned() and _llvm_bitwidth(dtype) * width == src_width,
         (
-            "the width of the bool vector must be the same as the bitwidth of"
-            " the target type. "
+            "the logical bitwidth of the bool vector must be the same as the"
+            " target type"
         ),
-        "Scalar bool (width=1) is not supported." if width == 1 else "",
     ]()
 
-    return __mlir_op.`pop.bitcast`[_type = Scalar[new_type]._mlir_type](
+    return __mlir_op.`pop.bitcast`[_type = SIMD[dtype, width]._mlir_type](
         val.value
     )

--- a/mojo/stdlib/stdlib/memory/unsafe.mojo
+++ b/mojo/stdlib/stdlib/memory/unsafe.mojo
@@ -81,18 +81,13 @@ fn bitcast[
     )
 
 
-alias _uint1 = DType(__mlir_attr.`#kgen.dtype.constant<ui1> : !kgen.dtype`)
-alias _uint2 = DType(__mlir_attr.`#kgen.dtype.constant<ui2> : !kgen.dtype`)
-alias _uint4 = DType(__mlir_attr.`#kgen.dtype.constant<ui4> : !kgen.dtype`)
-
-
 @always_inline("builtin")
 fn _uint(n: Int) -> DType:
     # fmt: off
     return (
-        _uint1 if n == 1 else
-        _uint2 if n == 2 else
-        _uint4 if n == 4 else
+        DType._uint1 if n == 1 else
+        DType._uint2 if n == 2 else
+        DType._uint4 if n == 4 else
         DType.uint8 if n == 8 else
         DType.uint16 if n == 16 else
         DType.uint32 if n == 32 else
@@ -107,9 +102,9 @@ fn _uint(n: Int) -> DType:
 fn _llvm_bitwidth(dtype: DType) -> Int:
     # fmt: off
     return (
-        1 if dtype is _uint1 else
-        2 if dtype is _uint2 else
-        4 if dtype is _uint4 else
+        1 if dtype is DType._uint1 else
+        2 if dtype is DType._uint2 else
+        4 if dtype is DType._uint4 else
         8 if dtype is DType.uint8 else
         16 if dtype is DType.uint16 else
         32 if dtype is DType.uint32 else

--- a/mojo/stdlib/test/memory/test_bitcast.mojo
+++ b/mojo/stdlib/test/memory/test_bitcast.mojo
@@ -29,8 +29,27 @@ def test_bitcast():
 
 
 def test_pack_bits():
-    alias b = SIMD[DType.bool, 8](1, 1, 1, 0, 1, 0, 1, 1)
-    assert_equal(pack_bits(b), UInt8(0b1101_0111))
+    alias b1 = SIMD[DType.bool, 1](True)
+    assert_equal(pack_bits(b1).cast[DType.bool](), b1)
+    assert_equal(pack_bits(b1).cast[DType.uint8](), UInt8(0b0000_0001))
+
+    alias b2 = SIMD[DType.bool, 2](1, 0)
+    assert_equal(pack_bits(b2).cast[DType.uint8](), UInt8(0b0000_0001))
+
+    alias b4 = SIMD[DType.bool, 4](1, 1, 0, 1)
+    assert_equal(pack_bits(b4).cast[DType.uint8](), UInt8(0b0000_1011))
+
+    alias b8 = SIMD[DType.bool, 8](1, 1, 1, 0, 1, 0, 1, 0)
+    assert_equal(pack_bits(b8), UInt8(0b0101_0111))
+
+    alias b16 = SIMD[DType.bool, 16](
+        1, 1, 1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 1
+    )
+    assert_equal(pack_bits(b16), UInt16(0b1000_1010_0101_0111))
+    assert_equal(
+        pack_bits[DType.uint8, 2](b16),
+        SIMD[DType.uint8, 2](0b0101_0111, 0b1000_1010),
+    )
 
 
 def main():


### PR DESCRIPTION
- Add private `DType`s (`_u1`, `_u2`, `_u4`) to support expressions like the following:
  ```mojo
  u2 = pack_bits(SIMD[bool, 2](True))  # this intermediate value isn't used directly
  n = u2.cast[DType.uint64]()
  ```
  This enables more robust generic programming.
- Clarify that LLVM `bitcast` *can* operate on logical, not physical, bit widths.
- Rename several parameters for consistency with the `bit` and `math` modules.
- Addresses #4503.