### PR TITLE
[stdlib] Implement DivModable trait

### DIFF
--- a/mojo/stdlib/stdlib/builtin/int.mojo
+++ b/mojo/stdlib/stdlib/builtin/int.mojo
@@ -26,7 +26,7 @@ from sys import bitwidthof
 from sys.info import is_32bit
 
 from builtin.device_passable import DevicePassable
-from builtin.math import Absable, Powable
+from builtin.math import Absable, DivModable, Powable
 from python import (
     Python,
     PythonObject,
@@ -217,6 +217,7 @@ struct Int(
     Copyable,
     Defaultable,
     DevicePassable,
+    DivModable,
     ExplicitlyCopyable,
     Floorable,
     Hashable,

--- a/mojo/stdlib/stdlib/builtin/math.mojo
+++ b/mojo/stdlib/stdlib/builtin/math.mojo
@@ -73,33 +73,41 @@ fn abs[T: Absable](value: T) -> T:
 # ===----------------------------------------------------------------------=== #
 
 
-fn divmod(numerator: Int, denominator: Int) -> Tuple[Int, Int]:
-    """Performs integer division and returns the quotient and the remainder.
-
-    Currently supported only for integers. Support for more standard library
-    types like Int8, Int16... is planned.
-
-    This method calls `a.__divmod__(b)`, thus, the actual implementation of
-    divmod should go in the `__divmod__` method of the struct of `a`.
-
-    Args:
-        numerator: The dividend.
-        denominator: The divisor.
-
-    Returns:
-        A `Tuple` containing the quotient and the remainder.
+trait DivModable(Copyable, Movable):
     """
-    return numerator.__divmod__(denominator)
+    The `DivModable` trait describes a type that defines division and
+    modulo operations returning both quotient and remainder.
+
+    Types that conform to `DivModable` will work with the builtin `divmod` function,
+    which will return the same type as the inputs.
+
+    For example:
+    ```mojo
+    @fieldwise_init
+    struct Bytes(DivModable):
+        var size: Int
+
+        fn __divmod__(self, other: Self) -> Tuple[Self, Self]:
+            var quotient_int = self.size // other.size
+            var remainder_int = self.size % other.size
+            return (Bytes(quotient_int), Bytes(remainder_int))
+    ```
+    """
+
+    fn __divmod__(self, denominator: Self) -> Tuple[Self, Self]:
+        """Performs division and returns the quotient and the remainder.
+
+        Returns:
+            A `Tuple` containing the quotient and the remainder.
+        """
+        ...
 
 
-fn divmod(numerator: UInt, denominator: UInt) -> Tuple[UInt, UInt]:
-    """Performs integer division and returns the quotient and the remainder.
+fn divmod[T: DivModable](numerator: T, denominator: T) -> Tuple[T, T]:
+    """Performs division and returns the quotient and the remainder.
 
-    Currently supported only for integers. Support for more standard library
-    types like Int8, Int16... is planned.
-
-    This method calls `a.__divmod__(b)`, thus, the actual implementation of
-    divmod should go in the `__divmod__` method of the struct of `a`.
+    Parameters:
+        T: A type conforming to the `DivModable` trait.
 
     Args:
         numerator: The dividend.

--- a/mojo/stdlib/stdlib/builtin/uint.mojo
+++ b/mojo/stdlib/stdlib/builtin/uint.mojo
@@ -19,7 +19,7 @@ from hashlib.hasher import Hasher
 from math import CeilDivable
 from sys import bitwidthof
 
-from builtin.math import Absable
+from builtin.math import Absable, DivModable
 
 from utils._visualizers import lldb_formatter_wrapping_type
 
@@ -33,6 +33,7 @@ struct UInt(
     Comparable,
     Copyable,
     Defaultable,
+    DivModable,
     ExplicitlyCopyable,
     Hashable,
     Indexer,


### PR DESCRIPTION
close: https://github.com/modular/modular/issues/2598

This PR implements the `DivModable` trait in the Mojo standard library to provide a generic interface for division and modulo operations.
  - Adds DivModable trait in `builtin/math.mojo` with divmod method requirement
  - Updates divmod function to use generic `DivModable` types instead of specific `Int/UInt` methods
  - Implements `DivModable` conformance for `Int` and `UInt` types

