### PR TITLE
[mojo][example] Cleanup `__del__` in life example

### DIFF
--- a/examples/mojo/life/gridv2.mojo
+++ b/examples/mojo/life/gridv2.mojo
@@ -39,8 +39,6 @@ struct Grid[rows: Int, cols: Int](Copyable, Movable, Stringable):
         # The lifetime of `existing` continues unchanged
 
     fn __del__(deinit self):
-        for i in range(self.num_cells):
-            (self.data + i).destroy_pointee()
         self.data.free()
 
     # ===-------------------------------------------------------------------===#

--- a/examples/mojo/life/gridv3.mojo
+++ b/examples/mojo/life/gridv3.mojo
@@ -40,8 +40,6 @@ struct Grid[rows: Int, cols: Int](Copyable, Movable, Stringable):
         # The lifetime of `existing` continues unchanged
 
     fn __del__(deinit self):
-        for i in range(self.num_cells):
-            (self.data + i).destroy_pointee()
         self.data.free()
 
     # ===-------------------------------------------------------------------===#


### PR DESCRIPTION
The current implementation of `__del__` in `gridv2.mojo` and `gridv3.mojo` is misleading.
`Int8` is a "trivial" `SIMD` struct and therefore no pointees are needed to be destroyed.