### PR TITLE
[CI] Fix buildifier lint, silence warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,19 +19,19 @@ repos:
         entry: mojo format
         language: system
         files: '^(mojo|examples/mojo).*\.(mojo|🔥|py)$'
-        stages: [commit]
+        stages: [pre-commit]
       - id: check-docstrings
         name: check-docstrings
         entry: python3 ./mojo/stdlib/scripts/check-docstrings.py
         language: system
         pass_filenames: false
-        stages: [commit]
+        stages: [pre-commit]
       - id: check-license
         name: check-license
         entry: mojo mojo/stdlib/scripts/check_licenses.mojo
         language: system
         files: '^(mojo|examples/mojo).*\.(mojo|🔥|py)$'
-        stages: [commit]
+        stages: [pre-commit]
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.40.0
     hooks:

--- a/bazel/mojo.MODULE.bazel
+++ b/bazel/mojo.MODULE.bazel
@@ -1,3 +1,5 @@
+"""Define the Mojo toolchain"""
+
 MOJO_VERSION = "25.4.0.dev2025051305"
 
 mojo = use_extension("@rules_mojo//mojo:extensions.bzl", "mojo")
@@ -5,5 +7,4 @@ mojo.toolchain(
     use_prebuilt_packages = False,
     version = MOJO_VERSION,
 )
-
 use_repo(mojo, "mojo_toolchains")


### PR DESCRIPTION
Fixes an error in CI (my fault, sorry).

Also fixes a warning:
```
Warning:  hook id `mojo-format` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
Warning:  hook id `check-docstrings` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
Warning:  hook id `check-license` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
```