### PR TITLE
add ability to set compile time variables in python->mojo interop layer

### DIFF
--- a/examples/mojo/python-interop/hello_comptime.py
+++ b/examples/mojo/python-interop/hello_comptime.py
@@ -1,0 +1,39 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import os
+import sys
+
+# add current directory to Path to enable importing Mojo modules from this directory
+current_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, current_dir)
+
+# The Mojo importer module will handle compilation of the Mojo files.
+import mojo.importer  # noqa: F401
+from mojo.importer import set_comptime_variables
+
+# Set compile-time variables before importing the Mojo module.
+# Variables are specified as key-value pairs where both keys and values are strings.
+# These variables will be available during Mojo compilation via env_get_string.
+set_comptime_variables(
+    module_name="hello_comptime_mojo",
+    values={"MOJO_COMPTIME_KEY": "world"}
+)
+
+# Importing our Mojo module, defined in the `hello_comptime_mojo.mojo` file.
+import hello_comptime_mojo  # type: ignore
+
+if __name__ == "__main__":
+    # Calling into a Mojo function that uses a compile-time variable:
+    result = hello_comptime_mojo.hello()
+    print(f"{result=}")

--- a/examples/mojo/python-interop/hello_comptime_mojo.mojo
+++ b/examples/mojo/python-interop/hello_comptime_mojo.mojo
@@ -1,0 +1,44 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+
+from os import abort
+
+from python import PythonObject
+from python.bindings import PythonModuleBuilder
+from sys.param_env import env_get_string
+
+
+
+# An interface for this Mojo module must be exported to Python.
+@export
+fn PyInit_hello_comptime_mojo() -> PythonObject:
+    try:
+        # A Python module is constructed, matching the name of this Mojo module.
+        var module = PythonModuleBuilder("hello_comptime_mojo")
+        # The functions to be exported are registered within this module.
+        module.def_function[hello]("hello")
+        return module.finalize()
+    except e:
+        return abort[PythonObject](
+            String("failed to create Python module: ", e)
+        )
+
+
+
+fn hello() raises -> PythonObject:
+    """A very basic function illustrating passing comptime strings to and from Mojo."""
+    # A comptime variable is declared and passed to the mojo compiler at runtime in Python
+    # see also: sys.param_env.env_get_int
+    alias comptime_value = env_get_string["MOJO_COMPTIME_KEY"]()
+    return "hello " + String(comptime_value) + " from mojo!"


### PR DESCRIPTION
This PR adds a mechanism for setting compile time variables in Mojo from runtime values in Python to the Mojo-Python interop layer

Key changes:
- added `mojo.importer.set_comptime_variables(module_name: str, variables: dict[str, str])
- added hash of comptime variables to cached dynamic library filename
- added example usage

Motivation:
- enabling compile time optimizations in mojo based on information only available at runtime in Python

This API is intended as a starting point for discussion, open to making any required changes

I put this together with Jeff Martin 