### PR TITLE
[Examples] Remove <26 pin from examples

### DIFF
--- a/examples/embedding-architecture/pixi.toml
+++ b/examples/embedding-architecture/pixi.toml
@@ -57,5 +57,5 @@ echo "If no prompt is provided, a default example will be used."
 
 [dependencies]
 python = ">=3.13.5,<3.14"
-modular = ">=25.6.0.dev2025081205,<26"
+modular = "*"
 ruff = ">=0.12.8,<0.13"

--- a/examples/pytorch_custom_ops/pixi.toml
+++ b/examples/pytorch_custom_ops/pixi.toml
@@ -14,7 +14,7 @@ torch-grayscale = "python torch-grayscale.py"
 whisper = "python whisper.py"
 
 [dependencies]
-modular = ">=25.6.0.dev2025080505,<26"
+modular = "*"
 pillow = ">=11.3.0,<12"
 numpy = ">=2.3.2,<3"
 pytorch = ">=2.7.1,<3"


### PR DESCRIPTION
We're moving on to 26.1 nightlies, this broke lockfile creation. We don't adhere to semver anyways, so pinning this doesn't actually get us any stability.

Committing here to unblock the nightly that is about to go out.
