### PR TITLE
[stdlib] Add atomic `fence`

### DIFF
--- a/mojo/stdlib/stdlib/benchmark/memory.mojo
+++ b/mojo/stdlib/stdlib/benchmark/memory.mojo
@@ -11,7 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-import os.atomic as atomic
+from os.atomic import Consistency, fence
 
 # ===-----------------------------------------------------------------------===#
 # clobber_memory
@@ -29,8 +29,4 @@ fn clobber_memory():
 
     # This operation corresponds to  atomic_signal_fence(memory_order_acq_rel)
     # in C++.
-    __mlir_op.`pop.fence`[
-        _type=None,
-        syncscope = "singlethread".value,
-        ordering = atomic.Consistency.ACQUIRE_RELEASE.__mlir_attr(),
-    ]()
+    fence[ordering = Consistency.ACQUIRE_RELEASE, scope="singlethread"]()

--- a/mojo/stdlib/stdlib/benchmark/memory.mojo
+++ b/mojo/stdlib/stdlib/benchmark/memory.mojo
@@ -29,4 +29,4 @@ fn clobber_memory():
 
     # This operation corresponds to  atomic_signal_fence(memory_order_acq_rel)
     # in C++.
-    fence[ordering = Consistency.ACQUIRE_RELEASE, scope="singlethread"]()
+    fence[Consistency.ACQUIRE_RELEASE, scope="singlethread"]()

--- a/mojo/stdlib/stdlib/gpu/sync.mojo
+++ b/mojo/stdlib/stdlib/gpu/sync.mojo
@@ -129,9 +129,9 @@ fn barrier():
         llvm_intrinsic["llvm.amdgcn.s.waitcnt", NoneType](Int32(0xC07F))
         llvm_intrinsic["llvm.amdgcn.s.barrier", NoneType]()
     elif is_amd_gpu():
-        fence[ordering = Consistency.RELEASE, scope="workgroup"]()
+        fence[Consistency.RELEASE, scope="workgroup"]()
         llvm_intrinsic["llvm.amdgcn.s.barrier", NoneType]()
-        fence[ordering = Consistency.ACQUIRE, scope="workgroup"]()
+        fence[Consistency.ACQUIRE, scope="workgroup"]()
     else:
         return CompilationTarget.unsupported_target_error[operation="barrier"]()
 

--- a/mojo/stdlib/stdlib/gpu/sync.mojo
+++ b/mojo/stdlib/stdlib/gpu/sync.mojo
@@ -24,7 +24,7 @@ thread blocks and warps, and manage memory consistency across different memory s
 """
 
 from os import abort
-from os.atomic import Consistency
+from os.atomic import Consistency, fence
 from sys import is_amd_gpu, is_nvidia_gpu, llvm_intrinsic
 from sys._assembly import inlined_assembly
 from sys.param_env import env_get_bool
@@ -129,17 +129,9 @@ fn barrier():
         llvm_intrinsic["llvm.amdgcn.s.waitcnt", NoneType](Int32(0xC07F))
         llvm_intrinsic["llvm.amdgcn.s.barrier", NoneType]()
     elif is_amd_gpu():
-        __mlir_op.`pop.fence`[
-            _type=None,
-            syncscope = "workgroup".value,
-            ordering = Consistency.RELEASE.__mlir_attr(),
-        ]()
+        fence[ordering = Consistency.RELEASE, scope="workgroup"]()
         llvm_intrinsic["llvm.amdgcn.s.barrier", NoneType]()
-        __mlir_op.`pop.fence`[
-            _type=None,
-            syncscope = "workgroup".value,
-            ordering = Consistency.ACQUIRE.__mlir_attr(),
-        ]()
+        fence[ordering = Consistency.ACQUIRE, scope="workgroup"]()
     else:
         return CompilationTarget.unsupported_target_error[operation="barrier"]()
 

--- a/mojo/stdlib/stdlib/os/atomic.mojo
+++ b/mojo/stdlib/stdlib/os/atomic.mojo
@@ -157,7 +157,7 @@ struct Consistency:
 
 @always_inline("nodebug")
 fn fence[
-    *, ordering: Consistency = Consistency.SEQUENTIAL, scope: StaticString = ""
+    ordering: Consistency = Consistency.SEQUENTIAL, *, scope: StaticString = ""
 ]():
     """Creates an atomic fence.
 

