### PR TITLE
[All] Fix typo 'seperate' -> 'separate'

### DIFF
--- a/max/kernels/src/nn/mha.mojo
+++ b/max/kernels/src/nn/mha.mojo
@@ -397,7 +397,7 @@ fn flash_attention_dispatch[
     alias depth = config.depth
     alias group = config.num_heads // kv_num_heads
 
-    # K V smem is only seperate for GPUs with shared memory greater or equal to A100's.
+    # K V smem is only separate for GPUs with shared memory greater or equal to A100's.
     alias is_shared_kv = ctx.device_info.shared_memory_per_multiprocessor < A100.shared_memory_per_multiprocessor
 
     constrained[depth == q.shape.get[rank - 1]()]()
@@ -508,7 +508,7 @@ fn flash_attention_dispatch[
             # smem for q
             var shared_mem_bytes = BM * depth * sizeof[q.type]()
 
-            # seperate KV smem if we have enough smem
+            # separate KV smem if we have enough smem
             @parameter
             if not is_shared_kv:
                 shared_mem_bytes += 2 * BN * depth * sizeof[k_t.type]()

--- a/max/nn/attention/interfaces.py
+++ b/max/nn/attention/interfaces.py
@@ -36,7 +36,7 @@ from ..linear import LinearV1
 class AttentionImpl(Layer, ABC):
     """
     A generalized attention interface, that will be used upstream by a general Transformer.
-    We would expect a seperate subclass, articulating each variation of Attention:
+    We would expect a separate subclass, articulating each variation of Attention:
 
     - AttentionWithRope
     - AttentionWithAlibi
@@ -138,7 +138,7 @@ class DistributedAttentionImpl(Module, ABC):
 class AttentionImplQKV(Layer, ABC):
     """
     A generalized attention interface, that will be used upstream by a general Transformer.
-    We would expect a seperate subclass, articulating each variation of Attention:
+    We would expect a separate subclass, articulating each variation of Attention:
 
     - AttentionWithRope
     - AttentionWithAlibi

--- a/max/serve/config.py
+++ b/max/serve/config.py
@@ -57,7 +57,7 @@ class MetricRecordingMethod(Enum):
     SYNC = "SYNC"
     # Record metrics asynchronously using asyncio
     ASYNCIO = "ASYNCIO"
-    # Send metric observations to a seperate process for recording
+    # Send metric observations to a separate process for recording
     PROCESS = "PROCESS"
 
 

--- a/mojo/stdlib/stdlib/algorithm/functional.mojo
+++ b/mojo/stdlib/stdlib/algorithm/functional.mojo
@@ -249,7 +249,7 @@ fn vectorize[
     ```
 
     If the remainder is not an exponent of 2 (2, 4, 8, 16 ...) there will be a
-    seperate iteration for each element. However passing `size` as a parameter
+    separate iteration for each element. However passing `size` as a parameter
     also allows the loop for the remaining elements to be unrolled.
 
     You can also unroll the main loop to potentially improve performance at the


### PR DESCRIPTION
## Summary
- correct the typo `seperate` in comments across the repo

## Testing
- `pre-commit` *(fails: command not found)*