### PR TITLE
[docs] EqualityComparable example incorrect for `__ne__`

### DIFF
--- a/mojo/docs/manual/operators.mdx
+++ b/mojo/docs/manual/operators.mdx
@@ -1588,7 +1588,7 @@ struct Complex(
         return self.re == other.re and self.im == other.im
 
     fn __ne__(self, other: Self) -> Bool:
-        return self.re != other.re and self.im != other.im
+        return self.re != other.re or self.im != other.im
 ```
 
 :::note


### PR DESCRIPTION
instances and unequal if either the "re" part OR (not AND)  the "im" part are unequal

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
