### PR TITLE
[max] nn: respect strict flag in Module.load_state_dict (fix PP staged loads)

### DIFF
--- a/max/nn/layer/layer.py
+++ b/max/nn/layer/layer.py
@@ -292,15 +292,19 @@ class Module(Layer, ABC):
             weight_alignment: If specified, overrides the alignment for each
                 weight in the `Module`. If left as `None`, each value in
                 state_dict must be aligned by the default dtype alignment.
-            strict: If True, raises an error if any keys in `state_dict` were
-                not used by the `Module`.
+            strict: If True, raises an error if any weights required by the
+                `Module` are missing from `state_dict`, or if any keys in
+                `state_dict` were not used by the `Module`. If False, both
+                missing and unexpected keys are tolerated and reported only
+                via return values/logging by callers.
 
         Raises:
-            ValueError: If any weight in the model is not present in the state dict.
-            ValueError: If `strict` is True and `state_dict` contains keys
-                not used by the `Module`.
+            ValueError: If `strict` is True and any required weight is missing
+                from `state_dict`, or if `state_dict` contains keys not used by
+                the `Module`.
         """
         loaded_keys = set()
+        missing_keys = set()
         for name, layer in recursive_named_layers(self):
             weight_prefix = f"{name}." if name else ""
             for weight_name, weight in layer.layer_weights.items():
@@ -330,23 +334,34 @@ class Module(Layer, ABC):
                     self._weight_values[full_weight_name] = data
                     weight.name = full_weight_name
                 else:
-                    msg = f"Could not find weight '{full_weight_name}'. "
-                    if possible_match := difflib.get_close_matches(
-                        full_weight_name, state_dict.keys(), n=1
-                    ):
-                        msg += f" Did you mean '{possible_match[0]}'?"
-                    raise ValueError(msg)
+                    # Missing key: respect `strict` flag.
+                    if strict:
+                        msg = f"Could not find weight '{full_weight_name}'. "
+                        if possible_match := difflib.get_close_matches(
+                            full_weight_name, state_dict.keys(), n=1
+                        ):
+                            msg += f" Did you mean '{possible_match[0]}'?"
+                        raise ValueError(msg)
+                    else:
+                        missing_keys.add(full_weight_name)
 
         if strict:
             unused_keys = state_dict.keys() - loaded_keys
-            if len(unused_keys) > 0:
-                unused_keys_str = ", ".join(sorted(unused_keys))
+            if missing_keys or len(unused_keys) > 0:
+                parts = []
+                if missing_keys:
+                    parts.append(
+                        "Missing required weights: "
+                        + ", ".join(sorted(missing_keys))
+                    )
+                if len(unused_keys) > 0:
+                    parts.append(
+                        "Unexpected keys in state_dict: "
+                        + ", ".join(sorted(unused_keys))
+                    )
                 msg = (
-                    f"load_state_dict() received an unexpected key(s) in state_dict. "
-                    f"If you want to load a model with a state_dict that may "
-                    f"contain unused keys, set strict=False. "
-                    f"The unused keys are:\n {unused_keys_str}"
-                    f"The loaded keys that are not unused are:\n {loaded_keys - state_dict.keys()}"
+                    "load_state_dict() strict=True validation failed. "
+                    + "; ".join(parts)
                 )
                 raise ValueError(msg)
 


### PR DESCRIPTION
## Summary
- Fix `Module.load_state_dict` to respect `strict` for missing/unexpected keys.
- Previously raised on missing weights even when `strict=False`, breaking Pipeline Parallel staged loading.
- Now only raises when `strict=True`; otherwise tolerates missing/unexpected keys.

## Rationale
- Aligns with common frameworks (e.g., PyTorch) and unblocks PP.
- Verified with Llama3 PP where `rope_freqs.weight` or `lm_head.weight` may be absent per stage.

## Details
- Collect `missing_keys`; only raise if `strict=True`.
- Keep unexpected keys validation gated by `strict=True`.
- Updated docstring.

## Repro enabled
MAX_SERVE_OFFLINE_INFERENCE=1 \
CUDA_VISIBLE_DEVICES=0,1 \
max generate \
  --model-path meta-llama/Llama-3.2-1B-Instruct \
  --devices=gpu:0,1 \
  --pipeline-parallel-degree 2 \
  --max-length 8192 \
  --device-memory-utilization 0.6 \
  --max-batch-size 1 \
  --max-new-tokens 10 \
  --prompt "hi"

## Notes
- No API break for strict=True; strict=False becomes lenient as intended.
- Follow-up: add unit test exercising both strict modes.