### PR TITLE
[stdlib] [kernels] Allow generic `LayoutTensor.stride` and `.shape` code

### DIFF
--- a/max/kernels/src/layout/layout_tensor.mojo
+++ b/max/kernels/src/layout/layout_tensor.mojo
@@ -2613,7 +2613,7 @@ struct LayoutTensor[
 
     @always_inline
     @staticmethod
-    fn shape[idx: Int]() -> Int where idx != UNKNOWN_VALUE:
+    fn shape[idx: Int]() -> Int:
         """Returns the size of the tensor along the specified dimension.
 
         Provides static access to the tensor's shape information. This method
@@ -2641,7 +2641,9 @@ struct LayoutTensor[
         - This is a static method that operates on the tensor's type information,
             not on a specific tensor instance.
         """
-
+        __comptime_assert (
+            0 <= idx < len(Self.layout.shape)
+        ), "idx must be within bounds"
         comptime shape = Self._to_static[
             Self.layout.shape, Self.layout_int_type
         ]()
@@ -2708,8 +2710,9 @@ struct LayoutTensor[
         - For non-contiguous tensors (e.g., tensor slices), strides may not
             follow a simple pattern.
         """
-        __comptime_assert idx != UNKNOWN_VALUE
-
+        __comptime_assert (
+            0 <= idx < len(Self.layout.shape)
+        ), "idx must be within bounds"
         comptime stride = Self._to_static[
             Self.layout.stride, Self.linear_idx_type
         ]()

--- a/max/kernels/test/layout/test_tensor.mojo
+++ b/max/kernels/test/layout/test_tensor.mojo
@@ -19,7 +19,7 @@ from layout._utils import ManagedLayoutTensor
 from layout.int_tuple import UNKNOWN_VALUE, product
 from layout.layout import Layout
 from layout.layout_tensor import *
-from testing import assert_equal
+from testing import assert_equal, assert_true
 
 
 fn print_raw_major_tensor(tensor: LayoutTensor):
@@ -2021,6 +2021,18 @@ fn test_merge():
     print(a)
 
 
+def test_generic_layout_logic():
+    comptime dims = Layout.row_major(4, 4, 4)
+    var _tensor = LayoutTensor[DType.uint8, dims](
+        UnsafePointer[Byte, ImmutAnyOrigin]()
+    )
+
+    @parameter
+    for i in range(len(dims) - 1):
+        assert_true(_tensor.stride[i]() > 1)
+        assert_equal(_tensor.shape[i](), 4)
+
+
 def main():
     test_basic_tensor_ops()
     test_tesnsor_fragments()
@@ -2054,3 +2066,4 @@ def main():
     test_vectorized_tile()
     test_nested_tile()
     test_tensor_size()
+    test_generic_layout_logic()


### PR DESCRIPTION
Allow generic `LayoutTensor.stride` and `.shape` code. Closes #5639

CC: @lsh 