### PR TITLE
[stdlib] Fix origin mutability of pointers in `memory.mojo` and `qmatmul_k.mojo` and add `NDBuffer[mut=False]` implicit ctor

### DIFF
--- a/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
@@ -5710,8 +5710,8 @@ struct VroomQ4KMatmul:
     ) raises:
         with Trace[TraceLevel.OP, target = StaticString("cpu")](_trace_name):
             matmul_Q4_K(
-                managed_tensor_slice_to_ndbuffer(a),
-                managed_tensor_slice_to_ndbuffer(b),
+                managed_tensor_slice_to_ndbuffer(a).get_immutable(),
+                managed_tensor_slice_to_ndbuffer(b).get_immutable(),
                 managed_tensor_slice_to_ndbuffer(c),
             )
 
@@ -5803,8 +5803,8 @@ struct VroomQ6KMatmul:
     ) raises:
         with Trace[TraceLevel.OP, target = StaticString("cpu")](_trace_name):
             matmul_Q6_K(
-                managed_tensor_slice_to_ndbuffer(a),
-                managed_tensor_slice_to_ndbuffer(b),
+                managed_tensor_slice_to_ndbuffer(a).get_immutable(),
+                managed_tensor_slice_to_ndbuffer(b).get_immutable(),
                 managed_tensor_slice_to_ndbuffer(c),
             )
 

--- a/max/kernels/src/linalg/accumulate.mojo
+++ b/max/kernels/src/linalg/accumulate.mojo
@@ -427,7 +427,7 @@ struct _Accumulator[
         partial_store: Bool = False,
     ](
         mut self,
-        output: UnsafePointer[Scalar[dt], **_],
+        output: UnsafePointer[Scalar[dt], mut=True, **_],
         output_stride: Int,
         partial_store_size: OptionalReg[Int] = None,
     ):
