### PR TITLE
[All] Fix typos across docs and code

### DIFF
--- a/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
@@ -6809,7 +6809,7 @@ struct Struct_fused_qkv_matmul_padded_ragged_quantized:
     ) raises:
         # In the group-wise quantization scheme, every `group_size` quantized weights
         # share the same scale. If `has_zp_int` is non-zero, there is also a group-wise
-        # zero point that need to be substracted from the quantized weights.
+        # zero point that need to be subtracted from the quantized weights.
         alias has_zp = True if has_zp_int == 1 else False
 
         return generic_fused_qkv_matmul_kv_cache_paged_ragged_kernel_api[
@@ -6937,7 +6937,7 @@ struct Struct_fused_qkv_matmul_padded_ragged_bias_quantized:
     ) raises:
         # In the group-wise quantization scheme, every `group_size` quantized weights
         # share the same scale. If `has_zp_int` is non-zero, there is also a group-wise
-        # zero point that need to be substracted from the quantized weights.
+        # zero point that need to be subtracted from the quantized weights.
         alias has_zp = True if has_zp_int == 1 else False
 
         return generic_fused_qkv_matmul_kv_cache_paged_ragged_kernel_api_bias[

--- a/max/kernels/src/nn/mha_sm90.mojo
+++ b/max/kernels/src/nn/mha_sm90.mojo
@@ -97,7 +97,7 @@ from utils.numerics import get_accum_type, min_or_neg_inf, neg_inf
 from utils.static_tuple import StaticTuple
 
 
-# The motivationn here is to be able to pass `StaticInt[1]()`
+# The motivation here is to be able to pass `StaticInt[1]()`
 # to indicate `decoding=True`, and have this not generate any code
 # when passing as a function argument.
 # That is, we want different specializations of a function to have

--- a/max/nn/kernels.py
+++ b/max/nn/kernels.py
@@ -342,7 +342,7 @@ def fused_qkv_ragged_matmul_quantized(
 
     # In the group-wise quantization scheme, every `group_size` quantized weights
     # share the same scale. If `has_zp` is `True`, there is also a group-wise zero
-    # point that need to be substracted from the quantized weights.
+    # point that need to be subtracted from the quantized weights.
     # Since the new extensibility API doesn't currently support `bool` type parameters,
     # we pass `has_zp` as an interger (`has_zp_int`).
     # For GPTQ, `has_zp_int` will always be 0.

--- a/mojo/stdlib/stdlib/benchmark/bencher.mojo
+++ b/mojo/stdlib/stdlib/benchmark/bencher.mojo
@@ -1162,7 +1162,7 @@ struct Bencher:
     """ Number of iterations to run the target function."""
 
     var elapsed: Int
-    """ The total time elpased when running the target function."""
+    """ The total time elapsed when running the target function."""
 
     @implicit
     fn __init__(out self, num_iters: Int):

--- a/mojo/stdlib/stdlib/gpu/_cudnn/cnn_infer.mojo
+++ b/mojo/stdlib/stdlib/gpu/_cudnn/cnn_infer.mojo
@@ -1331,7 +1331,7 @@ fn cudnnGetConvolutionNdForwardOutputDim(
     input_tensor_desc: UnsafePointer[cudnnTensorStruct],
     filter_desc: UnsafePointer[cudnnFilterStruct],
     nb_dims: Int16,
-    tensor_ouput_dim_a: UnsafePointer[NoneType],
+    tensor_output_dim_a: UnsafePointer[NoneType],
 ) -> cudnnStatus_t:
     return _get_dylib_function[
         "cudnnGetConvolutionNdForwardOutputDim",
@@ -1342,7 +1342,7 @@ fn cudnnGetConvolutionNdForwardOutputDim(
             Int16,
             UnsafePointer[NoneType],
         ) -> cudnnStatus_t,
-    ]()(conv_desc, input_tensor_desc, filter_desc, nb_dims, tensor_ouput_dim_a)
+    ]()(conv_desc, input_tensor_desc, filter_desc, nb_dims, tensor_output_dim_a)
 
 
 fn cudnnGetConvolutionForwardAlgorithmMaxCount(

--- a/mojo/stdlib/stdlib/utils/write.mojo
+++ b/mojo/stdlib/stdlib/utils/write.mojo
@@ -508,7 +508,7 @@ struct WritableVariadicPack[
     var value: Pointer[
         VariadicPack[is_owned, pack_origin, Writable, *Ts], origin
     ]
-    """Reference to a `VariadicPack` that comforms to `Writable`."""
+    """Reference to a `VariadicPack` that conforms to `Writable`."""
 
     fn __init__(
         out self,

--- a/mojo/stdlib/test/collections/test_counter.mojo
+++ b/mojo/stdlib/test/collections/test_counter.mojo
@@ -333,7 +333,7 @@ def test_add():
     assert_equal(c2["c"], 4)
 
 
-def test_substract():
+def test_subtract():
     var c1 = Counter[String]()
     c1["a"] = 4
     c1["b"] = 2
@@ -483,6 +483,6 @@ def main():
     test_or()
     test_pop()
     test_popitem()
-    test_substract()
+    test_subtract()
     test_total()
     test_update()


### PR DESCRIPTION
## Summary
- correct typo in `WritableVariadicPack` docstring
- fix parameter name in cudnn convolution helper
- clean up spelling in comments and tests
