### PR TITLE
[Docs] Remove possibly wrong annotation in docs

### DIFF
--- a/mojo/docs/manual/values/ownership.mdx
+++ b/mojo/docs/manual/values/ownership.mdx
@@ -101,7 +101,7 @@ reference and one that's immutable:
 
 ```mojo
 fn add(mut x: Int, read y: Int):
-    var x += y
+    x += y
 
 fn main():
     var a = 1


### PR DESCRIPTION
Mostly for my own understanding - I think this `var` should not be here in these docs.

Thank you!