### PR TITLE
[stdlib] Rename `char_length` to `count_codepoints` for consistency

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -672,6 +672,9 @@ what we publish.
 - `StringableRaising` has been deprecated and its usages in the stdlib have
   been removed.
 
+- `StringSlice.char_length()` has been renamed `count_codepoints()`. The same
+  function was added to `String` and `StringLiteral`.
+
 ### Tooling changes
 
 - The Mojo compiler now supports the `-Werror` flag, which treats all warnings

--- a/mojo/stdlib/benchmarks/collections/bench_string.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_string.mojo
@@ -229,10 +229,10 @@ fn bench_string_replace[
 
 
 # ===-----------------------------------------------------------------------===#
-# Benchmark string char_length
+# Benchmark string count_codepoints
 # ===-----------------------------------------------------------------------===#
 @parameter
-fn bench_string_char_length[
+fn bench_string_count_codepoints[
     length: Int = 0, filename: StaticString = "UN_charter_EN"
 ](mut b: Bencher) raises:
     var items = make_string[length](filename + ".txt")
@@ -240,7 +240,7 @@ fn bench_string_char_length[
     @always_inline
     @parameter
     fn call_fn() raises:
-        var res = items.as_string_slice().char_length()
+        var res = items.count_codepoints()
         keep(res)
 
     b.iter[call_fn]()
@@ -456,8 +456,8 @@ def main():
             m.bench_function[bench_string_replace[length, fname, old, new]](
                 BenchId(String("bench_string_replace", suffix))
             )
-            m.bench_function[bench_string_char_length[length, fname]](
-                BenchId(String("bench_string_char_length", suffix))
+            m.bench_function[bench_string_count_codepoints[length, fname]](
+                BenchId(String("bench_string_count_codepoints", suffix))
             )
             m.bench_function[bench_string_find_single[length, fname]](
                 BenchId(String("bench_string_find_single", suffix))

--- a/mojo/stdlib/std/builtin/string_literal.mojo
+++ b/mojo/stdlib/std/builtin/string_literal.mojo
@@ -323,6 +323,54 @@ struct StringLiteral[value: __mlir_type.`!kgen.string`](
         """
         return Int(mlir_value=__mlir_op.`pop.string.size`(self.value))
 
+    @always_inline
+    fn count_codepoints(self) -> UInt:
+        """Calculates the length in Unicode codepoints encoded in the
+        UTF-8 representation of this string.
+
+        Returns:
+            The length in Unicode codepoints.
+
+        Examples:
+
+            Query the length of a string, in bytes and Unicode codepoints:
+
+            ```mojo
+            %# from testing import assert_equal
+
+            var s = StringSlice("ನಮಸ್ಕಾರ")
+            assert_equal(s.count_codepoints(), 7)
+            assert_equal(s.byte_length(), 21)
+            ```
+
+            Strings containing only ASCII characters have the same byte and
+            Unicode codepoint length:
+
+            ```mojo
+            %# from testing import assert_equal
+
+            var s = StringSlice("abc")
+            assert_equal(s.count_codepoints(), 3)
+            assert_equal(s.byte_length(), 3)
+            ```
+
+            The character length of a string with visual combining characters is
+            the length in Unicode codepoints, not grapheme clusters:
+
+            ```mojo
+            %# from testing import assert_equal
+
+            var s = StringSlice("á")
+            assert_equal(s.count_codepoints(), 2)
+            assert_equal(s.byte_length(), 3)
+            ```
+
+        Notes:
+            This method needs to traverse the whole string to count, so it has
+            a performance hit compared to using the byte length.
+        """
+        return self.as_string_slice().count_codepoints()
+
     @always_inline("nodebug")
     fn unsafe_ptr(
         self,

--- a/mojo/stdlib/std/collections/string/string.mojo
+++ b/mojo/stdlib/std/collections/string/string.mojo
@@ -1454,6 +1454,54 @@ struct String(
         else:
             return self._len_or_data
 
+    @always_inline
+    fn count_codepoints(self) -> UInt:
+        """Calculates the length in Unicode codepoints encoded in the
+        UTF-8 representation of this string.
+
+        Returns:
+            The length in Unicode codepoints.
+
+        Examples:
+
+            Query the length of a string, in bytes and Unicode codepoints:
+
+            ```mojo
+            %# from testing import assert_equal
+
+            var s = StringSlice("ನಮಸ್ಕಾರ")
+            assert_equal(s.count_codepoints(), 7)
+            assert_equal(s.byte_length(), 21)
+            ```
+
+            Strings containing only ASCII characters have the same byte and
+            Unicode codepoint length:
+
+            ```mojo
+            %# from testing import assert_equal
+
+            var s = StringSlice("abc")
+            assert_equal(s.count_codepoints(), 3)
+            assert_equal(s.byte_length(), 3)
+            ```
+
+            The character length of a string with visual combining characters is
+            the length in Unicode codepoints, not grapheme clusters:
+
+            ```mojo
+            %# from testing import assert_equal
+
+            var s = StringSlice("á")
+            assert_equal(s.count_codepoints(), 2)
+            assert_equal(s.byte_length(), 3)
+            ```
+
+        Notes:
+            This method needs to traverse the whole string to count, so it has
+            a performance hit compared to using the byte length.
+        """
+        return self.as_string_slice().count_codepoints()
+
     fn set_byte_length(mut self, new_len: Int):
         """Set the byte length of the `String`.
 

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -309,30 +309,30 @@ fn test_slice_len() raises:
     assert_equal(len(s1.codepoints()), 3)
 
 
-fn test_slice_char_length() raises:
+fn test_slice_count_codepoints() raises:
     var s0 = StringSlice("")
     assert_equal(s0.byte_length(), 0)
-    assert_equal(s0.char_length(), 0)
+    assert_equal(s0.count_codepoints(), 0)
 
     var s1 = StringSlice("foo")
     assert_equal(s1.byte_length(), 3)
-    assert_equal(s1.char_length(), 3)
+    assert_equal(s1.count_codepoints(), 3)
 
     # This string contains 1-, 2-, 3-, and 4-byte codepoint sequences.
     var s2 = EVERY_CODEPOINT_LENGTH_STR
     assert_equal(s2.byte_length(), 13)
-    assert_equal(s2.char_length(), 5)
+    assert_equal(s2.count_codepoints(), 5)
 
     # Just a bit of Zalgo text.
     var s3 = StringSlice("H̵͙̖̼̬̬̲̱͊̇̅͂̍͐͌͘͜͝")
     assert_equal(s3.byte_length(), 37)
-    assert_equal(s3.char_length(), 19)
+    assert_equal(s3.count_codepoints(), 19)
 
     # Character length is codepoints, not graphemes
     # This is thumbs up + a skin tone modifier codepoint.
     var s4 = StringSlice("👍🏻")
     assert_equal(s4.byte_length(), 8)
-    assert_equal(s4.char_length(), 2)
+    assert_equal(s4.count_codepoints(), 2)
     # TODO: assert_equal(s4.grapheme_count(), 1)
 
 
@@ -923,7 +923,7 @@ def test_chars_iter():
     # sequence of 2 codepoints.
     var s2 = StringSlice("á")
     assert_equal(s2.byte_length(), 3)
-    assert_equal(s2.char_length(), 2)
+    assert_equal(s2.count_codepoints(), 2)
 
     var iter = s2.codepoints()
     assert_equal(iter.__next__(), Codepoint.ord("a"))
@@ -936,7 +936,7 @@ def test_chars_iter():
     # sequences.
     var s3 = EVERY_CODEPOINT_LENGTH_STR
     assert_equal(s3.byte_length(), 13)
-    assert_equal(s3.char_length(), 5)
+    assert_equal(s3.count_codepoints(), 5)
     var s3_iter = s3.codepoints()
 
     # Iterator __len__ returns length in codepoints, not bytes.


### PR DESCRIPTION
Rename `char_length` to `count_codepoints` for consistency and add the methods to `String` and `StringLiteral`