### PR TITLE
[docs] Fix broken relative path links in READMEs

### DIFF
--- a/max/kernels/README.md
+++ b/max/kernels/README.md
@@ -17,7 +17,7 @@ To evaluate kernel performance on NVIDIA hardware, see [Kernel profiling with
 Nsight Compute](docs/profiling.md).
 
 If you're looking for the high-level Python APIs based on these kernels and
-used to build MAX graphs, see the [`max/nn/`](../nn) directory.
+used to build MAX graphs, see the [`max/python/max/nn/`](/max/python/max/nn/) directory.
 
 ## Contributing
 

--- a/max/python/max/nn/README.md
+++ b/max/python/max/nn/README.md
@@ -6,4 +6,4 @@ performance-optimized MAX graphs such as those in the
 [`pipelines/architectures/`](../pipelines/architectures/) directory.
 
 If you're looking for the low-level compute kernels that correspond to these
-Python APIs, see the [`max/kernels/`](../kernels) directory.
+Python APIs, see the [`max/kernels/`](/max/kernels) directory.


### PR DESCRIPTION
I was going through the repository and noticed these two links don't work since `max/nn/` has moved to a new location. I've updated them.