### PR TITLE
[stdlib] Introduce default hasher type as a workaround

### DIFF
--- a/mojo/stdlib/stdlib/hashlib/_ahash.mojo
+++ b/mojo/stdlib/stdlib/hashlib/_ahash.mojo
@@ -80,7 +80,7 @@ fn _read_small(data: UnsafePointer[UInt8, mut=False, **_], length: Int) -> U128:
             return U128(0, 0)
 
 
-struct AHasher[key: U256](Defaultable, Hasher):
+struct AHasher[key: U256](Defaultable, Hasher, Copyable):
     """Adopted AHash algorithm which produces fast and high quality hash value by
     implementing `Hasher` trait.
 

--- a/mojo/stdlib/stdlib/hashlib/_ahash.mojo
+++ b/mojo/stdlib/stdlib/hashlib/_ahash.mojo
@@ -80,7 +80,7 @@ fn _read_small(data: UnsafePointer[UInt8, mut=False, **_], length: Int) -> U128:
             return U128(0, 0)
 
 
-struct AHasher[key: U256](Defaultable, Hasher, Copyable):
+struct AHasher[key: U256](Copyable, Defaultable, Hasher):
     """Adopted AHash algorithm which produces fast and high quality hash value by
     implementing `Hasher` trait.
 

--- a/mojo/stdlib/stdlib/hashlib/_fnv1a.mojo
+++ b/mojo/stdlib/stdlib/hashlib/_fnv1a.mojo
@@ -16,7 +16,7 @@
 from .hasher import Hasher
 
 
-struct Fnv1a(Defaultable, Hasher):
+struct Fnv1a(Defaultable, Hasher, Copyable):
     """Fnv1a is a very simple algorithm with good quality, but sub optimal runtime for long inputs.
     It can be used for comp time hash value generation.
 

--- a/mojo/stdlib/stdlib/hashlib/_fnv1a.mojo
+++ b/mojo/stdlib/stdlib/hashlib/_fnv1a.mojo
@@ -16,7 +16,7 @@
 from .hasher import Hasher
 
 
-struct Fnv1a(Defaultable, Hasher, Copyable):
+struct Fnv1a(Copyable, Defaultable, Hasher):
     """Fnv1a is a very simple algorithm with good quality, but sub optimal runtime for long inputs.
     It can be used for comp time hash value generation.
 

--- a/mojo/stdlib/stdlib/hashlib/hasher.mojo
+++ b/mojo/stdlib/stdlib/hashlib/hasher.mojo
@@ -17,14 +17,17 @@ from sys import is_compile_time
 alias default_hasher = DefaultHasher
 alias default_comp_time_hasher = Fnv1a
 
+
 struct DefaultHasher(Hasher):
     """
     DefaultHasher is a workaround type that delegates to AHasher at runtime and Fnv1a at compile time.
     This is necessary because AHasher is not yet usable at compile time. Once AHasher supports compile-time
     usage, this struct can be removed in favor of using AHasher directly.
     """
+
     var _ahasher: AHasher[SIMD[DType.uint64, 4](0)]
     var _fnv1a: Fnv1a
+
     fn __init__(out self):
         self._ahasher = AHasher[SIMD[DType.uint64, 4](0)]()
         self._fnv1a = Fnv1a()
@@ -60,9 +63,9 @@ struct DefaultHasher(Hasher):
         @parameter
         if is_compile_time():
             var hasher = self._fnv1a
-            return hasher^.finish() 
+            return hasher^.finish()
         else:
-            var hasher = self._ahasher 
+            var hasher = self._ahasher
             return hasher^.finish()
 
 

--- a/mojo/stdlib/stdlib/hashlib/hasher.mojo
+++ b/mojo/stdlib/stdlib/hashlib/hasher.mojo
@@ -12,9 +12,58 @@
 # ===----------------------------------------------------------------------=== #
 from ._ahash import AHasher
 from ._fnv1a import Fnv1a
+from sys import is_compile_time
 
-alias default_hasher = AHasher[SIMD[DType.uint64, 4](0)]
+alias default_hasher = DefaultHasher
 alias default_comp_time_hasher = Fnv1a
+
+struct DefaultHasher(Hasher):
+    """
+    DefaultHasher is a workaround type that delegates to AHasher at runtime and Fnv1a at compile time.
+    This is necessary because AHasher is not yet usable at compile time. Once AHasher supports compile-time
+    usage, this struct can be removed in favor of using AHasher directly.
+    """
+    var _ahasher: AHasher[SIMD[DType.uint64, 4](0)]
+    var _fnv1a: Fnv1a
+    fn __init__(out self):
+        self._ahasher = AHasher[SIMD[DType.uint64, 4](0)]()
+        self._fnv1a = Fnv1a()
+
+    fn _update_with_bytes(
+        mut self,
+        data: UnsafePointer[
+            UInt8, address_space = AddressSpace.GENERIC, mut=False, **_
+        ],
+        length: Int,
+    ):
+        @parameter
+        if is_compile_time():
+            self._fnv1a._update_with_bytes(data, length)
+        else:
+            self._ahasher._update_with_bytes(data, length)
+
+    fn _update_with_simd(mut self, value: SIMD[_, _]):
+        @parameter
+        if is_compile_time():
+            self._fnv1a._update_with_simd(value)
+        else:
+            self._ahasher._update_with_simd(value)
+
+    fn update[T: Hashable](mut self, value: T):
+        @parameter
+        if is_compile_time():
+            self._fnv1a.update(value)
+        else:
+            self._ahasher.update(value)
+
+    fn finish(var self) -> UInt64:
+        @parameter
+        if is_compile_time():
+            var hasher = self._fnv1a
+            return hasher^.finish() 
+        else:
+            var hasher = self._ahasher 
+            return hasher^.finish()
 
 
 trait Hasher:


### PR DESCRIPTION
This should make developer experience better until #4924 is fixed.

Side note:
I wanted to implement the finish function as following:
```
   fn finish(var self) -> UInt64:
        @parameter
        if is_compile_time():
            return self._fnv1a^.finish() 
        else:
            return self._ahasher^.finish()
```

But the compiler did not let me, so I had to make the Hasher Copyable, which in my opinion seems unnecessary.