### PR TITLE
[stdlib] Move `nan`, `inf`, `max`, `min` from fputils to `DType`

### DIFF
--- a/max/kernels/benchmarks/math/bench_exp.mojo
+++ b/max/kernels/benchmarks/math/bench_exp.mojo
@@ -250,7 +250,7 @@ fn exp_mojo_opt[
     var expr = ldexp(taylor_result, k.cast[DType.int32]())
     return expr
     # var val1 = (expr > min_val).select(expr, SIMD[dtype,simd_width](0))
-    # return (val1 < max_val).select(val1, SIMD[dtype,simd_width](inf[dtype]()))
+    # return (val1 < max_val).select(val1, SIMD[dtype,simd_width](DType.inf[dtype]()))
 
 
 @always_inline

--- a/max/kernels/src/Mogg/MOGGKernelAPI/logprobs.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/logprobs.mojo
@@ -15,7 +15,7 @@ from algorithm.functional import parallelize
 from compiler_internal import register
 from gpu import global_idx
 from gpu.host.info import is_cpu, is_gpu
-from math import ceildiv, exp, inf, log
+from math import ceildiv, exp, log
 from nn._ragged_utils import get_batch_from_row_offsets
 from runtime.asyncrt import DeviceContextPtr
 from tensor_internal import InputTensor, OutputTensor
@@ -109,7 +109,7 @@ fn compute_log_probabilities_1tok[
         post_heap_idx = 0
     else:
         var heap = FixedHeightMinHeap[token_dtype, logit_dtype, levels](
-            fill_k=vocab_size, fill_v=-inf[logit_dtype]()
+            fill_k=vocab_size, fill_v=-DType.inf[logit_dtype]()
         )
         for token_value in range(vocab_size):
             var logit_value = logits[logit_index, token_value]

--- a/max/kernels/src/internal_utils/_measure.mojo
+++ b/max/kernels/src/internal_utils/_measure.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 
 from collections import OptionalReg
-from math import inf, isnan, log, nan, sqrt
+from math import isnan, log, sqrt
 from sys import simd_width_of
 
 from algorithm import elementwise, mean, sum, vectorize
@@ -39,10 +39,10 @@ fn kl_div(x: SIMD, y: __type_of(x)) -> __type_of(x):
     $$
     """
     return (isnan(x) | isnan(y)).select(
-        nan[x.dtype](),
+        DType.nan[x.dtype](),
         (x.gt(0) & y.gt(0)).select(
             x * log(x / y) - x + y,
-            (x.eq(0) & y.ge(0)).select(y, inf[x.dtype]()),
+            (x.eq(0) & y.ge(0)).select(y, DType.inf[x.dtype]()),
         ),
     )
 

--- a/max/kernels/src/layout/_fillers.mojo
+++ b/max/kernels/src/layout/_fillers.mojo
@@ -24,8 +24,6 @@ The module includes:
 from random import random_float64
 from sys import is_nvidia_gpu
 
-from utils.numerics import max_finite
-
 # A batch size for filler functions loop bounds.
 alias BATCH_SIZE = 2048
 
@@ -91,7 +89,7 @@ fn arange[
     tensor: LayoutTensor[mut=True, dtype, layout, **_],
     start: Scalar[tensor.dtype] = 0,
     step: Scalar[tensor.dtype] = 1,
-    end: Scalar[tensor.dtype] = max_finite[tensor.dtype](),
+    end: Scalar[tensor.dtype] = DType.max_finite[tensor.dtype](),
 ):
     """Fills a tensor with a sequence of values.
 

--- a/max/kernels/src/layout/int_tuple.mojo
+++ b/max/kernels/src/layout/int_tuple.mojo
@@ -63,8 +63,6 @@ from builtin.range import _StridedRange
 from memory import memcpy
 from memory.pointer import _GPUAddressSpace
 
-from utils.numerics import max_finite
-
 alias INT_TUPLE_VALIDATION = False
 
 
@@ -81,7 +79,7 @@ fn _get_index_type(address_space: AddressSpace) -> DType:
 
 fn _get_index_type(layout: Layout) -> DType:
     """Returns int32 if layout size fits in uint32 range, int64 otherwise."""
-    if layout.cosize() < Int(max_finite[DType.uint32]()):
+    if layout.cosize() < Int(DType.max_finite[DType.uint32]()):
         return DType.int32
 
     return DType.int64
@@ -99,7 +97,7 @@ fn _get_unsigned_type(layout: Layout, address_space: AddressSpace) -> DType:
     """Returns int32 if layout fits in int32 range or index type is int32, otherwise index.
     """
     if layout.all_dims_known() and layout.cosize() < Int(
-        max_finite[DType.int32]()
+        DType.max_finite[DType.int32]()
     ):
         return DType.int32
     else:
@@ -115,7 +113,7 @@ fn _get_layout_type(layout: Layout, address_space: AddressSpace) -> DType:
         var shape = layout.shape.flatten()
 
         for i in range(len(shape)):
-            if shape[i].value() > Int(max_finite[DType.int32]()):
+            if shape[i].value() > Int(DType.max_finite[DType.int32]()):
                 return DType.int64
 
         return DType.int32

--- a/max/kernels/src/linalg/fp8_quantization.mojo
+++ b/max/kernels/src/linalg/fp8_quantization.mojo
@@ -31,7 +31,6 @@ from linalg.utils_gpu import MatmulConfig
 from runtime.tracing import trace_arg
 from utils.numerics import get_accum_type
 from utils.index import IndexList
-from utils.numerics import max_finite, min_finite
 from .utils import elementwise_epilogue_type
 from gpu import global_idx
 from utils.index import Index
@@ -86,8 +85,8 @@ fn quantize_static_scaled_fp8[
 
             scaled_input_f32 = in_vec_f32[i] * inversed_scale
             in_vec_f32[i] = max(
-                Float32(min_finite[out_dtype]()),
-                min(Float32(max_finite[out_dtype]()), scaled_input_f32),
+                Float32(DType.min_finite[out_dtype]()),
+                min(Float32(DType.max_finite[out_dtype]()), scaled_input_f32),
             )
 
         var scaled_in_vec = in_vec_f32.cast[out_dtype]()

--- a/max/kernels/test/gpu/basics/test_cast_roundtrip.mojo
+++ b/max/kernels/test/gpu/basics/test_cast_roundtrip.mojo
@@ -15,7 +15,7 @@ from gpu import *
 from gpu.host import DeviceContext
 from testing import assert_equal, assert_true
 
-from utils.numerics import inf, nan, neg_inf, isnan
+from utils.numerics import isnan
 
 
 fn id(
@@ -40,9 +40,9 @@ fn run_vec_add(ctx: DeviceContext) raises:
     for i in range(length):
         in_host[i] = Float32(i)
 
-    in_host[4] = nan[DType.float32]()
-    in_host[5] = inf[DType.float32]()
-    in_host[6] = neg_inf[DType.float32]()
+    in_host[4] = DType.nan[DType.float32]()
+    in_host[5] = DType.inf[DType.float32]()
+    in_host[6] = DType.neg_inf[DType.float32]()
     in_host[7] = -0.0
 
     var in_device = ctx.enqueue_create_buffer[DType.float32](length)
@@ -66,9 +66,9 @@ fn run_vec_add(ctx: DeviceContext) raises:
         1.0,
         2.0,
         3.0,
-        nan[DType.float32](),
-        inf[DType.float32](),
-        neg_inf[DType.float32](),
+        DType.nan[DType.float32](),
+        DType.inf[DType.float32](),
+        DType.neg_inf[DType.float32](),
         -0.0,
         8.0,
         9.0,

--- a/max/kernels/test/gpu/numerics/test_e4m3fn_conversion.mojo
+++ b/max/kernels/test/gpu/numerics/test_e4m3fn_conversion.mojo
@@ -11,8 +11,6 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from math import nan
-
 from gpu.host import DeviceContext
 from memory import bitcast
 
@@ -181,7 +179,7 @@ fn test_e4m3fn_initialization():
         384.0,
         416.0,
         448.0,
-        nan[DType.float8_e4m3fn](),
+        DType.nan[DType.float8_e4m3fn](),
         -0.0,
         -0.001953125,
         -0.00390625,
@@ -309,7 +307,7 @@ fn test_e4m3fn_initialization():
         -384.0,
         -416.0,
         -448.0,
-        nan[DType.float8_e4m3fn](),
+        DType.nan[DType.float8_e4m3fn](),
     )
 
     for i in range(256):

--- a/max/kernels/test/gpu/numerics/test_e5m2_conversion.mojo
+++ b/max/kernels/test/gpu/numerics/test_e5m2_conversion.mojo
@@ -11,8 +11,6 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from math import inf, nan
-
 from gpu.host import DeviceContext
 from memory import bitcast
 
@@ -178,10 +176,10 @@ fn test_e5m2_initialization():
         40960.0,
         49152.0,
         57344.0,
-        inf[DType.float8_e5m2](),
-        nan[DType.float8_e5m2](),
-        nan[DType.float8_e5m2](),
-        nan[DType.float8_e5m2](),
+        DType.inf[DType.float8_e5m2](),
+        DType.nan[DType.float8_e5m2](),
+        DType.nan[DType.float8_e5m2](),
+        DType.nan[DType.float8_e5m2](),
         -0.0,
         -1.52587890625e-05,
         -3.0517578125e-05,
@@ -306,10 +304,10 @@ fn test_e5m2_initialization():
         -40960.0,
         -49152.0,
         -57344.0,
-        -inf[DType.float8_e5m2](),
-        nan[DType.float8_e5m2](),
-        nan[DType.float8_e5m2](),
-        nan[DType.float8_e5m2](),
+        -DType.inf[DType.float8_e5m2](),
+        DType.nan[DType.float8_e5m2](),
+        DType.nan[DType.float8_e5m2](),
+        DType.nan[DType.float8_e5m2](),
     )
 
     for i in range(256):

--- a/max/kernels/test/gpu/quantization/test_scaled_fp8_quantization.mojo
+++ b/max/kernels/test/gpu/quantization/test_scaled_fp8_quantization.mojo
@@ -21,8 +21,6 @@ from linalg.fp8_quantization import (
 )
 from testing import assert_equal
 
-from utils.numerics import max_finite, min_finite
-
 
 fn test_scaled_fp8_quant[
     out_dtype: DType,
@@ -65,8 +63,8 @@ fn test_scaled_fp8_quant[
             )
 
             in_val_scaled_f32 = max(
-                Float32(min_finite[out_dtype]()),
-                min(Float32(max_finite[out_dtype]()), in_val_scaled_f32),
+                Float32(DType.min_finite[out_dtype]()),
+                min(Float32(DType.max_finite[out_dtype]()), in_val_scaled_f32),
             )
 
             assert_equal(

--- a/mojo/docs/manual/types.mdx
+++ b/mojo/docs/manual/types.mdx
@@ -287,13 +287,11 @@ a variable with the type `SIMD[DType.float64, 1]` (or  `Float64`, which is the
 same thing).
 
 ```mojo
-from utils.numerics import max_finite, min_finite
-
 def describeDType[dtype: DType]():
     print(dtype, "is floating point:", dtype.is_floating_point())
     print(dtype, "is integral:", dtype.is_integral())
     print("Min/max finite values for", dtype)
-    print(min_finite[dtype](), max_finite[dtype]())
+    print(DType.min_finite[dtype](), DType.max_finite[dtype]())
 
 describeDType[DType.float32]()
 ```

--- a/mojo/stdlib/stdlib/benchmark/benchmark.mojo
+++ b/mojo/stdlib/stdlib/benchmark/benchmark.mojo
@@ -140,7 +140,6 @@ Note that the min total time will take precedence over max iterations
 
 from time import time_function
 
-from utils.numerics import max_finite, min_finite
 from testing import assert_equal
 
 
@@ -278,7 +277,7 @@ struct Report(Copyable, Defaultable, Movable):
         """
         if len(self.runs) == 0:
             return 0
-        var min = max_finite[DType.float64]()
+        var min = DType.max_finite[DType.float64]()
         for i in range(len(self.runs)):
             if self.runs[i]._is_significant and self.runs[i].mean(unit) < min:
                 min = self.runs[i].mean(unit)
@@ -296,7 +295,7 @@ struct Report(Copyable, Defaultable, Movable):
         """
         if len(self.runs) == 0:
             return 0
-        var result = min_finite[DType.float64]()
+        var result = DType.min_finite[DType.float64]()
         for i in range(len(self.runs)):
             if (
                 self.runs[i]._is_significant

--- a/mojo/stdlib/stdlib/builtin/dtype.mojo
+++ b/mojo/stdlib/stdlib/builtin/dtype.mojo
@@ -1044,6 +1044,256 @@ struct DType(
         """
         return Self.get_dtype[T]() is not DType.invalid
 
+    # ===------------------------------------------------------------------=== #
+    # nan
+    # ===------------------------------------------------------------------=== #
+
+    @staticmethod
+    @always_inline("nodebug")
+    fn nan[dtype: DType]() -> Scalar[dtype]:
+        """Gets a NaN value for the given dtype.
+
+        Constraints:
+            Can only be used for FP dtypes.
+
+        Parameters:
+            dtype: The value dtype.
+
+        Returns:
+            The NaN value of the given dtype.
+        """
+        constrained[
+            dtype.is_floating_point(),
+            "Only floating point dtypes support NaN.",
+        ]()
+
+        @parameter
+        if dtype is DType.float8_e4m3fn:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f8e4m3fn>`,
+            )
+        elif dtype is DType.float8_e4m3fnuz:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f8e4m3fnuz>`,
+            )
+        elif dtype is DType.float8_e5m2:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f8e5m2>`,
+            )
+        elif dtype is DType.float8_e5m2fnuz:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f8e5m2fnuz>`,
+            )
+        elif dtype is DType.bfloat16:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<bf16>`,
+            )
+        elif dtype is DType.float16:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f16>`,
+            )
+        elif dtype is DType.float32:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f32>`,
+            )
+        elif dtype is DType.float64:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f64>`,
+            )
+        else:
+            constrained[False, "unsupported float type"]()
+            return {}
+
+    # ===------------------------------------------------------------------=== #
+    # inf
+    # ===------------------------------------------------------------------=== #
+
+    @staticmethod
+    @always_inline("nodebug")
+    fn inf[dtype: DType]() -> Scalar[dtype]:
+        """Gets a +inf value for the given dtype.
+
+        Constraints:
+            Can only be used for FP dtypes.
+
+        Parameters:
+            dtype: The value dtype.
+
+        Returns:
+            The +inf value of the given dtype.
+        """
+        constrained[
+            dtype.is_floating_point(),
+            "Only floating point dtypes support +inf.",
+        ]()
+
+        @parameter
+        if dtype is DType.float8_e4m3fnuz:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<f8e4m3fnuz>`,
+            )
+        elif dtype is DType.float8_e5m2:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<f8e5m2>`,
+            )
+        elif dtype is DType.float8_e5m2fnuz:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<f8e5m2fnuz>`,
+            )
+        elif dtype is DType.bfloat16:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<bf16>`,
+            )
+        elif dtype is DType.float16:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<f16>`,
+            )
+        elif dtype is DType.float32:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<f32>`,
+            )
+        elif dtype is DType.float64:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<f64>`,
+            )
+        else:
+            constrained[False, "unsupported float type"]()
+            return {}
+
+    # ===------------------------------------------------------------------=== #
+    # neg_inf
+    # ===------------------------------------------------------------------=== #
+
+    @staticmethod
+    @always_inline("nodebug")
+    fn neg_inf[dtype: DType]() -> Scalar[dtype]:
+        """Gets a -inf value for the given dtype.
+
+        Constraints:
+            Can only be used for FP dtypes.
+
+        Parameters:
+            dtype: The value dtype.
+
+        Returns:
+            The -inf value of the given dtype.
+        """
+        constrained[
+            dtype.is_floating_point(),
+            "Only floating point dtypes support -inf.",
+        ]()
+
+        @parameter
+        if dtype is DType.float8_e4m3fn:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f8e4m3fn>`,
+            )
+        elif dtype is DType.float8_e4m3fnuz:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f8e4m3fnuz>`,
+            )
+        elif dtype is DType.float8_e5m2:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f8e5m2>`,
+            )
+        elif dtype is DType.float8_e5m2fnuz:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f8e5m2fnuz>`,
+            )
+        elif dtype is DType.bfloat16:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<bf16>`,
+            )
+        elif dtype is DType.float16:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f16>`,
+            )
+        elif dtype is DType.float32:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f32>`,
+            )
+        elif dtype is DType.float64:
+            return rebind[Scalar[dtype]](
+                __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f64>`,
+            )
+        else:
+            constrained[False, "unsupported float type"]()
+            return {}
+
+    # ===------------------------------------------------------------------=== #
+    # max_finite
+    # ===------------------------------------------------------------------=== #
+
+    @staticmethod
+    @always_inline("nodebug")
+    fn max_finite[dtype: DType]() -> Scalar[dtype]:
+        """Returns the maximum finite value of type.
+
+        Parameters:
+            dtype: The value dtype.
+
+        Returns:
+            The maximum representable value of the type. Does not include
+            infinity for floating-point types.
+        """
+
+        @parameter
+        if dtype.is_unsigned():
+            return ~Scalar[dtype](0)
+        elif dtype.is_integral():
+            return Scalar[dtype](
+                ~Scalar[_unsigned_integral_type_of[dtype]()](0) >> 1
+            )
+        elif dtype is DType.float8_e4m3fn:
+            return 448
+        elif dtype is DType.float8_e4m3fnuz:
+            return 240
+        elif dtype in (DType.float8_e5m2, DType.float8_e5m2fnuz):
+            return 57344
+        elif dtype is DType.float16:
+            return 65504
+        elif dtype is DType.bfloat16:
+            return 3.38953139e38
+        elif dtype is DType.float32:
+            return 3.40282346638528859812e38
+        elif dtype is DType.float64:
+            return 1.79769313486231570815e308
+        elif dtype is DType.bool:
+            return Scalar(True)._refine[dtype]()
+        else:
+            constrained[False, "max_finite() called on unsupported dtype"]()
+            return {}
+
+    # ===------------------------------------------------------------------=== #
+    # min_finite
+    # ===------------------------------------------------------------------=== #
+
+    @staticmethod
+    @always_inline("nodebug")
+    fn min_finite[dtype: DType]() -> Scalar[dtype]:
+        """Returns the minimum (lowest) finite value of type.
+
+        Parameters:
+            dtype: The value dtype.
+
+        Returns:
+            The minimum representable value of the type. Does not include negative
+            infinity for floating-point types.
+        """
+
+        @parameter
+        if dtype.is_unsigned():
+            return 0
+        elif dtype.is_integral():
+            return -DType.max_finite[dtype]() - 1
+        elif dtype.is_floating_point():
+            return -DType.max_finite[dtype]()
+        elif dtype is DType.bool:
+            return Scalar(False)._refine[dtype]()
+        else:
+            constrained[False, "min_finite() called on unsupported dtype"]()
+            return {}
+
 
 # ===-------------------------------------------------------------------===#
 # integral_type_of

--- a/mojo/stdlib/stdlib/builtin/simd.mojo
+++ b/mojo/stdlib/stdlib/builtin/simd.mojo
@@ -81,14 +81,10 @@ from python import ConvertibleToPython, PythonObject, Python
 from utils import IndexList, StaticTuple
 from utils._visualizers import lldb_formatter_wrapping_type
 from utils.numerics import FPUtils
-from utils.numerics import inf as _inf
 from utils.numerics import isinf as _isinf
 from utils.numerics import isnan as _isnan
-from utils.numerics import max_finite as _max_finite
 from utils.numerics import max_or_inf as _max_or_inf
-from utils.numerics import min_finite as _min_finite
 from utils.numerics import min_or_neg_inf as _min_or_neg_inf
-from utils.numerics import nan as _nan
 
 from .dtype import (
     _integral_type_of,
@@ -410,10 +406,10 @@ struct SIMD[dtype: DType, size: Int](
     alias MIN = Self(_min_or_neg_inf[dtype]())
     """Gets the minimum value for the SIMD value, potentially -inf."""
 
-    alias MAX_FINITE = Self(_max_finite[dtype]())
+    alias MAX_FINITE = Self(DType.max_finite[dtype]())
     """Returns the maximum finite value of SIMD value."""
 
-    alias MIN_FINITE = Self(_min_finite[dtype]())
+    alias MIN_FINITE = Self(DType.min_finite[dtype]())
     """Returns the minimum (lowest) finite value of SIMD value."""
 
     alias _Mask = SIMD[DType.bool, size]
@@ -3304,7 +3300,7 @@ fn _powf_scalar(base: Scalar, exponent: Scalar) -> __type_of(base):
         return _powi(base, integral.cast[DType.int32]())
 
     if fractional and base < 0:
-        return _nan[base.dtype]()
+        return DType.nan[base.dtype]()
 
     return math.exp(exponent.cast[base.dtype]() * math.log(base))
 
@@ -3400,19 +3396,19 @@ fn _convert_float8_to_f32_scalar[
         @parameter
         if dtype is DType.float8_e4m3fn:
             if exp_mantissa == 0x7F:
-                result = _nan[result_dtype]()
+                result = DType.nan[result_dtype]()
         else:
             if exp_mantissa == 0x7C:
-                result = _inf[result_dtype]()
+                result = DType.inf[result_dtype]()
             elif exp_mantissa > 0x7C:
-                result = _nan[result_dtype]()
+                result = DType.nan[result_dtype]()
 
     result = FPUtils.set_sign(result, FPUtils.get_sign(x))
 
     @parameter
     if dtype in (DType.float8_e4m3fnuz, DType.float8_e5m2fnuz):
         if x_bits == 0x80:
-            result = _nan[result_dtype]()
+            result = DType.nan[result_dtype]()
 
     return result
 
@@ -3568,7 +3564,7 @@ fn _convert_f32_to_float8_scalar[
 
     var sticky_bit: Int32 = 0
 
-    if abs(x) >= Scalar[dtype](_max_finite[target]()):
+    if abs(x) >= Scalar[dtype](DType.max_finite[target]()):
         # satfinite
         return bitcast[target](sign | FP8_MAX_FLT)
     elif exp >= FP8_MIN_EXPONENT:
@@ -3759,7 +3755,7 @@ fn _f32_to_bfloat16[
     var bf16 = SIMD[DType.bfloat16, width](
         from_bits=bf16_bits.cast[DType.uint16]()
     )
-    return _isnan(f32).select(_nan[DType.bfloat16](), bf16)
+    return _isnan(f32).select(DType.nan[DType.bfloat16](), bf16)
 
 
 # ===----------------------------------------------------------------------=== #

--- a/mojo/stdlib/stdlib/math/__init__.mojo
+++ b/mojo/stdlib/stdlib/math/__init__.mojo
@@ -13,7 +13,7 @@
 """Implements the math package."""
 
 # In Python, these are in the math module, so we also expose them here.
-from utils.numerics import inf, isfinite, isinf, isnan, nan, nextafter
+from utils.numerics import isfinite, isinf, isnan, nextafter
 
 from .constants import e, pi, tau
 

--- a/mojo/stdlib/stdlib/math/math.mojo
+++ b/mojo/stdlib/stdlib/math/math.mojo
@@ -40,7 +40,7 @@ from builtin.dtype import _integral_type_of
 from builtin.simd import _modf, _simd_apply
 from memory import Span
 
-from utils.numerics import FPUtils, isnan, nan
+from utils.numerics import FPUtils, isnan
 from utils.static_tuple import StaticTuple
 
 from .constants import log2e
@@ -804,7 +804,9 @@ fn _log_base[
         y = exp.fma(ln2, y)
     else:
         y = y.fma(log2e, exp)
-    return x.eq(0).select(Scalar[dtype].MIN, x.gt(0).select(y, nan[dtype]()))
+    return x.eq(0).select(
+        Scalar[dtype].MIN, x.gt(0).select(y, DType.nan[dtype]())
+    )
 
 
 @always_inline
@@ -1657,9 +1659,9 @@ fn _atanh_float32(x: SIMD) -> __type_of(x):
     """This computes the `atanh` of the inputs for float32. It uses the same
     approximation used by Eigen library."""
 
-    alias nan_val = nan[x.dtype]()
-    alias inf_val = inf[x.dtype]()
-    alias neg_inf_val = -inf[x.dtype]()
+    alias nan_val = DType.nan[x.dtype]()
+    alias inf_val = DType.inf[x.dtype]()
+    alias neg_inf_val = -DType.inf[x.dtype]()
 
     var is_neg = x.lt(0)
     var x_abs = abs(x)
@@ -2508,7 +2510,7 @@ fn ulp[
     var nan_mask = isnan(x)
     var xabs = abs(x)
     var inf_mask = isinf(xabs)
-    alias inf_val = SIMD[dtype, width](inf[dtype]())
+    alias inf_val = SIMD[dtype, width](DType.inf[dtype]())
     var x2 = nextafter(xabs, inf_val)
     var x2_inf_mask = isinf(x2)
 

--- a/mojo/stdlib/stdlib/utils/numerics.mojo
+++ b/mojo/stdlib/stdlib/utils/numerics.mojo
@@ -459,67 +459,6 @@ struct FlushDenormals(Defaultable):
 
 
 # ===----------------------------------------------------------------------=== #
-# nan
-# ===----------------------------------------------------------------------=== #
-
-
-@always_inline("nodebug")
-fn nan[dtype: DType]() -> Scalar[dtype]:
-    """Gets a NaN value for the given dtype.
-
-    Constraints:
-        Can only be used for FP dtypes.
-
-    Parameters:
-        dtype: The value dtype.
-
-    Returns:
-        The NaN value of the given dtype.
-    """
-    constrained[
-        dtype.is_floating_point(),
-        "Only floating point dtypes support NaN.",
-    ]()
-
-    @parameter
-    if dtype is DType.float8_e4m3fn:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f8e4m3fn>`,
-        )
-    elif dtype is DType.float8_e4m3fnuz:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f8e4m3fnuz>`,
-        )
-    elif dtype is DType.float8_e5m2:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f8e5m2>`,
-        )
-    elif dtype is DType.float8_e5m2fnuz:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f8e5m2fnuz>`,
-        )
-    elif dtype is DType.bfloat16:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<bf16>`,
-        )
-    elif dtype is DType.float16:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f16>`,
-        )
-    elif dtype is DType.float32:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f32>`,
-        )
-    elif dtype is DType.float64:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f64>`,
-        )
-    else:
-        constrained[False, "unsupported float type"]()
-        return {}
-
-
-# ===----------------------------------------------------------------------=== #
 # isnan
 # ===----------------------------------------------------------------------=== #
 
@@ -567,200 +506,6 @@ fn isnan[
 
 
 # ===----------------------------------------------------------------------=== #
-# inf
-# ===----------------------------------------------------------------------=== #
-
-
-@always_inline("nodebug")
-fn inf[dtype: DType]() -> Scalar[dtype]:
-    """Gets a +inf value for the given dtype.
-
-    Constraints:
-        Can only be used for FP dtypes.
-
-    Parameters:
-        dtype: The value dtype.
-
-    Returns:
-        The +inf value of the given dtype.
-    """
-    constrained[
-        dtype.is_floating_point(),
-        "Only floating point dtypes support +inf.",
-    ]()
-
-    @parameter
-    if dtype is DType.float8_e4m3fnuz:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<f8e4m3fnuz>`,
-        )
-    elif dtype is DType.float8_e5m2:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<f8e5m2>`,
-        )
-    elif dtype is DType.float8_e5m2fnuz:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<f8e5m2fnuz>`,
-        )
-    elif dtype is DType.bfloat16:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<bf16>`,
-        )
-    elif dtype is DType.float16:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<f16>`,
-        )
-    elif dtype is DType.float32:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<f32>`,
-        )
-    elif dtype is DType.float64:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<f64>`,
-        )
-    else:
-        constrained[False, "unsupported float type"]()
-        return {}
-
-
-# ===----------------------------------------------------------------------=== #
-# neg_inf
-# ===----------------------------------------------------------------------=== #
-
-
-@always_inline("nodebug")
-fn neg_inf[dtype: DType]() -> Scalar[dtype]:
-    """Gets a -inf value for the given dtype.
-
-    Constraints:
-        Can only be used for FP dtypes.
-
-    Parameters:
-        dtype: The value dtype.
-
-    Returns:
-        The -inf value of the given dtype.
-    """
-    constrained[
-        dtype.is_floating_point(),
-        "Only floating point dtypes support -inf.",
-    ]()
-
-    @parameter
-    if dtype is DType.float8_e4m3fn:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f8e4m3fn>`,
-        )
-    elif dtype is DType.float8_e4m3fnuz:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f8e4m3fnuz>`,
-        )
-    elif dtype is DType.float8_e5m2:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f8e5m2>`,
-        )
-    elif dtype is DType.float8_e5m2fnuz:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f8e5m2fnuz>`,
-        )
-    elif dtype is DType.bfloat16:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<bf16>`,
-        )
-    elif dtype is DType.float16:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f16>`,
-        )
-    elif dtype is DType.float32:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f32>`,
-        )
-    elif dtype is DType.float64:
-        return rebind[Scalar[dtype]](
-            __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f64>`,
-        )
-    else:
-        constrained[False, "unsupported float type"]()
-        return {}
-
-
-# ===----------------------------------------------------------------------=== #
-# max_finite
-# ===----------------------------------------------------------------------=== #
-
-
-@always_inline("nodebug")
-fn max_finite[dtype: DType]() -> Scalar[dtype]:
-    """Returns the maximum finite value of type.
-
-    Parameters:
-        dtype: The value dtype.
-
-    Returns:
-        The maximum representable value of the type. Does not include infinity
-        for floating-point types.
-    """
-
-    @parameter
-    if dtype.is_unsigned():
-        return ~Scalar[dtype](0)
-    elif dtype.is_integral():
-        return Scalar[dtype](
-            ~Scalar[_unsigned_integral_type_of[dtype]()](0) >> 1
-        )
-    elif dtype is DType.float8_e4m3fn:
-        return 448
-    elif dtype is DType.float8_e4m3fnuz:
-        return 240
-    elif dtype in (DType.float8_e5m2, DType.float8_e5m2fnuz):
-        return 57344
-    elif dtype is DType.float16:
-        return 65504
-    elif dtype is DType.bfloat16:
-        return 3.38953139e38
-    elif dtype is DType.float32:
-        return 3.40282346638528859812e38
-    elif dtype is DType.float64:
-        return 1.79769313486231570815e308
-    elif dtype is DType.bool:
-        return Scalar(True)._refine[dtype]()
-    else:
-        constrained[False, "max_finite() called on unsupported dtype"]()
-        return {}
-
-
-# ===----------------------------------------------------------------------=== #
-# min_finite
-# ===----------------------------------------------------------------------=== #
-
-
-@always_inline
-fn min_finite[dtype: DType]() -> Scalar[dtype]:
-    """Returns the minimum (lowest) finite value of type.
-
-    Parameters:
-        dtype: The value dtype.
-
-    Returns:
-        The minimum representable value of the type. Does not include negative
-        infinity for floating-point types.
-    """
-
-    @parameter
-    if dtype.is_unsigned():
-        return 0
-    elif dtype.is_integral():
-        return -max_finite[dtype]() - 1
-    elif dtype.is_floating_point():
-        return -max_finite[dtype]()
-    elif dtype is DType.bool:
-        return Scalar(False)._refine[dtype]()
-    else:
-        constrained[False, "min_finite() called on unsupported dtype"]()
-        return {}
-
-
-# ===----------------------------------------------------------------------=== #
 # max_or_inf
 # ===----------------------------------------------------------------------=== #
 
@@ -780,9 +525,9 @@ fn max_or_inf[dtype: DType]() -> Scalar[dtype]:
     @parameter
     if dtype.is_floating_point():
         # TODO: some floating point types don't support inf
-        return inf[dtype]()
+        return DType.inf[dtype]()
     else:
-        return max_finite[dtype]()
+        return DType.max_finite[dtype]()
 
 
 # ===----------------------------------------------------------------------=== #
@@ -805,9 +550,9 @@ fn min_or_neg_inf[dtype: DType]() -> Scalar[dtype]:
     @parameter
     if dtype.is_floating_point():
         # TODO: some floating point types don't support inf
-        return neg_inf[dtype]()
+        return DType.neg_inf[dtype]()
     else:
-        return min_finite[dtype]()
+        return DType.min_finite[dtype]()
 
 
 # ===----------------------------------------------------------------------=== #

--- a/mojo/stdlib/test/builtin/test_simd.mojo
+++ b/mojo/stdlib/test/builtin/test_simd.mojo
@@ -24,7 +24,7 @@ from testing import (
 )
 
 from utils import StaticTuple
-from utils.numerics import isfinite, isinf, isnan, nan
+from utils.numerics import isfinite, isinf, isnan
 
 
 def test_cast():
@@ -315,7 +315,7 @@ def test_simd_repr():
     assert_equal(Float16(324).__repr__(), "SIMD[DType.float16, 1](324.0)")
     assert_equal(
         SIMD[DType.float32, 4](
-            Float32.MAX, Float32.MIN, -0.0, nan[DType.float32]()
+            Float32.MAX, Float32.MIN, -0.0, DType.nan[DType.float32]()
         ).__repr__(),
         "SIMD[DType.float32, 4](inf, -inf, -0.0, nan)",
     )

--- a/mojo/stdlib/test/collections/string/test_atof.mojo
+++ b/mojo/stdlib/test/collections/string/test_atof.mojo
@@ -11,7 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from math import inf, isinf, isnan
+from math import isinf, isnan
 
 from testing import assert_equal, assert_raises, assert_true
 
@@ -60,7 +60,7 @@ def test_trailing_f():
 
 def test_large_exponents():
     """Test handling of large exponents."""
-    assert_equal(atof("1e309"), inf[DType.float64]())
+    assert_equal(atof("1e309"), DType.inf[DType.float64]())
     assert_equal(atof("1e-309"), 1e-309)
 
 

--- a/mojo/stdlib/test/math/test_math.mojo
+++ b/mojo/stdlib/test/math/test_math.mojo
@@ -41,7 +41,7 @@ from sys import CompilationTarget
 
 from testing import assert_almost_equal, assert_equal, assert_false, assert_true
 
-from utils.numerics import inf, isinf, isnan, nan, neg_inf
+from utils.numerics import isinf, isnan
 
 
 fn test_sin() raises:
@@ -73,10 +73,13 @@ def test_copysign():
 
     assert_equal(Float32(1.0), copysign(Float32(1.0), Float32(2.0)))
     assert_equal(Float32(-1.0), copysign(Float32(1.0), Float32(-2.0)))
-    assert_equal(neg_inf[DType.float32](), copysign(inf[DType.float32](), -2.0))
     assert_equal(
-        String(-nan[DType.float32]()),
-        String(copysign(nan[DType.float32](), -2.0)),
+        DType.neg_inf[DType.float32](),
+        copysign(DType.inf[DType.float32](), -2.0),
+    )
+    assert_equal(
+        String(-DType.nan[DType.float32]()),
+        String(copysign(DType.nan[DType.float32](), -2.0)),
     )
 
     # Test some cases with 0 and signed zero
@@ -95,8 +98,8 @@ fn test_isclose_numerics[*, symm: Bool]() raises:
     alias atol = 1e-8
     alias rtol = 1e-5
 
-    alias inf_ = inf[dtype]()
-    alias nan_ = nan[dtype]()
+    alias inf_ = DType.inf[dtype]()
+    alias nan_ = DType.nan[dtype]()
     alias v = T(0.1, 0.2)
 
     fn edge_val[symm: Bool](a: T, atol: T, rtol: T) -> T:
@@ -163,7 +166,7 @@ def test_isclose():
     alias dtype = DType.float32
     alias S = Scalar[dtype]
     alias T = SIMD[dtype, 4]
-    alias nan_ = nan[dtype]()
+    alias nan_ = DType.nan[dtype]()
 
     assert_true(isclose(S(2), S(2)))
     assert_true(isclose(S(2), S(2), rtol=1e-9))
@@ -536,9 +539,9 @@ def test_lcm():
 
 
 def test_ulp():
-    assert_true(isnan(ulp(nan[DType.float32]())))
-    assert_true(isinf(ulp(inf[DType.float32]())))
-    assert_true(isinf(ulp(-inf[DType.float32]())))
+    assert_true(isnan(ulp(DType.nan[DType.float32]())))
+    assert_true(isinf(ulp(DType.inf[DType.float32]())))
+    assert_true(isinf(ulp(-DType.inf[DType.float32]())))
     assert_almost_equal(ulp(Float64(0)), 5e-324)
     assert_equal(ulp(Float64.MAX_FINITE), 1.99584030953472e292)
     assert_equal(ulp(Float64(5)), 8.881784197001252e-16)
@@ -611,8 +614,8 @@ def test_clamp():
 
 
 def test_atanh():
-    assert_equal(atanh(Float32(1)), inf[DType.float32]())
-    assert_equal(atanh(Float32(-1)), -inf[DType.float32]())
+    assert_equal(atanh(Float32(1)), DType.inf[DType.float32]())
+    assert_equal(atanh(Float32(-1)), -DType.inf[DType.float32]())
     assert_true(isnan(atanh(Float32(2))))
     assert_true(isnan(atanh(Float32(-2))))
     assert_almost_equal(

--- a/mojo/stdlib/test/memory/test_memory.mojo
+++ b/mojo/stdlib/test/memory/test_memory.mojo
@@ -27,7 +27,6 @@ from testing import (
     assert_true,
 )
 
-from utils.numerics import nan
 
 alias void = __mlir_attr.`#kgen.dtype.constant<invalid> : !kgen.dtype`
 alias int8_pop = __mlir_type.`!pop.scalar<si8>`
@@ -209,8 +208,8 @@ def test_memcmp_extensive[
             ptr2[i] = i + 1
             dptr2[i] = i + 1
         elif extermes == "nan":
-            ptr2[i] = nan[dtype]()
-            dptr2[i] = nan[dtype]()
+            ptr2[i] = DType.nan[dtype]()
+            dptr2[i] = DType.nan[dtype]()
         elif extermes == "inf":
             ptr2[i] = Scalar[dtype].MAX
             dptr2[i] = Scalar[dtype].MAX

--- a/mojo/stdlib/test/testing/test_assertion.mojo
+++ b/mojo/stdlib/test/testing/test_assertion.mojo
@@ -22,8 +22,6 @@ from testing import (
     assert_true,
 )
 
-from utils.numerics import inf, nan
-
 
 def test_assert_messages():
     assertion = "test_assertion.mojo:"
@@ -107,8 +105,8 @@ def test_assert_not_equal_with_list():
 
 def test_assert_almost_equal():
     alias float_type = DType.float32
-    alias _inf = inf[float_type]()
-    alias _nan = nan[float_type]()
+    alias _inf = DType.inf[float_type]()
+    alias _nan = DType.nan[float_type]()
 
     @parameter
     def _should_succeed[

--- a/mojo/stdlib/test/utils/test_numerics.mojo
+++ b/mojo/stdlib/test/utils/test_numerics.mojo
@@ -18,16 +18,11 @@ from testing import assert_almost_equal, assert_equal, assert_false, assert_true
 from utils.numerics import (
     FPUtils,
     get_accum_type,
-    inf,
     isfinite,
     isinf,
     isnan,
-    max_finite,
     max_or_inf,
-    min_finite,
     min_or_neg_inf,
-    nan,
-    neg_inf,
     nextafter,
 )
 
@@ -80,19 +75,19 @@ def test_isfinite():
     # TODO(KERN-228): support BF16 on neon systems.
     @parameter
     if not CompilationTarget.has_neon():
-        assert_false(isfinite(inf[DType.bfloat16]()))
-        assert_false(isfinite(neg_inf[DType.bfloat16]()))
-        assert_false(isfinite(nan[DType.bfloat16]()))
+        assert_false(isfinite(DType.inf[DType.bfloat16]()))
+        assert_false(isfinite(DType.neg_inf[DType.bfloat16]()))
+        assert_false(isfinite(DType.nan[DType.bfloat16]()))
 
-    assert_false(isfinite(inf[DType.float16]()))
-    assert_false(isfinite(inf[DType.float32]()))
-    assert_false(isfinite(inf[DType.float64]()))
-    assert_false(isfinite(neg_inf[DType.float16]()))
-    assert_false(isfinite(neg_inf[DType.float32]()))
-    assert_false(isfinite(neg_inf[DType.float64]()))
-    assert_false(isfinite(nan[DType.float16]()))
-    assert_false(isfinite(nan[DType.float32]()))
-    assert_false(isfinite(nan[DType.float64]()))
+    assert_false(isfinite(DType.inf[DType.float16]()))
+    assert_false(isfinite(DType.inf[DType.float32]()))
+    assert_false(isfinite(DType.inf[DType.float64]()))
+    assert_false(isfinite(DType.neg_inf[DType.float16]()))
+    assert_false(isfinite(DType.neg_inf[DType.float32]()))
+    assert_false(isfinite(DType.neg_inf[DType.float64]()))
+    assert_false(isfinite(DType.nan[DType.float16]()))
+    assert_false(isfinite(DType.nan[DType.float32]()))
+    assert_false(isfinite(DType.nan[DType.float64]()))
 
 
 def test_isinf():
@@ -101,19 +96,19 @@ def test_isinf():
     # TODO(KERN-228): support BF16 on neon systems.
     @parameter
     if not CompilationTarget.has_neon():
-        assert_true(isinf(inf[DType.bfloat16]()))
-        assert_true(isinf(neg_inf[DType.bfloat16]()))
-        assert_false(isinf(nan[DType.bfloat16]()))
+        assert_true(isinf(DType.inf[DType.bfloat16]()))
+        assert_true(isinf(DType.neg_inf[DType.bfloat16]()))
+        assert_false(isinf(DType.nan[DType.bfloat16]()))
 
-    assert_true(isinf(inf[DType.float16]()))
-    assert_true(isinf(inf[DType.float32]()))
-    assert_true(isinf(inf[DType.float64]()))
-    assert_true(isinf(neg_inf[DType.float16]()))
-    assert_true(isinf(neg_inf[DType.float32]()))
-    assert_true(isinf(neg_inf[DType.float64]()))
-    assert_false(isinf(nan[DType.float16]()))
-    assert_false(isinf(nan[DType.float32]()))
-    assert_false(isinf(nan[DType.float64]()))
+    assert_true(isinf(DType.inf[DType.float16]()))
+    assert_true(isinf(DType.inf[DType.float32]()))
+    assert_true(isinf(DType.inf[DType.float64]()))
+    assert_true(isinf(DType.neg_inf[DType.float16]()))
+    assert_true(isinf(DType.neg_inf[DType.float32]()))
+    assert_true(isinf(DType.neg_inf[DType.float64]()))
+    assert_false(isinf(DType.nan[DType.float16]()))
+    assert_false(isinf(DType.nan[DType.float32]()))
+    assert_false(isinf(DType.nan[DType.float64]()))
 
 
 def test_isnan():
@@ -122,26 +117,26 @@ def test_isnan():
     # TODO(KERN-228): support BF16 on neon systems.
     @parameter
     if not CompilationTarget.has_neon():
-        assert_false(isnan(inf[DType.bfloat16]()))
-        assert_false(isnan(neg_inf[DType.bfloat16]()))
-        assert_true(isnan(nan[DType.bfloat16]()))
+        assert_false(isnan(DType.inf[DType.bfloat16]()))
+        assert_false(isnan(DType.neg_inf[DType.bfloat16]()))
+        assert_true(isnan(DType.nan[DType.bfloat16]()))
 
-    assert_false(isnan(inf[DType.float16]()))
-    assert_false(isnan(inf[DType.float32]()))
-    assert_false(isnan(inf[DType.float64]()))
-    assert_false(isnan(neg_inf[DType.float16]()))
-    assert_false(isnan(neg_inf[DType.float32]()))
-    assert_false(isnan(neg_inf[DType.float64]()))
-    assert_true(isnan(nan[DType.float16]()))
-    assert_true(isnan(nan[DType.float32]()))
-    assert_true(isnan(nan[DType.float64]()))
+    assert_false(isnan(DType.inf[DType.float16]()))
+    assert_false(isnan(DType.inf[DType.float32]()))
+    assert_false(isnan(DType.inf[DType.float64]()))
+    assert_false(isnan(DType.neg_inf[DType.float16]()))
+    assert_false(isnan(DType.neg_inf[DType.float32]()))
+    assert_false(isnan(DType.neg_inf[DType.float64]()))
+    assert_true(isnan(DType.nan[DType.float16]()))
+    assert_true(isnan(DType.nan[DType.float32]()))
+    assert_true(isnan(DType.nan[DType.float64]()))
 
 
 fn overflow_int[dtype: DType]() -> Bool:
     constrained[
         dtype.is_integral(), "comparison only valid on integral types"
     ]()
-    return max_finite[dtype]() + 1 < max_finite[dtype]()
+    return DType.max_finite[dtype]() + 1 < DType.max_finite[dtype]()
 
 
 fn overflow_fp[dtype: DType]() -> Bool:
@@ -149,14 +144,16 @@ fn overflow_fp[dtype: DType]() -> Bool:
         dtype.is_floating_point(),
         "comparison only valid on floating point types",
     ]()
-    return max_finite[dtype]() + 1 == max_finite[dtype]()
+    return DType.max_finite[dtype]() + 1 == DType.max_finite[dtype]()
 
 
 def test_max_finite():
-    assert_almost_equal(max_finite[DType.float32](), 3.4028235e38)
-    assert_almost_equal(max_finite[DType.float64](), 1.7976931348623157e308)
+    assert_almost_equal(DType.max_finite[DType.float32](), 3.4028235e38)
+    assert_almost_equal(
+        DType.max_finite[DType.float64](), 1.7976931348623157e308
+    )
 
-    assert_true(max_finite[DType.bool]())
+    assert_true(DType.max_finite[DType.bool]())
 
     assert_true(overflow_int[DType.int8]())
     assert_true(overflow_int[DType.uint8]())
@@ -171,42 +168,42 @@ def test_max_finite():
     assert_true(overflow_fp[DType.float32]())
     assert_true(overflow_fp[DType.float64]())
 
-    assert_equal(max_finite[DType.int8](), 127)
-    assert_equal(max_finite[DType.uint8](), 255)
-    assert_equal(max_finite[DType.int16](), 32767)
-    assert_equal(max_finite[DType.uint16](), 65535)
-    assert_equal(max_finite[DType.int32](), 2147483647)
-    assert_equal(max_finite[DType.uint32](), 4294967295)
-    assert_equal(max_finite[DType.int64](), 9223372036854775807)
-    assert_equal(max_finite[DType.uint64](), 18446744073709551615)
+    assert_equal(DType.max_finite[DType.int8](), 127)
+    assert_equal(DType.max_finite[DType.uint8](), 255)
+    assert_equal(DType.max_finite[DType.int16](), 32767)
+    assert_equal(DType.max_finite[DType.uint16](), 65535)
+    assert_equal(DType.max_finite[DType.int32](), 2147483647)
+    assert_equal(DType.max_finite[DType.uint32](), 4294967295)
+    assert_equal(DType.max_finite[DType.int64](), 9223372036854775807)
+    assert_equal(DType.max_finite[DType.uint64](), 18446744073709551615)
     # FIXME(#5214): uncomment once it is closed
     # assert_equal(
-    #     max_finite[DType.int128](), 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
+    #     DType.max_finite[DType.int128](), 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
     # )
     # assert_equal(
-    #     max_finite[DType.uint128](), 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
+    #     DType.max_finite[DType.uint128](), 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
     # )
     # assert_equal(
-    #     max_finite[DType.int256](),
+    #     DType.max_finite[DType.int256](),
     #     0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF,
     # )
     # assert_equal(
-    #     max_finite[DType.uint256](),
+    #     DType.max_finite[DType.uint256](),
     #     0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF,
     # )
 
     @parameter
     if is_64bit():
-        assert_equal(max_finite[DType.index](), 9223372036854775807)
+        assert_equal(DType.max_finite[DType.index](), 9223372036854775807)
     else:
-        assert_equal(max_finite[DType.index](), 2147483647)
+        assert_equal(DType.max_finite[DType.index](), 2147483647)
 
 
 fn underflow_int[dtype: DType]() -> Bool:
     constrained[
         dtype.is_integral(), "comparison only valid on integral types"
     ]()
-    return min_finite[dtype]() - 1 > min_finite[dtype]()
+    return DType.min_finite[dtype]() - 1 > DType.min_finite[dtype]()
 
 
 fn underflow_fp[dtype: DType]() -> Bool:
@@ -214,14 +211,16 @@ fn underflow_fp[dtype: DType]() -> Bool:
         dtype.is_floating_point(),
         "comparison only valid on floating point types",
     ]()
-    return min_finite[dtype]() - 1 == min_finite[dtype]()
+    return DType.min_finite[dtype]() - 1 == DType.min_finite[dtype]()
 
 
 def test_min_finite():
-    assert_almost_equal(min_finite[DType.float32](), -3.4028235e38)
-    assert_almost_equal(min_finite[DType.float64](), -1.7976931348623157e308)
+    assert_almost_equal(DType.min_finite[DType.float32](), -3.4028235e38)
+    assert_almost_equal(
+        DType.min_finite[DType.float64](), -1.7976931348623157e308
+    )
 
-    assert_false(min_finite[DType.bool]())
+    assert_false(DType.min_finite[DType.bool]())
 
     assert_true(underflow_int[DType.int8]())
     assert_true(underflow_int[DType.uint8]())
@@ -236,57 +235,66 @@ def test_min_finite():
     assert_true(underflow_fp[DType.float32]())
     assert_true(underflow_fp[DType.float64]())
 
-    assert_equal(min_finite[DType.int8](), -128)
-    assert_equal(min_finite[DType.int16](), -32768)
-    assert_equal(min_finite[DType.int32](), -2147483648)
-    assert_equal(min_finite[DType.int64](), -9223372036854775808)
+    assert_equal(DType.min_finite[DType.int8](), -128)
+    assert_equal(DType.min_finite[DType.int16](), -32768)
+    assert_equal(DType.min_finite[DType.int32](), -2147483648)
+    assert_equal(DType.min_finite[DType.int64](), -9223372036854775808)
     # FIXME(#5214): uncomment once it is closed
     # assert_equal(
-    #     min_finite[DType.int128](), -0x8000_0000_0000_0000_0000_0000_0000_0000
+    #     DType.min_finite[DType.int128](),
+    #     -0x8000_0000_0000_0000_0000_0000_0000_0000,
     # )
     # assert_equal(
-    #     min_finite[DType.int256](),
+    #     DType.min_finite[DType.int256](),
     #     -0x8000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000,
     # )
 
     @parameter
     if is_64bit():
-        assert_equal(min_finite[DType.index](), -9223372036854775808)
+        assert_equal(DType.min_finite[DType.index](), -9223372036854775808)
     else:
-        assert_equal(min_finite[DType.index](), -2147483648)
+        assert_equal(DType.min_finite[DType.index](), -2147483648)
 
 
 def test_max_or_inf():
-    assert_almost_equal(max_or_inf[DType.float32](), inf[DType.float32]())
-    assert_almost_equal(max_or_inf[DType.float64](), inf[DType.float64]())
+    assert_almost_equal(max_or_inf[DType.float32](), DType.inf[DType.float32]())
+    assert_almost_equal(max_or_inf[DType.float64](), DType.inf[DType.float64]())
     assert_true(max_or_inf[DType.bool]())
 
 
 def test_min_or_neg_inf():
     assert_almost_equal(
-        min_or_neg_inf[DType.float32](), neg_inf[DType.float32]()
+        min_or_neg_inf[DType.float32](), DType.neg_inf[DType.float32]()
     )
     assert_almost_equal(
-        min_or_neg_inf[DType.float64](), neg_inf[DType.float64]()
+        min_or_neg_inf[DType.float64](), DType.neg_inf[DType.float64]()
     )
     assert_false(min_or_neg_inf[DType.bool]())
 
 
 def test_neg_inf():
-    assert_false(isfinite(neg_inf[DType.float32]()))
-    assert_false(isfinite(neg_inf[DType.float64]()))
-    assert_true(isinf(neg_inf[DType.float32]()))
-    assert_true(isinf(neg_inf[DType.float64]()))
-    assert_false(isnan(neg_inf[DType.float32]()))
-    assert_false(isnan(neg_inf[DType.float64]()))
-    assert_equal(-inf[DType.float32](), neg_inf[DType.float32]())
-    assert_equal(-inf[DType.float64](), neg_inf[DType.float64]())
+    assert_false(isfinite(DType.neg_inf[DType.float32]()))
+    assert_false(isfinite(DType.neg_inf[DType.float64]()))
+    assert_true(isinf(DType.neg_inf[DType.float32]()))
+    assert_true(isinf(DType.neg_inf[DType.float64]()))
+    assert_false(isnan(DType.neg_inf[DType.float32]()))
+    assert_false(isnan(DType.neg_inf[DType.float64]()))
+    assert_equal(-DType.inf[DType.float32](), DType.neg_inf[DType.float32]())
+    assert_equal(-DType.inf[DType.float64](), DType.neg_inf[DType.float64]())
 
 
 def test_nextafter():
-    assert_true(isnan(nextafter(nan[DType.float32](), nan[DType.float32]())))
-    assert_true(isinf(nextafter(inf[DType.float32](), inf[DType.float32]())))
-    assert_true(isinf(nextafter(-inf[DType.float32](), -inf[DType.float32]())))
+    assert_true(
+        isnan(nextafter(DType.nan[DType.float32](), DType.nan[DType.float32]()))
+    )
+    assert_true(
+        isinf(nextafter(DType.inf[DType.float32](), DType.inf[DType.float32]()))
+    )
+    assert_true(
+        isinf(
+            nextafter(-DType.inf[DType.float32](), -DType.inf[DType.float32]())
+        )
+    )
     assert_almost_equal(nextafter(Float64(0), Float64(0)), 0)
     assert_almost_equal(nextafter(Float64(0), Float64(1)), 5e-324)
     assert_almost_equal(nextafter(Float64(0), Float64(-1)), -5e-324)


### PR DESCRIPTION
Move `nan`, `inf`, `max`, `min` from fputils to `DType`. Closes #4685.