### PR TITLE
[stdlib] Micro-optimize `_utf8_byte_type()`

### DIFF
--- a/mojo/stdlib/stdlib/collections/string/_utf8.mojo
+++ b/mojo/stdlib/stdlib/collections/string/_utf8.mojo
@@ -173,7 +173,7 @@ fn _is_valid_utf8_comptime(span: Span[mut=False, Byte, **_]) -> Bool:
         if byte_type == 0:
             offset += 1
             continue
-        elif byte_type == 1:
+        elif byte_type == 1 or byte_type > 4:
             return False
 
         for i in range(1, byte_type):
@@ -183,15 +183,15 @@ fn _is_valid_utf8_comptime(span: Span[mut=False, Byte, **_]) -> Bool:
 
         # special unicode ranges
         var b1 = ptr[offset + 1]
-        if byte_type == 2 and b0 < UInt8(0b1100_0010):
+        if byte_type == 2 and b0 < 0b1100_0010:
             return False
-        elif b0 == 0xE0 and b1 < UInt8(0xA0):
+        elif b0 == 0xE0 and b1 < 0xA0:
             return False
-        elif b0 == 0xED and b1 > UInt8(0x9F):
+        elif b0 == 0xED and b1 > 0x9F:
             return False
-        elif b0 == 0xF0 and b1 < UInt8(0x90):
+        elif b0 == 0xF0 and b1 < 0x90:
             return False
-        elif b0 == 0xF4 and b1 > UInt8(0x8F):
+        elif b0 == 0xF4 and b1 > 0x8F:
             return False
 
         offset += UInt(byte_type)
@@ -277,12 +277,7 @@ fn _utf8_byte_type(b: SIMD[DType.uint8, _], /) -> __type_of(b):
         - 3 -> start of 3 byte long sequence.
         - 4 -> start of 4 byte long sequence.
     """
-    return (
-        b.ge(0b1000_0000).cast[DType.uint8]()
-        + b.ge(0b1100_0000).cast[DType.uint8]()
-        + b.ge(0b1110_0000).cast[DType.uint8]()
-        + b.ge(0b1111_0000).cast[DType.uint8]()
-    )
+    return count_leading_zeros(~b)
 
 
 @always_inline

--- a/mojo/stdlib/test/collections/string/test_utf8.mojo
+++ b/mojo/stdlib/test/collections/string/test_utf8.mojo
@@ -27,6 +27,10 @@ from testing import TestSuite
 # Reusable testing data
 # ===----------------------------------------------------------------------=== #
 
+# NOTE: since the biggest unicode codepoint is 0x10FFFF then the biggest
+# first byte that a utf-8 sequence can have is 0b1111_0100 (0xF4)
+alias BIGGEST_UTF8_FIRST_BYTE = Byte(0b1111_0100)
+
 alias GOOD_SEQUENCES = [
     List("a".as_bytes()),
     List("\xc3\xb1".as_bytes()),
@@ -295,7 +299,7 @@ def test_utf8_byte_type():
         assert_equal(_utf8_byte_type(i), 2)
     for i in range(UInt8(0b1110_0000), UInt8(0b1111_0000)):
         assert_equal(_utf8_byte_type(i), 3)
-    for i in range(UInt8(0b1111_0000), UInt8(0b1111_1111)):
+    for i in range(UInt8(0b1111_0000), BIGGEST_UTF8_FIRST_BYTE):
         assert_equal(_utf8_byte_type(i), 4)
 
 


### PR DESCRIPTION
I had previously changed this from

```mojo
return count_leading_zeros(~b)
```
to
```mojo
return (
	b.ge(0b1000_0000).cast[DType.uint8]()
	+ b.ge(0b1100_0000).cast[DType.uint8]()
	+ b.ge(0b1110_0000).cast[DType.uint8]()
	+ b.ge(0b1111_0000).cast[DType.uint8]()
)
```
Because I thought I found a bug for some sequences that have length 4. When the last byte can be e.g. `0b1111_1000` then the `~b` logic would make it count 5 leading zeros.

But the maximum unicode codepoint is `0x10FFFF` whose first utf-8 byte is `1111_0100` so we can safely go back to the previous implementation and fix the tests.