### PR TITLE
[stdlib] Optimize base 16 and 64 encode and decode

### DIFF
--- a/mojo/stdlib/test/base64/test_base64.mojo
+++ b/mojo/stdlib/test/base64/test_base64.mojo
@@ -61,12 +61,12 @@ def test_b64decode():
     assert_equal(b64decode("QUJDREVGYWJjZGVm"), "ABCDEFabcdef")
 
     with assert_raises(
-        contains="ValueError: Input length 21 must be divisible by 4"
+        contains="ValueError: Input length '21' must be divisible by 4"
     ):
         _ = b64decode[validate=True]("invalid base64 string")
 
     with assert_raises(
-        contains='ValueError: Unexpected character " " encountered'
+        contains="ValueError: Unexpected character ' ' encountered"
     ):
         _ = b64decode[validate=True]("invalid base64 string!!!")
 


### PR DESCRIPTION
Optimize base 16 and 64 encode and decode by using `String` directly and fixing uses of `StringSlice` and parsing where using raw bytes is faster