### PR TITLE
[CI] Use larger runners for linux

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-15"]
+        os: ["large-oss-linux", "macos-15"]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
These jobs were running out of storage
