### PR TITLE
[docs] Update types.mdx      typo -- 6 items,  not 4 items

### DIFF
--- a/mojo/docs/manual/python/types.mdx
+++ b/mojo/docs/manual/python/types.mdx
@@ -139,7 +139,7 @@ def main():
 ```
 
 ```output
-4 items in the set.
+6 items in the set.
 Is 7 in the set: True
 ```
 


### PR DESCRIPTION
In the program output section:
"4 items in the set"    should be    "6 items in the set"
because the set is:
 var py_set = Python.evaluate('{2, 3, 2, 7, 11, 3}')

https://docs.modular.com/mojo/manual/python/types#mojo-wrapper-objects

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
