### PR TITLE
[max][nit] Migrate shmem/ to UnsafePointer v2 API

### DIFF
--- a/max/kernels/src/Mogg/MOGGKernelAPI/ep_api.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/ep_api.mojo
@@ -202,26 +202,18 @@ struct Struct_ep_init:
         shmem_init_thread(gpu_ctx, n_gpus_per_node)
 
         # Allocate SHMEM buffers for dispatch phase
-        var dispatch_send_p = shmem_malloc[DType.uint8, MutAnyOrigin](
+        var dispatch_send_p = shmem_malloc[DType.uint8](
             UInt(dispatch_send_size)
         )
-        var dispatch_recv_p = shmem_malloc[DType.uint8, MutAnyOrigin](
+        var dispatch_recv_p = shmem_malloc[DType.uint8](
             UInt(dispatch_recv_size)
         )
-        var dispatch_recv_count_p = shmem_malloc[DType.uint64, MutAnyOrigin](
-            UInt(n_experts)
-        )
+        var dispatch_recv_count_p = shmem_malloc[DType.uint64](UInt(n_experts))
 
         # Allocate SHMEM buffers for combine phase
-        var combine_send_p = shmem_malloc[DType.uint8, MutAnyOrigin](
-            UInt(combine_send_size)
-        )
-        var combine_recv_p = shmem_malloc[DType.uint8, MutAnyOrigin](
-            UInt(combine_recv_size)
-        )
-        var combine_recv_count_p = shmem_malloc[DType.uint64, MutAnyOrigin](
-            UInt(n_experts)
-        )
+        var combine_send_p = shmem_malloc[DType.uint8](UInt(combine_send_size))
+        var combine_recv_p = shmem_malloc[DType.uint8](UInt(combine_recv_size))
+        var combine_recv_count_p = shmem_malloc[DType.uint64](UInt(n_experts))
 
         # Initialize receive count buffers to MAX_FINITE
         # This sentinel value indicates that no data has been received yet

--- a/max/kernels/src/Mogg/MOGGKernelAPI/ep_api.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/ep_api.mojo
@@ -202,18 +202,26 @@ struct Struct_ep_init:
         shmem_init_thread(gpu_ctx, n_gpus_per_node)
 
         # Allocate SHMEM buffers for dispatch phase
-        var dispatch_send_p = shmem_malloc[DType.uint8](
+        var dispatch_send_p = shmem_malloc[DType.uint8, MutAnyOrigin](
             UInt(dispatch_send_size)
         )
-        var dispatch_recv_p = shmem_malloc[DType.uint8](
+        var dispatch_recv_p = shmem_malloc[DType.uint8, MutAnyOrigin](
             UInt(dispatch_recv_size)
         )
-        var dispatch_recv_count_p = shmem_malloc[DType.uint64](UInt(n_experts))
+        var dispatch_recv_count_p = shmem_malloc[DType.uint64, MutAnyOrigin](
+            UInt(n_experts)
+        )
 
         # Allocate SHMEM buffers for combine phase
-        var combine_send_p = shmem_malloc[DType.uint8](UInt(combine_send_size))
-        var combine_recv_p = shmem_malloc[DType.uint8](UInt(combine_recv_size))
-        var combine_recv_count_p = shmem_malloc[DType.uint64](UInt(n_experts))
+        var combine_send_p = shmem_malloc[DType.uint8, MutAnyOrigin](
+            UInt(combine_send_size)
+        )
+        var combine_recv_p = shmem_malloc[DType.uint8, MutAnyOrigin](
+            UInt(combine_recv_size)
+        )
+        var combine_recv_count_p = shmem_malloc[DType.uint64, MutAnyOrigin](
+            UInt(n_experts)
+        )
 
         # Initialize receive count buffers to MAX_FINITE
         # This sentinel value indicates that no data has been received yet

--- a/max/kernels/src/shmem/_mpi.mojo
+++ b/max/kernels/src/shmem/_mpi.mojo
@@ -11,12 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
-comptime OpaquePointer = LegacyUnsafePointer[
-    mut=True, NoneType, origin=MutAnyOrigin
-]
+from memory import UnsafePointer, MutOpaquePointer
 from pathlib import Path
 from os import getenv, abort
 from sys.ffi import (
@@ -82,7 +77,9 @@ fn _get_mpi_function[
 # Types and constants
 # ===-----------------------------------------------------------------------===#
 
-comptime MPIComm = UnsafePointer[OpaquePointer]
+comptime MPIComm = UnsafePointer[
+    MutOpaquePointer[MutOrigin.external], MutAnyOrigin
+]
 
 comptime MPI_THREAD_SINGLE = 0
 comptime MPI_THREAD_FUNNELED = 1
@@ -99,8 +96,8 @@ fn MPI_Init(mut argc: Int, mut argv: VariadicList[StaticString]) raises:
     var result = _get_mpi_function[
         "MPI_Init",
         fn (
-            UnsafePointer[Int],
-            UnsafePointer[VariadicList[StaticString]],
+            UnsafePointer[Int, MutAnyOrigin],
+            UnsafePointer[VariadicList[StaticString], MutAnyOrigin],
         ) -> c_int,
     ]()(UnsafePointer(to=argc), UnsafePointer(to=argv))
     if result != 0:
@@ -111,16 +108,16 @@ fn MPI_Init_thread(
     mut argc: Int,
     mut argv: VariadicList[StaticString],
     required: c_int,
-    provided: UnsafePointer[c_int],
+    provided: UnsafePointer[c_int, MutAnyOrigin],
 ) raises:
     """Initialize MPI."""
     var result = _get_mpi_function[
         "MPI_Init_thread",
         fn (
-            UnsafePointer[Int],
-            UnsafePointer[VariadicList[StaticString]],
+            UnsafePointer[Int, MutAnyOrigin],
+            UnsafePointer[VariadicList[StaticString], MutAnyOrigin],
             c_int,
-            UnsafePointer[c_int],
+            UnsafePointer[c_int, MutAnyOrigin],
         ) -> c_int,
     ]()(UnsafePointer(to=argc), UnsafePointer(to=argv), required, provided)
     if result != 0:
@@ -141,32 +138,38 @@ fn MPI_Comm_split(
     comm: MPIComm,
     color: c_int,
     key: c_int,
-    newcomm: UnsafePointer[MPIComm],
+    newcomm: UnsafePointer[MPIComm, MutAnyOrigin],
 ) raises:
     """Split a communicator into multiple subcommunicators."""
     var result = _get_mpi_function[
         "MPI_Comm_split",
-        fn (MPIComm, c_int, c_int, UnsafePointer[MPIComm]) -> c_int,
+        fn (
+            MPIComm, c_int, c_int, UnsafePointer[MPIComm, MutAnyOrigin]
+        ) -> c_int,
     ]()(comm, color, key, newcomm)
     if result != 0:
         raise Error("failed to MPI_Comm_split with error code:", result)
 
 
-fn MPI_Comm_rank(comm: MPIComm, rank: UnsafePointer[c_int]) raises:
+fn MPI_Comm_rank(
+    comm: MPIComm, rank: UnsafePointer[c_int, MutAnyOrigin]
+) raises:
     """Get the rank of the current process in the communicator."""
     var result = _get_mpi_function[
         "MPI_Comm_rank",
-        fn (MPIComm, UnsafePointer[c_int]) -> c_int,
+        fn (MPIComm, UnsafePointer[c_int, MutAnyOrigin]) -> c_int,
     ]()(comm, rank)
     if result != 0:
         raise Error("failed to get MPI_Comm_rank with error code:", result)
 
 
-fn MPI_Comm_size(comm: MPIComm, size: UnsafePointer[c_int]) raises:
+fn MPI_Comm_size(
+    comm: MPIComm, size: UnsafePointer[c_int, MutAnyOrigin]
+) raises:
     """Get the size of the communicator."""
     var result = _get_mpi_function[
         "MPI_Comm_size",
-        fn (MPIComm, UnsafePointer[c_int]) -> c_int,
+        fn (MPIComm, UnsafePointer[c_int, MutAnyOrigin]) -> c_int,
     ]()(comm, size)
     if result != 0:
         raise Error("failed to get MPI_Comm_size with error code:", result)
@@ -175,7 +178,7 @@ fn MPI_Comm_size(comm: MPIComm, size: UnsafePointer[c_int]) raises:
 fn get_mpi_comm_world() raises -> MPIComm:
     """Get the MPI_COMM_WORLD communicator."""
     var handle = MPI_LIBRARY.get_or_create_ptr()[].borrow()
-    var comm_world_ptr = handle.get_symbol[OpaquePointer](
-        cstr_name="ompi_mpi_comm_world".as_c_string_slice().unsafe_ptr()
-    )
+    var comm_world_ptr = handle.get_symbol[
+        MutOpaquePointer[MutOrigin.external]
+    ](cstr_name="ompi_mpi_comm_world".as_c_string_slice().unsafe_ptr())
     return comm_world_ptr

--- a/max/kernels/src/shmem/_nvshmem.mojo
+++ b/max/kernels/src/shmem/_nvshmem.mojo
@@ -427,29 +427,33 @@ fn nvshmem_n_pes() -> c_int:
 
 
 fn nvshmem_malloc[
-    dtype: DType, origin: Origin
-](size: c_size_t) -> UnsafePointer[Scalar[dtype], origin]:
+    dtype: DType
+](size: c_size_t) -> UnsafePointer[Scalar[dtype], MutOrigin.external]:
     return _get_nvshmem_function[
         "nvshmem_malloc",
-        fn (c_size_t) -> UnsafePointer[Scalar[dtype], origin],
+        fn (c_size_t) -> UnsafePointer[Scalar[dtype], MutOrigin.external],
     ]()(size)
 
 
 fn nvshmem_calloc[
-    dtype: DType, origin: Origin
-](count: c_size_t, size: c_size_t) -> UnsafePointer[Scalar[dtype], origin]:
+    dtype: DType
+](count: c_size_t, size: c_size_t) -> UnsafePointer[
+    Scalar[dtype], MutOrigin.external
+]:
     return _get_nvshmem_function[
         "nvshmem_calloc",
-        fn (c_size_t, c_size_t) -> UnsafePointer[Scalar[dtype], origin],
+        fn (
+            c_size_t, c_size_t
+        ) -> UnsafePointer[Scalar[dtype], MutOrigin.external],
     ]()(count, size)
 
 
 fn nvshmem_free[
-    dtype: DType, origin: Origin
-](ptr: UnsafePointer[Scalar[dtype], origin]):
+    dtype: DType, //
+](ptr: UnsafePointer[Scalar[dtype]]) where type_of(ptr).mut:
     _get_nvshmem_function[
         "nvshmem_free",
-        fn (UnsafePointer[Scalar[dtype], origin]) -> NoneType,
+        fn (type_of(ptr)) -> NoneType,
     ]()(ptr)
 
 

--- a/max/kernels/src/shmem/_rocshmem.mojo
+++ b/max/kernels/src/shmem/_rocshmem.mojo
@@ -11,9 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 from collections.string.string_slice import get_static_string
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
+from memory import UnsafePointer
 from os import abort, getenv
 from pathlib import Path
 from sys import argv, size_of
@@ -170,10 +168,10 @@ comptime ROCSHMEM_TEAM_INDEX_MAX: rocshmem_team_id_t = rocshmem_team_id_t.MAX
 # Structs
 struct ROCSHMEMInitAttr:
     var version: c_int
-    var mpi_comm: UnsafePointer[MPIComm]
+    var mpi_comm: UnsafePointer[MPIComm, MutAnyOrigin]
     var args: ROCSHMEMInitArgs
 
-    fn __init__(out self, mpi_comm: UnsafePointer[MPIComm]):
+    fn __init__(out self, mpi_comm: UnsafePointer[MPIComm, MutAnyOrigin]):
         __comptime_assert (
             size_of[Self]() == 144
         ), "ROCSHMEMInitAttr must be 144 bytes"
@@ -198,7 +196,7 @@ struct ROCSHMEMInitArgs:
 
 struct ROCSHMEMUniqueIDArgs:
     var version: c_int
-    var id: UnsafePointer[ROCSHMEMUniqueID]
+    var id: UnsafePointer[ROCSHMEMUniqueID, MutAnyOrigin]
     var myrank: c_int
     var nranks: c_int
 
@@ -207,7 +205,7 @@ struct ROCSHMEMUniqueIDArgs:
             size_of[Self]() == 24
         ), "ROCSHMEMUniqueIDArgs must be 24 bytes"
         self.version = (1 << 16) + size_of[ROCSHMEMUniqueIDArgs]()
-        self.id = UnsafePointer[ROCSHMEMUniqueID]()
+        self.id = UnsafePointer[ROCSHMEMUniqueID, MutAnyOrigin]()
         self.myrank = 0
         self.nranks = 0
 
@@ -331,18 +329,20 @@ fn rocshmem_init_thread(
 
 fn rocshmem_init_attr(
     flags: UInt32,
-    attr: UnsafePointer[ROCSHMEMInitAttr],
+    attr: UnsafePointer[ROCSHMEMInitAttr, MutAnyOrigin],
 ) -> c_int:
     return _get_rocshmem_function[
         "rocshmem_init_attr",
-        fn (UInt32, UnsafePointer[ROCSHMEMInitAttr]) -> c_int,
+        fn (UInt32, UnsafePointer[ROCSHMEMInitAttr, MutAnyOrigin]) -> c_int,
     ]()(flags, attr)
 
 
-fn rocshmem_get_uniqueid(uid: UnsafePointer[ROCSHMEMUniqueID]) -> c_int:
+fn rocshmem_get_uniqueid(
+    uid: UnsafePointer[ROCSHMEMUniqueID, MutAnyOrigin]
+) -> c_int:
     return _get_rocshmem_function[
         "rocshmem_get_uniqueid",
-        fn (UnsafePointer[ROCSHMEMUniqueID]) -> c_int,
+        fn (UnsafePointer[ROCSHMEMUniqueID, MutAnyOrigin]) -> c_int,
     ]()(uid)
 
 
@@ -383,18 +383,20 @@ fn rocshmem_n_pes() -> c_int:
 
 
 fn rocshmem_malloc[
-    dtype: DType
-](size: c_size_t) -> UnsafePointer[Scalar[dtype]]:
+    dtype: DType, origin: Origin
+](size: c_size_t) -> UnsafePointer[Scalar[dtype], origin]:
     return _get_rocshmem_function[
         "rocshmem_malloc",
-        fn (c_size_t) -> UnsafePointer[Scalar[dtype]],
+        fn (c_size_t) -> UnsafePointer[Scalar[dtype], origin],
     ]()(size)
 
 
-fn rocshmem_free[dtype: DType](ptr: UnsafePointer[Scalar[dtype]]):
+fn rocshmem_free[
+    dtype: DType, origin: Origin
+](ptr: UnsafePointer[Scalar[dtype], origin]):
     _get_rocshmem_function[
         "rocshmem_free",
-        fn (UnsafePointer[Scalar[dtype]]) -> NoneType,
+        fn (UnsafePointer[Scalar[dtype], origin]) -> NoneType,
     ]()(ptr)
 
 
@@ -419,8 +421,8 @@ fn rocshmem_put[
     dtype: DType,
     //,
 ](
-    dest: UnsafePointer[Scalar[dtype]],
-    source: UnsafePointer[Scalar[dtype]],
+    dest: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    source: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     nelems: c_size_t,
     pe: c_int,
 ):
@@ -433,8 +435,8 @@ fn rocshmem_put[
         _get_rocshmem_function[
             symbol,
             fn (
-                UnsafePointer[Scalar[dtype]],
-                UnsafePointer[Scalar[dtype]],
+                UnsafePointer[Scalar[dtype], MutAnyOrigin],
+                UnsafePointer[Scalar[dtype], MutAnyOrigin],
                 c_size_t,
                 c_int,
             ) -> NoneType,
@@ -445,8 +447,8 @@ fn rocshmem_put_nbi[
     dtype: DType,
     //,
 ](
-    dest: UnsafePointer[Scalar[dtype]],
-    source: UnsafePointer[Scalar[dtype]],
+    dest: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    source: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     nelems: c_size_t,
     pe: c_int,
 ):
@@ -456,7 +458,11 @@ fn rocshmem_put_nbi[
 
 fn rocshmem_p[
     dtype: DType
-](dest: UnsafePointer[Scalar[dtype]], value: Scalar[dtype], pe: c_int,):
+](
+    dest: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    value: Scalar[dtype],
+    pe: c_int,
+):
     comptime symbol = _dtype_to_rocshmem_type["rocshmem_", dtype, "_p"]()
 
     @parameter
@@ -466,7 +472,7 @@ fn rocshmem_p[
         _get_rocshmem_function[
             symbol,
             fn (
-                UnsafePointer[Scalar[dtype]],
+                UnsafePointer[Scalar[dtype], MutAnyOrigin],
                 Scalar[dtype],
                 c_int,
             ) -> NoneType,
@@ -477,8 +483,8 @@ fn rocshmem_get[
     dtype: DType,
     //,
 ](
-    dest: UnsafePointer[Scalar[dtype]],
-    source: UnsafePointer[Scalar[dtype]],
+    dest: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    source: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     nelems: c_size_t,
     pe: c_int,
 ):

--- a/max/kernels/src/shmem/_rocshmem.mojo
+++ b/max/kernels/src/shmem/_rocshmem.mojo
@@ -383,20 +383,20 @@ fn rocshmem_n_pes() -> c_int:
 
 
 fn rocshmem_malloc[
-    dtype: DType, origin: Origin
-](size: c_size_t) -> UnsafePointer[Scalar[dtype], origin]:
+    dtype: DType
+](size: c_size_t) -> UnsafePointer[Scalar[dtype], MutOrigin.external]:
     return _get_rocshmem_function[
         "rocshmem_malloc",
-        fn (c_size_t) -> UnsafePointer[Scalar[dtype], origin],
+        fn (c_size_t) -> UnsafePointer[Scalar[dtype], MutOrigin.external],
     ]()(size)
 
 
 fn rocshmem_free[
-    dtype: DType, origin: Origin
-](ptr: UnsafePointer[Scalar[dtype], origin]):
+    dtype: DType, //
+](ptr: UnsafePointer[Scalar[dtype]]) where type_of(ptr).mut:
     _get_rocshmem_function[
         "rocshmem_free",
-        fn (UnsafePointer[Scalar[dtype], origin]) -> NoneType,
+        fn (type_of(ptr)) -> NoneType,
     ]()(ptr)
 
 
@@ -422,7 +422,7 @@ fn rocshmem_put[
     //,
 ](
     dest: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    source: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    source: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
     nelems: c_size_t,
     pe: c_int,
 ):
@@ -436,7 +436,7 @@ fn rocshmem_put[
             symbol,
             fn (
                 UnsafePointer[Scalar[dtype], MutAnyOrigin],
-                UnsafePointer[Scalar[dtype], MutAnyOrigin],
+                UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
                 c_size_t,
                 c_int,
             ) -> NoneType,
@@ -448,7 +448,7 @@ fn rocshmem_put_nbi[
     //,
 ](
     dest: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    source: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    source: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
     nelems: c_size_t,
     pe: c_int,
 ):
@@ -484,7 +484,7 @@ fn rocshmem_get[
     //,
 ](
     dest: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    source: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    source: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
     nelems: c_size_t,
     pe: c_int,
 ):

--- a/max/kernels/src/shmem/shmem_buffer.mojo
+++ b/max/kernels/src/shmem/shmem_buffer.mojo
@@ -24,6 +24,7 @@ from gpu.host import DeviceContext, HostBuffer
 from gpu.host.device_context import _checked, _DeviceContextPtr
 
 from .shmem_api import shmem_free, shmem_malloc
+from memory import UnsafePointer
 from builtin.device_passable import DevicePassable
 
 
@@ -56,7 +57,7 @@ struct SHMEMBuffer[dtype: DType](DevicePassable, Sized):
     ) raises:
         @parameter
         if has_nvidia_gpu_accelerator() or has_amd_gpu_accelerator():
-            self._data = shmem_malloc[Self.dtype](UInt(size))
+            self._data = shmem_malloc[Self.dtype, MutAnyOrigin](UInt(size))
             self._ctx_ptr = ctx._handle
             self._size = size
         else:

--- a/max/kernels/src/shmem/shmem_buffer.mojo
+++ b/max/kernels/src/shmem/shmem_buffer.mojo
@@ -57,7 +57,7 @@ struct SHMEMBuffer[dtype: DType](DevicePassable, Sized):
     ) raises:
         @parameter
         if has_nvidia_gpu_accelerator() or has_amd_gpu_accelerator():
-            self._data = shmem_malloc[Self.dtype, MutAnyOrigin](UInt(size))
+            self._data = shmem_malloc[Self.dtype](UInt(size))
             self._ctx_ptr = ctx._handle
             self._size = size
         else:


### PR DESCRIPTION
This PR completes the migration of the `shmem/` module from `LegacyUnsafePointer` to the new `UnsafePointer` API with explicit origins. This is Part 2 of the work to address #5673 (Part 1 migrated the `comm/` module).

## Changes

Updated all pointer types across the shmem module to use explicit origin parameters:

- **_mpi.mojo**: Added `MutAnyOrigin` to MPI function signatures and fixed pointer creation syntax
- **_nvshmem.mojo**: Updated malloc/calloc/free functions and struct fields (`NVSHMEMXInitAttr`, `NVSHMEMXUniqueIDArgs`) to use explicit origins
- **_rocshmem.mojo**: Similar updates to ROCm SHMEM backend, including RMA functions (`rocshmem_put`, `rocshmem_get`, etc.)
- **shmem_api.mojo**: Migrated public API functions (`shmem_malloc`, `shmem_calloc`, `shmem_free`, `shmem_p`) to use origin parameters
- **shmem_buffer.mojo**: Updated `SHMEMBuffer` struct and all methods to use `MutAnyOrigin`

## Testing

-  Full build passes: `./bazelw build //max/kernels/src/shmem:shmem`
-  Formatting applied and validated
-  All type inference errors resolved
<img width="699" height="184" alt="image" src="https://github.com/user-attachments/assets/8bb2582a-5fe7-438d-adde-833b85188a9a" />


This completes the pointer migration work for the kernels module alongside the comm/ changes from Part 1.

Part 2 to fix #5673