### PR TITLE
[Kernels] Migrate `bicubic` from `NDBuffer` to `LayoutTensor`

### DIFF
--- a/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
@@ -3955,7 +3955,7 @@ struct ResizeBicubic:
         size: InputTensor[rank=1],
         ctx: DeviceContextPtr,
     ) raises:
-        resize_bicubic[target](
+        resize_bicubic[dtype=dtype, target=target](
             output.to_layout_tensor(), input.to_layout_tensor(), ctx
         )
 

--- a/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
@@ -3955,11 +3955,9 @@ struct ResizeBicubic:
         size: InputTensor[rank=1],
         ctx: DeviceContextPtr,
     ) raises:
-        # Get input and output dimensions from tensors
-        var output_buffer = managed_tensor_slice_to_ndbuffer(output)
-        var input_buffer = managed_tensor_slice_to_ndbuffer(input)
-
-        resize_bicubic[target](output_buffer, input_buffer, ctx)
+        resize_bicubic[target](
+            output.to_layout_tensor(), input.to_layout_tensor(), ctx
+        )
 
     @staticmethod
     fn shape[

--- a/max/kernels/src/nn/bicubic.mojo
+++ b/max/kernels/src/nn/bicubic.mojo
@@ -18,11 +18,12 @@ around the target location to compute the interpolated value.
 """
 from math import clamp, floor
 
-from buffer import NDBuffer
-from buffer.dimlist import DimList
 from gpu.host.info import is_gpu
 from gpu.id import block_dim, block_idx, thread_idx
+from layout import Layout, LayoutTensor
+from memory import AddressSpace
 from runtime.asyncrt import DeviceContextPtr
+from utils import Index
 
 
 @always_inline
@@ -103,28 +104,31 @@ fn cubic_kernel(x: SIMD) -> __type_of(x):
     return abs_x.le(1).select(case_1, abs_x.lt(2).select(case_2, case_3))
 
 
-fn cpu_bicubic_kernel[
-    dtype: DType,
-    rank: Int, //,
-](
-    output_host: NDBuffer[mut=True, dtype, rank, *_],
-    input_host: NDBuffer[dtype, rank, *_],
+fn cpu_bicubic_kernel(
+    output_host: LayoutTensor[mut=True, **_],
+    input_host: LayoutTensor[**_],
 ) -> None:
-    """Perform bicubic interpolation on an NDBuffer of form NCHW.
+    """Perform bicubic interpolation on a LayoutTensor of form NCHW.
 
     Args:
         output_host: Output tensor with desired dimensions.
         input_host: Input tensor of shape [B, C, H, W].
     """
-    constrained[rank == 4, "bicubic resize only supports rank 4 tensors"]()
+    constrained[
+        output_host.rank == 4 and input_host.rank == 4,
+        "bicubic resize only supports rank 4 tensors",
+    ]()
+    constrained[output_host.dtype == input_host.dtype]()
 
     # get dimensions
-    var batch_size = input_host.dim[0]()
-    var channels = input_host.dim[1]()
-    var in_height = input_host.dim[2]()
-    var in_width = input_host.dim[3]()
-    var out_height = output_host.dim[2]()
-    var out_width = output_host.dim[3]()
+    var input_shape = input_host.runtime_layout.shape.value.canonicalize()
+    var output_shape = output_host.runtime_layout.shape.value.canonicalize()
+    var batch_size = input_shape[0]
+    var channels = input_shape[1]
+    var in_height = input_shape[2]
+    var in_width = input_shape[3]
+    var out_height = output_shape[2]
+    var out_width = output_shape[3]
 
     var scale_h = Float32(in_height) / Float32(out_height)
     var scale_w = Float32(in_width) / Float32(out_width)
@@ -173,23 +177,31 @@ fn cpu_bicubic_kernel[
 
                             # now that i have the weight y and x of said pixel, i multiply it by its weight and add it to the sum
                             var pixel_value = Float32(
-                                input_host[b, c, y_pos, x_pos]
+                                input_host.load[width=1](
+                                    Index(b, c, y_pos, x_pos)
+                                )
                             )
                             sum_value += pixel_value * weight
                             sum_weights += weight
 
                     # store the result in the output tensor
-                    output_host[b, c, y_out, x_out] = sum_value.cast[dtype]()
+                    output_host.store[width=1](
+                        Index(b, c, y_out, x_out),
+                        sum_value.cast[output_host.dtype](),
+                    )
 
 
 fn gpu_bicubic_kernel[
     dtype: DType,
-    rank: Int,
-    output_shape: DimList,
-    input_shape: DimList,
+    layout: Layout,
+    address_space: AddressSpace = AddressSpace.GENERIC,
 ](
-    output: NDBuffer[mut=True, dtype, rank, MutableAnyOrigin, output_shape],
-    input: NDBuffer[dtype, rank, MutableAnyOrigin, input_shape],
+    output: LayoutTensor[
+        mut=True, dtype, layout, MutableAnyOrigin, address_space=address_space
+    ],
+    input: LayoutTensor[
+        dtype, layout, MutableAnyOrigin, address_space=address_space
+    ],
 ) -> None:
     """Perform bicubic interpolation using GPU.
 
@@ -201,10 +213,12 @@ fn gpu_bicubic_kernel[
     var c = block_idx.y
     var tid = thread_idx.x
 
-    var in_height = input.dim[2]()
-    var in_width = input.dim[3]()
-    var out_height = output.dim[2]()
-    var out_width = output.dim[3]()
+    var input_shape = input.runtime_layout.shape.value.canonicalize()
+    var output_shape = output.runtime_layout.shape.value.canonicalize()
+    var in_height = input_shape[2]
+    var in_width = input_shape[3]
+    var out_height = output_shape[2]
+    var out_width = output_shape[3]
 
     var scale_h = Float32(in_height) / Float32(out_height)
     var scale_w = Float32(in_width) / Float32(out_width)
@@ -250,24 +264,22 @@ fn gpu_bicubic_kernel[
                 var weight = weights_y[i] * weights_x[j]
 
                 # now that i have the weight y and x of said pixel, i multiply it by its weight and add it to the sum
-                var pixel_value = input[b, c, y_pos, x_pos].cast[
-                    DType.float32
-                ]()
+                var pixel_value = input.load[width=1](
+                    Index(b, c, y_pos, x_pos)
+                ).cast[DType.float32]()
                 sum_value += pixel_value * weight
                 sum_weights += weight
 
-        output[b, c, y_out, x_out] = sum_value.cast[dtype]()
+        output.store[width=1](
+            Index(b, c, y_out, x_out), sum_value.cast[dtype]()
+        )
 
 
 fn resize_bicubic[
-    dtype: DType,
-    rank: Int,
-    output_shape: DimList,
-    input_shape: DimList, //,
-    target: StaticString,
+    target: StaticString, //,
 ](
-    output: NDBuffer[mut=True, dtype, rank, MutableAnyOrigin, output_shape],
-    input: NDBuffer[dtype, rank, MutableAnyOrigin, input_shape],
+    output: LayoutTensor[mut=True, **_],
+    input: LayoutTensor[**_],
     ctx: DeviceContextPtr,
 ) raises:
     """Perform bicubic interpolation.
@@ -277,17 +289,22 @@ fn resize_bicubic[
         input: Input tensor of shape [B, C, H, W] on host or device.
         ctx: Device context to enqueue GPU kernels on.
     """
-    constrained[rank == 4, "bicubic resize only supports rank 4 tensors"]()
+    constrained[
+        output.rank == 4 and input.rank == 4,
+        "bicubic resize only supports rank 4 tensors",
+    ]()
+    constrained[output.dtype == input.dtype]()
 
     @parameter
     if is_gpu[target]():
-        var N = input.dim[0]()
-        var C = input.dim[1]()
+        var input_shape = input.runtime_layout.shape.value.canonicalize()
+        var N = input_shape[0]
+        var C = input_shape[1]
 
         # Use a fixed block size to avoid exceeding CUDA thread limits.
         var block_size = 256
         alias kernel = gpu_bicubic_kernel[
-            dtype, rank, output_shape, input_shape
+            output.dtype, output.layout, output.address_space
         ]
         ctx.get_device_context().enqueue_function_checked[kernel, kernel](
             output,

--- a/max/kernels/src/nn/bicubic.mojo
+++ b/max/kernels/src/nn/bicubic.mojo
@@ -276,10 +276,11 @@ fn gpu_bicubic_kernel[
 
 
 fn resize_bicubic[
-    target: StaticString, //,
+    dtype: DType, //,
+    target: StaticString,
 ](
-    output: LayoutTensor[mut=True, **_],
-    input: LayoutTensor[**_],
+    output: LayoutTensor[mut=True, dtype, **_],
+    input: LayoutTensor[dtype, **_],
     ctx: DeviceContextPtr,
 ) raises:
     """Perform bicubic interpolation.
@@ -293,7 +294,6 @@ fn resize_bicubic[
         output.rank == 4 and input.rank == 4,
         "bicubic resize only supports rank 4 tensors",
     ]()
-    constrained[output.dtype == input.dtype]()
 
     @parameter
     if is_gpu[target]():

--- a/max/kernels/test/gpu/nn/test_bicubic.mojo
+++ b/max/kernels/test/gpu/nn/test_bicubic.mojo
@@ -143,7 +143,7 @@ fn test_bicubic_kernel[
         " upsampling kernel--------------------------------"
     )
     # Call the bicubic upsampling kernel.
-    resize_bicubic[target="cpu"](output_host.tensor, input_host.tensor, ctx)
+    resize_bicubic[dtype, target="cpu"](output_host.tensor, input_host.tensor, ctx)
     print(
         "--------------------------------after calling the bicubic upsampling"
         " kernel--------------------------------"
@@ -607,7 +607,7 @@ fn test_bicubic_kernel[
     var H = output_shape[2]
     var W = output_shape[3]
 
-    resize_bicubic[target="gpu"](output_dev.tensor, input_dev.tensor, ctx)
+    resize_bicubic[dtype, target="gpu"](output_dev.tensor, input_dev.tensor, ctx)
 
     ctx.enqueue_copy(output_ref_host.tensor.ptr, output_dev.buffer)
     ctx.synchronize()


### PR DESCRIPTION
- Migrate bicubic interpolation kernels from `NDBuffer` to `LayoutTensor`
- Update `ResizeBicubic` kernel to use `LayoutTensor` instead of `NDBuffer`
- Migrate `bicubic` interpolation tests from `NDBuffer` to `LayoutTensor`
