### PR TITLE
[stdlib] Remove the `Copyable` and `Moveable` bounds from `Intable`

### DIFF
--- a/mojo/stdlib/stdlib/buffer/dimlist.mojo
+++ b/mojo/stdlib/stdlib/buffer/dimlist.mojo
@@ -337,7 +337,7 @@ struct DimList(Representable, Sized, Stringable, Writable):
 
     @always_inline("nodebug")
     @implicit
-    fn __init__[I: Indexer](out self, values: (I,)):
+    fn __init__[I: Indexer & Copyable & Movable](out self, values: (I,)):
         """Creates a dimension list from the given list of values.
 
         Parameters:
@@ -350,7 +350,10 @@ struct DimList(Representable, Sized, Stringable, Writable):
 
     @always_inline("nodebug")
     @implicit
-    fn __init__[I0: Indexer, I1: Indexer](out self, values: (I0, I1)):
+    fn __init__[
+        I0: Indexer & Copyable & Movable,
+        I1: Indexer & Copyable & Movable,
+    ](out self, values: (I0, I1)):
         """Creates a dimension list from the given list of values.
 
         Parameters:
@@ -365,7 +368,9 @@ struct DimList(Representable, Sized, Stringable, Writable):
     @always_inline("nodebug")
     @implicit
     fn __init__[
-        I0: Indexer, I1: Indexer, I2: Indexer
+        I0: Indexer & Copyable & Movable,
+        I1: Indexer & Copyable & Movable,
+        I2: Indexer & Copyable & Movable,
     ](out self, values: (I0, I1, I2)):
         """Creates a dimension list from the given list of values.
 
@@ -382,7 +387,10 @@ struct DimList(Representable, Sized, Stringable, Writable):
         )
 
     @always_inline("nodebug")
-    fn __init__[I0: Indexer, I1: Indexer](out self, val0: I0, val1: I1):
+    fn __init__[
+        I0: Indexer & Copyable & Movable,
+        I1: Indexer & Copyable & Movable,
+    ](out self, val0: I0, val1: I1):
         """Creates a dimension list from the given list of values.
 
         Parameters:

--- a/mojo/stdlib/stdlib/builtin/int.mojo
+++ b/mojo/stdlib/stdlib/builtin/int.mojo
@@ -86,7 +86,7 @@ fn index[T: Indexer](idx: T, /) -> __mlir_type.index:
 # ===----------------------------------------------------------------------=== #
 
 
-trait Intable(Copyable, Movable):
+trait Intable:
     """The `Intable` trait describes a type that can be converted to an Int.
 
     Any type that conforms to `Intable` or

--- a/mojo/stdlib/stdlib/gpu/host/dim.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/dim.mojo
@@ -78,7 +78,7 @@ struct Dim(Stringable, Writable):
         self._value = IndexList[3](index(x), index(y), index(z))
 
     @implicit
-    fn __init__[I: Indexer](out self, dims: (I,)):
+    fn __init__[I: Indexer & Copyable & Movable](out self, dims: (I,)):
         """Initializes Dim with a tuple containing a single indexable value.
 
         y and z dimensions are set to 1.
@@ -92,7 +92,10 @@ struct Dim(Stringable, Writable):
         self._value = IndexList[3](index(dims[0]), 1, 1)
 
     @implicit
-    fn __init__[I0: Indexer, I1: Indexer](out self, dims: (I0, I1)):
+    fn __init__[
+        I0: Indexer & Copyable & Movable,
+        I1: Indexer & Copyable & Movable,
+    ](out self, dims: (I0, I1)):
         """Initializes Dim with a tuple of two indexable values.
 
         The z dimension is set to 1.
@@ -108,7 +111,9 @@ struct Dim(Stringable, Writable):
 
     @implicit
     fn __init__[
-        I0: Indexer, I1: Indexer, I2: Indexer
+        I0: Indexer & Copyable & Movable,
+        I1: Indexer & Copyable & Movable,
+        I2: Indexer & Copyable & Movable,
     ](out self, dims: (I0, I1, I2)):
         """Initializes Dim with a tuple of three indexable values.
 


### PR DESCRIPTION
Fix #4934.