### PR TITLE
[docs] Change parameter type from `StringLiteral` to `String`

### DIFF
--- a/mojo/docs/manual/parameters/index.mdx
+++ b/mojo/docs/manual/parameters/index.mdx
@@ -562,7 +562,7 @@ their position in the function signature.
 For example, here's a function with two parameters, each with a default value:
 
 ```mojo
-fn speak[a: Int = 3, msg: StringLiteral = "woof"]():
+fn speak[a: Int = 3, msg: String = "woof"]():
     print(msg, a)
 
 fn use_defaults() raises:
@@ -588,7 +588,7 @@ but this is just for demonstration purposes):
 struct Bar[v: Int]:
     pass
 
-fn speak[a: Int = 3, msg: StringLiteral = "woof"](bar: Bar[a]):
+fn speak[a: Int = 3, msg: String = "woof"](bar: Bar[a]):
     print(msg, a)
 
 fn use_inferred():


### PR DESCRIPTION
<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->

Cannot implicitly convert 'StringLiteral["woof"]' value to 'StringLiteral[value]' in doc https://docs.modular.com/mojo/manual/parameters/#optional-parameters-and-keyword-parameters