### PR TITLE
[stdlib] Add PyBool_Check and PyLong_Check* support

### DIFF
--- a/mojo/stdlib/stdlib/python/_cpython.mojo
+++ b/mojo/stdlib/stdlib/python/_cpython.mojo
@@ -2347,10 +2347,10 @@ struct CPython(Defaultable, Movable):
     # ===-------------------------------------------------------------------===#
 
     fn PyLong_Type(self) -> PyTypeObjectPtr:
-        """The PyLong_Type Object.
+        """The `PyLong_Type` Object.
 
-        This instance of PyTypeObject represents the Python integer type. This is
-        the same object as int in the Python layer.
+        This instance of `PyTypeObject` represents the Python integer type. This is
+        the same object as `int` in the Python layer.
 
         References:
         - https://docs.python.org/3.10/c-api/long.html#c.PyLong_Type
@@ -2358,8 +2358,8 @@ struct CPython(Defaultable, Movable):
         return self._PyLong_Type
 
     fn PyLong_Check(self, obj: PyObjectPtr) -> c_int:
-        """Return true if its argument is a PyLongObject or a subtype of
-        PyLongObject. This function always succeeds.
+        """Return true if its argument is a `PyLongObject` or a subtype of
+        `PyLongObject`. This function always succeeds.
 
         Note: this a C macro in the Python C API.
 
@@ -2372,8 +2372,8 @@ struct CPython(Defaultable, Movable):
         )
 
     fn PyLong_CheckExact(self, obj: PyObjectPtr) -> c_int:
-        """Return true if its argument is a PyLongObject, but not a subtype of
-        PyLongObject. This function always succeeds.
+        """Return true if its argument is a `PyLongObject`, but not a subtype of
+        `PyLongObject`. This function always succeeds.
 
         Note: this a C macro in the Python C API.
 
@@ -2424,10 +2424,10 @@ struct CPython(Defaultable, Movable):
     # ===-------------------------------------------------------------------===#
 
     fn PyBool_Type(self) -> PyTypeObjectPtr:
-        """The PyBool_Type Object.
+        """The `PyBool_Type` Object.
 
-        This instance of PyTypeObject represents the Python boolean type; it
-        is the same object as bool in the Python layer.
+        This instance of `PyTypeObject` represents the Python boolean type; it
+        is the same object as `bool` in the Python layer.
 
         References:
         - https://docs.python.org/3.10/c-api/bool.html#c.PyBool_Type
@@ -2435,7 +2435,7 @@ struct CPython(Defaultable, Movable):
         return self._PyBool_Type
 
     fn PyBool_Check(self, obj: PyObjectPtr) -> c_int:
-        """Return true if o is of type PyBool_Type. This function always
+        """Return true if `obj` is of type `PyBool_Type`. This function always
         succeeds.
 
         Note: this a C macro in the Python C API.
@@ -2463,10 +2463,10 @@ struct CPython(Defaultable, Movable):
     # ===-------------------------------------------------------------------===#
 
     fn PyFloat_Type(self) -> PyTypeObjectPtr:
-        """The PyFloat_Type Object.
+        """The `PyFloat_Type` Object.
 
-        This instance of PyTypeObject represents the Python floating loint
-        type. This is the same object as float in the Python layer.
+        This instance of `PyTypeObject` represents the Python floating point
+        type. This is the same object as `float` in the Python layer.
 
         References:
         - https://docs.python.org/3.10/c-api/float.html#c.PyFloat_Type
@@ -2474,8 +2474,8 @@ struct CPython(Defaultable, Movable):
         return self._PyFloat_Type
 
     fn PyFloat_Check(self, obj: PyObjectPtr) -> c_int:
-        """Return true if its argument is a PyFloatObject or a subtype of
-        PyFloatObject. This function always succeeds.
+        """Return true if its argument is a `PyFloatObject` or a subtype of
+        `PyFloatObject`. This function always succeeds.
 
         Note: this a C macro in the Python C API.
 
@@ -2486,8 +2486,8 @@ struct CPython(Defaultable, Movable):
         return self.PyObject_TypeCheck(obj, self._PyFloat_Type)
 
     fn PyFloat_CheckExact(self, obj: PyObjectPtr) -> c_int:
-        """Return true if its argument is a PyFloatObject, but not a subtype of
-        PyFloatObject. This function always succeeds.
+        """Return true if its argument is a `PyFloatObject`, but not a subtype of
+        `PyFloatObject`. This function always succeeds.
 
         Note: this a C macro in the Python C API.
 

