### PR TITLE
[stdlib] Refactor and optimize testing utils `Error` construction

### DIFF
--- a/mojo/stdlib/std/builtin/_location.mojo
+++ b/mojo/stdlib/std/builtin/_location.mojo
@@ -1,0 +1,133 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Implements utilities to capture and represent source code location.
+"""
+
+
+@fieldwise_init
+@register_passable("trivial")
+struct _SourceLocation(ImplicitlyCopyable, Stringable, Writable):
+    """Type to carry file name, line, and column information."""
+
+    var line: Int
+    var col: Int
+    var file_name: StaticString
+
+    @no_inline
+    fn __str__(self) -> String:
+        return String.write(self)
+
+    @no_inline
+    fn prefix[T: Writable](self, msg: T) -> Error:
+        """Return the given message prefixed with the pretty-printer location.
+
+        Parameters:
+            T: The type of the message.
+
+        Args:
+            msg: The message to attach the prefix to.
+        """
+        return Error("At ", self, ": ", msg)
+
+    # FIXME(#5274): this should use the Writer trait but it doesn't yet accept
+    # capturing write_to functions.
+    @no_inline
+    fn _prefix_error[
+        append_message: fn[W: Writer] (mut writer: W) capturing
+    ](self) -> Error:
+        """Return the given message prefixed with the pretty-printer location.
+
+        Parameters:
+            append_message: The function to write the message to be appended.
+        """
+
+        @parameter
+        fn write_to[W: Writer](mut writer: W):
+            writer.write("At ", self, ": ")
+            append_message(writer)
+
+        return Error.__init__[write_to]()
+
+    fn write_to(self, mut writer: Some[Writer]):
+        """Formats the source location to the provided Writer.
+
+        Args:
+            writer: The object to write to.
+        """
+        writer.write(self.file_name, ":", self.line, ":", self.col)
+
+
+@always_inline("nodebug")
+fn __source_location() -> _SourceLocation:
+    """Returns the location for where this function is called.
+
+    This currently doesn't work when called in a parameter expression.
+
+    Returns:
+        The location information of the __source_location() call.
+    """
+    var line, col, file_name = __mlir_op.`kgen.source_loc`[
+        inlineCount = Int(0)._mlir_value,
+        _type = Tuple[
+            __mlir_type.index,
+            __mlir_type.index,
+            __mlir_type.`!kgen.string`,
+        ],
+    ]()
+
+    return _SourceLocation(
+        Int(mlir_value=line),
+        Int(mlir_value=col),
+        StaticString(file_name),
+    )
+
+
+@always_inline("nodebug")
+fn __call_location[*, inline_count: Int = 1]() -> _SourceLocation:
+    """Returns the location for where the caller of this function is called. An
+    optional `inline_count` parameter can be specified to skip over that many
+    levels of calling functions.
+
+    This should only be used when enclosed in a series of `@always_inline` or
+    `@always_inline("nodebug")` function calls, where the layers of calling
+    functions is no fewer than `inline_count`.
+
+    For example, when `inline_count = 1`, only the caller of this function needs
+    to be `@always_inline` or `@always_inline("nodebug")`. This function will
+    return the source location of the caller's invocation.
+
+    When `inline_count = 2`, the caller of the caller of this function also
+    needs to be inlined. This function will return the source location of the
+    caller's caller's invocation.
+
+    This currently doesn't work when the `inline_count`-th wrapping caller is
+    called in a parameter expression.
+
+    Returns:
+        The location information of where the caller of this function (i.e. the
+          function whose body __call_location() is used in) is called.
+    """
+    var line, col, file_name = __mlir_op.`kgen.source_loc`[
+        inlineCount = inline_count._mlir_value,
+        _type = Tuple[
+            __mlir_type.index,
+            __mlir_type.index,
+            __mlir_type.`!kgen.string`,
+        ],
+    ]()
+
+    return _SourceLocation(
+        Int(mlir_value=line),
+        Int(mlir_value=col),
+        StaticString(file_name),
+    )

--- a/mojo/stdlib/std/builtin/error.mojo
+++ b/mojo/stdlib/std/builtin/error.mojo
@@ -465,6 +465,27 @@ struct Error(
         """
         self = Error(String(args), depth=0)
 
