### PR TITLE
Addition example in gpu_functions

### DIFF
--- a/examples/gpu_functions/README.md
+++ b/examples/gpu_functions/README.md
@@ -18,7 +18,7 @@ run on the CPU or GPU in Mojo.
 A [MAX-compatible GPU](https://docs.modular.com/max/faq/#gpu-requirements) is
 necessary to run these examples.
 
-The four examples of GPU functions defined in Mojo consist of:
+The five examples of GPU functions defined in Mojo consist of:
 
 - **vector_addition.mojo**: A common "hello world" example for GPU programming,
   this adds two vectors together in the same way as seen in Chapter 2 of
@@ -31,6 +31,7 @@ The four examples of GPU functions defined in Mojo consist of:
 - **mandelbrot.mojo**: A parallel calculation of the number of iterations to
   escape in the Mandelbrot set. An example of the same computation performed as
   a custom graph operation can be found [here](../custom_ops/).
+- **reduction.mojo**: A highly performant reduction kernel. For a detailed explanation see [this blogpost](https://veitner.bearblog.dev/very-fast-vector-sum-without-cuda/).
 
 A single Magic command runs each of the examples:
 
@@ -39,6 +40,7 @@ magic run vector_addition
 magic run grayscale
 magic run naive_matrix_multiplication
 magic run mandelbrot
+magic run reduction
 ```
 
 For larger computations, we recommend staging them as part of a

--- a/examples/gpu_functions/mojoproject.toml
+++ b/examples/gpu_functions/mojoproject.toml
@@ -11,7 +11,8 @@ vector_addition = "mojo run vector_addition.mojo"
 grayscale = "mojo run grayscale.mojo"
 naive_matrix_multiplication = "mojo run naive_matrix_multiplication.mojo"
 mandelbrot = "mojo run mandelbrot.mojo"
-test = { depends-on = ["vector_addition", "grayscale", "naive_matrix_multiplication", "mandelbrot"] }
+reduction = "mojo run reduction.mojo"
+test = { depends-on = ["vector_addition", "grayscale", "naive_matrix_multiplication", "mandelbrot", "reduction"] }
 
 [dependencies]
 max = ">=24.6.0.dev2024090821"

--- a/examples/gpu_functions/reduction.mojo
+++ b/examples/gpu_functions/reduction.mojo
@@ -1,0 +1,109 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from math import ceildiv
+from memory import UnsafePointer
+from os.atomic import Atomic
+from random import randint
+from sys import has_amd_gpu_accelerator, has_nvidia_gpu_accelerator
+from testing import assert_equal
+
+from gpu import thread_idx, block_idx, block_dim, grid_dim, warp, barrier
+from gpu.host import DeviceContext
+from gpu.memory import load
+from layout.tensor_builder import LayoutTensorBuild as tb
+
+# Initialize parameters
+# To archieve high bandwidth increase SIZE to large value
+alias TPB = 512
+alias LOG_TPB = 9
+alias BATCH_SIZE = 8  # needs to be power of 2
+alias SIZE = 1 << 25
+alias NUM_BLOCKS = ceildiv(SIZE, TPB * BATCH_SIZE)
+alias dtype = DType.int32
+
+fn sum_kernel[
+    size: Int, batch_size: Int
+](out: UnsafePointer[Int32], a: UnsafePointer[Int32],):
+    """Efficent reduction of the vector a."""
+    sums = tb[dtype]().row_major[TPB]().shared().alloc()
+    global_tid = block_idx.x * block_dim.x + thread_idx.x
+    tid = thread_idx.x
+    threads_in_grid = TPB * grid_dim.x
+    var sum: Int32 = 0
+
+    for i in range(global_tid, size, threads_in_grid):
+        idx = i * batch_size
+        # Load in a vectorized fashion and reduce the loaded SIMD vector
+        if idx < size:
+            sum += load[width=batch_size](a, idx).reduce_add()
+    sums[tid] = sum
+    barrier()
+
+    # Reduce until the first warp
+    active_threads = TPB
+    @parameter
+    for power in range(1, LOG_TPB - 4):
+        active_threads >>= 1
+        if tid < active_threads:
+            sums[tid] += sums[tid + active_threads]
+        barrier()
+
+    # Reduce the warp and accumulate via atomic addition
+    if tid < 32:
+        var warp_sum: Int32 = sums[tid][0]
+        warp_sum = warp.sum(warp_sum)
+
+        if tid == 0:
+            _ = Atomic.fetch_add(out, warp_sum)
+
+def main():
+    constrained[
+        has_nvidia_gpu_accelerator() or has_amd_gpu_accelerator(),
+        "This example requires a supported GPU",
+    ]()
+
+    with DeviceContext() as ctx:
+        # Allocate memory on the device 
+        out = ctx.enqueue_create_buffer[dtype](1).enqueue_fill(0)
+        a = ctx.enqueue_create_buffer[dtype](SIZE).enqueue_fill(0)
+
+        # Initialise a with random integers between 0 and 10
+        with a.map_to_host() as a_host:
+            randint[dtype](a_host.unsafe_ptr(), SIZE, 0, 10)
+
+        # Get unsafe pointers to device 
+        out_ptr = out.unsafe_ptr()
+        a_ptr = a.unsafe_ptr()
+
+        # Call the kernel
+        ctx.enqueue_function[sum_kernel[SIZE, BATCH_SIZE]](
+            out_ptr,
+            a_ptr,
+            grid_dim=NUM_BLOCKS,
+            block_dim=TPB,
+        )
+        ctx.synchronize()
+
+        # Calculate the sum in a sequential fashion on the host 
+        # for correctness check
+        expected = ctx.enqueue_create_host_buffer[dtype](1).enqueue_fill(0)
+        with a.map_to_host() as a_host:
+            for i in range(SIZE):
+                expected[0] += a_host[i]
+
+        # Assert the correctness of the kernel
+        with out.map_to_host() as out_host:
+            print("out:", out_host)
+            print("expected:", expected)
+            assert_equal(out_host[0], expected[0])


### PR DESCRIPTION
This PR adds an additional example to the `examples/gpu_functions` folder.
I adjusted the project file and README accordingly and striped down the [original implementation](https://github.com/simveit/effective-reduction-mojo/blob/master/kernel/one_pass_4.mojo) to be more inline with the rest of the examples.