### PR TITLE
[stdlib][tests] Remove deprecated `__iter__` call in `String` test.

### DIFF
--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -896,8 +896,8 @@ def test_ascii_aliases():
     assert_true("'" in String.PUNCTUATION)
 
     var text = "I love my Mom and Dad so much!!!\n"
-    for char in text:
-        assert_true(char in String.PRINTABLE)
+    for cp in text.codepoint_slices():
+        assert_true(cp in String.PRINTABLE)
 
 
 def test_rstrip():


### PR DESCRIPTION
Removes the following warning in test_string: "Use `str.codepoints()` or `str.codepoint_slices()` instead."
