### PR TITLE
[stdlib] feat: Add `name()` method to `Path` struct.

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -67,6 +67,9 @@ what we publish.
 
 ### Standard library changes
 
+- Added `Path(..).name()` method to the `Path` type, which returns the name of
+  the file or directory.
+
 - The `Copyable` trait now requires `ExplicitlyCopyable`, ensuring that all
   all types that can be implicitly copied may also be copied using an explicit
   `.copy()` method call.

--- a/mojo/stdlib/stdlib/pathlib/path.mojo
+++ b/mojo/stdlib/stdlib/pathlib/path.mojo
@@ -393,3 +393,17 @@ struct Path(
             res.append(ls[i])
 
         return res
+
+    fn name(self) -> String:
+        """Returns the name of the path.
+
+        ```mojo
+        from pathlib import Path
+
+        Path("a/path/foo.txt").name()  # returns "foo.txt"
+        ```
+
+        Returns:
+            The name of the path.
+        """
+        return os.path.basename(self)

--- a/mojo/stdlib/test/pathlib/test_pathlib.mojo
+++ b/mojo/stdlib/test/pathlib/test_pathlib.mojo
@@ -177,6 +177,32 @@ def test_stat():
     )
 
 
+# More elaborate tests in `os/path/test_basename.mojo`
+def test_name():
+    # Root directories
+    assert_equal("", Path("/").name())
+
+    # Empty strings
+    assert_equal("", Path("").name())
+
+    # Current directory (matching behavior of python, doesn't resolve `..` etc.)
+    assert_equal(".", Path(".").name())
+
+    # Parent directory
+    assert_equal("..", Path("..").name())
+
+    # Absolute paths
+    assert_equal("file", Path("/file").name())
+    assert_equal("file.txt", Path("/file.txt").name())
+    assert_equal("file", Path("/dir/file").name())
+    assert_equal("file", Path("/dir/subdir/file").name())
+
+    # Relative paths
+    assert_equal("file", Path("dir/file").name())
+    assert_equal("file", Path("dir/subdir/file").name())
+    assert_equal("file", Path("file").name())
+
+
 def main():
     test_cwd()
     test_path()
@@ -189,3 +215,4 @@ def main():
     test_expand_user()
     test_home()
     test_stat()
+    test_name()


### PR DESCRIPTION
Adds the `name()` method to the pathlib Path struct. Operates like the `name` property in python.
