### PR TITLE
Update hash.mojo

### DIFF
--- a/mojo/stdlib/stdlib/hashlib/hash.mojo
+++ b/mojo/stdlib/stdlib/hashlib/hash.mojo
@@ -46,6 +46,8 @@ trait Hashable:
     common hash map implementations.
 
     ```mojo
+    from hashlib.hasher import Hasher
+
     @fieldwise_init
     struct Foo(Hashable):
         var value: Int


### PR DESCRIPTION
fix of error

```
error: use of unknown declaration 'Hasher'
    fn __hash__[H: Hasher](self, mut hasher: H):
```

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
