### PR TITLE
[stdlib] Optimise `copysign` for signed integer scalars

### DIFF
--- a/mojo/stdlib/stdlib/math/math.mojo
+++ b/mojo/stdlib/stdlib/math/math.mojo
@@ -911,6 +911,12 @@ fn copysign[
     if dtype.is_unsigned():
         return magnitude
     elif dtype.is_integral():
+
+        @parameter
+        if width == 1:
+            alias sign_mask = 1 << dtype.bitwidth()
+            alias mag_mask = ~sign_mask
+            return magnitude & mag_mask | sign & sign_mask
         var mag_abs = abs(magnitude)
         return (sign < 0).select(-mag_abs, mag_abs)
     return llvm_intrinsic[


### PR DESCRIPTION
ASM (before):

```asm
movl	%edi, %ecx
negl	%ecx
cmovsl	%edi, %ecx
movl	%ecx, %eax
negl	%eax
testl	%esi, %esi
cmovnsl	%ecx, %eax
retq
```

ASM (after):
```asm
andl	$2147483647, %edi
andl	$-2147483648, %esi
leal	(%rsi,%rdi), %eax
retq
```

We probably want to avoid the `vbroadcastss` instruction, so we didn't apply this optimization to the SIMD code.