### PR TITLE
[stdlib] Greatly optimize unicode casing

### DIFF
--- a/mojo/stdlib/benchmarks/collections/bench_string.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_string.mojo
@@ -173,8 +173,9 @@ def bench_string_lower[
 
     @always_inline
     def call_fn() unified {read}:
-        var res = black_box(items).lower()
-        keep(res)
+        for _ in range(10**6 // length):
+            var res = black_box(items).lower()
+            keep(res)
 
     b.iter(call_fn)
 
@@ -190,8 +191,9 @@ def bench_string_upper[
 
     @always_inline
     def call_fn() unified {read}:
-        var res = black_box(items).upper()
-        keep(res)
+        for _ in range(10**6 // length):
+            var res = black_box(items).upper()
+            keep(res)
 
     b.iter(call_fn)
 

--- a/mojo/stdlib/std/collections/string/_unicode.mojo
+++ b/mojo/stdlib/std/collections/string/_unicode.mojo
@@ -23,6 +23,7 @@ from std.collections.string._unicode_lookups import (
 )
 
 from std.memory import Span
+from std.sys.intrinsics import likely
 
 
 def _uppercase_mapping_index(rune: Codepoint) -> Int:
@@ -183,21 +184,41 @@ def to_lowercase(s: StringSlice[mut=False, _]) -> String:
     Returns:
         A new string where cased letters have been converted to lowercase.
     """
-    var result = String(capacity=_estimate_needed_size(s.byte_length()))
+    # lowercased strings always have the same amount of bytes
+    var result = String(capacity=s.byte_length())
     var input_offset = 0
     while input_offset < s.byte_length():
-        var rune_and_size = Codepoint.unsafe_decode_utf8_codepoint(
-            s.as_bytes()[input_offset:]
-        )
-        var lowercase_char_opt = _get_lowercase_mapping(rune_and_size[0])
-        if lowercase_char_opt is None:
-            result.write_string(
-                s[byte = input_offset : input_offset + rune_and_size[1]]
-            )
-        else:
-            result += String(lowercase_char_opt.unsafe_value())
+        comptime `a` = Byte(ord("a"))
+        comptime `A` = Byte(ord("A"))
+        comptime lower_ascii_latin1 = `A` ^ `a`
 
-        input_offset += rune_and_size[1]
+        ref rune, size = Codepoint.unsafe_decode_utf8_codepoint(
+            s[byte=input_offset:].as_bytes()
+        )
+
+        if likely(size == 1):  # ASCII fast path
+            comptime `z` = Byte(ord("z"))
+            var b = Byte(rune.to_u32())
+            var low = b | lower_ascii_latin1
+            result._unsafe_append_byte(low if `a` <= low <= `z` else b)
+        elif size == 2:  # latin-1 fast path
+            comptime `à` = Byte(ord("à"))
+            comptime `þ` = Byte(ord("þ"))
+            comptime `÷` = Byte(ord("÷"))
+            var b = Byte(rune.to_u32())
+            var low = b | lower_ascii_latin1
+            var c = Codepoint(low if `à` <= low <= `þ` and low != `÷` else b)
+            result += String(c)
+        else:
+            var lowercase_char_opt = _get_lowercase_mapping(rune)
+            if lowercase_char_opt is None:
+                result.write_string(
+                    s[byte = input_offset : input_offset + size]
+                )
+            else:
+                result += String(lowercase_char_opt.unsafe_value())
+
+        input_offset += size
 
     return result^
 
@@ -211,34 +232,56 @@ def to_uppercase(s: StringSlice[mut=False, _]) -> String:
     Returns:
         A new string where cased letters have been converted to uppercase.
     """
-    var result = String(capacity=_estimate_needed_size(s.byte_length()))
+    var data = s.as_bytes()
+    # estimate the size since some codepoints require multiple chars to uppercase
+    var result = String(capacity=3 * (len(data) // 2))
     var input_offset = 0
-    while input_offset < s.byte_length():
-        var rune_and_size = Codepoint.unsafe_decode_utf8_codepoint(
-            s.as_bytes()[input_offset:]
+    while input_offset < len(data):
+        comptime `a` = Byte(ord("a"))
+        comptime `A` = Byte(ord("A"))
+        comptime upper_ascii_latin1 = ~(`A` ^ `a`)
+
+        ref rune, size = Codepoint.unsafe_decode_utf8_codepoint(
+            data[input_offset:]
         )
-        var uppercase_replacement_opt = _get_uppercase_mapping(rune_and_size[0])
-
-        if uppercase_replacement_opt:
-            # A given character can be replaced with a sequence of characters
-            # up to 3 characters in length. A fixed size `Codepoint` array is
-            # returned, along with a `count` (1, 2, or 3) of how many
-            # replacement characters are in the uppercase replacement sequence.
-            count, ref uppercase_replacement_chars = (
-                uppercase_replacement_opt.unsafe_value()
-            )
-            for char_idx in range(count):
-                result += String(uppercase_replacement_chars[char_idx])
+        if likely(size == 1):  # ASCII fast path
+            comptime `Z` = Byte(ord("Z"))
+            var b = Byte(rune.to_u32())
+            var up = b & upper_ascii_latin1
+            result._unsafe_append_byte(up if `A` <= up <= `Z` else b)
+        elif size == 2:  # latin-1 fast path
+            comptime `À` = Byte(ord("À"))
+            comptime `Þ` = Byte(ord("Þ"))
+            comptime `×` = Byte(ord("×"))
+            comptime `ÿ` = Byte(ord("ÿ"))
+            comptime `Ÿ` = Byte(ord("Ÿ"))
+            comptime `ß` = Byte(ord("ß"))
+            var b = Byte(rune.to_u32())
+            if likely(b != `ß`):
+                b = `Ÿ` if b == `ÿ` else b
+                var up = b & upper_ascii_latin1
+                var c = Codepoint(up if `À` <= up <= `Þ` and up != `×` else b)
+                result += String(c)
+            else:
+                result += "SS"
         else:
-            result.write_string(
-                s[byte = input_offset : input_offset + rune_and_size[1]]
-            )
+            var uppercase_replacement_opt = _get_uppercase_mapping(rune)
 
-        input_offset += rune_and_size[1]
+            if uppercase_replacement_opt:
+                # A given character can be replaced with a sequence of characters
+                # up to 3 characters in length. A fixed size `Codepoint` array is
+                # returned, along with a `count` (1, 2, or 3) of how many
+                # replacement characters are in the uppercase replacement sequence.
+                count, ref uppercase_replacement_chars = (
+                    uppercase_replacement_opt.unsafe_value()
+                )
+                for char_idx in range(count):
+                    result += String(uppercase_replacement_chars[char_idx])
+            else:
+                result.write_string(
+                    s[byte = input_offset : input_offset + size]
+                )
+
+        input_offset += size
 
     return result^
-
-
-@always_inline
-def _estimate_needed_size(byte_len: Int) -> Int:
-    return 3 * (byte_len >> 1) + 1

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -906,8 +906,14 @@ def test_lower() raises:
 
     assert_equal(StringSlice("MOJO🔥").lower(), "mojo🔥")
 
-    assert_equal(StringSlice("É").lower(), "é")
-    assert_equal(StringSlice("é").lower(), "é")
+    # latin-1 range
+    assert_equal(
+        StringSlice("ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞß").lower(),
+        "àáâãäåæçèéêëìíîïðñòóôõö×øùúûüýþß",
+    )
+    for i in range(0x7F + 1, ord("À")):
+        var s = String(Codepoint(i))
+        assert_equal(s.lower(), s)
 
 
 def test_upper() raises:
@@ -917,8 +923,14 @@ def test_upper() raises:
 
     assert_equal(StringSlice("mojo🔥").upper(), "MOJO🔥")
 
-    assert_equal(StringSlice("É").upper(), "É")
-    assert_equal(StringSlice("é").upper(), "É")
+    # latin-1 range
+    assert_equal(
+        StringSlice("àáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþß").upper(),
+        "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ÷ØÙÚÛÜÝÞSS",
+    )
+    for i in range(0x7F + 1, ord("À")):
+        var s = String(Codepoint(i))
+        assert_equal(s.upper(), s)
 
 
 def test_is_ascii_digit() raises:


### PR DESCRIPTION
Greatly optimize unicode casing by adding fast paths for ASCII and Latin-1 encodings.

## Benchmark results

CPU: Intel® Core™ i7-7700HQ

|bench | old value (ms) | new value (ms) | markdown perc | magnitude|
|-- | -- | -- | -- | --|
|bench_string_lower[10] | 72.42 | 15.50 | 0.79 | 4.67|
|bench_string_upper[10] | 121.40 | 22.11 | 0.82 | 5.49|
|bench_string_lower[30] | 74.95 | 15.39 | 0.79 | 4.87|
|bench_string_upper[30] | 125.36 | 21.35 | 0.83 | 5.87|
|bench_string_lower[50] | 77.73 | 14.76 | 0.81 | 5.27|
|bench_string_upper[50] | 132.22 | 20.05 | 0.85 | 6.59|
|bench_string_lower[100] | 86.46 | 14.48 | 0.83 | 5.97|
|bench_string_upper[100] | 119.76 | 19.96 | 0.83 | 6.00|
|bench_string_lower[1000] | 69.18 | 14.03 | 0.80 | 4.93|
|bench_string_upper[1000] | 125.47 | 19.48 | 0.84 | 6.44|
|bench_string_lower[10000] | 67.78 | 13.90 | 0.79 | 4.88|
|bench_string_upper[10000] | 125.44 | 19.44 | 0.85 | 6.45|
|bench_string_lower[100000] | 67.40 | 14.68 | 0.78 | 4.59|
|bench_string_upper[100000] | 125.52 | 20.99 | 0.83 | 5.98|
|bench_string_lower[1000000] | 67.39 | 15.11 | 0.78 | 4.46|
|bench_string_upper[1000000] | 125.58 | 20.58 | 0.84 | 6.10|
