### PR TITLE
[stdlib] Add variadic hypot function for multiple arguments

### DIFF
--- a/mojo/stdlib/stdlib/math/math.mojo
+++ b/mojo/stdlib/stdlib/math/math.mojo
@@ -2017,6 +2017,92 @@ fn hypot[
     return _simd_apply[_float32_dispatch, dtype, width](arg0, arg1)
 
 
+fn hypot(l: List[Float64, *_], /) -> Float64:
+    """Computes the hypot of a list of floating-point values.
+
+    This function computes the Euclidean norm (square root of sum of squares)
+    of the given values, similar to Python's math.hypot(*coordinates).
+
+    Args:
+        l: A list containing floating-point values.
+
+    Returns:
+        The hypot of the given values. Returns 0.0 if the list is empty.
+
+    Examples:
+        ```mojo
+        from math import hypot
+        
+        # Two arguments (same as existing hypot)
+        let result1 = hypot(3.0, 4.0)  # Returns 5.0
+        
+        # Multiple arguments
+        let result2 = hypot(3.0, 4.0, 5.0)  # Returns ~7.071
+        
+        # Single argument
+        let result3 = hypot(3.0)  # Returns 3.0
+        
+        # No arguments
+        let result4 = hypot()  # Returns 0.0
+        ```
+    """
+    if len(l) == 0:
+        return 0.0
+    elif len(l) == 1:
+        return abs(l[0])
+    elif len(l) == 2:
+        return hypot(l[0], l[1])
+    else:
+        # For more than 2 arguments, compute pairwise
+        var result = hypot(l[0], l[1])
+        for i in range(2, len(l)):
+            result = hypot(result, l[i])
+        return result
+
+
+fn hypot(*values: Float64) -> Float64:
+    """Computes the hypot of a variadic number of floating-point values.
+
+    This function computes the Euclidean norm (square root of sum of squares)
+    of the given values, similar to Python's math.hypot(*coordinates).
+
+    Args:
+        values: A variadic list of floating-point values.
+
+    Returns:
+        The hypot of the given values. Returns 0.0 if no arguments are provided.
+
+    Examples:
+        ```mojo
+        from math import hypot
+        
+        # Two arguments (same as existing hypot)
+        let result1 = hypot(3.0, 4.0)  # Returns 5.0
+        
+        # Multiple arguments
+        let result2 = hypot(3.0, 4.0, 5.0)  # Returns ~7.071
+        
+        # Single argument
+        let result3 = hypot(3.0)  # Returns 3.0
+        
+        # No arguments
+        let result4 = hypot()  # Returns 0.0
+        ```
+    """
+    if len(values) == 0:
+        return 0.0
+    elif len(values) == 1:
+        return abs(values[0])
+    elif len(values) == 2:
+        return hypot(values[0], values[1])
+    else:
+        # For more than 2 arguments, compute pairwise
+        var result = hypot(values[0], values[1])
+        for i in range(2, len(values)):
+            result = hypot(result, values[i])
+        return result
+
+
 # ===----------------------------------------------------------------------=== #
 # erfc
 # ===----------------------------------------------------------------------=== #

--- a/mojo/stdlib/test/math/test_math.mojo
+++ b/mojo/stdlib/test/math/test_math.mojo
@@ -25,6 +25,7 @@ from math import (
     floor,
     frexp,
     gcd,
+    hypot,
     iota,
     isclose,
     isqrt,
@@ -650,6 +651,38 @@ def test_atanh():
     )
 
 
+fn test_hypot() raises:
+    """Test the variadic hypot function with various inputs."""
+    # Test with no arguments
+    assert_equal(hypot(), 0.0)
+    
+    # Test with single argument
+    assert_almost_equal(hypot(3.0), 3.0)
+    assert_almost_equal(hypot(-3.0), 3.0)
+    assert_almost_equal(hypot(0.0), 0.0)
+    
+    # Test with two arguments (should match existing hypot behavior)
+    assert_almost_equal(hypot(3.0, 4.0), 5.0)
+    assert_almost_equal(hypot(-3.0, -4.0), 5.0)
+    assert_almost_equal(hypot(0.0, 0.0), 0.0)
+    
+    # Test with three arguments
+    assert_almost_equal(hypot(3.0, 4.0, 5.0), 7.0710678118654755)
+    assert_almost_equal(hypot(1.0, 1.0, 1.0), 1.7320508075688772)  # sqrt(3)
+    
+    # Test with four arguments
+    assert_almost_equal(hypot(1.0, 1.0, 1.0, 1.0), 2.0)  # sqrt(4)
+    
+    # Test with mixed positive and negative values
+    assert_almost_equal(hypot(3.0, -4.0, 5.0), 7.0710678118654755)
+    
+    # Test with very small values
+    assert_almost_equal(hypot(1e-10, 1e-10), 1.4142135623730951e-10)
+    
+    # Test with very large values
+    assert_almost_equal(hypot(1e10, 1e10), 1.4142135623730951e10)
+
+
 def main():
     test_sin()
     test_cos()
@@ -675,3 +708,4 @@ def main():
     test_align_up()
     test_clamp()
     test_atanh()
+    test_hypot()


### PR DESCRIPTION
- Add hypot(*values: Float64) -> Float64 for variadic arguments
- Add hypot(l: List[Float64, *_], /) -> Float64 for list arguments
- Add comprehensive tests covering all edge cases
- Update imports in test file
- Matches Python's math.hypot(*coordinates) behavior
- Fixes TODO: implement for variadic inputs as Python

Examples:
- hypot(3.0, 4.0, 5.0) returns ~7.071
- hypot(3.0) returns 3.0
- hypot() returns 0.0

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
