### PR TITLE
[stdlib] Dict: re-use removed slots instead of always using empty slots.

### DIFF
--- a/mojo/stdlib/stdlib/collections/dict.mojo
+++ b/mojo/stdlib/stdlib/collections/dict.mojo
@@ -1137,17 +1137,26 @@ struct Dict[K: KeyElement, V: Copyable & Movable, H: Hasher = default_hasher](
         # Return (found, slot, index)
         var slot = hash & (self._reserved() - 1)
         var perturb = hash
+        var removed_slot = Optional[UInt64](None)
         while True:
             var index = self._get_index(slot)
             if index == Self.EMPTY:
+                # we just determined that the key is not in dict.
+                # if we encountered an removed slot on the way, let's use it:
+                if removed_slot:
+                    return (False, removed_slot.value(), self._n_entries)
+                # if we did not encountered one, normally use the empty slot:
                 return (False, slot, self._n_entries)
             elif index == Self.REMOVED:
-                pass
+                # we encounter an removed slot, let's keep the first one:
+                if not removed_slot:
+                    removed_slot = slot
             else:
                 ref entry = self._entries[index]
                 debug_assert(entry.__bool__(), "entry in index must be full")
                 ref val = entry.unsafe_value()
                 if val.hash == hash and likely(val.key == key):
+                    # we just determined that key is in dict:
                     return True, slot, index
             self._next_index_slot(slot, perturb)
 
@@ -1181,12 +1190,12 @@ struct Dict[K: KeyElement, V: Copyable & Movable, H: Hasher = default_hasher](
             while not self._entries[right]:
                 right += 1
                 debug_assert(right < self._reserved(), "Invalid dict state")
-            var entry = self._entries[right]
-            debug_assert(entry.__bool__(), "Logic error")
-            var slot = self._find_empty_index(entry.value().hash)
+            var entry = Pointer(to=self._entries[right])
+            debug_assert(entry[].__bool__(), "Logic error")
+            var slot = self._find_empty_index(entry[].value().hash)
             self._set_index(slot, left)
             if left != right:
-                self._entries[left] = entry.unsafe_take()
+                self._entries[left] = entry[].unsafe_take()
             right += 1
 
         self._n_entries = self._len


### PR DESCRIPTION
**Overview**

If we don't re-use the removed slots, the next empty slots gets further and further.

And we need to encounter one empty slot to determine when the dict don't contains an key. 
We also currently need to encouter an empty slot to insert an key_value entry.

Some empty slots are on the path of many hashes.
This can compound into an huge slowdown/issues so this patch fix that. 
The result is also an massive speedup that users can naturally appreciate.

**Why it works**

While in the loop,
we place the first encoutered removed slot in an optional. 
When we reach the empty slot, it means the dict don't contain the key. 
Instead of using the empty slot, we use the removed one if any was encountered on the way!

That entry lookup will be faster because it won't have to loop as far as the empty slot was. 
The next insertion that collide with this entry won't need to go further than the empty slot. 
Because if we'd use that empty slot before, the new insertion would need to loop at least that amount + 1.

So this prevent the empty slots to drift further and further away. 
(fixing an issue and creating an speedup by removing an slowdown)

**While in what loop ?**

The dict currently takes an hash and trucate it by modulo capacity (hash%256 for example). 
So if the hash is 1, the first slot checked is 1 (1%256). 
If it needs to check next slot: multiply and truncate again. 
What happens after a lot of "check next", is an wrap around: (258%256) = 2
And this happen until we get either an existing slot for the key or an empty slot.

So, the amount of any looping (time) depends on:
- how far the empty slot is. (don't contain the key, this is an insertion)
- how far the slot for an entry is. (contains the key, this is an lookup)

What we need is to minimize how far the first empty slot is (by not using it)! 
by reusing removed slots, we also minimize how far the new entry is.

**+Speedup: useful**

And what we get is faster lookup and insertions, sometimes massive, 
but only in situations where we used pop.
because pop turns an used slot into an removed slot.

**-Slowdown: security**

This solves an problem with pop.
The next empty slot don't drift further an further away anymore. 
For large dicts, it was an larger problem.
This is the main reason we should re-use the removed slots

**Conclusion**

While not being an expert at all,
i think it make sense to re-use the removed slots. 
The pr description shows that this logically can work. 
(especially for the goal of preventing large slowdowns)

@JoeLoser asked for rebase to merge, this is a new PR (merge conflict). 
Please do as always, all you can to make sure this is an good change ! 
I really don't wanna have the working dict having an bug. 
Users naturally love this type and often benchmark it.