### PR TITLE
[stdlib] Deprecate `Codepoint.ord()`

### DIFF
--- a/mojo/docs/code/stdlib/collections/string/codepoint.mojo
+++ b/mojo/docs/code/stdlib/collections/string/codepoint.mojo
@@ -17,7 +17,7 @@ def summary() raises:
     from std.testing import assert_true, assert_equal
 
     # Create a codepoint from a character
-    var c = Codepoint.ord("A")
+    var c = Codepoint("A")
 
     # Check properties
     assert_true(c.is_ascii())
@@ -32,14 +32,14 @@ def run_is_python_space() raises:
     from std.testing import assert_true, assert_false
 
     # ASCII space characters
-    assert_true(Codepoint.ord(" ").is_python_space())
-    assert_true(Codepoint.ord("	").is_python_space())
+    assert_true(Codepoint(" ").is_python_space())
+    assert_true(Codepoint("	").is_python_space())
 
     # Unicode paragraph separator:
     assert_true(Codepoint.from_u32(0x2029).value().is_python_space())
 
     # Letters are not space characters
-    assert_false(Codepoint.ord("a").is_python_space())
+    assert_false(Codepoint("a").is_python_space())
 
 
 def main() raises:

--- a/mojo/stdlib/std/collections/string/codepoint.mojo
+++ b/mojo/stdlib/std/collections/string/codepoint.mojo
@@ -65,7 +65,7 @@ struct Codepoint(Comparable, ImplicitlyCopyable, Intable, Movable, Writable):
     from std.testing import assert_true
 
     # Create a codepoint from a character
-    var c = Codepoint.ord('A')
+    var c = Codepoint('A')
 
     # Check properties
     assert_true(c.is_ascii())
@@ -136,6 +136,31 @@ struct Codepoint(Comparable, ImplicitlyCopyable, Intable, Movable, Writable):
         """
         self._scalar_value = UInt32(Int(codepoint))
 
+    def __init__(out self, string: StringSlice[mut=False, _]):
+        """Constructs the `Codepoint` that represents the given single-character
+        string.
+
+        Args:
+            string: The input string, which must contain only a single
+                character.
+        """
+        if string.byte_length() == 0:
+            abort("An empty string has no defined codepoint")
+
+        # SAFETY:
+        #   This is safe because `StringSlice` is guaranteed to point to valid
+        #   UTF-8.
+        var char, num_bytes = Codepoint.unsafe_decode_utf8_codepoint(
+            string.as_bytes()
+        )
+
+        debug_assert(
+            string.byte_length() == Int(num_bytes),
+            "input string must be one character",
+        )
+
+        self = char
+
     # ===-------------------------------------------------------------------===#
     # Factory methods
     # ===-------------------------------------------------------------------===#
@@ -158,6 +183,7 @@ struct Codepoint(Comparable, ImplicitlyCopyable, Intable, Movable, Writable):
         else:
             return None
 
+    @deprecated("Use the Codepoint(string) constructor instead.")
     @staticmethod
     def ord(string: StringSlice[mut=False, _]) -> Codepoint:
         """Returns the `Codepoint` that represents the given single-character
@@ -177,21 +203,7 @@ struct Codepoint(Comparable, ImplicitlyCopyable, Intable, Movable, Writable):
         Returns:
             A `Codepoint` representing the codepoint of the given character.
         """
-        if string.byte_length() == 0:
-            abort("Codepoint.ord: input string must not be empty")
-
-        # SAFETY:
-        #   This is safe because `StringSlice` is guaranteed to point to valid
-        #   UTF-8, and we verified above that the input is non-empty.
-        var char, num_bytes = Codepoint.unsafe_decode_utf8_codepoint(
-            string.as_bytes()
-        )
-
-        assert (
-            string.byte_length() == num_bytes
-        ), "input string must be one character"
-
-        return char
+        return Codepoint(string)
 
     # TODO: add optimize_ascii and branchless optimization options like unsafe_write_utf8
     @staticmethod
@@ -411,14 +423,14 @@ struct Codepoint(Comparable, ImplicitlyCopyable, Intable, Movable, Writable):
         from std.testing import assert_true, assert_false
 
         # ASCII space characters
-        assert_true(Codepoint.ord(" ").is_python_space())
-        assert_true(Codepoint.ord("\t").is_python_space())
+        assert_true(Codepoint(" ").is_python_space())
+        assert_true(Codepoint("\t").is_python_space())
 
         # Unicode paragraph separator:
         assert_true(Codepoint.from_u32(0x2029).value().is_python_space())
 
         # Letters are not space characters
-        assert_false(Codepoint.ord("a").is_python_space())
+        assert_false(Codepoint("a").is_python_space())
         ```
         """
 

