### PR TITLE
[stdlib] Fix unnecessary copy when moving elements, optimize copy

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -189,3 +189,6 @@ mutation.
 
 - [#3927](https://github.com/modular/modular/issues/3927) - `InlineArray`
   now can be constructed with a size of 0.
+
+- [#4954](https://github.com/modular/modular/issues/4954) - `InlineArray` 
+  now does not call the copy constructor when being moved.

--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -190,5 +190,5 @@ mutation.
 - [#3927](https://github.com/modular/modular/issues/3927) - `InlineArray`
   now can be constructed with a size of 0.
 
-- [#4954](https://github.com/modular/modular/issues/4954) - `InlineArray` 
+- [#4954](https://github.com/modular/modular/issues/4954) - `InlineArray`
   now does not call the copy constructor when being moved.

--- a/mojo/stdlib/stdlib/collections/inline_array.mojo
+++ b/mojo/stdlib/stdlib/collections/inline_array.mojo
@@ -290,7 +290,7 @@ struct InlineArray[
         # Do not destroy the elements when their backing storage goes away.
         __disable_del storage
 
-    fn copy(self) -> Self:
+    fn copy(self, out copy: Self):
         """Creates a deep copy of the array.
 
         Returns:
@@ -304,13 +304,14 @@ struct InlineArray[
         ```
         """
 
-        var copy = Self(uninitialized=True)
+        copy = Self(uninitialized=True)
 
+        @parameter
         for idx in range(size):
             var ptr = copy.unsafe_ptr() + idx
-            ptr.init_pointee_copy(self[idx])
+            ptr.init_pointee_copy(self.unsafe_get(idx))
 
-        return copy^
+        return copy
 
     fn __copyinit__(out self, other: Self):
         """Copy constructs the array from another array.
@@ -336,9 +337,10 @@ struct InlineArray[
 
         __mlir_op.`lit.ownership.mark_initialized`(__get_mvalue_as_litref(self))
 
+        @parameter
         for idx in range(size):
-            var ptr = self.unsafe_ptr() + idx
-            ptr.init_pointee_move(other[idx])
+            var other_ptr = other.unsafe_ptr() + idx
+            other_ptr.move_pointee_into(self.unsafe_ptr() + idx)
 
     fn __del__(owned self):
         """Deallocates the array and destroys its elements.

--- a/mojo/stdlib/stdlib/collections/inline_array.mojo
+++ b/mojo/stdlib/stdlib/collections/inline_array.mojo
@@ -311,8 +311,6 @@ struct InlineArray[
             var ptr = copy.unsafe_ptr() + idx
             ptr.init_pointee_copy(self.unsafe_get(idx))
 
-        return copy
-
     fn __copyinit__(out self, other: Self):
         """Copy constructs the array from another array.
 

--- a/mojo/stdlib/stdlib/collections/inline_array.mojo
+++ b/mojo/stdlib/stdlib/collections/inline_array.mojo
@@ -306,7 +306,6 @@ struct InlineArray[
 
         copy = Self(uninitialized=True)
 
-        @parameter
         for idx in range(size):
             var ptr = copy.unsafe_ptr() + idx
             ptr.init_pointee_copy(self.unsafe_get(idx))
@@ -335,7 +334,6 @@ struct InlineArray[
 
         __mlir_op.`lit.ownership.mark_initialized`(__get_mvalue_as_litref(self))
 
-        @parameter
         for idx in range(size):
             var other_ptr = other.unsafe_ptr() + idx
             other_ptr.move_pointee_into(self.unsafe_ptr() + idx)

--- a/mojo/stdlib/test/collections/test_inline_array.mojo
+++ b/mojo/stdlib/test/collections/test_inline_array.mojo
@@ -15,7 +15,7 @@
 from sys.info import sizeof
 
 from memory.maybe_uninitialized import UnsafeMaybeUninitialized
-from test_utils import DelRecorder, MoveCounter
+from test_utils import CopyCounter, DelRecorder, MoveCounter
 from testing import assert_equal, assert_true
 
 
@@ -267,6 +267,8 @@ def test_sizeof_array[current_type: Copyable & Movable, capacity: Int]():
 
 def test_move():
     """Test that moving an InlineArray works correctly."""
+
+    # 1. Check that the move constructor is called correctly.
     var arr = InlineArray[MoveCounter[Int], 3]({1}, {2}, {3})
     var copied_arr = arr.copy()
 
@@ -279,8 +281,39 @@ def test_move():
     for i in range(len(moved_arr)):
         # Check that the moved array has the same elements as the copied array
         assert_equal(copied_arr[i].value, moved_arr[i].value)
-        # Check that the move constructor was called exactly again for each element
+        # Check that the move constructor was called again for each element
         assert_equal(moved_arr[i].move_count, 2)
+
+    # 2. Check that the copy constructor is not called when moving.
+
+    var arr2 = InlineArray[CopyCounter, 3]({}, {}, {})
+    for i in range(len(arr2)):
+        # The elements were moved into the array and not copied
+        assert_equal(arr2[i].copy_count, 0)
+
+    var moved_arr2 = arr2^
+
+    for i in range(len(moved_arr2)):
+        # Check that the copy constructor was not called
+        assert_equal(moved_arr2[i].copy_count, 0)
+
+    # 3. Check that the destructor is not called when moving.
+    var destructor_counter = List[Int]()
+    var pointer_to_destructor_counter = UnsafePointer(to=destructor_counter)
+    var del_recorder = DelRecorder(0, pointer_to_destructor_counter)
+    var arr3 = InlineArray[DelRecorder, 1, run_destructors=True](del_recorder)
+
+    assert_equal(len(pointer_to_destructor_counter[]), 0)
+
+    var moved_arr3 = arr3^
+
+    assert_equal(len(pointer_to_destructor_counter[]), 0)
+
+    _ = moved_arr3
+
+    # Double check that the destructor is called when the array is destroyed
+    assert_equal(len(pointer_to_destructor_counter[]), 1)
+    _ = del_recorder
 
 
 def main():
@@ -293,3 +326,4 @@ def main():
     test_inline_array_runs_destructors()
     test_unsafe_ptr()
     test_sizeof_array[Int, capacity=32]()
+    test_move()

--- a/mojo/stdlib/test/collections/test_inline_array.mojo
+++ b/mojo/stdlib/test/collections/test_inline_array.mojo
@@ -268,7 +268,8 @@ def test_sizeof_array[current_type: Copyable & Movable, capacity: Int]():
 def test_move():
     """Test that moving an InlineArray works correctly."""
 
-    # 1. Check that the move constructor is called correctly.
+    # === 1. Check that the move constructor is called correctly. ===
+
     var arr = InlineArray[MoveCounter[Int], 3]({1}, {2}, {3})
     var copied_arr = arr.copy()
 
@@ -284,7 +285,7 @@ def test_move():
         # Check that the move constructor was called again for each element
         assert_equal(moved_arr[i].move_count, 2)
 
-    # 2. Check that the copy constructor is not called when moving.
+    # === 2. Check that the copy constructor is not called when moving. ===
 
     var arr2 = InlineArray[CopyCounter, 3]({}, {}, {})
     for i in range(len(arr2)):
@@ -297,7 +298,8 @@ def test_move():
         # Check that the copy constructor was not called
         assert_equal(moved_arr2[i].copy_count, 0)
 
-    # 3. Check that the destructor is not called when moving.
+    # === 3. Check that the destructor is not called when moving. ===
+
     var destructor_counter = List[Int]()
     var pointer_to_destructor_counter = UnsafePointer(to=destructor_counter)
     var del_recorder = DelRecorder(0, pointer_to_destructor_counter)


### PR DESCRIPTION
This fixes #4954.

Furthermore, copy now directly emplaces the result into the output slot, which saves a move operation.