### PR TITLE
[stdlib] [proposal] Make `splitlines` return an iterator

### DIFF
--- a/bazel/lint/check_licenses.mojo
+++ b/bazel/lint/check_licenses.mojo
@@ -77,14 +77,14 @@ fn get_git_files() raises -> Set[String]:
 
 fn check_path(path: Path, mut files_without_license: List[Path]) raises:
     file_text = path.read_text()
-
+    var start = file_text.as_string_slice()
     # Ignore #! in scripts
     if file_text.startswith("#!"):
-        has_license = "\n".join(file_text.splitlines()[1:]).startswith(LICENSE)
-    else:
-        has_license = file_text.startswith(LICENSE)
+        var idx = file_text.find("\n")
+        if idx >= 0 and len(file_text) > idx:
+            start = start[idx + 1 :]
 
-    if not has_license:
+    if not start.startswith(LICENSE):
         files_without_license.append(path)
 
 

--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -52,6 +52,9 @@ Literals now have a default type. For example, you can now bind
 - `Optional` now conforms to `Iterable` and `Iterator` acting as a collection of
   size 1 or 0.
 
+- `String.splitlines()` now returns an iterator instead of a
+  `List[StringSlice]`.
+
 ### Tooling changes
 
 - Error messages now preserve symbolic calls to `always_inline("builtin")`

--- a/mojo/stdlib/benchmarks/collections/bench_string.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_string.mojo
@@ -13,7 +13,7 @@
 
 from collections import Optional
 from collections.string._utf8 import _is_valid_utf8
-from collections.string.string_slice import _split
+from collections.string.string_slice import _split, _to_string_slice_list
 from os import abort
 from pathlib import _dir_of_current_file
 from random import seed
