### PR TITLE
[stdlib] Moving DJBX33A from hash to it's own module

### DIFF
--- a/mojo/stdlib/stdlib/hashlib/_ahash.mojo
+++ b/mojo/stdlib/stdlib/hashlib/_ahash.mojo
@@ -126,7 +126,11 @@ struct AHasher[key: U256](Defaultable, _Hasher):
         self.buffer = rotate_bits_left[ROT]((self.buffer + self.pad) ^ combined)
 
     fn _update_with_bytes(
-        mut self, data: UnsafePointer[UInt8, mut=False, **_], length: Int
+        mut self,
+        data: UnsafePointer[
+            UInt8, address_space = AddressSpace.GENERIC, mut=False, **_
+        ],
+        length: Int,
     ):
         """Consume provided data to update the internal buffer.
 

--- a/mojo/stdlib/stdlib/hashlib/_djbx33a.mojo
+++ b/mojo/stdlib/stdlib/hashlib/_djbx33a.mojo
@@ -1,0 +1,215 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Implements a specialized DJBX33a hash function, 
+which was the initial hash function implementation in Mojo standrard library.
+"""
+
+from sys import bitwidthof, simdwidthof, sizeof
+
+from builtin.dtype import _uint_type_of_width
+from memory import UnsafePointer, bitcast, memcpy, memset_zero
+from ._hasher import _Hasher, _HashableWithHasher
+
+
+fn _djbx33a_init[dtype: DType, size: Int]() -> SIMD[dtype, size]:
+    return SIMD[dtype, size](5361)
+
+
+fn _djbx33a_hash_update[
+    dtype: DType, size: Int
+](data: SIMD[dtype, size], next: SIMD[dtype, size]) -> SIMD[dtype, size]:
+    return data * 33 + next
+
+
+# Based on the hash function used by ankerl::unordered_dense::hash
+# https://martin.ankerl.com/2022/08/27/hashmap-bench-01/#ankerl__unordered_dense__hash
+fn _ankerl_init[dtype: DType, size: Int]() -> SIMD[dtype, size]:
+    alias int_type = _uint_type_of_width[bitwidthof[dtype]()]()
+    alias init = Int64(-7046029254386353131).cast[int_type]()
+    return SIMD[dtype, size](bitcast[dtype, 1](init))
+
+
+fn _ankerl_hash_update[
+    dtype: DType, size: Int
+](data: SIMD[dtype, size], next: SIMD[dtype, size]) -> SIMD[dtype, size]:
+    # compute the hash as though the type is uint
+    alias int_type = _uint_type_of_width[bitwidthof[dtype]()]()
+    var data_int = bitcast[int_type, size](data)
+    var next_int = bitcast[int_type, size](next)
+    var result = (data_int * next_int) ^ next_int
+    return bitcast[dtype, size](result)
+
+
+alias _HASH_INIT = _djbx33a_init
+alias _HASH_UPDATE = _djbx33a_hash_update
+
+
+# This is incrementally better than DJBX33A, in that it fixes some of the
+# performance issue we've been seeing with Dict. It's still not ideal as
+# a long-term hash function.
+@always_inline
+fn _hash_simd[dtype: DType, size: Int](data: SIMD[dtype, size]) -> UInt:
+    """Hash a SIMD byte vector using direct DJBX33A hash algorithm.
+
+    See `hash(bytes, n)` documentation for more details.
+
+    Parameters:
+        dtype: The SIMD dtype of the input data.
+        size: The SIMD width of the input data.
+
+    Args:
+        data: The input data to hash.
+
+    Returns:
+        A 64-bit integer hash. This hash is _not_ suitable for
+        cryptographic purposes, but will have good low-bit
+        hash collision statistical properties for common data structures.
+    """
+
+    @parameter
+    if dtype is DType.bool:
+        return _hash_simd(data.cast[DType.int8]())
+
+    var hash_data = _ankerl_init[dtype, size]()
+    hash_data = _ankerl_hash_update(hash_data, data)
+
+    alias int_type = _uint_type_of_width[bitwidthof[dtype]()]()
+    var final_data = bitcast[int_type, 1](hash_data[0]).cast[DType.uint64]()
+
+    @parameter
+    for i in range(1, size):
+        final_data = _ankerl_hash_update(
+            final_data,
+            bitcast[int_type, 1](hash_data[i]).cast[DType.uint64](),
+        )
+
+    return UInt(final_data)
+
+
+fn hash(
+    bytes: UnsafePointer[
+        UInt8, address_space = AddressSpace.GENERIC, mut=False, **_
+    ],
+    n: Int,
+) -> UInt:
+    """Hash a byte array using a SIMD-modified DJBX33A hash algorithm.
+
+    _This hash function is not suitable for cryptographic purposes._ The
+    algorithm is easy to reverse and produce deliberate hash collisions.
+    The hash function is designed to have relatively good mixing and statistical
+    properties for use in hash-based data structures.  We _do_ however initialize
+    a random hash secret which is mixed into the final hash output. This can help
+    prevent DDOS attacks on applications which make use of this function for
+    dictionary hashing. As a consequence, hash values are deterministic within an
+    individual runtime instance ie.  a value will always hash to the same thing,
+    but in between runs this value will change based on the hash secret.
+
+    We take advantage of Mojo's first-class SIMD support to create a
+    SIMD-vectorized hash function, using some simple hash algorithm as a base.
+
+    - Interpret those bytes as a SIMD vector, padded with zeros to align
+        to the system SIMD width.
+    - Apply the simple hash function parallelized across SIMD vectors.
+    - Hash the final SIMD vector state to reduce to a single value.
+
+    Python uses DJBX33A with a hash secret for smaller strings, and
+    then the SipHash algorithm for longer strings. The arguments and tradeoffs
+    are well documented in PEP 456. We should consider this and deeper
+    performance/security tradeoffs as Mojo evolves.
+
+    References:
+
+    - [Wikipedia: Non-cryptographic hash function](https://en.wikipedia.org/wiki/Non-cryptographic_hash_function)
+    - [Python PEP 456](https://peps.python.org/pep-0456/)
+    - [PHP Hash algorithm and collisions](https://www.phpinternalsbook.com/php5/hashtables/hash_algorithm.html)
+
+
+    ```mojo
+    from random import rand
+    var n = 64
+    var rand_bytes = UnsafePointer[UInt8].alloc(n)
+    rand(rand_bytes, n)
+    hash(rand_bytes, n)
+    ```
+
+    Args:
+        bytes: The byte array to hash.
+        n: The length of the byte array.
+
+    Returns:
+        A 64-bit integer hash. This hash is _not_ suitable for
+        cryptographic purposes, but will have good low-bit
+        hash collision statistical properties for common data structures.
+    """
+    alias dtype = DType.uint64
+    alias type_width = sizeof[dtype]()
+    alias simd_width = simdwidthof[dtype]()
+    # stride is the byte length of the whole SIMD vector
+    alias stride = type_width * simd_width
+
+    # Compute our SIMD strides and tail length
+    # n == k * stride + r
+    var k = n._positive_div(stride)
+    var r = n._positive_rem(stride)
+    debug_assert(n == k * stride + r, "wrong hash tail math")
+
+    # 1. Reinterpret the underlying data as a larger int type
+    var simd_data = bytes.bitcast[Scalar[dtype]]()
+
+    # 2. Compute the hash, but strided across the SIMD vector width.
+    var hash_data = _HASH_INIT[dtype, simd_width]()
+    for i in range(k):
+        var update = simd_data.load[width=simd_width](i * simd_width)
+        hash_data = _HASH_UPDATE(hash_data, update)
+
+    # 3. Copy the tail data (smaller than the SIMD register) into
+    #    a final hash state update vector that's stack-allocated.
+    if r != 0:
+        var remaining = InlineArray[UInt8, stride](uninitialized=True)
+        var ptr = remaining.unsafe_ptr()
+        memcpy(ptr, bytes + k * stride, r)
+        memset_zero(ptr + r, stride - r)  # set the rest to 0
+        var last_value = ptr.bitcast[Scalar[dtype]]().load[width=simd_width]()
+        hash_data = _HASH_UPDATE(hash_data, last_value)
+
+    # Now finally, hash the final SIMD vector state.
+    return _hash_simd(hash_data)
+
+
+struct DJBX33A(_Hasher):
+    """A Hasher which uses SIMD-modified DJBX33A hash algorithm,
+    which was the default hash function in Mojo standard library from the beginning.
+    """
+
+    var _value: UInt64
+
+    fn __init__(out self):
+        self._value = 0
+
+    fn _update_with_bytes(
+        mut self,
+        data: UnsafePointer[
+            UInt8, address_space = AddressSpace.GENERIC, mut=False, **_
+        ],
+        length: Int,
+    ):
+        self._value = _HASH_UPDATE(self._value, hash(data, length))
+
+    fn _update_with_simd(mut self, value: SIMD[_, _]):
+        self._value = _HASH_UPDATE(self._value, _hash_simd(value))
+
+    fn update[T: _HashableWithHasher](mut self, value: T):
+        value.__hash__(self)
+
+    fn finish(owned self) -> UInt64:
+        return self._value

