### PR TITLE
[example][mojo] Fix matrix_multiplication.mojo example (naive case)

### DIFF
--- a/examples/custom_ops/kernels/matrix_multiplication.mojo
+++ b/examples/custom_ops/kernels/matrix_multiplication.mojo
@@ -138,8 +138,8 @@ fn naive_matrix_multiplication[
             # Multiply the elements and accumulate the result.
             dst_reg = dst_reg + a[row, k_index] * b[k_index, col]
 
-    # Write the final accumulated result to the output matrix.
-    c[row, col] = dst_reg
+        # Write the final accumulated result to the output matrix.
+        c[row, col] = dst_reg
 
 
 # ===-----------------------------------------------------------------------===#
@@ -205,8 +205,8 @@ fn coalescing_matrix_multiplication[
             # Multiply the elements and accumulate the result.
             dst_reg = dst_reg + a[row, k_index] * b[k_index, col]
 
-    # Write the final accumulated result to the output matrix.
-    c[row, col] = dst_reg
+        # Write the final accumulated result to the output matrix.
+        c[row, col] = dst_reg
 
 
 # ===-----------------------------------------------------------------------===#
@@ -863,8 +863,8 @@ struct MatrixMultiplication[algorithm: StaticString]:
                     a_layout,
                     b_layout,
                     out_layout,
-                    grid_dim=(ceildiv(N, BN), ceildiv(M, BM)),
-                    block_dim=(BN, BM),
+                    grid_dim=(ceildiv(M, BM), ceildiv(N, BN)),
+                    block_dim=(BM, BN),
                 )
             elif algorithm == "coalescing":
                 alias BM = OPTIMIZED_BLOCK_SIZE


### PR DESCRIPTION
1. The writeback operation needs to be guarded as well. 
2. The naive matmul is mapping (x, y) to MxN, not NxM.

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
