### PR TITLE
[StdLib] fixes list docstring for deep copy example to use explicit copy

### DIFF
--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -148,7 +148,7 @@ struct List[T: Copyable](
 
       ```mojo
       var list1 = [1, 2, 3]
-      var list2 = list1        # Deep copy
+      var list2 = list1.copy()        # Deep copy
       list2.append(4)
       print(list1.__str__())   # => [1, 2, 3]
       print(list2.__str__())   # => [1, 2, 3, 4]


### PR DESCRIPTION
## Summary
- Fixed missing `.copy()` call in List's deep copy docstrings example

related to [#3572](https://github.com/modular/modular/issues/3572)

note: this is my first contribution/PR. i'm planning on auditing `collections/` for similar docstring issues and will follow up with additional PRs if necessary. just wanted to keep this one small to familiarize myself with the process.

## Test plan
- [x] verified LSP no longer flags example and code compiles by reproducing in a test function 

```mojo
var implCopyList1 = [1, 2, 3, 4, 5]
var implCopyList2 = implCopyList1 # error: value of type `List[Int]` cannot be implicitly copied, it does not conform to `ImplicitlyCopyable`

# fix:
var explCopyList1 = [1, 2, 3, 4, 5]
var explCopyList2 = explCopyList1.copy() # deep copy
```

note: i sandboxed in a function and ran in `test_list.mojo` (i omitted the test because it didn't seem prudent to include one strictly for docstring exprs, but i'm happy to add one if required).