### PR TITLE
[stdlib] Enable Python module-level Mojo imports

### DIFF
--- a/mojo/docs/manual/python/mojo-from-python.mdx
+++ b/mojo/docs/manual/python/mojo-from-python.mdx
@@ -19,13 +19,12 @@ work in progress. See below for [known limitations](#known-limitations).
 
 :::
 
-## Import a Mojo module in Python
+## Import a simple Mojo module in Python
 
-To illustrate what calling Mojo from Python looks like, we'll start with a
-simple example, and then dig into the details of how it works and what is
-possible today.
+We'll start with a simple example, what calling Mojo from Python looks like
+and then dig into the details of how it works and what is possible today.
 
-Consider a project with the following structure:
+Consider the following directory structure of a simple project:
 
 ```text
 project
@@ -33,36 +32,39 @@ project
 └── 🔥 mojo_module.mojo
 ```
 
-The main entrypoint is a Python program called `main.py`, and the Mojo code
-includes functions to call from Python.
+The main Python entrypoint is called `main.py`. The Mojo code in
+`mojo_module.mojo` includes a function that we want to call from Python.
 
-For example, let's say we want a Mojo function to take a Python value as an
-argument:
-
-```mojo title="mojo_module.mojo"
-fn factorial(py_obj: PythonObject) raises -> Python
-    var n = Int(py_obj)
-    return math.factorial(n)
-```
-
-And we want to call it from Python like this:
-
-```python title="main.py"
+```python title="Python Entrypoint"
 import mojo_module
 
 print(mojo_module.factorial(5))
 ```
 
-However, before we can call the Mojo function from Python, we must declare it
-so Python knows it exists.
+In Mojo we define a function to take a Python value as an argument:
 
-Because Python is trying to load `mojo_module`, it looks for a function called
-`PyInit_mojo_module()`. (If our file was called `foo.mojo`, the function Python
-looked for would be `PyInit_foo()`.) Within the `PyInit_mojo_module()`, we must
-declare all Mojo functions and types that are callable from Python using
+```mojo title="Mojo Function"
+fn factorial(py_obj: PythonObject) raises -> Python
+    var n = Int(py_obj)
+    return math.factorial(n)
+```
+
+Before we can call the Mojo function from Python, we must declare and export
+it to Python.
+
+Python is trying to load `mojo_module`, it looks for a function called
+`PyInit_mojo_module()`. Within the `PyInit_mojo_module()`, we declare all
+Mojo functions and types that are callable from Python using
 [`PythonModuleBuilder`](/mojo/stdlib/python/bindings/PythonModuleBuilder).
 
-So the complete Mojo code looks like this:
+:::note
+
+If the Mojo file is called `foo.mojo`, the Python initializer must be
+named `PyInit_foo()`.
+
+:::
+
+The complete Mojo code looks like this:
 
 ```mojo title="mojo_module.mojo"
 from python import PythonObject
@@ -100,7 +102,7 @@ import mojo_module
 print(mojo_module.factorial(5))
 ```
 
-That's it! Try it:
+That's it! Try to call it from Python:
 
 ```sh
 python main.py
@@ -110,10 +112,72 @@ python main.py
 120
 ```
 
-### How it works
+## Packaged Python Mojo module extensions
+
+Mojo extensoins can be shipped with Python packages using the `mojo.import` hook. The
+modules are built in user-space at runtime to leverage Mojo's system-specific
+hardware optimization. This requires a runtime dependency to the
+[Mojo](https://pypi.org/project/mojo/) package.
+
+Add the dependency to the project's `pyproject.toml`:
+
+```toml title="pyproject.toml`
+[project]
+name = "awesome-project"
+version = "0.1.0"
+description = "Python project packaging Mojo extension"
+authors = [
+    { name = "Joe", email = "doe@modular.com" }
+]
+requires-python = ">=3.12"
+dependencies = [
+    "mojo"
+]
+```
+
+The package structure can includes the `.mojo` extension files.
+
+:::warning
+
+The extension is compiled at runtime.
+The package directory must be writeable by the user.
+
+:::
+
+```text
+awesome-project/
+├── pyproject.toml
+└── src
+    └── awesome_project
+        ├── __init__.py
+        └── mojo_module.mojo
+```
+
+The module-level `__init__.py` file can include the lightweight wrapper code
+to expose the Mojo extension to Python.
+
+```python title="__init__.py"
+import mojo.importer  # ignore: F401
+
+from awesome_project import mojo_module
+
+def factorial(number: int) -> int:
+    return mojo_module.factorial(number)
+```
+
+The module can be exposed to the user without worrying about import hooks and
+the underlying Mojo code.
+
+```python
+from awesome_package import factorial
+
+factorial(5)
+```
+
+### How the Mojo import works
 
 Python supports a standard mechanism called [Python extension
-modules](https://docs.python.org/3/extending/extending.html) that enables
+modules](https://docs.python.org/3/extending/extending.html) enabling
 compiled languages (like Mojo, C, C++, or Rust) to make themselves callable
 from Python in an intuitive way. Concretely, a Python extension module is
 simply a dynamic library that defines a suitable `PyInit_*()` function.
@@ -130,7 +194,7 @@ project
 ├── main.py
 ├── mojo_module.mojo
 └── __mojocache__
-    └── mojo_module.hash-ABC123.so
+    └── mojo_module.<hash>.so
 ```
 
 Loading `mojo.importer` loads our Python Mojo [import

--- a/mojo/python/mojo/importer.py
+++ b/mojo/python/mojo/importer.py
@@ -12,13 +12,14 @@
 # ===----------------------------------------------------------------------=== #
 
 import hashlib
-import logging
-import os
 import subprocess
 import sys
 from collections.abc import Sequence
+from importlib.abc import MetaPathFinder
+from importlib.machinery import ModuleSpec
 from importlib.util import spec_from_file_location
 from pathlib import Path
+from typing import ClassVar
 
 from .paths import MojoCompilationError, MojoModulePath, find_mojo_module_in_dir
 from .run import subprocess_run_mojo
@@ -30,9 +31,13 @@ from .run import subprocess_run_mojo
 
 def _calculate_mojo_source_hash(mojo_dir: Path) -> str:
     """Calculates a truncated SHA256 hash of all .mojo/.🔥 files in a directory."""
+    if not mojo_dir.is_dir():
+        raise ImportError(
+            f"Expected mojo_dir to be a directory, got: {mojo_dir}"
+        )
+
     # Find all .mojo and .🔥 files recursively
     source_files = sorted((*mojo_dir.rglob("*.mojo"), *mojo_dir.rglob("*.🔥")))
-
     if not source_files:
         # This should be unreachable if the caller validates that mojo_dir
         # contains Mojo source files before calling this function.
@@ -44,14 +49,12 @@ def _calculate_mojo_source_hash(mojo_dir: Path) -> str:
     for file_path in source_files:
         try:
             # Add file path to hash to distinguish identical content in different files
-            hasher.update(str(file_path.relative_to(mojo_dir)).encode("utf-8"))
-            # Add file content to hash
-            with open(file_path, "rb") as f:
-                hasher.update(f.read())
-        except (ValueError, UnicodeError, OSError) as e:
+            hasher.update(str(file_path.relative_to(mojo_dir)).encode())
+            hasher.update(file_path.read_bytes())
+        except (ValueError, UnicodeError, OSError) as exc:
             raise ImportError(
                 f"Could not process Mojo source file '{file_path}' for hashing"
-            ) from e
+            ) from exc
 
     # Return only the first 16 characters of the hex digest, since the full
     # hash is quite long and this is just a best-effort heuristic to check for
@@ -61,12 +64,16 @@ def _calculate_mojo_source_hash(mojo_dir: Path) -> str:
 
 def _compile_mojo_to_so(root_mojo_path: Path, output_so_path: Path) -> None:
     """Compiles a Mojo file to a shared object library."""
-    # Assertions from _build_mojo_file_to_python_extension_module
-    assert root_mojo_path.is_file()
-    assert output_so_path.suffix == ".so"
+    if not root_mojo_path.is_file():
+        raise ImportError(
+            f"Expected root_mojo_path to be a file, got: {root_mojo_path}"
+        )
+    if not output_so_path.suffix == ".so":
+        raise ImportError(
+            f"Expected output_so_path to have .so suffix, got: {output_so_path}"
+        )
 
     mojo_cli_args = [
-        # First arg is implicitly the `mojo` executable (handled by subprocess_run_mojo)
         "build",
         str(root_mojo_path),
         "--emit",
@@ -76,112 +83,113 @@ def _compile_mojo_to_so(root_mojo_path: Path, output_so_path: Path) -> None:
     ]
 
     try:
-        # Run the `mojo` that's embedded in the `max` package layout via subprocess_run_mojo.
         subprocess_run_mojo(mojo_cli_args, capture_output=True, check=True)
-    except subprocess.CalledProcessError as e:
+    except subprocess.CalledProcessError as exc:
         error = MojoCompilationError.from_subprocess_error(
-            root_mojo_path, mojo_cli_args, e
+            root_mojo_path, mojo_cli_args, exc
         )
-        logging.error(str(error))
-        # Propagate compilation errors as ImportError
         raise ImportError(
             "Import of Mojo module failed due to compilation error."
         ) from error
-    except FileNotFoundError:
-        # Handle case where mojo executable is not found
+    except FileNotFoundError as exc:
         raise ImportError(
             "Mojo executable not found via subprocess_run_mojo."
-        ) from None
+        ) from exc
 
 
 # TODO: Instead of being careful about only deleting old files, we could just
 #   delete all files in the cache directory?
