### PR TITLE
[stdlib] Add comptime `SIMD.slice()` branch and fix codepoint length problem

### DIFF
--- a/mojo/stdlib/stdlib/builtin/simd.mojo
+++ b/mojo/stdlib/stdlib/builtin/simd.mojo
@@ -52,6 +52,7 @@ from sys import (
     bitwidthof,
     is_amd_gpu,
     is_big_endian,
+    is_compile_time,
     is_gpu,
     is_nvidia_gpu,
     llvm_intrinsic,
@@ -2311,18 +2312,24 @@ struct SIMD[dtype: DType, size: Int](
             "output width must be a positive integer less than simd size",
         ]()
 
+        @always_inline
         @parameter
-        if output_width == 1:
-            return self[offset]
-
-        @parameter
-        if offset % simdwidthof[dtype]():
-            var res = SIMD[dtype, output_width]()
+        fn slice_body() -> SIMD[dtype, output_width]:
+            var tmp = SIMD[dtype, output_width]()
 
             @parameter
             for i in range(output_width):
-                res[i] = self[i + offset]
-            return res
+                tmp[i] = self[i + offset]
+            return tmp
+
+        @parameter
+        if output_width == 1:
+            return self[offset]
+        elif offset % simdwidthof[dtype]():
+            return slice_body()
+
+        if is_compile_time():
+            return slice_body()
 
         return llvm_intrinsic[
             "llvm.vector.extract",

--- a/mojo/stdlib/stdlib/collections/string/codepoint.mojo
+++ b/mojo/stdlib/stdlib/collections/string/codepoint.mojo
@@ -586,12 +586,4 @@ struct Codepoint(Copyable, EqualityComparable, Intable, Movable, Stringable):
 
         # Count how many of the minimums this codepoint exceeds, which is equal
         # to the number of bytes needed to encode it.
-        var lt = (sizes <= self.to_u32()).cast[DType.uint8]()
-
-        # TODO(MOCO-1537): Support `reduce_add()` at compile time.
-        #   var count = Int(lt.reduce_add())
-        var count = 0
-        for i in range(len(lt)):
-            count += Int(lt[i])
-
-        return UInt(count)
+        return UInt((sizes <= self.to_u32()).cast[DType.uint8]().reduce_add())

--- a/mojo/stdlib/test/builtin/test_simd.mojo
+++ b/mojo/stdlib/test/builtin/test_simd.mojo
@@ -1205,8 +1205,10 @@ def test_deinterleave():
 
 
 def test_extract():
-    assert_equal(Int64(99).slice[1](), 99)
-    assert_equal(Int64(99).slice[1, offset=0](), 99)
+    alias s1 = Int64(99).slice[1]()  # test compile time
+    alias s2 = Int64(99).slice[1, offset=0]()
+    assert_equal(s1, 99)
+    assert_equal(s2, 99)
 
     assert_equal(
         SIMD[DType.index, 4](99, 1, 2, 4).slice[4](),


### PR DESCRIPTION
Add comptime `SIMD.slice()` branch and fix codepoint length problem. Closes #4314

CC: @lattner 