### PR TITLE
Enhanced Mojo notebook magic for returning any Python object (SVG, DataFrames, etc.)

### DIFF
--- a/mojo/proposals/unsafe-pointer-v2.md
+++ b/mojo/proposals/unsafe-pointer-v2.md
@@ -63,15 +63,32 @@ The proposal introduces a new `UnsafePointerV2` type that corrects these issues
 and provides a migration path. During transition, `v1` and `v2` pointers will
 support implicit conversions to avoid breaking existing code.
 
----
+## `UnsafePointer` API (current)
+
+```mojo
+@register_passable("trivial")
+struct UnsafePointer[
+    type: AnyType,
+    *,
+    address_space: AddressSpace = AddressSpace.GENERIC,
+    mut: Bool = True,  # ⚠️ Defaulted to mutable
+    origin: Origin[mut] = Origin[mut].cast_from[MutableAnyOrigin],  # ⚠️ Defaulted to AnyOrigin
+]:
+    ...
+```
+
+**Issues:**
+- `mut` defaults to `True`, making pointers mutable by default
+- `origin` defaults to `MutableAnyOrigin`, bypassing lifetime tracking
+- Allows unsafe implicit conversions (immutable → mutable, origin casts)
 
 ## `UnsafePointerV2` API
 
 ```mojo
 struct UnsafePointerV2[
-    mut: Bool, //, # Inferred mutability
+    mut: Bool, //, # ✅ Inferred mutability, no default
     type: AnyType,
-    origin: Origin[mut], # Non-defaulted origin
+    origin: Origin[mut], # ✅ Non-defaulted origin, must be explicit
     *,
     address_space: AddressSpace = AddressSpace.GENERIC,
 ]:
@@ -80,6 +97,11 @@ struct UnsafePointerV2[
 alias UnsafeMutPointer[...] = UnsafePointerV2[mut=True, ...]
 alias UnsafeImmutPointer[...] = UnsafePointerV2[mut=False, ...]
 ```
+
+**Improvements:**
+- `mut` is inferred (using `//` marker) and has no default value
+- `origin` must be explicitly specified or parameterized
+- Prevents unsafe implicit conversions (compile-time errors)
 
 ### Cross-language Comparison
 

--- a/mojo/python/mojo/notebook.py
+++ b/mojo/python/mojo/notebook.py
@@ -12,13 +12,20 @@
 # ===----------------------------------------------------------------------=== #
 
 import argparse
+import importlib
+import re
+import sys
 import tempfile
+import uuid
 from pathlib import Path
 
 try:
     # Don't require including IPython as a dependency
+
     from IPython.core.magic import register_cell_magic  # type: ignore
+    from IPython.display import SVG, display
 except ImportError:
+    SVG, display = None, None
 
     def register_cell_magic(fn):  # noqa: ANN001, ANN201
         return fn
@@ -27,13 +34,57 @@ except ImportError:
 from .paths import MojoCompilationError
 from .run import subprocess_run_mojo
 
+# Enable Mojo import hook for dynamic compilation
+try:
+    import mojo.importer
+except ImportError:
+    pass  # Will fall back to subprocess approach
+
+
+# Template for creating a Mojo module with Python bindings that can return any object
+ENTRYPOINT_TEMPLATE = """\
+from python import PythonObject
+from python.bindings import PythonModuleBuilder
+from os import abort
+
+# --- User code:
+{USER_CODE}
+
+# --- Python module binding:
+@export
+fn PyInit_{MODNAME}() -> PythonObject:
+    try:
+        var m = PythonModuleBuilder("{MODNAME}")
+        # Register the entrypoint function that should exist in user code:
+        m.def_function[entrypoint]("entrypoint", docstring="Execute cell entry and return a PythonObject")
+        return m.finalize()
+    except e:
+        return abort[PythonObject](String("error creating Python Mojo module:", e))
+"""
+
 
 @register_cell_magic
 def mojo(line, cell) -> None:  # noqa: ANN001
-    """A Mojo cell.
+    """A Mojo cell with enhanced Python integration.
 
     Usage:
