### PR TITLE
[Docs][Bug] Fix link to `where` clauses proposal in the "Mojo Roadmap"

### DIFF
--- a/mojo/docs/roadmap.mdx
+++ b/mojo/docs/roadmap.mdx
@@ -122,13 +122,13 @@ proposal](https://github.com/modular/modular/blob/main/mojo/proposals/parametric
 - 🚧 **Closure refinement**: Improve capture modeling and unify
 compile-time/runtime representations.
 
-- 🚧 **`requires` clauses**: Enable early constraint checking and better error
-messages for generics. See the [requires clause
-proposal](https://github.com/modular/modular/blob/main/mojo/proposals/requires-clause.md).
+- 🚧 **`where` clauses**: Enable early constraint checking and better error
+messages for generics. See the [where clauses
+proposal](https://github.com/modular/modular/blob/main/mojo/proposals/where_clauses.md).
 
 - 🚧 **Conditional conformance**: Allow trait conformance based on predicates
 over parameters.
-
+ 
 - 🚧 **Struct extensions**: Post-hoc type extension and better modular
 refactoring. See the [struct extension
 proposal](https://github.com/modular/modular/blob/main/mojo/proposals/struct-extensions.md).

--- a/mojo/docs/roadmap.mdx
+++ b/mojo/docs/roadmap.mdx
@@ -128,7 +128,7 @@ proposal](https://github.com/modular/modular/blob/main/mojo/proposals/where_clau
 
 - 🚧 **Conditional conformance**: Allow trait conformance based on predicates
 over parameters.
- 
+
 - 🚧 **Struct extensions**: Post-hoc type extension and better modular
 refactoring. See the [struct extension
 proposal](https://github.com/modular/modular/blob/main/mojo/proposals/struct-extensions.md).


### PR DESCRIPTION
The `required`clauses proposal has been renamed to `where` clauses.
This PR fixes the naming and the broken link in the "Mojo Roadmap".