--- a/mojo/stdlib/stdlib/os/atomic.mojo
+++ b/mojo/stdlib/stdlib/os/atomic.mojo
@@ -151,6 +151,37 @@ struct Consistency:
 
 
 # ===-----------------------------------------------------------------------===#
+# fence
+# ===-----------------------------------------------------------------------===#
+
+
+@always_inline("nodebug")
+fn fence[
+    *, ordering: Consistency = Consistency.SEQUENTIAL, scope: StaticString = ""
+]():
+    """Creates an atomic fence.
+
+    Parameters:
+        ordering: The memory ordering for the fence.
+        scope: The memory synchronization scope.
+
+    Fences create synchronization between themselves and atomic operations or
+    fences in other thread without an explicit load or store to an atomic
+    variable. The fence prevents reordering of certain types of memory
+    operations around it as specified by the ordering parameter.
+    """
+
+    if is_compile_time():
+        return
+
+    __mlir_op.`pop.fence`[
+        ordering = ordering.__mlir_attr(),
+        syncscope = _get_kgen_string[scope](),
+        _type=None,
+    ]()
+
+
+# ===-----------------------------------------------------------------------===#
 # Atomic
 # ===-----------------------------------------------------------------------===#
 

--- a/mojo/stdlib/test/os/test_atomic.mojo
+++ b/mojo/stdlib/test/os/test_atomic.mojo
@@ -11,7 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from os import Atomic
+from os.atomic import Atomic, fence
 
 from testing import assert_equal, assert_false, assert_true
 
@@ -100,8 +100,18 @@ def test_comptime_atomic():
     assert_equal(value, 3)
 
 
+def test_comptime_fence():
+    fn comptime_fn() -> Int:
+        fence()
+        return 1
+
+    alias value = comptime_fn()
+    assert_equal(value, 1)
+
+
 def main():
     test_atomic()
     test_atomic_floating_point()
     test_compare_exchange_weak()
     test_comptime_atomic()
+    test_comptime_fence()

--- a/mojo/stdlib/test/os/test_compile_atomic.mojo
+++ b/mojo/stdlib/test/os/test_compile_atomic.mojo
@@ -11,7 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from os import Atomic
+from os.atomic import Atomic, fence
 
 from compile import compile_info
 from testing import assert_true
@@ -34,5 +34,16 @@ def test_compile_atomic():
     )
 
 
+def test_compile_fence():
+    @parameter
+    fn my_fence_function():
+        fence[scope="agent"]()
+
+    var asm = compile_info[my_fence_function, emission_kind="llvm"]()
+
+    assert_true('fence syncscope("agent") seq_cst' in asm)
+
+
 def main():
     test_compile_atomic()
+    test_compile_fence()


### PR DESCRIPTION
This adds an `os.atomic.fence` function (synonymous with C++'s [atomic_thread_fence](https://en.cppreference.com/w/cpp/atomic/atomic_thread_fence.html)).

A few notes:
- I did not add the equivalent of [atomic_signal_fence](https://en.cppreference.com/w/cpp/atomic/atomic_signal_fence.html) but I can easily add that for completeness if so desired. Not sure on a good name for this however, since in Rust it's called `compiler_fence` and in LLVM talk it is an atomic fence with `scope ="singlethread"`.
- I could add quite a bit to the documentation for `fence`, however the other atomic function's documentation is also quite lack-luster and it would probably be beneficial to have a single overhaul of all atomic docs.
- For tests, there are not currently any "real" atomic tests via fuzzing or actually spawning threading to check if the atomic behave as they're supposed to so I didn't add any for `fence` - but lmk if that is something I should do.

Linked issue: #5196 
