### PR TITLE
[stdlib] Add `is_in` function to `Variant` class.

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -64,6 +64,17 @@ what we publish.
 
 ### Standard library changes
 
+- Added `is_in` function to `Variant` class.
+
+```mojo
+from utils import Variant
+
+def main():
+    var x = Variant[Int, Float64](1)
+    alias OnlyFloats = Variant[Float64, Float32]
+    print(x.is_in[*OnlyFloats.Ts]())
+```
+
 - Added `unsafe_get`, `unsafe_swap_elements` and `unsafe_subspan` to `Span`.
 
 - The deprecated `DType.index` is now removed in favor of the `DType.int`.

--- a/mojo/stdlib/stdlib/utils/variant.mojo
+++ b/mojo/stdlib/stdlib/utils/variant.mojo
@@ -427,3 +427,30 @@ struct Variant[*Ts: Copyable & Movable](ImplicitlyCopyable, Movable):
         For example, the `Variant[Int, Bool]` permits `Int` and `Bool`.
         """
         return Self._check[T]() != Self._sentinel
+
+    fn is_in[*V: Copyable & Movable](self) -> Bool:
+        """Check if a variant instance is also in another variant instance.
+
+        Parameters:
+            V: The variant to check.
+
+        Returns:
+            True if the variant contains the requested type.
+
+        Example:
+        ```mojo
+        from utils import Variant
+
+        def main():
+            var x = Variant[Int, Float64](1)
+            alias OnlyFloats = Variant[Float64, Float32]
+            print(x.is_in[*OnlyFloats.Ts]())
+        ```
+        """
+
+        @parameter
+        for j in range(len(VariadicList(V))):
+            alias T = V[j]
+            if self.isa[T]():
+                return True
+        return False

--- a/mojo/stdlib/test/utils/test_variant.mojo
+++ b/mojo/stdlib/test/utils/test_variant.mojo
@@ -184,5 +184,17 @@ def test_is_type_supported():
     assert_equal(_y.is_type_supported[SIMD[DType.uint8, 8]](), False)
 
 
+def test_is_in():
+    alias IntsVariant = Variant[Int8, Int16, Int32, Int64]
+    alias NumbersVariant = Variant[Int8, Float32, Float64]
+    alias JustFloatsVariant = Variant[Float32, Float64]
+    var _x = NumbersVariant(Float32(1))
+    assert_equal(_x.is_in[*JustFloatsVariant.Ts](), True)
+    assert_equal(_x.is_in[*IntsVariant.Ts](), False)
+    var _y = NumbersVariant(Int8(1))
+    assert_equal(_y.is_in[*JustFloatsVariant.Ts](), False)
+    assert_equal(_y.is_in[*NumbersVariant.Ts](), True)
+
+
 def main():
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Used to check if a variant instance also is in another variant instance / variadic list. Useful for operating on types that are in a super set variant and then filtering subsets.

For example:
```mojo
        from utils import Variant

        def main():
            var x = Variant[Int, Float64](1)
            alias OnlyFloats = Variant[Float64, Float32]
            # Note the unpacked *VariantName.Ts syntax. This is required to
            # see if x also belongs to OnlyFloats.
            print(x.is_in[*OnlyFloats.Ts]())
````

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
