### PR TITLE
[stdlib] Change default from `Representable` to `Writable` for several collections

### DIFF
--- a/mojo/stdlib/stdlib/collections/deque.mojo
+++ b/mojo/stdlib/stdlib/collections/deque.mojo
@@ -404,14 +404,14 @@ struct Deque[ElementType: Copyable & Movable](
 
     @no_inline
     fn write_to[
-        T: Representable & Copyable & Movable,
+        T: Writable & Copyable & Movable,
         WriterType: Writer,
     ](self: Deque[T], mut writer: WriterType):
         """Writes `my_deque.__str__()` to a `Writer`.
 
         Parameters:
             T: The type of the Deque elements.
-                Must implement the trait `Representable`.
+                Must implement the trait `Writable`.
             WriterType: A type conforming to the Writable trait.
 
         Args:
@@ -420,15 +420,13 @@ struct Deque[ElementType: Copyable & Movable](
         writer.write("Deque(")
         for i in range(len(self)):
             offset = self._physical_index(self._head + i)
-            writer.write(repr((self._data + offset)[]))
+            writer.write(self._data[offset])
             if i < len(self) - 1:
                 writer.write(", ")
         writer.write(")")
 
     @no_inline
-    fn __str__[
-        T: Representable & Copyable & Movable, //
-    ](self: Deque[T]) -> String:
+    fn __str__[T: Writable & Copyable & Movable, //](self: Deque[T]) -> String:
         """Returns a string representation of a `Deque`.
 
         Note that since we can't condition methods on a trait yet,
@@ -444,7 +442,7 @@ struct Deque[ElementType: Copyable & Movable](
 
         Parameters:
             T: The type of the elements in the deque.
-                Must implement the trait `Representable`.
+                Must implement the trait `Writable`.
 
         Returns:
             A string representation of the deque.
@@ -454,9 +452,7 @@ struct Deque[ElementType: Copyable & Movable](
         return output^
 
     @no_inline
-    fn __repr__[
-        T: Representable & Copyable & Movable, //
-    ](self: Deque[T]) -> String:
+    fn __repr__[T: Writable & Copyable & Movable, //](self: Deque[T]) -> String:
         """Returns a string representation of a `Deque`.
 
         Note that since we can't condition methods on a trait yet,
@@ -472,7 +468,7 @@ struct Deque[ElementType: Copyable & Movable](
 
         Parameters:
             T: The type of the elements in the deque.
-                Must implement the trait `Representable`.
+                Must implement the trait `Writable`.
 
         Returns:
             A string representation of the deque.

--- a/mojo/stdlib/stdlib/collections/list.mojo
+++ b/mojo/stdlib/stdlib/collections/list.mojo
@@ -415,13 +415,13 @@ struct List[T: Copyable & Movable, hint_trivial_type: Bool = False](
 
     @no_inline
     fn __str__[
-        U: Representable & Copyable & Movable, //
+        U: Writable & Copyable & Movable, //
     ](self: List[U, *_]) -> String:
         """Returns a string representation of a `List`.
 
         Parameters:
             U: The type of the elements in the list. Must implement the
-              trait `Representable`.
+                trait `Writable`.
 
         Returns:
             A string representation of the list.
@@ -447,34 +447,33 @@ struct List[T: Copyable & Movable, hint_trivial_type: Bool = False](
 
     @no_inline
     fn write_to[
-        W: Writer, U: Representable & Copyable & Movable, //
+        W: Writer, U: Writable & Copyable & Movable, //
     ](self: List[U, *_], mut writer: W):
         """Write `my_list.__str__()` to a `Writer`.
 
         Parameters:
             W: A type conforming to the Writable trait.
-            U: The type of the List elements. Must have the trait
-                `Representable`.
+            U: The type of the List elements. Must have the trait `Writable`.
 
         Args:
             writer: The object to write to.
         """
         writer.write("[")
         for i in range(len(self)):
-            writer.write(repr(self[i]))
+            writer.write(self[i])
             if i < len(self) - 1:
                 writer.write(", ")
         writer.write("]")
 
     @no_inline
     fn __repr__[
-        U: Representable & Copyable & Movable, //
+        U: Writable & Copyable & Movable, //
     ](self: List[U, *_]) -> String:
         """Returns a string representation of a `List`.
 
         Parameters:
             U: The type of the elements in the list. Must implement the
-              trait `Representable`.
+                trait `Writable`.
 
         Returns:
             A string representation of the list.

--- a/mojo/stdlib/stdlib/collections/optional.mojo
+++ b/mojo/stdlib/stdlib/collections/optional.mojo
@@ -271,13 +271,13 @@ struct Optional[T: Copyable & Movable](
         return self.value()
 
     fn __str__[
-        U: Copyable & Movable & Representable, //
+        U: Copyable & Movable & Writable, //
     ](self: Optional[U]) -> String:
         """Return the string representation of the value of the Optional.
 
         Parameters:
             U: The type of the elements in the list. Must implement the
-              traits `Representable`, `Copyable` and `Movable`.
+                traits `Writable`, `Copyable` and `Movable`.
 
         Returns:
             A string representation of the Optional.
@@ -288,13 +288,13 @@ struct Optional[T: Copyable & Movable](
 
     # TODO: Include the Parameter type in the string as well.
     fn __repr__[
-        U: Representable & Copyable & Movable, //
+        U: Writable & Copyable & Movable, //
     ](self: Optional[U]) -> String:
         """Returns the verbose string representation of the Optional.
 
         Parameters:
             U: The type of the elements in the list. Must implement the
-              traits `Representable`, `Copyable` and `Movable`.
+                traits `Writable`, `Copyable` and `Movable`.
 
         Returns:
             A verbose string representation of the Optional.
@@ -306,20 +306,20 @@ struct Optional[T: Copyable & Movable](
         return output
 
     fn write_to[
-        W: Writer, U: Representable & Copyable & Movable, //
+        W: Writer, U: Writable & Copyable & Movable, //
     ](self: Optional[U], mut writer: W):
         """Write Optional string representation to a `Writer`.
 
         Parameters:
             W: A type conforming to the Writable trait.
             U: The type of the elements in the list. Must implement the
-              traits `Representable`, `Copyable` and `Movable`.
+                traits `Writable`, `Copyable` and `Movable`.
 
         Args:
             writer: The object to write to.
         """
         if self:
-            writer.write(repr(self.value()))
+            writer.write(self.unsafe_value())
         else:
             writer.write("None")
 

--- a/mojo/stdlib/stdlib/collections/set.mojo
+++ b/mojo/stdlib/stdlib/collections/set.mojo
@@ -294,11 +294,11 @@ struct Set[T: KeyElement](
         return hash_value
 
     @no_inline
-    fn __str__[U: KeyElement & Representable, //](self: Set[U]) -> String:
+    fn __str__[U: KeyElement & Writable, //](self: Set[U]) -> String:
         """Returns the string representation of the set.
 
         Parameters:
-            U: The type of the List elements. Must implement the `Representable`
+            U: The type of the List elements. Must implement the `Writable`
                 and `KeyElement` traits.
 
         Returns:
@@ -309,11 +309,11 @@ struct Set[T: KeyElement](
         return output
 
     @no_inline
-    fn __repr__[U: KeyElement & Representable, //](self: Set[U]) -> String:
+    fn __repr__[U: KeyElement & Writable, //](self: Set[U]) -> String:
         """Returns the string representation of the set.
 
         Parameters:
-            U: The type of the List elements. Must implement the `Representable`
+            U: The type of the List elements. Must implement the `Writable`
                 and `KeyElement` traits.
 
         Returns:
@@ -322,13 +322,13 @@ struct Set[T: KeyElement](
         return self.__str__()
 
     fn write_to[
-        W: Writer, U: KeyElement & Representable, //
+        W: Writer, U: KeyElement & Writable, //
     ](self: Set[U], mut writer: W):
         """Write Set string representation to a `Writer`.
 
         Parameters:
             W: A type conforming to the Writer trait.
-            U: The type of the List elements. Must implement the `Representable`
+            U: The type of the List elements. Must implement the `Writable`
                 and `KeyElement` traits.
 
         Args:
@@ -337,7 +337,7 @@ struct Set[T: KeyElement](
         writer.write("{")
         var written = 0
         for item in self:
-            writer.write(repr(item[]))
+            writer.write(item[])
             if written < len(self) - 1:
                 writer.write(", ")
             written += 1

--- a/mojo/stdlib/stdlib/testing/testing.mojo
+++ b/mojo/stdlib/stdlib/testing/testing.mojo
@@ -198,7 +198,7 @@ fn assert_equal[
 
 @always_inline
 fn assert_equal[
-    T: Copyable & Movable & EqualityComparable & Representable, //
+    T: Copyable & Movable & EqualityComparable & Writable, //
 ](
     lhs: List[T],
     rhs: List[T],
@@ -436,7 +436,7 @@ fn assert_not_equal[
 
 @always_inline
 fn assert_not_equal[
-    T: Copyable & Movable & EqualityComparable & Representable, //
+    T: Copyable & Movable & EqualityComparable & Writable, //
 ](
     lhs: List[T],
     rhs: List[T],


### PR DESCRIPTION
Change default from `Representable` to `Writable` for several collections