### PR TITLE
[kernels] Change function parameters `type: DType` -> `dtype`

### DIFF
--- a/max/kernels/src/linalg/_multistage_gemm_gpu.mojo
+++ b/max/kernels/src/linalg/_multistage_gemm_gpu.mojo
@@ -69,9 +69,11 @@ from .utils_gpu import MatmulConfig, block_swizzle
 
 @always_inline
 fn distance[
-    type: DType, //
-](arg0: UnsafePointer[Scalar[type]], arg1: UnsafePointer[Scalar[type]]) -> Int:
-    return (Int(arg0) - Int(arg1)) // size_of[arg1.type]()
+    dtype: DType, //
+](
+    arg0: UnsafePointer[Scalar[dtype]], arg1: UnsafePointer[Scalar[dtype]]
+) -> Int:
+    return (Int(arg0) - Int(arg1)) // dtype.size_of()
 
 
 @always_inline

--- a/max/kernels/src/linalg/bmm.mojo
+++ b/max/kernels/src/linalg/bmm.mojo
@@ -276,12 +276,12 @@ fn _small_batched_matmul[
             @__copy_capture(a_view, b_view)
             @parameter
             fn input_fn[
-                type: DType, width: Int, rank: Int
-            ](idx: IndexList[rank]) -> SIMD[type, width]:
+                dtype: DType, width: Int, rank: Int
+            ](idx: IndexList[rank]) -> SIMD[dtype, width]:
                 return (
-                    a_view.load[width=width](idx[0]).cast[type]()
-                    * b_view.load[width=width](idx[0]).cast[type]()
-                ).cast[type]()
+                    a_view.load[width=width](idx[0]).cast[dtype]()
+                    * b_view.load[width=width](idx[0]).cast[dtype]()
+                ).cast[dtype]()
 
             @always_inline
             @parameter
@@ -826,9 +826,9 @@ fn _batched_matmul_gpu[
                 @parameter
                 @__copy_capture(c_buf)
                 fn elementwise_epilogue_fn_wrapper[
-                    type: DType, width: Int, *, alignment: Int = 1
+                    dtype: DType, width: Int, *, alignment: Int = 1
                 ](
-                    out_coords: IndexList[2], val: SIMD[type, width]
+                    out_coords: IndexList[2], val: SIMD[dtype, width]
                 ) capturing -> None:
                     var batch_coords = IndexList[rank](0)
 

--- a/max/kernels/src/linalg/dual_gemm.mojo
+++ b/max/kernels/src/linalg/dual_gemm.mojo
@@ -767,8 +767,8 @@ fn multistage_dual_gemm_kernel[
 
 
 fn swilu[
-    type: DType, width: Int
-](x: SIMD[type, width], y: SIMD[type, width]) -> SIMD[type, width]:
+    dtype: DType, width: Int
+](x: SIMD[dtype, width], y: SIMD[dtype, width]) -> SIMD[dtype, width]:
     return (x * y) / (1 + exp(-x))
 
 

--- a/max/kernels/src/linalg/gemv.mojo
+++ b/max/kernels/src/linalg/gemv.mojo
@@ -881,12 +881,12 @@ fn gemv[
     @always_inline
     @parameter
     fn input_fn[
-        type: DType, width: Int, rank: Int
-    ](idx: IndexList[rank]) -> SIMD[type, width]:
+        dtype: DType, width: Int, rank: Int
+    ](idx: IndexList[rank]) -> SIMD[dtype, width]:
         return (
-            a_buf.load[width=width](Index(idx[0], idx[1])).cast[type]()
-            * b_buf.load[width=width](idx[1]).cast[type]()
-        ).cast[type]()
+            a_buf.load[width=width](Index(idx[0], idx[1])).cast[dtype]()
+            * b_buf.load[width=width](idx[1]).cast[dtype]()
+        ).cast[dtype]()
 
     @always_inline
     @parameter
@@ -926,11 +926,11 @@ fn naive_gemv[
     c_size: Dim,
     a_shape: DimList,
     b_size: Dim,
-    type: DType,
+    dtype: DType,
 ](
-    c_buf: NDBuffer[mut=True, type, 1, _, c_size],
-    a_buf: NDBuffer[type, 2, _, a_shape],
-    b_buf: NDBuffer[type, 1, _, b_size],
+    c_buf: NDBuffer[mut=True, dtype, 1, _, c_size],
+    a_buf: NDBuffer[dtype, 2, _, a_shape],
+    b_buf: NDBuffer[dtype, 1, _, b_size],
 ):
     var M = a_buf.dim[0]()
     var K = a_buf.dim[1]()