-def _delete_matching_cached_files(
-    cache_dir: Path, *, stem: str, ext: str
+def _delete_old_cached_files(
+    cache_dir: Path,
+    stem: str,
+    extension: str = "so",
 ) -> None:
     """Removes outdated cache files for a given Mojo module."""
     if not cache_dir.is_dir():
         return
 
-    for old_cache_file in cache_dir.glob(f"{stem}.*.{ext}"):
-        os.remove(old_cache_file)
+    for old_cache_file in cache_dir.glob(f"{stem}.*.{extension}"):
+        old_cache_file.unlink(missing_ok=True)
 
 
 # ---------------------------------------
-# Define custom importer
+# Define custom Mojo importer
 # ---------------------------------------
-
-
 # Resources:
 #    https://docs.python.org/3/reference/import.html#the-meta-path
 #    https://docs.python.org/3/library/importlib.html#importlib.abc.MetaPathFinder.find_spec
 #    https://docs.python.org/3/library/importlib.html#importlib.machinery.ExtensionFileLoader
 #    https://peps.python.org/pep-0489/#module-creation-phase
-class MojoImporter:
-    def find_spec(  # noqa: ANN201
+class MojoImporter(MetaPathFinder):
+    caches: ClassVar[list[Path]] = []
+
+    def find_spec(
         self,
         name: str,
         import_path: Sequence[str] | None,
         target: object | None,
-    ):
-        # This importer only handles top-level imports. `import foo.bar` is not
-        # supported.
-        if "." in name or import_path is not None:
-            return None
+    ) -> ModuleSpec | None:
+        search_path = import_path if import_path else sys.path
 
         mojo_module: MojoModulePath | None = None
-        # Search sys.path for the Mojo source file or package
-        for path_entry in sys.path:
-            # Use the helper function to check this directory
-            mojo_module = find_mojo_module_in_dir(Path(path_entry), name)
-
+        for path_entry in search_path:
+            mojo_module = find_mojo_module_in_dir(
+                dir_path=Path(path_entry),
+                module_name=name.split(".")[-1],
+            )
             if mojo_module:
-                break  # Found the source, stop searching sys.path
+                break
 
         # If no Mojo source found, let other importers handle it.
         if not mojo_module:
             return None
 
-        # `root_mojo_path` is the path to the specific Mojo source file.
-        root_mojo_path = mojo_module.path
+        mojo_source_path = mojo_module.path
+        mojo_source_dir = mojo_source_path.parent
 
-        # `mojo_dir` is the directory containing the Mojo source file(s); it is
-        # the directory that will be hashed to check for changes.
-        mojo_dir = root_mojo_path.parent
+        cache_dir = mojo_source_dir / "__mojocache__"
+        source_file_hash = _calculate_mojo_source_hash(mojo_source_dir)
 
-        # Determine cache location and directory to hash
-        cache_dir = mojo_dir / "__mojocache__"
-
-        # Calculate hash.
-        current_hash = _calculate_mojo_source_hash(mojo_dir)
-
-        expected_cache_file = (
-            cache_dir / f"{root_mojo_path.stem}.hash-{current_hash}.so"
+        mojo_extension = (
+            cache_dir / f"{mojo_source_path.stem}.{source_file_hash}.so"
         )
 
-        # Compile if cache doesn't exist or is invalid
-        if not expected_cache_file.is_file():
-            # No matching cached file exists, so compile the Mojo source file.
-            os.makedirs(cache_dir, exist_ok=True)
-            # Delete any non-matching cached .so's, to prevent the number of
-            # stale cached files from growing without bound.
-            _delete_matching_cached_files(
-                cache_dir, stem=root_mojo_path.stem, ext="so"
+        if not mojo_extension.is_file():
+            cache_dir.mkdir(exist_ok=True)
+            _delete_old_cached_files(
+                cache_dir,
+                stem=mojo_source_path.stem,
+                extension="so",
             )
-            _compile_mojo_to_so(root_mojo_path, expected_cache_file)
+            _compile_mojo_to_so(mojo_source_path, mojo_extension)
 
-        # If we reach here, expected_cache_file should exist (either pre-existing or just compiled)
-        assert expected_cache_file.is_file()
+        if not mojo_extension.is_file():
+            raise ImportError(
+                f"Failed to compile Mojo module '{name}' to shared object."
+            )
 
-        # Constructs an ExtensionFileLoader automatically based on the .so
-        # file extension.
+        self.add_cached_file(mojo_extension)
+
+        # Constructs an ExtensionFileLoader based on the compiled .so file extension.
         return spec_from_file_location(
-            name, str(expected_cache_file), submodule_search_locations=None
+            name,
+            str(mojo_extension),
+            submodule_search_locations=None,
         )
+
+    @classmethod
+    def add_cached_file(cls, cache_file: Path) -> None:
+        """Registers a compiled Mojo cached file for future invalidation."""
+        cls.caches.append(cache_file)
+
+    @classmethod
+    def invalidate_caches(cls) -> None:
+        """Invalidates all cached Mojo compiled files."""
+        for cached_file in cls.caches:
+            cached_file.unlink(missing_ok=True)
 
 
 # -------------------------------------------------------
 # Side Effect: Add custom importer to the Python metapath
 # -------------------------------------------------------
-
 sys.meta_path.append(MojoImporter())  # type: ignore


### PR DESCRIPTION
Adds module-level imports to `MojoImporter`.

This enables shipping Python packages with mojo code, where the package only needs a runtime dependency on the Mojo package.

```python
from awesome_package.extensions.mojo import factorial

factorial(123)
```

The compiler and hashing logic are the same. The importer will create a `__mojocache__` directory in the module path. I.e. `<package_path>/autumn_package/extensions/mojo/__mojocache__/factorial.ae43a431b521.so`.

* Improved clarity, renamed helper functions and removed implicit comments.
* Replaced `assert` with meaningful `ImportError` raises.
* Implemented `invalidate_caches`, removing compiled Mojo extension.
  https://docs.python.org/3/library/importlib.html#importlib.invalidate_caches
* Compiled files: Removed implicit `hash-` prefix from filename
* Docs: Added documentation of module-level Python imports

