### PR TITLE
[stdlib] Fix `UnsafePointer` origins for `StringSlice` and `Span`

### DIFF
--- a/mojo/stdlib/stdlib/builtin/format_int.mojo
+++ b/mojo/stdlib/stdlib/builtin/format_int.mojo
@@ -325,10 +325,7 @@ fn _try_write_int[
         #   Support printing non-null-terminated strings on GPU and switch
         #   back to this code without a workaround.
         # ptr=digit_chars_array,
-        var zero = StringSlice[ImmutableAnyOrigin](
-            ptr=zero_buf.unsafe_ptr(), length=1
-        )
-        writer.write(zero)
+        writer.write(StringSlice(ptr=zero_buf.unsafe_ptr(), length=1))
 
         return None
 

--- a/mojo/stdlib/stdlib/builtin/sort.mojo
+++ b/mojo/stdlib/stdlib/builtin/sort.mojo
@@ -351,9 +351,7 @@ fn _stable_sort[
     cmp_fn: fn (_SortWrapper[T], _SortWrapper[T]) capturing [_] -> Bool,
 ](span: Span[T, origin]):
     var temp_buff = UnsafePointer[T].alloc(len(span))
-    var temp_buff_span = Span[T, __origin_of(temp_buff)](
-        ptr=temp_buff, length=len(span)
-    )
+    var temp_buff_span = Span(ptr=temp_buff, length=len(span))
     _stable_sort_impl[cmp_fn](span, temp_buff_span)
     temp_buff.free()
 

--- a/mojo/stdlib/stdlib/collections/string/format.mojo
+++ b/mojo/stdlib/stdlib/collections/string/format.mojo
@@ -212,9 +212,7 @@ struct _FormatCurlyEntry(Copyable, Movable, ExplicitlyCopyable):
         fn _build_slice(
             p: UnsafePointer[UInt8, mut=_, origin=_], start: Int, end: Int
         ) -> StringSlice[p.origin]:
-            return StringSlice[p.origin](
-                ptr=p.origin_cast[mut=False]() + start, length=end - start
-            )
+            return StringSlice(ptr=p + start, length=end - start)
 
         var auto_arg_index = 0
         for e in entries:
@@ -331,9 +329,7 @@ struct _FormatCurlyEntry(Copyable, Movable, ExplicitlyCopyable):
         fn _build_slice(
             p: UnsafePointer[UInt8, mut=_, origin=_], start: Int, end: Int
         ) -> StringSlice[p.origin]:
-            return StringSlice[p.origin](
-                ptr=p.origin_cast[mut=False]() + start, length=end - start
-            )
+            return StringSlice(ptr=p + start, length=end - start)
 
         var field = _build_slice(fmt_src.unsafe_ptr(), start_value + 1, i)
         var field_ptr = field.unsafe_ptr()

--- a/mojo/stdlib/stdlib/collections/string/string.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string.mojo
@@ -527,11 +527,7 @@ struct String(
             - `unsafe_from_utf8_ptr` MUST be null terminated.
         """
         # Copy the data.
-        self = String(
-            StringSlice[MutableAnyOrigin](
-                unsafe_from_utf8_ptr=unsafe_from_utf8_ptr
-            )
-        )
+        self = String(StringSlice(unsafe_from_utf8_ptr=unsafe_from_utf8_ptr))
 
     @always_inline
     fn __init__(
@@ -547,11 +543,7 @@ struct String(
             - `unsafe_from_utf8_ptr` MUST be null terminated.
         """
         # Copy the data.
-        self = String(
-            StringSlice[MutableAnyOrigin](
-                unsafe_from_utf8_ptr=unsafe_from_utf8_ptr
-            )
-        )
+        self = String(StringSlice(unsafe_from_utf8_ptr=unsafe_from_utf8_ptr))
 
     @always_inline("nodebug")
     fn __moveinit__(out self, owned other: Self):
@@ -1044,7 +1036,9 @@ struct String(
         Returns:
             The joined string.
         """
-        var sep = StaticString(ptr=self.unsafe_ptr(), length=len(self))
+        var sep = rebind[StaticString](  # FIXME(#4414): this should not be so
+            StringSlice(ptr=self.unsafe_ptr(), length=len(self))
+        )
         return String(elems, sep=sep)
 
     fn join[

--- a/mojo/stdlib/stdlib/collections/string/string_slice.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string_slice.mojo
@@ -545,7 +545,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         self = StaticString(lit.value)
 
     @always_inline("builtin")
-    fn __init__(out self, *, unsafe_from_utf8: Span[Byte, origin]):
+    fn __init__(out self, *, unsafe_from_utf8: Span[Byte, origin, **_]):
         """Construct a new `StringSlice` from a sequence of UTF-8 encoded bytes.
 
         Args:
@@ -562,14 +562,24 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         # debug_assert(
         #     _is_valid_utf8(value.as_bytes()), "value is not valid utf8"
         # )
-        self._slice = unsafe_from_utf8
+        self._slice = Span[Byte, origin](
+            ptr=unsafe_from_utf8.unsafe_ptr()
+            .address_space_cast[Span[Byte, origin].address_space]()
+            .static_alignment_cast[Span[Byte, origin].alignment](),
+            length=unsafe_from_utf8.__len__(),
+        )
 
-    fn __init__(out self, *, unsafe_from_utf8_ptr: UnsafePointer[Byte]):
-        """Construct a new StringSlice from a `UnsafePointer[Byte]` pointing to null-terminated UTF-8
-        encoded bytes.
+    fn __init__(
+        out self,
+        *,
+        unsafe_from_utf8_ptr: UnsafePointer[Byte, mut=mut, origin=origin, **_],
+    ):
+        """Construct a new StringSlice from a `UnsafePointer[Byte]` pointing to
+        null-terminated UTF-8 encoded bytes.
 
         Args:
-            unsafe_from_utf8_ptr: An `UnsafePointer[Byte]` of null-terminated bytes encoded in UTF-8.
+            unsafe_from_utf8_ptr: An `UnsafePointer[Byte]` of null-terminated
+                bytes encoded in UTF-8.
 
         Safety:
             - `unsafe_from_utf8_ptr` MUST point to data that is valid for
@@ -578,18 +588,25 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
             - `unsafe_from_utf8_ptr` MUST be null terminated.
         """
 
-        var byte_slice = Span[Byte, origin](
+        var byte_slice = Span(
             ptr=unsafe_from_utf8_ptr,
             length=_unsafe_strlen(unsafe_from_utf8_ptr),
         )
         self = Self(unsafe_from_utf8=byte_slice)
 
-    fn __init__(out self, *, unsafe_from_utf8_ptr: UnsafePointer[c_char]):
-        """Construct a new StringSlice from a `UnsafePointer[c_char]` pointing to null-terminated UTF-8
-        encoded bytes.
+    fn __init__(
+        out self,
+        *,
+        unsafe_from_utf8_ptr: UnsafePointer[
+            c_char, mut=mut, origin=origin, **_
+        ],
+    ):
+        """Construct a new StringSlice from a `UnsafePointer[c_char]` pointing
+        to null-terminated UTF-8 encoded bytes.
 
         Args:
-            unsafe_from_utf8_ptr: An `UnsafePointer[c_char]` of null-terminated bytes encoded in UTF-8.
+            unsafe_from_utf8_ptr: An `UnsafePointer[c_char]` of null-terminated
+                bytes encoded in UTF-8.
 
         Safety:
             - `unsafe_from_utf8_ptr` MUST be valid UTF-8 encoded data.
@@ -602,7 +619,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
     fn __init__(
         out self,
         *,
-        ptr: UnsafePointer[Byte, mut=mut, origin=origin],
+        ptr: UnsafePointer[Byte, mut=mut, origin=origin, **_],
         length: UInt,
     ):
         """Construct a `StringSlice` from a pointer to a sequence of UTF-8
@@ -618,7 +635,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
             - `ptr` must point to data that is live for the duration of
                 `origin`.
         """
-        self = Self(unsafe_from_utf8=Span[Byte, origin](ptr=ptr, length=length))
+        self = Self(unsafe_from_utf8=Span(ptr=ptr, length=length))
 
     @always_inline
     fn copy(self) -> Self:
@@ -2330,16 +2347,17 @@ fn _to_string_list[O: Origin](items: List[Span[Byte, O]]) -> List[String]:
 
 
 @always_inline
-fn _unsafe_strlen(owned ptr: UnsafePointer[Byte]) -> Int:
-    """
-    Get the length of a null-terminated string from a pointer.
-    Note: the length does NOT include the null terminator.
+fn _unsafe_strlen(ptr: UnsafePointer[Byte, mut=False, **_]) -> Int:
+    """Get the length of a null-terminated string from a pointer.
 
     Args:
         ptr: The null-terminated pointer to the string.
 
     Returns:
         The length of the null terminated string without the null terminator.
+
+    Notes:
+        The length does NOT include the null terminator.
     """
     var len = 0
     while ptr[len]:
@@ -2351,8 +2369,10 @@ fn _unsafe_strlen(owned ptr: UnsafePointer[Byte]) -> Int:
 fn _memchr[
     dtype: DType, //
 ](
-    source: UnsafePointer[Scalar[dtype]], char: Scalar[dtype], len: Int
-) -> UnsafePointer[Scalar[dtype]]:
+    source: UnsafePointer[Scalar[dtype], mut=False, **_],
+    char: Scalar[dtype],
+    len: Int,
+) -> __type_of(source):
     if is_compile_time() or len < simdwidthof[dtype]():
         return _memchr_simple(source, char, len)
     else:
@@ -2363,22 +2383,26 @@ fn _memchr[
 fn _memchr_simple[
     dtype: DType, //
 ](
-    source: UnsafePointer[Scalar[dtype]], char: Scalar[dtype], len: Int
-) -> UnsafePointer[Scalar[dtype]]:
+    source: UnsafePointer[Scalar[dtype], mut=False, **_],
+    char: Scalar[dtype],
+    len: Int,
+) -> __type_of(source):
     for i in range(len):
         if source[i] == char:
             return source + i
-    return UnsafePointer[Scalar[dtype]]()
+    return {}
 
 
 @always_inline
 fn _memchr_impl[
     dtype: DType, //
 ](
-    source: UnsafePointer[Scalar[dtype]], char: Scalar[dtype], len: Int
-) -> UnsafePointer[Scalar[dtype]]:
+    source: UnsafePointer[Scalar[dtype], mut=False, **_],
+    char: Scalar[dtype],
+    len: Int,
+) -> __type_of(source):
     if not len:
-        return UnsafePointer[Scalar[dtype]]()
+        return {}
     alias bool_mask_width = simdwidthof[DType.bool]()
     var first_needle = SIMD[dtype, bool_mask_width](char)
     var vectorized_end = align_down(len, bool_mask_width)
@@ -2392,22 +2416,26 @@ fn _memchr_impl[
     for i in range(vectorized_end, len):
         if source[i] == char:
             return source + i
-    return UnsafePointer[Scalar[dtype]]()
+    return {}
 
 
 @always_inline
 fn _memmem[
-    dtype: DType, //
+    dtype: DType, address_space: AddressSpace, //
 ](
-    haystack: UnsafePointer[Scalar[dtype]],
+    haystack: UnsafePointer[
+        Scalar[dtype], address_space=address_space, mut=False, **_
+    ],
     haystack_len: Int,
-    needle: UnsafePointer[Scalar[dtype]],
+    needle: UnsafePointer[
+        Scalar[dtype], address_space=address_space, mut=False, **_
+    ],
     needle_len: Int,
-) -> UnsafePointer[Scalar[dtype]]:
+) -> __type_of(haystack):
     if not needle_len:
         return haystack
     if needle_len > haystack_len:
-        return UnsafePointer[Scalar[dtype]]()
+        return {}
     if needle_len == 1:
         return _memchr(haystack, needle[0], haystack_len)
 
@@ -2419,13 +2447,17 @@ fn _memmem[
 
 @always_inline
 fn _memmem_impl_simple[
-    dtype: DType, //
+    dtype: DType, address_space: AddressSpace, //
 ](
-    haystack: UnsafePointer[Scalar[dtype]],
+    haystack: UnsafePointer[
+        Scalar[dtype], address_space=address_space, mut=False, **_
+    ],
     haystack_len: Int,
-    needle: UnsafePointer[Scalar[dtype]],
+    needle: UnsafePointer[
+        Scalar[dtype], address_space=address_space, mut=False, **_
+    ],
     needle_len: Int,
-) -> UnsafePointer[Scalar[dtype]]:
+) -> __type_of(haystack):
     for i in range(haystack_len - needle_len + 1):
         if haystack[i] != needle[0]:
             continue
@@ -2433,18 +2465,22 @@ fn _memmem_impl_simple[
         if memcmp(haystack + i + 1, needle + 1, needle_len - 1) == 0:
             return haystack + i
 
-    return UnsafePointer[Scalar[dtype]]()
+    return {}
 
 
 @always_inline
 fn _memmem_impl[
-    dtype: DType, //
+    dtype: DType, address_space: AddressSpace, //
 ](
-    haystack: UnsafePointer[Scalar[dtype]],
+    haystack: UnsafePointer[
+        Scalar[dtype], address_space=address_space, mut=False, **_
+    ],
     haystack_len: Int,
-    needle: UnsafePointer[Scalar[dtype]],
+    needle: UnsafePointer[
+        Scalar[dtype], address_space=address_space, mut=False, **_
+    ],
     needle_len: Int,
-) -> UnsafePointer[Scalar[dtype]]:
+) -> __type_of(haystack):
     alias bool_mask_width = simdwidthof[DType.bool]()
     var vectorized_end = align_down(
         haystack_len - needle_len + 1, bool_mask_width
@@ -2480,36 +2516,42 @@ fn _memmem_impl[
         if memcmp(haystack + i + 1, needle + 1, needle_len - 1) == 0:
             return haystack + i
 
-    return UnsafePointer[Scalar[dtype]]()
+    return {}
 
 
 @always_inline
 fn _memrchr[
     dtype: DType
 ](
-    source: UnsafePointer[Scalar[dtype]], char: Scalar[dtype], len: Int
-) -> UnsafePointer[Scalar[dtype]]:
+    source: UnsafePointer[Scalar[dtype], mut=False, **_],
+    char: Scalar[dtype],
+    len: Int,
+) -> __type_of(source):
     if not len:
-        return UnsafePointer[Scalar[dtype]]()
+        return {}
     for i in reversed(range(len)):
         if source[i] == char:
             return source + i
-    return UnsafePointer[Scalar[dtype]]()
+    return {}
 
 
 @always_inline
 fn _memrmem[
-    dtype: DType
+    dtype: DType, address_space: AddressSpace
 ](
-    haystack: UnsafePointer[Scalar[dtype]],
+    haystack: UnsafePointer[
+        Scalar[dtype], address_space=address_space, mut=False, **_
+    ],
     haystack_len: Int,
-    needle: UnsafePointer[Scalar[dtype]],
+    needle: UnsafePointer[
+        Scalar[dtype], address_space=address_space, mut=False, **_
+    ],
     needle_len: Int,
-) -> UnsafePointer[Scalar[dtype]]:
+) -> __type_of(haystack):
     if not needle_len:
         return haystack
     if needle_len > haystack_len:
-        return UnsafePointer[Scalar[dtype]]()
+        return {}
     if needle_len == 1:
         return _memrchr[dtype](haystack, needle[0], haystack_len)
     for i in reversed(range(haystack_len - needle_len + 1)):
@@ -2517,7 +2559,7 @@ fn _memrmem[
             continue
         if memcmp(haystack + i + 1, needle + 1, needle_len - 1) == 0:
             return haystack + i
-    return UnsafePointer[Scalar[dtype]]()
+    return {}
 
 
 fn _split[

--- a/mojo/stdlib/stdlib/utils/write.mojo
+++ b/mojo/stdlib/stdlib/utils/write.mojo
@@ -304,9 +304,7 @@ struct _WriteBufferStack[
 
     fn flush(mut self):
         self.writer[].write_bytes(
-            Span[Byte, ImmutableAnyOrigin](
-                ptr=self.data.unsafe_ptr(), length=self.pos
-            )
+            Span(ptr=self.data.unsafe_ptr(), length=self.pos)
         )
         self.pos = 0
 


### PR DESCRIPTION
Part of https://github.com/modular/modular/pull/4396

I had to do both `StringSlice` and `Span` in one PR because they are too intertwined.