### PR TITLE
[stdlib] adding le, lt, gt, ge for Codepoint

### DIFF
--- a/mojo/stdlib/stdlib/collections/string/codepoint.mojo
+++ b/mojo/stdlib/stdlib/collections/string/codepoint.mojo
@@ -293,6 +293,58 @@ struct Codepoint(
         """
         return self.to_u32() != other.to_u32()
 
+    fn __lt__(self, other: Self) -> Bool:
+        """Return True if this character is less than a different codepoint value from
+        `other`.
+
+        Args:
+            other: The codepoint value to compare against.
+
+        Returns:
+            True if this character's values is less than the other codepoint values;
+            False otherwise.
+        """
+        return self.to_u32() < other.to_u32()
+
+    fn __le__(self, other: Self) -> Bool:
+        """Return True if this character is less than or equal to a different codepoint value from
+        `other`.
+
+        Args:
+            other: The codepoint value to compare against.
+
+        Returns:
+            True if this character's values is less than or equal to the other codepoint values;
+            False otherwise.
+        """
+        return self.to_u32() <= other.to_u32()
+
+    fn __ge__(self, other: Self) -> Bool:
+        """Return True if this character is greater than or equal to a different codepoint value from
+        `other`.
+
+        Args:
+            other: The codepoint value to compare against.
+
+        Returns:
+            True if this character's values is greater than or equal the other codepoint values;
+            False otherwise.
+        """
+        return self.to_u32() >= other.to_u32()
+
+    fn __gt__(self, other: Self) -> Bool:
+        """Return True if this character is greater than a different codepoint value from
+        `other`.
+
+        Args:
+            other: The codepoint value to compare against.
+
+        Returns:
+            True if this character's values is greater than to other codepoint values;
+            False otherwise.
+        """
+        return self.to_u32() > other.to_u32()
+
     # ===-------------------------------------------------------------------===#
     # Trait implementations
     # ===-------------------------------------------------------------------===#

--- a/mojo/stdlib/test/collections/test_codepoint.mojo
+++ b/mojo/stdlib/test/collections/test_codepoint.mojo
@@ -54,6 +54,21 @@ def test_char_comparison():
     assert_equal(Codepoint(0), Codepoint(0))
     assert_not_equal(Codepoint(0), Codepoint(1))
 
+    # Test less than and less than or equal to
+    assert_true(Codepoint.__le__(Codepoint(0), Codepoint(1)))
+    assert_true(Codepoint.__le__(Codepoint(1), Codepoint(1)))
+    assert_false(Codepoint.__le__(Codepoint(1), Codepoint(0)))
+    assert_false(Codepoint.__lt__(Codepoint(1), Codepoint(1)))
+    assert_true(Codepoint.__lt__(Codepoint(0), Codepoint(1)))
+    assert_false(Codepoint.__lt__(Codepoint(1), Codepoint(0)))
+
+    # Test greater than and greater than or equal to
+    assert_true(Codepoint.__ge__(Codepoint(1), Codepoint(0)))
+    assert_true(Codepoint.__ge__(Codepoint(1), Codepoint(1)))
+    assert_false(Codepoint.__ge__(Codepoint(0), Codepoint(1)))
+    assert_true(Codepoint.__gt__(Codepoint(1), Codepoint(0)))
+    assert_false(Codepoint.__gt__(Codepoint(0), Codepoint(1)))
+    assert_false(Codepoint.__gt__(Codepoint(1), Codepoint(1)))
 
 def test_char_formatting():
     assert_equal(String(Codepoint(0)), "\0")


### PR DESCRIPTION
<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->

addresses https://github.com/modular/modular/issues/5373

Implementing `__lt__`, `__le__`, `__gt__`, `__ge__` for Codepoint