### PR TITLE
[stdlib] Remove remaining usages of @value in stdlib

### DIFF
--- a/mojo/stdlib/stdlib/collections/string/_parsing_numbers/parsing_floats.mojo
+++ b/mojo/stdlib/stdlib/collections/string/_parsing_numbers/parsing_floats.mojo
@@ -42,9 +42,9 @@ from .constants import (
 from .parsing_integers import to_integer
 
 
-@value
+@fieldwise_init
 @register_passable
-struct UInt128Decomposed:
+struct UInt128Decomposed(Copyable, Movable):
     var high: UInt64
     var low: UInt64
 

--- a/mojo/stdlib/stdlib/hashlib/hash.mojo
+++ b/mojo/stdlib/stdlib/hashlib/hash.mojo
@@ -54,7 +54,7 @@ trait Hashable:
     common hash map implementations.
 
     ```mojo
-    @value
+    @fieldwise_init
     struct Foo(Hashable):
         fn __hash__(self) -> UInt:
             return 4  # chosen by fair random dice roll

--- a/mojo/stdlib/stdlib/logger/logger.mojo
+++ b/mojo/stdlib/stdlib/logger/logger.mojo
@@ -56,8 +56,8 @@ alias DEFAULT_LEVEL = Level._from_str(
 # ===-----------------------------------------------------------------------===#
 
 
-@value
-struct Level(Stringable, Writable):
+@fieldwise_init
+struct Level(Stringable, Writable, Copyable, Movable):
     """Represents logging severity levels.
 
     Defines the available logging levels in ascending order of severity.

--- a/mojo/stdlib/stdlib/math/math.mojo
+++ b/mojo/stdlib/stdlib/math/math.mojo
@@ -2781,8 +2781,8 @@ trait Ceilable:
     ```mojo
     from math import Ceilable, ceil
 
-    @value
-    struct Complex(Ceilable):
+    @fieldwise_init
+    struct Complex(Ceilable, Copyable):
         var re: Float64
         var im: Float64
 
@@ -2818,8 +2818,8 @@ trait Floorable:
     ```mojo
     from math import Floorable, floor
 
-    @value
-    struct Complex(Floorable):
+    @fieldwise_init
+    struct Complex(Floorable, Copyable):
         var re: Float64
         var im: Float64
 
@@ -2856,8 +2856,8 @@ trait CeilDivable:
     ```mojo
     from math import CeilDivable
 
-    @value
-    struct Foo(CeilDivable):
+    @fieldwise_init
+    struct Foo(CeilDivable, Copyable):
         var x: Float64
 
         fn __ceildiv__(self, denominator: Self) -> Self:
@@ -2889,8 +2889,8 @@ trait CeilDivableRaising:
     ```mojo
     from math import CeilDivableRaising
 
-    @value
-    struct Foo(CeilDivableRaising):
+    @fieldwise_init
+    struct Foo(CeilDivableRaising, Copyable):
         var x: Float64
 
         fn __ceildiv__(self, denominator: Self) raises -> Self:
@@ -2927,8 +2927,8 @@ trait Truncable:
     ```mojo
     from math import Truncable, trunc
 
-    @value
-    struct Complex(Truncable):
+    @fieldwise_init
+    struct Complex(Truncable, Copyable):
         var re: Float64
         var im: Float64
 

--- a/mojo/stdlib/stdlib/memory/pointer.mojo
+++ b/mojo/stdlib/stdlib/memory/pointer.mojo
@@ -26,9 +26,8 @@ from sys import is_nvidia_gpu
 # ===-----------------------------------------------------------------------===#
 
 
-@value
 @register_passable("trivial")
-struct _GPUAddressSpace(EqualityComparable):
+struct _GPUAddressSpace(EqualityComparable, Copyable, Movable):
     var _value: Int
 
     # See https://docs.nvidia.com/cuda/nvvm-ir-spec/#address-space
@@ -157,7 +156,6 @@ struct _GPUAddressSpace(EqualityComparable):
         return self.value() != other.value()
 
 
-@value
 @register_passable("trivial")
 struct AddressSpace(
     EqualityComparable,
@@ -297,7 +295,6 @@ struct AddressSpace(
 # ===-----------------------------------------------------------------------===#
 
 
-@value
 @register_passable("trivial")
 struct Pointer[
     mut: Bool, //,

--- a/mojo/stdlib/stdlib/memory/span.mojo
+++ b/mojo/stdlib/stdlib/memory/span.mojo
@@ -27,7 +27,7 @@ from memory import Pointer, UnsafePointer
 from memory.unsafe_pointer import _default_alignment
 
 
-@value
+@fieldwise_init
 struct _SpanIter[
     mut: Bool, //,
     T: Copyable & Movable,
@@ -35,7 +35,7 @@ struct _SpanIter[
     forward: Bool = True,
     address_space: AddressSpace = AddressSpace.GENERIC,
     alignment: Int = _default_alignment[T](),
-]:
+](Copyable, Movable):
     """Iterator for Span.
 
     Parameters:
@@ -78,7 +78,7 @@ struct _SpanIter[
             return self.index
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct Span[
     mut: Bool, //,

--- a/mojo/stdlib/stdlib/os/_macos.mojo
+++ b/mojo/stdlib/stdlib/os/_macos.mojo
@@ -29,8 +29,8 @@ alias blkcnt_t = Int64
 alias blksize_t = Int32
 
 
-@value
-struct _c_stat(Stringable, Writable):
+@fieldwise_init
+struct _c_stat(Stringable, Writable, Copyable, Movable):
     var st_dev: dev_t
     """ID of device containing file."""
     var st_mode: mode_t

--- a/mojo/stdlib/stdlib/pathlib/path.mojo
+++ b/mojo/stdlib/stdlib/pathlib/path.mojo
@@ -62,7 +62,6 @@ fn _dir_of_current_file_impl(file_name: StaticString) raises -> Path:
     return Path(file_name[0:i])
 
 
-@value
 struct Path(
     Stringable,
     Boolable,

--- a/mojo/stdlib/stdlib/runtime/asyncrt.mojo
+++ b/mojo/stdlib/stdlib/runtime/asyncrt.mojo
@@ -279,9 +279,9 @@ struct Task[type: AnyType, origins: OriginSet]:
 # ===-----------------------------------------------------------------------===#
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
-struct TaskGroupContext:
+struct TaskGroupContext(Copyable, Movable):
     """Context structure for task group operations.
 
     This structure holds a callback function and a pointer to a TaskGroup,

--- a/mojo/stdlib/stdlib/runtime/tracing.mojo
+++ b/mojo/stdlib/stdlib/runtime/tracing.mojo
@@ -41,7 +41,7 @@ fn _build_info_asyncrt_max_profiling_level() -> OptionalReg[Int]:
 # ===-----------------------------------------------------------------------===#
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
 struct TraceCategory(EqualityComparable, Intable):
     """An enum-like struct specifying the type of tracing to perform."""
@@ -119,9 +119,8 @@ struct TraceCategory(EqualityComparable, Intable):
 # ===-----------------------------------------------------------------------===#
 
 
-@value
 @register_passable("trivial")
-struct TraceLevel(EqualityComparable):
+struct TraceLevel(EqualityComparable, Copyable, Movable):
     """An enum-like struct specifying the level of tracing to perform."""
 
     alias ALWAYS = Self(0)
@@ -354,13 +353,13 @@ fn trace_arg(name: String, buf: NDBuffer) -> String:
 # ===-----------------------------------------------------------------------===#
 
 
-@value
+@fieldwise_init
 struct Trace[
     level: TraceLevel,
     *,
     category: TraceCategory = TraceCategory.MAX,
     target: Optional[StaticString] = None,
-]:
+](Copyable, Movable):
     """An object representing a specific trace.
 
     This struct provides functionality for creating and managing trace events

--- a/mojo/stdlib/stdlib/time/time.mojo
+++ b/mojo/stdlib/stdlib/time/time.mojo
@@ -58,9 +58,9 @@ alias _NSEC_PER_SEC = _NSEC_PER_USEC * _USEC_PER_MSEC * _MSEC_PER_SEC
 alias _WINDOWS_LARGE_INTEGER = Int64
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
-struct _CTimeSpec(Stringable, Writable):
+struct _CTimeSpec(Stringable, Writable, Copyable, Movable):
     var tv_sec: Int  # Seconds
     var tv_subsec: Int  # subsecond (nanoseconds on linux and usec on mac)
 
@@ -84,9 +84,9 @@ struct _CTimeSpec(Stringable, Writable):
         writer.write(self.as_nanoseconds(), "ns")
 
 
-@value
+@fieldwise_init
 @register_passable("trivial")
-struct _FILETIME:
+struct _FILETIME(Copyable, Movable):
     var dw_low_date_time: UInt32
     var dw_high_date_time: UInt32
 

--- a/mojo/stdlib/stdlib/utils/index.mojo
+++ b/mojo/stdlib/stdlib/utils/index.mojo
@@ -164,7 +164,6 @@ fn _is_unsigned[dtype: DType]() -> Bool:
     return dtype in (DType.uint8, DType.uint16, DType.uint32, DType.uint64)
 
 
-@value
 @register_passable("trivial")
 struct IndexList[size: Int, *, element_type: DType = DType.int64](
     Sized,

--- a/mojo/stdlib/stdlib/utils/static_tuple.mojo
+++ b/mojo/stdlib/stdlib/utils/static_tuple.mojo
@@ -104,9 +104,10 @@ fn _static_tuple_construction_checks[size: Int]():
     constrained[size >= 0, "number of elements in `StaticTuple` must be >= 0"]()
 
 
-@value
 @register_passable("trivial")
-struct StaticTuple[element_type: AnyTrivialRegType, size: Int](Sized):
+struct StaticTuple[element_type: AnyTrivialRegType, size: Int](
+    Sized, Copyable, Movable
+):
     """A statically sized tuple type which contains elements of homogeneous types.
 
     Parameters:

--- a/mojo/stdlib/stdlib/utils/write.mojo
+++ b/mojo/stdlib/stdlib/utils/write.mojo
@@ -36,8 +36,8 @@ trait Writer:
     ```mojo
     from memory import Span
 
-    @value
-    struct NewString(Writer, Writable):
+    @fieldwise_init
+    struct NewString(Writer, Writable, Copyable, Movable):
         var s: String
 
         # Writer requirement to write a Span of Bytes
@@ -55,8 +55,8 @@ trait Writer:
             writer.write(self.s)
 
 
-    @value
-    struct Point(Writable):
+    @fieldwise_init
+    struct Point(Writable, Copyable, Movable):
         var x: Int
         var y: Int
 


### PR DESCRIPTION
Remove remaining references to @value in Mojo stdlib lib code.

There's still plenty left in MAX but I didn't want to cross over into that for this PR.

Related to https://github.com/modular/modular/issues/4586