### PR TITLE
Tweak git clone command

### DIFF
--- a/mojo/docs/manual/gpu/basics.mdx
+++ b/mojo/docs/manual/gpu/basics.mdx
@@ -72,7 +72,7 @@ install
 then clone the repo that contains the markdown that generated this website:
 
 ```sh
-git clone git@github.com:modular/modular
+git clone https://github.com/modular/modular
 cd modular/mojo/docs/manual/gpu
 ```
 


### PR DESCRIPTION
As is, the command gives me the following error:

```
% git clone git@github.com:modular/modular
Cloning into 'modular'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

The replacement works (and I think matches pretty common usage?).

Thank you for the tutorial!

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
