### PR TITLE
[stdlib] [BUG] Fix incorrect unrecognized `Vendor` value

### DIFF
--- a/mojo/stdlib/stdlib/gpu/host/info.mojo
+++ b/mojo/stdlib/stdlib/gpu/host/info.mojo
@@ -256,8 +256,10 @@ struct Vendor(Identifiable, Writable):
             return
         if self is Vendor.APPLE_GPU:
             writer.write("apple_gpu")
+            return
         if self is Vendor.NVIDIA_GPU:
             writer.write("nvidia_gpu")
+            return
 
         abort("unable to format unrecognized `Vendor` value")
 


### PR DESCRIPTION
Vendor.write_to was missing returns for some
of the if statements.

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