--- a/mojo/stdlib/stdlib/hashlib/_fnv1a.mojo
+++ b/mojo/stdlib/stdlib/hashlib/_fnv1a.mojo
@@ -33,7 +33,11 @@ struct Fnv1a(Defaultable, _Hasher):
         self._value = 0xCBF29CE484222325
 
     fn _update_with_bytes(
-        mut self, data: UnsafePointer[UInt8, mut=False, **_], length: Int
+        mut self,
+        data: UnsafePointer[
+            UInt8, address_space = AddressSpace.GENERIC, mut=False, **_
+        ],
+        length: Int,
     ):
         """Consume provided data to update the internal buffer.
 

--- a/mojo/stdlib/stdlib/hashlib/_hasher.mojo
+++ b/mojo/stdlib/stdlib/hashlib/_hasher.mojo
@@ -26,7 +26,11 @@ trait _Hasher:
         ...
 
     fn _update_with_bytes(
-        mut self, data: UnsafePointer[UInt8, mut=False, **_], length: Int
+        mut self,
+        data: UnsafePointer[
+            UInt8, address_space = AddressSpace.GENERIC, mut=False, **_
+        ],
+        length: Int,
     ):
         ...
 

--- a/mojo/stdlib/stdlib/hashlib/hash.mojo
+++ b/mojo/stdlib/stdlib/hashlib/hash.mojo
@@ -25,20 +25,13 @@ There are a few main tools in this module:
     These are useful helpers to specialize for the general bytes implementation.
 """
 
-import random
-from collections import InlineArray
-from sys import bitwidthof, simdwidthof, sizeof
-
-from builtin.dtype import _uint_type_of_width
-from memory import UnsafePointer, bitcast, memcpy, memset_zero
+import ._djbx33a
+from memory import UnsafePointer
+from ._djbx33a import _hash_simd
 
 # ===----------------------------------------------------------------------=== #
 # Implementation
 # ===----------------------------------------------------------------------=== #
-
-
-fn _init_hash_secret() -> Int:
-    return Int(random.random_ui64(0, UInt64.MAX))
 
 
 trait Hashable:
@@ -87,166 +80,10 @@ fn hash[T: Hashable](hashable: T) -> UInt:
     return hashable.__hash__()
 
 
-fn _djbx33a_init[dtype: DType, size: Int]() -> SIMD[dtype, size]:
-    return SIMD[dtype, size](5361)
-
-
-fn _djbx33a_hash_update[
-    dtype: DType, size: Int
-](data: SIMD[dtype, size], next: SIMD[dtype, size]) -> SIMD[dtype, size]:
-    return data * 33 + next
-
-
-# Based on the hash function used by ankerl::unordered_dense::hash
-# https://martin.ankerl.com/2022/08/27/hashmap-bench-01/#ankerl__unordered_dense__hash
-fn _ankerl_init[dtype: DType, size: Int]() -> SIMD[dtype, size]:
-    alias int_type = _uint_type_of_width[bitwidthof[dtype]()]()
-    alias init = Int64(-7046029254386353131).cast[int_type]()
-    return SIMD[dtype, size](bitcast[dtype, 1](init))
-
-
-fn _ankerl_hash_update[
-    dtype: DType, size: Int
-](data: SIMD[dtype, size], next: SIMD[dtype, size]) -> SIMD[dtype, size]:
-    # compute the hash as though the type is uint
-    alias int_type = _uint_type_of_width[bitwidthof[dtype]()]()
-    var data_int = bitcast[int_type, size](data)
-    var next_int = bitcast[int_type, size](next)
-    var result = (data_int * next_int) ^ next_int
-    return bitcast[dtype, size](result)
-
-
-alias _HASH_INIT = _djbx33a_init
-alias _HASH_UPDATE = _djbx33a_hash_update
-
-
-# This is incrementally better than DJBX33A, in that it fixes some of the
-# performance issue we've been seeing with Dict. It's still not ideal as
-# a long-term hash function.
-@always_inline
-fn _hash_simd[dtype: DType, size: Int](data: SIMD[dtype, size]) -> UInt:
-    """Hash a SIMD byte vector using direct DJBX33A hash algorithm.
-
-    See `hash(bytes, n)` documentation for more details.
-
-    Parameters:
-        dtype: The SIMD dtype of the input data.
-        size: The SIMD width of the input data.
-
-    Args:
-        data: The input data to hash.
-
-    Returns:
-        A 64-bit integer hash. This hash is _not_ suitable for
-        cryptographic purposes, but will have good low-bit
-        hash collision statistical properties for common data structures.
-    """
-
-    @parameter
-    if dtype is DType.bool:
-        return _hash_simd(data.cast[DType.int8]())
-
-    var hash_data = _ankerl_init[dtype, size]()
-    hash_data = _ankerl_hash_update(hash_data, data)
-
-    alias int_type = _uint_type_of_width[bitwidthof[dtype]()]()
-    var final_data = bitcast[int_type, 1](hash_data[0]).cast[DType.uint64]()
-
-    @parameter
-    for i in range(1, size):
-        final_data = _ankerl_hash_update(
-            final_data,
-            bitcast[int_type, 1](hash_data[i]).cast[DType.uint64](),
-        )
-
-    return Int(final_data)
-
-
 fn hash(
     bytes: UnsafePointer[
         UInt8, address_space = AddressSpace.GENERIC, mut=False, **_
     ],
     n: Int,
 ) -> UInt:
