### PR TITLE
[stdlib] Add `assert_equal` overload for `SIMD` again

### DIFF
--- a/mojo/stdlib/stdlib/testing/testing.mojo
+++ b/mojo/stdlib/stdlib/testing/testing.mojo
@@ -163,6 +163,41 @@ fn assert_equal(
 
 @always_inline
 fn assert_equal[
+    dtype: DType, size: Int
+](
+    lhs: SIMD[dtype, size],
+    rhs: SIMD[dtype, size],
+    msg: String = "",
+    *,
+    location: Optional[_SourceLocation] = None,
+) raises:
+    """Asserts that the input values are equal. If it is not then an
+    Error is raised.
+
+    Parameters:
+        dtype: The dtype of the left- and right-hand-side SIMD vectors.
+        size: The width of the left- and right-hand-side SIMD vectors.
+
+    Args:
+        lhs: The lhs of the equality.
+        rhs: The rhs of the equality.
+        msg: The message to be printed if the assertion fails.
+        location: The location of the error (defaults to `__call_location`).
+
+    Raises:
+        An Error with the provided message if assert fails and `None` otherwise.
+    """
+    if lhs != rhs:
+        raise _assert_cmp_error["`left == right` comparison"](
+            String(lhs),
+            String(rhs),
+            msg=msg,
+            loc=location.or_else(__call_location()),
+        )
+
+
+@always_inline
+fn assert_equal[
     T: Copyable & Movable & EqualityComparable & Representable, //
 ](
     lhs: List[T],
@@ -393,7 +428,7 @@ fn assert_not_equal[
     Raises:
         An Error with the provided message if assert fails and `None` otherwise.
     """
-    if all(lhs.eq(rhs)):
+    if lhs == rhs:
         raise _assert_cmp_error["`left != right` comparison"](
             String(lhs),
             String(rhs),

--- a/mojo/stdlib/test/testing/test_assertion.mojo
+++ b/mojo/stdlib/test/testing/test_assertion.mojo
@@ -80,6 +80,10 @@ def test_assert_not_equal_is_generic():
 
 def test_assert_equal_with_simd():
     assert_equal(SIMD[DType.uint8, 2](1, 1), SIMD[DType.uint8, 2](1, 1))
+    # comparison with IntLiteral should be straightforward and not require
+    # using any constructor
+    assert_equal(1, UInt8(1))
+    assert_equal(1, Int8(1))
 
     with assert_raises():
         assert_equal(SIMD[DType.uint8, 2](1, 1), SIMD[DType.uint8, 2](1, 2))


### PR DESCRIPTION
Add `assert_equal` overload for `SIMD` again. This should not have been deleted, because without it doing simple comparisons to `IntLiteral` fail (due to Mojo inferring both `Int` and the `SIMD` `DType`) and the tests become hugely verbose by having to use constructors.