### PR TITLE
[stdlib] Remove the `SIMD.element_type` alias

### DIFF
--- a/mojo/stdlib/stdlib/algorithm/reduction.mojo
+++ b/mojo/stdlib/stdlib/algorithm/reduction.mojo
@@ -183,7 +183,7 @@ fn reduce[
     reduce_fn: fn[acc_type: DType, type: DType, width: Int] (
         SIMD[acc_type, width], SIMD[type, width]
     ) capturing [_] -> SIMD[acc_type, width]
-](src: NDBuffer[rank=1], init: Scalar) raises -> Scalar[init.element_type]:
+](src: NDBuffer[rank=1], init: Scalar) raises -> Scalar[init.dtype]:
     """Computes a custom reduction of buffer elements.
 
     Parameters:
@@ -204,7 +204,7 @@ fn reduce[
     ](idx: IndexList[rank]) -> SIMD[_type, width]:
         return src.load[width=width](idx[0])._refine[_type]()
 
-    var out: Scalar[init.element_type] = 0
+    var out: Scalar[init.dtype] = 0
 
     @always_inline
     @parameter
@@ -344,7 +344,7 @@ fn _reduce_3D[
         @__copy_capture(w)
         @parameter
         fn reduce_w_chunked[simd_width: Int](idx: Int):
-            var accum = SIMD[init.element_type, simd_width](init)
+            var accum = SIMD[init.dtype, simd_width](init)
             for j in range(w):
                 var chunk = src.load[width=simd_width](
                     IndexList[src.rank](i, j, idx)
@@ -740,12 +740,10 @@ fn _reduce_generator[
         constrained[reduction_idx < num_reductions, "invalid reduction index"]()
         return reduce_function[type, width](val, acc)
 
-    var init_wrapped = StaticTuple[Scalar[init.element_type], num_reductions](
-        init
-    )
+    var init_wrapped = StaticTuple[Scalar[init.dtype], num_reductions](init)
     return _reduce_generator[
         num_reductions,
-        init.element_type,
+        init.dtype,
         input_0_fn,
         output_fn_wrapper,
         reduce_fn_wrapper,

--- a/mojo/stdlib/stdlib/builtin/simd.mojo
+++ b/mojo/stdlib/stdlib/builtin/simd.mojo
@@ -326,13 +326,9 @@ struct SIMD[dtype: DType, size: Int](
         return Self.get_type_name()
 
     # Fields
-    alias _Mask = SIMD[DType.bool, size]
-
-    alias element_type = dtype
     alias _mlir_type = __mlir_type[
         `!pop.simd<`, size.value, `, `, dtype.value, `>`
     ]
-
     var value: Self._mlir_type
     """The underlying storage for the vector."""
 
@@ -348,6 +344,7 @@ struct SIMD[dtype: DType, size: Int](
     alias MIN_FINITE = Self(_min_finite[dtype]())
     """Returns the minimum (lowest) finite value of SIMD value."""
 
+    alias _Mask = SIMD[DType.bool, size]
     alias _default_alignment = alignof[Scalar[dtype]]() if is_gpu() else 1
 
     # ===-------------------------------------------------------------------===#


### PR DESCRIPTION
The `SIMD` type parameter has been renamed to `dtype`, so the alias is no longer necessary.

Part of #4215.