### PR TITLE
[stdlib] Move `PythonObject` test from `test_string` to `test_python_object`

### DIFF
--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -1553,17 +1553,6 @@ def test_sso():
     assert_equal(s._is_inline(), True)
 
 
-def test_python_object():
-    var s = String(PythonObject("hello"))
-    assert_equal(s, "hello")
-
-    var p = Python()
-    _ = p.eval("class A:\n  def __str__(self): pass")
-    var a = p.evaluate("A()")
-    with assert_raises(contains="__str__ returned non-string"):
-        _ = String(a)
-
-
 def test_copyinit():
     alias sizes = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512)
     assert_equal(len(sizes), 10)

--- a/mojo/stdlib/test/python/test_python_object.mojo
+++ b/mojo/stdlib/test/python/test_python_object.mojo
@@ -776,5 +776,16 @@ def test_with_python_eval_and_evaluate():
     test_python_eval_and_evaluate(python)
 
 
+def test_python_object_string():
+    var s = String(PythonObject("hello"))
+    assert_equal(s, "hello")
+
+    var p = Python()
+    _ = p.eval("class A:\n  def __str__(self): pass")
+    var a = p.evaluate("A()")
+    with assert_raises(contains="__str__ returned non-string"):
+        _ = String(a)
+
+
 def main():
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Not sure if there is some kind of warmup for the interpreter that might make this execute faster in the same file as the other python object tests, but it certainly slows string's tests considerably (48ms of the total that is less than 49 ms)