--- a/mojo/stdlib/std/collections/string/string.mojo
+++ b/mojo/stdlib/std/collections/string/string.mojo
@@ -1142,9 +1142,9 @@ struct String(
 
         var s = "abc"
         var iter = s.codepoints()
-        assert_equal(iter.__next__(), Codepoint.ord("a"))
-        assert_equal(iter.__next__(), Codepoint.ord("b"))
-        assert_equal(iter.__next__(), Codepoint.ord("c"))
+        assert_equal(iter.__next__(), Codepoint("a"))
+        assert_equal(iter.__next__(), Codepoint("b"))
+        assert_equal(iter.__next__(), Codepoint("c"))
         with assert_raises():
             _ = iter.__next__() # raises StopIteration
         ```
@@ -1160,7 +1160,7 @@ struct String(
         assert_equal(s.byte_length(), 3)
 
         var iter = s.codepoints()
-        assert_equal(iter.__next__(), Codepoint.ord("a"))
+        assert_equal(iter.__next__(), Codepoint("a"))
          # U+0301 Combining Acute Accent
         assert_equal(iter.__next__().to_u32(), 0x0301)
         with assert_raises():
@@ -2079,7 +2079,7 @@ def ord(s: StringSlice) -> Int:
     Returns:
         An integer representing the code point of the given character.
     """
-    return Int(Codepoint.ord(s))
+    return Int(Codepoint(s))
 
 
 # ===----------------------------------------------------------------------=== #

--- a/mojo/stdlib/std/collections/string/string_slice.mojo
+++ b/mojo/stdlib/std/collections/string/string_slice.mojo
@@ -416,16 +416,16 @@ struct CodepointsIter[mut: Bool, //, origin: Origin[mut=mut]](
         var input = StringSlice("123")
         var iter = input.codepoints()
 
-        assert_equal(iter.peek_next().value(), Codepoint.ord("1"))
-        assert_equal(iter.peek_next().value(), Codepoint.ord("1"))
-        assert_equal(iter.peek_next().value(), Codepoint.ord("1"))
+        assert_equal(iter.peek_next().value(), Codepoint("1"))
+        assert_equal(iter.peek_next().value(), Codepoint("1"))
+        assert_equal(iter.peek_next().value(), Codepoint("1"))
 
         # A call to `next()` return the same value as `peek_next()` had,
         # but also advance the iterator.
-        assert_equal(iter.next().value(), Codepoint.ord("1"))
+        assert_equal(iter.next().value(), Codepoint("1"))
 
         # Later `peek_next()` calls will return the _new_ next character:
-        assert_equal(iter.peek_next().value(), Codepoint.ord("2"))
+        assert_equal(iter.peek_next().value(), Codepoint("2"))
         ```
         """
         if len(self._slice) > 0:
@@ -1496,9 +1496,9 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
 
         var s = StringSlice("abc")
         var iter = s.codepoints()
-        assert_equal(iter.__next__(), Codepoint.ord("a"))
-        assert_equal(iter.__next__(), Codepoint.ord("b"))
-        assert_equal(iter.__next__(), Codepoint.ord("c"))
+        assert_equal(iter.__next__(), Codepoint("a"))
+        assert_equal(iter.__next__(), Codepoint("b"))
+        assert_equal(iter.__next__(), Codepoint("c"))
         with assert_raises():
             _ = iter.__next__() # raises StopIteration
         ```
@@ -1515,7 +1515,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
         assert_equal(s.byte_length(), 3)
 
         var iter = s.codepoints()
-        assert_equal(iter.__next__(), Codepoint.ord("a"))
+        assert_equal(iter.__next__(), Codepoint("a"))
          # U+0301 Combining Acute Accent
         assert_equal(iter.__next__().to_u32(), 0x0301)
         with assert_raises():

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -1098,9 +1098,9 @@ def test_indexing() raises:
 def test_string_codepoints_iter() raises:
     var s = "abc"
     var iter = s.codepoints()
-    assert_equal(iter.__next__(), Codepoint.ord("a"))
-    assert_equal(iter.__next__(), Codepoint.ord("b"))
-    assert_equal(iter.__next__(), Codepoint.ord("c"))
+    assert_equal(iter.__next__(), Codepoint("a"))
+    assert_equal(iter.__next__(), Codepoint("b"))
+    assert_equal(iter.__next__(), Codepoint("c"))
     with assert_raises():
         _ = iter.__next__()  # raises StopIteration
 
@@ -1782,15 +1782,15 @@ def test_from_utf8() raises:
 
 def test_append_codepoint() raises:
     var s = String()
-    s.append(Codepoint.ord("a"))
+    s.append(Codepoint("a"))
     assert_equal(s, "a")
     assert_equal(s.byte_length(), 1)
 
-    s.append(Codepoint.ord("€"))
+    s.append(Codepoint("€"))
     assert_equal(s, "a€")
     assert_equal(s.byte_length(), 4)
 
-    s.append(Codepoint.ord("🔥"))
+    s.append(Codepoint("🔥"))
     assert_equal(s, "a€🔥")
     assert_equal(s.byte_length(), 8)
 

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -969,9 +969,7 @@ def test_count() raises:
 def test_chars_iter() raises:
     # Test `for` loop iteration support
     for char in StringSlice("abc").codepoints():
-        assert_true(
-            char in (Codepoint.ord("a"), Codepoint.ord("b"), Codepoint.ord("c"))
-        )
+        assert_true(char in (Codepoint("a"), Codepoint("b"), Codepoint("c")))
 
     # Test empty string chars
     var s0 = StringSlice("")
@@ -986,9 +984,9 @@ def test_chars_iter() raises:
     var s1 = StringSlice("abc")
     var s1_iter = s1.codepoints()
 
-    assert_equal(s1_iter.next().value(), Codepoint.ord("a"))
-    assert_equal(s1_iter.next().value(), Codepoint.ord("b"))
-    assert_equal(s1_iter.next().value(), Codepoint.ord("c"))
+    assert_equal(s1_iter.next().value(), Codepoint("a"))
+    assert_equal(s1_iter.next().value(), Codepoint("b"))
+    assert_equal(s1_iter.next().value(), Codepoint("c"))
     assert_true(s1_iter.next() is None)
 
     # Multibyte character decoding: A visual character composed of a combining
@@ -998,7 +996,7 @@ def test_chars_iter() raises:
     assert_equal(s2.count_codepoints(), 2)
 
     var iter = s2.codepoints()
-    assert_equal(iter.__next__(), Codepoint.ord("a"))
+    assert_equal(iter.__next__(), Codepoint("a"))
     # U+0301 Combining Acute Accent
     assert_equal(iter.__next__().to_u32(), 0x0301)
     with assert_raises():
@@ -1014,25 +1012,25 @@ def test_chars_iter() raises:
     # Iterator __len__ returns length in codepoints, not bytes.
     assert_equal(s3_iter.__len__(), 5)
     assert_equal(s3_iter._slice.byte_length(), 13)
-    assert_equal(s3_iter.__next__(), Codepoint.ord("߷"))
+    assert_equal(s3_iter.__next__(), Codepoint("߷"))
 
     assert_equal(s3_iter.__len__(), 4)
     assert_equal(s3_iter._slice.byte_length(), 11)
-    assert_equal(s3_iter.__next__(), Codepoint.ord("ക"))
+    assert_equal(s3_iter.__next__(), Codepoint("ക"))
 
     # Combining character, visually comes first, but codepoint-wise comes
     # after the character it combines with.
     assert_equal(s3_iter.__len__(), 3)
     assert_equal(s3_iter._slice.byte_length(), 8)
-    assert_equal(s3_iter.__next__(), Codepoint.ord("ൈ"))
+    assert_equal(s3_iter.__next__(), Codepoint("ൈ"))
 
     assert_equal(s3_iter.__len__(), 2)
     assert_equal(s3_iter._slice.byte_length(), 5)
-    assert_equal(s3_iter.__next__(), Codepoint.ord("🔄"))
+    assert_equal(s3_iter.__next__(), Codepoint("🔄"))
 
     assert_equal(s3_iter.__len__(), 1)
     assert_equal(s3_iter._slice.byte_length(), 1)
-    assert_equal(s3_iter.__next__(), Codepoint.ord("!"))
+    assert_equal(s3_iter.__next__(), Codepoint("!"))
 
     assert_equal(s3_iter.__len__(), 0)
     assert_equal(s3_iter._slice.byte_length(), 0)

--- a/mojo/stdlib/test/collections/test_codepoint.mojo
+++ b/mojo/stdlib/test/collections/test_codepoint.mojo
@@ -114,31 +114,31 @@ def test_char_properties() raises:
 
 def test_char_is_posix_space() raises:
     # checking true cases
-    assert_true(Codepoint.ord(" ").is_posix_space())
-    assert_true(Codepoint.ord("\n").is_posix_space())
-    assert_true(Codepoint.ord("\n").is_posix_space())
-    assert_true(Codepoint.ord("\t").is_posix_space())
-    assert_true(Codepoint.ord("\r").is_posix_space())
-    assert_true(Codepoint.ord("\v").is_posix_space())
-    assert_true(Codepoint.ord("\f").is_posix_space())
+    assert_true(Codepoint(" ").is_posix_space())
+    assert_true(Codepoint("\n").is_posix_space())
+    assert_true(Codepoint("\n").is_posix_space())
+    assert_true(Codepoint("\t").is_posix_space())
+    assert_true(Codepoint("\r").is_posix_space())
+    assert_true(Codepoint("\v").is_posix_space())
+    assert_true(Codepoint("\f").is_posix_space())
 
     # Checking false cases
-    assert_false(Codepoint.ord("a").is_posix_space())
-    assert_false(Codepoint.ord("a").is_posix_space())
-    assert_false(Codepoint.ord("u").is_posix_space())
-    assert_false(Codepoint.ord("s").is_posix_space())
-    assert_false(Codepoint.ord("t").is_posix_space())
-    assert_false(Codepoint.ord("i").is_posix_space())
-    assert_false(Codepoint.ord("n").is_posix_space())
-    assert_false(Codepoint.ord("z").is_posix_space())
-    assert_false(Codepoint.ord(".").is_posix_space())
+    assert_false(Codepoint("a").is_posix_space())
+    assert_false(Codepoint("a").is_posix_space())
+    assert_false(Codepoint("u").is_posix_space())
+    assert_false(Codepoint("s").is_posix_space())
+    assert_false(Codepoint("t").is_posix_space())
+    assert_false(Codepoint("i").is_posix_space())
+    assert_false(Codepoint("n").is_posix_space())
+    assert_false(Codepoint("z").is_posix_space())
+    assert_false(Codepoint(".").is_posix_space())
 
 
 def test_char_is_lower() raises:
-    assert_true(Codepoint.ord("a").is_ascii_lower())
-    assert_true(Codepoint.ord("b").is_ascii_lower())
-    assert_true(Codepoint.ord("y").is_ascii_lower())
-    assert_true(Codepoint.ord("z").is_ascii_lower())
+    assert_true(Codepoint("a").is_ascii_lower())
+    assert_true(Codepoint("b").is_ascii_lower())
+    assert_true(Codepoint("y").is_ascii_lower())
+    assert_true(Codepoint("z").is_ascii_lower())
 
     assert_false(
         Codepoint.from_u32(UInt32(ord("a") - 1)).value().is_ascii_lower()
@@ -147,15 +147,15 @@ def test_char_is_lower() raises:
         Codepoint.from_u32(UInt32(ord("z") + 1)).value().is_ascii_lower()
     )
 
-    assert_false(Codepoint.ord("!").is_ascii_lower())
-    assert_false(Codepoint.ord("0").is_ascii_lower())
+    assert_false(Codepoint("!").is_ascii_lower())
+    assert_false(Codepoint("0").is_ascii_lower())
 
 
 def test_char_is_upper() raises:
-    assert_true(Codepoint.ord("A").is_ascii_upper())
-    assert_true(Codepoint.ord("B").is_ascii_upper())
-    assert_true(Codepoint.ord("Y").is_ascii_upper())
-    assert_true(Codepoint.ord("Z").is_ascii_upper())
+    assert_true(Codepoint("A").is_ascii_upper())
+    assert_true(Codepoint("B").is_ascii_upper())
+    assert_true(Codepoint("Y").is_ascii_upper())
+    assert_true(Codepoint("Z").is_ascii_upper())
 
     assert_false(
         Codepoint.from_u32(UInt32(ord("A") - 1)).value().is_ascii_upper()
@@ -164,25 +164,25 @@ def test_char_is_upper() raises:
         Codepoint.from_u32(UInt32(ord("Z") + 1)).value().is_ascii_upper()
     )
 
-    assert_false(Codepoint.ord("!").is_ascii_upper())
-    assert_false(Codepoint.ord("0").is_ascii_upper())
+    assert_false(Codepoint("!").is_ascii_upper())
+    assert_false(Codepoint("0").is_ascii_upper())
 
 
 def test_char_is_digit() raises:
-    assert_true(Codepoint.ord("1").is_ascii_digit())
-    assert_false(Codepoint.ord("g").is_ascii_digit())
+    assert_true(Codepoint("1").is_ascii_digit())
+    assert_false(Codepoint("g").is_ascii_digit())
 
     # Devanagari Digit 6 — non-ASCII digits are not "ascii digit".
-    assert_false(Codepoint.ord("६").is_ascii_digit())
+    assert_false(Codepoint("६").is_ascii_digit())
 
 
 def test_char_is_printable() raises:
-    assert_true(Codepoint.ord("a").is_ascii_printable())
-    assert_false(Codepoint.ord("\n").is_ascii_printable())
-    assert_false(Codepoint.ord("\t").is_ascii_printable())
+    assert_true(Codepoint("a").is_ascii_printable())
+    assert_false(Codepoint("\n").is_ascii_printable())
+    assert_false(Codepoint("\t").is_ascii_printable())
 
     # Non-ASCII characters are not considered "ascii printable".
-    assert_false(Codepoint.ord("स").is_ascii_printable())
+    assert_false(Codepoint("स").is_ascii_printable())
 
 
 comptime SIGNIFICANT_CODEPOINTS: List[Tuple[Int, List[Byte]]] = [


### PR DESCRIPTION
Deprecate `Codepoint.ord()`. Closes #5645