### PR TITLE
[max] nvml changes to initilization and driverversion.patch level handling (wsl2)

### DIFF
--- a/max/kernels/src/nvml/nvml.mojo
+++ b/max/kernels/src/nvml/nvml.mojo
@@ -53,10 +53,12 @@ alias CUDA_NVML_LIBRARY = _Global[
 fn _init_dylib() -> _OwnedDLHandle:
     try:
         var dylib = _try_find_dylib(_get_nvml_library_paths())
-        _ = dylib._handle.get_function[fn () -> Result]("nvmlInit_v2")()
+        _check_error(
+            dylib._handle.get_function[fn () -> Result]("nvmlInit_v2")()
+        )
         return dylib^
     except e:
-        return abort[_OwnedDLHandle](String("CUDA NVML library not found: ", e))
+        return abort[_OwnedDLHandle](String("CUDA NVML library initialization failed: ", e))
 
 
 @always_inline
@@ -89,7 +91,7 @@ struct DriverVersion(Copyable, Movable, StringableRaising):
         return Int(self._value[1])
 
     fn patch(self) raises -> Int:
-        return Int(self._value[2])
+        return Int(self._value[2]) if len(self._value) > 2 else 0
 
     fn __str__(self) raises -> String:
         return String(self.major(), ".", self.minor(), ".", self.patch())


### PR DESCRIPTION
After spending some more time investigating the test failures in https://github.com/modular/modular/pull/5075, I was able to identify the root cause: wrong libnvidia-ml.so library files were being used.

Initially, the test was failing with:

`Unhandled exception caught during execution: NVML_UNINITIALIZED`

After improving the NVML initialization error handling, the actual underlying issue became clear:

`ABORT: CUDA NVML library initialization failed: NVML_DRIVER_NOT_LOADED
`
This indicated that the NVML library couldn't be initialized because the driver wasn't properly loaded.

Once the correct library was in place and properly initialized, the test was able to proceed and retrieve the driver version as expected. However, I noticed that on WSL2 the driver version reported by `nvidia-smi` does not include the patch-level version. 

For reference, here's the output of nvidia-smi on my WSL2 setup:

```
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 550.163.01             Driver Version: 555.85         CUDA Version: 12.5     |
|-----------------------------------------+------------------------+----------------------+
```