### PR TITLE
[kernels] Leaky ReLU

### DIFF
--- a/max/kernels/src/nn/activations.mojo
+++ b/max/kernels/src/nn/activations.mojo
@@ -231,6 +231,7 @@ fn gelu_approximate[
 # leaky_relu
 # ===----------------------------------------------------------------------=== #
 
+
 @always_inline
 fn leaky_relu[
     dtype: DType, simd_width: Int

--- a/max/kernels/src/nn/activations.mojo
+++ b/max/kernels/src/nn/activations.mojo
@@ -224,3 +224,36 @@ fn gelu_approximate[
     return (
         0.5 * val * (1 + math.tanh(SQRT_TWO_OVER_PI * (val + 0.044715 * val3)))
     ).cast[dtype]()
+
+
+
+# ===----------------------------------------------------------------------=== #
+# leaky_relu
+# ===----------------------------------------------------------------------=== #
+
+@always_inline
+fn leaky_relu[
+    dtype: DType, simd_width: Int
+](x: SIMD[dtype, simd_width], negative_slope: SIMD[dtype, 1]) -> SIMD[dtype, simd_width]:
+    """Compute the Leaky ReLU using the equation
+    $max(0, x) + negative_slope * min(0, x)$.
+
+    Parameters:
+        dtype: DType used for the computation.
+        simd_width: SIMD width used for the computation.
+
+    Args:
+        x: The value to compute the Leaky ReLU operation on.
+        negative_slope: The slope for negative values.
+    
+    Constraints:
+        Type must be a floating point Dtype.
+
+    Returns:
+        The result of the Leaky ReLU operation.
+    """
+    constrained[
+        dtype.is_floating_point(),
+        "dtype must be a floating point dtype",
+    ]()
+    return (x >= 0).select(x, negative_slope * x)

--- a/max/kernels/src/nn/activations.mojo
+++ b/max/kernels/src/nn/activations.mojo
@@ -257,5 +257,4 @@ fn leaky_relu[
         dtype.is_floating_point(),
         "dtype must be a floating point dtype",
     ]()
-    
     return (x >= 0).select(x, negative_slope * x)

--- a/max/kernels/src/nn/activations.mojo
+++ b/max/kernels/src/nn/activations.mojo
@@ -257,4 +257,5 @@ fn leaky_relu[
         dtype.is_floating_point(),
         "dtype must be a floating point dtype",
     ]()
+    
     return (x >= 0).select(x, negative_slope * x)

--- a/max/kernels/test/nn/test_activations.mojo
+++ b/max/kernels/test/nn/test_activations.mojo
@@ -15,7 +15,7 @@ from math import iota
 from random import randn, seed
 from sys.info import CompilationTarget
 
-from nn.activations import elu, gelu, gelu_approximate, relu, relu_n1
+from nn.activations import elu, gelu, gelu_approximate, leaky_relu, relu, relu_n1
 from test_utils import compare, libm_call
 from testing import assert_almost_equal
 
@@ -66,6 +66,32 @@ fn test_relu_n1():
 
     # CHECK: [0.0, 0.5, 1.0, 1.0]
     print(relu_n1(0.5 * simd_val))
+
+
+# CHECK-LABEL: test_leaky_relu
+fn test_leaky_relu():
+    print("== test_leaky_relu")
+
+    var simd_val = iota[DType.float32, 4]()
+
+    # Test with negative slope of 0.01
+    var slope_001 = SIMD[DType.float32, 1](0.01)
+    
+    # CHECK: [0.0, 1.0, 2.0, 3.0]
+    print(leaky_relu(simd_val, slope_001))
+
+    # For negative values: [-2, -1, 0, 1] with slope 0.01
+    # Expected: [-0.02, -0.01, 0.0, 1.0]
+    # CHECK: [-0.02, -0.01, 0.0, 1.0]
+    print(leaky_relu(simd_val - 2, slope_001))
+
+    # Test with different slope (0.1)
+    var slope_01 = SIMD[DType.float32, 1](0.1)
+    
+    # For negative values: [-2, -1, 0, 1] with slope 0.1
+    # Expected: [-0.2, -0.1, 0.0, 1.0]
+    # CHECK: [-0.2, -0.1, 0.0, 1.0]
+    print(leaky_relu(simd_val - 2, slope_01))
 
 
 def test_gelu_bfloat16():
@@ -209,6 +235,7 @@ def main():
     test_elu()
     test_relu()
     test_relu_n1()
+    test_leaky_relu()
     test_gelu_float32()
     test_gelu_float64()
     test_gelu_libm()


### PR DESCRIPTION
The MAX kernels library was missing a Leaky ReLU activation function and this PR adds it. The changes include the Leaky ReLU activation function kernel and unit tests for the same.
