### PR TITLE
[stdlib] Fix changelog for renaming  in `sys.info`

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -234,23 +234,20 @@ language across multiple phases.
   ```
 
 - Deprecated the following functions with `flatcase` names in `sys.info`:
-  - `simdbitwidth`
-  - `simdbytewidth`
-  - `sizeof`
   - `alignof`
   - `bitwidthof`
-  - `bitwidthof`
+  - `simdbitwidth`
+  - `simdbytewidth`
   - `simdwidthof`
-  - `simdwidthof`
+  - `sizeof`
+
   in favor of `snake_case` counterparts, respectively:
-  - `simd_bit_width`
-  - `simd_byte_width`
-  - `size_of`
   - `align_of`
   - `bit_width_of`
-  - `bit_width_of`
+  - `simd_bit_width`
+  - `simd_byte_width`
   - `simd_width_of`
-  - `simd_width_of`
+  - `size_of`
 
 - Added support for AMD RX 6900 XT consumer-grade GPU.
 


### PR DESCRIPTION
I've messed up changelog in https://github.com/modular/modular/pull/5240 (duplicated names from overloads). This patch fixes this. Now names are also sorted

cc @laszlokindrat 