### PR TITLE
[kernels] Migrate comm/ from LegacyUnsafePointer to UnsafePointer

### DIFF
--- a/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
@@ -8793,7 +8793,7 @@ struct DistributedAllReduceSum:
 
         # Marshal signal buffers.
         var rank_sigs = InlineArray[
-            RealUnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
+            RealUnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
         ](fill={})
 
         @parameter
@@ -8879,7 +8879,7 @@ struct DistributedAllGather:
             out_bufs[i] = managed_tensor_slice_to_ndbuffer(outputs[i])
 
         var rank_sigs = InlineArray[
-            RealUnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
+            RealUnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
         ](fill={})
 
         @parameter
@@ -8982,7 +8982,7 @@ struct DistributedMatmulAllReduce:
             ](managed_tensor_slice_to_ndbuffer(outputs[i]))
 
         var rank_sigs = InlineArray[
-            RealUnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
+            RealUnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
         ](fill={})
 
         @parameter

--- a/max/kernels/src/comm/allgather.mojo
+++ b/max/kernels/src/comm/allgather.mojo
@@ -33,9 +33,7 @@ from math import ceildiv
 from sys import simd_width_of
 
 from buffer import NDBuffer
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
+from memory import UnsafePointer
 from gpu import WARP_SIZE, global_idx, grid_dim
 from gpu.host import DeviceBuffer, DeviceContext, get_gpu_target
 