+    # FIXME(#5274): this should use the Writer trait but it doesn't yet accept
+    # capturing write_to functions.
+    @no_inline
+    fn __init__[
+        message_func: fn[W: Writer] (mut writer: W) capturing
+    ](out self: Error):
+        """Construct an Error by executing a function that writes the message.
+
+        Parameters:
+            message_func: The function that writes the message.
+
+        Warning:
+            This function is for temporary internal use only. Due to some
+            language-level limitations, this needs to be a public `__init__`
+            function.
+        """
+
+        var string = String()
+        message_func(string)
+        self = Error(string, depth=0)
+
     # ===-------------------------------------------------------------------===#
     # Trait implementations
     # ===-------------------------------------------------------------------===#

--- a/mojo/stdlib/std/builtin/error.mojo
+++ b/mojo/stdlib/std/builtin/error.mojo
@@ -24,7 +24,7 @@ from memory import (
 )
 from sys import external_call, is_gpu
 from sys.info import size_of, align_of
-
+from format._utils import _TotalWritableBytes
 
 # ===-----------------------------------------------------------------------===#
 # StackTrace
@@ -482,7 +482,9 @@ struct Error(
             function.
         """
 
-        var string = String()
+        var total_bytes = _TotalWritableBytes()
+        message_func(total_bytes)
+        var string = String(capacity=total_bytes.size)
         message_func(string)
         self = Error(string, depth=0)
 

--- a/mojo/stdlib/std/collections/string/codepoint.mojo
+++ b/mojo/stdlib/std/collections/string/codepoint.mojo
@@ -305,6 +305,21 @@ struct Codepoint(
         """
         return Int(self._scalar_value)
 
+    fn write_to(self, mut writer: Some[Writer]):
+        """Formats the string representation of this type to the provided
+        `Writer`.
+
+        Args:
+            writer: The type conforming to `Writer`.
+        """
+        var buf = InlineArray[Byte, 4](uninitialized=True)
+        var char_len = self.utf8_byte_length()
+        var written = self.unsafe_write_utf8(buf.unsafe_ptr())
+        debug_assert(char_len == written, "Didn't write what was expected")
+        writer.write_bytes(
+            Span(ptr=buf.unsafe_ptr().origin_cast[False](), length=written)
+        )
+
     @no_inline
     fn __str__(self) -> String:
         """Formats this `Codepoint` as a single-character string.

--- a/mojo/stdlib/std/gpu/host/device_context.mojo
+++ b/mojo/stdlib/std/gpu/host/device_context.mojo
@@ -174,7 +174,7 @@ fn _raise_checked_impl(
     err_msg: _ConstCharPtr, msg: String, location: SourceLocation
 ) raises:
     var err = _string_from_owned_charptr(err_msg)
-    raise Error(location.prefix(err + ((" " + msg) if msg else "")))
+    raise location.prefix(err + ((" " + msg) if msg else ""))
 
 
 # Checks that the given `dim` has only positive integers in them.
@@ -188,7 +188,7 @@ fn _check_dim[
             dim_name_for_msg,
             ".x must be a positive number.",
         )
-        raise Error(location.prefix(msg))
+        raise location.prefix(msg)
     if dim.y() <= 0:
         comptime msg = String(
             func_name_for_msg,
@@ -196,7 +196,7 @@ fn _check_dim[
             dim_name_for_msg,
             ".y must be a positive number.",
         )
-        raise Error(location.prefix(msg))
+        raise location.prefix(msg)
     if dim.z() <= 0:
         comptime msg = String(
             func_name_for_msg,
@@ -204,7 +204,7 @@ fn _check_dim[
             dim_name_for_msg,
             ".z must be a positive number.",
         )
-        raise Error(location.prefix(msg))
+        raise location.prefix(msg)
 
 
 struct _DeviceTimer:

--- a/mojo/stdlib/std/os/atomic.mojo
+++ b/mojo/stdlib/std/os/atomic.mojo
@@ -37,6 +37,7 @@ struct Consistency(
     Representable,
     Stringable,
     TrivialRegisterType,
+    Writable,
 ):
     """Represents the consistency model for atomic operations.
 
@@ -114,15 +115,23 @@ struct Consistency(
         """
         return self.as_string_slice()
 
+    fn write_to(self, mut writer: Some[Writer]):
+        """Formats the string representation of this type to the provided
+        `Writer`.
+
+        Args:
+            writer: The type conforming to `Writer`.
+        """
+        alias prefix_len = "Consistency.".byte_length()
+        writer.write_bytes(self.as_string_slice().as_bytes()[prefix_len:])
+
     fn __str__(self) -> String:
         """Returns a string representation of a `Consistency`.
 
         Returns:
             A string representation of this consistency.
         """
-
-        comptime prefix_len = len("Consistency.")
-        return self.as_string_slice()[prefix_len:]
+        return String.write(self)
 
     fn as_string_slice(self) -> StaticString:
         """Returns a string slice representation of a `Consistency`.

--- a/mojo/stdlib/std/reflection/location.mojo
+++ b/mojo/stdlib/std/reflection/location.mojo
@@ -111,6 +111,22 @@ struct SourceLocation(Stringable, TrivialRegisterType, Writable):
         """
         return String("At ", self, ": ", msg)
 
+    fn _prefix_error[
+        append_message: fn[W: Writer] (mut writer: W) capturing
+    ](self) -> Error:
+        """Return the given message prefixed with the pretty-printer location.
+
+        Parameters:
+            append_message: The function to write the message to be appended.
+        """
+
+        @parameter
+        fn write_to[W: Writer](mut writer: W):
+            writer.write("At ", self, ": ")
+            append_message(writer)
+
+        return Error.__init__[write_to]()
+
     fn write_to(self, mut writer: Some[Writer]):
         """
         Formats the source location to the provided Writer.

--- a/mojo/stdlib/std/testing/testing.mojo
+++ b/mojo/stdlib/std/testing/testing.mojo
@@ -43,9 +43,18 @@ from utils._ansi import Color, Text
 # ===----------------------------------------------------------------------=== #
 
 
+# FIXME(#5274): this should use the Writer trait but it doesn't yet accept
+# capturing write_to functions.
 @always_inline
-fn _assert_error[T: Writable](msg: T, loc: SourceLocation) -> Error:
-    return Error(loc.prefix(String("AssertionError: ", msg)))
+fn _assert_error[
+    append_message: fn[W: Writer] (mut writer: W) capturing
+](loc: _SourceLocation) -> Error:
+    @parameter
+    fn write_to[W: Writer](mut writer: W):
+        writer.write("AssertionError: ")
+        append_message(writer)
+
+    return loc._prefix_error[write_to]()
 
 
 @always_inline
@@ -71,7 +80,12 @@ fn assert_true[
         An Error with the provided message if assert fails and `None` otherwise.
     """
     if not val:
-        raise _assert_error(msg, location.or_else(call_location()))
+
+        @parameter
+        fn write_to[W: Writer](mut writer: W):
+            writer.write(msg)
+
+        raise _assert_error[write_to](location.or_else(__call_location()))
 
 
 @always_inline
@@ -97,12 +111,17 @@ fn assert_false[
         An Error with the provided message if assert fails and `None` otherwise.
     """
     if val:
-        raise _assert_error(msg, location.or_else(call_location()))
+
+        @parameter
+        fn write_to[W: Writer](mut writer: W):
+            writer.write(msg)
+
+        raise _assert_error[write_to](location.or_else(__call_location()))
 
 
 @always_inline
 fn assert_equal[
-    T: Equatable & Stringable, //
+    T: Equatable & Writable, //
 ](
     lhs: T,
     rhs: T,
@@ -127,8 +146,8 @@ fn assert_equal[
     """
     if lhs != rhs:
         raise _assert_cmp_error["`left == right` comparison"](
-            String(lhs),
-            String(rhs),
+            lhs,
+            rhs,
             msg=msg,
             loc=location.or_else(call_location()),
         )
@@ -170,17 +189,19 @@ fn assert_equal[
 
     # Cast `rhs` to have the same origin as `lhs`, so that we can delegate to
     # `List.__ne__`.
-    var rhs_origin_casted = rebind[List[StringSlice[O1]]](rhs).copy()
+    ref lhs_origin_casted = rebind[List[StringSlice[O1].Immutable]](lhs)
+    ref rhs_origin_casted = rebind[List[StringSlice[O1].Immutable]](rhs)
 
-    if lhs != rhs_origin_casted:
+    if lhs_origin_casted != rhs_origin_casted:
         raise _assert_cmp_error["`left == right` comparison"](
-            lhs.__str__(),
-            rhs.__str__(),
+            lhs,
+            rhs,
             msg=msg,
             loc=location.or_else(call_location()),
         )
 
 
+@doc_private
 @always_inline
 fn assert_equal(
     lhs: StringSlice[mut=False],
@@ -202,8 +223,8 @@ fn assert_equal(
     """
     if lhs != rhs:
         raise _assert_cmp_error["`left == right` comparison"](
-            lhs.__str__(),
-            rhs.__str__(),
+            lhs,
+            rhs,
             msg=msg,
             loc=location.or_else(call_location()),
         )
@@ -240,8 +261,8 @@ fn assert_equal_pyobj[
 
     if lhs_obj != rhs_obj:
         raise _assert_cmp_error["`left == right` comparison"](
-            String(lhs_obj),
-            String(rhs_obj),
+            lhs,
+            rhs,
             msg=msg,
             loc=location.or_else(call_location()),
         )
@@ -249,7 +270,7 @@ fn assert_equal_pyobj[
 
 @always_inline
 fn assert_not_equal[
-    T: Equatable & Stringable, //
+    T: Equatable & Writable, //
 ](
     lhs: T,
     rhs: T,
@@ -274,8 +295,8 @@ fn assert_not_equal[
     """
     if lhs == rhs:
         raise _assert_cmp_error["`left != right` comparison"](
-            String(lhs),
-            String(rhs),
+            lhs,
+            rhs,
             msg=msg,
             loc=location.or_else(call_location()),
         )
@@ -283,8 +304,8 @@ fn assert_not_equal[
 
 @always_inline
 fn assert_not_equal(
-    lhs: String,
-    rhs: String,
+    lhs: StringSlice[mut=False],
+    rhs: StringSlice[mut=False],
     msg: String = "",
     *,
     location: Optional[SourceLocation] = None,
@@ -356,16 +377,19 @@ fn assert_almost_equal[
     )
 
     if not all(almost_equal):
-        var err = String(lhs, " is not close to ", rhs)
 
         @parameter
-        if dtype.is_integral() or dtype.is_floating_point():
-            err += String(" with a diff of ", abs(lhs - rhs))
+        fn write_to[W: Writer](mut writer: W):
+            writer.write(lhs, " is not close to ", rhs)
 
-        if msg:
-            err += String(" (", msg, ")")
+            @parameter
+            if dtype.is_integral() or dtype.is_floating_point():
+                writer.write(" with a diff of ", abs(lhs - rhs))
 
-        raise _assert_error(err, location.or_else(call_location()))
+            if msg:
+                writer.write(" (", msg, ")")
+
+        raise _assert_error[write_to](location.or_else(__call_location()))
 
 
 @always_inline
@@ -482,16 +506,21 @@ fn _create_colored_diff(lhs: String, rhs: String) -> String:
 
 
 fn _assert_cmp_error[
-    cmp: String
-](lhs: String, rhs: String, *, msg: String, loc: SourceLocation) -> Error:
-    var err = cmp + " failed:"
+    cmp: StringSlice[mut=False]
+](
+    lhs: Some[Writable],
+    rhs: Some[Writable],
+    *,
+    msg: String,
+    loc: _SourceLocation,
+) -> Error:
+    @parameter
+    fn write_to[W: Writer](mut writer: W):
+        writer.write(cmp, " failed:\n   left: ", lhs, "\n  right: ", rhs)
+        if msg:
+            writer.write("\n  reason: ", msg)
 
-    # For string comparisons, show colored diff
-    err += _create_colored_diff(lhs, rhs)
-
-    if msg:
-        err += "\n  reason: " + msg
-    return _assert_error(err, loc)
+    return _assert_error[write_to](loc)
 
 
 struct assert_raises:
@@ -579,5 +608,5 @@ struct assert_raises:
             True if the error message contained the expected string.
         """
         if self.message_contains:
-            return self.message_contains.value() in String(error)
+            return self.message_contains.value() in error.as_string_slice()
         return True

--- a/mojo/stdlib/std/testing/testing.mojo
+++ b/mojo/stdlib/std/testing/testing.mojo
@@ -48,7 +48,7 @@ from utils._ansi import Color, Text
 @always_inline
 fn _assert_error[
     append_message: fn[W: Writer] (mut writer: W) capturing
-](loc: _SourceLocation) -> Error:
+](loc: SourceLocation) -> Error:
     @parameter
     fn write_to[W: Writer](mut writer: W):
         writer.write("AssertionError: ")
@@ -512,7 +512,7 @@ fn _assert_cmp_error[
     rhs: Some[Writable],
     *,
     msg: String,
-    loc: _SourceLocation,
+    loc: SourceLocation,
 ) -> Error:
     @parameter
     fn write_to[W: Writer](mut writer: W):

--- a/mojo/stdlib/test/builtin/test_print.mojo
+++ b/mojo/stdlib/test/builtin/test_print.mojo
@@ -20,8 +20,8 @@ from utils import IndexList
 
 
 @always_inline
-fn _assert_error[T: Writable](msg: T, loc: SourceLocation) -> Error:
-    return Error(loc.prefix(String("AssertionError: ", msg)))
+fn _assert_error[T: Writable](msg: T, loc: _SourceLocation) -> Error:
+    return loc.prefix(String("AssertionError: ", msg))
 
 
 fn _assert_equal_error(

--- a/mojo/stdlib/test/math/test_exp.mojo
+++ b/mojo/stdlib/test/math/test_exp.mojo
@@ -73,7 +73,7 @@ def test_exp_libm():
 
 
 @fieldwise_init
-struct Float32Expable(Equatable, Stringable, _Expable):
+struct Float32Expable(Equatable, Writable, _Expable):
     """This is a test struct that implements the Expable trait for Float32."""
 
     var x: Float32
@@ -87,12 +87,12 @@ struct Float32Expable(Equatable, Stringable, _Expable):
     fn __ne__(self, other: Self) -> Bool:
         return self.x != other.x
 
-    fn __str__(self) -> String:
-        return String("Float32Expable(", self.x, ")")
+    fn write_to(self, mut writer: Some[Writer]):
+        writer.write("Float32Expable(", self.x, ")")
 
 
 @fieldwise_init
-struct FakeExpable(Equatable, Stringable, _Expable):
+struct FakeExpable(Equatable, Writable, _Expable):
     """Test struct using default reflection-based __eq__."""
 
     var x: Int
@@ -102,8 +102,8 @@ struct FakeExpable(Equatable, Stringable, _Expable):
 
     # Uses default reflection-based __eq__ from Equatable trait
 
-    fn __str__(self) -> String:
-        return String("FakeExpable(", self.x, ")")
+    fn write_to(self, mut writer: Some[Writer]):
+        writer.write("FakeExpable(", self.x, ")")
 
 
 def test_exapble_trait():

--- a/mojo/stdlib/test/testing/test_assertion.mojo
+++ b/mojo/stdlib/test/testing/test_assertion.mojo
@@ -50,7 +50,7 @@ def test_assert_messages():
 
 
 @fieldwise_init
-struct DummyStruct(Equatable, Stringable):
+struct DummyStruct(Equatable, Writable):
     """Test struct using default reflection-based __eq__."""
 
     var value: Int
@@ -58,8 +58,8 @@ struct DummyStruct(Equatable, Stringable):
     # Uses default reflection-based __eq__ from Equatable trait
 
     @no_inline
-    fn __str__(self) -> String:
-        return "Dummy"  # Can't be used for equality
+    fn write_to(self, mut writer: Some[Writer]):
+        writer.write("Dummy")  # Can't be used for equality
 
 
 def test_assert_equal_is_generic():


### PR DESCRIPTION
Refactor and optimize testing utils `Error` construction. Partly motivated by  #4789, partly because this was on my TODO list.

This should improve the runtime performance of all tests by a significant amount.

I tried not having to pass around the `write_to` functions by building a wrapper type:
```mojo
struct _Wrapper[write_message: fn[W: Writer] (mut writer: W) capturing](Writable):
    fn write_to[W: Writer](self, mut writer: W):
        write_message(writer)
```
but the `Writable` trait won't be accepted because the `write_to` function would be capturing. I made all the involved functions private for now until that `Writer` feature (#5274) is implemented then going back to using the writable trait should be simply switching.