### PR TITLE
[All] Fix typos across repository

### DIFF
--- a/benchmark/benchmark_serving.py
+++ b/benchmark/benchmark_serving.py
@@ -48,7 +48,7 @@ AIOHTTP_TIMEOUT = aiohttp.ClientTimeout(total=10 * 60)
 logger = logging.getLogger("benchmark_serving")
 
 
-CODE_DEBUG_TEMPLATE = "There is ONLY ONE function in the large project that is deliberately made to include an obvious error. Please find the function that contains the most obvious errors. I will give you four options to narrow your scope. You can inspect the options and think. Eventually, tell me the answer using one single letter (A, B, C, or D).\n\n{context}\n\nWhich funtion has deliberate error?\nA. {OPTION_A}\nB. {OPTION_B}\nC. {OPTION_C}\nD. {OPTION_D}\n\nYou should first find the functions in the options. Repeat their content, inspect through code, and at last give me your answer for the function that has the deliberate and obvious error in A, B, C, or D."
+CODE_DEBUG_TEMPLATE = "There is ONLY ONE function in the large project that is deliberately made to include an obvious error. Please find the function that contains the most obvious errors. I will give you four options to narrow your scope. You can inspect the options and think. Eventually, tell me the answer using one single letter (A, B, C, or D).\n\n{context}\n\nWhich function has deliberate error?\nA. {OPTION_A}\nB. {OPTION_B}\nC. {OPTION_C}\nD. {OPTION_D}\n\nYou should first find the functions in the options. Repeat their content, inspect through code, and at last give me your answer for the function that has the deliberate and obvious error in A, B, C, or D."
 
 
 @dataclass

--- a/max/kernels/benchmarks/autotune/kbench.py
+++ b/max/kernels/benchmarks/autotune/kbench.py
@@ -470,7 +470,7 @@ class Spec:
         # Expand with CLI params
         extra_params = self.parse_params(param_list)
 
-        # For all params in each config either, update the exisiting `value_set``
+        # For all params in each config either, update the existing `value_set`
         # with the new param value(s).
         for cfg in self.params:
             for k, v in extra_params.items():
