### PR TITLE
[stdlib] Add origins to `test_utils` to make them a bit safer

### DIFF
--- a/mojo/stdlib/test/collections/test_inline_array.mojo
+++ b/mojo/stdlib/test/collections/test_inline_array.mojo
@@ -220,23 +220,23 @@ def test_array_contains():
 
 def test_inline_array_runs_destructors():
     """Ensure we delete the right number of elements."""
-    var destructor_counter = List[Int]()
-    var pointer_to_destructor_counter = UnsafePointer(to=destructor_counter)
+    var destructor_recorder = List[Int]()
+    var ptr = UnsafePointer[mut=False](to=destructor_recorder)
     alias capacity = 32
-    var inline_list = InlineArray[DelRecorder, 4](
-        DelRecorder(0, pointer_to_destructor_counter),
-        DelRecorder(10, pointer_to_destructor_counter),
-        DelRecorder(20, pointer_to_destructor_counter),
-        DelRecorder(30, pointer_to_destructor_counter),
+    var inline_list = InlineArray[DelRecorder[ptr.origin], 4](
+        DelRecorder(0, ptr),
+        DelRecorder(10, ptr),
+        DelRecorder(20, ptr),
+        DelRecorder(30, ptr),
     )
     _ = inline_list
     # This is the last use of the inline list, so it should be destroyed here,
     # along with each element.
-    assert_equal(len(destructor_counter), 4)
-    assert_equal(destructor_counter[0], 0)
-    assert_equal(destructor_counter[1], 10)
-    assert_equal(destructor_counter[2], 20)
-    assert_equal(destructor_counter[3], 30)
+    assert_equal(len(destructor_recorder), 4)
+    assert_equal(destructor_recorder[0], 0)
+    assert_equal(destructor_recorder[1], 10)
+    assert_equal(destructor_recorder[2], 20)
+    assert_equal(destructor_recorder[3], 30)
 
 
 fn test_unsafe_ptr() raises:
@@ -299,21 +299,21 @@ def test_move():
 
     # === 3. Check that the destructor is not called when moving. ===
 
-    var destructor_counter = List[Int]()
-    var pointer_to_destructor_counter = UnsafePointer(to=destructor_counter)
-    var del_recorder = DelRecorder(0, pointer_to_destructor_counter)
-    var arr3 = InlineArray[DelRecorder, 1](del_recorder)
+    var del_counter = List[Int]()
+    var del_counter_ptr = UnsafePointer(to=del_counter).origin_cast[mut=False]()
+    var del_recorder = DelRecorder(0, del_counter_ptr)
+    var arr3 = InlineArray[DelRecorder[del_counter_ptr.origin], 1](del_recorder)
 
-    assert_equal(len(pointer_to_destructor_counter[]), 0)
+    assert_equal(len(del_counter_ptr[]), 0)
 
     var moved_arr3 = arr3^
 
-    assert_equal(len(pointer_to_destructor_counter[]), 0)
+    assert_equal(len(del_counter_ptr[]), 0)
 
     _ = moved_arr3
 
     # Double check that the destructor is called when the array is destroyed
-    assert_equal(len(pointer_to_destructor_counter[]), 1)
+    assert_equal(len(del_counter_ptr[]), 1)
     _ = del_recorder
 
 

--- a/mojo/stdlib/test/collections/test_linked_list.mojo
+++ b/mojo/stdlib/test/collections/test_linked_list.mojo
@@ -539,10 +539,11 @@ def test_indexing():
 def test_list_dtor():
     var dtor_count = 0
 
-    var l = LinkedList[DelCounter]()
+    var ptr = UnsafePointer[mut=False](to=dtor_count)
+    var l = LinkedList[DelCounter[ptr.origin]]()
     assert_equal(dtor_count, 0)
 
-    l.append(DelCounter(UnsafePointer(to=dtor_count)))
+    l.append(DelCounter(ptr))
     assert_equal(dtor_count, 0)
 
     l^.__del__()

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -866,10 +866,11 @@ def test_indexing():
 def test_list_dtor():
     var dtor_count = 0
 
-    var l = List[DelCounter]()
+    var ptr = UnsafePointer[mut=False](to=dtor_count)
+    var l = List[DelCounter[ptr.origin]]()
     assert_equal(dtor_count, 0)
 
-    l.append(DelCounter(UnsafePointer(to=dtor_count)))
+    l.append(DelCounter(ptr))
     assert_equal(dtor_count, 0)
 
     l^.__del__()
@@ -880,8 +881,9 @@ def test_list_dtor():
 def test_destructor_trivial_elements():
     var dtor_count = 0
 
-    var l = List[DelCounter, hint_trivial_type=True]()
-    l.append(DelCounter(UnsafePointer(to=dtor_count)))
+    var ptr = UnsafePointer[mut=False](to=dtor_count)
+    var l = List[DelCounter[ptr.origin], hint_trivial_type=True]()
+    l.append(DelCounter(ptr))
 
     l^.__del__()
 

--- a/mojo/stdlib/test/memory/test_arc.mojo
+++ b/mojo/stdlib/test/memory/test_arc.mojo
@@ -35,9 +35,7 @@ def test_is():
 
 def test_deleter_not_called_until_no_references():
     var deleted = False
-    var p = ArcPointer(
-        ObservableDel(UnsafePointer(to=deleted).origin_cast[mut=False]())
-    )
+    var p = ArcPointer(ObservableDel(UnsafePointer[mut=False](to=deleted)))
     var p2 = p
     _ = p^
     assert_false(deleted)
@@ -52,9 +50,7 @@ def test_deleter_not_called_until_no_references():
 
 def test_deleter_not_called_until_no_references_explicit_copy():
     var deleted = False
-    var p = ArcPointer(
-        ObservableDel(UnsafePointer(to=deleted).origin_cast[mut=False]())
-    )
+    var p = ArcPointer(ObservableDel(UnsafePointer[mut=False](to=deleted)))
     var p2 = p.copy()
     _ = p^
     assert_false(deleted)

--- a/mojo/stdlib/test/memory/test_maybe_uninitialized.mojo
+++ b/mojo/stdlib/test/memory/test_maybe_uninitialized.mojo
@@ -18,25 +18,26 @@ from testing import assert_equal
 
 def test_maybe_uninitialized():
     # Every time an Int is destroyed, it's going to be recorded here.
-    var destructor_counter = List[Int]()
+    var destructor_recorder = List[Int]()
 
-    var a = UnsafeMaybeUninitialized[DelRecorder]()
-    a.write(DelRecorder(42, UnsafePointer(to=destructor_counter)))
+    var ptr = UnsafePointer[mut=False](to=destructor_recorder)
+    var a = UnsafeMaybeUninitialized[DelRecorder[ptr.origin]]()
+    a.write(DelRecorder(42, ptr))
 
     assert_equal(a.assume_initialized().value, 42)
-    assert_equal(len(destructor_counter), 0)
+    assert_equal(len(destructor_recorder), 0)
 
     assert_equal(a.unsafe_ptr()[].value, 42)
-    assert_equal(len(destructor_counter), 0)
+    assert_equal(len(destructor_recorder), 0)
 
     a.assume_initialized_destroy()
-    assert_equal(len(destructor_counter), 1)
-    assert_equal(destructor_counter[0], 42)
+    assert_equal(len(destructor_recorder), 1)
+    assert_equal(destructor_recorder[0], 42)
     _ = a
 
     # Last use of a, but the destructor should not have run
     # since we assume uninitialized memory
-    assert_equal(len(destructor_counter), 1)
+    assert_equal(len(destructor_recorder), 1)
 
 
 def test_write_does_not_trigger_destructor():

--- a/mojo/stdlib/test/memory/test_owned_pointer.mojo
+++ b/mojo/stdlib/test/memory/test_owned_pointer.mojo
@@ -96,9 +96,7 @@ def test_take():
 
 def test_moveinit():
     var deleted = False
-    var b = OwnedPointer(
-        ObservableDel(UnsafePointer(to=deleted).origin_cast[mut=False]())
-    )
+    var b = OwnedPointer(ObservableDel(UnsafePointer[mut=False](to=deleted)))
     var p1 = b.unsafe_ptr()
 
     var b2 = b^

--- a/mojo/stdlib/test/memory/test_unsafepointer.mojo
+++ b/mojo/stdlib/test/memory/test_unsafepointer.mojo
@@ -21,10 +21,10 @@ from testing import assert_equal, assert_false, assert_not_equal, assert_true
 
 
 def test_unsafepointer_of_move_only_type():
-    var actions_ptr = UnsafePointer[List[String]].alloc(1)
-    actions_ptr.init_pointee_move(List[String]())
+    var actions = List[String]()
+    var actions_ptr = UnsafePointer[mut=False](to=actions)
 
-    var ptr = UnsafePointer[ObservableMoveOnly].alloc(1)
+    var ptr = UnsafePointer[ObservableMoveOnly[actions_ptr.origin]].alloc(1)
     ptr.init_pointee_move(ObservableMoveOnly(42, actions_ptr))
     assert_equal(len(actions_ptr[0]), 2)
     assert_equal(actions_ptr[0][0], "__init__")
@@ -43,8 +43,6 @@ def test_unsafepointer_of_move_only_type():
     ptr.free()
     assert_equal(len(actions_ptr[0]), 4)
     assert_equal(actions_ptr[0][3], "__del__")
-
-    actions_ptr.free()
 
 
 def test_unsafepointer_move_pointee_move_count():
@@ -143,6 +141,7 @@ def test_unsafepointer_string():
 
 def test_eq():
     var local = 1
+    # FIXME(#5133): should just be UnsafePointer[mut=False](to=local)
     var p1 = UnsafePointer(to=local).origin_cast[mut=False]()
     var p2 = p1
     assert_equal(p1, p2)


### PR DESCRIPTION
Add origins to `test_utils` to make them a bit safer. I came across some segfaults in the `InlineArray` tests in #4793 and #4807 due to how they currently don't carry an origin.