### PR TITLE
[docs] Fix "not copyable" error of `__enter__` method in `ConditionalTimer` case (#4941)

### DIFF
--- a/mojo/docs/manual/errors.mdx
+++ b/mojo/docs/manual/errors.mdx
@@ -384,7 +384,7 @@ type of error condition and propagates all others:
 import sys
 import time
 
-struct ConditionalTimer:
+struct ConditionalTimer(Copyable):
     var start_time: Int
 
     fn __init__(out self):


### PR DESCRIPTION
<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->

issue: https://github.com/modular/modular/issues/4941