### PR TITLE
[stdlib] [NFC] Remove `Dict` imports

### DIFF
--- a/mojo/stdlib/benchmarks/bit/bench_bit.mojo
+++ b/mojo/stdlib/benchmarks/bit/bench_bit.mojo
@@ -14,7 +14,6 @@
 # NOTE: to test changes on the current branch using run-benchmarks.sh, remove
 # the -t flag. Remember to replace it again before pushing any code.
 
-from collections import Dict
 from random import random_ui64, seed
 from sys import bitwidthof
 from sys.intrinsics import likely, unlikely

--- a/mojo/stdlib/benchmarks/collections/bench_dict.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_dict.mojo
@@ -14,7 +14,6 @@
 # NOTE: to test changes on the current branch using run-benchmarks.sh, remove
 # the -t flag. Remember to replace it again before pushing any code.
 
-from collections import Dict, Optional
 from collections.dict import DictEntry
 from math import ceil
 from random import *

--- a/mojo/stdlib/benchmarks/collections/bench_string.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_string.mojo
@@ -15,7 +15,6 @@
 # NOTE: to test changes on the current branch using run-benchmarks.sh, remove
 # the -t flag. Remember to replace it again before pushing any code.
 
-from collections import Dict, Optional
 from collections.string import String
 from collections.string._utf8 import _is_valid_utf8
 from os import abort

--- a/mojo/stdlib/stdlib/benchmark/bencher.mojo
+++ b/mojo/stdlib/stdlib/benchmark/bencher.mojo
@@ -12,7 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 
 import time
-from collections import Dict, Optional
 from collections.string import StaticString, StringSlice
 from collections.string.string import _calc_initial_buffer_size_int32
 from os import abort

--- a/mojo/stdlib/stdlib/builtin/reversed.mojo
+++ b/mojo/stdlib/stdlib/builtin/reversed.mojo
@@ -15,7 +15,7 @@
 These are Mojo built-ins, so you don't need to import them.
 """
 
-from collections import Deque, Dict
+from collections import Deque
 from collections.deque import _DequeIter
 from collections.dict import _DictEntryIter, _DictKeyIter, _DictValueIter
 from collections.list import _ListIter

--- a/mojo/stdlib/stdlib/collections/dict.mojo
+++ b/mojo/stdlib/stdlib/collections/dict.mojo
@@ -40,8 +40,6 @@ from sys.ffi import OpaquePointer
 
 from memory import UnsafePointer, bitcast, memcpy
 
-from .optional import Optional
-
 
 trait KeyElement(Copyable, Movable, Hashable, EqualityComparable):
     """A trait composition for types which implement all requirements of
@@ -367,7 +365,6 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
     Examples:
 
     ```mojo
-    from collections import Dict
     var d = Dict[String, Int]()
     d["a"] = 1
     d["b"] = 2
@@ -499,8 +496,6 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
         Examples:
 
         ```mojo
-        from collections import Dict
-
         var x = Dict[Int, Int](power_of_two_initial_capacity = 1024)
         # Insert (2/3 of 1024) entries without reallocation.
         ```
@@ -718,8 +713,6 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
             this method is a bit special. Here is an example below:
 
             ```mojo
-            from collections import Dict
-
             var my_dict = Dict[Int, Float64]()
             my_dict[1] = 1.1
             my_dict[2] = 2.2
@@ -923,8 +916,6 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
         Examples:
 
         ```mojo
-        from collections import Dict
-
         var my_dict = Dict[String, Int]()
         my_dict["a"] = 1
         my_dict["b"] = 2
@@ -1281,8 +1272,6 @@ struct OwnedKwargsDict[V: Copyable & Movable](
         Examples:
 
         ```mojo
-        from collections import Dict
-
         var my_dict = Dict[String, Int]()
         my_dict["a"] = 1
         my_dict["b"] = 2

--- a/mojo/stdlib/stdlib/python/python.mojo
+++ b/mojo/stdlib/stdlib/python/python.mojo
@@ -19,7 +19,6 @@ from python import Python
 ```
 """
 
-from collections import Dict
 from collections.dict import OwnedKwargsDict
 from os import abort, getenv
 from sys import external_call, sizeof

--- a/mojo/stdlib/stdlib/python/python_object.mojo
+++ b/mojo/stdlib/stdlib/python/python_object.mojo
@@ -19,7 +19,6 @@ from python import PythonObject
 ```
 """
 
-from collections import Dict
 from hashlib._hasher import _HashableWithHasher, _Hasher
 from os import abort
 from sys.ffi import c_ssize_t

--- a/mojo/stdlib/test/builtin/test_reversed.mojo
+++ b/mojo/stdlib/test/builtin/test_reversed.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo %s
 
-from collections import Deque, Dict
+from collections import Deque
 
 from testing import assert_equal
 

--- a/mojo/stdlib/test/collections/test_dict.mojo
+++ b/mojo/stdlib/test/collections/test_dict.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 # RUN: %mojo %s
 
-from collections import Dict, KeyElement, Optional
+from collections import KeyElement
 from collections.dict import OwnedKwargsDict
 from os import abort
 

--- a/mojo/stdlib/test/python/test_python_object.mojo
+++ b/mojo/stdlib/test/python/test_python_object.mojo
@@ -13,7 +13,6 @@
 # XFAIL: asan && !system-darwin
 # RUN: %mojo %s
 
-from collections import Dict
 
 from python import Python, PythonObject
 from testing import assert_equal, assert_false, assert_raises, assert_true

--- a/mojo/stdlib/test/tempfile/test_tempfile.mojo
+++ b/mojo/stdlib/test/tempfile/test_tempfile.mojo
@@ -13,7 +13,6 @@
 # RUN: %mojo %s
 
 import os
-from collections import Dict, Optional
 from os.path import exists, split
 from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory, gettempdir, mkdtemp


### PR DESCRIPTION
Remove `Dict` imports. It is already imported in the prelude