### PR TITLE
[stdlib][proposal] Allow `Scalar[DType.bool].__index__()`

### DIFF
--- a/mojo/stdlib/stdlib/builtin/simd.mojo
+++ b/mojo/stdlib/stdlib/builtin/simd.mojo
@@ -1859,7 +1859,8 @@ struct SIMD[dtype: DType, size: Int](
             The corresponding __mlir_type.index value.
         """
         constrained[
-            dtype.is_integral(), "cannot index using a floating point type"
+            not dtype.is_floating_point(),
+            "cannot index using a floating point type",
         ]()
         # NOTE: using Int(self) here would cause an infinite recursion.
         return self.__int__()._mlir_value


### PR DESCRIPTION
Allow `Scalar[DType.bool].__index__()`. This is useful for constructing things like `UInt`. A secondary effect this has that might or not be desired is that now one can do:
```mojo
var options = [1, 2]
var some_condition = Scalar[DType.bool](True)
print(options[some_condition]) # 2
```