### PR TITLE
[stdlib] Add `reap` to `DictEntry` with examples.

### DIFF
--- a/mojo/stdlib/stdlib/collections/dict.mojo
+++ b/mojo/stdlib/stdlib/collections/dict.mojo
@@ -322,6 +322,23 @@ struct DictEntry[K: KeyElement, V: Copyable & Movable, H: Hasher](
         self.key = existing.key.copy()
         self.value = existing.value.copy()
 
+    fn reap(deinit self) -> Tuple[Optional[K], Optional[V]]:
+        """Take the key and value from an owned entry.
+
+        Wrapped in `Optional`s to allow for moving each field individually.
+
+        Example:
+            ```mojo
+            var entry = DictEntry(key="a", value=1)
+            var k, v = entry^.reap()
+            print(k.take(), v.take())
+            ```
+
+        Returns:
+            The key and value of the entries as a tuple of `Optional`s.
+        """
+        return Optional(self.key^), Optional(self.value^)
+
     fn reap_value(deinit self) -> V:
         """Take the value from an owned entry.
 
@@ -1139,6 +1156,20 @@ struct Dict[K: KeyElement, V: Copyable & Movable, H: Hasher = default_hasher](
 
         for entry in my_dict.take_items():
             print(entry.key, entry.value)
+
+        print(len(my_dict))
+        # prints 0
+        ```
+
+        Example of moving out the key and value individually:
+        ```mojo
+        var my_dict = Dict[String, Int]()
+        my_dict["a"] = 1
+        my_dict["b"] = 2
+
+        for entry in my_dict.take_items():
+            var k, v = entry^.reap()
+            print(k.take(), v.take())
 
         print(len(my_dict))
         # prints 0

--- a/mojo/stdlib/test/collections/test_dict.mojo
+++ b/mojo/stdlib/test/collections/test_dict.mojo
@@ -291,6 +291,18 @@ def test_iter_take_items():
     assert_false(dict.take_items().__has_next__())
 
 
+def test_iter_take_items_reap():
+    var my_dict = Dict[String, Int]()
+    my_dict["a"] = 1
+    my_dict["b"] = 2
+
+    for entry in my_dict.take_items():
+        var k, v = entry^.reap()
+        print(k.take(), v.take())
+
+    print(len(my_dict))
+
+
 def test_dict_contains():
     var dict: Dict[String, Int] = {}
     dict["abc"] = 1
@@ -759,3 +771,5 @@ def main():
     test_dict_comprehension()
     test_dict_repr_wrap()
     test_popitem_no_copies()
+    test_iter_take_items()
+    test_iter_take_items_reap()


### PR DESCRIPTION
This allows for moving out the key and value individually from the dictionary entries. For example:
```mojo
    for item in d.take_items():
        # Access fields before consuming the entry
        var k, v = item^.reap()
        new_item = Item(key=k.take(), value=v.take())
        print(new_item.key, new_item.value)
```
Attempting to move the fields directly will result in a seg fault:

```mojo
var k = item.key^
var v = item.value^
````
Since item.value^ tries to move `item` which has `key` uninitialized. We need to be able to move both fields out at the same time, then deinit item altogether.

This is why we return a tuple of `Optional`s to allow for unpacking the field values, and moving them out individually.

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
