### PR TITLE
[max][layout] Add load_scalar method to LayoutTensor for scalar element access

### DIFF
--- a/max/kernels/src/layout/layout_tensor.mojo
+++ b/max/kernels/src/layout/layout_tensor.mojo
@@ -1898,6 +1898,24 @@ struct LayoutTensor[
         )
 
     @always_inline("nodebug")
+    fn _load_scalar_offset(
+        self, offset: Scalar[Self.linear_idx_type]
+    ) -> Scalar[Self.dtype]:
+        """Retrieves a single scalar from the tensor at the specified offset.
+
+        This method loads the element at the given offset and returns the first
+        scalar lane. For tensors with element_size == 1, this is the only value.
+        For tiled/vectorized elements, this returns the 0th lane.
+
+        Args:
+            offset: The integer offset for array indexing.
+
+        Returns:
+            The scalar value at the specified offset.
+        """
+        return self._load_offset(offset)[0]
+
+    @always_inline("nodebug")
     fn __getitem__[*Tys: Indexer](self, *args: *Tys) -> Self.element_type:
         """Retrieves a single element from the tensor at the specified indices.
 
@@ -1954,6 +1972,69 @@ struct LayoutTensor[
 
         var offset = self.runtime_layout(crd)
         return self._load_offset(offset)
+
+    @always_inline("nodebug")
+    fn load_scalar[*Tys: Indexer](self, *args: *Tys) -> Scalar[Self.dtype]:
+        """Retrieves a single scalar from the tensor at the specified indices.
+
+        This method provides scalar element access for the tensor, which is
+        useful in generic contexts where `__getitem__` returns a SIMD vector
+        of `element_size` elements. This method always returns a single scalar
+        value (the 0th lane of the element).
+
+        The number of indices provided must match the rank of the tensor,
+        otherwise an error will occur at runtime.
+
+        Parameters:
+            Tys: The type of the indices. Must implement the `Indexer` trait,
+                and match the rank of the tensor.
+
+        Args:
+            args: The indices specifying the element's position in the tensor.
+
+        Returns:
+            The scalar value at the specified position with the tensor's dtype.
+        """
+        comptime arg_count = args.__len__()
+
+        constrained[
+            Self.rank == arg_count or Self.num_strides == arg_count,
+            "Indexed with "
+            + String(arg_count)
+            + " dims, but Self.rank, Self.num_strides = "
+            + String(Self.rank)
+            + ", "
+            + String(self.num_strides),
+        ]()
+
+        var index_list = Self.idx_list_t[arg_count](fill=0)
+
+        @parameter
+        for arg_idx in range(arg_count):
+            index_list[arg_idx] = index(args[arg_idx])
+
+        var strides = self.runtime_layout.stride.value
+        var offset = Self._get_offset[rank=arg_count](strides, index_list)
+        return self._load_scalar_offset(offset)
+
+    @always_inline("nodebug")
+    fn load_scalar(self, crd: RuntimeTuple) -> Scalar[Self.dtype]:
+        """Retrieves a single scalar from the tensor at the specified coordinates.
+
+        This method provides scalar element access for the tensor, which is
+        useful in generic contexts where `__getitem__` returns a SIMD vector
+        of `element_size` elements. This method always returns a single scalar
+        value (the 0th lane of the element).
+
+        Args:
+            crd: The coordinate specifying the element's position in each
+                dimension. For example, in a 3D tensor, you would use (i, j, k).
+
+        Returns:
+            The scalar value at the specified position with the tensor's dtype.
+        """
+        var offset = self.runtime_layout(crd)
+        return self._load_scalar_offset(offset)
 
     @always_inline("nodebug")
     fn __setitem__[

--- a/max/kernels/test/layout/test_layout_tensor_load_scalar.mojo
+++ b/max/kernels/test/layout/test_layout_tensor_load_scalar.mojo
@@ -1,0 +1,211 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Tests for LayoutTensor.load_scalar() method.
+
+These tests verify that the load_scalar method correctly returns scalar values
+from tensors, addressing the issue where __getitem__ returns SIMD[dtype, element_size]
+which can be surprising in generic contexts when element_size > 1.
+"""
+
+from layout import Layout, LayoutTensor, RuntimeLayout, RuntimeTuple
+from layout._fillers import arange
+from layout.int_tuple import UNKNOWN_VALUE
+from memory import LegacyUnsafePointer as UnsafePointer
+from testing import assert_equal
+
+
+def main():
+    test_load_scalar_static_layout()
+    test_load_scalar_dynamic_layout()
+    test_load_scalar_with_runtime_tuple()
+    test_load_scalar_matches_getitem_lane0()
+    test_load_scalar_vectorized_element_size_gt_1()
+    print("All tests passed!")
+
+
+fn test_load_scalar_static_layout() raises:
+    """Test load_scalar with a static 2x3 row-major layout."""
+    print("== test_load_scalar_static_layout")
+
+    comptime layout = Layout.row_major(2, 3)
+    var storage = UnsafePointer[Float32].alloc(6)
+
+    # Initialize storage with values 0..5
+    for i in range(6):
+        storage[i] = Float32(i)
+
+    var tensor = LayoutTensor[DType.float32, layout](storage)
+
+    # Test scalar access at various positions
+    var v00: Scalar[DType.float32] = tensor.load_scalar(0, 0)
+    assert_equal(v00, 0.0)
+
+    var v01: Scalar[DType.float32] = tensor.load_scalar(0, 1)
+    assert_equal(v01, 1.0)
+
+    var v02: Scalar[DType.float32] = tensor.load_scalar(0, 2)
+    assert_equal(v02, 2.0)
+
+    var v10: Scalar[DType.float32] = tensor.load_scalar(1, 0)
+    assert_equal(v10, 3.0)
+
+    var v11: Scalar[DType.float32] = tensor.load_scalar(1, 1)
+    assert_equal(v11, 4.0)
+
+    var v12: Scalar[DType.float32] = tensor.load_scalar(1, 2)
+    assert_equal(v12, 5.0)
+
+    storage.free()
+    print("  PASSED")
+
+
+fn test_load_scalar_dynamic_layout() raises:
+    """Test load_scalar with a dynamic runtime layout."""
+    print("== test_load_scalar_dynamic_layout")
+
+    comptime layout = Layout.row_major(UNKNOWN_VALUE, UNKNOWN_VALUE)
+
+    var dynamic_layout = RuntimeLayout[
+        layout, element_type = DType.int32, linear_idx_type = DType.int32
+    ](
+        RuntimeTuple[layout.shape, element_type = DType.int32](3, 4),
+        RuntimeTuple[layout.stride, element_type = DType.int32](4, 1),
+    )
+
+    var storage = UnsafePointer[Float32].alloc(dynamic_layout.size())
+
+    var tensor = LayoutTensor[
+        DType.float32,
+        layout,
+        layout_int_type = DType.int32,
+        linear_idx_type = DType.int32,
+    ](storage, dynamic_layout)
+
+    # Fill tensor with sequential values
+    arange(tensor)
+
+    # Test load_scalar at various positions
+    var v00: Scalar[DType.float32] = tensor.load_scalar(0, 0)
+    assert_equal(v00, 0.0)
+
+    var v11: Scalar[DType.float32] = tensor.load_scalar(1, 1)
+    assert_equal(v11, 5.0)  # row 1, col 1 = 1*4 + 1 = 5
+
+    var v23: Scalar[DType.float32] = tensor.load_scalar(2, 3)
+    assert_equal(v23, 11.0)  # row 2, col 3 = 2*4 + 3 = 11
+
+    storage.free()
+    print("  PASSED")
+
+
+fn test_load_scalar_with_runtime_tuple() raises:
+    """Test load_scalar using RuntimeTuple coordinates."""
+    print("== test_load_scalar_with_runtime_tuple")
+
+    comptime layout = Layout.row_major(UNKNOWN_VALUE, UNKNOWN_VALUE)
+
+    var dynamic_layout = RuntimeLayout[
+        layout, element_type = DType.int32, linear_idx_type = DType.int32
+    ](
+        RuntimeTuple[layout.shape, element_type = DType.int32](4, 4),
+        RuntimeTuple[layout.stride, element_type = DType.int32](4, 1),
+    )
+
+    var storage = UnsafePointer[Float32].alloc(dynamic_layout.size())
+
+    var tensor = LayoutTensor[
+        DType.float32,
+        layout,
+        layout_int_type = DType.int32,
+        linear_idx_type = DType.int32,
+    ](storage, dynamic_layout)
+
+    arange(tensor)
+
+    # Test load_scalar with RuntimeTuple
+    var coord = RuntimeTuple[layout.shape, element_type = DType.int32](2, 3)
+    var val: Scalar[DType.float32] = tensor.load_scalar(coord)
+    assert_equal(val, 11.0)  # row 2, col 3 = 2*4 + 3 = 11
+
+    storage.free()
+    print("  PASSED")
+
+
+fn test_load_scalar_matches_getitem_lane0() raises:
+    """Test that load_scalar returns the same value as __getitem__[0]."""
+    print("== test_load_scalar_matches_getitem_lane0")
+
+    comptime layout = Layout.row_major(4, 4)
+    var storage = UnsafePointer[Float32].alloc(16)
+
+    var tensor = LayoutTensor[DType.float32, layout](storage)
+    arange(tensor)
+
+    # Verify load_scalar matches the 0th lane of __getitem__
+    for i in range(4):
+        for j in range(4):
+            var scalar_val = tensor.load_scalar(i, j)
+            var simd_val = tensor[i, j]
+            assert_equal(scalar_val, simd_val[0])
+
+    storage.free()
+    print("  PASSED")
+
+
+fn test_load_scalar_vectorized_element_size_gt_1() raises:
+    """Test load_scalar with a vectorized tensor where element_size > 1.
+
+    This is the primary use case for load_scalar: when element_layout.size() > 1,
+    __getitem__ returns a SIMD vector, but users often want just one scalar.
+    """
+    print("== test_load_scalar_vectorized_element_size_gt_1")
+
+    # Create an 8x8 tensor and vectorize it to have 4-element vectors
+    comptime layout = Layout.row_major(8, 8)
+    var storage = UnsafePointer[Float32].alloc(64)
+
+    var tensor = LayoutTensor[DType.float32, layout](storage)
+    arange(tensor)
+
+    # Vectorize to 1x4 elements - this creates a tensor where each "element"
+    # is a SIMD[float32, 4] (element_size = 4)
+    var vec_tensor = tensor.vectorize[1, 4]()
+
+    # Verify element_size > 1
+    constrained[
+        vec_tensor.element_size == 4,
+        "Expected element_size == 4 for vectorized tensor",
+    ]()
+
+    # __getitem__ returns SIMD[float32, 4], load_scalar returns just the 0th lane
+    # For position (0, 0): the element contains [0, 1, 2, 3], load_scalar returns 0
+    var simd_val = vec_tensor[0, 0]  # Returns SIMD[float32, 4] = [0, 1, 2, 3]
+    var scalar_val = vec_tensor.load_scalar(0, 0)  # Returns Scalar = 0.0
+
+    assert_equal(scalar_val, simd_val[0])
+    assert_equal(scalar_val, 0.0)
+
+    # Test another position: (0, 1) should have elements [4, 5, 6, 7]
+    var simd_val2 = vec_tensor[0, 1]
+    var scalar_val2 = vec_tensor.load_scalar(0, 1)
+
+    assert_equal(scalar_val2, simd_val2[0])
+    assert_equal(scalar_val2, 4.0)
+
+    # Test position (1, 0): row 1, col 0 of vectorized tensor
+    # In original tensor this is position (1, 0) = value 8.0
+    var scalar_val3 = vec_tensor.load_scalar(1, 0)
+    assert_equal(scalar_val3, 8.0)
+
+    storage.free()
+    print("  PASSED")