@@ -946,7 +946,7 @@ fn _simd_load_maybe_partial[
 fn _simd_store_maybe_partial[
     dt: DType, //, simd_width: Int, partial_store: Bool
 ](
-    ptr: UnsafePointer[Scalar[dt], **_],
+    ptr: UnsafePointer[Scalar[dt], mut=True, **_],
     offset: Int,
     vec: SIMD[dt, simd_width],
     partial_store_size: OptionalReg[Int] = None,

--- a/max/kernels/src/nn/mla.mojo
+++ b/max/kernels/src/nn/mla.mojo
@@ -1434,21 +1434,9 @@ fn flare_mla_prefill_dispatch[
 
     alias smem_use = (q_smem + k_smem + v_smem) * config.dtype.size_of()
 
-    var softmax_info_ptr = (
-        softmax_info.value().data if softmax_info else UnsafePointer[
-            Scalar[softmax_type]
-        ]()
-    )
-    var prev_output_ptr = (
-        prev_output.value().data if prev_output else UnsafePointer[
-            Scalar[output_type]
-        ]()
-    )
-    var prev_softmax_info_ptr = (
-        prev_softmax_info.value().data if prev_softmax_info else UnsafePointer[
-            Scalar[softmax_type]
-        ]()
-    )
+    var softmax_info_ptr = softmax_info.or_else({}).data
+    var prev_output_ptr = prev_output.or_else({}).data
+    var prev_softmax_info_ptr = prev_softmax_info.or_else({}).data
 
     alias kernel = mla_prefill[
         config.dtype,

--- a/max/kernels/src/quantization/qmatmul.mojo
+++ b/max/kernels/src/quantization/qmatmul.mojo
@@ -1106,9 +1106,7 @@ fn _matmul_qint4_m_any[
                     k_batch_groups * tile_n * simd_width,
                     DType.int32,
                     alignment=alignment,
-                ]() if needs_correction else UnsafePointer[
-                    Int32,
-                ]()
+                ]() if needs_correction else {}
 
                 _unpack_weights[
                     group_size,

--- a/max/kernels/test/quantization/test_qmatmul_k.mojo
+++ b/max/kernels/test/quantization/test_qmatmul_k.mojo
@@ -47,7 +47,10 @@ fn random_float16(min: Float64 = 0, max: Float64 = 1) -> Float16:
 
 fn quantize_a_Q8[
     group_size: Int
-](a: UnsafePointer[Float32, **_], a_quant: UnsafePointer[Int8, **_]) -> Float32:
+](
+    a: UnsafePointer[Float32, mut=False, **_],
+    a_quant: UnsafePointer[Int8, mut=True, **_],
+) -> Float32:
     var fp_data = a.load[width=group_size]()
     var max_value = abs(fp_data).reduce_max()
     var multiplier = 127.0 / max_value if max_value != 0.0 else 0.0
@@ -64,9 +67,9 @@ fn dot_product_QK_K[
     group_size: Int,
     b_zero_point: Int32 = 0,
 ](
-    a_quant_data: UnsafePointer[Int8, **_],
-    b_quant_data: UnsafePointer[UInt8, **_],
-    b_scales: UnsafePointer[Scalar[b_scales_type], **_],
+    a_quant_data: UnsafePointer[Int8, mut=False, **_],
+    b_quant_data: UnsafePointer[UInt8, mut=False, **_],
+    b_scales: UnsafePointer[Scalar[b_scales_type], mut=False, **_],
 ) -> Int32:
     var sum: Int32 = 0
     for i in range(_block_QK_K.quantized_k):
@@ -98,16 +101,16 @@ trait QuantizedGemm:
 
     @staticmethod
     fn kernel(
-        a: NDBuffer[DType.float32, 2],
-        b: NDBuffer[DType.uint8, 2],
-        c: NDBuffer[DType.float32, 2],
+        a: NDBuffer[mut=False, DType.float32, 2],
+        b: NDBuffer[mut=False, DType.uint8, 2],
+        c: NDBuffer[mut=True, DType.float32, 2],
     ):
         ...
 
     @staticmethod
     fn dot_product(
-        a: NDBuffer[DType.float32, 2],
-        b: NDBuffer[DType.uint8, 2],
+        a: NDBuffer[mut=False, DType.float32, 2],
+        b: NDBuffer[mut=False, DType.uint8, 2],
         m: Int,
         n: Int,
         k: Int,
@@ -156,16 +159,16 @@ struct qgemm_Q4_0(QuantizedGemm):
 
     @staticmethod
     fn kernel(
-        a: NDBuffer[DType.float32, 2],
-        b: NDBuffer[DType.uint8, 2],
-        c: NDBuffer[DType.float32, 2],
+        a: NDBuffer[mut=False, DType.float32, 2],
+        b: NDBuffer[mut=False, DType.uint8, 2],
+        c: NDBuffer[mut=True, DType.float32, 2],
     ):
         matmul_qint4[_block_Q4_0.group_size](a, b, c)
 
     @staticmethod
     fn dot_product(
-        a: NDBuffer[DType.float32, 2],
-        b: NDBuffer[DType.uint8, 2],
+        a: NDBuffer[mut=False, DType.float32, 2],
+        b: NDBuffer[mut=False, DType.uint8, 2],
         m: Int,
         n: Int,
         k: Int,
@@ -251,16 +254,16 @@ struct qgemm_Q4_K(QuantizedGemm):
 
     @staticmethod
     fn kernel(
-        a: NDBuffer[DType.float32, 2],
-        b: NDBuffer[DType.uint8, 2],
-        c: NDBuffer[DType.float32, 2],
+        a: NDBuffer[mut=False, DType.float32, 2],
+        b: NDBuffer[mut=False, DType.uint8, 2],
+        c: NDBuffer[mut=True, DType.float32, 2],
     ):
         matmul_Q4_K(a, b, c)
 
     @staticmethod
     fn dot_product(
-        a: NDBuffer[DType.float32, 2],
-        b: NDBuffer[DType.uint8, 2],
+        a: NDBuffer[mut=False, DType.float32, 2],
+        b: NDBuffer[mut=False, DType.uint8, 2],
         m: Int,
         n: Int,
         k: Int,
@@ -383,16 +386,16 @@ struct qgemm_Q6_K(QuantizedGemm):
 
     @staticmethod
     fn kernel(
-        a: NDBuffer[DType.float32, 2],
-        b: NDBuffer[DType.uint8, 2],
-        c: NDBuffer[DType.float32, 2],
+        a: NDBuffer[mut=False, DType.float32, 2],
+        b: NDBuffer[mut=False, DType.uint8, 2],
+        c: NDBuffer[mut=True, DType.float32, 2],
     ):
         matmul_Q6_K(a, b, c)
 
     @staticmethod
     fn dot_product(
-        a: NDBuffer[DType.float32, 2],
-        b: NDBuffer[DType.uint8, 2],
+        a: NDBuffer[mut=False, DType.float32, 2],
+        b: NDBuffer[mut=False, DType.uint8, 2],
         m: Int,
         n: Int,
         k: Int,

--- a/mojo/stdlib/stdlib/algorithm/reduction.mojo
+++ b/mojo/stdlib/stdlib/algorithm/reduction.mojo
@@ -334,7 +334,11 @@ fn _reduce_3D[
     reduce_fn: fn[dtype: DType, width: Int] (SIMD[dtype, width]) -> Scalar[
         dtype
     ],
-](src: NDBuffer, dst: NDBuffer[mut=True, **_], init: Scalar[dst.type]) raises:
+](
+    src: NDBuffer[mut=False, *_, **_],
+    dst: NDBuffer[mut=True, *_, **_],
+    init: Scalar[dst.type],
+) raises:
     """Performs a reduction across axis 1 of a 3D input buffer."""
 
     alias simd_width = simd_width_of[dst.type]()

--- a/mojo/stdlib/stdlib/memory/memory.mojo
+++ b/mojo/stdlib/stdlib/memory/memory.mojo
@@ -46,8 +46,8 @@ from memory.pointer import AddressSpace, _GPUAddressSpace
 fn _memcmp_impl_unconstrained[
     dtype: DType, //
 ](
-    s1: UnsafePointer[Scalar[dtype], **_],
-    s2: UnsafePointer[Scalar[dtype], **_],
+    s1: UnsafePointer[Scalar[dtype], mut=False, **_],
+    s2: UnsafePointer[Scalar[dtype], mut=False, **_],
     count: Int,
 ) -> Int:
     for i in range(count):
@@ -62,8 +62,8 @@ fn _memcmp_impl_unconstrained[
 fn _memcmp_opt_impl_unconstrained[
     dtype: DType, //
 ](
-    s1: UnsafePointer[Scalar[dtype], **_],
-    s2: UnsafePointer[Scalar[dtype], **_],
+    s1: UnsafePointer[Scalar[dtype], mut=False, **_],
+    s2: UnsafePointer[Scalar[dtype], mut=False, **_],
     count: Int,
 ) -> Int:
     alias simd_width = simd_width_of[dtype]()
@@ -108,8 +108,8 @@ fn _memcmp_opt_impl_unconstrained[
 fn _memcmp_impl[
     dtype: DType
 ](
-    s1: UnsafePointer[Scalar[dtype], **_],
-    s2: UnsafePointer[Scalar[dtype], **_],
+    s1: UnsafePointer[Scalar[dtype], mut=False, **_],
+    s2: UnsafePointer[Scalar[dtype], mut=False, **_],
     count: Int,
 ) -> Int:
     constrained[dtype.is_integral(), "the input dtype must be integral"]()
@@ -123,8 +123,8 @@ fn _memcmp_impl[
 fn memcmp[
     type: AnyType, address_space: AddressSpace
 ](
-    s1: UnsafePointer[type, address_space=address_space],
-    s2: UnsafePointer[type, address_space=address_space],
+    s1: UnsafePointer[type, address_space=address_space, mut=False, **_],
+    s2: UnsafePointer[type, address_space=address_space, mut=False, **_],
     count: Int,
 ) -> Int:
     """Compares two buffers. Both strings are assumed to be of the same length.
@@ -163,8 +163,8 @@ fn memcmp[
 
 @always_inline
 fn _memcpy_impl(
-    dest_data: UnsafePointer[Byte, mut=True, *_, **_],
-    src_data: UnsafePointer[Byte, mut=False, *_, **_],
+    dest_data: UnsafePointer[Byte, mut=True, **_],
+    src_data: UnsafePointer[Byte, mut=False, **_],
     n: Int,
 ):
     """Copies a memory area.
@@ -244,8 +244,8 @@ fn _memcpy_impl(
 fn memcpy[
     T: AnyType
 ](
-    dest: UnsafePointer[T, address_space = AddressSpace.GENERIC, **_],
-    src: UnsafePointer[T, address_space = AddressSpace.GENERIC, **_],
+    dest: UnsafePointer[T, address_space = AddressSpace.GENERIC, mut=True, **_],
+    src: UnsafePointer[T, address_space = AddressSpace.GENERIC, mut=False, **_],
     count: Int,
 ):
     """Copies a memory area.
@@ -264,16 +264,10 @@ fn memcpy[
         # A fast version for the interpreter to evaluate
         # this function during compile time.
         llvm_intrinsic["llvm.memcpy", NoneType](
-            dest.bitcast[Byte]().origin_cast[True, MutableAnyOrigin](),
-            src.bitcast[Byte]().origin_cast[True, MutableAnyOrigin](),
-            n,
+            dest.bitcast[Byte](), src.bitcast[Byte](), n
         )
     else:
-        _memcpy_impl(
-            dest.bitcast[Byte]().origin_cast[True, MutableAnyOrigin](),
-            src.bitcast[Byte]().origin_cast[False](),
-            n,
-        )
+        _memcpy_impl(dest.bitcast[Byte](), src.bitcast[Byte](), n)
 
 
 # ===-----------------------------------------------------------------------===#
@@ -285,7 +279,7 @@ fn memcpy[
 fn _memset_impl[
     address_space: AddressSpace
 ](
-    ptr: UnsafePointer[Byte, address_space=address_space],
+    ptr: UnsafePointer[Byte, address_space=address_space, mut=True, **_],
     value: Byte,
     count: Int,
 ):
@@ -301,7 +295,7 @@ fn _memset_impl[
 fn memset[
     type: AnyType, address_space: AddressSpace
 ](
-    ptr: UnsafePointer[type, address_space=address_space],
+    ptr: UnsafePointer[type, address_space=address_space, mut=True, **_],
     value: Byte,
     count: Int,
 ):
@@ -327,7 +321,10 @@ fn memset[
 @always_inline
 fn memset_zero[
     type: AnyType, address_space: AddressSpace, //
-](ptr: UnsafePointer[type, address_space=address_space], count: Int):
+](
+    ptr: UnsafePointer[type, address_space=address_space, mut=True, **_],
+    count: Int,
+):
     """Fills memory with zeros.
 
     Parameters:
@@ -344,7 +341,11 @@ fn memset_zero[
 @always_inline
 fn memset_zero[
     dtype: DType, address_space: AddressSpace, //, *, count: Int
-](ptr: UnsafePointer[Scalar[dtype], address_space=address_space]):
+](
+    ptr: UnsafePointer[
+        Scalar[dtype], address_space=address_space, mut=True, **_
+    ]
+):
     """Fills memory with zeros.
 
     Parameters:
@@ -406,7 +407,7 @@ fn stack_allocation[
     name: Optional[StaticString] = None,
     alignment: Int = align_of[type](),
     address_space: AddressSpace = AddressSpace.GENERIC,
-]() -> UnsafePointer[type, address_space=address_space]:
+](out result: UnsafePointer[type, address_space=address_space]):
     """Allocates data buffer space on the stack given a data type and number of
     elements.
 
@@ -433,9 +434,7 @@ fn stack_allocation[
                 name = _get_kgen_string[global_name](),
                 count = count._mlir_value,
                 memoryType = __mlir_attr.`#pop<global_alloc_addr_space gpu_shared>`,
-                _type = UnsafePointer[
-                    type, address_space=address_space
-                ]._mlir_type,
+                _type = __type_of(result)._mlir_type,
                 alignment = alignment._mlir_value,
             ]()
         elif address_space == _GPUAddressSpace.CONSTANT:
@@ -445,9 +444,7 @@ fn stack_allocation[
             return __mlir_op.`pop.global_alloc`[
                 name = _get_kgen_string[global_name](),
                 count = count._mlir_value,
-                _type = UnsafePointer[
-                    type, address_space=address_space
-                ]._mlir_type,
+                _type = __type_of(result)._mlir_type,
                 alignment = alignment._mlir_value,
             ]()
 
@@ -461,15 +458,13 @@ fn stack_allocation[
                 alignment = alignment._mlir_value,
             ]()
             return __mlir_op.`pop.pointer.bitcast`[
-                _type = UnsafePointer[
-                    type, address_space=address_space
-                ]._mlir_type
+                _type = __type_of(result)._mlir_type
             ](generic_ptr)
 
     # Perform a stack allocation of the requested size, alignment, and type.
     return __mlir_op.`pop.stack_allocation`[
         count = count._mlir_value,
-        _type = UnsafePointer[type, address_space=address_space]._mlir_type,
+        _type = __type_of(result)._mlir_type,
         alignment = alignment._mlir_value,
     ]()
 
@@ -506,7 +501,9 @@ fn _malloc[
 
 
 @always_inline
-fn _free(ptr: UnsafePointer[_, address_space = AddressSpace.GENERIC, *_, **_]):
+fn _free(
+    ptr: UnsafePointer[_, address_space = AddressSpace.GENERIC, mut=True, **_]
+):
     @parameter
     if is_gpu():
         libc.free(ptr.bitcast[NoneType]())


### PR DESCRIPTION
Part of https://github.com/modular/modular/pull/4396.

This also adds an implicit constructor from NDBuffer[mut=_] -> NDBuffer[mut=False] to avoid having to fix ambiguous function signatures all up the call-stack


 #4398 got closed because I accidentally pushed before doing the commit.

CC: @lsh @JoeLoser 