-        - Run Mojo code in a cell
+        - Run Mojo code with entrypoint function (returns Python objects):
+
+            ```mojo
+            %%mojo entrypoint
+            from python import PythonObject
+            from IPython.display import SVG
+
+            fn entrypoint() -> PythonObject:
+                # Return any Python object - SVG, DataFrame, etc.
+                svg_content = '''<?xml version="1.0"?>
+                <svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+                    <circle cx="50" cy="50" r="40" fill="red" />
+                </svg>'''
+                return SVG(data=svg_content)
+            ```
+
+        - Traditional main() approach (prints to stdout):
 
             ```mojo
             %%mojo
@@ -41,7 +92,7 @@ def mojo(line, cell) -> None:  # noqa: ANN001
                 print("Hello from Mojo!")
             ```
 
-        - Compile a python extension SO file
+        - Compile a python extension SO file:
 
             ```mojo
             %%mojo build --emit shared-lib -o mojo_module.so
@@ -97,28 +148,80 @@ def mojo(line, cell) -> None:  # noqa: ANN001
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("command", nargs="?", default="run")
+    parser.add_argument(
+        "--entrypoint",
+        action="store_true",
+        help="Use entrypoint mode for returning Python objects",
+    )
 
     args, extra_args = parser.parse_known_args(line.strip().split())
 
+    # Check if entrypoint mode is requested
+    is_entrypoint = args.command == "entrypoint" or args.entrypoint
+
     with tempfile.TemporaryDirectory() as tempdir:
         path = Path(tempdir)
-        mojo_path = path / "cell.mojo"
-        with open(mojo_path, "w") as f:
-            f.write(cell)
-        (path / "__init__.mojo").touch()
 
-        input_path = path if args.command == "package" else mojo_path
-        command = [
-            args.command,
-            str(input_path),
-            *extra_args,
-        ]
+        if is_entrypoint:
+            # Use entrypoint approach with Python module binding
+            modname = f"mojocell_{uuid.uuid4().hex[:8]}"
 
-        result = subprocess_run_mojo(command, capture_output=True)
+            # Validate module name
+            if not re.match(r"^[A-Za-z_]\w*$", modname):
+                raise ValueError(f"Invalid module name: {modname}")
 
-    if not result.returncode:
-        print(result.stdout.decode())
-    else:
-        raise MojoCompilationError(
-            input_path, command, result.stdout.decode(), result.stderr.decode()
-        )
+            # Create Mojo source with entrypoint template
+            mojo_content = ENTRYPOINT_TEMPLATE.format(
+                USER_CODE=cell, MODNAME=modname
+            )
+            mojo_path = path / f"{modname}.mojo"
+            with open(mojo_path, "w") as f:
+                f.write(mojo_content)
+
+            # Add the temp directory to Python path for import
+            sys.path.insert(0, str(path))
+
+            try:
+                # Import the Mojo module (compiles and loads)
+                mod = importlib.import_module(modname)
+
+                # Call entrypoint function and display result
+                result = mod.entrypoint()
+
+                # Use IPython display for rich rendering
+                if display:
+                    display(result)
+                else:
+                    print(result)
+
+            finally:
+                # Clean up path (but keep temp directory for __mojocache__)
+                if str(path) in sys.path:
+                    sys.path.remove(str(path))
+
+        else:
+            # Use traditional approach with subprocess
+            mojo_path = path / "cell.mojo"
+            with open(mojo_path, "w") as f:
+                f.write(cell)
+            (path / "__init__.mojo").touch()
+
+            input_path = path if args.command == "package" else mojo_path
+            command = [
+                args.command,
+                str(input_path),
+                *extra_args,
+            ]
+
+            result = subprocess_run_mojo(command, capture_output=True)
+
+            if not result.returncode:
+                stdout = result.stdout.decode()
+                print(stdout)
+            else:
+                raise MojoCompilationError(
+                    input_path,
+                    command,
+                    result.stdout.decode(),
+                    result.stderr.decode(),
+                )


### PR DESCRIPTION

- Enables returning any Python object (SVG, DataFrames, etc.) from Mojo cells
- Uses mojo.importer for dynamic compilation and Python integration
- Maintains backward compatibility with traditional main() approach
- Provides better visualization support in Jupyter notebooks