### PR TITLE
[bazel] Add separate mojo module

### DIFF
--- a/bazel/mojo.MODULE.bazel
+++ b/bazel/mojo.MODULE.bazel
@@ -1,0 +1,9 @@
+MOJO_VERSION = "25.4.0.dev2025051305"
+
+mojo = use_extension("@rules_mojo//mojo:extensions.bzl", "mojo")
+mojo.toolchain(
+    use_prebuilt_packages = False,
+    version = MOJO_VERSION,
+)
+
+use_repo(mojo, "mojo_toolchains")


### PR DESCRIPTION
We want to push a version update each nightly to stay up to date with the latest version. However the current MODULE.bazel is synced internally, which complicates the copybara setup. This file will be purely public and allows a one-way push each nightly.