### PR TITLE
[stdlib] Add bit_not function for Int type

### DIFF
--- a/mojo/stdlib/stdlib/bit/bit.mojo
+++ b/mojo/stdlib/stdlib/bit/bit.mojo
@@ -274,6 +274,19 @@ fn pop_count[
 
 
 @always_inline("nodebug")
+fn bit_not(val: Int) -> Int:
+    """Performs a bitwise NOT operation on an integer value.
+
+    Args:
+        val: The input value.
+
+    Returns:
+        The bitwise NOT of the input value.
+    """
+    return ~val
+
+
+@always_inline("nodebug")
 fn bit_not[
     dtype: DType, width: Int, //
 ](val: SIMD[dtype, width]) -> SIMD[dtype, width]:

--- a/mojo/stdlib/test/bit/test_bit.mojo
+++ b/mojo/stdlib/test/bit/test_bit.mojo
@@ -253,6 +253,20 @@ def test_pop_count_simd():
     assert_equal(pop_count(var4), SIMD[int64_t, simd_width](51, 0, 10, 1))
 
 
+def test_bit_not():
+    assert_equal(bit_not(0), -1)
+    assert_equal(bit_not(-1), 0)
+    assert_equal(bit_not(1), -2)
+    assert_equal(bit_not(2), -3)
+    assert_equal(bit_not(3), -4)
+    assert_equal(bit_not(4), -5)
+    assert_equal(bit_not(5), -6)
+    assert_equal(bit_not(100), -101)
+    assert_equal(bit_not(-100), 99)
+    assert_equal(bit_not(2**20), -(2**20) - 1)
+    assert_equal(bit_not(-(2**20)), 2**20 - 1)
+
+
 def test_bit_not_simd():
     alias simd_width = 4
     alias int8_t = DType.int8
@@ -653,6 +667,7 @@ def main():
     test_byte_swap_simd()
     test_pop_count()
     test_pop_count_simd()
+    test_bit_not()
     test_bit_not_simd()
     test_log2_floor()
     test_log2_ceil()


### PR DESCRIPTION
- Add missing bit_not function for Int type in bit module
- Add comprehensive tests for the new function
- Follows the same pattern as other bit manipulation functions
- Completes the bit_not API by providing both Int and SIMD variants

I have read the CLA Document and I hereby sign the CLA

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
