### PR TITLE
[stdlib] Fix test_sub assertions to match Counter operator behavior

### DIFF
--- a/mojo/stdlib/test/collections/test_counter.mojo
+++ b/mojo/stdlib/test/collections/test_counter.mojo
@@ -372,7 +372,7 @@ def test_sub():
 
     assert_equal(c3["a"], 3)
     assert_equal(c3["b"], 4)
-    # assert_equal(c3["c"], -3)  # TODO(MSTDL-1920): fix this
+    assert_equal(c3["c"], 0)
 
     # Check that the original counters are not modified
     assert_equal(c1["a"], 4)
@@ -381,8 +381,8 @@ def test_sub():
 
     c2 -= c1
 
-    # assert_equal(c2["a"], -3)  # TODO(MSTDL-1920): fix this
-    # assert_equal(c2["b"], -4)  # TODO(MSTDL-1920): fix this
+    assert_equal(c2["a"], 0)
+    assert_equal(c2["b"], 0)
     assert_equal(c2["c"], 3)
 
 


### PR DESCRIPTION
## Description
This PR fixes the failing test assertions in `test_sub` that were marked with TODO(MSTDL-1920).

## Issue
Fixes #5408 
https://github.com/modular/modular/issues/5408

## Changes
- Update test_sub assertions to expect 0 instead of negative values
- The `__sub__` and `__isub__` operators correctly remove non-positive counts as documented
