### PR TITLE
[stdlib] Fix `Atomic.compare_exchange` and add tests.

### DIFF
--- a/mojo/stdlib/stdlib/os/atomic.mojo
+++ b/mojo/stdlib/stdlib/os/atomic.mojo
@@ -393,8 +393,71 @@ struct Atomic[dtype: DType, *, scope: StaticString = ""]:
         """
         _ = self.fetch_sub(rhs)
 
-    @always_inline
-    fn compare_exchange_weak[
+    @staticmethod
+    @always_inline("nodebug")
+    fn compare_exchange[
+        *,
+        failure_ordering: Consistency = Consistency.SEQUENTIAL,
+        success_ordering: Consistency = Consistency.SEQUENTIAL,
+    ](
+        ptr: UnsafePointer[Scalar[dtype], mut=True, **_],
+        mut expected: Scalar[dtype],
+        desired: Scalar[dtype],
+    ) -> Bool:
+        """Atomically compares the value in ptr with that of the expected value.
+        If the values are equal, then the ptr value is replaced with the
+        desired value and True is returned. Otherwise, False is returned the
+        the expected value is rewritten with the self value.
+
+        Parameters:
+            failure_ordering: The memory ordering for the failure case.
+            success_ordering: The memory ordering for the success case.
+
+        Args:
+          ptr: The source pointer.
+          expected: The expected value.
+          desired: The desired value.
+
+        Returns:
+          True if ptr == expected and ptr was updated to desired. False otherwise.
+        """
+        constrained[dtype.is_numeric(), "the input type must be arithmetic"]()
+
+        if is_compile_time():
+            if ptr[] == expected:
+                ptr[] = desired
+                return True
+            expected = ptr[]
+            return False
+
+        @parameter
+        if dtype.is_integral():
+            return _compare_exchange_integral_impl[
+                scope=scope,
+                failure_ordering=failure_ordering,
+                success_ordering=success_ordering,
+            ](ptr, UnsafePointer(to=expected), desired)
+
+        # For the floating point case, we need to bitcast the floating point
+        # values to their integral representation and perform the atomic
+        # operation on that.
+
+        alias integral_type = _integral_type_of[dtype]()
+
+        var atomic_integral_ptr = ptr.bitcast[Scalar[integral_type]]()
+        var expected_integral_ptr = UnsafePointer(to=expected).bitcast[
+            Scalar[integral_type]
+        ]()
+        var desired_integral = bitcast[integral_type](desired)
+
+        return _compare_exchange_integral_impl[
+            scope=scope,
+            failure_ordering=failure_ordering,
+            success_ordering=success_ordering,
+        ](atomic_integral_ptr, expected_integral_ptr, desired_integral)
+
+    @always_inline("nodebug")
+    fn compare_exchange[
         *,
         failure_ordering: Consistency = Consistency.SEQUENTIAL,
         success_ordering: Consistency = Consistency.SEQUENTIAL,
@@ -413,33 +476,13 @@ struct Atomic[dtype: DType, *, scope: StaticString = ""]:
           desired: The desired value.
 
         Returns:
-          True if self == expected and False otherwise.
+          True if self == expected and self was updated to desired. False otherwise.
         """
-        constrained[dtype.is_numeric(), "the input type must be arithmetic"]()
 
-        @parameter
-        if dtype.is_integral():
-            return _compare_exchange_weak_integral_impl[
-                scope=scope,
-                failure_ordering=failure_ordering,
-                success_ordering=success_ordering,
-            ](UnsafePointer(to=self.value), expected, desired)
-
-        # For the floating point case, we need to bitcast the floating point
-        # values to their integral representation and perform the atomic
-        # operation on that.
-
-        alias integral_type = _integral_type_of[dtype]()
-        var value_integral_addr = UnsafePointer(to=self.value).bitcast[
-            Scalar[integral_type]
-        ]()
-        var expected_integral = bitcast[integral_type](expected)
-        var desired_integral = bitcast[integral_type](desired)
-        return _compare_exchange_weak_integral_impl[
-            scope=scope,
+        return Self.compare_exchange[
             failure_ordering=failure_ordering,
             success_ordering=success_ordering,
-        ](value_integral_addr, expected_integral, desired_integral)
+        ](UnsafePointer(to=self.value), expected, desired)
 
     @staticmethod
     @always_inline
