### PR TITLE
[stdlib] [NFC] Remove `String`, `StringSlice`, and `StaticString` imports

### DIFF
--- a/mojo/stdlib/benchmarks/collections/bench_string.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_string.mojo
@@ -16,7 +16,6 @@
 # the -t flag. Remember to replace it again before pushing any code.
 
 from collections import Dict, Optional
-from collections.string import String
 from collections.string._utf8 import _is_valid_utf8
 from os import abort
 from pathlib import _dir_of_current_file

--- a/mojo/stdlib/stdlib/algorithm/functional.mojo
+++ b/mojo/stdlib/stdlib/algorithm/functional.mojo
@@ -19,7 +19,7 @@ from algorithm import map
 ```
 """
 
-from collections.string.string_slice import StaticString, get_static_string
+from collections.string.string_slice import get_static_string
 from math import align_down, ceildiv
 from os import abort
 from sys import bitwidthof, is_nvidia_gpu, num_physical_cores, simdwidthof

--- a/mojo/stdlib/stdlib/algorithm/reduction.mojo
+++ b/mojo/stdlib/stdlib/algorithm/reduction.mojo
@@ -20,7 +20,6 @@ from algorithm import map_reduce
 """
 
 from collections import OptionalReg
-from collections.string import StaticString
 from math import align_down, ceildiv, iota
 from os import abort
 from sys.info import bitwidthof, is_nvidia_gpu, simdwidthof, sizeof

--- a/mojo/stdlib/stdlib/benchmark/bencher.mojo
+++ b/mojo/stdlib/stdlib/benchmark/bencher.mojo
@@ -13,7 +13,6 @@
 
 import time
 from collections import Dict, Optional
-from collections.string import StaticString, StringSlice
 from collections.string.string import _calc_initial_buffer_size_int32
 from os import abort
 from pathlib import Path

--- a/mojo/stdlib/stdlib/builtin/string_literal.mojo
+++ b/mojo/stdlib/stdlib/builtin/string_literal.mojo
@@ -17,7 +17,7 @@ These are Mojo built-ins, so you don't need to import them.
 
 from collections import List
 from collections.string.format import _CurlyEntryFormattable
-from collections.string.string_slice import CodepointSliceIter, StaticString
+from collections.string.string_slice import CodepointSliceIter
 from os import PathLike
 from sys.ffi import c_char
 

--- a/mojo/stdlib/stdlib/collections/string/format.mojo
+++ b/mojo/stdlib/stdlib/collections/string/format.mojo
@@ -50,11 +50,9 @@ Note that the following features from Python's `str.format()` are
 - Accessing an indexed value from the argument (for example, `"{1[0]}"`).
 - Format specifiers for controlling output format (width, precision, and so on).
 
-Example:
+Examples:
 
 ```mojo
-from collections.string import String
-
 # Basic formatting
 var s1 = String("Hello {0}!").format("World")  # Hello World!
 

