### PR TITLE
[stdlib] Optimize `.splitlines()` using new `splat` bit mask util

### DIFF
--- a/mojo/stdlib/benchmarks/bit/bench_bit.mojo
+++ b/mojo/stdlib/benchmarks/bit/bench_bit.mojo
@@ -17,6 +17,7 @@ from sys.intrinsics import likely, unlikely
 
 from benchmark import Bench, BenchConfig, Bencher, BenchId, keep
 from bit import bit_width, count_leading_zeros
+from bit._mask import splat
 
 # ===-----------------------------------------------------------------------===#
 # Benchmarks
@@ -56,7 +57,7 @@ fn next_power_of_two_int_v3(val: Int) -> Int:
 fn next_power_of_two_int_v4(val: Int) -> Int:
     return 1 << (
         (bitwidthof[Int]() - count_leading_zeros(val - 1))
-        & -Int(likely(val > 1))
+        & splat(likely(val > 1))
     )
 
 

--- a/mojo/stdlib/benchmarks/collections/bench_string.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_string.mojo
@@ -155,13 +155,14 @@ fn bench_string_join[short: Bool](mut b: Bencher) raises:
 fn bench_string_splitlines[
     length: UInt = 0, filename: StaticString = "UN_charter_EN"
 ](mut b: Bencher) raises:
-    var items = make_string[length](filename + ".txt")
+    var items = make_string[length](filename + ".txt").as_string_slice()
 
     @always_inline
     @parameter
     fn call_fn() raises:
-        var res = items.splitlines()
-        keep(res.unsafe_ptr())
+        for _ in range(1_000_000 // length):
+            var res = items.splitlines()
+            keep(res.unsafe_ptr())
 
     b.iter[call_fn]()
     keep(Bool(items))

--- a/mojo/stdlib/stdlib/bit/_mask.mojo
+++ b/mojo/stdlib/stdlib/bit/_mask.mojo
@@ -82,3 +82,17 @@ fn splat[
         otherwise.
     """
     return (-(value.cast[DType.int8]())).cast[dtype]()
+
+
+@always_inline
+fn splat(value: Bool) -> Int:
+    """Get a bitmask of whether the value is `True`.
+
+    Args:
+        value: The value to check.
+
+    Returns:
+        A bitmask filled with `1` if the value is `True`, filled with `0`
+        otherwise.
+    """
+    return Int(splat[DType.index](Scalar[DType.bool](value)))

--- a/mojo/stdlib/stdlib/collections/string/_utf8.mojo
+++ b/mojo/stdlib/stdlib/collections/string/_utf8.mojo
@@ -229,7 +229,7 @@ fn _count_utf8_continuation_bytes(str_slice: StringSlice) -> Int:
 
 
 @always_inline
-fn _utf8_first_byte_sequence_length(b: Byte) -> Int:
+fn _utf8_first_byte_sequence_length(b: Byte) -> UInt:
     """Get the length of the sequence starting with given byte. Do note that
     this does not work correctly if given a continuation byte."""
 
@@ -262,9 +262,9 @@ fn _is_newline_char_utf8[
     include_r_n: Bool = False
 ](
     p: UnsafePointer[Byte, mut=False, **_],
-    eol_start: Int,
+    eol_start: UInt,
     b0: Byte,
-    char_len: Int,
+    char_len: UInt,
 ) -> Bool:
     """Returns whether the char is a newline char.
 
@@ -278,14 +278,19 @@ fn _is_newline_char_utf8[
     alias `\x1c` = UInt8(ord("\x1c"))
     alias `\x1e` = UInt8(ord("\x1e"))
 
-    # here it's actually faster to have branching due to the branch predictor
-    # "realizing" that the char_len == 1 path is often taken. Using the likely
-    # intrinsic is to make the machine code be ordered to optimize machine
-    # instruction fetching, which is an optimization for the CPU front-end.
+    # Since line-breaks are a relatively uncommon occurrence it is best to
+    # branch here because the algorithm that calls this needs low latency rather
+    # than high throughput, which is what a branchless algorithm with SIMD would
+    # provide. So we do branching and add the likely intrinsic to reorder the
+    # machine instructions optimally. Also memory reads are expensive and the
+    # "happy path" of char_len == 1 is cheaper because it has none.
     if likely(char_len == 1):
         return `\t` <= b0 <= `\x1e` and not (`\r` < b0 < `\x1c`)
-    elif char_len == 2:
-        var b1 = p[eol_start + 1]
+    elif char_len == 4:
+        return False
+
+    var b1 = p[eol_start + 1]
+    if char_len == 2:
         var is_next_line = b0 == 0xC2 and b1 == 0x85  # unicode next line \x85
 
         @parameter
@@ -293,8 +298,7 @@ fn _is_newline_char_utf8[
             return is_next_line or (b0 == `\r` and b1 == `\n`)
         else:
             return is_next_line
-    elif char_len == 3:  # unicode line sep or paragraph sep: \u2028 , \u2029
-        var b1 = p[eol_start + 1]
+    else:  # unicode line sep or paragraph sep: \u2028 , \u2029
+        debug_assert(char_len == 3, "invalid UTF-8 byte length")
         var b2 = p[eol_start + 2]
         return b0 == 0xE2 and b1 == 0x80 and (b2 == 0xA8 or b2 == 0xA9)
-    return False

--- a/mojo/stdlib/stdlib/collections/string/codepoint.mojo
+++ b/mojo/stdlib/stdlib/collections/string/codepoint.mojo
@@ -44,6 +44,7 @@ var s = String(c)  # "A"
 from sys.intrinsics import likely
 
 from bit import count_leading_zeros
+from bit._mask import splat
 
 
 @always_inline
@@ -561,7 +562,7 @@ struct Codepoint(Copyable, EqualityComparable, Intable, Movable, Stringable):
                 var mask = UInt8(0xFF) >> (num_bytes + Int(num_bytes > 1))
                 var num_bytes_marker = UInt8(0xFF) << (8 - num_bytes)
                 ptr[0] = ((c >> shift) & mask) | (
-                    num_bytes_marker & -Int(num_bytes != 1)
+                    num_bytes_marker & splat(num_bytes != 1)
                 )
                 for i in range(1, num_bytes):
                     shift -= 6


### PR DESCRIPTION
Optimize `.splitlines()` using new `splat` bit mask util


### Benchmark results

CPU: Intel® Core™ i7-7700HQ

|  | old value (ms) | new value (ms) | percentage | magnitude
|-- | --:| --:| --:| --:|
|bench_string_splitlines[10] | 9.93 | 8.76 | 0.12 | 1.13|
|bench_string_splitlines[30] | 6.46 | 5.00 | 0.23 | 1.29|
|bench_string_splitlines[50] | 4.91 | 4.60 | 0.06 | 1.07|
|bench_string_splitlines[100] | 4.49 | 3.85 | 0.14 | 1.17|
|bench_string_splitlines[1000] | 3.98 | 3.57 | 0.10 | 1.12|
|bench_string_splitlines[10000] | 3.67 | 3.36 | 0.08 | 1.09|
|bench_string_splitlines[100000] | 3.67 | 3.34 | 0.09 | 1.10|
|bench_string_splitlines[1000000] | 3.67 | 3.42 | 0.07 | 1.07|
|average improvement |   |   | 0.11 | 1.13|