### PR TITLE
[Docs] Corrects `animals` List in Mojo variables reference bindings documentation

### DIFF
--- a/mojo/docs/manual/lifecycle/life.mdx
+++ b/mojo/docs/manual/lifecycle/life.mdx
@@ -91,7 +91,7 @@ struct MyPet:
 
 :::note
 
-Mojo does not require a destructor to destroy an instance. But in some cases you
+Mojo does not require a destructor to destroy an instance. But in some cases, you
 may need to define a custom destructor to release resources (for example, if a
 struct dynamically allocates memory using
 [`UnsafePointer`](/mojo/std/memory/unsafe_pointer/UnsafePointer)). We'll
@@ -207,7 +207,7 @@ var b = Target(a)
 ```
 
 In general, types should only support implicit conversions when the conversion
-is lossless, and ideally inexpensive. For example, converting an integer to a
+is lossless and ideally inexpensive. For example, converting an integer to a
 floating-point number is usually lossless (except for very large positive and
 negative integers, where the conversion may be approximate), but converting a
 floating-point number to an integer is very likely to lose information. So
@@ -454,7 +454,7 @@ this destructor more in [Death of a value](/mojo/manual/lifecycle/death).
 If your type doesn't use any pointers for heap-allocated data, then writing the
 constructor and copy constructor is all boilerplate code that you shouldn't have
 to write. For most structs that don't manage memory explicitly, you can just add
-the `Copyable` trait to your struct definition and Mojo will synthesize the
+the `Copyable` trait to your struct definition, and Mojo will synthesize the
 `__copyinit__()` method.
 
 :::note
@@ -638,7 +638,7 @@ ownership of a stored value, the `OwnedPointer` can be moved, but not copied.
 
 In some (rare) cases, you may not want a type to be copyable *or* movable. The
 [`Atomic`](/mojo/std/os/atomic/Atomic/) type is an example of a type that's
-neither copyable or movable.
+neither copyable nor movable.
 
 ## Trivial types
 
@@ -657,7 +657,7 @@ registers, not indirectly through memory.
 
 As such, Mojo provides a struct decorator to declare these types of values:
 `@register_passable("trivial")`. This decorator tells Mojo that the type should
-be copyable and movable but that it has no user-defined logic for this (no
+be copyable and movable, but that it has no user-defined logic for this (no
 custom copy constructor or move constructor). It also tells Mojo to pass the
 value in CPU registers whenever possible, which has clear performance benefits.
 

--- a/mojo/docs/manual/structs/index.mdx
+++ b/mojo/docs/manual/structs/index.mdx
@@ -234,7 +234,7 @@ To make a struct move-only, add the `Movable` trait:
   ...
   ```
 
