### PR TITLE
[stdlib] Remove `__len__` from iter structs to match the `Iterator` trait

### DIFF
--- a/max/kernels/src/layout/int_tuple.mojo
+++ b/max/kernels/src/layout/int_tuple.mojo
@@ -287,8 +287,12 @@ that are not known at compile time or have not been specified.
 
 
 @register_passable("trivial")
-struct _IntTupleIter[origin: ImmutableOrigin, tuple_origin: ImmutableOrigin]:
+struct _IntTupleIter[origin: ImmutableOrigin, tuple_origin: ImmutableOrigin](
+    Iterator
+):
     """Iterator for traversing elements of an IntTuple."""
+
+    alias Element = IntTuple[origin]
 
     var src: Pointer[IntTuple[tuple_origin], origin]
     """Pointer to the source IntTuple being iterated."""
@@ -305,21 +309,15 @@ struct _IntTupleIter[origin: ImmutableOrigin, tuple_origin: ImmutableOrigin]:
         self.idx = idx
 
     @always_inline("nodebug")
+    fn __has_next__(self) -> Bool:
+        return self.idx < len(self.src[])
+
+    @always_inline("nodebug")
     fn __next__(mut self) -> IntTuple[origin]:
         """Get the next element and advance the iterator."""
         var idx = self.idx
         self.idx += 1
         return self.src[][idx]