--- a/mojo/stdlib/stdlib/python/_cpython.mojo
+++ b/mojo/stdlib/stdlib/python/_cpython.mojo
@@ -1365,6 +1365,7 @@ struct CPython(Defaultable, Movable):
     var _PyLong_Type: PyTypeObjectPtr
     # Boolean Objects
     var _PyBool_FromLong: PyBool_FromLong.type
+    var _PyBool_Type: PyTypeObjectPtr
     # Floating-Point Objects
     var _PyFloat_FromDouble: PyFloat_FromDouble.type
     var _PyFloat_AsDouble: PyFloat_AsDouble.type
@@ -1547,6 +1548,10 @@ struct CPython(Defaultable, Movable):
         )
         # Boolean Objects
         self._PyBool_FromLong = PyBool_FromLong.load(self.lib)
+        self._PyBool_Type = PyTypeObjectPtr(
+            # PyTypeObject PyBool_Type
+            self.lib.get_symbol[PyTypeObject]("PyBool_Type")
+        )
         # Floating-Point Objects
         self._PyFloat_FromDouble = PyFloat_FromDouble.load(self.lib)
         self._PyFloat_AsDouble = PyFloat_AsDouble.load(self.lib)
@@ -2364,6 +2369,16 @@ struct CPython(Defaultable, Movable):
         - https://docs.python.org/3/c-api/bool.html#c.PyBool_FromLong
         """
         return self._PyBool_FromLong(value)
+
+    fn PyBool_Check(self, obj: PyObjectPtr) -> Bool:
+        """Return True if the `obj` is a boolean.
+
+        References:
+        - https://docs.python.org/3.13/c-api/bool.html#c.PyBool_Check
+        - https://github.com/python/cpython/blob/main/Include/boolobject.h
+        """
+        # Note: this a C macro in the Python C API.
+        return self.Py_TYPE(obj) == self._PyBool_Type
 
     # ===-------------------------------------------------------------------===#
     # Floating-Point Objects

--- a/mojo/stdlib/test/python/test_python_cpython.mojo
+++ b/mojo/stdlib/test/python/test_python_cpython.mojo
@@ -192,6 +192,12 @@ def _test_floating_point_object_api(cpy: CPython):
     var f = cpy.PyFloat_FromDouble(3.14)
     assert_true(f)
     assert_equal(cpy.PyFloat_AsDouble(f), 3.14)
+    assert_true(cpy.PyFloat_Check(f))
+    assert_true(cpy.PyFloat_CheckExact(f))
+
+    var none = cpy.Py_None()
+    assert_false(cpy.PyFloat_Check(none))
+    assert_false(cpy.PyFloat_CheckExact(none))
 
 
 def _test_unicode_object_api(cpy: CPython):

--- a/mojo/stdlib/test/python/test_python_cpython.mojo
+++ b/mojo/stdlib/test/python/test_python_cpython.mojo
@@ -161,10 +161,16 @@ def _test_integer_object_api(cpy: CPython):
     var n = cpy.PyLong_FromSsize_t(-42)
     assert_true(n)
     assert_equal(cpy.PyLong_AsSsize_t(n), -42)
+    assert_true(cpy.PyLong_Check(n))
+    assert_true(cpy.PyLong_CheckExact(n))
 
     var z = cpy.PyLong_FromSize_t(57)
     assert_true(z)
     assert_equal(cpy.PyLong_AsSsize_t(z), 57)
+
+    var none = cpy.Py_None()
+    assert_false(cpy.PyLong_Check(none))
+    assert_false(cpy.PyLong_CheckExact(none))
 
 
 def _test_boolean_object_api(cpy: CPython):

--- a/mojo/stdlib/test/python/test_python_cpython.mojo
+++ b/mojo/stdlib/test/python/test_python_cpython.mojo
@@ -177,10 +177,15 @@ def _test_boolean_object_api(cpy: CPython):
     var t = cpy.PyBool_FromLong(1)
     assert_true(t)
     assert_equal(cpy.PyObject_IsTrue(t), 1)
+    assert_true(cpy.PyBool_Check(t))
 
     var f = cpy.PyBool_FromLong(0)
     assert_true(f)
     assert_equal(cpy.PyObject_IsTrue(f), 0)
+    assert_true(cpy.PyBool_Check(t))
+
+    var none = cpy.Py_None()
+    assert_false(cpy.PyBool_Check(none))
 
 
 def _test_floating_point_object_api(cpy: CPython):

--- a/mojo/stdlib/test/python/test_python_cpython.mojo
+++ b/mojo/stdlib/test/python/test_python_cpython.mojo
@@ -15,9 +15,12 @@ from python import Python
 from python._cpython import (
     CPython,
     Py_eval_input,
+    Py_file_input,
     Py_ssize_t,
     PyMethodDef,
     PyObjectPtr,
+    Py_TPFLAGS_LONG_SUBCLASS,
+    Py_TPFLAGS_LIST_SUBCLASS,
 )
 from testing import (
     assert_equal,
@@ -157,12 +160,40 @@ def _test_type_object_api(cpy: CPython):
     assert_true(cpy.PyType_GetName(dict_type))
 
 
+def _helper_instantiate_derived_class(
+    base_class: String, cpy: CPython
+) -> PyObjectPtr:
+    """Create a derived class from one of the basic types and 
+    then instantiate it.
+    """
+    # Setup the environment for PyRun_String.
+    var test_mod = cpy.PyModule_Create("test_mod")
+    var globals = cpy.PyDict_New()
+    var locals = cpy.PyModule_GetDict(test_mod)
+    # Create a derived class.
+    #
+    # Note: the second argument must be Py_file_input otherwise the
+    # result is NULL.
+    _ = cpy.PyRun_String(
+        "class D({}):\n    pass\n\n".format(base_class),
+        Py_file_input,
+        globals,
+        locals,
+    )
+    # Get a handle to the constructor we have just created.
+    var constructor = cpy.PyObject_GetAttrString(test_mod, "D")
+    # We need to pass in some arguments from the newly defined constructor.
+    var args = cpy.PyTuple_New(0)
+    return cpy.PyObject_CallObject(constructor, args)
+
+
 def _test_integer_object_api(cpy: CPython):
     var n = cpy.PyLong_FromSsize_t(-42)
     assert_true(n)
     assert_equal(cpy.PyLong_AsSsize_t(n), -42)
     assert_true(cpy.PyLong_Check(n))
     assert_true(cpy.PyLong_CheckExact(n))
+    assert_true(cpy.PyObject_TypeCheck(n, cpy.PyLong_Type()))
 
     var z = cpy.PyLong_FromSize_t(57)
     assert_true(z)
@@ -172,17 +203,24 @@ def _test_integer_object_api(cpy: CPython):
     assert_false(cpy.PyLong_Check(none))
     assert_false(cpy.PyLong_CheckExact(none))
 
+    # Derive a class from int to be able to test some more the Check* API.
+    var instantiated = _helper_instantiate_derived_class("int", cpy)
+    assert_true(cpy.PyLong_Check(instantiated))
+    assert_false(cpy.PyLong_CheckExact(instantiated))
+
 
 def _test_boolean_object_api(cpy: CPython):
     var t = cpy.PyBool_FromLong(1)
     assert_true(t)
     assert_equal(cpy.PyObject_IsTrue(t), 1)
     assert_true(cpy.PyBool_Check(t))
+    assert_true(cpy.PyObject_TypeCheck(t, cpy.PyBool_Type()))
 
     var f = cpy.PyBool_FromLong(0)
     assert_true(f)
     assert_equal(cpy.PyObject_IsTrue(f), 0)
     assert_true(cpy.PyBool_Check(t))
+    assert_true(cpy.PyObject_TypeCheck(t, cpy.PyBool_Type()))
 
     var none = cpy.Py_None()
     assert_false(cpy.PyBool_Check(none))
@@ -194,10 +232,15 @@ def _test_floating_point_object_api(cpy: CPython):
     assert_equal(cpy.PyFloat_AsDouble(f), 3.14)
     assert_true(cpy.PyFloat_Check(f))
     assert_true(cpy.PyFloat_CheckExact(f))
+    assert_true(cpy.PyObject_TypeCheck(f, cpy.PyFloat_Type()))
 
     var none = cpy.Py_None()
     assert_false(cpy.PyFloat_Check(none))
     assert_false(cpy.PyFloat_CheckExact(none))
+    # Derive a class from float to be able to test some more the Check* API.
+    var instantiated = _helper_instantiate_derived_class("float", cpy)
+    assert_true(cpy.PyFloat_Check(instantiated))
+    assert_false(cpy.PyFloat_CheckExact(instantiated))
 
 
 def _test_unicode_object_api(cpy: CPython):

--- a/mojo/stdlib/test/python/test_python_cpython.mojo
+++ b/mojo/stdlib/test/python/test_python_cpython.mojo
@@ -163,7 +163,7 @@ def _test_type_object_api(cpy: CPython):
 def _helper_instantiate_derived_class(
     base_class: String, cpy: CPython
 ) -> PyObjectPtr:
-    """Create a derived class from one of the basic types and 
+    """Create a derived class from one of the basic types and
     then instantiate it.
     """
     # Setup the environment for PyRun_String.


### PR DESCRIPTION
When writing a Mojo module to interface with Python it is useful to be able to check the types of the input arguments.

This PR adds some missing APIs to check the type of PythonObject. The initial implementation handles boolean and long.
