### PR TITLE
[stdlib] Rename `PythonObject` ctors argument keyword from `from_[owned|borrowed]_ptr` to `from_[owned|borrowed]`

### DIFF
--- a/mojo/integration-test/python-extension-modules/block-hasher/mojo_module.mojo
+++ b/mojo/integration-test/python-extension-modules/block-hasher/mojo_module.mojo
@@ -104,7 +104,7 @@ fn _mojo_block_hasher[
 
         prev_hash = curr_hash
 
-    return PythonObject(from_owned_ptr=result_py_list)
+    return PythonObject(from_owned=result_py_list)
 
 
 @export

--- a/mojo/integration-test/python-extension-modules/feature-overview/mojo_module.mojo
+++ b/mojo/integration-test/python-extension-modules/feature-overview/mojo_module.mojo
@@ -85,7 +85,7 @@ fn case_raise_empty_error() -> PythonObject:
 
     cpython.PyErr_SetNone(error_type)
 
-    return PythonObject(from_owned_ptr=PyObjectPtr())
+    return PythonObject(from_owned=PyObjectPtr())
 
 
 fn case_raise_string_error() -> PythonObject:
@@ -95,7 +95,7 @@ fn case_raise_string_error() -> PythonObject:
 
     cpython.PyErr_SetString(error_type, "sample value error".unsafe_cstr_ptr())
 
-    return PythonObject(from_owned_ptr=PyObjectPtr())
+    return PythonObject(from_owned=PyObjectPtr())
 
 
 # Returning New Mojo Values

--- a/mojo/stdlib/stdlib/python/_cpython.mojo
+++ b/mojo/stdlib/stdlib/python/_cpython.mojo
@@ -1555,7 +1555,7 @@ struct CPython(Copyable, Defaultable, Movable):
 
         var error: String
         try:
-            error = String(PythonObject(from_owned_ptr=err_ptr))
+            error = String(PythonObject(from_owned=err_ptr))
         except e:
             return abort[Error](
                 "internal error: Python exception occurred but cannot be"

--- a/mojo/stdlib/stdlib/python/bindings.mojo
+++ b/mojo/stdlib/stdlib/python/bindings.mojo
@@ -688,7 +688,7 @@ struct PythonTypeBuilder(Copyable, Movable):
         if not type_obj_ptr:
             raise cpython.get_error()
 
-        var type_obj = PythonObject(from_owned_ptr=type_obj_ptr)
+        var type_obj = PythonObject(from_owned=type_obj_ptr)
 
         # Every Mojo type that is exposed to Python must have EXACTLY ONE
         # `PyTypeObject` instance that represents it. That is important for
@@ -1023,8 +1023,8 @@ fn _py_init_function_wrapper[
     Python.
     """
 
-    var kwargs = PythonObject(from_borrowed_ptr=kwargs_ptr)
-    var args = PythonObject(from_borrowed_ptr=args_ptr)
+    var kwargs = PythonObject(from_borrowed=kwargs_ptr)
+    var args = PythonObject(from_borrowed=args_ptr)
 
     var cpython = Python().cpython()
 
@@ -1086,8 +1086,8 @@ fn _py_c_function_wrapper[
     # We turn these into owned references, knowing that their destructors will
     # appropriately decrement the reference count.
 
-    var py_self = PythonObject(from_borrowed_ptr=py_self_ptr)
-    var args = PythonObject(from_borrowed_ptr=args_ptr)
+    var py_self = PythonObject(from_borrowed=py_self_ptr)
+    var args = PythonObject(from_borrowed=args_ptr)
 
     # SAFETY:
     #   Call the user provided function, and take ownership of the
@@ -1140,7 +1140,7 @@ fn _py_c_function_wrapper[
                 )
 
                 # Return a NULL `PyObject*`.
-                return PythonObject(from_owned_ptr=PyObjectPtr())
+                return PythonObject(from_owned=PyObjectPtr())
 
     # TODO:
     #   Does this lead to multiple levels of indirect function calls for
@@ -1159,9 +1159,9 @@ fn _py_c_function_with_kwargs_wrapper[
     Python.
     """
 
-    var py_self = PythonObject(from_borrowed_ptr=py_self_ptr)
-    var kwargs = PythonObject(from_borrowed_ptr=kwargs_ptr)
-    var args = PythonObject(from_borrowed_ptr=args_ptr)
+    var py_self = PythonObject(from_borrowed=py_self_ptr)
+    var kwargs = PythonObject(from_borrowed=kwargs_ptr)
+    var args = PythonObject(from_borrowed=args_ptr)
 
     return user_func(py_self, args, kwargs).steal_data()
 
@@ -1376,7 +1376,7 @@ fn _get_type_name(obj: PythonObject) raises -> String:
 
     var actual_type = cpython.Py_TYPE(obj._obj_ptr)
     var actual_type_name = PythonObject(
-        from_owned_ptr=cpython.PyType_GetName(actual_type)
+        from_owned=cpython.PyType_GetName(actual_type)
     )
 
     return String(actual_type_name)

--- a/mojo/stdlib/stdlib/python/python.mojo
+++ b/mojo/stdlib/stdlib/python/python.mojo
@@ -141,10 +141,10 @@ struct Python(Defaultable):
         var cpython = Self().cpython()
         # PyImport_AddModule returns a read-only reference.
         var module = PythonObject(
-            from_borrowed_ptr=cpython.PyImport_AddModule(name)
+            from_borrowed=cpython.PyImport_AddModule(name)
         )
         var dict_obj = PythonObject(
-            from_borrowed_ptr=cpython.PyModule_GetDict(module._obj_ptr)
+            from_borrowed=cpython.PyModule_GetDict(module._obj_ptr)
         )
         if file:
             # We compile the code as provided and execute in the module
@@ -160,7 +160,7 @@ struct Python(Defaultable):
             )
             if not code_obj_ptr:
                 raise cpython.get_error()
-            var code = PythonObject(from_owned_ptr=code_obj_ptr)
+            var code = PythonObject(from_owned=code_obj_ptr)
 
             # For this evaluation, we pass the dictionary both as the globals
             # and the locals. This is because the globals is defined as the
@@ -173,7 +173,7 @@ struct Python(Defaultable):
             if not result_ptr:
                 raise cpython.get_error()
 
-            var result = PythonObject(from_owned_ptr=result_ptr)
+            var result = PythonObject(from_owned=result_ptr)
             _ = result^
             _ = code^
             return module
@@ -186,7 +186,7 @@ struct Python(Defaultable):
             )
             if not result:
                 raise cpython.get_error()
-            return PythonObject(from_owned_ptr=result)
+            return PythonObject(from_owned=result)
 
     @staticmethod
     fn add_to_path(dir_path: StringSlice) raises:
@@ -245,7 +245,7 @@ struct Python(Defaultable):
         var module_ptr = cpython.PyImport_ImportModule(module^)
         if not module_ptr:
             raise cpython.get_error()
-        return PythonObject(from_owned_ptr=module_ptr)
+        return PythonObject(from_owned=module_ptr)
 
     @staticmethod
     fn create_module(name: StaticString) raises -> PythonObject:
@@ -273,7 +273,7 @@ struct Python(Defaultable):
         if not module_ptr:
             raise cpython.get_error()
 
-        return PythonObject(from_owned_ptr=module_ptr)
+        return PythonObject(from_owned=module_ptr)
 
     @staticmethod
     fn add_functions(
@@ -411,7 +411,7 @@ struct Python(Defaultable):
             On failure to construct the dictionary or convert the values to
             Python objects.
         """
-        return PythonObject(from_owned_ptr=Self._dict(kwargs))
+        return PythonObject(from_owned=Self._dict(kwargs))
 
     @staticmethod
     fn dict[
@@ -452,7 +452,7 @@ struct Python(Defaultable):
             if result == -1:
                 raise cpython.get_error()
 
-        return PythonObject(from_owned_ptr=dict_obj_ptr)
+        return PythonObject(from_owned=dict_obj_ptr)
 
     @staticmethod
     fn list[
@@ -476,7 +476,7 @@ struct Python(Defaultable):
             var obj = values[i].to_python_object()
             cpython.Py_IncRef(obj._obj_ptr)
             _ = cpython.PyList_SetItem(obj_ptr, i, obj._obj_ptr)
-        return PythonObject(from_owned_ptr=obj_ptr)
+        return PythonObject(from_owned=obj_ptr)
 
     @staticmethod
     fn _list[
@@ -503,7 +503,7 @@ struct Python(Defaultable):
             var obj = values[i].to_python_object()
             cpython.Py_IncRef(obj._obj_ptr)
             _ = cpython.PyList_SetItem(obj_ptr, i, obj._obj_ptr)
-        return PythonObject(from_owned_ptr=obj_ptr)
+        return PythonObject(from_owned=obj_ptr)
 
     @always_inline
     @staticmethod
@@ -548,7 +548,7 @@ struct Python(Defaultable):
             var obj = values[i].to_python_object()
             cpython.Py_IncRef(obj._obj_ptr)
             _ = cpython.PyTuple_SetItem(obj_ptr, i, obj._obj_ptr)
-        return PythonObject(from_owned_ptr=obj_ptr)
+        return PythonObject(from_owned=obj_ptr)
 
     @always_inline
     @staticmethod
@@ -594,7 +594,7 @@ struct Python(Defaultable):
             A PythonObject that holds the type object.
         """
         var cpython = Python().cpython()
-        return PythonObject(from_owned_ptr=cpython.PyObject_Type(obj._obj_ptr))
+        return PythonObject(from_owned=cpython.PyObject_Type(obj._obj_ptr))
 
     @staticmethod
     fn none() -> PythonObject:
@@ -623,7 +623,7 @@ struct Python(Defaultable):
         if not py_str_ptr:
             raise cpython.get_error()
 
-        return PythonObject(from_owned_ptr=py_str_ptr)
+        return PythonObject(from_owned=py_str_ptr)
 
     @staticmethod
     fn int(obj: PythonObject) raises -> PythonObject:
@@ -644,7 +644,7 @@ struct Python(Defaultable):
         if not py_obj_ptr:
             raise cpython.get_error()
 
-        return PythonObject(from_owned_ptr=py_obj_ptr)
+        return PythonObject(from_owned=py_obj_ptr)
 
     @staticmethod
     fn float(obj: PythonObject) raises -> PythonObject:
@@ -665,7 +665,7 @@ struct Python(Defaultable):
         if not float_obj:
             raise cpython.get_error()
 
-        return PythonObject(from_owned_ptr=float_obj)
+        return PythonObject(from_owned=float_obj)
 
     # ===-------------------------------------------------------------------===#
     # Checked Conversions


### PR DESCRIPTION
- The type is already clear from the signature.