--- a/mojo/stdlib/stdlib/compile/compile.mojo
+++ b/mojo/stdlib/stdlib/compile/compile.mojo
@@ -38,7 +38,7 @@ print(info)
 ```
 """
 
-from collections.string.string_slice import StaticString, _get_kgen_string
+from collections.string.string_slice import _get_kgen_string
 from os import PathLike
 from pathlib import Path
 from sys.info import _current_target

--- a/mojo/stdlib/stdlib/compile/reflection.mojo
+++ b/mojo/stdlib/stdlib/compile/reflection.mojo
@@ -11,7 +11,6 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from collections.string import StaticString
 from sys.info import _current_target
 
 

--- a/mojo/stdlib/stdlib/gpu/_cublas/cublas.mojo
+++ b/mojo/stdlib/stdlib/gpu/_cublas/cublas.mojo
@@ -12,7 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 
 from collections import List
-from collections.string import StaticString
 from os import abort
 from pathlib import Path
 from sys.ffi import _find_dylib

--- a/mojo/stdlib/stdlib/gpu/_cublas/cublaslt.mojo
+++ b/mojo/stdlib/stdlib/gpu/_cublas/cublaslt.mojo
@@ -12,7 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 
 from collections import List
-from collections.string import StaticString
 from os import abort
 from pathlib import Path
 from sys.ffi import _find_dylib

--- a/mojo/stdlib/stdlib/gpu/_cufft/utils.mojo
+++ b/mojo/stdlib/stdlib/gpu/_cufft/utils.mojo
@@ -12,7 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 
 from collections import List
-from collections.string import StaticString
 from pathlib import Path
 from sys.ffi import _find_dylib
 from sys.ffi import _get_dylib_function as _ffi_get_dylib_function

--- a/mojo/stdlib/stdlib/gpu/_curand/curand.mojo
+++ b/mojo/stdlib/stdlib/gpu/_curand/curand.mojo
@@ -11,7 +11,6 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from collections.string import StaticString
 from os import abort
 from pathlib import Path
 from sys.ffi import _find_dylib

--- a/mojo/stdlib/stdlib/gpu/_rocblas/hipblaslt.mojo
+++ b/mojo/stdlib/stdlib/gpu/_rocblas/hipblaslt.mojo
@@ -11,7 +11,6 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from collections.string import StaticString
 from os import abort
 from pathlib import Path
 from sys.ffi import _find_dylib

--- a/mojo/stdlib/stdlib/gpu/_rocblas/utils.mojo
+++ b/mojo/stdlib/stdlib/gpu/_rocblas/utils.mojo
@@ -12,7 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 
 from collections import List
-from collections.string import StaticString
 from pathlib import Path
 from sys.ffi import _find_dylib
 from sys.ffi import _get_dylib_function as _ffi_get_dylib_function

--- a/mojo/stdlib/stdlib/gpu/host/_compile.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/_compile.mojo
@@ -15,7 +15,6 @@
 import subprocess
 import tempfile
 from collections import Optional
-from collections.string import StaticString
 from pathlib import Path
 from sys.info import _get_arch
 

--- a/mojo/stdlib/stdlib/gpu/host/_tracing.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/_tracing.mojo
@@ -12,7 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 
 from collections import List, Optional
-from collections.string import StaticString
 from os import abort
 from pathlib import Path
 from sys import (

--- a/mojo/stdlib/stdlib/gpu/host/constant_memory_mapping.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/constant_memory_mapping.mojo
@@ -16,7 +16,6 @@ The module includes the `ConstantMemoryMapping` struct which represents a mappin
 constant memory that can be used for efficient data transfer between host and GPU device.
 """
 
-from collections.string import StaticString
 
 from memory import UnsafePointer
 

--- a/mojo/stdlib/stdlib/gpu/host/device_context.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/device_context.mojo
@@ -20,7 +20,6 @@ use this struct to allocate accelerator memory, copy data to and from the
 accelerator, and compile and execute functions on the accelerator."""
 
 from collections import List, Optional, OptionalReg
-from collections.string import StaticString, StringSlice
 from math import align_up
 from os import abort
 from pathlib import Path

--- a/mojo/stdlib/stdlib/gpu/host/info.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/info.mojo
@@ -18,7 +18,6 @@ NVIDIA and AMD GPUs. It includes information about compute capabilities,
 memory specifications, thread organization, and performance characteristics.
 """
 
-from collections.string.string_slice import StaticString, StringSlice
 from math import ceildiv, floor
 from os import abort
 from sys import env_get_string

--- a/mojo/stdlib/stdlib/gpu/memory.mojo
+++ b/mojo/stdlib/stdlib/gpu/memory.mojo
@@ -27,7 +27,6 @@ achieve optimal memory access patterns and cache utilization.
 """
 
 from collections import OptionalReg
-from collections.string import StaticString
 from collections.string.string_slice import _get_kgen_string, get_static_string
 from sys import (
     alignof,

--- a/mojo/stdlib/stdlib/gpu/warp.mojo
+++ b/mojo/stdlib/stdlib/gpu/warp.mojo
@@ -31,7 +31,6 @@ implementations of the core operations. It supports various data types including
 integers, floats, and half-precision floats, with SIMD vectorization.
 """
 
-from collections.string import StringSlice
 from sys import bitwidthof, is_nvidia_gpu, llvm_intrinsic, sizeof
 from sys._assembly import inlined_assembly
 from sys.info import _is_sm_100x_or_newer

--- a/mojo/stdlib/stdlib/python/python_object.mojo
+++ b/mojo/stdlib/stdlib/python/python_object.mojo
@@ -25,8 +25,8 @@ from os import abort
 from sys.ffi import c_ssize_t
 from sys.intrinsics import _unsafe_aliasing_address_to_pointer
 
-# This apparently redundant import is needed so PythonBindingsGen.cpp can find
-# the StringLiteral declaration.
+# NOTE: This apparently redundant import is needed so PythonBindingsGen.cpp can
+# find the StringLiteral declaration.
 from builtin.string_literal import StringLiteral
 from memory import UnsafePointer
 

--- a/mojo/stdlib/stdlib/runtime/tracing.mojo
+++ b/mojo/stdlib/stdlib/runtime/tracing.mojo
@@ -14,7 +14,6 @@
 
 from collections import Optional
 from collections.optional import OptionalReg
-from collections.string import StaticString
 from sys import external_call
 from sys.param_env import env_get_int, is_defined
 

--- a/mojo/stdlib/stdlib/subprocess/subprocess.mojo
+++ b/mojo/stdlib/stdlib/subprocess/subprocess.mojo
@@ -14,7 +14,6 @@
 
 
 import sys._libc as libc
-from collections.string import StringSlice
 from sys import external_call
 from sys._libc import FILE_ptr, pclose, popen
 from sys.ffi import c_char

--- a/mojo/stdlib/test/compile/test_compile_with_datalayout.mojo
+++ b/mojo/stdlib/test/compile/test_compile_with_datalayout.mojo
@@ -12,7 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo-no-debug %s
 
-from collections.string import StaticString
 
 from compile import compile_info
 from gpu import *

--- a/mojo/stdlib/test/runtime/test_tracing.mojo
+++ b/mojo/stdlib/test/runtime/test_tracing.mojo
@@ -12,7 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: env MODULAR_PROFILE_FILENAME="-" %mojo-no-debug %s | FileCheck %s
 
-from collections.string import StaticString
 from pathlib import Path
 
 from runtime.asyncrt import create_task


### PR DESCRIPTION
Remove `String`, `StringSlice`, and `StaticString` imports. They are already imported in the prelude.