### PR TITLE
[stdlib] Migrate off value decorator in `stdlib/test`

### DIFF
--- a/mojo/stdlib/stdlib/collections/string/string_slice.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string_slice.mojo
@@ -458,6 +458,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
     ExplicitlyCopyable,
     EqualityComparable,
     Hashable,
+    _HashableWithHasher,
     KeyElement,
     PathLike,
     FloatableRaising,

--- a/mojo/stdlib/stdlib/pathlib/path.mojo
+++ b/mojo/stdlib/stdlib/pathlib/path.mojo
@@ -72,6 +72,7 @@ struct Path(
     ExplicitlyCopyable,
     PathLike,
     KeyElement,
+    _HashableWithHasher,
 ):
     """The Path object."""
 

--- a/mojo/stdlib/test/asyncrt/function_regress.mojo
+++ b/mojo/stdlib/test/asyncrt/function_regress.mojo
@@ -27,7 +27,7 @@ trait MaybeZeroSized:
         ...
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct ZeroSized(MaybeZeroSized, DevicePassable):
     alias device_type: AnyTrivialRegType = Self
@@ -60,7 +60,7 @@ struct ZeroSized(MaybeZeroSized, DevicePassable):
         writer.write(")")
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct NotZeroSized(MaybeZeroSized, DevicePassable):
     alias device_type: AnyTrivialRegType = Self

--- a/mojo/stdlib/test/builtin/test_bool.mojo
+++ b/mojo/stdlib/test/builtin/test_bool.mojo
@@ -39,7 +39,7 @@ def test_bool_none():
     assert_equal(Bool(test), False)
 
 
-@value
+@fieldwise_init
 struct MyTrue:
     fn __bool__(self) -> Bool:
         return True

--- a/mojo/stdlib/test/builtin/test_debug_assert.mojo
+++ b/mojo/stdlib/test/builtin/test_debug_assert.mojo
@@ -48,7 +48,7 @@ def test_debug_assert_writable():
     print("is reached")
 
 
-@value
+@fieldwise_init
 struct WritableOnly:
     var message: String
 

--- a/mojo/stdlib/test/builtin/test_format_int.mojo
+++ b/mojo/stdlib/test/builtin/test_format_int.mojo
@@ -77,7 +77,7 @@ fn test_hex() raises:
     assert_equal(hex(False), "0x0")
 
 
-@value
+@fieldwise_init
 struct Ind(Intable):
     fn __int__(self) -> Int:
         return 1

--- a/mojo/stdlib/test/builtin/test_rebind.mojo
+++ b/mojo/stdlib/test/builtin/test_rebind.mojo
@@ -47,7 +47,7 @@ def test_rebind_register():
 # ===----------------------------------------------------------------------=== #
 
 
-@value
+@fieldwise_init
 struct MyMemStruct[size: Int]:
     var value: Int
 

--- a/mojo/stdlib/test/builtin/test_repr.mojo
+++ b/mojo/stdlib/test/builtin/test_repr.mojo
@@ -15,7 +15,7 @@
 from testing import assert_equal
 
 
-@value
+@fieldwise_init
 struct Dog(Representable):
     var name: String
     var age: Int
@@ -29,7 +29,7 @@ def test_explicit_conformance():
     assert_equal(repr(dog), "Dog(name='Fido', age=3)")
 
 
-@value
+@fieldwise_init
 struct Cat:
     var name: String
     var age: Int

--- a/mojo/stdlib/test/builtin/test_slice.mojo
+++ b/mojo/stdlib/test/builtin/test_slice.mojo
@@ -23,15 +23,15 @@ def test_none_end_folds():
 
 
 # This requires parameter inference of StartT.
-@value
-struct FunnySlice:
+@fieldwise_init
+struct FunnySlice(Copyable, Movable):
     var start: Int
     var upper: String
     var stride: Float64
 
 
-@value
-struct BoringSlice:
+@fieldwise_init
+struct BoringSlice(Copyable, Movable):
     var a: Int
     var b: Int
     var c: String

--- a/mojo/stdlib/test/builtin/test_sort.mojo
+++ b/mojo/stdlib/test/builtin/test_sort.mojo
@@ -483,7 +483,7 @@ fn test_sort_stress() raises:
         test[_lt, _leq](length)
 
 
-@value
+@fieldwise_init
 struct MyStruct(Copyable, Movable):
     var val: Int
 
@@ -535,7 +535,7 @@ def test_sort_strings():
     assert_sorted_string(strings)
 
 
