### PR TITLE
[stdlib] Add KeyElement trait to StringSlice

### DIFF
--- a/mojo/stdlib/stdlib/collections/string/string_slice.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string_slice.mojo
@@ -459,6 +459,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
     ExplicitlyCopyable,
     EqualityComparable,
     Hashable,
+    KeyElement,
     PathLike,
     FloatableRaising,
     Boolable,


### PR DESCRIPTION
Solve all warnings introduced by the ExplicitTraitConformance rule, when using StringSlice as a KeyElement (e.j. in Dict).