### PR TITLE
[stdlib] Add default implementation for ImplicitlyBoolable trait

### DIFF
--- a/mojo/stdlib/stdlib/builtin/bool.mojo
+++ b/mojo/stdlib/stdlib/builtin/bool.mojo
@@ -87,13 +87,14 @@ trait ImplicitlyBoolable(Boolable):
     ```
     """
 
+    @always_inline
     fn __as_bool__(self) -> Bool:
         """Get the boolean representation of the value.
 
         Returns:
             The boolean representation of the value.
         """
-        ...
+        return self.__bool__()
 
 
 # ===----------------------------------------------------------------------=== #

--- a/mojo/stdlib/stdlib/builtin/float_literal.mojo
+++ b/mojo/stdlib/stdlib/builtin/float_literal.mojo
@@ -162,7 +162,7 @@ struct FloatLiteral[value: __mlir_type.`!pop.float_literal`](
     # Unary Operators
     # ===------------------------------------------------------------------===#
 
-    @always_inline("nodebug")
+    @always_inline("builtin")
     fn __bool__(self) -> Bool:
         """A FloatLiteral value is true if it is non-zero.
 
@@ -171,7 +171,7 @@ struct FloatLiteral[value: __mlir_type.`!pop.float_literal`](
         """
         return self != 0.0
 
-    @always_inline("nodebug")
+    @always_inline("builtin")
     fn __as_bool__(self) -> Bool:
         """A FloatLiteral value is true if it is non-zero.
 

--- a/mojo/stdlib/stdlib/memory/unsafe_pointer.mojo
+++ b/mojo/stdlib/stdlib/memory/unsafe_pointer.mojo
@@ -512,15 +512,6 @@ struct UnsafePointer[
         return Int(self) != 0
 
     @always_inline
-    fn __as_bool__(self) -> Bool:
-        """Return true if the pointer is non-null.
-
-        Returns:
-            Whether the pointer is null.
-        """
-        return self.__bool__()
-
-    @always_inline
     fn __int__(self) -> Int:
         """Returns the pointer address as an integer.
 

--- a/mojo/stdlib/test/builtin/test_bool.mojo
+++ b/mojo/stdlib/test/builtin/test_bool.mojo
@@ -43,9 +43,6 @@ struct MyTrue(ImplicitlyBoolable):
     fn __bool__(self) -> Bool:
         return True
 
-    fn __as_bool__(self) -> Bool:
-        return self.__bool__()
-
 
 fn takes_bool(cond: Bool) -> Bool:
     return cond


### PR DESCRIPTION
Take advantage of default trait impls for `ImplicitlyBoolable`

Upon review, this unfortunately doesn't appear to be applicable to any of the stdlib types that currently use this trait as they all also include some sort of `@always_inline` annotation.

Also moved `FloatLiteral.__bool__` to use `@always_inline("builtin")` as that appears to have been missed in the past