### PR TITLE
[stdlib] Replace uses of `raise String(...)`

### DIFF
--- a/max/kernels/src/_cublas/cublas.mojo
+++ b/max/kernels/src/_cublas/cublas.mojo
@@ -35,8 +35,8 @@ alias CUDA_CUBLAS_LIBRARY_PATHS = List[Path](
 )
 
 
-fn _on_error_msg() -> String:
-    return String(
+fn _on_error_msg() -> Error:
+    return Error(
         (
             "Cannot find the cuBLAS libraries. Please make sure that "
             "the CUDA toolkit is installed and that the library path is "

--- a/max/kernels/src/_cublas/cublaslt.mojo
+++ b/max/kernels/src/_cublas/cublaslt.mojo
@@ -38,8 +38,8 @@ alias CUDA_CUBLASLT_LIBRARY_PATHS = List[Path](
 )
 
 
-fn _on_error_msg() -> String:
-    return String(
+fn _on_error_msg() -> Error:
+    return Error(
         (
             "Cannot find the cuBLASLT libraries. Please make sure that "
             "the CUDA toolkit is installed and that the library path is "

--- a/max/kernels/src/_cudnn/backend.mojo
+++ b/max/kernels/src/_cudnn/backend.mojo
@@ -32,8 +32,8 @@ alias CUDA_CUDNN_LIBRARY_PATHS = List[Path](
 )
 
 
-fn _on_error_msg() -> String:
-    return String(
+fn _on_error_msg() -> Error:
+    return Error(
         (
             "Cannot find the CUDNN libraries. Please make sure that "
             "the CUDA toolkit is installed and that the library path is "

--- a/max/kernels/src/_cudnn/cnn_infer.mojo
+++ b/max/kernels/src/_cudnn/cnn_infer.mojo
@@ -44,8 +44,8 @@ alias CUDA_CUDNN_CNN_INFER_LIBRARY_PATHS = List[Path](
 )
 
 
-fn _on_error_msg() -> String:
-    return String(
+fn _on_error_msg() -> Error:
+    return Error(
         (
             "Cannot find the CUDNN libraries. Please make sure that "
             "the CUDA toolkit is installed and that the library path is "

--- a/max/kernels/src/_cudnn/infer.mojo
+++ b/max/kernels/src/_cudnn/infer.mojo
@@ -34,8 +34,8 @@ alias CUDA_CUDNN_LIBRARY_PATHS = List[Path](
 )
 
 
-fn _on_error_msg() -> String:
-    return String(
+fn _on_error_msg() -> Error:
+    return Error(
         (
             "Cannot find the CUDNN libraries. Please make sure that "
             "the CUDA toolkit is installed and that the library path is "

--- a/max/kernels/src/_cufft/utils.mojo
+++ b/max/kernels/src/_cufft/utils.mojo
@@ -28,8 +28,8 @@ alias CUDA_CUFFT_LIBRARY_PATHS = List[Path](
 )
 
 
-fn _on_error_msg() -> String:
-    return String(
+fn _on_error_msg() -> Error:
+    return Error(
         (
             "Cannot find the cuFFT libraries. Please make sure that "
             "the CUDA toolkit is installed and that the library path is "

--- a/max/kernels/src/_curand/curand.mojo
+++ b/max/kernels/src/_curand/curand.mojo
@@ -31,8 +31,8 @@ alias CUDA_CURAND_LIBRARY_PATHS = List[Path](
 )
 
 
-fn _on_error_msg() -> String:
-    return String(
+fn _on_error_msg() -> Error:
+    return Error(
         (
             "Cannot find the CUDNN libraries. Please make sure that "
             "the CUDA toolkit is installed and that the library path is "

--- a/max/kernels/src/_rocblas/utils.mojo
+++ b/max/kernels/src/_rocblas/utils.mojo
@@ -30,8 +30,8 @@ alias ROCM_ROCBLAS_LIBRARY_PATHS = List[Path](
 )
 
 
-fn _on_error_msg() -> String:
-    return String(
+fn _on_error_msg() -> Error:
+    return Error(
         (
             "Cannot find the rocBLAS libraries. Please make sure that "
             "the ROCM toolkit is installed and that the library path is "

--- a/max/kernels/src/linalg/matmul/cpu/apple_accelerate.mojo
+++ b/max/kernels/src/linalg/matmul/cpu/apple_accelerate.mojo
@@ -66,8 +66,8 @@ alias LIB_ACC_PATH = "/System/Library/Frameworks/Accelerate.framework/Accelerate
 # ===-----------------------------------------------------------------------===#
 
 
-fn _on_error_msg() -> String:
-    return String(
+fn _on_error_msg() -> Error:
+    return Error(
         (
             "Cannot find the Apple Accelerate libraries. Please make sure that "
             "the XCode package is installed and that the library path is "

--- a/max/kernels/src/shmem/_nvshmem.mojo
+++ b/max/kernels/src/shmem/_nvshmem.mojo
@@ -54,8 +54,8 @@ struct NVSHMEMIVersion:
         self.patch = 5
 
 
-fn _on_error_msg() -> String:
-    return String(
+fn _on_error_msg() -> Error:
+    return Error(
         (
             "Cannot find the NVShmem libraries. Please make sure that "
             "the CUDA toolkit is installed and that the library path is "

--- a/max/kernels/test/gpu/nn/test_scatter_set_constant.mojo
+++ b/max/kernels/test/gpu/nn/test_scatter_set_constant.mojo
@@ -73,9 +73,16 @@ fn test_scatter_set_constant(ctx: DeviceContext) raises:
     for i in range(3):
         for j in range(3):
             if data[i, j] != expected_output[i, j]:
-                raise "data[" + String(i) + ", " + String(j) + "] = " + String(
-                    data[i, j]
-                ) + " != " + String(expected_output[i, j])
+                raise Error(
+                    "data[",
+                    i,
+                    ", ",
+                    j,
+                    "] = ",
+                    data[i, j],
+                    " != ",
+                    expected_output[i, j],
+                )
 
     data_ptr.free()
     expected_output_ptr.free()

--- a/max/kernels/test/nn/test_scatter_set_constant.mojo
+++ b/max/kernels/test/nn/test_scatter_set_constant.mojo
@@ -54,9 +54,16 @@ fn test_scatter_set_constant() raises:
     for i in range(3):
         for j in range(3):
             if data[i, j] != expected_output[i, j]:
-                raise "data[" + String(i) + ", " + String(j) + "] = " + String(
-                    data[i, j]
-                ) + " != " + String(expected_output[i, j])
+                raise Error(
+                    "data[",
+                    i,
+                    ", ",
+                    j,
+                    "] = ",
+                    data[i, j],
+                    " != ",
+                    expected_output[i, j],
+                )
 
     data_ptr.free()
     expected_output_ptr.free()

--- a/mojo/integration-test/python-extension-modules/non-trivial-init/mojo_module.mojo
+++ b/mojo/integration-test/python-extension-modules/non-trivial-init/mojo_module.mojo
@@ -75,7 +75,7 @@ struct MojoPair(Defaultable, ImplicitlyCopyable, Movable, Representable):
 
         # Handle different argument patterns
         if tuple_len + kwargs_len == 0:
-            raise String("MojoPair requires at least 1 argument")
+            raise Error("MojoPair requires at least 1 argument")
 
         var first_val: Int
         var second_val: Int
@@ -85,7 +85,7 @@ struct MojoPair(Defaultable, ImplicitlyCopyable, Movable, Representable):
             try:
                 first_val = Int(args[0])
             except e:
-                raise String("Failed to convert first argument to integer: ", e)
+                raise Error("Failed to convert first argument to integer: ", e)
         else:
             first_val = 0  # Default if not provided positionally
 
@@ -93,14 +93,12 @@ struct MojoPair(Defaultable, ImplicitlyCopyable, Movable, Representable):
             try:
                 second_val = Int(args[1])
             except e:
-                raise String(
-                    "Failed to convert second argument to integer: ", e
-                )
+                raise Error("Failed to convert second argument to integer: ", e)
         else:
             second_val = 0  # Default if not provided positionally
 
         if tuple_len > 2:
-            raise String(
+            raise Error(
                 "MojoPair accepts at most 2 positional arguments, got ",
                 tuple_len,
             )
@@ -116,26 +114,26 @@ struct MojoPair(Defaultable, ImplicitlyCopyable, Movable, Representable):
                 if "second" in kwargs:
                     second_val = Int(kwargs["second"])
             except e:
-                raise String("Failed to process keyword arguments: ", e)
+                raise Error("Failed to process keyword arguments: ", e)
 
         # Ensure we have valid values for both
         if tuple_len == 0 and kwargs_len > 0:
             # Pure keyword argument case - need both
             if "first" not in kwargs or "second" not in kwargs:
-                raise String(
+                raise Error(
                     "When using only keyword arguments, both 'first' and"
                     " 'second' must be provided"
                 )
         elif tuple_len == 1 and kwargs_len > 0:
             # Mixed case with one positional - need 'second' in kwargs
             if "second" not in kwargs:
-                raise String(
+                raise Error(
                     "When providing 1 positional argument, 'second' must be"
                     " provided as keyword argument"
                 )
         elif tuple_len == 1 and kwargs_len == 0:
             # Single positional argument case - need exactly 2
-            raise String(
+            raise Error(
                 "MojoPair requires exactly 2 arguments when using only"
                 " positional arguments"
             )

--- a/mojo/stdlib/stdlib/gpu/host/_tracing.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/_tracing.mojo
@@ -68,8 +68,8 @@ fn _setup_categories(
     _setup_category(name_category, _TraceType_MAX, "Max")
 
 
-fn _on_error_msg() -> String:
-    return String(
+fn _on_error_msg() -> Error:
+    return Error(
         (
             "Cannot find the GPU Tracing libraries. Please make sure that "
             "the library path is correctly set in one of the following paths ["

--- a/mojo/stdlib/stdlib/sys/ffi.mojo
+++ b/mojo/stdlib/stdlib/sys/ffi.mojo
@@ -608,7 +608,7 @@ struct _Global[
     StorageType: Movable, //,
     name: StaticString,
     init_fn: fn () -> StorageType,
-    on_error_msg: Optional[fn () -> String] = None,
+    on_error_msg: Optional[fn () -> Error] = None,
 ](Defaultable):
     alias ResultType = UnsafePointer[StorageType]
 


### PR DESCRIPTION
Replace uses of `raise String(...)`. Split off from #4807

This is very inefficient because `Error`'s constructor copies the whole data again.