### PR TITLE
[stdlib] Add TRACE log level to the logger

### DIFF
--- a/mojo/stdlib/stdlib/logger/logger.mojo
+++ b/mojo/stdlib/stdlib/logger/logger.mojo
@@ -74,19 +74,24 @@ struct Level(
     alias NOTSET = Self(0)
     """Lowest level, used when no level is set."""
 
-    alias DEBUG = Self(10)
+    alias TRACE = Self(10)
+    """Repetitive trace information, Indicates repeated execution or IO-coupled 
+    activity, typically only of interest when diagnosing hangs or ensuring a 
+    section of code is executing."""
+
+    alias DEBUG = Self(20)
     """Detailed information, typically of interest only when diagnosing problems."""
 
-    alias INFO = Self(20)
+    alias INFO = Self(30)
     """Confirmation that things are working as expected."""
 
-    alias WARNING = Self(30)
+    alias WARNING = Self(40)
     """Indication that something unexpected happened, or may happen in the near future."""
 
-    alias ERROR = Self(40)
+    alias ERROR = Self(50)
     """Due to a more serious problem, the software has not been able to perform some function."""
 
-    alias CRITICAL = Self(50)
+    alias CRITICAL = Self(60)
     """A serious error indicating that the program itself may be unable to continue running."""
 
     fn __eq__(self, other: Self) -> Bool:
@@ -168,6 +173,8 @@ struct Level(
         var lname = name.lower()
         if lname == "notset":
             return Self.NOTSET
+        if lname == "trace":
+            return Self.TRACE
         if lname == "debug":
             return Self.DEBUG
         if lname == "info":
@@ -188,6 +195,8 @@ struct Level(
         """
         if self is Self.NOTSET:
             writer.write("NOTSET")
+        elif self is Self.TRACE:
+            writer.write("TRACE")
         elif self is Self.DEBUG:
             writer.write("DEBUG")
         elif self is Self.INFO:
@@ -254,6 +263,21 @@ struct Logger[level: Level = DEFAULT_LEVEL]:
         if level == Level.NOTSET:
             return True
         return level > target_level
+
+    fn trace[*Ts: Writable](self, *values: *Ts):
+        """Logs a trace message.
+
+        Parameters:
+            Ts: The types of values to log.
+
+        Args:
+            values: The values to log.
+        """
+        alias target_level = Level.TRACE
+
+        @parameter
+        if not Self._is_disabled[target_level]():
+            self._write_out[target_level](values)
 
     fn debug[*Ts: Writable](self, *values: *Ts):
         """Logs a debug message.

--- a/mojo/stdlib/test/logger/test_logger.mojo
+++ b/mojo/stdlib/test/logger/test_logger.mojo
@@ -14,6 +14,19 @@
 from logger import Level, Logger
 
 
+# CHECK-LABEL: Test logging at trace level
+def test_log_trace():
+    print("=== Test logging at trace level")
+    var log = Logger[Level.TRACE]()
+
+    # CHECK: TRACE::: hello
+    log.trace("hello")
+
+    var log2 = Logger[Level.DEBUG]()
+    # CHECK-NOT: TRACE::: hello
+    log2.trace("hello")
+
+
 # CHECK-LABEL: Test logging at info level
 def test_log_info():
     print("=== Test logging at info level")
@@ -39,5 +52,6 @@ fn test_log_noset():
 
 
 def main():
+    test_log_trace()
     test_log_info()
     test_log_noset()


### PR DESCRIPTION
Mojo’s stdlib logging previously followed Python’s standard [log levels](https://docs.python.org/3/library/logging.html): NOTSET, DEBUG, INFO, WARNING, ERROR, CRITICAL.

This commit introduces a new level below DEBUG, named TRACE. This level is intended for logging statements inside repetitive or performance-sensitive sections of code (e.g., loops, tight IO operations). TRACE provides visibility into whether code is executing at all, answering questions like:

- Is this section of the program running?

- Why is the program hanging or unresponsive?

The updated numbering is:
```
NOTSET = 0
TRACE = 10
DEBUG = 20
INFO = 30
WARNING = 40
ERROR = 50
CRITICAL = 60
```

The python documentation describes DEBUG as:
```
Detailed information, typically only of interest to a developer trying to diagnose a problem.
```
In practice, DEBUG logs usually describe state or context, but they are not used within tight loops or hot paths because they produce too much output. In contrast, TRACE is meant for lightweight “heartbeat” signals confirming that a loop is advancing, an IO call is being reached, or a program is not stuck.

[Historical context for requests for python to include TRACE](https://bugs.python.org/issue31732) and [even more historical context](https://peps.python.org/pep-0282/)

This distinction makes TRACE valuable in debugging scenarios such as networking, concurrency, or streaming, where the core question is not “what is happening in detail?” but rather “is anything happening at all?”

A concise definition of TRACE:
```
Indicates repeated execution or IO-coupled activity, typically only of interest when diagnosing hangs or ensuring a section of code is executing.
```

By including TRACE, this gives developers 2 levels to toggle for diagnosing issues as opposed to just the one DEBUG.

Discussed in https://github.com/modular/modular/issues/5226