### PR TITLE
[Stdlib] Add implicit Codepoint(StringLiteral) constructor

### DIFF
--- a/mojo/stdlib/stdlib/collections/string/codepoint.mojo
+++ b/mojo/stdlib/stdlib/collections/string/codepoint.mojo
@@ -138,6 +138,54 @@ struct Codepoint(
         """
         self._scalar_value = UInt32(Int(codepoint))
 
+    @always_inline("nodebug")
+    @implicit
+    fn __init__[
+        value: __mlir_type.`!kgen.string`
+    ](out self, lit: StringLiteral[value]):
+        """Construct a `Codepoint` from a single-character `StringLiteral`.
+
+        This constructor validates at compile-time that the literal contains
+        exactly one byte, and computes the codepoint value as a compile-time
+        constant. This provides an ergonomic and efficient way to create
+        codepoints from string literals without runtime overhead.
+
+        Parameters:
+            value: The compile-time string literal value.
+
+        Args:
+            lit: A string literal containing exactly one byte.
+
+        Constraints:
+            The string literal must have a byte length of exactly 1. Multi-byte
+            UTF-8 sequences are not currently supported.
+
+        Examples:
+
+        ```mojo
+        from collections.string import Codepoint
+        from testing import assert_equal
+
+        # Create codepoints from literals
+        var a = Codepoint("A")
+        assert_equal(a.to_u32(), 65)
+
+        var space = Codepoint(" ")
+        assert_equal(space, Codepoint.ord(" "))
+        ```
+        """
+        # Reconstruct the literal from the type parameter to force compile-time evaluation
+        alias sl: StringLiteral[value] = {}
+        
+        # Compile-time constraint - fails if literal isn't exactly 1 byte
+        constrained[len(sl) == 1, "StringLiteral must contain exactly one byte"]()
+        
+        # Compute the codepoint at compile-time using alias
+        alias cp = Codepoint.ord(StaticString(sl))
+        
+        # Assign the computed value
+        self = cp
+
     # ===-------------------------------------------------------------------===#
     # Factory methods
     # ===-------------------------------------------------------------------===#

--- a/mojo/stdlib/stdlib/collections/string/codepoint.mojo
+++ b/mojo/stdlib/stdlib/collections/string/codepoint.mojo
@@ -182,9 +182,9 @@ struct Codepoint(
         comptime sl: StringLiteral[value] = {}
 
         # Compile-time validation for proper UTF-8 codepoint
-        constrained[
-            sl.byte_length() > 0, "Cannot construct an empty codepoint"
-        ]()
+        __comptime_assert (
+            sl.byte_length() > 0
+        ), "Cannot construct an empty codepoint"
 
         # SAFETY:
         #   This is safe because `StringLiteral` is guaranteed to point to valid
@@ -193,10 +193,9 @@ struct Codepoint(
             sl.as_bytes()
         )
 
-        constrained[
-            sl.byte_length() == Int(num_bytes),
-            "input string must be one character",
-        ]()
+        __comptime_assert sl.byte_length() == Int(
+            num_bytes
+        ), "input string must be one character"
 
         self = char
 

--- a/mojo/stdlib/stdlib/collections/string/codepoint.mojo
+++ b/mojo/stdlib/stdlib/collections/string/codepoint.mojo
@@ -176,13 +176,15 @@ struct Codepoint(
         """
         # Reconstruct the literal from the type parameter to force compile-time evaluation
         alias sl: StringLiteral[value] = {}
-        
+
         # Compile-time constraint - fails if literal isn't exactly 1 byte
-        constrained[len(sl) == 1, "StringLiteral must contain exactly one byte"]()
-        
+        constrained[
+            len(sl) == 1, "StringLiteral must contain exactly one byte"
+        ]()
+
         # Compute the codepoint at compile-time using alias
         alias cp = Codepoint.ord(StaticString(sl))
-        
+
         # Assign the computed value
         self = cp
 

--- a/mojo/stdlib/stdlib/collections/string/codepoint.mojo
+++ b/mojo/stdlib/stdlib/collections/string/codepoint.mojo
@@ -139,19 +139,13 @@ struct Codepoint(
         self._scalar_value = UInt32(Int(codepoint))
 
     @always_inline("nodebug")
-    @implicit
-    fn __init__[
-        value: __mlir_type.`!kgen.string`
-    ](out self, lit: StringLiteral[value]):
+    fn __init__(out self, lit: StringLiteral):
         """Construct a `Codepoint` from a single-codepoint `StringLiteral`.
 
         This constructor validates at compile-time that the literal contains
         exactly one Unicode codepoint, and computes the codepoint value as a
         compile-time constant. This provides an ergonomic and efficient way to
         create codepoints from string literals without runtime overhead.
-
-        Parameters:
-            value: The compile-time string literal value.
 
         Args:
             lit: A string literal containing exactly one Unicode codepoint.
@@ -179,7 +173,7 @@ struct Codepoint(
         ```
         """
         # Reconstruct the literal from the type parameter to force compile-time evaluation
-        comptime sl: StringLiteral[value] = {}
+        comptime sl: StringLiteral[lit.value] = {}
 
         # Compile-time validation for proper UTF-8 codepoint
         __comptime_assert (

--- a/mojo/stdlib/stdlib/collections/string/codepoint.mojo
+++ b/mojo/stdlib/stdlib/collections/string/codepoint.mojo
@@ -183,7 +183,9 @@ struct Codepoint(
         comptime sl: StringLiteral[value] = {}
 
         # Compile-time validation for proper UTF-8 codepoint
-        constrained[sl.byte_length() > 0, "Cannot construct an empty codepoint"]()
+        constrained[
+            sl.byte_length() > 0, "Cannot construct an empty codepoint"
+        ]()
         constrained[
             sl.byte_length()
             == Int(_utf8_first_byte_sequence_length(sl.as_bytes()[0])),

--- a/mojo/stdlib/test/collections/test_codepoint.mojo
+++ b/mojo/stdlib/test/collections/test_codepoint.mojo
@@ -311,6 +311,11 @@ def test_char_from_stringliteral():
     var c_null = Codepoint("\0")
     assert_equal(c_null.to_u32(), 0)
 
+    # Multi-byte UTF-8 codepoints
+    var c_emoji = Codepoint("🔥")
+    assert_equal(c_emoji, Codepoint.ord("🔥"))
+    assert_equal(c_emoji.to_u32(), 0x1F525)
+
     # Verify it works in compile-time contexts
     comptime c_comptime = Codepoint("X")
     assert_equal(c_comptime.to_u32(), 88)

--- a/mojo/stdlib/test/collections/test_codepoint.mojo
+++ b/mojo/stdlib/test/collections/test_codepoint.mojo
@@ -275,5 +275,46 @@ def test_char_comptime():
     assert_equal(c1_bytes, 1)
 
 
+def test_char_from_stringliteral():
+    """Test the implicit constructor from StringLiteral."""
+    # Basic ASCII characters
+    var c_a = Codepoint("A")
+    assert_equal(c_a.to_u32(), 65)
+    assert_equal(c_a, Codepoint.ord("A"))
+    
+    var c_z = Codepoint("Z")
+    assert_equal(c_z.to_u32(), 90)
+    assert_equal(c_z, Codepoint.ord("Z"))
+    
+    var c_zero = Codepoint("0")
+    assert_equal(c_zero.to_u32(), 48)
+    assert_equal(c_zero, Codepoint.ord("0"))
+    
+    # Whitespace characters (motivation from issue #5490)
+    var c_space = Codepoint(" ")
+    assert_equal(c_space.to_u32(), 32)
+    assert_equal(c_space, Codepoint.ord(" "))
+    
+    var c_tab = Codepoint("\t")
+    assert_equal(c_tab.to_u32(), 9)
+    assert_equal(c_tab, Codepoint.ord("\t"))
+    
+    var c_newline = Codepoint("\n")
+    assert_equal(c_newline.to_u32(), 10)
+    assert_equal(c_newline, Codepoint.ord("\n"))
+    
+    var c_carriage = Codepoint("\r")
+    assert_equal(c_carriage.to_u32(), 13)
+    assert_equal(c_carriage, Codepoint.ord("\r"))
+    
+    # Special characters
+    var c_null = Codepoint("\0")
+    assert_equal(c_null.to_u32(), 0)
+    
+    # Verify it works in compile-time contexts
+    comptime c_comptime = Codepoint("X")
+    assert_equal(c_comptime.to_u32(), 88)
+
+
 def main():
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/mojo/stdlib/test/collections/test_codepoint.mojo
+++ b/mojo/stdlib/test/collections/test_codepoint.mojo
@@ -281,36 +281,36 @@ def test_char_from_stringliteral():
     var c_a = Codepoint("A")
     assert_equal(c_a.to_u32(), 65)
     assert_equal(c_a, Codepoint.ord("A"))
-    
+
     var c_z = Codepoint("Z")
     assert_equal(c_z.to_u32(), 90)
     assert_equal(c_z, Codepoint.ord("Z"))
-    
+
     var c_zero = Codepoint("0")
     assert_equal(c_zero.to_u32(), 48)
     assert_equal(c_zero, Codepoint.ord("0"))
-    
+
     # Whitespace characters (motivation from issue #5490)
     var c_space = Codepoint(" ")
     assert_equal(c_space.to_u32(), 32)
     assert_equal(c_space, Codepoint.ord(" "))
-    
+
     var c_tab = Codepoint("\t")
     assert_equal(c_tab.to_u32(), 9)
     assert_equal(c_tab, Codepoint.ord("\t"))
-    
+
     var c_newline = Codepoint("\n")
     assert_equal(c_newline.to_u32(), 10)
     assert_equal(c_newline, Codepoint.ord("\n"))
-    
+
     var c_carriage = Codepoint("\r")
     assert_equal(c_carriage.to_u32(), 13)
     assert_equal(c_carriage, Codepoint.ord("\r"))
-    
+
     # Special characters
     var c_null = Codepoint("\0")
     assert_equal(c_null.to_u32(), 0)
-    
+
     # Verify it works in compile-time contexts
     comptime c_comptime = Codepoint("X")
     assert_equal(c_comptime.to_u32(), 88)


### PR DESCRIPTION
Fixes #5490 

This adds an implicit constructor to `Codepoint` that accepts a compile-time `StringLiteral` parameter, making it much easier to create codepoint constants.

### What changed
- Added `__init__[value: __mlir_type.\`!kgen.string\`](out self, lit: StringLiteral[value])`
- Constructor validates at compile-time that the literal is exactly 1 byte
- Computes the codepoint value using `alias` for compile-time evaluation
- Added comprehensive tests covering ASCII, whitespace, and compile-time usage

### Why
Currently, the only way to create a `Codepoint` from a literal is `Codepoint.ord("x")`, which is verbose and can generate suboptimal IR. The stdlib has been working around this with patterns like:
```mojo
alias ` ` = UInt8(ord(" "))
alias `\t` = UInt8(ord("\t"))
```

Now you can just write:
```
var space = Codepoint(" ")
var tab = Codepoint("\t")
```

The constructor enforces the single-byte constraint at compile-time, so invalid literals like Codepoint("") or Codepoint("ab") will fail to build rather than causing runtime issues.

### Testing
./bazelw test //mojo/stdlib/test/collections:test_codepoint.mojo.test passes
Added test_char_from_stringliteral() with coverage for ASCII, whitespace, and compile-time contexts