### PR TITLE
[stdlib] Change `assert_equal` and `assert_not_equal` to use `Writable`

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -672,6 +672,9 @@ what we publish.
 - `StringableRaising` has been deprecated and its usages in the stdlib have
   been removed.
 
+- `assert_equal` and `assert_not_equal` now take in `Writable` arguments instead
+  of `Stringable` ones.
+
 ### Tooling changes
 
 - The Mojo compiler now supports the `-Werror` flag, which treats all warnings

--- a/mojo/stdlib/std/os/atomic.mojo
+++ b/mojo/stdlib/std/os/atomic.mojo
@@ -37,6 +37,7 @@ struct Consistency(
     ImplicitlyCopyable,
     Representable,
     Stringable,
+    Writable,
 ):
     """Represents the consistency model for atomic operations.
 
@@ -114,15 +115,23 @@ struct Consistency(
         """
         return self.as_string_slice()
 
+    fn write_to(self, mut writer: Some[Writer]):
+        """Formats the string representation of this type to the provided
+        `Writer`.
+
+        Args:
+            writer: The type conforming to `Writer`.
+        """
+        comptime prefix_len = "Consistency.".byte_length()
+        writer.write(self.as_string_slice()[prefix_len:])
+
     fn __str__(self) -> String:
         """Returns a string representation of a `Consistency`.
 
         Returns:
             A string representation of this consistency.
         """
-
-        comptime prefix_len = len("Consistency.")
-        return self.as_string_slice()[prefix_len:]
+        return String.write(self)
 
     fn as_string_slice(self) -> StaticString:
         """Returns a string slice representation of a `Consistency`.

--- a/mojo/stdlib/std/testing/testing.mojo
+++ b/mojo/stdlib/std/testing/testing.mojo
@@ -102,7 +102,7 @@ fn assert_false[
 
 @always_inline
 fn assert_equal[
-    T: Equatable & Stringable, //
+    T: Equatable & Writable, //
 ](
     lhs: T,
     rhs: T,
@@ -249,7 +249,7 @@ fn assert_equal_pyobj[
 
 @always_inline
 fn assert_not_equal[
-    T: Equatable & Stringable, //
+    T: Equatable & Writable, //
 ](
     lhs: T,
     rhs: T,

--- a/mojo/stdlib/test/math/test_exp.mojo
+++ b/mojo/stdlib/test/math/test_exp.mojo
@@ -73,7 +73,7 @@ def test_exp_libm():
 
 
 @fieldwise_init
-struct Float32Expable(Equatable, Stringable, _Expable):
+struct Float32Expable(Equatable, Writable, _Expable):
     """This is a test struct that implements the Expable trait for Float32."""
 
     var x: Float32
@@ -87,12 +87,12 @@ struct Float32Expable(Equatable, Stringable, _Expable):
     fn __ne__(self, other: Self) -> Bool:
         return self.x != other.x
 
-    fn __str__(self) -> String:
-        return String("Float32Expable(", self.x, ")")
+    fn write_to(self, mut writer: Some[Writer]):
+        writer.write("Float32Expable(", self.x, ")")
 
 
 @fieldwise_init
-struct FakeExpable(Equatable, Stringable, _Expable):
+struct FakeExpable(Equatable, Writable, _Expable):
     """This is a test struct that has a dummy definition of exp function."""
 
     var x: Int
@@ -106,8 +106,8 @@ struct FakeExpable(Equatable, Stringable, _Expable):
     fn __ne__(self, other: Self) -> Bool:
         return self.x != other.x
 
-    fn __str__(self) -> String:
-        return String("FakeExpable(", self.x, ")")
+    fn write_to(self, mut writer: Some[Writer]):
+        writer.write("FakeExpable(", self.x, ")")
 
 
 def test_exapble_trait():

--- a/mojo/stdlib/test/testing/test_assertion.mojo
+++ b/mojo/stdlib/test/testing/test_assertion.mojo
@@ -50,7 +50,7 @@ def test_assert_messages():
 
 
 @fieldwise_init
-struct DummyStruct(Equatable, Stringable):
+struct DummyStruct(Equatable, Writable):
     var value: Int
 
     fn __eq__(self, other: Self) -> Bool:
@@ -60,8 +60,8 @@ struct DummyStruct(Equatable, Stringable):
         return self.value != other.value
 
     @no_inline
-    fn __str__(self) -> String:
-        return "Dummy"  # Can't be used for equality
+    fn write_to(self, mut writer: Some[Writer]):
+        writer.write("Dummy")  # Can't be used for equality
 
 
 def test_assert_equal_is_generic():


### PR DESCRIPTION
Change `assert_equal` and `assert_not_equal` to use `Writable`. Split off from #4793