### PR TITLE
[stdlib] [NFC] Use `_is_utf8_continuation_byte` instead of `_utf8_byte_type(b) == 1`

### DIFF
--- a/mojo/stdlib/std/collections/string/string_slice.mojo
+++ b/mojo/stdlib/std/collections/string/string_slice.mojo
@@ -25,6 +25,7 @@ from collections.string._utf8 import (
     _is_valid_utf8,
     _utf8_byte_type,
     _utf8_first_byte_sequence_length,
+    _is_utf8_continuation_byte,
 )
 from collections.string.format import _CurlyEntryFormattable, _FormatUtils
 from hashlib.hasher import Hasher
@@ -259,7 +260,7 @@ struct CodepointSliceIter[
             #   Guaranteed not to go out of bounds because UTF-8
             #   guarantees there is always a "start" byte eventually before any
             #   continuation bytes.
-            while _utf8_byte_type(back_ptr[]) == 1:
+            while _is_utf8_continuation_byte(back_ptr[]):
                 byte_len += 1
                 back_ptr -= 1
 
@@ -1711,7 +1712,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
 
         var byte = self.as_bytes()[index]
         # If this is not a continuation byte, then it must be a start byte.
-        return _utf8_byte_type(byte) != 1
+        return not _is_utf8_continuation_byte(byte)
 
     fn startswith(
         self, prefix: StringSlice, start: Int = 0, end: Int = -1

--- a/mojo/stdlib/test/collections/string/test_utf8.mojo
+++ b/mojo/stdlib/test/collections/string/test_utf8.mojo
@@ -276,8 +276,14 @@ def test_count_utf8_continuation_bytes():
     comptime b3 = UInt8(0b1110_0000)
     comptime b4 = UInt8(0b1111_0000)
 
+    for i in range(c):
+        assert_false(_is_utf8_continuation_byte(i))
+
     for i in range(c, b2):
         assert_true(_is_utf8_continuation_byte(i))
+
+    for i in range(b2, UInt8.MAX):
+        assert_false(_is_utf8_continuation_byte(i))
 
     def _test(amnt: Int, items: List[UInt8]):
         var p = items.unsafe_ptr()


### PR DESCRIPTION
Use `_is_utf8_continuation_byte` instead of `_utf8_byte_type(b) == 1`.

This is slightly faster (micro-op level diff), and a bit easier to understand at a glance