### PR TITLE
[stdlib] Fix origins in `memory.mojo`

### DIFF
--- a/max/kernels/src/quantization/qmatmul_k.mojo
+++ b/max/kernels/src/quantization/qmatmul_k.mojo
@@ -1149,7 +1149,11 @@ fn _matmul_Q4_K_columns[
 
     # Fast path for M=1 that avoids materializing the unpacked weights.
     if M == 1:
-        var b_q_bits_ptr = b_tile_ptr[].q_bits.bits.unsafe_ptr()
+        var b_q_bits_ptr = (
+            b_tile_ptr[]
+            .q_bits.bits.unsafe_ptr()
+            .origin_cast[True, MutableAnyOrigin]()
+        )
 
         @parameter
         fn matmul_group_packed(
@@ -1185,7 +1189,7 @@ fn _matmul_Q4_K_columns[
     @__copy_capture(b_tile_ptr, b_q_scales_and_mins_buf, b_q_bits)
     @always_inline
     fn process_rows[tile_m: Int](m: Int):
-        var b_q_bits_ptr = b_q_bits
+        var b_q_bits_ptr = b_q_bits.origin_cast[True, MutableAnyOrigin]()
 
         @parameter
         fn matmul_group_unpacked(
@@ -1391,7 +1395,11 @@ fn _matmul_Q6_K_columns[
 
     # Fast path for M=1 that avoids materializing the unpacked weights.
     if M == 1:
-        var b_q_bits_ptr = b_tile_ptr[].q_bits.bits.unsafe_ptr()
+        var b_q_bits_ptr = (
+            b_tile_ptr[]
+            .q_bits.bits.unsafe_ptr()
+            .origin_cast[True, MutableAnyOrigin]()
+        )
 
         @parameter
         fn matmul_group_packed(
@@ -1419,7 +1427,7 @@ fn _matmul_Q6_K_columns[
     @__copy_capture(b_tile_ptr, b_q_bits)
     @always_inline
     fn process_rows[tile_m: Int](m: Int):
-        var b_q_bits_ptr = b_q_bits
+        var b_q_bits_ptr = b_q_bits.origin_cast[True, MutableAnyOrigin]()
 
         @parameter
         fn matmul_group_unpacked(


### PR DESCRIPTION
Fix origins in `memory.mojo`. Supersedes  #5316, I managed to reduce the scope of the PR