### PR TITLE
[stdlib] Rename `DType.bit_width()` and replace uses of `sys.info.bit_width_of`

### DIFF
--- a/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
@@ -33,7 +33,7 @@ from math import (
     tanh,
 )
 from random import randn, seed
-from sys import bit_width_of, external_call, llvm_intrinsic
+from sys import external_call, llvm_intrinsic
 from sys.info import simd_width_of, size_of
 from sys.intrinsics import _type_is_eq
 

--- a/max/kernels/src/layout/tensor_core_async.mojo
+++ b/max/kernels/src/layout/tensor_core_async.mojo
@@ -270,7 +270,7 @@ fn select_k_atom[
         `Layout` - A core matrix layout optimized for tensor core operations.
     """
     alias a = _select_k_atom_bits[swizzle_mode]()
-    return upcast(a, dtype.bitwidth())
+    return upcast(a, dtype.bit_width())
 
 
 fn _checked_tile_shape[

--- a/max/kernels/src/nn/toppminp_gpu.mojo
+++ b/max/kernels/src/nn/toppminp_gpu.mojo
@@ -13,7 +13,7 @@
 
 
 from math import ceildiv
-from sys import align_of, bit_width_of
+from sys import align_of
 
 from buffer import NDBuffer, DimList
 from builtin.dtype import _uint_type_of_width
@@ -165,7 +165,7 @@ fn normalize(value: BFloat16) -> Scalar[DType.uint16]:
     # Normalize bf16 values by flipping the sign bit for positive and fully
     # inverting negative numbers
     var bits = reinterpret(value)
-    alias sign_bit_mask = (0b1 << (bit_width_of[DType.bfloat16]() - 1))
+    alias sign_bit_mask = (0b1 << (DType.bfloat16.bit_width() - 1))
     if bits & sign_bit_mask:
         # For negative numbers, flip all bits (two's complement behavior)
         return ~bits
@@ -190,7 +190,7 @@ fn normalize(value: Int32) -> UInt32:
     # For signed integers: Flip the most significant bit to ensure correct ordering
     # This makes negative numbers appear "smaller" than positive numbers in
     # unsigned comparison
-    alias sign_bit_mask = (0b1 << (bit_width_of[DType.int32]() - 1))
+    alias sign_bit_mask = (0b1 << (DType.int32.bit_width() - 1))
 
     return reinterpret(value) ^ sign_bit_mask
 
@@ -210,7 +210,7 @@ fn normalize(value: Float32) -> UInt32:
         return bitcast[DType.uint32, 1](value)
 
     var bits = reinterpret(value)
-    alias sign_bit = bit_width_of[DType.float32]() - 1
+    alias sign_bit = DType.float32.bit_width() - 1
     # Flip all bits if the value is negative (sign bit is 1)
     # This makes more negative numbers appear "smaller" in unsigned comparison
     return bits ^ ((-(bits >> sign_bit)) | (0b1 << sign_bit))
@@ -219,7 +219,7 @@ fn normalize(value: Float32) -> UInt32:
 @always_inline
 fn normalize(
     value: Scalar,
-    out result: Scalar[_uint_type_of_width[bit_width_of[value.dtype]()]()],
+    out result: Scalar[_uint_type_of_width[value.dtype.bit_width()]()],
 ):
     """
     Normalize the value to the appropriate unsigned integer type. This is needed
@@ -509,7 +509,7 @@ fn run_radix_sort_pairs_gpu[
     var vocab_size = in_shape[1]
 
     @parameter
-    for current_bit in range(0, bit_width_of[dtype](), NUM_BITS_PER_PASS):
+    for current_bit in range(0, dtype.bit_width(), NUM_BITS_PER_PASS):
         alias kernel = radix_sort_pairs_kernel[
             dtype, out_idx_type, current_bit, ascending, BLOCK_SIZE
         ]

--- a/max/kernels/test/gpu/linalg/test_matmul.mojo
+++ b/max/kernels/test/gpu/linalg/test_matmul.mojo
@@ -273,7 +273,7 @@ fn test[
             var actual = c_host_tensor[m, n]
 
             @parameter
-            if bit_width_of[dtype]() <= 16:
+            if dtype.bit_width() <= 16:
                 var ulp_dist = ulp_distance(actual, expect)
                 if ulp_dist <= _max_ulp_distance:
                     continue

--- a/mojo/stdlib/stdlib/bit/_mask.mojo
+++ b/mojo/stdlib/stdlib/bit/_mask.mojo
@@ -59,7 +59,7 @@ fn is_negative[dtype: DType, //](value: SIMD[dtype, _]) -> __type_of(value):
     alias d = dtype if dtype is not DType.index else (
         DType.int32 if dtype.size_of() == 4 else DType.int64
     )
-    return (value.cast[d]() >> (bit_width_of[d]() - 1)).cast[dtype]()
+    return (value.cast[d]() >> (d.bit_width() - 1)).cast[dtype]()
 
 
 @always_inline

--- a/mojo/stdlib/stdlib/bit/bit.mojo
+++ b/mojo/stdlib/stdlib/bit/bit.mojo
@@ -216,7 +216,7 @@ fn byte_swap[
     constrained[dtype.is_integral(), "must be integral"]()
 
     @parameter
-    if dtype.bitwidth() < 16:
+    if dtype.bit_width() < 16:
         return val
     return llvm_intrinsic["llvm.bswap", __type_of(val), has_side_effect=False](
         val
@@ -335,7 +335,7 @@ fn bit_width[
         A SIMD value where the element at position `i` equals the number of bits required to represent the integer at position `i` of the input.
     """
     constrained[dtype.is_integral(), "must be integral"]()
-    alias bitwidth = bit_width_of[dtype]()
+    alias bitwidth = dtype.bit_width()
 
     @parameter
     if dtype.is_unsigned():
@@ -398,7 +398,7 @@ fn log2_floor[
     """
     constrained[dtype.is_integral(), "dtype must be integral"]()
 
-    alias bitwidth = bit_width_of[dtype]()
+    alias bitwidth = dtype.bit_width()
     var res = bitwidth - count_leading_zeros(val) - 1
 
     @parameter

--- a/mojo/stdlib/stdlib/builtin/dtype.mojo
+++ b/mojo/stdlib/stdlib/builtin/dtype.mojo
@@ -59,7 +59,7 @@ struct DType(
       for SIMD vectors, tensors, and other data structures
     - **Type parameters**: Pass `DType` values as compile-time parameters to
       parameterized types like `SIMD[dtype, size]`
-    - **Type introspection**: Call methods like `.bitwidth()`, `.is_floating_point()`
+    - **Type introspection**: Call methods like `.bit_width()`, `.is_floating_point()`
       to query type properties at compile time
     - **Type conversion**: Use in casting operations to convert between different
       numeric representations
@@ -74,7 +74,7 @@ struct DType(
     var dtype = data.dtype
 
     print("Is float:", dtype.is_floating_point())  # True
-    print("Bit width:", dtype.bitwidth())          # 16
+    print("Bit width:", dtype.bit_width())          # 16
     print("Is signed:", dtype.is_signed())         # True
     ```
     """
@@ -662,7 +662,7 @@ struct DType(
         return size_of[DType.invalid]()
 
     @always_inline
-    fn bitwidth(self) -> Int:
+    fn bit_width(self) -> Int:
         """Returns the size in bits of the current DType.
 
         Returns:
@@ -686,7 +686,7 @@ struct DType(
             The mantissa width.
         """
         constrained[dtype.is_floating_point(), "dtype must be floating point"]()
-        return bit_width_of[dtype]() - DType.exponent_width[dtype]() - 1
+        return dtype.bit_width() - DType.exponent_width[dtype]() - 1
 
     @staticmethod
     @always_inline("nodebug")
@@ -837,7 +837,7 @@ struct DType(
         Parameters:
             func: A parametrized on dtype function to dispatch.
         """
-        var bitwidth = self.bitwidth()
+        var bitwidth = self.bit_width()
         if bitwidth == 8:
             func[DType.uint8]()
         elif bitwidth == 16:
@@ -1084,7 +1084,7 @@ fn _unsigned_integral_type_of[dtype: DType]() -> DType:
     if dtype.is_unsigned():
         return dtype
     elif dtype.is_integral():
-        return _uint_type_of_width[bit_width_of[dtype]()]()
+        return _uint_type_of_width[dtype.bit_width()]()
 
     elif dtype.is_float8():
         return DType.uint8

--- a/mojo/stdlib/stdlib/builtin/format_int.mojo
+++ b/mojo/stdlib/stdlib/builtin/format_int.mojo
@@ -333,7 +333,7 @@ fn _try_write_int[
     # Stack allocate enough bytes to store any formatted integer up to 256 bits
     # TODO: use a dynamic size when #2194 is resolved
     # +1 for storing NUL terminator.
-    alias CAPACITY: Int = max(64, dtype.bitwidth()) + 1
+    alias CAPACITY: Int = max(64, dtype.bit_width()) + 1
 
     var buf = InlineArray[UInt8, CAPACITY](uninitialized=True)
 

--- a/mojo/stdlib/stdlib/builtin/int.mojo
+++ b/mojo/stdlib/stdlib/builtin/int.mojo
@@ -22,7 +22,6 @@ from collections.string.string import (
 from collections.interval import IntervalElement
 from hashlib.hasher import Hasher
 from math import CeilDivable, Ceilable, Floorable, Truncable
-from sys import bit_width_of
 from sys.info import is_32bit
 
 from builtin.device_passable import DevicePassable
@@ -244,7 +243,7 @@ struct Int(
     # Aliases
     # ===-------------------------------------------------------------------===#
 
-    alias BITWIDTH = Int(bit_width_of[DType.index]())
+    alias BITWIDTH = Int(DType.index.bit_width())
     """The bit width of the integer type."""
 
     alias MAX = Int(Scalar[DType.index].MAX)

--- a/mojo/stdlib/stdlib/builtin/simd.mojo
+++ b/mojo/stdlib/stdlib/builtin/simd.mojo
@@ -530,7 +530,7 @@ struct SIMD[dtype: DType, size: Int](
         _simd_construction_checks[dtype, size]()
 
         @parameter
-        if bit_width_of[dtype]() > bit_width_of[DType.index]():
+        if dtype.bit_width() > DType.index.bit_width():
             alias dt = _unsigned_integral_type_of[DType.index]()
             self = bitcast[dt](Scalar[DType.index](value.__int__())).cast[
                 dtype
@@ -624,7 +624,7 @@ struct SIMD[dtype: DType, size: Int](
                 raise cpy.unsafe_get_error()
             # NOTE: if dtype is not float64, we truncate.
             self = Scalar[dtype](float_value)
-        elif dtype.is_integral() and dtype.bitwidth() <= 64:
+        elif dtype.is_integral() and dtype.bit_width() <= 64:
             self = Int(obj)
         else:
             self = Scalar[dtype]()
@@ -1164,7 +1164,7 @@ struct SIMD[dtype: DType, size: Int](
         constrained[dtype.is_integral(), "must be an integral type"]()
         debug_assert(all(rhs.ge(0)), "unhandled negative value")
         debug_assert(
-            all(rhs.lt(bit_width_of[dtype]())),
+            all(rhs.lt(dtype.bit_width())),
             "unhandled value greater than size",
         )
         return Self(
@@ -1187,7 +1187,7 @@ struct SIMD[dtype: DType, size: Int](
         constrained[dtype.is_integral(), "must be an integral type"]()
         debug_assert(all(rhs.ge(0)), "unhandled negative value")
         debug_assert(
-            all(rhs.lt(bit_width_of[dtype]())),
+            all(rhs.lt(dtype.bit_width())),
             "unhandled value greater than size",
         )
         return Self(
@@ -2236,7 +2236,7 @@ struct SIMD[dtype: DType, size: Int](
 
     @always_inline
     fn to_bits[
-        dtype: DType = _uint_type_of_width[bit_width_of[dtype]()]()
+        dtype: DType = _uint_type_of_width[dtype.bit_width()]()
     ](self) -> SIMD[dtype, size]:
         """Bitcasts the SIMD vector to an integer SIMD vector.
 
@@ -2251,7 +2251,7 @@ struct SIMD[dtype: DType, size: Int](
             "the target type must be unsigned integral",
         ]()
         constrained[
-            dtype.bitwidth() >= Self.dtype.bitwidth(),
+            dtype.bit_width() >= Self.dtype.bit_width(),
             "the target type must be at least as wide as the source type",
         ]()
 
@@ -3536,7 +3536,7 @@ fn _convert_f32_to_float8_scalar[
 
     alias FP8_NUM_MANTISSA_BITS = FPUtils[target].mantissa_width()
     alias FP8_NUM_EXPONENT_BITS = FPUtils[target].exponent_width()
-    alias FP32_NUM_BITS = bit_width_of[dtype]()
+    alias FP32_NUM_BITS = dtype.bit_width()
     alias FP8_EXPONENT_MASK: UInt8 = (1 << FP8_NUM_EXPONENT_BITS) - 1
     alias FP8_MANTISSA_MASK: UInt8 = (1 << FP8_NUM_MANTISSA_BITS) - 1
     alias FP8_EXPONENT_BIAS = FPUtils[target].exponent_bias()
@@ -3885,7 +3885,7 @@ fn _floor(x: SIMD) -> __type_of(x):
         return x
 
     alias integral_type = FPUtils[x.dtype].integral_type
-    alias bitwidth = bit_width_of[x.dtype]()
+    alias bitwidth = x.dtype.bit_width()
     alias exponent_width = FPUtils[x.dtype].exponent_width()
     alias mantissa_width = FPUtils[x.dtype].mantissa_width()
     alias mask = FPUtils[x.dtype].exponent_mask()

--- a/mojo/stdlib/stdlib/builtin/sort.mojo
+++ b/mojo/stdlib/stdlib/builtin/sort.mojo
@@ -16,7 +16,6 @@ These are Mojo built-ins, so you don't need to import them.
 """
 
 from math import ceil
-from sys import bit_width_of
 
 from bit import count_leading_zeros
 from memory import Span
@@ -162,7 +161,7 @@ fn _heap_sort[
 fn _estimate_initial_height(size: Int) -> Int:
     # Compute the log2 of the size rounded upward.
     var log2 = Int(
-        (bit_width_of[DType.index]() - 1) ^ count_leading_zeros(size | 1)
+        (DType.index.bit_width() - 1) ^ count_leading_zeros(size | 1)
     )
     # The number 1.3 was chosen by experimenting the max stack size for random
     # input. This also depends on insertion_sort_threshold

--- a/mojo/stdlib/stdlib/builtin/uint.mojo
+++ b/mojo/stdlib/stdlib/builtin/uint.mojo
@@ -17,7 +17,6 @@ These are Mojo built-ins, so you don't need to import them.
 
 from hashlib.hasher import Hasher
 from math import CeilDivable
-from sys import bit_width_of
 
 from builtin.math import Absable, DivModable
 
@@ -69,7 +68,7 @@ struct UInt(
     # Aliases
     # ===-------------------------------------------------------------------===#
 
-    alias BITWIDTH = Int(bit_width_of[DType.index]())
+    alias BITWIDTH = UInt(DType.index.bit_width())
     """The bit width of the integer type."""
 
     alias MAX = UInt((1 << Self.BITWIDTH) - 1)

--- a/mojo/stdlib/stdlib/collections/bitset.mojo
+++ b/mojo/stdlib/stdlib/collections/bitset.mojo
@@ -36,7 +36,7 @@ from algorithm import vectorize
 from bit import log2_floor, pop_count
 from math import ceildiv
 from memory import pack_bits
-from sys import bit_width_of, simd_width_of
+from sys import simd_width_of
 
 from .inline_array import InlineArray
 
@@ -44,7 +44,7 @@ from .inline_array import InlineArray
 # Utilities
 # ===-----------------------------------------------------------------------===#
 
-alias _WORD_BITS = bit_width_of[UInt64]()
+alias _WORD_BITS = DType.uint64.bit_width()
 alias _WORD_BITS_LOG2 = log2_floor(_WORD_BITS)
 
 

--- a/mojo/stdlib/stdlib/collections/string/string.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string.mojo
@@ -85,7 +85,7 @@ from collections.string.string_slice import (
 from hashlib.hasher import Hasher
 from os import PathLike, abort
 from os.atomic import Atomic, Consistency, fence
-from sys import bit_width_of, size_of
+from sys import size_of
 from sys.info import is_32bit
 from sys.ffi import c_char
 
@@ -2335,9 +2335,7 @@ fn _calc_initial_buffer_size_int32(n0: Int) -> Int:
         42949672960,
     )
     var n = UInt32(n0)
-    var log2 = Int(
-        (bit_width_of[DType.uint32]() - 1) ^ count_leading_zeros(n | 1)
-    )
+    var log2 = Int((DType.uint32.bit_width() - 1) ^ count_leading_zeros(n | 1))
     return (n0 + lookup_table[Int(log2)]) >> 32
 
 
@@ -2375,7 +2373,7 @@ fn _calc_initial_buffer_size[dtype: DType](n0: Scalar[dtype]) -> Int:
         var sign = 0 if n0 > 0 else 1
 
         @parameter
-        if is_32bit() or bit_width_of[dtype]() <= 32:
+        if is_32bit() or dtype.bit_width() <= 32:
             return sign + _calc_initial_buffer_size_int32(Int(n)) + 1
         else:
             return (

--- a/mojo/stdlib/stdlib/gpu/host/device_context.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/device_context.mojo
@@ -5710,7 +5710,7 @@ struct DeviceContext(ImplicitlyCopyable, Movable):
             dst: Destination buffer.
             val: Value to set all elements of `dst` to.
         """
-        alias bitwidth = bit_width_of[dtype]()
+        alias bitwidth = dtype.bit_width()
         constrained[
             bitwidth == 8 or bitwidth == 16 or bitwidth == 32 or bitwidth == 64,
             "bitwidth of memset dtype must be one of [8,16,32,64]",
@@ -5757,7 +5757,7 @@ struct DeviceContext(ImplicitlyCopyable, Movable):
             dst: Destination buffer.
             val: Value to set all elements of `dst` to.
         """
-        alias bitwidth = bit_width_of[dtype]()
+        alias bitwidth = dtype.bit_width()
         constrained[
             bitwidth == 8 or bitwidth == 16 or bitwidth == 32 or bitwidth == 64,
             "bitwidth of memset dtype must be one of [8,16,32,64]",

--- a/mojo/stdlib/stdlib/gpu/intrinsics.mojo
+++ b/mojo/stdlib/stdlib/gpu/intrinsics.mojo
@@ -631,7 +631,7 @@ fn threadfence[scope: Scope = Scope.GPU]():
 
 
 fn _get_type_suffix[dtype: DType]() -> StaticString:
-    alias str = get_static_string["u", _int_to_str[bit_width_of[dtype]()]()]()
+    alias str = get_static_string["u", _int_to_str[dtype.bit_width()]()]()
     return str
 
 
@@ -641,7 +641,7 @@ fn _get_register_constraint[dtype: DType]() -> StaticString:
     if dtype.is_half_float():
         return "h"
     if dtype.is_integral():
-        alias width = bit_width_of[dtype]()
+        alias width = dtype.bit_width()
         if width == 16:
             return "c"
         if width == 32:

--- a/mojo/stdlib/stdlib/gpu/memory.mojo
+++ b/mojo/stdlib/stdlib/gpu/memory.mojo
@@ -1451,7 +1451,7 @@ fn _load_impl[
         constrained[prefetch_size.value() in (64, 128, 256)]()
 
     alias bytes_to_load = size_of[dtype]() * width
-    alias dtype_bitwidth = bit_width_of[dtype]()
+    alias dtype_bitwidth = dtype.bit_width()
 
     @parameter
     if bytes_to_load < size_of[DType.uint32]():

--- a/mojo/stdlib/stdlib/gpu/warp.mojo
+++ b/mojo/stdlib/stdlib/gpu/warp.mojo
@@ -146,10 +146,10 @@ fn _shuffle_amd_helper[
         return _shuffle_amd_helper(dst_lane, val.cast[DType.int32]()).cast[
             dtype
         ]()
-    elif bit_width_of[dtype]() == 16:
+    elif dtype.bit_width() == 16:
         var val_splatted = SIMD[dtype, 2](val._refine[size=1]())
         return _shuffle_amd_helper(dst_lane, val_splatted)[0]
-    elif bit_width_of[dtype]() == 64:
+    elif dtype.bit_width() == 64:
         var val_bitcast = bitcast[DType.uint32, simd_width * 2](val)
         var val_half1, val_half2 = val_bitcast.deinterleave()
         var shuffle1 = _shuffle_amd_helper(dst_lane, val_half1)

--- a/mojo/stdlib/stdlib/math/math.mojo
+++ b/mojo/stdlib/stdlib/math/math.mojo
@@ -1718,7 +1718,7 @@ fn atanh[dtype: DType, width: Int, //](x: SIMD[dtype, width]) -> __type_of(x):
     ]()
 
     @parameter
-    if bit_width_of[dtype]() <= 16:
+    if dtype.bit_width() <= 16:
         # We promote the input to float32 and then cast back to the original
         # type. This is done to avoid precision issues that can occur when
         # using the lower-precision floating-point types.

--- a/mojo/stdlib/stdlib/utils/fast_div.mojo
+++ b/mojo/stdlib/stdlib/utils/fast_div.mojo
@@ -17,7 +17,6 @@ This method replaces division by constants with a sequence of shifts and
 multiplications, significantly optimizing division performance.
 """
 
-from sys import bit_width_of
 from bit import log2_ceil
 from builtin.dtype import _uint_type_of_width
 from gpu.intrinsics import mulhi
@@ -33,7 +32,7 @@ struct FastDiv[dtype: DType](Stringable, Writable):
     especially in scenarios where division is a frequent operation.
     """
 
-    alias uint_type = _uint_type_of_width[bit_width_of[dtype]()]()
+    alias uint_type = _uint_type_of_width[dtype.bit_width()]()
 
     var _div: Scalar[Self.uint_type]
     var _mprime: Scalar[Self.uint_type]
@@ -54,7 +53,7 @@ struct FastDiv[dtype: DType](Stringable, Writable):
                 Defaults to 1.
         """
         constrained[
-            bit_width_of[dtype]() <= 32,
+            dtype.bit_width() <= 32,
             "larger types are not currently supported",
         ]()
         self._div = divisor
@@ -66,7 +65,7 @@ struct FastDiv[dtype: DType](Stringable, Writable):
         if not self._is_pow2:
             self._mprime = (
                 (
-                    (UInt64(1) << bit_width_of[dtype]())
+                    (UInt64(1) << dtype.bit_width())
                     * ((1 << self._log2_shift.cast[DType.uint64]()) - divisor)
                     / divisor
                 )

--- a/mojo/stdlib/stdlib/utils/index.mojo
+++ b/mojo/stdlib/stdlib/utils/index.mojo
@@ -21,7 +21,6 @@ from utils import IndexList
 """
 
 from hashlib.hasher import Hasher
-from sys import bit_width_of
 
 from builtin.dtype import _int_type_of_width, _uint_type_of_width
 from builtin.device_passable import DevicePassable
@@ -701,7 +700,7 @@ struct IndexList[size: Int, *, element_type: DType = DType.int64](
             var element = self[i]
 
             @parameter
-            if bit_width_of[element_type]() == 32:
+            if element_type.bit_width() == 32:
                 writer.write(Int32(element))
             else:
                 writer.write(Int64(element))

--- a/mojo/stdlib/test/bit/test_mask.mojo
+++ b/mojo/stdlib/test/bit/test_mask.mojo
@@ -29,7 +29,7 @@ def test_is_negative():
     @parameter
     for i in range(len(dtypes)):
         alias D = dtypes[i]
-        var last_value = 2 ** (bit_width_of[D]() - 1) - 1
+        var last_value = 2 ** (D.bit_width() - 1) - 1
         var values = [1, 2, last_value - 1, last_value]
 
         @parameter
@@ -80,7 +80,7 @@ def test_compare():
     @parameter
     for i in range(len(dtypes)):
         alias D = dtypes[i]
-        var last_value = 2 ** (bit_width_of[D]() - 1) - 1
+        var last_value = 2 ** (D.bit_width() - 1) - 1
         var values = [1, 2, last_value - 1, last_value]
 
         @parameter

--- a/mojo/stdlib/test/builtin/test_int.mojo
+++ b/mojo/stdlib/test/builtin/test_int.mojo
@@ -11,15 +11,13 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from sys.info import bit_width_of
-
 from python import PythonObject
 from testing import assert_equal, assert_false, assert_raises, assert_true
 
 
 def test_properties():
-    assert_equal(Int.MAX, (1 << bit_width_of[DType.index]() - 1) - 1)
-    assert_equal(Int.MIN, -(1 << bit_width_of[DType.index]() - 1))
+    assert_equal(Int.MAX, (1 << DType.index.bit_width() - 1) - 1)
+    assert_equal(Int.MIN, -(1 << DType.index.bit_width() - 1))
 
 
 def test_add():

--- a/mojo/stdlib/test/builtin/test_uint.mojo
+++ b/mojo/stdlib/test/builtin/test_uint.mojo
@@ -11,7 +11,6 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from sys import bit_width_of
 
 from bit import count_trailing_zeros
 from testing import assert_equal, assert_false, assert_not_equal, assert_true
@@ -89,7 +88,7 @@ def test_inequality():
 
 def test_properties():
     assert_equal(UInt.MIN, UInt(0))
-    if bit_width_of[DType.index]() == 32:
+    if DType.index.bit_width() == 32:
         assert_equal(UInt.MAX, (1 << 32) - 1)
     else:
         assert_equal(UInt.MAX, (1 << 64) - 1)

--- a/mojo/stdlib/test/test_utils/math_helpers.mojo
+++ b/mojo/stdlib/test/test_utils/math_helpers.mojo
@@ -11,14 +11,13 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from sys import bit_width_of
 
 from builtin.dtype import _integral_type_of
 from memory import bitcast
 
 
 fn ulp_distance[dtype: DType](a: Scalar[dtype], b: Scalar[dtype]) -> Int:
-    alias bitwidth = bit_width_of[dtype]()
+    alias bitwidth = dtype.bit_width()
     alias T = _integral_type_of[dtype]()
     # widen to Int first to avoid overflow
     var a_int = Int(bitcast[T](a))


### PR DESCRIPTION
Rename `DType.bit_width()` and replace uses of `sys.info.bit_width_of`