### PR TITLE
[stdlib] Make `bit.byte_swap` a no-op for `uint8`

### DIFF
--- a/mojo/stdlib/stdlib/bit/bit.mojo
+++ b/mojo/stdlib/stdlib/bit/bit.mojo
@@ -198,8 +198,7 @@ fn byte_swap[
         width: SIMD width used for the computation.
 
     Constraints:
-        The element type of the input vector must be an integral type with an
-        even number of bytes (Bitwidth % 16 == 0).
+        The element type of the input vector must be an integral type.
 
     Args:
         val: The input value.
@@ -209,6 +208,10 @@ fn byte_swap[
         element at position `i` of the input value with its bytes swapped.
     """
     constrained[dtype.is_integral(), "must be integral"]()
+
+    @parameter
+    if dtype.bitwidth() < 16:
+        return val
     return llvm_intrinsic["llvm.bswap", __type_of(val), has_side_effect=False](
         val
     )

--- a/mojo/stdlib/test/bit/test_bit.mojo
+++ b/mojo/stdlib/test/bit/test_bit.mojo
@@ -177,9 +177,13 @@ def test_byte_swap():
 
 def test_byte_swap_simd():
     alias simd_width = 4
+    alias int8_t = DType.int8
     alias int16_t = DType.int16
     alias int32_t = DType.int32
     alias int64_t = DType.int64
+
+    alias var1 = SIMD[int8_t, simd_width](0x01, 0x23, 0x45, 0x67)
+    assert_equal(byte_swap(var1), var1)
 
     alias var2 = SIMD[int16_t, simd_width](-0x0123, 0x0000, 0x0102, 0x0201)
     assert_equal(


### PR DESCRIPTION
So it works better with generic programming.

Example use: #3873
