### PR TITLE
[stdlib] Use `List[UInt8]` as data type for `b[16|64][en|de]code` functions

### DIFF
--- a/mojo/stdlib/std/base64/_b64encode.mojo
+++ b/mojo/stdlib/std/base64/_b64encode.mojo
@@ -203,16 +203,29 @@ def load_incomplete_simd[
 
 
 @no_inline
-def _b64encode(input_bytes: Span[mut=False, Byte, _], mut result: String):
+def _b64encode(
+    input_bytes: Span[mut=False, Byte, _],
+    output_bytes: Span[mut=True, Byte, _],
+) -> Int:
+    """Writes base64-encoded `input_bytes` into `output_bytes`.
+
+    The output buffer must be at least `4 * ceildiv(len(input_bytes), 3)`
+    bytes. Returns the number of bytes written.
+    """
+    debug_assert(
+        len(output_bytes) >= 4 * ceildiv(len(input_bytes), 3),
+        "output buffer too small for base64 encoding: need ",
+        4 * ceildiv(len(input_bytes), 3),
+        ", got ",
+        len(output_bytes),
+    )
     comptime simd_width = sys.simd_byte_width()
     comptime input_simd_width = simd_width * 3 // 4
     comptime equal_vector = SIMD[DType.uint8, simd_width](ord("="))
 
-    # 4 character bytes for each 3 bytes (or less) block
-    result.resize(unsafe_uninit_length=4 * ceildiv(len(input_bytes), 3))
     var input_bytes_len = len(input_bytes)
     var input_index = 0
-    var res_ptr = result.unsafe_ptr_mut()
+    var res_ptr = output_bytes.unsafe_ptr()
     var res_offset = 0
 
     # Main loop
@@ -266,7 +279,7 @@ def _b64encode(input_bytes: Span[mut=False, Byte, _], mut result: String):
         res_offset += nb_of_elements_to_store
         input_index += input_simd_width
 
-    result.resize(res_offset)
+    return res_offset
 
 
 # Utility functions

--- a/mojo/stdlib/std/base64/base64.mojo
+++ b/mojo/stdlib/std/base64/base64.mojo
@@ -20,6 +20,7 @@ from std.base64 import b64encode
 """
 
 
+from std.math import ceildiv
 from std.memory import Span
 
 from ._b64encode import _b64encode
@@ -79,18 +80,40 @@ def _ascii_to_value[validate: Bool = False](char: Byte) raises -> Byte:
 
 
 @always_inline
-def b64encode(input_bytes: Span[mut=False, Byte, _], mut result: String):
-    """Performs base64 encoding on the input string.
+def unsafe_b64encode(
+    input_bytes: Span[mut=False, Byte, _],
+    output_bytes: Span[mut=True, Byte, _],
+) -> Int:
+    """Performs base64 encoding from input bytes to output bytes.
+
+    The caller must ensure the output buffer is at least
+    `4 * ceildiv(len(input_bytes), 3)` bytes; no bounds check is performed.
 
     Args:
-        input_bytes: The input string buffer.
-        result: The string in which to store the values.
+        input_bytes: The input bytes to encode.
+        output_bytes: The output buffer to write encoded bytes into.
 
-    Notes:
-        This method reserves the necessary capacity. `result` can be a 0
-        capacity string.
+    Returns:
+        The number of bytes written to output_bytes.
     """
-    _b64encode(input_bytes, result)
+    return _b64encode(input_bytes, output_bytes)
+
+
+@always_inline
+def b64encode(input_bytes: Span[mut=False, Byte, _], mut result: String):
+    """Performs base64 encoding, writing into a reusable `String` buffer.
+
+    `result` is resized to fit the encoded output; existing contents are
+    overwritten. Capacity is reused when possible, so calling this in a
+    loop with the same `result` avoids per-call allocation.
+
+    Args:
+        input_bytes: The input bytes to encode.
+        result: The string buffer to write into.
+    """
+    var output_len = 4 * ceildiv(len(input_bytes), 3)
+    result.resize(unsafe_uninit_length=output_len)
+    _ = unsafe_b64encode(input_bytes, result.unsafe_as_bytes_mut())
 
 
 @always_inline
@@ -108,10 +131,10 @@ def b64encode(input_string: StringSlice[mut=False, _]) -> String:
 
 @always_inline
 def b64encode(input_bytes: Span[mut=False, Byte, _]) -> String:
-    """Performs base64 encoding on the input string.
+    """Performs base64 encoding on the input bytes.
 
     Args:
-        input_bytes: The input string buffer.
+        input_bytes: The input bytes to encode.
 
     Returns:
         The ASCII base64 encoded string.
@@ -126,30 +149,45 @@ def b64encode(input_bytes: Span[mut=False, Byte, _]) -> String:
 # ===-----------------------------------------------------------------------===#
 
 
-def b64decode[
+def unsafe_b64decode[
     *, validate: Bool = False
 ](
-    input_bytes: Span[mut=False, Byte, _],
+    str: StringSlice[mut=False, _],
     mut output_bytes: Span[mut=True, Byte, _],
 ) raises -> Int:
-    """Performs base64 decoding from input bytes to output bytes.
+    """Performs base64 decoding from a string to output bytes.
 
-    The output buffer must be at least (input length * 3) // 4 bytes.
+    The caller must ensure the output buffer is at least
+    `(len(str) * 3) // 4` bytes; no bounds check is performed.
 
     Parameters:
         validate: If true, the function will validate the input and that the
             output buffer is large enough.
 
     Args:
-        input_bytes: The input base64 encoded bytes.
+        str: A base64 encoded string.
         output_bytes: The output buffer to write decoded bytes into.
 
     Returns:
         The number of bytes written to output_bytes.
+
+    Raises:
+        If `validate` is true and the input length is not a multiple of 4,
+        the output buffer is too small, or the input contains non-base64
+        characters.
     """
     comptime `=` = Byte(ord("="))
-    var n = len(input_bytes)
+    var input_bytes = str.as_bytes()
+    var n = str.byte_length()
     var write_pos = 0
+
+    debug_assert(
+        len(output_bytes) >= n * 3 // 4,
+        "output buffer too small for base64 decoding: need ",
+        n * 3 // 4,
+        ", got ",
+        len(output_bytes),
+    )
 
     comptime if validate:
         if n % 4 != 0:
@@ -190,9 +228,37 @@ def b64decode[
     return write_pos
 
 
+@always_inline
 def b64decode[
     *, validate: Bool = False
-](str: StringSlice[mut=False, _]) raises -> List[UInt8]:
+](str: StringSlice[mut=False, _], mut result: List[Byte]) raises:
+    """Performs base64 decoding into a reusable `List[Byte]` buffer.
+
+    `result` is resized to fit the decoded output; existing contents are
+    overwritten. Capacity is reused when possible, so calling this in a
+    loop with the same `result` avoids per-call allocation.
+
+    Parameters:
+        validate: If true, the function will validate the input string.
+
+    Args:
+        str: A base64 encoded string.
+        result: The byte buffer to write into.
+
+    Raises:
+        If `validate` is true and the input is not valid base64.
+    """
+    var output_len = str.byte_length() * 3 // 4
+    result.resize(unsafe_uninit_length=output_len)
+    var output_span = Span(result)
+    var written = unsafe_b64decode[validate=validate](str, output_span)
+    result.resize(unsafe_uninit_length=written)
+
+
+@always_inline
+def b64decode[
+    *, validate: Bool = False
+](str: StringSlice[mut=False, _]) raises -> List[Byte]:
     """Performs base64 decoding on a string, returning decoded bytes.
 
     Parameters:
@@ -202,15 +268,13 @@ def b64decode[
         str: A base64 encoded string.
 
     Returns:
-        The decoded bytes as a List[UInt8].
+        The decoded bytes as a List[Byte].
+
+    Raises:
+        If `validate` is true and the input is not valid base64.
     """
-    var data = str.as_bytes()
-    var n = str.byte_length()
-    var result = List[UInt8](capacity=n * 3 // 4)
-    result.resize(n * 3 // 4, 0)
-    var output_span = Span(result)
-    var written = b64decode[validate=validate](data, output_span)
-    result.resize(written, 0)
+    var result = List[Byte]()
+    b64decode[validate=validate](str, result)
     return result^
 
 
@@ -219,29 +283,54 @@ def b64decode[
 # ===-----------------------------------------------------------------------===#
 
 
-def b16encode[origin: Origin](input_bytes: Span[UInt8, origin]) -> String:
-    """Performs base16 encoding on input bytes, returning a String.
+def unsafe_b16encode(
+    input_bytes: Span[mut=False, Byte, _],
+    output_bytes: Span[mut=True, Byte, _],
+) -> Int:
+    """Performs base16 encoding from input bytes to output bytes.
+
+    The caller must ensure the output buffer is at least
+    `2 * len(input_bytes)` bytes; no bounds check is performed.
 
     Args:
         input_bytes: The input bytes to encode.
+        output_bytes: The output buffer to write encoded bytes into.
 
     Returns:
-        Base16 encoding of the input bytes.
+        The number of bytes written to output_bytes.
     """
+    var length = len(input_bytes)
+    debug_assert(
+        len(output_bytes) >= 2 * length,
+        "output buffer too small for base16 encoding: need ",
+        2 * length,
+        ", got ",
+        len(output_bytes),
+    )
     comptime lookup = "0123456789ABCDEF"
     var b16chars = lookup.unsafe_ptr()
-
-    var length = len(input_bytes)
-    var result = String(capacity=length * 2)
-
     for i in range(length):
         var byte = input_bytes[i]
-        var hi = byte >> 4
-        var lo = byte & 0b1111
-        result._unsafe_append_byte(b16chars[hi])
-        result._unsafe_append_byte(b16chars[lo])
+        output_bytes[2 * i] = b16chars[byte >> 4]
+        output_bytes[2 * i + 1] = b16chars[byte & 0b1111]
+    return length * 2
 
-    return result^
+
+@always_inline
+def b16encode(input_bytes: Span[mut=False, Byte, _], mut result: String):
+    """Performs base16 encoding, writing into a reusable `String` buffer.
+
+    `result` is resized to fit the encoded output; existing contents are
+    overwritten. Capacity is reused when possible, so calling this in a
+    loop with the same `result` avoids per-call allocation.
+
+    Args:
+        input_bytes: The input bytes to encode.
+        result: The string buffer to write into.
+    """
+    var output_len = 2 * len(input_bytes)
+    result.resize(unsafe_uninit_length=output_len)
+    _ = unsafe_b16encode(input_bytes, result.unsafe_as_bytes_mut())
 
 
 @always_inline
@@ -257,44 +346,69 @@ def b16encode(str: StringSlice[mut=False, _]) -> String:
     return b16encode(str.as_bytes())
 
 
+@always_inline
+def b16encode(input_bytes: Span[mut=False, Byte, _]) -> String:
+    """Performs base16 encoding on the input bytes.
+
+    Args:
+        input_bytes: The input bytes to encode.
+
+    Returns:
+        Base16 encoding of the input bytes.
+    """
+    var result = String()
+    b16encode(input_bytes, result)
+    return result^
+
+
 # ===-----------------------------------------------------------------------===#
 # b16decode
 # ===-----------------------------------------------------------------------===#
 
 
-def b16decode(
-    input_bytes: Span[mut=False, UInt8, _],
-    mut output_bytes: Span[mut=True, UInt8, _],
+def unsafe_b16decode(
+    str: StringSlice[mut=False, _],
+    mut output_bytes: Span[mut=True, Byte, _],
 ):
-    """Performs base16 decoding from input bytes to output bytes.
+    """Performs base16 decoding from a string to output bytes.
 
-    The output buffer must be exactly input length / 2 bytes.
+    The caller must ensure the output buffer is at least
+    `len(str) // 2` bytes; no bounds check is performed.
 
     Args:
-        input_bytes: The input base16 encoded bytes.
+        str: A base16 encoded string.
         output_bytes: The output buffer to write decoded bytes into.
     """
-    comptime `A` = UInt8(ord("A"))
-    comptime `a` = UInt8(ord("a"))
-    comptime `Z` = UInt8(ord("Z"))
-    comptime `z` = UInt8(ord("z"))
-    comptime `0` = UInt8(ord("0"))
-    comptime `9` = UInt8(ord("9"))
+    comptime `A` = Byte(ord("A"))
+    comptime `a` = Byte(ord("a"))
+    comptime `Z` = Byte(ord("Z"))
+    comptime `z` = Byte(ord("z"))
+    comptime `0` = Byte(ord("0"))
+    comptime `9` = Byte(ord("9"))
 
+    # TODO: Measure perf against lookup table approach
     @parameter
     @always_inline
-    def decode(c: UInt8) -> UInt8:
+    def decode(c: Byte) -> Byte:
         if `A` <= c <= `Z`:
-            return c - `A` + UInt8(10)
+            return c - `A` + Byte(10)
         elif `a` <= c <= `z`:
-            return c - `a` + UInt8(10)
+            return c - `a` + Byte(10)
         elif `0` <= c <= `9`:
             return c - `0`
         else:
-            return UInt8(-1)
+            return Byte(-1)
 
-    var n = len(input_bytes)
+    var input_bytes = str.as_bytes()
+    var n = str.byte_length()
     debug_assert(n % 2 == 0, "Input length '", n, "' must be divisible by 2")
+    debug_assert(
+        len(output_bytes) >= n // 2,
+        "output buffer too small for base16 decoding: need ",
+        n // 2,
+        ", got ",
+        len(output_bytes),
+    )
 
     for i in range(0, n, 2):
         var hi = input_bytes[i]
@@ -302,19 +416,34 @@ def b16decode(
         output_bytes[i // 2] = decode(hi) << 4 | decode(lo)
 
 
-def b16decode(str: StringSlice[mut=False, _]) -> List[UInt8]:
+@always_inline
+def b16decode(str: StringSlice[mut=False, _], mut result: List[Byte]):
+    """Performs base16 decoding into a reusable `List[Byte]` buffer.
+
+    `result` is resized to fit the decoded output; existing contents are
+    overwritten. Capacity is reused when possible, so calling this in a
+    loop with the same `result` avoids per-call allocation.
+
+    Args:
+        str: A base16 encoded string.
+        result: The byte buffer to write into.
+    """
+    var output_len = str.byte_length() // 2
+    result.resize(unsafe_uninit_length=output_len)
+    var output_span = Span(result)
+    unsafe_b16decode(str, output_span)
+
+
+@always_inline
+def b16decode(str: StringSlice[mut=False, _]) -> List[Byte]:
     """Performs base16 decoding on a string, returning decoded bytes.
 
     Args:
         str: A base16 encoded string.
 
     Returns:
-        The decoded bytes as a List[UInt8].
+        The decoded bytes as a List[Byte].
     """
-    var data = str.as_bytes()
-    var output_len = str.byte_length() // 2
-    var result = List[UInt8](capacity=output_len)
-    result.resize(output_len, 0)
-    var output_span = Span(result)
-    b16decode(data, output_span)
+    var result = List[Byte]()
+    b16decode(str, result)
     return result^

--- a/mojo/stdlib/std/base64/base64.mojo
+++ b/mojo/stdlib/std/base64/base64.mojo
@@ -128,8 +128,72 @@ def b64encode(input_bytes: Span[mut=False, Byte, _]) -> String:
 
 def b64decode[
     *, validate: Bool = False
-](str: StringSlice[mut=False, _]) raises -> String:
-    """Performs base64 decoding on the input string.
+](
+    input_bytes: Span[mut=False, Byte, _],
+    mut output_bytes: Span[mut=True, Byte, _],
+) raises -> Int:
+    """Performs base64 decoding from input bytes to output bytes.
+
+    The output buffer must be at least (input length * 3) // 4 bytes.
+
+    Parameters:
+        validate: If true, the function will validate the input and that the
+            output buffer is large enough.
+
+    Args:
+        input_bytes: The input base64 encoded bytes.
+        output_bytes: The output buffer to write decoded bytes into.
+
+    Returns:
+        The number of bytes written to output_bytes.
+    """
+    comptime `=` = Byte(ord("="))
+    var n = len(input_bytes)
+    var write_pos = 0
+
+    comptime if validate:
+        if n % 4 != 0:
+            raise Error(
+                "ValueError: Input length '", n, "' must be divisible by 4"
+            )
+        if len(output_bytes) < n * 3 // 4:
+            raise Error(
+                "ValueError: Output buffer length '",
+                len(output_bytes),
+                "' is too small for input length '",
+                n,
+                "'",
+            )
+
+    # This algorithm is based on https://arxiv.org/abs/1704.00605
+    for i in range(0, n, 4):
+        var a = _ascii_to_value[validate](input_bytes[i])
+        var b = _ascii_to_value[validate](input_bytes[i + 1])
+        var c = _ascii_to_value[validate](input_bytes[i + 2])
+        var d = _ascii_to_value[validate](input_bytes[i + 3])
+
+        output_bytes[write_pos] = (a << 2) | (b >> 4)
+        write_pos += 1
+
+        if input_bytes[i + 2] == `=`:
+            break
+
+        output_bytes[write_pos] = ((b & 0x0F) << 4) | (c >> 2)
+        write_pos += 1
+
+        if input_bytes[i + 3] == `=`:
+            break
+
+        output_bytes[write_pos] = ((c & 0x03) << 6) | d
+        write_pos += 1
+
+    return write_pos
+
+
+def b64decode[
+    *, validate: Bool = False
+](str: StringSlice[mut=False, _]) raises -> List[UInt8]:
+    """Performs base64 decoding on a string, returning decoded bytes.
 
     Parameters:
         validate: If true, the function will validate the input string.
@@ -138,38 +202,15 @@ def b64decode[
         str: A base64 encoded string.
 
     Returns:
-        The decoded string.
-
-    Raises:
-        If the operation fails.
+        The decoded bytes as a List[UInt8].
     """
-    comptime `=` = Byte(ord("="))
     var data = str.as_bytes()
     var n = str.byte_length()
-
-    comptime if validate:
-        if n % 4 != 0:
-            raise Error(
-                "ValueError: Input length '", n, "' must be divisible by 4"
-            )
-
-    var result = String(capacity=n)
-
-    # This algorithm is based on https://arxiv.org/abs/1704.00605
-    for i in range(0, n, 4):
-        var a = _ascii_to_value[validate](data[i])
-        var b = _ascii_to_value[validate](data[i + 1])
-        var c = _ascii_to_value[validate](data[i + 2])
-        var d = _ascii_to_value[validate](data[i + 3])
-
-        result._unsafe_append_byte((a << 2) | (b >> 4))
-        if data[i + 2] == `=`:
-            break
-        result._unsafe_append_byte(((b & 0x0F) << 4) | (c >> 2))
-        if data[i + 3] == `=`:
-            break
-        result._unsafe_append_byte(((c & 0x03) << 6) | d)
-
+    var result = List[UInt8](capacity=n * 3 // 4)
+    result.resize(n * 3 // 4, 0)
+    var output_span = Span(result)
+    var written = b64decode[validate=validate](data, output_span)
+    result.resize(written, 0)
     return result^
 
 
@@ -178,6 +219,32 @@ def b64decode[
 # ===-----------------------------------------------------------------------===#
 
 
+def b16encode[origin: Origin](input_bytes: Span[UInt8, origin]) -> String:
+    """Performs base16 encoding on input bytes, returning a String.
+
+    Args:
+        input_bytes: The input bytes to encode.
+
+    Returns:
+        Base16 encoding of the input bytes.
+    """
+    comptime lookup = "0123456789ABCDEF"
+    var b16chars = lookup.unsafe_ptr()
+
+    var length = len(input_bytes)
+    var result = String(capacity=length * 2)
+
+    for i in range(length):
+        var byte = input_bytes[i]
+        var hi = byte >> 4
+        var lo = byte & 0b1111
+        result._unsafe_append_byte(b16chars[hi])
+        result._unsafe_append_byte(b16chars[lo])
+
+    return result^
+
+
+@always_inline
 def b16encode(str: StringSlice[mut=False, _]) -> String:
     """Performs base16 encoding on the input string slice.
 
@@ -187,21 +254,7 @@ def b16encode(str: StringSlice[mut=False, _]) -> String:
     Returns:
         Base16 encoding of the input string.
     """
-    comptime lookup = "0123456789ABCDEF"
-    var b16chars = lookup.unsafe_ptr()
-
-    var data = str.as_bytes()
-    var length = str.byte_length()
-    var result = String(capacity=length * 2)
-
-    for i in range(length):
-        var str_byte = data[i]
-        var hi = str_byte >> 4
-        var lo = str_byte & 0b1111
-        result._unsafe_append_byte(b16chars[hi])
-        result._unsafe_append_byte(b16chars[lo])
-
-    return result^
+    return b16encode(str.as_bytes())
 
 
 # ===-----------------------------------------------------------------------===#
@@ -209,45 +262,59 @@ def b16encode(str: StringSlice[mut=False, _]) -> String:
 # ===-----------------------------------------------------------------------===#
 
 
-def b16decode(str: StringSlice[mut=False, _]) -> String:
-    """Performs base16 decoding on the input string.
+def b16decode(
+    input_bytes: Span[mut=False, UInt8, _],
+    mut output_bytes: Span[mut=True, UInt8, _],
+):
+    """Performs base16 decoding from input bytes to output bytes.
+
+    The output buffer must be exactly input length / 2 bytes.
+
+    Args:
+        input_bytes: The input base16 encoded bytes.
+        output_bytes: The output buffer to write decoded bytes into.
+    """
+    comptime `A` = UInt8(ord("A"))
+    comptime `a` = UInt8(ord("a"))
+    comptime `Z` = UInt8(ord("Z"))
+    comptime `z` = UInt8(ord("z"))
+    comptime `0` = UInt8(ord("0"))
+    comptime `9` = UInt8(ord("9"))
+
+    @parameter
+    @always_inline
+    def decode(c: UInt8) -> UInt8:
+        if `A` <= c <= `Z`:
+            return c - `A` + UInt8(10)
+        elif `a` <= c <= `z`:
+            return c - `a` + UInt8(10)
+        elif `0` <= c <= `9`:
+            return c - `0`
+        else:
+            return UInt8(-1)
+
+    var n = len(input_bytes)
+    debug_assert(n % 2 == 0, "Input length '", n, "' must be divisible by 2")
+
+    for i in range(0, n, 2):
+        var hi = input_bytes[i]
+        var lo = input_bytes[i + 1]
+        output_bytes[i // 2] = decode(hi) << 4 | decode(lo)
+
+
+def b16decode(str: StringSlice[mut=False, _]) -> List[UInt8]:
+    """Performs base16 decoding on a string, returning decoded bytes.
 
     Args:
         str: A base16 encoded string.
 
     Returns:
-        The decoded string.
+        The decoded bytes as a List[UInt8].
     """
-
-    comptime `A` = Byte(ord("A"))
-    comptime `a` = Byte(ord("a"))
-    comptime `Z` = Byte(ord("Z"))
-    comptime `z` = Byte(ord("z"))
-    comptime `0` = Byte(ord("0"))
-    comptime `9` = Byte(ord("9"))
-
-    # TODO: Measure perf against lookup table approach
-    @parameter
-    @always_inline
-    def decode(c: Byte) -> Byte:
-        if `A` <= c <= `Z`:
-            return c - `A` + Byte(10)
-        elif `a` <= c <= `z`:
-            return c - `a` + Byte(10)
-        elif `0` <= c <= `9`:
-            return c - `0`
-        else:
-            return Byte(-1)
-
     var data = str.as_bytes()
-    var n = str.byte_length()
-    debug_assert(n % 2 == 0, "Input length '", n, "' must be divisible by 2")
-
-    var result = String(capacity=n // 2)
-
-    for i in range(0, n, 2):
-        var hi = data[i]
-        var lo = data[i + 1]
-        result._unsafe_append_byte(decode(hi) << 4 | decode(lo))
-
+    var output_len = str.byte_length() // 2
+    var result = List[UInt8](capacity=output_len)
+    result.resize(output_len, 0)
+    var output_span = Span(result)
+    b16decode(data, output_span)
     return result^

--- a/mojo/stdlib/test/base64/test_base64.mojo
+++ b/mojo/stdlib/test/base64/test_base64.mojo
@@ -72,37 +72,34 @@ def test_b64decode():
 
 
 def test_b16encode():
-    assert_equal(b16encode("a"), "61")
-
-    assert_equal(b16encode("fo"), "666F")
-
-    assert_equal(b16encode("Hello Mojo!!!"), "48656C6C6F204D6F6A6F212121")
-
-    assert_equal(b16encode("Hello 🔥!!!"), "48656C6C6F20F09F94A5212121")
-
+    assert_equal(b16encode("a".as_bytes()), "61")
+    assert_equal(b16encode("fo".as_bytes()), "666F")
+    assert_equal(b16encode("Hello Mojo!!!".as_bytes()), "48656C6C6F204D6F6A6F212121")
+    assert_equal(b16encode("Hello 🔥!!!".as_bytes()), "48656C6C6F20F09F94A5212121")
     assert_equal(
-        b16encode("the quick brown fox jumps over the lazy dog"),
+        b16encode("the quick brown fox jumps over the lazy dog".as_bytes()),
         "74686520717569636B2062726F776E20666F78206A756D7073206F76657220746865206C617A7920646F67",
     )
-
-    assert_equal(b16encode("ABCDEFabcdef"), "414243444546616263646566")
+    assert_equal(b16encode("ABCDEFabcdef".as_bytes()), "414243444546616263646566")
 
 
 def test_b16decode():
-    assert_equal(b16decode("61"), "a")
+    def bytes_to_str(b: List[UInt8]) -> String:
+        # Helper to convert List[UInt8] to String for test comparison
+        var s = String(capacity=b.size())
+        for byte in b:
+            s.append_byte(byte)
+        return s^
 
-    assert_equal(b16decode("666F"), "fo")
-
-    assert_equal(b16decode("48656C6C6F204D6F6A6F212121"), "Hello Mojo!!!")
-
-    assert_equal(b16decode("48656C6C6F20F09F94A5212121"), "Hello 🔥!!!")
-
+    assert_equal(bytes_to_str(b16decode("61")), "a")
+    assert_equal(bytes_to_str(b16decode("666F")), "fo")
+    assert_equal(bytes_to_str(b16decode("48656C6C6F204D6F6A6F212121")), "Hello Mojo!!!")
+    assert_equal(bytes_to_str(b16decode("48656C6C6F20F09F94A5212121")), "Hello 🔥!!!")
     assert_equal(
-        b16encode("the quick brown fox jumps over the lazy dog"),
+        b16encode("the quick brown fox jumps over the lazy dog".as_bytes()),
         "74686520717569636B2062726F776E20666F78206A756D7073206F76657220746865206C617A7920646F67",
     )
-
-    assert_equal(b16decode("414243444546616263646566"), "ABCDEFabcdef")
+    assert_equal(bytes_to_str(b16decode("414243444546616263646566")), "ABCDEFabcdef")
 
 
 def main():

--- a/mojo/stdlib/test/base64/test_base64.mojo
+++ b/mojo/stdlib/test/base64/test_base64.mojo
@@ -17,6 +17,14 @@ from base64 import b16decode, b16encode, b64decode, b64encode
 from testing import assert_equal, assert_raises
 
 
+def bytes_to_str(b: Span[mut=False, UInt8]) -> String:
+    # Helper to convert Span[UInt8] to String for test comparison
+    var s = String(capacity=len(b))
+    for byte in b:
+        s.append_byte(byte)
+    return s^
+
+
 def test_b64encode():
     assert_equal(b64encode("a"), "YQ==")
 
@@ -43,22 +51,21 @@ def test_b64encode():
 
 
 def test_b64decode():
-    assert_equal(b64decode("YQ=="), "a")
-
-    assert_equal(b64decode("Zm8="), "fo")
-
-    assert_equal(b64decode("SGVsbG8gTW9qbyEhIQ=="), "Hello Mojo!!!")
-
-    assert_equal(b64decode("SGVsbG8g8J+UpSEhIQ=="), "Hello 🔥!!!")
-
+    assert_equal(bytes_to_str(b64decode("YQ==")), "a")
+    assert_equal(bytes_to_str(b64decode("Zm8=")), "fo")
     assert_equal(
-        b64decode(
-            "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw=="
+        bytes_to_str(b64decode("SGVsbG8gTW9qbyEhIQ==")), "Hello Mojo!!!"
+    )
+    assert_equal(bytes_to_str(b64decode("SGVsbG8g8J+UpSEhIQ==")), "Hello 🔥!!!")
+    assert_equal(
+        bytes_to_str(
+            b64decode(
+                "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw=="
+            )
         ),
         "the quick brown fox jumps over the lazy dog",
     )
-
-    assert_equal(b64decode("QUJDREVGYWJjZGVm"), "ABCDEFabcdef")
+    assert_equal(bytes_to_str(b64decode("QUJDREVGYWJjZGVm")), "ABCDEFabcdef")
 
     with assert_raises(
         contains="ValueError: Input length '21' must be divisible by 4"
@@ -74,32 +81,37 @@ def test_b64decode():
 def test_b16encode():
     assert_equal(b16encode("a".as_bytes()), "61")
     assert_equal(b16encode("fo".as_bytes()), "666F")
-    assert_equal(b16encode("Hello Mojo!!!".as_bytes()), "48656C6C6F204D6F6A6F212121")
-    assert_equal(b16encode("Hello 🔥!!!".as_bytes()), "48656C6C6F20F09F94A5212121")
+    assert_equal(
+        b16encode("Hello Mojo!!!".as_bytes()), "48656C6C6F204D6F6A6F212121"
+    )
+    assert_equal(
+        b16encode("Hello 🔥!!!".as_bytes()), "48656C6C6F20F09F94A5212121"
+    )
     assert_equal(
         b16encode("the quick brown fox jumps over the lazy dog".as_bytes()),
         "74686520717569636B2062726F776E20666F78206A756D7073206F76657220746865206C617A7920646F67",
     )
-    assert_equal(b16encode("ABCDEFabcdef".as_bytes()), "414243444546616263646566")
+    assert_equal(
+        b16encode("ABCDEFabcdef".as_bytes()), "414243444546616263646566"
+    )
 
 
 def test_b16decode():
-    def bytes_to_str(b: List[UInt8]) -> String:
-        # Helper to convert List[UInt8] to String for test comparison
-        var s = String(capacity=b.size())
-        for byte in b:
-            s.append_byte(byte)
-        return s^
-
     assert_equal(bytes_to_str(b16decode("61")), "a")
     assert_equal(bytes_to_str(b16decode("666F")), "fo")
-    assert_equal(bytes_to_str(b16decode("48656C6C6F204D6F6A6F212121")), "Hello Mojo!!!")
-    assert_equal(bytes_to_str(b16decode("48656C6C6F20F09F94A5212121")), "Hello 🔥!!!")
+    assert_equal(
+        bytes_to_str(b16decode("48656C6C6F204D6F6A6F212121")), "Hello Mojo!!!"
+    )
+    assert_equal(
+        bytes_to_str(b16decode("48656C6C6F20F09F94A5212121")), "Hello 🔥!!!"
+    )
     assert_equal(
         b16encode("the quick brown fox jumps over the lazy dog".as_bytes()),
         "74686520717569636B2062726F776E20666F78206A756D7073206F76657220746865206C617A7920646F67",
     )
-    assert_equal(bytes_to_str(b16decode("414243444546616263646566")), "ABCDEFabcdef")
+    assert_equal(
+        bytes_to_str(b16decode("414243444546616263646566")), "ABCDEFabcdef"
+    )
 
 
 def main():

--- a/mojo/stdlib/test/base64/test_base64.mojo
+++ b/mojo/stdlib/test/base64/test_base64.mojo
@@ -18,12 +18,8 @@ from std.testing import assert_equal, assert_raises
 from std.testing import TestSuite
 
 
-def bytes_to_str(b: Span[mut=False, UInt8, _]) -> String:
-    # Helper to convert Span[UInt8] to String for test comparison
-    var s = String(capacity=len(b))
-    for byte in b:
-        s._unsafe_append_byte(byte)
-    return s^
+def _bytes(s: StringSlice) -> List[Byte]:
+    return List[Byte](s.as_bytes())
 
 
 def test_b64encode() raises:
@@ -61,28 +57,17 @@ def test_b64encode() raises:
 
 
 def test_b64decode() raises:
-    assert_equal(bytes_to_str(b64decode("YQ==")), "a")
-
-    assert_equal(bytes_to_str(b64decode("Zm8=")), "fo")
-
+    assert_equal(b64decode("YQ=="), _bytes("a"))
+    assert_equal(b64decode("Zm8="), _bytes("fo"))
+    assert_equal(b64decode("SGVsbG8gTW9qbyEhIQ=="), _bytes("Hello Mojo!!!"))
+    assert_equal(b64decode("SGVsbG8g8J+UpSEhIQ=="), _bytes("Hello 🔥!!!"))
     assert_equal(
-        bytes_to_str(b64decode("SGVsbG8gTW9qbyEhIQ==")), "Hello Mojo!!!"
-    )
-
-    assert_equal(
-        bytes_to_str(b64decode("SGVsbG8g8J+UpSEhIQ==")), "Hello 🔥!!!"
-    )
-
-    assert_equal(
-        bytes_to_str(
-            b64decode(
-                "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw=="
-            )
+        b64decode(
+            "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw=="
         ),
-        "the quick brown fox jumps over the lazy dog",
+        _bytes("the quick brown fox jumps over the lazy dog"),
     )
-
-    assert_equal(bytes_to_str(b64decode("QUJDREVGYWJjZGVm")), "ABCDEFabcdef")
+    assert_equal(b64decode("QUJDREVGYWJjZGVm"), _bytes("ABCDEFabcdef"))
 
     with assert_raises(
         contains="ValueError: Input length '21' must be divisible by 4"
@@ -108,21 +93,61 @@ def test_b16encode() raises:
 
 
 def test_b16decode() raises:
-    assert_equal(bytes_to_str(b16decode("61")), "a")
-    assert_equal(bytes_to_str(b16decode("666F")), "fo")
+    assert_equal(b16decode("61"), _bytes("a"))
+    assert_equal(b16decode("666F"), _bytes("fo"))
     assert_equal(
-        bytes_to_str(b16decode("48656C6C6F204D6F6A6F212121")), "Hello Mojo!!!"
+        b16decode("48656C6C6F204D6F6A6F212121"), _bytes("Hello Mojo!!!")
     )
+    assert_equal(b16decode("48656C6C6F20F09F94A5212121"), _bytes("Hello 🔥!!!"))
     assert_equal(
-        bytes_to_str(b16decode("48656C6C6F20F09F94A5212121")), "Hello 🔥!!!"
+        b16decode(
+            "74686520717569636B2062726F776E20666F78206A756D7073206F76657220746865206C617A7920646F67"
+        ),
+        _bytes("the quick brown fox jumps over the lazy dog"),
     )
-    assert_equal(
-        b16encode("the quick brown fox jumps over the lazy dog"),
-        "74686520717569636B2062726F776E20666F78206A756D7073206F76657220746865206C617A7920646F67",
-    )
-    assert_equal(
-        bytes_to_str(b16decode("414243444546616263646566")), "ABCDEFabcdef"
-    )
+    assert_equal(b16decode("414243444546616263646566"), _bytes("ABCDEFabcdef"))
+
+
+def test_b64encode_reuse_buffer() raises:
+    var buf = String()
+    b64encode("hello".as_bytes(), buf)
+    assert_equal(buf, "aGVsbG8=")
+    b64encode("hi".as_bytes(), buf)  # reuse same buffer; expect shrink
+    assert_equal(buf, "aGk=")
+    b64encode(
+        "a longer payload to grow capacity".as_bytes(), buf
+    )  # reuse; expect grow
+    assert_equal(buf, "YSBsb25nZXIgcGF5bG9hZCB0byBncm93IGNhcGFjaXR5")
+
+
+def test_b64decode_reuse_buffer() raises:
+    var buf = List[Byte]()
+    b64decode("aGVsbG8=", buf)
+    assert_equal(buf, _bytes("hello"))
+    b64decode("aGk=", buf)  # reuse; expect shrink
+    assert_equal(buf, _bytes("hi"))
+    b64decode("YSBsb25nZXIgcGF5bG9hZCB0byBncm93IGNhcGFjaXR5", buf)  # grow
+    assert_equal(buf, _bytes("a longer payload to grow capacity"))
+
+
+def test_b16encode_reuse_buffer() raises:
+    var buf = String()
+    b16encode("hi".as_bytes(), buf)
+    assert_equal(buf, "6869")
+    b16encode("a".as_bytes(), buf)  # reuse; expect shrink
+    assert_equal(buf, "61")
+    b16encode("hello world".as_bytes(), buf)  # reuse; expect grow
+    assert_equal(buf, "68656C6C6F20776F726C64")
+
+
+def test_b16decode_reuse_buffer() raises:
+    var buf = List[Byte]()
+    b16decode("6869", buf)
+    assert_equal(buf, _bytes("hi"))
+    b16decode("61", buf)  # reuse; expect shrink
+    assert_equal(buf, _bytes("a"))
+    b16decode("68656C6C6F20776F726C64", buf)  # reuse; expect grow
+    assert_equal(buf, _bytes("hello world"))
 
 
 def main() raises:

--- a/mojo/stdlib/test/base64/test_base64.mojo
+++ b/mojo/stdlib/test/base64/test_base64.mojo
@@ -18,6 +18,14 @@ from std.testing import assert_equal, assert_raises
 from std.testing import TestSuite
 
 
+def bytes_to_str(b: Span[mut=False, UInt8, _]) -> String:
+    # Helper to convert Span[UInt8] to String for test comparison
+    var s = String(capacity=len(b))
+    for byte in b:
+        s._unsafe_append_byte(byte)
+    return s^
+
+
 def test_b64encode() raises:
     assert_equal(b64encode("a"), "YQ==")
 
@@ -53,22 +61,28 @@ def test_b64encode() raises:
 
 
 def test_b64decode() raises:
-    assert_equal(b64decode("YQ=="), "a")
+    assert_equal(bytes_to_str(b64decode("YQ==")), "a")
 
-    assert_equal(b64decode("Zm8="), "fo")
-
-    assert_equal(b64decode("SGVsbG8gTW9qbyEhIQ=="), "Hello Mojo!!!")
-
-    assert_equal(b64decode("SGVsbG8g8J+UpSEhIQ=="), "Hello 🔥!!!")
+    assert_equal(bytes_to_str(b64decode("Zm8=")), "fo")
 
     assert_equal(
-        b64decode(
-            "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw=="
+        bytes_to_str(b64decode("SGVsbG8gTW9qbyEhIQ==")), "Hello Mojo!!!"
+    )
+
+    assert_equal(
+        bytes_to_str(b64decode("SGVsbG8g8J+UpSEhIQ==")), "Hello 🔥!!!"
+    )
+
+    assert_equal(
+        bytes_to_str(
+            b64decode(
+                "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw=="
+            )
         ),
         "the quick brown fox jumps over the lazy dog",
     )
 
-    assert_equal(b64decode("QUJDREVGYWJjZGVm"), "ABCDEFabcdef")
+    assert_equal(bytes_to_str(b64decode("QUJDREVGYWJjZGVm")), "ABCDEFabcdef")
 
     with assert_raises(
         contains="ValueError: Input length '21' must be divisible by 4"
@@ -83,36 +97,32 @@ def test_b64decode() raises:
 
 def test_b16encode() raises:
     assert_equal(b16encode("a"), "61")
-
     assert_equal(b16encode("fo"), "666F")
-
     assert_equal(b16encode("Hello Mojo!!!"), "48656C6C6F204D6F6A6F212121")
-
     assert_equal(b16encode("Hello 🔥!!!"), "48656C6C6F20F09F94A5212121")
-
     assert_equal(
         b16encode("the quick brown fox jumps over the lazy dog"),
         "74686520717569636B2062726F776E20666F78206A756D7073206F76657220746865206C617A7920646F67",
     )
-
     assert_equal(b16encode("ABCDEFabcdef"), "414243444546616263646566")
 
 
 def test_b16decode() raises:
-    assert_equal(b16decode("61"), "a")
-
-    assert_equal(b16decode("666F"), "fo")
-
-    assert_equal(b16decode("48656C6C6F204D6F6A6F212121"), "Hello Mojo!!!")
-
-    assert_equal(b16decode("48656C6C6F20F09F94A5212121"), "Hello 🔥!!!")
-
+    assert_equal(bytes_to_str(b16decode("61")), "a")
+    assert_equal(bytes_to_str(b16decode("666F")), "fo")
+    assert_equal(
+        bytes_to_str(b16decode("48656C6C6F204D6F6A6F212121")), "Hello Mojo!!!"
+    )
+    assert_equal(
+        bytes_to_str(b16decode("48656C6C6F20F09F94A5212121")), "Hello 🔥!!!"
+    )
     assert_equal(
         b16encode("the quick brown fox jumps over the lazy dog"),
         "74686520717569636B2062726F776E20666F78206A756D7073206F76657220746865206C617A7920646F67",
     )
-
-    assert_equal(b16decode("414243444546616263646566"), "ABCDEFabcdef")
+    assert_equal(
+        bytes_to_str(b16decode("414243444546616263646566")), "ABCDEFabcdef"
+    )
 
 
 def main() raises:


### PR DESCRIPTION
The `b64decode` and `b16decode` functions should really return a `bytes`-like structure rather than a `str`-like structure. Similarly, the `b64encode` and `b16encode` functions should accept a `bytes`-like structure (in this case, `Span[UInt8]`). This PR fixes that.