### PR TITLE
[BUG] Replace `.le()` call with `<=` operator for SIMD comparison

### DIFF
--- a/examples/mojo/mandelbrot.mojo
+++ b/examples/mojo/mandelbrot.mojo
@@ -59,7 +59,7 @@ fn mandelbrot_kernel_SIMD[
             break
         var y2 = y * y
         y = x.fma(y + y, cy)
-        t = x.fma(x, y2).le(4)
+        t = (x.fma(x, y2) <= 4)
         x = x.fma(x, cx - y2)
         iters = t.select(iters + 1, iters)
     return iters


### PR DESCRIPTION
**Summary**
Fix incorrect method usage in Mandelbrot SIMD kernel. The original code attempted to call `.le(4)` on a `SIMD[float32, simd_width]` type, which is invalid because the SIMD type has no `le` method.

**Description**
In the original code: `t = x.fma(x, y2).le(4)`, `x.fma(x, y2)` returns a `SIMD[float32, simd_width]` value, which has no `.le()` method in current Mojo versions.   
Replaced with: `t = (x.fma(x, y2) <= 4)`. This uses the standard element-wise comparison operator, which is supported and functionally equivalent. This resolves the error and preserves the intended comparison against the value 4.

**Environment Details**
Mojo version - Mojo 25.5.0.dev2025072105 (068b9cc8) 
OS - Ubuntu 22.04.5 LTS
Hardware - AMD Ryzen Threadripper 1950X 16-Core Processor

**Severity/Frequency**
Severity: This is a blocking compile-time error in the current code and prevents execution.
Frequency: 100% reproducible whenever the code is compiled.