### PR TITLE
[stdlib] Add tests for `T.__*__is_trivial`.

### DIFF
--- a/mojo/stdlib/test/builtin/test_value.mojo
+++ b/mojo/stdlib/test/builtin/test_value.mojo
@@ -13,17 +13,16 @@
 
 
 from testing import assert_false, assert_true, assert_equal
-from memory import memcpy
 
 # ===-----------------------------------------------------------------------===#
 # Triviality Struct
 # ===-----------------------------------------------------------------------===#
 
-alias event_trivial = 1
-alias event_init = 2
-alias event_del = 4
-alias event_copy = 8
-alias event_move = 16
+alias EVENT_TRIVIAL = 0b1  # 1
+alias EVENT_INIT = 0b10  # 2
+alias EVENT_DEL = 0b100  # 4
+alias EVENT_COPY = 0b1000  # 8
+alias EVENT_MOVE = 0b10000  # 16
 
 
 struct ConditionalTriviality[T: Movable & Copyable](Copyable, Movable):
@@ -34,32 +33,32 @@ struct ConditionalTriviality[T: Movable & Copyable](Copyable, Movable):
 
     fn __init__(out self, mut events: List[Int]):
         self.events = UnsafePointer(to=events)
-        self.add_event(event_init)
+        self.add_event(EVENT_INIT)
 
     fn __del__(deinit self):
         @parameter
         if T.__del__is_trivial:
-            self.add_event(event_del | event_trivial)
+            self.add_event(EVENT_DEL | EVENT_TRIVIAL)
         else:
-            self.add_event(event_del)
+            self.add_event(EVENT_DEL)
 
     fn __copyinit__(out self, other: Self):
         self.events = other.events
 
         @parameter
         if T.__copyinit__is_trivial:
-            self.add_event(event_copy | event_trivial)
+            self.add_event(EVENT_COPY | EVENT_TRIVIAL)
         else:
-            self.add_event(event_copy)
+            self.add_event(EVENT_COPY)
 
     fn __moveinit__(out self, deinit other: Self):
         self.events = other.events
 
         @parameter
         if T.__moveinit__is_trivial:
-            self.add_event(event_move | event_trivial)
+            self.add_event(EVENT_MOVE | EVENT_TRIVIAL)
         else:
-            self.add_event(event_move)
+            self.add_event(EVENT_MOVE)
 
 
 # ===-----------------------------------------------------------------------===#
@@ -78,11 +77,11 @@ def test_type_trivial():
     assert_equal(
         events,
         [
-            event_init,
-            event_copy | event_trivial,
-            event_del | event_trivial,
-            event_move | event_trivial,
-            event_del | event_trivial,
+            EVENT_INIT,
+            EVENT_COPY | EVENT_TRIVIAL,
+            EVENT_DEL | EVENT_TRIVIAL,
+            EVENT_MOVE | EVENT_TRIVIAL,
+            EVENT_DEL | EVENT_TRIVIAL,
         ],
     )
 
@@ -96,7 +95,7 @@ def test_type_not_trivial():
     value^.__del__()
     var value_move = value_copy^
     assert_equal(
-        events, [event_init, event_copy, event_del, event_move, event_del]
+        events, [EVENT_INIT, EVENT_COPY, EVENT_DEL, EVENT_MOVE, EVENT_DEL]
     )
 
 

--- a/mojo/stdlib/test/builtin/test_value.mojo
+++ b/mojo/stdlib/test/builtin/test_value.mojo
@@ -25,14 +25,16 @@ alias EVENT_COPY = 0b1000  # 8
 alias EVENT_MOVE = 0b10000  # 16
 
 
-struct ConditionalTriviality[T: Movable & Copyable](Copyable, Movable):
-    var events: UnsafePointer[List[Int]]
+struct ConditionalTriviality[O: MutableOrigin, //, T: Movable & Copyable](
+    Copyable, Movable
+):
+    var events: Pointer[List[Int], O]
 
-    fn add_event(self, event: Int):
+    fn add_event(mut self, event: Int):
         self.events[].append(event)
 
-    fn __init__(out self, mut events: List[Int]):
-        self.events = UnsafePointer(to=events)
+    fn __init__(out self, ref [O]events: List[Int]):
+        self.events = Pointer(to=events)
         self.add_event(EVENT_INIT)
 
     fn __del__(deinit self):

--- a/mojo/stdlib/test/builtin/test_value.mojo
+++ b/mojo/stdlib/test/builtin/test_value.mojo
@@ -1,0 +1,110 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+
+from testing import assert_false, assert_true, assert_equal
+from memory import memcpy
+
+# ===-----------------------------------------------------------------------===#
+# Triviality Struct
+# ===-----------------------------------------------------------------------===#
+
+alias event_trivial = 1
+alias event_init = 2
+alias event_del = 4
+alias event_copy = 8
+alias event_move = 16
+
+
+struct ConditionalTriviality[T: Movable & Copyable](Copyable, Movable):
+    var events: UnsafePointer[List[Int]]
+
+    fn add_event(self, event: Int):
+        self.events[].append(event)
+
+    fn __init__(out self, mut events: List[Int]):
+        self.events = UnsafePointer(to=events)
+        self.add_event(event_init)
+
+    fn __del__(deinit self):
+        @parameter
+        if T.__del__is_trivial:
+            self.add_event(event_del | event_trivial)
+        else:
+            self.add_event(event_del)
+
+    fn __copyinit__(out self, other: Self):
+        self.events = other.events
+
+        @parameter
+        if T.__copyinit__is_trivial:
+            self.add_event(event_copy | event_trivial)
+        else:
+            self.add_event(event_copy)
+
+    fn __moveinit__(out self, deinit other: Self):
+        self.events = other.events
+
+        @parameter
+        if T.__moveinit__is_trivial:
+            self.add_event(event_move | event_trivial)
+        else:
+            self.add_event(event_move)
+
+
+# ===-----------------------------------------------------------------------===#
+# Individual tests
+# ===-----------------------------------------------------------------------===#
+
+
+def test_type_trivial():
+    var events = List[Int]()
+    var value = ConditionalTriviality[Int](events)
+    var value_copy = value
+    # ^ optimized copy->move
+    # keep it:
+    value^.__del__()
+    var value_move = value_copy^
+    assert_equal(
+        events,
+        [
+            event_init,
+            event_copy | event_trivial,
+            event_del | event_trivial,
+            event_move | event_trivial,
+            event_del | event_trivial,
+        ],
+    )
+
+
+def test_type_not_trivial():
+    var events = List[Int]()
+    var value = ConditionalTriviality[String](events)
+    var value_copy = value
+    # ^ optimized copy->move
+    # keep it:
+    value^.__del__()
+    var value_move = value_copy^
+    assert_equal(
+        events, [event_init, event_copy, event_del, event_move, event_del]
+    )
+
+
+# ===-----------------------------------------------------------------------===#
+# Main
+# ===-----------------------------------------------------------------------===#
+
+
+def main():
+    test_type_trivial()
+    test_type_not_trivial()


### PR DESCRIPTION
An type is given as an parameters and the struct is instantiated. 
The struct value is then interacted with in any ways.

As interactions goes, the struct register the corresponding events for:
- `__init__`
- `__moveinit__`
- `__copyinit__`
- `__del__`

The event registered depends of `T`.
For example, when `T.__moveinit__is_trivial`,
The event registered on `__moveinit__` is `event_move | event_trivial`.

We can then compare the sequence of events to the expected one.

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
