### PR TITLE
[stdlib] Add generic min max finite for integers

### DIFF
--- a/mojo/stdlib/stdlib/utils/numerics.mojo
+++ b/mojo/stdlib/stdlib/utils/numerics.mojo
@@ -702,26 +702,12 @@ fn max_finite[dtype: DType]() -> Scalar[dtype]:
     """
 
     @parameter
-    if dtype is DType.int8:
-        return 127
-    elif dtype is DType.uint8:
-        return 255
-    elif dtype is DType.int16:
-        return 32767
-    elif dtype is DType.uint16:
-        return 65535
-    elif dtype is DType.int32 or (
-        dtype is DType.index and bitwidthof[DType.index]() == 32
-    ):
-        return 2147483647
-    elif dtype is DType.uint32:
-        return 4294967295
-    elif dtype is DType.int64 or (
-        dtype is DType.index and bitwidthof[DType.index]() == 64
-    ):
-        return 9223372036854775807
-    elif dtype is DType.uint64:
-        return 18446744073709551615
+    if dtype.is_unsigned():
+        return ~Scalar[dtype](0)
+    elif dtype.is_integral():
+        return Scalar[dtype](
+            ~Scalar[_unsigned_integral_type_of[dtype]()](0) >> 1
+        )
     elif dtype is DType.float8_e4m3fn:
         return 448
     elif dtype is DType.float8_e4m3fnuz:
@@ -737,9 +723,9 @@ fn max_finite[dtype: DType]() -> Scalar[dtype]:
     elif dtype is DType.float64:
         return 1.79769313486231570815e308
     elif dtype is DType.bool:
-        return rebind[Scalar[dtype]](Scalar(True))
+        return Scalar(True)._refine[dtype]()
     else:
-        constrained[False, "max_finite() called on unsupported type"]()
+        constrained[False, "max_finite() called on unsupported dtype"]()
         return {}
 
 
@@ -763,26 +749,14 @@ fn min_finite[dtype: DType]() -> Scalar[dtype]:
     @parameter
     if dtype.is_unsigned():
         return 0
-    elif dtype is DType.bool:
-        return Scalar(False)._refine[dtype]()
-    elif dtype is DType.int8:
-        return -128
-    elif dtype is DType.int16:
-        return -32768
-    elif dtype is DType.int32 or (
-        dtype is DType.index and bitwidthof[DType.index]() == 32
-    ):
-        return -2147483648
-    elif dtype is DType.int64 or (
-        dtype is DType.index and bitwidthof[DType.index]() == 64
-    ):
-        return -9223372036854775808
+    elif dtype.is_integral():
+        return -max_finite[dtype]() - 1
     elif dtype.is_floating_point():
         return -max_finite[dtype]()
     elif dtype is DType.bool:
-        return rebind[Scalar[dtype]](Scalar(False))
+        return Scalar(False)._refine[dtype]()
     else:
-        constrained[False, "min_finite() called on unsupported type"]()
+        constrained[False, "min_finite() called on unsupported dtype"]()
         return {}
 
 

--- a/mojo/stdlib/test/utils/test_numerics.mojo
+++ b/mojo/stdlib/test/utils/test_numerics.mojo
@@ -11,7 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from sys.info import CompilationTarget
+from sys.info import CompilationTarget, is_64bit
 
 from testing import assert_almost_equal, assert_equal, assert_false, assert_true
 
@@ -170,6 +170,36 @@ def test_max_finite():
     assert_true(overflow_fp[DType.float32]())
     assert_true(overflow_fp[DType.float64]())
 
+    assert_equal(max_finite[DType.int8](), 127)
+    assert_equal(max_finite[DType.uint8](), 255)
+    assert_equal(max_finite[DType.int16](), 32767)
+    assert_equal(max_finite[DType.uint16](), 65535)
+    assert_equal(max_finite[DType.int32](), 2147483647)
+    assert_equal(max_finite[DType.uint32](), 4294967295)
+    assert_equal(max_finite[DType.int64](), 9223372036854775807)
+    assert_equal(max_finite[DType.uint64](), 18446744073709551615)
+    # FIXME(#5214): uncomment once it is closed
+    # assert_equal(
+    #     max_finite[DType.int128](), 0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
+    # )
+    # assert_equal(
+    #     max_finite[DType.uint128](), 0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF
+    # )
+    # assert_equal(
+    #     max_finite[DType.int256](),
+    #     0x7FFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF,
+    # )
+    # assert_equal(
+    #     max_finite[DType.uint256](),
+    #     0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF,
+    # )
+
+    @parameter
+    if is_64bit():
+        assert_equal(max_finite[DType.index](), 9223372036854775807)
+    else:
+        assert_equal(max_finite[DType.index](), 2147483647)
+
 
 fn underflow_int[dtype: DType]() -> Bool:
     constrained[
@@ -203,6 +233,25 @@ def test_min_finite():
 
     assert_true(underflow_fp[DType.float32]())
     assert_true(underflow_fp[DType.float64]())
+
+    assert_equal(min_finite[DType.int8](), -128)
+    assert_equal(min_finite[DType.int16](), -32768)
+    assert_equal(min_finite[DType.int32](), -2147483648)
+    assert_equal(min_finite[DType.int64](), -9223372036854775808)
+    # FIXME(#5214): uncomment once it is closed
+    # assert_equal(
+    #     min_finite[DType.int128](), -0x8000_0000_0000_0000_0000_0000_0000_0000
+    # )
+    # assert_equal(
+    #     min_finite[DType.int256](),
+    #     -0x8000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000_0000,
+    # )
+
+    @parameter
+    if is_64bit():
+        assert_equal(min_finite[DType.index](), -9223372036854775808)
+    else:
+        assert_equal(min_finite[DType.index](), -2147483648)
 
 
 def test_max_or_inf():


### PR DESCRIPTION
Add generic min max finite for integers.

CC: @soraros 