### PR TITLE
[kernel] Fix `kl_div` test so for each input `a`, we have `a_i^i = 1`

### DIFF
--- a/max/kernels/test/internal_utils/test_measure.mojo
+++ b/max/kernels/test/internal_utils/test_measure.mojo
@@ -72,14 +72,14 @@ fn test_kl_div() raises:
     var a = InlineArray[Scalar[dtype], len](uninitialized=True)
     var b = InlineArray[Scalar[dtype], len](uninitialized=True)
     for i in range(len):
-        a[i] = Scalar[dtype](0.01 * i)
-        b[i] = Scalar[dtype](0.1 * i)
+        a[i] = Scalar[dtype](1 / len)
+        b[i] = Scalar[dtype](2 * (i + 1) / (len * (len + 1)))
 
     var aa = kl_div[out_type=out_dtype](a.unsafe_ptr(), a.unsafe_ptr(), len)
     var ab = kl_div[out_type=out_dtype](a.unsafe_ptr(), b.unsafe_ptr(), len)
     assert_almost_equal(0.0, aa)
     # exact value computed using Mathematica
-    assert_almost_equal(3.013836708152679, ab)
+    assert_almost_equal(0.19430683493087375, ab)
 
 
 def main():


### PR DESCRIPTION
Motivation:

```suggestion
        a[i] = Scalar[dtype](1.0 / len)
        b[i] = Scalar[dtype](2.0 * (i + 1) / (len * (len + 1)))
```
NIT:
I would expect the inputs of KL Div to individually sum to 1.0, here's two which do, 
Since it's floating point math they won't really, but it's less confusing to me.

If it's a hassle to compute a new reference value, feel free to skip this comment

_Originally posted by @tboerstad in https://github.com/modular/modular/pull/4753#discussion_r2137956754_
            