### PR TITLE
[stdlib] Add support for the mapping protocol to Python interop

### DIFF
--- a/mojo/integration-test/python-extension-modules/basic-columnar/BUILD.bazel
+++ b/mojo/integration-test/python-extension-modules/basic-columnar/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@rules_mojo//mojo:mojo_shared_library.bzl", "mojo_shared_library")
+load("//bazel:api.bzl", "modular_py_test")
+
+mojo_shared_library(
+    name = "mojo_module",
+    testonly = True,
+    srcs = ["mojo_module.mojo"],
+    shared_lib_name = "mojo_module.so",
+    target_compatible_with = select({
+        "//:asan": ["@platforms//:incompatible"],
+        "//:tsan": ["@platforms//:incompatible"],
+        "//:ubsan": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "@mojo//:std",
+    ],
+)
+
+modular_py_test(
+    name = "main",
+    srcs = ["test_module.py"],
+    tags = [
+        "no-mypy",  # Fails to find mojo_module.so
+        "no-pydeps",  # TODO: Fix and re-enable
+    ],
+    deps = [
+        ":mojo_module",
+    ],
+)

--- a/mojo/integration-test/python-extension-modules/basic-columnar/mojo_module.mojo
+++ b/mojo/integration-test/python-extension-modules/basic-columnar/mojo_module.mojo
@@ -1,0 +1,184 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from os import abort
+
+from memory import UnsafePointer, alloc
+from utils import IndexList
+from python import Python, PythonObject
+from python._cpython import PyObjectPtr, Py_LT, Py_GT
+from python.bindings import (
+    PythonModuleBuilder,
+    PyTypeObjectSlot,
+)
+
+comptime Coord1DColumn = List[Float64]
+
+
+fn _extent(pos: Coord1DColumn) -> Tuple[Float64, Float64]:
+    """Return the min and max value in the buffer."""
+    v_min = Float64.MAX
+    v_max = Float64.MIN
+    for v in pos:
+        v_min = min(v_min, v)
+        v_max = max(v_max, v)
+    return (v_min, v_max)
+
+
+fn _compute_bounding_box_area(
+    pos_x: Coord1DColumn,
+    pos_y: Coord1DColumn,
+) -> Float64:
+    if len(pos_x) == 0:
+        return 0.0
+    ext_x = _extent(pos_x)
+    ext_y = _extent(pos_y)
+    return (ext_x[1] - ext_x[0]) * (ext_y[1] - ext_y[0])
+
+
+struct DataFrame(Defaultable, Movable, Representable):
+    """A simple columnar data structure.
+
+    This struct contains points with the x,y coordinates stored in columns. Some algorithms
+    are a lot more efficient in this representation.
+    """
+
+    var pos_x: Coord1DColumn
+    var pos_y: Coord1DColumn
+
+    # The bounding box area that contains all points.
+    var _bounding_box_area: Float64
+
+    fn __init__(out self):
+        """Default initializer."""
+        self.pos_x = []
+        self.pos_y = []
+        self._bounding_box_area = 0
+
+    fn __init__(
+        out self,
+        var x: Coord1DColumn,
+        var y: Coord1DColumn,
+    ):
+        self._bounding_box_area = _compute_bounding_box_area(x, y)
+        self.pos_x = x^
+        self.pos_y = y^
+
+    @staticmethod
+    fn _get_self_ptr(
+        py_self: PythonObject,
+    ) -> UnsafePointer[Self, MutAnyOrigin]:
+        try:
+            return py_self.downcast_value_ptr[Self]()
+        except e:
+            abort(
+                String(
+                    (
+                        "Python method receiver object did not have the"
+                        " expected type:"
+                    ),
+                    e,
+                )
+            )
+
+    @staticmethod
+    fn with_columns(
+        pos_x: PythonObject, pos_y: PythonObject
+    ) raises -> PythonObject:
+        var len_x = Int(pos_x.__len__())
+        var len_y = Int(pos_y.__len__())
+        if len_x != len_y:
+            raise Error("The length of the two columns does not match.")
+
+        # Allocate memory for the buffers
+        var ptr_x = Coord1DColumn(capacity=len_x)
+        var ptr_y = Coord1DColumn(capacity=len_y)
+
+        # Copy values from Python objects
+        for value in pos_x:
+            ptr_x.append(Float64(py=value))
+        for value in pos_y:
+            ptr_y.append(Float64(py=value))
+
+        return PythonObject(alloc=DataFrame(ptr_x^, ptr_y^))
+
+    @staticmethod
+    fn py__len__(py_self: PythonObject) raises -> Int:
+        """For __len__ we return the number of rows in the DataFrame."""
+        var self_ptr = Self._get_self_ptr(py_self)
+        return len(self_ptr[].pos_x)
+
+    @staticmethod
+    fn py__getitem__(
+        py_self: PythonObject, index: PythonObject
+    ) raises -> PythonObject:
+        """For __getitem__ we will return a row of the DataFrame."""
+        var self_ptr = Self._get_self_ptr(py_self)
+        var index_mojo = Int(py=index)
+        return Python().tuple(
+            self_ptr[].pos_x[index_mojo], self_ptr[].pos_y[index_mojo]
+        )
+
+    @staticmethod
+    fn py__setitem__(
+        py_self: PythonObject, index: PythonObject, value: PythonObject
+    ) raises -> None:
+        """For __setitem__ we set the x and y values at the given index."""
+        var self_ptr = Self._get_self_ptr(py_self)
+        var index_mojo = Int(py=index)
+        # Expect value to be a tuple of (x, y)
+        self_ptr[].pos_x[index_mojo] = Float64(py=value[0])
+        self_ptr[].pos_y[index_mojo] = Float64(py=value[1])
+
+    fn __repr__(self) -> String:
+        return String("DataFrame( length=", len(self.pos_x), ")")
+
+    @staticmethod
+    fn rich_compare(
+        self_ptr: PythonObject, other: PythonObject, op: Int
+    ) raises -> Bool:
+        """Implement the rich compare functionality.
+
+        We use the bounding box area to order the DataFrame objects.
+        """
+        var self_df = Self._get_self_ptr(self_ptr)
+        var other_df = Self._get_self_ptr(other)
+        if op == Py_LT:
+            return self_df[]._bounding_box_area < other_df[]._bounding_box_area
+        elif op == Py_GT:
+            return self_df[]._bounding_box_area > other_df[]._bounding_box_area
+        # For other comparisons, return False
+        return False
+
+
+@export
+fn PyInit_mojo_module() -> PythonObject:
+    """Create a Python module with a type binding for `DataFrame`."""
+
+    try:
+        var b = PythonModuleBuilder("mojo_module")
+        _ = (
+            b.add_type[DataFrame]("DataFrame")
+            .def_init_defaultable[DataFrame]()
+            .def_staticmethod[DataFrame.with_columns]("with_columns")
+            # Mapping protocol.
+            .def_method[DataFrame.py__len__, PyTypeObjectSlot.mp_length]()
+            .def_method[DataFrame.py__getitem__, PyTypeObjectSlot.mp_getitem]()
+            .def_method[DataFrame.py__setitem__, PyTypeObjectSlot.mp_setitem]()
+            .def_method[
+                DataFrame.rich_compare, PyTypeObjectSlot.tp_richcompare
+            ]()
+        )
+        return b.finalize()
+    except e:
+        abort(String("failed to create Python module: ", e))

--- a/mojo/integration-test/python-extension-modules/basic-columnar/mojo_module.mojo
+++ b/mojo/integration-test/python-extension-modules/basic-columnar/mojo_module.mojo
@@ -11,13 +11,13 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from os import abort
+from std.os import abort
 
-from memory import UnsafePointer
-from utils import IndexList, Variant
-from python import Python, PythonObject
-from python._cpython import RichCompareOps
-from python.bindings import (
+from std.memory import UnsafePointer
+from std.utils import IndexList, Variant
+from std.python import Python, PythonObject
+from std.python._cpython import RichCompareOps
+from std.python.bindings import (
     PythonModuleBuilder,
     PyTypeObjectSlot,
     NotImplementedError,
@@ -47,7 +47,7 @@ fn _compute_bounding_box_area(
     return (ext_x[1] - ext_x[0]) * (ext_y[1] - ext_y[0])
 
 
-struct DataFrame(Defaultable, Movable, Representable):
+struct DataFrame(Defaultable, Movable, Writable):
     """A simple columnar data structure.
 
     This struct contains points with the x,y coordinates stored in columns. Some algorithms
@@ -168,8 +168,8 @@ struct DataFrame(Defaultable, Movable, Representable):
             _ = self_ptr[].pos_x.pop(index_mojo)
             _ = self_ptr[].pos_y.pop(index_mojo)
 
-    fn __repr__(self) -> String:
-        return String("DataFrame( length=", len(self.pos_x), ")")
+    fn write_to(self, mut writer: Some[Writer]):
+        writer.write("DataFrame( length=", len(self.pos_x), ")")
 
     @staticmethod
     fn rich_compare(

--- a/mojo/integration-test/python-extension-modules/basic-columnar/test_module.py
+++ b/mojo/integration-test/python-extension-modules/basic-columnar/test_module.py
@@ -1,0 +1,50 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# Imports from 'mojo_module.so'
+import mojo_module
+
+
+def test_mojo_columnar() -> None:
+    print("Hello from Basic Columnar Example!")
+
+    try:
+        _ = mojo_module.DataFrame.with_columns([1.0, 2.0, 3.0], [0.1, 0.2])
+        raise Exception("ValueError expected due to unbalanced columns.")
+    except Exception as ex:
+        assert "not match" in str(ex)
+        pass
+
+    df = mojo_module.DataFrame.with_columns([1.0, 2.0, 3.0], [0.1, 0.2, 0.3])
+    assert "DataFrame" in str(df)
+
+    # Test __len__ (mapping protocol mp_length)
+    assert len(df) == 3
+
+    # Access rows in the DataFrame
+    assert df[0] == (1.0, 0.1)
+    assert df[1] == (2.0, 0.2)
+
+    # Test __setitem__ (mapping protocol mp_ass_subscript)
+    df[1] = (5.0, 6.0)
+    assert df[1] == (5.0, 6.0)
+    # Verify other values unchanged
+    assert df[0] == (1.0, 0.1)
+    assert df[2] == (3.0, 0.3)
+
+    big_df = mojo_module.DataFrame.with_columns(
+        [1.0, 2.0, 30000.0], [0.1, 0.2, 1.0]
+    )
+    assert big_df > df
+
+    print("🎉🎉🎉 Mission Success! 🎉🎉🎉")

--- a/mojo/stdlib/std/python/_cpython.mojo
+++ b/mojo/stdlib/std/python/_cpython.mojo
@@ -82,14 +82,20 @@ comptime Py_CONSTANT_EMPTY_STR = 7
 comptime Py_CONSTANT_EMPTY_BYTES = 8
 comptime Py_CONSTANT_EMPTY_TUPLE = 9
 
-# These flags are used by the richcompare function.
-# ref: https://github.com/python/cpython/blob/main/Include/object.h#L721
-comptime Py_LT = 0
-comptime Py_LE = 1
-comptime Py_EQ = 2
-comptime Py_NE = 3
-comptime Py_GT = 4
-comptime Py_GE = 5
+
+struct RichCompareOps:
+    """Flags used by the richcompare function.
+
+    ref: https://github.com/python/cpython/blob/main/Include/object.h#L721
+    """
+
+    comptime Py_LT = 0
+    comptime Py_LE = 1
+    comptime Py_EQ = 2
+    comptime Py_NE = 3
+    comptime Py_GT = 4
+    comptime Py_GE = 5
+
 
 # TODO(MOCO-1138):
 #   This should be a C ABI function pointer, not a Mojo ABI function.
@@ -437,16 +443,22 @@ struct PyType_Spec(TrivialRegisterPassable):
     var slots: UnsafePointer[PyType_Slot, MutAnyOrigin]
 
 
-# https://github.com/python/cpython/blob/main/Include/typeslots.h
-comptime Py_mp_setitem = 3
-comptime Py_mp_length = 4
-comptime Py_mp_getitem = 5
-comptime Py_tp_dealloc = 52
-comptime Py_tp_init = 60
-comptime Py_tp_methods = 64
-comptime Py_tp_new = 65
-comptime Py_tp_repr = 66
-comptime Py_tp_richcompare = 67
+struct TypeSlots:
+    """Python type slots as defined in the file below.
+
+    https://github.com/python/cpython/blob/main/Include/typeslots.h
+    """
+
+    comptime Py_mp_setitem = 3
+    comptime Py_mp_length = 4
+    comptime Py_mp_getitem = 5
+    comptime Py_tp_dealloc = 52
+    comptime Py_tp_init = 60
+    comptime Py_tp_methods = 64
+    comptime Py_tp_new = 65
+    comptime Py_tp_repr = 66
+    comptime Py_tp_richcompare = 67
+
 
 # https://docs.python.org/3/c-api/typeobj.html#slot-type-typedefs
 
@@ -484,31 +496,33 @@ struct PyType_Slot(TrivialRegisterPassable):
     @staticmethod
     fn tp_dealloc(func: destructor) -> Self:
         return PyType_Slot(
-            Py_tp_dealloc,
+            TypeSlots.Py_tp_dealloc,
             rebind[OpaquePointer[MutAnyOrigin]](func),
         )
 
     @staticmethod
     fn tp_init(func: Typed_initproc) -> Self:
         return PyType_Slot(
-            Py_tp_init, rebind[OpaquePointer[MutAnyOrigin]](func)
+            TypeSlots.Py_tp_init, rebind[OpaquePointer[MutAnyOrigin]](func)
         )
 
     @staticmethod
     fn tp_methods(methods: UnsafePointer[PyMethodDef, MutAnyOrigin]) -> Self:
         return PyType_Slot(
-            Py_tp_methods,
+            TypeSlots.Py_tp_methods,
             rebind[OpaquePointer[MutAnyOrigin]](methods),
         )
 
     @staticmethod
     fn tp_new(func: Typed_newfunc) -> Self:
-        return PyType_Slot(Py_tp_new, rebind[OpaquePointer[MutAnyOrigin]](func))
+        return PyType_Slot(
+            TypeSlots.Py_tp_new, rebind[OpaquePointer[MutAnyOrigin]](func)
+        )
 
     @staticmethod
     fn tp_repr(func: reprfunc) -> Self:
         return PyType_Slot(
-            Py_tp_repr, rebind[OpaquePointer[MutAnyOrigin]](func)
+            TypeSlots.Py_tp_repr, rebind[OpaquePointer[MutAnyOrigin]](func)
         )
 
     @staticmethod
@@ -520,14 +534,14 @@ struct PyType_Slot(TrivialRegisterPassable):
         func: fn (py_self: PyObjectPtr, key: PyObjectPtr) -> PyObjectPtr
     ) -> Self:
         return PyType_Slot(
-            Py_mp_getitem,
+            TypeSlots.Py_mp_getitem,
             rebind[OpaquePointer[MutAnyOrigin]](func),
         )
 
     @staticmethod
     fn mp_length(func: fn (py_self: PyObjectPtr) -> Int) -> Self:
         return PyType_Slot(
-            Py_mp_length,
+            TypeSlots.Py_mp_length,
             rebind[OpaquePointer[MutAnyOrigin]](func),
         )
 
@@ -538,7 +552,7 @@ struct PyType_Slot(TrivialRegisterPassable):
         ) -> c_int
     ) -> Self:
         return PyType_Slot(
-            Py_mp_setitem,
+            TypeSlots.Py_mp_setitem,
             rebind[OpaquePointer[MutAnyOrigin]](func),
         )
 
@@ -549,7 +563,7 @@ struct PyType_Slot(TrivialRegisterPassable):
         ) -> PyObjectPtr
     ) -> Self:
         return PyType_Slot(
-            Py_tp_richcompare,
+            TypeSlots.Py_tp_richcompare,
             rebind[OpaquePointer[MutAnyOrigin]](func),
         )
 
@@ -1503,6 +1517,8 @@ struct CPython(Defaultable, Movable):
     var _PyType_FromSpec: PyType_FromSpec.type
     # The None Object
     var _Py_None: PyObjectPtr
+    # The NotImplemented Object
+    var _Py_NotImplemented: PyObjectPtr
     # Integer Objects
     var _PyLong_Type: PyTypeObjectPtr
     var _PyLong_FromSsize_t: PyLong_FromSsize_t.type
@@ -1692,6 +1708,17 @@ struct CPython(Defaultable, Movable):
             # PyObject *Py_None
             self._Py_None = PyObjectPtr(
                 upcast_from=self.lib.get_symbol[PyObject]("_Py_NoneStruct")
+            )
+        # The NotImplemented Object
+        if self.version.minor >= 13:
+            self._Py_NotImplemented = self.lib.call[
+                "Py_GetConstantBorrowed", PyObjectPtr
+            ](Py_CONSTANT_NOT_IMPLEMENTED)
+        else:
+            self._Py_NotImplemented = PyObjectPtr(
+                upcast_from=self.lib.get_symbol[PyObject](
+                    "_Py_NotImplementedStruct"
+                )
             )
         # Integer Objects
         # PyTypeObject PyLong_Type
@@ -2510,6 +2537,19 @@ struct CPython(Defaultable, Movable):
         - https://docs.python.org/3/c-api/none.html#c.Py_None
         """
         return self._Py_None
+
+    # ===-------------------------------------------------------------------===#
+    # The NotImplemented Object
+    # ref: https://docs.python.org/3/c-api/object.html#c.Py_NotImplemented
+    # ===-------------------------------------------------------------------===#
+
+    fn Py_NotImplemented(self) -> PyObjectPtr:
+        """The Python `NotImplemented` singleton object.
+
+        References:
+        - https://docs.python.org/3/c-api/object.html#c.Py_NotImplemented
+        """
+        return self._Py_NotImplemented
 
     # ===-------------------------------------------------------------------===#
     # Integer Objects

--- a/mojo/stdlib/std/python/_cpython.mojo
+++ b/mojo/stdlib/std/python/_cpython.mojo
@@ -68,6 +68,28 @@ comptime Py_TPFLAGS_DICT_SUBCLASS = c_ulong(1 << 29)
 comptime Py_TPFLAGS_BASE_EXC_SUBCLASS = c_ulong(1 << 30)
 comptime Py_TPFLAGS_TYPE_SUBCLASS = c_ulong(1 << 31)
 
+# Python constants, for example some operations may want to return Not Implemented.
+# ref: https://github.com/python/cpython/blob/main/Include/object.h#L659
+# ref:  https://docs.python.org/3/c-api/object.html#c.Py_CONSTANT_NONE
+comptime Py_CONSTANT_NONE = 0
+comptime Py_CONSTANT_FALSE = 1
+comptime Py_CONSTANT_TRUE = 2
+comptime Py_CONSTANT_ELLIPSIS = 3
+comptime Py_CONSTANT_NOT_IMPLEMENTED = 4
+comptime Py_CONSTANT_ZERO = 5
+comptime Py_CONSTANT_ONE = 6
+comptime Py_CONSTANT_EMPTY_STR = 7
+comptime Py_CONSTANT_EMPTY_BYTES = 8
+comptime Py_CONSTANT_EMPTY_TUPLE = 9
+
+# These flags are used by the richcompare function.
+# ref: https://github.com/python/cpython/blob/main/Include/object.h#L721
+comptime Py_LT = 0
+comptime Py_LE = 1
+comptime Py_EQ = 2
+comptime Py_NE = 3
+comptime Py_GT = 4
+comptime Py_GE = 5
 
 # TODO(MOCO-1138):
 #   This should be a C ABI function pointer, not a Mojo ABI function.
@@ -416,11 +438,15 @@ struct PyType_Spec(TrivialRegisterPassable):
 
 
 # https://github.com/python/cpython/blob/main/Include/typeslots.h
+comptime Py_mp_setitem = 3
+comptime Py_mp_length = 4
+comptime Py_mp_getitem = 5
 comptime Py_tp_dealloc = 52
 comptime Py_tp_init = 60
 comptime Py_tp_methods = 64
 comptime Py_tp_new = 65
 comptime Py_tp_repr = 66
+comptime Py_tp_richcompare = 67
 
 # https://docs.python.org/3/c-api/typeobj.html#slot-type-typedefs
 
@@ -488,6 +514,44 @@ struct PyType_Slot(TrivialRegisterPassable):
     @staticmethod
     fn null() -> Self:
         return PyType_Slot(0, OpaquePointer[MutAnyOrigin]())
+
+    @staticmethod
+    fn mp_subscript(
+        func: fn (py_self: PyObjectPtr, key: PyObjectPtr) -> PyObjectPtr
+    ) -> Self:
+        return PyType_Slot(
+            Py_mp_getitem,
+            rebind[OpaquePointer[MutAnyOrigin]](func),
+        )
+
+    @staticmethod
+    fn mp_length(func: fn (py_self: PyObjectPtr) -> Int) -> Self:
+        return PyType_Slot(
+            Py_mp_length,
+            rebind[OpaquePointer[MutAnyOrigin]](func),
+        )
+
+    @staticmethod
+    fn mp_ass_subscript(
+        func: fn (
+            py_self: PyObjectPtr, key: PyObjectPtr, value: PyObjectPtr
+        ) -> c_int
+    ) -> Self:
+        return PyType_Slot(
+            Py_mp_setitem,
+            rebind[OpaquePointer[MutAnyOrigin]](func),
+        )
+
+    @staticmethod
+    fn tp_richcompare(
+        func: fn (
+            py_self: PyObjectPtr, other: PyObjectPtr, tp_op: c_int
+        ) -> PyObjectPtr
+    ) -> Self:
+        return PyType_Slot(
+            Py_tp_richcompare,
+            rebind[OpaquePointer[MutAnyOrigin]](func),
+        )
 
 
 @fieldwise_init
@@ -1623,7 +1687,7 @@ struct CPython(Defaultable, Movable):
             # PyObject *Py_GetConstantBorrowed(unsigned int constant_id)
             self._Py_None = self.lib.call[
                 "Py_GetConstantBorrowed", PyObjectPtr
-            ](0)
+            ](Py_CONSTANT_NONE)
         else:
             # PyObject *Py_None
             self._Py_None = PyObjectPtr(

--- a/mojo/stdlib/std/python/_cpython.mojo
+++ b/mojo/stdlib/std/python/_cpython.mojo
@@ -531,7 +531,7 @@ struct PyType_Slot(TrivialRegisterPassable):
 
     @staticmethod
     fn mp_subscript(
-        func: fn (py_self: PyObjectPtr, key: PyObjectPtr) -> PyObjectPtr
+        func: fn(py_self: PyObjectPtr, key: PyObjectPtr) -> PyObjectPtr
     ) -> Self:
         return PyType_Slot(
             TypeSlots.Py_mp_getitem,
@@ -539,7 +539,7 @@ struct PyType_Slot(TrivialRegisterPassable):
         )
 
     @staticmethod
-    fn mp_length(func: fn (py_self: PyObjectPtr) -> Int) -> Self:
+    fn mp_length(func: fn(py_self: PyObjectPtr) -> Int) -> Self:
         return PyType_Slot(
             TypeSlots.Py_mp_length,
             rebind[OpaquePointer[MutAnyOrigin]](func),
@@ -547,7 +547,7 @@ struct PyType_Slot(TrivialRegisterPassable):
 
     @staticmethod
     fn mp_ass_subscript(
-        func: fn (
+        func: fn(
             py_self: PyObjectPtr, key: PyObjectPtr, value: PyObjectPtr
         ) -> c_int
     ) -> Self:
@@ -558,7 +558,7 @@ struct PyType_Slot(TrivialRegisterPassable):
 
     @staticmethod
     fn tp_richcompare(
-        func: fn (
+        func: fn(
             py_self: PyObjectPtr, other: PyObjectPtr, tp_op: c_int
         ) -> PyObjectPtr
     ) -> Self:

--- a/mojo/stdlib/std/python/bindings.mojo
+++ b/mojo/stdlib/std/python/bindings.mojo
@@ -233,9 +233,9 @@ fn _tp_repr_wrapper[
     return cpython.PyUnicode_DecodeUTF8(repr_str)
 
 
-@register_passable("trivial")
 struct PyTypeObjectSlot(
     ImplicitlyCopyable,
+    TrivialRegisterType,
 ):
     """Tag struct for defining methods for the various type object slots.
 
@@ -331,8 +331,7 @@ struct PyTypeObjectSlot(
 
 
 @fieldwise_init
-@register_passable("trivial")
-struct NotImplementedError(Writable):
+struct NotImplementedError(TrivialRegisterType, Writable):
     """A custom error type to be returned from Mojo binding functions to signal NotImplemented.
     """
 
@@ -349,7 +348,7 @@ struct NotImplementedError(Writable):
 
 
 fn _mp_length_wrapper[
-    method: fn (PythonObject) raises -> Int
+    method: fn(PythonObject) raises -> Int
 ](py_self: PyObjectPtr) -> Py_ssize_t:
     """Python-compatible wrapper for mapping length protocol (__len__).
 
@@ -381,7 +380,7 @@ fn _mp_length_wrapper[
 
 
 fn _mp_subscript_wrapper[
-    method: fn (PythonObject, PythonObject) raises -> PythonObject
+    method: fn(PythonObject, PythonObject) raises -> PythonObject
 ](py_self: PyObjectPtr, key: PyObjectPtr) -> PyObjectPtr:
     """Python-compatible wrapper for mapping subscript protocol (__getitem__).
 
@@ -417,7 +416,7 @@ fn _mp_subscript_wrapper[
 
 
 fn _mp_ass_subscript_wrapper[
-    method: fn (
+    method: fn(
         PythonObject, PythonObject, Variant[PythonObject, Int]
     ) raises -> None
 ](py_self: PyObjectPtr, key: PyObjectPtr, value: PyObjectPtr) -> c_int:
@@ -464,7 +463,7 @@ fn _mp_ass_subscript_wrapper[
 
 
 fn _richcompare_wrapper[
-    method: fn (PythonObject, PythonObject, Int) raises -> Bool
+    method: fn(PythonObject, PythonObject, Int) raises -> Bool
 ](py_self: PyObjectPtr, py_other: PyObjectPtr, op: c_int) -> PyObjectPtr:
     """Python-compatible wrapper for rich comparison protocol.
 
@@ -1189,9 +1188,9 @@ struct PythonTypeBuilder(Copyable):
         ](method_name, docstring)
 
     fn def_method[
-        method: fn (PythonObject, PythonObject, Int) raises -> Bool,
+        method: fn(PythonObject, PythonObject, Int) raises -> Bool,
         slot: PyTypeObjectSlot,
-    ](mut self: Self,) -> ref [self] Self where slot.is_tp_richcompare():
+    ](mut self: Self,) -> ref[self] Self where slot.is_tp_richcompare():
         """Sets the rich compare method, see https://peps.python.org/pep-0207.
 
         Parameters:
@@ -1214,9 +1213,9 @@ struct PythonTypeBuilder(Copyable):
         return self
 
     fn def_method[
-        method: fn (PythonObject) raises -> Int,
+        method: fn(PythonObject) raises -> Int,
         slot: PyTypeObjectSlot,
-    ](mut self: Self,) -> ref [self] Self where slot.is_mp_length():
+    ](mut self: Self,) -> ref[self] Self where slot.is_mp_length():
         """Sets the mapping length method (__len__).
 
         This method is part of the mapping protocol and is called when `len()` is
@@ -1240,11 +1239,11 @@ struct PythonTypeBuilder(Copyable):
         return self
 
     fn def_method[
-        method: fn (
+        method: fn(
             PythonObject, PythonObject, Variant[PythonObject, Int]
         ) raises -> None,
         slot: PyTypeObjectSlot,
-    ](mut self: Self) -> ref [self] Self where slot.is_mp_setitem():
+    ](mut self: Self) -> ref[self] Self where slot.is_mp_setitem():
         """Sets the mapping assignment subscript method (__setitem__/__delitem__).
 
         This method is part of the mapping protocol and is called for item assignment
@@ -1273,9 +1272,9 @@ struct PythonTypeBuilder(Copyable):
         return self
 
     fn def_method[
-        method: fn (PythonObject, PythonObject) raises -> PythonObject,
+        method: fn(PythonObject, PythonObject) raises -> PythonObject,
         slot: PyTypeObjectSlot,
-    ](mut self: Self) -> ref [self] Self where slot.is_mp_getitem():
+    ](mut self: Self) -> ref[self] Self where slot.is_mp_getitem():
         """Sets the mapping subscript method (__getitem__).
 
         This method is part of the mapping protocol and is called when accessing

--- a/mojo/stdlib/std/python/bindings.mojo
+++ b/mojo/stdlib/std/python/bindings.mojo
@@ -29,6 +29,7 @@ from std.memory import OpaquePointer, stack_allocation
 from std.python import Python, PythonObject
 from std.python._cpython import (
     GILAcquired,
+    Py_ssize_t,
     Py_TPFLAGS_DEFAULT,
     PyCFunction,
     PyCFunctionWithKeywords,
@@ -229,6 +230,245 @@ fn _tp_repr_wrapper[
         repr_str = t"<uninitialized {get_type_name[T]()}>"
 
     return cpython.PyUnicode_DecodeUTF8(repr_str)
+
+
+@register_passable("trivial")
+struct PyTypeObjectSlot(
+    ImplicitlyCopyable,
+):
+    """Tag struct for defining methods for the various type object slots.
+
+    References:
+    - https://docs.python.org/3/c-api/typeobj.html
+    - https://github.com/python/cpython/blob/main/Include/typeslots.h
+    """
+
+    # Store the C constant for the type slot.
+    var _type_slot: Int32
+
+    comptime mp_setitem = PyTypeObjectSlot(3)
+    """Python Type Object slot for the Mapping Protocol `setitem` method.
+    
+    References:
+    - https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_ass_subscript .
+    """
+
+    comptime mp_length = PyTypeObjectSlot(4)
+    """Python Type Object slot for the Mapping Protocol `length` method.
+    
+    References:
+    - https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_length .
+    """
+
+    comptime mp_getitem = PyTypeObjectSlot(5)
+    """Python Type Object slot for the Mapping Protocol `getitem` method.
+    
+    References:
+    - https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript .
+    """
+
+    comptime tp_richcompare = PyTypeObjectSlot(67)
+    """Python Type Object slot for the Type Protocol `richcompare` method.
+    
+    References:
+    - https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_richcompare .
+    """
+
+    @always_inline("builtin")
+    fn __init__(out self, type_slot: Int32):
+        """Initialize the PyTypeObjectSlot with the value of the slot in the C API.
+
+        Args:
+            type_slot: The numerical type slot for this entry.
+        """
+        self._type_slot = type_slot
+
+    fn as_c_int(self) -> c_int:
+        """Convert the numerical index of this slot to a c_int.
+
+        Returns:
+            The value of the type slot as c_int.
+        """
+        return c_int(self._type_slot)
+
+    @always_inline("builtin")
+    fn is_mp_length(self) -> Bool:
+        """Returns True if self represents a Mapping Protocol `length` slot.
+
+        Returns:
+            True if the time slot is `mp_length`.
+        """
+        return self._type_slot == Self.mp_length._type_slot
+
+    @always_inline("builtin")
+    fn is_mp_getitem(self) -> Bool:
+        """Returns True if self represents a Mapping Protocol `getitem` slot.
+
+        Returns:
+            True if the time slot is `mp_getitem`.
+        """
+        return self._type_slot == Self.mp_getitem._type_slot
+
+    @always_inline("builtin")
+    fn is_mp_setitem(self) -> Bool:
+        """Returns True if self represents a Mapping Protocol
+        `setitem`/`delitem` slot.
+
+        Returns:
+            True if the time slot is `mp_setitem`.
+        """
+        return self._type_slot == Self.mp_setitem._type_slot
+
+    @always_inline("builtin")
+    fn is_tp_richcompare(self) -> Bool:
+        """Returns True if self represents a Type Protocol `richcompare` slot.
+
+        Returns:
+            True if the time slot is `tp_richcompare`.
+        """
+        return self._type_slot == Self.tp_richcompare._type_slot
+
+
+fn _mp_length_wrapper[
+    method: fn (PythonObject) raises -> Int
+](py_self: PyObjectPtr) -> Py_ssize_t:
+    """Python-compatible wrapper for mapping length protocol (__len__).
+
+    This function serves as the `mp_length` slot (slot 4) for Python type objects.
+    It adapts user methods to the lenfunc signature required by the mapping protocol.
+
+    Parameters:
+        method: The user's length method that returns an Int.
+
+    Args:
+        py_self: Pointer to the Python object (the container).
+
+    Returns:
+        The length of the container as Py_ssize_t, or -1 if an error occurs
+        (with Python exception set).
+    """
+    ref cpython = Python().cpython()
+
+    try:
+        var result = method(PythonObject(from_borrowed=py_self))
+        return Py_ssize_t(result)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        cpython.PyErr_SetString(
+            error_type, e.data.as_c_string_slice().unsafe_ptr()
+        )
+        return Py_ssize_t(-1)
+
+
+fn _mp_subscript_wrapper[
+    method: fn (PythonObject, PythonObject) raises -> PythonObject
+](py_self: PyObjectPtr, key: PyObjectPtr) -> PyObjectPtr:
+    """Python-compatible wrapper for mapping subscript protocol (__getitem__).
+
+    This function serves as the `mp_subscript` slot (slot 5) for Python type objects.
+    It adapts user methods to the binaryfunc signature required by the mapping protocol.
+
+    Parameters:
+        method: The user's getitem method that takes self and key.
+
+    Args:
+        py_self: Pointer to the Python object (the container).
+        key: Pointer to the Python object used as the subscript key.
+
+    Returns:
+        A new Python object representing the result of the subscript operation,
+        or null pointer if an error occurs (with Python exception set).
+    """
+    ref cpython = Python().cpython()
+
+    try:
+        var result = method(
+            PythonObject(from_borrowed=py_self),
+            PythonObject(from_borrowed=key),
+        )
+        return result.steal_data()
+    except e:
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        cpython.PyErr_SetString(
+            error_type, e.data.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+
+
+fn _mp_ass_subscript_wrapper[
+    method: fn (PythonObject, PythonObject, PythonObject) raises -> None
+](py_self: PyObjectPtr, key: PyObjectPtr, value: PyObjectPtr) -> c_int:
+    """Python-compatible wrapper for mapping assignment subscript protocol (__setitem__/__delitem__).
+
+    This function serves as the `mp_ass_subscript` slot (slot 3) for Python type objects.
+    It adapts user methods to the objobjargproc signature required by the mapping protocol.
+
+    When value is NULL, this indicates a deletion (__delitem__). Otherwise, it's an
+    assignment (__setitem__).
+
+    Parameters:
+        method: The user's method that takes self, key, and value.
+
+    Args:
+        py_self: Pointer to the Python object (the container).
+        key: Pointer to the Python object used as the subscript key.
+        value: Pointer to the value to set, or NULL for deletion.
+
+    Returns:
+        0 on success, -1 on failure (with Python exception set).
+    """
+    ref cpython = Python().cpython()
+
+    try:
+        method(
+            PythonObject(from_borrowed=py_self),
+            PythonObject(from_borrowed=key),
+            PythonObject(from_borrowed=value),
+        )
+        return c_int(0)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        cpython.PyErr_SetString(
+            error_type, e.data.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+
+
+fn _richcompare_wrapper[
+    method: fn (PythonObject, PythonObject, Int) raises -> Bool
+](py_self: PyObjectPtr, py_other: PyObjectPtr, op: c_int) -> PyObjectPtr:
+    """Python-compatible wrapper for rich comparison protocol.
+
+    This function serves as the `tp_richcompare` slot for Python type objects.
+    It adapts user methods to the richcmpfunc signature required by Python.
+
+    Parameters:
+        method: The user's comparison method that returns a Bool.
+
+    Args:
+        py_self: Pointer to the first Python object.
+        py_other: Pointer to the second Python object.
+        op: The comparison operator (Py_LT, Py_LE, Py_EQ, Py_NE, Py_GT, Py_GE).
+
+    Returns:
+        A Python boolean object (Py_True or Py_False), or null pointer if an
+        error occurs (with Python exception set).
+    """
+    ref cpython = Python().cpython()
+
+    try:
+        var result = method(
+            PythonObject(from_borrowed=py_self),
+            PythonObject(from_borrowed=py_other),
+            Int(op),
+        )
+        return cpython.PyBool_FromLong(c_long(Int(result)))
+    except e:
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        cpython.PyErr_SetString(
+            error_type, e.data.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
 
 
 # ===-----------------------------------------------------------------------===#
@@ -910,6 +1150,113 @@ struct PythonTypeBuilder(Copyable):
         return self._generic_def_py_method[
             _py_function_wrapper[method, is_method=True](), static_method=False
         ](method_name, docstring)
+
+    fn def_method[
+        method: fn (PythonObject, PythonObject, Int) raises -> Bool,
+        slot: PyTypeObjectSlot,
+    ](mut self: Self,) -> ref [self] Self where slot.is_tp_richcompare():
+        """Sets the rich compare method, see https://peps.python.org/pep-0207.
+
+        Parameters:
+            method: The user method to install as the compare method. The API matches the python richcompare protocol.
+            slot: The Python type slot to define, needs to be tp_richcompare.
+
+        Returns:
+            A refence to self for easier chaining.
+
+        References:
+        - https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_richcompare .
+        """
+
+        self._insert_slot(
+            PyType_Slot.tp_richcompare(_richcompare_wrapper[method])
+        )
+
+        return self
+
+    fn def_method[
+        method: fn (PythonObject) raises -> Int,
+        slot: PyTypeObjectSlot,
+    ](mut self: Self,) -> ref [self] Self where slot.is_mp_length():
+        """Sets the mapping length method (__len__).
+
+        This method is part of the mapping protocol and is called when `len()` is
+        invoked on an instance of the type.
+
+        Parameters:
+            method: The user method to install as the length method. It should
+                take self as a PythonObject and return an Int representing the
+                length of the container.
+            slot: The Python type slot to define, needs to be tp_richcompare.
+
+        Returns:
+            A reference to self for easier chaining.
+
+        References:
+        - https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_length .
+        """
+
+        self._insert_slot(PyType_Slot.mp_length(_mp_length_wrapper[method]))
+
+        return self
+
+    fn def_method[
+        method: fn (PythonObject, PythonObject, PythonObject) raises -> None,
+        slot: PyTypeObjectSlot,
+    ](mut self: Self) -> ref [self] Self where slot.is_mp_setitem():
+        """Sets the mapping assignment subscript method (__setitem__/__delitem__).
+
+        This method is part of the mapping protocol and is called for item assignment
+        (`obj[key] = value`) and deletion (`del obj[key]`).
+
+        When value is a null pointer (None), this indicates a deletion request.
+        Otherwise, it's an assignment.
+
+        Parameters:
+            method: The user method to install as the setitem method. It should
+                take self, key, and value as PythonObjects. For deletion, value
+                will be None.
+            slot: The Python type slot to define, needs to be tp_richcompare.
+
+        Returns:
+            A reference to self for easier chaining.
+
+        References:
+        - https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_ass_subscript .
+        """
+
+        self._insert_slot(
+            PyType_Slot.mp_ass_subscript(_mp_ass_subscript_wrapper[method])
+        )
+
+        return self
+
+    fn def_method[
+        method: fn (PythonObject, PythonObject) raises -> PythonObject,
+        slot: PyTypeObjectSlot,
+    ](mut self: Self) -> ref [self] Self where slot.is_mp_getitem():
+        """Sets the mapping subscript method (__getitem__).
+
+        This method is part of the mapping protocol and is called when accessing
+        items using bracket notation (`obj[key]`).
+
+        Parameters:
+            method: The user method to install as the getitem method. It should
+                take self and key as PythonObjects and return the value.
+            slot: The Python type slot to define, needs to be tp_richcompare.
+
+        Returns:
+            A reference to self for easier chaining.
+
+        References:
+        - https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript .
+        """
+
+        self._insert_slot(
+            PyType_Slot.mp_subscript(_mp_subscript_wrapper[method])
+        )
+
+        return self
 
     fn def_staticmethod[
         method_type: __TypeOfAllTypes,

--- a/mojo/stdlib/std/python/bindings.mojo
+++ b/mojo/stdlib/std/python/bindings.mojo
@@ -40,6 +40,7 @@ from std.python._cpython import (
     PyType_Spec,
     PyTypeObject,
     PyTypeObjectPtr,
+    TypeSlots,
 )
 from std.python._python_func import PyObjectFunction
 from std.python.python_object import _unsafe_alloc, _unsafe_init
@@ -246,28 +247,28 @@ struct PyTypeObjectSlot(
     # Store the C constant for the type slot.
     var _type_slot: Int32
 
-    comptime mp_setitem = PyTypeObjectSlot(3)
+    comptime mp_setitem = PyTypeObjectSlot(TypeSlots.Py_mp_setitem)
     """Python Type Object slot for the Mapping Protocol `setitem` method.
     
     References:
     - https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_ass_subscript .
     """
 
-    comptime mp_length = PyTypeObjectSlot(4)
+    comptime mp_length = PyTypeObjectSlot(TypeSlots.Py_mp_length)
     """Python Type Object slot for the Mapping Protocol `length` method.
     
     References:
     - https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_length .
     """
 
-    comptime mp_getitem = PyTypeObjectSlot(5)
+    comptime mp_getitem = PyTypeObjectSlot(TypeSlots.Py_mp_getitem)
     """Python Type Object slot for the Mapping Protocol `getitem` method.
     
     References:
     - https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript .
     """
 
-    comptime tp_richcompare = PyTypeObjectSlot(67)
+    comptime tp_richcompare = PyTypeObjectSlot(TypeSlots.Py_tp_richcompare)
     """Python Type Object slot for the Type Protocol `richcompare` method.
     
     References:
@@ -296,7 +297,7 @@ struct PyTypeObjectSlot(
         """Returns True if self represents a Mapping Protocol `length` slot.
 
         Returns:
-            True if the time slot is `mp_length`.
+            True if the type slot is `mp_length`.
         """
         return self._type_slot == Self.mp_length._type_slot
 
@@ -305,7 +306,7 @@ struct PyTypeObjectSlot(
         """Returns True if self represents a Mapping Protocol `getitem` slot.
 
         Returns:
-            True if the time slot is `mp_getitem`.
+            True if the type slot is `mp_getitem`.
         """
         return self._type_slot == Self.mp_getitem._type_slot
 
@@ -315,7 +316,7 @@ struct PyTypeObjectSlot(
         `setitem`/`delitem` slot.
 
         Returns:
-            True if the time slot is `mp_setitem`.
+            True if the type slot is `mp_setitem`.
         """
         return self._type_slot == Self.mp_setitem._type_slot
 
@@ -324,9 +325,27 @@ struct PyTypeObjectSlot(
         """Returns True if self represents a Type Protocol `richcompare` slot.
 
         Returns:
-            True if the time slot is `tp_richcompare`.
+            True if the type slot is `tp_richcompare`.
         """
         return self._type_slot == Self.tp_richcompare._type_slot
+
+
+@fieldwise_init
+@register_passable("trivial")
+struct NotImplementedError(Writable):
+    """A custom error type to be returned from Mojo binding functions to signal NotImplemented.
+    """
+
+    comptime name: String = "NotImplementedError"
+    """Define a well known name so that we can dispatch on it until we get more compiler support."""
+
+    fn write_to(self, mut writer: Some[Writer]):
+        """This always writes "NotImplemented".
+
+        Args:
+            writer: The writer to write to.
+        """
+        writer.write(Self.name)
 
 
 fn _mp_length_wrapper[
@@ -354,8 +373,9 @@ fn _mp_length_wrapper[
         return Py_ssize_t(result)
     except e:
         var error_type = cpython.get_error_global("PyExc_Exception")
+        var msg = String(e)
         cpython.PyErr_SetString(
-            error_type, e.data.as_c_string_slice().unsafe_ptr()
+            error_type, msg.as_c_string_slice().unsafe_ptr()
         )
         return Py_ssize_t(-1)
 
@@ -389,22 +409,25 @@ fn _mp_subscript_wrapper[
         return result.steal_data()
     except e:
         var error_type = cpython.get_error_global("PyExc_Exception")
+        var msg = String(e)
         cpython.PyErr_SetString(
-            error_type, e.data.as_c_string_slice().unsafe_ptr()
+            error_type, msg.as_c_string_slice().unsafe_ptr()
         )
         return PyObjectPtr()
 
 
 fn _mp_ass_subscript_wrapper[
-    method: fn (PythonObject, PythonObject, PythonObject) raises -> None
+    method: fn (
+        PythonObject, PythonObject, Variant[PythonObject, Int]
+    ) raises -> None
 ](py_self: PyObjectPtr, key: PyObjectPtr, value: PyObjectPtr) -> c_int:
     """Python-compatible wrapper for mapping assignment subscript protocol (__setitem__/__delitem__).
 
     This function serves as the `mp_ass_subscript` slot (slot 3) for Python type objects.
     It adapts user methods to the objobjargproc signature required by the mapping protocol.
 
-    When value is NULL, this indicates a deletion (__delitem__). Otherwise, it's an
-    assignment (__setitem__).
+    A value of NULL indicates a deletion (__delitem__) and the 3rd argument will be an Int
+    with value 0. Otherwise, it's an assignment (__setitem__) and the 3rd argument is the value.
 
     Parameters:
         method: The user's method that takes self, key, and value.
@@ -417,19 +440,25 @@ fn _mp_ass_subscript_wrapper[
     Returns:
         0 on success, -1 on failure (with Python exception set).
     """
+    comptime PassedValue = Variant[PythonObject, Int]
     ref cpython = Python().cpython()
 
     try:
+        var passed_value = PassedValue(
+            PythonObject(from_borrowed=value)
+        ) if value else PassedValue(Int(0))
+
         method(
             PythonObject(from_borrowed=py_self),
             PythonObject(from_borrowed=key),
-            PythonObject(from_borrowed=value),
+            passed_value,
         )
         return c_int(0)
     except e:
         var error_type = cpython.get_error_global("PyExc_Exception")
+        var msg = String(e)
         cpython.PyErr_SetString(
-            error_type, e.data.as_c_string_slice().unsafe_ptr()
+            error_type, msg.as_c_string_slice().unsafe_ptr()
         )
         return c_int(-1)
 
@@ -442,16 +471,19 @@ fn _richcompare_wrapper[
     This function serves as the `tp_richcompare` slot for Python type objects.
     It adapts user methods to the richcmpfunc signature required by Python.
 
+    If the user function raises NotImplementedError this wrapper returns Py_NotImplemented.
+
     Parameters:
-        method: The user's comparison method that returns a Bool.
+        method: The user's comparison method that returns a Bool and can mark
+            comparisons as NotImplemented.
 
     Args:
         py_self: Pointer to the first Python object.
         py_other: Pointer to the second Python object.
-        op: The comparison operator (Py_LT, Py_LE, Py_EQ, Py_NE, Py_GT, Py_GE).
+        op: The comparison operator constants in RichCompareOps (Py_LT, Py_LE, Py_EQ, Py_NE, Py_GT, Py_GE).
 
     Returns:
-        A Python boolean object (Py_True or Py_False), or null pointer if an
+        A Python boolean object (Py_True,Py_False or NotImplemented), or null pointer if an
         error occurs (with Python exception set).
     """
     ref cpython = Python().cpython()
@@ -464,9 +496,14 @@ fn _richcompare_wrapper[
         )
         return cpython.PyBool_FromLong(c_long(Int(result)))
     except e:
+        # Mojo does not have support for multiple `except` branches. It also does not have support for `isinstance`.
+        # For name dispatch on the string representation of the exception.
+        var msg = String(e)
+        if NotImplementedError.name == msg:
+            return cpython.Py_NewRef(cpython.Py_NotImplemented())
         var error_type = cpython.get_error_global("PyExc_Exception")
         cpython.PyErr_SetString(
-            error_type, e.data.as_c_string_slice().unsafe_ptr()
+            error_type, msg.as_c_string_slice().unsafe_ptr()
         )
         return PyObjectPtr()
 
@@ -1158,8 +1195,10 @@ struct PythonTypeBuilder(Copyable):
         """Sets the rich compare method, see https://peps.python.org/pep-0207.
 
         Parameters:
-            method: The user method to install as the compare method. The API matches the python richcompare protocol.
-            slot: The Python type slot to define, needs to be tp_richcompare.
+            method: The user method to install as the compare method. The API
+                matches the python richcompare protocol and can return
+                NotImplemented by setting the out parameter.
+            slot: The Python type slot to define, must be `tp_richcompare`.
 
         Returns:
             A refence to self for easier chaining.
@@ -1187,7 +1226,7 @@ struct PythonTypeBuilder(Copyable):
             method: The user method to install as the length method. It should
                 take self as a PythonObject and return an Int representing the
                 length of the container.
-            slot: The Python type slot to define, needs to be tp_richcompare.
+            slot: The Python type slot to define, must be `mp_length`.
 
         Returns:
             A reference to self for easier chaining.
@@ -1201,7 +1240,9 @@ struct PythonTypeBuilder(Copyable):
         return self
 
     fn def_method[
-        method: fn (PythonObject, PythonObject, PythonObject) raises -> None,
+        method: fn (
+            PythonObject, PythonObject, Variant[PythonObject, Int]
+        ) raises -> None,
         slot: PyTypeObjectSlot,
     ](mut self: Self) -> ref [self] Self where slot.is_mp_setitem():
         """Sets the mapping assignment subscript method (__setitem__/__delitem__).
@@ -1216,7 +1257,7 @@ struct PythonTypeBuilder(Copyable):
             method: The user method to install as the setitem method. It should
                 take self, key, and value as PythonObjects. For deletion, value
                 will be None.
-            slot: The Python type slot to define, needs to be tp_richcompare.
+            slot: The Python type slot to define, must be `mp_setitem`.
 
         Returns:
             A reference to self for easier chaining.
@@ -1243,7 +1284,7 @@ struct PythonTypeBuilder(Copyable):
         Parameters:
             method: The user method to install as the getitem method. It should
                 take self and key as PythonObjects and return the value.
-            slot: The Python type slot to define, needs to be tp_richcompare.
+            slot: The Python type slot to define, must be `mp_getitem`.
 
         Returns:
             A reference to self for easier chaining.

--- a/mojo/stdlib/std/python/bindings.mojo
+++ b/mojo/stdlib/std/python/bindings.mojo
@@ -20,7 +20,7 @@ conversion. This enables seamless bidirectional interoperability between Mojo
 and Python code.
 """
 
-from std.ffi import _Global, c_int
+from std.ffi import _Global, c_int, c_long
 from std.sys.info import size_of
 
 from std.builtin._startup import _ensure_current_or_global_runtime_init
@@ -235,7 +235,7 @@ fn _tp_repr_wrapper[
 
 struct PyTypeObjectSlot(
     ImplicitlyCopyable,
-    TrivialRegisterType,
+    TrivialRegisterPassable,
 ):
     """Tag struct for defining methods for the various type object slots.
 
@@ -331,7 +331,7 @@ struct PyTypeObjectSlot(
 
 
 @fieldwise_init
-struct NotImplementedError(TrivialRegisterType, Writable):
+struct NotImplementedError(TrivialRegisterPassable, Writable):
     """A custom error type to be returned from Mojo binding functions to signal NotImplemented.
     """
 


### PR DESCRIPTION
Currently if you define a `__getitem__` method and export the struct to Python you can call the 
given method but you cannot use []. That's because the methods of the Mapping protocol need 
to be plumbed through special `tp_slots` in the type definition.

This PR proposes an approach for how this could be done. I am not familiar with current and future
directions of the Python Interop design. There are many of these type slots here:
https://github.com/python/cpython/blob/main/Include/typeslots.h. The design should accommodate
all those.

Feedback appreciated.
