### PR TITLE
Amdgcn dpp

### DIFF
--- a/examples/custom_ops/kernels/top_k.mojo
+++ b/examples/custom_ops/kernels/top_k.mojo
@@ -106,8 +106,8 @@ struct TopK:
                     # value from a thread 'offset' positions higher, keeping the
                     # larger value.
                     var shuffled = TopKElement(
-                        warp.shuffle_down(reduced.idx, offset),
-                        warp.shuffle_down(reduced.val, offset),
+                        warp.shuffle_down[offset](reduced.idx),
+                        warp.shuffle_down[offset](reduced.val),
                     )
                     reduced = max(reduced, shuffled)
 

--- a/max/kernels/src/nn/normalization.mojo
+++ b/max/kernels/src/nn/normalization.mojo
@@ -143,9 +143,9 @@ fn welford_warp_reduce[
 
     @parameter
     for mask in reversed(range(limit)):
-        var mean = warp.shuffle_down(res_mean, 1 << mask)
-        var m2 = warp.shuffle_down(res_m2, 1 << mask)
-        var count = warp.shuffle_down(res_count, 1 << mask)
+        var mean = warp.shuffle_down[1 << mask](res_mean)
+        var m2 = warp.shuffle_down[1 << mask](res_m2)
+        var count = warp.shuffle_down[1 << mask](res_count)
         welford_combine(mean, m2, count, res_mean, res_m2, res_count)
 
 

--- a/max/kernels/src/nn/topk.mojo
+++ b/max/kernels/src/nn/topk.mojo
@@ -567,12 +567,12 @@ fn _warp_reduce_topk[
 
     # Shuffle down function for TopK_2 structure
     @parameter
-    fn shuffle_down_topk2(
-        v: TopK_2[T, largest], offset: Int
+    fn shuffle_down_topk2[offset: UInt](
+        v: TopK_2[T, largest]
     ) -> TopK_2[T, largest]:
         return TopK_2[T, largest](
-            u=warp.shuffle_down(v.u, offset),  # u is the value
-            p=Int(warp.shuffle_down(Int32(v.p), offset)),  # p is the index
+            u=warp.shuffle_down[offset](v.u),  # u is the value
+            p=Int(warp.shuffle_down[offset](Int32(v.p))),  # p is the index
         )
 
     @parameter
@@ -599,7 +599,7 @@ fn _warp_reduce_topk[
     @parameter
     for i in reversed(range(limit)):
         alias mask = 1 << i
-        res = reduce_fn(res, shuffle_down_topk2(res, mask))
+        res = reduce_fn(res, shuffle_down_topk2[mask](res))
 
     return res
 

--- a/max/kernels/test/gpu/basics/test_prefix_sum.mojo
+++ b/max/kernels/test/gpu/basics/test_prefix_sum.mojo
@@ -13,7 +13,7 @@
 
 from math import ceildiv
 
-from gpu import block, global_idx, warp
+from gpu import block, global_idx, warp, lane_id
 from gpu.host import DeviceContext
 from gpu.host import DeviceContext
 from gpu.globals import WARP_SIZE
@@ -168,6 +168,68 @@ def test_block_prefix_sum[exclusive: Bool](ctx: DeviceContext):
     out_host.free()
 
 
+fn warp_rank_kernel[
+    dtype: DType,
+](
+    output: UnsafePointer[Scalar[dtype]],
+    input: UnsafePointer[Scalar[dtype]],
+):
+    var tid = lane_id()
+    var v = input[tid]
+    var condition = v % 4 == 1
+    var rank = warp.rank(condition)
+    if condition:
+      output[rank] = v + 100
+
+def test_warp_rank(ctx: DeviceContext):
+    alias size = WARP_SIZE
+
+    # Allocate and initialize host memory
+    var in_host = UnsafePointer[Scalar[dtype]].alloc(size)
+    var out_host = UnsafePointer[Scalar[dtype]].alloc(size)
+
+    for i in range(size):
+        in_host[i] = i
+        out_host[i] = 0
+
+    # Create device buffers and copy input data
+    var in_device = ctx.enqueue_create_buffer[dtype](size)
+    var out_device = ctx.enqueue_create_buffer[dtype](size)
+    ctx.enqueue_copy(in_device, in_host)
+    ctx.enqueue_copy(out_device, out_host)
+
+    # Launch kernel
+    ctx.enqueue_function[warp_rank_kernel[dtype=dtype]](
+        out_device.unsafe_ptr(),
+        in_device.unsafe_ptr(),
+        block_dim=WARP_SIZE,
+        grid_dim=1,
+    )
+
+    # Copy results back and verify
+    ctx.synchronize()
+    ctx.enqueue_copy(out_host, out_device)
+    ctx.synchronize()
+
+    var expected = List[Scalar[dtype]](length=size, fill=0)
+
+    for i in range(size // 4):
+      expected[i] = 100 + 1 + i * 4
+
+    for i in range(size):
+        assert_equal(
+            out_host[i],
+            expected[i],
+            msg=String(
+                "out_host[", i, "] = ", out_host[i], " expected = ", expected[i]
+            ),
+        )
+
+    # Cleanup
+    in_host.free()
+    out_host.free()
+
+
 def main():
     with DeviceContext() as ctx:
         test_warp_prefix_sum[exclusive=True](ctx)
@@ -175,3 +237,6 @@ def main():
 
         test_block_prefix_sum[exclusive=True](ctx)
         test_block_prefix_sum[exclusive=False](ctx)
+
+        test_warp_rank(ctx)
+        test_warp_rank(ctx)

--- a/max/kernels/test/gpu/basics/test_prefix_sum.mojo
+++ b/max/kernels/test/gpu/basics/test_prefix_sum.mojo
@@ -19,6 +19,7 @@ from gpu.host import DeviceContext
 from gpu.globals import WARP_SIZE
 from math import ceildiv
 from testing import assert_equal
+from sys.intrinsics import lanemask_lt
 
 alias dtype = DType.uint64
 
@@ -179,6 +180,7 @@ fn warp_rank_kernel[
     var condition = v % 4 == 1
     var rank = warp.rank(condition)
     if condition:
+      print("tid", tid, "rank", rank, "value", v + 100, "lanemask_lt", lanemask_lt())
       output[rank] = v + 100
 
 def test_warp_rank(ctx: DeviceContext):

--- a/mojo/stdlib/stdlib/algorithm/_gpu/reduction.mojo
+++ b/mojo/stdlib/stdlib/algorithm/_gpu/reduction.mojo
@@ -109,7 +109,11 @@ fn block_reduce[
             ]:
                 return reduce_fn[dtype, width, i](lhs, rhs)
 
-            result[i] = warp.reduce[warp.shuffle_down, reduce_wrapper](val[i])
+            @always_inline
+            fn _shuffle[dtype: DType, simd_width: Int, offset: UInt](val: SIMD[dtype, simd_width]) -> SIMD[dtype, simd_width]:
+                return warp.shuffle_down[offset](val)
+
+            result[i] = warp.reduce[_shuffle, reduce_wrapper](val[i])
 
         return result
 

--- a/mojo/stdlib/stdlib/builtin/simd.mojo
+++ b/mojo/stdlib/stdlib/builtin/simd.mojo
@@ -63,7 +63,7 @@ from sys._assembly import inlined_assembly
 from sys.info import _is_sm_9x_or_newer, _is_sm_100x_or_newer
 from sys.intrinsics import _type_is_eq
 
-from bit import bit_width, byte_swap, pop_count
+from bit import bit_width, byte_swap, pop_count, count_leading_zeros, count_trailing_zeros
 from builtin._format_float import _write_float
 from builtin.device_passable import DevicePassable
 from builtin.format_int import _try_write_int
@@ -2848,6 +2848,42 @@ struct SIMD[dtype: DType, size: Int](
             return Int(self.cast[DType.uint8]().reduce_add())
         else:
             return Int(pop_count(self).reduce_add())
+
+    @always_inline
+    fn leading_zeros(self) -> SIMD[dtype, size]:
+        """Counts the number of leading zero bits, starting from the most
+            significant bit (MSB).
+
+        Constraints:
+            Must be either an integral type.
+
+        Returns:
+            Count of leading zero bits across all elements of the vector.
+        """
+        constrained[
+            dtype.is_integral() or dtype is DType.bool,
+            "Expected either integral or bool type",
+        ]()
+
+        return count_leading_zeros(self)
+
+    @always_inline
+    fn trailing_zeros(self) -> SIMD[dtype, size]:
+        """Counts the number of trailing zero bits, starting from the most
+            significant bit (MSB).
+
+        Constraints:
+            Must be either an integral type.
+
+        Returns:
+            Count of trailing zero bits across all elements of the vector.
+        """
+        constrained[
+            dtype.is_integral() or dtype is DType.bool,
+            "Expected either integral or bool type",
+        ]()
+
+        return count_trailing_zeros(self)
 
     # ===------------------------------------------------------------------=== #
     # select

--- a/mojo/stdlib/stdlib/gpu/amdgcn_dpp.mojo
+++ b/mojo/stdlib/stdlib/gpu/amdgcn_dpp.mojo
@@ -1,0 +1,112 @@
+from gpu import *
+from gpu.host.info import _get_info_from_target, Vendor
+from gpu.warp import *
+from sys import llvm_intrinsic, is_amd_gpu
+from sys.info import _accelerator_arch
+
+# Instructions used in this module can be found by looking for "DPP_CTRL" in these documents describing the ISA:
+#
+# [1]: Vega https://www.amd.com/content/dam/amd/en/documents/radeon-tech-docs/instruction-set-architectures/vega-shader-instruction-set-architecture.pdf
+# [2]: MI300 https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/instruction-set-architectures/amd-instinct-mi300-cdna3-instruction-set-architecture.pdf
+
+# TODO: put somewhere more appropriate
+alias current_target = _get_info_from_target[_accelerator_arch()]()
+
+fn _gpu_arch_check[f: fn(Float32)->Bool]() -> Bool:
+    return current_target.vendor == Vendor.AMD_GPU and f(current_target.compute)
+
+fn _amdgcn_dpp[
+    dtype: DType,
+    width: Int, //,
+    dpp_ctrl: UInt32,
+    row_mask: UInt32 = 0b1111,
+    bank_mask: UInt32 = 0b1111,
+](old: SIMD[dtype, width], src: SIMD[dtype, width]) -> SIMD[dtype, width]:
+    constrained[is_amd_gpu()]()
+    constrained[
+        dtype.bitwidth() in (32, 64), "Can only use DPP with 32/64-bit dtypes"
+    ]()
+
+    bound_ctrl = True
+    return llvm_intrinsic["llvm.amdgcn.update.dpp", SIMD[dtype, width]](
+        old, src, dpp_ctrl, row_mask, bank_mask, bound_ctrl
+    )
+
+
+fn amdgcn_row_mirror[
+    dtype: DType, width: Int, //
+](old: SIMD[dtype, width], src: SIMD[dtype, width]) -> SIMD[dtype, width]:
+    return _amdgcn_dpp[dpp_ctrl=0x140](old, src)
+
+
+fn amdgcn_row_shift_left[
+    dtype: DType, width: Int, //, offset: Int
+](src: SIMD[dtype, width], old: SIMD[dtype, width] = 0) -> SIMD[dtype, width]:
+    constrained[
+        offset > 0 and offset < 16, "Can only shift row by up to 15 positions"
+    ]()
+    return _amdgcn_dpp[dpp_ctrl = 0x100 + offset](old, src)
+
+
+fn amdgcn_row_rotate_left[
+    dtype: DType, width: Int, //, offset: Int
+](src: SIMD[dtype, width], old: SIMD[dtype, width] = 0) -> SIMD[dtype, width]:
+    constrained[
+        offset > 0 and offset < 16, "Can only rotate row by up to 15 positions"
+    ]()
+    return _amdgcn_dpp[dpp_ctrl = 0x110 + offset](old, src)
+
+# Seen in Vega ISA[1] up to MI300 ISA[2]
+fn amdgcn_supports_shifts() -> Bool:
+    fn check(version: Float32) -> Bool:
+      return version >= 9.0 and version < 10.0
+    return _gpu_arch_check[check]()
+
+fn amdgcn_shift_left[
+    dtype: DType, width: Int, //
+](src: SIMD[dtype, width], old: SIMD[dtype, width] = 0) -> SIMD[dtype, width]:
+    constrained[amdgcn_supports_shifts(), "DPP wavefront shift only supported on CDNA"]()
+    return _amdgcn_dpp[dpp_ctrl=0x130](old, src)
+
+
+fn amdgcn_rotate_left[
+    dtype: DType, width: Int, //
+](src: SIMD[dtype, width], old: SIMD[dtype, width] = 0) -> SIMD[dtype, width]:
+    return _amdgcn_dpp[dpp_ctrl=0x134](old, src)
+
+
+fn amdgcn_row_read_lane[
+    dtype: DType, width: Int, //, offset: Int
+](src: SIMD[dtype, width], old: SIMD[dtype, width] = 0) -> SIMD[dtype, width]:
+    constrained[
+        offset >= 0 and offset < 16, "Can only broadcast within each row (0-15)"
+    ]()
+    return _amdgcn_dpp[dpp_ctrl = 0x150 + offset](old, src)
+
+
+fn amdgcn_quad_perm[
+    dtype: DType, width: Int, //, perm: Int
+](src: SIMD[dtype, width], old: SIMD[dtype, width] = 0) -> SIMD[dtype, width]:
+    constrained[
+        perm >= 0 and perm <= 0xFF, "DPP_QUAD_PERM must be between 0 and 0xFF"
+    ]()
+    return _amdgcn_dpp[dpp_ctrl = 0x0 + perm](old, src)
+
+
+fn amdgcn_quad_shuffle_xor[
+    dtype: DType, width: Int, //, mask: Int
+](src: SIMD[dtype, width], old: SIMD[dtype, width] = 0) -> SIMD[dtype, width]:
+    constrained[
+        mask >= 0 and mask <= 3, "Quad shuffle mask must be between 0 and 3"
+    ]()
+
+    fn calculate_bitmask(xor: Int) -> Int:
+        # calculate lane indices for a quad
+        mask = 0
+        for i in range(4):
+            mask |= (i ^ xor) << 2 * i
+        return mask
+
+    alias bitmask = calculate_bitmask(mask)
+    return amdgcn_quad_perm[bitmask](src, old)
+

--- a/mojo/stdlib/stdlib/gpu/warp.mojo
+++ b/mojo/stdlib/stdlib/gpu/warp.mojo
@@ -422,7 +422,7 @@ fn _shuffle_down_amd[
       return _shuffle_amd_helper(dst_lane, val)
 
     @parameter
-    if amdgcn_supports_shifts():
+    if amdgcn_supports_shifts() and (dtype.bitwidth() % 32) == 0:
       # sanity check - varying offset or partial participation is not supported (yet)
       if mask == _FULL_MASK and min(UInt64(mask)) == max(UInt64(mask)):
         # small shifts only

--- a/mojo/stdlib/stdlib/gpu/warp.mojo
+++ b/mojo/stdlib/stdlib/gpu/warp.mojo
@@ -424,7 +424,8 @@ fn _shuffle_down_amd[
     @parameter
     if amdgcn_supports_shifts() and (dtype.bitwidth() % 32) == 0:
       # sanity check - varying offset or partial participation is not supported (yet)
-      if mask == _FULL_MASK and min(UInt64(mask)) == max(UInt64(mask)):
+      # TODO: should check for `min(UInt64(offset)) == max(UInt64(offset)):` but that causes infinite recursion
+      if mask == _FULL_MASK: 
         # small shifts only
         if offset <= 4:
           var x = val

--- a/mojo/stdlib/stdlib/sys/intrinsics.mojo
+++ b/mojo/stdlib/stdlib/sys/intrinsics.mojo
@@ -957,15 +957,11 @@ fn lanemask_lt() -> UInt:
 
     @parameter
     if is_nvidia_gpu():
-        return UInt(
-            Int(
-                llvm_intrinsic[
-                    "llvm.nvvm.read.ptx.sreg.lanemask_lt",
-                    Int32,
-                    has_side_effect=False,
-                ]().cast[DType.uint32]()
-            )
-        )
+        var mlir_result = __mlir_op.`nvvm.read.ptx.sreg.lanemask.lt`[_type=__mlir_type.`i32`]()
+        var result = Int32(__mlir_op.`pop.cast_from_builtin`[
+            _type = __mlir_type.`!pop.scalar<si32>`
+        ](mlir_result))
+        return UInt(Int(result))
 
     else:
         return (1 << lane_id()) - 1

--- a/mojo/stdlib/stdlib/sys/intrinsics.mojo
+++ b/mojo/stdlib/stdlib/sys/intrinsics.mojo
@@ -1088,20 +1088,25 @@ fn ballot[dtype: DType](value: Bool) -> Scalar[dtype]:
         value: The value to place across the mask.
 
     Returns:
-        A bitfield(Int32 or Int64) containing the result of its Bool argument in all active lanes.
+        A bitfield(Int32 or Int64) containing the result of its Bool argumentin all active lanes.
     """
     @parameter
     if is_amd_gpu():
-      constrained[dtype == DType.int32 or dtype == DType.int64, "This intrinsic is only defined for i32 or i64 on AMD GPUs"]()
+      constrained[
+          dtype == DType.int32 or dtype == DType.int64,
+          "This intrinsic is only defined for i32 or i64 on AMD GPUs"
+      ]()
       return llvm_intrinsic["llvm.amdgcn.ballot", Scalar[dtype]](value)
     else:
-      constrained[dtype == DType.int32, "This intrinsic is only defined for i32 on NVIDIA GPUs"]()
-      # mode 3 means BALLOT
+      constrained[
+          dtype == DType.int32,
+          "This intrinsic is only defined for i32 on NVIDIA GPUs"
+      ]()
       var result = llvm_intrinsic[
-          "llvm.nvvm.vote.sync",
-          _RegisterPackType[Int, Bool]
-      ](Int(_FULL_MASK), Int(3), value)
-      return rebind[Scalar[dtype]](Int32(result[0]))
+          "llvm.nvvm.vote.ballot.sync",
+          Int32
+      ](Int32(_FULL_MASK), value)
+      return result.cast[dtype]()
 
 
 # ===-----------------------------------------------------------------------===#


### PR DESCRIPTION
Continuing my proposal here: https://forum.modular.com/t/amdgcn-dpp-instructions-for-warp-communication/1677/3

I ran the tests on MI300 against the upstream master branch and this one, no regressions.

TODOS:
- [ ] Implement other warp-wide operations
- [ ] Fix the guard on mask `min(UInt64(offset)) == max(UInt64(offset))` - this needs something like `all(offset == broadcast(offset)` but I don't think ballot ops have been implemented yet
- [ ] Finally, for known reductions like `lane_group_reduce` (but with `_FULL_MASK`), there should be parallel functions that pass the offset for a warp operation as a parameter.

With function overloading, I don't think there need to be separate names for these functions, just extra overloads.

For example, besides the existing 
```mojo
reduce[
  val_type: DType, 
  simd_width: Int, 
  //, 
  shuffle: fn[DType, Int](val: SIMD[$0, $1], offset: SIMD[uint32, 1]) -> SIMD[$0, $1], 
  func: fn[DType, Int](SIMD[$0, $1], SIMD[$0, $1]) capturing -> SIMD[$0, $1]
](val: SIMD[val_type, simd_width]) -> SIMD[val_type, simd_width]
```

I would also add 

```mojo
reduce[
  val_type: DType, 
  simd_width: Int, 
  //, 
  shuffle: fn[DType, Int, UInt](val: SIMD[$0, $1]) -> SIMD[$0, $1],  # this is different, offset in a parameter
  func: fn[DType, Int](SIMD[$0, $1], SIMD[$0, $1]) capturing -> SIMD[$0, $1]
](val: SIMD[val_type, simd_width]) -> SIMD[val_type, simd_width]
```

And the same for `shuffle_down`, a new overload like so:

```mojo
shuffle_down[
type: DType, 
simd_width: Int, 
//,
offset: UInt,
](val: SIMD[type, simd_width]) -> SIMD[type, simd_width]
```