@@ -160,8 +160,8 @@ fn bench_string_splitlines[
     @always_inline
     @parameter
     fn call_fn() raises:
-        for _ in range(1_000_000 // length):
-            var res = items.splitlines()
+        for _ in range(10**6 // length):
+            var res = _to_string_slice_list(items.splitlines())
             keep(res.unsafe_ptr())
 
     b.iter[call_fn]()

--- a/mojo/stdlib/benchmarks/collections/string/bench_atof.mojo
+++ b/mojo/stdlib/benchmarks/collections/string/bench_atof.mojo
@@ -21,6 +21,7 @@ from benchmark import (
     ThroughputMeasure,
     keep,
 )
+from collections.string.string_slice import _to_string_slice_list
 
 
 # ===-----------------------------------------------------------------------===#
@@ -53,7 +54,9 @@ def main():
     @parameter
     for filename in files:
         var file_path = _dir_of_current_file() / "data" / (filename + ".txt")
-        var items_to_parse = file_path.read_text().splitlines()
+        var items_to_parse = _to_string_slice_list(
+            file_path.read_text().splitlines()
+        )
         var nb_of_bytes = 0
         for item2 in items_to_parse:
             nb_of_bytes += len(item2)

--- a/mojo/stdlib/stdlib/collections/string/string.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string.mojo
@@ -80,8 +80,8 @@ from collections.string._parsing_numbers.parsing_floats import _atof
 from collections.string.format import _CurlyEntryFormattable, _FormatCurlyEntry
 from collections.string.string_slice import (
     CodepointSliceIter,
-    _to_string_list,
     _unsafe_strlen,
+    _SplitlinesIter,
 )
 from hashlib.hasher import Hasher
 from io.write import STACK_BUFFER_BYTES, _TotalWritableBytes, _WriteBufferStack
@@ -1452,21 +1452,23 @@ struct String(
         """
         return self.as_string_slice().split(sep, maxsplit=maxsplit)
 
-    fn splitlines(
-        self, keepends: Bool = False
-    ) -> List[StringSlice[__origin_of(self)]]:
+    fn splitlines[
+        keep_ends: Bool = False
+    ](self) -> _SplitlinesIter[
+        __origin_of(self), keep_ends=keep_ends, forward=True
+    ]:
         """Split the string at line boundaries. This corresponds to Python's
         [universal newlines:](
         https://docs.python.org/3/library/stdtypes.html#str.splitlines)
         `"\\r\\n"` and `"\\t\\n\\v\\f\\r\\x1c\\x1d\\x1e\\x85\\u2028\\u2029"`.
 
-        Args:
-            keepends: If True, line breaks are kept in the resulting strings.
+        Parameters:
+            keep_ends: Whether to keep the line breaks in the resulting slices.
 
         Returns:
-            A List of Strings containing the input split by line boundaries.
+            An iterator of StringSlices over the input split by line boundaries.
         """
-        return self.as_string_slice().splitlines(keepends)
+        return self.as_string_slice().splitlines[keep_ends=keep_ends]()
 
     fn replace(self, old: StringSlice, new: StringSlice) -> String:
         """Return a copy of the string with all occurrences of substring `old`

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -15,7 +15,10 @@ from collections.string.string import (
     _calc_initial_buffer_size_int32,
     _calc_initial_buffer_size_int64,
 )
-from collections.string.string_slice import _to_string_list
+from collections.string.string_slice import (
+    _to_string_slice_list,
+    _to_string_list,
+)
 from math import isinf, isnan
 
 from memory import memcpy
@@ -768,37 +771,48 @@ def test_splitlines():
     alias L = List[StaticString]
 
     # Test with no line breaks
-    assert_equal(S("hello world").splitlines(), L("hello world"))
+    assert_equal(
+        _to_string_slice_list(S("hello world").splitlines()), L("hello world")
+    )
 
     # Test with line breaks
-    assert_equal(S("hello\nworld").splitlines(), L("hello", "world"))
-    assert_equal(S("hello\rworld").splitlines(), L("hello", "world"))
-    assert_equal(S("hello\r\nworld").splitlines(), L("hello", "world"))
+    assert_equal(
+        _to_string_slice_list(S("hello\nworld").splitlines()),
+        L("hello", "world"),
+    )
+    assert_equal(
+        _to_string_slice_list(S("hello\rworld").splitlines()),
+        L("hello", "world"),
+    )
+    assert_equal(
+        _to_string_slice_list(S("hello\r\nworld").splitlines()),
+        L("hello", "world"),
+    )
 
     # Test with multiple different line breaks
     s1 = S("hello\nworld\r\nmojo\rlanguage\r\n")
     hello_mojo = L("hello", "world", "mojo", "language")
-    assert_equal(s1.splitlines(), hello_mojo)
+    assert_equal(_to_string_slice_list(s1.splitlines()), hello_mojo)
     assert_equal(
-        s1.splitlines(keepends=True),
+        _to_string_slice_list(s1.splitlines[keep_ends=True]()),
         L("hello\n", "world\r\n", "mojo\r", "language\r\n"),
     )
 
     # Test with an empty string
-    assert_equal(S("").splitlines(), L())
+    assert_equal(_to_string_slice_list(S("").splitlines()), L())
     # test \v \f \x1c \x1d
     s2 = S("hello\vworld\fmojo\x1clanguage\x1d")
-    assert_equal(s2.splitlines(), hello_mojo)
+    assert_equal(_to_string_slice_list(s2.splitlines()), hello_mojo)
     assert_equal(
-        s2.splitlines(keepends=True),
+        _to_string_slice_list(s2.splitlines[keep_ends=True]()),
         L("hello\v", "world\f", "mojo\x1c", "language\x1d"),
     )
 
     # test \x1c \x1d \x1e
     s3 = S("hello\x1cworld\x1dmojo\x1elanguage\x1e")
-    assert_equal(s3.splitlines(), hello_mojo)
+    assert_equal(_to_string_slice_list(s3.splitlines()), hello_mojo)
     assert_equal(
-        s3.splitlines(keepends=True),
+        _to_string_slice_list(s3.splitlines[keep_ends=True]()),
         L("hello\x1c", "world\x1d", "mojo\x1e", "language\x1e"),
     )
 
@@ -811,9 +825,9 @@ def test_splitlines():
         item = StaticString("").join(
             "hello", u, "world", u, "mojo", u, "language", u
         )
-        assert_equal(item.splitlines(), hello_mojo)
+        assert_equal(_to_string_slice_list(item.splitlines()), hello_mojo)
         assert_equal(
-            _to_string_list(item.splitlines(keepends=True)),
+            _to_string_list(item.splitlines[keep_ends=True]()),
             List("hello" + u, "world" + u, "mojo" + u, "language" + u),
         )
 

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -11,7 +11,12 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from collections.string.string_slice import _to_string_list, get_static_string
+from collections.string.string_slice import (
+    get_static_string,
+    _SplitlinesIter,
+    _to_string_slice_list,
+    _to_string_list,
+)
 from sys.info import size_of
 
 from testing import assert_equal, assert_false, assert_true
@@ -613,37 +618,48 @@ def test_splitlines():
     alias L = List[StaticString]
 
     # Test with no line breaks
-    assert_equal(S("hello world").splitlines(), L("hello world"))
+    assert_equal(
+        _to_string_slice_list(S("hello world").splitlines()), L("hello world")
+    )
 
     # Test with line breaks
-    assert_equal(S("hello\nworld").splitlines(), L("hello", "world"))
-    assert_equal(S("hello\rworld").splitlines(), L("hello", "world"))
-    assert_equal(S("hello\r\nworld").splitlines(), L("hello", "world"))
+    assert_equal(
+        _to_string_slice_list(S("hello\nworld").splitlines()),
+        L("hello", "world"),
+    )
+    assert_equal(
+        _to_string_slice_list(S("hello\rworld").splitlines()),
+        L("hello", "world"),
+    )
+    assert_equal(
+        _to_string_slice_list(S("hello\r\nworld").splitlines()),
+        L("hello", "world"),
+    )
 
     # Test with multiple different line breaks
     s1 = S("hello\nworld\r\nmojo\rlanguage\r\n")
     hello_mojo = L("hello", "world", "mojo", "language")
-    assert_equal(s1.splitlines(), hello_mojo)
+    assert_equal(_to_string_slice_list(s1.splitlines()), hello_mojo)
     assert_equal(
-        s1.splitlines(keepends=True),
+        _to_string_slice_list(s1.splitlines[keep_ends=True]()),
         L("hello\n", "world\r\n", "mojo\r", "language\r\n"),
     )
 
     # Test with an empty string
-    assert_equal(S("").splitlines(), L())
+    assert_equal(_to_string_slice_list(S("").splitlines()), L())
     # test \v \f \x1c \x1d
     s2 = S("hello\vworld\fmojo\x1clanguage\x1d")
-    assert_equal(s2.splitlines(), hello_mojo)
+    assert_equal(_to_string_slice_list(s2.splitlines()), hello_mojo)
     assert_equal(
-        s2.splitlines(keepends=True),
+        _to_string_slice_list(s2.splitlines[keep_ends=True]()),
         L("hello\v", "world\f", "mojo\x1c", "language\x1d"),
     )
 
     # test \x1c \x1d \x1e
     s3 = S("hello\x1cworld\x1dmojo\x1elanguage\x1e")
-    assert_equal(s3.splitlines(), hello_mojo)
+    assert_equal(_to_string_slice_list(s3.splitlines()), hello_mojo)
     assert_equal(
-        s3.splitlines(keepends=True),
+        _to_string_slice_list(s3.splitlines[keep_ends=True]()),
         L("hello\x1c", "world\x1d", "mojo\x1e", "language\x1e"),
     )
 
@@ -656,9 +672,9 @@ def test_splitlines():
         item = StaticString("").join(
             "hello", u, "world", u, "mojo", u, "language", u
         )
-        assert_equal(item.splitlines(), hello_mojo)
+        assert_equal(_to_string_slice_list(item.splitlines()), hello_mojo)
         assert_equal(
-            _to_string_list(item.splitlines(keepends=True)),
+            _to_string_list(item.splitlines[keep_ends=True]()),
             List("hello" + u, "world" + u, "mojo" + u, "language" + u),
         )
 

--- a/mojo/stdlib/test/iter/test_ranged_iter.mojo
+++ b/mojo/stdlib/test/iter/test_ranged_iter.mojo
@@ -1,0 +1,54 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+
+from testing import TestSuite, assert_true, assert_equal
+from stdlib.collections.string.string_slice import (
+    _SplitlinesIter,
+    _RangedIteratorWrapper,
+    _to_string_list,
+)
+
+
+fn test_ranged_iter() raises:
+    var data = "0\n1\n2\n3\n4\n5"
+    var iterator = data.splitlines()
+    assert_equal(
+        _to_string_list(iterator.copy()[0:6:1]),
+        ["0", "1", "2", "3", "4", "5"],
+    )
+    assert_equal(
+        _to_string_list(iterator.copy()[::]),
+        ["0", "1", "2", "3", "4", "5"],
+    )
+    assert_equal(_to_string_list(iterator.copy()[0:2]), ["0", "1"])
+    assert_equal(_to_string_list(iterator.copy()[1:3]), ["1", "2"])
+    assert_equal(
+        _to_string_list(iterator.copy()[1:6]), ["1", "2", "3", "4", "5"]
+    )
+    assert_equal(_to_string_list(iterator.copy()[1:6:2]), ["1", "3", "5"])
+    assert_equal(_to_string_list(iterator.copy()[0:6:2]), ["0", "2", "4"])
+    assert_equal(_to_string_list(iterator.copy()[0:6:3]), ["0", "3"])
+    assert_equal(_to_string_list(iterator.copy()[1:6:3]), ["1", "4"])
+    # once we make it general enough so that the inner_iter type can be itself
+    # assert_equal(_to_string_list(iterator.copy()[1:2:3][:]), ["1"])
+    # assert_equal(_to_string_list(iterator.copy()[1:6:3][:1]), ["1"])
+    # assert_equal(_to_string_list(iterator.copy()[1:6:2][::2]), ["0", "4"])
+
+
+def main():
+    var suite = TestSuite()
+
+    suite.test[test_ranged_iter]()
+
+    suite^.run()


### PR DESCRIPTION
Make `splitlines` return an iterator. Successor to  #3858

I think functions like this one and `split` should return iterators that are indexable and sliceable. Most of the use cases for them iterate over the result of calling the function anyway. So IMO we should nudge users towards allocating only when necessary.