-    """Hash a byte array using a SIMD-modified DJBX33A hash algorithm.
-
-    _This hash function is not suitable for cryptographic purposes._ The
-    algorithm is easy to reverse and produce deliberate hash collisions.
-    The hash function is designed to have relatively good mixing and statistical
-    properties for use in hash-based data structures.  We _do_ however initialize
-    a random hash secret which is mixed into the final hash output. This can help
-    prevent DDOS attacks on applications which make use of this function for
-    dictionary hashing. As a consequence, hash values are deterministic within an
-    individual runtime instance ie.  a value will always hash to the same thing,
-    but in between runs this value will change based on the hash secret.
-
-    We take advantage of Mojo's first-class SIMD support to create a
-    SIMD-vectorized hash function, using some simple hash algorithm as a base.
-
-    - Interpret those bytes as a SIMD vector, padded with zeros to align
-        to the system SIMD width.
-    - Apply the simple hash function parallelized across SIMD vectors.
-    - Hash the final SIMD vector state to reduce to a single value.
-
-    Python uses DJBX33A with a hash secret for smaller strings, and
-    then the SipHash algorithm for longer strings. The arguments and tradeoffs
-    are well documented in PEP 456. We should consider this and deeper
-    performance/security tradeoffs as Mojo evolves.
-
-    References:
-
-    - [Wikipedia: Non-cryptographic hash function](https://en.wikipedia.org/wiki/Non-cryptographic_hash_function)
-    - [Python PEP 456](https://peps.python.org/pep-0456/)
-    - [PHP Hash algorithm and collisions](https://www.phpinternalsbook.com/php5/hashtables/hash_algorithm.html)
-
-
-    ```mojo
-    from random import rand
-    var n = 64
-    var rand_bytes = UnsafePointer[UInt8].alloc(n)
-    rand(rand_bytes, n)
-    hash(rand_bytes, n)
-    ```
-
-    Args:
-        bytes: The byte array to hash.
-        n: The length of the byte array.
-
-    Returns:
-        A 64-bit integer hash. This hash is _not_ suitable for
-        cryptographic purposes, but will have good low-bit
-        hash collision statistical properties for common data structures.
-    """
-    alias dtype = DType.uint64
-    alias type_width = sizeof[dtype]()
-    alias simd_width = simdwidthof[dtype]()
-    # stride is the byte length of the whole SIMD vector
-    alias stride = type_width * simd_width
-
-    # Compute our SIMD strides and tail length
-    # n == k * stride + r
-    var k = n._positive_div(stride)
-    var r = n._positive_rem(stride)
-    debug_assert(n == k * stride + r, "wrong hash tail math")
-
-    # 1. Reinterpret the underlying data as a larger int type
-    var simd_data = bytes.bitcast[Scalar[dtype]]()
-
-    # 2. Compute the hash, but strided across the SIMD vector width.
-    var hash_data = _HASH_INIT[dtype, simd_width]()
-    for i in range(k):
-        var update = simd_data.load[width=simd_width](i * simd_width)
-        hash_data = _HASH_UPDATE(hash_data, update)
-
-    # 3. Copy the tail data (smaller than the SIMD register) into
-    #    a final hash state update vector that's stack-allocated.
-    if r != 0:
-        var remaining = InlineArray[UInt8, stride](uninitialized=True)
-        var ptr = remaining.unsafe_ptr()
-        memcpy(ptr, bytes + k * stride, r)
-        memset_zero(ptr + r, stride - r)  # set the rest to 0
-        var last_value = ptr.bitcast[Scalar[dtype]]().load[width=simd_width]()
-        hash_data = _HASH_UPDATE(hash_data, last_value)
-
-    # Now finally, hash the final SIMD vector state.
-    return _hash_simd(hash_data)
+    return _djbx33a.hash(bytes, n)

--- a/mojo/stdlib/test/hashlib/test_ahash.mojo
+++ b/mojo/stdlib/test/hashlib/test_ahash.mojo
@@ -17,13 +17,15 @@ from hashlib._ahash import AHasher
 from hashlib._hasher import _hash_with_hasher as hash
 from hashlib.hash import hash as old_hash
 
