### PR TITLE
[stdlib] Add x y z setters to dim

### DIFF
--- a/mojo/stdlib/stdlib/gpu/host/dim.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/dim.mojo
@@ -193,3 +193,36 @@ struct Dim(Stringable, Writable):
             The value of the x dimension.
         """
         return self[0]
+
+    fn set_z[T: Indexer](mut self, z: T):
+        """Sets the z dimension.
+
+        Parameters:
+            T: An indexer type infered from the argument.
+
+        Args:
+            z: The value for the z dimension.
+        """
+        self._value[2] = index(z)
+
+    fn set_y[T: Indexer](mut self, y: T):
+        """Sets the y dimension.
+
+        Parameters:
+            T: An indexer type infered from the argument.
+
+        Args:
+            y: The value for the y dimension.
+        """
+        self._value[1] = index(y)
+
+    fn set_x[T: Indexer](mut self, x: T):
+        """Sets the x dimension.
+
+        Parameters:
+            T: An indexer type infered from the argument.
+
+        Args:
+            x: The value for the x dimension.
+        """
+        self._value[0] = index(x)

--- a/mojo/stdlib/test/gpu/host/BUILD.bazel
+++ b/mojo/stdlib/test/gpu/host/BUILD.bazel
@@ -1,0 +1,25 @@
+load("//bazel:api.bzl", "mojo_test")
+
+[
+    mojo_test(
+        name = src + ".test",
+        size = "large",
+        srcs = [src],
+        tags = ["gpu"],
+        target_compatible_with = ["//:has_gpu"] + select({
+            "@platforms//os:macos": ["@platforms//:incompatible"],  # FIXME MOCO-2509
+            "//conditions:default": [],
+        }),
+        deps = [
+            "@mojo//:stdlib",
+            "@mojo//:test_utils",
+        ],
+    )
+    for src in glob(["*.mojo"])
+]
+
+filegroup(
+    name = "test-sources",
+    srcs = glob(["**/*.mojo"]),
+    visibility = ["//utils/debugging/gpu-build-benchmarking:__subpackages__"],
+)

--- a/mojo/stdlib/test/gpu/host/test_dim.mojo
+++ b/mojo/stdlib/test/gpu/host/test_dim.mojo
@@ -1,0 +1,29 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from testing import assert_equal, TestSuite
+from gpu.host import Dim
+
+
+def test_dim_set_x_y_z():
+    var dim: Dim = (10, 20, 30)
+    dim.set_x(40)
+    dim.set_y(50)
+    dim.set_z(60)
+    assert_equal(dim.x(), 40)
+    assert_equal(dim.y(), 50)
+    assert_equal(dim.z(), 60)
+
+
+def main():
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Adds setters to the DIm struct similar to what we can do with the `dim3` struct from cuda.

An alternative is via function overload: `fn [...]x(self, value: T)`. Let me know if there is a preference.