### PR TITLE
[All] Fix typos across docs and comments

### DIFF
--- a/docs/eng-design/README.md
+++ b/docs/eng-design/README.md
@@ -44,7 +44,7 @@ date: January 30, 2025
 ---
 ```
 
-Images can optinally include captions:
+Images can optionally include captions:
 
 ```md
 [KV Cache](docs/img/genai-paged-attention/img01-kvcache.png)

--- a/docs/eng-design/docs/genai-paged-attention.md
+++ b/docs/eng-design/docs/genai-paged-attention.md
@@ -407,7 +407,7 @@ comparatively cheaper than re-computation.
 ### Implementing Prefix Caching
 
 Prefix caching is implemented in both vLLM and SGLang using entirely different
-strategies. vLLM uses a hasing based implementation while SGLang uses a Trie based
+strategies. vLLM uses a hashing based implementation while SGLang uses a Trie based
 implementation.
 
 **SGLang utilizes a Radix Trie data structure:**
@@ -453,7 +453,7 @@ million tokens).
 
 Unlike the basic PagedAttention algorithm which removes a request’s pages from
 the cache once it is terminated, with prefix caching they remain there to
-potentially be re-used in future.
+potentially be reused in future.
 
 This means that over time the paged cache slowly fills up more and more. As
 such, the prefix cache need to **evict blocks** that are not in use by an

