### PR TITLE
[Docs] Fixes Mojo documentation references to ArcPointer

### DIFF
--- a/mojo/docs/changelog-released.md
+++ b/mojo/docs/changelog-released.md
@@ -4379,10 +4379,10 @@ detailed information in the following sections:
     ([PR #3524](https://github.com/modular/modular/pull/3524))
 
   - `Arc` has been renamed to
-    [`ArcPointer`](/mojo/std/memory/arc/ArcPointer), for consistency with
+    [`ArcPointer`](/mojo/std/memory/arc_pointer/ArcPointer), for consistency with
     `OwnedPointer`.
 
-  - [`ArcPointer`](/mojo/std/memory/arc/ArcPointer) now implements
+  - [`ArcPointer`](/mojo/std/memory/arc_pointer/ArcPointer) now implements
     [`Identifiable`](/mojo/std/builtin/identifiable/Identifiable), and can be
     compared for pointer equivalence using `a is b`.
 

--- a/mojo/docs/manual/pointers/index.mdx
+++ b/mojo/docs/manual/pointers/index.mdx
@@ -101,7 +101,7 @@ characteristics:
   pointer that points to a single value, and maintains exclusive ownership of
   that value.
 
-- [`ArcPointer`](/mojo/std/memory/arc/ArcPointer) is a reference-counted
+- [`ArcPointer`](/mojo/std/memory/arc_pointer/ArcPointer) is a reference-counted
   smart pointer that points to an owned value with ownership potentially shared
   with other instances of `ArcPointer`.
 
@@ -197,7 +197,7 @@ to use `ArcPointer` where you need a smart pointer that can be `Optional`.)
 
 ## `ArcPointer`
 
-An [`ArcPointer`](/mojo/std/memory/arc/ArcPointer) is a reference-counted
+An [`ArcPointer`](/mojo/std/memory/arc_pointer/ArcPointer) is a reference-counted
 smart pointer, ideal for shared resources where the last owner for a given value
 may not be clear. Like an `OwnedPointer`, it points to a single value, and it
 allocates memory when you initialize the `ArcPointer` with a value:


### PR DESCRIPTION
`arc.mojo` was renamed to `arc_pointer.mojo` in #5713. This PR fixes the `/mojo/std/memory/arc/ArcPointer` Markdown references to `/mojo/std/memory/arc_pointer/ArcPointer` in the Mojo "Intro to Pointers" documentation. (I have also updated the references in the released changelog, but I'm unsure if that is desired.)