### PR TITLE
[stdlib] Optimize `Dict._find_index()` and consequently contains, insert, and lookup

### DIFF
--- a/mojo/stdlib/benchmarks/collections/bench_dict.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_dict.mojo
@@ -17,7 +17,7 @@
 from collections.dict import DictEntry
 from hashlib import Hasher
 from math import ceil
-from random import *
+from random.random import random_si64, seed
 from sys import sizeof
 
 from benchmark import Bench, BenchConfig, Bencher, BenchId, Unit, keep, run
@@ -27,10 +27,15 @@ from bit import next_power_of_two
 # ===-----------------------------------------------------------------------===#
 # Benchmark Data
 # ===-----------------------------------------------------------------------===#
-fn make_dict[size: Int]() -> Dict[Int, Int]:
+fn make_dict[size: Int, *, random: Bool = False]() -> Dict[Int, Int]:
     var d = Dict[Int, Int]()
     for i in range(0, size):
-        d[i] = Int(random.random_si64(0, size))
+
+        @parameter
+        if random:
+            d[i] = Int(random_si64(0, size))
+        else:
+            d[i] = i
     return d
 
 
@@ -55,14 +60,15 @@ fn bench_dict_init(mut b: Bencher) raises:
 # ===-----------------------------------------------------------------------===#
 @parameter
 fn bench_dict_insert[size: Int](mut b: Bencher) raises:
-    """Insert 100 new items."""
+    """Insert 10 new items 100_000 times."""
     var items = make_dict[size]()
 
     @always_inline
     @parameter
     fn call_fn() raises:
-        for key in range(size, size + 100):
-            items[key] = Int(random.random_si64(0, size))
+        for _ in range(10_000):
+            for key in range(size, size + 10):
+                items[key] = Int(random_si64(0, size))
 
     b.iter[call_fn]()
     keep(Bool(items))
@@ -73,23 +79,35 @@ fn bench_dict_insert[size: Int](mut b: Bencher) raises:
 # ===-----------------------------------------------------------------------===#
 @parameter
 fn bench_dict_lookup[size: Int](mut b: Bencher) raises:
-    """Lookup 100 items."""
+    """Lookup 10 items 100_000 times."""
     var items = make_dict[size]()
-    var closest_divisor = ceil(100 / size)
 
-    @__copy_capture(closest_divisor)
     @always_inline
     @parameter
     fn call_fn() raises:
