### PR TITLE
[docs] Fix broken link to Code of Conduct in CONTRIBUTING.md 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ is a template of the information that should accompany every submitted issue.
 Before you start your first pull request, please complete this checklist:
 
 - Read this entire contributor guide.
-- Read the [Code of Conduct](../CODE_OF_CONDUCT.md).
+- Read the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ### Step 1: Evaluate and get buy-in on the change
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->

This PR fixes a broken link to the `CODE_OF_CONDUCT.md` within the `CONTRIBUTING.md` file.

The incorrect link path resulted in a 404 error. This change corrects the path to ensure contributors can easily access the Code of Conduct.

Resolves #5129