### PR TITLE
[stdlib] Fix usage of string length when byte length is required

### DIFF
--- a/max/kernels/test/gpu/basics/test_amd_format.mojo
+++ b/max/kernels/test/gpu/basics/test_amd_format.mojo
@@ -28,7 +28,7 @@ struct Buffer[capacity: Int](Defaultable, Writer):
         self.pos = 0
 
     fn write_string(mut self, string: StringSlice):
-        len_bytes = len(string)
+        len_bytes = string.byte_length()
         # If empty then return
         if len_bytes == 0:
             return

--- a/mojo/stdlib/std/builtin/debug_assert.mojo
+++ b/mojo/stdlib/std/builtin/debug_assert.mojo
@@ -161,7 +161,9 @@ fn debug_assert[
         message.nul_terminate()
 
         var slice = message.as_string_slice()
-        _debug_assert_msg(slice.unsafe_ptr(), len(slice), __call_location())
+        _debug_assert_msg(
+            slice.unsafe_ptr(), slice.byte_length(), __call_location()
+        )
 
 
 @always_inline
@@ -270,7 +272,9 @@ fn debug_assert[
         message.nul_terminate()
 
         var slice = message.as_string_slice()
-        _debug_assert_msg(slice.unsafe_ptr(), len(slice), __call_location())
+        _debug_assert_msg(
+            slice.unsafe_ptr(), slice.byte_length(), __call_location()
+        )
 
     elif _use_compiler_assume:
         assume(cond)

--- a/mojo/stdlib/std/collections/string/_unicode.mojo
+++ b/mojo/stdlib/std/collections/string/_unicode.mojo
@@ -174,9 +174,9 @@ fn to_lowercase(s: StringSlice[mut=False]) -> String:
     Returns:
         A new string where cased letters have been converted to lowercase.
     """
-    var result = String(capacity=_estimate_needed_size(len(s)))
+    var result = String(capacity=_estimate_needed_size(s.byte_length()))
     var input_offset = 0
-    while input_offset < len(s):
+    while input_offset < s.byte_length():
         var rune_and_size = Codepoint.unsafe_decode_utf8_codepoint(
             s.as_bytes()[input_offset:]
         )
@@ -202,9 +202,9 @@ fn to_uppercase(s: StringSlice[mut=False]) -> String:
     Returns:
         A new string where cased letters have been converted to uppercase.
     """
-    var result = String(capacity=_estimate_needed_size(len(s)))
+    var result = String(capacity=_estimate_needed_size(s.byte_length()))
     var input_offset = 0
-    while input_offset < len(s):
+    while input_offset < s.byte_length():
         var rune_and_size = Codepoint.unsafe_decode_utf8_codepoint(
             s.as_bytes()[input_offset:]
         )

--- a/mojo/stdlib/std/format/_utils.mojo
+++ b/mojo/stdlib/std/format/_utils.mojo
@@ -58,7 +58,7 @@ struct _WriteBufferHeap(Writable, Writer):
     # We should consider uses _WriteBufferStack on AMD instead.
     @always_inline
     fn write_string(mut self, string: StringSlice):
-        var len_bytes = len(string)
+        var len_bytes = string.byte_length()
         if len_bytes + self._pos > HEAP_BUFFER_BYTES:
             _printf[
                 "HEAP_BUFFER_BYTES exceeded, increase with: `mojo -D"
@@ -137,7 +137,7 @@ struct _WriteBufferStack[
         self.pos = 0
 
     fn write_string(mut self, string: StringSlice):
-        len_bytes = len(string)
+        len_bytes = string.byte_length()
         # If span is too large to fit in buffer, write directly and return
         if len_bytes > Int(Self.stack_buffer_bytes):
             self.flush()
@@ -180,7 +180,7 @@ struct _TotalWritableBytes(Writer):
                 self.write(sep, values[i])
 
     fn write_string(mut self, string: StringSlice):
-        self.size += len(string)
+        self.size += string.byte_length()
 
 
 # fmt: off


### PR DESCRIPTION
Fix usage of string length when byte length is required.

@NathanSWard in https://github.com/modular/modular/commit/a4ffad780fc19c23b19b03d966cc89f3b0ff3528 you introduced a lot of usage of `String.__len__` which I've been trying for the last year to remove everywhere except where unicode length is required to pave the way for the switch to codepoint indexing. There are also a lot of places where byte slicing processing was changed to string slicing which will also take a performance hit once the switch happens now, but it's in unimportant places like the path library and outside the scope of this PR.

@JoeLoser Could we please officialize that we will switch to codepoint indexing? I see way too many bugs like this every single time and I'm constantly fixing them. Or let's just straight up deprecate `String.__len__` and be done with the debate of what it should return in favor of explicit functions (currently `byte_length` and `char_length` in `StringSlice`), what do you guys think?