### PR TITLE
[stdlib] Remove `Bool.__neg__`

### DIFF
--- a/mojo/stdlib/stdlib/builtin/bool.mojo
+++ b/mojo/stdlib/stdlib/builtin/bool.mojo
@@ -521,15 +521,6 @@ struct Bool(
         """
         return lhs ^ self
 
-    @always_inline("builtin")
-    fn __neg__(self) -> Int:
-        """Defines the unary `-` operation.
-
-        Returns:
-            0 for False and -1 for True.
-        """
-        return select[Int](self, -1, 0)
-
     fn __hash__[H: Hasher](self, mut hasher: H):
         """Updates hasher with the underlying bytes.
 

--- a/mojo/stdlib/test/builtin/test_bool.mojo
+++ b/mojo/stdlib/test/builtin/test_bool.mojo
@@ -107,11 +107,6 @@ def test_bitwise():
     assert_false(value)
 
 
-def test_neg():
-    assert_equal(-1, -True)
-    assert_equal(0, -False)
-
-
 def test_indexer():
     assert_true(1 == index(Bool(True)))
     assert_true(0 == index(Bool(False)))
@@ -173,7 +168,6 @@ def main():
     test_convert_from_implicitly_boolable()
     test_bool_representation()
     test_bitwise()
-    test_neg()
     test_indexer()
     test_comparisons()
     test_float_conversion()


### PR DESCRIPTION
Mojo is a language with strong typing, there's no point mimic Python oddity here.

> I'd suggest we remove that behavior since Mojo has strong typing.  I remember me and you were talking about this last year sometime and it made one particular thing easier, but it is not a great thing for Mojo to keep from Python IMO.  We've moved on from the "superset of Python" and needing to copy some of its not-so-great things.  This is one of those things we should deviate from IMO.  Any interest in opening a PR?

_Originally posted by @JoeLoser in https://github.com/modular/modular/pull/4898#discussion_r2168080582_
            