### PR TITLE
[stdlib][benchmark] Force benchmark to respect max_iters

### DIFF
--- a/mojo/stdlib/stdlib/benchmark/bencher.mojo
+++ b/mojo/stdlib/stdlib/benchmark/bencher.mojo
@@ -271,9 +271,9 @@ struct BenchConfig(Copyable, Movable):
     var out_file: Optional[Path]
     """Output file to write results to."""
     var min_runtime_secs: Float64
-    """Upper bound on benchmarking time in secs."""
-    var max_runtime_secs: Float64
     """Lower bound on benchmarking time in secs."""
+    var max_runtime_secs: Float64
+    """Upper bound on benchmarking time in secs."""
     var min_warmuptime_secs: Float64
     """Lower bound on warmup time in secs."""
     var num_warmup_iters: Int

--- a/mojo/stdlib/stdlib/benchmark/benchmark.mojo
+++ b/mojo/stdlib/stdlib/benchmark/benchmark.mojo
@@ -405,8 +405,8 @@ fn run[
 
     Args:
         max_iters: Max number of iterations to run (default `1_000_000_000`).
-        min_runtime_secs: Upper bound on benchmarking time in secs (default `2`).
-        max_runtime_secs: Lower bound on benchmarking time in secs (default `60`).
+        min_runtime_secs: Lower bound on benchmarking time in secs (default `2`).
+        max_runtime_secs: Upper bound on benchmarking time in secs (default `60`).
         max_batch_size: The maximum number of iterations to perform per time
             measurement.
 
@@ -454,8 +454,8 @@ fn run[
 
     Args:
         max_iters: Max number of iterations to run (default `1_000_000_000`).
-        min_runtime_secs: Upper bound on benchmarking time in secs (default `2`).
-        max_runtime_secs: Lower bound on benchmarking time in secs (default `60`).
+        min_runtime_secs: Lower bound on benchmarking time in secs (default `2`).
+        max_runtime_secs: Upper bound on benchmarking time in secs (default `60`).
         max_batch_size: The maximum number of iterations to perform per time
             measurement.
 
@@ -491,8 +491,8 @@ fn run[
 
     Args:
         max_iters: Max number of iterations to run (default `1_000_000_000`).
-        min_runtime_secs: Upper bound on benchmarking time in secs (default `2`).
-        max_runtime_secs: Lower bound on benchmarking time in secs (default `60`).
+        min_runtime_secs: Lower bound on benchmarking time in secs (default `2`).
+        max_runtime_secs: Upper bound on benchmarking time in secs (default `60`).
         max_batch_size: The maximum number of iterations to perform per time
             measurement.
 
@@ -540,8 +540,8 @@ fn run[
 
     Args:
         max_iters: Max number of iterations to run (default `1_000_000_000`).
-        min_runtime_secs: Upper bound on benchmarking time in secs (default `2`).
-        max_runtime_secs: Lower bound on benchmarking time in secs (default `60`).
+        min_runtime_secs: Lower bound on benchmarking time in secs (default `2`).
+        max_runtime_secs: Upper bound on benchmarking time in secs (default `60`).
         max_batch_size: The maximum number of iterations to perform per time
             measurement.
 
@@ -600,18 +600,21 @@ fn _run_impl(opts: _RunOptions) raises -> Report:
     var min_time_ns = Int(opts.min_runtime_secs * 1_000_000_000)
     var max_time_ns = Int(opts.max_runtime_secs * 1_000_000_000)
 
-    while time_elapsed < min_time_ns:
-        if time_elapsed > max_time_ns or total_iters > opts.max_iters:
-            break
+    # Continue until min_time_ns has elapsed and either max_time_ns or max_iters
+    # is achieved
+    while time_elapsed < max_time_ns:
 
         var n = Float64(opts.max_batch_size)
         if opts.max_batch_size == 0:
             # We now count the next batchSize. A user might run the benchmark
             # with no warmup phase, so we need to make sure the divisor is not
             # zero.
-            # Compute the next batch size.
             if prev_dur > 0:
-                n = 1.2 * min_time_ns * prev_iters / Float64(prev_dur)
+                # Propose batch size which lasts at least min_time_ns or opts.max_iters
+                n = opts.max_iters
+                if min_time_ns > 0:
+                    n = 1.2 * min_time_ns * prev_iters / Float64(prev_dur)
+
             # We should not grow too fast, so we cap it to only 10x the growth
             # from the prior iteration. Fast growth can happen when the function
             # is too fast.
@@ -621,6 +624,13 @@ fn _run_impl(opts: _RunOptions) raises -> Report:
             n = max(n, prev_iters + 1)
             # The batch size should not be larger than 1.0e9.
             n = min(n, 1.0e9)
+            # Process at least one batch. i.e. Ensure n does not exceed opts.max_iters on the first iteration
+            if total_iters == 0:
+                n = min(n, opts.max_iters)
+
+        # Respect hard limit of opts.max_iters if min_time_ns has elapsed
+        if time_elapsed >= min_time_ns and (total_iters + Int(n)) > opts.max_iters:
+            break
 
         prev_dur = opts.timing_fn(Int(n))
         prev_iters = Int(n)
@@ -639,17 +649,18 @@ fn _run_impl(opts: _RunOptions) raises -> Report:
 fn _is_significant_measurement(
     idx: Int, batch: Batch, num_batches: Int, opts: _RunOptions
 ) -> Bool:
-    # The measurement number of iteration is the same as the requested
-    # maxBatchSize and the measurement duration exceeded the requested min
-    # runtime.
+    # When a fixed batch size is requested (opts.max_batch_size != 0), 
+    # the measurement is considered valid if the actual number of iterations
+    # performed equals or exceeds the requested batch size.
     if (
         opts.max_batch_size
         and batch.iterations >= opts.max_batch_size
-        and Float64(batch.duration) >= opts.min_runtime_secs
     ):
         return True
 
-    # This measurement occurred in the last 10% of the run.
+    # All or part of this measurement occurred in the last 10% of batches.
+    # Note: Using >= may include one extra measurement but preserves existing
+    # timing behavior.  This will be addressed in the near future.
     if Float64(idx + 1) >= 0.9 * num_batches:
         return True
 

--- a/mojo/stdlib/test/benchmark/BUILD.bazel
+++ b/mojo/stdlib/test/benchmark/BUILD.bazel
@@ -6,7 +6,6 @@ _FILECHECK_TESTS = [
 ]
 
 _PLATFORM_CONSTRAINTS = {
-    "test_benchmark.mojo": ["@platforms//:incompatible"],  # TODO (#34267): reenable
 }
 
 _TEST_RUNTIME_ARGS = {

--- a/mojo/stdlib/test/benchmark/test_benchmark.mojo
+++ b/mojo/stdlib/test/benchmark/test_benchmark.mojo
@@ -16,9 +16,11 @@ from time import sleep, time_function
 from benchmark import Report, clobber_memory, keep, run
 
 
-# CHECK-LABEL: test_benchmark
-fn test_benchmark():
-    print("== test_benchmark")
+# CHECK-LABEL: test_stopping_criteria
+fn test_stopping_criteria() raises:
+    print("== test_stopping_criteria")
+    # Stop when min_runtime_secs has elapsed and either max_runtime_secs or max_iters
+    # is reached
 
     @always_inline
     @parameter
@@ -27,40 +29,65 @@ fn test_benchmark():
         clobber_memory()
         return
 
-    # check that benchmark_function returns after max_time_ns is hit.
     var lb = 0.02  # 20ms
     var ub = 0.1  # 100ms
-    var max_iters = 1000_000_000
 
-    @__copy_capture(max_iters, lb, ub)
+    # stop after ub (max_runtime_secs)
+    var max_iters_1 = 1000_000_000
+    @__copy_capture(lb, ub)
     @parameter
-    fn timer():
-        var b3 = run[time_me](
-            0, max_iters, min_runtime_secs=lb, max_runtime_secs=ub
+    fn timer() raises:
+        var report = run[time_me](
+            max_iters=max_iters_1, min_runtime_secs=lb, max_runtime_secs=ub
         )
         # CHECK: True
-        print(b3.mean() > 0)
+        print(report.mean() > 0)
+        # CHECK: True
+        print(report.iters() != max_iters_1)
 
-    var t3 = time_function[timer]()
+    var t1 = time_function[timer]()
     # CHECK: True
-    print(t3 / 1e9 >= lb)
+    print(t1 / 1e9 >= ub)
 
+    # stop after lb (min_runtime_secs)
     var ub_big = 1  # 1s
-
+    var max_iters_2 = 1
     @__copy_capture(ub_big, lb)
     @parameter
-    fn timer2():
-        var b4 = run[time_me](
-            0, 1, min_runtime_secs=lb, max_runtime_secs=ub_big
+    fn timer2() raises:
+        var report = run[time_me](
+            max_iters=max_iters_2, min_runtime_secs=lb, max_runtime_secs=ub_big
         )
         # CHECK: True
-        print(b4.mean() > 0)
+        print(report.mean() > 0)
+        # CHECK: True
+        print(report.iters() >= max_iters_2)
 
-    var t4 = time_function[timer2]()
+    var t2 = time_function[timer2]()
+
     # CHECK: True
-    print(t4 / 1e9 >= lb and t4 / 1e9 <= ub_big)
+    print(t2 / 1e9 >= lb and t2 / 1e9 <= ub_big)
+
+    # stop on or before max_iters
+    var max_iters_3 = 3
+    @__copy_capture(ub_big)
+    @parameter
+    fn timer3() raises:
+        var report = run[time_me](
+            max_iters=max_iters_3, min_runtime_secs=0, max_runtime_secs=ub_big
+        )
+        # CHECK: True
+        print(report.mean() > 0)
+        # CHECK: True
+        print(report.iters() <= max_iters_3)
+
+    var t3 = time_function[timer3]()
+
+    # CHECK: True
+    print(t3 / 1e9 <= ub_big)
 
 
+@register_passable("trivial")
 struct SomeStruct:
     var x: Int
     var y: Int
@@ -84,7 +111,7 @@ struct SomeTrivialStruct:
 
 # CHECK-LABEL: test_keep
 # There is nothing to test here other than the code executes and does not crash.
-fn test_keep():
+fn test_keep() raises:
     print("== test_keep")
 
     keep(False)
@@ -108,7 +135,7 @@ fn sleeper():
 
 
 # CHECK-LABEL: test_non_capturing
-fn test_non_capturing():
+fn test_non_capturing() raises:
     print("== test_non_capturing")
     var report = run[sleeper](min_runtime_secs=0.1, max_runtime_secs=0.3)
     # CHECK: True
@@ -116,7 +143,7 @@ fn test_non_capturing():
 
 
 # CHECK-LABEL: test_change_units
-fn test_change_units():
+fn test_change_units() raises:
     print("== test_change_units")
     var report = run[sleeper](min_runtime_secs=0.1, max_runtime_secs=0.3)
     # CHECK: True
@@ -126,7 +153,7 @@ fn test_change_units():
 
 
 # CHECK-LABEL: test_report
-fn test_report():
+fn test_report() raises:
     print("== test_report")
     var report = run[sleeper](min_runtime_secs=0.1, max_runtime_secs=0.3)
 
@@ -135,7 +162,7 @@ fn test_report():
 
 
 def main():
-    test_benchmark()
+    test_stopping_criteria()
     test_keep()
     test_non_capturing()
     test_change_units()


### PR DESCRIPTION
The current benchmarking logic does not respect `max_iters`.  I've tried to fix this but I am not 100% sure my interpretation of the benchmarking logic is correct.  I have implemented the fix using the following interpretation:

1. Benchmarking should continue until `min_time_ns` has elapsed and either `max_time_ns` or `max_iters` is hit.
2. If `max_batch_size`  isn't specified then we attempt to choose a size which will last for at least `min_time_ns` if the other constraints from 1 (`max_iter` and `max_time_ns`) allow it.
3. If `max_batch_size` is specified use that on every iteration.
4. A batch is significant if:
   i.  `max_batch_size` is specified and it contains `max_batch_size` measurements. Currently there is an extra condition that the runtime should be greater than or equal to the min time for a batch but the condition currently evaluates `min_time_sec` and as there is no `min_batch_time_sec` argument I have removed the condition.
   ii.  Part of it is within the last 10% of batches.

If my understanding is correct should the `max_batch_size` argument be replaced with `batch_size` because it is fixed and not an upper bound on the size of the batch?
