### PR TITLE
[Docs] Updated repo name and paths in the documentation from max to modular

### DIFF
--- a/mojo/CONTRIBUTING.md
+++ b/mojo/CONTRIBUTING.md
@@ -222,7 +222,7 @@ for more details.
 
 #### Fork and clone the repo
 
-Go to the [MAX repo](https://github.com/modular/modular) and click the fork
+Go to the [modular repo](https://github.com/modular/modular) and click the fork
 button:
 
 ![Create Fork](stdlib/docs/images/create-fork.png)
@@ -230,14 +230,14 @@ button:
 Clone your forked repo locally with the command:
 
 ```bash
-git clone git@github.com:[your-username]/max.git
-cd max/mojo
+git clone git@github.com:[your-username]/modular.git
+cd modular
 ```
 
 Add the upstream remote and fetch it:
 
 ```bash
-git remote add upstream git@github.com:modular/max.git
+git remote add upstream git@github.com:modular/modular.git
 git fetch upstream
 ```
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
Updated repo name and paths in the documentation from max to modular, which is from [CONTRIBUTING.md](https://github.com/modular/modular/compare/main...Hundo1018:modular:fix-contribMD-pr?expand=1#diff-779bb712e7e6ca7810a7424d380ffcbb34d0b5fb9db63a3046babced72d3deca).


I noticed the repo name in doc is still 'max' not 'modular', and deal with a simple change, to help those who want to do first time contribution less confuse