### PR TITLE
Update mandelbrot.mojo

### DIFF
--- a/examples/mojo/mandelbrot.mojo
+++ b/examples/mojo/mandelbrot.mojo
@@ -59,7 +59,7 @@ fn mandelbrot_kernel_SIMD[
             break
         var y2 = y * y
         y = x.fma(y + y, cy)
-        t = x.fma(x, y2).le(4)
+        t = (x.fma(x, y2) <= 4)
         x = x.fma(x, cx - y2)
         iters = t.select(iters + 1, iters)
     return iters


### PR DESCRIPTION
Fix: Replace unsupported ".le()" call with "<=" operator for SIMD comparison

In the original code: t = x.fma(x, y2).le(4)
"x.fma(x, y2)" returns a "SIMD[float32, simd_width]" value, which has no ".le()" method in current Mojo versions.  

Replaced with: t = (x.fma(x, y2) <= 4)

This uses the standard element-wise comparison operator, which is supported and functionally equivalent.

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
