### PR TITLE
[stdlib] Fix: Switch `TestReport.name` from `StaticString` to `String`

### DIFF
--- a/mojo/stdlib/stdlib/testing/suite.mojo
+++ b/mojo/stdlib/stdlib/testing/suite.mojo
@@ -121,7 +121,7 @@ struct TestReport(Copyable, Movable, Writable):
 
     comptime _ErrorIndent = 3
 
-    var name: StaticString
+    var name: String
     """The name of the test."""
 
     var duration_ns: UInt
@@ -134,7 +134,7 @@ struct TestReport(Copyable, Movable, Writable):
     """The error associated with a failing test."""
 
     @staticmethod
-    fn passed(*, name: StaticString, duration_ns: UInt) -> Self:
+    fn passed(*, var name: String, duration_ns: UInt) -> Self:
         """Create a passing test report.
 
         Args:
@@ -145,15 +145,13 @@ struct TestReport(Copyable, Movable, Writable):
             A new passing test report.
         """
         return {
-            name = name,
+            name = name^,
             duration_ns = duration_ns,
             result = TestResult.PASS,
         }
 
     @staticmethod
-    fn failed(
-        *, name: StaticString, duration_ns: UInt, var error: Error
-    ) -> Self:
+    fn failed(*, var name: String, duration_ns: UInt, var error: Error) -> Self:
         """Create a failing test report.
 
         Args:
@@ -165,14 +163,14 @@ struct TestReport(Copyable, Movable, Writable):
             A new failing test report.
         """
         return {
-            name = name,
+            name = name^,
             duration_ns = duration_ns,
             result = TestResult.FAIL,
             error = error^,
         }
 
     @staticmethod
-    fn skipped(*, name: StaticString) -> Self:
+    fn skipped(*, var name: String) -> Self:
         """Create a skipped test report.
 
         Args:
@@ -181,18 +179,18 @@ struct TestReport(Copyable, Movable, Writable):
         Returns:
             A new skipped test report.
         """
-        return {name = name, duration_ns = 0, result = TestResult.SKIP}
+        return {name = name^, duration_ns = 0, result = TestResult.SKIP}
 
     @doc_private
     fn __init__(
         out self,
         *,
-        name: StaticString,
+        var name: String,
         duration_ns: UInt,
         result: TestResult,
         var error: Error = {},
     ):
-        self.name = name
+        self.name = name^
         self.duration_ns = duration_ns
         self.result = result
         self.error = error^
@@ -371,10 +369,10 @@ struct TestSuite(Movable):
     var location: _SourceLocation
     """The source location where the test suite was created."""
 
-    var skip_list: Set[StaticString]
+    var skip_list: Set[String]
     """The list of tests to skip in this suite."""
 
-    var allow_list: Optional[Set[StaticString]]
+    var allow_list: Optional[Set[String]]
     """The list of tests to allow in this suite."""
 
     var cli_args: List[StaticString]
@@ -397,7 +395,7 @@ struct TestSuite(Movable):
         """
         self.tests = List[_Test]()
         self.location = location.or_else(__call_location())
-        self.skip_list = Set[StaticString]()
+        self.skip_list = {}
         self.allow_list = None  # None means no allow list specified.
         self.cli_args = cli_args.or_else(List[StaticString](argv()))
 
@@ -489,12 +487,12 @@ struct TestSuite(Movable):
             return
 
         if args[1] == "--only":
-            self.allow_list = Set[StaticString]()
+            self.allow_list = Set[String]()
         elif args[1] == "--skip-all":
             if num_args > 2:
                 raise Error("'--skip-all' does not take any arguments")
             # --skip-all implies an empty allow list.
-            self.allow_list = Set[StaticString]()
+            self.allow_list = Set[String]()
             return
         elif args[1] != "--skip":
             raise Error(
@@ -507,7 +505,7 @@ struct TestSuite(Movable):
             raise Error("expected test name(s) after '--only' or '--skip'")
 
         # TODO: would be better if this was StaticString
-        var discovered_tests = Set[StaticString]()
+        var discovered_tests = Set[String]()
         for test in self.tests:
             discovered_tests.add(test.name)
 
@@ -573,7 +571,7 @@ struct TestSuite(Movable):
         # when we have a proper argument parsing library.
         self._parse_filter_lists()
         if skip_all:
-            self.allow_list = Set[StaticString]()
+            self.allow_list = Set[String]()
 
         var reports = List[TestReport](capacity=len(self.tests))
         for test in self.tests:

--- a/mojo/stdlib/stdlib/testing/suite.mojo
+++ b/mojo/stdlib/stdlib/testing/suite.mojo
@@ -504,7 +504,6 @@ struct TestSuite(Movable):
         if num_args == 2:
             raise Error("expected test name(s) after '--only' or '--skip'")
 
-        # TODO: would be better if this was StaticString
         var discovered_tests = Set[String]()
         for test in self.tests:
             discovered_tests.add(test.name)


### PR DESCRIPTION
This is to support runtime test discovery.

Example runtime test discovery:
```mojo
from subprocess import run
from testing.suite import TestSuiteReport, TestReport, TestResult
from builtin._location import __call_location
from pathlib import Path
from time import perf_counter_ns

comptime TEST_DIR = Path("tests")

def test_file(file: Path) -> TestReport:
    var result = run("pixi run test " + String(file))
    if "Unhandled exception caught during execution" in result:
        return TestReport.failed(
            name=file.name(), duration_ns=0, error=Error(result)
        )
    return TestReport.passed(name=file.name(), duration_ns=0)

def walk_tests(path: Path, mut test_results: List[TestReport]):
    for f in path.listdir():
        file = path / f
        if file.is_file() and file.suffix() == ".mojo":
            var result = test_file(file)
            test_results.append(result^)
        elif file.is_dir():
            walk_tests(file, test_results)


def main():
    var test_results = List[TestReport]()
    walk_tests(TEST_DIR, test_results)
    var report = TestSuiteReport(
        reports=test_results^, location=__call_location[inline_count=0]()
    )
    print(report)
```
Compile time inter-file test discover also still works:
```mojo
from testing import assert_equal, TestSuite

def test_lightbug_http_backend():
    assert_equal(2, 1)

def main():
    TestSuite.discover_tests[__functions_in_module()]().run()
```
Example output:
<img width="1004" height="334" alt="Screenshot 2025-11-26 at 3 43 29 PM" src="https://github.com/user-attachments/assets/c6bf47e6-fc9e-4a93-ade9-178543a16b01" />


