### PR TITLE
[stdlib] `Variant` and `Optional` auto-optimizes on type trivialities.

### DIFF
--- a/mojo/stdlib/stdlib/collections/optional.mojo
+++ b/mojo/stdlib/stdlib/collections/optional.mojo
@@ -40,6 +40,10 @@ from utils import Variant
 # TODO(27780): NoneType can't currently conform to traits
 @fieldwise_init
 struct _NoneType(ImplicitlyCopyable, Movable):
+    alias __copyinit__is_trivial = True
+    alias __moveinit__is_trivial = True
+    alias __del__is_trivial = True
+
     fn __copyinit__(out self, other: Self):
         pass
 
@@ -86,6 +90,9 @@ struct Optional[T: Copyable & Movable](
     alias _type = Variant[_NoneType, T]
     var _value: Self._type
 
+    alias __copyinit__is_trivial = Self._type.__copyinit__is_trivial
+    alias __moveinit__is_trivial = Self._type.__moveinit__is_trivial
+    alias __del__is_trivial = Self._type.__del__is_trivial
     # ===-------------------------------------------------------------------===#
     # Life cycle methods
     # ===-------------------------------------------------------------------===#

--- a/mojo/stdlib/stdlib/collections/optional.mojo
+++ b/mojo/stdlib/stdlib/collections/optional.mojo
@@ -40,12 +40,7 @@ from utils import Variant
 # TODO(27780): NoneType can't currently conform to traits
 @fieldwise_init
 struct _NoneType(ImplicitlyCopyable, Movable):
-    alias __copyinit__is_trivial = True
-    alias __moveinit__is_trivial = True
-    alias __del__is_trivial = True
-
-    fn __copyinit__(out self, other: Self):
-        pass
+    ...
 
 
 # ===-----------------------------------------------------------------------===#
@@ -90,9 +85,6 @@ struct Optional[T: Copyable & Movable](
     alias _type = Variant[_NoneType, T]
     var _value: Self._type
 
-    alias __copyinit__is_trivial = Self._type.__copyinit__is_trivial
-    alias __moveinit__is_trivial = Self._type.__moveinit__is_trivial
-    alias __del__is_trivial = Self._type.__del__is_trivial
     # ===-------------------------------------------------------------------===#
     # Life cycle methods
     # ===-------------------------------------------------------------------===#

--- a/mojo/stdlib/stdlib/utils/variant.mojo
+++ b/mojo/stdlib/stdlib/utils/variant.mojo
@@ -128,6 +128,11 @@ struct Variant[*Ts: Copyable & Movable](ImplicitlyCopyable, Movable):
     ]
     var _impl: Self._mlir_type
 
+    # Trivialities from Ts
+    alias __copyinit__is_trivial = Self._all_t_trivial["__copyinit__"]()
+    alias __moveinit__is_trivial = Self._all_t_trivial["__moveinit__"]()
+    alias __del__is_trivial = Self._all_t_trivial["__del__"]()
+
     # ===-------------------------------------------------------------------===#
     # Life cycle methods
     # ===-------------------------------------------------------------------===#
@@ -163,17 +168,20 @@ struct Variant[*Ts: Copyable & Movable](ImplicitlyCopyable, Movable):
             other: The variant to copy from.
         """
 
-        self = Self(unsafe_uninitialized=())
-        self._get_discr() = other._get_discr()
-
+        # Delegate to explicit copy initializer.
         @parameter
-        for i in range(len(VariadicList(Ts))):
-            alias T = Ts[i]
-            if self._get_discr() == i:
-                self._get_ptr[T]().init_pointee_move(
-                    other._get_ptr[T]()[].copy()
-                )
-                return
+        if Self.__copyinit__is_trivial:
+            self._impl = other._impl
+        else:
+            self = Self(unsafe_uninitialized=())
+            self._get_discr() = other._get_discr()
+
+            @parameter
+            for i in range(len(VariadicList(Ts))):
+                alias T = Ts[i]
+                if self._get_discr() == i:
+                    self._get_ptr[T]().init_pointee_copy(other._get_ptr[T]()[])
+                    return
 
     fn __moveinit__(out self, deinit other: Self):
         """Move initializer for the variant.
@@ -181,25 +189,35 @@ struct Variant[*Ts: Copyable & Movable](ImplicitlyCopyable, Movable):
         Args:
             other: The variant to move.
         """
-        __mlir_op.`lit.ownership.mark_initialized`(__get_mvalue_as_litref(self))
-        self._get_discr() = other._get_discr()
 
         @parameter
-        for i in range(len(VariadicList(Ts))):
-            alias T = Ts[i]
-            if self._get_discr() == i:
-                # Calls the correct __moveinit__
-                other._get_ptr[T]().move_pointee_into(self._get_ptr[T]())
-                return
+        if Self.__moveinit__is_trivial:
+            self._impl = other._impl
+        else:
+            __mlir_op.`lit.ownership.mark_initialized`(
+                __get_mvalue_as_litref(self)
+            )
+            self._get_discr() = other._get_discr()
+
+            @parameter
+            for i in range(len(VariadicList(Ts))):
+                alias T = Ts[i]
+                if self._get_discr() == i:
+                    # Calls the correct __moveinit__
+                    other._get_ptr[T]().move_pointee_into(self._get_ptr[T]())
+                    return
 
     fn __del__(deinit self):
         """Destroy the variant."""
 
         @parameter
-        for i in range(len(VariadicList(Ts))):
-            if self._get_discr() == i:
-                self._get_ptr[Ts[i]]().destroy_pointee()
-                return
+        if not Self.__del__is_trivial:
+
+            @parameter
+            for i in range(len(VariadicList(Ts))):
+                if self._get_discr() == i:
+                    self._get_ptr[Ts[i]]().destroy_pointee()
+                    return
 
     # ===-------------------------------------------------------------------===#
     # Operator dunders
@@ -398,6 +416,26 @@ struct Variant[*Ts: Copyable & Movable](ImplicitlyCopyable, Movable):
             if _type_is_eq[Ts[i], T]():
                 return i
         return Self._sentinel
+
+    @staticmethod
+    fn _all_t_trivial[_dunder: String]() -> Bool:
+        var is_trivial = True
+
+        @parameter
+        for i in range(len(VariadicList(Ts))):
+
+            @parameter
+            if _dunder == "__del__":
+                is_trivial &= Bool(Ts[i].__del__is_trivial)
+
+            @parameter
+            if _dunder == "__copyinit__":
+                is_trivial &= Bool(Ts[i].__copyinit__is_trivial)
+
+            @parameter
+            if _dunder == "__moveinit__":
+                is_trivial &= Bool(Ts[i].__moveinit__is_trivial)
+        return is_trivial
 
     @staticmethod
     fn is_type_supported[T: AnyType]() -> Bool:

--- a/mojo/stdlib/stdlib/utils/variant.mojo
+++ b/mojo/stdlib/stdlib/utils/variant.mojo
@@ -419,23 +419,25 @@ struct Variant[*Ts: Copyable & Movable](ImplicitlyCopyable, Movable):
 
     @staticmethod
     fn _all_t_trivial[_dunder: String]() -> Bool:
-        var is_trivial = True
 
         @parameter
         for i in range(len(VariadicList(Ts))):
 
             @parameter
             if _dunder == "__del__":
-                is_trivial &= Bool(Ts[i].__del__is_trivial)
+                if not Bool(Ts[i].__del__is_trivial):
+                    return False
 
             @parameter
             if _dunder == "__copyinit__":
-                is_trivial &= Bool(Ts[i].__copyinit__is_trivial)
+                if not Bool(Ts[i].__copyinit__is_trivial):
+                    return False
 
             @parameter
             if _dunder == "__moveinit__":
-                is_trivial &= Bool(Ts[i].__moveinit__is_trivial)
-        return is_trivial
+                if not Bool(Ts[i].__moveinit__is_trivial):
+                    return False
+        return True
 
     @staticmethod
     fn is_type_supported[T: AnyType]() -> Bool:

--- a/mojo/stdlib/test/utils/test_variant.mojo
+++ b/mojo/stdlib/test/utils/test_variant.mojo
@@ -104,8 +104,11 @@ def test_move():
     var v1 = TestVariant(MoveCopyCounter())
     var v2 = v1
     # didn't call moveinit
+    # Fix: test changed here because we fixed something in Variant.__copyinit__
+    # (it was previously moving an copy, now it is doing init_pointee_copy)
     assert_equal(v1[MoveCopyCounter].moved, 1)
-    assert_equal(v2[MoveCopyCounter].moved, 2)
+    assert_equal(v2[MoveCopyCounter].moved, 1)
+    assert_equal(v2[MoveCopyCounter].copied, 1)
     # test that we didn't call the other moveinit too!
     assert_no_poison()
 


### PR DESCRIPTION
Hello,
this is early bottom-up work for auto-optimizing.

The PR is status: draft,
because i'm not sure if this is the way to go, is it?

What we have here is quite encouraging.
Mojo's meta-programing is powerful,
we can auto-optimize the types based on their parameters. 
(Even with *Ts)

So for example if T is trivial on an Optional,
the optional can become Trivial too for that dunder.

This is bottom-up, because Optional uses Variant[_NoneType, T]. 
The Optional itself ask the Variant for its trivialities. 
And the Variant get it from all T in Ts.

So if we implement this for InlineArray too,
InlineArray[Optional[Int]] would get its trivialities like this: 
_NoneType&Int -> Variant[_NoneType, Int] -> Optional -> InlineArray.

Any ideas and thoughts?

InlineArray trivialities could work in an nested way too: 
InlineArray[InlineArray[Int, 64], 64]

But not sure if it is not "too soon" for theses features, 
should we wait for using T.__*__is_trivial ?

