### PR TITLE
[stdlib] Adds hasher parameter to Dict

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -39,6 +39,12 @@ what we publish.
 
 ### Standard library changes
 
+- The `Dict` now has an `H` parameter which allows users to provider a
+  custom `Hasher` type.
+  - `default_hasher` (AHasher) and `default_comp_time_hasher` (Fnv1a)
+    are now provided
+  - The `H` parameter of `Dict` defaults to `default_hasher`
+
 - The `Hashable` trait has been updated to use a new data flow strategy.
   - Users are now required to implement the method
     `fn __hash__[H: Hasher](self, mut hasher: H):`

--- a/mojo/integration-test/python-extension-modules/block-hasher/mojo_module.mojo
+++ b/mojo/integration-test/python-extension-modules/block-hasher/mojo_module.mojo
@@ -11,6 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+from hashlib import default_comp_time_hasher
 from os import abort
 from sys import sizeof
 
@@ -82,7 +83,9 @@ fn _mojo_block_hasher[
     var result_py_list = cpython.PyList_New(num_hashes)
 
     # Initial hash seed value
-    alias initial_hash = hash(String("None"))
+    alias initial_hash = hash[HasherType=default_comp_time_hasher](
+        String("None")
+    )
 
     # Performing hashing
     var prev_hash = initial_hash
@@ -91,9 +94,11 @@ fn _mojo_block_hasher[
     for block_idx in range(num_hashes):
         var hash_ptr_ints = hash_ptr_base.offset(block_idx * block_size)
         var hash_ptr_bytes = hash_ptr_ints.bitcast[Byte]()
-        var token_hash = hash(hash_ptr_bytes, num_bytes)
+        var token_hash = hash[HasherType=default_comp_time_hasher](
+            hash_ptr_bytes, num_bytes
+        )
         var pair_to_hash = SIMD[DType.uint64, 2](prev_hash, token_hash)
-        var curr_hash = hash(pair_to_hash)
+        var curr_hash = hash[HasherType=default_comp_time_hasher](pair_to_hash)
         # Convert the hash result to a Python object and store it in our
         # uninitialized list.
         var curr_hash_obj = cpython.PyLong_FromSsize_t(Int(curr_hash))

--- a/mojo/stdlib/benchmarks/collections/bench_dict.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_dict.mojo
@@ -15,6 +15,7 @@
 # the -t flag. Remember to replace it again before pushing any code.
 
 from collections.dict import DictEntry
+from hashlib import Hasher
 from math import ceil
 from random import *
 from sys import sizeof
@@ -100,9 +101,9 @@ fn bench_dict_lookup[size: Int](mut b: Bencher) raises:
 # ===-----------------------------------------------------------------------===#
 
 
-fn total_bytes_used(items: Dict[Int, Int]) -> Int:
+fn total_bytes_used[H: Hasher](items: Dict[Int, Int, H]) -> Int:
     # the allocated memory by entries:
-    var entry_size = sizeof[Optional[DictEntry[Int, Int]]]()
+    var entry_size = sizeof[Optional[DictEntry[Int, Int, H]]]()
     var amnt_bytes = items._entries.capacity * entry_size
     amnt_bytes += sizeof[Dict[Int, Int]]()
 

--- a/mojo/stdlib/stdlib/builtin/reversed.mojo
+++ b/mojo/stdlib/stdlib/builtin/reversed.mojo
@@ -20,6 +20,8 @@ from collections.deque import _DequeIter
 from collections.dict import _DictEntryIter, _DictKeyIter, _DictValueIter
 from collections.list import _ListIter
 
+from hashlib import Hasher
+
 from memory.span import Span, _SpanIter
 
 from .range import _StridedRange
@@ -122,7 +124,12 @@ fn reversed[
 fn reversed[
     K: KeyElement,
     V: Copyable & Movable,
-](ref value: Dict[K, V],) -> _DictKeyIter[K, V, __origin_of(value), False]:
+    H: Hasher,
+](
+    ref value: Dict[K, V, H],
+) -> _DictKeyIter[
+    K, V, H, __origin_of(value), False
+]:
     """Get a reversed iterator of the input dict.
 
     **Note**: iterators are currently non-raising.
@@ -130,6 +137,7 @@ fn reversed[
     Parameters:
         K: The type of the keys in the dict.
         V: The type of the values in the dict.
+        H: The type of the hasher in the dict.
 
     Args:
         value: The dict to get the reversed iterator of.
@@ -143,10 +151,11 @@ fn reversed[
 fn reversed[
     K: KeyElement,
     V: Copyable & Movable,
+    H: Hasher,
     dict_mutability: Bool,
     dict_origin: Origin[dict_mutability],
-](ref value: _DictValueIter[K, V, dict_origin]) -> _DictValueIter[
-    K, V, dict_origin, False
+](ref value: _DictValueIter[K, V, H, dict_origin]) -> _DictValueIter[
+    K, V, H, dict_origin, False
 ]:
     """Get a reversed iterator of the input dict values.
 
@@ -155,6 +164,7 @@ fn reversed[
     Parameters:
         K: The type of the keys in the dict.
         V: The type of the values in the dict.
+        H: The type of the hasher in the dict.
         dict_mutability: Whether the reference to the dict values is mutable.
         dict_origin: The origin of the dict values.
 
@@ -170,10 +180,11 @@ fn reversed[
 fn reversed[
     K: KeyElement,
     V: Copyable & Movable,
+    H: Hasher,
     dict_mutability: Bool,
     dict_origin: Origin[dict_mutability],
-](ref value: _DictEntryIter[K, V, dict_origin]) -> _DictEntryIter[
-    K, V, dict_origin, False
+](ref value: _DictEntryIter[K, V, H, dict_origin]) -> _DictEntryIter[
+    K, V, H, dict_origin, False
 ]:
     """Get a reversed iterator of the input dict items.
 
@@ -182,6 +193,7 @@ fn reversed[
     Parameters:
         K: The type of the keys in the dict.
         V: The type of the values in the dict.
+        H: The type of the hasher in the dict.
         dict_mutability: Whether the reference to the dict items is mutable.
         dict_origin: The origin of the dict items.
 
@@ -192,7 +204,7 @@ fn reversed[
         The reversed iterator of the dict items.
     """
     var src = value.src
-    return _DictEntryIter[K, V, dict_origin, False](
+    return _DictEntryIter[K, V, H, dict_origin, False](
         src[]._reserved() - 1, 0, src
     )
 

--- a/mojo/stdlib/stdlib/collections/counter.mojo
+++ b/mojo/stdlib/stdlib/collections/counter.mojo
@@ -20,11 +20,15 @@ from collections import Counter
 """
 from collections.dict import Dict, _DictEntryIter, _DictKeyIter, _DictValueIter
 
+from hashlib import Hasher, default_hasher
+
 from utils import Variant
 
 
 @fieldwise_init
-struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
+struct Counter[V: KeyElement, H: Hasher = default_hasher](
+    Boolable, Copyable, Defaultable, Movable, Sized
+):
     """A container for counting hashable items.
 
     The value type must be specified statically, unlike a Python
@@ -43,10 +47,11 @@ struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
     ```
     Parameters:
         V: The value type to be counted. Currently must be KeyElement.
+        H: The type of the hasher in the dict.
     """
 
     # Fields
-    var _data: Dict[V, Int]
+    var _data: Dict[V, Int, H]
 
     # ===------------------------------------------------------------------=== #
     # Life cycle methods
@@ -54,7 +59,7 @@ struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
 
     fn __init__(out self):
         """Create a new, empty Counter object."""
-        self._data = Dict[V, Int]()
+        self._data = Dict[V, Int, H]()
 
     fn __init__(out self, owned *values: V):
         """Create a new Counter from a list of values.
@@ -70,7 +75,7 @@ struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
         print(c["b"])  # print 2
         ```
         """
-        self._data = Dict[V, Int]()
+        self._data = Dict[V, Int, H]()
         for item in values:
             self._data[item] = self._data.get(item, 0) + 1
 
@@ -90,7 +95,7 @@ struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
         print(c["b"]) # prints 2
         ```
         """
-        self._data = Dict[V, Int]()
+        self._data = Dict[V, Int, H]()
         for item in items:
             self._data[item] = self._data.get(item, 0) + 1
 
@@ -118,7 +123,7 @@ struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
             value >= 0,
             "value must be non-negative",
         )
-        var result = Counter[V]()
+        var result = Counter[V, H]()
         for key in keys:
             result[key] = value
         return result
@@ -147,7 +152,7 @@ struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
         """
         self._data[value] = count
 
-    fn __iter__(self) -> _DictKeyIter[V, Int, __origin_of(self._data)]:
+    fn __iter__(self) -> _DictKeyIter[V, Int, H, __origin_of(self._data)]:
         """Iterate over the keyword dict's keys as immutable references.
 
         Returns:
@@ -291,7 +296,7 @@ struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
         Returns:
             A new Counter with the counts from both Counters added together.
         """
-        var result = Counter[V]()
+        var result = Counter[V, H]()
 
         result.update(self)
         result.update(other)
@@ -342,7 +347,7 @@ struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
             A new Counter with the common elements and the minimum count of
             the two Counters.
         """
-        var result = Counter[V]()
+        var result = Counter[V, H]()
 
         for key in self.keys():
             if key in other:
@@ -377,7 +382,7 @@ struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
             A new Counter with all elements and the maximum count of the two
             Counters.
         """
-        var result = Counter[V]()
+        var result = Counter[V, H]()
 
         for key in self.keys():
             var newcount = max(self.get(key, 0), other.get(key, 0))
@@ -421,7 +426,7 @@ struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
         Returns:
             A shallow copy of the Counter.
         """
-        var result = Counter[V]()
+        var result = Counter[V, H]()
         for item in self.items():
             if item.value > 0:
                 result[item.key] = item.value
@@ -434,7 +439,7 @@ struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
         Returns:
             A new Counter with stripped counts and negative counts.
         """
-        var result = Counter[V]()
+        var result = Counter[V, H]()
         for item in self.items():
             if item.value < 0:
                 result[item.key] = -item.value
@@ -500,7 +505,7 @@ struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
         """
         return self._data.pop(value, default)
 
-    fn keys(ref self) -> _DictKeyIter[V, Int, __origin_of(self._data)]:
+    fn keys(ref self) -> _DictKeyIter[V, Int, H, __origin_of(self._data)]:
         """Iterate over the Counter's keys as immutable references.
 
         Returns:
@@ -508,7 +513,7 @@ struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
         """
         return self._data.keys()
 
-    fn values(ref self) -> _DictValueIter[V, Int, __origin_of(self._data)]:
+    fn values(ref self) -> _DictValueIter[V, Int, H, __origin_of(self._data)]:
         """Iterate over the Counter's values as references.
 
         Returns:
@@ -516,7 +521,7 @@ struct Counter[V: KeyElement](Boolable, Copyable, Defaultable, Movable, Sized):
         """
         return self._data.values()
 
-    fn items(self) -> _DictEntryIter[V, Int, __origin_of(self._data)]:
+    fn items(self) -> _DictEntryIter[V, Int, H, __origin_of(self._data)]:
         """Iterate over the dict's entries as immutable references.
 
         Returns:

--- a/mojo/stdlib/stdlib/collections/dict.mojo
+++ b/mojo/stdlib/stdlib/collections/dict.mojo
@@ -37,6 +37,7 @@ value types must always be Movable so we can resize the dictionary as it grows.
 See the `Dict` docs for more details.
 """
 
+from hashlib import Hasher, default_hasher, default_comp_time_hasher
 from memory import bitcast, memcpy
 
 
@@ -52,6 +53,7 @@ struct _DictEntryIter[
     dict_mutability: Bool, //,
     K: KeyElement,
     V: Copyable & Movable,
+    H: Hasher,
     dict_origin: Origin[dict_mutability],
     forward: Bool = True,
 ](Copyable, Movable):
@@ -61,16 +63,17 @@ struct _DictEntryIter[
         dict_mutability: Whether the reference to the dictionary is mutable.
         K: The key type of the elements in the dictionary.
         V: The value type of the elements in the dictionary.
+        H: The type of the hasher in the dictionary.
         dict_origin: The origin of the List
         forward: The iteration direction. `False` is backwards.
     """
 
     var index: Int
     var seen: Int
-    var src: Pointer[Dict[K, V], dict_origin]
+    var src: Pointer[Dict[K, V, H], dict_origin]
 
     fn __init__(
-        out self, index: Int, seen: Int, ref [dict_origin]dict: Dict[K, V]
+        out self, index: Int, seen: Int, ref [dict_origin]dict: Dict[K, V, H]
     ):
         self.index = index
         self.seen = seen
@@ -82,7 +85,7 @@ struct _DictEntryIter[
     @always_inline
     fn __next__(
         mut self,
-    ) -> ref [self.src[]._entries[0].value()] DictEntry[K, V]:
+    ) -> ref [self.src[]._entries[0].value()] DictEntry[K, V, H]:
         while True:
             ref opt_entry_ref = self.src[]._entries[self.index]
 
@@ -109,6 +112,7 @@ struct _DictKeyIter[
     dict_mutability: Bool, //,
     K: KeyElement,
     V: Copyable & Movable,
+    H: Hasher,
     dict_origin: Origin[dict_mutability],
     forward: Bool = True,
 ](Copyable, IteratorTrait, Movable):
@@ -118,11 +122,12 @@ struct _DictKeyIter[
         dict_mutability: Whether the reference to the vector is mutable.
         K: The key type of the elements in the dictionary.
         V: The value type of the elements in the dictionary.
+        H: The type of the hasher in the dictionary.
         dict_origin: The origin of the List
         forward: The iteration direction. `False` is backwards.
     """
 
-    alias dict_entry_iter = _DictEntryIter[K, V, dict_origin, forward]
+    alias dict_entry_iter = _DictEntryIter[K, V, H, dict_origin, forward]
     alias Element = K
 
     var iter: Self.dict_entry_iter
@@ -152,6 +157,7 @@ struct _DictValueIter[
     dict_mutability: Bool, //,
     K: KeyElement,
     V: Copyable & Movable,
+    H: Hasher,
     dict_origin: Origin[dict_mutability],
     forward: Bool = True,
 ](Copyable, IteratorTrait, Movable):
@@ -162,20 +168,21 @@ struct _DictValueIter[
         dict_mutability: Whether the reference to the vector is mutable.
         K: The key type of the elements in the dictionary.
         V: The value type of the elements in the dictionary.
+        H: The type of the hasher in the dictionary.
         dict_origin: The origin of the List
         forward: The iteration direction. `False` is backwards.
     """
 
-    var iter: _DictEntryIter[K, V, dict_origin, forward]
+    var iter: _DictEntryIter[K, V, H, dict_origin, forward]
     alias Element = V
 
     fn __iter__(self) -> Self:
         return self
 
-    fn __reversed__(self) -> _DictValueIter[K, V, dict_origin, False]:
+    fn __reversed__(self) -> _DictValueIter[K, V, H, dict_origin, False]:
         var src = self.iter.src
         return _DictValueIter(
-            _DictEntryIter[K, V, dict_origin, False](
+            _DictEntryIter[K, V, H, dict_origin, False](
                 src[]._reserved() - 1, 0, src
             )
         )
@@ -201,7 +208,7 @@ struct _DictValueIter[
 
 
 @fieldwise_init
-struct DictEntry[K: KeyElement, V: Copyable & Movable](
+struct DictEntry[K: KeyElement, V: Copyable & Movable, H: Hasher](
     Copyable, ExplicitlyCopyable, Movable
 ):
     """Store a key-value pair entry inside a dictionary.
@@ -209,6 +216,7 @@ struct DictEntry[K: KeyElement, V: Copyable & Movable](
     Parameters:
         K: The key type of the dict. Must be Hashable+EqualityComparable.
         V: The value type of the dict.
+        H: The type of the hasher used to hash the key.
     """
 
     var hash: UInt64
@@ -226,7 +234,7 @@ struct DictEntry[K: KeyElement, V: Copyable & Movable](
             key: The key of the entry.
             value: The value of the entry.
         """
-        self.hash = hash(key)
+        self.hash = hash[HasherType=H](key)
         self.key = key^
         self.value = value^
 
@@ -345,7 +353,7 @@ struct _DictIndex(Movable):
         self.data.free()
 
 
-struct Dict[K: KeyElement, V: Copyable & Movable](
+struct Dict[K: KeyElement, V: Copyable & Movable, H: Hasher = default_hasher](
     Boolable, Copyable, Defaultable, ExplicitlyCopyable, Movable, Sized
 ):
     """A container that stores key-value pairs.
@@ -355,6 +363,7 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
             `EqualityComparable` so we can find the key in the map.
         V: The value type of the dictionary. Currently must be
             Copyable & Movable.
+        H: The type of the hasher used to hash the keys.
 
     The key type and value type must be specified statically, unlike a Python
     dictionary, which can accept arbitrary key and value types.
@@ -475,7 +484,7 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
 
     # We use everything available in the list. Which means that
     # len(self._entries) == self._entries.capacity == self._reserved()
-    var _entries: List[Optional[DictEntry[K, V]]]
+    var _entries: List[Optional[DictEntry[K, V, H]]]
 
     # ===-------------------------------------------------------------------===#
     # Life cycle methods
@@ -565,7 +574,7 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
         Returns:
             The new dictionary.
         """
-        var my_dict = Dict[K, V]()
+        var my_dict = Dict[K, V, H]()
         for key in keys:
             my_dict[key] = value
         return my_dict
@@ -573,7 +582,7 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
     @staticmethod
     fn fromkeys(
         keys: List[K, *_], value: Optional[V] = None
-    ) -> Dict[K, Optional[V]]:
+    ) -> Dict[K, Optional[V], H]:
         """Create a new dictionary with keys from list and values set to value.
 
         Args:
@@ -583,7 +592,7 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
         Returns:
             The new dictionary.
         """
-        return Dict[K, Optional[V]].fromkeys(keys, value)
+        return Dict[K, Optional[V], H].fromkeys(keys, value)
 
     fn __copyinit__(out self, existing: Self):
         """Copy an existing dictiontary.
@@ -636,7 +645,7 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
         """
         return self.find(key).__bool__()
 
-    fn __iter__(ref self) -> _DictKeyIter[K, V, __origin_of(self)]:
+    fn __iter__(ref self) -> _DictKeyIter[K, V, H, __origin_of(self)]:
         """Iterate over the dict's keys as immutable references.
 
         Returns:
@@ -644,7 +653,9 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
         """
         return _DictKeyIter(_DictEntryIter(0, 0, self))
 
-    fn __reversed__(ref self) -> _DictKeyIter[K, V, __origin_of(self), False]:
+    fn __reversed__(
+        ref self,
+    ) -> _DictKeyIter[K, V, H, __origin_of(self), False]:
         """Iterate backwards over the dict keys, returning immutable references.
 
         Returns:
@@ -782,7 +793,7 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
             An optional value containing a reference to the value if it is
             present, otherwise an empty Optional.
         """
-        var hash = hash(key)
+        var hash = hash[HasherType=H](key)
         var found, _, index = self._find_index(hash, key)
 
         if found:
@@ -847,7 +858,7 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
         Raises:
             "KeyError" if the key was not present in the dictionary.
         """
-        var hash = hash(key)
+        var hash = hash[HasherType=H](key)
         var found, slot, index = self._find_index(hash, key)
         if found:
             self._set_index(slot, Self.REMOVED)
@@ -859,7 +870,7 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
             return entry_value^.reap_value()
         raise "KeyError"
 
-    fn popitem(mut self) raises -> DictEntry[K, V]:
+    fn popitem(mut self) raises -> DictEntry[K, V, H]:
         """Remove and return a (key, value) pair from the dictionary.
 
         Returns:
@@ -885,11 +896,11 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
 
         if key:
             _ = self.pop(key.value())
-            return DictEntry[K, V](key.value(), val.value())
+            return DictEntry[K, V, H](key.value(), val.value())
 
         raise "KeyError: popitem(): dictionary is empty"
 
-    fn keys(ref self) -> _DictKeyIter[K, V, __origin_of(self)]:
+    fn keys(ref self) -> _DictKeyIter[K, V, H, __origin_of(self)]:
         """Iterate over the dict's keys as immutable references.
 
         Returns:
@@ -897,7 +908,7 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
         """
         return Self.__iter__(self)
 
-    fn values(ref self) -> _DictValueIter[K, V, __origin_of(self)]:
+    fn values(ref self) -> _DictValueIter[K, V, H, __origin_of(self)]:
         """Iterate over the dict's values as references.
 
         Returns:
@@ -905,7 +916,7 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
         """
         return _DictValueIter(_DictEntryIter(0, 0, self))
 
-    fn items(ref self) -> _DictEntryIter[K, V, __origin_of(self)]:
+    fn items(ref self) -> _DictEntryIter[K, V, H, __origin_of(self)]:
         """Iterate over the dict's entries as immutable references.
 
         Returns:
@@ -963,10 +974,10 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
             present.
         """
         self._maybe_resize()
-        var found, slot, index = self._find_index(hash(key), key)
+        var found, slot, index = self._find_index(hash[HasherType=H](key), key)
         ref entry = self._entries[index]
         if not found:
-            entry = DictEntry(key, default^)
+            entry = DictEntry[H=H](key, default^)
             self._set_index(slot, index)
             self._len += 1
             self._n_entries += 1
@@ -974,19 +985,23 @@ struct Dict[K: KeyElement, V: Copyable & Movable](
 
     @staticmethod
     @always_inline
-    fn _new_entries(reserve_at_least: Int) -> List[Optional[DictEntry[K, V]]]:
-        var entries = List[Optional[DictEntry[K, V]]](capacity=reserve_at_least)
+    fn _new_entries(
+        reserve_at_least: Int,
+    ) -> List[Optional[DictEntry[K, V, H]]]:
+        var entries = List[Optional[DictEntry[K, V, H]]](
+            capacity=reserve_at_least
+        )
         # We have memory available, we'll use everything.
         for _ in range(entries.capacity):
             entries.append(None)
         return entries
 
     fn _insert(mut self, owned key: K, owned value: V):
-        self._insert(DictEntry[K, V](key^, value^))
+        self._insert(DictEntry[K, V, H](key^, value^))
 
     fn _insert[
         safe_context: Bool = False
-    ](mut self, owned entry: DictEntry[K, V]):
+    ](mut self, owned entry: DictEntry[K, V, H]):
         @parameter
         if not safe_context:
             self._maybe_resize()
@@ -1092,7 +1107,7 @@ struct OwnedKwargsDict[V: Copyable & Movable](
     # Fields
     alias key_type = String
 
-    var _dict: Dict[Self.key_type, V]
+    var _dict: Dict[Self.key_type, V, default_comp_time_hasher]
 
     # ===-------------------------------------------------------------------===#
     # Life cycle methods
@@ -1100,7 +1115,7 @@ struct OwnedKwargsDict[V: Copyable & Movable](
 
     fn __init__(out self):
         """Initialize an empty keyword dictionary."""
-        self._dict = Dict[Self.key_type, V]()
+        self._dict = Dict[Self.key_type, V, default_comp_time_hasher]()
 
     fn copy(self) -> Self:
         """Copy an existing keyword dictionary.
@@ -1231,7 +1246,9 @@ struct OwnedKwargsDict[V: Copyable & Movable](
 
     fn __iter__(
         ref self,
-    ) -> _DictKeyIter[Self.key_type, V, __origin_of(self._dict)]:
+    ) -> _DictKeyIter[
+        Self.key_type, V, default_comp_time_hasher, __origin_of(self._dict)
+    ]:
         """Iterate over the keyword dict's keys as immutable references.
 
         Returns:
@@ -1241,7 +1258,9 @@ struct OwnedKwargsDict[V: Copyable & Movable](
 
     fn keys(
         ref self,
-    ) -> _DictKeyIter[Self.key_type, V, __origin_of(self._dict)]:
+    ) -> _DictKeyIter[
+        Self.key_type, V, default_comp_time_hasher, __origin_of(self._dict)
+    ]:
         """Iterate over the keyword dict's keys as immutable references.
 
         Returns:
@@ -1251,7 +1270,9 @@ struct OwnedKwargsDict[V: Copyable & Movable](
 
     fn values(
         ref self,
-    ) -> _DictValueIter[Self.key_type, V, __origin_of(self._dict)]:
+    ) -> _DictValueIter[
+        Self.key_type, V, default_comp_time_hasher, __origin_of(self._dict)
+    ]:
         """Iterate over the keyword dict's values as references.
 
         Returns:
@@ -1261,7 +1282,9 @@ struct OwnedKwargsDict[V: Copyable & Movable](
 
     fn items(
         ref self,
-    ) -> _DictEntryIter[Self.key_type, V, __origin_of(self._dict)]:
+    ) -> _DictEntryIter[
+        Self.key_type, V, default_comp_time_hasher, __origin_of(self._dict)
+    ]:
         """Iterate over the keyword dictionary's entries as immutable
         references.
 

--- a/mojo/stdlib/stdlib/collections/set.mojo
+++ b/mojo/stdlib/stdlib/collections/set.mojo
@@ -13,10 +13,10 @@
 """Implements the  Set datatype."""
 
 from .dict import Dict, KeyElement, _DictEntryIter, _DictKeyIter
-from hashlib import Hasher
+from hashlib import Hasher, default_hasher
 
 
-struct Set[T: KeyElement](
+struct Set[T: KeyElement, H: Hasher = default_hasher](
     Boolable, Comparable, Copyable, Hashable, KeyElement, Movable, Sized
 ):
     """A set data type.
@@ -42,10 +42,11 @@ struct Set[T: KeyElement](
 
     Parameters:
         T: The element type of the set. Must implement KeyElement.
+        H: The tpe of the hasher used to hash keys.
     """
 
     # Fields
-    var _data: Dict[T, NoneType]
+    var _data: Dict[T, NoneType, H]
 
     # ===-------------------------------------------------------------------===#
     # Life cycle methods
@@ -61,7 +62,7 @@ struct Set[T: KeyElement](
         """
         # TODO: Reserve space in this set. Also, take the elements as 'owned'
         # and transfer them into the set to eliminate copyability.
-        self._data = Dict[T, NoneType]()
+        self._data = Dict[T, NoneType, H]()
         for t in ts:
             self.add(t)
 
@@ -352,7 +353,9 @@ struct Set[T: KeyElement](
     # Methods
     # ===-------------------------------------------------------------------===#
 
-    fn __iter__(ref self) -> _DictKeyIter[T, NoneType, __origin_of(self._data)]:
+    fn __iter__(
+        ref self,
+    ) -> _DictKeyIter[T, NoneType, H, __origin_of(self._data)]:
         """Iterate over elements of the set, returning immutable references.
 
         Returns:
@@ -426,7 +429,7 @@ struct Set[T: KeyElement](
             A new set containing only the elements which appear in both
             this set and the `other` set.
         """
-        var result = Set[T]()
+        var result = Set[T, H]()
         for v in self:
             if v in other:
                 result.add(v)
@@ -443,7 +446,7 @@ struct Set[T: KeyElement](
             A new set containing elements that are in this set but not in
             the `other` set.
         """
-        var result = Set[T]()
+        var result = Set[T, H]()
         for e in self:
             if e not in other:
                 result.add(e)
@@ -549,7 +552,7 @@ struct Set[T: KeyElement](
         Returns:
             A new set containing the symmetric difference of the two sets.
         """
-        var result = Set[T]()
+        var result = Set[T, H]()
 
         for element in self:
             if element not in other:

--- a/mojo/stdlib/stdlib/hashlib/__init__.mojo
+++ b/mojo/stdlib/stdlib/hashlib/__init__.mojo
@@ -12,4 +12,4 @@
 # ===----------------------------------------------------------------------=== #
 """Implements the hashlib package that provides various hash algorithms."""
 from .hash import Hashable, hash
-from .hasher import Hasher
+from .hasher import Hasher, default_hasher, default_comp_time_hasher

--- a/mojo/stdlib/stdlib/hashlib/hash.mojo
+++ b/mojo/stdlib/stdlib/hashlib/hash.mojo
@@ -25,10 +25,9 @@ There are a few main tools in this module:
     These are useful helpers to specialize for the general bytes implementation.
 """
 
-from .hasher import Hasher
+from .hasher import Hasher, default_hasher
 from memory import UnsafePointer
 from sys import is_compile_time
-from ._fnv1a import Fnv1a
 
 
 # ===----------------------------------------------------------------------=== #
@@ -72,7 +71,9 @@ trait Hashable:
         ...
 
 
-fn hash[T: Hashable, HasherType: Hasher = Fnv1a](hashable: T) -> UInt64:
+fn hash[
+    T: Hashable, HasherType: Hasher = default_hasher
+](hashable: T) -> UInt64:
     """Hash a Hashable type using its underlying hash implementation.
 
     Parameters:
@@ -92,7 +93,7 @@ fn hash[T: Hashable, HasherType: Hasher = Fnv1a](hashable: T) -> UInt64:
 
 
 fn hash[
-    HasherType: Hasher = Fnv1a
+    HasherType: Hasher = default_hasher
 ](
     bytes: UnsafePointer[
         UInt8, address_space = AddressSpace.GENERIC, mut=False, **_

--- a/mojo/stdlib/stdlib/hashlib/hasher.mojo
+++ b/mojo/stdlib/stdlib/hashlib/hasher.mojo
@@ -10,6 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
+from ._ahash import AHasher
+from ._fnv1a import Fnv1a
+
+alias default_hasher = AHasher[SIMD[DType.uint64, 4](0)]
+alias default_comp_time_hasher = Fnv1a
 
 
 trait Hasher:

--- a/mojo/stdlib/test/collections/test_dict.mojo
+++ b/mojo/stdlib/test/collections/test_dict.mojo
@@ -15,7 +15,7 @@
 from collections.dict import OwnedKwargsDict
 
 from test_utils import CopyCounter
-from hashlib import Hashable, Hasher
+from hashlib import Hashable, Hasher, default_comp_time_hasher
 from testing import assert_equal, assert_false, assert_raises, assert_true
 
 
@@ -613,8 +613,8 @@ fn test_dict_setdefault() raises:
 def test_compile_time_dict():
     alias N = 10
 
-    fn _get_dict() -> Dict[String, Int32]:
-        var res = Dict[String, Int32]()
+    fn _get_dict() -> Dict[String, Int32, default_comp_time_hasher]:
+        var res = Dict[String, Int32, default_comp_time_hasher]()
         for i in range(N):
             res[String(i)] = i
         return res

--- a/mojo/stdlib/test/hashlib/test_hash.mojo
+++ b/mojo/stdlib/test/hashlib/test_hash.mojo
@@ -18,6 +18,7 @@
 # These tests aren't _great_. They're platform specific, and implementation
 # specific. But for now they test behavior and reproducibility.
 
+from hashlib import default_comp_time_hasher
 from testing import assert_equal, assert_not_equal, assert_true
 
 
@@ -138,11 +139,15 @@ fn test_issue_31111():
 
 
 def test_hash_comptime():
-    alias hash_123 = hash(StaticString("123"))
-    assert_equal(hash_123, hash(StaticString("123")))
+    alias hash_123 = hash[HasherType=default_comp_time_hasher](
+        StaticString("123")
+    )
+    assert_equal(
+        hash_123, hash[HasherType=default_comp_time_hasher](StaticString("123"))
+    )
 
-    alias hash_22 = hash(22)
-    assert_equal(hash_22, hash(22))
+    alias hash_22 = hash[HasherType=default_comp_time_hasher](22)
+    assert_equal(hash_22, hash[HasherType=default_comp_time_hasher](22))
 
 
 def main():


### PR DESCRIPTION
This PR concludes the transformation of the hashing strategy to data flow based hashing. With this PR users are able to provide a parameter to the Dict in order to customise the way a hash value is computed for the keys.

Important note! As at this point in time the AHasher implementation does not work at compile time and the Dict parameter defaults to AHasher, the users would need to provide a different hasher (e.g. Fnv1a) if they chose to have a comp time Dict, Set, or other Dict based data structure.