### PR TITLE
[stdlib] Add performant `String.is_like()` to replace `lhs.lower() == rhs.lower()` patterns

### DIFF
--- a/max/kernels/src/internal_utils/_utils.mojo
+++ b/max/kernels/src/internal_utils/_utils.mojo
@@ -647,14 +647,13 @@ struct Mode(ImplicitlyCopyable, Movable, Stringable):
     alias SEP = "+"
 
     fn __init__(out self, handle: String = "run+benchmark+verify") raises:
-        var handle_lower = handle.lower().split(Self.SEP)
         self = Self.NONE
-        for h in handle_lower:
-            if String(Self.RUN.handle) == h:
+        for h in handle.split(Self.SEP):
+            if h.is_like[value = Self.RUN.handle]():
                 self.append(Self.RUN)
-            elif String(Self.BENCHMARK.handle) == h:
+            elif h.is_like[value = Self.BENCHMARK.handle]():
                 self.append(Self.BENCHMARK)
-            elif String(Self.VERIFY.handle) == h:
+            elif h.is_like[value = Self.VERIFY.handle]():
                 self.append(Self.VERIFY)
 
     fn append(mut self, other: Self):

--- a/mojo/stdlib/stdlib/benchmark/bencher.mojo
+++ b/mojo/stdlib/stdlib/benchmark/bencher.mojo
@@ -91,7 +91,7 @@ struct BenchMetric(ImplicitlyCopyable, Movable, Stringable, Writable):
         Returns:
             True if 'alt_name' is valid alternative of the metric's name.
         """
-        return self.name.lower() == alt_name.lower()
+        return self.name.is_like(alt_name)
 
     @staticmethod
     fn get_metric_from_list(

--- a/mojo/stdlib/stdlib/collections/string/_parsing_numbers/parsing_floats.mojo
+++ b/mojo/stdlib/stdlib/collections/string/_parsing_numbers/parsing_floats.mojo
@@ -284,48 +284,6 @@ fn lemire_algorithm(var w: UInt64, var q: Int64) -> Float64:
     return create_float64(m, p)
 
 
-alias _ascii_lower: Byte = ord("A") ^ ord("a")
-
-
-@always_inline
-fn _is_nan(stripped: StringSlice) -> Bool:
-    alias `n` = Byte(ord("n"))
-    alias `a` = Byte(ord("a"))
-    var ptr = stripped.unsafe_ptr()
-    return stripped.byte_length() == 3 and (
-        (ptr[0] | _ascii_lower == `n`)
-        and (ptr[1] | _ascii_lower == `a`)
-        and (ptr[2] | _ascii_lower == `n`)
-    )
-
-
-@always_inline
-fn _is_inf(stripped: StringSlice) -> Bool:
-    alias `i` = Byte(ord("i"))
-    alias `n` = Byte(ord("n"))
-    alias `f` = Byte(ord("f"))
-    alias `t` = Byte(ord("t"))
-    alias `y` = Byte(ord("y"))
-    var ptr = stripped.unsafe_ptr()
-    var in_start = (ptr[0] | _ascii_lower == `i`) and (
-        ptr[1] | _ascii_lower == `n`
-    )
-    # f was removed previously
-    var is_in = stripped.byte_length() == 2 and in_start
-    return in_start and (
-        is_in
-        or (
-            stripped.byte_length() == 8
-            and (ptr[2] | _ascii_lower == `f`)
-            and (ptr[3] | _ascii_lower == `i`)
-            and (ptr[4] | _ascii_lower == `n`)
-            and (ptr[5] | _ascii_lower == `i`)
-            and (ptr[6] | _ascii_lower == `t`)
-            and (ptr[7] | _ascii_lower == `y`)
-        )
-    )
-
-
 fn _atof(x: StringSlice) raises -> Float64:
     """Parses the given string as a floating point and returns that value.
 
@@ -347,9 +305,10 @@ fn _atof(x: StringSlice) raises -> Float64:
     sign_and_stripped = get_sign(stripped)
     sign = sign_and_stripped[0]
     stripped = sign_and_stripped[1]
-    if _is_nan(stripped):
+    if stripped.is_like[value="nan"]():
         return FloatLiteral.nan
-    elif _is_inf(stripped):
+    # f was removed previously so it could be just "in"
+    elif stripped.is_like[value="infinity"]() or stripped.is_like[value="in"]():
         return FloatLiteral.infinity * sign
     try:
         w_and_q = _get_w_and_q_from_float_string(stripped)

