### PR TITLE
[stdlib] feat: Add `parts()` method to `Path` struct.

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -131,6 +131,21 @@ language across multiple phases.
 
 ### Standard library changes
 
+- Added `Path(...).parts()` method to the `Path` type, for example instead of
+  writing:
+
+  ```mojo
+  var path = Path("path/to/file")
+  var parts = path.path.split(DIR_SEPARATOR)
+  ```
+
+  you can now write:
+
+  ```mojo
+  var path = Path("path/to/file")
+  var parts = path.parts()
+  ```
+
 - Added `Path(..).name()` method to the `Path` type, which returns the name of
   the file or directory.
 

--- a/mojo/stdlib/stdlib/pathlib/path.mojo
+++ b/mojo/stdlib/stdlib/pathlib/path.mojo
@@ -393,3 +393,11 @@ struct Path(
             The name of the path.
         """
         return os.path.basename(self)
+
+    fn parts(self) -> List[StringSlice[__origin_of(self.path)]]:
+        """Returns the parts of the path separated by `DIR_SEPARATOR`.
+
+        Returns:
+            The parts of the path separated by `DIR_SEPARATOR`.
+        """
+        return self.path.split(DIR_SEPARATOR)

--- a/mojo/stdlib/test/pathlib/test_pathlib.mojo
+++ b/mojo/stdlib/test/pathlib/test_pathlib.mojo
@@ -203,6 +203,25 @@ def test_name():
     assert_equal("file", Path("file").name())
 
 
+def test_parts():
+    var path_to_file = Path("/path/to/file")
+    assert_equal(path_to_file.parts(), path_to_file.path.split("/"))
+
+    var rel_path = Path("path/to/file")
+    assert_equal(rel_path.parts(), rel_path.path.split("/"))
+
+    var path_no_slash = Path("path")
+    assert_equal(path_no_slash.parts(), path_no_slash.path.split("/"))
+
+    var path_with_tail_slash = Path("path/")
+    assert_equal(
+        path_with_tail_slash.parts(), path_with_tail_slash.path.split("/")
+    )
+
+    var root_path = Path("/")
+    assert_equal(root_path.parts(), root_path.path.split("/"))
+
+
 def main():
     test_cwd()
     test_path()
@@ -216,3 +235,4 @@ def main():
     test_home()
     test_stat()
     test_name()
+    test_parts()


### PR DESCRIPTION
Adds the `parts` method. Allows for cross platform (windows vs unix) path splitting.
