### PR TITLE
[stdlib] [NFC] Remove hack for `DType.index` lowering issue

### DIFF
--- a/mojo/stdlib/stdlib/bit/_mask.mojo
+++ b/mojo/stdlib/stdlib/bit/_mask.mojo
@@ -54,12 +54,7 @@ fn is_negative[dtype: DType, //](value: SIMD[dtype, _]) -> __type_of(value):
         dtype.is_integral() and dtype.is_signed(),
         "This function is for signed integral types.",
     ]()
-
-    # HACK(#5003): remove this workaround
-    alias d = dtype if dtype is not DType.index else (
-        DType.int32 if dtype.size_of() == 4 else DType.int64
-    )
-    return (value.cast[d]() >> (bit_width_of[d]() - 1)).cast[dtype]()
+    return value >> (bit_width_of[dtype]() - 1)
 
 
 @always_inline

--- a/mojo/stdlib/stdlib/bit/bit.mojo
+++ b/mojo/stdlib/stdlib/bit/bit.mojo
@@ -64,14 +64,9 @@ fn count_leading_zeros[
         leading zeros at position `i` of the input value.
     """
     constrained[dtype.is_integral(), "must be integral"]()
-
-    # HACK(#5003): remove this workaround
-    alias d = dtype if dtype is not DType.index else (
-        DType.int32 if dtype.size_of() == 4 else DType.int64
-    )
-    return llvm_intrinsic["llvm.ctlz", SIMD[d, width], has_side_effect=False](
-        val.cast[d](), False
-    ).cast[dtype]()
+    return llvm_intrinsic[
+        "llvm.ctlz", SIMD[dtype, width], has_side_effect=False
+    ](val, False)
 
 
 # ===-----------------------------------------------------------------------===#


### PR DESCRIPTION
Remove hack for `DType.index` lowering issue. Related to issue #5003