### PR TITLE
[docs] Fix typo: “librar” to “library”

### DIFF
--- a/mojo/docs/roadmap.mdx
+++ b/mojo/docs/roadmap.mdx
@@ -361,7 +361,7 @@ accept your contributions there. Although this roadmap mentions some standard
 library types because they depend on changes in the Mojo compiler, a lot of
 work on the standard library is not accounted for here.
 
-You can learn more about contributing to the standard librar from the
+You can learn more about contributing to the standard library from the
 contributor doc below:
 
 - [Contributor


### PR DESCRIPTION
This pull request fixes a small typo in the Mojo roadmap documentation by correcting **"librar"** to **"library"**.

This change improves clarity and maintains consistency within the documentation.

Related to issue #5579.