### PR TITLE
[stdlib] Change `polynomial_evaluate` to accept a list of scalar coefficients

### DIFF
--- a/max/kernels/benchmarks/math/bench_exp.mojo
+++ b/max/kernels/benchmarks/math/bench_exp.mojo
@@ -205,7 +205,7 @@ fn exp_sleef[
 fn _exp_taylor0[
     type: DType, simd_width: Int
 ](x: SIMD[type, simd_width]) -> SIMD[type, simd_width]:
-    alias coefficients = List[SIMD[type, simd_width]](
+    alias coefficients = List[Scalar[type]](
         1.0,
         1.0,
         0.5,
@@ -275,7 +275,7 @@ fn exp_mojo_opt2[
 fn _exp_taylor3[
     type: DType, simd_width: Int
 ](x: SIMD[type, simd_width]) -> SIMD[type, simd_width]:
-    alias coefficients = List[SIMD[type, simd_width]](
+    alias coefficients = List[Scalar[type]](
         0.5,
         0.16666666666666666667,
         0.041666666666666666667,
@@ -315,7 +315,7 @@ fn _exp_taylor_mlas[
     type: DType, simd_width: Int
 ](x: SIMD[type, simd_width]) -> SIMD[type, simd_width]:
     return polynomial_evaluate[
-        List[SIMD[type, simd_width]](
+        List[Scalar[type]](
             1.0,
             1.0,
             0.499999851,

--- a/mojo/stdlib/stdlib/math/math.mojo
+++ b/mojo/stdlib/stdlib/math/math.mojo
@@ -447,7 +447,7 @@ fn exp2[
     xc -= m.cast[dtype]()
 
     var r = polynomial_evaluate[
-        List[SIMD[dtype, width]](
+        List[Scalar[dtype]](
             1.0,
             0.693144857883,
             0.2401793301105,
@@ -566,7 +566,7 @@ trait _Expable:
 fn _exp_taylor[
     dtype: DType, width: Int, //
 ](x: SIMD[dtype, width]) -> SIMD[dtype, width]:
-    alias coefficients = List[SIMD[dtype, width]](
+    alias coefficients = List[Scalar[dtype]](
         1.0,
         1.0,
         0.5,
@@ -773,7 +773,7 @@ fn _log_base[
 
     var y = (
         polynomial_evaluate[
-            List[SIMD[dtype, width]](
+            List[Scalar[dtype]](
                 3.3333331174e-1,
                 -2.4999993993e-1,
                 2.0000714765e-1,
@@ -934,7 +934,7 @@ fn erf[
     var x_abs = abs(x)
 
     var r_large = polynomial_evaluate[
-        List[SIMD[dtype, width]](
+        List[Scalar[dtype]](
             1.28717512e-1,
             6.34846687e-1,
             1.06777847e-1,
@@ -949,7 +949,7 @@ fn erf[
     r_large = copysign(1 - exp(-r_large), x)
 
     var r_small = polynomial_evaluate[
-        List[SIMD[dtype, width]](
+        List[Scalar[dtype]](
             1.28379151e-1,
             -3.76124859e-1,
             1.12818025e-1,
@@ -1025,7 +1025,7 @@ fn tanh[
     var x_squared = xc * xc
 
     var numerator = xc * polynomial_evaluate[
-        List[SIMD[dtype, width]](
+        List[Scalar[dtype]](
             4.89352455891786e-03,
             6.37261928875436e-04,
             1.48572235717979e-05,
@@ -1037,7 +1037,7 @@ fn tanh[
     ](x_squared)
 
     var denominator = polynomial_evaluate[
-        List[SIMD[dtype, width]](
+        List[Scalar[dtype]](
             4.89352518554385e-03,
             2.26843463243900e-03,
             1.18534705686654e-04,
@@ -1646,7 +1646,7 @@ fn _atanh_float32(x: SIMD) -> __type_of(x):
     # When x is in the range [0, 0.5], we use a polynomial approximation.
     # P(x) = x + x^3*(c[4] + x^2 * (c[3] + x^2 * (... x^2 * c[0]) ... )).
     var p = polynomial_evaluate[
-        List[__type_of(x)](
+        List[Scalar[x.dtype]](
             0.3333373963832855224609375,
             0.1997792422771453857421875,
             0.14672131836414337158203125,

--- a/mojo/stdlib/stdlib/math/polynomial.mojo
+++ b/mojo/stdlib/stdlib/math/polynomial.mojo
@@ -28,14 +28,14 @@ from math.polynomial import polynomial_evaluate
 @always_inline
 fn polynomial_evaluate[
     dtype: DType,
-    simd_width: Int, //,
-    coefficients: List[SIMD[dtype, simd_width], *_],
-](x: SIMD[dtype, simd_width]) -> SIMD[dtype, simd_width]:
+    width: Int, //,
+    coefficients: List[Scalar[dtype], *_],
+](x: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Evaluates the polynomial.
 
     Parameters:
         dtype: The dtype of the value.
-        simd_width: The simd_width of the computed value.
+        width: The width of the computed value.
         coefficients: The coefficients.
 
     Args:
@@ -56,9 +56,9 @@ fn polynomial_evaluate[
 @always_inline
 fn _horner_evaluate[
     dtype: DType,
-    simd_width: Int, //,
-    coefficients: List[SIMD[dtype, simd_width], *_],
-](x: SIMD[dtype, simd_width]) -> SIMD[dtype, simd_width]:
+    width: Int, //,
+    coefficients: List[Scalar[dtype], *_],
+](x: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Evaluates the polynomial using the passed in value and the specified
     coefficients using the Horner scheme. The Horner scheme evaluates the
     polynomial at point x as `horner(x, coeffs)` where x is a scalar and coeffs
@@ -71,7 +71,7 @@ fn _horner_evaluate[
 
     Parameters:
         dtype: The dtype of the value.
-        simd_width: The simd_width of the computed value.
+        width: The width of the computed value.
         coefficients: The coefficients.
 
     Args:

--- a/mojo/stdlib/test/math/test_polynomial.mojo
+++ b/mojo/stdlib/test/math/test_polynomial.mojo
@@ -19,7 +19,7 @@ from testing import assert_equal
 
 def test_polynomial_evaluate_degree3():
     # Evaluate 1000 + x + x^2
-    alias coeffs = List[SIMD[DType.float64, 1]](1000.0, 1.0, 1.0)
+    alias coeffs = List[Float64](1000.0, 1.0, 1.0)
 
     assert_equal(_horner_evaluate[coeffs](1.0), 1002.0)
     assert_equal(polynomial_evaluate[coeffs](1.0), 1002.0)
@@ -29,9 +29,7 @@ def test_polynomial_evaluate_degree3():
 
 def test_polynomial_evaluate_degree4():
     # Evalaute 1000 + 99 x - 43 x^2 + 12 x^3 - 14 x^4
-    alias coeffs = List[SIMD[DType.float64, 1]](
-        1000.0, 99.0, -43.0, 12.0, -14.0
-    )
+    alias coeffs = List[Float64](1000.0, 99.0, -43.0, 12.0, -14.0)
 
     assert_equal(_horner_evaluate[coeffs](1.0), 1054.0)
     assert_equal(polynomial_evaluate[coeffs](1.0), 1054.0)
@@ -42,7 +40,7 @@ def test_polynomial_evaluate_degree4():
 def test_polynomial_evaluate_degree10():
     # Evaluate 20.0 + 9.0 x + 1.0 x^2 + 1.0 x^3 + 1.0 x^4 + 1.0 x^5 + 1.0 x^6 +
     # 1.0 x^7 + 1.0 x^8 + 43.0 x^9 + 10.0 x^10
-    alias coeffs = List[SIMD[DType.float64, 1]](
+    alias coeffs = List[Float64](
         20.0, 9.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 43.0, 10.0
     )
 


### PR DESCRIPTION
- I see no reason for it to take a comptime list of simd values
- Also renamed the parameter `simd_width` to `width` to match other `math` functions