### PR TITLE
[stdlib] Optimize `String.write()`

### DIFF
--- a/mojo/stdlib/benchmarks/collections/bench_string.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_string.mojo
@@ -283,6 +283,40 @@ fn bench_write_utf8[
 
 
 # ===-----------------------------------------------------------------------===#
+# Benchmark string write
+# ===-----------------------------------------------------------------------===#
+@parameter
+fn bench_string_write[short: Bool](mut b: Bencher) raises:
+    var items = make_string[1000]("UN_charter_EN.txt")
+    # workaround for "allows writing to mem location ..."
+    # even though I tried using an immutable StringSlice
+    var items_2 = items.copy()
+    var items_3 = items.copy()
+    var items_4 = items.copy()
+    var items_5 = items.copy()
+
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        for _ in range(1_000_000):
+            var res: String
+
+            @parameter
+            if short:  # less than 24 bytes
+                res = String.write(0, " is ", "a", String(" number"))
+            else:  # 5001 bytes long
+                res = String.write(0, items, items_2, items_3, items_4, items_5)
+            keep(Bool(res))
+
+    b.iter[call_fn]()
+    keep(Bool(items))
+    keep(Bool(items_2))
+    keep(Bool(items_3))
+    keep(Bool(items_4))
+    keep(Bool(items_5))
+
+
+# ===-----------------------------------------------------------------------===#
 # Benchmark Main
 # ===-----------------------------------------------------------------------===#
 def main():
@@ -325,6 +359,12 @@ def main():
     """
 
     m.bench_function[bench_string_init](BenchId("bench_string_init"))
+    m.bench_function[bench_string_write[True]](
+        BenchId(String("bench_string_write_short"))
+    )
+    m.bench_function[bench_string_write[False]](
+        BenchId(String("bench_string_write_long"))
+    )
 
     @parameter
     for i in range(len(lengths)):


### PR DESCRIPTION
Optimize `String.write()`

Inspired by #4562

@msaelices it's pretty much the same implementation I showed in https://github.com/modular/modular/pull/4562#issuecomment-2878160467 plus an end character. We should maybe take the join implementation to a `String.write` overload at some point

## Benchmark results

CPU: Intel® Core™ i7-7700HQ

|| old value (ms) | new value (ms) | percentage | magnitude|
|-- | -- | -- | -- | --|
|bench_string_write_short | 41.65 | 40.4554731666667 | 0.0286284878335058 | 1.02947223330614|
|bench_string_write_long | 451.978725333333 | 281.21740075 | 0.377808323737798 | 1.60722175842575|
|average improvement  | - |- | 0.203218405785652 | 1.31834699586594|
