### PR TITLE
[docs] Fix typo

### DIFF
--- a/mojo/docs/manual/values/ownership.mdx
+++ b/mojo/docs/manual/values/ownership.mdx
@@ -83,7 +83,7 @@ keyword at the beginning of an argument declaration:
   happens. The callee might receive a newly-created value, or a copy of an
   existing value.
 
-* `ref`: The function gets a reference with an parametric mutability: that is,
+* `ref`: The function gets a reference with a parametric mutability: that is,
   the reference can be either mutable or immutable. You can think of `ref`
   arguments as a generalization of the `read` and `mut` conventions.
   `ref` arguments are an advanced topic, and they're described in more detail in


### PR DESCRIPTION
"with a parametric mutability", not "with an parametric mutability".