### PR TITLE
[stdlib] Improve `String` and `ArcPointer` ref-counting

### DIFF
--- a/mojo/stdlib/stdlib/collections/string/string.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string.mojo
@@ -640,6 +640,7 @@ struct String(
     fn _is_unique(mut self) -> Bool:
         """Return true if the refcount is 1."""
         if self._capacity_or_data & Self.FLAG_IS_REF_COUNTED:
+            # TODO: use `load[MONOTONIC]` once load supports memory orderings.
             return (
                 self._refcount().fetch_sub[ordering = Consistency.MONOTONIC](0)
                 == 1
@@ -651,8 +652,8 @@ struct String(
     fn _add_ref(mut self):
         """Atomically increment the refcount."""
         if self._capacity_or_data & Self.FLAG_IS_REF_COUNTED:
-            # See `ArcPointer`'s refcount implementation for more docs
-            # on the use of memory orderings.
+            # See `ArcPointer`'s refcount implementation for more details on the
+            # use of memory orderings.
             _ = self._refcount().fetch_add[ordering = Consistency.MONOTONIC](1)
 
     @always_inline("nodebug")

--- a/mojo/stdlib/stdlib/collections/string/string.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string.mojo
@@ -84,7 +84,7 @@ from collections.string.string_slice import (
 )
 from hashlib.hasher import Hasher
 from os import PathLike, abort
-from os.atomic import Atomic
+from os.atomic import Atomic, Consistency, fence
 from sys import bit_width_of, size_of
 from sys.info import is_32bit
 from sys.ffi import c_char
@@ -640,7 +640,10 @@ struct String(
     fn _is_unique(mut self) -> Bool:
         """Return true if the refcount is 1."""
         if self._capacity_or_data & Self.FLAG_IS_REF_COUNTED:
-            return self._refcount().load() == 1
+            return (
+                self._refcount().fetch_sub[ordering = Consistency.MONOTONIC](0)
+                == 1
+            )
         else:
             return False
 
@@ -648,7 +651,9 @@ struct String(
     fn _add_ref(mut self):
         """Atomically increment the refcount."""
         if self._capacity_or_data & Self.FLAG_IS_REF_COUNTED:
-            _ = self._refcount().fetch_add(1)
+            # See `ArcPointer`'s refcount implementation for more docs
+            # on the use of memory orderings.
+            _ = self._refcount().fetch_add[ordering = Consistency.MONOTONIC](1)
 
     @always_inline("nodebug")
     fn _drop_ref(mut self):
@@ -656,9 +661,11 @@ struct String(
         hits zero."""
         # If indirect or inline we don't need to do anything.
         if self._capacity_or_data & Self.FLAG_IS_REF_COUNTED:
-            var ptr = self._ptr_or_data - Self.REF_COUNT_SIZE
-            var refcount = ptr.bitcast[Atomic[DType.index]]()
-            if refcount[].fetch_sub(1) == 1:
+            if (
+                self._refcount().fetch_sub[ordering = Consistency.RELEASE](1)
+                == 1
+            ):
+                fence[Consistency.ACQUIRE]()
                 ptr.free()
 
     @staticmethod

--- a/mojo/stdlib/stdlib/collections/string/string.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string.mojo
@@ -662,10 +662,9 @@ struct String(
         hits zero."""
         # If indirect or inline we don't need to do anything.
         if self._capacity_or_data & Self.FLAG_IS_REF_COUNTED:
-            if (
-                self._refcount().fetch_sub[ordering = Consistency.RELEASE](1)
-                == 1
-            ):
+            var ptr = self._ptr_or_data - Self.REF_COUNT_SIZE
+            var refcount = ptr.bitcast[Atomic[DType.index]]()
+            if refcount[].fetch_sub[ordering = Consistency.RELEASE](1) == 1:
                 fence[Consistency.ACQUIRE]()
                 ptr.free()
 

--- a/mojo/stdlib/stdlib/memory/arc.mojo
+++ b/mojo/stdlib/stdlib/memory/arc.mojo
@@ -34,9 +34,10 @@ struct _ArcPointerInner[T: Movable]:
     fn add_ref(mut self):
         """Atomically increment the refcount."""
 
-        # `MONOTONIC` is ok here since since we know the original reference
-        # this ArcPointer is copied from prevents an erroneous deletion from
-        # a different ArcPointer in another thread.
+        # `MONOTONIC` is ok here since this ArcPointer is currently being copied
+        # from an existing ArcPointer inside of __copyinit__. This means any
+        # other ArcPointer in different threads running their destructors will
+        # not see a refcount of 0 and will not delete the shared data.
         #
         # This is further explained in the [boost documentation]
         # (https://www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html)
@@ -48,13 +49,15 @@ struct _ArcPointerInner[T: Movable]:
 
         # `RELEASE` is needed to ensure that all data access happens before
         # decreasing the refcount. `ACQUIRE_RELEASE` is not needed since we
-        # don't need the guarantees of `ACQUIRE` if the recount is not yet zero.
+        # don't need the guarantees of `ACQUIRE` on the load portion of
+        # fetch_sub if the recount does not reach zero.
         if self.refcount.fetch_sub[ordering = Consistency.RELEASE](1) != 1:
             return False
 
-        # However, if the refcount is zero, this `ACQUIRE` fence synchronizes with the
-        # `fetch_sub[RELEASE]` above, ensuring that use of data happens before the fence,
-        # and before the deletion of the data.
+        # However, if the refcount results in zero, this `ACQUIRE` fence is
+        # needed to synchronize with the `fetch_sub[RELEASE]` above, ensuring
+        # that use of data happens before the fence and therefore before the
+        # deletion of the data.
         fence[ordering = Consistency.ACQUIRE]()
         return True
 
@@ -173,7 +176,16 @@ struct ArcPointer[T: Movable](
         Returns:
             The current amount of references to the pointee.
         """
-        return self._inner[].refcount.load()
+        # TODO: this should use `load[MONOTONIC]()` once load supports memory
+        # orderings.
+        #
+        # MONOTONIC is okay here - reading refcount simply needs to be atomic.
+        # No synchronization is needed as this is not attempting to free the
+        # shared data and it is not possible for the data to be freed until
+        # this ArcPointer is destroyed.
+        return self._inner[].refcount.fetch_sub[
+            ordering = Consistency.MONOTONIC
+        ](0)
 
     fn __is__(self, rhs: Self) -> Bool:
         """Returns True if the two `ArcPointer` instances point at the same


### PR DESCRIPTION
This improves the atomic operations for both `ArcPointer` and `String`'s reference counting.
We can use explicit memory orderings in the operations along with a `fence` to improve both the performance and to more clearly state the intent of the atomic ops.

If you're curious, you can read more about the standard ref-count pointer type in the [boost docs](https://www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html#boost_atomic.usage_examples.example_reference_counters.implementation).