### PR TITLE
[stdlib] Make inferred parameters explicit in `math.mojo`

### DIFF
--- a/max/kernels/src/linalg/accumulate.mojo
+++ b/max/kernels/src/linalg/accumulate.mojo
@@ -846,7 +846,7 @@ struct _Accumulator[
                     for i in range(row_start, row_stop):
                         # The following should be lifted to registers and show up as
                         # FMA instructions.
-                        self[i, j] = fma[type, simd_width](
+                        self[i, j] = fma[dtype=type, width=simd_width](
                             a_vecs[i][lane].cast[type](),
                             b_vec.cast[type](),
                             self[i, j],
@@ -905,7 +905,7 @@ struct _Accumulator[
                     for i in range(row_start, row_stop):
                         # The following should be lifted to registers and show up as
                         # FMA instructions.
-                        self[i, j] = fma[type, simd_width](
+                        self[i, j] = fma[dtype=type, width=simd_width](
                             a_vecs[i][lane].cast[type](),
                             b_vec.cast[type](),
                             self[i, j],

--- a/max/kernels/src/linalg/matmul_neon.mojo
+++ b/max/kernels/src/linalg/matmul_neon.mojo
@@ -91,7 +91,7 @@ struct Inner_matmul_neon(InnerMatmulKernel):
                 for row in range(kernel_rows):
                     var a_val = a_vals[row]
                     var c_val = c_local[row, col]
-                    c_val = fma[c_local.type, simd_size](
+                    c_val = fma[dtype = c_local.type, width=simd_size](
                         a_val[lane], b_val, c_val
                     )
                     c_local[row, col] = c_val


### PR DESCRIPTION
So we can pass them partially bound to higher-order functions. Example: #3083