### PR TITLE
[stdlib] Fix `math.exp2` for `float64` values

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -51,3 +51,6 @@ what we publish.
 ### ❌ Removed
 
 ### 🛠️ Fixed
+
+- [#4820](https://github.com/modular/modular/issues/4820) - `math.exp2` picks
+  the wrong implementation for `float64`.

--- a/mojo/stdlib/test/math/test_math.mojo
+++ b/mojo/stdlib/test/math/test_math.mojo
@@ -215,6 +215,18 @@ def test_exp2():
     assert_equal(exp2(Float32(0)), 1.0)
     assert_equal(exp2(Float32(-1)), 0.5)
     assert_equal(exp2(Float32(2)), 4.0)
+    assert_almost_equal(exp2(Float32(-125)), 2.3509887e-38)
+    assert_almost_equal(exp2(Float32(125)), 4.2535296e37)
+
+    assert_equal(exp2(Float64(1)), 2.0)
+    assert_almost_equal(exp2(Float64(0.2)), 1.148696)
+    assert_equal(exp2(Float64(0)), 1.0)
+    assert_equal(exp2(Float64(-1)), 0.5)
+    assert_equal(exp2(Float64(2)), 4.0)
+    assert_almost_equal(exp2(Float64(-127)), 5.877471754111438e-39)
+    assert_almost_equal(exp2(Float64(127)), 1.7014118346046923e38)
+    assert_almost_equal(exp2(Float64(-1023)), 1.1125369292536007e-308)
+    assert_almost_equal(exp2(Float64(1023)), 8.98846567431158e307)
 
 
 def test_iota():


### PR DESCRIPTION
Fix #4820.