### PR TITLE
[stdlib] Add Movable trait to FileHandle

### DIFF
--- a/mojo/stdlib/stdlib/builtin/file.mojo
+++ b/mojo/stdlib/stdlib/builtin/file.mojo
@@ -68,7 +68,7 @@ struct _OwnedStringRef(Boolable):
         return self.length != 0
 
 
-struct FileHandle(Writer):
+struct FileHandle(Writer, Movable):
     """File handle to an opened file."""
 
     var handle: OpaquePointer


### PR DESCRIPTION
Fixes `warning: struct 'FileHandle' utilizes conformance to trait 'MovableWriter' but does not explicitly declare it (implicit conformance is deprecated)`

Related to https://github.com/modular/modular/issues/4750