-from bit import pop_count
 from builtin._location import __call_location
 from memory import Span, memset_zero
 from testing import assert_equal, assert_not_equal, assert_true
 
 from test_utils import (
+    dif_bits,
     gen_word_pairs,
+    assert_dif_hashes,
+    assert_fill_factor,
     words_ar,
     words_el,
     words_en,
@@ -31,25 +33,8 @@ from test_utils import (
     words_lv,
     words_pl,
     words_ru,
+    dif_bits,
 )
-
-
-def dif_bits(i1: UInt64, i2: UInt64) -> Int:
-    return Int(pop_count(i1 ^ i2))
-
-
-@always_inline
-def assert_dif_hashes(hashes: List[UInt64], upper_bound: Int):
-    for i in range(len(hashes)):
-        for j in range(i + 1, len(hashes)):
-            var diff = dif_bits(hashes[i], hashes[j])
-            assert_true(
-                diff > upper_bound,
-                String("Index: {}:{}, diff between: {} and {} is: {}").format(
-                    i, j, hashes[i], hashes[j], diff
-                ),
-                location=__call_location(),
-            )
 
 
 alias hasher0 = AHasher[SIMD[DType.uint64, 4](0, 0, 0, 0)]
@@ -135,31 +120,6 @@ def test_trailing_zeros():
 
 
 @always_inline
-def assert_fill_factor[
-    label: String
-](words: List[String], num_buckets: Int, lower_bound: Float64):
-    # A perfect hash function is when the number of buckets is equal to number of words
-    # and the fill factor results in 1.0
-    var buckets = List[Int](0) * num_buckets
-    for w in words:
-        var h = hash[HasherType=hasher0](w)
-        buckets[Int(h) % num_buckets] += 1
-    var unfilled = 0
-    for v in buckets:
-        if v == 0:
-            unfilled += 1
-
-    var fill_factor = 1 - unfilled / num_buckets
-    assert_true(
-        fill_factor >= lower_bound,
-        String("Fill factor for {} is {}, provided lower boound was {}").format(
-            label, fill_factor, lower_bound
-        ),
-        location=__call_location(),
-    )
-
-
-@always_inline
 def assert_fill_factor_old_hash[
     label: String
 ](words: List[String], num_buckets: Int, lower_bound: Float64):
@@ -186,59 +146,59 @@ def assert_fill_factor_old_hash[
 
 def test_fill_factor():
     var words: List[String] = gen_word_pairs[words_ar]()
-    assert_fill_factor["AR"](words, len(words), 0.63)
-    assert_fill_factor["AR"](words, len(words) // 2, 0.86)
-    assert_fill_factor["AR"](words, len(words) // 4, 0.98)
-    assert_fill_factor["AR"](words, len(words) // 13, 1.0)
+    assert_fill_factor["AR", hasher0](words, len(words), 0.63)
+    assert_fill_factor["AR", hasher0](words, len(words) // 2, 0.86)
+    assert_fill_factor["AR", hasher0](words, len(words) // 4, 0.98)
+    assert_fill_factor["AR", hasher0](words, len(words) // 13, 1.0)
 
     # TODO: flaky test
     # assert_fill_factor_old_hash["AR"](words, len(words), 0.59)
 
     words = gen_word_pairs[words_el]()
-    assert_fill_factor["EL"](words, len(words), 0.63)
-    assert_fill_factor["EL"](words, len(words) // 2, 0.86)
-    assert_fill_factor["EL"](words, len(words) // 4, 0.98)
-    assert_fill_factor["EL"](words, len(words) // 13, 1.0)
+    assert_fill_factor["EL", hasher0](words, len(words), 0.63)
+    assert_fill_factor["EL", hasher0](words, len(words) // 2, 0.86)
+    assert_fill_factor["EL", hasher0](words, len(words) // 4, 0.98)
+    assert_fill_factor["EL", hasher0](words, len(words) // 13, 1.0)
 
     assert_fill_factor_old_hash["EL"](words, len(words), 0.015)
 
     words = gen_word_pairs[words_en]()
-    assert_fill_factor["EN"](words, len(words), 0.63)
-    assert_fill_factor["EN"](words, len(words) // 2, 0.85)
-    assert_fill_factor["EN"](words, len(words) // 4, 0.98)
-    assert_fill_factor["EN"](words, len(words) // 14, 1.0)
+    assert_fill_factor["EN", hasher0](words, len(words), 0.63)
+    assert_fill_factor["EN", hasher0](words, len(words) // 2, 0.85)
+    assert_fill_factor["EN", hasher0](words, len(words) // 4, 0.98)
+    assert_fill_factor["EN", hasher0](words, len(words) // 14, 1.0)
 
     assert_fill_factor_old_hash["EN"](words, len(words), 0.015)
 
     words = gen_word_pairs[words_he]()
-    assert_fill_factor["HE"](words, len(words), 0.63)
-    assert_fill_factor["HE"](words, len(words) // 2, 0.86)
-    assert_fill_factor["HE"](words, len(words) // 4, 0.98)
-    assert_fill_factor["HE"](words, len(words) // 14, 1.0)
+    assert_fill_factor["HE", hasher0](words, len(words), 0.63)
+    assert_fill_factor["HE", hasher0](words, len(words) // 2, 0.86)
+    assert_fill_factor["HE", hasher0](words, len(words) // 4, 0.98)
+    assert_fill_factor["HE", hasher0](words, len(words) // 14, 1.0)
 
     assert_fill_factor_old_hash["HE"](words, len(words), 0.2)
 
     words = gen_word_pairs[words_lv]()
-    assert_fill_factor["LV"](words, len(words), 0.63)
-    assert_fill_factor["LV"](words, len(words) // 2, 0.86)
-    assert_fill_factor["LV"](words, len(words) // 4, 0.98)
-    assert_fill_factor["LV"](words, len(words) // 13, 0.99)
+    assert_fill_factor["LV", hasher0](words, len(words), 0.63)
+    assert_fill_factor["LV", hasher0](words, len(words) // 2, 0.86)
+    assert_fill_factor["LV", hasher0](words, len(words) // 4, 0.98)
+    assert_fill_factor["LV", hasher0](words, len(words) // 13, 0.99)
 
     assert_fill_factor_old_hash["LV"](words, len(words), 0.015)
 
     words = gen_word_pairs[words_pl]()
-    assert_fill_factor["PL"](words, len(words), 0.63)
-    assert_fill_factor["PL"](words, len(words) // 2, 0.86)
-    assert_fill_factor["PL"](words, len(words) // 4, 0.98)
-    assert_fill_factor["PL"](words, len(words) // 13, 1.0)
+    assert_fill_factor["PL", hasher0](words, len(words), 0.63)
+    assert_fill_factor["PL", hasher0](words, len(words) // 2, 0.86)
+    assert_fill_factor["PL", hasher0](words, len(words) // 4, 0.98)
+    assert_fill_factor["PL", hasher0](words, len(words) // 13, 1.0)
 
     assert_fill_factor_old_hash["PL"](words, len(words), 0.015)
 
     words = gen_word_pairs[words_ru]()
-    assert_fill_factor["RU"](words, len(words), 0.63)
-    assert_fill_factor["RU"](words, len(words) // 2, 0.86)
-    assert_fill_factor["RU"](words, len(words) // 4, 0.98)
-    assert_fill_factor["RU"](words, len(words) // 13, 1.0)
+    assert_fill_factor["RU", hasher0](words, len(words), 0.63)
+    assert_fill_factor["RU", hasher0](words, len(words) // 2, 0.86)
+    assert_fill_factor["RU", hasher0](words, len(words) // 4, 0.98)
+    assert_fill_factor["RU", hasher0](words, len(words) // 13, 1.0)
 
     assert_fill_factor_old_hash["RU"](words, len(words), 0.015)
 

--- a/mojo/stdlib/test/hashlib/test_djbx33a.mojo
+++ b/mojo/stdlib/test/hashlib/test_djbx33a.mojo
@@ -1,0 +1,198 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# RUN: %mojo %s
+
+from bit import pop_count
+from hashlib._djbx33a import DJBX33A
+from hashlib._hasher import _Hasher, _HashableWithHasher, _hash_with_hasher
+from testing import assert_equal, assert_not_equal, assert_true
+from memory import memset_zero, UnsafePointer
+from test_utils import (
+    dif_bits,
+    gen_word_pairs,
+    assert_dif_hashes,
+    assert_fill_factor,
+    words_ar,
+    words_el,
+    words_en,
+    words_he,
+    words_lv,
+    words_pl,
+    words_ru,
+)
+
+
+def test_hash_byte_array():
+    assert_equal(
+        _hash_with_hasher[HasherType=DJBX33A](String("a")),
+        _hash_with_hasher[HasherType=DJBX33A](String("a")),
+    )
+    assert_equal(
+        _hash_with_hasher[HasherType=DJBX33A](String("b")),
+        _hash_with_hasher[HasherType=DJBX33A](String("b")),
+    )
+
+    assert_equal(
+        _hash_with_hasher[HasherType=DJBX33A](String("c")),
+        _hash_with_hasher[HasherType=DJBX33A](String("c")),
+    )
+
+    assert_equal(
+        _hash_with_hasher[HasherType=DJBX33A](String("d")),
+        _hash_with_hasher[HasherType=DJBX33A](String("d")),
+    )
+    assert_equal(
+        _hash_with_hasher[HasherType=DJBX33A](String("d")),
+        _hash_with_hasher[HasherType=DJBX33A](String("d")),
+    )
+
+
+def test_avalanche():
+    # test that values which differ just in one bit,
+    # produce significatly different hash values
+    var buffer = InlineArray[UInt8, 256](fill=0)
+    var hashes = List[UInt64]()
+    hashes.append(
+        _hash_with_hasher[HasherType=DJBX33A](buffer.unsafe_ptr(), 256)
+    )
+
+    for i in range(256):
+        memset_zero(buffer.unsafe_ptr(), 256)
+        var v = 1 << (i & 7)
+        buffer[i >> 3] = v
+        hashes.append(
+            _hash_with_hasher[HasherType=DJBX33A](buffer.unsafe_ptr(), 256)
+        )
+
+    assert_dif_hashes(hashes, -1)
+
+
+def test_trailing_zeros():
+    # checks that a value with different amount of trailing zeros,
+    # results in significantly different hash values
+    var buffer = InlineArray[UInt8, 8](fill=0)
+    buffer[0] = 23
+    var hashes = List[UInt64]()
+    for i in range(1, 9):
+        hashes.append(
+            _hash_with_hasher[HasherType=DJBX33A](buffer.unsafe_ptr(), i)
+        )
+
+    assert_dif_hashes(hashes, -1)
+
+
+def test_fill_factor():
+    words = gen_word_pairs[words_ar]()
+    assert_fill_factor["AR", DJBX33A](words, len(words), 0.22)
+    assert_fill_factor["AR", DJBX33A](words, len(words) // 2, 0.249)
+    assert_fill_factor["AR", DJBX33A](words, len(words) // 4, 0.25)
+    assert_fill_factor["AR", DJBX33A](words, len(words) // 14, 0.25)
+
+    words = gen_word_pairs[words_el]()
+    assert_fill_factor["EL", DJBX33A](words, len(words), 0.63)
+    assert_fill_factor["EL", DJBX33A](words, len(words) // 2, 0.248)
+    assert_fill_factor["EL", DJBX33A](words, len(words) // 4, 0.249)
+    assert_fill_factor["EL", DJBX33A](words, len(words) // 13, 0.5)
+
+    words = gen_word_pairs[words_en]()
+    assert_fill_factor["EN", DJBX33A](words, len(words), 0.24)
+    assert_fill_factor["EN", DJBX33A](words, len(words) // 2, 0.249)
+    assert_fill_factor["EN", DJBX33A](words, len(words) // 4, 0.249)
+    assert_fill_factor["EN", DJBX33A](words, len(words) // 14, 0.25)
+
+    words = gen_word_pairs[words_he]()
+    assert_fill_factor["HE", DJBX33A](words, len(words), 0.63)
+    assert_fill_factor["HE", DJBX33A](words, len(words) // 2, 0.249)
+    assert_fill_factor["HE", DJBX33A](words, len(words) // 4, 0.499)
+    assert_fill_factor["HE", DJBX33A](words, len(words) // 14, 1.0)
+
+    words = gen_word_pairs[words_lv]()
+    assert_fill_factor["LV", DJBX33A](words, len(words), 0.245)
+    assert_fill_factor["LV", DJBX33A](words, len(words) // 2, 0.49)
+    assert_fill_factor["LV", DJBX33A](words, len(words) // 4, 0.98)
+    assert_fill_factor["LV", DJBX33A](words, len(words) // 14, 0.25)
+
+    words = gen_word_pairs[words_pl]()
+    assert_fill_factor["PL", DJBX33A](words, len(words), 0.245)
+    assert_fill_factor["PL", DJBX33A](words, len(words) // 2, 0.49)
+    assert_fill_factor["PL", DJBX33A](words, len(words) // 4, 0.98)
+    assert_fill_factor["PL", DJBX33A](words, len(words) // 14, 0.5)
+
+    words = gen_word_pairs[words_ru]()
+    assert_fill_factor["RU", DJBX33A](words, len(words), 0.63)
+    assert_fill_factor["RU", DJBX33A](words, len(words) // 2, 0.246)
+    assert_fill_factor["RU", DJBX33A](words, len(words) // 4, 0.249)
+    assert_fill_factor["RU", DJBX33A](words, len(words) // 14, 1.0)
+
+
+def test_hash_simd_values():
+    fn hash(value: SIMD) -> UInt64:
+        hasher = DJBX33A()
+        hasher._update_with_simd(value)
+        return hasher^.finish()
+
+    assert_equal(hash(SIMD[DType.float16, 1](1.5)), 10240)
+    assert_equal(hash(SIMD[DType.float32, 1](1.5)), 83886080)
+    assert_equal(hash(SIMD[DType.float64, 1](1.5)), 6962565023914786816)
+    assert_equal(hash(SIMD[DType.float16, 1](1)), 53248)
+    assert_equal(hash(SIMD[DType.float32, 1](1)), 167772160)
+    assert_equal(hash(SIMD[DType.float64, 1](1)), 4701758010974797824)
+
+    assert_equal(hash(SIMD[DType.int8, 1](1)), 20)
+    assert_equal(hash(SIMD[DType.int16, 1](1)), 31764)
+    assert_equal(hash(SIMD[DType.int32, 1](1)), 2135587860)
+    assert_equal(hash(SIMD[DType.int64, 1](1)), 11400714819323198484)
+    assert_equal(hash(SIMD[DType.bool, 1](True)), 20)
+    assert_equal(hash(SIMD[DType.int128, 1](1)), 11400714819323198484)
+    assert_equal(hash(SIMD[DType.int64, 2](1, 0)), 0)
+    assert_equal(hash(SIMD[DType.int256, 1](1)), 11400714819323198484)
+    assert_equal(hash(SIMD[DType.int64, 4](1, 0, 0, 0)), 0)
+
+    assert_equal(hash(SIMD[DType.int8, 1](-1)), 20)
+    assert_equal(hash(SIMD[DType.int16, 1](-1)), 31764)
+    assert_equal(hash(SIMD[DType.int32, 1](-1)), 2135587860)
+    assert_equal(hash(SIMD[DType.int64, 1](-1)), 11400714819323198484)
+    assert_equal(hash(SIMD[DType.int128, 1](-1)), 11400714819323198484)
+    assert_equal(hash(SIMD[DType.int64, 2](-1)), 4387139453214858628)
+    assert_equal(hash(SIMD[DType.int256, 1](-1)), 11400714819323198484)
+    assert_equal(hash(SIMD[DType.int64, 4](-1)), 4736282921286787396)
+
+    assert_equal(hash(SIMD[DType.int8, 1](0)), 0)
+    assert_equal(hash(SIMD[DType.int8, 2](0)), 0)
+    assert_equal(hash(SIMD[DType.int8, 4](0)), 0)
+    assert_equal(hash(SIMD[DType.int8, 8](0)), 0)
+    assert_equal(hash(SIMD[DType.int8, 16](0)), 0)
+    assert_equal(hash(SIMD[DType.int8, 32](0)), 0)
+    assert_equal(hash(SIMD[DType.int8, 64](0)), 0)
+
+    assert_equal(hash(SIMD[DType.int32, 1](0)), 0)
+    assert_equal(hash(SIMD[DType.int32, 2](0)), 0)
+    assert_equal(hash(SIMD[DType.int32, 4](0)), 0)
+    assert_equal(hash(SIMD[DType.int32, 8](0)), 0)
+    assert_equal(hash(SIMD[DType.int32, 16](0)), 0)
+    assert_equal(hash(SIMD[DType.int32, 32](0)), 0)
+    assert_equal(hash(SIMD[DType.int32, 64](0)), 0)
+
+
+def test_hash_at_compile_time():
+    alias h = _hash_with_hasher[HasherType=DJBX33A](String("hello"))
+    assert_equal(h, 1201726784820358244)
+
+
+def main():
+    test_hash_byte_array()
+    test_avalanche()
+    test_trailing_zeros()
+    test_fill_factor()
+    test_hash_simd_values()
+    test_hash_at_compile_time()

--- a/mojo/stdlib/test/hashlib/test_djbx33a.mojo
+++ b/mojo/stdlib/test/hashlib/test_djbx33a.mojo
@@ -92,46 +92,47 @@ def test_trailing_zeros():
 
 
 def test_fill_factor():
+    # this algorithm is generally very unstable and returns dufferent result on different archs
     words = gen_word_pairs[words_ar]()
-    assert_fill_factor["AR", DJBX33A](words, len(words), 0.22)
-    assert_fill_factor["AR", DJBX33A](words, len(words) // 2, 0.249)
+    assert_fill_factor["AR", DJBX33A](words, len(words), 0.06)
+    assert_fill_factor["AR", DJBX33A](words, len(words) // 2, 0.125)
     assert_fill_factor["AR", DJBX33A](words, len(words) // 4, 0.25)
     assert_fill_factor["AR", DJBX33A](words, len(words) // 14, 0.25)
 
     words = gen_word_pairs[words_el]()
-    assert_fill_factor["EL", DJBX33A](words, len(words), 0.63)
-    assert_fill_factor["EL", DJBX33A](words, len(words) // 2, 0.248)
-    assert_fill_factor["EL", DJBX33A](words, len(words) // 4, 0.249)
+    assert_fill_factor["EL", DJBX33A](words, len(words), 0.60)
+    assert_fill_factor["EL", DJBX33A](words, len(words) // 2, 0.06)
+    assert_fill_factor["EL", DJBX33A](words, len(words) // 4, 0.089)
     assert_fill_factor["EL", DJBX33A](words, len(words) // 13, 0.5)
 
     words = gen_word_pairs[words_en]()
-    assert_fill_factor["EN", DJBX33A](words, len(words), 0.24)
-    assert_fill_factor["EN", DJBX33A](words, len(words) // 2, 0.249)
-    assert_fill_factor["EN", DJBX33A](words, len(words) // 4, 0.249)
+    assert_fill_factor["EN", DJBX33A](words, len(words), 0.015)
+    assert_fill_factor["EN", DJBX33A](words, len(words) // 2, 0.03)
+    assert_fill_factor["EN", DJBX33A](words, len(words) // 4, 0.062)
     assert_fill_factor["EN", DJBX33A](words, len(words) // 14, 0.25)
 
     words = gen_word_pairs[words_he]()
-    assert_fill_factor["HE", DJBX33A](words, len(words), 0.63)
+    assert_fill_factor["HE", DJBX33A](words, len(words), 0.59)
     assert_fill_factor["HE", DJBX33A](words, len(words) // 2, 0.249)
     assert_fill_factor["HE", DJBX33A](words, len(words) // 4, 0.499)
     assert_fill_factor["HE", DJBX33A](words, len(words) // 14, 1.0)
 
     words = gen_word_pairs[words_lv]()
-    assert_fill_factor["LV", DJBX33A](words, len(words), 0.245)
-    assert_fill_factor["LV", DJBX33A](words, len(words) // 2, 0.49)
-    assert_fill_factor["LV", DJBX33A](words, len(words) // 4, 0.98)
-    assert_fill_factor["LV", DJBX33A](words, len(words) // 14, 0.25)
+    assert_fill_factor["LV", DJBX33A](words, len(words), 0.242)
+    assert_fill_factor["LV", DJBX33A](words, len(words) // 2, 0.485)
+    assert_fill_factor["LV", DJBX33A](words, len(words) // 4, 0.971)
+    assert_fill_factor["LV", DJBX33A](words, len(words) // 14, 0.062)
 
     words = gen_word_pairs[words_pl]()
-    assert_fill_factor["PL", DJBX33A](words, len(words), 0.245)
-    assert_fill_factor["PL", DJBX33A](words, len(words) // 2, 0.49)
-    assert_fill_factor["PL", DJBX33A](words, len(words) // 4, 0.98)
+    assert_fill_factor["PL", DJBX33A](words, len(words), 0.242)
+    assert_fill_factor["PL", DJBX33A](words, len(words) // 2, 0.485)
+    assert_fill_factor["PL", DJBX33A](words, len(words) // 4, 0.971)
     assert_fill_factor["PL", DJBX33A](words, len(words) // 14, 0.5)
 
     words = gen_word_pairs[words_ru]()
-    assert_fill_factor["RU", DJBX33A](words, len(words), 0.63)
-    assert_fill_factor["RU", DJBX33A](words, len(words) // 2, 0.246)
-    assert_fill_factor["RU", DJBX33A](words, len(words) // 4, 0.249)
+    assert_fill_factor["RU", DJBX33A](words, len(words), 0.607)
+    assert_fill_factor["RU", DJBX33A](words, len(words) // 2, 0.038)
+    assert_fill_factor["RU", DJBX33A](words, len(words) // 4, 0.066)
     assert_fill_factor["RU", DJBX33A](words, len(words) // 14, 1.0)
 
 
@@ -186,7 +187,8 @@ def test_hash_simd_values():
 
 def test_hash_at_compile_time():
     alias h = _hash_with_hasher[HasherType=DJBX33A](String("hello"))
-    assert_equal(h, 1201726784820358244)
+    # can not do equality compare as the hash function is unstable on different platforms
+    assert_true(h != 0)
 
 
 def main():

--- a/mojo/stdlib/test/hashlib/test_fnv1a.mojo
+++ b/mojo/stdlib/test/hashlib/test_fnv1a.mojo
@@ -13,13 +13,15 @@
 # RUN: %mojo %s
 
 from bit import pop_count
-from builtin._location import __call_location
 from hashlib._fnv1a import Fnv1a
-from hashlib._hasher import _Hasher, _HashableWithHasher
+from hashlib._hasher import _Hasher, _HashableWithHasher, _hash_with_hasher
 from testing import assert_equal, assert_not_equal, assert_true
 from memory import memset_zero, UnsafePointer
 from test_utils import (
+    dif_bits,
     gen_word_pairs,
+    assert_dif_hashes,
+    assert_fill_factor,
     words_ar,
     words_el,
     words_en,
@@ -30,57 +32,28 @@ from test_utils import (
 )
 
 
-def dif_bits(i1: UInt64, i2: UInt64) -> Int:
-    return Int(pop_count(i1 ^ i2))
-
-
-fn hash[
-    HashableType: _HashableWithHasher, HasherType: _Hasher
-](hashable: HashableType) -> UInt64:
-    var hasher = HasherType()
-    hasher.update(hashable)
-    var value = hasher^.finish()
-    return value
-
-
-fn hash[HasherType: _Hasher](bytes: Span[UInt8, _], n: Int) -> UInt64:
-    var hasher = HasherType()
-    hasher._update_with_bytes(bytes.unsafe_ptr(), n)
-    var value = hasher^.finish()
-    return value
-
-
-@always_inline
-def assert_dif_hashes(hashes: List[UInt64], upper_bound: Int):
-    for i in range(len(hashes)):
-        for j in range(i + 1, len(hashes)):
-            var diff = dif_bits(hashes[i], hashes[j])
-            assert_true(
-                diff > upper_bound,
-                String("Index: {}:{}, diff between: {} and {} is: {}").format(
-                    i, j, hashes[i], hashes[j], diff
-                ),
-                location=__call_location(),
-            )
-
-
 def test_hash_byte_array():
     assert_equal(
-        hash[HasherType=Fnv1a](String("a")), hash[HasherType=Fnv1a](String("a"))
+        _hash_with_hasher[HasherType=Fnv1a](String("a")),
+        _hash_with_hasher[HasherType=Fnv1a](String("a")),
     )
     assert_equal(
-        hash[HasherType=Fnv1a](String("b")), hash[HasherType=Fnv1a](String("b"))
-    )
-
-    assert_equal(
-        hash[HasherType=Fnv1a](String("c")), hash[HasherType=Fnv1a](String("c"))
+        _hash_with_hasher[HasherType=Fnv1a](String("b")),
+        _hash_with_hasher[HasherType=Fnv1a](String("b")),
     )
 
     assert_equal(
-        hash[HasherType=Fnv1a](String("d")), hash[HasherType=Fnv1a](String("d"))
+        _hash_with_hasher[HasherType=Fnv1a](String("c")),
+        _hash_with_hasher[HasherType=Fnv1a](String("c")),
+    )
+
+    assert_equal(
+        _hash_with_hasher[HasherType=Fnv1a](String("d")),
+        _hash_with_hasher[HasherType=Fnv1a](String("d")),
     )
     assert_equal(
-        hash[HasherType=Fnv1a](String("d")), hash[HasherType=Fnv1a](String("d"))
+        _hash_with_hasher[HasherType=Fnv1a](String("d")),
+        _hash_with_hasher[HasherType=Fnv1a](String("d")),
     )
 
 
@@ -89,13 +62,15 @@ def test_avalanche():
     # produce significatly different hash values
     var buffer = InlineArray[UInt8, 256](fill=0)
     var hashes = List[UInt64]()
-    hashes.append(hash[HasherType=Fnv1a](buffer, 256))
+    hashes.append(_hash_with_hasher[HasherType=Fnv1a](buffer.unsafe_ptr(), 256))
 
     for i in range(256):
         memset_zero(buffer.unsafe_ptr(), 256)
         var v = 1 << (i & 7)
         buffer[i >> 3] = v
-        hashes.append(hash[HasherType=Fnv1a](buffer, 256))
+        hashes.append(
+            _hash_with_hasher[HasherType=Fnv1a](buffer.unsafe_ptr(), 256)
+        )
 
     assert_dif_hashes(hashes, 15)
 
@@ -107,78 +82,55 @@ def test_trailing_zeros():
     buffer[0] = 23
     var hashes = List[UInt64]()
     for i in range(1, 9):
-        hashes.append(hash[HasherType=Fnv1a](buffer, i))
+        hashes.append(
+            _hash_with_hasher[HasherType=Fnv1a](buffer.unsafe_ptr(), i)
+        )
 
     assert_dif_hashes(hashes, 21)
 
 
-@always_inline
-def assert_fill_factor[
-    label: String
-](words: List[String], num_buckets: Int, lower_bound: Float64):
-    # A perfect hash function is when the number of buckets is equal to number of words
-    # and the fill factor results in 1.0
-    var buckets = List[Int](0) * num_buckets
-    for w in words:
-        var h = hash[HasherType=Fnv1a](w)
-        buckets[h % num_buckets] += 1
-    var unfilled = 0
-    for v in buckets:
-        if v == 0:
-            unfilled += 1
-
-    var fill_factor = 1 - unfilled / num_buckets
-    assert_true(
-        fill_factor >= lower_bound,
-        String("Fill factor for {} is {}, provided lower bound was {}").format(
-            label, fill_factor, lower_bound
-        ),
-        location=__call_location(),
-    )
-
-
 def test_fill_factor():
     words = gen_word_pairs[words_ar]()
-    assert_fill_factor["AR"](words, len(words), 0.63)
-    assert_fill_factor["AR"](words, len(words) // 2, 0.86)
-    assert_fill_factor["AR"](words, len(words) // 4, 0.98)
-    assert_fill_factor["AR"](words, len(words) // 14, 1.0)
+    assert_fill_factor["AR", Fnv1a](words, len(words), 0.63)
+    assert_fill_factor["AR", Fnv1a](words, len(words) // 2, 0.86)
+    assert_fill_factor["AR", Fnv1a](words, len(words) // 4, 0.98)
+    assert_fill_factor["AR", Fnv1a](words, len(words) // 14, 1.0)
 
     words = gen_word_pairs[words_el]()
-    assert_fill_factor["EL"](words, len(words), 0.63)
-    assert_fill_factor["EL"](words, len(words) // 2, 0.86)
-    assert_fill_factor["EL"](words, len(words) // 4, 0.98)
-    assert_fill_factor["EL"](words, len(words) // 13, 1.0)
+    assert_fill_factor["EL", Fnv1a](words, len(words), 0.63)
+    assert_fill_factor["EL", Fnv1a](words, len(words) // 2, 0.86)
+    assert_fill_factor["EL", Fnv1a](words, len(words) // 4, 0.98)
+    assert_fill_factor["EL", Fnv1a](words, len(words) // 13, 1.0)
 
     words = gen_word_pairs[words_en]()
-    assert_fill_factor["EN"](words, len(words), 0.63)
-    assert_fill_factor["EN"](words, len(words) // 2, 0.86)
-    assert_fill_factor["EN"](words, len(words) // 4, 0.98)
-    assert_fill_factor["EN"](words, len(words) // 14, 1.0)
+    assert_fill_factor["EN", Fnv1a](words, len(words), 0.63)
+    assert_fill_factor["EN", Fnv1a](words, len(words) // 2, 0.86)
+    assert_fill_factor["EN", Fnv1a](words, len(words) // 4, 0.98)
+    assert_fill_factor["EN", Fnv1a](words, len(words) // 14, 1.0)
 
     words = gen_word_pairs[words_he]()
-    assert_fill_factor["HE"](words, len(words), 0.63)
-    assert_fill_factor["HE"](words, len(words) // 2, 0.86)
-    assert_fill_factor["HE"](words, len(words) // 4, 0.98)
-    assert_fill_factor["HE"](words, len(words) // 14, 1.0)
+    assert_fill_factor["HE", Fnv1a](words, len(words), 0.63)
+    assert_fill_factor["HE", Fnv1a](words, len(words) // 2, 0.86)
+    assert_fill_factor["HE", Fnv1a](words, len(words) // 4, 0.98)
+    assert_fill_factor["HE", Fnv1a](words, len(words) // 14, 1.0)
 
     words = gen_word_pairs[words_lv]()
-    assert_fill_factor["LV"](words, len(words), 0.63)
-    assert_fill_factor["LV"](words, len(words) // 2, 0.86)
-    assert_fill_factor["LV"](words, len(words) // 4, 0.98)
-    assert_fill_factor["LV"](words, len(words) // 14, 1.0)
+    assert_fill_factor["LV", Fnv1a](words, len(words), 0.63)
+    assert_fill_factor["LV", Fnv1a](words, len(words) // 2, 0.86)
+    assert_fill_factor["LV", Fnv1a](words, len(words) // 4, 0.98)
+    assert_fill_factor["LV", Fnv1a](words, len(words) // 14, 1.0)
 
     words = gen_word_pairs[words_pl]()
-    assert_fill_factor["PL"](words, len(words), 0.63)
-    assert_fill_factor["PL"](words, len(words) // 2, 0.86)
-    assert_fill_factor["PL"](words, len(words) // 4, 0.98)
-    assert_fill_factor["PL"](words, len(words) // 14, 1.0)
+    assert_fill_factor["PL", Fnv1a](words, len(words), 0.63)
+    assert_fill_factor["PL", Fnv1a](words, len(words) // 2, 0.86)
+    assert_fill_factor["PL", Fnv1a](words, len(words) // 4, 0.98)
+    assert_fill_factor["PL", Fnv1a](words, len(words) // 14, 1.0)
 
     words = gen_word_pairs[words_ru]()
-    assert_fill_factor["RU"](words, len(words), 0.63)
-    assert_fill_factor["RU"](words, len(words) // 2, 0.86)
-    assert_fill_factor["RU"](words, len(words) // 4, 0.98)
-    assert_fill_factor["RU"](words, len(words) // 14, 1.0)
+    assert_fill_factor["RU", Fnv1a](words, len(words), 0.63)
+    assert_fill_factor["RU", Fnv1a](words, len(words) // 2, 0.86)
+    assert_fill_factor["RU", Fnv1a](words, len(words) // 4, 0.98)
+    assert_fill_factor["RU", Fnv1a](words, len(words) // 14, 1.0)
 
 
 def test_hash_simd_values():
@@ -231,7 +183,7 @@ def test_hash_simd_values():
 
 
 def test_hash_at_compile_time():
-    alias h = hash[HasherType=Fnv1a](String("hello"))
+    alias h = _hash_with_hasher[HasherType=Fnv1a](String("hello"))
     assert_equal(h, 11831194018420276491)
 
 

--- a/mojo/stdlib/test/hashlib/test_hasher.mojo
+++ b/mojo/stdlib/test/hashlib/test_hasher.mojo
@@ -28,7 +28,11 @@ struct DummyHasher(_Hasher):
         self._dummy_value = 0
 
     fn _update_with_bytes(
-        mut self, data: UnsafePointer[UInt8, mut=False, **_], length: Int
+        mut self,
+        data: UnsafePointer[
+            UInt8, address_space = AddressSpace.GENERIC, mut=False, **_
+        ],
+        length: Int,
     ):
         for i in range(length):
             self._dummy_value += data[i].cast[DType.uint64]()

--- a/mojo/stdlib/test/test_utils/__init__.mojo
+++ b/mojo/stdlib/test/test_utils/__init__.mojo
@@ -12,6 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 
 from .compare_helpers import compare
+from .hash import dif_bits, assert_dif_hashes, assert_fill_factor
 from .math_helpers import ulp_distance
 from .test_utils import libm_call
 from .types import (

--- a/mojo/stdlib/test/test_utils/hash.mojo
+++ b/mojo/stdlib/test/test_utils/hash.mojo
@@ -1,0 +1,60 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from bit import pop_count
+from builtin._location import __call_location
+from hashlib._hasher import _Hasher, _HashableWithHasher, _hash_with_hasher
+from testing import assert_true
+
+
+def dif_bits(i1: UInt64, i2: UInt64) -> Int:
+    return Int(pop_count(i1 ^ i2))
+
+
+@always_inline
+def assert_dif_hashes(hashes: List[UInt64], upper_bound: Int):
+    for i in range(len(hashes)):
+        for j in range(i + 1, len(hashes)):
+            var diff = dif_bits(hashes[i], hashes[j])
+            assert_true(
+                diff > upper_bound,
+                String("Index: {}:{}, diff between: {} and {} is: {}").format(
+                    i, j, hashes[i], hashes[j], diff
+                ),
+                location=__call_location(),
+            )
+
+
+@always_inline
+def assert_fill_factor[
+    label: String, HasherType: _Hasher
+](words: List[String], num_buckets: Int, lower_bound: Float64):
+    # A perfect hash function is when the number of buckets is equal to number of words
+    # and the fill factor results in 1.0
+    var buckets = List[Int](0) * num_buckets
+    for w in words:
+        var h = _hash_with_hasher[HasherType=HasherType](w)
+        buckets[h % num_buckets] += 1
+    var unfilled = 0
+    for v in buckets:
+        if v == 0:
+            unfilled += 1
+
+    var fill_factor = 1 - unfilled / num_buckets
+    assert_true(
+        fill_factor >= lower_bound,
+        String("Fill factor for {} is {}, provided lower bound was {}").format(
+            label, fill_factor, lower_bound
+        ),
+        location=__call_location(),
+    )


### PR DESCRIPTION
This PR is another preparation for the switch to Hasher based hashing. Now the default DJBX33A hash function is moved to a separate module and we have a separate unit test which highlights the issues this hash function has, compared to ahash and fnv1a. After this PR is merged I will try to reproduce PR #3701 in a new simpler PR.
