### PR TITLE
[CI] Migrate to GitHub App for CLA management

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -29,6 +29,15 @@ jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e
+        id: app-token
+        with:
+          app-id: ${{ vars.CLA_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }}
+          owner: modular
+          repositories: cla
+          permission-contents: write
+
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08
@@ -36,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret
           # This token is required only if you have configured to store the signatures in a remote repository/organization
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           path-to-document: 'https://github.com/modular/cla/blob/main/CLA.md' # e.g. a CLA or a DCO document
           branch: 'main'


### PR DESCRIPTION
The CLA job is occasionally flaking because of rate limiting. Migrate to a dedicated GitHub app to avoid overloading one rate.