### PR TITLE
[docs] Remove typo in Overloaded functions documentation

### DIFF
--- a/mojo/docs/manual/functions.mdx
+++ b/mojo/docs/manual/functions.mdx
@@ -526,7 +526,7 @@ Arguments](https://peps.python.org/pep-3102/).
 ## Overloaded functions
 
 All function declarations must specify argument types, so if you want a
-want a function to work with different data types, you need to implement
+function to work with different data types, you need to implement
 separate versions of the function that each specify different argument types.
 This is called "overloading" a function.
 


### PR DESCRIPTION
This is just a small typo I stumbled over reading the greatly written documentation.

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
