### PR TITLE
[stdlib] [kernels] Fix wrong 2D slice layout constraint

### DIFF
--- a/max/kernels/src/layout/layout_tensor.mojo
+++ b/max/kernels/src/layout/layout_tensor.mojo
@@ -4436,10 +4436,7 @@ struct LayoutTensor[
     fn _compute_slice_layout(
         slice_0: Slice, slice_1: Slice, slice_0_axis: Int, slice_1_axis: Int
     ) -> Layout:
-        constrained[
-            Self.layout.shape.__len__() > 2,
-            "Rank should be >= 2",
-        ]()
+        __comptime_assert Self.layout.rank() >= 2, "Rank should be >= 2"
         var sliced_layout = sublayout(Self.layout, slice_0_axis, slice_1_axis)
         return Layout(
             [


### PR DESCRIPTION
Fix wrong 2D slice layout constraint.

This is blocking the 1D version of my generic n-dimensional fft code. While I can branch based on the number of dimensions I'd rather this get fixed at the source