### PR TITLE
[Kernels] Migrate medium complexity quantization kernels off LegacyUnsafePointer (#5671)

### DIFF
--- a/max/kernels/src/quantization/per_channel_grouped_4bit.mojo
+++ b/max/kernels/src/quantization/per_channel_grouped_4bit.mojo
@@ -269,7 +269,7 @@ struct Q4sym[
             Self.float_dtype, address_space = AddressSpace.GENERIC, ...
         ],
         output_tensor: LayoutTensor[
-            DType.uint8, address_space = AddressSpace.GENERIC, ...
+            mut=True, DType.uint8, address_space = AddressSpace.GENERIC, ...
         ],
         input_shape: IndexList[input_tensor.rank],
     ):
@@ -334,10 +334,9 @@ struct Q4sym[
                 var src_ptr = UnsafePointer(to=encoded_data).address_space_cast[
                     output_ptr.address_space
                 ]()
-                # Use unsafe_mut_cast for memcpy compatibility
                 memcpy(
-                    dest=output_ptr.unsafe_mut_cast[True](),
-                    src=src_ptr.unsafe_mut_cast[False](),
+                    dest=output_ptr,
+                    src=src_ptr,
                     count=1,
                 )
                 _ = encoded_data^

--- a/max/kernels/src/quantization/per_channel_grouped_4bit.mojo
+++ b/max/kernels/src/quantization/per_channel_grouped_4bit.mojo
@@ -14,9 +14,7 @@ from math import ceil, ceildiv
 from sys.info import size_of
 
 from layout import Layout, LayoutTensor
-from memory import LegacyUnsafePointer, bitcast, memcpy
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
+from memory import UnsafePointer, bitcast, memcpy
 from utils import IndexList, StaticTuple, product
 
 
@@ -336,7 +334,12 @@ struct Q4sym[
                 var src_ptr = UnsafePointer(to=encoded_data).address_space_cast[
                     output_ptr.address_space
                 ]()
-                memcpy(dest=output_ptr, src=src_ptr, count=1)
+                # Use unsafe_mut_cast for memcpy compatibility
+                memcpy(
+                    dest=output_ptr.unsafe_mut_cast[True](),
+                    src=src_ptr.unsafe_mut_cast[False](),
+                    count=1,
+                )
                 _ = encoded_data^
 
     @staticmethod

--- a/max/kernels/src/quantization/qmatmul_gpu.mojo
+++ b/max/kernels/src/quantization/qmatmul_gpu.mojo
@@ -13,7 +13,6 @@
 
 from collections import OptionalReg
 from math import ceildiv
-from memory import UnsafePointer
 
 from sys import align_of, is_nvidia_gpu, simd_width_of, size_of
 

--- a/max/kernels/src/quantization/qmatmul_gpu.mojo
+++ b/max/kernels/src/quantization/qmatmul_gpu.mojo
@@ -13,9 +13,8 @@
 
 from collections import OptionalReg
 from math import ceildiv
-from memory import LegacyUnsafePointer
+from memory import UnsafePointer
 
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys import align_of, is_nvidia_gpu, simd_width_of, size_of
 
 from bit import log2_floor
@@ -2165,8 +2164,9 @@ fn gpu_qint4_repack_GPTQ[
             False,
         ]
 
+        # Create null tensor using MutExternalOrigin (null pointer with no real origin)
         var null_tensor = LayoutTensor[DType.int32, Layout()](
-            UnsafePointer[Int32]()
+            UnsafePointer[Int32, MutExternalOrigin]()
         )
 
         cuda_ctx.enqueue_function[repack, repack](


### PR DESCRIPTION
This PR migrates two medium-complexity quantization kernels from the deprecated `LegacyUnsafePointer` to the new `UnsafePointer` API as part of issue #5671.

### Changes
- **per_channel_grouped_4bit.mojo**: Updated pointer types and fixed memcpy calls using `unsafe_mut_cast`
- **qmatmul_gpu.mojo**: Migrated all pointer usage and updated null pointer creation to use `MutExternalOrigin`

### Testing
- Verified all files compile successfully
- Built dependent modules (nn, Mogg) to ensure no breakage
- Ran `pixi format` to satisfy CI requirements

Part of the work to resolve #5671, which tracks the removal of LegacyUnsafePointer from quantization kernels under the broader stdlib modernization effort (#5665).