### PR TITLE
[max] [NFC] Fix deprecated use of `UnsafePointer.address_of()`

### DIFF
--- a/max/kernels/src/nn/conv.mojo
+++ b/max/kernels/src/nn/conv.mojo
@@ -3259,7 +3259,7 @@ fn conv_cudnn[
     # to disable tf32, run export NVIDIA_TF32_OVERRIDE=0 in the environment
     alias algo = cudnnConvolutionFwdAlgo_t.CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM
     var workspace_size_var = 0
-    var workspace_size_ptr = UnsafePointer[Int].address_of(workspace_size_var)
+    var workspace_size_ptr = UnsafePointer(to=workspace_size_var)
     check_cudnn_error(
         cudnnGetConvolutionForwardWorkspaceSize(
             ptr_meta[].ptr_handle,

--- a/max/kernels/test/gpu/nn/test_cudnn_conv.mojo
+++ b/max/kernels/test/gpu/nn/test_cudnn_conv.mojo
@@ -15,7 +15,6 @@ from math import ceildiv, isclose
 from random import rand
 from sys import sizeof
 from sys.info import num_physical_cores, simdwidthof
-import time
 
 from buffer import NDBuffer
 from buffer.dimlist import DimList


### PR DESCRIPTION
Fix deprecated use of `UnsafePointer.address_of()`