### PR TITLE
[stdlib] Add Dict to prelude and adapt docs to the Dict literals emission feature

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -35,6 +35,9 @@ what we publish.
 
 ### Language changes
 
+- The type [`Dict`(/mojo/stdlib/collections/dict/Dict/) is now part of the 
+  prelude, so there is no need to import them anymore.
+
 - The Mojo compiler will now synthesize `__moveinit__` and `__copyinit__` and
   `copy()` methods for structs that conform to `Movable`, `Copyable`, and
   `ExplicitlyCopyable` (respectively) but that do not implement the methods

--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -35,7 +35,7 @@ what we publish.
 
 ### Language changes
 
-- The type [`Dict`(/mojo/stdlib/collections/dict/Dict/) is now part of the 
+- The type [`Dict`](/mojo/stdlib/collections/dict/Dict/) is now part of the
   prelude, so there is no need to import them anymore.
 
 - The Mojo compiler will now synthesize `__moveinit__` and `__copyinit__` and

--- a/mojo/docs/manual/control-flow.mdx
+++ b/mojo/docs/manual/control-flow.mdx
@@ -295,12 +295,11 @@ There are two techniques for iterating over a Mojo
 using the `Dict`, which produces a sequence of the dictionary's keys.
 
 ```mojo
-from collections import Dict
-
-capitals = Dict[String, String]()
-capitals["California"] = "Sacramento"
-capitals["Hawaii"] = "Honolulu"
-capitals["Oregon"] = "Salem"
+capitals: Dict[String, String] = {
+    "California": "Sacramento",
+    "Hawaii": "Honolulu",
+    "Oregon": "Salem"
+}
 
 for state in capitals:
     print(capitals[state[]] + ", " + state[])

--- a/mojo/docs/manual/parameters/index.mdx
+++ b/mojo/docs/manual/parameters/index.mdx
@@ -858,11 +858,8 @@ contexts. For example, you can alias a partially-bound type to create a new type
 that requires fewer parameters:
 
 ```mojo
-from collections import Dict
-
 alias StringKeyDict = Dict[String, _]
-var b = StringKeyDict[UInt8]()
-b["answer"] = 42
+var b: StringKeyDict[UInt8] = {"answer": 42}
 ```
 
 Here, `StringKeyDict` is a type alias for a `Dict` that takes `String` keys. The

--- a/mojo/docs/manual/pointers/index.mdx
+++ b/mojo/docs/manual/pointers/index.mdx
@@ -197,7 +197,7 @@ may not be clear. Like an `OwnedPointer`, it points to a single value, and it
 allocates memory when you initialize the `ArcPointer` with a value:
 
 ```python
-attributesDict = Dict[String, String]()
+attributesDict: Dict[String, String] = {}
 attributes = ArcPointer(attributesDict)
 ```
 
@@ -214,13 +214,12 @@ store a dictionary. Copying an instance of `SharedDict` only copies the
 
 ```python
 from memory import ArcPointer
-from collections import Dict
 
 struct SharedDict:
     var attributes: ArcPointer[Dict[String, String]]
 
     fn __init__(out self):
-        attributesDict = Dict[String, String]()
+        attributesDict: Dict[String, String] = {}
         self.attributes = ArcPointer(attributesDict)
 
     fn __copyinit__(out self, other: Self):

--- a/mojo/docs/manual/python/types.mdx
+++ b/mojo/docs/manual/python/types.mdx
@@ -72,22 +72,15 @@ For example, to create a Python dictionary, use the
 from python import Python
 
 def main():
-    # Create a Python dictionary using the Python.dict() method
     py_dict = Python.dict()
     py_dict["item_name"] = "whizbang"
     py_dict["price"] = 11.75
     py_dict["inventory"] = 100
     print(py_dict)
-    
-    # Alternatively, you can create Python dictionary using dictionary literal
-    # syntax for PythonObject:
-    py_dict2 = {"item_name": "gadget", "price": 8.50, "inventory": 42}
-    print(py_dict2)
 ```
 
 ```output
 {'item_name': 'whizbang', 'price': 11.75, 'inventory': 100}
-{'item_name': 'gadget', 'price': 8.5, 'inventory': 42}
 ```
 
 With the [`Python.list()`](/mojo/stdlib/python/python/Python#list) method, you

--- a/mojo/docs/manual/python/types.mdx
+++ b/mojo/docs/manual/python/types.mdx
@@ -72,15 +72,22 @@ For example, to create a Python dictionary, use the
 from python import Python
 
 def main():
+    # Create a Python dictionary using the Python.dict() method
     py_dict = Python.dict()
     py_dict["item_name"] = "whizbang"
     py_dict["price"] = 11.75
     py_dict["inventory"] = 100
     print(py_dict)
+    
+    # Alternatively, you can create Python dictionary using dictionary literal
+    # syntax for PythonObject:
+    py_dict2 = {"item_name": "gadget", "price": 8.50, "inventory": 42}
+    print(py_dict2)
 ```
 
 ```output
 {'item_name': 'whizbang', 'price': 11.75, 'inventory': 100}
+{'item_name': 'gadget', 'price': 8.5, 'inventory': 42}
 ```
 
 With the [`Python.list()`](/mojo/stdlib/python/python/Python#list) method, you

--- a/mojo/docs/manual/types.mdx
+++ b/mojo/docs/manual/types.mdx
@@ -595,16 +595,14 @@ Note that the previous code sample leaves out the type parameter when creating
 the list. Because the list is being created with a set of `Int` values, Mojo can
 *infer* the type from the arguments.
 
-There are some notable limitations when using `List`:
-
-* You can't currently initialize a list from a list literal, like this:
+* Mojo supports list and dictionary literals for collection initialization:
 
   ```mojo
-  # Doesn't work!
-  var list: List[Int] = [2, 3, 5]
+  # List literal
+  var nums: List[Int] = [2, 3, 5]
   ```
 
-  But you can use variadic arguments to achieve the same thing:
+  You can also use variadic arguments for lists:
 
   ```mojo
   var list = List(2, 3, 5)
@@ -653,7 +651,17 @@ for i in range(len(list)):
 
 The [`Dict`](/mojo/stdlib/collections/dict/Dict) type is an associative array
 that holds key-value pairs. You can create a `Dict` by specifying the key type
-and value type as parameters, like this:
+and value type as parameters and using dictionary literals:
+
+```mojo
+# Empty dictionary
+var empty_dict: Dict[String, Float64] = {}
+
+# Dictionary with initial key-value pairs
+var values: Dict[String, Float64] = {"pi": 3.14159, "e": 2.71828}
+```
+
+You can also use the constructor syntax:
 
 ```mojo
 var values = Dict[String, Float64]()
@@ -671,12 +679,11 @@ The `Dict` iterators all yield references, so you need to use the dereference
 operator `[]` as shown in the following example:
 
 ```mojo
-from collections import Dict
-
-var d = Dict[String, Float64]()
-d["plasticity"] = 3.1
-d["elasticity"] = 1.3
-d["electricity"] = 9.7
+var d: Dict[String, Float64] = {
+    "plasticity": 3.1,
+    "elasticity": 1.3,
+    "electricity": 9.7
+}
 for item in d.items():
     print(item[].key, item[].value)
 ```
@@ -696,6 +703,8 @@ intersections between two sets.
 
 Sets are generic and the element type must conform to the
 [`KeyElement`](/mojo/stdlib/collections/dict/KeyElement) trait.
+
+Unlike lists and dictionaries, sets do not yet support literal syntax.
 
 ```mojo
 from collections import Set

--- a/mojo/stdlib/stdlib/prelude/__init__.mojo
+++ b/mojo/stdlib/stdlib/prelude/__init__.mojo
@@ -16,7 +16,7 @@ that are automatically imported into every Mojo program.
 
 from collections import (
     Dict,
-    InlineArray, 
+    InlineArray,
     KeyElement,
     List,
     Optional,

--- a/mojo/stdlib/stdlib/prelude/__init__.mojo
+++ b/mojo/stdlib/stdlib/prelude/__init__.mojo
@@ -14,7 +14,13 @@
 that are automatically imported into every Mojo program.
 """
 
-from collections import InlineArray, KeyElement, List, Optional
+from collections import (
+    Dict,
+    InlineArray, 
+    KeyElement,
+    List,
+    Optional,
+)
 from collections.string import (
     Codepoint,
     StaticString,

--- a/mojo/stdlib/test/collections/test_dict.mojo
+++ b/mojo/stdlib/test/collections/test_dict.mojo
@@ -54,10 +54,11 @@ def test_dict_fromkeys():
 
 def test_dict_fromkeys_optional():
     alias keys = List[String]("a", "b", "c")
-    var expected_dict = Dict[String, Optional[Int]]()
-    expected_dict["a"] = None
-    expected_dict["b"] = None
-    expected_dict["c"] = None
+    var expected_dict :Dict[String, Optional[Int]] = {
+        "a": None,
+        "b": None,
+        "c": None,
+    }
     var dict = Dict[_, Int].fromkeys(keys)
 
     assert_equal(len(dict), len(expected_dict))
@@ -70,7 +71,7 @@ def test_dict_fromkeys_optional():
 
 
 def test_basic():
-    var dict = Dict[String, Int]()
+    var dict: Dict[String, Int] = {}
     dict["a"] = 1
     dict["b"] = 2
 
@@ -88,7 +89,7 @@ def test_basic_no_copies():
 
 
 def test_multiple_resizes():
-    var dict = Dict[String, Int]()
+    var dict: Dict[String, Int] = {}
     for i in range(20):
         dict[String("key", i)] = i + 1
     assert_equal(11, dict["key10"])
@@ -96,7 +97,7 @@ def test_multiple_resizes():
 
 
 def test_bool_conversion():
-    var dict = Dict[String, Int]()
+    var dict: Dict[String, Int] = {}
     assert_false(dict)
     dict["a"] = 1
     assert_true(dict)
@@ -109,14 +110,14 @@ def test_bool_conversion():
 
 
 def test_big_dict():
-    var dict = Dict[String, Int]()
+    var dict: Dict[String, Int] = {}
     for i in range(2000):
         dict[String("key", i)] = i + 1
     assert_equal(2000, len(dict))
 
 
 def test_dict_string_representation_string_int():
-    var some_dict = Dict[String, Int]()
+    var some_dict: Dict[String, Int] = {}
     some_dict["a"] = 1
     some_dict["b"] = 2
     dict_as_string = some_dict.__str__()
@@ -128,7 +129,7 @@ def test_dict_string_representation_string_int():
 
 
 def test_dict_string_representation_int_int():
-    var some_dict = Dict[Int, Int]()
+    var some_dict: Dict[Int, Int] = {}
     some_dict[3] = 1
     some_dict[4] = 2
     some_dict[5] = 3
@@ -142,7 +143,7 @@ def test_dict_string_representation_int_int():
 
 
 def test_compact():
-    var dict = Dict[String, Int]()
+    var dict: Dict[String, Int] = {}
     for i in range(20):
         var key = String("key", i)
         dict[key] = i + 1
@@ -151,7 +152,7 @@ def test_compact():
 
 
 def test_compact_with_elements():
-    var dict = Dict[String, Int]()
+    var dict: Dict[String, Int] = {}
     for i in range(5):
         var key = String("key", i)
         dict[key] = i + 1
@@ -163,7 +164,7 @@ def test_compact_with_elements():
 
 
 def test_pop_default():
-    var dict = Dict[String, Int]()
+    var dict: Dict[String, Int] = {}
     dict["a"] = 1
     dict["b"] = 2
 
@@ -173,7 +174,7 @@ def test_pop_default():
 
 
 def test_key_error():
-    var dict = Dict[String, Int]()
+    var dict: Dict[String, Int] = {}
 
     with assert_raises(contains="KeyError"):
         _ = dict["a"]
@@ -182,7 +183,7 @@ def test_key_error():
 
 
 def test_iter():
-    var dict = Dict[String, Int]()
+    var dict: Dict[String, Int] = {}
     dict["a"] = 1
     dict["b"] = 2
 
@@ -194,7 +195,7 @@ def test_iter():
 
 
 def test_iter_keys():
-    var dict = Dict[String, Int]()
+    var dict: Dict[String, Int] = {}
     dict["a"] = 1
     dict["b"] = 2
 
@@ -206,7 +207,7 @@ def test_iter_keys():
 
 
 def test_iter_values():
-    var dict = Dict[String, Int]()
+    var dict: Dict[String, Int] = {}
     dict["a"] = 1
     dict["b"] = 2
 
@@ -218,7 +219,7 @@ def test_iter_values():
 
 
 def test_iter_values_mut():
-    var dict = Dict[String, Int]()
+    var dict: Dict[String, Int] = {}
     dict["a"] = 1
     dict["b"] = 2
 
@@ -231,7 +232,7 @@ def test_iter_values_mut():
 
 
 def test_iter_items():
-    var dict = Dict[String, Int]()
+    var dict: Dict[String, Int] = {}
     dict["a"] = 1
     dict["b"] = 2
 
@@ -246,7 +247,7 @@ def test_iter_items():
 
 
 def test_dict_copy():
-    var orig = Dict[String, Int]()
+    var orig: Dict[String, Int] = {}
     orig["a"] = 1
 
     # test values copied to new Dict
@@ -261,7 +262,7 @@ def test_dict_copy():
 
 
 def test_dict_copy_delete_original():
-    var orig = Dict[String, Int]()
+    var orig: Dict[String, Int] = {}
     orig["a"] = 1
 
     # test values copied to new Dict
@@ -272,7 +273,7 @@ def test_dict_copy_delete_original():
 
 
 def test_dict_copy_add_new_item():
-    var orig = Dict[String, Int]()
+    var orig: Dict[String, Int] = {}
     orig["a"] = 1
 
     # test values copied to new Dict
@@ -286,7 +287,7 @@ def test_dict_copy_add_new_item():
 
 
 def test_dict_copy_calls_copy_constructor():
-    var orig = Dict[String, CopyCounter]()
+    var orig: Dict[String, CopyCounter] = {}
     orig["a"] = CopyCounter()
 
     # test values copied to new Dict
@@ -298,11 +299,11 @@ def test_dict_copy_calls_copy_constructor():
 
 
 def test_dict_update_nominal():
-    var orig = Dict[String, Int]()
+    var orig: Dict[String, Int] = {}
     orig["a"] = 1
     orig["b"] = 2
 
-    var new = Dict[String, Int]()
+    var new: Dict[String, Int] = {}
     new["b"] = 3
     new["c"] = 4
 
@@ -314,8 +315,8 @@ def test_dict_update_nominal():
 
 
 def test_dict_update_empty_origin():
-    var orig = Dict[String, Int]()
-    var new = Dict[String, Int]()
+    var orig: Dict[String, Int] = {}
+    var new: Dict[String, Int] = {}
     new["b"] = 3
     new["c"] = 4
 
@@ -326,8 +327,8 @@ def test_dict_update_empty_origin():
 
 
 def test_dict_or():
-    var orig = Dict[String, Int]()
-    var new = Dict[String, Int]()
+    var orig: Dict[String, Int] = {}
+    var new: Dict[String, Int] = {}
 
     new["b"] = 3
     new["c"] = 4
@@ -386,11 +387,11 @@ def test_dict_or():
 
 
 def test_dict_update_empty_new():
-    var orig = Dict[String, Int]()
+    var orig: Dict[String, Int] = {}
     orig["a"] = 1
     orig["b"] = 2
 
-    var new = Dict[String, Int]()
+    var new: Dict[String, Int] = {}
 
     orig.update(new)
 
@@ -427,7 +428,7 @@ def test_mojo_issue_1729():
         -649171104678427962,
         -6981562940350531355,
     ]
-    var d = Dict[DummyKey, Int]()
+    var d: Dict[DummyKey, Int] = {}
     for i in range(len(keys)):
         d[DummyKey(keys[i])] = i
     assert_equal(len(d), len(keys))
@@ -525,7 +526,7 @@ def test_owned_kwargs_dict():
 
 
 def test_find_get():
-    var some_dict = Dict[String, Int]()
+    var some_dict: Dict[String, Int] = {}
     some_dict["key"] = 1
     assert_equal(some_dict.find("key").value(), 1)
     assert_equal(some_dict.get("key").value(), 1)
@@ -534,7 +535,7 @@ def test_find_get():
 
 
 def test_dict_popitem():
-    var dict = Dict[String, Int]()
+    var dict: Dict[String, Int] = {}
     dict["a"] = 1
     dict["b"] = 2
 
@@ -549,7 +550,7 @@ def test_dict_popitem():
 
 
 def test_pop_string_values():
-    var dict = Dict[String, String]()
+    var dict: Dict[String, String] = {}
     dict["mojo"] = "lang"
     dict["max"] = "engine"
     dict["a"] = ""
@@ -564,7 +565,7 @@ def test_pop_string_values():
 
 
 fn test_clear() raises:
-    var some_dict = Dict[String, Int]()
+    var some_dict: Dict[String, Int] = {}
     some_dict["key"] = 1
     some_dict.clear()
     assert_equal(len(some_dict), 0)
@@ -589,7 +590,7 @@ def test_init_initial_capacity():
 
 
 fn test_dict_setdefault() raises:
-    var some_dict = Dict[String, Int]()
+    var some_dict: Dict[String, Int] = {}
     some_dict["key1"] = 1
     some_dict["key2"] = 2
     assert_equal(some_dict.setdefault("key1", 0), 1)
@@ -598,7 +599,7 @@ fn test_dict_setdefault() raises:
     assert_equal(some_dict["not_key"], 0)
 
     # Check that there is no copy of the default value, so it's performant
-    var other_dict = Dict[String, CopyCounter]()
+    var other_dict: Dict[String, CopyCounter] = {}
     var a = CopyCounter()
     var a_def = CopyCounter()
     var b_def = CopyCounter()

--- a/mojo/stdlib/test/collections/test_dict.mojo
+++ b/mojo/stdlib/test/collections/test_dict.mojo
@@ -54,7 +54,7 @@ def test_dict_fromkeys():
 
 def test_dict_fromkeys_optional():
     alias keys = List[String]("a", "b", "c")
-    var expected_dict :Dict[String, Optional[Int]] = {
+    var expected_dict: Dict[String, Optional[Int]] = {
         "a": None,
         "b": None,
         "c": None,


### PR DESCRIPTION
Adapting code and docs to this new feature: https://github.com/modular/modular/commit/2912183a666d975fd861d9c3d361e39cd628b369

Changes:

-  Use Dict literals in the test_dict module
- Include Dict in prelude modules So we don't have to import it from collections to use it
- Adapt the Mojo manual to the Dict literals emission feature