-@value
+@fieldwise_init
 struct Person(Copyable, Movable, Comparable):
     var name: String
     var age: Int
@@ -598,7 +598,8 @@ fn test_sort_empty_comparable_elements_list() raises:
     assert_true(len(person_list) == 0)
 
 
-@value
+@fieldwise_init
+@register_passable("trivial")
 struct IntPair:
     var x: Int
     var idx: Int

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -32,7 +32,7 @@ from testing import (
 from math import isinf, isnan
 
 
-@value
+@fieldwise_init
 struct AString(Stringable):
     fn __str__(self) -> String:
         return "a string"

--- a/mojo/stdlib/test/collections/test_dict.mojo
+++ b/mojo/stdlib/test/collections/test_dict.mojo
@@ -388,13 +388,9 @@ def test_dict_update_empty_new():
     assert_equal(len(orig), 2)
 
 
-@value
+@fieldwise_init("implicit")
 struct DummyKey(KeyElement):
     var value: Int
-
-    @implicit
-    fn __init__(out self, value: Int):
-        self.value = value
 
     fn __init__(out self, *, other: Self):
         self = other

--- a/mojo/stdlib/test/hashlib/test_hasher.mojo
+++ b/mojo/stdlib/test/hashlib/test_hasher.mojo
@@ -43,8 +43,8 @@ struct DummyHasher(_Hasher):
         return self._dummy_value
 
 
-@value
-struct SomeHashableStruct(_HashableWithHasher):
+@fieldwise_init
+struct SomeHashableStruct(_HashableWithHasher, Copyable, Movable):
     var _value: Int64
 
     fn __hash__[H: _Hasher](self, mut hasher: H):
@@ -63,8 +63,8 @@ def test_hash_with_hasher():
     assert_equal(_hash_with_hasher[HasherType=DummyHasher](hashable), 10)
 
 
-@value
-struct ComplexeHashableStruct(_HashableWithHasher):
+@fieldwise_init
+struct ComplexHashableStruct(_HashableWithHasher):
     var _value1: SomeHashableStruct
     var _value2: SomeHashableStruct
 
@@ -75,21 +75,21 @@ struct ComplexeHashableStruct(_HashableWithHasher):
 
 def test_complex_hasher():
     var hasher = DummyHasher()
-    var hashable = ComplexeHashableStruct(
+    var hashable = ComplexHashableStruct(
         SomeHashableStruct(42), SomeHashableStruct(10)
     )
     hasher.update(hashable)
     assert_equal(hasher^.finish(), 52)
 
 
-def test_complexe_hash_with_hasher():
-    var hashable = ComplexeHashableStruct(
+def test_complex_hash_with_hasher():
+    var hashable = ComplexHashableStruct(
         SomeHashableStruct(42), SomeHashableStruct(10)
     )
     assert_equal(_hash_with_hasher[HasherType=DummyHasher](hashable), 52)
 
 
-@value
+@fieldwise_init
 struct ComplexHashableStructWithList(_HashableWithHasher):
     var _value1: SomeHashableStruct
     var _value2: SomeHashableStruct
@@ -107,7 +107,7 @@ struct ComplexHashableStructWithList(_HashableWithHasher):
         _ = self._value3
 
 
-@value
+@fieldwise_init
 struct ComplexHashableStructWithListAndWideSIMD(_HashableWithHasher):
     var _value1: SomeHashableStruct
     var _value2: SomeHashableStruct
@@ -170,7 +170,7 @@ def main():
     test_hasher()
     test_hash_with_hasher()
     test_complex_hasher()
-    test_complexe_hash_with_hasher()
+    test_complex_hash_with_hasher()
     test_update_with_bytes()
     test_with_ahasher()
     test_hash_hashable_with_hasher_types()

--- a/mojo/stdlib/test/math/test_exp.mojo
+++ b/mojo/stdlib/test/math/test_exp.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo-no-debug %s
 
-from math import exp
+from math.math import exp, _Expable
 from random import randn_float64, seed
 from sys import has_neon
 
@@ -70,8 +70,8 @@ def test_exp_libm[type: DType]():
         )
 
 
-@value
-struct Float32Expable(EqualityComparable, Stringable):
+@fieldwise_init
+struct Float32Expable(EqualityComparable, Stringable, _Expable):
     """This is a test struct that implements the Expable trait for Float32."""
 
     var x: Float32
@@ -89,14 +89,11 @@ struct Float32Expable(EqualityComparable, Stringable):
         return String("Float32Expable(", self.x, ")")
 
 
-@value
-struct FakeExpable(EqualityComparable, Stringable):
+@fieldwise_init
+struct FakeExpable(EqualityComparable, Stringable, _Expable):
     """This is a test struct that has a dummy definition of exp function."""
 
     var x: Int
-
-    fn __init__(out self, x: Int):
-        self.x = x
 
     fn __exp__(self) -> Self:
         return Self(99)

--- a/mojo/stdlib/test/memory/test_memory.mojo
+++ b/mojo/stdlib/test/memory/test_memory.mojo
@@ -36,7 +36,7 @@ alias void = __mlir_attr.`#kgen.dtype.constant<invalid> : !kgen.dtype`
 alias int8_pop = __mlir_type.`!pop.scalar<si8>`
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Pair:
     var lo: Int

--- a/mojo/stdlib/test/os/path/test_expandvars.mojo
+++ b/mojo/stdlib/test/os/path/test_expandvars.mojo
@@ -18,8 +18,8 @@ from os.path import expandvars
 from testing import assert_equal
 
 
-@value
-struct EnvVar:
+@fieldwise_init
+struct EnvVar(Copyable, Movable):
     var name: String
 
     fn __init__(out self, name: String, value: String):

--- a/mojo/stdlib/test/test_utils/types.mojo
+++ b/mojo/stdlib/test/test_utils/types.mojo
@@ -236,8 +236,8 @@ struct MoveCopyCounter(Copyable, Movable):
 # ===----------------------------------------------------------------------=== #
 
 
-@value
-struct DelRecorder(ExplicitlyCopyable):
+@fieldwise_init
+struct DelRecorder(ExplicitlyCopyable, Copyable, Movable):
     var value: Int
     var destructor_counter: UnsafePointer[List[Int]]
 
@@ -249,7 +249,7 @@ struct DelRecorder(ExplicitlyCopyable):
         self.destructor_counter[].append(self.value)
 
     fn copy(self) -> Self:
-        return self
+        return DelRecorder(other=self)
 
 
 # ===----------------------------------------------------------------------=== #
@@ -257,7 +257,7 @@ struct DelRecorder(ExplicitlyCopyable):
 # ===----------------------------------------------------------------------=== #
 
 
-@value
+@fieldwise_init
 struct ObservableDel[origin: MutableOrigin = MutableAnyOrigin](
     Copyable & Movable
 ):
@@ -308,8 +308,8 @@ struct DelCounter(Copyable, Movable, Writable):
 # ===----------------------------------------------------------------------=== #
 
 
-@value
-struct AbortOnDel:
+@fieldwise_init
+struct AbortOnDel(Copyable, Movable):
     var value: Int
 
     fn __del__(owned self):
@@ -321,7 +321,7 @@ struct AbortOnDel:
 # ===----------------------------------------------------------------------=== #
 
 
-@value
+@fieldwise_init
 struct CopyCountedStruct(Copyable, Movable):
     var counter: CopyCounter
     var value: String
@@ -341,7 +341,7 @@ struct CopyCountedStruct(Copyable, Movable):
 # ===----------------------------------------------------------------------=== #
 
 
-@value
+@fieldwise_init
 struct AbortOnCopy(Copyable, ExplicitlyCopyable):
     fn __copyinit__(out self, other: Self):
         abort("We should never implicitly copy AbortOnCopy")

--- a/mojo/stdlib/test/testing/test_assertion.mojo
+++ b/mojo/stdlib/test/testing/test_assertion.mojo
@@ -52,7 +52,7 @@ def test_assert_messages():
         assert_true(assertion in String(e) and assertion_error in String(e))
 
 
-@value
+@fieldwise_init
 struct DummyStruct:
     var value: Int
 

--- a/mojo/stdlib/test/utils/test_write.mojo
+++ b/mojo/stdlib/test/utils/test_write.mojo
@@ -25,7 +25,7 @@ fn main() raises:
     test_write_int_padded()
 
 
-@value
+@fieldwise_init
 struct Point(Writable, Stringable):
     var x: Int
     var y: Int

--- a/mojo/stdlib/test/utils/test_write_to_stdout.mojo
+++ b/mojo/stdlib/test/utils/test_write_to_stdout.mojo
@@ -21,7 +21,7 @@ fn main() raises:
     test_write_to_stdout()
 
 
-@value
+@fieldwise_init
 struct Point(Writable):
     var x: Int
     var y: Int


### PR DESCRIPTION
Migrate off value decorator in `stdlib/test`. Part of #4586