### PR TITLE
[stdlib] Allow `Dict.__getitem__` to return mutable references

### DIFF
--- a/mojo/stdlib/stdlib/collections/dict.mojo
+++ b/mojo/stdlib/stdlib/collections/dict.mojo
@@ -598,7 +598,7 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
     # ===-------------------------------------------------------------------===#
 
     fn __getitem__(
-        self, key: K
+        ref self, key: K
     ) raises -> ref [self._entries[0].value().value] Self.V:
         """Retrieve a value out of the dictionary.
 


### PR DESCRIPTION
Mutable references are necessary if a mutable pointer into the  dict needs to be created.

This fixes #4695.

Signed-off-by: Samuel M. Fischer <samufi@web.de>