### PR TITLE
[stdlib] Fix block-level sum and prefix sum operations

### DIFF
--- a/max/kernels/test/gpu/basics/test_sum.mojo
+++ b/max/kernels/test/gpu/basics/test_sum.mojo
@@ -21,9 +21,8 @@ from testing import assert_equal
 alias type = DType.uint64
 
 
-fn warp_prefix_sum_kernel[
+fn warp_sum_kernel[
     type: DType,
-    exclusive: Bool,
 ](
     output: UnsafePointer[Scalar[type]],
     input: UnsafePointer[Scalar[type]],
@@ -32,10 +31,10 @@ fn warp_prefix_sum_kernel[
     var tid = global_idx.x
     if tid >= size:
         return
-    output[tid] = warp.prefix_sum[exclusive=exclusive](input[tid])
+    output[tid] = warp.sum(input[tid])
 
 
-def test_warp_prefix_sum[exclusive: Bool](ctx: DeviceContext):
+def test_warp_sum(ctx: DeviceContext):
     alias size = WARP_SIZE
     alias BLOCK_SIZE = WARP_SIZE
 
@@ -54,9 +53,7 @@ def test_warp_prefix_sum[exclusive: Bool](ctx: DeviceContext):
 
     # Launch kernel
     var grid_dim = ceildiv(size, BLOCK_SIZE)
-    ctx.enqueue_function[
-        warp_prefix_sum_kernel[type=type, exclusive=exclusive]
-    ](
+    ctx.enqueue_function[warp_sum_kernel[type=type]](
         out_device.unsafe_ptr(),
         in_device.unsafe_ptr(),
         size,
@@ -69,13 +66,7 @@ def test_warp_prefix_sum[exclusive: Bool](ctx: DeviceContext):
     ctx.synchronize()
 
     for i in range(size):
-        var expected: Scalar[type]
-
-        @parameter
-        if exclusive:
-            expected = i * (i - 1) // 2
-        else:
-            expected = i * (i + 1) // 2
+        var expected: Scalar[type] = size * (size - 1) // 2
 
         assert_equal(
             out_host[i],
@@ -90,10 +81,9 @@ def test_warp_prefix_sum[exclusive: Bool](ctx: DeviceContext):
     out_host.free()
 
 
-fn block_prefix_sum_kernel[
+fn block_sum_kernel[
     type: DType,
     block_size: Int,
-    exclusive: Bool,
 ](
     output: UnsafePointer[Scalar[type]],
     input: UnsafePointer[Scalar[type]],
@@ -102,15 +92,13 @@ fn block_prefix_sum_kernel[
     var tid = global_idx.x
     if tid >= size:
         return
-    output[tid] = block.prefix_sum[exclusive=exclusive, block_size=block_size](
-        input[tid]
-    )
+    output[tid] = block.sum[block_size=block_size, broadcast=True](input[tid])
 
 
-def test_block_prefix_sum[exclusive: Bool](ctx: DeviceContext):
-    # Initialize a block with several warps. The prefix sum for each warp is
-    # tested above.
-    alias BLOCK_SIZE = WARP_SIZE * 13
+def test_block_sum(ctx: DeviceContext):
+    # Initialize a block with several warps. The sum for each warp is tested
+    # above.
+    alias BLOCK_SIZE = WARP_SIZE * 2
     alias size = BLOCK_SIZE
 
     # Allocate and initialize host memory
@@ -128,11 +116,7 @@ def test_block_prefix_sum[exclusive: Bool](ctx: DeviceContext):
 
     # Launch kernel
     var grid_dim = ceildiv(size, BLOCK_SIZE)
-    ctx.enqueue_function[
-        block_prefix_sum_kernel[
-            type=type, block_size=BLOCK_SIZE, exclusive=exclusive
-        ]
-    ](
+    ctx.enqueue_function[block_sum_kernel[type=type, block_size=BLOCK_SIZE]](
         out_device.unsafe_ptr(),
         in_device.unsafe_ptr(),
         size,
@@ -145,13 +129,7 @@ def test_block_prefix_sum[exclusive: Bool](ctx: DeviceContext):
     ctx.synchronize()
 
     for i in range(size):
-        var expected: Scalar[type]
-
-        @parameter
-        if exclusive:
-            expected = i * (i - 1) // 2
-        else:
-            expected = i * (i + 1) // 2
+        var expected: Scalar[type] = size * (size - 1) // 2
 
         assert_equal(
             out_host[i],
@@ -168,8 +146,6 @@ def test_block_prefix_sum[exclusive: Bool](ctx: DeviceContext):
 
 def main():
     with DeviceContext() as ctx:
-        test_warp_prefix_sum[exclusive=True](ctx)
-        test_warp_prefix_sum[exclusive=False](ctx)
+        test_warp_sum(ctx)
 
-        test_block_prefix_sum[exclusive=True](ctx)
-        test_block_prefix_sum[exclusive=False](ctx)
+        test_block_sum(ctx)

--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -59,6 +59,14 @@ what we publish.
 - A new `json` module was added the provides a way to deserialize JSON objects
   into Mojo.
 
+- Fixed GPU `sum` and `prefix_sum` implementations in `gpu.warp` and `gpu.block`
+  modules. Previously, the implementations have been incorrect and would either
+  return wrong results or hang the kernel (due to the deadlock). [PR
+  4508](https://github.com/modular/modular/pull/4508) and [PR
+  4553](https://github.com/modular/modular/pull/4553) by [Kirill
+  Bobyrev](https://github.com/kirillbobyrev) mitigate the found issues and add
+  tests to ensure correctness going forward.
+
 Changes to Python-Mojo interoperability:
 
 - `Python.{unsafe_get_python_exception, throw_python_exception_if_error_state}`

--- a/mojo/stdlib/stdlib/gpu/block.mojo
+++ b/mojo/stdlib/stdlib/gpu/block.mojo
@@ -57,6 +57,7 @@ fn _block_reduce[
     warp_reduce_fn: fn[dtype: DType, width: Int] (
         SIMD[dtype, width]
     ) capturing -> SIMD[dtype, width],
+    broadcast: Bool = False,
 ](val: SIMD[type, width], *, initial_val: SIMD[type, width]) -> SIMD[
     type, width
 ]:
@@ -71,46 +72,59 @@ fn _block_reduce[
         width: The SIMD width for vector operations.
         block_size: The number of threads in the block.
         warp_reduce_fn: A function that performs warp-level reduction.
+        broadcast: If True, the final reduced value is broadcast to all
+            threads in the block. If False, only the first thread will have the
+            complete result.
 
     Args:
         val: The input value from each thread to include in the reduction.
         initial_val: The initial value for the reduction.
 
     Returns:
-        The result of the reduction operation for each thread.
+        If broadcast is True, each thread in the block will receive the reduced
+        value. Otherwise, only the first thread will have the complete result.
     """
     constrained[
         block_size % WARP_SIZE == 0,
         "Block size must be a multiple of warp size",
     ]()
 
-    # Allocate shared memory for inter-warp communication
+    # Allocate shared memory for inter-warp communication.
     alias n_warps = block_size // WARP_SIZE
     var shared_mem = stack_allocation[
         n_warps * width, type, address_space = AddressSpace.SHARED
     ]()
 
-    # Step 1: Perform warp-level reduction
+    # Step 1: Perform warp-level reduction.
     var warp_result = warp_reduce_fn(val)
 
     # Step 2: Store warp results to shared memory
-    if lane_id() == 0:
-        shared_mem.store(warp_id(), warp_result)
+    var wid = warp_id()
+    var lid = lane_id()
+    # Each leader thread (lane 0) is responsible for its warp.
+    if lid == 0:
+        shared_mem.store(wid, warp_result)
 
     barrier()
 
-    # Step 3: Have the first warp reduce the warp results
-    if warp_id() == 0:
-        # Load this warp's share of the warp results
+    # Step 3: Have the first warp reduce all warp results.
+    if wid == 0:
+        # Make sure that the "ghost" warps do not contribute to the sum.
         var block_val = initial_val
-        if lane_id() < n_warps:
-            block_val = shared_mem.load[width=width](lane_id())
+        # Load values from the shared memory (ith lane will have ith warp's
+        # value).
+        if lid < n_warps:
+            block_val = shared_mem.load[width=width](lid)
 
         # Reduce across the first warp
         warp_result = warp_reduce_fn(block_val)
 
-    # Step 4: Broadcast the result from thread 0 to all threads
-    return warp_broadcast(warp_result)
+    @parameter
+    if broadcast:
+        # Broadcast the result to all threads in the block
+        warp_result = block.broadcast[block_size=block_size](warp_result, 0)
+
+    return warp_result
 
 
 # ===-----------------------------------------------------------------------===#
@@ -120,7 +134,7 @@ fn _block_reduce[
 
 @always_inline
 fn sum[
-    type: DType, width: Int, //, *, block_size: Int
+    type: DType, width: Int, //, *, block_size: Int, broadcast: Bool = True
 ](val: SIMD[type, width]) -> SIMD[type, width]:
     """Computes the sum of values across all threads in a block.
 
@@ -131,14 +145,16 @@ fn sum[
         type: The data type of the SIMD elements.
         width: The number of elements in each SIMD vector.
         block_size: The total number of threads in the block.
+        broadcast: If True, the final sum is broadcast to all threads in the
+            block. If False, only the first thread will have the complete sum.
 
     Args:
         val: The SIMD value to reduce. Each thread contributes its value to the
              sum.
 
     Returns:
-        A SIMD value where all threads contain the sum found across the entire
-        block.
+        If broadcast is True, each thread in the block will receive the final
+        sum. Otherwise, only the first thread will have the complete sum.
     """
 
     @parameter
@@ -147,7 +163,9 @@ fn sum[
     ](x: SIMD[dtype, width]) capturing -> SIMD[dtype, width]:
         return warp_sum(x)
 
-    return _block_reduce[block_size, _warp_sum](val, initial_val=0)
+    return _block_reduce[block_size, _warp_sum, broadcast=broadcast](
+        val, initial_val=0
+    )
 
 
 # ===-----------------------------------------------------------------------===#
@@ -157,7 +175,7 @@ fn sum[
 
 @always_inline
 fn max[
-    type: DType, width: Int, //, *, block_size: Int
+    type: DType, width: Int, //, *, block_size: Int, broadcast: Bool = True
 ](val: SIMD[type, width]) -> SIMD[type, width]:
     """Computes the maximum value across all threads in a block.
 
@@ -168,14 +186,18 @@ fn max[
         type: The data type of the SIMD elements.
         width: The number of elements in each SIMD vector.
         block_size: The total number of threads in the block.
+        broadcast: If True, the final reduced value is broadcast to all
+            threads in the block. If False, only the first thread will have the
+            complete result.
 
     Args:
         val: The SIMD value to reduce. Each thread contributes its value to find
              the maximum.
 
     Returns:
-        A SIMD value where all threads contain the maximum value found across
-        the entire block.
+        If broadcast is True, each thread in the block will receive the maximum
+        value across the entire block. Otherwise, only the first thread will
+        have the complete result.
     """
 
     @parameter
@@ -184,7 +206,7 @@ fn max[
     ](x: SIMD[dtype, width]) capturing -> SIMD[dtype, width]:
         return warp_max(x)
 
-    return _block_reduce[block_size, _warp_max](
+    return _block_reduce[block_size, _warp_max, broadcast=broadcast](
         val, initial_val=Scalar[type].MIN_FINITE
     )
 
@@ -196,7 +218,7 @@ fn max[
 
 @always_inline
 fn min[
-    type: DType, width: Int, //, *, block_size: Int
+    type: DType, width: Int, //, *, block_size: Int, broadcast: Bool = True
 ](val: SIMD[type, width]) -> SIMD[type, width]:
     """Computes the minimum value across all threads in a block.
 
@@ -207,14 +229,17 @@ fn min[
         type: The data type of the SIMD elements.
         width: The number of elements in each SIMD vector.
         block_size: The total number of threads in the block.
+        broadcast: If True, the final minimum is broadcast to all threads in the
+            block. If False, only the first thread will have the complete min.
 
     Args:
         val: The SIMD value to reduce. Each thread contributes its value to find
              the minimum.
 
     Returns:
-        A SIMD value where all threads contain the minimum value found across
-        the entire block.
+        If broadcast is True, each thread in the block will receive the minimum
+        value across the entire block. Otherwise, only the first thread will
+        have the complete result.
     """
 
     @parameter
@@ -223,7 +248,7 @@ fn min[
     ](x: SIMD[dtype, width]) capturing -> SIMD[dtype, width]:
         return warp_min(x)
 
-    return _block_reduce[block_size, _warp_min](
+    return _block_reduce[block_size, _warp_min, broadcast=broadcast](
         val, initial_val=Scalar[type].MAX_FINITE
     )
 
@@ -316,30 +341,33 @@ fn prefix_sum[
     var thread_result = warp_prefix_sum[exclusive=exclusive](val)
 
     # Step 2: Store last value from each warp to shared memory
+    var wid = warp_id()
     if lane_id() == WARP_SIZE - 1:
-        warp_mem[warp_id()] = thread_result
+        var inclusive_warp_sum: Scalar[type] = thread_result
+
+        @parameter
+        if exclusive:
+            # For exclusive scan, thread_result is the sum of elements 0 to
+            # WARP_SIZE-2. 'val' is the value of the element at WARP_SIZE-1.
+            # Adding them gives the inclusive sum of the warp.
+            inclusive_warp_sum += val
+
+        warp_mem[wid] = inclusive_warp_sum
 
     barrier()
 
     # Step 3: Have the first warp perform a scan on the warp results
-    if warp_id() == 0 and lane_id() < n_warps:
-        var warp_val = warp_mem[lane_id()]
-
-        # Perform scan on warp results
-        @parameter
-        for offset in range(1, n_warps):
-            var addend = shuffle_up(warp_val, offset)
-            if lane_id() >= offset:
-                warp_val += addend
-
-        # Store scanned warp results back
-        warp_mem[lane_id()] = warp_val
+    var lid = lane_id()
+    if wid == 0:
+        previous_warps_prefix = warp_prefix_sum[exclusive=False](warp_mem[lid])
+        if lid < n_warps:
+            warp_mem[lid] = previous_warps_prefix
 
     barrier()
 
     # Step 4: Add the prefix from previous warps
-    if warp_id() > 0:
-        var warp_prefix = warp_mem[warp_id() - 1]
+    if wid > 0:
+        var warp_prefix = warp_mem[wid - 1]
         thread_result += warp_prefix
 
     return thread_result

--- a/mojo/stdlib/stdlib/gpu/warp.mojo
+++ b/mojo/stdlib/stdlib/gpu/warp.mojo
@@ -736,9 +736,9 @@ fn sum[
 ](val: SIMD[val_type, simd_width]) -> SIMD[val_type, simd_width]:
     """Computes the sum of values across all lanes in a warp.
 
-    This is a convenience wrapper around lane_group_sum that operates on the entire warp.
-    It performs a parallel reduction using warp shuffle operations to find the global sum
-    across all lanes in the warp.
+    This is a convenience wrapper around lane_group_sum_and_broadcast that
+    operates on the entire warp.  It performs a parallel reduction using warp
+    shuffle operations to find the global sum across all lanes in the warp.
 
     Parameters:
         val_type: The data type of the SIMD elements (e.g. float32, int32).
@@ -751,7 +751,7 @@ fn sum[
         A SIMD value where all lanes contain the sum found across the entire warp.
         The sum is broadcast to all lanes.
     """
-    return lane_group_sum[num_lanes=WARP_SIZE](val)
+    return lane_group_sum_and_broadcast[num_lanes=WARP_SIZE](val)
 
 
 @value


### PR DESCRIPTION
Block-level `sum` and `prefix_sum` are not currently implemented correctly. The problems are:

- Multiple places where the execution is blocked (`warp_id()` and `lane_id()` broadcast the values to all warp lanes, but only one of the lanes enters the block where these functions are called - as the result, synchronize operations are blocking the execution because every thread other than the leader is not joining the execution)
- Incorrect `exclusive` handling

This commit is a part of the project submission for "Modular GPU Kernel Hackathon" at the AGI House.