--- a/mojo/stdlib/stdlib/collections/string/string.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string.mojo
@@ -1872,6 +1872,41 @@ struct String(
         self._capacity_or_data = new_capacity
         self._set_ref_counted()
 
+    @always_inline
+    fn is_ascii(self) -> Bool:
+        """Return whether the values in the string are all ASCII.
+
+        Returns:
+            Whether the values in the string are all ASCII.
+        """
+        return self.as_string_slice().is_ascii()
+
+    @always_inline
+    fn is_like[value: StringSlice](self) -> Bool:
+        """Whether the string is like the given value. This is the equivalent
+        of doing `self.lower() == value.lower()`, but optimized.
+
+        Parameters:
+            value: The given value to compare against.
+
+        Returns:
+            Whether the string is like the given value.
+        """
+        return self.as_string_slice().is_like[value=value]()
+
+    @always_inline
+    fn is_like(self, value: StringSlice) -> Bool:
+        """Whether the string is like the given value. This is the equivalent
+        of doing `self.lower() == value.lower()`, but optimized.
+
+        Args:
+            value: The given value to compare against.
+
+        Returns:
+            Whether the string is like the given value.
+        """
+        return self.as_string_slice().is_like(value)
+
 
 # ===----------------------------------------------------------------------=== #
 # ord

--- a/mojo/stdlib/stdlib/logger/logger.mojo
+++ b/mojo/stdlib/stdlib/logger/logger.mojo
@@ -172,20 +172,19 @@ struct Level(
         Returns:
             The corresponding Level value, or NOTSET if not recognized.
         """
-        var lname = name.lower()
-        if lname == "notset":
+        if name.is_like[value="notset"]():
             return Self.NOTSET
-        if lname == "trace":
+        if name.is_like[value="trace"]():
             return Self.TRACE
-        if lname == "debug":
+        if name.is_like[value="debug"]():
             return Self.DEBUG
-        if lname == "info":
+        if name.is_like[value="info"]():
             return Self.INFO
-        if lname == "warning":
+        if name.is_like[value="warning"]():
             return Self.WARNING
-        if lname == "error":
+        if name.is_like[value="error"]():
             return Self.ERROR
-        if lname == "critical":
+        if name.is_like[value="critical"]():
             return Self.CRITICAL
         return Self.NOTSET
 

--- a/mojo/stdlib/stdlib/sys/param_env.mojo
+++ b/mojo/stdlib/stdlib/sys/param_env.mojo
@@ -59,16 +59,24 @@ fn is_defined[name: StaticString]() -> Bool:
     ]
 
 
-fn _is_bool_like[val: StaticString]() -> Bool:
-    alias lower_val = val.lower()
+fn _truthy[val: StaticString]() -> Bool:
     return (
-        lower_val == "true"
-        or lower_val == "1"
-        or lower_val == "on"
-        or lower_val == "false"
-        or lower_val == "0"
-        or lower_val == "off"
+        val.is_like[value="true"]()
+        or val.is_like[value="1"]()
+        or val.is_like[value="on"]()
     )
+
+
+fn _falsy[val: StaticString]() -> Bool:
+    return (
+        val.is_like[value="false"]()
+        or val.is_like[value="0"]()
+        or val.is_like[value="off"]()
+    )
+
+
+fn _is_bool_like[val: StaticString]() -> Bool:
+    return _truthy[val]() or _falsy[val]()
 
 
 fn env_get_bool[name: StaticString]() -> Bool:
@@ -81,20 +89,14 @@ fn env_get_bool[name: StaticString]() -> Bool:
     Returns:
         An boolean parameter value.
     """
-    alias val = env_get_string[name]().lower()
+    alias val = env_get_string[name]()
 
+    alias env_val = "the boolean environment value of `"
     constrained[
         _is_bool_like[val](),
-        String(
-            "the boolean environment value of `",
-            name,
-            "` with value `",
-            env_get_string[name](),
-            "` is not recognized",
-        ),
+        String(env_val, name, "` with value `", val, "` is not recognized"),
     ]()
-
-    return val == "true" or val == "1" or val == "on"
+    return _truthy[val]()
 
 
 fn env_get_bool[name: StaticString, default: Bool]() -> Bool:

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -1051,6 +1051,96 @@ def test_merge():
     _ = cond(True, a, b)
 
 
+def test_is_like():
+    var elems = String("Mojo")
+    assert_true(elems.is_like[value="MOJO"]())
+    assert_true(elems.is_like[value="mojo"]())
+    assert_true(elems.is_like[value="MoJo"]())
+    assert_true(elems.is_like[value="mOjO"]())
+    assert_true(elems.is_like("MOJO"))
+    assert_true(elems.is_like("mojo"))
+    assert_true(elems.is_like("MoJo"))
+    assert_true(elems.is_like("mOjO"))
+    elems = "Mojo\x10\x11\x12"
+    assert_true(elems.is_like[value="MOJO\x10\x11\x12"]())
+    assert_true(elems.is_like[value="mojo\x10\x11\x12"]())
+    assert_true(elems.is_like[value="MoJo\x10\x11\x12"]())
+    assert_true(elems.is_like[value="mOjO\x10\x11\x12"]())
+    assert_true(elems.is_like("MOJO\x10\x11\x12"))
+    assert_true(elems.is_like("mojo\x10\x11\x12"))
+    assert_true(elems.is_like("MoJo\x10\x11\x12"))
+    assert_true(elems.is_like("mOjO\x10\x11\x12"))
+    assert_false(elems.is_like[value="mOjO012"]())
+    assert_false(elems.is_like("mOjO012"))
+    elems = "🔥Mojo🔥"
+    assert_true(elems.is_like[value="🔥MOJO🔥"]())
+    assert_true(elems.is_like[value="🔥mojo🔥"]())
+    assert_true(elems.is_like[value="🔥MoJo🔥"]())
+    assert_true(elems.is_like[value="🔥mOjO🔥"]())
+    assert_true(elems.is_like("🔥MOJO🔥"))
+    assert_true(elems.is_like("🔥mojo🔥"))
+    assert_true(elems.is_like("🔥MoJo🔥"))
+    assert_true(elems.is_like("🔥mOjO🔥"))
+    elems = "Ñanduti"
+    assert_true(elems.is_like[value="ÑANDUTI"]())
+    assert_true(elems.is_like[value="ñanduti"]())
+    assert_true(elems.is_like[value="ÑaNdUtI"]())
+    assert_true(elems.is_like[value="ñAnDuTi"]())
+    assert_true(elems.is_like("ÑANDUTI"))
+    assert_true(elems.is_like("ñanduti"))
+    assert_true(elems.is_like("ÑaNdUtI"))
+    assert_true(elems.is_like("ñAnDuTi"))
+
+    # special cases we are ignoring
+    elems = "SS"
+    assert_false(elems.is_like("ß"))
+    assert_false(elems.is_like("ẞ"))
+    assert_true(StaticString("ß").is_like("ẞ"))
+    assert_true(StaticString("ẞ").is_like("ß"))
+    mappings: List[(StaticString, StaticString)] = {
+        {"ŉ", "ʼN"},
+        {"ǰ", "J̌"},
+        {"և", "ԵՒ"},
+        {"ẖ", "H̱"},
+        {"ẗ", "T̈"},
+        {"ẘ", "W̊"},
+        {"ẙ", "Y̊"},
+        {"ẚ", "Aʾ"},
+        {"ὐ", "Υ̓"},
+        {"ᾶ", "Α͂"},
+        {"ῆ", "Η͂"},
+        {"ῖ", "Ι͂"},
+        {"ῤ", "Ρ̓"},
+        {"ῦ", "Υ͂"},
+        {"ῶ", "Ω͂"},
+        {"ﬀ", "FF"},
+        {"ﬁ", "FI"},
+        {"ﬂ", "FL"},
+        {"ﬅ", "ST"},
+        {"ﬆ", "ST"},
+        {"ﬓ", "ՄՆ"},
+        {"ﬔ", "ՄԵ"},
+        {"ﬕ", "ՄԻ"},
+        {"ﬖ", "ՎՆ"},
+        {"ﬗ", "ՄԽ"},
+        {"ΐ", "Ϊ́"},
+        {"ΰ", "Ϋ́"},
+        {"ὒ", "Υ̓̀"},
+        {"ὔ", "Υ̓́"},
+        {"ὖ", "Υ̓͂"},
+        {"ῒ", "Ϊ̀"},
+        {"ΐ", "Ϊ́"},
+        {"ῗ", "Ϊ͂"},
+        {"ῢ", "Ϋ̀"},
+        {"ΰ", "Ϋ́"},
+        {"ῧ", "Ϋ͂"},
+        {"ﬃ", "FFI"},
+        {"ﬄ", "FFL"},
+    }
+    for lower, upper in mappings:
+        assert_false(upper.is_like(lower))
+
+
 def main():
     var suite = TestSuite()
 
@@ -1090,5 +1180,6 @@ def main():
     suite.test[test_replace]()
     suite.test[test_join]()
     suite.test[test_string_slice_intern]()
+    suite.test[test_is_like]()
 
     suite^.run()


### PR DESCRIPTION
Add performant `String.is_like()` to replace `lhs.lower() == rhs.lower()` patterns.


CC: @soraros 