### PR TITLE
[stdlib] Speed-up `List.__copyinit__()` by using `append(*elements)` optimizations

### DIFF
--- a/mojo/stdlib/stdlib/collections/list.mojo
+++ b/mojo/stdlib/stdlib/collections/list.mojo
@@ -211,8 +211,7 @@ struct List[T: Copyable & Movable, hint_trivial_type: Bool = False](
             existing: The list to copy.
         """
         self = Self(capacity=existing.capacity)
-        for i in range(len(existing)):
-            self.append(existing[i])
+        self.append(existing)
 
     fn __del__(owned self):
         """Destroy all elements in the list and free its memory."""


### PR DESCRIPTION
Specially when `hint_trivial_type` is `True`, it has a big impact on performance, as `append(*elements)` does just one call to `memcpy()`, and before this optimization it would be moving the pointee once per element in the list, even if the items are trivial.

## Benchmarks

Before:

```
| name                                        | met (ms)               | iters   |
| ------------------------------------------- | ---------------------- | ------- |
| List[Scalar[DT], True].__copyinit__ [1]     | 3.4457256999999995e-05 | 1000000 |
| List[Scalar[DT], False].__copyinit__ [1]    | 3.2929131e-05          | 1000000 |
| List[Scalar[DT], True].__copyinit__ [2]     | 3.0187294999999998e-05 | 1000000 |
| List[Scalar[DT], False].__copyinit__ [2]    | 3.0544032e-05          | 1000000 |
| List[Scalar[DT], True].__copyinit__ [4]     | 3.1536637e-05          | 1000000 |
| List[Scalar[DT], False].__copyinit__ [4]    | 3.2293515e-05          | 1000000 |
| List[Scalar[DT], True].__copyinit__ [8]     | 3.3347988999999996e-05 | 1000000 |
| List[Scalar[DT], False].__copyinit__ [8]    | 3.5665772e-05          | 1000000 |
| List[Scalar[DT], True].__copyinit__ [16]    | 3.6628439e-05          | 1000000 |
| List[Scalar[DT], False].__copyinit__ [16]   | 3.5949385e-05          | 1000000 |
| List[Scalar[DT], True].__copyinit__ [32]    | 4.4479470999999994e-05 | 1000000 |
| List[Scalar[DT], False].__copyinit__ [32]   | 5.1672269e-05          | 1000000 |
| List[Scalar[DT], True].__copyinit__ [128]   | 0.00013229368400000002 | 1000000 |
| List[Scalar[DT], False].__copyinit__ [128]  | 0.000113906732         | 1000000 |
| List[Scalar[DT], True].__copyinit__ [256]   | 0.000181112522         | 1000000 |
| List[Scalar[DT], False].__copyinit__ [256]  | 0.000179121587         | 1000000 |
| List[Scalar[DT], True].__copyinit__ [512]   | 0.0003433150518119548  | 939455  |
| List[Scalar[DT], False].__copyinit__ [512]  | 0.00034543658385877255 | 752545  |
| List[Scalar[DT], True].__copyinit__ [1024]  | 0.000616582120341553   | 501240  |
| List[Scalar[DT], False].__copyinit__ [1024] | 0.0006830770624421494  | 506693  |
| List[Scalar[DT], True].__copyinit__ [2048]  | 0.0014912772726150198  | 202465  |
| List[Scalar[DT], False].__copyinit__ [2048] | 0.0012296131567474577  | 254607  |
| List[Scalar[DT], True].__copyinit__ [4096]  | 0.00240442825          | 100000  |
| List[Scalar[DT], False].__copyinit__ [4096] | 0.00229129084          | 100000  |
```

After:

```
| name                                        | met (ms)               | iters   |
| ------------------------------------------- | ---------------------- | ------- |
| List[Scalar[DT], True].__copyinit__ [1]     | 2.9846126000000003e-05 | 1000000 |
| List[Scalar[DT], False].__copyinit__ [1]    | 2.8885057e-05          | 1000000 |
| List[Scalar[DT], True].__copyinit__ [2]     | 2.8553316e-05          | 1000000 |
| List[Scalar[DT], False].__copyinit__ [2]    | 2.8962115e-05          | 1000000 |
| List[Scalar[DT], True].__copyinit__ [4]     | 2.9336022e-05          | 1000000 |
| List[Scalar[DT], False].__copyinit__ [4]    | 3.0269902e-05          | 1000000 |
| List[Scalar[DT], True].__copyinit__ [8]     | 2.9063472e-05          | 1000000 |
| List[Scalar[DT], False].__copyinit__ [8]    | 3.1422664e-05          | 1000000 |
| List[Scalar[DT], True].__copyinit__ [16]    | 3.0034451e-05          | 1000000 |
| List[Scalar[DT], False].__copyinit__ [16]   | 3.6165257e-05          | 1000000 |
| List[Scalar[DT], True].__copyinit__ [32]    | 2.9231306e-05          | 1000000 |
| List[Scalar[DT], False].__copyinit__ [32]   | 4.0505119e-05          | 1000000 |
| List[Scalar[DT], True].__copyinit__ [128]   | 3.1353293e-05          | 1000000 |
| List[Scalar[DT], False].__copyinit__ [128]  | 9.040786e-05           | 1000000 |
| List[Scalar[DT], True].__copyinit__ [256]   | 3.092608e-05           | 1000000 |
| List[Scalar[DT], False].__copyinit__ [256]  | 0.00015647973          | 1000000 |
| List[Scalar[DT], True].__copyinit__ [512]   | 3.9220819e-05          | 1000000 |
| List[Scalar[DT], False].__copyinit__ [512]  | 0.000267013737         | 1000000 |
| List[Scalar[DT], True].__copyinit__ [1024]  | 4.9896868e-05          | 1000000 |
| List[Scalar[DT], False].__copyinit__ [1024] | 0.0004990919088101353  | 507688  |
| List[Scalar[DT], True].__copyinit__ [2048]  | 4.902834e-05           | 1000000 |
| List[Scalar[DT], False].__copyinit__ [2048] | 0.0008962651299875885  | 331147  |
| List[Scalar[DT], True].__copyinit__ [4096]  | 6.9644355e-05          | 1000000 |
| List[Scalar[DT], False].__copyinit__ [4096] | 0.0018774443125659395  | 144072  |
```

## Speed-up

With `hint_trivial_type=False` the speed-up is small, but with `hint_trivial_type=True` the speed-up is bigger as the copied list is larger.

For example, in the benchmark with 4096 trivial items, the speed-up is X34.
