### PR TITLE
[kernel] Remove redundant `alias` from `layout_tensor`

### DIFF
--- a/max/kernels/src/layout/layout_tensor.mojo
+++ b/max/kernels/src/layout/layout_tensor.mojo
@@ -6837,8 +6837,6 @@ fn copy_local_to_dram[
             src.runtime_element_layout,
         )
 
-        alias dst_element_type = Element[dst.dtype, dst.linear_idx_type]
-
         alias element_stride = dst_fragments.element_layout.stride[1].value()
 
         @parameter


### PR DESCRIPTION
This line doesn't even type check. I'm not sure why the compiler didn't catch it.

Related compiler bug filed at #4759.