@@ -548,35 +591,44 @@ struct Atomic[dtype: DType, *, scope: StaticString = ""]:
 
 
 @always_inline
-fn _compare_exchange_weak_integral_impl[
+fn _compare_exchange_integral_impl[
     dtype: DType, //,
     *,
     scope: StaticString,
     failure_ordering: Consistency,
     success_ordering: Consistency,
 ](
-    value_addr: UnsafePointer[Scalar[dtype], **_],
-    mut expected: Scalar[dtype],
+    atomic_ptr: UnsafePointer[Scalar[dtype], **_],
+    expected_ptr: UnsafePointer[Scalar[dtype], mut=True, **_],
     desired: Scalar[dtype],
 ) -> Bool:
     constrained[dtype.is_integral(), "the input type must be integral"]()
+
     var cmpxchg_res = __mlir_op.`pop.atomic.cmpxchg`[
         failure_ordering = failure_ordering.__mlir_attr(),
         success_ordering = success_ordering.__mlir_attr(),
         syncscope = _get_kgen_string[scope](),
     ](
-        value_addr.bitcast[Scalar[dtype]._mlir_type]().address,
-        expected.value,
+        atomic_ptr.bitcast[Scalar[dtype]._mlir_type]().address,
+        expected_ptr[].value,
         desired.value,
     )
-    var ok = Bool(
+
+    var loaded_value = Scalar[dtype](
+        __mlir_op.`kgen.struct.extract`[index = __mlir_attr.`0:index`,](
+            cmpxchg_res
+        )
+    )
+
+    expected_ptr[] = loaded_value
+
+    var success = Bool(
         mlir_value=__mlir_op.`kgen.struct.extract`[
-            index = __mlir_attr.`1:index`
+            index = __mlir_attr.`1:index`,
         ](cmpxchg_res)
     )
-    if not ok:
-        expected = value_addr[]
-    return ok
+
+    return success
 
 
 @always_inline

--- a/mojo/stdlib/stdlib/os/atomic.mojo
+++ b/mojo/stdlib/stdlib/os/atomic.mojo
@@ -406,8 +406,8 @@ struct Atomic[dtype: DType, *, scope: StaticString = ""]:
     ) -> Bool:
         """Atomically compares the value in ptr with that of the expected value.
         If the values are equal, then the ptr value is replaced with the
-        desired value and True is returned. Otherwise, False is returned the
-        the expected value is rewritten with the self value.
+        desired value and True is returned. Otherwise, False is returned and
+        the expected value is rewritten with the ptr value.
 
         Parameters:
             failure_ordering: The memory ordering for the failure case.
@@ -464,7 +464,7 @@ struct Atomic[dtype: DType, *, scope: StaticString = ""]:
     ](self, mut expected: Scalar[dtype], desired: Scalar[dtype]) -> Bool:
         """Atomically compares the self value with that of the expected value.
         If the values are equal, then the self value is replaced with the
-        desired value and True is returned. Otherwise, False is returned the
+        desired value and True is returned. Otherwise, False is returned and
         the expected value is rewritten with the self value.
 
         Parameters:

--- a/mojo/stdlib/stdlib/sys/_amdgpu.mojo
+++ b/mojo/stdlib/stdlib/sys/_amdgpu.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 
 from collections import InlineArray
-from os.atomic import Atomic, Consistency, _compare_exchange_weak_integral_impl
+from os import Atomic
 from sys.intrinsics import (
     ballot,
     implicitarg_ptr,
@@ -661,11 +661,7 @@ struct Buffer(Copyable, Movable):
                 UnsafePointer(to=p._handle[].next),
                 0,
             )
-            if _compare_exchange_weak_integral_impl[
-                scope="",
-                failure_ordering = Consistency.SEQUENTIAL,
-                success_ordering = Consistency.SEQUENTIAL,
-            ](top, f, n):
+            if Atomic.compare_exchange(top, f, n):
                 break
 
             sleep(UInt(1))
@@ -698,11 +694,7 @@ struct Buffer(Copyable, Movable):
         var p = self.get_header(ptr)
         while True:
             p._handle[].next = f
-            if _compare_exchange_weak_integral_impl[
-                scope="",
-                failure_ordering = Consistency.SEQUENTIAL,
-                success_ordering = Consistency.SEQUENTIAL,
-            ](top, f, ptr):
+            if Atomic.compare_exchange(top, f, ptr):
                 break
             sleep(UInt(1))
 

--- a/mojo/stdlib/stdlib/utils/lock.mojo
+++ b/mojo/stdlib/stdlib/utils/lock.mojo
@@ -71,7 +71,7 @@ struct BlockingSpinLock(Defaultable):
 
         var expected = Int64(Self.UNLOCKED)
         var waiter = SpinWaiter()
-        while not self.counter.compare_exchange_weak(expected, owner):
+        while not self.counter.compare_exchange(expected, owner):
             # this should be yield
             waiter.wait()
             expected = Self.UNLOCKED
@@ -90,7 +90,7 @@ struct BlockingSpinLock(Defaultable):
         if self.counter.load() != owner:
             # No one else can modify other than owner
             return False
-        while not self.counter.compare_exchange_weak(expected, Self.UNLOCKED):
+        while not self.counter.compare_exchange(expected, Self.UNLOCKED):
             expected = owner
         return True
 

--- a/mojo/stdlib/test/os/test_atomic.mojo
+++ b/mojo/stdlib/test/os/test_atomic.mojo
@@ -16,77 +16,52 @@ from os import Atomic
 from testing import assert_equal, assert_false, assert_true
 
 
-fn test_atomic() raises:
-    var atom = Atomic[DType.index](3)
+fn test_atomic[dtype: DType]() raises:
+    alias scalar = Scalar[dtype]
+    var atom = Atomic[dtype](3)
 
-    assert_equal(atom.load(), 3)
+    assert_equal(atom.load(), scalar(3))
 
-    assert_equal(atom.value, 3)
+    assert_equal(atom.value, scalar(3))
 
-    atom += 4
-    assert_equal(atom.value, 7)
+    atom += scalar(4)
+    assert_equal(atom.value, scalar(7))
 
-    atom -= 4
-    assert_equal(atom.value, 3)
+    atom -= scalar(4)
+    assert_equal(atom.value, scalar(3))
 
-    atom.max(0)
-    assert_equal(atom.value, 3)
+    atom.max(scalar(0))
+    assert_equal(atom.value, scalar(3))
 
-    atom.max(42)
-    assert_equal(atom.value, 42)
+    atom.max(scalar(42))
+    assert_equal(atom.value, scalar(42))
 
-    atom.min(3)
-    assert_equal(atom.value, 3)
+    atom.min(scalar(3))
+    assert_equal(atom.value, scalar(3))
 
-    atom.min(0)
-    assert_equal(atom.value, 0)
-
-
-fn test_atomic_floating_point() raises:
-    var atom = Atomic(Float32(3.0))
-
-    assert_equal(atom.value, 3.0)
-
-    atom += 4
-    assert_equal(atom.value, 7.0)
-
-    atom -= 4
-    assert_equal(atom.value, 3.0)
-
-    atom.max(0)
-    assert_equal(atom.value, 3.0)
-
-    atom.max(42)
-    assert_equal(atom.value, 42.0)
-
-    atom.min(3)
-    assert_equal(atom.value, 3.0)
-
-    atom.min(0)
-    assert_equal(atom.value, 0.0)
+    atom.min(scalar(0))
+    assert_equal(atom.value, scalar(0))
 
 
-def test_compare_exchange_weak():
-    var atom = Atomic[DType.int64](3)
-    var expected = Int64(3)
-    var desired = Int64(3)
-    var ok = atom.compare_exchange_weak(expected, desired)
+def test_compare_exchange[dtype: DType]():
+    alias scalar = Scalar[dtype]
+    var atom = Atomic[dtype](3)
 
-    assert_equal(expected, 3)
-    assert_true(ok)
+    # Successful cmpxchg
+    var expected = scalar(3)
+    var success = atom.compare_exchange(expected, scalar(42))
 
-    expected = Int64(4)
-    ok = atom.compare_exchange_weak(expected, desired)
+    assert_true(success)
+    assert_equal(expected, scalar(3))
+    assert_equal(atom.load(), scalar(42))
 
-    assert_equal(expected, 3)
-    assert_false(ok)
+    # Failure cmpxchg
+    expected = scalar(3)
+    var failure = atom.compare_exchange(expected, scalar(99))
 
-    expected = Int64(4)
-    desired = Int64(6)
-    ok = atom.compare_exchange_weak(expected, desired)
-
-    assert_equal(expected, 3)
-    assert_false(ok)
+    assert_false(failure)
+    assert_equal(expected, scalar(42))
+    assert_equal(atom.load(), scalar(42))
 
 
 def test_comptime_atomic():
@@ -100,8 +75,28 @@ def test_comptime_atomic():
     assert_equal(value, 3)
 
 
+def test_comptime_compare_exchange():
+    fn comptime_fn(expected_in: Int32) -> Tuple[Bool, Int32, Int32]:
+        var expected = expected_in
+        var atom = Atomic[DType.int32](0)
+        var success = atom.compare_exchange(expected, 42)
+        return (success, expected, atom.load())
+
+    alias result_success = comptime_fn(0)
+    assert_true(result_success[0])
+    assert_equal(result_success[1], 0)
+    assert_equal(result_success[2], 42)
+
+    alias result_failure = comptime_fn(1)
+    assert_false(result_failure[0])
+    assert_equal(result_failure[1], 0)
+    assert_equal(result_failure[2], 0)
+
+
 def main():
-    test_atomic()
-    test_atomic_floating_point()
-    test_compare_exchange_weak()
+    test_atomic[DType.int32]()
+    test_atomic[DType.float64]()
+    test_compare_exchange[DType.int32]()
+    test_compare_exchange[DType.float64]()
     test_comptime_atomic()
+    test_comptime_compare_exchange()

--- a/mojo/stdlib/test/os/test_compile_atomic.mojo
+++ b/mojo/stdlib/test/os/test_compile_atomic.mojo
@@ -14,7 +14,7 @@
 from os import Atomic
 
 from compile import compile_info
-from testing import assert_true
+from testing import assert_true, assert_false
 
 
 def test_compile_atomic():
@@ -34,5 +34,20 @@ def test_compile_atomic():
     )
 
 
