### PR TITLE
[stdlib] Remove `BitSet.is_empty`

### DIFF
--- a/mojo/stdlib/stdlib/collections/bitset.mojo
+++ b/mojo/stdlib/stdlib/collections/bitset.mojo
@@ -160,27 +160,13 @@ struct BitSet[size: UInt](
         return total
 
     @always_inline
-    fn is_empty(self) -> Bool:
-        """Checks if the bitset contains any set bits.
-
-        Equivalent to `len(self) == 0`. Note that this checks the logical
-        size, not the allocated capacity.
-
-        Returns:
-            True if no bits are set (logical size is 0), False otherwise.
-        """
-        return len(self) == 0
-
-    @always_inline
     fn __bool__(self) -> Bool:
         """Checks if the bitset is non-empty (contains at least one set bit).
-
-        Equivalent to `len(self) != 0` or `not self.is_empty()`.
 
         Returns:
             True if at least one bit is set, False otherwise.
         """
-        return not self.is_empty()
+        return len(self) != 0
 
     # --------------------------------------------------------------------- #
     # Bit manipulation

--- a/mojo/stdlib/test/collections/test_bitset.mojo
+++ b/mojo/stdlib/test/collections/test_bitset.mojo
@@ -20,7 +20,7 @@ def test_bitset_init():
     # Test default initialization
     var bs = BitSet[128]()
     assert_equal(len(bs), 0, msg="Empty BitSet should have length 0")
-    assert_true(bs.is_empty(), msg="Empty BitSet should be empty")
+    assert_false(bs, msg="Empty BitSet should be empty")
 
     # Test with initial bits
     var bs2 = BitSet[64]()
@@ -200,7 +200,7 @@ def test_bitset_consecutive_operations():
     # Clear all and verify
     bs.clear_all()
     assert_equal(len(bs), 0, msg="Count should be 0 after clear_all")
-    assert_true(bs.is_empty(), msg="BitSet should be empty after clear_all")
+    assert_false(bs, msg="BitSet should be empty after clear_all")
 
 
 def test_bitset_word_boundaries():
@@ -572,9 +572,7 @@ def test_bitset_small_size():
     assert_equal(
         len(bs), 0, msg="Small BitSet: Should be empty after clear_all"
     )
-    assert_true(
-        bs.is_empty(), msg="Small BitSet: Should be empty after clear_all"
-    )
+    assert_false(bs, msg="Small BitSet: Should be empty after clear_all")
 
     # Test very small BitSet (size 1)
     var bs1 = BitSet[1]()


### PR DESCRIPTION
It's more Pythonic to simply write `not bs`.