### PR TITLE
[stdlib] Fix `unsafe_decode_utf8_codepoint` to validate input and discourage empty strings

### DIFF
--- a/mojo/stdlib/stdlib/collections/string/_unicode.mojo
+++ b/mojo/stdlib/stdlib/collections/string/_unicode.mojo
@@ -178,9 +178,9 @@ fn to_lowercase(s: StringSlice[mut=False]) -> String:
     var result = String(capacity=_estimate_needed_size(len(data)))
     var input_offset = 0
     while input_offset < len(data):
-        var rune_and_size = Codepoint.unsafe_decode_utf8_codepoint(
-            data[input_offset:]
-        )
+        var rune_and_size = Codepoint.unsafe_decode_utf8_codepoint[
+            fallback_empty_codepoint=False
+        ](data[input_offset:])
         var lowercase_char_opt = _get_lowercase_mapping(rune_and_size[0])
         if lowercase_char_opt is None:
             result.write_bytes(
@@ -207,9 +207,9 @@ fn to_uppercase(s: StringSlice[mut=False]) -> String:
     var result = String(capacity=_estimate_needed_size(len(data)))
     var input_offset = 0
     while input_offset < len(data):
-        var rune_and_size = Codepoint.unsafe_decode_utf8_codepoint(
-            data[input_offset:]
-        )
+        var rune_and_size = Codepoint.unsafe_decode_utf8_codepoint[
+            fallback_empty_codepoint=False
+        ](data[input_offset:])
         var uppercase_replacement_opt = _get_uppercase_mapping(rune_and_size[0])
 
         if uppercase_replacement_opt:

--- a/mojo/stdlib/stdlib/collections/string/string_slice.mojo
+++ b/mojo/stdlib/stdlib/collections/string/string_slice.mojo
@@ -447,9 +447,9 @@ struct CodepointsIter[mut: Bool, //, origin: Origin[mut]](
         if len(self._slice) > 0:
             # SAFETY: Will not read out of bounds because `_slice` is guaranteed
             #   to contain valid UTF-8.
-            codepoint, _ = Codepoint.unsafe_decode_utf8_codepoint(
-                self._slice._slice
-            )
+            codepoint, _ = Codepoint.unsafe_decode_utf8_codepoint[
+                fallback_empty_codepoint=False
+            ](self._slice._slice)
             return codepoint
         else:
             return None


### PR DESCRIPTION
Fix `unsafe_decode_utf8_codepoint` to validate input and discourage empty strings