### PR TITLE
[stdlib] Simplify List iterable ctor and enable type inference

### DIFF
--- a/mojo/stdlib/stdlib/collections/list.mojo
+++ b/mojo/stdlib/stdlib/collections/list.mojo
@@ -329,20 +329,19 @@ struct List[T: Copyable & Movable](
         for value in span:
             self.append(value.copy())
 
-    fn __init__[
-        IterableType: Iterable
-    ](out self, iterable: IterableType) where _type_is_eq_parse_time[
-        T, IterableType.IteratorType[__origin_of(iterable)].Element
-    ]():
+    fn __init__(
+        var iterable: Some[Iterable],
+        out self: List[__type_of(iterable).IteratorType[__origin_of()].Element],
+    ):
         """Constructs a list from an iterable of values.
 
         Args:
             iterable: The iterable of values to populate the list with.
         """
         var lower, _ = iter(iterable).bounds()
-        self = Self(capacity=lower)
-        for value in iterable:
-            self.append(rebind[T](value).copy())
+        self = {capacity = lower}
+        for var value in iterable:
+            self.append(rebind_var[__type_of(self).T](value^))
 
     @always_inline
     fn __init__(out self, *, unsafe_uninit_length: Int):

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -899,7 +899,7 @@ def test_list_init_span():
 def test_list_init_iter():
     var l = [String("a"), "bb", "cc", "def"]
     var it = iter(l)
-    var l2 = List[String](it)
+    var l2 = List(it)
     assert_equal(len(l), len(l2))
     assert_equal(l[0], l2[0])
     assert_equal(l[1], l2[1])


### PR DESCRIPTION
Simplify List iterable ctor and enable type inference