### PR TITLE
[stdlib] Remove unnecessary allocs in unicode casing

### DIFF
--- a/mojo/stdlib/std/collections/string/_unicode.mojo
+++ b/mojo/stdlib/std/collections/string/_unicode.mojo
@@ -11,6 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+from std.builtin.globals import global_constant
 from std.collections.string._unicode_lookups import (
     has_uppercase_mapping,
     has_lowercase_mapping,
@@ -22,47 +23,28 @@ from std.collections.string._unicode_lookups import (
     uppercase_mapping3,
 )
 
-from std.memory import Span
 
-
-def _uppercase_mapping_index(rune: Codepoint) -> Int:
-    """Return index for upper case mapping or -1 if no mapping is given."""
-    return _to_index[has_uppercase_mapping](rune)
-
-
-def _uppercase_mapping2_index(rune: Codepoint) -> Int:
-    """Return index for upper case mapping converting the rune to 2 runes, or -1 if no mapping is given.
-    """
-    return _to_index[has_uppercase_mapping2](rune)
-
-
-def _uppercase_mapping3_index(rune: Codepoint) -> Int:
-    """Return index for upper case mapping converting the rune to 3 runes, or -1 if no mapping is given.
-    """
-    return _to_index[has_uppercase_mapping3](rune)
-
-
-def _lowercase_mapping_index(rune: Codepoint) -> Int:
-    """Return index for lower case mapping or -1 if no mapping is given."""
-    return _to_index[has_lowercase_mapping](rune)
+@always_inline
+fn _maybe_get_index[
+    lookup: InlineArray[UInt32, ...]
+](rune: Codepoint) -> Optional[UInt]:
+    if __is_run_in_comptime_interpreter:
+        return Span(materialize[lookup]())._binary_search_index(rune.to_u32())
+    return Span(global_constant[lookup]())._binary_search_index(rune.to_u32())
 
 
 @always_inline
-def _to_index[lookup: List[UInt32, ...]](rune: Codepoint) -> Int:
-    """Find index of rune in lookup with binary search.
-    Returns -1 if not found."""
+fn _get_mapping[
+    inner_size: Int,
+    outer_size: Int,
+    //,
+    mapping: InlineArray[SIMD[DType.uint32, inner_size], outer_size],
+](index: UInt) -> SIMD[DType.uint32, inner_size]:
+    if __is_run_in_comptime_interpreter:
+        return materialize[mapping]().unsafe_get(index)
+    return global_constant[mapping]().unsafe_get(index)
 
-    var result = Span(materialize[lookup]())._binary_search_index(rune.to_u32())
 
-    if result:
-        return Int(result.unsafe_value())
-    else:
-        return -1
-
-
-# TODO:
-#   Refactor this to return a Span[Codepoint, StaticConstantOrigin], so that the
-#   return `UInt` count and fixed-size `InlineArray` are not necessary.
 def _get_uppercase_mapping(
     char: Codepoint,
 ) -> Optional[Tuple[UInt, InlineArray[Codepoint, 3]]]:
@@ -73,45 +55,34 @@ def _get_uppercase_mapping(
     """
     var array = InlineArray[Codepoint, 3](fill=Codepoint(0))
 
-    var index1 = _uppercase_mapping_index(char)
-    if index1 != -1:
-        var rune = materialize[uppercase_mapping]()[index1]
+    if index := _maybe_get_index[has_uppercase_mapping](char):
+        var rune = _get_mapping[uppercase_mapping](index.unsafe_value())
         array[0] = Codepoint(unsafe_unchecked_codepoint=rune)
         return Tuple(UInt(1), array^)
-
-    var index2 = _uppercase_mapping2_index(char)
-    if index2 != -1:
-        var runes = materialize[uppercase_mapping2]()[index2]
+    elif index := _maybe_get_index[has_uppercase_mapping2](char):
+        var runes = _get_mapping[uppercase_mapping2](index.unsafe_value())
         array[0] = Codepoint(unsafe_unchecked_codepoint=runes[0])
         array[1] = Codepoint(unsafe_unchecked_codepoint=runes[1])
         return Tuple(UInt(2), array^)
-
-    var index3 = _uppercase_mapping3_index(char)
-    if index3 != -1:
-        var runes = materialize[uppercase_mapping3]()[index3]
+    elif index := _maybe_get_index[has_uppercase_mapping3](char):
+        var runes = _get_mapping[uppercase_mapping3](index.unsafe_value())
         array[0] = Codepoint(unsafe_unchecked_codepoint=runes[0])
         array[1] = Codepoint(unsafe_unchecked_codepoint=runes[1])
         array[2] = Codepoint(unsafe_unchecked_codepoint=runes[2])
         return Tuple(UInt(3), array^)
-
-    return None
-
-
-def _get_lowercase_mapping(char: Codepoint) -> Optional[Codepoint]:
-    var index: Optional[UInt] = Span(
-        materialize[has_lowercase_mapping]()
-    )._binary_search_index(char.to_u32())
-
-    if index:
-        # SAFETY: We just checked that `result` is present.
-        var codepoint = materialize[lowercase_mapping]()[index.unsafe_value()]
-
-        # SAFETY:
-        #   We know this is a valid `Codepoint` because the mapping data tables
-        #   contain only valid codepoints.
-        return Codepoint(unsafe_unchecked_codepoint=codepoint)
     else:
         return None
+
+
+fn _get_lowercase_mapping(char: Codepoint) -> Optional[Codepoint]:
+    var index = _maybe_get_index[has_lowercase_mapping](char)
+    if not index:
+        return None
+    # SAFETY:
+    #   We know this is a valid `Codepoint` because the mapping data tables
+    #   contain only valid codepoints.
+    var value = _get_mapping[lowercase_mapping](index.unsafe_value())
+    return Codepoint(unsafe_unchecked_codepoint=value)
 
 
 def is_uppercase(s: StringSlice[mut=False, _]) -> Bool:
@@ -127,18 +98,14 @@ def is_uppercase(s: StringSlice[mut=False, _]) -> Bool:
     """
     var found = False
     for char in s.codepoints():
-        var index = _lowercase_mapping_index(char)
-        if index != -1:
+        if _maybe_get_index[has_lowercase_mapping](char):
             found = True
             continue
-        index = _uppercase_mapping_index(char)
-        if index != -1:
+        elif _maybe_get_index[has_uppercase_mapping](char):
             return False
-        index = _uppercase_mapping2_index(char)
-        if index != -1:
+        elif _maybe_get_index[has_uppercase_mapping2](char):
             return False
-        index = _uppercase_mapping3_index(char)
-        if index != -1:
+        elif _maybe_get_index[has_uppercase_mapping3](char):
             return False
     return found
 
@@ -156,20 +123,16 @@ def is_lowercase(s: StringSlice[mut=False, _]) -> Bool:
     """
     var found = False
     for char in s.codepoints():
-        var index = _uppercase_mapping_index(char)
-        if index != -1:
+        if _maybe_get_index[has_uppercase_mapping](char):
             found = True
             continue
-        index = _uppercase_mapping2_index(char)
-        if index != -1:
+        elif _maybe_get_index[has_uppercase_mapping2](char):
             found = True
             continue
-        index = _uppercase_mapping3_index(char)
-        if index != -1:
+        elif _maybe_get_index[has_uppercase_mapping3](char):
             found = True
             continue
-        index = _lowercase_mapping_index(char)
-        if index != -1:
+        elif _maybe_get_index[has_lowercase_mapping](char):
             return False
     return found
 
@@ -183,21 +146,20 @@ def to_lowercase(s: StringSlice[mut=False, _]) -> String:
     Returns:
         A new string where cased letters have been converted to lowercase.
     """
-    var result = String(capacity=_estimate_needed_size(s.byte_length()))
+    # lowercased strings always have the same amount of bytes
+    var result = String(capacity=s.byte_length())
     var input_offset = 0
     while input_offset < s.byte_length():
-        var rune_and_size = Codepoint.unsafe_decode_utf8_codepoint(
+        ref rune, size = Codepoint.unsafe_decode_utf8_codepoint(
             s.as_bytes()[input_offset:]
         )
-        var lowercase_char_opt = _get_lowercase_mapping(rune_and_size[0])
-        if lowercase_char_opt is None:
-            result.write_string(
-                s[byte = input_offset : input_offset + rune_and_size[1]]
-            )
+        var maybe_replace = _get_lowercase_mapping(rune)
+        if maybe_replace:
+            result += String(maybe_replace.unsafe_value())
         else:
-            result += String(lowercase_char_opt.unsafe_value())
+            result.write_string(s[byte = input_offset : input_offset + size])
 
-        input_offset += rune_and_size[1]
+        input_offset += size
 
     return result^
 
@@ -211,34 +173,28 @@ def to_uppercase(s: StringSlice[mut=False, _]) -> String:
     Returns:
         A new string where cased letters have been converted to uppercase.
     """
-    var result = String(capacity=_estimate_needed_size(s.byte_length()))
+    # estimate the size since some codepoints require multiple chars to uppercase
+    var result = String(capacity=3 * (s.byte_length() // 2))
     var input_offset = 0
     while input_offset < s.byte_length():
-        var rune_and_size = Codepoint.unsafe_decode_utf8_codepoint(
+        ref rune, size = Codepoint.unsafe_decode_utf8_codepoint(
             s.as_bytes()[input_offset:]
         )
-        var uppercase_replacement_opt = _get_uppercase_mapping(rune_and_size[0])
+        var maybe_replace = _get_uppercase_mapping(rune)
 
-        if uppercase_replacement_opt:
+        if maybe_replace:
             # A given character can be replaced with a sequence of characters
             # up to 3 characters in length. A fixed size `Codepoint` array is
             # returned, along with a `count` (1, 2, or 3) of how many
             # replacement characters are in the uppercase replacement sequence.
-            count, ref uppercase_replacement_chars = (
-                uppercase_replacement_opt.unsafe_value()
+            ref count, uppercase_replacement_chars = (
+                maybe_replace.unsafe_value()
             )
             for char_idx in range(count):
                 result += String(uppercase_replacement_chars[char_idx])
         else:
-            result.write_string(
-                s[byte = input_offset : input_offset + rune_and_size[1]]
-            )
+            result.write_string(s[byte = input_offset : input_offset + size])
 
-        input_offset += rune_and_size[1]
+        input_offset += size
 
     return result^
-
-
-@always_inline
-def _estimate_needed_size(byte_len: Int) -> Int:
-    return 3 * (byte_len >> 1) + 1

--- a/mojo/stdlib/std/collections/string/_unicode_lookups.mojo
+++ b/mojo/stdlib/std/collections/string/_unicode_lookups.mojo
@@ -14,7 +14,7 @@
 UnicodeData.txt and SpecialCasing.txt files, which can be found at
 https://www.unicode.org/Public/16.0.0/"""
 
-comptime has_uppercase_mapping: List[UInt32] = [
+comptime has_uppercase_mapping: InlineArray[UInt32, 1450] = [
     0x0061,  # LATIN SMALL LETTER A a
     0x0062,  # LATIN SMALL LETTER B b
     0x0063,  # LATIN SMALL LETTER C c
@@ -1466,7 +1466,7 @@ comptime has_uppercase_mapping: List[UInt32] = [
     0x1E942,  # ADLAM SMALL LETTER KPO 𞥂
     0x1E943,  # ADLAM SMALL LETTER SHA 𞥃
 ]
-comptime has_lowercase_mapping: List[UInt32] = [
+comptime has_lowercase_mapping: InlineArray[UInt32, 1433] = [
     0x0041,  # LATIN CAPITAL LETTER A A
     0x0042,  # LATIN CAPITAL LETTER B B
     0x0043,  # LATIN CAPITAL LETTER C C
@@ -2901,7 +2901,7 @@ comptime has_lowercase_mapping: List[UInt32] = [
     0x1E920,  # ADLAM CAPITAL LETTER KPO 𞤠
     0x1E921,  # ADLAM CAPITAL LETTER SHA 𞤡
 ]
-comptime uppercase_mapping: List[UInt32] = [
+comptime uppercase_mapping: InlineArray[UInt32, 1450] = [
     0x0041,  # a -> A
     0x0042,  # b -> B
     0x0043,  # c -> C
@@ -4353,7 +4353,7 @@ comptime uppercase_mapping: List[UInt32] = [
     0x1E920,  # 𞥂 -> 𞤠
     0x1E921,  # 𞥃 -> 𞤡
 ]
-comptime lowercase_mapping: List[UInt32] = [
+comptime lowercase_mapping: InlineArray[UInt32, 1433] = [
     0x0061,  # A -> a
     0x0062,  # B -> b
     0x0063,  # C -> c
@@ -5788,89 +5788,89 @@ comptime lowercase_mapping: List[UInt32] = [
     0x1E942,  # 𞤠 -> 𞥂
     0x1E943,  # 𞤡 -> 𞥃
 ]
-comptime has_uppercase_mapping2: List[UInt32] = [
-    0xDF,  #  # LATIN SMALL LETTER SHARP S ß
-    0x149,  #  # LATIN SMALL LETTER N PRECEDED BY APOSTROPHE ŉ
-    0x1F0,  #  # LATIN SMALL LETTER J WITH CARON ǰ
-    0x587,  #  # ARMENIAN SMALL LIGATURE ECH YIWN և
-    0x1E96,  #  # LATIN SMALL LETTER H WITH LINE BELOW ẖ
-    0x1E97,  #  # LATIN SMALL LETTER T WITH DIAERESIS ẗ
-    0x1E98,  #  # LATIN SMALL LETTER W WITH RING ABOVE ẘ
-    0x1E99,  #  # LATIN SMALL LETTER Y WITH RING ABOVE ẙ
-    0x1E9A,  #  # LATIN SMALL LETTER A WITH RIGHT HALF RING ẚ
-    0x1F50,  #  # GREEK SMALL LETTER UPSILON WITH PSILI ὐ
-    0x1FB6,  #  # GREEK SMALL LETTER ALPHA WITH PERISPOMENI ᾶ
-    0x1FC6,  #  # GREEK SMALL LETTER ETA WITH PERISPOMENI ῆ
-    0x1FD6,  #  # GREEK SMALL LETTER IOTA WITH PERISPOMENI ῖ
-    0x1FE4,  #  # GREEK SMALL LETTER RHO WITH PSILI ῤ
-    0x1FE6,  #  # GREEK SMALL LETTER UPSILON WITH PERISPOMENI ῦ
-    0x1FF6,  #  # GREEK SMALL LETTER OMEGA WITH PERISPOMENI ῶ
-    0xFB00,  #  # LATIN SMALL LIGATURE FF ﬀ
-    0xFB01,  #  # LATIN SMALL LIGATURE FI ﬁ
-    0xFB02,  #  # LATIN SMALL LIGATURE FL ﬂ
-    0xFB05,  #  # LATIN SMALL LIGATURE LONG S T ﬅ
-    0xFB06,  #  # LATIN SMALL LIGATURE ST ﬆ
-    0xFB13,  #  # ARMENIAN SMALL LIGATURE MEN NOW ﬓ
-    0xFB14,  #  # ARMENIAN SMALL LIGATURE MEN ECH ﬔ
-    0xFB15,  #  # ARMENIAN SMALL LIGATURE MEN INI ﬕ
-    0xFB16,  #  # ARMENIAN SMALL LIGATURE VEW NOW ﬖ
-    0xFB17,  #  # ARMENIAN SMALL LIGATURE MEN XEH ﬗ
+comptime has_uppercase_mapping2: InlineArray[UInt32, 26] = [
+    0xDF,  # LATIN SMALL LETTER SHARP S ß
+    0x149,  # LATIN SMALL LETTER N PRECEDED BY APOSTROPHE ŉ
+    0x1F0,  # LATIN SMALL LETTER J WITH CARON ǰ
+    0x587,  # ARMENIAN SMALL LIGATURE ECH YIWN և
+    0x1E96,  # LATIN SMALL LETTER H WITH LINE BELOW ẖ
+    0x1E97,  # LATIN SMALL LETTER T WITH DIAERESIS ẗ
+    0x1E98,  # LATIN SMALL LETTER W WITH RING ABOVE ẘ
+    0x1E99,  # LATIN SMALL LETTER Y WITH RING ABOVE ẙ
+    0x1E9A,  # LATIN SMALL LETTER A WITH RIGHT HALF RING ẚ
+    0x1F50,  # GREEK SMALL LETTER UPSILON WITH PSILI ὐ
+    0x1FB6,  # GREEK SMALL LETTER ALPHA WITH PERISPOMENI ᾶ
+    0x1FC6,  # GREEK SMALL LETTER ETA WITH PERISPOMENI ῆ
+    0x1FD6,  # GREEK SMALL LETTER IOTA WITH PERISPOMENI ῖ
+    0x1FE4,  # GREEK SMALL LETTER RHO WITH PSILI ῤ
+    0x1FE6,  # GREEK SMALL LETTER UPSILON WITH PERISPOMENI ῦ
+    0x1FF6,  # GREEK SMALL LETTER OMEGA WITH PERISPOMENI ῶ
+    0xFB00,  # LATIN SMALL LIGATURE FF ﬀ
+    0xFB01,  # LATIN SMALL LIGATURE FI ﬁ
+    0xFB02,  # LATIN SMALL LIGATURE FL ﬂ
+    0xFB05,  # LATIN SMALL LIGATURE LONG S T ﬅ
+    0xFB06,  # LATIN SMALL LIGATURE ST ﬆ
+    0xFB13,  # ARMENIAN SMALL LIGATURE MEN NOW ﬓ
+    0xFB14,  # ARMENIAN SMALL LIGATURE MEN ECH ﬔ
+    0xFB15,  # ARMENIAN SMALL LIGATURE MEN INI ﬕ
+    0xFB16,  # ARMENIAN SMALL LIGATURE VEW NOW ﬖ
+    0xFB17,  # ARMENIAN SMALL LIGATURE MEN XEH ﬗ
 ]
-comptime uppercase_mapping2: List[SIMD[DType.uint32, 2]] = [
-    SIMD[DType.uint32, 2](0x0053, 0x0053),  #  ß -> SS
-    SIMD[DType.uint32, 2](0x02BC, 0x004E),  #  ŉ -> ʼN
-    SIMD[DType.uint32, 2](0x004A, 0x030C),  #  ǰ -> J̌
-    SIMD[DType.uint32, 2](0x0535, 0x0552),  #  և -> ԵՒ
-    SIMD[DType.uint32, 2](0x0048, 0x0331),  #  ẖ -> H̱
-    SIMD[DType.uint32, 2](0x0054, 0x0308),  #  ẗ -> T̈
-    SIMD[DType.uint32, 2](0x0057, 0x030A),  #  ẘ -> W̊
-    SIMD[DType.uint32, 2](0x0059, 0x030A),  #  ẙ -> Y̊
-    SIMD[DType.uint32, 2](0x0041, 0x02BE),  #  ẚ -> Aʾ
-    SIMD[DType.uint32, 2](0x03A5, 0x0313),  #  ὐ -> Υ̓
-    SIMD[DType.uint32, 2](0x0391, 0x0342),  #  ᾶ -> Α͂
-    SIMD[DType.uint32, 2](0x0397, 0x0342),  #  ῆ -> Η͂
-    SIMD[DType.uint32, 2](0x0399, 0x0342),  #  ῖ -> Ι͂
-    SIMD[DType.uint32, 2](0x03A1, 0x0313),  #  ῤ -> Ρ̓
-    SIMD[DType.uint32, 2](0x03A5, 0x0342),  #  ῦ -> Υ͂
-    SIMD[DType.uint32, 2](0x03A9, 0x0342),  #  ῶ -> Ω͂
-    SIMD[DType.uint32, 2](0x0046, 0x0046),  #  ﬀ -> FF
-    SIMD[DType.uint32, 2](0x0046, 0x0049),  #  ﬁ -> FI
-    SIMD[DType.uint32, 2](0x0046, 0x004C),  #  ﬂ -> FL
-    SIMD[DType.uint32, 2](0x0053, 0x0054),  #  ﬅ -> ST
-    SIMD[DType.uint32, 2](0x0053, 0x0054),  #  ﬆ -> ST
-    SIMD[DType.uint32, 2](0x0544, 0x0546),  #  ﬓ -> ՄՆ
-    SIMD[DType.uint32, 2](0x0544, 0x0535),  #  ﬔ -> ՄԵ
-    SIMD[DType.uint32, 2](0x0544, 0x053B),  #  ﬕ -> ՄԻ
-    SIMD[DType.uint32, 2](0x054E, 0x0546),  #  ﬖ -> ՎՆ
-    SIMD[DType.uint32, 2](0x0544, 0x053D),  #  ﬗ -> ՄԽ
+comptime uppercase_mapping2: InlineArray[SIMD[DType.uint32, 2], 26] = [
+    {0x0053, 0x0053},  #  ß -> SS
+    {0x02BC, 0x004E},  #  ŉ -> ʼN
+    {0x004A, 0x030C},  #  ǰ -> J̌
+    {0x0535, 0x0552},  #  և -> ԵՒ
+    {0x0048, 0x0331},  #  ẖ -> H̱
+    {0x0054, 0x0308},  #  ẗ -> T̈
+    {0x0057, 0x030A},  #  ẘ -> W̊
+    {0x0059, 0x030A},  #  ẙ -> Y̊
+    {0x0041, 0x02BE},  #  ẚ -> Aʾ
+    {0x03A5, 0x0313},  #  ὐ -> Υ̓
+    {0x0391, 0x0342},  #  ᾶ -> Α͂
+    {0x0397, 0x0342},  #  ῆ -> Η͂
+    {0x0399, 0x0342},  #  ῖ -> Ι͂
+    {0x03A1, 0x0313},  #  ῤ -> Ρ̓
+    {0x03A5, 0x0342},  #  ῦ -> Υ͂
+    {0x03A9, 0x0342},  #  ῶ -> Ω͂
+    {0x0046, 0x0046},  #  ﬀ -> FF
+    {0x0046, 0x0049},  #  ﬁ -> FI
+    {0x0046, 0x004C},  #  ﬂ -> FL
+    {0x0053, 0x0054},  #  ﬅ -> ST
+    {0x0053, 0x0054},  #  ﬆ -> ST
+    {0x0544, 0x0546},  #  ﬓ -> ՄՆ
+    {0x0544, 0x0535},  #  ﬔ -> ՄԵ
+    {0x0544, 0x053B},  #  ﬕ -> ՄԻ
+    {0x054E, 0x0546},  #  ﬖ -> ՎՆ
+    {0x0544, 0x053D},  #  ﬗ -> ՄԽ
 ]
-comptime has_uppercase_mapping3: List[UInt32] = [
-    0x390,  #  # GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS ΐ
-    0x3B0,  #  # GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS ΰ
-    0x1F52,  #  # GREEK SMALL LETTER UPSILON WITH PSILI AND VARIA ὒ
-    0x1F54,  #  # GREEK SMALL LETTER UPSILON WITH PSILI AND OXIA ὔ
-    0x1F56,  #  # GREEK SMALL LETTER UPSILON WITH PSILI AND PERISPOMENI ὖ
-    0x1FD2,  #  # GREEK SMALL LETTER IOTA WITH DIALYTIKA AND VARIA ῒ
-    0x1FD3,  #  # GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA ΐ
-    0x1FD7,  #  # GREEK SMALL LETTER IOTA WITH DIALYTIKA AND PERISPOMENI ῗ
-    0x1FE2,  #  # GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND VARIA ῢ
-    0x1FE3,  #  # GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND OXIA ΰ
-    0x1FE7,  #  # GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND PERISPOMENI ῧ
-    0xFB03,  #  # LATIN SMALL LIGATURE FFI ﬃ
-    0xFB04,  #  # LATIN SMALL LIGATURE FFL ﬄ
+comptime has_uppercase_mapping3: InlineArray[UInt32, 13] = [
+    0x390,  # GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS ΐ
+    0x3B0,  # GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS ΰ
+    0x1F52,  # GREEK SMALL LETTER UPSILON WITH PSILI AND VARIA ὒ
+    0x1F54,  # GREEK SMALL LETTER UPSILON WITH PSILI AND OXIA ὔ
+    0x1F56,  # GREEK SMALL LETTER UPSILON WITH PSILI AND PERISPOMENI ὖ
+    0x1FD2,  # GREEK SMALL LETTER IOTA WITH DIALYTIKA AND VARIA ῒ
+    0x1FD3,  # GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA ΐ
+    0x1FD7,  # GREEK SMALL LETTER IOTA WITH DIALYTIKA AND PERISPOMENI ῗ
+    0x1FE2,  # GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND VARIA ῢ
+    0x1FE3,  # GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND OXIA ΰ
+    0x1FE7,  # GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND PERISPOMENI ῧ
+    0xFB03,  # LATIN SMALL LIGATURE FFI ﬃ
+    0xFB04,  # LATIN SMALL LIGATURE FFL ﬄ
 ]
-comptime uppercase_mapping3: List[SIMD[DType.uint32, 4]] = [
-    SIMD[DType.uint32, 4](0x0399, 0x0308, 0x0301, 0),  #  ΐ -> Ϊ́
-    SIMD[DType.uint32, 4](0x03A5, 0x0308, 0x0301, 0),  #  ΰ -> Ϋ́
-    SIMD[DType.uint32, 4](0x03A5, 0x0313, 0x0300, 0),  #  ὒ -> Υ̓̀
-    SIMD[DType.uint32, 4](0x03A5, 0x0313, 0x0301, 0),  #  ὔ -> Υ̓́
-    SIMD[DType.uint32, 4](0x03A5, 0x0313, 0x0342, 0),  #  ὖ -> Υ̓͂
-    SIMD[DType.uint32, 4](0x0399, 0x0308, 0x0300, 0),  #  ῒ -> Ϊ̀
-    SIMD[DType.uint32, 4](0x0399, 0x0308, 0x0301, 0),  #  ΐ -> Ϊ́
-    SIMD[DType.uint32, 4](0x0399, 0x0308, 0x0342, 0),  #  ῗ -> Ϊ͂
-    SIMD[DType.uint32, 4](0x03A5, 0x0308, 0x0300, 0),  #  ῢ -> Ϋ̀
-    SIMD[DType.uint32, 4](0x03A5, 0x0308, 0x0301, 0),  #  ΰ -> Ϋ́
-    SIMD[DType.uint32, 4](0x03A5, 0x0308, 0x0342, 0),  #  ῧ -> Ϋ͂
-    SIMD[DType.uint32, 4](0x0046, 0x0046, 0x0049, 0),  #  ﬃ -> FFI
-    SIMD[DType.uint32, 4](0x0046, 0x0046, 0x004C, 0),  #  ﬄ -> FFL
+comptime uppercase_mapping3: InlineArray[SIMD[DType.uint32, 4], 13] = [
+    {0x0399, 0x0308, 0x0301, 0},  #  ΐ -> Ϊ́
+    {0x03A5, 0x0308, 0x0301, 0},  #  ΰ -> Ϋ́
+    {0x03A5, 0x0313, 0x0300, 0},  #  ὒ -> Υ̓̀
+    {0x03A5, 0x0313, 0x0301, 0},  #  ὔ -> Υ̓́
+    {0x03A5, 0x0313, 0x0342, 0},  #  ὖ -> Υ̓͂
+    {0x0399, 0x0308, 0x0300, 0},  #  ῒ -> Ϊ̀
+    {0x0399, 0x0308, 0x0301, 0},  #  ΐ -> Ϊ́
+    {0x0399, 0x0308, 0x0342, 0},  #  ῗ -> Ϊ͂
+    {0x03A5, 0x0308, 0x0300, 0},  #  ῢ -> Ϋ̀
+    {0x03A5, 0x0308, 0x0301, 0},  #  ΰ -> Ϋ́
+    {0x03A5, 0x0308, 0x0342, 0},  #  ῧ -> Ϋ͂
+    {0x0046, 0x0046, 0x0049, 0},  #  ﬃ -> FFI
+    {0x0046, 0x0046, 0x004C, 0},  #  ﬄ -> FFL
 ]

--- a/mojo/stdlib/std/memory/span.mojo
+++ b/mojo/stdlib/std/memory/span.mojo
@@ -838,10 +838,13 @@ struct Span[
         //,
     ](self: Span[Scalar[dtype], _], needle: Scalar[dtype]) -> Optional[UInt]:
         """Finds the index of `needle` with binary search.
+
         Args:
             needle: The value to binary search for.
+
         Returns:
             Returns None if `needle` is not present.
+
         Notes:
             This function will return an unspecified index if `self` is not
             sorted in ascending order.


### PR DESCRIPTION
Remove unnecessary allocs in unicode casing.