### PR TITLE
[stdlib] Fix `fn unsafe_ptr(ref self) -> ...` methods to handle address space

### DIFF
--- a/mojo/stdlib/stdlib/collections/inline_array.mojo
+++ b/mojo/stdlib/stdlib/collections/inline_array.mojo
@@ -499,12 +499,13 @@ struct InlineArray[
         return UnsafePointer(ptr)[]
 
     @always_inline
-    fn unsafe_ptr(
-        ref self,
-    ) -> UnsafePointer[
+    fn unsafe_ptr[
+        origin: Origin, address_space: AddressSpace, //
+    ](ref [origin, address_space]self) -> UnsafePointer[
         Self.ElementType,
-        mut = Origin(__origin_of(self)).mut,
-        origin = __origin_of(self),
+        mut = origin.mut,
+        origin=origin,
+        address_space=address_space,
     ]:
         """Gets an unsafe pointer to the underlying array storage.
 
@@ -534,9 +535,8 @@ struct InlineArray[
         return (
             UnsafePointer(to=self._array)
             .bitcast[Self.ElementType]()
-            .origin_cast[
-                mut = Origin(__origin_of(self)).mut, origin = __origin_of(self)
-            ]()
+            .origin_cast[origin.mut, origin]()
+            .address_space_cast[address_space]()
         )
 
     @always_inline

--- a/mojo/stdlib/stdlib/collections/list.mojo
+++ b/mojo/stdlib/stdlib/collections/list.mojo
@@ -1058,20 +1058,22 @@ struct List[T: Copyable & Movable, hint_trivial_type: Bool = False](
         if elt_idx_1 != elt_idx_2:
             swap((self.data + elt_idx_1)[], (self.data + elt_idx_2)[])
 
-    fn unsafe_ptr(
-        ref self,
-    ) -> UnsafePointer[
-        T,
-        mut = Origin(__origin_of(self)).mut,
-        origin = __origin_of(self),
+    fn unsafe_ptr[
+        origin: Origin, address_space: AddressSpace, //
+    ](ref [origin, address_space]self) -> UnsafePointer[
+        T, mut = origin.mut, origin=origin, address_space=address_space
     ]:
         """Retrieves a pointer to the underlying memory.
+
+        Parameters:
+            origin: The origin of the `List`.
+            address_space: The `AddressSpace` of the `List`.
 
         Returns:
             The pointer to the underlying memory.
         """
-        return self.data.origin_cast[
-            mut = Origin(__origin_of(self)).mut, origin = __origin_of(self)
+        return self.data.origin_cast[origin.mut, origin]().address_space_cast[
+            address_space
         ]()
 
     @always_inline

--- a/mojo/stdlib/stdlib/collections/string/string.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string.mojo
@@ -1159,9 +1159,13 @@ struct String(
         """
         if self._capacity_or_data.is_inline():
             # The string itself holds the data.
-            return UnsafePointer(to=self).bitcast[Byte]()
+            return (
+                UnsafePointer(to=self)
+                .bitcast[Byte]()
+                .origin_cast[False, __origin_of(self)]()
+            )
         else:
-            return self._ptr_or_data
+            return self._ptr_or_data.origin_cast[False, __origin_of(self)]()
 
     fn unsafe_ptr_mut(
         mut self,


### PR DESCRIPTION
Fix `fn unsafe_ptr(ref self) -> ...` methods to handle address space. Part of #4754, workaround for #4739


CC: @soraros 