### PR TITLE
[stdlib] Explicitly import `StaticString` in `string_literal.mojo`

### DIFF
--- a/mojo/stdlib/stdlib/builtin/string_literal.mojo
+++ b/mojo/stdlib/stdlib/builtin/string_literal.mojo
@@ -17,7 +17,7 @@ These are Mojo built-ins, so you don't need to import them.
 
 from collections import List
 from collections.string.format import _CurlyEntryFormattable
-from collections.string.string_slice import CodepointSliceIter
+from collections.string.string_slice import CodepointSliceIter, StaticString
 from os import PathLike
 from sys.ffi import c_char
 


### PR DESCRIPTION
Fix #4559. It's good practice anyways.