### PR TITLE
[docs] Update roadmap: remove outdated note about list/dict comprehensions (fixes #4780)

### DIFF
--- a/mojo/docs/roadmap.md
+++ b/mojo/docs/roadmap.md
@@ -207,10 +207,9 @@ surprising or unexpected. This section of the document describes a variety of
 expect all of these to be resolved in time, but in the meantime, they are
 documented here.
 
-### No list or dict comprehensions
+### List / dict / set comprehensions
 
-Mojo does not yet support Python list or dictionary comprehension expressions,
-like `[x for x in range(10)]`.
+Supported since Mojo 25.4 (see the `Types → List` docs for examples).
 
 ### No `lambda` syntax
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.
Fixes #4780

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
Fixes #4780
The roadmap said “No list or dict comprehensions”, but Mojo 25.4 implements them. This patch removes the stale knowledge and updaets them