### PR TITLE
[docs] Correct module for NDBuffer (#4861)

### DIFF
--- a/mojo/stdlib/stdlib/buffer/buffer.mojo
+++ b/mojo/stdlib/stdlib/buffer/buffer.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 """Implements the NDBuffer struct.
 
-You can import these APIs from the `memory` package. For example:
+You can import these APIs from the `buffer` package. For example:
 
 ```mojo
 from buffer import NDBuffer


### PR DESCRIPTION
Edited `memory` -> `buffer`
Fixes #4861
