### PR TITLE
[stdlib] Use `memcmp` to dispatch to optimized implementation in `StringSlice`

### DIFF
--- a/mojo/stdlib/stdlib/collections/string/string_slice.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string_slice.mojo
@@ -78,7 +78,6 @@ from memory import (
     memcpy,
     pack_bits,
 )
-from memory.memory import _memcmp_impl_unconstrained
 from python import ConvertibleToPython, Python, PythonObject
 
 comptime StaticString = StringSlice[StaticConstantOrigin]
@@ -987,7 +986,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut]](
         """
         var len1 = len(self)
         var len2 = len(rhs)
-        return Int(len1 < len2) > _memcmp_impl_unconstrained(
+        return Int(len1 < len2) > memcmp(
             self.unsafe_ptr(), rhs.unsafe_ptr(), min(len1, len2)
         )
 


### PR DESCRIPTION
This PR updates the comparison logic in `StringSlice` to use the public `memcmp` API instead of the internal `_memcmp_impl_unconstrained`.

Previously, `StringSlice` was directly calling `_memcmp_impl_unconstrained`. By switching to the standard `memcmp`, we allow the call to be properly dispatched to the optimized implementation (`_memcmp_impl_opt_unconstrained`).

This ensures that string slice comparisons leverage the best available memory comparison implementation provided by the standard library.