### PR TITLE
[bazel] Use smaller llvm downloads

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,14 @@
 # Avoid PATH leaking into actions
 common --incompatible_strict_action_env
 
+# Enable --config=(macos|windows|linux) based on the host OS
+common --enable_platform_specific_config
+
 # Force hermetic toolchain, make sure we don't accidentally used the default one
-common --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-common --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
+common:linux --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+common:linux --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
+
+common --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 
 # Use a custom platform to detect GPU hardware
 common --platforms=@modular_host_platform

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,6 +25,13 @@ archive_override(
 
 bazel_dep(name = "rules_uv", version = "0.69.0", dev_dependency = True)
 bazel_dep(name = "toolchains_llvm", version = "1.4.0", dev_dependency = True)
+single_version_override(
+    module_name = "toolchains_llvm",
+    patch_strip = 1,
+    patches = [
+        "//bazel:toolchains_llvm.patch",
+    ],
+)
 
 mojo_aliases = use_repo_rule("//bazel:mojo_aliases.bzl", "mojo_aliases")
 
@@ -56,7 +63,24 @@ pip.parse(
 use_repo(pip, "modular_test_deps")
 
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
-llvm.toolchain(llvm_version = "20.1.2")
+llvm.toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "20.1.1",
+    sha256 = {
+        "darwin-aarch64": "6e6c22adca634aba0e3b969ce999549131c7f74b3330828a4fd6fa18eca73525",
+        "linux-aarch64": "86314680f7abea8e054d635c0e54b3f3f6993f8e826df0da8cfd02e456976625",
+        "linux-x86_64": "58d7a1a8fa22a001794e82a8e9ca441e12fb6d62fd8b7d47040df58a459dec8e",
+    },
+    stdlib = {
+        "linux-aarch64": "dynamic-stdc++",
+        "linux-x86_64": "dynamic-stdc++",
+    },
+    urls = {
+        "darwin-aarch64": ["https://github.com/dzbarsky/static-clang/releases/download/v20.1.1/darwin_arm64.tar.xz"],
+        "linux-aarch64": ["https://github.com/dzbarsky/static-clang/releases/download/v20.1.1/linux_arm64.tar.xz"],
+        "linux-x86_64": ["https://github.com/dzbarsky/static-clang/releases/download/v20.1.1/linux_amd64.tar.xz"],
+    },
+)
 use_repo(llvm, "llvm_toolchain")
 
 register_toolchains("@llvm_toolchain//:all")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -65,9 +65,11 @@ use_repo(pip, "modular_test_deps")
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm", dev_dependency = True)
 llvm.toolchain(
     name = "llvm_toolchain",
-    llvm_version = "20.1.1",
+    llvm_versions = {
+        "linux-aarch64": "20.1.1",
+        "linux-x86_64": "20.1.1",
+    },
     sha256 = {
-        "darwin-aarch64": "6e6c22adca634aba0e3b969ce999549131c7f74b3330828a4fd6fa18eca73525",
         "linux-aarch64": "86314680f7abea8e054d635c0e54b3f3f6993f8e826df0da8cfd02e456976625",
         "linux-x86_64": "58d7a1a8fa22a001794e82a8e9ca441e12fb6d62fd8b7d47040df58a459dec8e",
     },
@@ -76,7 +78,6 @@ llvm.toolchain(
         "linux-x86_64": "dynamic-stdc++",
     },
     urls = {
-        "darwin-aarch64": ["https://github.com/dzbarsky/static-clang/releases/download/v20.1.1/darwin_arm64.tar.xz"],
         "linux-aarch64": ["https://github.com/dzbarsky/static-clang/releases/download/v20.1.1/linux_arm64.tar.xz"],
         "linux-x86_64": ["https://github.com/dzbarsky/static-clang/releases/download/v20.1.1/linux_amd64.tar.xz"],
     },

--- a/bazel/toolchains_llvm.patch
+++ b/bazel/toolchains_llvm.patch
@@ -1,0 +1,63 @@
+diff --git a/toolchain/BUILD.llvm_repo b/toolchain/BUILD.llvm_repo
+index f2bbc76..1a4c985 100644
+--- a/toolchain/BUILD.llvm_repo
++++ b/toolchain/BUILD.llvm_repo
+@@ -41,7 +41,6 @@ filegroup(
+     srcs = [
+         "bin/ld.lld",
+         "bin/ld64.lld",
+-        "bin/wasm-ld",
+     ],
+ )
+ 
+@@ -146,20 +145,6 @@ filegroup(
+     srcs = ["bin/llvm-symbolizer"],
+ )
+ 
+-filegroup(
+-    name = "clang-tidy",
+-    srcs = ["bin/clang-tidy"],
+-)
+-
+-filegroup(
+-    name = "clang-format",
+-    srcs = ["bin/clang-format"],
+-)
+-
+-filegroup(
+-    name = "git-clang-format",
+-    srcs = ["bin/git-clang-format"],
+-)
+ 
+ filegroup(
+     name = "libclang",
+diff --git a/toolchain/aliases.bzl b/toolchain/aliases.bzl
+index 2754751..17a56d0 100644
+--- a/toolchain/aliases.bzl
++++ b/toolchain/aliases.bzl
+@@ -20,11 +20,4 @@ aliased_libs = [
+ ]
+ 
+ aliased_tools = [
+-    "clang-apply-replacements",
+-    "clang-format",
+-    "clang-tidy",
+-    "clangd",
+-    "llvm-cov",
+-    "llvm-profdata",
+-    "llvm-symbolizer",
+ ]
+diff --git a/toolchain/internal/common.bzl b/toolchain/internal/common.bzl
+index b5d8e57..f88d739 100644
+--- a/toolchain/internal/common.bzl
++++ b/toolchain/internal/common.bzl
+@@ -30,9 +30,6 @@ _toolchain_tools = {
+     name: name
+     for name in [
+         "clang-cpp",
+-        "clang-format",
+-        "clang-tidy",
+-        "clangd",
+         "ld.lld",
+         "llvm-ar",
+         "llvm-dwp",


### PR DESCRIPTION
Previously it took forever to download and untar the llvm release. These
entirely statically linked binaries are much smaller. 1.5gb vs 100mbs

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>
