### PR TITLE
[stdlib] Fix PyType_GetName for python versions pre 3.11

### DIFF
--- a/mojo/stdlib/stdlib/python/_cpython.mojo
+++ b/mojo/stdlib/stdlib/python/_cpython.mojo
@@ -1289,7 +1289,20 @@ struct CPython(Copyable, Defaultable, Movable):
         return ob_raw.unsized_obj_ptr[].object_type
 
     fn PyType_GetName(self, type: UnsafePointer[PyTypeObject]) -> PyObjectPtr:
-        return self.lib.call["PyType_GetName", PyObjectPtr](type)
+        """Retrieve the name of the Python type.
+
+        [Rereference](
+        https://docs.python.org/3/c-api/type.html#c.PyType_GetName).
+        """
+        if self.version.minor >= 11:
+            # PyObject *PyType_GetName(PyTypeObject *type)
+            var r = self.lib.call["PyType_GetName", PyObjectPtr](type)
+            self._inc_total_rc()
+            return r
+        else:
+            return self.PyObject_GetAttrString(
+                rebind[PyObjectPtr](type), "__name__"
+            )
 
     fn PyType_FromSpec(self, spec: UnsafePointer[PyType_Spec]) -> PyObjectPtr:
         """[Reference](


### PR DESCRIPTION
When trying to use the python-mojo interop with Python 3.10 some code paths fail with unknown symbol `PyType_GetName`.

```
At: open-source/max/mojo/stdlib/stdlib/sys/ffi.mojo:450:36: Assert Error: symbol not found: PyType_GetName
```

According to the docs this was introduced in Python 3.11: https://docs.python.org/3/c-api/type.html#c.PyType_GetName

This PR fixes this use case.

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
