### PR TITLE
[stdlib] Fix LinkedList docstrings: update time complexity and correct "head" to "tail"

### DIFF
--- a/mojo/stdlib/stdlib/collections/linked_list.mojo
+++ b/mojo/stdlib/stdlib/collections/linked_list.mojo
@@ -373,10 +373,10 @@ struct LinkedList[
         raise String("Invalid index for pop: {}").format(Int(i))
 
     fn maybe_pop(mut self) -> Optional[ElementType]:
-        """Removes the head of the list and returns it, if it exists.
+        """Removes the tail of the list and returns it, if it exists.
 
         Returns:
-            The head of the list, if it was present.
+            The tail of the list, if it was present.
 
         Notes:
             Time Complexity: O(1).

--- a/mojo/stdlib/stdlib/collections/linked_list.mojo
+++ b/mojo/stdlib/stdlib/collections/linked_list.mojo
@@ -345,7 +345,7 @@ struct LinkedList[
             Ownership of the indicated element.
 
         Notes:
-            Time Complexity: O(1).
+            Time Complexity: O(n) in len(self).
         """
         var current = self._get_node_ptr(Int(i))
 
@@ -408,7 +408,7 @@ struct LinkedList[
             The element, if it was found.
 
         Notes:
-            Time Complexity: O(1).
+            Time Complexity: O(n) in len(self).
         """
         var current = self._get_node_ptr(Int(i))
 
@@ -482,7 +482,7 @@ struct LinkedList[
             elem: The item to insert into the list.
 
         Notes:
-            Time Complexity: O(1).
+            Time Complexity: O(n) in len(self).
         """
         var i = max(0, index(idx) if Int(idx) >= 0 else index(idx) + len(self))
 


### PR DESCRIPTION
This PR improves the accuracy of the LinkedList documentation by making two key fixes:

1. Time Complexity Update
   - Changed several member function docstrings that incorrectly stated O(1) time complexity to O(n),
     reflecting the actual traversal cost in these methods.

2. Correcting Terminology
   - Fixed the maybe_pop function docstring to correctly refer to the "tail" of the list instead of the "head".

Please review and provide feedback on the updated complexity notation;  
future improvements might specify it as O(min(i, n - i)) if agreed.

Note that the current time complexity notation "O(n) in len(self)" was kept to match the existing style,  
but I personally think that "O(n), where n = len(self)" or simply "O(len(self))" would be clearer and more accurate.  
I hope we can discuss and possibly improve this notation in the future.