### PR TITLE
[stdlib] Included intrincics for tanh

### DIFF
--- a/mojo/stdlib/stdlib/math/math.mojo
+++ b/mojo/stdlib/stdlib/math/math.mojo
@@ -993,13 +993,31 @@ fn tanh[
         alias instruction = "tanh.approx.f32"
 
         @parameter
-        if sizeof[dtype]() < sizeof[DType.float32]():
+        if dtype is DType.float16:
             return _call_ptx_intrinsic[
-                instruction=instruction, constraints="=f,f"
-            ](x.cast[DType.float32]()).cast[dtype]()
+                scalar_instruction="tanh.approx.f16",
+                vector2_instruction="tanh.approx.f16x2",
+                scalar_constraints="=h,h",
+                vector_constraints="=r,r",
+            ](x)
+
+        elif dtype is DType.bfloat16:
+            @parameter
+            if _is_sm_9x_or_newer():
+                return _call_ptx_intrinsic[
+                    scalar_instruction="tanh.approx.bf16",
+                    vector2_instruction="tanh.approx.bf16x2",
+                    scalar_constraints="=h,h",
+                    vector_constraints="=r,r",
+                ](x)
+            else:
+                 return _call_ptx_intrinsic[
+                    instruction="tanh.approx.f32", constraints="=f,f"
+                ](x.cast[DType.float32]()).cast[dtype]()
+        
         elif dtype is DType.float32:
             return _call_ptx_intrinsic[
-                instruction=instruction, constraints="=f,f"
+                instruction="tanh.approx.f32", constraints="=f,f"
             ](x)
 
     var xc = x.clamp(-9, 9)

--- a/mojo/stdlib/stdlib/math/math.mojo
+++ b/mojo/stdlib/stdlib/math/math.mojo
@@ -1002,6 +1002,7 @@ fn tanh[
             ](x)
 
         elif dtype is DType.bfloat16:
+
             @parameter
             if _is_sm_9x_or_newer():
                 return _call_ptx_intrinsic[
@@ -1011,10 +1012,10 @@ fn tanh[
                     vector_constraints="=r,r",
                 ](x)
             else:
-                 return _call_ptx_intrinsic[
+                return _call_ptx_intrinsic[
                     instruction="tanh.approx.f32", constraints="=f,f"
                 ](x.cast[DType.float32]()).cast[dtype]()
-        
+
         elif dtype is DType.float32:
             return _call_ptx_intrinsic[
                 instruction="tanh.approx.f32", constraints="=f,f"


### PR DESCRIPTION
According to [PTX isa doc](https://docs.nvidia.com/cuda/parallel-thread-execution/#half-precision-floating-point-instructions-tanh) implemented half floating point instructions for `tanh` following `exp2` implementation