### PR TITLE
[stdlib] Add a safer `String[bytes=...]` getter

### DIFF
--- a/mojo/stdlib/std/collections/string/string.mojo
+++ b/mojo/stdlib/std/collections/string/string.mojo
@@ -913,15 +913,20 @@ struct String(
         Returns:
             A new string containing the string at the specified positions.
         """
-        var start: Int
-        var end: Int
-        # TODO(#933): implement this for unicode when we support llvm intrinsic evaluation at compile time
+        return self.as_string_slice()[bytes=span]
 
-        start, end = span.indices(self.byte_length())
-        return StringSlice(
-            ptr=self.unsafe_ptr() + start,
-            length=end - start,
-        )
+    fn __getitem__(
+        self, *, bytes: ContiguousSlice
+    ) -> StringSlice[origin_of(self)]:
+        """Gets the sequence of characters at the specified positions.
+
+        Args:
+            bytes: A slice that specifies positions of the new substring.
+
+        Returns:
+            A new string containing the string at the specified positions.
+        """
+        return self.as_string_slice()[bytes=bytes]
 
     fn __eq__(self, rhs: String) -> Bool:
         """Compares two Strings if they have the same values.

--- a/mojo/stdlib/std/collections/string/string_slice.mojo
+++ b/mojo/stdlib/std/collections/string/string_slice.mojo
@@ -902,6 +902,24 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
         """
         return Self(unsafe_from_utf8=self._slice[span])
 
+    @always_inline
+    fn __getitem__(self, *, bytes: ContiguousSlice) -> Self:
+        """Gets the sequence of characters at the specified positions.
+
+        Args:
+            bytes: A slice that specifies positions of the new substring.
+
+        Returns:
+            A new StringSlice containing the substring at the specified positions.
+        """
+        var sliced = Self(unsafe_from_utf8=self._slice[bytes])
+
+        if not sliced.is_codepoint_boundary(0):
+            abort("incorrectly sliced a multi-byte sequence at the start")
+        elif not sliced.is_codepoint_boundary(UInt(sliced.byte_length())):
+            abort("incorrectly sliced a multi-byte sequence at the end")
+        return sliced
+
     fn to_python_object(var self) raises -> PythonObject:
         """Convert this value to a PythonObject.
 


### PR DESCRIPTION
Add a safer `String[bytes=...]` getter. This should eventually replace the current getter and deprecate it (I don't think it should be deleted right away because a lot of people index strings using slices). Closes #5402. Closes  #5405