### PR TITLE
[stdlib] Apply trivial cleanups to `numerics.mojo` to prepare for the `float8` fixes

### DIFF
--- a/mojo/stdlib/stdlib/utils/numerics.mojo
+++ b/mojo/stdlib/stdlib/utils/numerics.mojo
@@ -558,7 +558,7 @@ fn nan[dtype: DType]() -> Scalar[dtype]:
 
 @always_inline("nodebug")
 fn isnan[
-    dtype: DType, width: Int
+    dtype: DType, width: Int, //
 ](val: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
     """Checks if the value is Not a Number (NaN).
 
@@ -887,7 +887,7 @@ fn min_or_neg_inf[dtype: DType]() -> Scalar[dtype]:
 
 @always_inline("nodebug")
 fn isinf[
-    dtype: DType, width: Int
+    dtype: DType, width: Int, //
 ](val: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
     """Checks if the value is infinite.
 
@@ -929,7 +929,7 @@ fn isinf[
 
 @always_inline("nodebug")
 fn isfinite[
-    dtype: DType, width: Int
+    dtype: DType, width: Int, //
 ](val: SIMD[dtype, width]) -> SIMD[DType.bool, width]:
     """Checks if the value is not infinite.
 
@@ -1016,7 +1016,7 @@ fn get_accum_type[
 
 
 fn nextafter[
-    dtype: DType, width: Int
+    dtype: DType, width: Int, //
 ](arg0: SIMD[dtype, width], arg1: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Computes next representable value of `arg0` in the direction of `arg1`.
 

--- a/mojo/stdlib/stdlib/utils/numerics.mojo
+++ b/mojo/stdlib/stdlib/utils/numerics.mojo
@@ -727,7 +727,7 @@ fn neg_inf[dtype: DType]() -> Scalar[dtype]:
 # ===----------------------------------------------------------------------=== #
 
 
-@always_inline
+@always_inline("nodebug")
 fn max_finite[dtype: DType]() -> Scalar[dtype]:
     """Returns the maximum finite value of type.
 
@@ -790,7 +790,7 @@ fn max_finite[dtype: DType]() -> Scalar[dtype]:
 # ===----------------------------------------------------------------------=== #
 
 
-@always_inline
+@always_inline("nodebug")
 fn min_finite[dtype: DType]() -> Scalar[dtype]:
     """Returns the minimum (lowest) finite value of type.
 

--- a/mojo/stdlib/stdlib/utils/numerics.mojo
+++ b/mojo/stdlib/stdlib/utils/numerics.mojo
@@ -736,7 +736,7 @@ fn max_finite[dtype: DType]() -> Scalar[dtype]:
 
     @parameter
     if dtype is DType.bool:
-        return rebind[Scalar[dtype]](Scalar(True))
+        return Scalar(True)._refine[dtype]()
 
     elif dtype is DType.index and DType.index.bitwidth() == 32:
         return 2147483647
@@ -799,7 +799,7 @@ fn min_finite[dtype: DType]() -> Scalar[dtype]:
 
     @parameter
     if dtype is DType.bool:
-        return rebind[Scalar[dtype]](Scalar(False))
+        return Scalar(False)._refine[dtype]()
 
     elif dtype is DType.index and DType.index.bitwidth() == 32:
         return -2147483648


### PR DESCRIPTION
Related to #4794. CC @jackos. Please review by commits.