### PR TITLE
[stdlib] Add `take_items` to `List` with examples.

### DIFF
--- a/mojo/stdlib/stdlib/collections/list.mojo
+++ b/mojo/stdlib/stdlib/collections/list.mojo
@@ -93,6 +93,43 @@ struct _ListIter[
         return (iter_len, {iter_len})
 
 
+@fieldwise_init
+struct _TakeListIter[T: Copyable & Movable, origin: Origin[True]](
+    ImplicitlyCopyable, Iterable, Iterator, Movable
+):
+    """Iterator for List that pops the first element per iteration.
+
+    Parameters:
+        T: The type of the elements in the list.
+        origin: The origin of the List
+    """
+
+    alias Element = T  # FIXME(MOCO-2068): shouldn't be needed.
+
+    alias IteratorType[
+        iterable_mut: Bool, //, iterable_origin: Origin[iterable_mut]
+    ]: Iterator = Self
+
+    var src: Pointer[List[Self.Element], origin]
+
+    @always_inline
+    fn __iter__(ref self) -> Self.IteratorType[__origin_of(self)]:
+        return self.copy()
+
+    @always_inline
+    fn __has_next__(self) -> Bool:
+        return len(self.src[]) > 0
+
+    @always_inline
+    fn __next__(mut self) -> Self.Element:
+        return self.src[].pop(0)
+
+    @always_inline
+    fn bounds(self) -> Tuple[Int, Optional[Int]]:
+        var iter_len: Int = len(self.src[])
+        return (iter_len, {iter_len})
+
+
 struct List[T: Copyable & Movable](
     Boolable, Copyable, Defaultable, Iterable, Movable, Sized
 ):
@@ -842,6 +879,34 @@ struct List[T: Copyable & Movable](
         self._len -= 1
 
         return ret_val^
+
+    fn take_items(mut self) -> _TakeListIter[T, __origin_of(self)]:
+        """Returns a mutating iterator that pops items out of the list.
+
+        Examples:
+        ```mojo
+        var l = List[String]("a", "b", "c")
+        for item in l.take_items():
+            # Unlike the default iterator, we
+            # can take ownership of each item.
+            var v = item^
+            print(v)
+        print('List length:', len(l))
+        ```
+
+        This will print:
+
+        ```
+        a
+        b
+        c
+        List length: 0
+        ```
+
+        Returns:
+            A mutating iterator that pops items out of the list.
+        """
+        return _TakeListIter(Pointer(to=self))
 
     fn reserve(mut self, new_capacity: Int):
         """Reserves the requested capacity.

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -1006,6 +1006,15 @@ def test_list_repr_wrap():
     )
 
 
+def test_list_take_items():
+    var l = List[String]("a", "b", "c")
+    var l2 = l.copy()
+    for item in l.take_items():
+        var v = item^
+        assert_true(v in l2)
+    assert_equal(len(l), 0)
+
+
 # ===-------------------------------------------------------------------===#
 # main
 # ===-------------------------------------------------------------------===#
@@ -1051,3 +1060,4 @@ def main():
     test_copyinit_trivial_types_dtypes()
     test_list_comprehension()
     test_list_repr_wrap()
+    test_list_take_items()


### PR DESCRIPTION
This allows for moving out the items from the list. For example:
```mojo
    for item in l.take_items():
        print(item)
```

Note, this does not work with zip, you need to do:

```
    var l = List[Optional[UnCopyable]](Optional(UnCopyable(x=1)), Optional(UnCopyable(x=2)), Optional(UnCopyable(x=3)))
    var l2 = List[Optional[Int]](Optional(10), Optional(20), Optional(30))
    var it = zip(l.take_items(), l2.take_items())
    for item in it:
        var v = item[0].take()^
        print('This is v:', v)
        var v2 = item[1].take()^
        print('This is v2:', v2)
```

I had to do a similar thing to dict take_items via adding a reap to dict entry https://github.com/modular/modular/pull/5327

My question is, should "take_items" type iterators always wrap the return elements in Optional? That would clean up the UX for all of these, and should plugin nicer with other iter tools like zip. 

Is there a smarter way to resolve this?