### PR TITLE
[Kbench] Added `init-kbench`

### DIFF
--- a/max/kernels/benchmarks/autotune/init-kbench.sh
+++ b/max/kernels/benchmarks/autotune/init-kbench.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+kbench_path="$(realpath $(dirname $BASH_SOURCE))"
+pip install -r $kbench_path/requirements.txt
+alias kbench="python3 $kbench_path/kbench.py"
+export KERNEL_BENCHMARKS_ROOT="$(realpath $kbench_path/..)"


### PR DESCRIPTION
Running the following line should install and enable `kbench` in your env:
```
source max/kernels/benchmarks/autotune/init-kbench.sh
```

Example:
```
cd $KERNEL_BENCHMARKS_ROOT
kbench -v bench_vec_add.yaml
kbench -v bench_matmul.yaml
```
<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