-        @parameter
-        if size < 100:
-            for _ in range(closest_divisor):
-                for key in range(Int(100 // closest_divisor)):
-                    var res = items[key]
-                    keep(res)
-        else:
-            for key in range(100):
+        for _ in range(10_000):
+            for key in range(10):
                 var res = items[key]
+                keep(res)
+
+    b.iter[call_fn]()
+    keep(Bool(items))
+
+
+# ===-----------------------------------------------------------------------===#
+# Benchmark Dict contains
+# ===-----------------------------------------------------------------------===#
+@parameter
+fn bench_dict_contains[size: Int](mut b: Bencher) raises:
+    """Check if the dict contains 10 keys 100_000 times."""
+    var items = make_dict[size]()
+
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        for _ in range(100_000):
+            for key in range(10):
+                var res = key in items
                 keep(res)
 
     b.iter[call_fn]()
@@ -126,7 +144,7 @@ fn total_bytes_used[H: Hasher](items: Dict[Int, Int, H]) -> Int:
 # ===-----------------------------------------------------------------------===#
 def main():
     seed()
-    var m = Bench(BenchConfig(num_repetitions=1))
+    var m = Bench(BenchConfig(num_repetitions=5))
     m.bench_function[bench_dict_init](BenchId("bench_dict_init"))
     alias sizes = (10, 30, 50, 100, 1000, 10_000, 100_000, 1_000_000)
 
@@ -139,11 +157,22 @@ def main():
         m.bench_function[bench_dict_lookup[size]](
             BenchId(String("bench_dict_lookup[", size, "]"))
         )
+        m.bench_function[bench_dict_contains[size]](
+            BenchId(String("bench_dict_contains[", size, "]"))
+        )
 
-    m.dump_report()
+    results = Dict[String, (Float64, Int)]()
+    for info in m.info_vec:
+        n = info.name
+        time = info.result.mean("ms")
+        avg, amnt = results.get(n, (Float64(0), 0))
+        results[n] = ((avg * amnt + time) / (amnt + 1), amnt + 1)
+    print("")
+    for k_v in results.items():
+        print(k_v.key, k_v.value[0], sep=",")
 
     @parameter
     for i in range(len(sizes)):
         alias size = sizes[i]
         var mem_s = total_bytes_used(make_dict[size]())
-        print('"bench_dict_memory_size[', size, ']",', mem_s, ",0")
+        print("dict_memory_size[", size, "]: ", mem_s, sep="")

--- a/mojo/stdlib/test/collections/test_dict.mojo
+++ b/mojo/stdlib/test/collections/test_dict.mojo
@@ -245,6 +245,15 @@ def test_iter_items():
     assert_equal(sum, 3)
 
 
+def test_dict_contains():
+    var dict: Dict[String, Int] = {}
+    dict["abc"] = 1
+    dict["def"] = 2
+    assert_true("abc" in dict)
+    assert_true("def" in dict)
+    assert_false("c" in dict)
+
+
 def test_dict_copy():
     var orig: Dict[String, Int] = {}
     orig["a"] = 1
@@ -460,6 +469,7 @@ def test_dict():
     test["test_iter_values", test_iter_values]()
     test["test_iter_values_mut", test_iter_values_mut]()
     test["test_iter_items", test_iter_items]()
+    test["test_dict_contains", test_dict_contains]()
     test["test_dict_copy", test_dict_copy]()
     test["test_dict_copy_add_new_item", test_dict_copy_add_new_item]()
     test["test_dict_copy_delete_original", test_dict_copy_delete_original]()


### PR DESCRIPTION
Optimize `Dict._find_index()` and consequently contains, insert, and lookup.

Also:
- Fix the dict benchmarks
- Add the compile time branch for the llvm expect intrinsic (separate PR  #4289)

## Benchmark results

CPU: Intel® Core™ i7-7700HQ

||	old	value	(ms)	|	new	value	(ms)	|	percentage	|	magnitude|
|--|--:|--:|--:|--:|			
|contains|											
|bench_dict_contains[10]	|	5.56	|	3.78	|	0.32	|	1.47	|		
|bench_dict_contains[30]	|	3.84	|	2.73	|	0.29	|	1.40	|		
|bench_dict_contains[50]	|	3.90	|	2.67	|	0.32	|	1.46	|		
|bench_dict_contains[100]	|	5.21	|	3.18	|	0.39	|	1.64	|		
|bench_dict_contains[1000]	|	5.19	|	3.28	|	0.37	|	1.58	|		
|insert|											
|bench_dict_insert[10]	|	2.25	|	2.33	|	-0.03	|	0.97	|		
|bench_dict_insert[30]	|	2.68	|	2.66	|	0.01	|	1.01	|		
|bench_dict_insert[50]	|	2.33	|	2.29	|	0.01	|	1.01	|		
|bench_dict_insert[100]	|	2.56	|	2.38	|	0.07	|	1.08	|		
|bench_dict_insert[1000]	|	2.57	|	2.44	|	0.05	|	1.05	|		
|lookup|											
|bench_dict_lookup[10]	|	0.64	|	0.58	|	0.09	|	1.10	|		
|bench_dict_lookup[30]	|	0.48	|	0.43	|	0.10	|	1.12	|		
|bench_dict_lookup[50]	|	0.45	|	0.45	|	0.01	|	1.01	|		
|bench_dict_lookup[100]	|	0.44	|	0.39	|	0.10	|	1.12	|		
|bench_dict_lookup[1000]	|	0.44	|	0.36	|	0.18	|	1.47	|		







