### PR TITLE
[Docs] remove unused import in docs

### DIFF
--- a/mojo/docs/manual/python/mojo-from-python.mdx
+++ b/mojo/docs/manual/python/mojo-from-python.mdx
@@ -90,7 +90,6 @@ work (but this will improve soon):
 
 ```python title="main.py"
 import max.mojo.importer
-import os
 import sys
 
 sys.path.insert(0, "")


### PR DESCRIPTION
The docs say "we currently need some more boilerplate code to make it work (but this will improve soon)" but I think it can improve *now* (`os` is unused)