### PR TITLE
[stdlib] [NFC] Make `__call_location[inline_count]` keyword only

### DIFF
--- a/mojo/stdlib/stdlib/builtin/_location.mojo
+++ b/mojo/stdlib/stdlib/builtin/_location.mojo
@@ -77,7 +77,7 @@ fn __source_location() -> _SourceLocation:
 
 
 @always_inline("nodebug")
-fn __call_location[inline_count: Int = 1]() -> _SourceLocation:
+fn __call_location[*, inline_count: Int = 1]() -> _SourceLocation:
     """Returns the location for where the caller of this function is called. An
     optional `inline_count` parameter can be specified to skip over that many
     levels of calling functions.

--- a/mojo/stdlib/stdlib/gpu/host/device_context.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/device_context.mojo
@@ -115,7 +115,7 @@ fn _checked(
     location: OptionalReg[_SourceLocation] = None,
 ) raises:
     if err:
-        _raise_checked_impl(err, msg, location.or_else(__call_location[1]()))
+        _raise_checked_impl(err, msg, location.or_else(__call_location()))
 
 
 @no_inline

--- a/mojo/stdlib/test/builtin/test_location.mojo
+++ b/mojo/stdlib/test/builtin/test_location.mojo
@@ -130,7 +130,7 @@ fn capture_call_loc[depth: Int = 1](cond: Bool = False) -> _SourceLocation:
     if (
         not cond
     ):  # NOTE: we test that __call_location works even in a nested scope.
-        return __call_location[depth]()
+        return __call_location[inline_count=depth]()
     return _SourceLocation(-1, -1, "")
 
 
@@ -141,7 +141,7 @@ fn capture_call_loc_nodebug[
     if (
         not cond
     ):  # NOTE: we test that __call_location works even in a nested scope.
-        return __call_location[depth]()
+        return __call_location[inline_count=depth]()
     return _SourceLocation(-1, -1, "")
 
 


### PR DESCRIPTION
Make `__call_location[inline_count]` keyword only. Split off from  #4793