### PR TITLE
[stdlib] Make `Consistency` comparable and string representable.

### DIFF
--- a/mojo/stdlib/stdlib/os/atomic.mojo
+++ b/mojo/stdlib/stdlib/os/atomic.mojo
@@ -32,7 +32,9 @@ from memory import bitcast
 
 
 @register_passable("trivial")
-struct Consistency(Copyable, EqualityComparable, Movable, Representable, Stringable):
+struct Consistency(
+    Copyable, EqualityComparable, Movable, Representable, Stringable
+):
     """Represents the consistency model for atomic operations.
 
     The class provides a set of constants that represent different consistency
@@ -131,7 +133,7 @@ struct Consistency(Copyable, EqualityComparable, Movable, Representable, Stringa
         Returns:
             A string representation of this consistency.
         """
-         return self.as_string_slice()   
+        return self.as_string_slice()
 
     fn __str__(self) -> String:
         """Returns a string representation of a `Consistency`.

--- a/mojo/stdlib/stdlib/os/atomic.mojo
+++ b/mojo/stdlib/stdlib/os/atomic.mojo
@@ -32,7 +32,7 @@ from memory import bitcast
 
 
 @register_passable("trivial")
-struct Consistency:
+struct Consistency(Copyable, EqualityComparable, Movable, Representable, Stringable):
     """Represents the consistency model for atomic operations.
 
     The class provides a set of constants that represent different consistency
@@ -124,6 +124,48 @@ struct Consistency:
             True if the objects are not the same, False otherwise.
         """
         return self != other
+
+    fn __repr__(self) -> String:
+        """Returns a string representation of a `Consistency`.
+
+        Returns:
+            A string representation of this consistency.
+        """
+         return self.as_string_slice()   
+
+    fn __str__(self) -> String:
+        """Returns a string representation of a `Consistency`.
+
+        Returns:
+            A string representation of this consistency.
+        """
+
+        alias prefix_len = len("Consistency.")
+        return self.as_string_slice()[prefix_len:]
+
+    fn as_string_slice(self) -> StaticString:
+        """Returns a string slice representation of a `Consistency`.
+
+        Returns:
+            A string slice representation of this consistency.
+        """
+
+        if self is Self.NOT_ATOMIC:
+            return "Consistency.NOT_ATOMIC"
+        if self is Self.UNORDERED:
+            return "Consistency.UNORDERED"
+        if self is Self.MONOTONIC:
+            return "Consistency.MONOTONIC"
+        if self is Self.ACQUIRE:
+            return "Consistency.ACQUIRE"
+        if self is Self.RELEASE:
+            return "Consistency.RELEASE"
+        if self is Self.ACQUIRE_RELEASE:
+            return "Consistency.ACQUIRE_RELEASE"
+        if self is Self.SEQUENTIAL:
+            return "Consistency.SEQUENTIAL"
+
+        return "Consistency.UNKNOWN"
 
     @always_inline("nodebug")
     fn __mlir_attr(self) -> __mlir_type.`!kgen.deferred`:

--- a/mojo/stdlib/test/os/test_atomic.mojo
+++ b/mojo/stdlib/test/os/test_atomic.mojo
@@ -11,9 +11,46 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from os import Atomic
+from os.atomic import Atomic, Consistency
 
-from testing import assert_equal, assert_false, assert_true
+from testing import assert_equal, assert_not_equal, assert_false, assert_true
+
+
+def test_consistency_equality_comparable():
+    var ordering = Consistency.SEQUENTIAL
+
+    assert_not_equal(ordering, Consistency(42))
+    assert_not_equal(ordering, Consistency.NOT_ATOMIC)
+    assert_not_equal(ordering, Consistency.UNORDERED)
+    assert_not_equal(ordering, Consistency.MONOTONIC)
+    assert_not_equal(ordering, Consistency.ACQUIRE)
+    assert_not_equal(ordering, Consistency.RELEASE)
+    assert_not_equal(ordering, Consistency.ACQUIRE_RELEASE)
+    assert_equal(ordering, Consistency.SEQUENTIAL)
+
+
+def test_consistency_representable():
+    assert_equal(repr(Consistency(42)), "Consistency.UNKNOWN")
+    assert_equal(repr(Consistency.NOT_ATOMIC), "Consistency.NOT_ATOMIC")
+    assert_equal(repr(Consistency.UNORDERED), "Consistency.UNORDERED")
+    assert_equal(repr(Consistency.MONOTONIC), "Consistency.MONOTONIC")
+    assert_equal(repr(Consistency.ACQUIRE), "Consistency.ACQUIRE")
+    assert_equal(repr(Consistency.RELEASE), "Consistency.RELEASE")
+    assert_equal(
+        repr(Consistency.ACQUIRE_RELEASE), "Consistency.ACQUIRE_RELEASE"
+    )
+    assert_equal(repr(Consistency.SEQUENTIAL), "Consistency.SEQUENTIAL")
+
+
+def test_consistency_stringable():
+    assert_equal(String(Consistency(42)), "UNKNOWN")
+    assert_equal(String(Consistency.NOT_ATOMIC), "NOT_ATOMIC")
+    assert_equal(String(Consistency.UNORDERED), "UNORDERED")
+    assert_equal(String(Consistency.MONOTONIC), "MONOTONIC")
+    assert_equal(String(Consistency.ACQUIRE), "ACQUIRE")
+    assert_equal(String(Consistency.RELEASE), "RELEASE")
+    assert_equal(String(Consistency.ACQUIRE_RELEASE), "ACQUIRE_RELEASE")
+    assert_equal(String(Consistency.SEQUENTIAL), "SEQUENTIAL")
 
 
 fn test_atomic() raises:
@@ -101,6 +138,9 @@ def test_comptime_atomic():
 
 
 def main():
+    test_consistency_equality_comparable()
+    test_consistency_representable()
+    test_consistency_stringable()
     test_atomic()
     test_atomic_floating_point()
     test_compare_exchange_weak()


### PR DESCRIPTION
Adds `EqualityComparable`, `Representable`, and `Stringable` to the `Consistency` type. This will be useful for when we enforce orderings for specific atomic functions and want to print a nice compiler error message.
For example
```mojo
fn store[*, ordering: Consistency](self, value: T):
    alias disallowed_orderings [Consistency.ACQUIRE, Consistency.ACQUIRE_RELEASE]
    constrained[
        ordering not in disallowed_orderings, 
        "store ordering must not be any of: ",
        get_static_string[disallowed_orderings.__str__()]
    ]()

    # ...
```