### PR TITLE
[stdlib] Remove `PyObjectPtr.is_null()` in favour of using `not ptr`

### DIFF
--- a/mojo/stdlib/stdlib/python/_cpython.mojo
+++ b/mojo/stdlib/stdlib/python/_cpython.mojo
@@ -217,15 +217,6 @@ struct PyObjectPtr(
     # Methods
     # ===-------------------------------------------------------------------===#
 
-    @always_inline
-    fn is_null(self) -> Bool:
-        """Check if the pointer is null.
-
-        Returns:
-            Bool: True if the pointer is null, False otherwise.
-        """
-        return not self
-
     fn write_to[W: Writer](self, mut writer: W):
         """Formats to the provided Writer.
 
@@ -921,7 +912,7 @@ struct CPython(Copyable, Movable):
         # TODO(MSTDL-1479): PyErr_Fetch is deprecated since Python 3.12.
         var err_ptr = self.PyErr_Fetch()
         debug_assert(
-            not err_ptr.is_null(),
+            Bool(err_ptr),
             "Python exception occurred but PyErr_Fetch returned null",
         )
 
@@ -1015,7 +1006,7 @@ struct CPython(Copyable, Movable):
     # debugging. We shouldn't rely on this function anywhere - its only purpose
     # is debugging.
     fn _Py_REFCNT(self, ptr: PyObjectPtr) -> Int:
-        if ptr.is_null():
+        if not ptr:
             return -1
         # NOTE:
         #   The "obvious" way to write this would be:
@@ -1998,7 +1989,7 @@ struct CPython(Copyable, Movable):
         """[Reference](
         https://docs.python.org/3/c-api/exceptions.html#c.PyErr_Occurred).
         """
-        return not self.lib.call["PyErr_Occurred", PyObjectPtr]().is_null()
+        return Bool(self.lib.call["PyErr_Occurred", PyObjectPtr]())
 
     fn PyErr_Fetch(self) -> PyObjectPtr:
         """[Reference](

--- a/mojo/stdlib/stdlib/python/bindings.mojo
+++ b/mojo/stdlib/stdlib/python/bindings.mojo
@@ -210,7 +210,7 @@ fn _default_tp_new_wrapper[
     var cpython = Python().cpython()
 
     try:
-        if len(args) != 0 or keyword_args != PyObjectPtr():
+        if len(args) or keyword_args:
             raise "unexpected arguments passed to default initializer function of wrapped Mojo type"
 
         # Create a new Python object with a default initialized Mojo value.
@@ -648,7 +648,7 @@ struct PythonTypeBuilder(Movable, Copyable):
         # Construct a Python 'type' object from our type spec.
         var type_obj_ptr = cpython.PyType_FromSpec(UnsafePointer(to=type_spec))
 
-        if type_obj_ptr.is_null():
+        if not type_obj_ptr:
             raise cpython.get_error()
 
         var type_obj = PythonObject(from_owned_ptr=type_obj_ptr)

--- a/mojo/stdlib/stdlib/python/python.mojo
+++ b/mojo/stdlib/stdlib/python/python.mojo
@@ -156,7 +156,7 @@ struct Python:
             var code_obj_ptr = cpython.Py_CompileString(
                 expr^, "<evaluate>", Py_file_input
             )
-            if code_obj_ptr.is_null():
+            if not code_obj_ptr:
                 raise cpython.get_error()
             var code = PythonObject(from_owned_ptr=code_obj_ptr)
 
@@ -168,7 +168,7 @@ struct Python:
             var result_ptr = cpython.PyEval_EvalCode(
                 code.py_object, dict_obj.py_object, dict_obj.py_object
             )
-            if result_ptr.is_null():
+            if not result_ptr:
                 raise cpython.get_error()
 
             var result = PythonObject(from_owned_ptr=result_ptr)
@@ -182,7 +182,7 @@ struct Python:
             var result = cpython.PyRun_String(
                 expr^, dict_obj.py_object, dict_obj.py_object, Py_eval_input
             )
-            if result.is_null():
+            if not result:
                 raise cpython.get_error()
             return PythonObject(from_owned_ptr=result)
 
@@ -241,7 +241,7 @@ struct Python:
         # Throw error if it occurred during initialization
         cpython.check_init_error()
         var module_ptr = cpython.PyImport_ImportModule(module^)
-        if module_ptr.is_null():
+        if not module_ptr:
             raise cpython.get_error()
         return PythonObject(from_owned_ptr=module_ptr)
 
@@ -268,7 +268,7 @@ struct Python:
         cpython.check_init_error()
 
         var module_ptr = cpython.PyModule_Create(name)
-        if module_ptr.is_null():
+        if not module_ptr:
             raise cpython.get_error()
 
         return PythonObject(from_owned_ptr=module_ptr)
@@ -370,14 +370,14 @@ struct Python:
     ](kwargs: OwnedKwargsDict[V]) raises -> PyObjectPtr:
         var cpython = Python().cpython()
         var dict_obj_ptr = cpython.PyDict_New()
-        if dict_obj_ptr.is_null():
+        if not dict_obj_ptr:
             raise Error("internal error: PyDict_New failed")
 
         for ref entry in kwargs.items():
             var key_ptr = cpython.PyUnicode_DecodeUTF8(
                 entry.key.as_string_slice()
             )
-            if key_ptr.is_null():
+            if not key_ptr:
                 raise Error("internal error: PyUnicode_DecodeUTF8 failed")
 
             var val_obj = entry.value.to_python_object()
@@ -438,7 +438,7 @@ struct Python:
 
         var cpython = Python().cpython()
         var dict_obj_ptr = cpython.PyDict_New()
-        if dict_obj_ptr.is_null():
+        if not dict_obj_ptr:
             raise Error("internal error: PyDict_New failed")
 
         for i in range(len(tuples)):
@@ -618,7 +618,7 @@ struct Python:
         """
         var cpython = Python().cpython()
         var py_str_ptr = cpython.PyObject_Str(obj.py_object)
-        if py_str_ptr.is_null():
+        if not py_str_ptr:
             raise cpython.get_error()
 
         return PythonObject(from_owned_ptr=py_str_ptr)
@@ -639,7 +639,7 @@ struct Python:
         """
         var cpython = Python().cpython()
         var py_obj_ptr = cpython.PyNumber_Long(obj.py_object)
-        if py_obj_ptr.is_null():
+        if not py_obj_ptr:
             raise cpython.get_error()
 
         return PythonObject(from_owned_ptr=py_obj_ptr)
@@ -660,7 +660,7 @@ struct Python:
         var cpython = Python().cpython()
 
         var float_obj = cpython.PyNumber_Float(obj.py_object)
-        if float_obj.is_null():
+        if not float_obj:
             raise cpython.get_error()
 
         return PythonObject(from_owned_ptr=float_obj)

--- a/mojo/stdlib/stdlib/python/python_object.mojo
+++ b/mojo/stdlib/stdlib/python/python_object.mojo
@@ -104,7 +104,7 @@ struct _PyIter(Sized):
         var cpython = Python().cpython()
         self.iterator = iter
         var maybe_next_item = cpython.PyIter_Next(self.iterator.py_object)
-        if maybe_next_item.is_null():
+        if not maybe_next_item:
             self.is_done = True
             self.prepared_next_item = PythonObject(from_owned_ptr=PyObjectPtr())
         else:
@@ -135,7 +135,7 @@ struct _PyIter(Sized):
         var cpython = Python().cpython()
         var current = self.prepared_next_item
         var maybe_next_item = cpython.PyIter_Next(self.iterator.py_object)
-        if maybe_next_item.is_null():
+        if not maybe_next_item:
             self.is_done = True
         else:
             self.prepared_next_item = PythonObject(
@@ -427,7 +427,7 @@ struct PythonObject(
         """
         var cpython = Python().cpython()
         var obj_ptr = cpython.PySet_New()
-        if obj_ptr.is_null():
+        if not obj_ptr:
             raise cpython.get_error()
 
         @parameter
@@ -455,7 +455,7 @@ struct PythonObject(
         """
         var cpython = Python().cpython()
         var dict_obj_ptr = cpython.PyDict_New()
-        if dict_obj_ptr.is_null():
+        if not dict_obj_ptr:
             raise Error("internal error: PyDict_New failed")
 
         for i in range(len(keys)):
@@ -490,7 +490,7 @@ struct PythonObject(
         # Acquire GIL such that __del__ can be called safely for cases where the
         # PyObject is handled in non-python contexts.
         var state = cpython.PyGILState_Ensure()
-        if not self.py_object.is_null():
+        if self.py_object:
             cpython.Py_DecRef(self.py_object)
         self.py_object = PyObjectPtr()
         cpython.PyGILState_Release(state)
@@ -562,7 +562,7 @@ struct PythonObject(
         """
         var cpython = Python().cpython()
         var iter_ptr = cpython.PyObject_GetIter(self.py_object)
-        if iter_ptr.is_null():
+        if not iter_ptr:
             raise cpython.get_error()
         return _PyIter(PythonObject(from_owned_ptr=iter_ptr))
 
@@ -577,7 +577,7 @@ struct PythonObject(
         """
         var cpython = Python().cpython()
         var result = cpython.PyObject_GetAttrString(self.py_object, name^)
-        if result.is_null():
+        if not result:
             raise cpython.get_error()
         return PythonObject(from_owned_ptr=result)
 
@@ -659,7 +659,7 @@ struct PythonObject(
         cpython.Py_IncRef(key_obj)
         var result = cpython.PyObject_GetItem(self.py_object, key_obj)
         cpython.Py_DecRef(key_obj)
-        if result.is_null():
+        if not result:
             raise cpython.get_error()
         return PythonObject(from_owned_ptr=result)
 
@@ -689,7 +689,7 @@ struct PythonObject(
         cpython.Py_IncRef(key_obj)
         var result = cpython.PyObject_GetItem(self.py_object, key_obj)
         cpython.Py_DecRef(key_obj)
-        if result.is_null():
+        if not result:
             raise cpython.get_error()
         return PythonObject(from_owned_ptr=result)
 
@@ -1316,7 +1316,7 @@ struct PythonObject(
         cpython.Py_DecRef(callable_obj)
         cpython.Py_DecRef(tuple_obj)
         cpython.Py_DecRef(dict_ptr)
-        if result.is_null():
+        if not result:
             raise cpython.get_error()
         return PythonObject(from_owned_ptr=result)
 


### PR DESCRIPTION
Follow-up to #4734.

The rationale is to eliminate a redundant API and make the codebase more consistent with standard Python conventions.