### PR TITLE
[docs] Add missing import statements to pointer documentation

### DIFF
--- a/mojo/docs/manual/pointers/index.mdx
+++ b/mojo/docs/manual/pointers/index.mdx
@@ -16,6 +16,8 @@ example, the following code creates an `OwnedPointer` that points to an `Int`
 value:
 
 ```mojo
+from memory import OwnedPointer
+
 var ptr: OwnedPointer[Int]
 ptr = OwnedPointer(100)
 ```
@@ -156,6 +158,8 @@ You can construct a `Pointer` to an existing value by calling the constructor
 with the `to` keyword argument:
 
 ```mojo
+from memory import Pointer
+
 ptr = Pointer(to=some_value)
 ```
 
@@ -173,6 +177,8 @@ when you initialize the `OwnedPointer`. The `OwnedPointer` allocates memory and
 moves or copies the value into the reserved memory.
 
 ```mojo
+from memory import OwnedPointer
+
 o_ptr = OwnedPointer(some_big_struct)
 ```
 
@@ -197,6 +203,8 @@ may not be clear. Like an `OwnedPointer`, it points to a single value, and it
 allocates memory when you initialize the `ArcPointer` with a value:
 
 ```mojo
+from memory import ArcPointer
+
 attributesDict: Dict[String, String] = {}
 attributes = ArcPointer(attributesDict)
 ```


### PR DESCRIPTION
## Summary

Add `from memory import` statements to code examples in the "Intro to pointers" documentation.

## Problem

Fixes #5630

The pointer documentation shows code examples using `Pointer`, `OwnedPointer`, and `ArcPointer` without including the required import statements. This causes confusion and errors for newcomers trying to run the example code.

## Solution

Added the following import statements to standalone code examples:
- `from memory import OwnedPointer` (first example and OwnedPointer section)
- `from memory import Pointer` (Pointer section)
- `from memory import ArcPointer` (ArcPointer section)

## Testing

Verified that the documented code examples compile and run correctly with the added imports using Mojo 0.26.1.0.dev2025121305.

Without import:
```
error: use of unknown declaration 'OwnedPointer'
```

With import: Works correctly.

Signed-off-by: magi8101 <mj7841@srmist.edu.in>