-Mojo will generate a move constructor for you. You have rarely need to
+Mojo will generate a move constructor for you. You rarely need to
 write your own custom move constructor. For more information,
 see the section on
 [move constructors](/mojo/manual/lifecycle/life#move-constructor).
@@ -384,7 +384,7 @@ described in
 
 If you're writing code that you expect to use widely or distribute as a package,
 you may want to use `fn` functions for APIs that can't raise an error to limit
-the number of places users need to add error handling code.
+the number of places users need to add error-handling code.
 
 A struct's `__del__()` method, or destructor, **must** be a non-raising method,
 so it's always declared with `fn` (and without the `raises` keyword).

--- a/mojo/docs/manual/traits.mdx
+++ b/mojo/docs/manual/traits.mdx
@@ -106,12 +106,12 @@ trait Quackable:
 ```
 
 A trait looks a lot like a struct, except it's introduced by the `trait`
-keyword. Note that the `quack()` method signature is followed three dots
+keyword. Note that the `quack()` method signature is followed by three dots
 (`...`). This indicates it isn't implemented within the trait. In this
 example, `quack` is a *required method* and must be implemented by
 any conforming struct.
 
-A trait can supply a default implementation so conforming structs
+A trait can supply a default implementation, so conforming structs
 don’t need to implement the method themselves. You can provide a full
 implementation or use the `pass` keyword. Using `pass` creates a
 no-op method that does nothing. In your conforming struct, you
@@ -133,7 +133,7 @@ traits that describe generic types. For more information, see
 
 ### Adding traits to structs
 
-Next we need some structs that conform to the `Quackable` trait. Since the
+Next, we need some structs that conform to the `Quackable` trait. Since the
 `Duck` and `StealthCow` structs above already implement the `quack()` method,
 all we need to do is add the `Quackable` trait to the traits it conforms to
 (in parenthesis, after the struct name).
@@ -155,7 +155,7 @@ struct StealthCow(Copyable, Quackable):
 
 The struct needs to implement any methods that are declared in the trait. The
 compiler enforces conformance: if a struct says it conforms to a trait, it must
-implement everything required by the trait or the code won't compile.
+implement everything required by the trait, or the code won't compile.
 
 ### Using a trait as a type bound
 
@@ -569,7 +569,7 @@ sequence of `Writable` arguments constituting the `String` representation of
 your type.
 
 An important feature of the `Writer` trait is that it **only accepts valid UTF-8
-text**. This means when you write data to a `Writer`, you can only use
+text**. This means that when you write data to a `Writer`, you can only use
 `StringSlice` values (via the
 [`write_string()`](/mojo/std/io/write/Writer#write_string) method) or other
 `Writable` types; you cannot write arbitrary bytes. This guarantee ensures that
@@ -653,8 +653,8 @@ unused without being explicitly destroyed.
 
 You can also use traits when defining a generic container. A generic container
 is a container (for example, an array or hashmap) that can hold different data
-types. In a dynamic language like Python it's easy to add  different types of
-items to a container. But in a statically-typed environment the compiler needs
+types. In a dynamic language like Python it's easy to add different types of
+items to a container. But in a statically-typed environment, the compiler needs
 to be able to identify the types at compile time. For example, if the container
 needs to copy a value, the compiler needs to verify that the type can be copied.
 
@@ -682,7 +682,7 @@ for i in range(len(list)):
 You can use traits to define requirements for elements that are stored in a
 container. For example, `List` requires elements that can be moved and
 copied. To store a struct in a `List`, the struct needs to conform to
-the `Copyable` trait, which require a
+the `Copyable` trait, which requires a
 [copy constructor](/mojo/manual/lifecycle/life#copy-constructor) and a
 [move constructor](/mojo/manual/lifecycle/life#move-constructor).
 

--- a/mojo/docs/manual/variables.mdx
+++ b/mojo/docs/manual/variables.mdx
@@ -38,7 +38,7 @@ Mojo has two ways to declare a variable:
   ```
 
 * Implicitly-declared variables are created the first time the variable is used,
-  either with an assignment statement, or with a type annotation:
+  either with an assignment statement or with a type annotation:
 
   ```mojo
   a = 5
@@ -97,7 +97,7 @@ name: String = "Sam"
 user_id: Int
 ```
 
-Here the `user_id` variable has a type, but is uninitialized.
+Here, the `user_id` variable has a type, but is uninitialized.
 
 Implicitly-declared variables are scoped at the function level. You create an
 implicitly-declared variable the first time you assign a value to a given name
@@ -371,12 +371,12 @@ specifically, if the values are movable, copyable, or implicitly copyable.
   another_value = one_value  # implicit copy
   ```
 
-  Here `one_value` is unchanged, and `another_value` gets a copy of the value.
+  Here, `one_value` is unchanged, and `another_value` gets a copy of the value.
 
   Implicitly copyable types are generally simple value types like `Int`,
-  `Float64`, and `Bool` which can be copied trivially.
+  `Float64`, and `Bool`, which can be copied trivially.
 
-- The ownership of a value can be  be explicitly transferred from one variable
+- The ownership of a value can be explicitly transferred from one variable
   to another by appending the *transfer sigil* (`^`) after the value to
   transfer:
 
@@ -404,7 +404,7 @@ when you retrieve a value from a collection, the collection returns a reference,
 instead of a copy.
 
 ```mojo
-animals: List[String] = ["Cats", "Dogs, "Zebras"]
+animals: List[String] = ["Cats", "Dogs", "Zebras"]
 print(animals[2])  # Prints "Zebras", does not copy the value.
 ```
 
@@ -426,7 +426,7 @@ item_ref += 1  # increments items[1]
 print(items[1])  # prints 78
 ```
 
-Here the name `item_ref` is bound to the reference to `items[1]`. All reads and
+Here, the name `item_ref` is bound to the reference to `items[1]`. All reads and
 writes to `item_ref` go to the referenced item.
 
 Reference bindings can also be used when iterating through collections with


### PR DESCRIPTION
In the `animals` example in the reference bindings section of the Mojo variables documentation.

https://github.com/modular/modular/blob/6189fd73d4ad87778c70b45ffba65bf6f3c19404/mojo/docs/manual/variables.mdx?plain=1#L407

This PR adds a missing `"` after `Dogs` and fixes some other minor grammatical and punctuation issues in the Mojo documentation.