### PR TITLE
[stdlib] Optimize `StringSlice.char_length` using SIMD `pack_bits` and `pop_count` (12x speedup)

### DIFF
--- a/mojo/stdlib/benchmarks/collections/bench_string.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_string.mojo
@@ -229,6 +229,25 @@ fn bench_string_replace[
 
 
 # ===-----------------------------------------------------------------------===#
+# Benchmark string char_length
+# ===-----------------------------------------------------------------------===#
+@parameter
+fn bench_string_char_length[
+    length: Int = 0, filename: StaticString = "UN_charter_EN"
+](mut b: Bencher) raises:
+    var items = make_string[length](filename + ".txt")
+
+    @always_inline
+    @parameter
+    fn call_fn() raises:
+        var res = items.as_string_slice().char_length()
+        keep(res)
+
+    b.iter[call_fn]()
+    keep(Bool(items))
+
+
+# ===-----------------------------------------------------------------------===#
 # Benchmark string find single
 # ===-----------------------------------------------------------------------===#
 @parameter
@@ -436,6 +455,9 @@ def main():
             )
             m.bench_function[bench_string_replace[length, fname, old, new]](
                 BenchId(String("bench_string_replace", suffix))
+            )
+            m.bench_function[bench_string_char_length[length, fname]](
+                BenchId(String("bench_string_char_length", suffix))
             )
             m.bench_function[bench_string_find_single[length, fname]](
                 BenchId(String("bench_string_find_single", suffix))

--- a/mojo/stdlib/stdlib/builtin/simd.mojo
+++ b/mojo/stdlib/stdlib/builtin/simd.mojo
@@ -75,7 +75,7 @@ from builtin.device_passable import DevicePassable
 from builtin.format_int import _try_write_int
 from builtin.math import DivModable, Powable
 from documentation import doc_private
-from memory import bitcast, memcpy
+from memory import bitcast, memcpy, pack_bits
 from python import ConvertibleToPython, Python, PythonObject
 
 from utils import IndexList, StaticTuple
@@ -3042,7 +3042,16 @@ struct SIMD[dtype: DType, size: Int](
 
         @parameter
         if Self.dtype is DType.bool:
-            return Int(self.cast[DType.uint8]().reduce_add())
+
+            @parameter
+            if Self.size == 1:
+                return Int(self)
+            else:
+                var packed_mask = pack_bits(
+                    rebind[SIMD[DType.bool, Self.size]](self)
+                )
+                var count = pop_count(packed_mask)
+                return Int(count)
         else:
             return Int(pop_count(self).reduce_add())
 

--- a/mojo/stdlib/stdlib/memory/span.mojo
+++ b/mojo/stdlib/stdlib/memory/span.mojo
@@ -22,6 +22,8 @@ from memory import Span
 
 from builtin._location import __call_location
 from bit._mask import splat
+from bit import pop_count
+from memory import pack_bits
 from collections._index_normalization import normalize_index
 from sys import align_of
 from sys.info import simd_width_of
@@ -745,26 +747,17 @@ struct Span[mut: Bool, //, T: Copyable & Movable, origin: Origin[mut]](
             The amount of times the function returns `True`.
         """
 
-        comptime simdwidth = simd_width_of[DType.int]()
+        comptime simdwidth = simd_width_of[dtype]()
         var ptr = self.unsafe_ptr()
         var length = len(self)
-        var countv = SIMD[DType.int, simdwidth](0)
-        var count = Scalar[DType.int](0)
+        var count = 0
 
-        fn do_count[
-            width: Int
-        ](idx: Int) unified {mut count, mut countv, read ptr}:
-            var vec = func(ptr.load[width=width](idx)).cast[DType.int]()
-
-            @parameter
-            if width == 1:
-                count += rebind[type_of(count)](vec)
-            else:
-                countv += rebind[type_of(countv)](vec)
+        fn do_count[width: Int](idx: Int) unified {mut count, read ptr}:
+            var mask = func(ptr.load[width=width](idx))
+            count += mask.reduce_bit_count()
 
         vectorize[simdwidth](length, do_count)
-
-        return UInt(countv.reduce_add() + count)
+        return UInt(count)
 
     @always_inline
     fn unsafe_subspan(self, *, offset: Int, length: Int) -> Self:


### PR DESCRIPTION
This PR significantly optimizes `StringSlice.char_length` by maximizing SIMD register throughput.

The Optimization: The previous (or naive) SIMD approaches often require casting `int8` predicates to wider integer types (e.g., `int32`) to perform reductions, which reduces the effective SIMD width by 4x or 8x.

This implementation uses `pack_bits` to compress the comparison results (continuation byte detection) into a single integer mask, followed by `pop_count`. This approach:

1. Maintains 100% data density: Processes 64 bytes per instruction on AVX-512 (vs 16 bytes if casted to 32-bit ints).

2. Utilizes hardware acceleration: Maps efficiently to `vpmovmskb/popcnt` on x86 and equivalent instructions on ARM.

Benchmarks (1MB text): The new implementation removes the performance penalty for multi-byte characters seen in the current implementation.

Language | Before (ms) | After (ms) | Speedup
-- | -- | -- | --
EN (ASCII) | ~0.019 | ~0.020 | 1.0x
ZH (Chinese) | 0.241 | 0.020 | 12.0x 🚀
AR (Arabic) | 0.245 | 0.017 | 14.4x 🚀

Device: Mac mini M4