--- a/max/kernels/src/linalg/matmul_default.mojo
+++ b/max/kernels/src/linalg/matmul_default.mojo
@@ -78,7 +78,7 @@ struct Inner_matmul_default(InnerMatmulKernel, Movable):
         var K = a.dim[1]()
         var a_ptr = a.data.offset(global_offset.M * K + global_k)
 
-        alias c_type = c_local.type
+        alias c_type = c_local.dtype
 
         # Loop over local accumulator tiles.
         @parameter

--- a/max/kernels/src/linalg/matmul_i8mm.mojo
+++ b/max/kernels/src/linalg/matmul_i8mm.mojo
@@ -204,7 +204,7 @@ struct Inner_matmul_i8mm(InnerMatmulKernel, Movable):
 
             @parameter
             for idx1 in range(kernel_cols // simd_size):
-                alias alignment = align_of[SIMD[c_local.type, simd_size]]()
+                alias alignment = align_of[SIMD[c_local.dtype, simd_size]]()
                 var a_val = a_ptr.load[width = simd_size * 4](2 * idx0 * K)
                 var b_val = b_ptr.offset(16 * idx1).load[
                     width = simd_size * 4, alignment=alignment

--- a/max/kernels/src/linalg/matmul_loadop_sm90.mojo
+++ b/max/kernels/src/linalg/matmul_loadop_sm90.mojo
@@ -342,15 +342,19 @@ fn async_load_AB[
 
 @always_inline
 fn async_copy_with_bound_check[
-    type: DType, //,
+    dtype: DType, //,
     thread_layout: Layout,
     swizzle_mode: TensorMapSwizzle,
 ](
     src: LayoutTensor[
-        type, _, MutableAnyOrigin, address_space = AddressSpace.GENERIC, *_, **_
+        dtype,
+        _,
+        MutableAnyOrigin,
+        address_space = AddressSpace.GENERIC,
+        *_, **_,
     ],
     dst: LayoutTensor[
-        type, _, MutableAnyOrigin, address_space = AddressSpace.SHARED, *_, **_
+        dtype, _, MutableAnyOrigin, address_space = AddressSpace.SHARED, *_, **_
     ],
 ):
     constrained[src.layout.rank() == 2, "Global memory tile must be rank 2."]()

--- a/max/kernels/src/linalg/matmul_neon.mojo
+++ b/max/kernels/src/linalg/matmul_neon.mojo
@@ -62,7 +62,7 @@ struct Inner_matmul_neon(InnerMatmulKernel, Movable):
 
         var b_ptr = b_packed._offset(Index(n_outer_idx, tile_n_k_idx[1], 0))
 
-        var a_vals = InlineArray[SIMD[c_local.type, a_col_size], kernel_rows](
+        var a_vals = InlineArray[SIMD[c_local.dtype, a_col_size], kernel_rows](
             uninitialized=True
         )
 
@@ -70,7 +70,7 @@ struct Inner_matmul_neon(InnerMatmulKernel, Movable):
         for row in range(kernel_rows):
             var global_m = global_offset.M + row
             var a_val = a.load[width=a_col_size](global_m, global_k).cast[
-                c_local.type
+                c_local.dtype
             ]()
             a_vals[row] = a_val
 
@@ -82,14 +82,14 @@ struct Inner_matmul_neon(InnerMatmulKernel, Movable):
                 var b_val = (
                     b_ptr.offset(col * simd_size)
                     .load[width=simd_size]()
-                    .cast[c_local.type]()
+                    .cast[c_local.dtype]()
                 )
 
                 @parameter
                 for row in range(kernel_rows):
                     var a_val = a_vals[row]
                     var c_val = c_local[row, col]
-                    c_val = fma[dtype = c_local.type, width=simd_size](
+                    c_val = fma[dtype = c_local.dtype, width=simd_size](
                         a_val[lane], b_val, c_val
                     )
                     c_local[row, col] = c_val

--- a/max/kernels/src/linalg/matmul_sm100_composable.mojo
+++ b/max/kernels/src/linalg/matmul_sm100_composable.mojo
@@ -240,16 +240,16 @@ trait OutputOp:
 
 
 struct STOutputOpArgs[
-    type: DType,
+    dtype: DType,
     layout: Layout,
     sb: Origin,
 ](OpArgs):
-    var c: LayoutTensor[type, layout, sb]
+    var c: LayoutTensor[dtype, layout, sb]
 
     @always_inline
     fn __init__(
         out self,
-        c: LayoutTensor[type, layout, sb],
+        c: LayoutTensor[dtype, layout, sb],
     ):
         self.c = c
 
@@ -260,16 +260,16 @@ struct STOutputOpArgs[
 
 struct R2GOutputOp[
     accum_type: DType,
-    type: DType,
+    dtype: DType,
     layout: Layout,
     num_threads: Int,
     mma_shape: IndexList[3],
     block_tile_shape: IndexList[3],
     o: Origin,
 ](OutputOp):
-    alias args_type = STOutputOpArgs[type, layout, o]
+    alias args_type = STOutputOpArgs[dtype, layout, o]
 
-    var c: LayoutTensor[type, layout, o]
+    var c: LayoutTensor[dtype, layout, o]
 
     @always_inline
     fn __init__(out self, args: Self.args_type):
@@ -278,7 +278,7 @@ struct R2GOutputOp[
     @staticmethod
     @always_inline
     fn to_kernel_args(
-        c: LayoutTensor[type, layout, o], ctx: DeviceContext
+        c: LayoutTensor[dtype, layout, o], ctx: DeviceContext
     ) -> Self.args_type:
         return Self.args_type(c)
 
@@ -340,7 +340,7 @@ struct R2GOutputOp[
                         ](
                             SIMD[accum_type, 2](
                                 c_frag[2 * i_vec], c_frag[2 * i_vec + 1]
-                            ).cast[type]()
+                            ).cast[dtype]()
                         )
 
 

--- a/max/kernels/src/linalg/matmul_vnni.mojo
+++ b/max/kernels/src/linalg/matmul_vnni.mojo
@@ -63,7 +63,7 @@ struct Inner_matmul_vnni[saturated_vnni: Bool](InnerMatmulKernel, Movable):
                 processing tile to index the packed B matrix.
             tile_n_k: TODO
         """
-        alias c_type = c_local.type
+        alias c_type = c_local.dtype
         # Seek outer indices in packed layout.
         var n_outer_idx = tile_n_k_idx[0] // kernel_cols
         var kl = tile_n_k_idx[1]

--- a/max/kernels/src/linalg/mmaop_sm100.mojo
+++ b/max/kernels/src/linalg/mmaop_sm100.mojo
@@ -50,20 +50,20 @@ struct Major:
 
 
 # TODO: add create method to mma_operand trait and unify this with
-# SM90 counter part by abstracting the return type.
+# SM90 counter part by abstracting the return dtype.
 fn _create_mma_desc[
-    type: DType, //, canonical_layout: Layout, swizzle_mode: TensorMapSwizzle
+    dtype: DType, //, canonical_layout: Layout, swizzle_mode: TensorMapSwizzle
 ](
     ptr: UnsafePointer[
-        Scalar[type], address_space = AddressSpace.SHARED, *_, **_
+        Scalar[dtype], address_space = AddressSpace.SHARED, *_, **_
     ]
 ) -> MMASmemDescriptor:
     # Extract the stride values from the canonical layout
     # The canonical layout is expected to have at least 2 dimensions
     alias stride01 = canonical_layout[0].stride[1].value()
     alias stride11 = canonical_layout[1].stride[1].value()
-    alias SBO = stride01 * size_of[type]()
-    alias LBO = stride11 * size_of[type]()
+    alias SBO = stride01 * size_of[dtype]()
+    alias LBO = stride11 * size_of[dtype]()
 
     # Create and return the MMA shared memory descriptor
     # This will be used by the SM100 MMA operations to access shared memory

--- a/max/kernels/src/nn/mha_cross.mojo
+++ b/max/kernels/src/nn/mha_cross.mojo
@@ -247,11 +247,11 @@ fn mha_cross_gpu_naive[
     """
     constrained[rank == 3, "only support rank 3 inputs for ragged inputs."]()
     constrained[
-        q.type == cache_t.dtype == cache_t.dtype == output.type,
+        q.dtype == cache_t.dtype == cache_t.dtype == output.type,
         "Q, K, V, output should have same type.",
     ]()
     constrained[
-        q.type is DType.float32 or q.type.is_half_float(),
+        q.dtype is DType.float32 or q.dtype.is_half_float(),
         "Only support single and half precision.",
     ]()
 
@@ -267,7 +267,7 @@ fn mha_cross_gpu_naive[
     var batch_size = q_input_row_offsets.dim[0]() - 1
     var max_cache_size = Int(k.max_context_length())
 
-    alias q_type = q.type
+    alias q_type = q.dtype
     alias k_type = cache_t.dtype
     alias v_type = cache_t.dtype
 
@@ -318,7 +318,7 @@ fn mha_cross_gpu_naive[
         Index(batch_size * num_heads, q_max_seq_len, num_keys), p_buffer, 2, ctx
     )
 
-    ctx.enqueue_function[_bmm1_bs[__type_of(v), p_type, output.type]](
+    ctx.enqueue_function[_bmm1_bs[__type_of(v), p_type, output.dtype]](
         output.data,
         p_device,
         v,

--- a/max/kernels/src/nn/mha_sm100.mojo
+++ b/max/kernels/src/nn/mha_sm100.mojo
@@ -1278,7 +1278,7 @@ fn mha_sm100_dispatch[
 ) raises:
     alias decoding: Bool = MaxPromptLenType.static_value.or_else(0) == 1
     alias new_config = MHAConfig(
-        config.type,
+        config.dtype,
         config.num_heads,
         config.depth,
         num_queries_per_block=OptionalReg[UInt](64),
@@ -1304,7 +1304,7 @@ fn mha_sm100_dispatch[
         num_threads % 128 == 0, "num_threads = " + String(num_threads)
     ]()
     constrained[
-        config.type == KVType.dtype and config.type == q_type,
+        config.dtype == KVType.dtype and config.dtype == q_type,
         "config, kv, and q types must all match for FA3.",
     ]()
     q = rebind[UnsafePointer[Scalar[KVType.dtype]]](q_arg)
@@ -1910,7 +1910,7 @@ fn _mha_sm100[
 
     """
     alias kv_type = KVLUTType.dtype
-    constrained[kv_type == config.type]()
+    constrained[kv_type == config.dtype]()
     alias decoding: Bool = _is_decoding[MaxSeqLenType]()
 
     alias simd_size: Int = simd_width_of[kv_type]()

--- a/max/kernels/src/nn/mha_sm90.mojo
+++ b/max/kernels/src/nn/mha_sm90.mojo
@@ -136,14 +136,14 @@ fn mha_sm90_dispatch[
     sink_weights: OptionalReg[NDBuffer[q_type, 1, MutableAnyOrigin]],
 ) raises:
     constrained[
-        config.type == KVType.dtype and config.type == q_type,
+        config.dtype == KVType.dtype and config.dtype == q_type,
         "config, kv, and q types must all match for FA3.",
     ]()
     alias swizzle_mode = TensorMapSwizzle.SWIZZLE_128B
     q = rebind[UnsafePointer[Scalar[KVType.dtype]]](q_arg)
     alias decoding: Bool = MaxPromptLenType.static_value.or_else(0) == 1
     alias new_config = MHAConfig(
-        config.type,
+        config.dtype,
         config.num_heads,
         config.depth,
         num_queries_per_block=OptionalReg[UInt](64),

--- a/max/kernels/src/nn/mla.mojo
+++ b/max/kernels/src/nn/mla.mojo
@@ -102,17 +102,17 @@ fn flare_mla_decoding[
     cache_t: KVCacheT,
     mask_t: MHAMask,
     score_mod_t: ScoreModTrait,
-    type: DType,
+    dtype: DType,
     q_shape: DimList, //,
     use_score_mod: Bool = False,
     config: MHAConfig = MHAConfig(
-        type, UInt(q_shape.get[rank - 2]()), UInt(q_shape.get[rank - 1]())
+        dtype, UInt(q_shape.get[rank - 2]()), UInt(q_shape.get[rank - 1]())
     ),
     ragged: Bool = False,
     decoding_warp_split_k: Bool = False,
 ](
     output: NDBuffer[mut=True, _, rank, *_],
-    q: NDBuffer[type, rank, _, q_shape, *_],
+    q: NDBuffer[dtype, rank, _, q_shape, *_],
     k: cache_t,
     mask_functor: mask_t,
     score_mod_functor: score_mod_t,
@@ -205,16 +205,16 @@ fn flare_mla_decoding[
     rank: Int,
     mask_t: MHAMask,
     score_mod_t: ScoreModTrait,
-    type: DType,
+    dtype: DType,
     q_shape: DimList, //,
     use_score_mod: Bool = False,
     config: MHAConfig = MHAConfig(
-        type, UInt(q_shape.get[2]()), UInt(q_shape.get[3]())
+        dtype, UInt(q_shape.get[2]()), UInt(q_shape.get[3]())
     ),
     decoding_warp_split_k: Bool = False,
 ](
     output: NDBuffer[mut=True, _, rank, *_],
-    q: NDBuffer[type, rank, _, q_shape, *_],
+    q: NDBuffer[dtype, rank, _, q_shape, *_],
     k: NDBuffer[_, rank, *_],
     mask_functor: mask_t,
     score_mod_functor: score_mod_t,
@@ -265,12 +265,12 @@ fn flare_mla_decoding_dispatch[
     k_t: MHAOperand,
     mask_t: MHAMask,
     score_mod_t: ScoreModTrait,
-    type: DType,
+    dtype: DType,
     q_shape: DimList, //,
     kv_num_heads: Int,
     use_score_mod: Bool = False,
     config: MHAConfig = MHAConfig(
-        type, UInt(q_shape.get[rank - 2]()), UInt(q_shape.get[rank - 1]())
+        dtype, UInt(q_shape.get[rank - 2]()), UInt(q_shape.get[rank - 1]())
     ),
     ragged: Bool = False,
     # Work arounds to unify KVCache and NDBuffer inputs:
@@ -284,7 +284,7 @@ fn flare_mla_decoding_dispatch[
     decoding_warp_split_k: Bool = False,
 ](
     output: NDBuffer[_, rank, *_],
-    q: NDBuffer[type, rank, _, q_shape, *_],
+    q: NDBuffer[dtype, rank, _, q_shape, *_],
     k: k_t,
     mask_functor: mask_t,
     score_mod_functor: score_mod_t,
@@ -319,7 +319,7 @@ fn flare_mla_decoding_dispatch[
     ]()
 
     constrained[
-        q.type.is_half_float(),
+        q.dtype.is_half_float(),
         "Only support half precision.",
     ]()
 
@@ -1120,7 +1120,7 @@ fn flare_mla_prefill[
     cache_t: KVCacheT,
     mask_t: MHAMask,
     score_mod_t: ScoreModTrait,
-    type: DType,
+    dtype: DType,
     output_type: DType,
     softmax_type: DType,
     q_shape: DimList, //,
@@ -1129,7 +1129,7 @@ fn flare_mla_prefill[
     use_cascade_attention: Bool = False,
 ](
     output: NDBuffer[mut=True, output_type, rank, *_],
-    q: NDBuffer[type, rank, _, q_shape, *_],
+    q: NDBuffer[dtype, rank, _, q_shape, *_],
     k: NDBuffer[_, 3, *_],
     v: NDBuffer[_, 3, *_],
     k_rope: cache_t,
@@ -1214,7 +1214,7 @@ fn flare_mla_prefill[
         alias q_depth = q_shape.get[rank - 1]()
 
         alias mha_config = MHAConfig(
-            type,
+            dtype,
             UInt(q_shape.get[rank - 2]()),  # num_heads
             UInt(k.shape.get[rank - 1]()),  # depth
             num_keys_per_block=UInt(64),
@@ -1254,7 +1254,7 @@ fn flare_mla_prefill[
     rank: Int,
     mask_t: MHAMask,
     score_mod_t: ScoreModTrait,
-    type: DType,
+    dtype: DType,
     softmax_type: DType,
     q_shape: DimList, //,
     use_score_mod: Bool = False,
@@ -1262,7 +1262,7 @@ fn flare_mla_prefill[
     use_cascade_attention: Bool = False,
 ](
     output: NDBuffer[mut=True, _, rank, *_],
-    q: NDBuffer[type, rank, _, q_shape, *_],
+    q: NDBuffer[dtype, rank, _, q_shape, *_],
     k: NDBuffer[_, 3, *_],
     v: NDBuffer[_, 3, *_],
     k_rope: NDBuffer[_, 4, *_],
@@ -1322,7 +1322,7 @@ fn flare_mla_prefill[
         alias q_depth = q_shape.get[rank - 1]()  # hard code for now
 
         alias mha_config = MHAConfig(
-            type,
+            dtype,
             UInt(q_shape.get[rank - 2]()),
             UInt(k.shape.get[rank - 1]()),
             num_keys_per_block=UInt(64),
@@ -1369,7 +1369,7 @@ fn flare_mla_prefill_dispatch[
     k_rope_t: MHAOperand,
     mask_t: MHAMask,
     score_mod_t: ScoreModTrait,
-    type: DType,
+    dtype: DType,
     output_type: DType,
     softmax_type: DType,
     q_shape: DimList, //,
@@ -1380,12 +1380,12 @@ fn flare_mla_prefill_dispatch[
     q_depth: Int = 192,
     cache_depth: Int = 576,
     config: MHAConfig = MHAConfig(
-        type, UInt(q_shape.get[rank - 2]()), UInt(q_shape.get[rank - 1]())
+        dtype, UInt(q_shape.get[rank - 2]()), UInt(q_shape.get[rank - 1]())
     ),
     _ndbuffer_mha_operand: Bool = False,
 ](
     output: NDBuffer[output_type, rank, *_],
-    q: NDBuffer[type, rank, _, q_shape, *_],
+    q: NDBuffer[dtype, rank, _, q_shape, *_],
     k: k_t,
     v: v_t,
     k_rope: k_rope_t,
@@ -1421,7 +1421,7 @@ fn flare_mla_prefill_dispatch[
 
     var batch_size: Int = valid_length.dim[0]() - 1
 
-    alias q_half_float = type in (DType.float16, DType.bfloat16)
+    alias q_half_float = dtype in (DType.float16, DType.bfloat16)
 
     alias BM = config.block_m()
     alias BN = config.block_n()
@@ -1431,7 +1431,7 @@ fn flare_mla_prefill_dispatch[
     alias k_smem = BN * q_depth
     alias v_smem = BN * depth
 
-    alias smem_use = (q_smem + k_smem + v_smem) * config.type.size_of()
+    alias smem_use = (q_smem + k_smem + v_smem) * config.dtype.size_of()
 
     var softmax_info_ptr = (
         softmax_info.value().data if softmax_info else UnsafePointer[
@@ -1450,11 +1450,11 @@ fn flare_mla_prefill_dispatch[
     )
 
     alias kernel = mla_prefill[
-        config.type,
+        config.dtype,
         k_t,
         v_t,
         k_rope_t,
-        output.type,
+        output.dtype,
         softmax_type,
         mask_t,
         score_mod_t,
@@ -2648,14 +2648,14 @@ fn mla_prefill_plan_kernel[
 
 @always_inline
 fn _k_cache_to_buffer[
-    type: DType,
+    dtype: DType,
     cache_t: KVCacheT,
 ](
     buffer_row_offsets: NDBuffer[DType.uint32, 1, *_],
     cache_offsets: NDBuffer[DType.uint32, 1, *_],
     k_cache: cache_t,
     length: Int32,
-    buffer: NDBuffer[mut=True, type, 2, *_],
+    buffer: NDBuffer[mut=True, dtype, 2, *_],
     context: DeviceContext,
 ) raises:
     alias num_heads = cache_t.kv_params.num_heads
@@ -2684,7 +2684,7 @@ fn _k_cache_to_buffer[
 
         var head_dim_idx = idx[1]
 
-        var cache_val = rebind[SIMD[type, width]](
+        var cache_val = rebind[SIMD[dtype, width]](
             k_cache.load[width=width](batch_idx, 0, token_idx, head_dim_idx)
         )
 
@@ -2694,7 +2694,7 @@ fn _k_cache_to_buffer[
         Int(length),
         buffer.dim[1](),
     )
-    alias target_simd_width = simd_width_of[type, target = get_gpu_target()]()
+    alias target_simd_width = simd_width_of[dtype, target = get_gpu_target()]()
 
     _elementwise_impl_gpu[func=copy_fn, simd_width = UInt(target_simd_width)](
         launch_shape, context

--- a/max/kernels/src/nn/pool.mojo
+++ b/max/kernels/src/nn/pool.mojo
@@ -1186,17 +1186,17 @@ fn avg_pool_gpu[
 
 @always_inline
 fn avg_pool[
-    type: DType,
+    dtype: DType,
     int_type: DType,
     count_boundary: Bool = False,
     target: StaticString = "cpu",
 ](
-    input: LayoutTensor[type, **_],
+    input: LayoutTensor[dtype, **_],
     filter: LayoutTensor[int_type, **_],
     strides: LayoutTensor[int_type, **_],
     dilations: LayoutTensor[int_type, **_],
     paddings: LayoutTensor[int_type, **_],
-    output: LayoutTensor[mut=True, type, **_],
+    output: LayoutTensor[mut=True, dtype, **_],
     ceil_mode: Bool = False,
     ctx_ptr: DeviceContextPtr = DeviceContextPtr(),
 ) raises:
@@ -1216,16 +1216,16 @@ fn avg_pool[
 
 @always_inline
 fn max_pool[
-    type: DType,
+    dtype: DType,
     int_type: DType,
     target: StaticString = "cpu",
 ](
-    input: LayoutTensor[type, **_],
+    input: LayoutTensor[dtype, **_],
     filter: LayoutTensor[int_type, **_],
     strides: LayoutTensor[int_type, **_],
     dilations: LayoutTensor[int_type, **_],
     paddings: LayoutTensor[int_type, **_],
-    output: LayoutTensor[mut=True, type, **_],
+    output: LayoutTensor[mut=True, dtype, **_],
     ceil_mode: Bool = False,
     ctx_ptr: DeviceContextPtr = DeviceContextPtr(),
 ) raises:

--- a/max/kernels/src/nn/split.mojo
+++ b/max/kernels/src/nn/split.mojo
@@ -30,17 +30,17 @@ from utils import IndexList, StaticTuple
 
 
 fn split[
-    type: DType,
+    dtype: DType,
     num_outputs: Int,
     target: StaticString,
     trace_description: StaticString,
     outputs_origin: MutableOrigin,
     outputs_layout: Layout,
 ](
-    input: LayoutTensor[type, **_],
+    input: LayoutTensor[dtype, **_],
     axis: Int,
     outputs: StaticTuple[
-        LayoutTensor[type, outputs_layout, outputs_origin], num_outputs
+        LayoutTensor[dtype, outputs_layout, outputs_origin], num_outputs
     ],
     ctx: DeviceContext,
 ) raises:
@@ -118,7 +118,7 @@ fn split[
         alias compile_target = _current_target() if is_cpu[
             target
         ]() else get_gpu_target()
-        alias target_simd_width = simd_width_of[type, target=compile_target]()
+        alias target_simd_width = simd_width_of[dtype, target=compile_target]()
 
         elementwise[
             elementwise_fn_wrapper,

--- a/max/kernels/src/nn/tile.mojo
+++ b/max/kernels/src/nn/tile.mojo
@@ -26,14 +26,14 @@ from utils import IndexList
 
 @always_inline
 fn tile[
-    type: DType, type_repeats: DType
+    dtype: DType, type_repeats: DType
 ](
-    input: LayoutTensor[type, address_space = AddressSpace.GENERIC, **_],
+    input: LayoutTensor[dtype, address_space = AddressSpace.GENERIC, **_],
     repeats: LayoutTensor[
         type_repeats, address_space = AddressSpace.GENERIC, **_
     ],
     output: LayoutTensor[
-        mut=True, type, address_space = AddressSpace.GENERIC, **_
+        mut=True, dtype, address_space = AddressSpace.GENERIC, **_
     ],
 ) raises:
     """
@@ -41,7 +41,7 @@ fn tile[
     tile, but without broadcast.
 
     Parameters:
-        type: Type of the input and output tensors.
+        dtype: Type of the input and output tensors.
         type_repeats: Type of the repeats tensor.
 
     Args:

--- a/max/kernels/test/gpu/basics/test_fast_div_ptx.mojo
+++ b/max/kernels/test/gpu/basics/test_fast_div_ptx.mojo
@@ -48,21 +48,21 @@ def contains_power_of_2_sequence(asm: String) -> Bool:
 
 
 fn fast_div_kernel[
-    type: DType,
+    dtype: DType,
     layout: Layout,
     divisor: Int,
-](input: LayoutTensor[type, layout, MutableAnyOrigin],):
-    alias fast_div = FastDiv[type](divisor)
+](input: LayoutTensor[dtype, layout, MutableAnyOrigin],):
+    alias fast_div = FastDiv[dtype](divisor)
     var x = input[0]
     var result = rebind[Scalar[fast_div.uint_type]](x) / fast_div
-    input[0] = result.cast[type]()
+    input[0] = result.cast[dtype]()
 
 
 def main():
-    alias type = DType.uint32
+    alias dtype = DType.uint32
     alias layout = Layout(IntTuple(1))
-    alias kernel_fast_div_4 = fast_div_kernel[type, layout, 4]
-    alias kernel_fast_div_3 = fast_div_kernel[type, layout, 3]
+    alias kernel_fast_div_4 = fast_div_kernel[dtype, layout, 4]
+    alias kernel_fast_div_3 = fast_div_kernel[dtype, layout, 3]
 
     var asm = _compile_code[
         kernel_fast_div_4,

--- a/max/kernels/test/gpu/linalg/test_dual_gemm.mojo
+++ b/max/kernels/test/gpu/linalg/test_dual_gemm.mojo
@@ -38,8 +38,8 @@ from utils.numerics import FPUtils
 
 
 fn binary_sub[
-    type: DType, width: Int
-](x: SIMD[type, width], y: SIMD[type, width]) -> SIMD[type, width]:
+    dtype: DType, width: Int
+](x: SIMD[dtype, width], y: SIMD[dtype, width]) -> SIMD[dtype, width]:
     return x - y
 
 

--- a/max/kernels/test/gpu/linalg/test_gemv2.mojo
+++ b/max/kernels/test/gpu/linalg/test_gemv2.mojo
@@ -33,22 +33,22 @@ alias epilogue_func_type = fn[type: DType, width: Int, *, alignment: Int = 1] (
 @parameter
 @always_inline
 fn epilogue_test_fn[
-    type: DType, width: Int, *, alignment: Int = 1
+    dtype: DType, width: Int, *, alignment: Int = 1
 ](
     idx: IndexList[2],
     dim_space: IndexList[2],
-    val: SIMD[type, width],
+    val: SIMD[dtype, width],
 ) -> SIMD[
-    type, width
+    dtype, width
 ]:
-    var bias = SIMD[type, width](0)
+    var bias = SIMD[dtype, width](0)
 
     @parameter
     for i in range(width):
         bias[i] = (
             0.5
             + ((idx[0] + idx[1] + i) / (dim_space[0] + dim_space[1])).cast[
-                type
+                dtype
             ]()
         )
 

--- a/mojo/docs/code/manual/parameters/index/anatomy_parameter_list.mojo
+++ b/mojo/docs/code/manual/parameters/index/anatomy_parameter_list.mojo
@@ -16,18 +16,18 @@
 # parameter list.
 fn my_sort[
     # infer-only parameters
-    Type: DType,
+    dtype: DType,
     width: Int, //,
     # positional-only parameter
-    values: SIMD[Type, width],
+    values: SIMD[dtype, width],
     /,
     # positional-or-keyword parameter
-    compare: fn (Scalar[Type], Scalar[Type]) -> Int,
+    compare: fn (Scalar[dtype], Scalar[dtype]) -> Int,
     *,
     # keyword-only parameter
     reverse: Bool = False,
-]() -> SIMD[Type, width]:
-    sorted = SIMD[Type, width](values)
+]() -> SIMD[dtype, width]:
+    sorted = SIMD[dtype, width](values)
     for output_position in range(width):
         lowest = output_position
         for compare_position in range(output_position + 1, width):

--- a/mojo/docs/manual/parameters/index.mdx
+++ b/mojo/docs/manual/parameters/index.mdx
@@ -92,18 +92,18 @@ Here's an example:
 ```mojo
 def my_sort[
     # infer-only parameters
-    Type: DType,
+    dtype: DType,
     width: Int,
     //,
     # positional-only parameter
-    values: SIMD[Type, width],
+    values: SIMD[dtype, width],
     /,
     # positional-or-keyword parameter
-    compare: fn (Scalar[Type], Scalar[Type]) -> Int,
+    compare: fn (Scalar[dtype], Scalar[dtype]) -> Int,
     *,
     # keyword-only parameter
     reverse: Bool = False,
-]() -> SIMD[Type, width]:
+]() -> SIMD[dtype, width]:
 ```
 
 Here's a quick overview of the special characters in the parameter list:


### PR DESCRIPTION
Change function parameters `type: DType` -> `dtype`. Rename `MHAConfig.type` to `dtype` as well.

Also some small changes from `size_of[type]() * 8` -> `dtype.bitwidth()` or `size_of[type]()` -> `dtype.size_of()`, and other similar instances. Because those lines were being edited anyway due to the parameter name change