### PR TITLE
[stdlib] Fix int formatting to not go out of bounds, add MIN and MAX for 128 and 256 sized integers

### DIFF
--- a/mojo/stdlib/stdlib/builtin/format_int.mojo
+++ b/mojo/stdlib/stdlib/builtin/format_int.mojo
@@ -331,8 +331,7 @@ fn _try_write_int[
     # Create a buffer to store the formatted value
 
     # Stack allocate enough bytes to store any formatted 64-bit integer
-    # TODO: use a dynamic size when #2194 is resolved
-    alias CAPACITY: Int = 64 + 1  # +1 for storing NUL terminator.
+    alias CAPACITY: Int = dtype.bitwidth() + 1  # +1 for storing NUL terminator.
 
     var buf = InlineArray[UInt8, CAPACITY](uninitialized=True)
 

--- a/mojo/stdlib/stdlib/utils/numerics.mojo
+++ b/mojo/stdlib/stdlib/utils/numerics.mojo
@@ -745,6 +745,17 @@ fn max_finite[dtype: DType]() -> Scalar[dtype]:
         return 9223372036854775807
     elif dtype is DType.uint64:
         return 18446744073709551615
+    elif dtype is DType.int128:
+        return 170141183460469231731687303715884105727
+    elif dtype is DType.uint128:
+        # TODO: Creating a SIMD from an IntLiteral goes through a si128.
+        return ~Scalar[dtype](0)
+    elif dtype is DType.int256:
+        # TODO: Creating a SIMD from an IntLiteral goes through a si128.
+        return (Scalar[dtype](1) << 255) - 1
+    elif dtype is DType.uint256:
+        # TODO: Creating a SIMD from an IntLiteral goes through a si128.
+        return ~Scalar[dtype](0)
     elif dtype is DType.float8_e4m3fn:
         return 448
     elif dtype is DType.float8_e4m3fnuz:
@@ -798,6 +809,11 @@ fn min_finite[dtype: DType]() -> Scalar[dtype]:
         dtype is DType.index and bitwidthof[DType.index]() == 64
     ):
         return -9223372036854775808
+    elif dtype is DType.int128:
+        return -170141183460469231731687303715884105728
+    elif dtype is DType.int256:
+        # TODO: Creating a SIMD from an IntLiteral goes through a si128.
+        return Scalar[dtype](1) << 255
     elif dtype.is_floating_point():
         return -max_finite[dtype]()
     elif dtype is DType.bool:

--- a/mojo/stdlib/test/builtin/test_format_int.mojo
+++ b/mojo/stdlib/test/builtin/test_format_int.mojo
@@ -26,6 +26,41 @@ fn test_format_int() raises:
     assert_equal(_format_int[DType.index](-123, 10), "-123")
     assert_equal(_format_int[DType.index](-999_999_999, 10), "-999999999")
 
+    # Max and Min values for wide types
+    assert_equal(
+        _format_int(UInt256.MAX, 10),
+        "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+    )
+    assert_equal(
+        _format_int(Int256.MAX, 10),
+        "57896044618658097711785492504343953926634992332820282019728792003956564819967",
+    )
+    assert_equal(
+        _format_int(UInt256.MIN, 10),
+        "0",
+    )
+    assert_equal(
+        _format_int(Int256.MIN, 10),
+        "-57896044618658097711785492504343953926634992332820282019728792003956564819968",
+    )
+
+    assert_equal(
+        _format_int(Int128.MAX, 10),
+        "170141183460469231731687303715884105727",
+    )
+    assert_equal(
+        _format_int(UInt128.MAX, 10),
+        "340282366920938463463374607431768211455",
+    )
+    assert_equal(
+        _format_int(UInt128.MIN, 10),
+        "0",
+    )
+    assert_equal(
+        _format_int(Int128.MIN, 10),
+        "-170141183460469231731687303715884105728",
+    )
+
     #
     # Max and min i64 values in base 10
     #


### PR DESCRIPTION
Fixes issue reported here: https://forum.modular.com/t/segmentation-fault-with-dict/1656/9 and identified by @soraros here: https://forum.modular.com/t/uint256-returns-wrong-value/1643/6

When creating a buffer to write the string, it was previously hardcoded to 64+1. This right-sizes it to `dtype.bitwidth() + 1`. Additionally, this adds support for MIN and MAX on 128/256 integers and tests for format_int on 128/256.

There's another todo here, which is that converting an `IntLiteral` to a `SIMD[...]` looks like it goes through a `si128`. So IntLiterals outside the range of si128 can't be converted easily. I've worked around that in this MR, but a better solution is probably warranted. 

I'd be open to fixing that if someone can point me in the right direction since it would require something larger than a 256, or more complex logic.

edit - the ubuntu test runner still failed when I accidentally still had the small dict example from the forum post in the tests. So this doesn't completely fix the all issues there.