### PR TITLE
fix: make `--enable-structured-output` work again

### DIFF
--- a/max/pipelines/lib/sampling/sampling.py
+++ b/max/pipelines/lib/sampling/sampling.py
@@ -86,8 +86,10 @@ def _sampling_input_types(
 
     # If we have structured_outputs enabled
     if sampling_config.enable_structured_output:
+        # Use separate symbolic dimension to avoid conflicts with logits' vocab_size
+        # since llguidance creates 32-bit aligned bitmasks.
         bitmask_type = TensorType(
-            DType.bool, ["batch", "vocab_size"], device=device
+            DType.bool, ["batch", "vocab_size_structured"], device=device
         )
         inputs["bitmask"] = bitmask_type
 
@@ -214,6 +216,9 @@ def token_sampler(
 
         if "bitmask" in _input_dict:
             bitmask = graph.inputs[list(_input_dict).index("bitmask")].tensor
+            # removes llguidance alignment padding
+            if logits.shape[1] != bitmask.shape[1]:
+                bitmask = bitmask[:, :logits.shape[1]]
             logits = ops.where(
                 bitmask,
                 logits,

--- a/max/pipelines/lib/sampling/sampling_logits_processor.py
+++ b/max/pipelines/lib/sampling/sampling_logits_processor.py
@@ -188,8 +188,12 @@ class FusedSamplingProcessor:
         logits = inputs.logits
         logit_offsets = inputs.logit_offsets
         tensor_bitmask = None
-        if self.bitmask is not None and self.step_counter > 0:
-            raise ValueError("A new bitmask must be provided for each step.")
+        if self.bitmask is not None:
+            if self.step_counter == 0:
+                # Create tensor from bitmask (llguidance padding will be handled in graph)
+                tensor_bitmask = Tensor.from_numpy(self.bitmask.astype(np.bool_)).to(self.device)
+            elif self.step_couter > 0:
+                raise ValueError("A new bitmask must be provided for each step.")
 
         new_tokens, new_generated_tokens, new_seed = _sample_logits(
             self.sampler,


### PR DESCRIPTION
draft attempt to fix issue #5497 

We are fixing 2 things:

1. provide an initial bitmask tensor
2. handle the difference between model's vocab_size and llguiadance's vocab_size (which is 32-bit aligned). For example, for gemma3-27b-it, model's vocab_size is 262145, while llguiadance pad the bitmask to 262176. This may result problem for the graph compiling/capturing