### PR TITLE
Fix spelling errors in schema, utilities and build scripts

### DIFF
--- a/bazel/internal/bazel-debug.sh
+++ b/bazel/internal/bazel-debug.sh
@@ -87,7 +87,7 @@ elif [[ "$kind" == binary_test ]]; then
   # cc_test has an underlying binary that is debuggable with bazel run
   target="$target.debug"
 elif [[ "$kind" == mojo_test ]]; then
-  # mojo_test has an underyling mojo_binary that is debuggable with bazel run
+  # mojo_test has an underlying mojo_binary that is debuggable with bazel run
   target="$target.debug"
 elif [[ "$kind" == modular_genrule ]]; then
   echo "error: modular_genrule not currently supported for debugging" >&2

--- a/bazel/internal/common.bazelrc
+++ b/bazel/internal/common.bazelrc
@@ -149,7 +149,7 @@ build --strategy=UvLock=sandboxed,standalone
 # https://github.com/bazelbuild/bazel/issues/25221
 build --strategy=TestRunner=remote,worker,sandboxed,standalone
 
-# Separate CI config that doesn't affect build output for verifing we share caches
+# Separate CI config that doesn't affect build output for verifying we share caches
 build:ci-no-config --build_metadata=ROLE=CI
 build:ci-no-config --config=cache
 build:ci-no-config --disk_cache=

--- a/bazel/public-patches/opentelemetry.patch
+++ b/bazel/public-patches/opentelemetry.patch
@@ -81,7 +81,7 @@ index a70d249f..2c9dd418 100644
 +    return data;
 +  }
 +  google::protobuf::ArenaOptions arena_options;
-+  // It's easy to allocate datas larger than 1024 when we populate basic resource and attributes
+  +  // It's easy to allocate data larger than 1024 when we populate basic resource and attributes
 +  arena_options.initial_block_size = 1024;
 +  // When in batch mode, it's easy to export a large number of spans at once, we can alloc a lager
 +  // block to reduce memory fragments.
@@ -115,7 +115,7 @@ index 5c2bc768..1452e515 100644
 +{
 +
 +  google::protobuf::ArenaOptions arena_options;
-+  // It's easy to allocate datas larger than 1024 when we populate basic resource and attributes
+  +  // It's easy to allocate data larger than 1024 when we populate basic resource and attributes
 +  arena_options.initial_block_size = 1024;
 +  // When in batch mode, it's easy to export a large number of spans at once, we can alloc a lager
 +  // block to reduce memory fragments.

--- a/benchmark/benchmark_datasets.py
+++ b/benchmark/benchmark_datasets.py
@@ -755,7 +755,7 @@ class RandomBenchmarkDataset(BenchmarkDataset):
 
     def _generate_random_image(self, height: int, width: int) -> Image.Image:
         # Truly random images end up being too large and incompressible.
-        # Instead create a much more limited block based random image with limited color pallete.
+        # Instead create a much more limited block based random image with limited color palette.
         block_size = 16
         colors = np.array([0, 64, 128, 192, 255], dtype=np.uint8)
 

--- a/max/pipelines/lib/hf_utils.py
+++ b/max/pipelines/lib/hf_utils.py
@@ -525,7 +525,7 @@ class HuggingFaceRepo:
                     supported_encodings.add(SupportedEncoding.bfloat16)
             else:
                 logger.warning(
-                    "torch_dtype not available, cant infer encoding from config.json"
+                    "torch_dtype not available, can't infer encoding from config.json"
                 )
 
         return list(supported_encodings)

--- a/max/pipelines/lib/lora.py
+++ b/max/pipelines/lib/lora.py
@@ -752,8 +752,8 @@ class LoRAManager:
 
     def _get_lora_weights(self, key: str, base_weight: Weight) -> WeightData:
         """
-        Get's the LoRA weights for the specified key for each LoRA that is loaded.
-        If the LoRA's don't contain the weight for the key, a zero-weight is returned.
+        Gets the LoRA weights for the specified key for each LoRA that is loaded.
+        If the LoRAs don't contain the weight for the key, a zero-weight is returned.
 
         Args:
             key: Key for LoRA selection.

--- a/max/serve/schemas/openai.yaml
+++ b/max/serve/schemas/openai.yaml
@@ -9705,7 +9705,7 @@ components:
                   description: |
                       Specifies the latency tier to use for processing the request. This parameter is relevant for customers subscribed to the scale tier service:
                         - If set to 'auto', the system will utilize scale tier credits until they are exhausted.
-                        - If set to 'default', the request will be processed using the default service tier with a lower uptime SLA and no latency guarentee.
+                        - If set to 'default', the request will be processed using the default service tier with a lower uptime SLA and no latency guarantee.
                         - When not set, the default behavior is 'auto'.
 
                         When this parameter is set, the response body will include the `service_tier` utilized.
@@ -11841,7 +11841,7 @@ components:
                     nullable: true
                 metadata:
                     description: &metadata_description |
-                        Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.
+                        Set of 16 key-value pairs that can be attached to an object. This can be useful for storing additional information about the object in a structured format. Keys can be a maximum of 64 characters long and values can be a maximum of 512 characters long.
                     type: object
                     x-oaiTypeLabel: map
                     nullable: true
@@ -12037,7 +12037,7 @@ components:
                                             metadata:
                                                 type: object
                                                 description: |
-                                                    Set of 16 key-value pairs that can be attached to a vector store. This can be useful for storing additional information about the vector store in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.
+                                                    Set of 16 key-value pairs that can be attached to a vector store. This can be useful for storing additional information about the vector store in a structured format. Keys can be a maximum of 64 characters long and values can be a maximum of 512 characters long.
                                                 x-oaiTypeLabel: map
                             oneOf:
                                 - required: [vector_store_ids]
@@ -13046,7 +13046,7 @@ components:
                                             metadata:
                                                 type: object
                                                 description: |
-                                                    Set of 16 key-value pairs that can be attached to a vector store. This can be useful for storing additional information about the vector store in a structured format. Keys can be a maximum of 64 characters long and values can be a maxium of 512 characters long.
+                                                    Set of 16 key-value pairs that can be attached to a vector store. This can be useful for storing additional information about the vector store in a structured format. Keys can be a maximum of 64 characters long and values can be a maximum of 512 characters long.
                                                 x-oaiTypeLabel: map
                                         x-oaiExpandable: true
                             oneOf:
@@ -16983,7 +16983,7 @@ x-oaiMeta:
                 path: list
               - type: endpoint
                 key: create-project-user
-                path: creeate
+                path: create
               - type: endpoint
                 key: retrieve-project-user
                 path: retrieve


### PR DESCRIPTION
## Summary
- fix spelling errors in OpenAI service schema
- correct typos in pipeline utilities and LoRA docs
- clean up spelling in Bazel scripts, telemetry patch, and dataset comments

## Testing
- `bash -n bazel/internal/bazel-debug.sh`
- `python -m py_compile max/pipelines/lib/hf_utils.py max/pipelines/lib/lora.py benchmark/benchmark_datasets.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'dependency')*
 