### PR DESCRIPTION
Fixes #4847

## Problem

Currently, `LayoutTensor.__getitem__` returns `Self.element_type` which is `SIMD[dtype, element_size]`. Since `element_size` isn't guaranteed to be 1 (e.g., in tiled/vectorized layouts), users working in generic contexts often get a SIMD vector when they just want a single scalar value. This leads to confusion and awkward workarounds like `tensor[i, j][0]`.

## Solution

This PR adds a `load_scalar` method that explicitly returns `Scalar[dtype]` for cases where you need a single value:

```mojo
# Before: have to extract lane 0 manually
var val = tensor[i, j][0]

# After: clear intent, returns Scalar directly  
var val = tensor.load_scalar(i, j)
```

## Changes

Added `_load_scalar_offset` private helper that reuses existing `_load_offset `and returns lane 0
Added `load_scalar[*Tys: Indexer]` for variadic indices like `tensor.load_scalar(i, j)`
Added load_scalar(RuntimeTuple) overload for coordinate-based access
Added tests covering static layouts, dynamic layouts, and RuntimeTuple coordinates

## Design note

I went with a named method rather than a `__getitem__` overload because having two methods with identical parameter signatures but different return types would cause ambiguity issues. The `load_scalar` name also makes the intent explicit at the call site, which seems cleaner for this use case.