### PR TITLE
[stdlib] Refactor the `Roundable` trait

### DIFF
--- a/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
@@ -195,7 +195,6 @@ from nn.repeat_interleave import repeat_interleave, repeat_interleave_shape
 from nn.reshape import reshape, reshape_shape
 from nn.resize import (
     CoordinateTransformationMode,
-    RoundMode,
     resize_linear,
     resize_nearest_neighbor,
 )

--- a/max/kernels/src/nn/resize.mojo
+++ b/max/kernels/src/nn/resize.mojo
@@ -24,7 +24,6 @@ from layout import (
 )
 from layout.int_tuple import fill_like
 from memory import memcpy
-
 from utils import IndexList, StaticTuple
 
 
@@ -73,22 +72,6 @@ fn coord_transform[
     else:
         constrained[False, "coordinate_transformation_mode not implemented"]()
         return 0
-
-
-struct RoundMode(ImplicitlyCopyable, Movable):
-    var value: Int
-    alias HalfDown = RoundMode(0)
-    alias HalfUp = RoundMode(1)
-    alias Floor = RoundMode(2)
-    alias Ceil = RoundMode(3)
-
-    @always_inline
-    fn __init__(out self, value: Int):
-        self.value = value
-
-    @always_inline
-    fn __eq__(self, other: RoundMode) -> Bool:
-        return self.value == other.value
 
 
 @fieldwise_init
@@ -158,9 +141,9 @@ fn resize_nearest_neighbor[
             return ceil(val - 0.5)
         elif round_mode == RoundMode.HalfUp:
             return floor(val + 0.5)
-        elif round_mode == RoundMode.Floor:
+        elif round_mode == RoundMode.Down:
             return floor(val)
-        elif round_mode == RoundMode.Ceil:
+        elif round_mode == RoundMode.Up:
             return ceil(val)
         else:
             constrained[False, "round_mode not implemented"]()

--- a/max/kernels/test/nn/test_resize.mojo
+++ b/max/kernels/test/nn/test_resize.mojo
@@ -15,7 +15,6 @@ from buffer import DimList
 from internal_utils import TestTensor
 from nn.resize import (
     CoordinateTransformationMode,
-    RoundMode,
     resize_linear,
     resize_nearest_neighbor,
 )
@@ -141,7 +140,7 @@ def main():
         var output = TestTensor[dtype, 4](DimList(1, 1, 8, 8))
 
         test_case_nearest[
-            4, CoordinateTransformationMode.AlignCorners, RoundMode.Floor
+            4, CoordinateTransformationMode.AlignCorners, RoundMode.Down
         ](input, output)
 
     # CHECK-LABEL: test_upsample_sizes_nearest_floor_align_corners
@@ -179,7 +178,7 @@ def main():
         var output = TestTensor[dtype, 4](DimList(1, 1, 8, 8))
 
         test_case_nearest[
-            4, CoordinateTransformationMode.HalfPixel, RoundMode.Ceil
+            4, CoordinateTransformationMode.HalfPixel, RoundMode.Up
         ](input, output)
 
     # CHECK-LABEL: test_upsample_sizes_nearest_ceil_half_pixel

--- a/mojo/stdlib/stdlib/builtin/int.mojo
+++ b/mojo/stdlib/stdlib/builtin/int.mojo
@@ -243,6 +243,10 @@ struct Int(
     # Aliases
     # ===-------------------------------------------------------------------===#
 
+    alias _RoundMultipleType = Self
+    alias _RoundMultipleDefault = Self(1)
+    alias _RoundModeDefault = RoundMode.HalfToEven
+
     alias BITWIDTH = Int(DType.int.bit_width())
     """The bit width of the integer type."""
 
@@ -1060,14 +1064,21 @@ struct Int(
         """
         return self
 
-    @always_inline("builtin")
-    fn __round__(self) -> Self:
-        """Return the rounded value of the Int value, which is itself.
+    @always_inline("nodebug")
+    fn __round__[
+        mode: RoundMode, to_multiple_of: Self._RoundMultipleType
+    ](self) -> Self:
+        """Get a rounded value for `Int`.
+
+        Parameters:
+            mode: The `RoundMode` for the operation.
+            to_multiple_of: The target base for which self is is rounded until
+                reaching a multiple thereof.
 
         Returns:
-            The Int value itself.
+            The rounded value.
         """
-        return self
+        return Int(Scalar[DType.int](self).__round__[mode, to_multiple_of]())
 
     @always_inline("nodebug")
     fn __round__(self, ndigits: Int) -> Self:

--- a/mojo/stdlib/stdlib/builtin/uint.mojo
+++ b/mojo/stdlib/stdlib/builtin/uint.mojo
@@ -41,6 +41,7 @@ struct UInt(
     KeyElement,
     Movable,
     Representable,
+    Roundable,
     Stringable,
     Writable,
 ):
@@ -69,6 +70,10 @@ struct UInt(
     # ===-------------------------------------------------------------------===#
     # Aliases
     # ===-------------------------------------------------------------------===#
+
+    alias _RoundMultipleType = Self
+    alias _RoundMultipleDefault = Self(1)
+    alias _RoundModeDefault = RoundMode.HalfToEven
 
     alias BITWIDTH = UInt(DType.uint.bit_width())
     """The bit width of the integer type."""
@@ -784,17 +789,24 @@ struct UInt(
         """
         return self
 
-    @always_inline("builtin")
-    fn __round__(self) -> Self:
-        """Return the rounded value of the UInt value, which is itself.
+    @always_inline("nodebug")
+    fn __round__[
+        mode: RoundMode, to_multiple_of: Self._RoundMultipleType
+    ](self) -> Self:
+        """Get a rounded value for `Int`.
+
+        Parameters:
+            mode: The `RoundMode` for the operation.
+            to_multiple_of: The target base for which self is is rounded until
+                reaching a multiple thereof.
 
         Returns:
-            The UInt value itself.
+            The rounded value.
         """
-        return self
+        return UInt(Scalar[DType.uint](self).__round__[mode, to_multiple_of]())
 
-    @always_inline("builtin")
-    fn __round__(self, ndigits: UInt) -> Self:
+    @always_inline("nodebug")
+    fn __round__(self, ndigits: Int) -> Self:
         """Return the rounded value of the UInt value, which is itself.
 
         Args:
@@ -803,7 +815,7 @@ struct UInt(
         Returns:
             The UInt value itself if ndigits >= 0 else the rounded value.
         """
-        return self
+        return UInt(Int(self).__round__(ndigits))
 
     @always_inline("builtin")
     fn __trunc__(self) -> Self:

--- a/mojo/stdlib/stdlib/prelude/__init__.mojo
+++ b/mojo/stdlib/stdlib/prelude/__init__.mojo
@@ -66,6 +66,7 @@ from builtin.len import Sized, SizedRaising, UIntSized, len
 from builtin.math import (
     Absable,
     Powable,
+    RoundMode,
     Roundable,
     abs,
     divmod,

--- a/mojo/stdlib/test/builtin/test_int.mojo
+++ b/mojo/stdlib/test/builtin/test_int.mojo
@@ -69,13 +69,13 @@ def test_floor():
 
 
 def test_round():
-    assert_equal(Int.__round__(Int(5)), 5)
-    assert_equal(Int.__round__(Int(0)), 0)
-    assert_equal(Int.__round__(Int(-5)), -5)
-    assert_equal(Int.__round__(5, 1), 5)
-    assert_equal(Int.__round__(0, 1), 0)
-    assert_equal(Int.__round__(-5, 1), -5)
-    assert_equal(Int.__round__(100, -2), 100)
+    assert_equal(round(Int(5)), 5)
+    assert_equal(round(Int(0)), 0)
+    assert_equal(round(Int(-5)), -5)
+    assert_equal(round(Int(5), 1), 5)
+    assert_equal(round(Int(0), 1), 0)
+    assert_equal(round(Int(-5), 1), -5)
+    assert_equal(round(Int(100), -2), 100)
 
 
 def test_trunc():

--- a/mojo/stdlib/test/builtin/test_uint.mojo
+++ b/mojo/stdlib/test/builtin/test_uint.mojo
@@ -143,13 +143,13 @@ def test_floor():
 
 
 def test_round():
-    assert_equal(UInt.__round__(UInt(5)), UInt(5))
-    assert_equal(UInt.__round__(UInt(0)), UInt(0))
-    assert_equal(UInt.__round__(UInt(Int(-5))), UInt(Int(-5)))
-    assert_equal(UInt.__round__(UInt(5), UInt(1)), UInt(5))
-    assert_equal(UInt.__round__(UInt(0), UInt(1)), UInt(0))
-    assert_equal(UInt.__round__(UInt(Int(-5)), UInt(1)), UInt(Int(-5)))
-    assert_equal(UInt.__round__(UInt(100), UInt(Int(-2))), UInt(100))
+    assert_equal(round(UInt(5)), UInt(5))
+    assert_equal(round(UInt(0)), UInt(0))
+    assert_equal(round(UInt(Int(-5))), UInt(Int(-5)))
+    assert_equal(round(UInt(5), UInt(1)), UInt(5))
+    assert_equal(round(UInt(0), UInt(1)), UInt(0))
+    assert_equal(round(UInt(Int(-5)), UInt(1)), UInt(Int(-5)))
+    assert_equal(round(UInt(100), UInt(Int(-2))), UInt(100))
 
 
 def test_trunc():


### PR DESCRIPTION
Refactor the `Roundable` trait. Closes #5224, closes #5200, closes  #4416. Closes MOCO-333

This adds an optimized version that handles most of the rounding modes that are used. It will also be a nice replacement for functions that are very used like `align_down` by being a compile time version (that is very optimized for powers of two) e.g. 
```mojo
var vectorized_end = align_down(length, bool_mask_width)
```
can become (we could also use an alias that binds the parametrized round builtin)
```mojo
var vectorized_end = round[RoundMode.Down, to_multiple_of=bool_mask_width](length)
```
which is the equivalent of doing: 
```mojo
alias offset = bool_mask_width - 1
var vectorized_end = length & ~offset
```

CC: @laszlokindrat 