### PR TITLE
[docs] Update section 'Dev Container'

### DIFF
--- a/mojo/stdlib/docs/development.md
+++ b/mojo/stdlib/docs/development.md
@@ -47,8 +47,8 @@ externally maintained
 [Mojo Dev Container](https://github.com/benz0li/mojo-dev-container) with all
 prerequisites installed.
 
-The Dev Container also includes the unit test dependencies `lit` and `FileCheck`
-(from LLVM) and has `pre-commit` already set up.
+The unit test dependency `lit` is also pre-installed and `pre-commit` is
+already set up.
 
 See [Mojo Dev Container &gt; Usage](https://github.com/benz0li/mojo-dev-container#usage)
 on how to use with [Github Codespaces](https://docs.github.com/en/codespaces/developing-in-codespaces/creating-a-codespace-for-a-repository#creating-a-codespace-for-a-repository)


### PR DESCRIPTION
Refactoring of the Dev Container due to the switch to [Pixi](https://pixi.sh) and the use of [Bazel](https://bazel.build):

* https://github.com/benz0li/mojo-dev-container/compare/c0f37b0796701123dcaf6931b94d77551b110f35..bd56d1d97a6ed9547268778b344bf075e5dd2bfa