### PR TITLE
[stdlib] Fix `_utf8_byte_type()` test and utf8 validation logic

### DIFF
--- a/mojo/stdlib/test/collections/string/test_utf8.mojo
+++ b/mojo/stdlib/test/collections/string/test_utf8.mojo
@@ -18,6 +18,7 @@ from collections.string._utf8 import (
     _is_valid_utf8_comptime,
     _is_valid_utf8_runtime,
     _utf8_byte_type,
+    BIGGEST_UTF8_FIRST_BYTE,
 )
 
 from testing import assert_equal, assert_false, assert_raises, assert_true
@@ -26,6 +27,7 @@ from testing import TestSuite
 # ===----------------------------------------------------------------------=== #
 # Reusable testing data
 # ===----------------------------------------------------------------------=== #
+
 
 alias GOOD_SEQUENCES = [
     List("a".as_bytes()),
@@ -295,7 +297,7 @@ def test_utf8_byte_type():
         assert_equal(_utf8_byte_type(i), 2)
     for i in range(UInt8(0b1110_0000), UInt8(0b1111_0000)):
         assert_equal(_utf8_byte_type(i), 3)
-    for i in range(UInt8(0b1111_0000), UInt8(0b1111_1111)):
+    for i in range(UInt8(0b1111_0000), BIGGEST_UTF8_FIRST_BYTE + 1):
         assert_equal(_utf8_byte_type(i), 4)
 
 


### PR DESCRIPTION
I had previously changed this from
```mojo
return count_leading_zeros(~b)
```
to
```mojo
return count_leading_zeros(~b | 0b0000_1111)
```

Because I thought I found a bug for some sequences that have length 4. When the last byte can be e.g. `0b1111_1000` then the ~b logic would make it count 5 leading zeros.

But the maximum unicode codepoint is `0x10FFFF` whose first utf-8 byte is `0b1111_0100` so we can safely go back to the previous implementation and fix the tests and utf8 validation logic.