@@ -1221,7 +1221,7 @@ help_str = (
     "--filter",
     "filter",
     help=(
-        "Define a single filter (should match a valid paramter, can have"
+        "Define a single filter (should match a valid parameter, can have"
         " multiple ones). The filters should of the format `--filter"
         " PARAM=VALUE`, that is, the subset of parameters that satisfy this"
         " condition will be included."

--- a/max/kernels/benchmarks/autotune/kdiff.py
+++ b/max/kernels/benchmarks/autotune/kdiff.py
@@ -81,7 +81,7 @@ def check_argo_workflow_exists(git_sha):
 
 def search_workflows(branch_sha, last_n_commits=100, timeout_secs=60):
     print(
-        f"Checking {last_n_commits} of origin/main for exisiting CI workflows"
+        f"Checking {last_n_commits} of origin/main for existing CI workflows"
         " (baseline)"
     )
     main_git_sha_list = shell(

--- a/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
@@ -144,7 +144,7 @@ from nn.kv_cache_ragged import (
     generic_flare_mla_decompress_k_cache_ragged_paged,
     generic_flare_mla_prefill_ragged_paged_plan,
     generic_flash_attention_kv_cache_ragged,
-    generic_fused_qk_rope_bshd_continous_batch_ragged,
+    generic_fused_qk_rope_bshd_continuous_batch_ragged,
     generic_fused_qk_rope_bshd_paged_ragged,
     generic_fused_qkv_matmul_kv_cache_cont_batch_ragged,
     generic_fused_qkv_matmul_kv_cache_paged_ragged,
@@ -7038,7 +7038,7 @@ fn generic_fused_qk_rope_bshd_continuous_batch_ragged_kernel_api[
     layer_idx: UInt32,
     ctx: DeviceContextPtr,
 ) raises:
-    generic_fused_qk_rope_bshd_continous_batch_ragged[
+    generic_fused_qk_rope_bshd_continuous_batch_ragged[
         interleaved=interleaved, target=target
     ](
         managed_tensor_slice_to_ndbuffer(q_proj),

--- a/max/kernels/src/layout/tma_async.mojo
+++ b/max/kernels/src/layout/tma_async.mojo
@@ -505,7 +505,7 @@ struct TMATensorTile[
 
         # The descriptor layout i.e. data per copy can be smaller than the shared memory
         # tile shape due to WGMMA requirement. E.g. k-major no swizzle WGMMA BM x 16B to be
-        # one continous chunk in shared memory. We need to break down tile shape in K by 16B.
+        # one continuous chunk in shared memory. We need to break down tile shape in K by 16B.
         #
         # dim0, dim1 are MN, K for K-major and K, MN for MN-major because our inputs are
         # row_major(K, MN) for the latter.
@@ -567,7 +567,7 @@ struct TMATensorTile[
 
         # The descriptor layout i.e. data per copy can be smaller than the shared memory
         # tile shape due to WGMMA requirement. E.g. k-major no swizzle WGMMA BM x 16B to be
-        # one continous chunk in shared memory. We need to break down tile shape in K by 16B.
+        # one continuous chunk in shared memory. We need to break down tile shape in K by 16B.
         #
         # dim0, dim1 are MN, K for K-major and K, MN for MN-major because our inputs are
         # row_major(K, MN) for the latter.
@@ -765,7 +765,7 @@ struct TMATensorTile[
         """
         Wait for the completion of asynchronous copy until a specified number of groups are waiting.
 
-        This funtion behaves the same as `cp_async_bulk_wait_group`, which causes causes the executing
+        This function behaves the same as `cp_async_bulk_wait_group`, which causes the executing
         thread to wait until a specified number of the most recent TMA copy are pending.
 
         Parameters:

--- a/max/kernels/src/linalg/matmul_gpu.mojo
+++ b/max/kernels/src/linalg/matmul_gpu.mojo
@@ -1401,7 +1401,7 @@ fn multistage_gemm[
             ]()
             alias work_space_type = config.split_k_reduction_type
 
-            # For the serial reduction we dont use workspace
+            # For the serial reduction we don't use workspace
             var work_space = NDBuffer[work_space_type, 3](
                 UnsafePointer[Scalar[work_space_type]](),
                 Index(0, 0, 0),

--- a/max/kernels/src/nn/image.mojo
+++ b/max/kernels/src/nn/image.mojo
@@ -100,7 +100,7 @@ struct ImageData[
 
     fn get_layout(self) -> Image2DLayout:
         """The getter function of the underlying data layout, resolving from
-        either staticall or dynamicall information.
+        either statically or dynamically provided information.
 
         Returns:
             The resolved data layout tag for this image instance.

--- a/max/kernels/src/nn/kv_cache_ragged.mojo
+++ b/max/kernels/src/nn/kv_cache_ragged.mojo
@@ -1725,7 +1725,7 @@ fn _qmatmul_gguf_quantized_common[
 
 
 @always_inline
-fn generic_fused_qk_rope_bshd_continous_batch_ragged[
+fn generic_fused_qk_rope_bshd_continuous_batch_ragged[
     type: DType, //,
     *,
     interleaved: Bool,

--- a/max/kernels/src/nn/mla.mojo
+++ b/max/kernels/src/nn/mla.mojo
@@ -621,13 +621,13 @@ fn mla_decoding_single_batch[
     alias kv_smem_size = BN * depth
     var k_smem = (q_smem + q_smem_size).bitcast[Scalar[k_type]]()
 
-    # For MLA, We define V = K[:, :nope_dim], thus we spilt the K tensor
+    # For MLA, We define V = K[:, :nope_dim], thus we split the K tensor
     # in two parts when storing it in the smem: K[:, :nope_dim] and
     # K[:, nope_dim:(nope_dim+rope_dim)].
-    # Instead of intializing the tiled iterator with a row-major layout
-    # (BN, BK) like standard mha kernels, we manully set the following
+    # Instead of initializing the tiled iterator with a row-major layout
+    # (BN, BK) like standard mha kernels, we manually set the following
     # layout. This ensures that once Q @ K calculation is complete, the
-    # K[:, :nope_dim] tensor stored continously in the smem.
+    # K[:, :nope_dim] tensor stored continuously in the smem.
     var kv_nope_smem_iter = LayoutTensorIter[
         k_type,
         Layout(IntTuple(BN, BK), IntTuple(nope_dim, 1)),

--- a/max/kernels/src/quantization/qmatmul_gpu.mojo
+++ b/max/kernels/src/quantization/qmatmul_gpu.mojo
@@ -878,7 +878,7 @@ fn multistage_qgemm_kernel[
 #      | tile | tile |     |
 #   128+------+------+-----+
 #
-# Elements within each tile are stored continously
+# Elements within each tile are stored continuously
 #                  K
 #      0     1     2     3     4
 #     0+-----+-----+-----+-----+

--- a/max/kernels/test/gpu/nn/test_fused_qk_rope_ragged.mojo
+++ b/max/kernels/test/gpu/nn/test_fused_qk_rope_ragged.mojo
@@ -540,7 +540,7 @@ def execute_fused_qk_rope_ragged_mla(ctx: DeviceContext):
     cache_lengths_host.tensor[0] = 0
     var cache_lengths_device = cache_lengths_host.copy_to_device(ctx)
 
-    # intialize our max_prompt_length and max_cache_length
+    # initialize our max_prompt_length and max_cache_length
     var max_prompt_length = Int(seq_len)
     var max_cache_length = Int(0)
 

--- a/max/kernels/test/gpu/quantization/test_multistage_gemm_q.mojo
+++ b/max/kernels/test/gpu/quantization/test_multistage_gemm_q.mojo
@@ -238,9 +238,9 @@ fn repack_Q4_0_for_sm8x[
                 64, group_size // pack_factor
             ](warp_x, warp_y)
             # The repack_warp_tile is of shape [64, (2, 2)]. In this case,
-            # elements [0, 0], [0, 1], [1, 0] and [1, 1] are stored continously
+            # elements [0, 0], [0, 1], [1, 0] and [1, 1] are stored continuously
             # in the memory. We need to use a element shape of [2, 2] to
-            # correctly vectorize this tenosr.
+            # correctly vectorize this tensor.
             repack_warp_tile.vectorize[2, 2]().store(
                 lane_id, 0, pack_Q_tile(frag_0)
             )

--- a/max/pipelines/core/context.py
+++ b/max/pipelines/core/context.py
@@ -404,7 +404,7 @@ class TextContext:
         """Updates the next_tokens and extends existing tokens to include all generated tokens."""
         # This is required for chunked prefill.
         # The scheduler will update the active_idx via bump_token_indices and pass through the model
-        # To accomodate for this, if we identify that the active_idx is not at the end of the completed
+        # To accommodate this, if we identify that the active_idx is not at the end of the completed
         # token array, we only update the start_idx and active_idx, leaving the token array alone.
         if self._active_idx < self._end_idx:
             self._start_idx = self._active_idx

--- a/max/serve/scheduler/prefill_scheduler.py
+++ b/max/serve/scheduler/prefill_scheduler.py
@@ -245,7 +245,7 @@ class PrefillScheduler(Scheduler):
                     pass
 
             except Exception as e:
-                logger.exception("An error occured during scheduling.")
+                logger.exception("An error occurred during scheduling.")
                 raise e
 
 

--- a/max/serve/schemas/openai.yaml
+++ b/max/serve/schemas/openai.yaml
@@ -12263,7 +12263,7 @@ components:
         TruncationObject:
             type: object
             title: Thread Truncation Controls
-            description: Controls for how a thread will be truncated prior to the run. Use this to control the intial context window of the run.
+            description: Controls for how a thread will be truncated prior to the run. Use this to control the initial context window of the run.
             properties:
                 type:
                     type: string

--- a/mojo/stdlib/stdlib/benchmark/benchmark.mojo
+++ b/mojo/stdlib/stdlib/benchmark/benchmark.mojo
@@ -648,7 +648,7 @@ fn _is_significant_measurement(
     idx: Int, batch: Batch, num_batches: Int, opts: _RunOptions
 ) -> Bool:
     # The measurement number of iteration is the same as the requested
-    # maxBatchSize and the measurement duration execeeded the requested min
+    # maxBatchSize and the measurement duration exceeded the requested min
     # runtime.
     if (
         opts.max_batch_size
@@ -657,9 +657,9 @@ fn _is_significant_measurement(
     ):
         return True
 
-    # This measument occured in the last 10% of the run.
+    # This measurement occurred in the last 10% of the run.
     if Float64(idx + 1) >= 0.9 * num_batches:
         return True
 
-    # Otherwise the result is not statically significant.
+    # Otherwise the result is not statistically significant.
     return False

--- a/mojo/stdlib/stdlib/builtin/floatable.mojo
+++ b/mojo/stdlib/stdlib/builtin/floatable.mojo
@@ -79,7 +79,7 @@ trait FloatableRaising:
     try:
         print(Float64(MaybeFloat(4.6)))
     except:
-        print("error occured")
+        print("error occurred")
     ```
     """
 

--- a/mojo/stdlib/stdlib/gpu/_cublas/cublaslt.mojo
+++ b/mojo/stdlib/stdlib/gpu/_cublas/cublaslt.mojo
@@ -1030,7 +1030,7 @@ struct cublasLtMatmulDescAttributes_t:
     """
     alias CUBLASLT_MATMUL_DESC_POINTER_MODE = Self(2)
     """UnsafePointer mode of alpha and beta, see PointerMode. When DEVICE_VECTOR is in use,
-    alpha/beta vector lenghts must match number of output matrix rows.
+    alpha/beta vector lengths must match number of output matrix rows.
 
     int32_t, default: HOST.
     """


### PR DESCRIPTION
- correct spelling mistakes in comments, strings and docs
- rename `continous_batch_ragged` helper to `continuous_batch_ragged`
- clean up docstrings for clarity
