### PR TITLE
[CI] Convert CI to use pixi

### DIFF
--- a/.github/workflows/standard_library_tests_and_examples.yml
+++ b/.github/workflows/standard_library_tests_and_examples.yml
@@ -47,11 +47,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Download Magic CLI
+      - name: Install Pixi
         run: |
-          curl -ssL https://magic.modular.com/cfba4c92-2390-4b86-93de-04b2f47114d5 | bash
-          # Add magic to PATH
-          echo "$HOME/.modular/bin" >> $GITHUB_PATH
+          curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=0.47.0 sh
+          # Add pixi to PATH
+          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
 
       - name: Install build tools (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -68,6 +68,6 @@ jobs:
           MOJO_ENABLE_ASSERTIONS_IN_TESTS: ${{ matrix.mojo-enable-assertions }}
         working-directory: mojo
         run: |
-          magic run --frozen tests
-          magic run --frozen examples
-          magic run --frozen benchmarks
+          pixi run --frozen tests
+          pixi run --frozen examples
+          pixi run --frozen benchmarks

--- a/.github/workflows/test_pre_commit.yml
+++ b/.github/workflows/test_pre_commit.yml
@@ -36,11 +36,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Download Magic CLI
+      - name: Install Pixi
         run: |
-          curl -ssL https://magic.modular.com/cfba4c92-2390-4b86-93de-04b2f47114d5 | bash
-          # Add magic to PATH
-          echo "$HOME/.modular/bin" >> $GITHUB_PATH
+          curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=0.47.0 sh
+          # Add pixi to PATH
+          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
 
       - name: Install pre-commit
         run: |
@@ -48,4 +48,4 @@ jobs:
           pre-commit install
 
       - name: Run pre-commit
-        run: magic run --manifest-path mojo pre-commit run --all-files
+        run: pixi run --manifest-path mojo pre-commit run --all-files

--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ examples/models/*
 
 # Magic cache
 .magic
+
+# Pixi cache
+.pixi


### PR DESCRIPTION
The main build workflow is going away soon, but to aid in the `magic` decommission let's move the workflow to use `pixi` instead.