### PR TITLE
[MAX] cleanup clobbered value annotation changes

### DIFF
--- a/max/kernels/src/nn/mha_utils.mojo
+++ b/max/kernels/src/nn/mha_utils.mojo
@@ -635,9 +635,8 @@ trait OptionallyStaticInt(Intable):
 
 # These are used to avoid generating code for passing unused values to kernels.
 # That is, if we have a static int, no argument should be passed.
-@value
 @register_passable("trivial")
-struct StaticInt[value: Int](OptionallyStaticInt):
+struct StaticInt[value: Int](OptionallyStaticInt, Defaultable):
     alias static_value: OptionalReg[Int] = OptionalReg[Int](value)
 
     @always_inline("nodebug")
@@ -653,7 +652,6 @@ struct StaticInt[value: Int](OptionallyStaticInt):
         return UInt32(Self.value)
 
 
-@value
 @register_passable("trivial")
 struct DynamicInt(OptionallyStaticInt):
     var value: UInt32
@@ -693,9 +691,8 @@ trait MHAPartitionScheme:
         ...
 
 
-@value
 @register_passable("trivial")
-struct NoPartition[dtype: DType](MHAPartitionScheme):
+struct NoPartition[dtype: DType](MHAPartitionScheme, Copyable, Movable, Defaultable):
     alias do_partition: Bool = False
     alias accum_dtype: DType = dtype
 
@@ -714,9 +711,8 @@ struct NoPartition[dtype: DType](MHAPartitionScheme):
         return UnsafePointer[Scalar[Self.accum_dtype]]()
 
 
-@value
 @register_passable("trivial")
-struct SplitKPartition[dtype: DType](MHAPartitionScheme):
+struct SplitKPartition[dtype: DType](MHAPartitionScheme, Copyable, Movable):
     alias do_partition: Bool = True
     alias accum_dtype: DType = Self.dtype
     var ptr: UnsafePointer[Scalar[Self.accum_dtype]]


### PR DESCRIPTION
@JoeLoser Looks like some the `@value` migration got clobbered yesterday.

Related to [#4586](https://github.com/modular/modular/issues/4586)