### PR TITLE
[stdlib] Move binary search to `Span`

### DIFF
--- a/mojo/stdlib/stdlib/collections/list.mojo
+++ b/mojo/stdlib/stdlib/collections/list.mojo
@@ -1019,32 +1019,6 @@ struct List[T: Copyable & Movable](
                 return i
         raise "ValueError: Given element is not in list"
 
-    fn _binary_search_index[
-        dtype: DType, //,
-    ](self: List[Scalar[dtype], **_], needle: Scalar[dtype]) -> Optional[UInt]:
-        """Finds the index of `needle` with binary search.
-
-        Args:
-            needle: The value to binary search for.
-
-        Returns:
-            Returns None if `needle` is not present, or if `self` was not
-            sorted.
-
-        Notes:
-            This function will return an unspecified index if `self` is not
-            sorted in ascending order.
-        """
-        var cursor = UInt(0)
-        var b = self._data
-        var length = len(self)
-        while length > 1:
-            var half = length >> 1
-            length -= half
-            cursor += UInt(Int(b[cursor + UInt(half) - 1] < needle) * half)
-
-        return Optional(cursor) if b[cursor] == needle else None
-
     fn clear(mut self):
         """Clears the elements in the list."""
         for i in range(self._len):

--- a/mojo/stdlib/stdlib/collections/string/_unicode.mojo
+++ b/mojo/stdlib/stdlib/collections/string/_unicode.mojo
@@ -43,7 +43,7 @@ fn _to_index[lookup: List[UInt32, **_]](rune: Codepoint) -> Int:
     """Find index of rune in lookup with binary search.
     Returns -1 if not found."""
 
-    var result = materialize[lookup]()._binary_search_index(rune.to_u32())
+    var result = Span(materialize[lookup]())._binary_search_index(rune.to_u32())
 
     if result:
         return Int(result.unsafe_value())
@@ -89,9 +89,9 @@ fn _get_uppercase_mapping(
 
 
 fn _get_lowercase_mapping(char: Codepoint) -> Optional[Codepoint]:
-    var index: Optional[UInt] = materialize[
-        has_lowercase_mapping
-    ]()._binary_search_index(char.to_u32())
+    var index: Optional[UInt] = Span(
+        materialize[has_lowercase_mapping]()
+    )._binary_search_index(char.to_u32())
 
     if index:
         # SAFETY: We just checked that `result` is present.

--- a/mojo/stdlib/stdlib/memory/span.mojo
+++ b/mojo/stdlib/stdlib/memory/span.mojo
@@ -21,6 +21,7 @@ from memory import Span
 """
 
 from builtin._location import __call_location
+from bit._mask import splat
 from collections._index_normalization import normalize_index
 from sys import align_of
 from sys.info import simd_width_of
@@ -783,3 +784,27 @@ struct Span[
             "subspan out of bounds.",
         )
         return Self(ptr=self._data + offset, length=length)
+
+    fn _binary_search_index[
+        dtype: DType, //,
+    ](self: Span[Scalar[dtype], **_], needle: Scalar[dtype]) -> Optional[UInt]:
+        """Finds the index of `needle` with binary search.
+        Args:
+            needle: The value to binary search for.
+        Returns:
+            Returns None if `needle` is not present.
+        Notes:
+            This function will return an unspecified index if `self` is not
+            sorted in ascending order.
+        """
+
+        var cursor = UInt(0)
+        var length = UInt(len(self))
+        var value = needle - Scalar[dtype](1)  # just to make it different
+        while length > 0:
+            var half = length >> UInt(Int(length > 1))
+            length -= half
+            value = self.unsafe_get(cursor + half - 1)
+            cursor += UInt(splat(value < needle)) & half
+
+        return Optional(cursor) if value == needle else None

--- a/mojo/stdlib/test/memory/test_span.mojo
+++ b/mojo/stdlib/test/memory/test_span.mojo
@@ -13,6 +13,7 @@
 
 from testing import TestSuite
 from testing import assert_equal, assert_raises, assert_true
+from math import iota
 
 
 def test_span_list_int():
@@ -348,6 +349,36 @@ def test_unsafe_subspan():
 
     var subspan2 = data.unsafe_subspan(offset=1, length=3)
     assert_equal(List(subspan2), [1, 2, 3])
+
+
+def test_binary_search():
+    def _test[dtype: DType]():
+        alias max_val = Int(Scalar[dtype].MAX)
+        var data = List[Scalar[dtype]](unsafe_uninit_length=max_val + 1)
+        iota(data)
+
+        # make sure we aren't reading an empty pointer
+        var view = Span(data)[:0]
+        assert_true(view._binary_search_index(0) is None)
+        view = Span(data)[:1]
+        assert_true(view._binary_search_index(0))
+        assert_equal(view._binary_search_index(0).value(), 0)
+        view = Span(data)[: len(data) - 1]
+        assert_true(view._binary_search_index(1))
+        assert_equal(view._binary_search_index(1).value(), 1)
+        view = Span(data)
+        assert_true(view._binary_search_index(max_val))
+        assert_equal(view._binary_search_index(max_val).value(), UInt(max_val))
+        view = Span(data)[: len(data) - 1]
+        assert_true(view._binary_search_index(max_val - 1))
+        assert_equal(
+            view._binary_search_index(max_val - 1).value(), UInt(max_val - 1)
+        )
+
+    _test[DType.uint8]()
+    _test[DType.int8]()
+    _test[DType.uint16]()
+    _test[DType.int16]()
 
 
 def main():


### PR DESCRIPTION
Move binary search to `Span`. Closes https://github.com/modular/modular/issues/5372. Split off from  #5381