### PR TITLE
[CI] Testing with no sidecar

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -65,6 +65,12 @@ jobs:
             )
           fi
 
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            # NOTE: Remove the first line of .bazelversion to skip the buildbuddy sidecar on linux where the machine is too small.
+            # TODO: Remove this once upstream has fixed the issue.
+            sed -i '1d' .bazelversion
+          fi
+
           ./bazelw test --config=ci --config=public-cache "${args[@]}" --build_tag_filters=-skip-external-ci-${{ matrix.os }},-requires-network --test_tag_filters=-skip-external-ci-${{ matrix.os }},-requires-network -- //...
         env:
           BUILDBUDDY_TOKEN: ${{ secrets.BUILDBUDDY_TOKEN }}


### PR DESCRIPTION
We're seeing many timeouts that look like: https://github.com/modular/modular/actions/runs/16626735866/job/47045136587?pr=4793

```
Bazel caught terminate signal; cancelling pending invocation.

Warning: BuildBuddy CLI sidecar did not respond to ping request: rpc error: code = Unavailable desc = connection error: desc = "error reading server preface: read unix @->/tmp/sidecar-1577246469.sock: use of closed network connection"

Could not interrupt server: (14) recvmsg:Connection reset by peer


Server terminated abruptly (error code: 14, error message: 'recvmsg:Connection reset by peer', log file: '/home/runner/.cache/bazel/_bazel_runner/d1f0f411dcb60eded45786004bb5ff97/server/jvm.out')

Error: The operation was canceled.
```

Disabling the sidecar to see if the CI workers are just too small to run both side-by-side.