### PR TITLE
[stdlib] Small typo fix

### DIFF
--- a/mojo/stdlib/stdlib/gpu/sync.mojo
+++ b/mojo/stdlib/stdlib/gpu/sync.mojo
@@ -560,7 +560,7 @@ fn mbarrier_try_wait_parity_shared[
         constrained[
             False,
             (
-                "The mbarrier_try_wait_arity_shared function is not supported"
+                "The mbarrier_try_wait_parity_shared function is not supported"
                 " on AMD GPUs."
             ),
         ]()


### PR DESCRIPTION
Fixed a small typo in `mbarrier_try_wait_parity_shared`