### PR TITLE
[Models] Added model support for OrionStarAI/Orion-14B-Chat

### DIFF
--- a/max/python/max/pipelines/architectures/__init__.py
+++ b/max/python/max/pipelines/architectures/__init__.py
@@ -41,6 +41,7 @@ def register_all_models() -> None:
     from .mpnet import mpnet_arch
     from .olmo import olmo_arch
     from .olmo2 import olmo2_arch
+    from .orion import orion_arch
     from .phi3 import phi3_arch
     from .pixtral import pixtral_arch
     from .qwen2 import qwen2_arch
@@ -67,6 +68,7 @@ def register_all_models() -> None:
         mpnet_arch,
         olmo_arch,
         olmo2_arch,
+        orion_arch,
         phi3_arch,
         pixtral_arch,
         qwen2_arch,

--- a/max/python/max/pipelines/architectures/orion/__init__.py
+++ b/max/python/max/pipelines/architectures/orion/__init__.py
@@ -15,4 +15,4 @@ from .arch import orion_arch
 
 ARCHITECTURES = [orion_arch]
 
-__all__ = [ "ARCHITECTURES", "orion_arch"]
+__all__ = ["ARCHITECTURES", "orion_arch"]

--- a/max/python/max/pipelines/architectures/orion/__init__.py
+++ b/max/python/max/pipelines/architectures/orion/__init__.py
@@ -1,0 +1,18 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from .arch import orion_arch
+
+ARCHITECTURES = [orion_arch]
+
+__all__ = [ "ARCHITECTURES", "orion_arch"]

--- a/max/python/max/pipelines/architectures/orion/arch.py
+++ b/max/python/max/pipelines/architectures/orion/arch.py
@@ -14,6 +14,8 @@
 from max.graph.weights import WeightsFormat
 from max.interfaces import PipelineTask
 from max.nn.kv_cache import KVCacheStrategy
+from max.pipelines.architectures.llama3 import weight_adapters
+from max.pipelines.architectures.llama3.model import Llama3Model
 from max.pipelines.core import TextContext
 from max.pipelines.lib import (
     RopeType,
@@ -21,8 +23,6 @@ from max.pipelines.lib import (
     SupportedEncoding,
     TextTokenizer,
 )
-from max.pipelines.architectures.llama3 import weight_adapters
-from max.pipelines.architectures.llama3.model import Llama3Model
 
 orion_arch = SupportedArchitecture(
     name="OrionForCausalLM",

--- a/max/python/max/pipelines/architectures/orion/arch.py
+++ b/max/python/max/pipelines/architectures/orion/arch.py
@@ -1,0 +1,47 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from max.graph.weights import WeightsFormat
+from max.interfaces import PipelineTask
+from max.nn.kv_cache import KVCacheStrategy
+from max.pipelines.core import TextContext
+from max.pipelines.lib import (
+    RopeType,
+    SupportedArchitecture,
+    SupportedEncoding,
+    TextTokenizer,
+)
+from max.pipelines.architectures.llama3 import weight_adapters
+from max.pipelines.architectures.llama3.model import Llama3Model
+
+orion_arch = SupportedArchitecture(
+    name="OrionForCausalLM",
+    task=PipelineTask.TEXT_GENERATION,
+    example_repo_ids=["OrionStarAI/Orion-14B-Chat"],
+    default_weights_format=WeightsFormat.safetensors,
+    default_encoding=SupportedEncoding.bfloat16,
+    supported_encodings={
+        SupportedEncoding.q4_0: [KVCacheStrategy.PAGED],
+        SupportedEncoding.q4_k: [KVCacheStrategy.PAGED],
+        SupportedEncoding.q6_k: [KVCacheStrategy.PAGED],
+        SupportedEncoding.bfloat16: [KVCacheStrategy.PAGED],
+    },
+    pipeline_model=Llama3Model,
+    tokenizer=TextTokenizer,
+    context_type=TextContext,
+    rope_type=RopeType.normal,
+    weight_adapters={
+        WeightsFormat.safetensors: weight_adapters.convert_safetensor_state_dict,
+        WeightsFormat.gguf: weight_adapters.convert_gguf_state_dict,
+    },
+)


### PR DESCRIPTION
This PR adds support for the OrionStarAI / Orion-14B-Chat model to the Modular framework, leveraging the existing LLaMA architecture.
- Implemented the Orion model by inheriting from the LLaMA base to reuse weight loading, attention mechanisms, and decoder blocks while avoiding code duplication.
- Integrated Orion-specific configuration and model registration to enable seamless loading and inference through existing pipelines.
- Verified model correctness by running multiple prompts and matching the generated outputs with expected responses.