### PR TITLE
[Kernels] LegacyUnsafePointer-to-UnsafePointer-migration

### DIFF
--- a/max/kernels/benchmarks/nn/bench_scatter.mojo
+++ b/max/kernels/benchmarks/nn/bench_scatter.mojo
@@ -11,9 +11,6 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from random import rand, randint
 
 from benchmark import *
@@ -43,11 +40,11 @@ fn bench_scatter(mut bencher: Bencher, spec: ScatterSpec):
     var input_shape = Index(spec.m1, spec.m2)
     var indices_shape = Index(spec.n1, spec.n2)
 
-    var data_ptr = UnsafePointer[Float32].alloc(input_shape.flattened_length())
+    var data_ptr = alloc[Float32](input_shape.flattened_length())
     rand(data_ptr, input_shape.flattened_length())
     var data_tensor = DynamicTensor[DType.float32, 2](data_ptr, input_shape)
 
-    var indices_ptr = UnsafePointer[Int32].alloc(
+    var indices_ptr = alloc[Int32](
         indices_shape.flattened_length()
     )
     randint(
@@ -60,7 +57,7 @@ fn bench_scatter(mut bencher: Bencher, spec: ScatterSpec):
         indices_ptr, indices_shape
     )
 
-    var updates_ptr = UnsafePointer[Float32].alloc(
+    var updates_ptr = alloc[Float32](
         indices_shape.flattened_length()
     )
     rand(updates_ptr, indices_shape.flattened_length())
@@ -68,7 +65,7 @@ fn bench_scatter(mut bencher: Bencher, spec: ScatterSpec):
         updates_ptr, indices_shape
     )
 
-    var output_ptr = UnsafePointer[Float32].alloc(
+    var output_ptr = alloc[Float32](
         input_shape.flattened_length()
     )
     var output_tensor = DynamicTensor[DType.float32, 2](output_ptr, input_shape)

--- a/max/kernels/src/Mogg/MOGGPrimitives/MOGGPrimitives.mojo
+++ b/max/kernels/src/Mogg/MOGGPrimitives/MOGGPrimitives.mojo
@@ -20,12 +20,8 @@ from compiler_internal import StaticTensorSpec
 from gpu.host import DeviceBuffer
 from gpu.host.info import is_cpu, is_gpu
 from layout import UNKNOWN_VALUE, Layout, LayoutTensor, RuntimeLayout
-from memory import memcpy, LegacyUnsafePointer
+from memory import memcpy
 
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
-comptime OpaquePointer = LegacyUnsafePointer[
-    mut=True, NoneType, origin=MutAnyOrigin
-]
 from nn.concat import concat
 from register import register_internal
 from runtime.asyncrt import DeviceContextPtr
@@ -63,10 +59,10 @@ struct StateContext:
     This is currently meant as a mojo-side container for GML::StateContext."""
 
     var num_slots: Int
-    var ctx_ptr: OpaquePointer
+    var ctx_ptr: OpaquePointer[MutAnyOrigin]
 
     @always_inline
-    fn __init__(out self, num_slots: Int, ctx_ptr: OpaquePointer):
+    fn __init__(out self, num_slots: Int, ctx_ptr: OpaquePointer[MutAnyOrigin]):
         self.num_slots = num_slots
         self.ctx_ptr = ctx_ptr
 
@@ -76,17 +72,17 @@ struct StateContext:
         )
 
     @always_inline
-    fn __getitem__(self, index: Int) -> OpaquePointer:
+    fn __getitem__(self, index: Int) -> OpaquePointer[MutAnyOrigin]:
         debug_assert(0 <= index < self.num_slots, "index must be within bounds")
         return external_call[
             "MGP_RT_GetContextPayloadPtr",
-            OpaquePointer,
+            OpaquePointer[MutAnyOrigin],
         ](index, self.ctx_ptr)
 
 
-fn pack_string_res(str_ptr: UnsafePointer[Byte], str_len: Int) raises -> String:
+fn pack_string_res(str_ptr: UnsafePointer[Byte, ImmutAnyOrigin], str_len: Int) raises -> String:
     var span = Span[Byte, ImmutAnyOrigin](
-        ptr=LegacyUnsafePointer[Byte, origin=ImmutAnyOrigin](str_ptr),
+        ptr=UnsafePointer[Byte, origin=ImmutAnyOrigin](str_ptr),
         length=Int(str_len),
     )
     # We can not free the resource ptr embedded in MEF, create a copy
@@ -101,7 +97,7 @@ fn pack_string_res(str_ptr: UnsafePointer[Byte], str_len: Int) raises -> String:
 @register_internal("builtin.create_error_async_values_and_destruct_error")
 @no_inline
 fn create_error_async_values_and_destruct_error(
-    async_ptr: UnsafePointer[OpaquePointer],
+    async_ptr: UnsafePointer[OpaquePointer[MutAnyOrigin], MutAnyOrigin],
     async_len: Int,
     var err: Error,
 ):
@@ -116,20 +112,20 @@ fn create_error_async_values_and_destruct_error(
 
 @register_internal("builtin.create_index_async")
 @no_inline
-fn create_index_async(value: Int, async_ptr: OpaquePointer):
+fn create_index_async(value: Int, async_ptr: OpaquePointer[MutAnyOrigin]):
     external_call["MGP_RT_CreateAsync_ssizet", NoneType](value, async_ptr)
 
 
 @register_internal("builtin.create_si64_async")
 @no_inline
 @export
-fn create_si64_async(value: Int64, async_ptr: OpaquePointer):
+fn create_si64_async(value: Int64, async_ptr: OpaquePointer[MutAnyOrigin]):
     external_call["MGP_RT_CreateAsync_int64t", NoneType](value, async_ptr)
 
 
 @register_internal("builtin.create_chain_async")
 @no_inline
-fn create_chain_async(async_ptr: OpaquePointer):
+fn create_chain_async(async_ptr: OpaquePointer[MutAnyOrigin]):
     external_call["MGP_RT_CreateAsync_chain", NoneType](async_ptr)
 
 
@@ -138,7 +134,7 @@ fn create_chain_async(async_ptr: OpaquePointer):
 @no_inline
 fn create_i1_async(
     value: Bool,
-    async_ptr: OpaquePointer,
+    async_ptr: OpaquePointer[MutAnyOrigin],
 ):
     external_call["MGP_RT_CreateAsync_bool", NoneType](value, async_ptr)
 
@@ -147,7 +143,7 @@ fn create_i1_async(
 @no_inline
 fn create_buffer_ref_async(
     buffer: NDBuffer[DType.int8, 1, MutAnyOrigin],
-    async_ptr: OpaquePointer,
+    async_ptr: OpaquePointer[MutAnyOrigin],
     call_ctx: DeviceContextPtr,
 ):
     external_call["MGP_RT_CreateAsyncDeviceBufferRef", NoneType](
@@ -159,7 +155,7 @@ fn create_buffer_ref_async(
 @no_inline
 fn create_non_tracked_buffer_ref_async(
     buffer: NDBuffer[DType.int8, 1, MutAnyOrigin],
-    async_ptr: OpaquePointer,
+    async_ptr: OpaquePointer[MutAnyOrigin],
 ):
     external_call["MGP_RT_CreateAsyncNonTrackedBufferRef", NoneType](
         buffer.data, len(buffer), async_ptr
@@ -174,7 +170,7 @@ fn create_non_tracked_tensor_async[
     dtype: DType,
 ](
     buffer: NDBuffer[dtype, buffer_rank, MutAnyOrigin],
-    async_ptr: OpaquePointer,
+    async_ptr: OpaquePointer[MutAnyOrigin],
 ):
     __comptime_assert tensor_rank == buffer_rank or (
         tensor_rank == 0 and buffer_rank == 1
@@ -183,7 +179,7 @@ fn create_non_tracked_tensor_async[
         buffer.data,
         bytecount_with_dtype[dtype](buffer.dynamic_shape),
         tensor_rank,
-        LegacyUnsafePointer(to=buffer.dynamic_shape.data),
+        UnsafePointer(to=buffer.dynamic_shape.data),
         dtype,
         async_ptr,
     )
@@ -195,8 +191,8 @@ fn create_buffer_ref_with_borrow_async[
     borrowee_type: Int,
 ](
     buffer: NDBuffer[DType.int8, 1, MutAnyOrigin],
-    async_to_borrow: OpaquePointer,
-    output_async: OpaquePointer,
+    async_to_borrow: OpaquePointer[MutAnyOrigin],
+    output_async: OpaquePointer[MutAnyOrigin],
 ):
     external_call["MGP_RT_CreateAsyncBufferWithBorrow", NoneType](
         buffer.data,
@@ -211,11 +207,11 @@ fn create_buffer_ref_with_borrow_async[
 @no_inline
 fn create_tensor_spec_async[
     spec_rank: Int
-](spec: IndexList[spec_rank], async_ptr: OpaquePointer,):
+](spec: IndexList[spec_rank], async_ptr: OpaquePointer[MutAnyOrigin],):
     # Mojo impl is bitwise compatible with cpp variant, can construct TensorSpec in mojo
     # and pass it back to C++ -- However, this is an issue for the heap allocated dims.
     # For the benefit of simplicity, allocate the shapes and ptrs and free explicitly after
-    var shape_ptr = UnsafePointer[Int].alloc(spec_rank)
+    var shape_ptr = alloc[Int](spec_rank)
 
     @parameter
     for i in range(spec_rank):
@@ -236,8 +232,8 @@ fn create_tensor_async[
     borrowee_type: Int,
 ](
     buffer: NDBuffer[dtype, buffer_rank, MutAnyOrigin],
-    async_to_borrow: OpaquePointer,
-    output_async: OpaquePointer,
+    async_to_borrow: OpaquePointer[MutAnyOrigin],
+    output_async: OpaquePointer[MutAnyOrigin],
 ):
     # Tensor and the underlying buffer must have the same rank, unless it is a
     # scalar tensor stored with a NDBuffer<[1]>
@@ -248,7 +244,7 @@ fn create_tensor_async[
         buffer.data,
         bytecount_with_dtype[dtype](buffer.dynamic_shape),
         tensor_rank,
-        LegacyUnsafePointer(to=buffer.dynamic_shape.data),
+        UnsafePointer(to=buffer.dynamic_shape.data),
         dtype,
         async_to_borrow,
         borrowee_type,
@@ -258,19 +254,19 @@ fn create_tensor_async[
 
 
 @export
-fn empty_destructor(ptr: UnsafePointer[UInt8]):
+fn empty_destructor(ptr: UnsafePointer[UInt8, MutExternalOrigin]):
     pass
 
 
 @register_internal("builtin.create_mojo_value_async")
 @no_inline
 fn create_mojo_value_async(
-    val_ptr: UnsafePointer[UInt8],
-    async_ptr: OpaquePointer,
+    val_ptr: UnsafePointer[UInt8, MutAnyOrigin],
+    async_ptr: OpaquePointer[MutAnyOrigin],
     size: Int,
     align: Int,
-    destructor_fn: fn (UnsafePointer[UInt8]) -> None,
-    move_fn: fn (UnsafePointer[UInt8], UnsafePointer[UInt8]) -> None,
+    destructor_fn: fn (UnsafePointer[UInt8, MutExternalOrigin]) -> None,
+    move_fn: fn (UnsafePointer[UInt8, MutAnyOrigin], UnsafePointer[UInt8, MutAnyOrigin]) -> None,
 ):
     # Check if we have a nullptr, if so, don't use a destructor.
     if not val_ptr:
@@ -281,7 +277,7 @@ fn create_mojo_value_async(
         )
         return
     var dst_ptr = external_call[
-        "MGP_RT_MojoValueAllocateBuffer", UnsafePointer[UInt8]
+        "MGP_RT_MojoValueAllocateBuffer", UnsafePointer[UInt8, MutExternalOrigin]
     ](size, align)
     move_fn(val_ptr, dst_ptr)
 
@@ -295,15 +291,15 @@ fn create_mojo_value_async(
 @register_internal("builtin.create_python_mojo_value_async")
 @no_inline
 fn create_python_mojo_value_async(
-    val_ptr: UnsafePointer[UInt8],
-    async_ptr: OpaquePointer,
+    val_ptr: UnsafePointer[UInt8, MutAnyOrigin],
+    async_ptr: OpaquePointer[MutAnyOrigin],
     size: Int,
     align: Int,
-    destructor_fn: fn (UnsafePointer[UInt8]) -> None,
-    move_fn: fn (UnsafePointer[UInt8], UnsafePointer[UInt8]) -> None,
+    destructor_fn: fn (UnsafePointer[UInt8, MutExternalOrigin]) -> None,
+    move_fn: fn (UnsafePointer[UInt8, MutAnyOrigin], UnsafePointer[UInt8, MutAnyOrigin]) -> None,
 ):
     var dst_ptr = external_call[
-        "MGP_RT_MojoValueAllocateBuffer", UnsafePointer[UInt8]
+        "MGP_RT_MojoValueAllocateBuffer", UnsafePointer[UInt8, MutExternalOrigin]
     ](size, align)
     move_fn(val_ptr, dst_ptr)
 
@@ -317,8 +313,8 @@ fn create_python_mojo_value_async(
 @register_internal("builtin.transfer_async")
 @no_inline
 fn transfer_async(
-    async_src: OpaquePointer,
-    async_dst: OpaquePointer,
+    async_src: OpaquePointer[MutAnyOrigin],
+    async_dst: OpaquePointer[MutAnyOrigin],
 ):
     external_call[
         "MGP_RT_TransferAsyncRef",
@@ -329,22 +325,22 @@ fn transfer_async(
 @register_internal("builtin.unpack_async")
 @no_inline
 fn unpack_async(
-    async_ptr: OpaquePointer,
-) -> OpaquePointer:
+    async_ptr: OpaquePointer[MutAnyOrigin],
+) -> OpaquePointer[MutAnyOrigin]:
     return external_call[
         "MGP_RT_GetValueFromAsync",
-        OpaquePointer,
+        OpaquePointer[MutAnyOrigin],
     ](async_ptr)
 
 
 @register_internal("builtin.unpack_device_ctx")
 @no_inline
 fn unpack_device_ctx(
-    async_ptr: OpaquePointer,
+    async_ptr: OpaquePointer[MutAnyOrigin],
 ) -> DeviceContextPtr:
     var ptr = external_call[
         "MGP_RT_UnpackDeviceContext",
-        OpaquePointer,
+        OpaquePointer[MutAnyOrigin],
     ](async_ptr)
 
     return DeviceContextPtr(ptr.unsafe_origin_cast[MutExternalOrigin]())
@@ -353,13 +349,13 @@ fn unpack_device_ctx(
 @register_internal("builtin.unpack_buffer_ref")
 @no_inline
 fn unpack_buffer_ref(
-    async_ptr: OpaquePointer,
+    async_ptr: OpaquePointer[MutAnyOrigin],
 ) -> NDBuffer[DType.int8, 1, MutAnyOrigin]:
     var size: UInt64 = 0
     var data_ptr = external_call[
         "MGP_RT_GetDataFromBuffer",
-        OpaquePointer,
-    ](async_ptr, LegacyUnsafePointer(to=size))
+        OpaquePointer[MutAnyOrigin],
+    ](async_ptr, UnsafePointer(to=size))
     var shape = IndexList[1](Int(size))
     return NDBuffer[DType.int8, 1](data_ptr.bitcast[Int8](), shape)
 
@@ -370,7 +366,7 @@ fn unpack_tensor[
     buffer_rank: Int,
     tensor_rank: Int,
     dtype: DType,
-](tensor_async_ptr: OpaquePointer) -> NDBuffer[
+](tensor_async_ptr: OpaquePointer[MutAnyOrigin]) -> NDBuffer[
     dtype, buffer_rank, MutAnyOrigin
 ]:
     # Tensor and the underlying buffer must have the same rank, unless it is a
@@ -381,9 +377,9 @@ fn unpack_tensor[
     var shapes = IndexList[buffer_rank]()
     var buffer_ptr = external_call[
         "MGP_RT_GetShapeAndDataFromTensor",
-        OpaquePointer,
+        OpaquePointer[MutAnyOrigin],
     ](
-        LegacyUnsafePointer(to=shapes.data),
+        UnsafePointer(to=shapes.data),
         tensor_async_ptr,
     )
 
@@ -400,8 +396,8 @@ fn unpack_tensor[
 @no_inline
 fn unpack_tensor_spec[
     spec_rank: Int
-](async_ptr: OpaquePointer) -> IndexList[spec_rank]:
-    var shape_ptr = UnsafePointer[Int].alloc(spec_rank)
+](async_ptr: OpaquePointer[MutAnyOrigin]) -> IndexList[spec_rank]:
+    var shape_ptr = alloc[Int](spec_rank)
     external_call[
         "MGP_RT_GetTensorShapeFromAsync",
         NoneType,
@@ -419,14 +415,14 @@ fn unpack_tensor_spec[
 @register_internal("builtin.unpack_context")
 @no_inline
 fn unpack_context(
-    async_ptr: OpaquePointer,
+    async_ptr: OpaquePointer[MutAnyOrigin],
 ) -> StateContext:
     # We want to construct this because we want all payloads to be implemented
     var num_slots: UInt64 = 0
-    var ctx_ptr: OpaquePointer = external_call[
+    var ctx_ptr: OpaquePointer[MutAnyOrigin] = external_call[
         "MGP_RT_GetContextAndSizeFromAsync",
-        OpaquePointer,
-    ](LegacyUnsafePointer(to=num_slots), async_ptr)
+        OpaquePointer[MutAnyOrigin],
+    ](UnsafePointer(to=num_slots), async_ptr)
     return StateContext(Int(num_slots), ctx_ptr)
 
 
@@ -434,7 +430,7 @@ fn unpack_context(
 @always_inline
 fn get_buffer_data(
     buffer: NDBuffer[DType.int8, 1, MutAnyOrigin]
-) -> UnsafePointer[Int8]:
+) -> UnsafePointer[Int8, MutAnyOrigin]:
     return buffer.data
 
 
@@ -523,7 +519,7 @@ fn mgp_buffer_alloc(
 @register_internal("mgp.buffer.constant")
 @export
 fn mgp_buffer_constant(
-    resource_ptr: OpaquePointer,
+    resource_ptr: OpaquePointer[MutAnyOrigin],
     resource_bytecount: Int,
 ) -> NDBuffer[DType.int8, 1, MutAnyOrigin]:
     # Should we keep the alignment? It seems that the static alignment is
@@ -535,8 +531,8 @@ fn mgp_buffer_constant(
 
 @register_internal("mgp.buffer.constant.external")
 fn mgp_buffer_constant_external(
-    weights: UnsafePointer[WeightsRegistry],
-    name_ptr: UnsafePointer[Byte],
+    weights: UnsafePointer[WeightsRegistry, MutAnyOrigin],
+    name_ptr: UnsafePointer[Byte, MutAnyOrigin],
     name_len: UInt,
     size: UInt64,
     align: UInt64,
@@ -757,15 +753,15 @@ fn mgp_buffer_host_to_device[
 fn mgp_buffer_get_cached(
     ctx: StateContext,
     buffer_slot: UInt,
-    storage_ref_addr: UnsafePointer[OpaquePointer],
+    storage_ref_addr: UnsafePointer[OpaquePointer[MutAnyOrigin], MutAnyOrigin],
 ) raises -> NDBuffer[DType.int8, 1, MutAnyOrigin]:
     var buffer_size: UInt64 = 0
-    var buffer_data: OpaquePointer = external_call[
-        "MGP_RT_GetCachedBuffer", OpaquePointer
+    var buffer_data: OpaquePointer[MutAnyOrigin] = external_call[
+        "MGP_RT_GetCachedBuffer", OpaquePointer[MutAnyOrigin]
     ](
         Int(buffer_slot),
         ctx.ctx_ptr,
-        LegacyUnsafePointer(to=buffer_size),
+        UnsafePointer(to=buffer_size),
         storage_ref_addr,
     )
 
@@ -791,7 +787,7 @@ fn mgp_buffer_get_size(buf: NDBuffer[DType.int8, 1, MutAnyOrigin]) -> Int:
 @register_internal("destruct_async_refs")
 @no_inline
 fn destruct_async_refs(
-    storage_ref_addr: UnsafePointer[OpaquePointer],
+    storage_ref_addr: UnsafePointer[OpaquePointer[MutAnyOrigin], MutAnyOrigin],
     size: Int,
     direct_ref: Bool,
 ):
@@ -872,14 +868,14 @@ fn mgp_debug_tensor_print[
 ](
     buffer: NDBuffer[DType.int8, 1, MutAnyOrigin],
     shape: IndexList[spec_rank],
-    label_ptr: UnsafePointer[Byte],
+    label_ptr: UnsafePointer[Byte, MutAnyOrigin],
     label_len: Int,
 ) raises:
     external_call["MGP_RT_DebugTensorPrint", NoneType](
         label_ptr,
         UInt(label_len),
         dtype,
-        LegacyUnsafePointer(to=shape.data),
+        UnsafePointer(to=shape.data),
         spec_rank,
         buffer.data,
         len(buffer),
@@ -1141,8 +1137,8 @@ fn build_static_tensor_specs_tuple[
 fn to_managed_tensor_slice[
     dtype: DType, rank: Int, mut: Bool, input: IO
 ](
-    data: UnsafePointer[Scalar[dtype]],
-    shape: UnsafePointer[Int],
+    data: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    shape: UnsafePointer[Int, MutAnyOrigin],
 ) -> ManagedTensorSlice[
     io_spec = IOSpec[mut, input](),
     static_spec = StaticTensorSpec[dtype, rank].create_unknown(),
@@ -1227,7 +1223,7 @@ fn rebuild_static_tensor_specs_with_output_compute_lambda[
 fn _to_managed_tensor_slice_index_list_shape[
     dtype: DType, rank: Int, mut: Bool, input: IO
 ](
-    data: UnsafePointer[Scalar[dtype]],
+    data: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     shape_tuple: IndexList[rank],
 ) -> ManagedTensorSlice[
     io_spec = IOSpec[mut, input](),
@@ -1254,7 +1250,7 @@ fn _to_managed_tensor_slice_index_list_shape[
 fn to_managed_tensor_slice_list[
     dtype: DType, rank: Int, mut: Bool, input: IO
 ](
-    raw_list_ptr: OpaquePointer,
+    raw_list_ptr: OpaquePointer[MutAnyOrigin],
 ) -> List[
     ManagedTensorSlice[
         io_spec = IOSpec[mut, input](),
@@ -1265,7 +1261,7 @@ fn to_managed_tensor_slice_list[
         raw_list_ptr
     ).__int__()
 
-    var data_ptrs = List[OpaquePointer](capacity=num_elements)
+    var data_ptrs = List[OpaquePointer[MutAnyOrigin]](capacity=num_elements)
     var dim_values = List[Int64](capacity=num_elements * rank)
 
     # Collect the data pointers and dimensions of each element from the list.
@@ -1397,15 +1393,15 @@ fn test_my_int_reg2_to_index(x: MyIntReg2) -> Int:
 # AnyAsyncValueRef is a C++ struct. The runtime passes a reference to it.
 # Therefore, we alias it to OpaquePointer which will have the same bitwidth as
 # C++'s pointers.
-comptime AnyAsyncValueRefPtr = OpaquePointer
+comptime AnyAsyncValueRefPtr = OpaquePointer[MutAnyOrigin]
 
 # TensorBufferRef is a C++ struct. Primitives should always manipulate a
 # reference to it. Therefore, it is modeled here as an OpaquePointer.
-comptime TensorBufferRefPtr = OpaquePointer
+comptime TensorBufferRefPtr = OpaquePointer[MutAnyOrigin]
 
 # StateContext is a C++ struct. Primitives should always manipulate a reference
 # to it. Therefore, it is modeled here as an OpaquePointer.
-comptime StateContextRef = OpaquePointer
+comptime StateContextRef = OpaquePointer[MutAnyOrigin]
 
 
 # ===-----------------------------------------------------------------------===#
@@ -1421,7 +1417,7 @@ fn mogg_as_scalar(tensor: ManagedTensorSlice) -> Scalar[tensor.dtype]:
 
 @register_internal("mogg.async.__del__")
 @no_inline
-fn mogg_async_del(async_ptr: UnsafePointer[AnyAsyncValueRefPtr], size: Int):
+fn mogg_async_del(async_ptr: UnsafePointer[AnyAsyncValueRefPtr, MutAnyOrigin], size: Int):
     """
     Decrement the AnyAsyncValueRef. Typically called at the end of a kernel for
     all input and output operands.
@@ -1435,11 +1431,11 @@ fn mogg_async_unpack[T: AnyTrivialRegType](async_ptr: AnyAsyncValueRefPtr) -> T:
     """
     Returns the value stored in the AnyAsyncValueRef.
     """
-    var ptr = external_call["MGP_RT_GetValueFromAsync", OpaquePointer](
+    var ptr = external_call["MGP_RT_GetValueFromAsync", OpaquePointer[MutAnyOrigin]](
         async_ptr
     ).bitcast[T]()
 
-    return UnsafePointer[T].__getitem__(ptr, 0)
+    return UnsafePointer[T, MutAnyOrigin].__getitem__(ptr, 0)
 
 
 struct MoggAsyncPackHelper:
@@ -1503,11 +1499,11 @@ struct MoggAsyncPackHelper:
 
         # MGP_RT_CreateOwnedAsyncMojoValue expects a type erased destructor
         @always_inline("nodebug")
-        fn erased_destructor(ptr: UnsafePointer[UInt8]):
+        fn erased_destructor(ptr: UnsafePointer[UInt8, MutExternalOrigin]):
             ptr.bitcast[Type]().destroy_pointee()
 
         var dst_ptr = external_call[
-            "MGP_RT_MojoValueAllocateBuffer", UnsafePointer[UInt8]
+            "MGP_RT_MojoValueAllocateBuffer", UnsafePointer[UInt8, MutExternalOrigin]
         ](size_of[Type](), align_of[Type]())
 
         dst_ptr.bitcast[Type]().init_pointee_move(data^)
@@ -1569,7 +1565,7 @@ fn mogg_async_pack_borrow_v2[
             buffer.data,
             bytecount_with_dtype[dtype](buffer.dynamic_shape),
             spec_rank,
-            LegacyUnsafePointer(to=buffer.dynamic_shape.data),
+            UnsafePointer(to=buffer.dynamic_shape.data),
             dtype,
             mem,
         )
@@ -1608,7 +1604,7 @@ fn mogg_tensor_init[
     static_stride: DimList,
     alignment: Int,
     exclusive: Bool,
-](ptr: OpaquePointer, shape: IndexList[rank]) -> ManagedTensorSlice[
+](ptr: OpaquePointer[MutAnyOrigin], shape: IndexList[rank]) -> ManagedTensorSlice[
     io_spec = IOSpec[mut, input](),
     static_spec = StaticTensorSpec[dtype, rank](
         static_shape,
@@ -1713,15 +1709,15 @@ fn tmp_mgp_buffer_get_cached(
     Get a reference to the cached tensor.
     """
     var buffer_size: UInt64 = 0
-    var buffer_data = OpaquePointer()
+    var buffer_data = OpaquePointer[MutAnyOrigin]()
 
     var buffer_ref = external_call[
         "TMP_MGP_RT_GetCachedBuffer", TensorBufferRefPtr
     ](
         buffer_slot,
         ctx,
-        LegacyUnsafePointer(to=buffer_size),
-        LegacyUnsafePointer(to=buffer_data),
+        UnsafePointer(to=buffer_size),
+        UnsafePointer(to=buffer_data),
     )
 
     var buffer = NDBuffer[DType.int8, 1](
@@ -1742,7 +1738,7 @@ fn tmp_mgp_buffer_remove_cached(ctx: StateContextRef, buffer_slot: UInt64):
 
 @register_internal("mgp.assert")
 @no_inline
-fn mgp_assert(cond: Bool, msg_ptr: UnsafePointer[Byte], msg_len: Int) raises:
+fn mgp_assert(cond: Bool, msg_ptr: UnsafePointer[Byte, MutAnyOrigin], msg_len: Int) raises:
     """
     Raises an error when the input condition is not true.
     """
@@ -1843,7 +1839,7 @@ fn all_zeros(indices: IndexList) -> Bool:
 
 
 fn get_buffer_mem_storage_handle(
-    buffer: OpaquePointer, type: Int, memStorageHandle: OpaquePointer
+    buffer: OpaquePointer[MutAnyOrigin], type: Int, memStorageHandle: OpaquePointer[MutAnyOrigin]
 ):
     external_call["MGP_RT_GetBufferMemStorageHandle", NoneType](
         buffer, type, memStorageHandle

--- a/max/kernels/src/extensibility/tensor/managed_tensor_slice.mojo
+++ b/max/kernels/src/extensibility/tensor/managed_tensor_slice.mojo
@@ -33,10 +33,6 @@ from layout._coord import Coord, _DimsToCoordLike
 from layout._tile_tensor import TileTensor
 from memory import LegacyUnsafePointer
 
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
-comptime OpaquePointer = LegacyUnsafePointer[
-    mut=True, NoneType, origin=MutAnyOrigin
-]
 from register import register_internal
 from runtime.asyncrt import DeviceContextPtr
 from runtime.tracing import trace_arg
@@ -153,7 +149,7 @@ fn simd_store_into_tensor_pointer[
     simd_width: Int,
     element_alignment: Int = 1,
 ](
-    ptr: UnsafePointer[Scalar[dtype]],
+    ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     shape: IndexList[rank],
     strides: IndexList[rank],
     indices: IndexList[rank],
@@ -201,7 +197,7 @@ fn simd_load_from_tensor_pointer[
     simd_width: Int,
     element_alignment: Int = 1,
 ](
-    ptr: UnsafePointer[Scalar[dtype]],
+    ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     shape: IndexList[rank],
     strides: IndexList[rank],
     indices: IndexList[rank],
@@ -719,13 +715,13 @@ struct ManagedTensorSlice[
     comptime _in_lambda = Self.static_spec.in_lambda
     comptime _out_lambda = Self.static_spec.out_lambda
 
-    var _ptr: UnsafePointer[Scalar[Self.dtype]]
+    var _ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]
     var _spec: RuntimeTensorSpec[Self.dtype, Self.rank]
     var _runtime_strides: IndexList[Self.rank]
 
     fn __init__(
         out self,
-        ptr: UnsafePointer[Scalar[Self.dtype]],
+        ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
         slices: InlineArray[Slice, Self.rank],
         slicer_spec: RuntimeTensorSpec[Self.dtype, Self.rank],
     ):
@@ -774,7 +770,7 @@ struct ManagedTensorSlice[
 
     fn __init__(
         out self,
-        ptr: UnsafePointer[Scalar[Self.dtype]],
+        ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
         shape: IndexList[Self.rank],
     ):
         """Initializes a ManagedTensorSlice from a pointer and shape.
@@ -789,7 +785,7 @@ struct ManagedTensorSlice[
 
     fn __init__(
         out self,
-        ptr: UnsafePointer[Scalar[Self.dtype]],
+        ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
         shape: IndexList[Self.rank],
         strides: IndexList[Self.rank],
     ):
@@ -986,7 +982,7 @@ struct ManagedTensorSlice[
     @always_inline
     fn unsafe_ptr[
         _dtype: DType = Self.dtype
-    ](self) -> UnsafePointer[Scalar[_dtype]]:
+    ](self) -> UnsafePointer[Scalar[_dtype], MutAnyOrigin]:
         """Get the pointer stored in this tensor slice.
 
         Since this method obtains the pointer stored in this tensor slice, it
@@ -999,7 +995,7 @@ struct ManagedTensorSlice[
         Returns:
             The `UnsafePointer` which contains the data for this tensor slice.
         """
-        return rebind[UnsafePointer[Scalar[_dtype]]](self._ptr)
+        return self._ptr.bitcast[Scalar[_dtype]]()
 
     @always_inline
     fn load[
@@ -1231,7 +1227,7 @@ struct ManagedTensorSlice[
         self,
         new_runtime_shape: IndexList[new_rank],
         new_runtime_strides: IndexList[new_rank],
-        offset_ptr: OptionalReg[UnsafePointer[Scalar[Self.dtype]]] = None,
+        offset_ptr: OptionalReg[UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]] = None,
         out result: ManagedTensorSlice[
             rank=new_rank,
             io_spec = Self.io_spec,

--- a/max/kernels/src/internal_utils/_measure.mojo
+++ b/max/kernels/src/internal_utils/_measure.mojo
@@ -18,9 +18,6 @@ from sys import simd_width_of
 from algorithm import elementwise, mean, sum, vectorize
 from algorithm.functional import unswitch
 
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from utils import IndexList
 
 # ===----------------------------------------------------------------------=== #
@@ -54,7 +51,7 @@ fn kl_div(
 fn kl_div[
     dtype: DType, //
 ](
-    output: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     x: type_of(output),
     y: type_of(output),
     len: Int,
@@ -77,7 +74,7 @@ fn kl_div[
 fn kl_div[
     dtype: DType, //, out_type: DType = DType.float64
 ](
-    x: UnsafePointer[Scalar[dtype]],
+    x: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
     y: type_of(x),
     len: Int,
 ) -> Scalar[
@@ -113,8 +110,8 @@ fn kl_div[
 fn correlation[
     dtype: DType, //, out_type: DType = dtype
 ](
-    u: UnsafePointer[Scalar[dtype]],
-    v: type_of(u),
+    u: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    v: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     len: Int,
     *,
     w: OptionalReg[type_of(u)] = None,
@@ -137,7 +134,7 @@ fn correlation[
     var vmu = Scalar[out_type]()
     var w_val = type_of(u)()
     if w:
-        w_val = type_of(u).alloc(len)
+        w_val = alloc[Scalar[dtype]](len)
         _div(w_val, w.value(), _sum(w.value(), len), len)
     if centered:
         if w:
@@ -200,12 +197,10 @@ fn correlation[
 fn uncentered_unweighted_correlation[
     dtype: DType, //, out_type: DType = dtype
 ](
-    u: UnsafePointer[Scalar[dtype]],
+    u: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
     v: type_of(u),
     len: Int,
-) -> Scalar[
-    out_type
-]:
+) -> Scalar[out_type]:
     """Compute the uncentered and unweighted correlation
     distance between two 1-D arrays.
     Unlike `correlation` with arguments set, this does not raise.
@@ -236,7 +231,11 @@ fn uncentered_unweighted_correlation[
 fn cosine[
     dtype: DType,
     //,
-](u: UnsafePointer[Scalar[dtype]], v: type_of(u), len: Int,) -> Float64:
+](
+    u: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    v: type_of(u),
+    len: Int,
+) -> Float64:
     """Compute the Cosine distance between 1-D arrays.
 
     The Cosine distance between `u` and `v`, is defined as
@@ -259,7 +258,7 @@ fn relative_difference[
     dtype: DType,
     //,
 ](
-    output: LegacyUnsafePointer[mut=False, Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
     ref_out: type_of(output),
     len: Int,
 ) -> Float64:
@@ -289,7 +288,11 @@ fn relative_difference[
 
 fn _sqrt[
     dtype: DType, //
-](output: UnsafePointer[Scalar[dtype]], x: type_of(output), len: Int) raises:
+](
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    x: type_of(output),
+    len: Int,
+) raises:
     @parameter
     fn apply_fn[
         simd_width: Int, rank: Int, alignment: Int = 1
@@ -307,7 +310,7 @@ fn _sqrt[
 fn _mul[
     dtype: DType, //
 ](
-    output: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     x: type_of(output),
     y: type_of(output),
     len: Int,
@@ -330,7 +333,7 @@ fn _mul[
 fn _div[
     dtype: DType, //
 ](
-    output: UnsafePointer[Scalar[dtype]],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     x: type_of(output),
     c: Scalar[dtype],
     len: Int,
@@ -350,19 +353,25 @@ fn _div[
 
 fn _sum[
     dtype: DType, //
-](src: UnsafePointer[Scalar[dtype]], len: Int) raises -> Scalar[dtype]:
+](src: UnsafePointer[Scalar[dtype], ImmutAnyOrigin], len: Int) raises -> Scalar[
+    dtype
+]:
     return sum(Span[Scalar[dtype]](ptr=src, length=len))
 
 
 fn _mean[
     dtype: DType, //
-](src: UnsafePointer[Scalar[dtype]], len: Int) raises -> Scalar[dtype]:
+](src: UnsafePointer[Scalar[dtype], ImmutAnyOrigin], len: Int) raises -> Scalar[
+    dtype
+]:
     return mean(Span[Scalar[dtype]](ptr=src, length=len))
 
 
 fn _dot[
     dtype: DType, //, out_type: DType = dtype
-](x: UnsafePointer[Scalar[dtype]], y: type_of(x), len: Int) -> Scalar[out_type]:
+](
+    x: UnsafePointer[Scalar[dtype], ImmutAnyOrigin], y: type_of(x), len: Int
+) -> Scalar[out_type]:
     # loads are the expensive part, so we use the (probably) smaller
     # input type for determining simd width.
     comptime simd_width = simd_width_of[dtype]()

--- a/max/kernels/src/internal_utils/_testing.mojo
+++ b/max/kernels/src/internal_utils/_testing.mojo
@@ -16,10 +16,8 @@ from collections import OptionalReg
 from math import exp2
 
 import testing
+from buffer import NDBuffer
 from builtin._location import __call_location, _SourceLocation
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from testing.testing import _assert_cmp_error
 
 from utils.numerics import FPUtils
@@ -89,7 +87,7 @@ fn assert_almost_equal[
     //,
 ](
     x: UnsafePointer[Scalar[dtype]],
-    y: type_of(x),
+    y: UnsafePointer[Scalar[dtype]],
     num_elements: Int,
     msg: String = "",
     *,
@@ -155,7 +153,7 @@ fn assert_equal[
     //,
 ](
     x: UnsafePointer[Scalar[dtype]],
-    y: type_of(x),
+    y: UnsafePointer[Scalar[dtype]],
     num_elements: Int,
     msg: String = "",
     *,
@@ -208,13 +206,13 @@ fn assert_with_measure[
     dtype: DType,
     //,
     measure: fn[dtype: DType] (
-        LegacyUnsafePointer[mut=False, Scalar[dtype]],
-        LegacyUnsafePointer[mut=False, Scalar[dtype]],
+        UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+        UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
         Int,
     ) -> Float64,
 ](
-    x: UnsafePointer[Scalar[dtype], ...],
-    y: type_of(x),
+    x: UnsafePointer[Scalar[dtype]],
+    y: UnsafePointer[Scalar[dtype]],
     num_elements: Int,
     msg: String = "",
     *,

--- a/max/kernels/src/internal_utils/_utils.mojo
+++ b/max/kernels/src/internal_utils/_utils.mojo
@@ -13,13 +13,9 @@
 
 import time
 from collections import OptionalReg
+from io.io import _snprintf
 from math import ceildiv, floor
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
-comptime OpaquePointer = LegacyUnsafePointer[
-    mut=True, NoneType, origin=MutAnyOrigin
-]
+from random import rand, random_float64
 from sys import argv, env_get_string
 from builtin.device_passable import DevicePassable
 
@@ -373,7 +369,7 @@ struct Timer:
 fn init_vector_gpu[
     dtype: DType
 ](
-    x: UnsafePointer[Scalar[dtype]],
+    x: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     len: Int,
     mode: InitializationType,
     value: Scalar[dtype],

--- a/max/kernels/src/kv_cache/types.mojo
+++ b/max/kernels/src/kv_cache/types.mojo
@@ -32,12 +32,6 @@ from layout.tma_async import (
     create_split_tma,
     RaggedTMA3DTile,
 )
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
-comptime OpaquePointer = LegacyUnsafePointer[
-    mut=True, NoneType, origin=MutAnyOrigin
-]
 
 from utils import Index, IndexList
 from sys import size_of
@@ -188,7 +182,7 @@ trait KVCacheT(DevicePassable, ImplicitlyCopyable):
         start_tok_idx: Int,
         head_idx: Int,
         head_dim_idx: Int = 0,
-    ) -> UnsafePointer[Scalar[Self.dtype]]:
+    ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]:
         """Returns a LayoutTensor pointing to the KVCache block at the given index.
 
         Paged KVCache implementations must have a block_size which is a multiple of the
@@ -511,7 +505,7 @@ struct ContinuousBatchingKVCache[
         start_tok_idx: Int,
         head_idx: Int,
         head_dim_idx: Int = 0,
-    ) -> UnsafePointer[Scalar[Self.dtype]]:
+    ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]:
         var block_idx = Int(self.lookup_table[batch_idx])
         var full_block_idx = self._get_idx_tuple(
             block_idx, head_idx, start_tok_idx, head_dim_idx
@@ -818,7 +812,7 @@ struct PagedKVCache[
         start_tok_idx: Int,
         head_idx: Int,
         head_dim_idx: Int = 0,
-    ) -> UnsafePointer[Scalar[Self.dtype]]:
+    ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]:
         __comptime_assert (
             tile_size <= Self.page_size and Self.page_size % tile_size == 0
         ), (

--- a/max/kernels/test/internal_utils/test_measure.mojo
+++ b/max/kernels/test/internal_utils/test_measure.mojo
@@ -14,15 +14,13 @@
 from internal_utils import correlation, kl_div
 from internal_utils._testing import assert_with_measure
 from itertools import product
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
+from memory import UnsafePointer, alloc
 from testing import assert_almost_equal
 
 
 fn test_assert_with_custom_measure() raises:
-    var t0 = UnsafePointer[Float32].alloc(100)
-    var t1 = UnsafePointer[Float32].alloc(100)
+    var t0 = alloc[Float32](100)
+    var t1 = alloc[Float32](100)
     for i in range(100):
         t0[i] = 1.0
         t1[i] = 1.0
@@ -30,8 +28,8 @@ fn test_assert_with_custom_measure() raises:
     fn always_zero[
         dtype: DType
     ](
-        lhs: LegacyUnsafePointer[mut=False, Scalar[dtype]],
-        rhs: LegacyUnsafePointer[mut=False, Scalar[dtype]],
+        lhs: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+        rhs: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
         n: Int,
     ) -> Float64:
         return 0
@@ -46,9 +44,9 @@ fn test_correlation() raises:
     var a = 10
     var b = 10
     var len = a * b
-    var u = UnsafePointer[Float32].alloc(len)
-    var v = UnsafePointer[Float32].alloc(len)
-    var x = UnsafePointer[Float32].alloc(len)
+    var u = alloc[Float32](len)
+    var v = alloc[Float32](len)
+    var x = alloc[Float32](len)
     for i in range(len):
         u.store(i, (0.01 * i).cast[DType.float32]())
         v.store(i, (-0.01 * i).cast[DType.float32]())

--- a/max/kernels/test/nn/test_scatter_elements.mojo
+++ b/max/kernels/test/nn/test_scatter_elements.mojo
@@ -11,10 +11,6 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
-
 from nn.gather_scatter import scatter_elements
 from tensor import DynamicTensor
 from testing import assert_equal
@@ -26,12 +22,12 @@ def main():
     fn test_scatter_ax0() raises:
         print("== test_scatter_ax0")
 
-        var data_ptr = UnsafePointer[Float32].alloc(9)
+        var data_ptr = alloc[Float32](9)
         for i in range(9):
             data_ptr[i] = 0
         var data = DynamicTensor[DType.float32, 2](data_ptr, IndexList[2](3, 3))
 
-        var indices_ptr = UnsafePointer[Int32].alloc(6)
+        var indices_ptr = alloc[Int32](6)
         indices_ptr[0] = 1
         indices_ptr[1] = 0
         indices_ptr[2] = 2
@@ -42,7 +38,7 @@ def main():
             indices_ptr, IndexList[2](2, 3)
         )
 
-        var updates_ptr = UnsafePointer[Float32].alloc(6)
+        var updates_ptr = alloc[Float32](6)
         updates_ptr[0] = 1.0
         updates_ptr[1] = 1.1
         updates_ptr[2] = 1.2
@@ -53,7 +49,7 @@ def main():
             updates_ptr, IndexList[2](2, 3)
         )
 
-        var output_ptr = UnsafePointer[Float32].alloc(9)
+        var output_ptr = alloc[Float32](9)
         var output = DynamicTensor[DType.float32, 2](
             output_ptr, IndexList[2](3, 3)
         )
@@ -88,26 +84,26 @@ def main():
     fn test_scatter_ax1() raises:
         print("== test_scatter_ax1")
 
-        var data_ptr = UnsafePointer[Float32].alloc(5)
+        var data_ptr = alloc[Float32](5)
         for i in range(5):
             data_ptr[i] = i + 1
         var data = DynamicTensor[DType.float32, 2](data_ptr, IndexList[2](1, 5))
 
-        var indices_ptr = UnsafePointer[Int32].alloc(2)
+        var indices_ptr = alloc[Int32](2)
         indices_ptr[0] = 1
         indices_ptr[1] = 3
         var indices = DynamicTensor[DType.int32, 2](
             indices_ptr, IndexList[2](1, 2)
         )
 
-        var updates_ptr = UnsafePointer[Float32].alloc(2)
+        var updates_ptr = alloc[Float32](2)
         updates_ptr[0] = 1.1
         updates_ptr[1] = 2.1
         var updates = DynamicTensor[DType.float32, 2](
             updates_ptr, IndexList[2](1, 2)
         )
 
-        var output_ptr = UnsafePointer[Float32].alloc(5)
+        var output_ptr = alloc[Float32](5)
         var output = DynamicTensor[DType.float32, 2](
             output_ptr, IndexList[2](1, 5)
         )
@@ -140,26 +136,26 @@ def main():
     fn test_scatter_neg_indices() raises:
         print("== test_scatter_neg_indices")
 
-        var data_ptr = UnsafePointer[Float32].alloc(5)
+        var data_ptr = alloc[Float32](5)
         for i in range(5):
             data_ptr[i] = i + 1
         var data = DynamicTensor[DType.float32, 2](data_ptr, IndexList[2](1, 5))
 
-        var indices_ptr = UnsafePointer[Int32].alloc(2)
+        var indices_ptr = alloc[Int32](2)
         indices_ptr[0] = 1
         indices_ptr[1] = -3
         var indices = DynamicTensor[DType.int32, 2](
             indices_ptr, IndexList[2](1, 2)
         )
 
-        var updates_ptr = UnsafePointer[Float32].alloc(2)
+        var updates_ptr = alloc[Float32](2)
         updates_ptr[0] = 1.1
         updates_ptr[1] = 2.1
         var updates = DynamicTensor[DType.float32, 2](
             updates_ptr, IndexList[2](1, 2)
         )
 
-        var output_ptr = UnsafePointer[Float32].alloc(5)
+        var output_ptr = alloc[Float32](5)
         var output = DynamicTensor[DType.float32, 2](
             output_ptr, IndexList[2](1, 5)
         )
@@ -192,26 +188,26 @@ def main():
     fn test_scatter_reduce_max() raises:
         print("== test_scatter_reduce_max")
 
-        var data_ptr = UnsafePointer[Float32].alloc(5)
+        var data_ptr = alloc[Float32](5)
         for i in range(5):
             data_ptr[i] = i + 1
         var data = DynamicTensor[DType.float32, 2](data_ptr, IndexList[2](1, 5))
 
-        var indices_ptr = UnsafePointer[Int32].alloc(2)
+        var indices_ptr = alloc[Int32](2)
         indices_ptr[0] = 1
         indices_ptr[1] = 1
         var indices = DynamicTensor[DType.int32, 2](
             indices_ptr, IndexList[2](1, 2)
         )
 
-        var updates_ptr = UnsafePointer[Float32].alloc(2)
+        var updates_ptr = alloc[Float32](2)
         updates_ptr[0] = 1.1
         updates_ptr[1] = 2.1
         var updates = DynamicTensor[DType.float32, 2](
             updates_ptr, IndexList[2](1, 2)
         )
 
-        var output_ptr = UnsafePointer[Float32].alloc(5)
+        var output_ptr = alloc[Float32](5)
         var output = DynamicTensor[DType.float32, 2](
             output_ptr, IndexList[2](1, 5)
         )


### PR DESCRIPTION
## Summary
migrates scoped kernel files from `LegacyUnsafePointer` to `UnsafePointer`.

files migrated:
- `extensibility/tensor/managed_tensor_slice.mojo` (UPDATE: impacted by upstream changes, not migrated yet)
- `internal_utils/_measure.mojo`
- `internal_utils/_testing.mojo`
- `internal_utils/_utils.mojo`
- `kv_cache/types.mojo`

## Test Plan
- `./bazelw build //max/kernels/...` passes
- `./bazelw test //max/kernels/test/...` passes

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
