### PR TITLE
[stdlib] Rename the `PythonObject` overload of `assert_equal` to `assert_equal_pyobj`

### DIFF
--- a/mojo/stdlib/stdlib/testing/__init__.mojo
+++ b/mojo/stdlib/stdlib/testing/__init__.mojo
@@ -16,6 +16,7 @@
 from .testing import (
     assert_almost_equal,
     assert_equal,
+    assert_equal_py_object,
     assert_false,
     assert_is,
     assert_is_not,

--- a/mojo/stdlib/stdlib/testing/testing.mojo
+++ b/mojo/stdlib/stdlib/testing/testing.mojo
@@ -311,14 +311,14 @@ fn assert_equal[
 
 
 @always_inline
-fn assert_equal(
+fn assert_equal_py_object(
     lhs: PythonObject,
     rhs: PythonObject,
     msg: String = "",
     *,
     location: Optional[_SourceLocation] = None,
 ) raises:
-    """Asserts that the input values are equal. If it is not then an Error
+    """Asserts that the `PythonObject`s are equal. If it is not then an Error
     is raised.
 
     Args:

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -1099,20 +1099,30 @@ def test_endswith():
     assert_false(str.endswith("llo", 2, 3))
 
 
+# TODO: Remove the explicit conversion to `String` once #4790 is resolved.
 def test_removeprefix():
-    assert_equal(String("hello world").removeprefix(""), String("hello world"))
-    assert_equal(String("hello world").removeprefix("hello"), " world")
-    assert_equal(String("hello world").removeprefix("world"), "hello world")
-    assert_equal(String("hello world").removeprefix("hello world"), "")
-    assert_equal(String("hello world").removeprefix("llo wor"), "hello world")
+    assert_equal(String(String("hello world").removeprefix("")), "hello world")
+    assert_equal(String(String("hello world").removeprefix("hello")), " world")
+    assert_equal(
+        String(String("hello world").removeprefix("world")), "hello world"
+    )
+    assert_equal(String(String("hello world").removeprefix("hello world")), "")
+    assert_equal(
+        String(String("hello world").removeprefix("llo wor")), "hello world"
+    )
 
 
+# TODO: Remove the explicit conversion to `String` once #4790 is resolved.
 def test_removesuffix():
-    assert_equal(String("hello world").removesuffix(""), String("hello world"))
-    assert_equal(String("hello world").removesuffix("world"), "hello ")
-    assert_equal(String("hello world").removesuffix("hello"), "hello world")
-    assert_equal(String("hello world").removesuffix("hello world"), "")
-    assert_equal(String("hello world").removesuffix("llo wor"), "hello world")
+    assert_equal(String(String("hello world").removesuffix("")), "hello world")
+    assert_equal(String(String("hello world").removesuffix("world")), "hello ")
+    assert_equal(
+        String(String("hello world").removesuffix("hello")), "hello world"
+    )
+    assert_equal(String(String("hello world").removesuffix("hello world")), "")
+    assert_equal(
+        String(String("hello world").removesuffix("llo wor")), "hello world"
+    )
 
 
 def test_intable():

--- a/mojo/stdlib/test/python/test_python_object.mojo
+++ b/mojo/stdlib/test/python/test_python_object.mojo
@@ -16,7 +16,13 @@
 
 from python import Python, PythonObject
 from python.bindings import PythonModuleBuilder
-from testing import assert_equal, assert_false, assert_raises, assert_true
+from testing import (
+    assert_equal,
+    assert_equal_py_object,
+    assert_false,
+    assert_raises,
+    assert_true,
+)
 
 
 def test_dunder_methods(mut python: Python):
@@ -25,197 +31,197 @@ def test_dunder_methods(mut python: Python):
 
     # __add__
     var c = a + b
-    assert_equal(c, 44)
+    assert_equal_py_object(c, 44)
 
     # __add__
     c = a + 100
-    assert_equal(c, 134)
+    assert_equal_py_object(c, 134)
 
     # __iadd__
     c += 100
-    assert_equal(c, 234)
+    assert_equal_py_object(c, 234)
 
     # __radd__
     c = 100 + a
-    assert_equal(c, 134)
+    assert_equal_py_object(c, 134)
 
     # __sub__
     c = a - b
-    assert_equal(c, 24)
+    assert_equal_py_object(c, 24)
 
     # __isub__
     c -= 100
-    assert_equal(c, -76)
+    assert_equal_py_object(c, -76)
 
     # __sub__
     c = a - 100
-    assert_equal(c, -66)
+    assert_equal_py_object(c, -66)
 
     # __rsub__
     c = 100 - a
-    assert_equal(c, 66)
+    assert_equal_py_object(c, 66)
 
     # __mul__
     c = a * b
-    assert_equal(c, 340)
+    assert_equal_py_object(c, 340)
 
     # __imul__
     c *= 10
-    assert_equal(c, 3400)
+    assert_equal_py_object(c, 3400)
 
     # __mul__
     c = a * 10
-    assert_equal(c, 340)
+    assert_equal_py_object(c, 340)
 
     # __rmul__
     c = 34 * b
-    assert_equal(c, 340)
+    assert_equal_py_object(c, 340)
 
     # __floordiv__
     c = a // b
-    assert_equal(c, 3)
+    assert_equal_py_object(c, 3)
 
     # __ifloordiv__
     c //= 2
-    assert_equal(c, 1)
+    assert_equal_py_object(c, 1)
 
     # __floordiv__
     c = a // 10
-    assert_equal(c, 3)
+    assert_equal_py_object(c, 3)
 
     # __rfloordiv__
     c = 34 // b
-    assert_equal(c, 3)
+    assert_equal_py_object(c, 3)
 
     # __truediv__
     c = a / b
-    assert_equal(c, 3.4)
+    assert_equal_py_object(c, 3.4)
 
     # __itruediv__
     c /= 2
-    assert_equal(c, 1.7)
+    assert_equal_py_object(c, 1.7)
 
     # __truediv__
     c = a / 10
-    assert_equal(c, 3.4)
+    assert_equal_py_object(c, 3.4)
 
     # __rtruediv__
     c = 34 / b
-    assert_equal(c, 3.4)
+    assert_equal_py_object(c, 3.4)
 
     # __mod__
     c = a % b
-    assert_equal(c, 4)
+    assert_equal_py_object(c, 4)
 
     # __imod__
     c %= 3
-    assert_equal(c, 1)
+    assert_equal_py_object(c, 1)
 
     # __mod__
     c = a % 10
-    assert_equal(c, 4)
+    assert_equal_py_object(c, 4)
 
     # __rmod__
     c = 34 % b
-    assert_equal(c, 4)
+    assert_equal_py_object(c, 4)
 
     # __xor__
     c = a ^ b
-    assert_equal(c, 40)
+    assert_equal_py_object(c, 40)
 
     # __ixor__
     c ^= 15
-    assert_equal(c, 39)
+    assert_equal_py_object(c, 39)
 
     # __xor__
     c = a ^ 10
-    assert_equal(c, 40)
+    assert_equal_py_object(c, 40)
 
     # __rxor__
     c = 34 ^ b
-    assert_equal(c, 40)
+    assert_equal_py_object(c, 40)
 
     # __or__
     c = a | b
-    assert_equal(c, 42)
+    assert_equal_py_object(c, 42)
 
     # __ior__
     c |= 9
-    assert_equal(c, 43)
+    assert_equal_py_object(c, 43)
 
     # __or__
     c = a | 10
-    assert_equal(c, 42)
+    assert_equal_py_object(c, 42)
 
     # __ror__
     c = 34 | b
-    assert_equal(c, 42)
+    assert_equal_py_object(c, 42)
 
     # __and__
     c = a & b
-    assert_equal(c, 2)
+    assert_equal_py_object(c, 2)
 
     # __iand__
     c &= 6
-    assert_equal(c, 2)
+    assert_equal_py_object(c, 2)
 
     # __and__
     c = a & 10
-    assert_equal(c, 2)
+    assert_equal_py_object(c, 2)
 
     # __rand__
     c = 34 & b
-    assert_equal(c, 2)
+    assert_equal_py_object(c, 2)
 
     # __rshift__
     var d = PythonObject(2)
     c = a >> d
-    assert_equal(c, 8)
+    assert_equal_py_object(c, 8)
 
     # __irshift__
     c >>= 2
-    assert_equal(c, 2)
+    assert_equal_py_object(c, 2)
 
     # __rshift__
     c = a >> 2
-    assert_equal(c, 8)
+    assert_equal_py_object(c, 8)
 
     # __rrshift__
     c = 34 >> d
-    assert_equal(c, 8)
+    assert_equal_py_object(c, 8)
 
     # __lshift__
     c = a << d
-    assert_equal(c, 136)
+    assert_equal_py_object(c, 136)
 
     # __ilshift__
     c <<= 1
-    assert_equal(c, 272)
+    assert_equal_py_object(c, 272)
 
     # __lshift__
     c = a << 2
-    assert_equal(c, 136)
+    assert_equal_py_object(c, 136)
 
     # __rlshift__
     c = 34 << d
-    assert_equal(c, 136)
+    assert_equal_py_object(c, 136)
 
     # __pow__
     c = a**d
-    assert_equal(c, 1156)
+    assert_equal_py_object(c, 1156)
 
     # __ipow__
     c = 3
     c **= 4
-    assert_equal(c, 81)
+    assert_equal_py_object(c, 81)
 
     # __pow__
     c = a**2
-    assert_equal(c, 1156)
+    assert_equal_py_object(c, 1156)
 
     # __rpow__
     c = 34**d
-    assert_equal(c, 1156)
+    assert_equal_py_object(c, 1156)
 
     # __lt__
     c = a < b
@@ -243,15 +249,15 @@ def test_dunder_methods(mut python: Python):
 
     # __pos__
     c = +a
-    assert_equal(c, 34)
+    assert_equal_py_object(c, 34)
 
     # __neg__
     c = -a
-    assert_equal(c, -34)
+    assert_equal_py_object(c, -34)
 
     # __invert__
     c = ~a
-    assert_equal(c, -35)
+    assert_equal_py_object(c, -35)
 
 
 def test_inplace_dunder_methods(mut python: Python):
@@ -267,7 +273,7 @@ def test_inplace_dunder_methods(mut python: Python):
     _ = python.eval("class A:\n  def __iadd__(self, other):\n    return 1")
     var a = python.evaluate("A()")
     a += 1
-    assert_equal(a, 1)
+    assert_equal_py_object(a, 1)
 
 
 def test_num_conversion():
@@ -362,11 +368,11 @@ fn test_iter() raises:
     var i = 0
     for fruit in list_obj:
         if i == 0:
-            assert_equal(fruit, "apple")
+            assert_equal_py_object(fruit, "apple")
         elif i == 1:
-            assert_equal(fruit, "orange")
+            assert_equal_py_object(fruit, "orange")
         elif i == 2:
-            assert_equal(fruit, "banana")
+            assert_equal_py_object(fruit, "banana")
         i += 1
 
     var list2: PythonObject = []


### PR DESCRIPTION
This prevents values from being accidentally considered equal through implicit conversion to `PyObj`.