### PR TITLE
[CI] Fix skipping autotune tests in Bazel

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,4 +47,4 @@ jobs:
 
       - name: Build and Test
         run: |
-          ./bazelw test --config=ci --build_tag_filters=-skip-external-ci-${{ matrix.os }} --test_tag_filters=-skip-external-ci-${{ matrix.os }} -- //... -//max/serve/... -//max/kernels/benchmarks:autotune_tests
+          ./bazelw test --config=ci --build_tag_filters=-skip-external-ci-${{ matrix.os }} --test_tag_filters=-skip-external-ci-${{ matrix.os }} -- //... -//max/serve/...


### PR DESCRIPTION
https://github.com/modular/modular/commit/997204763fd77afc64eac0d82e716a3766711a28 broken the open source Bazel build due to directory moves.  Adjust the Bazel skip filters to account for the new directory location of the `autotune_tests`.