### PR TITLE
[stdlib] Migrate off value decorator in `stdlib/gpu`

### DIFF
--- a/mojo/stdlib/stdlib/gpu/_cublas/cublas.mojo
+++ b/mojo/stdlib/stdlib/gpu/_cublas/cublas.mojo
@@ -759,7 +759,7 @@ fn cublasStrmv(
     ]()(handle, uplo, trans, diag, n, _a, lda, x, incx)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cublasPointerMode_t:
     var _value: Int32
@@ -921,7 +921,7 @@ fn cublasDgemmStridedBatched(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cublasMath_t:
     var _value: Int32
@@ -2038,7 +2038,7 @@ fn cublasSrotm(
     ]()(handle, n, x, incx, y, incy, param)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Algorithm:
     var _value: Int32
@@ -2610,7 +2610,7 @@ fn cublasRotgEx(
     ]()(handle, a, b, ab_type, c, s, cs_type, executiontype)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cublasDiagType_t:
     var _value: Int32
@@ -2639,7 +2639,7 @@ struct cublasDiagType_t:
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct ComputeType:
     var _value: Int32
@@ -4655,7 +4655,7 @@ fn cublasAsumEx(
     ]()(handle, n, x, x_type, incx, result, result_type, executiontype)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct FillMode:
     var _value: Int32
@@ -6104,7 +6104,7 @@ fn cublasDtbmv(
     ]()(handle, uplo, trans, diag, n, k, _a, lda, x, incx)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cublasAtomicsMode_t:
     var _value: Int32
@@ -6406,7 +6406,7 @@ fn cublasCherkEx(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cublasSideMode_t:
     var _value: Int32
@@ -7034,7 +7034,7 @@ fn cublasStrmm(
     ]()(handle, side, uplo, trans, diag, m, n, alpha, _a, lda, _b, ldb, _c, ldc)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cublasOperation_t:
     var _value: Int32

--- a/mojo/stdlib/stdlib/gpu/_cublas/cublaslt.mojo
+++ b/mojo/stdlib/stdlib/gpu/_cublas/cublaslt.mojo
@@ -117,7 +117,7 @@ fn cublasLtMatrixTransformDescCreate(
     ]()(transform_desc, scale_type)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Order:
     """Enum for data ordering ."""
@@ -210,7 +210,7 @@ fn cublasLtMatrixLayoutSetAttribute(
     ]()(mat_layout, attr, buf, size_in_bytes)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct ClusterShape:
     """Thread Block Cluster size.
@@ -684,7 +684,7 @@ fn cublasLtGetStatusString(status: Result) raises -> UnsafePointer[Int8]:
     ]()(status)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct PointerMode:
     """UnsafePointer mode to use for alpha/beta ."""
@@ -828,7 +828,7 @@ fn cublasLtMatmulAlgoCheck(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Search:
     """Matmul heuristic search mode
@@ -884,7 +884,7 @@ struct Search:
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct ReductionScheme:
     """Reduction scheme for portions of the dot-product calculated in parallel (a. k. a. "split - K").
@@ -1009,7 +1009,7 @@ struct PreferenceOpaque:
     var data: StaticTuple[UInt64, 8]  # uint64_t data[8]
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cublasLtMatmulDescAttributes_t:
     """Matmul descriptor attributes to define details of the operation. ."""
@@ -1611,7 +1611,7 @@ fn cublasLtMatrixLayoutInit_internal(
     ]()(mat_layout, size, type, rows, cols, ld)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Preference:
     """Algo search preference to fine tune the heuristic function. ."""
@@ -1736,7 +1736,7 @@ struct MatmulAlgorithm:
 alias cublasLtNumericalImplFlags_t = UInt64
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct AlgorithmConfig:
     """Algo Configuration Attributes that can be set according to the Algo capabilities
@@ -1905,7 +1905,7 @@ fn cublasLtMatmulAlgoGetHeuristic(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct InnerShape:
     """Inner size of the kernel.
@@ -1952,7 +1952,7 @@ struct InnerShape:
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct LayoutAttribute:
     """Attributes of memory layout ."""
@@ -2154,7 +2154,7 @@ fn cublasLtLoggerSetLevel(level: Int16) -> Result:
     ]()(level)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Stages:
     """Size and number of stages in which elements are read into shared memory.
@@ -2407,7 +2407,7 @@ fn cublasLtMatmulAlgoInit(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Epilogue:
     """Postprocessing options for the epilogue
@@ -2583,7 +2583,7 @@ fn cublasLtMatrixLayoutCreate(
     ]()(mat_layout, type, rows, cols, ld)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct PointerModeMask:
     """Mask to define pointer mode capability ."""
@@ -2655,7 +2655,7 @@ fn cublasLtMatmulDescCreate(
     ]()(matmul_desc, compute_type, scale_type)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Tile:
     """Tile size (in C/D matrix Rows x Cols).
@@ -3023,7 +3023,7 @@ struct Transform:
     var data: StaticTuple[UInt64, 8]  # uint64_t data[8]
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct TransformDescriptor:
     """Matrix transform descriptor attributes to define details of the operation.

--- a/mojo/stdlib/stdlib/gpu/_cudnn/adv_infer.mojo
+++ b/mojo/stdlib/stdlib/gpu/_cudnn/adv_infer.mojo
@@ -66,7 +66,8 @@ alias cudnnSeqDataStruct = UnsafePointer[NoneType]
 alias cudnnPersistentRNNPlan = NoneType
 
 
-@value
+@fieldwise_init
+@register_passable("trivial")
 struct cudnnRNNInputMode_t:
     var _value: Int32
 
@@ -76,7 +77,8 @@ struct cudnnRNNInputMode_t:
     """Fixed identity matrix in the first layer input GEMM."""
 
 
-@value
+@fieldwise_init
+@register_passable("trivial")
 struct cudnnDirectionMode_t:
     var _value: Int32
 
@@ -86,7 +88,8 @@ struct cudnnDirectionMode_t:
     """Output concatination at each layer."""
 
 
-@value
+@fieldwise_init
+@register_passable("trivial")
 struct cudnnRNNClipMode_t:
     var _value: Int32
 
@@ -96,7 +99,8 @@ struct cudnnRNNClipMode_t:
     """Enables LSTM cell clipping."""
 
 
-@value
+@fieldwise_init
+@register_passable("trivial")
 struct cudnnRNNMode_t:
     var _value: Int32
     alias RNN_RELU = Self(0)
@@ -109,7 +113,8 @@ struct cudnnRNNMode_t:
     """Using h' = tanh(r * Uh(t-1) + Wx) and h = (1 - z) * h' + z * h(t-1)."""
 
 
-@value
+@fieldwise_init
+@register_passable("trivial")
 struct cudnnMultiHeadAttnWeightKind_t:
     var _value: Int32
 
@@ -138,7 +143,8 @@ struct cudnnMultiHeadAttnWeightKind_t:
     "Output projection bias."
 
 
-@value
+@fieldwise_init
+@register_passable("trivial")
 struct cudnnRNNBiasMode_t:
     var _value: Int32
 
@@ -152,7 +158,8 @@ struct cudnnRNNBiasMode_t:
     """Rrnn cell formulas use one recurrent bias in recurrent GEMMs."""
 
 
-@value
+@fieldwise_init
+@register_passable("trivial")
 struct cudnnRNNDataLayout_t:
     var _value: Int32
     alias SEQ_MAJOR_UNPACKED = Self(0)
@@ -203,7 +210,7 @@ fn cudnnGetRNNDescriptor_v6(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnForwardMode_t(Writable):
     var _value: Int8
@@ -764,7 +771,7 @@ fn cudnnGetRNNDescriptor_v8(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnSeqDataAxis_t(Writable):
     var _value: Int8

--- a/mojo/stdlib/stdlib/gpu/_cudnn/backend.mojo
+++ b/mojo/stdlib/stdlib/gpu/_cudnn/backend.mojo
@@ -58,7 +58,7 @@ fn cudnnBackendInitialize(descriptor: UnsafePointer[NoneType]) -> cudnnStatus_t:
     ]()(descriptor)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnBackendKnobType_t(Writable):
     var _value: Int8
@@ -209,7 +209,7 @@ struct cudnnBackendKnobType_t(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnPointwiseMode_t(Writable):
     var _value: Int8
@@ -396,7 +396,7 @@ struct cudnnPointwiseMode_t(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnBackendDescriptorType_t(Writable):
     var _value: Int8
@@ -591,7 +591,7 @@ fn cudnnBackendSetAttribute(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnBackendBehaviorNote_t(Writable):
     var _value: Int8
@@ -644,7 +644,7 @@ struct cudnnBackendBehaviorNote_t(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnBackendLayoutType_t(Writable):
     var _value: Int8
@@ -696,7 +696,7 @@ struct cudnnBackendLayoutType_t(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnBackendNormFwdPhase_t(Writable):
     var _value: Int8
@@ -739,7 +739,7 @@ struct cudnnBackendNormFwdPhase_t(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnBackendHeurMode_t(Writable):
     var _value: Int8
@@ -797,7 +797,7 @@ struct cudnnFractionStruct:
     var denominator: Int64
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnBackendNumericalNote_t(Writable):
     var _value: Int8
@@ -878,7 +878,7 @@ fn cudnnBackendCreateDescriptor(
     ]()(descriptor_type, descriptor)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnBackendAttributeType_t(Writable):
     var _value: Int8
@@ -1005,7 +1005,7 @@ struct cudnnBackendAttributeType_t(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnRngDistribution_t(Writable):
     var _value: Int8
@@ -1057,7 +1057,7 @@ fn cudnnBackendFinalize(descriptor: UnsafePointer[NoneType]) -> cudnnStatus_t:
     ]()(descriptor)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnBackendTensorReordering_t(Writable):
     var _value: Int8
@@ -1103,7 +1103,7 @@ struct cudnnBackendTensorReordering_t(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnBackendAttributeName_t(Writable):
     var _value: Int8
@@ -1872,7 +1872,7 @@ struct cudnnBackendAttributeName_t(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnBackendNormMode_t(Writable):
     var _value: Int8
@@ -1924,7 +1924,7 @@ struct cudnnBackendNormMode_t(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnSignalMode_t(Writable):
     var _value: Int8
@@ -1970,7 +1970,7 @@ struct cudnnSignalMode_t(Writable):
 alias cudnnBackendDescriptor_t = UnsafePointer[NoneType]
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnBnFinalizeStatsMode_t(Writable):
     var _value: Int8
@@ -2013,7 +2013,7 @@ struct cudnnBnFinalizeStatsMode_t(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnGenStatsMode_t(Writable):
     var _value: Int8
@@ -2077,7 +2077,7 @@ fn cudnnBackendExecute(
     ]()(handle, execution_plan, variant_pack)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnResampleMode_t(Writable):
     var _value: Int8
@@ -2163,7 +2163,7 @@ fn cudnnBackendGetAttribute(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnPaddingMode_t(Writable):
     var _value: Int8

--- a/mojo/stdlib/stdlib/gpu/_cudnn/cnn_infer.mojo
+++ b/mojo/stdlib/stdlib/gpu/_cudnn/cnn_infer.mojo
@@ -311,7 +311,7 @@ fn cudnnGetConvolution2dDescriptor(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnFusedOpsConstParamLabel_t(Writable):
     var _value: Int8
@@ -477,7 +477,7 @@ fn cudnnSetConvolutionReorderType(
     ]()(conv_desc, reorder_type)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnReorderType_t(Writable):
     var _value: Int8
@@ -619,7 +619,7 @@ fn cudnnGetConvolutionForwardAlgorithm_v7(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnFusedOps_t(Writable):
     var _value: Int8
@@ -699,7 +699,7 @@ fn cudnnDestroyConvolutionDescriptor(
     ]()(conv_desc)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnFusedOpsPointerPlaceHolder_t(Writable):
     var _value: Int8
@@ -812,7 +812,7 @@ fn cudnnGetConvolutionReorderType(
     ]()(conv_desc, reorder_type)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnFusedOpsVariantParamLabel_t(Writable):
     var _value: Int8
@@ -1327,7 +1327,7 @@ fn cudnnGetConvolutionForwardAlgorithmMaxCount(
     ]()(handle, count)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnConvolutionMode_t(Writable):
     var _value: Int8

--- a/mojo/stdlib/stdlib/gpu/_cudnn/infer.mojo
+++ b/mojo/stdlib/stdlib/gpu/_cudnn/infer.mojo
@@ -78,7 +78,7 @@ alias cudnnCTCLossStruct = UnsafePointer[NoneType]
 alias cudnnRuntimeTag_t = NoneType
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnSoftmaxMode_t(Writable):
     var _value: Int8
@@ -142,7 +142,7 @@ fn cudnnCreate(
     ]()(handle)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnReduceTensorIndices_t(Writable):
     var _value: Int8
@@ -329,7 +329,7 @@ fn cudnnSetPoolingNdDescriptor(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnReduceTensorOp_t(Writable):
     var _value: Int8
@@ -443,7 +443,7 @@ fn cudnnLRNCrossChannelForward(
     ]()(handle, norm_desc, lrn_mode, alpha, x_desc, x, beta, y_desc, y)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnDeterminism_t(Writable):
     var _value: Int8
@@ -491,7 +491,7 @@ alias cudnnAlgorithmDescriptor_t = UnsafePointer[cudnnAlgorithmStruct]
 alias cudnnActivationDescriptor_t = UnsafePointer[cudnnActivationStruct]
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnStatus_t(Writable):
     var _value: Int8
@@ -573,7 +573,7 @@ struct cudnnStatus_t(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnCTCLossAlgo_t(Writable):
     var _value: Int8
@@ -639,7 +639,7 @@ fn cudnnGetFilter4dDescriptor(
     ]()(filter_desc, data_type, format, k, c, h, w)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnTensorFormat_t(Writable):
     var _value: Int8
@@ -808,7 +808,7 @@ fn cudnnSetActivationDescriptor(
     ]()(activation_desc, mode, relu_nan_opt, coef)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnNormAlgo_t(Writable):
     var _value: Int8
@@ -851,7 +851,7 @@ struct cudnnNormAlgo_t(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnOpTensorOp_t(Writable):
     var _value: Int8
@@ -1151,7 +1151,7 @@ fn cudnnDeriveBNTensorDescriptor(
     ]()(derived_bn_desc, x_desc, mode)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnActivationMode_t(Writable):
     var _value: Int8
@@ -1237,7 +1237,7 @@ fn cudnnGetTensorSizeInBytes(
     ]()(tensor_desc, size)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnConvolutionBwdDataAlgo_t(Writable):
     var _value: Int8
@@ -1344,7 +1344,7 @@ fn cudnnGetPooling2dForwardOutputDim(
 alias cudnnLRNDescriptor_t = UnsafePointer[cudnnLRNStruct]
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnSamplerType_t(Writable):
     var _value: Int8
@@ -1411,7 +1411,7 @@ fn cudnnSpatialTfSamplerForward(
     ]()(handle, st_desc, alpha, x_desc, x, grid, beta, y_desc, y)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnNormMode_t(Writable):
     var _value: Int8
@@ -1528,7 +1528,7 @@ fn cudnnGetPooling2dDescriptor(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnNormOps_t(Writable):
     var _value: Int8
@@ -1606,7 +1606,7 @@ alias cudnnSpatialTransformerDescriptor_t = UnsafePointer[
 ]
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnSoftmaxAlgorithm_t(Writable):
     var _value: Int8
@@ -1696,7 +1696,7 @@ fn cudnnGetStream(
     ]()(handle, stream_id)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnBatchNormOps_t(Writable):
     var _value: Int8
@@ -1742,7 +1742,7 @@ struct cudnnBatchNormOps_t(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnConvolutionFwdAlgo_t(Writable):
     var _value: Int8
@@ -1958,7 +1958,8 @@ fn cudnnCreateActivationDescriptor(
     ]()(activation_desc)
 
 
-@value
+@fieldwise_init
+@register_passable("trivial")
 struct libraryPropertyType_t:
     var _value: Int32
     alias MAJOR_VERSION = Self(0)
@@ -1995,7 +1996,7 @@ fn cudnnGetFilterSizeInBytes(
     ]()(filter_desc, size)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnLRNMode_t(Writable):
     var _value: Int8
@@ -2120,7 +2121,7 @@ fn cudnnGetAlgorithmDescriptor(
     ]()(algo_desc, algorithm)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnFoldingDirection_t(Writable):
     var _value: Int8
@@ -2184,7 +2185,7 @@ fn cudnnGetTensorNdDescriptor(
     ]()(tensor_desc, nb_dims_requested, data_type, nb_dims, dim_a, stride_a)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnErrQueryMode_t(Writable):
     var _value: Int8
@@ -2345,7 +2346,7 @@ fn cudnnSetTensor4dDescriptorEx(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnBatchNormMode_t(Writable):
     var _value: Int8
@@ -2435,7 +2436,7 @@ fn cudnnScaleTensor(
     ]()(handle, y_desc, y, alpha)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnSeverity_t(Writable):
     var _value: Int8
@@ -2487,7 +2488,7 @@ struct cudnnSeverity_t(Writable):
 alias cudnnDebug_t = cudnnDebugStruct
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnMathType_t(Writable):
     var _value: Int8
@@ -2536,7 +2537,7 @@ struct cudnnMathType_t(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnNanPropagation_t(Writable):
     var _value: Int8
@@ -2582,7 +2583,7 @@ struct cudnnNanPropagation_t(Writable):
 alias cudnnFilterDescriptor_t = UnsafePointer[cudnnFilterStruct]
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnRNNAlgo_t(Writable):
     var _value: Int8
@@ -2712,7 +2713,7 @@ fn cudnnGetAlgorithmSpaceSize(
     ]()(handle, algo_desc, algo_space_size_in_bytes)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnDataType_t(Writable):
     var _value: Int8
@@ -2914,7 +2915,7 @@ fn cudnnSetSpatialTransformerNdDescriptor(
 alias cudnnAlgorithm_t = cudnnAlgorithmUnionStruct
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnIndicesType_t(Writable):
     var _value: Int8
@@ -3200,7 +3201,7 @@ fn cudnnNormalizationForwardInference(
     )
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnConvolutionBwdFilterAlgo_t(Writable):
     var _value: Int8
@@ -3361,7 +3362,7 @@ fn cudnnDestroyOpTensorDescriptor(
     ]()(op_tensor_desc)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnPoolingMode_t(Writable):
     var _value: Int8
@@ -3463,7 +3464,7 @@ fn cudnnGetDropoutDescriptor(
     ]()(dropout_desc, handle, dropout, states, seed)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct cudnnDivNormMode_t(Writable):
     var _value: Int8

--- a/mojo/stdlib/stdlib/gpu/_cufft/types.mojo
+++ b/mojo/stdlib/stdlib/gpu/_cufft/types.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct LibraryProperty:
     var _value: Int32
@@ -44,7 +44,7 @@ struct LibraryProperty:
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Status(Stringable, Writable):
     var _value: Int8
@@ -134,7 +134,7 @@ struct Status(Stringable, Writable):
 #  CUFFT defines and supports the following data types
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Type(Stringable, Writable):
     var _value: Int8
@@ -188,7 +188,7 @@ struct Type(Stringable, Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Compatibility(Stringable, Writable):
     var _value: Int8
@@ -227,7 +227,7 @@ struct Compatibility(Stringable, Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Property(Stringable, Writable):
     var _value: Int8

--- a/mojo/stdlib/stdlib/gpu/_curand/curand.mojo
+++ b/mojo/stdlib/stdlib/gpu/_curand/curand.mojo
@@ -152,7 +152,8 @@ fn curandGenerateLongLong(
     ]()(generator, output_ptr, num)
 
 
-@value
+@fieldwise_init
+@register_passable("trivial")
 struct libraryPropertyType_t:
     var _value: Int32
     alias MAJOR_VERSION = Self(0)
@@ -182,7 +183,7 @@ fn curandGetProperty(
     ]()(type, value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct curandRngType(Writable):
     """
@@ -537,7 +538,7 @@ alias curandGenerator_st = NoneType
 alias curandGenerator_t = UnsafePointer[curandGenerator_st]
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct curandMethod(Writable):
     """\\cond UNHIDE_ENUMS ."""
@@ -700,7 +701,7 @@ alias curandHistogramM2K_st = Int16
 alias curandMethod_t = curandMethod
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct curandStatus(Writable):
     """
@@ -780,7 +781,7 @@ struct curandStatus(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct curandDirectionVectorSet(Writable):
     """
@@ -1250,7 +1251,7 @@ alias curandHistogramM2_t = UnsafePointer[curandHistogramM2_st]
 alias curandDirectionVectors64_t = StaticTuple[UInt64, 64]
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct curandOrdering(Writable):
     """

--- a/mojo/stdlib/stdlib/gpu/_rocblas/hipblaslt.mojo
+++ b/mojo/stdlib/stdlib/gpu/_rocblas/hipblaslt.mojo
@@ -28,7 +28,7 @@ alias hipblasLtMatrixLayout_t = UnsafePointer[NoneType]
 alias hipblasLtMatmulPreference_t = UnsafePointer[NoneType]
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Status(Writable):
     var _value: Int32
@@ -89,7 +89,7 @@ struct Status(Writable):
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct hipDataType_t:
     var _value: Int32
@@ -110,7 +110,7 @@ struct hipDataType_t:
         return not (self == other)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct hipblasComputeType_t:
     var _value: Int32
@@ -130,7 +130,7 @@ struct hipblasComputeType_t:
         return not (self == other)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct hipblasOperation_t:
     var _value: Int32
@@ -149,7 +149,7 @@ struct hipblasOperation_t:
         return not (self == other)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct hipblasLtMatmulDescAttributes_t:
     var _value: Int32

--- a/mojo/stdlib/stdlib/gpu/_rocblas/types.mojo
+++ b/mojo/stdlib/stdlib/gpu/_rocblas/types.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Handle:
     var _value: UnsafePointer[NoneType]
@@ -24,7 +24,7 @@ struct Handle:
         return self._value == other._value
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Operation:
     var _value: Int32
@@ -47,7 +47,7 @@ struct Operation:
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Fill:
     var _value: Int32
@@ -70,7 +70,7 @@ struct Fill:
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Diagonal:
     var _value: Int32
@@ -92,7 +92,7 @@ struct Diagonal:
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Side:
     var _value: Int32
@@ -115,7 +115,7 @@ struct Side:
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct DataType:
     var _value: Int32
@@ -197,7 +197,7 @@ struct ComputeType:
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Status(Writable):
     var _value: Int32
@@ -274,7 +274,7 @@ struct Status(Writable):
         return abort("unreachable: invalid Status entry")
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct PointerMode:
     var _value: Int32
@@ -296,13 +296,13 @@ struct PointerMode:
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct MallocBase:
     var _value: Int32
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Algorithm:
     var _value: Int32
@@ -324,7 +324,7 @@ struct Algorithm:
         return Int(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct GEAMExOp:
     var _value: Int32

--- a/mojo/stdlib/stdlib/gpu/comm/allreduce.mojo
+++ b/mojo/stdlib/stdlib/gpu/comm/allreduce.mojo
@@ -96,7 +96,7 @@ This constant sets the upper bound for the number of GPUS supported in this algo
 alias _flag_t = DType.uint32
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Signal:
     """A synchronization primitive for coordinating GPU thread blocks across multiple devices.

--- a/mojo/stdlib/stdlib/gpu/host/_nvidia_cuda.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/_nvidia_cuda.mojo
@@ -82,7 +82,7 @@ fn CUDA(stream: DeviceStream) raises -> CUstream:
 # ===----------------------------------------------------------------------=== #
 
 
-@value
+@fieldwise_init("implicit")
 @register_passable("trivial")
 struct TensorMapDataType:
     var _value: Int32
@@ -101,10 +101,6 @@ struct TensorMapDataType:
     alias TFLOAT32 = Self(11)
     alias TFLOAT32_FTZ = Self(12)
 
-    @implicit
-    fn __init__(out self, value: Int32):
-        self._value = value
-
     @staticmethod
     fn from_dtype[dtype: DType]() -> Self:
         constrained[
@@ -121,7 +117,7 @@ struct TensorMapDataType:
             return Self.BFLOAT16
 
 
-@value
+@fieldwise_init("implicit")
 @register_passable("trivial")
 struct TensorMapInterleave:
     var _value: Int32
@@ -130,12 +126,8 @@ struct TensorMapInterleave:
     alias INTERLEAVE_16B = Self(1)
     alias INTERLEAVE_32B = Self(2)
 
-    @implicit
-    fn __init__(out self, value: Int32):
-        self._value = value
 
-
-@value
+@fieldwise_init("implicit")
 @register_passable("trivial")
 struct TensorMapSwizzle(
     Copyable,
@@ -151,10 +143,6 @@ struct TensorMapSwizzle(
     alias SWIZZLE_32B = Self(1)
     alias SWIZZLE_64B = Self(2)
     alias SWIZZLE_128B = Self(3)
-
-    @implicit
-    fn __init__(out self, value: Int32):
-        self._value = value
 
     @always_inline("nodebug")
     fn __int__(self) -> Int:
@@ -190,7 +178,7 @@ struct TensorMapSwizzle(
             writer.write("invalid swizzle")
 
 
-@value
+@fieldwise_init("implicit")
 @register_passable("trivial")
 struct TensorMapL2Promotion:
     var _value: Int32
@@ -200,22 +188,14 @@ struct TensorMapL2Promotion:
     alias L2_128B = Self(2)
     alias L2_256B = Self(3)
 
-    @implicit
-    fn __init__(out self, value: Int32):
-        self._value = value
 
-
-@value
-@register_passable
+@fieldwise_init("implicit")
+@register_passable("trivial")
 struct TensorMapFloatOOBFill:
     var _value: Int32
 
     alias NONE = Self(0)
     alias NAN_REQUEST_ZERO_FMA = Self(1)
-
-    @implicit
-    fn __init__(out self, value: Int32):
-        self._value = value
 
 
 # The TMA descriptor is a 128-byte opaque object filled by the driver API.

--- a/mojo/stdlib/stdlib/gpu/host/_tracing.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/_tracing.mojo
@@ -135,7 +135,8 @@ alias EventPayload = UInt64
 alias NVTXVersion = 2
 
 
-@value
+@fieldwise_init
+@register_passable("trivial")
 struct Color(Intable):
     var _value: Int
 
@@ -153,7 +154,7 @@ struct Color(Intable):
         return self._value
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct _C_EventAttributes:
     var version: UInt16
@@ -200,7 +201,7 @@ fn color_from_category(category: Int) -> Color:
     return Color.PURPLE
 
 
-@register_passable
+@register_passable("trivial")
 struct EventAttributes:
     var _value: _C_EventAttributes
 

--- a/mojo/stdlib/stdlib/gpu/host/constant_memory_mapping.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/constant_memory_mapping.mojo
@@ -19,7 +19,7 @@ constant memory that can be used for efficient data transfer between host and GP
 from collections.string import StaticString
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct ConstantMemoryMapping(Copyable, Movable):
     """Represents a mapping of constant memory between host and device.
@@ -57,20 +57,3 @@ struct ConstantMemoryMapping(Copyable, Movable):
     runtime to determine how much data to transfer between host and device. The size
     must be sufficient to hold all data needed by GPU kernels.
     """
-
-    fn __init__(
-        out self,
-        name: StaticString,
-        ptr: UnsafePointer[NoneType],
-        byte_count: Int,
-    ):
-        """Initializes a new constant memory mapping.
-
-        Args:
-            name: A string identifier for the constant memory mapping.
-            ptr: Pointer to the memory location to be mapped.
-            byte_count: Size of the memory mapping in bytes.
-        """
-        self.name = name
-        self.ptr = ptr
-        self.byte_count = byte_count

--- a/mojo/stdlib/stdlib/gpu/host/device_attribute.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/device_attribute.mojo
@@ -23,7 +23,7 @@ supported features.
 """
 
 
-@value
+@fieldwise_init("implicit")
 @register_passable("trivial")
 struct DeviceAttribute:
     """
@@ -108,16 +108,3 @@ struct DeviceAttribute:
     alias MAX_ACCESS_POLICY_WINDOW_SIZE = Self(109)
     """ CUDA-only: Maximum value of CUaccessPolicyWindow::num_bytes.
     """
-
-    @implicit
-    fn __init__(out self, value: Int32):
-        """
-        Initialize a DeviceAttribute with the given integer value.
-
-        Args:
-            value: The integer value representing a specific device attribute.
-
-        This constructor allows implicit conversion from Int32 to DeviceAttribute,
-        making it easier to use integer constants with this type.
-        """
-        self._value = value

--- a/mojo/stdlib/stdlib/gpu/host/device_context.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/device_context.mojo
@@ -131,7 +131,8 @@ struct _DeviceTimer:
         )
 
 
-@value
+@fieldwise_init
+@register_passable("trivial")
 struct _DeviceBufferMode:
     var _mode: Int
 

--- a/mojo/stdlib/stdlib/gpu/host/dim.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/dim.mojo
@@ -15,7 +15,7 @@
 from utils.index import Index, IndexList
 
 
-@value
+@fieldwise_init("implicit")
 @register_passable("trivial")
 struct Dim(Stringable, Writable):
     """Represents a dimension with up to three components (x, y, z).
@@ -30,15 +30,6 @@ struct Dim(Stringable, Writable):
     This field stores the values for all three dimensions using an IndexList
     with a fixed size of 3. The dimensions are accessed in order: x, y, z.
     """
-
-    @implicit
-    fn __init__(out self, value: IndexList[3]):
-        """Initializes Dim with an IndexList[3].
-
-        Args:
-            value: The IndexList[3] representing the dimension.
-        """
-        self._value = value
 
     @implicit
     fn __init__[I: Indexer](out self, x: I):

--- a/mojo/stdlib/stdlib/gpu/host/func_attribute.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/func_attribute.mojo
@@ -27,7 +27,7 @@ such as shared memory allocation, cache behavior, and cluster configuration.
 """
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Attribute(Writable):
     """Represents GPU kernel function attributes.
@@ -205,7 +205,7 @@ struct Attribute(Writable):
             return writer.write("REQUIRED_CLUSTER_DEPTH")
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct FuncAttribute(Copyable, Movable, EqualityComparable):
     """Implements CUDA's CUfunction_attribute enum for GPU kernel function attributes.

--- a/mojo/stdlib/stdlib/gpu/host/info.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/info.mojo
@@ -35,7 +35,7 @@ alias _KB = 1024
 # ===-----------------------------------------------------------------------===#
 
 
-@value
+@fieldwise_init
 @register_passable
 struct Vendor(Writable):
     """Represents GPU vendors.
@@ -803,7 +803,7 @@ alias MI300X = Info(
 # ===-----------------------------------------------------------------------===#
 
 
-@value
+@fieldwise_init
 @register_passable
 struct Info(Writable):
     """

--- a/mojo/stdlib/stdlib/gpu/host/launch_attribute.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/launch_attribute.mojo
@@ -30,7 +30,7 @@ at a granular level, similar to CUDA's native launch attribute system.
 """
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct LaunchAttributeID(Writable):
     """Identifies the type of launch attribute for GPU kernel execution.
@@ -234,7 +234,7 @@ struct LaunchAttributeID(Writable):
         return writer.write(self._value)
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct LaunchAttributeValue:
     """Represents a value for a CUDA launch attribute.
@@ -290,7 +290,7 @@ struct LaunchAttributeValue:
         self._storage = ptr.bitcast[Self._storage_type]()[]
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct AccessProperty(Writable):
     """Specifies performance hint with AccessPolicyWindow for hit_prop and
@@ -394,7 +394,7 @@ struct AccessProperty(Writable):
         return writer.write("PERSISTING")
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct LaunchAttribute(Copyable, Movable):
     """Represents a complete launch attribute with ID and value.


### PR DESCRIPTION
Migrate off value decorator in `stdlib/gpu`. Part of #4586