@@ -104,9 +102,15 @@ fn _allgather_p2p_kernel[
     *,
     BLOCK_SIZE: Int,
 ](
-    outputs: StaticTuple[UnsafePointer[Scalar[dtype]], ngpus],
-    src_ptrs: StaticTuple[UnsafePointer[Scalar[dtype]], ngpus],
-    rank_sigs: InlineArray[UnsafePointer[Signal], MAX_GPUS],
+    outputs: StaticTuple[
+        UnsafePointer[mut=True, Scalar[dtype], MutAnyOrigin], ngpus
+    ],
+    src_ptrs: StaticTuple[
+        UnsafePointer[mut=False, Scalar[dtype], MutAnyOrigin], ngpus
+    ],
+    rank_sigs: InlineArray[
+        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
+    ],
     lengths: StaticTuple[Int, ngpus],
     max_num_blocks: Int,
     my_rank: Int,
@@ -120,7 +124,7 @@ fn _allgather_p2p_kernel[
 
     var global_tid = global_idx.x
     var stride = grid_dim.x * UInt(BLOCK_SIZE)
-    var my_sig: UnsafePointer[Signal] = rank_sigs[my_rank]
+    var my_sig = rank_sigs[my_rank]
 
     # Synchronize before reading.
     _multi_gpu_barrier[ngpus, is_start=True](rank_sigs, my_sig, my_rank)
@@ -164,14 +168,18 @@ fn _allgather_p2p[
     output_buffers: InlineArray[
         NDBuffer[dtype, rank, MutAnyOrigin], ngpus * ngpus
     ],
-    rank_sigs: InlineArray[UnsafePointer[Signal], MAX_GPUS],
+    rank_sigs: InlineArray[
+        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
+    ],
     max_num_blocks: Int,
     ctxs: List[DeviceContext],
 ) raises:
     """Performs allgather using peer-to-peer access between GPUs."""
 
     # Prepare input pointers
-    var list_of_in_ptrs = StaticTuple[UnsafePointer[Scalar[dtype]], ngpus]()
+    var list_of_in_ptrs = StaticTuple[
+        UnsafePointer[mut=False, Scalar[dtype], MutAnyOrigin], ngpus
+    ]()
     var lengths = StaticTuple[Int, ngpus]()
 
     @parameter
@@ -186,7 +194,9 @@ fn _allgather_p2p[
         var curr_ctx = ctxs[gpu_idx]
 
         # Prepare output pointers for this GPU.
-        var output_ptrs = StaticTuple[UnsafePointer[Scalar[dtype]], ngpus]()
+        var output_ptrs = StaticTuple[
+            UnsafePointer[mut=True, Scalar[dtype], MutAnyOrigin], ngpus
+        ]()
 
         @parameter
         for src_idx in range(ngpus):
@@ -236,7 +246,9 @@ fn allgather[
     output_buffers: InlineArray[
         NDBuffer[dtype, rank, MutAnyOrigin], ngpus * ngpus
     ],
-    rank_sigs: InlineArray[UnsafePointer[Signal], MAX_GPUS],
+    rank_sigs: InlineArray[
+        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
+    ],
     ctxs: List[DeviceContext],
     _max_num_blocks: Optional[Int] = None,
 ) raises:

--- a/max/kernels/src/comm/allgather.mojo
+++ b/max/kernels/src/comm/allgather.mojo
@@ -102,15 +102,9 @@ fn _allgather_p2p_kernel[
     *,
     BLOCK_SIZE: Int,
 ](
-    outputs: StaticTuple[
-        UnsafePointer[mut=True, Scalar[dtype], MutAnyOrigin], ngpus
-    ],
-    src_ptrs: StaticTuple[
-        UnsafePointer[mut=False, Scalar[dtype], MutAnyOrigin], ngpus
-    ],
-    rank_sigs: InlineArray[
-        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
-    ],
+    outputs: StaticTuple[UnsafePointer[Scalar[dtype], MutAnyOrigin], ngpus],
+    src_ptrs: StaticTuple[UnsafePointer[Scalar[dtype], ImmutAnyOrigin], ngpus],
+    rank_sigs: InlineArray[UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS],
     lengths: StaticTuple[Int, ngpus],
     max_num_blocks: Int,
     my_rank: Int,
@@ -168,9 +162,7 @@ fn _allgather_p2p[
     output_buffers: InlineArray[
         NDBuffer[dtype, rank, MutAnyOrigin], ngpus * ngpus
     ],
-    rank_sigs: InlineArray[
-        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
-    ],
+    rank_sigs: InlineArray[UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS],
     max_num_blocks: Int,
     ctxs: List[DeviceContext],
 ) raises:
@@ -178,7 +170,7 @@ fn _allgather_p2p[
 
     # Prepare input pointers
     var list_of_in_ptrs = StaticTuple[
-        UnsafePointer[mut=False, Scalar[dtype], MutAnyOrigin], ngpus
+        UnsafePointer[Scalar[dtype], ImmutAnyOrigin], ngpus
     ]()
     var lengths = StaticTuple[Int, ngpus]()
 
@@ -195,7 +187,7 @@ fn _allgather_p2p[
 
         # Prepare output pointers for this GPU.
         var output_ptrs = StaticTuple[
-            UnsafePointer[mut=True, Scalar[dtype], MutAnyOrigin], ngpus
+            UnsafePointer[Scalar[dtype], MutAnyOrigin], ngpus
         ]()
 
         @parameter
@@ -246,9 +238,7 @@ fn allgather[
     output_buffers: InlineArray[
         NDBuffer[dtype, rank, MutAnyOrigin], ngpus * ngpus
     ],
-    rank_sigs: InlineArray[
-        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
-    ],
+    rank_sigs: InlineArray[UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS],
     ctxs: List[DeviceContext],
     _max_num_blocks: Optional[Int] = None,
 ) raises:

--- a/max/kernels/src/comm/allreduce.mojo
+++ b/max/kernels/src/comm/allreduce.mojo
@@ -1388,8 +1388,10 @@ fn allreduce_2stage_quickreduce[
     atom_size: Int,
 ](
     result: NDBuffer[dtype, rank, MutAnyOrigin],
-    local_src: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    rank_sigs: InlineArray[UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS],
+    local_src: UnsafePointer[mut=False, Scalar[dtype], MutAnyOrigin],
+    rank_sigs: InlineArray[
+        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
+    ],
     num_elements: Int,
     my_rank: Int,
     iteration: Int,

--- a/max/kernels/src/comm/sync.mojo
+++ b/max/kernels/src/comm/sync.mojo
@@ -25,13 +25,7 @@ from gpu.intrinsics import (
     load_acquire,
     store_release,
 )
-from memory import UnsafePointer as UnsafePointerV2
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
-comptime OpaquePointer = LegacyUnsafePointer[
-    mut=True, NoneType, origin=MutAnyOrigin
-]
+from memory import MutOpaquePointer
 
 
 # No-op (currently) group operation functions (enables vendor_ccl drop in replacement)
@@ -43,12 +37,14 @@ fn group_end():
     return
 
 
-fn _p2p_cache_destroy_wrapper(ptr: OpaquePointer) -> None:
+fn _p2p_cache_destroy_wrapper(
+    ptr: MutOpaquePointer[MutOrigin.external],
+) -> None:
     # No resources to free for tagged-pointer encoding.
     pass
 
 
-fn _p2p_cache_init_wrapper() -> OpaquePointer:
+fn _p2p_cache_init_wrapper() -> MutOpaquePointer[MutOrigin.external]:
     """Initializer for the indexed global caching P2P availability.
 
     Returns an OpaquePointer encoding a small integer tag:
@@ -60,11 +56,11 @@ fn _p2p_cache_init_wrapper() -> OpaquePointer:
 
     try:
         DeviceContext.enable_all_peer_access()
-        return UnsafePointerV2[NoneType, MutOrigin.external](
+        return UnsafePointer[NoneType, MutOrigin.external](
             unsafe_from_address=p2p_available
         )
     except:
-        return UnsafePointerV2[NoneType, MutOrigin.external](
+        return UnsafePointer[NoneType, MutOrigin.external](
             unsafe_from_address=p2p_not_available
         )
 
@@ -81,7 +77,8 @@ fn can_enable_p2p() raises -> Bool:
 
     # Initialize once per process via indexed global, then reuse the tag.
     var cached = external_call[
-        "KGEN_CompilerRT_GetOrCreateGlobalIndexed", OpaquePointer
+        "KGEN_CompilerRT_GetOrCreateGlobalIndexed",
+        MutOpaquePointer[MutOrigin.external],
     ](
         _Global._gpu_comm_p2p_idx,
         _p2p_cache_init_wrapper,
@@ -162,8 +159,10 @@ fn _multi_gpu_barrier[
     is_start: Bool,
     need_fence: Bool = False,
 ](
-    rank_sigs: InlineArray[UnsafePointer[Signal], MAX_GPUS],
-    self_sg: UnsafePointer[Signal],
+    rank_sigs: InlineArray[
+        UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
+    ],
+    self_sg: UnsafePointer[Signal, MutAnyOrigin],
     my_rank: Int,
 ):
     """Implements a barrier synchronization across multiple GPUs to ensure all

--- a/max/kernels/src/comm/sync.mojo
+++ b/max/kernels/src/comm/sync.mojo
@@ -25,7 +25,6 @@ from gpu.intrinsics import (
     load_acquire,
     store_release,
 )
-from memory import MutOpaquePointer
 
 
 # No-op (currently) group operation functions (enables vendor_ccl drop in replacement)
@@ -159,9 +158,7 @@ fn _multi_gpu_barrier[
     is_start: Bool,
     need_fence: Bool = False,
 ](
-    rank_sigs: InlineArray[
-        UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-    ],
+    rank_sigs: InlineArray[UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS],
     self_sg: UnsafePointer[Signal, MutAnyOrigin],
     my_rank: Int,
 ):

--- a/max/kernels/src/linalg/distributed_matmul.mojo
+++ b/max/kernels/src/linalg/distributed_matmul.mojo
@@ -53,9 +53,7 @@ fn _matmul_allreduce[
     output_buffers: InlineArray[
         NDBuffer[out_dtype, 2, MutAnyOrigin, out_static_shape], ngpus
     ],
-    rank_sigs: InlineArray[
-        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
-    ],
+    rank_sigs: InlineArray[UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS],
     ctxs: List[DeviceContext],
 ) raises:
     """Performs C = matmul(A, B^T) followed with Out = allreduce(C) operation across multiple GPUs.
@@ -109,9 +107,7 @@ fn _matmul_allreduce_split_m[
     output_buffers: InlineArray[
         NDBuffer[out_dtype, 2, MutAnyOrigin, out_static_shape], ngpus
     ],
-    rank_sigs: InlineArray[
-        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
-    ],
+    rank_sigs: InlineArray[UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS],
     ctxs: List[DeviceContext],
     num_partitions: Int,
 ) raises:
@@ -245,9 +241,7 @@ fn _matmul_allreduce_split_n[
     output_buffers: InlineArray[
         NDBuffer[out_dtype, 2, MutAnyOrigin, out_static_shape], ngpus
     ],
-    rank_sigs: InlineArray[
-        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
-    ],
+    rank_sigs: InlineArray[UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS],
     ctxs: List[DeviceContext],
 ) raises:
     """Performs C = matmul(A, B^T) followed with Out = allreduce(C) operation across multiple GPUs.
@@ -379,9 +373,7 @@ fn matmul_allreduce[
     output_buffers: InlineArray[
         NDBuffer[out_dtype, 2, MutAnyOrigin, out_static_shape], ngpus
     ],
-    rank_sigs: InlineArray[
-        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
-    ],
+    rank_sigs: InlineArray[UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS],
     ctxs: List[DeviceContext],
     num_partitions: ValOrDim,
 ) raises:
@@ -464,9 +456,7 @@ fn matmul_allreduce[
     output_buffers: InlineArray[
         NDBuffer[out_dtype, 2, MutAnyOrigin, out_static_shape], ngpus
     ],
-    rank_sigs: InlineArray[
-        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
-    ],
+    rank_sigs: InlineArray[UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS],
     ctxs: List[DeviceContext],
 ) raises:
     """Performs C = matmul(A, B^T) followed with Out = allreduce(C) operation across multiple GPUs.

--- a/max/kernels/src/linalg/distributed_matmul.mojo
+++ b/max/kernels/src/linalg/distributed_matmul.mojo
@@ -22,9 +22,7 @@ from internal_utils._utils import ValOrDim, dynamic, static
 from utils import IndexList
 from .matmul.gpu import _matmul_gpu
 
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
+from memory import UnsafePointer
 
 comptime elementwise_epilogue_type = fn[
     input_index: Int, dtype: DType, rank: Int, width: Int, *, alignment: Int
@@ -55,7 +53,9 @@ fn _matmul_allreduce[
     output_buffers: InlineArray[
         NDBuffer[out_dtype, 2, MutAnyOrigin, out_static_shape], ngpus
     ],
-    rank_sigs: InlineArray[UnsafePointer[Signal], MAX_GPUS],
+    rank_sigs: InlineArray[
+        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
+    ],
     ctxs: List[DeviceContext],
 ) raises:
     """Performs C = matmul(A, B^T) followed with Out = allreduce(C) operation across multiple GPUs.
@@ -109,7 +109,9 @@ fn _matmul_allreduce_split_m[
     output_buffers: InlineArray[
         NDBuffer[out_dtype, 2, MutAnyOrigin, out_static_shape], ngpus
     ],
-    rank_sigs: InlineArray[UnsafePointer[Signal], MAX_GPUS],
+    rank_sigs: InlineArray[
+        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
+    ],
     ctxs: List[DeviceContext],
     num_partitions: Int,
 ) raises:
@@ -243,7 +245,9 @@ fn _matmul_allreduce_split_n[
     output_buffers: InlineArray[
         NDBuffer[out_dtype, 2, MutAnyOrigin, out_static_shape], ngpus
     ],
-    rank_sigs: InlineArray[UnsafePointer[Signal], MAX_GPUS],
+    rank_sigs: InlineArray[
+        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
+    ],
     ctxs: List[DeviceContext],
 ) raises:
     """Performs C = matmul(A, B^T) followed with Out = allreduce(C) operation across multiple GPUs.
@@ -375,7 +379,9 @@ fn matmul_allreduce[
     output_buffers: InlineArray[
         NDBuffer[out_dtype, 2, MutAnyOrigin, out_static_shape], ngpus
     ],
-    rank_sigs: InlineArray[UnsafePointer[Signal], MAX_GPUS],
+    rank_sigs: InlineArray[
+        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
+    ],
     ctxs: List[DeviceContext],
     num_partitions: ValOrDim,
 ) raises:
@@ -458,7 +464,9 @@ fn matmul_allreduce[
     output_buffers: InlineArray[
         NDBuffer[out_dtype, 2, MutAnyOrigin, out_static_shape], ngpus
     ],
-    rank_sigs: InlineArray[UnsafePointer[Signal], MAX_GPUS],
+    rank_sigs: InlineArray[
+        UnsafePointer[mut=True, Signal, MutAnyOrigin], MAX_GPUS
+    ],
     ctxs: List[DeviceContext],
 ) raises:
     """Performs C = matmul(A, B^T) followed with Out = allreduce(C) operation across multiple GPUs.


### PR DESCRIPTION
Fixes #5673 

## Summary

Migrates the comm module and its dependents from `LegacyUnsafePointer` to the new `UnsafePointer` API with explicit mutability and origin parameters.

Part 1 of #5673.

## Changes

**comm/ module:**
- `sync.mojo`: Updated imports, replaced `LegacyOpaquePointer` with `MutOpaquePointer[MutOrigin.external]` for FFI callbacks
- `allgather.mojo`: Added explicit `mut` and `MutAnyOrigin` to all pointer signatures
- `allreduce.mojo`: Migrated all pointer usages to new API

**Dependent files:**
- `linalg/distributed_matmul.mojo`: Updated import and `rank_sigs` signatures
- `Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo`: Added `RealUnsafePointer` alias for comm API calls while preserving `LegacyUnsafePointer` for other usages

## Testing

Builds successfully:
- `./bazelw build //max/kernels/src/comm:comm`
- `./bazelw build //max/kernels/src/linalg:linalg`
- `./bazelw build //max/kernels/src/Mogg/MOGGKernelAPI:MOGGKernelAPI`

## Next Steps

Follow-up PRs will migrate `shmem/` and `comm/vendor/ccl.mojo`.