### PR TITLE
[WIP][stdlib] Update `trait_downcast` to use `UnknownDestructibility`

### DIFF
--- a/mojo/stdlib/stdlib/builtin/rebind.mojo
+++ b/mojo/stdlib/stdlib/builtin/rebind.mojo
@@ -110,7 +110,7 @@ alias downcast[_Trait: type_of(AnyType), T: AnyType] = __mlir_attr[
 
 @always_inline
 fn trait_downcast[
-    T: AnyTrivialRegType, //, Trait: type_of(AnyType)
+    T: AnyTrivialRegType, //, Trait: type_of(UnknownDestructibility)
 ](var src: T) -> downcast[Trait, T]:
     """Downcast a parameter input type `T` and rebind the type such that the
     return value's type conforms the provided `Trait`. If `T`, after resolving
@@ -132,7 +132,7 @@ fn trait_downcast[
 
 @always_inline
 fn trait_downcast[
-    T: AnyType, //, Trait: type_of(AnyType)
+    T: UnknownDestructibility, //, Trait: type_of(UnknownDestructibility)
 ](ref src: T) -> ref [src] downcast[Trait, T]:
     """Downcast a parameter input type `T` and rebind the type such that the
     return value's type conforms the provided `Trait`. If `T`, after resolving

--- a/mojo/stdlib/stdlib/builtin/rebind.mojo
+++ b/mojo/stdlib/stdlib/builtin/rebind.mojo
@@ -44,8 +44,8 @@ fn rebind[
 
 @always_inline("nodebug")
 fn rebind[
-    src_type: AnyType, //,
-    dest_type: AnyType,
+    src_type: UnknownDestructibility, //,
+    dest_type: UnknownDestructibility,
 ](ref src: src_type) -> ref [src] dest_type:
     """Statically assert that a parameter input type `src_type` resolves to the
     same type as a parameter result type `dest_type` after function
@@ -103,7 +103,7 @@ fn rebind_var[
     __mlir_op.`lit.ownership.mark_destroyed`(__get_mvalue_as_litref(src))
 
 
-alias downcast[_Trait: type_of(AnyType), T: AnyType] = __mlir_attr[
+alias downcast[_Trait: type_of(UnknownDestructibility), T: UnknownDestructibility] = __mlir_attr[
     `#kgen.downcast<`, T, `> : `, _Trait
 ]
 

--- a/mojo/stdlib/stdlib/builtin/tuple.mojo
+++ b/mojo/stdlib/stdlib/builtin/tuple.mojo
@@ -27,7 +27,7 @@ from utils._visualizers import lldb_formatter_wrapping_type
 
 
 @lldb_formatter_wrapping_type
-struct Tuple[*element_types: Copyable & Movable](
+struct Tuple[*element_types: Copyable & Movable & AnyType](
     ImplicitlyCopyable, Movable, Sized
 ):
     """The type of a literal tuple expression.
@@ -40,7 +40,7 @@ struct Tuple[*element_types: Copyable & Movable](
 
     alias _mlir_type = __mlir_type[
         `!kgen.pack<:`,
-        VariadicOf[Copyable & Movable],
+        VariadicOf[Copyable & Movable & AnyType],
         element_types,
         `>`,
     ]

--- a/mojo/stdlib/stdlib/collections/deque.mojo
+++ b/mojo/stdlib/stdlib/collections/deque.mojo
@@ -29,7 +29,7 @@ from bit import next_power_of_two
 # ===-----------------------------------------------------------------------===#
 
 
-struct Deque[ElementType: Copyable & Movable](
+struct Deque[ElementType: Copyable & Movable & AnyType](
     Boolable, Copyable, Iterable, Movable, Sized
 ):
     """Implements a double-ended queue.

--- a/mojo/stdlib/stdlib/collections/inline_array.mojo
+++ b/mojo/stdlib/stdlib/collections/inline_array.mojo
@@ -56,7 +56,7 @@ fn _inline_array_construction_checks[size: Int]():
 
 
 struct InlineArray[
-    ElementType: Copyable & Movable,
+    ElementType: Copyable & Movable & AnyType,
     size: Int,
 ](Defaultable, DevicePassable, ImplicitlyCopyable, Movable, Sized):
     """A fixed-size sequence of homogeneous elements where size is a constant

--- a/mojo/stdlib/stdlib/collections/list.mojo
+++ b/mojo/stdlib/stdlib/collections/list.mojo
@@ -33,7 +33,7 @@ from .optional import Optional
 @fieldwise_init
 struct _ListIter[
     mut: Bool, //,
-    T: Copyable & Movable,
+    T: Copyable & Movable & AnyType,
     origin: Origin[mut],
     forward: Bool = True,
 ](ImplicitlyCopyable, Iterable, Iterator, Movable):
@@ -93,7 +93,7 @@ struct _ListIter[
         return (iter_len, {iter_len})
 
 
-struct List[T: Copyable & Movable](
+struct List[T: Copyable & Movable & AnyType](
     Boolable, Copyable, Defaultable, Iterable, Movable, Sized
 ):
     """A dynamically-allocated and resizable list.

--- a/mojo/stdlib/stdlib/memory/memory.mojo
+++ b/mojo/stdlib/stdlib/memory/memory.mojo
@@ -246,7 +246,7 @@ fn _memcpy_impl(
     " keyword-only arguments version instead."
 )
 fn memcpy[
-    T: AnyType,
+    T: UnknownDestructibility,
     __disambiguate: NoneType = None,
 ](
     dest: UnsafePointer[T, mut=True, origin=_],
@@ -258,7 +258,7 @@ fn memcpy[
 
 @always_inline
 fn memcpy[
-    T: AnyType
+    T: UnknownDestructibility
 ](
     *,
     dest: UnsafePointer[T, mut=True, origin=_],
@@ -475,7 +475,7 @@ fn stack_allocation[
 
 @always_inline
 fn _malloc[
-    type: AnyType,
+    type: UnknownDestructibility,
     /,
 ](
     size: Int,

--- a/mojo/stdlib/stdlib/memory/pointer.mojo
+++ b/mojo/stdlib/stdlib/memory/pointer.mojo
@@ -179,7 +179,7 @@ compatibility and will be removed in a future release."""
 @register_passable("trivial")
 struct Pointer[
     mut: Bool, //,
-    type: AnyType,
+    type: UnknownDestructibility,
     origin: Origin[mut],
     address_space: AddressSpace = AddressSpace.GENERIC,
 ](ImplicitlyCopyable, Movable, Stringable):

--- a/mojo/stdlib/stdlib/memory/span.mojo
+++ b/mojo/stdlib/stdlib/memory/span.mojo
@@ -81,7 +81,7 @@ struct _SpanIter[
 @register_passable("trivial")
 struct Span[
     mut: Bool, //,
-    T: Copyable & Movable,
+    T: Copyable & Movable & AnyType,
     origin: Origin[mut],
     *,
     address_space: AddressSpace = AddressSpace.GENERIC,

--- a/mojo/stdlib/stdlib/python/python_object.mojo
+++ b/mojo/stdlib/stdlib/python/python_object.mojo
@@ -22,6 +22,7 @@ from python import PythonObject
 from os import abort
 from sys.ffi import c_double, c_long, c_size_t, c_ssize_t
 from sys.intrinsics import _unsafe_aliasing_address_to_pointer
+from builtin.rebind import downcast
 
 from compile.reflection import get_type_name
 

--- a/mojo/stdlib/stdlib/sys/info.mojo
+++ b/mojo/stdlib/stdlib/sys/info.mojo
@@ -878,7 +878,7 @@ fn simd_byte_width[target: _TargetType = _current_target()]() -> Int:
 
 
 @always_inline("nodebug")
-fn size_of[type: AnyType, target: _TargetType = _current_target()]() -> Int:
+fn size_of[type: UnknownDestructibility, target: _TargetType = _current_target()]() -> Int:
     """Returns the size of (in bytes) of the type.
 
     Parameters:
@@ -908,7 +908,7 @@ fn size_of[type: AnyType, target: _TargetType = _current_target()]() -> Int:
         `#kgen.param.expr<rebind, #kgen.type<!kgen.param<`,
         type,
         `>> : `,
-        AnyType,
+        UnknownDestructibility,
         `> : !kgen.type`,
     ]
     return Int(
@@ -945,7 +945,7 @@ fn size_of[dtype: DType, target: _TargetType = _current_target()]() -> Int:
 
 
 @always_inline("nodebug")
-fn align_of[type: AnyType, target: _TargetType = _current_target()]() -> Int:
+fn align_of[type: UnknownDestructibility, target: _TargetType = _current_target()]() -> Int:
     """Returns the align of (in bytes) of the type.
 
     Parameters:
@@ -959,7 +959,7 @@ fn align_of[type: AnyType, target: _TargetType = _current_target()]() -> Int:
         `#kgen.param.expr<rebind, #kgen.type<!kgen.param<`,
         type,
         `>> : `,
-        AnyType,
+        UnknownDestructibility,
         `> : !kgen.type`,
     ]
     return Int(

--- a/mojo/stdlib/stdlib/utils/variant.mojo
+++ b/mojo/stdlib/stdlib/utils/variant.mojo
@@ -20,7 +20,7 @@ from sys.intrinsics import _type_is_eq
 # ===----------------------------------------------------------------------=== #
 
 
-struct Variant[*Ts: Copyable & Movable](ImplicitlyCopyable, Movable):
+struct Variant[*Ts: Copyable & Movable & AnyType](ImplicitlyCopyable, Movable):
     """A union that can hold a runtime-variant value from a set of predefined
     types.
 


### PR DESCRIPTION
Enable the use of linear types in trait downcasting, opening the door for collections to hold linear types.