+def test_compile_compare_exchange():
+    fn my_cmpxchg_function(atom: Atomic[DType.int32, scope="agent"]) -> Bool:
+        var expected = Int32(0)
+        return atom.compare_exchange(expected, 42)
+
+    var asm = compile_info[my_cmpxchg_function, emission_kind="llvm"]()
+
+    assert_true(
+        'cmpxchg ptr %3, i32 %4, i32 42 syncscope("agent") seq_cst seq_cst'
+        in asm
+    )
+    assert_false("cmpxchg weak" in asm)
+
+
 def main():
     test_compile_atomic()
+    test_compile_compare_exchange()


### PR DESCRIPTION
This fixes some current bugs and UB in the previously named `Atomic.compare_exchange_weak`.

1. Updates name to `compare_exchange`: The previous name indicated that this function was the `weak` variant of compare exchange which is was *not*. The compiled llvm instructions show the use of `cmpxchg` without the `weak`. We should add the weak variant in the future, but first we need to have the `pop.atomic.cmpxchg` MLIR operation support the `weak` attribute.
2. Correctly update the `expected` argument for floating-point atomics: Before, if an `Atomic`'s `DType` was a floating point, the inout parameter `expected` would not be correctly updated if the `cmpxchg` failed. 
3. Fix UB when writing the atomic's loaded value into the `expected` argument: Previously when the `cmpxchg` operation was called, if the success flag was `False`, the expected inout parameter would be written to by non-atomically reading the atomic pointer via `expected = value_addr[]`. This is UB as we are not allowed to read/write to the atomic pointer without an atomic operation. Instead, now we extract the loaded value from the result of the `cmpxchg` operation and store that in `expected`.