### PR TITLE
[stdlib] Fix benchmarks README.md

### DIFF
--- a/mojo/CLAUDE.md
+++ b/mojo/CLAUDE.md
@@ -40,13 +40,7 @@ Tests are run with `-D ASSERT=all` by default.
 
 ### Running Benchmarks
 
-```bash
-# Run all benchmarks
-./stdlib/scripts/run-benchmarks.sh
-
-# Run specific benchmark
-./stdlib/scripts/run-benchmarks.sh path/to/benchmark.mojo
-```
+Read the `mojo/stdlib/benchmarks/README.md` for details on how to run benchmarks.
 
 ### Code Formatting
 

--- a/mojo/stdlib/benchmarks/BUILD.bazel
+++ b/mojo/stdlib/benchmarks/BUILD.bazel
@@ -4,7 +4,7 @@ load("//bazel:api.bzl", "mojo_test")
     mojo_test(
         name = src + ".test",
         srcs = [src],
-        args = ["-t"],  # NOTE: to test changes on the current branch using run-benchmarks.sh, remove the -t flag. Remember to replace it again before pushing any code.
+        args = ["-t"],  # NOTE: to test changes on the current branch, remove the -t flag. Remember to replace it again before pushing any code.
         data = [
             "collections/data/UN_charter_AR.html",
             "collections/data/UN_charter_AR.txt",

--- a/mojo/stdlib/benchmarks/README.md
+++ b/mojo/stdlib/benchmarks/README.md
@@ -6,9 +6,9 @@ standard library.
 ## Layout
 
 There is 1-1 correspondence between the directory structure of
-the benchmarks and their source counterpart.  For example,
+the benchmarks and their source counterpart. For example,
 consider `collections/bench_dict.mojo` and its source counterpart:
-`collections/dict.mojo`.  This organization makes it easy to stay
+`collections/dict.mojo`. This organization makes it easy to stay
 organized.
 
 Benchmark files should be prefixed with `bench_` in the filename.
@@ -17,31 +17,44 @@ internally.
 
 ## How to run the benchmarks
 
-If you want to just compile and run all of the benchmarks as-is,
-there is a script provided [here](../../stdlib/scripts/run-benchmarks.sh).
-This script builds the open source `stdlib.mojopkg` and then executes
-all of the benchmarks sequentially. The script also allows specifying a
-subdirectory or a file to run.
+If you want to just compile and run all the benchmarks as-is,
+we need to execute the following command:
 
-Running e.g. `pixi run mojo run stdlib/benchmarks/collections/bench_dict.mojo`
-makes the linker use the existing branch that the compiler is on. If you wish to
-test changes you are making on the current branch, remove the `-t` flag on top
-of the benchmark file (`# RUN: %mojo-no-debug %s -t`) then run:
-`pixi run stdlib/scripts/run-benchmarks.sh
-stdlib/benchmarks/collections/bench_dict.mojo`.
-Remember to replace the `-t` flag again before pushing any code.
+```bash
+./bazelw test mojo/stdlib/benchmarks/... --local_test_jobs=1 --test_output=all
+```
+
+This script builds the open source `stdlib.mojopkg` and then executes
+all the benchmarks sequentially.
+
+If you wish to test changes you are making on the current branch, remove the `-t` flag on top
+of the `mojo/stdlib/benchmarks/BUILD.bazel` BAZEL file.
+
+To run a specific benchmark, you need to change the following line BAZEL file:
+
+```bash
+for src in glob(["**/*.mojo"])
+```
+
+To something like this:
+
+```bash
+for src in glob(["**/bench_list.mojo"])
+```
+
+Remember to revert the `-t` flag and the `glob` changes again before pushing any code.
 
 ## How to write effective benchmarks
 
-All of the benchmarks use the `benchmark` module.  `Bench` objects are built
-on top of the `benchmark` module.  You can also use `BenchConfig` to configure
+All the benchmarks use the `benchmark` module. `Bench` objects are built
+on top of the `benchmark` module. You can also use `BenchConfig` to configure
 `Bench`. For the most part, you can copy-paste from existing
 benchmarks to get started.
 
 ## Benchmarks in CI
 
 Currently, there is no short-term plans for adding these benchmarks with regression
-detection and such in the public Mojo CI.  We're working hard to improve the processes
+detection and such in the public Mojo CI. We're working hard to improve the processes
 for this internally first before we commit to doing this in the external repo.
 
 ## Other reading


### PR DESCRIPTION
## Summary

This PR updates the benchmarks documentation to reflect the new Bazel-based benchmark execution system:

- Updated `mojo/CLAUDE.md` to reference the benchmarks README instead of the deleted `run-benchmarks.sh` script
- Comprehensively updated `mojo/stdlib/benchmarks/README.md` with current Bazel commands and workflow
- Fixed comment in `mojo/stdlib/benchmarks/BUILD.bazel` to remove reference to the deleted script

