### PR TITLE
[stdlib] Move `StringSlice.from_utf8` factory method to be a constructor

### DIFF
--- a/max/kernels/src/Mogg/MOGGPrimitives/MOGGPrimitives.mojo
+++ b/max/kernels/src/Mogg/MOGGPrimitives/MOGGPrimitives.mojo
@@ -76,7 +76,7 @@ fn pack_string_res(
         length=str_len,
     )
     # We can not free the resource ptr embedded in MEF, create a copy
-    return StringSlice.from_utf8(span).__str__()
+    return String(StringSlice(from_utf8=span))
 
 
 # ===-----------------------------------------------------------------------===#
@@ -92,13 +92,11 @@ fn create_error_async_values_and_destruct_error(
     var err: Error,
 ):
     """Indicates to the C++ runtime that the kernel has failed."""
-    var str = err.__str__()
-    var strslice = str.as_string_slice()
     external_call["KGEN_CompilerRT_AsyncRT_CreateAsyncs_Error", NoneType](
         async_ptr,
         async_len,
-        strslice.unsafe_ptr(),
-        strslice.byte_length(),
+        err.unsafe_cstr_ptr(),
+        err.byte_length(),
     )
 
 

--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -185,6 +185,9 @@ added for AMD Radeon 860M, 880M, and 8060S GPUs.
   function.  This improves performance for trivially destructible types
   (such as `Int` and friends).
 
+- `StringSlice.from_utf8` factory method is now a constructor, use
+  `StringSlice(from_utf8=...)` instead.
+
 ### Tooling changes
 
 - `mojo test` now ignores folders with a leading `.` in the name. This will

--- a/mojo/stdlib/stdlib/collections/string/_utf8.mojo
+++ b/mojo/stdlib/stdlib/collections/string/_utf8.mojo
@@ -119,7 +119,7 @@ fn validate_chunk[
     return must23_as_80 ^ sc
 
 
-fn _is_valid_utf8_runtime(span: Span[Byte]) -> Bool:
+fn _is_valid_utf8_runtime(span: Span[mut=False, Byte, **_]) -> Bool:
     """Fast utf-8 validation using SIMD instructions.
 
     References for this algorithm:
@@ -162,7 +162,7 @@ fn _is_valid_utf8_runtime(span: Span[Byte]) -> Bool:
     return all(has_error.eq(0))
 
 
-fn _is_valid_utf8(span: Span[Byte]) -> Bool:
+fn _is_valid_utf8(span: Span[mut=False, Byte, **_]) -> Bool:
     """Verify that the bytes are valid UTF-8.
 
     Args:

--- a/mojo/stdlib/stdlib/collections/string/string_slice.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string_slice.mojo
@@ -594,6 +594,22 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         )
         self = Self(unsafe_from_utf8=byte_slice)
 
+    fn __init__(out self, *, from_utf8: Span[Byte, origin, **_]) raises:
+        """Construct a new `StringSlice` from a buffer containing UTF-8 encoded
+        data.
+
+        Args:
+            from_utf8: A span of bytes containing UTF-8 encoded data.
+
+        Raises:
+            An exception is raised if the provided buffer byte values do not
+            form valid UTF-8 encoded codepoints.
+        """
+        if not _is_valid_utf8(from_utf8.get_immutable()):
+            raise Error("StringSlice: buffer is not valid UTF-8")
+
+        self = Self(unsafe_from_utf8=from_utf8)
+
     fn __init__(
         out self,
         *,
@@ -663,33 +679,6 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
             value: The string value.
         """
         self = value.as_string_slice_mut()
-
-    # ===-------------------------------------------------------------------===#
-    # Factory methods
-    # ===-------------------------------------------------------------------===#
-
-    # TODO: Change to `__init__(out self, *, from_utf8: Span[..])` once ambiguity
-    #   with existing `unsafe_from_utf8` overload is fixed. Would require
-    #   signature comparison to take into account required named arguments.
-    @staticmethod
-    fn from_utf8(from_utf8: Span[Byte, origin]) raises -> StringSlice[origin]:
-        """Construct a new `StringSlice` from a buffer containing UTF-8 encoded
-        data.
-
-        Args:
-            from_utf8: A span of bytes containing UTF-8 encoded data.
-
-        Returns:
-            A new validated `StringSlice` pointing to the provided buffer.
-
-        Raises:
-            An exception is raised if the provided buffer byte values do not
-            form valid UTF-8 encoded codepoints.
-        """
-        if not _is_valid_utf8(from_utf8):
-            raise Error("StringSlice: buffer is not valid UTF-8")
-
-        return StringSlice[origin](unsafe_from_utf8=from_utf8)
 
     # ===------------------------------------------------------------------===#
     # Trait implementations

--- a/mojo/stdlib/stdlib/subprocess/subprocess.mojo
+++ b/mojo/stdlib/stdlib/subprocess/subprocess.mojo
@@ -68,20 +68,15 @@ struct _POpenHandle:
 
         while True:
             var read = external_call["getline", Int](
-                Pointer(to=line),
-                Pointer(to=len),
-                self._handle,
+                Pointer(to=line), Pointer(to=len), self._handle
             )
             if read == -1:
                 break
 
-            var span = Span[Byte, MutableAnyOrigin](
-                ptr=line.bitcast[Byte](),
-                length=read,
-            )
-
             # Note: This will raise if the subprocess yields non-UTF-8 bytes.
-            res += StringSlice.from_utf8(span)
+            res += StringSlice(
+                from_utf8=Span(ptr=line.bitcast[Byte](), length=read)
+            )
 
         if line:
             libc.free(line.bitcast[NoneType]())

--- a/mojo/stdlib/test/collections/string/test_utf8.mojo
+++ b/mojo/stdlib/test/collections/string/test_utf8.mojo
@@ -180,11 +180,11 @@ def test_bad_utf8_sequences():
 
 def test_stringslice_from_utf8():
     for sequence in GOOD_SEQUENCES:
-        _ = StringSlice.from_utf8(Span(sequence))
+        _ = StringSlice(from_utf8=Span(sequence))
 
     for sequence in BAD_SEQUENCES:
         with assert_raises(contains="buffer is not valid UTF-8"):
-            _ = StringSlice.from_utf8(Span(sequence))
+            _ = StringSlice(from_utf8=Span(sequence))
 
 
 def test_combination_good_utf8_sequences():


### PR DESCRIPTION
Move `StringSlice.from_utf8` factory method to be a constructor