### PR TITLE
[stdlib] Fix PyType_GetName usage for older pythons

### DIFF
--- a/mojo/stdlib/test/python/test_python_cpython.mojo
+++ b/mojo/stdlib/test/python/test_python_cpython.mojo
@@ -223,6 +223,26 @@ def test_PyCapsule(mut python: Python):
         )
 
 
+def test_PyType_GetName(mut python: Python) -> None:
+    """Test the PyType_GetName function."""
+    var cpython_env = python.cpython()
+
+    fn _get_type_name(obj: PythonObject) raises -> String:
+        """Helper function to get the type name in a format usable for asserting.
+        """
+        var actual_type = cpython_env.Py_TYPE(obj._obj_ptr)
+        var actual_type_name = PythonObject(
+            from_owned_ptr=cpython_env.PyType_GetName(actual_type)
+        )
+
+        return String(actual_type_name)
+
+    var str_obj = PythonObject("hello")
+    assert_equal(_get_type_name(str_obj).__str__(), "str")
+    var int_obj = PythonObject(32)
+    assert_equal(_get_type_name(int_obj).__str__(), "int")
+
+
 def main():
     # initializing Python instance calls init_python
     var python = Python()
@@ -255,3 +275,4 @@ def main():
 
     test_PyDict(python)
     test_PyCapsule(python)
+    test_PyType_GetName(python)


### PR DESCRIPTION
When trying to use the python-mojo interop with Python 3.10 some code paths fail with unknown symbol `PyType_GetName`. 

```
At: open-source/max/mojo/stdlib/stdlib/sys/ffi.mojo:450:36: Assert Error: symbol not found: PyType_GetName
```

According to the docs this was introduced in Python 3.11: https://docs.python.org/3/c-api/type.html#c.PyType_GetName

This PR fixes this use case and adds tests for all the supported Python versions.

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
