### PR TITLE
[docs] Remove broken link to tutorials directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Highlights include:
 - MAX inference server: [/max/serve](max/serve) (OpenAI-compatible endpoint)
 - MAX model pipelines: [/max/pipelines](max/pipelines) (Python-based graphs)
 - Code example: [/examples](examples)
-- Tutorials: [/tutorials](tutorials)
 
 This repo has two major branches:
 


### PR DESCRIPTION
The link for tutorials is broken, it could be removed to avoid confusion