### PR TITLE
[stdlib] [kernels] Adapt argsort cpu implementation and take it to stdlib `sort.mojo`

### DIFF
--- a/max/kernels/src/layout/layout_tensor.mojo
+++ b/max/kernels/src/layout/layout_tensor.mojo
@@ -318,6 +318,13 @@ struct LayoutTensor[
     ```
     """
 
+    alias _Span = Span[
+        Scalar[dtype],
+        origin=origin,
+        address_space=address_space,
+        alignment=alignment,
+    ]
+
     alias rank = layout.rank()
     """The number of dimensions in the tensor's layout."""
 
@@ -5581,6 +5588,9 @@ struct LayoutTensor[
             Element[index_type=linear_idx_type](
                 val, self.runtime_element_layout
             ).store(self.ptr.offset(offset))
+
+    fn _as_span(self) -> Self._Span:
+        return Self._Span(ptr=self.ptr, length=self.size())
 
 
 @always_inline

--- a/max/kernels/src/nn/argsort.mojo
+++ b/max/kernels/src/nn/argsort.mojo
@@ -17,6 +17,7 @@ from sys.info import simdwidthof
 
 from algorithm import elementwise
 from bit import next_power_of_two
+from builtin.sort import argsort as _stdlib_argsort
 from gpu import MAX_THREADS_PER_BLOCK_METADATA, global_idx
 from gpu.host import DeviceContext
 from gpu.host import get_gpu_target
@@ -53,20 +54,7 @@ fn _argsort_cpu[
         indices.size()
     )
 
-    @parameter
-    fn cmp_fn(a: Scalar[indices.dtype], b: Scalar[indices.dtype]) -> Bool:
-        @parameter
-        if ascending:
-            return Bool(input[Int(a)] < input[Int(b)])
-        else:
-            return Bool(input[Int(a)] > input[Int(b)])
-
-    sort[cmp_fn](
-        Span[
-            Scalar[indices.dtype],
-            indices.origin,
-        ](ptr=indices.ptr, length=indices.size())
-    )
+    _stdlib_argsort[ascending=ascending](input._as_span(), indices._as_span())
 
 
 @always_inline

--- a/mojo/stdlib/stdlib/builtin/sort.mojo
+++ b/mojo/stdlib/stdlib/builtin/sort.mojo
@@ -15,7 +15,7 @@
 These are Mojo built-ins, so you don't need to import them.
 """
 
-from math import ceil
+from math import ceil, iota
 from sys import bitwidthof
 
 from bit import count_leading_zeros
@@ -41,7 +41,7 @@ fn _insertion_sort[
     T: Copyable & Movable,
     origin: MutableOrigin, //,
     cmp_fn: fn (_SortWrapper[T], _SortWrapper[T]) capturing [_] -> Bool,
-](span: Span[T, origin]):
+](span: Span[T, origin, address_space = AddressSpace.GENERIC, **_]):
     """Sort the array[start:end] slice"""
     var array = span.unsafe_ptr().origin_cast[origin=MutableAnyOrigin]()
     var size = len(span)
@@ -66,7 +66,7 @@ fn _quicksort_partition_right[
     T: Copyable & Movable,
     origin: MutableOrigin, //,
     cmp_fn: fn (_SortWrapper[T], _SortWrapper[T]) capturing [_] -> Bool,
-](span: Span[T, origin]) -> Int:
+](span: Span[T, origin, address_space = AddressSpace.GENERIC, **_]) -> Int:
     var array = span.unsafe_ptr().origin_cast[origin=MutableAnyOrigin]()
     var size = len(span)
 
@@ -95,7 +95,7 @@ fn _quicksort_partition_left[
     T: Copyable & Movable,
     origin: MutableOrigin, //,
     cmp_fn: fn (_SortWrapper[T], _SortWrapper[T]) capturing [_] -> Bool,
-](span: Span[T, origin]) -> Int:
+](span: Span[T, origin, address_space = AddressSpace.GENERIC, **_]) -> Int:
     var array = span.unsafe_ptr().origin_cast[origin=MutableAnyOrigin]()
     var size = len(span)
 
@@ -121,7 +121,7 @@ fn _heap_sort_fix_down[
     T: Copyable & Movable,
     origin: MutableOrigin, //,
     cmp_fn: fn (_SortWrapper[T], _SortWrapper[T]) capturing [_] -> Bool,
-](span: Span[T, origin], idx: Int):
+](span: Span[T, origin, address_space = AddressSpace.GENERIC, **_], idx: Int):
     var array = span.unsafe_ptr().origin_cast[origin=MutableAnyOrigin]()
     var size = len(span)
     var i = idx
@@ -142,7 +142,7 @@ fn _heap_sort[
     T: Copyable & Movable,
     origin: MutableOrigin, //,
     cmp_fn: fn (_SortWrapper[T], _SortWrapper[T]) capturing [_] -> Bool,
-](span: Span[T, origin]):
+](span: Span[T, origin, address_space = AddressSpace.GENERIC, **_]):
     var array = span.unsafe_ptr().origin_cast[origin=MutableAnyOrigin]()
     var size = len(span)
     # heapify
@@ -171,7 +171,7 @@ fn _delegate_small_sort[
     T: Copyable & Movable,
     origin: MutableOrigin, //,
     cmp_fn: fn (_SortWrapper[T], _SortWrapper[T]) capturing [_] -> Bool,
-](span: Span[T, origin]):
+](span: Span[T, origin, address_space = AddressSpace.GENERIC, **_]):
     var array = span.unsafe_ptr().origin_cast[origin=MutableAnyOrigin]()
     var size = len(span)
     if size == 2:
@@ -202,7 +202,7 @@ fn _quicksort[
     T: Copyable & Movable,
     origin: MutableOrigin, //,
     cmp_fn: fn (_SortWrapper[T], _SortWrapper[T]) capturing [_] -> Bool,
-](span: Span[T, origin]):
+](span: Span[T, origin, address_space = AddressSpace.GENERIC, **_]):
     var array = span.unsafe_ptr().origin_cast[origin=MutableAnyOrigin]()
     var size = len(span)
     if size == 0:
@@ -265,9 +265,9 @@ fn _merge[
     result_origin: MutableOrigin, //,
     cmp_fn: fn (_SortWrapper[T], _SortWrapper[T]) capturing [_] -> Bool,
 ](
-    span1: Span[T, span_origin],
-    span2: Span[T, span_origin],
-    result: Span[T, result_origin],
+    span1: Span[T, span_origin, address_space = AddressSpace.GENERIC, **_],
+    span2: Span[T, span_origin, address_space = AddressSpace.GENERIC, **_],
+    result: Span[T, result_origin, address_space = AddressSpace.GENERIC, **_],
 ):
     """Merge span1 and span2 into result using the given cmp_fn. The function
     will crash if result is not large enough to hold both span1 and span2.
@@ -319,10 +319,13 @@ fn _merge[
 
 fn _stable_sort_impl[
     T: Copyable & Movable,
-    span_life: MutableOrigin,
-    tmp_life: MutableOrigin, //,
+    span_origin: MutableOrigin,
+    tmp_origin: MutableOrigin, //,
     cmp_fn: fn (_SortWrapper[T], _SortWrapper[T]) capturing [_] -> Bool,
-](span: Span[T, span_life], temp_buff: Span[T, tmp_life]):
+](
+    span: Span[T, span_origin, address_space = AddressSpace.GENERIC, **_],
+    temp_buff: Span[T, tmp_origin, address_space = AddressSpace.GENERIC, **_],
+):
     var size = len(span)
     if size <= 1:
         return
@@ -349,7 +352,7 @@ fn _stable_sort[
     T: Copyable & Movable,
     origin: MutableOrigin, //,
     cmp_fn: fn (_SortWrapper[T], _SortWrapper[T]) capturing [_] -> Bool,
-](span: Span[T, origin]):
+](span: Span[T, origin, address_space = AddressSpace.GENERIC, **_]):
     var temp_buff = UnsafePointer[T].alloc(len(span))
     var temp_buff_span = Span(ptr=temp_buff, length=len(span))
     _stable_sort_impl[cmp_fn](span, temp_buff_span)
@@ -366,7 +369,7 @@ fn _partition[
     T: Copyable & Movable,
     origin: MutableOrigin, //,
     cmp_fn: fn (_SortWrapper[T], _SortWrapper[T]) capturing [_] -> Bool,
-](span: Span[T, origin]) -> Int:
+](span: Span[T, origin, address_space = AddressSpace.GENERIC, **_]) -> Int:
     var size = len(span)
     if size <= 1:
         return 0
@@ -399,7 +402,10 @@ fn _partition[
     T: Copyable & Movable,
     origin: MutableOrigin, //,
     cmp_fn: fn (_SortWrapper[T], _SortWrapper[T]) capturing [_] -> Bool,
-](var span: Span[T, origin], var k: Int):
+](
+    owned span: Span[T, origin, address_space = AddressSpace.GENERIC, **_],
+    owned k: Int,
+):
     while True:
         var pivot = _partition[cmp_fn](span)
         if pivot == k:
@@ -417,7 +423,7 @@ fn partition[
     T: Copyable & Movable,
     origin: MutableOrigin, //,
     cmp_fn: fn (T, T) capturing [_] -> Bool,
-](span: Span[T, origin], k: Int):
+](span: Span[T, origin, address_space = AddressSpace.GENERIC, **_], k: Int):
     """Partition the input buffer inplace such that first k elements are the
     largest (or smallest if cmp_fn is < operator) elements.
     The ordering of the first k elements is undefined.
@@ -451,7 +457,7 @@ fn _sort[
     cmp_fn: fn (_SortWrapper[T], _SortWrapper[T]) capturing [_] -> Bool,
     *,
     stable: Bool = False,
-](span: Span[T, origin]):
+](span: Span[T, origin, address_space = AddressSpace.GENERIC, **_]):
     if len(span) <= 5:
         _delegate_small_sort[cmp_fn](span)
         return
@@ -467,7 +473,7 @@ fn _sort[
         _quicksort[cmp_fn](span)
 
 
-# TODO (MSTDL-766): The Int and Scalar[T] overload should be remove
+# TODO (MSTDL-766): The Int and Scalar[T] overload should be removed
 # (same for partition)
 # Eventually we want a sort that takes a Span and one that takes a List with
 # optional cmp_fn.
@@ -477,7 +483,7 @@ fn sort[
     cmp_fn: fn (T, T) capturing [_] -> Bool,
     *,
     stable: Bool = False,
-](span: Span[T, origin]):
+](span: Span[T, origin, address_space = AddressSpace.GENERIC, *_, **_]):
     """Sort the list inplace.
     The function doesn't return anything, the list is updated inplace.
 
@@ -503,7 +509,7 @@ fn sort[
     cmp_fn: fn (Int, Int) capturing [_] -> Bool,
     *,
     stable: Bool = False,
-](span: Span[Int, origin]):
+](span: Span[Int, origin, address_space = AddressSpace.GENERIC, **_]):
     """Sort the list inplace.
     The function doesn't return anything, the list is updated inplace.
 
@@ -527,7 +533,7 @@ fn sort[
     origin: MutableOrigin, //,
     *,
     stable: Bool = False,
-](span: Span[Int, origin]):
+](span: Span[Int, origin, address_space = AddressSpace.GENERIC, **_]):
     """Sort the list inplace.
     The function doesn't return anything, the list is updated inplace.
 
@@ -551,7 +557,7 @@ fn sort[
     origin: MutableOrigin, //,
     *,
     stable: Bool = False,
-](span: Span[Scalar[dtype], origin]):
+](span: Span[Scalar[dtype], origin, address_space = AddressSpace.GENERIC, **_]):
     """Sort the list inplace.
     The function doesn't return anything, the list is updated inplace.
 
@@ -576,7 +582,7 @@ fn sort[
     origin: MutableOrigin, //,
     *,
     stable: Bool = False,
-](span: Span[T, origin]):
+](span: Span[T, origin, address_space = AddressSpace.GENERIC, **_]):
     """Sort list of the order comparable elements in-place.
 
     Parameters:
@@ -696,3 +702,73 @@ fn _small_sort[
         _sort_partial_3[T, cmp_fn](array, 0, 2, 3)
         _sort_partial_3[T, cmp_fn](array, 1, 2, 3)
         return
+
+
+# ===-----------------------------------------------------------------------===#
+# argsort
+# ===-----------------------------------------------------------------------===#
+
+
+fn argsort[
+    values_dtype: DType, indices_dtype: DType, //, *, ascending: Bool = True
+](
+    values: Span[mut=False, Scalar[values_dtype], **_],
+    indices: Span[
+        mut=True,
+        Scalar[indices_dtype],
+        address_space = AddressSpace.GENERIC, **_,
+    ],
+):
+    """Sorts the index buffer according to the biggest/smallest values that they
+    correspond to.
+
+    Parameters:
+        values_dtype: The dtype of the value buffer.
+        indices_dtype: The dtype of the indices buffer.
+        ascending: Sort direction (True for ascending, False for descending).
+
+    Args:
+        values: Input buffer to sort.
+        indices: Output buffer to store sorted indices.
+    """
+
+    @always_inline
+    @parameter
+    fn cmp_fn(a: Scalar[indices_dtype], b: Scalar[indices_dtype]) -> Bool:
+        @parameter
+        if ascending:
+            return Bool(values[a] < values[b])
+        else:
+            return Bool(values[a] > values[b])
+
+    sort[cmp_fn](indices)
+
+
+@always_inline
+fn argsort[
+    values_dtype: DType, //,
+    *,
+    ascending: Bool = True,
+    indices_dtype: DType = DType.index,
+](values: Span[mut=False, Scalar[values_dtype], **_]) -> List[
+    Scalar[indices_dtype]
+]:
+    """Returns the sorted index buffer according to the biggest/smallest values
+    that they correspond to.
+
+    Parameters:
+        values_dtype: The dtype of the value buffer.
+        ascending: Sort direction (True for ascending, False for descending).
+        indices_dtype: The dtype of the indices buffer.
+
+    Args:
+        values: Input buffer to sort.
+
+    Returns:
+        The sorted index buffer.
+    """
+
+    var res = List[Scalar[indices_dtype]](unsafe_uninit_length=len(values))
+    iota(res)
+    argsort[ascending=ascending](values, res)
+    return res^

--- a/mojo/stdlib/stdlib/collections/list.mojo
+++ b/mojo/stdlib/stdlib/collections/list.mojo
@@ -534,6 +534,8 @@ struct List[T: Copyable & Movable, hint_trivial_type: Bool = False](
         self._unsafe_next_uninit_ptr().init_pointee_move(value^)
         self._len += 1
 
+    # TODO(#4998): this should be an overload of extend, not append. And we need
+    # to give users better control over the allocation reserve calculation.
     fn append(mut self, elements: Span[T, _]):
         """Appends elements to this list.
 

--- a/mojo/stdlib/stdlib/math/math.mojo
+++ b/mojo/stdlib/stdlib/math/math.mojo
@@ -1208,7 +1208,7 @@ fn iota[dtype: DType, //](mut v: List[Scalar[dtype], *_], offset: Int = 0):
         v: The list to fill with numbers.
         offset: The starting value to fill at index 0.
     """
-    iota(v.data, len(v), offset)
+    iota(v.unsafe_ptr(), len(v), offset)
 
 
 fn iota(mut v: List[Int, *_], offset: Int = 0):
@@ -1218,7 +1218,7 @@ fn iota(mut v: List[Int, *_], offset: Int = 0):
         v: The list to fill with numbers.
         offset: The starting value to fill at index 0.
     """
-    var buff = v.data.bitcast[Scalar[DType.index]]()
+    var buff = v.unsafe_ptr().bitcast[Scalar[DType.index]]()
     iota(buff, len(v), offset=offset)
 
 

--- a/mojo/stdlib/stdlib/memory/span.mojo
+++ b/mojo/stdlib/stdlib/memory/span.mojo
@@ -98,9 +98,19 @@ struct Span[
     """
 
     # Aliases
-    alias Mutable = Span[T, MutableOrigin.cast_from[origin]]
+    alias Mutable = Span[
+        T,
+        MutableOrigin.cast_from[origin],
+        address_space=address_space,
+        alignment=alignment,
+    ]
     """The mutable version of the `Span`."""
-    alias Immutable = Span[T, ImmutableOrigin.cast_from[origin]]
+    alias Immutable = Span[
+        T,
+        ImmutableOrigin.cast_from[origin],
+        address_space=address_space,
+        alignment=alignment,
+    ]
     """The immutable version of the `Span`."""
     # Fields
     var _data: UnsafePointer[
@@ -126,8 +136,13 @@ struct Span[
     @implicit
     @always_inline("nodebug")
     fn __init__(
-        other: Span[T, _],
-        out self: Span[T, ImmutableOrigin.cast_from[other.origin]],
+        other: Span,
+        out self: Span[
+            other.T,
+            ImmutableOrigin.cast_from[other.origin],
+            address_space = other.address_space,
+            alignment = other.alignment,
+        ],
     ):
         """Implicitly cast the mutable origin of self to an immutable one.
 

--- a/mojo/stdlib/test/builtin/test_sort.mojo
+++ b/mojo/stdlib/test/builtin/test_sort.mojo
@@ -15,7 +15,7 @@
 from pathlib import _dir_of_current_file
 from random import random_float64, random_si64, random_ui64, seed
 
-from builtin.sort import _quicksort, _small_sort, _SortWrapper
+from builtin.sort import _quicksort, _small_sort, _SortWrapper, argsort
 from testing import assert_equal, assert_false, assert_true
 
 
@@ -642,6 +642,12 @@ def test_stable_sort_stress():
         test[_lt, _lt_check](length)
 
 
+def test_argsort():
+    values = List[Byte](9, 8, 7, 6, 5, 4, 3, 2, 1)
+    expected = List[Scalar[DType.index]](8, 7, 6, 5, 4, 3, 2, 1, 0)
+    assert_equal(argsort(Span(values)), expected)
+
+
 def main():
     test_sort_small_3()
     test_sort_small_5()
@@ -672,3 +678,5 @@ def main():
     test_sort_strings()
     test_sort_comparamble_elements_list()
     test_sort_empty_comparable_elements_list()
+
+    test_argsort()


### PR DESCRIPTION
Adapt argsort cpu implementation and take it to stdlib `sort.mojo`. Closes #2979. IMO this should live in the stdlib because it is a useful API and the implementation is straightforward.

This PR makes the sort functions more generic over alignment and fixes immutable span inference for such cases.

This PR also adds a private convenience method to `LayoutTensor` to return a `Span`.