--- a/docs/eng-design/docs/matmul-to-flash-attention.md
+++ b/docs/eng-design/docs/matmul-to-flash-attention.md
@@ -225,7 +225,7 @@ Attention](https://www.notion.so/Multi-Head-Attention-bbc2d300937a495da40c18b6a2
 
 ```mojo
 # Per matmul, Q, K have shape [S, D]
-batch_matmul(P, Q, K, tranpose=True)
+batch_matmul(P, Q, K, transpose=True)
 P = P * scale + mask
 P = softmax(P)
 # Per matmul, P: [S, S], V: [S, D]

--- a/docs/eng-design/docs/multi-head-flash-attention.md
+++ b/docs/eng-design/docs/multi-head-flash-attention.md
@@ -7,7 +7,7 @@ date: May 7, 2025
 - **Author:** Chris Elrod
 - **Date:** May 7, 2025
 
-This document descibes the implementation of Multi-Head Attention (MHA) using
+This document describes the implementation of Multi-Head Attention (MHA) using
 Flash Attention 3.
 
 ## Background

--- a/max/graph/graph.py
+++ b/max/graph/graph.py
@@ -524,7 +524,7 @@ class Graph:
         """Create a region of the graph with tasks guaranteed to execute
         independently.
 
-        Overrides the implicit chaining of the graph to allow for asyncronous
+        Overrides the implicit chaining of the graph to allow for asynchronous
         execution of operations which might mutate state.
 
         Returns:

--- a/max/graph/ops/buffer.py
+++ b/max/graph/ops/buffer.py
@@ -52,7 +52,7 @@ def buffer_load(
 
 
 def buffer_store(destination: BufferValue, source: TensorValue) -> None:
-    """Stores the input tensor into the inout buffer.
+    """Stores the input tensor into the in-out buffer.
 
     It stores the immutable input tensor `x` in the mutable tensor `y`.
     This is semantically equivalent to a copy from `x` tensor to the `y` buffer.

--- a/max/graph/ops/fold.py
+++ b/max/graph/ops/fold.py
@@ -46,7 +46,7 @@ def fold(
 
     Args:
         input: The 3D tensor to fold with shape ``(N, C * kernel sizes, L)``.
-        output_size: Spacial dimensions of the output tensor. Must be a tuple of two ints.
+        output_size: Spatial dimensions of the output tensor. Must be a tuple of two ints.
         kernel_size: The size of the sliding blocks. Must be a tuple of two ints.
         stride: The stride of the sliding blocks in the input dimension
             (can be an int or a tuple of two ints).

--- a/max/graph/value.py
+++ b/max/graph/value.py
@@ -395,9 +395,9 @@ class TensorValue(Value[mo.TensorType]):
         Args:
             dim: The dimension value.
         """
-        ans = ops.shape_to_tensor([dim])
-        ans.type.device = DeviceRef.CPU()
-        return ans.reshape(())
+        result = ops.shape_to_tensor([dim])
+        result.type.device = DeviceRef.CPU()
+        return result.reshape(())
 
     @staticmethod
     def _from_shape(shape: ShapeLike) -> TensorValue:
@@ -406,9 +406,9 @@ class TensorValue(Value[mo.TensorType]):
         Args:
             shape: An iterable of integers or symbolic dimensions.
         """
-        ans = ops.shape_to_tensor(shape)
-        ans.type.device = DeviceRef.CPU()
-        return ans
+        result = ops.shape_to_tensor(shape)
+        result.type.device = DeviceRef.CPU()
+        return result
 
     def __repr__(self) -> str:
         """Returns a string representation of the :obj:`TensorValue`."""

--- a/max/kernels/benchmarks/BUILD.bazel
+++ b/max/kernels/benchmarks/BUILD.bazel
@@ -19,7 +19,7 @@ _EXTRA_CONSTRAINTS = {
         "//conditions:default": [],
     }),
     "gpu/bench_allreduce.mojo": ["//:nvidia_gpu"],  # FIXME: KERN-1377
-    "nn/bench_gather_reduce.mojo": ["@platforms//:incompatible"],  # TODO(KERN-464): reenable and remove this tag
+    "nn/bench_gather_reduce.mojo": ["@platforms//:incompatible"],  # TODO(KERN-464): re-enable and remove this tag
 }
 
 _CPU_TESTS = glob(

--- a/max/kernels/benchmarks/autotune/kdiff.py
+++ b/max/kernels/benchmarks/autotune/kdiff.py
@@ -98,7 +98,7 @@ def search_workflows(branch_sha, last_n_commits=100, timeout_secs=60):  # noqa: 
     while True:
         ref_branch_yaml = check_argo_workflow_exists(branch_sha)
         if not ref_branch_yaml:
-            print(f"could'nt find, check back in {timeout_secs} seconds")
+            print(f"couldn't find, check back in {timeout_secs} seconds")
             sleep(timeout_secs)
         else:
             break

--- a/max/kernels/benchmarks/math/bench_exp.mojo
+++ b/max/kernels/benchmarks/math/bench_exp.mojo
@@ -139,8 +139,8 @@ fn ldexp2kf[
     dtype, simd_width
 ]:
     # return d * (pow2if[simd_width](e >> 1) * pow2if[simd_width](e - (e >> 1))).cast[dtype]();
-    var ans = d * (pow2if[simd_width](e)).cast[dtype]()
-    var y = bitcast[DType.int32, simd_width](ans)
+    var result = d * (pow2if[simd_width](e)).cast[dtype]()
+    var y = bitcast[DType.int32, simd_width](result)
 
     var msb = y
     for _ in range(32):
@@ -152,8 +152,8 @@ fn ldexp2kf[
     #     y=y-(y&mask)
     # if e>=23:
     #     y=y+1
-    ans = bitcast[dtype, simd_width](y)
-    return ans
+    result = bitcast[dtype, simd_width](y)
+    return result
 
 
 @always_inline

--- a/max/kernels/src/extensibility/compiler_internal/directives.mojo
+++ b/max/kernels/src/extensibility/compiler_internal/directives.mojo
@@ -52,7 +52,7 @@ fn _row_major_strides[rank: Int](shape: DimList) -> DimList:
         return -1
 
 
-# Compile time Tensor informations
+# Compile time Tensor information
 @register_passable("trivial")
 struct StaticTensorSpec[
     dtype: DType,

--- a/max/kernels/src/internal_utils/_utils.mojo
+++ b/max/kernels/src/internal_utils/_utils.mojo
@@ -736,7 +736,7 @@ struct Timer:
         )
 
 
-# TODO: limited support for 1D, generalize to nD
+# TODO: limited support for 1D, generalize to n-D
 fn init_vector_gpu[
     dtype: DType
 ](

--- a/max/kernels/src/linalg/bmm.mojo
+++ b/max/kernels/src/linalg/bmm.mojo
@@ -147,7 +147,7 @@ fn _reshape_nd_buffer_with_batch_to_3d(
 fn _reshape_to_3d[layout: Layout]() -> Layout:
     alias rank = len(layout.shape)
 
-    # NOTE: need to cast becasue int tuple returns comptime int
+    # NOTE: need to cast because int tuple returns comptime int
     alias last = Int(layout.shape[rank - 1])
     alias second_last = Int(layout.shape[rank - 2])
 

--- a/max/kernels/src/linalg/gemv.mojo
+++ b/max/kernels/src/linalg/gemv.mojo
@@ -267,7 +267,7 @@ fn gemv_split_k[
     """GEMV with tiling in K dimension.
     Assuming the B (weight) matrix is transposed i.e. row major N x K, this kernel
     implements a vector (1 x K) times a matrix (N x K).
-    The impl can actually handle M > 1 but it's only optimal fro tiny M. We use
+    The impl can actually handle M > 1 but it's only optimal for tiny M. We use
     it for M = 1 only.
     """
     # tile_m represents how many rows each thread will process of the output activation matrix

--- a/max/kernels/src/linalg/matmul.mojo
+++ b/max/kernels/src/linalg/matmul.mojo
@@ -228,7 +228,7 @@ struct TiledMatmul[
         last_k_tile: Bool,
     ):
         """
-        Helper function: Pack a subtile of B and iterate through all the rows
+        Helper function: Pack a sub-tile of B and iterate through all the rows
             of C.
 
         Parameters:

--- a/max/kernels/src/linalg/matmul_sm100.mojo
+++ b/max/kernels/src/linalg/matmul_sm100.mojo
@@ -389,7 +389,7 @@ fn elementwise_helper[
     ],
 ):
     # Here we start keeping track of the index / indices this thread is
-    # responsbile for in shared memory. This is represented with shared_memory_row
+    # responsible for in shared memory. This is represented with shared_memory_row
     # and shared_memory_column and the children of these values shared_memory_row_upper_half
     # shared_memory_row_lower_half. We also need to update the global memory column c_col by
     # stageN since we are sliding through the overall compute block.
@@ -501,7 +501,7 @@ fn elementwise_helper[
             )
 
         else:
-            # cant cast to uint64 as it's not supported yet
+            # can't cast to uint64 as it's not supported yet
             # this will cost us slightly in performance
             alias fast_div = FastDiv[DType.uint32](shared_n)
 

--- a/max/kernels/src/linalg/matmul_sm100_blockwise_fp8.mojo
+++ b/max/kernels/src/linalg/matmul_sm100_blockwise_fp8.mojo
@@ -519,7 +519,7 @@ fn matmul_sm100_blockwise_scaled_fp8_1d2d_wrapper[
     b_scales: LayoutTensor[b_scales_type, b_scales_layout, MutableAnyOrigin],
     num_iters: UInt,
 ):
-    # NOTE: This wrapper is nessecary because batched blockwise scaling has a wrapper kernel
+    # NOTE: This wrapper is necessary because batched blockwise scaling has a wrapper kernel
     # for allocating matrices across the z index that kernel calls the function
     # `matmul_sm100_blockwise_scaled_fp8_1d2d_kernel` as well. That function requires the decroators
     # to not be present on the function so we moved it to this wrapper.

--- a/max/kernels/src/linalg/matmul_sm90.mojo
+++ b/max/kernels/src/linalg/matmul_sm90.mojo
@@ -2268,7 +2268,7 @@ fn warp_specialize_gemm_with_multicasting[
     # we need to use cp.async.ca for 4B and 8B access, and ld for
     # 2B or smaller access.
     # Note that K * size_of[a_type]() decides the 2nd row's alignment
-    # and Nvidia requries access alignmend by access size.
+    # and Nvidia requires access alignment by access size.
     # Dispatch kernel using TMA load when the stride is multiple of 16B.
     @parameter
     if k_align == 16:

--- a/max/kernels/src/linalg/packing.mojo
+++ b/max/kernels/src/linalg/packing.mojo
@@ -137,7 +137,7 @@ struct PackMatrixRows[
         ],
         local_off_set: IndexList[2],
     ):
-        """Helper function: transpose packs a [simd_size, simd_size] subtile of
+        """Helper function: transpose packs a [simd_size, simd_size] sub-tile of
         matrix, with bound checking and zero-filling. Bound checking can be
         statically skipped, based on the parameters.
            Args:
@@ -147,7 +147,7 @@ struct PackMatrixRows[
                    skpped if true.
                transpose_buffer(NDBuffer): pre-allocated work space to hold
                    transposed temporary data.
-               local_offset(IndexList): offset of the subtile to work on
+               local_offset(IndexList): offset of the sub-tile to work on
                    within the whole tile of data to pack.
         """
         # Calculate the remaining bound from the local offset.

--- a/max/kernels/src/linalg/transpose.mojo
+++ b/max/kernels/src/linalg/transpose.mojo
@@ -1685,7 +1685,7 @@ fn transpose[
     if simplified_rank == 1:
         # memcpy
         return transpose_trivial_memcpy(output, input)
-    # TODO: Reenable once #15947 is fixed.
+    # TODO: Re-enable once #15947 is fixed.
     # elif simplified_rank == 2:
     #     # tiled transpose
     #     return transpose_2d[rank, output_shape, input_shape, dtype](

--- a/max/kernels/src/nn/concat.mojo
+++ b/max/kernels/src/nn/concat.mojo
@@ -89,7 +89,7 @@ fn memcpy_or_fuse[
                 width=simd_width
             ](index)
 
-            # Convert the linearized address back to the nd indices.
+            # Convert the linearized address back to the n-D indices.
             constrained[_rank == 1]()
             var out_index = _get_start_indices_of_nth_subvolume[0](
                 index[0] + typed_offset,

--- a/max/kernels/src/nn/conv.mojo
+++ b/max/kernels/src/nn/conv.mojo
@@ -392,7 +392,7 @@ struct ConvDirectNHWC[
     var conv_shape: ConvShape[input_rank - 2]
 
     # Support partition in 4 dims: (n, c, f, ho_or_howo). If the input is
-    # padded, the output spacial dims are merged into one as howo. If not
+    # padded, the output spatial dims are merged into one as howo. If not
     # padded, only ho is partitioned for now.
     var partition: ConvPartition
 

--- a/max/kernels/src/nn/conv_transpose.mojo
+++ b/max/kernels/src/nn/conv_transpose.mojo
@@ -438,7 +438,7 @@ struct ConvTransposedPacked[
     var conv_shape: ConvShape[input_layout.rank() - 2]
 
     # Support partition in 4 dims: (n, c, f, ho_or_howo). If the input is
-    # padded, the output spacial dims are merged into one as howo. If not
+    # padded, the output spatial dims are merged into one as howo. If not
     # padded, only ho is partitioned for now.
     var partition: ConvPartition
 

--- a/max/kernels/src/nn/irfft.mojo
+++ b/max/kernels/src/nn/irfft.mojo
@@ -161,7 +161,7 @@ fn irfft[
         input: Complex input tensor (NDBuffer).
         output: Real output tensor (NDBuffer).
         n: Output signal size (if <= 0, computed as 2*(input.size(axis) - 1)).
-        buffer_size_mb: Esimated buffer size in MB.
+        buffer_size_mb: Estimated buffer size in MB.
         ctx: Device context.
     """
     constrained[
@@ -231,7 +231,7 @@ fn irfft[
 
         # Set up cuda stream.
         # Notice that we do not want to have this part of the cache
-        # The stream is set everytime the call is executed and we get the
+        # The stream is set every time the call is executed and we get the
         # stream from the context we are executing within
         check_error(cufftSetStream(plan, cuda_stream))
 

--- a/max/kernels/src/nn/mha_sm100.mojo
+++ b/max/kernels/src/nn/mha_sm100.mojo
@@ -1905,7 +1905,7 @@ fn _mha_sm100[
     1 Partition across B, H, and num_keys (TODO).  The last one is split-K and
       will need a separate reduction kernel at the end.
 
-    2 Frist bmm becomes gemv and second bmm becomes gevm.
+    2 First bmm becomes gemv and second bmm becomes gevm.
       TODO: use more optimized kernels for them
 
     """

--- a/max/kernels/src/nn/mha_sm90.mojo
+++ b/max/kernels/src/nn/mha_sm90.mojo
@@ -994,7 +994,7 @@ fn _mha_sm90[
     ]()
     alias k_smem_layout = k_tma_op.layout
     alias v_smem_layout = v_tma_op.layout
-    # for wgmma_0, we mutliply BM x depth @ depth x BN -> BM x BN
+    # for wgmma_0, we multiply BM x depth @ depth x BN -> BM x BN
     # for wgmma_1, we multiply BM x BN @ BN x depth -> BM x depth
     # For wgmma_0, we iterate over (depth//BK) tiles of size BKxBN
     # For wgmma_1, we iterate over (BN//BK) tiles of size BKxdepth

--- a/max/kernels/src/nn/normalization.mojo
+++ b/max/kernels/src/nn/normalization.mojo
@@ -470,7 +470,7 @@ fn layer_norm_gpu[
     fn input_fn_2d[
         simd_width: Int
     ](row: Int, col: Int) -> SIMD[dtype, simd_width]:
-        # Translate given 2d index back to original Nd tensor
+        # Translate a given 2D index back to the original n-D tensor
         var indices = _get_start_indices_of_nth_subvolume(row, shape)
         indices[rank - 1] = col
         return input_fn[simd_width](indices.canonicalize())
@@ -698,7 +698,7 @@ fn layer_norm_cpu[
         fn input_fn_2d[
             simd_width: Int
         ](row: Int, col: Int) -> SIMD[dtype, simd_width]:
-            # Translate given 2d index back to original Nd tensor
+            # Translate a given 2D index back to the original n-D tensor
             var indices = _get_start_indices_of_nth_subvolume(
                 row_idx + row, shape
             )
@@ -711,7 +711,7 @@ fn layer_norm_cpu[
         fn output_fn_2d[
             simd_width: Int, alignment: Int
         ](row: Int, col: Int, val: SIMD[dtype, simd_width]):
-            # Translate given 2d index back to original Nd tensor
+            # Translate a given 2D index back to the original n-D tensor
             var indices = _get_start_indices_of_nth_subvolume(
                 row_idx + row, shape
             )
@@ -1118,7 +1118,7 @@ fn rms_norm_gpu[
     fn output_fn_2d[
         simd_width: Int, alignment: Int
     ](row: Int, col: Int, val: SIMD[dtype, simd_width]) -> None:
-        # Translate given 2d index back to original Nd tensor
+        # Translate a given 2D index back to the original n-D tensor
         var indices = _get_start_indices_of_nth_subvolume(row, shape)
         indices[rank - 1] = col
         output_fn[simd_width, alignment](indices.canonicalize(), val)
@@ -1128,7 +1128,7 @@ fn rms_norm_gpu[
     fn input_fn_2d[
         simd_width: Int
     ](row: Int, col: Int) -> SIMD[dtype, simd_width]:
-        # Translate given 2d index back to original Nd tensor
+        # Translate a given 2D index back to the original n-D tensor
         var indices = _get_start_indices_of_nth_subvolume(row, shape)
         indices[rank - 1] = col
         return input_fn[simd_width](indices.canonicalize())
@@ -1342,7 +1342,7 @@ fn rms_norm_cpu[
         fn output_fn_2d[
             simd_width: Int, alignment: Int
         ](row: Int, col: Int, val: SIMD[dtype, simd_width]) -> None:
-            # Translate given 2d index back to the original Nd tensor.
+            # Translate a given 2D index back to the original n-D tensor.
             var indices = _get_start_indices_of_nth_subvolume(
                 row_idx + row, shape
             )
@@ -1355,7 +1355,7 @@ fn rms_norm_cpu[
         fn input_fn_2d[
             simd_width: Int
         ](row: Int, col: Int) -> SIMD[dtype, simd_width]:
-            # Translate given 2d index back to the original Nd tensor.
+            # Translate a given 2D index back to the original n-D tensor.
             var indices = _get_start_indices_of_nth_subvolume(
                 row_idx + row, shape
             )
@@ -1644,7 +1644,7 @@ fn rms_norm_fused_residual_add_gpu[
     fn output_fn_2d[
         simd_width: Int, alignment: Int
     ](row: Int, col: Int, val: SIMD[dtype, simd_width]) -> None:
-        # Translate given 2d index back to original Nd tensor
+        # Translate a given 2D index back to the original n-D tensor
         var indices = _get_start_indices_of_nth_subvolume(row, shape)
         indices[rank - 1] = col
         output_fn[simd_width, alignment](indices.canonicalize(), val)
@@ -1654,7 +1654,7 @@ fn rms_norm_fused_residual_add_gpu[
     fn output_residual_fn_2d[
         simd_width: Int, alignment: Int
     ](row: Int, col: Int, val: SIMD[dtype, simd_width]) -> None:
-        # Translate given 2d index back to original Nd tensor
+        # Translate a given 2D index back to the original n-D tensor
         var indices = _get_start_indices_of_nth_subvolume(row, shape)
         indices[rank - 1] = col
         output_residual_fn[simd_width, alignment](indices.canonicalize(), val)
@@ -1664,7 +1664,7 @@ fn rms_norm_fused_residual_add_gpu[
     fn input_fn_2d[
         simd_width: Int
     ](row: Int, col: Int) -> SIMD[dtype, simd_width]:
-        # Translate given 2d index back to original Nd tensor
+        # Translate a given 2D index back to the original n-D tensor
         var indices = _get_start_indices_of_nth_subvolume(row, shape)
         indices[rank - 1] = col
         return input_fn[simd_width](indices.canonicalize())
@@ -1674,7 +1674,7 @@ fn rms_norm_fused_residual_add_gpu[
     fn residual_input_fn_2d[
         simd_width: Int
     ](row: Int, col: Int) -> SIMD[dtype, simd_width]:
-        # Translate given 2d index back to original Nd tensor
+        # Translate a given 2D index back to the original n-D tensor
         var indices = _get_start_indices_of_nth_subvolume(row, shape)
         indices[rank - 1] = col
         return residual_input_fn[simd_width](indices.canonicalize())

--- a/max/kernels/src/nn/softmax.mojo
+++ b/max/kernels/src/nn/softmax.mojo
@@ -379,8 +379,8 @@ fn _softmax_3_pass_base[
         return max(v1, v2)
 
     # Input function
-    # Translate given input lambda from 1d to Nd because _reduce_generator
-    # needs Nd.
+    # Translate the given input lambda from 1D to n-D because _reduce_generator
+    # needs n-D.
     @parameter
     @always_inline
     fn input_fn[
@@ -603,7 +603,7 @@ fn _softmax_cpu[
             @always_inline
             # Given input lambda accepts N-dimensional coordinates, but the
             # softmax base routines operate on 1D buffers. Here we wrap the
-            # given input lambda with some 1d-to-Nd translation logic.
+            # given input lambda with some 1D-to-n-D translation logic.
             fn input_fn_1d[_width: Int](idx: Int) -> SIMD[dtype, _width]:
                 indices[rank - 1] = idx
                 return input_fn[_width, rank](indices)

--- a/max/kernels/src/shmem/shmem_api.mojo
+++ b/max/kernels/src/shmem/shmem_api.mojo
@@ -816,7 +816,7 @@ fn shmem_barrier_all_on_stream(stream: DeviceStream) raises:
 
 fn shmem_module_init(device_function: DeviceFunction) raises:
     """
-    Intializes the device state in the compiled function module so that it’s
+    Initializes the device state in the compiled function module so that it’s
     able to perform NVSHMEM operations. Must have completed device
     initialization prior to calling this function.
 

--- a/max/kernels/test/gpu/examples/test_matmul_kernel_10.mojo
+++ b/max/kernels/test/gpu/examples/test_matmul_kernel_10.mojo
@@ -89,11 +89,11 @@ fn sgemm_warp_tiling_kernel[
     var warp_col = warp_idx % (BN // WN)
     var warp_row = warp_idx // (BN // WN)
 
-    # Size of the warp subtile.
+    # Size of the warp sub-tile.
     alias w_sub_m = WM // WMITER  # 64/2=32
     alias w_sub_n = WN // WNITER  # 32/2=16
 
-    # Placement of the thread in the warp subtile.
+    # Placement of the thread in the warp sub-tile.
     var thread_Idx_In_warp = thread_idx.x % WARP_SIZE  # [0, 31]
     var thread_col_in_warp = thread_Idx_In_warp % (w_sub_n // TN)  # i%(16/4)
     var thread_row_in_warp = thread_Idx_In_warp // (w_sub_n // TN)  # i/4
@@ -250,7 +250,7 @@ fn sgemm_warp_tiling_kernel[
 
         @parameter
         for w_sub_col_idx in range(WNITER):
-            # Move C pointer to current warp subtile.
+            # Move C pointer to current warp sub-tile.
             var M_offset_subtile = w_sub_row_idx * w_sub_m
             var N_offset_subtile = w_sub_col_idx * w_sub_n
             var C_interim = cc_ptr.offset(
@@ -355,12 +355,12 @@ fn bench_matmuls(mut m: Bench, ctx: DeviceContext) raises:
     constrained[(K10_BN % K10_WN == 0) and (K10_BM % K10_WM == 0)]()
     constrained[(K10_BN / K10_WN) * (K10_BM / K10_WM) == NUM_WARPS]()
 
-    # Threads in warpsubtile.
+    # Threads in the warp sub-tile.
     constrained[
         (K10_WM * K10_WN) % (WARP_SIZE * K10_TM * K10_TN * K10_WNITER) == 0
     ]()
 
-    # Warpsubtile in warptile.
+    # Warp sub-tile in warp tile.
     constrained[(K10_WM % K10_WMITER == 0) and (K10_WN % K10_WNITER == 0)]()
 
     constrained[

--- a/max/kernels/test/gpu/examples/test_tiled_matmul_backtoback.mojo
+++ b/max/kernels/test/gpu/examples/test_tiled_matmul_backtoback.mojo
@@ -250,7 +250,7 @@ fn b2b_gemm[
     )
 
     # Each pipeline stage has its own buffer.
-    # We re-use `b_smem` for both `B` and `C`
+    # We reuse `b_smem` for both `B` and `C`
     var b_smem = (a_smem + a_smem_size).bitcast[Scalar[in_type]]()
     alias b_smem_size = num_pipeline_stages * BK * BN
     alias BD_0 = BN if transpose_b else BK

--- a/max/kernels/test/gpu/kv_cache/test_batch_kv_cache_flash_attention_causal_mask_ragged.mojo
+++ b/max/kernels/test/gpu/kv_cache/test_batch_kv_cache_flash_attention_causal_mask_ragged.mojo
@@ -182,7 +182,7 @@ def execute_ragged_flash_attention[
     var k_cache_device = kv_collection_device.get_key_cache(layer_idx)
     var v_cache_device = kv_collection_device.get_value_cache(layer_idx)
 
-    # Create sink weights (weird lifetime behavior if inside of parameter if, so we always creted it)
+    # Create sink weights (weird lifetime behavior if inside of parameter if, so we always create it)
     # TODO: fix this
     var sink_weights_shape = IndexList[1](num_q_heads)
     var sink_weights_host = HostNDBuffer[dtype, 1](sink_weights_shape)

--- a/max/kernels/test/gpu/memory/test_sharedmem_async_cp.mojo
+++ b/max/kernels/test/gpu/memory/test_sharedmem_async_cp.mojo
@@ -22,7 +22,7 @@ fn copy_via_shared(
     src: UnsafePointer[Float32],
     dst: UnsafePointer[Float32],
 ):
-    var thId = Int(thread_idx.x)
+    var thread_id = Int(thread_idx.x)
     var mem_buff: UnsafePointer[
         Float32, address_space = AddressSpace.SHARED
     ] = stack_allocation[16, Float32, address_space = AddressSpace.SHARED]()
@@ -31,8 +31,8 @@ fn copy_via_shared(
     ] = src.address_space_cast[AddressSpace.GLOBAL]()
 
     memory.async_copy[4](
-        src_global.offset(thId),
-        mem_buff.offset(thId),
+        src_global.offset(thread_id),
+        mem_buff.offset(thread_id),
     )
 
     var m_barrier = stack_allocation[
@@ -46,7 +46,7 @@ fn copy_via_shared(
         time.sleep(100 * 1e-6)
         not_wait = sync.mbarrier_test_wait(m_barrier, state)
 
-    dst[thId] = mem_buff[thId]
+    dst[thread_id] = mem_buff[thread_id]
 
 
 # CHECK-LABEL: run_copy_via_shared

--- a/max/kernels/test/gpu/shmem/test_ep_comm.mojo
+++ b/max/kernels/test/gpu/shmem/test_ep_comm.mojo
@@ -315,7 +315,7 @@ fn test_dispatch[
 
             # Check the results
 
-            # Fisrt, reproduce the input tokens and topk ids
+            # First, reproduce the input tokens and topk ids
             var all_ranks_input_tokens = UnsafePointer[
                 Scalar[input_type]
             ].alloc(n_tokens_per_rank * n_ranks * hidden_size)

--- a/max/kernels/test/internal_utils/test_dispatch.mojo
+++ b/max/kernels/test/internal_utils/test_dispatch.mojo
@@ -19,7 +19,7 @@ from internal_utils import TuningTableNvidia, TuningConfigNvidia
 from internal_utils import TuningTableAMD, TuningConfigAMD
 from testing import assert_equal
 
-# Highly recommneded to use "vendor_arch_dtype" format for table names.
+# Highly recommended to use "vendor_arch_dtype" format for table names.
 # For example:
 # nvidia_sm90_fp8 = Table[...]
 # import nvidia_sm90_fp8_configs

--- a/max/kernels/test/layout/test_tiled_matmul_backtoback.mojo
+++ b/max/kernels/test/layout/test_tiled_matmul_backtoback.mojo
@@ -642,7 +642,7 @@ fn matmulb2b[
     var AB: UnsafePointer[Scalar[elt]] = stack_allocation[
         Mc * Nc, elt, alignment=64
     ]()
-    # TODO: prefetches, as descried in nest
+    # TODO: prefetches, as described in nest
     # NOTE: Read comments within the loop from the inside out.
     #       I.e., read following a post-order depth first traversal of the
     #       loop tree.
@@ -664,12 +664,12 @@ fn matmulb2b[
                 #
                 # The use of `prefetchnta` on `A` helps more at this level, as
                 # `Mc x Kc` could be a very large chunk. Because `A[Mc, Kc]` is
-                # replaced, it is not actually held/re-used at the L3 cache level.
+                # replaced, it is not actually held/reused at the L3 cache level.
                 # Instead, we must stream through it.
                 # Because it is also held in the L1 cache, this is a prime candidate
                 # for `prefetchnta`, to load slices to the L1 where they may be
                 # held and reused, without polluting any of the other caches, where
-                # the memory is not re-used.
+                # the memory is not reused.
                 var pabk: UnsafePointer[Scalar[elt]] = AB
                 var pbk: UnsafePointer[Scalar[elt]] = pb
                 for _ in range(Mc // Mr):  # mr               - hold in l2 cache
@@ -732,7 +732,7 @@ fn matmulb2b[
                 # However, because of the different loop order for this
                 # nest, we hold `AB` in the L3 cache, while we streamed `A`.
                 # `AB` was also held in the `L3` cache in th previous subloop,
-                # allowing for re-use of the block across these subloops.
+                # allowing for reuse of the block across these subloops.
                 #
                 # Instead, we stream through `D` and `C`.
                 # `C` is held in the l2 cache, thus we may want to prefetch it

--- a/max/nn/module_v3/module.py
+++ b/max/nn/module_v3/module.py
@@ -149,7 +149,7 @@ class Module:
             model.apply_to_parameters(lambda _, t: t.to(Accelerator())
 
         Args:
-            f: The transfomation to apply to each local parameter.
+            f: The transformation to apply to each local parameter.
                 The transformation takes two arguments, a name and a tensor.
                 - The name is the attribute name of the parameter on the module
                 - The tensor is the current value of that parameter
@@ -175,7 +175,7 @@ class Module:
             model.apply_to_parameters(lambda _, t: t.to(Accelerator())
 
         Args:
-            f: The transfomation to apply to each parameter.
+            f: The transformation to apply to each parameter.
                 The transformation takes two arguments, a name and a tensor.
                 - The name is the qualified name of the parameter
                     with respect to the module on which `apply_to_parameters`
@@ -296,7 +296,7 @@ class Module:
             model_on_gpu = model.map_parameters(lambda _, t: t.to(Accelerator())
 
         Args:
-            f: The transfomation to apply to each parameter.
+            f: The transformation to apply to each parameter.
                 The transformation takes two arguments, a name and a tensor.
                 - The name is the qualified name of the parameter
                     with respect to the module on which `map_parameters`

--- a/max/nn/sampling/rejection_sampler.py
+++ b/max/nn/sampling/rejection_sampler.py
@@ -288,7 +288,7 @@ class RejectionSamplerWithResiduals(nn.Module):
         )
 
         rejected_with_sentinel = rejected_with_sentinel.cast(DType.int32)
-        # argmax is not reliable for getting the first max occurence when dealing with int tensors with [0,1] values so we weight them here to get the first occurence.
+        # argmax is not reliable for getting the first max occurrence when dealing with int tensors with [0,1] values, so we weight them here to get the first occurrence.
         # TODO: remove this when/if KERN-1862 is resolved
         argmax_weights = ops.range(
             rejected_with_sentinel.shape[1],

--- a/max/serve/pipelines/kvcache_worker.py
+++ b/max/serve/pipelines/kvcache_worker.py
@@ -66,7 +66,7 @@ def _kvcache_agent_process_fn(
 
 
 # Warning: This method is currently unused!
-# Keeping it around since it may be reenabled in the future.
+# Keeping it around since it may be re-enabled in the future.
 @asynccontextmanager
 async def start_kv_cache_service(
     settings: Settings,


### PR DESCRIPTION
## Summary
- Correct spelling in the GenAI engineering design docs, including caption guidance and algorithm descriptions.
- Standardize terminology throughout kernel implementations and utilities (n-D indexing, spatial dimensions, estimated sizes, reuse wording, etc.).
- Clean up module and test commentary, renaming helper variables for clarity and updating docstrings/messages across the graph and sampling code.
