### PR TITLE
[stdlib] Get the error message when calling os.remove and assert it (#2342)

### DIFF
--- a/mojo/stdlib/stdlib/os/os.mojo
+++ b/mojo/stdlib/stdlib/os/os.mojo
@@ -25,6 +25,7 @@ from collections.string.string_slice import _unsafe_strlen
 from io import FileDescriptor
 from sys import CompilationTarget, external_call, is_gpu
 from sys.ffi import c_char, c_int
+from sys._libc_errno import get_errno
 
 from .path import isdir, split
 from .pathlike import PathLike
@@ -287,11 +288,8 @@ fn remove[PathLike: os.PathLike](path: PathLike) raises:
     )
 
     if error != 0:
-        # TODO get error message, the following code prints it
-        # var error_str = String("Something went wrong")
-        # _ = external_call["perror", OpaquePointer](error_str.unsafe_ptr())
-        # _ = error_str
-        raise Error("Can not remove file: ", fspath)
+        var error_string = get_errno()
+        raise Error(error_string, ": ", fspath)
 
 
 fn unlink[PathLike: os.PathLike](path: PathLike) raises:

--- a/mojo/stdlib/test/os/test_remove.mojo
+++ b/mojo/stdlib/test/os/test_remove.mojo
@@ -45,9 +45,9 @@ def test_remove():
     )
 
     # trying to delete non existing file
-    with assert_raises(contains="Can not remove file: "):
+    with assert_raises(contains="No such file or directory: "):
         remove(my_file_name)
-    with assert_raises(contains="Can not remove file: "):
+    with assert_raises(contains="No such file or directory: "):
         remove(my_file_path)
 
     create_file_and_test_delete_path[remove, "remove"](my_file_name)


### PR DESCRIPTION
This PR is in order to address #2342 by adding error information from ``external_call`` from the ``os.remove`` function if an error has occurred.


P.S

First contribution to this project, just wanna say that I am a big fan of the layout so far + docs. It's been a lot to get my head situated into. I've never had to build a stdlib for instance, but outside of an initial steep learning curve, I've been enjoying it!

The tight iteration loop and tooling is really powerful already from my initial impression, so big props to the contributors! 