### PR TITLE
[stdlib] Add `StringSlice(mut String)` constructor

### DIFF
--- a/mojo/stdlib/stdlib/collections/string/string_slice.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string_slice.mojo
@@ -630,7 +630,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         return Self(unsafe_from_utf8=self._slice)
 
     @implicit
-    fn __init__[  # TODO: no reason for this to force immutability.
+    fn __init__[
         origin: ImmutableOrigin, //
     ](out self: StringSlice[origin], ref [origin]value: String):
         """Construct an immutable StringSlice.
@@ -642,6 +642,19 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
             value: The string value.
         """
         self = value.as_string_slice()
+
+    fn __init__[
+        origin: MutableOrigin, //
+    ](out self: StringSlice[origin], ref [origin]value: String):
+        """Construct a mutable StringSlice.
+
+        Parameters:
+            origin: The mutable origin.
+
+        Args:
+            value: The string value.
+        """
+        self = value.as_string_slice_mut()
 
     # ===-------------------------------------------------------------------===#
     # Factory methods

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -70,6 +70,18 @@ fn test_string_slice_layout() raises:
     assert_equal(second_word_ptr - base_ptr, sizeof[Int]())
 
 
+def test_constructors():
+    def some_func_immut(b: StringSlice[mut=False]):
+        assert_false(b.mut)
+
+    def some_func_mut(b: StringSlice[mut=True]):
+        assert_true(b.mut)
+
+    var a = String("123")
+    some_func_immut(a)
+    some_func_mut(StringSlice(a))
+
+
 fn test_string_literal_byte_span() raises:
     alias slc = "Hello".as_bytes()
 
@@ -1018,6 +1030,7 @@ def test_merge():
 
 def main():
     test_string_slice_layout()
+    test_constructors()
     test_string_literal_byte_span()
     test_string_byte_span()
     test_heap_string_from_string_slice()


### PR DESCRIPTION
Add `StringSlice(mut String)` constructor.

The separate constructor can't be implicit because there would be conflicts with the existing immutable one.

I tried doing
```mojo
    fn __init__[
        origin: Origin, //
    ](out self: StringSlice[origin], ref [origin]value: String):
        @parameter
        if origin.mut:
            self = value.as_string_slice_mut()
        else:
            self = value.as_string_slice()
```
but it segfaults