### PR TITLE
[stdlib] Change String bytes constructor to check utf8 validity and add an unsafe variant

### DIFF
--- a/max/kernels/src/Mogg/MOGGPrimitives/MOGGPrimitives.mojo
+++ b/max/kernels/src/Mogg/MOGGPrimitives/MOGGPrimitives.mojo
@@ -71,12 +71,9 @@ struct StateContext:
 fn pack_string_res(
     str_ptr: UnsafePointer[Byte], str_len: UInt
 ) raises -> String:
-    var span = Span[Byte, ImmutableAnyOrigin](
-        ptr=str_ptr,
-        length=str_len,
-    )
+    var span = Span[Byte, ImmutableAnyOrigin](ptr=str_ptr, length=str_len)
     # We can not free the resource ptr embedded in MEF, create a copy
-    return String(StringSlice(from_utf8=span))
+    return String(from_utf8=span)
 
 
 # ===-----------------------------------------------------------------------===#

--- a/mojo/stdlib/stdlib/io/file.mojo
+++ b/mojo/stdlib/stdlib/io/file.mojo
@@ -183,9 +183,7 @@ struct FileHandle(Defaultable, Movable, Writer):
         print(first_word)
         ```
         """
-
-        var list = self.read_bytes(size)
-        return String(bytes=list)
+        return String(from_utf8=self.read_bytes(size))
 
     fn read[
         dtype: DType, origin: Origin[True]

--- a/mojo/stdlib/test/builtin/test_file.mojo
+++ b/mojo/stdlib/test/builtin/test_file.mojo
@@ -48,13 +48,13 @@ def test_file_read_bytes_multi():
     ) as f:
         var bytes1 = f.read_bytes(12)
         assert_equal(len(bytes1), 12, "12 bytes")
-        var string1 = String(bytes=bytes1)
+        var string1 = String(unsafe_from_utf8=bytes1)
         assert_equal(len(string1), 12, "12 chars")
         assert_equal(string1, "Lorem ipsum ")
 
         var bytes2 = f.read_bytes(6)
         assert_equal(len(bytes2), 6, "6 bytes")
-        var string2 = String(bytes=bytes2)
+        var string2 = String(unsafe_from_utf8=bytes2)
         assert_equal(len(string2), 6, "6 chars")
         assert_equal(string2, "dolor ")
 

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -703,9 +703,9 @@ def test_split():
         "\x1c",
         "\x1d",
         "\x1e",
-        String(bytes=next_line),
-        String(bytes=unicode_line_sep),
-        String(bytes=unicode_paragraph_sep),
+        String(from_utf8=next_line),
+        String(from_utf8=unicode_line_sep),
+        String(from_utf8=unicode_paragraph_sep),
     )
     var s = univ_sep_var + "hello" + univ_sep_var + "world" + univ_sep_var
     assert_equal(StringSlice(s).split(), L("hello", "world"))
@@ -802,14 +802,12 @@ def test_splitlines():
     )
 
     # test \x85 \u2028 \u2029
-    var next_line = String(bytes=List[UInt8](0xC2, 0x85))
-    var unicode_line_sep = String(bytes=List[UInt8](0xE2, 0x80, 0xA8))
-    var unicode_paragraph_sep = String(bytes=List[UInt8](0xE2, 0x80, 0xA9))
+    var next_line = String(from_utf8=List[UInt8](0xC2, 0x85))
+    var unicode_line_sep = String(from_utf8=List[UInt8](0xE2, 0x80, 0xA8))
+    var unicode_paragraph_sep = String(from_utf8=List[UInt8](0xE2, 0x80, 0xA9))
 
     for u in [next_line, unicode_line_sep, unicode_paragraph_sep]:
-        item = StaticString("").join(
-            "hello", u, "world", u, "mojo", u, "language", u
-        )
+        item = String("hello", u, "world", u, "mojo", u, "language", u)
         assert_equal(item.splitlines(), hello_mojo)
         assert_equal(
             _to_string_list(item.splitlines(keepends=True)),
@@ -836,9 +834,9 @@ def test_isspace():
         "\x1c",
         "\x1d",
         "\x1e",
-        String(bytes=next_line),
-        String(bytes=unicode_line_sep),
-        String(bytes=unicode_paragraph_sep),
+        String(from_utf8=next_line),
+        String(from_utf8=unicode_line_sep),
+        String(from_utf8=unicode_paragraph_sep),
     ]
 
     for i in univ_sep_var:

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -502,9 +502,9 @@ def test_split():
         "\x1c",
         "\x1d",
         "\x1e",
-        String(bytes=next_line),
-        String(bytes=unicode_line_sep),
-        String(bytes=unicode_paragraph_sep),
+        String(from_utf8=next_line),
+        String(from_utf8=unicode_line_sep),
+        String(from_utf8=unicode_paragraph_sep),
     )
     var s = univ_sep_var + "hello" + univ_sep_var + "world" + univ_sep_var
     assert_equal(StringSlice(s).split(), L("hello", "world"))
@@ -601,9 +601,9 @@ def test_splitlines():
     )
 
     # test \x85 \u2028 \u2029
-    var next_line = String(bytes=List[UInt8](0xC2, 0x85))
-    var unicode_line_sep = String(bytes=List[UInt8](0xE2, 0x80, 0xA8))
-    var unicode_paragraph_sep = String(bytes=List[UInt8](0xE2, 0x80, 0xA9))
+    var next_line = String(from_utf8=List[UInt8](0xC2, 0x85))
+    var unicode_line_sep = String(from_utf8=List[UInt8](0xE2, 0x80, 0xA8))
+    var unicode_paragraph_sep = String(from_utf8=List[UInt8](0xE2, 0x80, 0xA9))
 
     for ref u in [next_line, unicode_line_sep, unicode_paragraph_sep]:
         item = StaticString("").join(

--- a/mojo/stdlib/test/python/test_python_object.mojo
+++ b/mojo/stdlib/test/python/test_python_object.mojo
@@ -206,7 +206,7 @@ fn test_string_conversions(mut python: Python) raises -> None:
 
     # check that invalid utf-8 encoding raises an error
     var buffer = InlineArray[Byte, 2](0xF0, 0x28)
-    var invalid = String(bytes=buffer)
+    var invalid = StringSlice(unsafe_from_utf8=buffer)
     with assert_raises(contains="'utf-8' codec can't decode byte"):
         _ = PythonObject(invalid)
 


### PR DESCRIPTION
Change String bytes constructor to check utf8 validity and add an unsafe variant