### PR TITLE
[stdlib] Make `SIMD.from_bits` a constructor

### DIFF
--- a/max/kernels/src/nn/mha_amd.mojo
+++ b/max/kernels/src/nn/mha_amd.mojo
@@ -142,7 +142,7 @@ fn convert_f32_to_bf16[dtype: DType](x: SIMD, out res: SIMD[dtype, x.size]):
 
     @parameter
     if use_truncation:
-        res = __type_of(res).from_bits((x.to_bits() >> 16).cast[DType.uint16]())
+        res = __type_of(res)(from_bits=(x.to_bits() >> 16).cast[DType.uint16]())
     else:
         res = x.cast[dtype]()
 

--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -185,6 +185,9 @@ added for AMD Radeon 860M, 880M, and 8060S GPUs.
   function.  This improves performance for trivially destructible types
   (such as `Int` and friends).
 
+- The `SIMD.from_bits` factory method is now a constructor, use
+  `SIMD(from_bits=...)` instead.
+
 ### Tooling changes
 
 - `mojo test` now ignores folders with a leading `.` in the name. This will

--- a/mojo/stdlib/stdlib/builtin/simd.mojo
+++ b/mojo/stdlib/stdlib/builtin/simd.mojo
@@ -790,27 +790,24 @@ struct SIMD[dtype: DType, size: Int](
         self = Self(res)
 
     @staticmethod
-    fn from_bits[
+    fn __init__[
         int_dtype: DType, //
-    ](value: SIMD[int_dtype, size]) -> SIMD[dtype, size]:
+    ](out self, *, from_bits: SIMD[int_dtype, size]):
         """Initializes the SIMD vector from the bits of an integral SIMD vector.
 
         Parameters:
             int_dtype: The integral type of the input SIMD vector.
 
         Args:
-            value: The SIMD vector to copy the bits from.
-
-        Returns:
-            The bitcast SIMD vector.
+            from_bits: The SIMD vector to copy the bits from.
         """
         constrained[int_dtype.is_integral(), "the SIMD type must be integral"]()
 
         @parameter
         if dtype is DType.bool and int_dtype in (DType.uint8, DType.int8):
-            return value.ne(0)._refine[dtype]()
+            self = from_bits.ne(0)._refine[dtype]()
         else:
-            return bitcast[dtype, size](value)
+            self = bitcast[dtype, size](from_bits)
 
     # ===-------------------------------------------------------------------===#
     # Operator dunders
@@ -1915,7 +1912,7 @@ struct SIMD[dtype: DType, size: Int](
                 )
 
             alias mask = FPUtils[dtype].exponent_mantissa_mask()
-            return Self.from_bits(self.to_bits() & mask)
+            return Self(from_bits=self.to_bits() & mask)
 
     @always_inline("nodebug")
     fn __round__(self) -> Self:
@@ -3680,8 +3677,8 @@ fn _f32_to_bfloat16[
     var lsb = (f32_bits >> _f32_bf16_mantissa_diff) & 1
     var rounding_bias = 0x7FFF + lsb
     var bf16_bits = (f32_bits + rounding_bias) >> _f32_bf16_mantissa_diff
-    var bf16 = SIMD[DType.bfloat16, width].from_bits(
-        bf16_bits.cast[DType.uint16]()
+    var bf16 = SIMD[DType.bfloat16, width](
+        from_bits=bf16_bits.cast[DType.uint16]()
     )
     return _isnan(f32).select(_nan[DType.bfloat16](), bf16)
 
@@ -3822,7 +3819,7 @@ fn _floor(x: SIMD) -> __type_of(x):
         bits & ~((1 << (shift_factor - e)) - 1),
         bits,
     )
-    return __type_of(x).from_bits(bits)
+    return __type_of(x)(from_bits=bits)
 
 
 fn _write_scalar[

--- a/mojo/stdlib/stdlib/math/math.mojo
+++ b/mojo/stdlib/stdlib/math/math.mojo
@@ -459,8 +459,8 @@ fn _exp2_float32(x: SIMD[DType.float32, _]) -> __type_of(x):
             1.33336498402e-3,
         ),
     ](xc)
-    return __type_of(x).from_bits(
-        r.to_bits[u32]()
+    return __type_of(x)(
+        from_bits=r.to_bits[u32]()
         + (m.cast[u32]() << FPUtils[DType.float32].mantissa_width())
     )
 
@@ -526,7 +526,7 @@ fn _ldexp_impl[
     alias integral_type = FPUtils[dtype].integral_type
     var m = exp.cast[integral_type]() + FPUtils[dtype].exponent_bias()
 
-    return x * __type_of(x).from_bits(m << FPUtils[dtype].mantissa_width())
+    return x * __type_of(x)(from_bits=m << FPUtils[dtype].mantissa_width())
 
 
 @always_inline
@@ -739,7 +739,7 @@ fn frexp[
         (((mask1 & x_int) >> mantissa_width) - exponent_bias).cast[dtype](),
         zero,
     )
-    var frac = selector.select(T.from_bits(x_int & ~mask1 | mask2), zero)
+    var frac = selector.select(T(from_bits=x_int & ~mask1 | mask2), zero)
     return StaticTuple[size=2](frac, exp)
 
 

--- a/mojo/stdlib/test/builtin/test_simd.mojo
+++ b/mojo/stdlib/test/builtin/test_simd.mojo
@@ -124,20 +124,20 @@ def test_init_from_index():
 
 
 def test_from_bits():
-    assert_true(Scalar[DType.bool].from_bits(UInt8(0x01)))
-    assert_false(Scalar[DType.bool].from_bits(UInt8(0x00)))
+    assert_true(Scalar[DType.bool](from_bits=UInt8(0x01)))
+    assert_false(Scalar[DType.bool](from_bits=UInt8(0x00)))
 
-    assert_equal(Int64.from_bits(UInt64(0xFFFFFFFFFFFFFFFF)), -1)
-    assert_equal(UInt128.from_bits(Int128(-1)), -1)
+    assert_equal(Int64(from_bits=UInt64(0xFFFFFFFFFFFFFFFF)), -1)
+    assert_equal(UInt128(from_bits=Int128(-1)), -1)
 
-    assert_equal(Float32.from_bits(UInt32(0x3F800000)), 1.0)
-    assert_equal(Float32.from_bits(UInt32(0xBF800000)), -1.0)
+    assert_equal(Float32(from_bits=UInt32(0x3F800000)), 1.0)
+    assert_equal(Float32(from_bits=UInt32(0xBF800000)), -1.0)
 
     # Test from_bits with different integer types
     var uint32_bits = SIMD[DType.uint32, 4](
         0x3F800000, 0x40000000, 0x40400000, 0x40800000
     )
-    var float32_from_bits = SIMD[DType.float32, 4].from_bits(uint32_bits)
+    var float32_from_bits = SIMD[DType.float32, 4](from_bits=uint32_bits)
 
     # These bit patterns represent 1.0, 2.0, 3.0, 4.0 in IEEE 754 float32
     assert_almost_equal(
@@ -157,7 +157,7 @@ def test_from_bits():
     var uint64_bits = SIMD[DType.uint64, 2](
         0x3FF0000000000000, 0x4000000000000000
     )
-    var float64_from_bits = SIMD[DType.float64, 2].from_bits(uint64_bits)
+    var float64_from_bits = SIMD[DType.float64, 2](from_bits=uint64_bits)
 
     assert_almost_equal(
         float64_from_bits[0], SIMD[DType.float64, 1](1.0), atol=1e-15
@@ -168,7 +168,7 @@ def test_from_bits():
 
     # Test with int32 -> int32 (identity)
     var int32_bits = SIMD[DType.int32, 4](42, -42, 100, -100)
-    var int32_from_bits = SIMD[DType.int32, 4].from_bits(int32_bits)
+    var int32_from_bits = SIMD[DType.int32, 4](from_bits=int32_bits)
     assert_equal(int32_from_bits, int32_bits)
 
 
@@ -187,7 +187,7 @@ def test_to_bits():
     var bits = float32_vals.to_bits()
 
     # Convert back and check
-    var reconstructed = SIMD[DType.float32, 4].from_bits(bits)
+    var reconstructed = SIMD[DType.float32, 4](from_bits=bits)
     assert_equal(reconstructed, float32_vals)
 
     # Test with different target bit width
@@ -195,7 +195,7 @@ def test_to_bits():
     var uint16_bits = int16_vals.to_bits[DType.uint16]()
 
     # Should preserve bit patterns
-    var reconstructed_int16 = SIMD[DType.int16, 4].from_bits(uint16_bits)
+    var reconstructed_int16 = SIMD[DType.int16, 4](from_bits=uint16_bits)
     assert_equal(reconstructed_int16, int16_vals)
 
 
@@ -221,7 +221,7 @@ def test_from_to_bits_roundtrip():
     for dt in dtypes:
         alias S = Scalar[dt]
         for n in range(-5, 5):
-            var res = S.from_bits(S(n).to_bits())
+            var res = S(from_bits=S(n).to_bits())
             assert_equal(res, S(n))
 
     fn floating_point_dtypes() -> List[DType]:
@@ -239,7 +239,7 @@ def test_from_to_bits_roundtrip():
         alias S = Scalar[dt]
         for i in range(-10, 10):
             var v = 1 / S(i)
-            var res = S.from_bits(S(v).to_bits())
+            var res = S(from_bits=S(v).to_bits())
             assert_equal(res, S(v))
 
 


### PR DESCRIPTION
Make `SIMD.from_bits` a constructor