-
-    @always_inline("nodebug")
-    fn __has_next__(self) -> Bool:
-        """Check if there are more elements to iterate."""
-        return self.__len__() > 0
-
-    @always_inline("nodebug")
-    fn __len__(self) -> Int:
-        """Get the number of remaining elements in the iteration."""
-        return len(self.src[]) - self.idx
 
 
 struct IntTuple[origin: ImmutableOrigin = __origin_of()](
@@ -1478,6 +1476,8 @@ fn is_tuple(t: IntTuple) -> Bool:
 struct _ZipIter[origin: ImmutableOrigin, n: Int](Copyable, Movable):
     """Iterator for zipped `IntTuple` collections."""
 
+    alias Element = IntTuple[origin]
+
     var index: Int
     var ts: InlineArray[Pointer[IntTuple, origin], n]
     var len: Int
@@ -1496,6 +1496,10 @@ struct _ZipIter[origin: ImmutableOrigin, n: Int](Copyable, Movable):
         for i in range(1, n):
             min_len = min(min_len, len(self.ts[i][]))
         self.len = min_len
+
+    @always_inline("nodebug")
+    fn __has_next__(self) -> Bool:
+        return self.index < self.len
 
     @always_inline("nodebug")
     fn __next__(mut self) -> IntTuple[origin]:
@@ -1522,16 +1526,6 @@ struct _ZipIter[origin: ImmutableOrigin, n: Int](Copyable, Movable):
             for i in range(1, n):
                 result.append(self.ts[i][][idx])
             return result
-
-    @always_inline("nodebug")
-    fn __has_next__(self) -> Bool:
-        """Check if there are more elements to iterate over."""
-        return self.__len__() > 0
-
-    @always_inline("nodebug")
-    fn __len__(self) -> Int:
-        """Get the number of remaining elements."""
-        return self.len - self.index
 
 
 @fieldwise_init

--- a/mojo/stdlib/stdlib/builtin/variadics.mojo
+++ b/mojo/stdlib/stdlib/builtin/variadics.mojo
@@ -35,16 +35,13 @@ struct _VariadicListIter[type: AnyTrivialRegType](Copyable, Iterator, Movable):
     var index: Int
     var src: VariadicList[type]
 
+    @always_inline
+    fn __has_next__(self) -> Bool:
+        return self.index < len(self.src)
+
     fn __next__(mut self) -> type:
         self.index += 1
         return self.src[self.index - 1]
-
-    @always_inline
-    fn __has_next__(self) -> Bool:
-        return self.__len__() > 0
-
-    fn __len__(self) -> Int:
-        return len(self.src) - self.index
 
 
 @register_passable("trivial")
@@ -143,6 +140,8 @@ struct _VariadicListMemIter[
         elt_type, elt_origin._mlir_origin, is_owned
     ]
 
+    alias Element = elt_type
+
     var index: Int
     var src: Pointer[
         Self.variadic_list_type,
@@ -155,18 +154,15 @@ struct _VariadicListMemIter[
         self.index = index
         self.src = Pointer(to=list)
 
+    @always_inline
+    fn __has_next__(self) -> Bool:
+        return self.index < len(self.src[])
+
     fn __next_ref__(mut self) -> ref [elt_origin] elt_type:
         self.index += 1
         return rebind[Self.variadic_list_type.reference_type](
             Pointer(to=self.src[][self.index - 1])
         )[]
-
-    @always_inline
-    fn __has_next__(self) -> Bool:
-        return self.__len__() > 0
-
-    fn __len__(self) -> Int:
-        return len(self.src[]) - self.index
 
 
 struct VariadicListMem[

--- a/mojo/stdlib/stdlib/collections/deque.mojo
+++ b/mojo/stdlib/stdlib/collections/deque.mojo
@@ -985,7 +985,7 @@ struct _DequeIter[
     ElementType: Copyable & Movable,
     deque_lifetime: Origin[deque_mutability],
     forward: Bool = True,
-](Copyable, Movable):
+](Copyable, Iterator, Movable):
     """Iterator for Deque.
 
     Parameters:
@@ -996,12 +996,21 @@ struct _DequeIter[
     """
 
     alias deque_type = Deque[ElementType]
+    alias Element = ElementType
 
     var index: Int
     var src: Pointer[Self.deque_type, deque_lifetime]
 
     fn __iter__(self) -> Self:
         return self
+
+    @always_inline
+    fn __has_next__(self) -> Bool:
+        @parameter
+        if forward:
+            return self.index < len(self.src[])
+        else:
+            return self.index > 0
 
     fn __next_ref__(mut self) -> ref [deque_lifetime] ElementType:
         @parameter
@@ -1015,14 +1024,3 @@ struct _DequeIter[
 
     fn __next__(mut self) -> ElementType:
         return self.__next_ref__()
-
-    fn __len__(self) -> Int:
-        @parameter
-        if forward:
-            return len(self.src[]) - self.index
-        else:
-            return self.index
-
-    @always_inline
-    fn __has_next__(self) -> Bool:
-        return self.__len__() > 0

--- a/mojo/stdlib/stdlib/collections/dict.mojo
+++ b/mojo/stdlib/stdlib/collections/dict.mojo
@@ -69,6 +69,8 @@ struct _DictEntryIter[
         forward: The iteration direction. `False` is backwards.
     """
 
+    alias Element = DictEntry[K, V, H]
+
     var index: Int
     var seen: Int
     var src: Pointer[Dict[K, V, H], dict_origin]
@@ -82,6 +84,10 @@ struct _DictEntryIter[
 
     fn __iter__(self) -> Self:
         return self
+
+    @always_inline
+    fn __has_next__(self) -> Bool:
+        return self.seen < len(self.src[])
 
     @always_inline
     fn __next__(
@@ -99,13 +105,6 @@ struct _DictEntryIter[
             if opt_entry_ref:
                 self.seen += 1
                 return opt_entry_ref.value()
-
-    @always_inline
-    fn __has_next__(self) -> Bool:
-        return self.__len__() > 0
-
-    fn __len__(self) -> Int:
-        return len(self.src[]) - self.seen
 
 
 @fieldwise_init
@@ -137,20 +136,16 @@ struct _DictKeyIter[
     fn __iter__(self) -> Self:
         return self
 
+    @always_inline
+    fn __has_next__(self) -> Bool:
+        return self.iter.__has_next__()
+
     fn __next_ref__(mut self) -> ref [self.iter.__next__().key] K:
         return self.iter.__next__().key
 
     @always_inline
     fn __next__(mut self) -> Self.Element:
         return self.__next_ref__()
-
-    @always_inline
-    fn __has_next__(self) -> Bool:
-        return self.__len__() > 0
-
-    @always_inline
-    fn __len__(self) -> Int:
-        return self.iter.__len__()
 
 
 @fieldwise_init
@@ -188,6 +183,10 @@ struct _DictValueIter[
             )
         )
 
+    @always_inline
+    fn __has_next__(self) -> Bool:
+        return self.iter.__has_next__()
+
     fn __next_ref__(mut self) -> ref [dict_origin] V:
         ref entry_ref = self.iter.__next__()
         # Cast through a pointer to grant additional mutability because
@@ -199,13 +198,6 @@ struct _DictValueIter[
     @always_inline
     fn __next__(mut self) -> Self.Element:
         return self.__next_ref__()
-
-    @always_inline
-    fn __has_next__(self) -> Bool:
-        return self.__len__() > 0
-
-    fn __len__(self) -> Int:
-        return self.iter.__len__()
 
 
 @fieldwise_init

--- a/mojo/stdlib/stdlib/collections/linked_list.mojo
+++ b/mojo/stdlib/stdlib/collections/linked_list.mojo
@@ -89,13 +89,9 @@ struct _LinkedListIter[
     ElementType: Copyable & Movable,
     origin: Origin[mut],
     forward: Bool = True,
-](Copyable, Iterator, Movable, Sized):
+](Copyable, Iterator, Movable):
     var src: Pointer[LinkedList[ElementType], origin]
     var curr: UnsafePointer[Node[ElementType]]
-
-    # Used to calculate remaining length of iterator in
-    # _LinkedListIter.__len__()
-    var seen: Int
 
     alias Element = ElementType  # FIXME(MOCO-2068): shouldn't be needed.
 
@@ -107,10 +103,12 @@ struct _LinkedListIter[
             self.curr = self.src[]._head
         else:
             self.curr = self.src[]._tail
-        self.seen = 0
 
     fn __iter__(self) -> Self:
         return self
+
+    fn __has_next__(self) -> Bool:
+        return Bool(self.curr)
 
     fn __next_ref__(mut self) -> ref [origin] Self.Element:
         var old = self.curr
@@ -120,19 +118,12 @@ struct _LinkedListIter[
             self.curr = self.curr[].next
         else:
             self.curr = self.curr[].prev
-        self.seen += 1
 
         return old[].value
 
     @always_inline
     fn __next__(mut self) -> Self.Element:
         return self.__next_ref__()
-
-    fn __has_next__(self) -> Bool:
-        return Bool(self.curr)
-
-    fn __len__(self) -> Int:
-        return len(self.src[]) - self.seen
 
 
 struct LinkedList[

--- a/mojo/stdlib/stdlib/collections/list.mojo
+++ b/mojo/stdlib/stdlib/collections/list.mojo
@@ -54,6 +54,14 @@ struct _ListIter[
     var index: Int
     var src: Pointer[Self.list_type, list_origin]
 
+    @always_inline
+    fn __has_next__(self) -> Bool:
+        @parameter
+        if forward:
+            return self.index < len(self.src[])
+        else:
+            return self.index > 0
+
     fn __next_ref__(mut self) -> ref [list_origin] T:
         @parameter
         if forward:
@@ -68,19 +76,8 @@ struct _ListIter[
         return self.__next_ref__()
 
     @always_inline
-    fn __has_next__(self) -> Bool:
-        return self.__len__() > 0
-
-    @always_inline
     fn __iter__(self) -> Self:
         return self
-
-    fn __len__(self) -> Int:
-        @parameter
-        if forward:
-            return len(self.src[]) - self.index
-        else:
-            return self.index
 
 
 struct List[T: Copyable & Movable, hint_trivial_type: Bool = False](

--- a/mojo/stdlib/stdlib/memory/span.mojo
+++ b/mojo/stdlib/stdlib/memory/span.mojo
@@ -56,6 +56,14 @@ struct _SpanIter[
         return self
 
     @always_inline
+    fn __has_next__(self) -> Bool:
+        @parameter
+        if forward:
+            return self.index < len(self.src)
+        else:
+            return self.index > 0
+
+    @always_inline
     fn __next_ref__(mut self) -> ref [origin, address_space] T:
         @parameter
         if forward:
@@ -64,18 +72,6 @@ struct _SpanIter[
         else:
             self.index -= 1
             return self.src[self.index]
-
-    @always_inline
-    fn __has_next__(self) -> Bool:
-        return self.__len__() > 0
-
-    @always_inline
-    fn __len__(self) -> Int:
-        @parameter
-        if forward:
-            return len(self.src) - self.index
-        else:
-            return self.index
 
 
 @fieldwise_init

--- a/mojo/stdlib/test/collections/test_linked_list.mojo
+++ b/mojo/stdlib/test/collections/test_linked_list.mojo
@@ -553,22 +553,16 @@ def test_iter():
     var l = LinkedList[Int](1, 2, 3)
     var iter = l.__iter__()
     assert_true(iter.__has_next__(), "Expected iter to have next")
-    assert_equal(len(iter), 3)
     assert_equal(iter.__next_ref__(), 1)
     assert_equal(iter.__next_ref__(), 2)
-    assert_equal(len(iter), 1)
     assert_equal(iter.__next_ref__(), 3)
-    assert_equal(len(iter), 0)
     assert_false(iter.__has_next__(), "Expected iter to not have next")
 
     var riter = l.__reversed__()
     assert_true(riter.__has_next__(), "Expected iter to have next")
-    assert_equal(len(riter), 3)
     assert_equal(riter.__next_ref__(), 3)
     assert_equal(riter.__next_ref__(), 2)
-    assert_equal(len(riter), 1)
     assert_equal(riter.__next_ref__(), 1)
-    assert_equal(len(riter), 0)
     assert_false(riter.__has_next__(), "Expected iter to not have next")
 
     var i = 0


### PR DESCRIPTION
- `__len__` was there as a step gap.
- Add conformance to `Iterator` when possible.