### PR TITLE
[CI] Remove use of `--remote-header` in new Bazel job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,7 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-name: Build and Test
+name: (Experimental, Bazel) Build and Test
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -47,6 +47,4 @@ jobs:
 
       - name: Build and Test
         run: |
-          ./bazelw test --config=ci --build_tag_filters=-skip-external-ci-${{ matrix.os }} --test_tag_filters=-skip-external-ci-${{ matrix.os }} --remote_header=$BUILDBUDDY_TOKEN -- //... -//max/serve/...
-        env:
-          BUILDBUDDY_TOKEN: ${{ secrets.BUILDBUDDY_TOKEN }}
+          ./bazelw test --config=ci --build_tag_filters=-skip-external-ci-${{ matrix.os }} --test_tag_filters=-skip-external-ci-${{ matrix.os }} -- //... -//max/serve/...


### PR DESCRIPTION
The `BUILDBUDDY_TOKEN` secret is only available to Modular employees part of the new org we set up for public CI.  However, this means when we always specify `--remote_header=$BUILDBUDDY_TOKEN`, it will expand to an empty value for non-Modular folks.  This creates a parsing error and the job never runs.

Workaround this for now by just removing the `remote_header`.  There's other things we need to figure out if we explore remote builds and caching for non-Modular contributors.  This unblocks the job from being experimented with in the non-Modular contributor case.

Uploading will still fail even with this change, but we can figure that out after this lands:

```
ERROR: The Build Event Protocol upload failed: Not retrying publishBuildEvents, no more attempts left: status='Status{code=PERMISSION_DENIED, description=Anonymous access disabled, permission denied., cause=null}' PERMISSION_DENIED: PERMISSION_DENIED: Anonymous access disabled, permission denied. PERMISSION_DENIED: PERMISSION_DENIED: Anonymous access disabled, permission denied.
```

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
