### PR TITLE
[Flux1] add model definitions for components of Flux1 pipeline

### DIFF
--- a/max/python/max/dtype/dtype_extension.py
+++ b/max/python/max/dtype/dtype_extension.py
@@ -1,0 +1,56 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Extension for max.dtype to support additional attributes."""
+
+from numpy import finfo as np_finfo
+
+from .dtype import DType
+
+
+class finfo:
+    """A numerical properties of a floating point max.dtype.DType.
+
+    This class mimics torch.finfo behavior without torch dependency,
+    including support for bfloat16.
+
+    NOTE: Currently, it's applied through patching.
+    This extension is better to be implemented in dtype library itself.
+    """
+
+    def __init__(self, dtype: DType):
+        """Initialize finfo for a given max.dtype.DType.
+
+        Args:
+            dtype: The data type to get limits for.
+        """
+        if dtype == DType.bfloat16:
+            self.min = -3.38953e38
+            self.max = 3.38953e38
+            self.bits = 16
+            self.eps = 0.0078125
+            self.resolution = 0.01
+            self.tiny = 1.17549e-38
+            self.dtype = "bfloat16"
+        else:
+            np_finfo_obj = np_finfo(dtype.to_numpy())
+            self.min = float(np_finfo_obj.min)
+            self.max = float(np_finfo_obj.max)
+            self.bits = np_finfo_obj.bits
+            self.eps = float(np_finfo_obj.eps)
+            self.resolution = float(np_finfo_obj.resolution)
+            self.tiny = float(np_finfo_obj.tiny)
+            self.dtype = str(np_finfo_obj.dtype)
+
+
+DType.finfo = finfo

--- a/max/python/max/nn/module_v3/__init__.py
+++ b/max/python/max/nn/module_v3/__init__.py
@@ -12,15 +12,21 @@
 # ===----------------------------------------------------------------------=== #
 """Module implementation using eager tensors."""
 
+from .conv import Conv2d
 from .embedding import Embedding
 from .linear import Linear
 from .module import Module, module_dataclass
+from .norm import GemmaRMSNorm, GroupNorm, RMSNorm
 from .sequential import Sequential
 
 __all__ = [
+    "Conv2d",
     "Embedding",
+    "GemmaRMSNorm",
+    "GroupNorm",
     "Linear",
     "Module",
+    "RMSNorm",
     "Sequential",
     "module_dataclass",
 ]

--- a/max/python/max/nn/module_v3/conv.py
+++ b/max/python/max/nn/module_v3/conv.py
@@ -1,0 +1,217 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Module for convolutional layers."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from ...driver import Accelerator, accelerator_api
+from ...dtype import DType
+from ...experimental import functional as F
+from ...experimental import random
+from ...experimental.tensor import Tensor
+from ...graph import DeviceRef
+from ...graph.type import FilterLayout
+from .module import Module
+
+
+class Conv2d(Module[[Tensor], Tensor]):
+    """A 2D convolution layer using module_v3.
+
+    This is a module_v3-compatible version of Conv2d that uses Tensor
+    instead of Weight objects.
+
+    Example:
+        .. code-block:: python
+
+            from max.nn.module_v3 import Conv2d
+            from max.experimental.tensor import Tensor
+
+            conv = Conv2d(
+                kernel_size=3,
+                in_channels=3,
+                out_channels=64,
+                has_bias=True,
+                permute=True,
+            )
+
+            x = Tensor.ones([1, 3, 32, 32])
+            result = conv(x)
+    """
+
+    weight: Tensor
+    """The weight tensor with shape [out_channels, in_channels // num_groups, kernel_height, kernel_width]."""
+
+    bias: Tensor | Literal[0]
+    """The bias tensor with shape [out_channels] (or 0 if bias is disabled)."""
+
+    def __init__(
+        self,
+        kernel_size: int | tuple[int, int],
+        in_channels: int,
+        out_channels: int,
+        dtype: DType | None = None,
+        stride: int | tuple[int, int] = 1,
+        padding: int | tuple[int, int] | tuple[int, int, int, int] = 0,
+        dilation: int | tuple[int, int] = 1,
+        num_groups: int = 1,
+        device: DeviceRef | None = None,
+        has_bias: bool = False,
+        permute: bool = False,
+        name: str | None = None,
+    ):
+        """Initialize Conv2d layer.
+
+        Args:
+            kernel_size: Size of the convolving kernel. Can be a single int (square kernel) or tuple (height, width).
+            in_channels: Number of channels in the input image.
+            out_channels: Number of channels produced by the convolution.
+            dtype: The data type for both weights and bias. In v3, this is optional as Tensor manages dtype automatically.
+            stride: Stride of the convolution for height and width dimensions.
+                Can be int (applied to both dimensions) or tuple (stride_h, stride_w). Default: 1
+            padding: Padding added to input. Can be int (applied to all sides),
+                tuple of 2 ints (pad_h, pad_w), or tuple of 4 ints (pad_top, pad_bottom, pad_left, pad_right) to support asymmetric padding. Default: 0
+            dilation: Spacing between kernel elements for height and width dimensions.
+                Can be int (applied to both dimensions) or tuple (dilation_h, dilation_w). Default: 1
+            num_groups: Number of blocked connections from input channels to output channels.
+                Input channels and output channels are divided into groups. Default: 1
+            device: The target device for computation. In v3, this is optional as Tensor manages device automatically.
+            has_bias: If true, adds a learnable bias vector to the layer.
+                Defaults to :obj:`False`.
+            permute: If true, permutes weights from PyTorch format to MAX format.
+                PyTorch order: (out_channels, in_channels / num_groups, height, width).
+                MAX API order: (height, width, in_channels / num_groups, out_channels).
+                Defaults to :obj:`False`.
+            name: Base name for weights. In v3, this is stored but not used for Weight naming.
+                Defaults to :obj:`None`.
+        """
+        # Store configuration for easy reconstruction
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.dtype = dtype
+        self.device = device
+        self.permute = permute
+        self.num_groups = num_groups
+        self.has_bias = has_bias
+        self.name = name
+
+        # Handle kernel_size as int or tuple
+        if isinstance(kernel_size, int):
+            kernel_height = kernel_width = kernel_size
+            self.kernel_size = (kernel_size, kernel_size)
+        else:
+            kernel_height, kernel_width = kernel_size
+            self.kernel_size = kernel_size
+
+        self.weight = random.normal(
+            [
+                out_channels,
+                in_channels // num_groups,
+                kernel_height,
+                kernel_width,
+            ]
+            if self.permute
+            else [
+                kernel_height,
+                kernel_width,
+                in_channels // num_groups,
+                out_channels,
+            ],
+            dtype=self.dtype,
+            device=self.device.to_device() if self.device is not None else None,
+        )
+
+        if has_bias:
+            self.bias = random.normal(
+                [out_channels],
+                dtype=self.dtype,
+                device=self.device.to_device()
+                if self.device is not None
+                else None,
+            )
+        else:
+            self.bias = 0
+
+        # Convert scalar parameters to tuples as needed
+        self.stride = (stride, stride) if isinstance(stride, int) else stride
+
+        if isinstance(padding, int):
+            padding = (padding, padding, padding, padding)
+        elif len(padding) == 2:
+            # Convert (pad_h, pad_w) to (pad_top, pad_bottom, pad_left, pad_right)
+            pad_h, pad_w = padding
+            padding = (pad_h, pad_h, pad_w, pad_w)
+
+        self.padding = padding
+
+        if isinstance(dilation, int):
+            dilation = (dilation, dilation)
+        self.dilation = dilation
+
+        if (
+            isinstance(self.weight, Tensor)
+            and hasattr(self.weight, "quantization_encoding")
+            and self.weight.quantization_encoding is not None
+        ):
+            raise ValueError("Conv2d not implemented with weight quantization.")
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Apply 2D convolution to input.
+
+        Args:
+            x: Input tensor. Shape depends on `permute`:
+                - If permute=True: [batch_size, in_channels, height, width]
+                - If permute=False: [batch_size, height, width, in_channels]
+
+        Returns:
+            Output tensor. Shape depends on `permute`:
+                - If permute=True: [batch_size, out_channels, new_height, new_width]
+                - If permute=False: [batch_size, new_height, new_width, out_channels]
+        """
+        # Move weight to same device as input
+        weight = self.weight.to(x.device)
+
+        is_nvidia_gpu = (
+            isinstance(x.device, Accelerator) and accelerator_api() == "cuda"
+        )
+
+        if self.permute:
+            # Input: [batch_size, in_channels, height, width] -> [batch_size, height, width, in_channels]
+            x = F.permute(x, [0, 2, 3, 1])
+
+            # GPU supports FCRS but CPU doesn't. On CPU, permute from
+            # FCRS to RSCF format.
+            if not is_nvidia_gpu:
+                # Permute weight from [out_channels, in_channels // num_groups, height, width]
+                # to [height, width, in_channels // num_groups, out_channels] (RSCF)
+                weight = F.permute(weight, [2, 3, 1, 0])
+
+        output = F.conv2d(
+            x,
+            weight,
+            self.stride,
+            self.dilation,
+            self.padding,
+            self.num_groups,
+            self.bias if isinstance(self.bias, Tensor) else None,
+            filter_layout=FilterLayout.FCRS
+            if (self.permute and is_nvidia_gpu)
+            else FilterLayout.RSCF,
+        )
+
+        if self.permute:
+            # Output: [batch_size, new_height, new_width, out_channels] -> [batch_size, out_channels, new_height, new_width]
+            output = F.permute(output, [0, 3, 1, 2])
+
+        return output

--- a/max/python/max/nn/module_v3/norm/__init__.py
+++ b/max/python/max/nn/module_v3/norm/__init__.py
@@ -11,9 +11,13 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+from .group_norm import GroupNorm
+from .layer_norm import LayerNorm
 from .rms_norm import GemmaRMSNorm, RMSNorm
 
 __all__ = [
     "GemmaRMSNorm",
+    "GroupNorm",
+    "LayerNorm",
     "RMSNorm",
 ]

--- a/max/python/max/nn/module_v3/norm/group_norm.py
+++ b/max/python/max/nn/module_v3/norm/group_norm.py
@@ -1,0 +1,171 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Group Normalization implementation using module_v3."""
+
+from __future__ import annotations
+
+from ....driver import CPU
+from ....dtype import DType
+from ....experimental import functional as F
+from ....experimental.tensor import Tensor
+from ..module import Module
+
+
+def group_norm(
+    x: Tensor,
+    weight: Tensor,
+    bias: Tensor,
+    num_groups: int,
+    eps: float,
+) -> Tensor:
+    """Applies Group Normalization to an input tensor.
+
+    Group Normalization divides the channels into groups and computes
+    normalization statistics within each group. This is useful for small
+    batch sizes where batch normalization is unstable.
+
+    Args:
+        x: Input tensor of shape [N, C, *] where C is number of channels
+        weight: Weight tensor of shape [C]
+        bias: Bias tensor of shape [C]
+        num_groups: Number of groups to separate the channels into
+        eps: Small constant added to denominator for numerical stability
+
+    Returns:
+        Normalized tensor of same shape as input
+    """
+    if len(x.shape) < 2:
+        raise ValueError(
+            f"Expected input tensor with >=2 dimensions, got shape {x.shape}"
+        )
+
+    return F.custom(
+        "group_norm",
+        x.device,
+        [
+            x,
+            weight.to(x.device),
+            bias.to(x.device),
+            F.constant(eps, dtype=x.dtype, device=CPU()),
+            F.constant(num_groups, dtype=DType.int32, device=CPU()),
+        ],
+        [x.type],
+    )[0]
+
+
+class GroupNorm(Module[[Tensor], Tensor]):
+    """Group normalization block using module_v3.
+
+    Divides channels into groups and computes normalization stats per group.
+    Follows the implementation pattern from PyTorch's group_norm.
+
+    This module_v3 implementation uses Tensor instead of Weight, which
+    automatically handles dtype matching with input tensors, eliminating
+    the need for dtype workarounds.
+
+    Example:
+        .. code-block:: python
+
+            from max.nn.module_v3 import GroupNorm
+            from max.experimental.tensor import Tensor
+
+            norm = GroupNorm(num_groups=32, num_channels=128)
+            x = Tensor.ones([1, 128, 32, 32])
+            result = norm(x)
+    """
+
+    weight: Tensor | None
+    """The weight tensor with shape [num_channels] (None if affine=False)."""
+    bias: Tensor | None
+    """The bias tensor with shape [num_channels] (None if affine=False)."""
+    num_groups: int
+    """Number of groups to separate the channels into."""
+    num_channels: int
+    """Number of input channels."""
+    eps: float
+    """Small constant added to denominator for numerical stability."""
+
+    def __init__(
+        self,
+        num_groups: int,
+        num_channels: int,
+        eps: float = 1e-5,
+        affine: bool = True,
+    ) -> None:
+        """Initialize GroupNorm module.
+
+        Args:
+            num_groups: Number of groups to separate the channels into
+            num_channels: Number of input channels
+            eps: Small constant added to denominator for numerical stability.
+                Default: 1e-5
+            affine: If True, apply learnable affine transform parameters.
+                Default: True
+        """
+        if num_channels % num_groups != 0:
+            raise ValueError(
+                f"num_channels({num_channels}) should be divisible by "
+                f"num_groups({num_groups})"
+            )
+
+        self.num_groups = num_groups
+        self.num_channels = num_channels
+        self.eps = eps
+        self.affine = affine
+
+        if self.affine:
+            self.weight = Tensor.ones([num_channels])
+            self.bias = Tensor.zeros([num_channels])
+        else:
+            self.weight = None
+            self.bias = None
+
+    def __rich_repr__(self):
+        """Rich representation for debugging."""
+        yield "num_groups", self.num_groups
+        yield "num_channels", self.num_channels
+        yield "eps", self.eps, 1e-5
+        yield "affine", self.affine, True
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Apply group normalization to input tensor.
+
+        Args:
+            x: Input tensor of shape [N, C, *] where C is number of channels
+
+        Returns:
+            Normalized tensor of same shape as input
+        """
+        if len(x.shape) < 2:
+            raise ValueError(
+                f"Expected input tensor with >=2 dimensions, got shape {x.shape}"
+            )
+        if x.shape[1] != self.num_channels:
+            raise ValueError(
+                f"Expected {self.num_channels} channels, got shape {x.shape}"
+            )
+
+        if self.affine:
+            weight = self.weight
+            bias = self.bias
+        else:
+            # Create temporary tensors of ones and zeros when affine=False
+            weight = Tensor.ones(
+                [self.num_channels], dtype=x.dtype, device=x.device
+            )
+            bias = Tensor.zeros(
+                [self.num_channels], dtype=x.dtype, device=x.device
+            )
+
+        return group_norm(x, weight, bias, self.num_groups, self.eps)

--- a/max/python/max/nn/module_v3/norm/layer_norm.py
+++ b/max/python/max/nn/module_v3/norm/layer_norm.py
@@ -1,0 +1,87 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Layer normalization for module_v3."""
+
+from __future__ import annotations
+
+from max.dtype import DType
+from max.experimental import functional as F
+from max.experimental.tensor import Tensor
+
+from ..module import Module
+
+
+class LayerNorm(Module[[Tensor], Tensor]):
+    """Layer normalization over the last dimension."""
+
+    def __init__(
+        self,
+        dim: int,
+        eps: float = 1e-5,
+        *,
+        keep_dtype: bool = True,
+        elementwise_affine: bool = True,
+        use_bias: bool = True,
+    ):
+        """Initialize LayerNorm.
+
+        Args:
+            dim: Size of the last dimension to normalize.
+            eps: Numerical stability constant.
+            keep_dtype: Whether to preserve input dtype in computation.
+            elementwise_affine: Whether to apply learned scale and bias.
+            use_bias: Whether to learn an additive bias term.
+        """
+        super().__init__()
+        self.eps = eps
+        self.keep_dtype = keep_dtype
+        self.elementwise_affine = elementwise_affine
+        self.use_bias = use_bias
+        if elementwise_affine:
+            self.weight = Tensor.ones([dim])
+            self.bias = Tensor.zeros([dim]) if use_bias else None
+        else:
+            self.weight = None
+            self.bias = None
+
+    def _affine_params(self, input: Tensor) -> tuple[Tensor, Tensor]:
+        if self.weight is None:
+            gamma = F.broadcast_to(
+                F.constant(1.0, dtype=input.dtype, device=input.device),
+                shape=(input.shape[-1],),
+            )
+        else:
+            gamma = self.weight
+
+        if self.bias is None:
+            beta = F.broadcast_to(
+                F.constant(0.0, dtype=input.dtype, device=input.device),
+                shape=(input.shape[-1],),
+            )
+        else:
+            beta = self.bias
+
+        return gamma, beta
+
+    def forward(self, input: Tensor) -> Tensor:
+        gamma, beta = self._affine_params(input)
+        if self.keep_dtype:
+            return F.layer_norm(input, gamma=gamma, beta=beta, epsilon=self.eps)
+        output = F.layer_norm(
+            F.cast(input, DType.float32),
+            gamma=F.cast(gamma, DType.float32),
+            beta=F.cast(beta, DType.float32),
+            epsilon=self.eps,
+        )
+        return F.cast(output, input.dtype)

--- a/max/python/max/nn/norm/group_norm.py
+++ b/max/python/max/nn/norm/group_norm.py
@@ -45,6 +45,7 @@ class GroupNorm(Module):
         eps: float = 1e-5,
         affine: bool = True,
         device: DeviceRef = DeviceRef.GPU(),
+        dtype: DType = DType.float32,
     ) -> None:
         super().__init__()
         self.num_groups = num_groups
@@ -65,13 +66,13 @@ class GroupNorm(Module):
             self.weight = Weight(
                 name="weight",
                 shape=(self.num_channels,),
-                dtype=DType.float32,
+                dtype=dtype,
                 device=device,
             )
             self.bias = Weight(
                 name="bias",
                 shape=(self.num_channels,),
-                dtype=DType.float32,
+                dtype=dtype,
                 device=device,
             )
 

--- a/max/python/max/pipelines/architectures/__init__.py
+++ b/max/python/max/pipelines/architectures/__init__.py
@@ -29,6 +29,7 @@ def register_all_models() -> None:
     from .deepseekV32 import deepseekV32_arch
     from .eagle_llama3 import eagle_llama_arch
     from .exaone import exaone_arch
+    from .flux1 import flux1_arch
     from .gemma3 import gemma3_arch
     from .gemma3multimodal import gemma3_multimodal_arch
     from .gpt_oss import gpt_oss_arch
@@ -56,6 +57,7 @@ def register_all_models() -> None:
         deepseekV3_arch,
         deepseekV32_arch,
         eagle_llama_arch,
+        flux1_arch,
         gemma3_arch,
         gemma3_multimodal_arch,
         granite_arch,

--- a/max/python/max/pipelines/architectures/autoencoder_kl/__init__.py
+++ b/max/python/max/pipelines/architectures/autoencoder_kl/__init__.py
@@ -11,5 +11,4 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from . import dtype_extension
-from .dtype import DType
+from .model import AutoencoderKLModel

--- a/max/python/max/pipelines/architectures/autoencoder_kl/autoencoder_kl.py
+++ b/max/python/max/pipelines/architectures/autoencoder_kl/autoencoder_kl.py
@@ -1,0 +1,750 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import math
+from dataclasses import dataclass
+
+import max.nn as nn
+from max.dtype import DType
+from max.graph import DeviceRef, TensorType, TensorValue, ops
+from max.nn import GroupNorm
+from max.nn.layer.layer_list import LayerList
+
+from .layers import Upsample2D
+from .model_config import AutoencoderKLConfig
+
+
+class ResnetBlock2D(nn.Module):
+    """Residual block for 2D VAE decoder.
+
+    This module implements a residual block with two convolutional layers,
+    group normalization, and optional shortcut connection. It supports
+    time embedding conditioning and configurable activation functions.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        temb_channels: int | None,
+        groups: int,
+        groups_out: int,
+        eps: float = 1e-6,
+        non_linearity: str = "silu",
+        use_conv_shortcut: bool = False,
+        conv_shortcut_bias: bool = True,
+        device: DeviceRef | None = None,
+        dtype: DType | None = None,
+    ) -> None:
+        """Initialize ResnetBlock2D module.
+
+        Args:
+            in_channels: Number of input channels.
+            out_channels: Number of output channels.
+            temb_channels: Number of time embedding channels (None if not used).
+            groups: Number of groups for first GroupNorm.
+            groups_out: Number of groups for second GroupNorm.
+            eps: Epsilon value for GroupNorm layers.
+            non_linearity: Activation function name (e.g., "silu").
+            use_conv_shortcut: Whether to use convolutional shortcut.
+            conv_shortcut_bias: Whether to use bias in shortcut convolution.
+            device: Device reference for module placement.
+            dtype: Data type for module parameters.
+        """
+        super().__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.use_conv_shortcut = use_conv_shortcut
+
+        self.norm1 = GroupNorm(
+            num_groups=groups,
+            num_channels=in_channels,
+            eps=eps,
+            affine=True,
+            device=device,
+            dtype=dtype,
+        )
+
+        self.conv1 = nn.Conv2d(
+            kernel_size=3,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            dtype=dtype,
+            stride=1,
+            padding=1,
+            dilation=1,
+            num_groups=1,
+            has_bias=True,
+            device=device,
+            permute=True,
+        )
+
+        self.norm2 = GroupNorm(
+            num_groups=groups_out,
+            num_channels=out_channels,
+            eps=eps,
+            affine=True,
+            device=device,
+            dtype=dtype,
+        )
+
+        self.conv2 = nn.Conv2d(
+            kernel_size=3,
+            in_channels=out_channels,
+            out_channels=out_channels,
+            dtype=dtype,
+            stride=1,
+            padding=1,
+            dilation=1,
+            num_groups=1,
+            has_bias=True,
+            device=device,
+            permute=True,
+        )
+
+        self.conv_shortcut = None
+        if self.use_conv_shortcut:
+            self.conv_shortcut = nn.Conv2d(
+                kernel_size=1,
+                in_channels=in_channels,
+                out_channels=out_channels,
+                dtype=dtype,
+                stride=1,
+                padding=0,
+                dilation=1,
+                num_groups=1,
+                has_bias=conv_shortcut_bias,
+                device=device,
+                permute=True,
+            )
+        elif in_channels != out_channels:
+            self.conv_shortcut = nn.Conv2d(
+                kernel_size=1,
+                in_channels=in_channels,
+                out_channels=out_channels,
+                dtype=dtype,
+                stride=1,
+                padding=0,
+                dilation=1,
+                num_groups=1,
+                has_bias=conv_shortcut_bias,
+                device=device,
+                permute=True,
+            )
+
+    def __call__(
+        self, x: TensorValue, temb: TensorValue | None = None
+    ) -> TensorValue:
+        """Apply ResnetBlock2D forward pass.
+
+        Args:
+            x: Input tensor of shape [N, C, H, W].
+            temb: Optional time embedding tensor (currently unused).
+
+        Returns:
+            Output tensor of shape [N, C_out, H, W] with residual connection.
+        """
+        shortcut = (
+            self.conv_shortcut(x) if self.conv_shortcut is not None else x
+        )
+
+        h = ops.silu(self.norm1(x))
+        h = self.conv1(h)
+
+        h = ops.silu(self.norm2(h))
+        h = self.conv2(h)
+
+        return h + shortcut
+
+
+class UpDecoderBlock2D(nn.Module):
+    """Upsampling decoder block for 2D VAE.
+
+    This module consists of multiple ResNet blocks followed by an optional
+    upsampling layer. It progressively increases spatial resolution while
+    processing features through residual connections.
+    """
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        resolution_idx: int | None = None,
+        dropout: float = 0.0,
+        num_layers: int = 1,
+        resnet_eps: float = 1e-6,
+        resnet_time_scale_shift: str = "default",
+        resnet_act_fn: str = "swish",
+        resnet_groups: int = 32,
+        resnet_pre_norm: bool = True,
+        output_scale_factor: float = 1.0,
+        add_upsample: bool = True,
+        temb_channels: int | None = None,
+        device: DeviceRef | None = None,
+        dtype: DType | None = None,
+    ) -> None:
+        """Initialize UpDecoderBlock2D module.
+
+        Args:
+            in_channels: Number of input channels.
+            out_channels: Number of output channels.
+            resolution_idx: Optional resolution index for tracking.
+            dropout: Dropout rate (currently unused).
+            num_layers: Number of ResNet blocks in this decoder block.
+            resnet_eps: Epsilon value for ResNet GroupNorm layers.
+            resnet_time_scale_shift: Time embedding scale/shift mode.
+            resnet_act_fn: Activation function for ResNet blocks.
+            resnet_groups: Number of groups for ResNet GroupNorm.
+            resnet_pre_norm: Whether to apply normalization before ResNet.
+            output_scale_factor: Scaling factor for output (currently unused).
+            add_upsample: Whether to add upsampling layer after ResNet blocks.
+            temb_channels: Number of time embedding channels (None if not used).
+            device: Device reference for module placement.
+            dtype: Data type for module parameters.
+        """
+        super().__init__()
+        resnets_list = []
+        for i in range(num_layers):
+            input_channels = in_channels if i == 0 else out_channels
+
+            resnet = ResnetBlock2D(
+                in_channels=input_channels,
+                out_channels=out_channels,
+                temb_channels=temb_channels,
+                groups=resnet_groups,
+                groups_out=resnet_groups,
+                eps=resnet_eps,
+                non_linearity=resnet_act_fn,
+                use_conv_shortcut=False,
+                conv_shortcut_bias=True,
+                device=device,
+                dtype=dtype,
+            )
+            resnets_list.append(resnet)
+        self.resnets = LayerList(resnets_list)
+
+        if add_upsample:
+            upsampler = Upsample2D(
+                channels=out_channels,
+                use_conv=True,
+                out_channels=out_channels,
+                name="conv",
+                kernel_size=3,
+                padding=1,
+                bias=True,
+                interpolate=True,
+                device=device,
+                dtype=dtype,
+            )
+            self.upsamplers = LayerList([upsampler])
+        else:
+            self.upsamplers = None
+
+    def __call__(
+        self, hidden_states: TensorValue, temb: TensorValue | None = None
+    ) -> TensorValue:
+        """Apply UpDecoderBlock2D forward pass.
+
+        Args:
+            hidden_states: Input tensor of shape [N, C_in, H, W].
+            temb: Optional time embedding tensor.
+
+        Returns:
+            Output tensor of shape [N, C_out, H*2, W*2] (if upsampling) or
+            [N, C_out, H, W] (if no upsampling).
+        """
+        # Process through all resnet blocks
+        for resnet in self.resnets:
+            hidden_states = resnet(hidden_states, temb)
+
+        # Apply upsampling if configured (compile-time decision)
+        if self.upsamplers is not None:
+            hidden_states = self.upsamplers[0](hidden_states)
+
+        return hidden_states
+
+
+class VAEAttention(nn.Module):
+    """Spatial attention module for VAE models.
+
+    This module performs self-attention on 2D spatial features by:
+    1. Converting [N, C, H, W] to [N, H*W, C] sequence format
+    2. Applying scaled dot-product attention (optimized for small sequences)
+    3. Converting back to [N, C, H, W] format
+
+    Note: Manual attention is used instead of flash_attention_gpu because
+    VAE attention typically has small sequence lengths (H*W) where flash
+    attention overhead outweighs benefits.
+    """
+
+    def __init__(
+        self,
+        query_dim: int,
+        heads: int,
+        dim_head: int,
+        num_groups: int = 32,
+        eps: float = 1e-6,
+        device: DeviceRef | None = None,
+        dtype: DType | None = None,
+    ) -> None:
+        """Initialize VAE attention module.
+
+        Args:
+            query_dim: Dimension of query (number of channels).
+            heads: Number of attention heads.
+            dim_head: Dimension of each attention head.
+            num_groups: Number of groups for GroupNorm.
+            eps: Epsilon value for GroupNorm.
+            device: Device reference.
+            dtype: Data type.
+        """
+        super().__init__()
+        self.query_dim = query_dim
+        self.heads = heads
+        self.dim_head = dim_head
+        self.inner_dim = heads * dim_head
+
+        self.group_norm = GroupNorm(
+            num_groups=num_groups,
+            num_channels=query_dim,
+            eps=eps,
+            affine=True,
+            device=device,
+            dtype=dtype,
+        )
+
+        self.to_q = nn.Linear(
+            query_dim, self.inner_dim, has_bias=True, device=device, dtype=dtype
+        )
+        self.to_k = nn.Linear(
+            query_dim, self.inner_dim, has_bias=True, device=device, dtype=dtype
+        )
+        self.to_v = nn.Linear(
+            query_dim, self.inner_dim, has_bias=True, device=device, dtype=dtype
+        )
+        self.to_out = LayerList(
+            [
+                nn.Linear(
+                    self.inner_dim,
+                    query_dim,
+                    has_bias=True,
+                    device=device,
+                    dtype=dtype,
+                )
+            ]
+        )
+
+        self.scale = 1.0 / math.sqrt(dim_head)
+
+    def __call__(self, x: TensorValue) -> TensorValue:
+        """Apply spatial attention to 2D image tensor.
+
+        Args:
+            x: Input tensor of shape [N, C, H, W].
+
+        Returns:
+            Output tensor of shape [N, C, H, W] with residual connection.
+        """
+        residual = x
+
+        x = self.group_norm(x)
+
+        n, c, h, w = x.shape
+        seq_len = h * w
+
+        x = ops.reshape(x, (n, c, seq_len))
+        x = ops.permute(x, (0, 2, 1))
+
+        q = self.to_q(x)
+        k = self.to_k(x)
+        v = self.to_v(x)
+
+        q = ops.reshape(q, (n, seq_len, self.heads, self.dim_head))
+        q = ops.permute(q, (0, 2, 1, 3))
+        k = ops.reshape(k, (n, seq_len, self.heads, self.dim_head))
+        k = ops.permute(k, (0, 2, 1, 3))
+        v = ops.reshape(v, (n, seq_len, self.heads, self.dim_head))
+        v = ops.permute(v, (0, 2, 1, 3))
+
+        attn = q @ ops.permute(k, (0, 1, 3, 2)) * self.scale
+        attn = ops.softmax(attn, axis=-1)
+        out = attn @ v
+
+        out = ops.permute(out, (0, 2, 1, 3))
+        out = ops.reshape(out, (n, seq_len, self.inner_dim))
+
+        out = self.to_out[0](out)
+
+        out = ops.permute(out, (0, 2, 1))
+        out = ops.reshape(out, (n, c, h, w))
+
+        return residual + out
+
+
+class MidBlock2D(nn.Module):
+    """Internal MAX module for MidBlock2D graph generation."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        temb_channels: int | None,
+        dropout: float = 0.0,
+        num_layers: int = 1,
+        resnet_eps: float = 1e-6,
+        resnet_time_scale_shift: str = "default",
+        resnet_act_fn: str = "swish",
+        resnet_groups: int = 32,
+        resnet_pre_norm: bool = True,
+        add_attention: bool = True,
+        attention_head_dim: int = 1,
+        output_scale_factor: float = 1.0,
+        device: DeviceRef | None = None,
+        dtype: DType | None = None,
+    ) -> None:
+        """Initialize MidBlock2D module."""
+        super().__init__()
+        resnets_list = []
+        attentions_list = []
+
+        resnet = ResnetBlock2D(
+            in_channels=in_channels,
+            out_channels=in_channels,
+            temb_channels=temb_channels,
+            groups=resnet_groups,
+            groups_out=resnet_groups,
+            eps=resnet_eps,
+            non_linearity=resnet_act_fn,
+            use_conv_shortcut=False,
+            conv_shortcut_bias=True,
+            device=device,
+            dtype=dtype,
+        )
+        resnets_list.append(resnet)
+
+        for _i in range(num_layers):
+            if add_attention:
+                attn = VAEAttention(
+                    query_dim=in_channels,
+                    heads=in_channels // attention_head_dim,
+                    dim_head=attention_head_dim,
+                    num_groups=resnet_groups,
+                    eps=resnet_eps,
+                    device=device,
+                    dtype=dtype,
+                )
+                attentions_list.append(attn)
+            else:
+                attentions_list.append(None)
+
+            resnet = ResnetBlock2D(
+                in_channels=in_channels,
+                out_channels=in_channels,
+                temb_channels=temb_channels,
+                groups=resnet_groups,
+                groups_out=resnet_groups,
+                eps=resnet_eps,
+                non_linearity=resnet_act_fn,
+                use_conv_shortcut=False,
+                conv_shortcut_bias=True,
+                device=device,
+                dtype=dtype,
+            )
+            resnets_list.append(resnet)
+
+        self.resnets = LayerList(resnets_list)
+        self.attentions = (
+            LayerList(attentions_list) if attentions_list else None
+        )
+
+    def __call__(
+        self, hidden_states: TensorValue, temb: TensorValue | None = None
+    ) -> TensorValue:
+        """Apply MidBlock2D forward pass.
+
+        Args:
+            hidden_states: Input tensor of shape [N, C, H, W].
+            temb: Optional time embedding tensor.
+
+        Returns:
+            Output tensor of shape [N, C, H, W] with same spatial dimensions.
+        """
+        hidden_states = self.resnets[0](hidden_states, temb)
+
+        for i in range(len(self.resnets) - 1):
+            if self.attentions is not None and self.attentions[i] is not None:
+                hidden_states = self.attentions[i](hidden_states)
+            hidden_states = self.resnets[i + 1](hidden_states, temb)
+
+        return hidden_states
+
+
+@dataclass
+class DecoderOutput:
+    r"""Output of decoding method.
+
+    Args:
+        sample (`TensorValue` of shape `(batch_size, num_channels, height, width)`):
+            The decoded output sample from the last layer of the model.
+    """
+
+    sample: TensorValue
+    commit_loss: TensorValue | None = None
+
+
+class Decoder(nn.Module):
+    """VAE decoder for generating images from latent representations.
+
+    This decoder progressively upsamples latent features through multiple
+    decoder blocks, applying ResNet layers and attention mechanisms to
+    reconstruct high-resolution images from compressed latent codes.
+    """
+
+    def __init__(
+        self,
+        in_channels: int = 3,
+        out_channels: int = 3,
+        up_block_types: tuple[str, ...] = ("UpDecoderBlock2D",),
+        block_out_channels: tuple[int, ...] = (64,),
+        layers_per_block: int = 2,
+        norm_num_groups: int = 32,
+        act_fn: str = "silu",
+        norm_type: str = "group",
+        mid_block_add_attention: bool = True,
+        use_post_quant_conv: bool = True,
+        device: DeviceRef | None = None,
+        dtype: DType | None = None,
+    ) -> None:
+        """Initialize Decoder module.
+
+        Args:
+            in_channels: Number of input channels (latent channels).
+            out_channels: Number of output channels (image channels).
+            up_block_types: Tuple of upsampling block types.
+            block_out_channels: Tuple of channel counts for each decoder block.
+            layers_per_block: Number of ResNet layers per decoder block.
+            norm_num_groups: Number of groups for GroupNorm layers.
+            act_fn: Activation function name (e.g., "silu").
+            norm_type: Normalization type ("group" or "spatial").
+            mid_block_add_attention: Whether to add attention in middle block.
+            use_post_quant_conv: Whether to use post-quantization convolution.
+            device: Device reference for module placement.
+            dtype: Data type for module parameters.
+        """
+        super().__init__()
+        self.layers_per_block = layers_per_block
+        self.session = None
+        self.in_channels = in_channels
+        self.device = device
+        self.dtype = dtype
+
+        self.post_quant_conv = None
+        if use_post_quant_conv:
+            self.post_quant_conv = nn.Conv2d(
+                kernel_size=1,
+                in_channels=in_channels,
+                out_channels=in_channels,
+                dtype=dtype,
+                stride=1,
+                padding=0,
+                dilation=1,
+                num_groups=1,
+                has_bias=True,
+                device=device,
+                permute=True,
+            )
+
+        self.conv_in = nn.Conv2d(
+            kernel_size=3,
+            in_channels=in_channels,
+            out_channels=block_out_channels[-1],
+            dtype=dtype,
+            stride=1,
+            padding=1,
+            dilation=1,
+            num_groups=1,
+            has_bias=True,
+            device=device,
+            permute=True,
+        )
+
+        temb_channels = in_channels if norm_type == "spatial" else None
+        self.mid_block = MidBlock2D(
+            in_channels=block_out_channels[-1],
+            temb_channels=temb_channels,
+            dropout=0.0,
+            num_layers=1,
+            resnet_eps=1e-6,
+            resnet_time_scale_shift=(
+                "default" if norm_type == "group" else norm_type
+            ),
+            resnet_act_fn=act_fn,
+            resnet_groups=norm_num_groups,
+            resnet_pre_norm=True,
+            add_attention=mid_block_add_attention,
+            attention_head_dim=block_out_channels[-1],
+            output_scale_factor=1.0,
+            device=device,
+            dtype=dtype,
+        )
+
+        up_blocks_list = []
+        reversed_block_out_channels = list(reversed(block_out_channels))
+        output_channel = reversed_block_out_channels[0]
+        for i, up_block_type in enumerate(up_block_types):
+            prev_output_channel = output_channel
+            output_channel = reversed_block_out_channels[i]
+            is_final_block = i == len(block_out_channels) - 1
+
+            if up_block_type == "UpDecoderBlock2D":
+                up_block = UpDecoderBlock2D(
+                    in_channels=prev_output_channel,
+                    out_channels=output_channel,
+                    resolution_idx=i,
+                    dropout=0.0,
+                    num_layers=self.layers_per_block + 1,
+                    resnet_eps=1e-6,
+                    resnet_time_scale_shift=norm_type,
+                    resnet_act_fn=act_fn,
+                    resnet_groups=norm_num_groups,
+                    resnet_pre_norm=True,
+                    output_scale_factor=1.0,
+                    add_upsample=not is_final_block,
+                    temb_channels=temb_channels,
+                    device=device,
+                    dtype=dtype,
+                )
+                up_blocks_list.append(up_block)
+            else:
+                raise ValueError(f"Unsupported up_block_type: {up_block_type}")
+
+            prev_output_channel = output_channel
+
+        self.up_blocks = LayerList(up_blocks_list)
+
+        if norm_type == "spatial":
+            raise NotImplementedError("SpatialNorm not implemented in MAX VAE")
+        else:
+            self.conv_norm_out = GroupNorm(
+                num_groups=norm_num_groups,
+                num_channels=block_out_channels[0],
+                eps=1e-6,
+                affine=True,
+                device=device,
+                dtype=dtype,
+            )
+
+        self.conv_out = nn.Conv2d(
+            kernel_size=3,
+            in_channels=block_out_channels[0],
+            out_channels=out_channels,
+            dtype=dtype,
+            stride=1,
+            padding=1,
+            dilation=1,
+            num_groups=1,
+            has_bias=True,
+            device=device,
+            permute=True,
+        )
+
+    def __call__(
+        self, z: TensorValue, temb: TensorValue | None = None
+    ) -> TensorValue:
+        """Apply Decoder forward pass.
+
+        Args:
+            z: Input latent tensor of shape [N, C_latent, H_latent, W_latent].
+            temb: Optional time embedding tensor.
+
+        Returns:
+            Decoded image tensor of shape [N, C_out, H, W] where H and W are
+            upsampled from H_latent and W_latent.
+        """
+        if self.post_quant_conv is not None:
+            z = self.post_quant_conv(z)
+        sample = self.conv_in(z)
+        sample = self.mid_block(sample, temb)
+
+        for up_block in self.up_blocks:
+            sample = up_block(sample, temb)
+
+        sample = self.conv_norm_out(sample)
+        sample = ops.silu(sample)
+        sample = self.conv_out(sample)
+
+        return sample
+
+    def input_types(self) -> tuple[TensorType, ...]:
+        """Define input tensor types for the decoder model.
+
+        Returns:
+            Tuple of TensorType specifications for decoder input.
+        """
+        latent_type = TensorType(
+            self.dtype,
+            shape=[
+                "batch_size",
+                self.in_channels,
+                "latent_height",
+                "latent_width",
+            ],
+            device=self.device,
+        )
+
+        return (latent_type,)
+
+
+class AutoencoderKL(nn.Module):
+    r"""A VAE model with KL loss for encoding images into latents and decoding latent representations into images."""
+
+    def __init__(
+        self,
+        config: AutoencoderKLConfig,
+    ):
+        """Initialize VAE AutoencoderKL model.
+
+        Args:
+            config: Autoencoder configuration containing channel sizes, block
+                structure, normalization settings, and device/dtype information.
+        """
+        super().__init__()
+        self.decoder = Decoder(
+            in_channels=config.latent_channels,
+            out_channels=config.out_channels,
+            up_block_types=config.up_block_types,
+            block_out_channels=config.block_out_channels,
+            layers_per_block=config.layers_per_block,
+            norm_num_groups=config.norm_num_groups,
+            act_fn=config.act_fn,
+            norm_type="group",
+            mid_block_add_attention=config.mid_block_add_attention,
+            use_post_quant_conv=config.use_post_quant_conv,
+            device=config.device,
+            dtype=config.dtype,
+        )
+
+    def __call__(self, *args, **kwargs):
+        pass

--- a/max/python/max/pipelines/architectures/autoencoder_kl/layers/__init__.py
+++ b/max/python/max/pipelines/architectures/autoencoder_kl/layers/__init__.py
@@ -11,5 +11,4 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from . import dtype_extension
-from .dtype import DType
+from .upsampling import Upsample2D

--- a/max/python/max/pipelines/architectures/autoencoder_kl/layers/upsampling.py
+++ b/max/python/max/pipelines/architectures/autoencoder_kl/layers/upsampling.py
@@ -1,0 +1,168 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Upsampling utilities for MAX framework."""
+
+import max.nn as nn
+from max.dtype import DType
+from max.experimental import tensor
+from max.graph import DeviceRef, TensorValue, ops
+
+
+class Interpolate2DNearest(nn.Module):
+    """2D nearest-neighbor upsampling module.
+
+    This is a workaround implementation because MAX framework does not have
+    a native `interpolate` operation. The workaround uses reshape and broadcast
+    operations to achieve nearest-neighbor upsampling by a factor of 2.
+
+    Note:
+        This workaround can be removed once MAX framework adds native interpolate support.
+    """
+
+    def __init__(
+        self,
+        scale_factor: int = 2,
+        device: DeviceRef = None,
+        dtype: DType = None,
+    ):
+        """Initialize 2D nearest-neighbor interpolation module.
+
+        Args:
+            scale_factor: Upsampling factor (currently only 2 is supported).
+            device: Device reference for creating intermediate tensors.
+            dtype: Data type for intermediate tensors.
+        """
+        super().__init__()
+        if scale_factor != 2:
+            raise NotImplementedError(
+                f"Only scale_factor=2 is currently supported, got {scale_factor}"
+            )
+
+        self.scale_factor = scale_factor
+        self.device = device
+        self.dtype = dtype
+
+    def __call__(self, x: TensorValue) -> TensorValue:
+        """Upsample a 2D tensor using nearest-neighbor interpolation.
+
+        Args:
+            x: Input tensor of shape [N, C, H, W].
+
+        Returns:
+            Upsampled tensor of shape [N, C, H*scale_factor, W*scale_factor].
+        """
+        n, c, h, w = x.shape
+        target_shape = [n, c, h * self.scale_factor, w * self.scale_factor]
+
+        x_reshaped = ops.reshape(x, [n, c, h, 1, w, 1])
+
+        ones = tensor.Tensor.ones(
+            shape=(1, 1, 1, self.scale_factor, 1, self.scale_factor),
+            dtype=self.dtype,
+            device=self.device,
+        )
+        x_expanded = x_reshaped * ones
+
+        x = ops.reshape(x_expanded, target_shape)
+
+        return x
+
+
+class Upsample2D(nn.Module):
+    """2D upsampling module with optional convolution.
+
+    This module performs 2D upsampling using nearest-neighbor interpolation
+    (via Interpolate2DNearest workaround) followed by an optional convolution layer.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        use_conv: bool = False,
+        use_conv_transpose: bool = False,
+        out_channels: int | None = None,
+        name: str = "conv",
+        kernel_size: int | None = None,
+        padding: int = 1,
+        bias: bool = True,
+        interpolate: bool = True,
+        device: DeviceRef | None = None,
+        dtype: DType | None = None,
+    ) -> None:
+        """Initialize 2D upsampling module.
+
+        Args:
+            channels: Number of input channels.
+            use_conv: Whether to apply a convolution after upsampling.
+            use_conv_transpose: Whether to use transposed convolution (not supported yet).
+            out_channels: Number of output channels. If None, uses channels.
+            name: Name for the convolution layer (unused, kept for compatibility).
+            kernel_size: Kernel size for the convolution.
+            padding: Padding for the convolution.
+            bias: Whether to use bias in the convolution.
+            interpolate: Whether to perform interpolation upsampling.
+            device: Device reference.
+            dtype: Data type.
+        """
+        super().__init__()
+        self.channels = channels
+        self.out_channels = out_channels or channels
+        self.use_conv = use_conv
+        self.use_conv_transpose = use_conv_transpose
+        self.interpolate = interpolate
+        self.device = device
+        self.dtype = dtype
+
+        self.interpolate_module = None
+        if interpolate:
+            self.interpolate_module = Interpolate2DNearest(
+                scale_factor=2, device=device, dtype=dtype
+            )
+
+        self.conv = None
+        if use_conv_transpose:
+            raise NotImplementedError(
+                "Upsample2D does not support use_conv_transpose=True yet."
+            )
+        elif use_conv:
+            if kernel_size is None:
+                kernel_size = 3
+            self.conv = nn.Conv2d(
+                kernel_size=kernel_size,
+                in_channels=self.channels,
+                out_channels=self.out_channels,
+                dtype=dtype,
+                stride=1,
+                padding=padding,
+                has_bias=bias,
+                device=device,
+                permute=True,
+            )
+
+    def __call__(self, x: TensorValue) -> TensorValue:
+        """Apply 2D upsampling with optional convolution.
+
+        Args:
+            x: Input tensor of shape [N, C, H, W].
+
+        Returns:
+            Upsampled tensor, optionally convolved.
+        """
+        if self.interpolate_module is not None:
+            x = self.interpolate_module(x)
+
+        if self.use_conv:
+            x = self.conv(x)
+
+        return x

--- a/max/python/max/pipelines/architectures/autoencoder_kl/layers/upsampling.py
+++ b/max/python/max/pipelines/architectures/autoencoder_kl/layers/upsampling.py
@@ -13,78 +13,83 @@
 
 """Upsampling utilities for MAX framework."""
 
-import max.nn as nn
 from max.dtype import DType
-from max.experimental import tensor
-from max.graph import DeviceRef, TensorValue, ops
+from max.experimental import functional as F
+from max.experimental.tensor import Tensor
+from max.graph import DeviceRef, TensorValue, TensorValueLike
+from max.nn.module_v3 import Conv2d, Module
 
 
-class Interpolate2DNearest(nn.Module):
-    """2D nearest-neighbor upsampling module.
+def interpolate_2d_nearest(
+    x: TensorValueLike,
+    scale_factor: int = 2,
+) -> TensorValue:
+    """Upsamples a 2D tensor using nearest-neighbor interpolation.
 
-    This is a workaround implementation because MAX framework does not have
-    a native `interpolate` operation. The workaround uses reshape and broadcast
-    operations to achieve nearest-neighbor upsampling by a factor of 2.
+    This is a workaround implementation because MAX framework's ops.resize
+    does not support NEAREST mode (only BICUBIC is currently supported).
+    The workaround uses reshape and broadcast operations to achieve
+    nearest-neighbor upsampling by a factor of 2.
+
+    This function works in both Graph context and eager execution contexts,
+    compatible with module_v3 style.
 
     Note:
-        This workaround can be removed once MAX framework adds native interpolate support.
+        This workaround can be removed once ops.resize supports NEAREST mode.
+
+    Args:
+        x: Input tensor of shape [N, C, H, W] in NCHW format.
+            Can be Tensor or TensorValue.
+        scale_factor: Upsampling factor. Currently only 2 is supported.
+            Default: 2
+
+    Returns:
+        Upsampled tensor of shape [N, C, H*scale_factor, W*scale_factor].
+
+    Raises:
+        ValueError: If input tensor doesn't have rank 4.
+        NotImplementedError: If scale_factor is not 2.
     """
+    x = TensorValue(x)
 
-    def __init__(
-        self,
-        scale_factor: int = 2,
-        device: DeviceRef = None,
-        dtype: DType = None,
-    ):
-        """Initialize 2D nearest-neighbor interpolation module.
+    if x.rank != 4:
+        raise ValueError(f"Input tensor must have rank 4, got {x.rank}")
 
-        Args:
-            scale_factor: Upsampling factor (currently only 2 is supported).
-            device: Device reference for creating intermediate tensors.
-            dtype: Data type for intermediate tensors.
-        """
-        super().__init__()
-        if scale_factor != 2:
-            raise NotImplementedError(
-                f"Only scale_factor=2 is currently supported, got {scale_factor}"
-            )
-
-        self.scale_factor = scale_factor
-        self.device = device
-        self.dtype = dtype
-
-    def __call__(self, x: TensorValue) -> TensorValue:
-        """Upsample a 2D tensor using nearest-neighbor interpolation.
-
-        Args:
-            x: Input tensor of shape [N, C, H, W].
-
-        Returns:
-            Upsampled tensor of shape [N, C, H*scale_factor, W*scale_factor].
-        """
-        n, c, h, w = x.shape
-        target_shape = [n, c, h * self.scale_factor, w * self.scale_factor]
-
-        x_reshaped = ops.reshape(x, [n, c, h, 1, w, 1])
-
-        ones = tensor.Tensor.ones(
-            shape=(1, 1, 1, self.scale_factor, 1, self.scale_factor),
-            dtype=self.dtype,
-            device=self.device,
+    if scale_factor != 2:
+        raise NotImplementedError(
+            f"Only scale_factor=2 is currently supported, got {scale_factor}"
         )
-        x_expanded = x_reshaped * ones
 
-        x = ops.reshape(x_expanded, target_shape)
+    n, c, h, w = x.shape
+    target_shape = [n, c, h * scale_factor, w * scale_factor]
 
-        return x
+    # Reshape: [N, C, H, W] -> [N, C, H, 1, W, 1]
+    x_reshaped = F.reshape(x, [n, c, h, 1, w, 1])
+
+    ones_scalar = F.constant(1.0, dtype=x.dtype, device=x.device)
+    ones = F.broadcast_to(
+        ones_scalar,
+        [1, 1, 1, scale_factor, 1, scale_factor],
+    )
+
+    # Broadcast: [N, C, H, 1, W, 1] * [1, 1, 1, 2, 1, 2] -> [N, C, H, 2, W, 2]
+    x_expanded = F.mul(x_reshaped, ones)
+
+    # Reshape: [N, C, H, 2, W, 2] -> [N, C, H*2, W*2]
+    return F.reshape(x_expanded, target_shape)
 
 
-class Upsample2D(nn.Module):
-    """2D upsampling module with optional convolution.
+class Upsample2D(Module[[Tensor], Tensor]):
+    """2D upsampling module with optional convolution using module_v3.
 
     This module performs 2D upsampling using nearest-neighbor interpolation
-    (via Interpolate2DNearest workaround) followed by an optional convolution layer.
+    (via interpolate_2d_nearest function) followed by an optional convolution layer.
+
+    This is a module_v3-compatible version that uses Tensor instead of TensorValue
     """
+
+    conv: Conv2d | None
+    """Optional Conv2d layer applied after upsampling."""
 
     def __init__(
         self,
@@ -112,10 +117,9 @@ class Upsample2D(nn.Module):
             padding: Padding for the convolution.
             bias: Whether to use bias in the convolution.
             interpolate: Whether to perform interpolation upsampling.
-            device: Device reference.
-            dtype: Data type.
+            device: Device reference (optional in module_v3).
+            dtype: Data type (optional in module_v3).
         """
-        super().__init__()
         self.channels = channels
         self.out_channels = out_channels or channels
         self.use_conv = use_conv
@@ -124,13 +128,6 @@ class Upsample2D(nn.Module):
         self.device = device
         self.dtype = dtype
 
-        self.interpolate_module = None
-        if interpolate:
-            self.interpolate_module = Interpolate2DNearest(
-                scale_factor=2, device=device, dtype=dtype
-            )
-
-        self.conv = None
         if use_conv_transpose:
             raise NotImplementedError(
                 "Upsample2D does not support use_conv_transpose=True yet."
@@ -138,7 +135,7 @@ class Upsample2D(nn.Module):
         elif use_conv:
             if kernel_size is None:
                 kernel_size = 3
-            self.conv = nn.Conv2d(
+            self.conv = Conv2d(
                 kernel_size=kernel_size,
                 in_channels=self.channels,
                 out_channels=self.out_channels,
@@ -149,8 +146,10 @@ class Upsample2D(nn.Module):
                 device=device,
                 permute=True,
             )
+        else:
+            self.conv = None
 
-    def __call__(self, x: TensorValue) -> TensorValue:
+    def forward(self, x: Tensor) -> Tensor:
         """Apply 2D upsampling with optional convolution.
 
         Args:
@@ -159,10 +158,10 @@ class Upsample2D(nn.Module):
         Returns:
             Upsampled tensor, optionally convolved.
         """
-        if self.interpolate_module is not None:
-            x = self.interpolate_module(x)
+        if self.interpolate:
+            x = interpolate_2d_nearest(x, scale_factor=2)
 
-        if self.use_conv:
+        if self.use_conv and self.conv is not None:
             x = self.conv(x)
 
         return x

--- a/max/python/max/pipelines/architectures/autoencoder_kl/model.py
+++ b/max/python/max/pipelines/architectures/autoencoder_kl/model.py
@@ -1,0 +1,74 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from max.driver import CPU, Accelerator, Buffer, Device
+from max.engine import InferenceSession, Model
+from max.graph import Graph
+from max.graph.weights import Weights
+from max.pipelines.lib import SupportedEncoding
+from max.pipelines.lib.interfaces.max_model import MaxModel
+
+from .autoencoder_kl import AutoencoderKL
+from .model_config import AutoencoderKLConfig
+
+
+class AutoencoderKLModel(MaxModel):
+    config_name = AutoencoderKLConfig.config_name
+
+    def __init__(
+        self,
+        config: dict,
+        encoding: SupportedEncoding,
+        devices: list[Device],
+        weights: Weights,
+    ) -> None:
+        super().__init__(config, encoding, devices, weights)
+        self.config = AutoencoderKLConfig.generate(
+            config,
+            encoding,
+            devices,
+        )
+        self.load_model()
+
+    def load_model(self) -> None:
+        autoencoder_kl = AutoencoderKL(self.config)
+
+        if self.config.device.is_cpu():
+            session = InferenceSession([CPU()])
+        else:
+            session = InferenceSession([Accelerator()])
+
+        self.load_decoder(session, autoencoder_kl)
+
+    def load_decoder(
+        self, session: InferenceSession, autoencoder_kl: AutoencoderKL
+    ) -> Model:
+        state_dict = {
+            key: value.data()
+            for key, value in self.weights.items()
+            if not key.startswith("encoder.")
+        }
+        autoencoder_kl.load_state_dict(state_dict)
+        with Graph(
+            "autoencoder_kl_decoder",
+            input_types=autoencoder_kl.decoder.input_types(),
+        ) as graph:
+            outputs = autoencoder_kl.decoder(*graph.inputs)
+            graph.output(outputs)
+            compiled_graph = graph
+        self.decode_session = session.load(
+            compiled_graph, weights_registry=autoencoder_kl.state_dict()
+        )
+
+    def decode(self, *args, **kwargs) -> list[Buffer]:
+        return self.decode_session.execute(*args, **kwargs)

--- a/max/python/max/pipelines/architectures/autoencoder_kl/model_config.py
+++ b/max/python/max/pipelines/architectures/autoencoder_kl/model_config.py
@@ -1,0 +1,66 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from typing import ClassVar
+
+from max.driver import Device
+from max.dtype import DType
+from max.graph import DeviceRef
+from max.pipelines.lib import MAXModelConfigBase, SupportedEncoding
+from pydantic import Field
+
+
+class AutoencoderKLConfigBase(MAXModelConfigBase):
+    in_channels: int = 3
+    out_channels: int = 3
+    down_block_types: list[str] = Field(default_factory=list, max_length=4)
+    up_block_types: list[str] = Field(default_factory=list, max_length=4)
+    block_out_channels: list[int] = Field(default_factory=list, max_length=4)
+    layers_per_block: int = 1
+    act_fn: str = "silu"
+    latent_channels: int = 4
+    norm_num_groups: int = 32
+    sample_size: int = 32
+    scaling_factor: float = 0.18215
+    shift_factor: float | None = None
+    latents_mean: tuple[float] | None = None
+    latents_std: tuple[float] | None = None
+    force_upcast: bool = True
+    use_quant_conv: bool = True
+    use_post_quant_conv: bool = True
+    mid_block_add_attention: bool = True
+    device: DeviceRef = Field(default_factory=DeviceRef.CPU)
+    dtype: DType = DType.bfloat16
+
+
+class AutoencoderKLConfig(AutoencoderKLConfigBase):
+    config_name: ClassVar[str] = "config.json"
+
+    @staticmethod
+    def generate(
+        config_dict: dict,
+        encoding: SupportedEncoding,
+        devices: list[Device],
+    ) -> AutoencoderKLConfigBase:
+        init_dict = {
+            key: value
+            for key, value in config_dict.items()
+            if key in AutoencoderKLConfigBase.__annotations__
+        }
+        init_dict.update(
+            {
+                "dtype": encoding.dtype,
+                "device": DeviceRef.from_device(devices[0]),
+            }
+        )
+        return AutoencoderKLConfigBase(**init_dict)

--- a/max/python/max/pipelines/architectures/clip/__init__.py
+++ b/max/python/max/pipelines/architectures/clip/__init__.py
@@ -11,5 +11,4 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from . import dtype_extension
-from .dtype import DType
+from .model import ClipModel

--- a/max/python/max/pipelines/architectures/clip/clip.py
+++ b/max/python/max/pipelines/architectures/clip/clip.py
@@ -13,10 +13,14 @@
 
 from functools import partial
 
-import max.nn as nn
+from max.driver import Device
 from max.dtype import DType
-from max.graph import TensorType, TensorValue, ops
-from max.nn import LayerNorm, Module
+from max.experimental import functional as F
+from max.experimental.tensor import Tensor
+from max.graph import TensorType
+from max.nn.module_v3 import Embedding, Linear, Module
+from max.nn.module_v3.norm import LayerNorm
+from max.nn.module_v3.sequential import ModuleList
 
 from .model_config import ClipConfig
 
@@ -34,25 +38,21 @@ class CLIPTextEmbeddings(Module):
         super().__init__()
         self.config = config
         self.embed_dim = config.hidden_size
-        self.position_embedding = nn.Embedding(
+        self.position_embedding = Embedding(
             config.max_position_embeddings,
-            self.embed_dim,
-            device=config.device,
-            dtype=config.dtype,
+            dim=self.embed_dim,
         )
-        self.token_embedding = nn.Embedding(
+        self.token_embedding = Embedding(
             config.vocab_size,
-            self.embed_dim,
-            device=config.device,
-            dtype=config.dtype,
+            dim=self.embed_dim,
         )
 
-    def __call__(
+    def forward(
         self,
-        input_ids: TensorValue | None = None,
-        position_ids: TensorValue | None = None,
-        inputs_embeds: TensorValue | None = None,
-    ) -> TensorValue:
+        input_ids: Tensor | None = None,
+        position_ids: Tensor | None = None,
+        inputs_embeds: Tensor | None = None,
+    ) -> Tensor:
         """Apply embeddings to input tokens.
 
         Args:
@@ -74,14 +74,15 @@ class CLIPTextEmbeddings(Module):
             seq_length = inputs_embeds.shape[-2]
 
         if position_ids is None:
-            position_ids = ops.range(
-                0,
-                seq_length,
-                step=1,
-                dtype=DType.int32,
-                device=self.config.device,
+            device = (
+                input_ids.device
+                if input_ids is not None
+                else inputs_embeds.device
             )
-            position_ids = ops.unsqueeze(position_ids, 0)
+            position_ids = F.arange(
+                0, seq_length, step=1, dtype=DType.int32, device=device
+            )
+            position_ids = F.unsqueeze(position_ids, 0)
 
         if inputs_embeds is None:
             inputs_embeds = self.token_embedding(input_ids)
@@ -115,41 +116,33 @@ class CLIPAttention(Module):
         self.scale = self.head_dim**-0.5
         self.dropout = config.attention_dropout
 
-        self.k_proj = nn.Linear(
+        self.k_proj = Linear(
             self.embed_dim,
             self.embed_dim,
-            has_bias=True,
-            device=config.device,
-            dtype=config.dtype,
+            bias=True,
         )
-        self.v_proj = nn.Linear(
+        self.v_proj = Linear(
             self.embed_dim,
             self.embed_dim,
-            has_bias=True,
-            device=config.device,
-            dtype=config.dtype,
+            bias=True,
         )
-        self.q_proj = nn.Linear(
+        self.q_proj = Linear(
             self.embed_dim,
             self.embed_dim,
-            has_bias=True,
-            device=config.device,
-            dtype=config.dtype,
+            bias=True,
         )
-        self.out_proj = nn.Linear(
+        self.out_proj = Linear(
             self.embed_dim,
             self.embed_dim,
-            has_bias=True,
-            device=config.device,
-            dtype=config.dtype,
+            bias=True,
         )
 
-    def __call__(
+    def forward(
         self,
-        hidden_states: TensorValue,
-        attention_mask: TensorValue | None = None,
-        causal_attention_mask: TensorValue | None = None,
-    ) -> TensorValue:
+        hidden_states: Tensor,
+        attention_mask: Tensor | None = None,
+        causal_attention_mask: Tensor | None = None,
+    ) -> Tensor:
         """Apply multi-head attention.
 
         Args:
@@ -166,41 +159,37 @@ class CLIPAttention(Module):
         key = self.k_proj(hidden_states)
         value = self.v_proj(hidden_states)
 
-        query = ops.reshape(
+        query = F.reshape(
             query, (batch_size, seq_length, self.num_heads, self.head_dim)
         )
-        query = ops.transpose(query, 1, 2)
+        query = F.transpose(query, 1, 2)
 
-        key = ops.reshape(
+        key = F.reshape(
             key, (batch_size, seq_length, self.num_heads, self.head_dim)
         )
-        key = ops.transpose(key, 1, 2)
+        key = F.transpose(key, 1, 2)
 
-        value = ops.reshape(
+        value = F.reshape(
             value, (batch_size, seq_length, self.num_heads, self.head_dim)
         )
-        value = ops.transpose(value, 1, 2)
+        value = F.transpose(value, 1, 2)
 
         if attention_mask is not None and causal_attention_mask is not None:
             attention_mask = attention_mask + causal_attention_mask
         elif causal_attention_mask is not None:
             attention_mask = causal_attention_mask
 
-        attn_weights = (
-            ops.matmul(query, ops.transpose(key, -1, -2)) * self.scale
-        )
+        attn_weights = F.matmul(query, F.transpose(key, -1, -2)) * self.scale
 
         if attention_mask is not None:
             attn_weights = attn_weights + attention_mask
 
-        attn_weights = ops.softmax(
-            ops.cast(attn_weights, DType.float32), axis=-1
-        )
-        attn_weights = ops.cast(attn_weights, hidden_states.dtype)
+        attn_weights = F.softmax(F.cast(attn_weights, DType.float32), axis=-1)
+        attn_weights = F.cast(attn_weights, hidden_states.dtype)
 
-        attn_output = ops.matmul(attn_weights, value)
-        attn_output = ops.transpose(attn_output, 1, 2)
-        attn_output = ops.reshape(
+        attn_output = F.matmul(attn_weights, value)
+        attn_output = F.transpose(attn_output, 1, 2)
+        attn_output = F.reshape(
             attn_output, (batch_size, seq_length, embed_dim)
         )
 
@@ -221,23 +210,19 @@ class CLIPMLP(Module):
         """
         super().__init__()
         self.config = config
-        self.fc1 = nn.Linear(
+        self.fc1 = Linear(
             config.hidden_size,
             config.intermediate_size,
-            has_bias=True,
-            device=config.device,
-            dtype=config.dtype,
+            bias=True,
         )
-        self.fc2 = nn.Linear(
+        self.fc2 = Linear(
             config.intermediate_size,
             config.hidden_size,
-            has_bias=True,
-            device=config.device,
-            dtype=config.dtype,
+            bias=True,
         )
-        self.act_fn = partial(ops.gelu, approximate="quick")
+        self.act_fn = partial(F.gelu, approximate="quick")
 
-    def __call__(self, hidden_states: TensorValue) -> TensorValue:
+    def forward(self, hidden_states: Tensor) -> Tensor:
         """Apply MLP block.
 
         Args:
@@ -268,25 +253,21 @@ class CLIPEncoderLayer(Module):
         self.layer_norm1 = LayerNorm(
             self.embed_dim,
             eps=config.layer_norm_eps,
-            devices=[config.device],
-            dtype=config.dtype,
             keep_dtype=True,
         )
         self.mlp = CLIPMLP(config)
         self.layer_norm2 = LayerNorm(
             self.embed_dim,
             eps=config.layer_norm_eps,
-            devices=[config.device],
-            dtype=config.dtype,
             keep_dtype=True,
         )
 
-    def __call__(
+    def forward(
         self,
-        hidden_states: TensorValue,
-        attention_mask: TensorValue,
-        causal_attention_mask: TensorValue,
-    ) -> TensorValue:
+        hidden_states: Tensor,
+        attention_mask: Tensor | None,
+        causal_attention_mask: Tensor | None,
+    ) -> Tensor:
         """Apply encoder layer.
 
         Args:
@@ -326,16 +307,16 @@ class CLIPEncoder(Module):
             config: CLIP configuration for encoder depth and dimensions.
         """
         super().__init__()
-        self.layers = nn.LayerList(
+        self.layers = ModuleList(
             [CLIPEncoderLayer(config) for _ in range(config.num_hidden_layers)]
         )
 
-    def __call__(
+    def forward(
         self,
-        inputs_embeds: TensorValue,
-        attention_mask: TensorValue | None = None,
-        causal_attention_mask: TensorValue | None = None,
-    ) -> TensorValue:
+        inputs_embeds: Tensor,
+        attention_mask: Tensor | None = None,
+        causal_attention_mask: Tensor | None = None,
+    ) -> Tensor:
         """Apply encoder (stack of layers).
 
         Args:
@@ -374,13 +355,13 @@ class CLIPTextTransformer(Module):
         self.final_layer_norm = LayerNorm(
             self.embed_dim,
             eps=config.layer_norm_eps,
-            devices=[config.device],
-            dtype=config.dtype,
             keep_dtype=True,
         )
         self.eos_token_id = config.eos_token_id
 
-    def _create_causal_mask(self, input_shape: tuple[int, int]) -> TensorValue:
+    def _create_causal_mask(
+        self, input_shape: tuple[int, int], device: Device
+    ) -> Tensor:
         """Create causal mask for the transformer.
 
         Args:
@@ -391,30 +372,29 @@ class CLIPTextTransformer(Module):
         """
         _, seq_length = input_shape
 
-        rows = ops.range(
-            0, seq_length, step=1, dtype=DType.int32, device=self.config.device
-        )
-        rows = ops.unsqueeze(rows, 1)
-        cols = ops.range(
-            0, seq_length, step=1, dtype=DType.int32, device=self.config.device
-        )
-        cols = ops.unsqueeze(cols, 0)
-        mask = ops.greater(cols, rows)
-        mask_float = mask.cast(self.config.dtype)
+        rows = F.arange(0, seq_length, step=1, dtype=DType.int32, device=device)
+        rows = F.unsqueeze(rows, 1)
+        cols = F.arange(0, seq_length, step=1, dtype=DType.int32, device=device)
+        cols = F.unsqueeze(cols, 0)
+        mask = F.greater(cols, rows)
+        mask_float = F.cast(mask, self.config.dtype)
 
         min_val = DType.finfo(self.config.dtype).min
+        min_val_tensor = F.constant(
+            min_val, dtype=self.config.dtype, device=device
+        )
 
-        causal_mask = mask_float * min_val
-        causal_mask = ops.unsqueeze(causal_mask, 0)
-        causal_mask = ops.unsqueeze(causal_mask, 1)
+        causal_mask = mask_float * min_val_tensor
+        causal_mask = F.unsqueeze(causal_mask, 0)
+        causal_mask = F.unsqueeze(causal_mask, 1)
         return causal_mask
 
-    def __call__(
+    def forward(
         self,
-        input_ids: TensorValue | None = None,
-        attention_mask: TensorValue | None = None,
-        position_ids: TensorValue | None = None,
-    ) -> TensorValue:
+        input_ids: Tensor | None = None,
+        attention_mask: Tensor | None = None,
+        position_ids: Tensor | None = None,
+    ) -> Tensor:
         """Apply text transformer.
 
         Args:
@@ -433,14 +413,26 @@ class CLIPTextTransformer(Module):
         )
 
         input_shape = input_ids.shape
-        causal_attention_mask = self._create_causal_mask(input_shape)
+        causal_attention_mask = self._create_causal_mask(
+            input_shape, input_ids.device
+        )
 
         if attention_mask is not None:
+            mask_multiplier = F.constant(
+                DType.finfo(hidden_states.dtype).min,
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
             inverted_mask = (
-                1.0 - attention_mask.cast(hidden_states.dtype)
-            ) * DType.finfo(hidden_states.dtype).min
-            attention_mask = ops.unsqueeze(inverted_mask, 1)
-            attention_mask = ops.unsqueeze(attention_mask, 1)
+                F.constant(
+                    1.0,
+                    dtype=hidden_states.dtype,
+                    device=hidden_states.device,
+                )
+                - F.cast(attention_mask, hidden_states.dtype)
+            ) * mask_multiplier
+            attention_mask = F.unsqueeze(inverted_mask, 1)
+            attention_mask = F.unsqueeze(attention_mask, 1)
 
         encoder_outputs = self.encoder(
             inputs_embeds=hidden_states,
@@ -451,14 +443,19 @@ class CLIPTextTransformer(Module):
         last_hidden_state = self.final_layer_norm(encoder_outputs)
 
         if self.eos_token_id == 2:
-            eos_token_indices = ops.argmax(input_ids, axis=-1).cast(DType.int32)
+            eos_token_indices = F.cast(
+                F.argmax(input_ids, axis=-1), DType.int32
+            )
         else:
-            eos_token_indices = ops.argmax(
-                ops.equal(input_ids, self.eos_token_id).cast(DType.int32),
-                axis=-1,
-            ).cast(DType.int32)
+            eos_token_indices = F.cast(
+                F.argmax(
+                    F.cast(F.equal(input_ids, self.eos_token_id), DType.int32),
+                    axis=-1,
+                ),
+                DType.int32,
+            )
 
-        pooled_output = ops.gather_nd(
+        pooled_output = F.gather_nd(
             last_hidden_state, eos_token_indices, batch_dims=1
         )
 
@@ -494,12 +491,12 @@ class CLIPTextModel(Module):
             ),
         )
 
-    def __call__(
+    def forward(
         self,
-        input_ids: TensorValue | None = None,
-        attention_mask: TensorValue | None = None,
-        position_ids: TensorValue | None = None,
-    ) -> tuple[TensorValue, TensorValue]:
+        input_ids: Tensor | None = None,
+        attention_mask: Tensor | None = None,
+        position_ids: Tensor | None = None,
+    ) -> tuple[Tensor, Tensor]:
         """Apply CLIP text model forward pass.
 
         Args:

--- a/max/python/max/pipelines/architectures/clip/clip.py
+++ b/max/python/max/pipelines/architectures/clip/clip.py
@@ -1,0 +1,517 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from functools import partial
+
+import max.nn as nn
+from max.dtype import DType
+from max.graph import TensorType, TensorValue, ops
+from max.nn import LayerNorm, Module
+
+from .model_config import ClipConfig
+
+
+class CLIPTextEmbeddings(Module):
+    def __init__(
+        self,
+        config: ClipConfig,
+    ):
+        """Initialize CLIP text embeddings.
+
+        Args:
+            config: CLIP configuration for embedding dimensions and device/dtype.
+        """
+        super().__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.position_embedding = nn.Embedding(
+            config.max_position_embeddings,
+            self.embed_dim,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.token_embedding = nn.Embedding(
+            config.vocab_size,
+            self.embed_dim,
+            device=config.device,
+            dtype=config.dtype,
+        )
+
+    def __call__(
+        self,
+        input_ids: TensorValue | None = None,
+        position_ids: TensorValue | None = None,
+        inputs_embeds: TensorValue | None = None,
+    ) -> TensorValue:
+        """Apply embeddings to input tokens.
+
+        Args:
+            input_ids: Input token IDs.
+            position_ids: Position IDs.
+            inputs_embeds: Pre-computed input embeddings.
+
+        Returns:
+            Combined embeddings.
+        """
+        if input_ids is None and inputs_embeds is None:
+            raise ValueError(
+                "You have to specify either input_ids or inputs_embeds"
+            )
+
+        if input_ids is not None:
+            seq_length = input_ids.shape[-1]
+        else:
+            seq_length = inputs_embeds.shape[-2]
+
+        if position_ids is None:
+            position_ids = ops.range(
+                0,
+                seq_length,
+                step=1,
+                dtype=DType.int32,
+                device=self.config.device,
+            )
+            position_ids = ops.unsqueeze(position_ids, 0)
+
+        if inputs_embeds is None:
+            inputs_embeds = self.token_embedding(input_ids)
+
+        position_embeddings = self.position_embedding(position_ids)
+        embeddings = inputs_embeds + position_embeddings
+
+        return embeddings
+
+
+class CLIPAttention(Module):
+    def __init__(
+        self,
+        config: ClipConfig,
+    ):
+        """Initialize CLIP attention module.
+
+        Args:
+            config: CLIP configuration for attention dimensions and device/dtype.
+        """
+        super().__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        if self.head_dim * self.num_heads != self.embed_dim:
+            raise ValueError(
+                f"embed_dim must be divisible by num_heads (got `embed_dim`: {self.embed_dim} and `num_heads`:"
+                f" {self.num_heads})."
+            )
+        self.scale = self.head_dim**-0.5
+        self.dropout = config.attention_dropout
+
+        self.k_proj = nn.Linear(
+            self.embed_dim,
+            self.embed_dim,
+            has_bias=True,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.v_proj = nn.Linear(
+            self.embed_dim,
+            self.embed_dim,
+            has_bias=True,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.q_proj = nn.Linear(
+            self.embed_dim,
+            self.embed_dim,
+            has_bias=True,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.out_proj = nn.Linear(
+            self.embed_dim,
+            self.embed_dim,
+            has_bias=True,
+            device=config.device,
+            dtype=config.dtype,
+        )
+
+    def __call__(
+        self,
+        hidden_states: TensorValue,
+        attention_mask: TensorValue | None = None,
+        causal_attention_mask: TensorValue | None = None,
+    ) -> TensorValue:
+        """Apply multi-head attention.
+
+        Args:
+            hidden_states: Input hidden states.
+            attention_mask: Attention mask.
+            causal_attention_mask: Causal attention mask.
+
+        Returns:
+            Attention output.
+        """
+        batch_size, seq_length, embed_dim = hidden_states.shape
+
+        query = self.q_proj(hidden_states)
+        key = self.k_proj(hidden_states)
+        value = self.v_proj(hidden_states)
+
+        query = ops.reshape(
+            query, (batch_size, seq_length, self.num_heads, self.head_dim)
+        )
+        query = ops.transpose(query, 1, 2)
+
+        key = ops.reshape(
+            key, (batch_size, seq_length, self.num_heads, self.head_dim)
+        )
+        key = ops.transpose(key, 1, 2)
+
+        value = ops.reshape(
+            value, (batch_size, seq_length, self.num_heads, self.head_dim)
+        )
+        value = ops.transpose(value, 1, 2)
+
+        if attention_mask is not None and causal_attention_mask is not None:
+            attention_mask = attention_mask + causal_attention_mask
+        elif causal_attention_mask is not None:
+            attention_mask = causal_attention_mask
+
+        attn_weights = (
+            ops.matmul(query, ops.transpose(key, -1, -2)) * self.scale
+        )
+
+        if attention_mask is not None:
+            attn_weights = attn_weights + attention_mask
+
+        attn_weights = ops.softmax(
+            ops.cast(attn_weights, DType.float32), axis=-1
+        )
+        attn_weights = ops.cast(attn_weights, hidden_states.dtype)
+
+        attn_output = ops.matmul(attn_weights, value)
+        attn_output = ops.transpose(attn_output, 1, 2)
+        attn_output = ops.reshape(
+            attn_output, (batch_size, seq_length, embed_dim)
+        )
+
+        attn_output = self.out_proj(attn_output)
+
+        return attn_output
+
+
+class CLIPMLP(Module):
+    def __init__(
+        self,
+        config: ClipConfig,
+    ):
+        """Initialize CLIP MLP.
+
+        Args:
+            config: CLIP configuration for MLP dimensions and device/dtype.
+        """
+        super().__init__()
+        self.config = config
+        self.fc1 = nn.Linear(
+            config.hidden_size,
+            config.intermediate_size,
+            has_bias=True,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.fc2 = nn.Linear(
+            config.intermediate_size,
+            config.hidden_size,
+            has_bias=True,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.act_fn = partial(ops.gelu, approximate="quick")
+
+    def __call__(self, hidden_states: TensorValue) -> TensorValue:
+        """Apply MLP block.
+
+        Args:
+            hidden_states: Input hidden states.
+
+        Returns:
+            Output hidden states.
+        """
+        hidden_states = self.fc1(hidden_states)
+        hidden_states = self.act_fn(hidden_states)
+        hidden_states = self.fc2(hidden_states)
+        return hidden_states
+
+
+class CLIPEncoderLayer(Module):
+    def __init__(
+        self,
+        config: ClipConfig,
+    ):
+        """Initialize CLIP encoder layer.
+
+        Args:
+            config: CLIP configuration for encoder layer structure.
+        """
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.self_attn = CLIPAttention(config)
+        self.layer_norm1 = LayerNorm(
+            self.embed_dim,
+            eps=config.layer_norm_eps,
+            devices=[config.device],
+            dtype=config.dtype,
+            keep_dtype=True,
+        )
+        self.mlp = CLIPMLP(config)
+        self.layer_norm2 = LayerNorm(
+            self.embed_dim,
+            eps=config.layer_norm_eps,
+            devices=[config.device],
+            dtype=config.dtype,
+            keep_dtype=True,
+        )
+
+    def __call__(
+        self,
+        hidden_states: TensorValue,
+        attention_mask: TensorValue,
+        causal_attention_mask: TensorValue,
+    ) -> TensorValue:
+        """Apply encoder layer.
+
+        Args:
+            hidden_states: Input hidden states.
+            attention_mask: Attention mask.
+            causal_attention_mask: Causal attention mask.
+
+        Returns:
+            Output hidden states.
+        """
+        residual = hidden_states
+
+        hidden_states = self.layer_norm1(hidden_states)
+        hidden_states = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            causal_attention_mask=causal_attention_mask,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+class CLIPEncoder(Module):
+    def __init__(
+        self,
+        config: ClipConfig,
+    ):
+        """Initialize CLIP encoder.
+
+        Args:
+            config: CLIP configuration for encoder depth and dimensions.
+        """
+        super().__init__()
+        self.layers = nn.LayerList(
+            [CLIPEncoderLayer(config) for _ in range(config.num_hidden_layers)]
+        )
+
+    def __call__(
+        self,
+        inputs_embeds: TensorValue,
+        attention_mask: TensorValue | None = None,
+        causal_attention_mask: TensorValue | None = None,
+    ) -> TensorValue:
+        """Apply encoder (stack of layers).
+
+        Args:
+            inputs_embeds: Input embeddings.
+            attention_mask: Attention mask.
+            causal_attention_mask: Causal attention mask.
+
+        Returns:
+            Encoded hidden states.
+        """
+        hidden_states = inputs_embeds
+        for encoder_layer in self.layers:
+            hidden_states = encoder_layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                causal_attention_mask=causal_attention_mask,
+            )
+        return hidden_states
+
+
+class CLIPTextTransformer(Module):
+    def __init__(
+        self,
+        config: ClipConfig,
+    ):
+        """Initialize CLIP text transformer.
+
+        Args:
+            config: CLIP configuration for embeddings, encoder, and device/dtype.
+        """
+        super().__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.embeddings = CLIPTextEmbeddings(config)
+        self.encoder = CLIPEncoder(config)
+        self.final_layer_norm = LayerNorm(
+            self.embed_dim,
+            eps=config.layer_norm_eps,
+            devices=[config.device],
+            dtype=config.dtype,
+            keep_dtype=True,
+        )
+        self.eos_token_id = config.eos_token_id
+
+    def _create_causal_mask(self, input_shape: tuple[int, int]) -> TensorValue:
+        """Create causal mask for the transformer.
+
+        Args:
+            input_shape: Shape of the input tensor.
+
+        Returns:
+            Causal mask tensor.
+        """
+        _, seq_length = input_shape
+
+        rows = ops.range(
+            0, seq_length, step=1, dtype=DType.int32, device=self.config.device
+        )
+        rows = ops.unsqueeze(rows, 1)
+        cols = ops.range(
+            0, seq_length, step=1, dtype=DType.int32, device=self.config.device
+        )
+        cols = ops.unsqueeze(cols, 0)
+        mask = ops.greater(cols, rows)
+        mask_float = mask.cast(self.config.dtype)
+
+        min_val = DType.finfo(self.config.dtype).min
+
+        causal_mask = mask_float * min_val
+        causal_mask = ops.unsqueeze(causal_mask, 0)
+        causal_mask = ops.unsqueeze(causal_mask, 1)
+        return causal_mask
+
+    def __call__(
+        self,
+        input_ids: TensorValue | None = None,
+        attention_mask: TensorValue | None = None,
+        position_ids: TensorValue | None = None,
+    ) -> TensorValue:
+        """Apply text transformer.
+
+        Args:
+            input_ids: Input token IDs.
+            attention_mask: Attention mask.
+            position_ids: Position IDs.
+
+        Returns:
+            Tuple of (last_hidden_state, pooled_output).
+        """
+        if input_ids is None:
+            raise ValueError("You have to specify input_ids")
+
+        hidden_states = self.embeddings(
+            input_ids=input_ids, position_ids=position_ids
+        )
+
+        input_shape = input_ids.shape
+        causal_attention_mask = self._create_causal_mask(input_shape)
+
+        if attention_mask is not None:
+            inverted_mask = (
+                1.0 - attention_mask.cast(hidden_states.dtype)
+            ) * DType.finfo(hidden_states.dtype).min
+            attention_mask = ops.unsqueeze(inverted_mask, 1)
+            attention_mask = ops.unsqueeze(attention_mask, 1)
+
+        encoder_outputs = self.encoder(
+            inputs_embeds=hidden_states,
+            attention_mask=attention_mask,
+            causal_attention_mask=causal_attention_mask,
+        )
+
+        last_hidden_state = self.final_layer_norm(encoder_outputs)
+
+        if self.eos_token_id == 2:
+            eos_token_indices = ops.argmax(input_ids, axis=-1).cast(DType.int32)
+        else:
+            eos_token_indices = ops.argmax(
+                ops.equal(input_ids, self.eos_token_id).cast(DType.int32),
+                axis=-1,
+            ).cast(DType.int32)
+
+        pooled_output = ops.gather_nd(
+            last_hidden_state, eos_token_indices, batch_dims=1
+        )
+
+        return last_hidden_state, pooled_output
+
+
+class CLIPTextModel(Module):
+    def __init__(
+        self,
+        config: ClipConfig,
+    ):
+        """Initialize CLIP text model with MAX.
+
+        Args:
+            config: CLIP configuration for vocabulary size, dimensions, and
+                device/dtype settings.
+        """
+        super().__init__()
+        self.text_model = CLIPTextTransformer(config)
+        self.device = config.device
+
+    def input_types(self) -> tuple[TensorType, ...]:
+        """Define input tensor types for the model.
+
+        Returns:
+            Tuple of TensorType specifications for model inputs.
+        """
+        return (
+            TensorType(
+                DType.int64,
+                shape=["batch_size", "sequence_length"],
+                device=self.device,
+            ),
+        )
+
+    def __call__(
+        self,
+        input_ids: TensorValue | None = None,
+        attention_mask: TensorValue | None = None,
+        position_ids: TensorValue | None = None,
+    ) -> tuple[TensorValue, TensorValue]:
+        """Apply CLIP text model forward pass.
+
+        Args:
+            input_ids: Input token IDs.
+            attention_mask: Attention mask.
+            position_ids: Position IDs.
+
+        Returns:
+            Tuple of (last_hidden_state, pooled_output).
+        """
+        return self.text_model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )

--- a/max/python/max/pipelines/architectures/clip/model.py
+++ b/max/python/max/pipelines/architectures/clip/model.py
@@ -1,0 +1,70 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from max.driver import CPU, Accelerator, Device
+from max.engine import InferenceSession, Model
+from max.graph import Graph
+from max.graph.weights import Weights
+from max.pipelines.lib import SupportedEncoding
+from max.pipelines.lib.interfaces.max_model import MaxModel
+
+from .clip import CLIPTextModel
+from .model_config import ClipConfig
+
+
+class ClipModel(MaxModel):
+    config_name = ClipConfig.config_name
+
+    def __init__(
+        self,
+        config: dict,
+        encoding: SupportedEncoding,
+        devices: list[Device],
+        weights: Weights,
+    ) -> None:
+        super().__init__(
+            config,
+            encoding,
+            devices,
+            weights,
+        )
+        self.config = ClipConfig.generate(
+            config,
+            encoding,
+            devices,
+        )
+        self.load_model()
+
+    def load_model(self) -> Model:
+        clip = CLIPTextModel(self.config)
+
+        if self.config.device.is_cpu():
+            session = InferenceSession([CPU()])
+        else:
+            session = InferenceSession([Accelerator()])
+        state_dict = {key: value.data() for key, value in self.weights.items()}
+        clip.load_state_dict(state_dict)
+        with Graph("clip_text_model", input_types=clip.input_types()) as graph:
+            outputs = clip(
+                *graph.inputs,
+                attention_mask=None,
+                position_ids=None,
+            )
+            graph.output(*outputs)
+            compiled_graph = graph
+        self.session = session.load(
+            compiled_graph, weights_registry=clip.state_dict()
+        )
+
+    def __call__(self, *args, **kwargs):
+        return self.session.execute(*args, **kwargs)

--- a/max/python/max/pipelines/architectures/clip/model_config.py
+++ b/max/python/max/pipelines/architectures/clip/model_config.py
@@ -1,0 +1,63 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from typing import ClassVar
+
+from max.driver import Device
+from max.dtype import DType
+from max.graph import DeviceRef
+from max.pipelines.lib import MAXModelConfigBase, SupportedEncoding
+from pydantic import Field
+
+
+class ClipConfigBase(MAXModelConfigBase):
+    vocab_size: int = 49408
+    hidden_size: int = 512
+    intermediate_size: int = 2048
+    projection_dim: int = 512
+    num_hidden_layers: int = 12
+    num_attention_heads: int = 8
+    max_position_embeddings: int = 77
+    hidden_act: str = "quick_gelu"
+    layer_norm_eps: float = 1e-5
+    attention_dropout: float = 0.0
+    initializer_range: float = 0.02
+    initializer_factor: float = 1.0
+    pad_token_id: int = 1
+    bos_token_id: int = 49406
+    eos_token_id: int = 49407
+    dtype: DType = DType.bfloat16
+    device: DeviceRef = Field(default_factory=DeviceRef.GPU)
+
+
+class ClipConfig(ClipConfigBase):
+    config_name: ClassVar[str] = "config.json"
+
+    @staticmethod
+    def generate(
+        config_dict: dict,
+        encoding: SupportedEncoding,
+        devices: list[Device],
+    ) -> ClipConfigBase:
+        init_dict = {
+            key: value
+            for key, value in config_dict.items()
+            if key in ClipConfigBase.__annotations__
+        }
+        init_dict.update(
+            {
+                "dtype": encoding.dtype,
+                "device": DeviceRef.from_device(devices[0]),
+            }
+        )
+        return ClipConfigBase(**init_dict)

--- a/max/python/max/pipelines/architectures/flux1/__init__.py
+++ b/max/python/max/pipelines/architectures/flux1/__init__.py
@@ -11,5 +11,4 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from . import dtype_extension
-from .dtype import DType
+from .arch import flux1_arch

--- a/max/python/max/pipelines/architectures/flux1/arch.py
+++ b/max/python/max/pipelines/architectures/flux1/arch.py
@@ -1,0 +1,38 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from max.graph.weights import WeightsFormat
+from max.interfaces import BaseContext, PipelineTask
+from max.pipelines.lib import (
+    SupportedArchitecture,
+    SupportedEncoding,
+    TextTokenizer,
+)
+
+from .pipeline_flux import FluxPipeline
+
+# TODO(minkyu): revisit default_encoding, supported_encodings, tokenizer.
+flux1_arch = SupportedArchitecture(
+    name="FluxPipeline",
+    task=PipelineTask.IMAGE_GENERATION,
+    default_encoding=SupportedEncoding.bfloat16,
+    supported_encodings={SupportedEncoding.bfloat16: []},
+    example_repo_ids=[
+        "black-forest-labs/FLUX.1-dev",
+        "black-forest-labs/FLUX.1-schnell",
+    ],
+    pipeline_model=FluxPipeline,
+    tokenizer=TextTokenizer,
+    context_type=BaseContext,
+    default_weights_format=WeightsFormat.safetensors,
+)

--- a/max/python/max/pipelines/architectures/flux1/flux1.py
+++ b/max/python/max/pipelines/architectures/flux1/flux1.py
@@ -1,0 +1,544 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import logging
+import os
+from collections.abc import Generator
+from contextlib import contextmanager
+from os import PathLike
+from typing import Any
+
+import max.nn as nn
+from max.driver import DLPackArray
+from max.dtype import DType
+from max.graph import DeviceRef, TensorType, TensorValue, ops
+from max.graph.weights import SafetensorWeights
+from max.nn import LayerNorm, Module
+
+from .layers.embeddings import (
+    CombinedTimestepGuidanceTextProjEmbeddings,
+    CombinedTimestepTextProjEmbeddings,
+)
+from .layers.flux_attention import FeedForward, FluxAttention, FluxPosEmbed
+from .layers.normalizations import (
+    AdaLayerNormContinuous,
+    AdaLayerNormZero,
+    AdaLayerNormZeroSingle,
+)
+from .model_config import FluxConfig
+
+logger = logging.getLogger(__name__)
+
+
+def get_weight_registry_from_diffusers(
+    safe_tensor_folder: PathLike,
+) -> dict[str, DLPackArray]:
+    weight_files = [
+        os.path.join(safe_tensor_folder, f)
+        for f in os.listdir(safe_tensor_folder)
+        if f.endswith(".safetensors")
+    ]
+    weights = SafetensorWeights(weight_files)
+    return {name: weight.data().data for name, weight in weights.items()}
+
+
+class FluxSingleTransformerBlock(Module):
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        mlp_ratio: float = 4.0,
+        device: DeviceRef = DeviceRef.CPU(),
+        dtype: DType = DType.bfloat16,
+    ):
+        """Initialize Flux single transformer block.
+
+        Args:
+            dim: Dimension of the input/output.
+            num_attention_heads: Number of attention heads.
+            attention_head_dim: Dimension of each attention head.
+            mlp_ratio: Ratio for MLP hidden dimension.
+            device: Device to place the module on.
+            dtype: Data type for the module.
+        """
+        super().__init__()
+        self.mlp_hidden_dim = int(dim * mlp_ratio)
+
+        self.norm = AdaLayerNormZeroSingle(dim, device=device, dtype=dtype)
+        self.proj_mlp = nn.Linear(
+            dim, self.mlp_hidden_dim, has_bias=True, device=device, dtype=dtype
+        )
+        self.act_mlp = ops.gelu
+        self.proj_out = nn.Linear(
+            dim + self.mlp_hidden_dim,
+            dim,
+            has_bias=True,
+            device=device,
+            dtype=dtype,
+        )
+        self.attn = FluxAttention(
+            query_dim=dim,
+            dim_head=attention_head_dim,
+            heads=num_attention_heads,
+            out_dim=dim,
+            bias=True,
+            eps=1e-6,
+            pre_only=True,
+            device=device,
+            dtype=dtype,
+        )
+
+    def __call__(
+        self,
+        hidden_states: TensorValue,
+        encoder_hidden_states: TensorValue,
+        temb: TensorValue,
+        image_rotary_emb: tuple[TensorValue, TensorValue] | None = None,
+        joint_attention_kwargs: dict[str, Any] | None = None,
+    ) -> tuple[TensorValue, TensorValue]:
+        """Apply single transformer block with attention and MLP.
+
+        Args:
+            hidden_states: Input hidden states.
+            encoder_hidden_states: Encoder hidden states for cross-attention.
+            temb: Time embedding.
+            image_rotary_emb: Optional rotary position embeddings.
+            joint_attention_kwargs: Optional attention kwargs.
+
+        Returns:
+            Tuple of (encoder_hidden_states, hidden_states).
+        """
+        text_seq_len = encoder_hidden_states.shape[1]
+        hidden_states = ops.concat(
+            [encoder_hidden_states, hidden_states], axis=1
+        )
+
+        residual = hidden_states
+        norm_hidden_states, gate = self.norm(hidden_states, emb=temb)
+        mlp_hidden_states = self.act_mlp(
+            self.proj_mlp(norm_hidden_states), approximate="tanh"
+        )
+        joint_attention_kwargs = joint_attention_kwargs or {}
+        attn_output = self.attn(
+            hidden_states=norm_hidden_states,
+            image_rotary_emb=image_rotary_emb,
+            **joint_attention_kwargs,
+        )
+
+        hidden_states = ops.concat([attn_output, mlp_hidden_states], axis=2)
+        gate = ops.unsqueeze(gate, 1)
+        hidden_states = gate * self.proj_out(hidden_states)
+        hidden_states = residual + hidden_states
+        if hidden_states.dtype == DType.float16:
+            hidden_states = hidden_states.clip(-65504, 65504)
+
+        encoder_hidden_states, hidden_states = (
+            hidden_states[:, :text_seq_len],
+            hidden_states[:, text_seq_len:],
+        )
+        return encoder_hidden_states, hidden_states
+
+
+class FluxTransformerBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_attention_heads: int,
+        attention_head_dim: int,
+        qk_norm: str = "rms_norm",
+        eps: float = 1e-6,
+        device: DeviceRef = DeviceRef.CPU(),
+        dtype: DType = DType.bfloat16,
+    ):
+        """Initialize Flux transformer block.
+
+        Args:
+            dim: Dimension of the input/output.
+            num_attention_heads: Number of attention heads.
+            attention_head_dim: Dimension of each attention head.
+            qk_norm: Type of normalization for query and key ("rms_norm").
+            eps: Epsilon for normalization layers.
+            device: Device to place the module on.
+            dtype: Data type for the module.
+        """
+        super().__init__()
+
+        self.norm1 = AdaLayerNormZero(dim, device=device, dtype=dtype)
+        self.norm1_context = AdaLayerNormZero(dim, device=device, dtype=dtype)
+
+        self.attn = FluxAttention(
+            query_dim=dim,
+            added_kv_proj_dim=dim,
+            dim_head=attention_head_dim,
+            heads=num_attention_heads,
+            out_dim=dim,
+            context_pre_only=False,
+            bias=True,
+            eps=eps,
+            device=device,
+            dtype=dtype,
+        )
+
+        self.norm2 = LayerNorm(
+            dim,
+            eps=1e-6,
+            devices=[device],
+            dtype=dtype,
+            keep_dtype=True,
+            elementwise_affine=False,
+        )
+        self.ff = FeedForward(
+            dim=dim,
+            dim_out=dim,
+            activation_fn="gelu-approximate",
+            device=device,
+            dtype=dtype,
+        )
+
+        self.norm2_context = LayerNorm(
+            dim,
+            eps=1e-6,
+            devices=[device],
+            dtype=dtype,
+            keep_dtype=True,
+            elementwise_affine=False,
+        )
+        self.ff_context = FeedForward(
+            dim=dim,
+            dim_out=dim,
+            activation_fn="gelu-approximate",
+            device=device,
+            dtype=dtype,
+        )
+
+    def __call__(
+        self,
+        hidden_states: TensorValue,
+        encoder_hidden_states: TensorValue,
+        temb: TensorValue,
+        image_rotary_emb: tuple[TensorValue, TensorValue] | None = None,
+        joint_attention_kwargs: dict[str, Any] | None = None,
+    ) -> tuple[TensorValue, TensorValue]:
+        """Apply transformer block with dual-stream attention and feedforward.
+
+        Args:
+            hidden_states: Input hidden states.
+            encoder_hidden_states: Encoder hidden states for cross-attention.
+            temb: Time embedding.
+            image_rotary_emb: Optional rotary position embeddings.
+            joint_attention_kwargs: Optional attention kwargs.
+
+        Returns:
+            Tuple of (encoder_hidden_states, hidden_states).
+        """
+        norm_hidden_states, gate_msa, shift_mlp, scale_mlp, gate_mlp = (
+            self.norm1(hidden_states, emb=temb)
+        )
+
+        (
+            norm_encoder_hidden_states,
+            c_gate_msa,
+            c_shift_mlp,
+            c_scale_mlp,
+            c_gate_mlp,
+        ) = self.norm1_context(encoder_hidden_states, emb=temb)
+        joint_attention_kwargs = joint_attention_kwargs or {}
+
+        # Attention.
+        attention_outputs = self.attn(
+            hidden_states=norm_hidden_states,
+            encoder_hidden_states=norm_encoder_hidden_states,
+            image_rotary_emb=image_rotary_emb,
+            **joint_attention_kwargs,
+        )
+
+        attn_output, context_attn_output = attention_outputs
+
+        # Process attention outputs for the `hidden_states`.
+        attn_output = ops.unsqueeze(gate_msa, 1) * attn_output
+        hidden_states = hidden_states + attn_output
+
+        norm_hidden_states = self.norm2(hidden_states)
+        norm_hidden_states = (
+            norm_hidden_states * (1 + scale_mlp[:, None]) + shift_mlp[:, None]
+        )
+
+        ff_output = self.ff(norm_hidden_states)
+        ff_output = ops.unsqueeze(gate_mlp, 1) * ff_output
+
+        hidden_states = hidden_states + ff_output
+
+        # Process attention outputs for the `encoder_hidden_states`.
+        context_attn_output = ops.unsqueeze(c_gate_msa, 1) * context_attn_output
+        encoder_hidden_states = encoder_hidden_states + context_attn_output
+
+        norm_encoder_hidden_states = self.norm2_context(encoder_hidden_states)
+        norm_encoder_hidden_states = (
+            norm_encoder_hidden_states * (1 + c_scale_mlp[:, None])
+            + c_shift_mlp[:, None]
+        )
+
+        context_ff_output = self.ff_context(norm_encoder_hidden_states)
+        encoder_hidden_states = (
+            encoder_hidden_states
+            + ops.unsqueeze(c_gate_mlp, 1) * context_ff_output
+        )
+        if encoder_hidden_states.dtype == DType.float16:
+            encoder_hidden_states = encoder_hidden_states.clip(-65504, 65504)
+
+        return encoder_hidden_states, hidden_states
+
+
+class FluxTransformer2DModel(nn.Module):
+    def __init__(
+        self,
+        config: FluxConfig,
+    ):
+        """Initialize Flux Transformer 2D model.
+
+        Args:
+            config: Flux configuration containing model dimensions, attention
+                settings, and device/dtype information.
+        """
+        super().__init__()
+        patch_size = config.patch_size
+        in_channels = config.in_channels
+        out_channels = config.out_channels
+        num_layers = config.num_layers
+        num_single_layers = config.num_single_layers
+        attention_head_dim = config.attention_head_dim
+        num_attention_heads = config.num_attention_heads
+        joint_attention_dim = config.joint_attention_dim
+        pooled_projection_dim = config.pooled_projection_dim
+        guidance_embeds = config.guidance_embeds
+        axes_dims_rope = config.axes_dims_rope
+        device = config.device
+        dtype = config.dtype
+        self.out_channels = out_channels or in_channels
+        self.inner_dim = num_attention_heads * attention_head_dim
+
+        self.pos_embed = FluxPosEmbed(theta=10000, axes_dim=axes_dims_rope)
+        self.guidance_embeds = guidance_embeds
+
+        text_time_guidance_cls = (
+            CombinedTimestepGuidanceTextProjEmbeddings
+            if guidance_embeds
+            else CombinedTimestepTextProjEmbeddings
+        )
+        self.time_text_embed = text_time_guidance_cls(
+            embedding_dim=self.inner_dim,
+            pooled_projection_dim=pooled_projection_dim,
+            device=device,
+            dtype=dtype,
+        )
+        self.context_embedder = nn.Linear(
+            joint_attention_dim,
+            self.inner_dim,
+            has_bias=True,
+            device=device,
+            dtype=dtype,
+        )
+        self.x_embedder = nn.Linear(
+            in_channels,
+            self.inner_dim,
+            has_bias=True,
+            device=device,
+            dtype=dtype,
+        )
+
+        self.transformer_blocks = nn.Sequential(
+            [
+                FluxTransformerBlock(
+                    dim=self.inner_dim,
+                    num_attention_heads=num_attention_heads,
+                    attention_head_dim=attention_head_dim,
+                    device=device,
+                    dtype=dtype,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
+        self.single_transformer_blocks = nn.Sequential(
+            [
+                FluxSingleTransformerBlock(
+                    dim=self.inner_dim,
+                    num_attention_heads=num_attention_heads,
+                    attention_head_dim=attention_head_dim,
+                    device=device,
+                    dtype=dtype,
+                )
+                for _ in range(num_single_layers)
+            ]
+        )
+
+        self.norm_out = AdaLayerNormContinuous(
+            self.inner_dim, self.inner_dim, eps=1e-6, device=device, dtype=dtype
+        )
+        self.proj_out = nn.Linear(
+            self.inner_dim,
+            patch_size * patch_size * self.out_channels,
+            has_bias=True,
+            device=device,
+            dtype=dtype,
+        )
+
+        self.gradient_checkpointing = False
+
+        self.max_device = device
+        self.max_dtype = dtype
+        self.in_channels = in_channels
+        self.joint_attention_dim = joint_attention_dim
+        self.pooled_projection_dim = pooled_projection_dim
+
+        self._cache_context_warning_shown = False
+
+    def input_types(self) -> tuple[TensorType, ...]:
+        """Define input tensor types for the model.
+
+        Returns:
+            Tuple of TensorType specifications for all model inputs.
+        """
+        hidden_states_type = TensorType(
+            self.max_dtype,
+            shape=["batch_size", "image_seq_len", self.in_channels],
+            device=self.max_device,
+        )
+        encoder_hidden_states_type = TensorType(
+            self.max_dtype,
+            shape=["batch_size", "text_seq_len", self.joint_attention_dim],
+            device=self.max_device,
+        )
+        pooled_projections_type = TensorType(
+            self.max_dtype,
+            shape=["batch_size", self.pooled_projection_dim],
+            device=self.max_device,
+        )
+        timestep_type = TensorType(
+            DType.float32, shape=["batch_size"], device=self.max_device
+        )
+        img_ids_type = TensorType(
+            self.max_dtype, shape=["image_seq_len", 3], device=self.max_device
+        )
+        txt_ids_type = TensorType(
+            self.max_dtype, shape=["text_seq_len", 3], device=self.max_device
+        )
+        guidance_type = TensorType(
+            self.max_dtype, shape=["batch_size"], device=self.max_device
+        )
+
+        return (
+            hidden_states_type,
+            encoder_hidden_states_type,
+            pooled_projections_type,
+            timestep_type,
+            img_ids_type,
+            txt_ids_type,
+            guidance_type,
+        )
+
+    @contextmanager
+    def cache_context(self, name: str) -> Generator[None, None, None]:
+        """Context manager for cache control (not implemented in MAX).
+
+        Args:
+            name: Name of the cache context.
+
+        Yields:
+            None.
+        """
+        if not self._cache_context_warning_shown:
+            logger.warning(
+                "cache_context is not implemented in MAX FluxTransformer2DModel. "
+                "Caching optimizations are disabled."
+            )
+            self._cache_context_warning_shown = True
+        yield
+
+    def __call__(
+        self,
+        hidden_states: TensorValue,
+        encoder_hidden_states: TensorValue = None,
+        pooled_projections: TensorValue = None,
+        timestep: TensorValue = None,
+        img_ids: TensorValue = None,
+        txt_ids: TensorValue = None,
+        guidance: TensorValue = None,
+        joint_attention_kwargs: dict[str, Any] | None = None,
+        controlnet_block_samples: Any | None = None,
+        controlnet_single_block_samples: Any | None = None,
+        return_dict: bool = True,
+        controlnet_blocks_repeat: bool = False,
+    ) -> tuple[TensorValue]:
+        """Apply Flux Transformer 2D model forward pass.
+
+        Args:
+            hidden_states: Input latent hidden states.
+            encoder_hidden_states: Text encoder hidden states.
+            pooled_projections: Pooled text embeddings.
+            timestep: Diffusion timestep.
+            img_ids: Image position IDs.
+            txt_ids: Text position IDs.
+            guidance: Guidance scale values.
+            joint_attention_kwargs: Additional attention arguments.
+            controlnet_block_samples: Optional controlnet block samples.
+            controlnet_single_block_samples: Optional controlnet single block samples.
+            return_dict: Whether to return as dictionary.
+            controlnet_blocks_repeat: Whether to repeat controlnet blocks.
+
+        Returns:
+            Tuple containing output tensor.
+        """
+        if joint_attention_kwargs is not None:
+            joint_attention_kwargs = joint_attention_kwargs.copy()
+
+        hidden_states = self.x_embedder(hidden_states)
+
+        timestep = ops.cast(timestep, hidden_states.dtype)
+        timestep = timestep * 1000.0
+        if guidance is not None:
+            guidance = guidance.cast(hidden_states.dtype) * 1000.0
+
+        temb = (
+            self.time_text_embed(timestep, pooled_projections)
+            if not self.guidance_embeds
+            else self.time_text_embed(timestep, guidance, pooled_projections)
+        )
+        encoder_hidden_states = self.context_embedder(encoder_hidden_states)
+
+        ids = ops.concat((txt_ids, img_ids), axis=0)
+        image_rotary_emb = self.pos_embed(ids)
+
+        for block in self.transformer_blocks:
+            encoder_hidden_states, hidden_states = block(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                temb=temb,
+                image_rotary_emb=image_rotary_emb,
+                joint_attention_kwargs=joint_attention_kwargs,
+            )
+
+        for block in self.single_transformer_blocks:
+            encoder_hidden_states, hidden_states = block(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                temb=temb,
+                image_rotary_emb=image_rotary_emb,
+                joint_attention_kwargs=joint_attention_kwargs,
+            )
+
+        hidden_states = self.norm_out(hidden_states, temb)
+        output = self.proj_out(hidden_states)
+
+        return (output,)

--- a/max/python/max/pipelines/architectures/flux1/layers/__init__.py
+++ b/max/python/max/pipelines/architectures/flux1/layers/__init__.py
@@ -10,6 +10,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-
-from . import dtype_extension
-from .dtype import DType

--- a/max/python/max/pipelines/architectures/flux1/layers/activations.py
+++ b/max/python/max/pipelines/architectures/flux1/layers/activations.py
@@ -1,0 +1,56 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import max.nn as nn
+from max.dtype import DType
+from max.graph import DeviceRef, TensorValue, ops
+
+
+class GELU(nn.Module):
+    def __init__(
+        self,
+        dim_in: int,
+        dim_out: int,
+        approximate: str = "none",
+        bias: bool = True,
+        device: DeviceRef = DeviceRef.CPU(),
+        dtype: DType = DType.bfloat16,
+    ):
+        """Initialize GELU activation layer with linear projection.
+
+        Args:
+            dim_in: Input dimension.
+            dim_out: Output dimension.
+            approximate: Approximation type for GELU ("none" or "tanh").
+            bias: Whether to include bias in the linear projection.
+            device: Device to place the layer on.
+            dtype: Data type for the layer.
+        """
+        super().__init__()
+        self.proj = nn.Linear(
+            dim_in, dim_out, has_bias=bias, dtype=dtype, device=device
+        )
+        self.approximate = approximate
+
+    def __call__(self, hidden_states: TensorValue) -> TensorValue:
+        """Apply GELU activation to the input.
+
+        Args:
+            hidden_states: Input tensor.
+
+        Returns:
+            Output tensor after linear projection and GELU activation.
+        """
+        hidden_states = self.proj(hidden_states)
+        hidden_states = ops.gelu(hidden_states, approximate=self.approximate)
+        return hidden_states

--- a/max/python/max/pipelines/architectures/flux1/layers/activations.py
+++ b/max/python/max/pipelines/architectures/flux1/layers/activations.py
@@ -11,20 +11,18 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-import max.nn as nn
-from max.dtype import DType
-from max.graph import DeviceRef, TensorValue, ops
+from max.experimental import functional as F
+from max.experimental.tensor import Tensor
+from max.nn.module_v3 import Linear, Module
 
 
-class GELU(nn.Module):
+class GELU(Module):
     def __init__(
         self,
         dim_in: int,
         dim_out: int,
         approximate: str = "none",
         bias: bool = True,
-        device: DeviceRef = DeviceRef.CPU(),
-        dtype: DType = DType.bfloat16,
     ):
         """Initialize GELU activation layer with linear projection.
 
@@ -33,16 +31,12 @@ class GELU(nn.Module):
             dim_out: Output dimension.
             approximate: Approximation type for GELU ("none" or "tanh").
             bias: Whether to include bias in the linear projection.
-            device: Device to place the layer on.
-            dtype: Data type for the layer.
         """
         super().__init__()
-        self.proj = nn.Linear(
-            dim_in, dim_out, has_bias=bias, dtype=dtype, device=device
-        )
+        self.proj = Linear(dim_in, dim_out, bias=bias)
         self.approximate = approximate
 
-    def __call__(self, hidden_states: TensorValue) -> TensorValue:
+    def forward(self, hidden_states: Tensor) -> Tensor:
         """Apply GELU activation to the input.
 
         Args:
@@ -52,5 +46,5 @@ class GELU(nn.Module):
             Output tensor after linear projection and GELU activation.
         """
         hidden_states = self.proj(hidden_states)
-        hidden_states = ops.gelu(hidden_states, approximate=self.approximate)
+        hidden_states = F.gelu(hidden_states, approximate=self.approximate)
         return hidden_states

--- a/max/python/max/pipelines/architectures/flux1/layers/embeddings.py
+++ b/max/python/max/pipelines/architectures/flux1/layers/embeddings.py
@@ -1,0 +1,471 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import math
+
+from max import nn
+from max.dtype import DType
+from max.graph import DeviceRef, TensorValue, ops
+
+
+def apply_rotary_emb(
+    x: TensorValue,
+    freqs_cis: tuple[TensorValue, TensorValue],
+    sequence_dim: int = 2,
+) -> TensorValue:
+    """Apply rotary embeddings to input tensors using the given frequency tensor.
+
+    This function applies rotary embeddings to the given query or key 'x' tensors using the provided frequency
+    tensor 'freqs_cis'. The input tensors are reshaped as complex numbers, and the frequency tensor is reshaped
+    for broadcasting compatibility. The resulting tensors contain rotary embeddings and are returned as real tensors.
+
+    Args:
+        x: Query or key tensor to apply rotary embeddings. Shape depends on
+            caller; the last dimension is split into complex pairs.
+        freqs_cis: Precomputed cosine/sine frequency tensors for complex
+            exponentials. Shape ([S, D], [S, D]).
+        sequence_dim: Dimension representing the sequence (1 or 2).
+
+    Returns:
+        Tensor: Tensor with rotary embeddings applied.
+    """
+    cos, sin = freqs_cis  # [S, D]
+    if sequence_dim == 2:
+        cos = cos[None, None, :, :]
+        sin = sin[None, None, :, :]
+    elif sequence_dim == 1:
+        cos = cos[None, :, None, :]
+        sin = sin[None, :, None, :]
+    else:
+        raise ValueError(f"`sequence_dim={sequence_dim}` but should be 1 or 2.")
+
+    cos, sin = cos.to(x.device), sin.to(x.device)
+
+    # Used for flux, cogvideox, hunyuan-dit
+    half_last_dim = x.shape[-1] // 2
+    chunks = ops.chunk(
+        x.reshape(list(x.shape[:-1]) + [half_last_dim, 2]), chunks=2, axis=-1
+    )
+    x_real = ops.squeeze(chunks[0], axis=-1)
+    x_imag = ops.squeeze(chunks[1], axis=-1)
+    # Stack and flatten: [B, S, H, D//2] -> [B, S, H, D//2, 2] -> [B, S, H, D]
+    x_rotated_stacked = ops.stack([-x_imag, x_real], axis=-1)
+    batch_sz = x_rotated_stacked.shape[0]
+    seq_len = x_rotated_stacked.shape[1]
+    heads = x_rotated_stacked.shape[2]
+    flattened_last_dim = x_rotated_stacked.shape[3] * x_rotated_stacked.shape[4]
+    x_rotated = ops.reshape(
+        x_rotated_stacked, (batch_sz, seq_len, heads, flattened_last_dim)
+    )
+
+    out = (
+        x.cast(DType.float32) * cos + x_rotated.cast(DType.float32) * sin
+    ).cast(x.dtype)
+
+    return out
+
+
+def get_timestep_embedding(
+    timesteps: TensorValue,
+    embedding_dim: int,
+    flip_sin_to_cos: bool = False,
+    downscale_freq_shift: float = 1,
+    scale: float = 1,
+    max_period: int = 10000,
+) -> TensorValue:
+    """Create sinusoidal timestep embeddings.
+
+    Matches the implementation in Diffusers/DDPM.
+    """
+    half_dim = embedding_dim // 2
+
+    # Create exponent: -math.log(max_period) * arange(0, half_dim)
+    # ops.range creates a sequence tensor
+    exponent = ops.range(
+        0, half_dim, step=1, dtype=DType.float32, device=timesteps.device
+    )
+    exponent = exponent * (-math.log(max_period))
+    exponent = exponent / (half_dim - downscale_freq_shift)
+
+    emb = ops.exp(exponent)
+
+    # emb = timesteps[:, None].float() * emb[None, :]
+    timesteps_f32 = timesteps.cast(DType.float32)
+    timesteps_dim = timesteps_f32.shape[0]
+    emb_dim = emb.shape[0]
+    emb = timesteps_f32.reshape((timesteps_dim, 1)) * emb.reshape((1, emb_dim))
+
+    # scale embeddings
+    emb = scale * emb
+
+    # concat sine and cosine embeddings
+    emb = ops.concat([ops.sin(emb), ops.cos(emb)], axis=-1)
+
+    # flip sine and cosine embeddings
+    if flip_sin_to_cos:
+        emb = ops.concat([emb[:, half_dim:], emb[:, :half_dim]], axis=-1)
+
+    # zero pad if embedding_dim is odd (rare case)
+    if embedding_dim % 2 == 1:
+        # Pad with one zero column at the end
+        zeros = ops.zeros((emb.shape[0], 1), dtype=emb.dtype, device=emb.device)
+        emb = ops.concat([emb, zeros], axis=-1)
+
+    return emb
+
+
+class Timesteps(nn.Module):
+    def __init__(
+        self,
+        num_channels: int,
+        flip_sin_to_cos: bool,
+        downscale_freq_shift: float,
+        scale: int = 1,
+        device: DeviceRef = DeviceRef.CPU(),
+        dtype: DType = DType.float32,
+    ):
+        """Initialize Timesteps embedding module.
+
+        Args:
+            num_channels: Number of channels in the embedding.
+            flip_sin_to_cos: Whether to flip sine and cosine embeddings.
+            downscale_freq_shift: Frequency downscaling shift parameter.
+            scale: Scaling factor for embeddings.
+            device: Device to place the module on.
+            dtype: Data type for the module.
+        """
+        super().__init__()
+        self.num_channels = num_channels
+        self.flip_sin_to_cos = flip_sin_to_cos
+        self.downscale_freq_shift = downscale_freq_shift
+        self.scale = scale
+
+    def __call__(self, timesteps: TensorValue) -> TensorValue:
+        """Generate timestep embeddings.
+
+        Args:
+            timesteps: Input timestep values.
+
+        Returns:
+            Timestep embeddings.
+        """
+        t_emb = get_timestep_embedding(
+            timesteps,
+            self.num_channels,
+            flip_sin_to_cos=self.flip_sin_to_cos,
+            downscale_freq_shift=self.downscale_freq_shift,
+            scale=self.scale,
+        )
+        return t_emb
+
+
+class TimestepEmbedding(nn.Module):
+    def __init__(
+        self,
+        in_channels: int,
+        time_embed_dim: int,
+        act_fn: str = "silu",
+        out_dim: int | None = None,
+        post_act_fn: str | None = None,
+        cond_proj_dim: int | None = None,
+        sample_proj_bias: bool = True,
+        device: DeviceRef = DeviceRef.CPU(),
+        dtype: DType = DType.bfloat16,
+    ):
+        """Initialize TimestepEmbedding module.
+
+        Args:
+            in_channels: Number of input channels.
+            time_embed_dim: Dimension of the time embedding.
+            act_fn: Activation function to use ("silu", "swish", or "gelu").
+            out_dim: Optional output dimension. Defaults to time_embed_dim if None.
+            post_act_fn: Optional post-activation function.
+            cond_proj_dim: Optional conditional projection dimension.
+            sample_proj_bias: Whether to use bias in projection layers.
+            device: Device to place the module on.
+            dtype: Data type for the module.
+        """
+        super().__init__()
+
+        self.linear_1 = nn.Linear(
+            in_channels,
+            time_embed_dim,
+            has_bias=sample_proj_bias,
+            device=device,
+            dtype=dtype,
+        )
+
+        if cond_proj_dim is not None:
+            self.cond_proj = nn.Linear(
+                cond_proj_dim,
+                in_channels,
+                has_bias=False,
+                device=device,
+                dtype=dtype,
+            )
+        else:
+            self.cond_proj = None
+        if act_fn == "silu" or act_fn == "swish":
+            self.act_fn = ops.silu
+        elif act_fn == "gelu":
+            self.act_fn = ops.gelu
+        else:
+            raise ValueError(f"Invalid activation function: {act_fn}")
+
+        if out_dim is not None:
+            time_embed_dim_out = out_dim
+        else:
+            time_embed_dim_out = time_embed_dim
+
+        self.linear_2 = nn.Linear(
+            time_embed_dim,
+            time_embed_dim_out,
+            has_bias=sample_proj_bias,
+            device=device,
+            dtype=dtype,
+        )
+
+        if post_act_fn is None:
+            self.post_act_fn = None
+        elif post_act_fn == "silu" or post_act_fn == "swish":
+            self.post_act_fn = ops.silu
+        elif post_act_fn == "gelu":
+            self.post_act_fn = ops.gelu
+        else:
+            raise ValueError(f"Invalid post activation function: {post_act_fn}")
+
+    def __call__(
+        self, sample: TensorValue, condition: TensorValue | None = None
+    ) -> TensorValue:
+        """Generate timestep embeddings with optional conditioning.
+
+        Args:
+            sample: Input sample tensor.
+            condition: Optional conditioning tensor.
+
+        Returns:
+            Timestep embeddings.
+        """
+        if condition is not None and self.cond_proj is not None:
+            sample = sample + self.cond_proj(condition)
+
+        sample = self.linear_1(sample)
+
+        sample = self.act_fn(sample)
+
+        sample = self.linear_2(sample)
+
+        if self.post_act_fn is not None:
+            sample = self.post_act_fn(sample)
+
+        return sample
+
+
+class PixArtAlphaTextProjection(nn.Module):
+    """Projects caption embeddings. Also handles dropout for classifier-free guidance."""
+
+    def __init__(
+        self,
+        in_features: int,
+        hidden_size: int,
+        out_features: int | None = None,
+        act_fn: str = "gelu_tanh",
+        device: DeviceRef = DeviceRef.CPU(),
+        dtype: DType = DType.bfloat16,
+    ):
+        """Initialize PixArtAlpha text projection module.
+
+        Args:
+            in_features: Number of input features.
+            hidden_size: Size of the hidden layer.
+            out_features: Number of output features. Defaults to hidden_size if None.
+            act_fn: Activation function to use ("gelu_tanh" or "silu").
+            device: Device to place the module on.
+            dtype: Data type for the module.
+        """
+        super().__init__()
+        if out_features is None:
+            out_features = hidden_size
+        self.linear_1 = nn.Linear(
+            in_features, hidden_size, has_bias=True, device=device, dtype=dtype
+        )
+        self.linear_2 = nn.Linear(
+            hidden_size, out_features, has_bias=True, device=device, dtype=dtype
+        )
+        if act_fn == "gelu_tanh":
+            self.act_fn = ops.gelu(approximate="tanh")
+        elif act_fn == "silu":
+            self.act_fn = ops.silu
+        else:
+            raise ValueError(f"Invalid activation function: {act_fn}")
+
+    def __call__(self, caption: TensorValue) -> TensorValue:
+        """Project caption embeddings.
+
+        Args:
+            caption: Input caption embeddings.
+
+        Returns:
+            Projected caption embeddings.
+        """
+        hidden_states = self.linear_1(caption)
+
+        hidden_states = self.act_fn(hidden_states)
+
+        hidden_states = self.linear_2(hidden_states)
+        return hidden_states
+
+
+class CombinedTimestepTextProjEmbeddings(nn.Module):
+    def __init__(
+        self,
+        embedding_dim: int,
+        pooled_projection_dim: int,
+        device: DeviceRef = DeviceRef.CPU(),
+        dtype: DType = DType.bfloat16,
+    ):
+        """Initialize combined timestep and text projection embeddings module.
+
+        Args:
+            embedding_dim: Dimension of the embedding.
+            pooled_projection_dim: Dimension of the pooled projection.
+            device: Device to place the module on.
+            dtype: Data type for the module.
+        """
+        super().__init__()
+
+        self.time_proj = Timesteps(
+            num_channels=256,
+            flip_sin_to_cos=True,
+            downscale_freq_shift=0,
+            device=device,
+            dtype=dtype,
+        )
+        self.timestep_embedder = TimestepEmbedding(
+            in_channels=256,
+            time_embed_dim=embedding_dim,
+            device=device,
+            dtype=dtype,
+        )
+        self.text_embedder = PixArtAlphaTextProjection(
+            pooled_projection_dim,
+            embedding_dim,
+            act_fn="silu",
+            device=device,
+            dtype=dtype,
+        )
+
+    def __call__(
+        self, timestep: TensorValue, pooled_projection: TensorValue
+    ) -> TensorValue:
+        """Combine timestep and text embeddings.
+
+        Args:
+            timestep: Input timestep values.
+            pooled_projection: Pooled text projection.
+
+        Returns:
+            Combined conditioning embeddings.
+        """
+        # Timestep projection and embedding
+        timesteps_proj = self.time_proj(timestep)
+        timesteps_emb = self.timestep_embedder(
+            timesteps_proj.cast(pooled_projection.dtype)
+        )
+
+        # Text projection
+        pooled_projections = self.text_embedder(pooled_projection)
+
+        # Combine
+        conditioning = timesteps_emb + pooled_projections
+
+        return conditioning
+
+
+class CombinedTimestepGuidanceTextProjEmbeddings(nn.Module):
+    def __init__(
+        self,
+        embedding_dim: int,
+        pooled_projection_dim: int,
+        device: DeviceRef = DeviceRef.CPU(),
+        dtype: DType = DType.bfloat16,
+    ):
+        """Initialize combined timestep, guidance, and text projection embeddings module.
+
+        Args:
+            embedding_dim: Dimension of the embedding.
+            pooled_projection_dim: Dimension of the pooled projection.
+            device: Device to place the module on.
+            dtype: Data type for the module.
+        """
+        super().__init__()
+
+        self.time_proj = Timesteps(
+            num_channels=256,
+            flip_sin_to_cos=True,
+            downscale_freq_shift=0,
+            device=device,
+            dtype=dtype,
+        )
+        self.timestep_embedder = TimestepEmbedding(
+            in_channels=256,
+            time_embed_dim=embedding_dim,
+            device=device,
+            dtype=dtype,
+        )
+        self.guidance_embedder = TimestepEmbedding(
+            in_channels=256,
+            time_embed_dim=embedding_dim,
+            device=device,
+            dtype=dtype,
+        )
+        self.text_embedder = PixArtAlphaTextProjection(
+            pooled_projection_dim,
+            embedding_dim,
+            act_fn="silu",
+            device=device,
+            dtype=dtype,
+        )
+
+    def __call__(
+        self,
+        timestep: TensorValue,
+        guidance: TensorValue,
+        pooled_projection: TensorValue,
+    ) -> TensorValue:
+        """Combine timestep, guidance, and text embeddings.
+
+        Args:
+            timestep: Input timestep values.
+            guidance: Guidance values.
+            pooled_projection: Pooled text projection.
+
+        Returns:
+            Combined conditioning embeddings.
+        """
+        timesteps_proj = self.time_proj(timestep)
+        timesteps_emb = self.timestep_embedder(
+            timesteps_proj.cast(pooled_projection.dtype)
+        )
+
+        guidance_proj = self.time_proj(guidance)
+        guidance_emb = self.guidance_embedder(
+            guidance_proj.cast(pooled_projection.dtype)
+        )
+
+        time_guidance_emb = timesteps_emb + guidance_emb
+
+        pooled_projections = self.text_embedder(pooled_projection)
+        conditioning = time_guidance_emb + pooled_projections
+
+        return conditioning

--- a/max/python/max/pipelines/architectures/flux1/layers/embeddings.py
+++ b/max/python/max/pipelines/architectures/flux1/layers/embeddings.py
@@ -13,16 +13,17 @@
 
 import math
 
-from max import nn
 from max.dtype import DType
-from max.graph import DeviceRef, TensorValue, ops
+from max.experimental import functional as F
+from max.experimental.tensor import Tensor
+from max.nn.module_v3 import Linear, Module
 
 
 def apply_rotary_emb(
-    x: TensorValue,
-    freqs_cis: tuple[TensorValue, TensorValue],
+    x: Tensor,
+    freqs_cis: tuple[Tensor, Tensor],
     sequence_dim: int = 2,
-) -> TensorValue:
+) -> Tensor:
     """Apply rotary embeddings to input tensors using the given frequency tensor.
 
     This function applies rotary embeddings to the given query or key 'x' tensors using the provided frequency
@@ -53,36 +54,35 @@ def apply_rotary_emb(
 
     # Used for flux, cogvideox, hunyuan-dit
     half_last_dim = x.shape[-1] // 2
-    chunks = ops.chunk(
-        x.reshape(list(x.shape[:-1]) + [half_last_dim, 2]), chunks=2, axis=-1
-    )
-    x_real = ops.squeeze(chunks[0], axis=-1)
-    x_imag = ops.squeeze(chunks[1], axis=-1)
+    x_reshaped = F.reshape(x, list(x.shape[:-1]) + [half_last_dim, 2])
+    chunks = F.split(x_reshaped, 1, axis=-1)
+    x_real = F.squeeze(chunks[0], axis=-1)
+    x_imag = F.squeeze(chunks[1], axis=-1)
     # Stack and flatten: [B, S, H, D//2] -> [B, S, H, D//2, 2] -> [B, S, H, D]
-    x_rotated_stacked = ops.stack([-x_imag, x_real], axis=-1)
+    x_rotated_stacked = F.stack([-x_imag, x_real], axis=-1)
     batch_sz = x_rotated_stacked.shape[0]
     seq_len = x_rotated_stacked.shape[1]
     heads = x_rotated_stacked.shape[2]
     flattened_last_dim = x_rotated_stacked.shape[3] * x_rotated_stacked.shape[4]
-    x_rotated = ops.reshape(
+    x_rotated = F.reshape(
         x_rotated_stacked, (batch_sz, seq_len, heads, flattened_last_dim)
     )
 
     out = (
-        x.cast(DType.float32) * cos + x_rotated.cast(DType.float32) * sin
+        F.cast(x, DType.float32) * cos + F.cast(x_rotated, DType.float32) * sin
     ).cast(x.dtype)
 
     return out
 
 
 def get_timestep_embedding(
-    timesteps: TensorValue,
+    timesteps: Tensor,
     embedding_dim: int,
     flip_sin_to_cos: bool = False,
     downscale_freq_shift: float = 1,
     scale: float = 1,
     max_period: int = 10000,
-) -> TensorValue:
+) -> Tensor:
     """Create sinusoidal timestep embeddings.
 
     Matches the implementation in Diffusers/DDPM.
@@ -91,16 +91,15 @@ def get_timestep_embedding(
 
     # Create exponent: -math.log(max_period) * arange(0, half_dim)
     # ops.range creates a sequence tensor
-    exponent = ops.range(
+    exponent = F.arange(
         0, half_dim, step=1, dtype=DType.float32, device=timesteps.device
     )
     exponent = exponent * (-math.log(max_period))
     exponent = exponent / (half_dim - downscale_freq_shift)
 
-    emb = ops.exp(exponent)
+    emb = F.exp(exponent)
 
-    # emb = timesteps[:, None].float() * emb[None, :]
-    timesteps_f32 = timesteps.cast(DType.float32)
+    timesteps_f32 = F.cast(timesteps, DType.float32)
     timesteps_dim = timesteps_f32.shape[0]
     emb_dim = emb.shape[0]
     emb = timesteps_f32.reshape((timesteps_dim, 1)) * emb.reshape((1, emb_dim))
@@ -109,30 +108,30 @@ def get_timestep_embedding(
     emb = scale * emb
 
     # concat sine and cosine embeddings
-    emb = ops.concat([ops.sin(emb), ops.cos(emb)], axis=-1)
+    emb = F.concat([F.sin(emb), F.cos(emb)], axis=-1)
 
     # flip sine and cosine embeddings
     if flip_sin_to_cos:
-        emb = ops.concat([emb[:, half_dim:], emb[:, :half_dim]], axis=-1)
+        emb = F.concat([emb[:, half_dim:], emb[:, :half_dim]], axis=-1)
 
     # zero pad if embedding_dim is odd (rare case)
     if embedding_dim % 2 == 1:
         # Pad with one zero column at the end
-        zeros = ops.zeros((emb.shape[0], 1), dtype=emb.dtype, device=emb.device)
-        emb = ops.concat([emb, zeros], axis=-1)
+        zeros = Tensor.zeros(
+            (emb.shape[0], 1), dtype=emb.dtype, device=timesteps.device
+        )
+        emb = F.concat([emb, zeros], axis=-1)
 
     return emb
 
 
-class Timesteps(nn.Module):
+class Timesteps(Module):
     def __init__(
         self,
         num_channels: int,
         flip_sin_to_cos: bool,
         downscale_freq_shift: float,
         scale: int = 1,
-        device: DeviceRef = DeviceRef.CPU(),
-        dtype: DType = DType.float32,
     ):
         """Initialize Timesteps embedding module.
 
@@ -141,8 +140,6 @@ class Timesteps(nn.Module):
             flip_sin_to_cos: Whether to flip sine and cosine embeddings.
             downscale_freq_shift: Frequency downscaling shift parameter.
             scale: Scaling factor for embeddings.
-            device: Device to place the module on.
-            dtype: Data type for the module.
         """
         super().__init__()
         self.num_channels = num_channels
@@ -150,7 +147,7 @@ class Timesteps(nn.Module):
         self.downscale_freq_shift = downscale_freq_shift
         self.scale = scale
 
-    def __call__(self, timesteps: TensorValue) -> TensorValue:
+    def forward(self, timesteps: Tensor) -> Tensor:
         """Generate timestep embeddings.
 
         Args:
@@ -169,7 +166,7 @@ class Timesteps(nn.Module):
         return t_emb
 
 
-class TimestepEmbedding(nn.Module):
+class TimestepEmbedding(Module):
     def __init__(
         self,
         in_channels: int,
@@ -179,8 +176,6 @@ class TimestepEmbedding(nn.Module):
         post_act_fn: str | None = None,
         cond_proj_dim: int | None = None,
         sample_proj_bias: bool = True,
-        device: DeviceRef = DeviceRef.CPU(),
-        dtype: DType = DType.bfloat16,
     ):
         """Initialize TimestepEmbedding module.
 
@@ -192,33 +187,27 @@ class TimestepEmbedding(nn.Module):
             post_act_fn: Optional post-activation function.
             cond_proj_dim: Optional conditional projection dimension.
             sample_proj_bias: Whether to use bias in projection layers.
-            device: Device to place the module on.
-            dtype: Data type for the module.
         """
         super().__init__()
 
-        self.linear_1 = nn.Linear(
+        self.linear_1 = Linear(
             in_channels,
             time_embed_dim,
-            has_bias=sample_proj_bias,
-            device=device,
-            dtype=dtype,
+            bias=sample_proj_bias,
         )
 
         if cond_proj_dim is not None:
-            self.cond_proj = nn.Linear(
+            self.cond_proj = Linear(
                 cond_proj_dim,
                 in_channels,
-                has_bias=False,
-                device=device,
-                dtype=dtype,
+                bias=False,
             )
         else:
             self.cond_proj = None
         if act_fn == "silu" or act_fn == "swish":
-            self.act_fn = ops.silu
+            self.act_fn = F.silu
         elif act_fn == "gelu":
-            self.act_fn = ops.gelu
+            self.act_fn = F.gelu
         else:
             raise ValueError(f"Invalid activation function: {act_fn}")
 
@@ -227,26 +216,24 @@ class TimestepEmbedding(nn.Module):
         else:
             time_embed_dim_out = time_embed_dim
 
-        self.linear_2 = nn.Linear(
+        self.linear_2 = Linear(
             time_embed_dim,
             time_embed_dim_out,
-            has_bias=sample_proj_bias,
-            device=device,
-            dtype=dtype,
+            bias=sample_proj_bias,
         )
 
         if post_act_fn is None:
             self.post_act_fn = None
         elif post_act_fn == "silu" or post_act_fn == "swish":
-            self.post_act_fn = ops.silu
+            self.post_act_fn = F.silu
         elif post_act_fn == "gelu":
-            self.post_act_fn = ops.gelu
+            self.post_act_fn = F.gelu
         else:
             raise ValueError(f"Invalid post activation function: {post_act_fn}")
 
-    def __call__(
-        self, sample: TensorValue, condition: TensorValue | None = None
-    ) -> TensorValue:
+    def forward(
+        self, sample: Tensor, condition: Tensor | None = None
+    ) -> Tensor:
         """Generate timestep embeddings with optional conditioning.
 
         Args:
@@ -271,7 +258,7 @@ class TimestepEmbedding(nn.Module):
         return sample
 
 
-class PixArtAlphaTextProjection(nn.Module):
+class PixArtAlphaTextProjection(Module):
     """Projects caption embeddings. Also handles dropout for classifier-free guidance."""
 
     def __init__(
@@ -280,8 +267,6 @@ class PixArtAlphaTextProjection(nn.Module):
         hidden_size: int,
         out_features: int | None = None,
         act_fn: str = "gelu_tanh",
-        device: DeviceRef = DeviceRef.CPU(),
-        dtype: DType = DType.bfloat16,
     ):
         """Initialize PixArtAlpha text projection module.
 
@@ -290,26 +275,20 @@ class PixArtAlphaTextProjection(nn.Module):
             hidden_size: Size of the hidden layer.
             out_features: Number of output features. Defaults to hidden_size if None.
             act_fn: Activation function to use ("gelu_tanh" or "silu").
-            device: Device to place the module on.
-            dtype: Data type for the module.
         """
         super().__init__()
         if out_features is None:
             out_features = hidden_size
-        self.linear_1 = nn.Linear(
-            in_features, hidden_size, has_bias=True, device=device, dtype=dtype
-        )
-        self.linear_2 = nn.Linear(
-            hidden_size, out_features, has_bias=True, device=device, dtype=dtype
-        )
+        self.linear_1 = Linear(in_features, hidden_size, bias=True)
+        self.linear_2 = Linear(hidden_size, out_features, bias=True)
         if act_fn == "gelu_tanh":
-            self.act_fn = ops.gelu(approximate="tanh")
+            self.act_fn = lambda x: F.gelu(x, approximate="tanh")
         elif act_fn == "silu":
-            self.act_fn = ops.silu
+            self.act_fn = F.silu
         else:
             raise ValueError(f"Invalid activation function: {act_fn}")
 
-    def __call__(self, caption: TensorValue) -> TensorValue:
+    def forward(self, caption: Tensor) -> Tensor:
         """Project caption embeddings.
 
         Args:
@@ -326,12 +305,11 @@ class PixArtAlphaTextProjection(nn.Module):
         return hidden_states
 
 
-class CombinedTimestepTextProjEmbeddings(nn.Module):
+class CombinedTimestepTextProjEmbeddings(Module):
     def __init__(
         self,
         embedding_dim: int,
         pooled_projection_dim: int,
-        device: DeviceRef = DeviceRef.CPU(),
         dtype: DType = DType.bfloat16,
     ):
         """Initialize combined timestep and text projection embeddings module.
@@ -339,7 +317,6 @@ class CombinedTimestepTextProjEmbeddings(nn.Module):
         Args:
             embedding_dim: Dimension of the embedding.
             pooled_projection_dim: Dimension of the pooled projection.
-            device: Device to place the module on.
             dtype: Data type for the module.
         """
         super().__init__()
@@ -348,26 +325,18 @@ class CombinedTimestepTextProjEmbeddings(nn.Module):
             num_channels=256,
             flip_sin_to_cos=True,
             downscale_freq_shift=0,
-            device=device,
-            dtype=dtype,
         )
         self.timestep_embedder = TimestepEmbedding(
             in_channels=256,
             time_embed_dim=embedding_dim,
-            device=device,
-            dtype=dtype,
         )
         self.text_embedder = PixArtAlphaTextProjection(
             pooled_projection_dim,
             embedding_dim,
             act_fn="silu",
-            device=device,
-            dtype=dtype,
         )
 
-    def __call__(
-        self, timestep: TensorValue, pooled_projection: TensorValue
-    ) -> TensorValue:
+    def forward(self, timestep: Tensor, pooled_projection: Tensor) -> Tensor:
         """Combine timestep and text embeddings.
 
         Args:
@@ -380,7 +349,7 @@ class CombinedTimestepTextProjEmbeddings(nn.Module):
         # Timestep projection and embedding
         timesteps_proj = self.time_proj(timestep)
         timesteps_emb = self.timestep_embedder(
-            timesteps_proj.cast(pooled_projection.dtype)
+            F.cast(timesteps_proj, pooled_projection.dtype)
         )
 
         # Text projection
@@ -392,12 +361,11 @@ class CombinedTimestepTextProjEmbeddings(nn.Module):
         return conditioning
 
 
-class CombinedTimestepGuidanceTextProjEmbeddings(nn.Module):
+class CombinedTimestepGuidanceTextProjEmbeddings(Module):
     def __init__(
         self,
         embedding_dim: int,
         pooled_projection_dim: int,
-        device: DeviceRef = DeviceRef.CPU(),
         dtype: DType = DType.bfloat16,
     ):
         """Initialize combined timestep, guidance, and text projection embeddings module.
@@ -405,7 +373,6 @@ class CombinedTimestepGuidanceTextProjEmbeddings(nn.Module):
         Args:
             embedding_dim: Dimension of the embedding.
             pooled_projection_dim: Dimension of the pooled projection.
-            device: Device to place the module on.
             dtype: Data type for the module.
         """
         super().__init__()
@@ -414,35 +381,27 @@ class CombinedTimestepGuidanceTextProjEmbeddings(nn.Module):
             num_channels=256,
             flip_sin_to_cos=True,
             downscale_freq_shift=0,
-            device=device,
-            dtype=dtype,
         )
         self.timestep_embedder = TimestepEmbedding(
             in_channels=256,
             time_embed_dim=embedding_dim,
-            device=device,
-            dtype=dtype,
         )
         self.guidance_embedder = TimestepEmbedding(
             in_channels=256,
             time_embed_dim=embedding_dim,
-            device=device,
-            dtype=dtype,
         )
         self.text_embedder = PixArtAlphaTextProjection(
             pooled_projection_dim,
             embedding_dim,
             act_fn="silu",
-            device=device,
-            dtype=dtype,
         )
 
-    def __call__(
+    def forward(
         self,
-        timestep: TensorValue,
-        guidance: TensorValue,
-        pooled_projection: TensorValue,
-    ) -> TensorValue:
+        timestep: Tensor,
+        guidance: Tensor,
+        pooled_projection: Tensor,
+    ) -> Tensor:
         """Combine timestep, guidance, and text embeddings.
 
         Args:
@@ -455,12 +414,12 @@ class CombinedTimestepGuidanceTextProjEmbeddings(nn.Module):
         """
         timesteps_proj = self.time_proj(timestep)
         timesteps_emb = self.timestep_embedder(
-            timesteps_proj.cast(pooled_projection.dtype)
+            F.cast(timesteps_proj, pooled_projection.dtype)
         )
 
         guidance_proj = self.time_proj(guidance)
         guidance_emb = self.guidance_embedder(
-            guidance_proj.cast(pooled_projection.dtype)
+            F.cast(guidance_proj, pooled_projection.dtype)
         )
 
         time_guidance_emb = timesteps_emb + guidance_emb

--- a/max/python/max/pipelines/architectures/flux1/layers/flux_attention.py
+++ b/max/python/max/pipelines/architectures/flux1/layers/flux_attention.py
@@ -1,0 +1,474 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import math
+
+import max.nn as nn
+from max.dtype import DType
+from max.graph import DeviceRef, TensorValue, ops
+from max.nn import (
+    Linear,
+    Module,
+    RMSNorm,
+)
+from max.nn.attention.mask_config import MHAMaskVariant
+from max.nn.kernels import flash_attention_gpu
+
+from .activations import GELU
+from .embeddings import apply_rotary_emb
+
+
+class FluxAttention(Module):
+    """Flux attention mechanism with QK normalization and optional dual stream."""
+
+    def __init__(
+        self,
+        query_dim: int,
+        heads: int = 8,
+        dim_head: int = 64,
+        dropout: float = 0.0,
+        bias: bool = False,
+        added_kv_proj_dim: int | None = None,
+        added_proj_bias: bool | None = True,
+        out_bias: bool = True,
+        eps: float = 1e-5,
+        out_dim: int | None = None,
+        context_pre_only: bool | None = None,
+        pre_only: bool = False,
+        elementwise_affine: bool = True,
+        device: DeviceRef = DeviceRef.CPU(),
+        dtype: DType = DType.bfloat16,
+    ):
+        """Initialize Flux attention module.
+
+        Args:
+            query_dim: Dimension of query vectors.
+            heads: Number of attention heads.
+            dim_head: Dimension of each attention head.
+            dropout: Dropout probability.
+            bias: Whether to use bias in projections.
+            added_kv_proj_dim: Optional dimension for additional key/value projections.
+            added_proj_bias: Whether to use bias in additional projections.
+            out_bias: Whether to use bias in output projection.
+            eps: Epsilon for normalization layers.
+            out_dim: Optional output dimension.
+            context_pre_only: Whether to use context pre-processing only.
+            pre_only: Whether to use pre-processing only.
+            elementwise_affine: Whether to use elementwise affine in normalization.
+            device: Device to place the module on.
+            dtype: Data type for the module.
+        """
+        super().__init__()
+
+        self.head_dim = dim_head
+        self.inner_dim = out_dim if out_dim is not None else dim_head * heads
+        self.query_dim = query_dim
+        self.use_bias = bias
+        self.dropout = dropout
+        self.out_dim = out_dim if out_dim is not None else query_dim
+        self.context_pre_only = context_pre_only
+        self.pre_only = pre_only
+        self.heads = out_dim // dim_head if out_dim is not None else heads
+        self.added_kv_proj_dim = added_kv_proj_dim
+        self.added_proj_bias = added_proj_bias
+        self.dtype = dtype
+        self.device = device
+
+        self.norm_q = RMSNorm(
+            dim_head,
+            dtype=self.dtype,
+            eps=eps,
+            multiply_before_cast=elementwise_affine,
+        )
+        self.norm_k = RMSNorm(
+            dim_head,
+            dtype=self.dtype,
+            eps=eps,
+            multiply_before_cast=elementwise_affine,
+        )
+        self.to_q = Linear(
+            query_dim,
+            self.inner_dim,
+            has_bias=bias,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        self.to_k = Linear(
+            query_dim,
+            self.inner_dim,
+            has_bias=bias,
+            dtype=self.dtype,
+            device=self.device,
+        )
+        self.to_v = Linear(
+            query_dim,
+            self.inner_dim,
+            has_bias=bias,
+            dtype=self.dtype,
+            device=self.device,
+        )
+
+        if not self.pre_only:
+            layers = []
+            layers.append(
+                Linear(
+                    self.inner_dim,
+                    self.out_dim,
+                    has_bias=out_bias,
+                    dtype=self.dtype,
+                    device=self.device,
+                )
+            )
+            # layers.append(Dropout(dropout)) # There is no Dropout in MAX
+            self.to_out = nn.Sequential(layers)
+
+        if added_kv_proj_dim is not None:
+            self.norm_added_q = RMSNorm(dim_head, dtype=self.dtype, eps=eps)
+            self.norm_added_k = RMSNorm(dim_head, dtype=self.dtype, eps=eps)
+            self.add_q_proj = Linear(
+                added_kv_proj_dim,
+                self.inner_dim,
+                has_bias=added_proj_bias,
+                dtype=self.dtype,
+                device=self.device,
+            )
+            self.add_k_proj = Linear(
+                added_kv_proj_dim,
+                self.inner_dim,
+                has_bias=added_proj_bias,
+                dtype=self.dtype,
+                device=self.device,
+            )
+            self.add_v_proj = Linear(
+                added_kv_proj_dim,
+                self.inner_dim,
+                has_bias=added_proj_bias,
+                dtype=self.dtype,
+                device=self.device,
+            )
+            self.to_add_out = Linear(
+                self.inner_dim,
+                query_dim,
+                has_bias=out_bias,
+                dtype=self.dtype,
+                device=self.device,
+            )
+
+    def __call__(
+        self,
+        hidden_states: TensorValue,
+        encoder_hidden_states: TensorValue = None,
+        attention_mask: TensorValue | None = None,
+        image_rotary_emb: tuple[TensorValue, TensorValue] | None = None,
+    ) -> TensorValue:
+        """Apply Flux attention to hidden states.
+
+        Args:
+            hidden_states: Input hidden states.
+            encoder_hidden_states: Optional encoder hidden states for cross-attention.
+            attention_mask: Optional attention mask.
+            image_rotary_emb: Optional rotary embeddings for position encoding.
+
+        Returns:
+            Output hidden states after attention, or tuple of (hidden_states, encoder_hidden_states) if encoder states provided.
+        """
+        batch_size = hidden_states.shape[0]
+
+        # get qkv projections
+        query = self.to_q(hidden_states)
+        key = self.to_k(hidden_states)
+        value = self.to_v(hidden_states)
+
+        seq_len = query.shape[1]
+        query = ops.reshape(
+            query, (batch_size, seq_len, self.heads, self.head_dim)
+        )
+        key = ops.reshape(key, (batch_size, seq_len, self.heads, self.head_dim))
+        value = ops.reshape(
+            value, (batch_size, seq_len, self.heads, self.head_dim)
+        )
+
+        query = self.norm_q(query)
+        key = self.norm_k(key)
+
+        encoder_query = encoder_key = encoder_value = None
+        if (
+            encoder_hidden_states is not None
+            and self.added_kv_proj_dim is not None
+        ):
+            encoder_query = self.add_q_proj(encoder_hidden_states)
+            encoder_key = self.add_k_proj(encoder_hidden_states)
+            encoder_value = self.add_v_proj(encoder_hidden_states)
+
+        query = self.norm_q(query)
+        key = self.norm_k(key)
+
+        if (
+            encoder_hidden_states is not None
+            and self.added_kv_proj_dim is not None
+        ):
+            encoder_seq_len = encoder_query.shape[1]
+            encoder_query = ops.reshape(
+                encoder_query,
+                (batch_size, encoder_seq_len, self.heads, self.head_dim),
+            )
+            encoder_key = ops.reshape(
+                encoder_key,
+                (batch_size, encoder_seq_len, self.heads, self.head_dim),
+            )
+            encoder_value = ops.reshape(
+                encoder_value,
+                (batch_size, encoder_seq_len, self.heads, self.head_dim),
+            )
+
+            encoder_query = self.norm_added_q(encoder_query)
+            encoder_key = self.norm_added_k(encoder_key)
+
+            query = ops.concat([encoder_query, query], axis=1)
+            key = ops.concat([encoder_key, key], axis=1)
+            value = ops.concat([encoder_value, value], axis=1)
+
+        if image_rotary_emb is not None:
+            query = apply_rotary_emb(query, image_rotary_emb, sequence_dim=1)
+            key = apply_rotary_emb(key, image_rotary_emb, sequence_dim=1)
+
+        hidden_states = flash_attention_gpu(
+            query,
+            key,
+            value,
+            mask_variant=MHAMaskVariant.NULL_MASK,
+            scale=math.sqrt(1.0 / self.head_dim),
+        )
+
+        total_seq_len = hidden_states.shape[1]
+        hidden_states = ops.reshape(
+            hidden_states,
+            (batch_size, total_seq_len, self.heads * self.head_dim),
+        )
+
+        if encoder_hidden_states is not None:
+            encoder_seq_len = encoder_hidden_states.shape[1]
+            encoder_hidden_states = hidden_states[:, :encoder_seq_len, :]
+            hidden_states = hidden_states[:, encoder_seq_len:, :]
+
+            hidden_states = self.to_out(hidden_states)
+            encoder_hidden_states = self.to_add_out(encoder_hidden_states)
+
+            return hidden_states, encoder_hidden_states
+        return hidden_states
+
+
+class FeedForward(Module):
+    def __init__(
+        self,
+        dim: int,
+        dim_out: int | None = None,
+        mult: int = 4,
+        dropout: float = 0.0,
+        activation_fn: str = "geglu",
+        final_dropout: bool = False,
+        inner_dim: int | None = None,
+        bias: bool = True,
+        device: DeviceRef = DeviceRef.CPU(),
+        dtype: DType = DType.bfloat16,
+    ):
+        """Initialize FeedForward module.
+
+        Args:
+            dim: Input dimension.
+            dim_out: Optional output dimension. Defaults to dim if None.
+            mult: Multiplier for hidden dimension.
+            dropout: Dropout probability.
+            activation_fn: Activation function to use ("gelu" or "gelu-approximate").
+            final_dropout: Whether to apply dropout at the end.
+            inner_dim: Optional inner dimension. Computed as dim * mult if None.
+            bias: Whether to use bias in linear layers.
+            device: Device to place the module on.
+            dtype: Data type for the module.
+        """
+        super().__init__()
+        if inner_dim is None:
+            inner_dim = int(dim * mult)
+        dim_out = dim_out if dim_out is not None else dim
+
+        if activation_fn == "gelu":
+            act_fn = GELU(dim, inner_dim, bias=bias, device=device, dtype=dtype)
+        if activation_fn == "gelu-approximate":
+            act_fn = GELU(
+                dim,
+                inner_dim,
+                approximate="tanh",
+                bias=bias,
+                device=device,
+                dtype=dtype,
+            )
+        else:
+            raise NotImplementedError(
+                f"Activation function {activation_fn} is not implemented"
+            )
+
+        self.net = nn.Sequential(
+            [
+                act_fn,
+                Linear(
+                    inner_dim,
+                    dim_out,
+                    has_bias=bias,
+                    dtype=dtype,
+                    device=device,
+                ),
+            ]
+        )
+
+    def __call__(
+        self, hidden_states: TensorValue, *args, **kwargs
+    ) -> TensorValue:
+        """Apply feedforward network to hidden states.
+
+        Args:
+            hidden_states: Input hidden states.
+            *args: Additional positional arguments (unused).
+            **kwargs: Additional keyword arguments (unused).
+
+        Returns:
+            Output hidden states after feedforward network.
+        """
+        return self.net(hidden_states)
+
+
+class FluxPosEmbed(nn.Module):
+    """Flux Position Embedding module for 3D rotary position embeddings.
+
+    This module computes separate rotary embeddings for each spatial dimension
+    (typically time, height, width) and concatenates them.
+
+    Args:
+        theta: Base value for frequency computation (typically 10000)
+        axes_dim: List of dimensions for each axis (e.g., [16, 56, 56] for time, height, width)
+    """
+
+    def __init__(
+        self, theta: int = 10000, axes_dim: tuple[int, int, int] = (16, 56, 56)
+    ):
+        """Initialize Flux position embedding module.
+
+        Args:
+            theta: Base value for frequency computation (typically 10000).
+            axes_dim: Dimensions for each axis (e.g., [16, 56, 56] for time, height, width).
+        """
+        super().__init__()
+        self.theta = float(theta)
+        self.axes_dim = list(axes_dim)
+
+    def _get_1d_rotary_pos_embed(
+        self, dim: int, pos: TensorValue, device: DeviceRef
+    ) -> tuple[TensorValue, TensorValue]:
+        """Compute 1D rotary position embeddings for a single axis.
+
+        Args:
+            dim: Dimension of the embedding (should be even)
+            pos: Position indices, shape [batch_size]
+            device: Device to compute on
+
+        Returns:
+            Tuple of (freqs_cos, freqs_sin), each with shape [batch_size, dim]
+        """
+        # Ensure dim is even
+        assert dim % 2 == 0, f"dim must be even, got {dim}"
+
+        # Cast position to float32 for computation
+        pos = ops.cast(pos, DType.float32)
+
+        # Compute frequencies: 1.0 / (theta ** (arange(0, dim, 2) / dim))
+        # Shape: [dim/2]
+        arange_vals = ops.range(
+            0, dim, step=2, dtype=DType.float32, device=device
+        )
+        exponents = arange_vals / float(dim)
+
+        # theta ** exponents
+        theta_tensor = ops.constant(self.theta, DType.float32, device=device)
+        theta_powered = ops.pow(theta_tensor, exponents)
+
+        # 1.0 / theta_powered
+        freqs = 1.0 / theta_powered  # Shape: [dim/2]
+
+        # Outer product: pos [batch_size] x freqs [dim/2] = [batch_size, dim/2]
+        freqs_outer = ops.outer(pos, freqs)
+
+        # Compute cos and sin
+        freqs_cos_half = ops.cos(freqs_outer)  # [batch_size, dim/2]
+        freqs_sin_half = ops.sin(freqs_outer)  # [batch_size, dim/2]
+
+        # Repeat interleave to get full dimension
+        # repeat_interleave(2, dim=1): [a, b, c] -> [a, a, b, b, c, c]
+        # Since repeat_interleave is not supported on GPU, we use reshape + tile
+
+        # 1. Unsqueeze: [batch_size, dim/2] -> [batch_size, dim/2, 1]
+        freqs_cos_expanded = ops.unsqueeze(freqs_cos_half, axis=2)
+        freqs_sin_expanded = ops.unsqueeze(freqs_sin_half, axis=2)
+
+        # 2. Concat to duplicate: [batch_size, dim/2, 1] -> [batch_size, dim/2, 2]
+        freqs_cos_tiled = ops.concat(
+            [freqs_cos_expanded, freqs_cos_expanded], axis=2
+        )
+        freqs_sin_tiled = ops.concat(
+            [freqs_sin_expanded, freqs_sin_expanded], axis=2
+        )
+
+        # 3. Reshape to flatten: [batch_size, dim/2, 2] -> [batch_size, dim]
+        flattened_dim = freqs_cos_tiled.shape[1] * freqs_cos_tiled.shape[2]
+        freqs_cos = ops.reshape(
+            freqs_cos_tiled, (freqs_cos_tiled.shape[0], flattened_dim)
+        )
+        freqs_sin = ops.reshape(
+            freqs_sin_tiled, (freqs_sin_tiled.shape[0], flattened_dim)
+        )
+
+        return freqs_cos, freqs_sin
+
+    def __call__(self, ids: TensorValue) -> tuple[TensorValue, TensorValue]:
+        """Forward pass to compute rotary position embeddings.
+
+        Args:
+            ids: Position indices tensor with shape [batch_size, n_axes]
+                 where n_axes is the number of spatial dimensions (e.g., 3 for time/height/width)
+
+        Returns:
+            Tuple of (freqs_cos, freqs_sin) with concatenated embeddings from all axes
+        """
+        # Get number of axes from the last dimension
+        n_axes = ids.shape[-1]
+        device = ids.device
+
+        cos_out = []
+        sin_out = []
+
+        # Compute embeddings for each axis
+        for i in range(int(n_axes)):
+            # Extract position for this axis: ids[:, i]
+            pos = ids[:, i]
+
+            # Compute 1D rotary embeddings for this axis
+            cos_embed, sin_embed = self._get_1d_rotary_pos_embed(
+                dim=self.axes_dim[i], pos=pos, device=device
+            )
+
+            cos_out.append(cos_embed)
+            sin_out.append(sin_embed)
+
+        # Concatenate embeddings from all axes along the last dimension
+        freqs_cos = ops.concat(cos_out, axis=-1)  # [batch_size, sum(axes_dim)]
+        freqs_sin = ops.concat(sin_out, axis=-1)  # [batch_size, sum(axes_dim)]
+
+        return freqs_cos, freqs_sin

--- a/max/python/max/pipelines/architectures/flux1/layers/flux_attention.py
+++ b/max/python/max/pipelines/architectures/flux1/layers/flux_attention.py
@@ -13,16 +13,15 @@
 
 import math
 
-import max.nn as nn
 from max.dtype import DType
-from max.graph import DeviceRef, TensorValue, ops
-from max.nn import (
-    Linear,
-    Module,
-    RMSNorm,
-)
+from max.experimental import functional as F
+from max.experimental.tensor import Tensor
+from max.graph import DeviceRef
 from max.nn.attention.mask_config import MHAMaskVariant
 from max.nn.kernels import flash_attention_gpu
+from max.nn.module_v3 import Linear, Module
+from max.nn.module_v3.norm import RMSNorm
+from max.nn.module_v3.sequential import ModuleList
 
 from .activations import GELU
 from .embeddings import apply_rotary_emb
@@ -46,7 +45,6 @@ class FluxAttention(Module):
         context_pre_only: bool | None = None,
         pre_only: bool = False,
         elementwise_affine: bool = True,
-        device: DeviceRef = DeviceRef.CPU(),
         dtype: DType = DType.bfloat16,
     ):
         """Initialize Flux attention module.
@@ -65,7 +63,6 @@ class FluxAttention(Module):
             context_pre_only: Whether to use context pre-processing only.
             pre_only: Whether to use pre-processing only.
             elementwise_affine: Whether to use elementwise affine in normalization.
-            device: Device to place the module on.
             dtype: Data type for the module.
         """
         super().__init__()
@@ -82,95 +79,63 @@ class FluxAttention(Module):
         self.added_kv_proj_dim = added_kv_proj_dim
         self.added_proj_bias = added_proj_bias
         self.dtype = dtype
-        self.device = device
 
-        self.norm_q = RMSNorm(
-            dim_head,
-            dtype=self.dtype,
-            eps=eps,
-            multiply_before_cast=elementwise_affine,
-        )
-        self.norm_k = RMSNorm(
-            dim_head,
-            dtype=self.dtype,
-            eps=eps,
-            multiply_before_cast=elementwise_affine,
-        )
+        self.norm_q = RMSNorm(dim_head, eps=eps)
+        self.norm_k = RMSNorm(dim_head, eps=eps)
         self.to_q = Linear(
             query_dim,
             self.inner_dim,
-            has_bias=bias,
-            dtype=self.dtype,
-            device=self.device,
+            bias=bias,
         )
         self.to_k = Linear(
             query_dim,
             self.inner_dim,
-            has_bias=bias,
-            dtype=self.dtype,
-            device=self.device,
+            bias=bias,
         )
         self.to_v = Linear(
             query_dim,
             self.inner_dim,
-            has_bias=bias,
-            dtype=self.dtype,
-            device=self.device,
+            bias=bias,
         )
 
         if not self.pre_only:
-            layers = []
-            layers.append(
-                Linear(
-                    self.inner_dim,
-                    self.out_dim,
-                    has_bias=out_bias,
-                    dtype=self.dtype,
-                    device=self.device,
-                )
+            self.to_out = Linear(
+                self.inner_dim,
+                self.out_dim,
+                bias=out_bias,
             )
-            # layers.append(Dropout(dropout)) # There is no Dropout in MAX
-            self.to_out = nn.Sequential(layers)
 
         if added_kv_proj_dim is not None:
-            self.norm_added_q = RMSNorm(dim_head, dtype=self.dtype, eps=eps)
-            self.norm_added_k = RMSNorm(dim_head, dtype=self.dtype, eps=eps)
+            self.norm_added_q = RMSNorm(dim_head, eps=eps)
+            self.norm_added_k = RMSNorm(dim_head, eps=eps)
             self.add_q_proj = Linear(
                 added_kv_proj_dim,
                 self.inner_dim,
-                has_bias=added_proj_bias,
-                dtype=self.dtype,
-                device=self.device,
+                bias=added_proj_bias,
             )
             self.add_k_proj = Linear(
                 added_kv_proj_dim,
                 self.inner_dim,
-                has_bias=added_proj_bias,
-                dtype=self.dtype,
-                device=self.device,
+                bias=added_proj_bias,
             )
             self.add_v_proj = Linear(
                 added_kv_proj_dim,
                 self.inner_dim,
-                has_bias=added_proj_bias,
-                dtype=self.dtype,
-                device=self.device,
+                bias=added_proj_bias,
             )
             self.to_add_out = Linear(
                 self.inner_dim,
                 query_dim,
-                has_bias=out_bias,
-                dtype=self.dtype,
-                device=self.device,
+                bias=out_bias,
             )
 
-    def __call__(
+    def forward(
         self,
-        hidden_states: TensorValue,
-        encoder_hidden_states: TensorValue = None,
-        attention_mask: TensorValue | None = None,
-        image_rotary_emb: tuple[TensorValue, TensorValue] | None = None,
-    ) -> TensorValue:
+        hidden_states: Tensor,
+        encoder_hidden_states: Tensor | None = None,
+        attention_mask: Tensor | None = None,
+        image_rotary_emb: tuple[Tensor, Tensor] | None = None,
+    ) -> Tensor | tuple[Tensor, Tensor]:
         """Apply Flux attention to hidden states.
 
         Args:
@@ -190,11 +155,11 @@ class FluxAttention(Module):
         value = self.to_v(hidden_states)
 
         seq_len = query.shape[1]
-        query = ops.reshape(
+        query = F.reshape(
             query, (batch_size, seq_len, self.heads, self.head_dim)
         )
-        key = ops.reshape(key, (batch_size, seq_len, self.heads, self.head_dim))
-        value = ops.reshape(
+        key = F.reshape(key, (batch_size, seq_len, self.heads, self.head_dim))
+        value = F.reshape(
             value, (batch_size, seq_len, self.heads, self.head_dim)
         )
 
@@ -218,15 +183,15 @@ class FluxAttention(Module):
             and self.added_kv_proj_dim is not None
         ):
             encoder_seq_len = encoder_query.shape[1]
-            encoder_query = ops.reshape(
+            encoder_query = F.reshape(
                 encoder_query,
                 (batch_size, encoder_seq_len, self.heads, self.head_dim),
             )
-            encoder_key = ops.reshape(
+            encoder_key = F.reshape(
                 encoder_key,
                 (batch_size, encoder_seq_len, self.heads, self.head_dim),
             )
-            encoder_value = ops.reshape(
+            encoder_value = F.reshape(
                 encoder_value,
                 (batch_size, encoder_seq_len, self.heads, self.head_dim),
             )
@@ -234,9 +199,9 @@ class FluxAttention(Module):
             encoder_query = self.norm_added_q(encoder_query)
             encoder_key = self.norm_added_k(encoder_key)
 
-            query = ops.concat([encoder_query, query], axis=1)
-            key = ops.concat([encoder_key, key], axis=1)
-            value = ops.concat([encoder_value, value], axis=1)
+            query = F.concat([encoder_query, query], axis=1)
+            key = F.concat([encoder_key, key], axis=1)
+            value = F.concat([encoder_value, value], axis=1)
 
         if image_rotary_emb is not None:
             query = apply_rotary_emb(query, image_rotary_emb, sequence_dim=1)
@@ -251,7 +216,7 @@ class FluxAttention(Module):
         )
 
         total_seq_len = hidden_states.shape[1]
-        hidden_states = ops.reshape(
+        hidden_states = F.reshape(
             hidden_states,
             (batch_size, total_seq_len, self.heads * self.head_dim),
         )
@@ -274,13 +239,9 @@ class FeedForward(Module):
         dim: int,
         dim_out: int | None = None,
         mult: int = 4,
-        dropout: float = 0.0,
         activation_fn: str = "geglu",
-        final_dropout: bool = False,
         inner_dim: int | None = None,
         bias: bool = True,
-        device: DeviceRef = DeviceRef.CPU(),
-        dtype: DType = DType.bfloat16,
     ):
         """Initialize FeedForward module.
 
@@ -288,13 +249,9 @@ class FeedForward(Module):
             dim: Input dimension.
             dim_out: Optional output dimension. Defaults to dim if None.
             mult: Multiplier for hidden dimension.
-            dropout: Dropout probability.
             activation_fn: Activation function to use ("gelu" or "gelu-approximate").
-            final_dropout: Whether to apply dropout at the end.
             inner_dim: Optional inner dimension. Computed as dim * mult if None.
             bias: Whether to use bias in linear layers.
-            device: Device to place the module on.
-            dtype: Data type for the module.
         """
         super().__init__()
         if inner_dim is None:
@@ -302,37 +259,31 @@ class FeedForward(Module):
         dim_out = dim_out if dim_out is not None else dim
 
         if activation_fn == "gelu":
-            act_fn = GELU(dim, inner_dim, bias=bias, device=device, dtype=dtype)
-        if activation_fn == "gelu-approximate":
+            act_fn = GELU(dim, inner_dim, bias=bias)
+        elif activation_fn == "gelu-approximate":
             act_fn = GELU(
                 dim,
                 inner_dim,
                 approximate="tanh",
                 bias=bias,
-                device=device,
-                dtype=dtype,
             )
         else:
             raise NotImplementedError(
                 f"Activation function {activation_fn} is not implemented"
             )
 
-        self.net = nn.Sequential(
+        self.net = ModuleList(
             [
                 act_fn,
                 Linear(
                     inner_dim,
                     dim_out,
-                    has_bias=bias,
-                    dtype=dtype,
-                    device=device,
+                    bias=bias,
                 ),
             ]
         )
 
-    def __call__(
-        self, hidden_states: TensorValue, *args, **kwargs
-    ) -> TensorValue:
+    def forward(self, hidden_states: Tensor, *args, **kwargs) -> Tensor:
         """Apply feedforward network to hidden states.
 
         Args:
@@ -343,10 +294,12 @@ class FeedForward(Module):
         Returns:
             Output hidden states after feedforward network.
         """
-        return self.net(hidden_states)
+        for layer in self.net:
+            hidden_states = layer(hidden_states)
+        return hidden_states
 
 
-class FluxPosEmbed(nn.Module):
+class FluxPosEmbed(Module):
     """Flux Position Embedding module for 3D rotary position embeddings.
 
     This module computes separate rotary embeddings for each spatial dimension
@@ -371,8 +324,8 @@ class FluxPosEmbed(nn.Module):
         self.axes_dim = list(axes_dim)
 
     def _get_1d_rotary_pos_embed(
-        self, dim: int, pos: TensorValue, device: DeviceRef
-    ) -> tuple[TensorValue, TensorValue]:
+        self, dim: int, pos: Tensor, device: DeviceRef
+    ) -> tuple[Tensor, Tensor]:
         """Compute 1D rotary position embeddings for a single axis.
 
         Args:
@@ -387,57 +340,57 @@ class FluxPosEmbed(nn.Module):
         assert dim % 2 == 0, f"dim must be even, got {dim}"
 
         # Cast position to float32 for computation
-        pos = ops.cast(pos, DType.float32)
+        pos = F.cast(pos, DType.float32)
 
         # Compute frequencies: 1.0 / (theta ** (arange(0, dim, 2) / dim))
         # Shape: [dim/2]
-        arange_vals = ops.range(
+        arange_vals = F.arange(
             0, dim, step=2, dtype=DType.float32, device=device
         )
         exponents = arange_vals / float(dim)
 
         # theta ** exponents
-        theta_tensor = ops.constant(self.theta, DType.float32, device=device)
-        theta_powered = ops.pow(theta_tensor, exponents)
+        theta_tensor = F.constant(self.theta, DType.float32, device=device)
+        theta_powered = F.pow(theta_tensor, exponents)
 
         # 1.0 / theta_powered
         freqs = 1.0 / theta_powered  # Shape: [dim/2]
 
         # Outer product: pos [batch_size] x freqs [dim/2] = [batch_size, dim/2]
-        freqs_outer = ops.outer(pos, freqs)
+        freqs_outer = F.outer(pos, freqs)
 
         # Compute cos and sin
-        freqs_cos_half = ops.cos(freqs_outer)  # [batch_size, dim/2]
-        freqs_sin_half = ops.sin(freqs_outer)  # [batch_size, dim/2]
+        freqs_cos_half = F.cos(freqs_outer)  # [batch_size, dim/2]
+        freqs_sin_half = F.sin(freqs_outer)  # [batch_size, dim/2]
 
         # Repeat interleave to get full dimension
         # repeat_interleave(2, dim=1): [a, b, c] -> [a, a, b, b, c, c]
         # Since repeat_interleave is not supported on GPU, we use reshape + tile
 
         # 1. Unsqueeze: [batch_size, dim/2] -> [batch_size, dim/2, 1]
-        freqs_cos_expanded = ops.unsqueeze(freqs_cos_half, axis=2)
-        freqs_sin_expanded = ops.unsqueeze(freqs_sin_half, axis=2)
+        freqs_cos_expanded = F.unsqueeze(freqs_cos_half, axis=2)
+        freqs_sin_expanded = F.unsqueeze(freqs_sin_half, axis=2)
 
         # 2. Concat to duplicate: [batch_size, dim/2, 1] -> [batch_size, dim/2, 2]
-        freqs_cos_tiled = ops.concat(
+        freqs_cos_tiled = F.concat(
             [freqs_cos_expanded, freqs_cos_expanded], axis=2
         )
-        freqs_sin_tiled = ops.concat(
+        freqs_sin_tiled = F.concat(
             [freqs_sin_expanded, freqs_sin_expanded], axis=2
         )
 
         # 3. Reshape to flatten: [batch_size, dim/2, 2] -> [batch_size, dim]
         flattened_dim = freqs_cos_tiled.shape[1] * freqs_cos_tiled.shape[2]
-        freqs_cos = ops.reshape(
+        freqs_cos = F.reshape(
             freqs_cos_tiled, (freqs_cos_tiled.shape[0], flattened_dim)
         )
-        freqs_sin = ops.reshape(
+        freqs_sin = F.reshape(
             freqs_sin_tiled, (freqs_sin_tiled.shape[0], flattened_dim)
         )
 
         return freqs_cos, freqs_sin
 
-    def __call__(self, ids: TensorValue) -> tuple[TensorValue, TensorValue]:
+    def forward(self, ids: Tensor) -> tuple[Tensor, Tensor]:
         """Forward pass to compute rotary position embeddings.
 
         Args:
@@ -468,7 +421,7 @@ class FluxPosEmbed(nn.Module):
             sin_out.append(sin_embed)
 
         # Concatenate embeddings from all axes along the last dimension
-        freqs_cos = ops.concat(cos_out, axis=-1)  # [batch_size, sum(axes_dim)]
-        freqs_sin = ops.concat(sin_out, axis=-1)  # [batch_size, sum(axes_dim)]
+        freqs_cos = F.concat(cos_out, axis=-1)  # [batch_size, sum(axes_dim)]
+        freqs_sin = F.concat(sin_out, axis=-1)  # [batch_size, sum(axes_dim)]
 
         return freqs_cos, freqs_sin

--- a/max/python/max/pipelines/architectures/flux1/layers/normalizations.py
+++ b/max/python/max/pipelines/architectures/flux1/layers/normalizations.py
@@ -1,0 +1,254 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+
+import max.nn as nn
+from max.dtype import DType
+from max.graph import DeviceRef, TensorValue, ops
+from max.nn import LayerNorm, RMSNorm
+
+
+class AdaLayerNormZeroSingle(nn.Module):
+    def __init__(
+        self,
+        embedding_dim: int,
+        norm_type: str = "layer_norm",
+        bias: bool = True,
+        device: DeviceRef = DeviceRef.CPU(),
+        dtype: DType = DType.bfloat16,
+    ):
+        """Initialize adaptive layer normalization zero single module.
+
+        Args:
+            embedding_dim: Size of each embedding vector.
+            norm_type: Type of normalization to use ("layer_norm").
+            bias: Whether to use bias in linear projection.
+            device: Device to place the module on.
+            dtype: Data type for the module.
+        """
+        super().__init__()
+        self.linear = nn.Linear(
+            embedding_dim,
+            3 * embedding_dim,
+            has_bias=bias,
+            device=device,
+            dtype=dtype,
+        )
+        if norm_type == "layer_norm":
+            self.norm = LayerNorm(
+                embedding_dim,
+                use_bias=False,
+                eps=1e-6,
+                devices=[device],
+                dtype=dtype,
+                keep_dtype=True,
+                elementwise_affine=False,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported `norm_type` ({norm_type}) provided. Supported ones are: 'layer_norm', 'fp32_layer_norm'."
+            )
+
+    def __call__(
+        self, x: TensorValue, emb: TensorValue | None = None
+    ) -> TensorValue:
+        """Apply adaptive layer normalization.
+
+        Args:
+            x: Input tensor.
+            emb: Optional embedding tensor for conditioning.
+
+        Returns:
+            Tuple of normalized tensor and gate values.
+        """
+        emb = self.linear(ops.silu(emb))
+        shift_msa, scale_msa, gate_msa = ops.chunk(emb, 3, axis=1)
+        x = self.norm(x) * (1 + scale_msa[:, None]) + shift_msa[:, None]
+        return x, gate_msa
+
+
+class AdaLayerNormZero(nn.Module):
+    r"""Norm layer adaptive layer norm zero (adaLN-Zero).
+
+    Parameters:
+        embedding_dim (`int`): The size of each embedding vector.
+        num_embeddings (`int`): The size of the embeddings dictionary.
+    """
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        num_embeddings: int | None = None,
+        norm_type: str = "layer_norm",
+        bias: bool = True,
+        device: DeviceRef = DeviceRef.CPU(),
+        dtype: DType = DType.bfloat16,
+    ):
+        """Initialize adaptive layer normalization zero module.
+
+        Args:
+            embedding_dim: Size of each embedding vector.
+            num_embeddings: Optional size of the embeddings dictionary.
+            norm_type: Type of normalization to use ("layer_norm" or "fp32_layer_norm").
+            bias: Whether to use bias in linear projection.
+            device: Device to place the module on.
+            dtype: Data type for the module.
+        """
+        super().__init__()
+        if num_embeddings is not None:
+            # self.emb = CombinedTimestepLabelEmbeddings(num_embeddings, embedding_dim)
+            raise NotImplementedError(
+                "CombinedTimestepLabelEmbeddings is not implemented"
+            )
+        else:
+            self.emb = None
+
+        self.linear = nn.Linear(
+            embedding_dim,
+            6 * embedding_dim,
+            has_bias=bias,
+            dtype=dtype,
+            device=device,
+        )
+        if norm_type == "layer_norm":
+            self.norm = LayerNorm(
+                embedding_dim,
+                use_bias=False,
+                eps=1e-6,
+                devices=[device],
+                dtype=dtype,
+                keep_dtype=True,
+                elementwise_affine=False,
+            )
+        elif norm_type == "fp32_layer_norm":
+            # self.norm = FP32LayerNorm(embedding_dim, elementwise_affine=False, bias=False)
+            raise NotImplementedError("FP32LayerNorm is not implemented")
+        else:
+            raise ValueError(
+                f"Unsupported `norm_type` ({norm_type}) provided. Supported ones are: 'layer_norm', 'fp32_layer_norm'."
+            )
+
+    def __call__(
+        self,
+        x: TensorValue,
+        timestep: TensorValue | None = None,
+        class_labels: TensorValue | None = None,
+        hidden_dtype: DType | None = None,
+        emb: TensorValue | None = None,
+    ) -> tuple[TensorValue, TensorValue, TensorValue, TensorValue, TensorValue]:
+        """Apply adaptive layer normalization with gate values for attention and MLP.
+
+        Args:
+            x: Input tensor.
+            timestep: Optional timestep tensor.
+            class_labels: Optional class label tensor.
+            hidden_dtype: Optional hidden data type.
+            emb: Optional embedding tensor for conditioning.
+
+        Returns:
+            Tuple of (normalized tensor, gate_msa, shift_mlp, scale_mlp, gate_mlp).
+        """
+        if self.emb is not None:
+            emb = self.emb(timestep, class_labels, hidden_dtype=hidden_dtype)
+        emb = self.linear(ops.silu(emb))
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = (
+            ops.chunk(emb, 6, axis=1)
+        )
+        x = self.norm(x)
+        x = x * (1 + scale_msa[:, None]) + shift_msa[:, None]
+        return x, gate_msa, shift_mlp, scale_mlp, gate_mlp
+
+
+class AdaLayerNormContinuous(nn.Module):
+    r"""Adaptive normalization layer with a norm layer (layer_norm or rms_norm).
+
+    Args:
+        embedding_dim (`int`): Embedding dimension to use during projection.
+        conditioning_embedding_dim (`int`): Dimension of the input condition.
+        elementwise_affine (`bool`, defaults to `True`):
+            Boolean flag to denote if affine transformation should be applied.
+        eps (`float`, defaults to 1e-5): Epsilon factor.
+        bias (`bias`, defaults to `True`): Boolean flag to denote if bias should be use.
+        norm_type (`str`, defaults to `"layer_norm"`):
+            Normalization layer to use. Values supported: "layer_norm", "rms_norm".
+    """
+
+    def __init__(
+        self,
+        embedding_dim: int,
+        conditioning_embedding_dim: int,
+        # NOTE: It is a bit weird that the norm layer can be configured to have scale and shift parameters
+        # because the output is immediately scaled and shifted by the projected conditioning embeddings.
+        # Note that AdaLayerNorm does not let the norm layer have scale and shift parameters.
+        # However, this is how it was implemented in the original code, and it's rather likely you should
+        # set `elementwise_affine` to False.
+        # elementwise_affine=True,
+        eps: float = 1e-5,
+        bias: bool = True,
+        norm_type: str = "layer_norm",
+        device: DeviceRef = DeviceRef.CPU(),
+        dtype: DType = DType.bfloat16,
+    ):
+        """Initialize adaptive layer normalization continuous module.
+
+        Args:
+            embedding_dim: Embedding dimension to use during projection.
+            conditioning_embedding_dim: Dimension of the input condition.
+            eps: Epsilon factor for normalization.
+            bias: Whether to use bias in linear projection.
+            norm_type: Type of normalization to use ("layer_norm" or "rms_norm").
+            device: Device to place the module on.
+            dtype: Data type for the module.
+        """
+        super().__init__()
+        self.silu = ops.silu
+        self.linear = nn.Linear(
+            conditioning_embedding_dim,
+            embedding_dim * 2,
+            has_bias=bias,
+            device=device,
+            dtype=dtype,
+        )
+        if norm_type == "layer_norm":
+            self.norm = LayerNorm(
+                embedding_dim,
+                eps=eps,
+                devices=[device],
+                dtype=dtype,
+                keep_dtype=True,
+                elementwise_affine=False,
+            )
+        elif norm_type == "rms_norm":
+            self.norm = RMSNorm(
+                embedding_dim, eps=eps, device=device, dtype=dtype
+            )
+        else:
+            raise ValueError(f"unknown norm_type {norm_type}")
+
+    def __call__(
+        self, x: TensorValue, conditioning_embedding: TensorValue
+    ) -> TensorValue:
+        """Apply adaptive layer normalization with conditioning.
+
+        Args:
+            x: Input tensor.
+            conditioning_embedding: Conditioning embedding tensor.
+
+        Returns:
+            Normalized and conditioned tensor.
+        """
+        # convert back to the original dtype in case `conditioning_embedding`` is upcasted to float32 (needed for hunyuanDiT)
+        emb = self.linear(self.silu(conditioning_embedding).cast(x.dtype))
+        scale, shift = ops.chunk(emb, 2, axis=1)
+        x = self.norm(x) * (1 + scale)[:, None, :] + shift[:, None, :]
+        return x

--- a/max/python/max/pipelines/architectures/flux1/model.py
+++ b/max/python/max/pipelines/architectures/flux1/model.py
@@ -1,0 +1,77 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from max.driver import CPU, Accelerator, Device
+from max.engine import InferenceSession, Model
+from max.graph import Graph
+from max.graph.weights import Weights
+from max.pipelines.lib import SupportedEncoding
+from max.pipelines.lib.interfaces.max_model import MaxModel
+
+from .flux1 import FluxTransformer2DModel
+from .model_config import FluxConfig
+from .weight_adapters import convert_safetensor_state_dict
+
+
+class Flux1Model(MaxModel):
+    config_name = FluxConfig.config_name
+
+    def __init__(
+        self,
+        config: dict,
+        encoding: SupportedEncoding,
+        devices: list[Device],
+        weights: Weights,
+    ) -> None:
+        super().__init__(
+            config,
+            encoding,
+            devices,
+            weights,
+        )
+        self.config = FluxConfig.generate(
+            config,
+            encoding,
+            devices,
+        )
+        self.load_model()
+
+    def load_model(self) -> Model:
+        flux = FluxTransformer2DModel(self.config)
+
+        if self.config.device.is_cpu():
+            session = InferenceSession([CPU()])
+        else:
+            session = InferenceSession([Accelerator()])
+        state_dict = {key: value.data() for key, value in self.weights.items()}
+        state_dict = convert_safetensor_state_dict(state_dict)
+        flux.load_state_dict(state_dict)
+        with Graph(
+            "flux_transformer_2d_model", input_types=flux.input_types()
+        ) as graph:
+            outputs = flux(
+                *graph.inputs,
+                joint_attention_kwargs={},
+                controlnet_block_samples=None,
+                controlnet_single_block_samples=None,
+                return_dict=False,
+                controlnet_blocks_repeat=False,
+            )
+            graph.output(*outputs)
+            compiled_graph = graph
+        self.session = session.load(
+            compiled_graph, weights_registry=flux.state_dict()
+        )
+
+    def __call__(self, *args, **kwargs):
+        return self.session.execute(*args, **kwargs)

--- a/max/python/max/pipelines/architectures/flux1/model_config.py
+++ b/max/python/max/pipelines/architectures/flux1/model_config.py
@@ -1,0 +1,59 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from typing import ClassVar
+
+from max.driver import Device
+from max.dtype import DType
+from max.graph import DeviceRef
+from max.pipelines.lib import MAXModelConfigBase, SupportedEncoding
+from pydantic import Field
+
+
+class FluxConfigBase(MAXModelConfigBase):
+    patch_size: int = 1
+    in_channels: int = 64
+    out_channels: int | None = None
+    num_layers: int = 19
+    num_single_layers: int = 38
+    attention_head_dim: int = 128
+    num_attention_heads: int = 24
+    joint_attention_dim: int = 4096
+    pooled_projection_dim: int = 768
+    guidance_embeds: bool = False
+    axes_dims_rope: tuple[int, int, int] = (16, 56, 56)
+    dtype: DType = DType.bfloat16
+    device: DeviceRef = Field(default_factory=DeviceRef.GPU)
+
+
+class FluxConfig(FluxConfigBase):
+    config_name: ClassVar[str] = "config.json"
+
+    @staticmethod
+    def generate(
+        config_dict: dict,
+        encoding: SupportedEncoding,
+        devices: list[Device],
+    ) -> FluxConfigBase:
+        init_dict = {
+            key: value
+            for key, value in config_dict.items()
+            if key in FluxConfigBase.__annotations__
+        }
+        init_dict.update(
+            {
+                "dtype": encoding.dtype,
+                "device": DeviceRef.from_device(devices[0]),
+            }
+        )
+        return FluxConfigBase(**init_dict)

--- a/max/python/max/pipelines/architectures/flux1/weight_adapters.py
+++ b/max/python/max/pipelines/architectures/flux1/weight_adapters.py
@@ -11,5 +11,20 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from . import dtype_extension
-from .dtype import DType
+import re
+
+from max.graph.weights import WeightData
+
+
+def convert_safetensor_state_dict(
+    state_dict: dict[str, WeightData],
+) -> dict[str, WeightData]:
+    keys = list(state_dict.keys())
+    for key in keys:
+        # Remap net.2 to net.1: Diffusers uses [GELU, Dropout, Linear], while MAX uses [GELU, Linear].
+        if re.match(
+            r"transformer_blocks\.\d+\.(ff|ff_context)\.net\.2\.(weight|bias)",
+            key,
+        ):
+            state_dict[key.replace("net.2.", "net.1.")] = state_dict.pop(key)
+    return state_dict

--- a/max/python/max/pipelines/architectures/t5/__init__.py
+++ b/max/python/max/pipelines/architectures/t5/__init__.py
@@ -11,5 +11,4 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from . import dtype_extension
-from .dtype import DType
+from .model import T5Model

--- a/max/python/max/pipelines/architectures/t5/model.py
+++ b/max/python/max/pipelines/architectures/t5/model.py
@@ -1,0 +1,64 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from max.driver import CPU, Accelerator, Device
+from max.engine import InferenceSession, Model
+from max.graph import Graph
+from max.graph.weights import Weights
+from max.pipelines.lib import SupportedEncoding
+from max.pipelines.lib.interfaces.max_model import MaxModel
+
+from .model_config import T5Config
+from .t5 import T5EncoderModel
+
+
+class T5Model(MaxModel):
+    config_name = T5Config.config_name
+
+    def __init__(
+        self,
+        config: dict,
+        encoding: SupportedEncoding,
+        devices: list[Device],
+        weights: Weights,
+    ) -> None:
+        super().__init__(config, encoding, devices, weights)
+        self.config = T5Config.generate(
+            config,
+            encoding,
+            devices,
+        )
+        self.load_model()
+
+    def load_model(self) -> Model:
+        t5 = T5EncoderModel(self.config)
+
+        if self.config.device.is_cpu():
+            session = InferenceSession([CPU()])
+        else:
+            session = InferenceSession([Accelerator()])
+        state_dict = {key: value.data() for key, value in self.weights.items()}
+        t5.load_state_dict(state_dict)
+        with Graph("t5_encoder_model", input_types=t5.input_types()) as graph:
+            outputs = t5(
+                input_ids=graph.inputs[0],
+                attention_mask=None,
+            )
+            graph.output(outputs)
+            compiled_graph = graph
+        self.session = session.load(
+            compiled_graph, weights_registry=t5.state_dict()
+        )
+
+    def __call__(self, *args, **kwargs):
+        return self.session.execute(*args, **kwargs)

--- a/max/python/max/pipelines/architectures/t5/model_config.py
+++ b/max/python/max/pipelines/architectures/t5/model_config.py
@@ -1,0 +1,69 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from typing import ClassVar
+
+from max.driver import Device
+from max.dtype import DType
+from max.graph import DeviceRef
+from max.pipelines.lib import MAXModelConfigBase, SupportedEncoding
+from pydantic import Field
+
+
+class T5ConfigBase(MAXModelConfigBase):
+    vocab_size: int = 32128
+    d_model: int = 512
+    d_kv: int = 64
+    d_ff: int = 2048
+    num_layers: int = 6
+    num_decoder_layers: int | None = None
+    num_heads: int = 8
+    relative_attention_num_buckets: int = 32
+    relative_attention_max_distance: int = 128
+    dropout_rate: float = 0.1
+    layer_norm_epsilon: float = 1e-6
+    initializer_factor: float = 1.0
+    feed_forward_proj: str = "relu"
+    dense_act_fn: str | None = Field(default=None, exclude=True)
+    is_gated_act: bool = Field(default=False, exclude=True)
+    is_decoder: bool = Field(default=False, exclude=True)
+    is_encoder_decoder: bool = True
+    use_cache: bool = True
+    pad_token_id: int = 0
+    eos_token_id: int = 1
+    classifier_dropout: float = 0.0
+    device: DeviceRef = Field(default_factory=DeviceRef.GPU)
+    dtype: DType = DType.bfloat16
+
+
+class T5Config(T5ConfigBase):
+    config_name: ClassVar[str] = "config.json"
+
+    @staticmethod
+    def generate(
+        config_dict: dict,
+        encoding: SupportedEncoding,
+        devices: list[Device],
+    ) -> T5ConfigBase:
+        init_dict = {
+            key: value
+            for key, value in config_dict.items()
+            if key in T5ConfigBase.__annotations__
+        }
+        init_dict.update(
+            {
+                "dtype": encoding.dtype,
+                "device": DeviceRef.from_device(devices[0]),
+            }
+        )
+        return T5ConfigBase(**init_dict)

--- a/max/python/max/pipelines/architectures/t5/t5.py
+++ b/max/python/max/pipelines/architectures/t5/t5.py
@@ -1,0 +1,823 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import math
+
+import max.nn as nn
+from max.dtype import DType
+from max.graph import DeviceRef, TensorType, TensorValue, Weight, ops
+from max.nn import Module
+
+from .model_config import T5Config
+
+
+class T5LayerNorm(Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        device: DeviceRef = DeviceRef.CPU(),
+        dtype: DType = DType.float32,
+    ):
+        """Construct a layernorm module in the T5 style. No bias and no subtraction of mean.
+
+        Args:
+            hidden_size: Hidden size.
+            eps: Epsilon.
+            device: Device to place the module on.
+            dtype: Data type for the module.
+        """
+        super().__init__()
+        self.weight = Weight("weight", dtype, (hidden_size,), device=device)
+        self.variance_epsilon = eps
+        self.dtype = dtype
+
+    def __call__(self, hidden_states: TensorValue) -> TensorValue:
+        """Process hidden states through the T5 layer norm.
+
+        Args:
+            hidden_states: Input tensor of shape (batch_size, seq_length, hidden_size).
+
+        Returns:
+            TensorValue: Output tensor of shape (batch_size, seq_length, hidden_size).
+        """
+        # T5 uses a layer_norm which only scales and doesn't shift, which is also known as Root Mean
+        # Square Layer Normalization https://huggingface.co/papers/1910.07467 thus variance is calculated
+        # w/o mean and there is no bias. Additionally we want to make sure that the accumulation for
+        # half-precision inputs is done in fp32
+
+        hidden_states_f32 = ops.cast(hidden_states, DType.float32)
+        variance = ops.mean(ops.pow(hidden_states_f32, 2), axis=-1)
+        hidden_states = hidden_states * ops.rsqrt(
+            variance + self.variance_epsilon
+        )
+
+        # convert into half-precision if necessary
+        if self.dtype in [DType.float16, DType.bfloat16]:
+            hidden_states = ops.cast(hidden_states, self.dtype)
+
+        return self.weight * hidden_states
+
+
+class T5DenseActDense(Module):
+    def __init__(
+        self,
+        config: T5Config,
+    ):
+        """Construct a dense-activation-dense module.
+
+        Args:
+            config: T5 configuration for feed-forward dimensions and dtype.
+        """
+        super().__init__()
+        self.wi = nn.Linear(
+            config.d_model,
+            config.d_ff,
+            has_bias=False,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.wo = nn.Linear(
+            config.d_ff,
+            config.d_model,
+            has_bias=False,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.act_fn = (
+            lambda x: 0.5
+            * x
+            * (
+                1.0
+                + ops.tanh(
+                    math.sqrt(2.0 / math.pi) * (x + 0.044715 * ops.pow(x, 3.0))
+                )
+            )
+        )
+
+    def __call__(self, hidden_states: TensorValue) -> TensorValue:
+        """Process hidden states through the dense-activation-dense block.
+
+        Args:
+            hidden_states: Input tensor of shape (batch_size, seq_length, hidden_size).
+
+        Returns:
+            TensorValue: Output tensor of shape (batch_size, seq_length, hidden_size).
+        """
+        hidden_states = self.wi(hidden_states)
+        hidden_states = self.act_fn(hidden_states)
+        hidden_states = self.wo(hidden_states)
+        return hidden_states
+
+
+class T5DenseGatedActDense(Module):
+    def __init__(
+        self,
+        config: T5Config,
+    ):
+        """Construct a dense-gated-activation-dense module.
+
+        Args:
+            config: T5 configuration for feed-forward dimensions and dtype.
+        """
+        super().__init__()
+        self.wi_0 = nn.Linear(
+            config.d_model,
+            config.d_ff,
+            has_bias=False,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.wi_1 = nn.Linear(
+            config.d_model,
+            config.d_ff,
+            has_bias=False,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.wo = nn.Linear(
+            config.d_ff,
+            config.d_model,
+            has_bias=False,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.act_fn = (
+            lambda x: 0.5
+            * x
+            * (
+                1.0
+                + ops.tanh(
+                    math.sqrt(2.0 / math.pi) * (x + 0.044715 * ops.pow(x, 3.0))
+                )
+            )
+        )
+
+    def __call__(self, hidden_states: TensorValue) -> TensorValue:
+        """Process hidden states through the dense-gated-activation-dense block.
+
+        Args:
+            hidden_states: Input tensor of shape (batch_size, seq_length, hidden_size).
+
+        Returns:
+            TensorValue: Output tensor of shape (batch_size, seq_length, hidden_size).
+        """
+        hidden_gelu = self.act_fn(self.wi_0(hidden_states))
+        hidden_linear = self.wi_1(hidden_states)
+        hidden_states = hidden_gelu * hidden_linear
+        hidden_states = self.wo(hidden_states)
+        return hidden_states
+
+
+class T5LayerFF(Module):
+    def __init__(
+        self,
+        config: T5Config,
+    ):
+        """Construct a feed-forward layer.
+
+        Args:
+            config: T5 configuration for gating, dimensions, and dtype.
+        """
+        super().__init__()
+        if config.is_gated_act:
+            self.DenseReluDense = T5DenseGatedActDense(config)
+        else:
+            self.DenseReluDense = T5DenseActDense(config)
+
+        self.layer_norm = T5LayerNorm(
+            config.d_model,
+            eps=config.layer_norm_epsilon,
+            device=config.device,
+            dtype=config.dtype,
+        )
+
+    def __call__(self, hidden_states: TensorValue) -> TensorValue:
+        """Process hidden states through the feed-forward layer.
+
+        Args:
+            hidden_states: Input tensor of shape (batch_size, seq_length, hidden_size).
+
+        Returns:
+            TensorValue: Output tensor of shape (batch_size, seq_length, hidden_size).
+        """
+        forwarded_states = self.layer_norm(hidden_states)
+        forwarded_states = self.DenseReluDense(forwarded_states)
+        hidden_states = hidden_states + forwarded_states
+        return hidden_states
+
+
+class T5Attention(Module):
+    def __init__(
+        self,
+        config: T5Config,
+        has_relative_attention_bias: bool = False,
+        layer_idx: int | None = None,
+    ):
+        """Construct an attention layer.
+
+        Args:
+            config: T5 configuration.
+            has_relative_attention_bias: Whether to use relative attention bias.
+            layer_idx: Index of the layer.
+        """
+        super().__init__()
+        self.is_decoder = config.is_decoder
+        self.has_relative_attention_bias = has_relative_attention_bias
+        self.relative_attention_num_buckets = (
+            config.relative_attention_num_buckets
+        )
+        self.relative_attention_max_distance = (
+            config.relative_attention_max_distance
+        )
+        self.d_model = config.d_model
+        self.key_value_proj_dim = config.d_kv
+        self.n_heads = config.num_heads
+        self.dropout = config.dropout_rate
+        self.inner_dim = self.n_heads * self.key_value_proj_dim
+        self.device = config.device
+        self.dtype = config.dtype
+
+        self.q = nn.Linear(
+            self.d_model,
+            self.inner_dim,
+            has_bias=False,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.k = nn.Linear(
+            self.d_model,
+            self.inner_dim,
+            has_bias=False,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.v = nn.Linear(
+            self.d_model,
+            self.inner_dim,
+            has_bias=False,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.o = nn.Linear(
+            self.inner_dim,
+            self.d_model,
+            has_bias=False,
+            device=config.device,
+            dtype=config.dtype,
+        )
+
+        if self.has_relative_attention_bias:
+            self.relative_attention_bias = nn.Embedding(
+                self.relative_attention_num_buckets,
+                self.n_heads,
+                device=config.device,
+                dtype=config.dtype,
+            )
+
+    def _relative_position_bucket(
+        self,
+        relative_position: TensorValue,
+        bidirectional: bool = True,
+        num_buckets: int = 32,
+        max_distance: int = 128,
+    ) -> TensorValue:
+        """Compute relative position bucket.
+
+        Adapted from Mesh Tensorflow:
+        https://github.com/tensorflow/mesh/blob/0cb87fe07da627bf0b7e60475d59f95ed6b5be3d/mesh_tensorflow/transformer/transformer_layers.py#L593
+
+        Args:
+            relative_position: Tensor with relative positions.
+            bidirectional: Whether the attention is bidirectional.
+            num_buckets: Number of buckets.
+            max_distance: Maximum distance for relative positions.
+
+        Returns:
+            TensorValue: Relative position buckets.
+        """
+        relative_buckets = ops.constant(0, DType.int32, self.device)
+
+        if bidirectional:
+            num_buckets = num_buckets // 2
+            is_positive = ops.greater(relative_position, 0)
+            relative_buckets = relative_buckets + (
+                is_positive.cast(DType.int32) * num_buckets
+            )
+            relative_position = ops.abs(relative_position)
+        else:
+            relative_position = -ops.min(relative_position, 0)
+
+        max_exact = num_buckets // 2
+        is_small = ops.greater(max_exact, relative_position)
+
+        scale = (num_buckets - max_exact) / math.log(max_distance / max_exact)
+        rel_pos_float = relative_position.cast(DType.float32)
+        val_log = ops.log(rel_pos_float / float(max_exact))
+        relative_position_if_large = max_exact + (val_log * scale).cast(
+            DType.int32
+        )
+        relative_position_if_large = ops.min(
+            relative_position_if_large, num_buckets - 1
+        )
+        return relative_buckets + ops.where(
+            is_small, relative_position, relative_position_if_large
+        )
+
+    def compute_bias(self, query_length: int, key_length: int) -> TensorValue:
+        """Compute relative attention bias.
+
+        Args:
+            query_length: Length of the query sequence.
+            key_length: Length of the key sequence.
+
+        Returns:
+            TensorValue: Relative attention bias tensor.
+        """
+        context_position = ops.range(
+            0, query_length, step=1, dtype=DType.int32, device=self.device
+        )
+        context_position = ops.unsqueeze(context_position, 1)
+
+        memory_position = ops.range(
+            0, key_length, step=1, dtype=DType.int32, device=self.device
+        )
+        memory_position = ops.unsqueeze(memory_position, 0)
+
+        relative_position = memory_position - context_position
+        relative_position_bucket = self._relative_position_bucket(
+            relative_position,
+            bidirectional=(not self.is_decoder),
+            num_buckets=self.relative_attention_num_buckets,
+            max_distance=self.relative_attention_max_distance,
+        )
+        values = self.relative_attention_bias(relative_position_bucket)
+        values = ops.permute(values, (2, 0, 1))
+        values = ops.unsqueeze(values, 0)
+        return values
+
+    def __call__(
+        self,
+        hidden_states: TensorValue,
+        mask: TensorValue | None = None,
+        key_value_states: TensorValue | None = None,
+        position_bias: TensorValue | None = None,
+        past_key_values: TensorValue | None = None,
+        layer_head_mask: TensorValue | None = None,
+        query_length: int | None = None,
+        use_cache: bool = False,
+        output_attentions: bool = False,
+        cache_position: TensorValue | None = None,
+    ) -> tuple[TensorValue, TensorValue]:
+        """Process hidden states through the attention layer.
+
+        Args:
+            hidden_states: Input tensor of shape (batch_size, seq_length, hidden_size).
+            mask: Attention mask.
+            key_value_states: Key-value states for cross-attention.
+            position_bias: Position bias tensor.
+            past_key_values: Past key values for caching (not implemented).
+            layer_head_mask: Mask for attention heads.
+            query_length: Length of the query sequence.
+            use_cache: Whether to use cache (not implemented).
+            output_attentions: Whether to return attention weights.
+            cache_position: Cache position.
+
+        Returns:
+            Tuple[TensorValue, TensorValue]: Output tensor and position bias.
+        """
+        batch_size, seq_length = hidden_states.shape[:2]
+
+        # if key_value_states are provided this layer is used as a cross-attention layer for the decoder
+        is_cross_attention = key_value_states is not None
+        if is_cross_attention:
+            raise NotImplementedError(
+                "T5 CrossAttention is not implemented yet."
+            )
+        if past_key_values is not None:
+            raise NotImplementedError(
+                "T5 auto regressive model is not implemented yet."
+            )
+
+        query = self.q(hidden_states)
+        key = self.k(hidden_states)
+        value = self.v(hidden_states)
+
+        # Reshape to (batch, seq, heads, head_dim)
+        query = ops.reshape(
+            query,
+            (batch_size, seq_length, self.n_heads, self.key_value_proj_dim),
+        )
+        key = ops.reshape(
+            key, (batch_size, seq_length, self.n_heads, self.key_value_proj_dim)
+        )
+        value = ops.reshape(
+            value,
+            (batch_size, seq_length, self.n_heads, self.key_value_proj_dim),
+        )
+
+        # Transpose to (batch, heads, seq, head_dim)
+        query = ops.permute(query, (0, 2, 1, 3))
+        key = ops.permute(key, (0, 2, 1, 3))
+        value = ops.permute(value, (0, 2, 1, 3))
+
+        scores = ops.matmul(query, ops.permute(key, (0, 1, 3, 2)))
+
+        if position_bias is None and self.has_relative_attention_bias:
+            position_bias = self.compute_bias(seq_length, seq_length)
+
+        if position_bias is not None:
+            scores = scores + position_bias
+
+        if mask is not None:
+            scores = scores + mask
+
+        attn_weights = ops.softmax(ops.cast(scores, DType.float32), axis=-1)
+        attn_weights = ops.cast(attn_weights, self.dtype)
+
+        if layer_head_mask is not None:
+            attn_weights = attn_weights * layer_head_mask
+
+        attn_output = ops.matmul(attn_weights, value)
+        attn_output = ops.permute(attn_output, (0, 2, 1, 3))
+        attn_output = ops.reshape(
+            attn_output, (batch_size, seq_length, self.inner_dim)
+        )
+        attn_output = self.o(attn_output)
+
+        outputs = (attn_output, position_bias)
+        if output_attentions:
+            outputs = outputs + (attn_weights,)
+        return outputs
+
+
+class T5LayerSelfAttention(Module):
+    def __init__(
+        self,
+        config: T5Config,
+        has_relative_attention_bias: bool = False,
+        layer_idx: int | None = None,
+    ):
+        """Construct a self-attention layer.
+
+        Args:
+            config: T5 configuration.
+            has_relative_attention_bias: Whether to use relative attention bias.
+            layer_idx: Index of the layer.
+        """
+        super().__init__()
+        self.SelfAttention = T5Attention(
+            config,
+            has_relative_attention_bias=has_relative_attention_bias,
+            layer_idx=layer_idx,
+        )
+        self.layer_norm = T5LayerNorm(
+            config.d_model,
+            eps=config.layer_norm_epsilon,
+            device=config.device,
+            dtype=config.dtype,
+        )
+
+    def __call__(
+        self,
+        hidden_states: TensorValue,
+        attention_mask: TensorValue | None = None,
+        position_bias: TensorValue | None = None,
+        layer_head_mask: TensorValue | None = None,
+        past_key_values: TensorValue | None = None,
+        use_cache: bool = False,
+        output_attentions: bool = False,
+        cache_position: TensorValue | None = None,
+    ) -> TensorValue:
+        """Process hidden states through the self-attention layer.
+
+        Args:
+            hidden_states: Input tensor of shape (batch_size, seq_length, hidden_size).
+            attention_mask: Attention mask.
+            position_bias: Position bias tensor.
+            layer_head_mask: Mask for attention heads.
+            past_key_values: Past key values for caching (not implemented).
+            use_cache: Whether to use cache (not implemented).
+            output_attentions: Whether to return attention weights.
+            cache_position: Cache position.
+
+        Returns:
+            TensorValue: Output tensor of shape (batch_size, seq_length, hidden_size).
+        """
+        normed_hidden_states = self.layer_norm(hidden_states)
+        attention_output = self.SelfAttention(
+            normed_hidden_states,
+            mask=attention_mask,
+            position_bias=position_bias,
+            layer_head_mask=layer_head_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            cache_position=cache_position,
+        )
+        hidden_states = hidden_states + attention_output[0]
+        outputs = (hidden_states,) + attention_output[1:]
+        return outputs
+
+
+class T5Block(Module):
+    def __init__(
+        self,
+        config: T5Config,
+        has_relative_attention_bias: bool = False,
+        layer_idx: int | None = None,
+    ):
+        """Construct a T5 block.
+
+        Args:
+            config: T5 configuration.
+            has_relative_attention_bias: Whether to use relative attention bias.
+            layer_idx: Index of the layer.
+        """
+        super().__init__()
+        layers = list()
+        self.is_decoder = config.is_decoder
+        if self.is_decoder:
+            raise NotImplementedError(
+                "T5 LayerCrossAttention is not implemented yet."
+            )
+
+        layers.append(
+            T5LayerSelfAttention(
+                config,
+                has_relative_attention_bias=has_relative_attention_bias,
+                layer_idx=layer_idx,
+            )
+        )
+        layers.append(T5LayerFF(config))
+        self.layer = nn.LayerList(layers)
+
+    def __call__(
+        self,
+        hidden_states: TensorValue,
+        attention_mask: TensorValue | None = None,
+        position_bias: TensorValue | None = None,
+        encoder_hidden_states: TensorValue | None = None,
+        encoder_attention_mask: TensorValue | None = None,
+        encoder_decoder_position_bias: TensorValue | None = None,
+        cross_attn_layer_head_mask: TensorValue | None = None,
+        layer_head_mask: TensorValue | None = None,
+        past_key_values: TensorValue | None = None,
+        use_cache: bool = False,
+        output_attentions: bool = False,
+        cache_position: TensorValue | None = None,
+    ) -> tuple[TensorValue, TensorValue]:
+        """Process hidden states through the T5 block.
+
+        Args:
+            hidden_states: Input tensor of shape (batch_size, seq_length, hidden_size).
+            attention_mask: Attention mask.
+            position_bias: Position bias tensor.
+            encoder_hidden_states: Encoder hidden states (not implemented).
+            encoder_attention_mask: Encoder attention mask (not implemented).
+            encoder_decoder_position_bias: Encoder-decoder position bias (not implemented).
+            cross_attn_layer_head_mask: Cross attention layer head mask (not implemented).
+            layer_head_mask: Mask for attention heads.
+            past_key_values: Past key values for caching (not implemented).
+            use_cache: Whether to use cache (not implemented).
+            output_attentions: Whether to return attention weights.
+            cache_position: Cache position.
+
+        Returns:
+            Tuple[TensorValue, TensorValue]: Output tensor and position bias.
+        """
+        self_attention_outputs = self.layer[0](
+            hidden_states,
+            attention_mask=attention_mask,
+            position_bias=position_bias,
+            layer_head_mask=layer_head_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            cache_position=cache_position,
+        )
+        hidden_states = self_attention_outputs[0]
+        attention_outputs = self_attention_outputs[1:]
+
+        if hidden_states.dtype == DType.float16:
+            clamp_value = DType.finfo(hidden_states.dtype).max - 1000
+            hidden_states = nn.clamp(
+                hidden_states, min=-clamp_value, max=clamp_value
+            )
+
+        do_cross_attention = (
+            self.is_decoder and encoder_hidden_states is not None
+        )
+        if do_cross_attention:
+            raise NotImplementedError(
+                "T5 CrossAttention is not implemented yet."
+            )
+
+        hidden_states = self.layer[-1](hidden_states)
+        if hidden_states.dtype == DType.float16:
+            clamp_value = DType.finfo(hidden_states.dtype).max - 1000
+            hidden_states = nn.clamp(
+                hidden_states, min=-clamp_value, max=clamp_value
+            )
+
+        outputs = (hidden_states,)
+        return outputs + attention_outputs
+
+
+class T5Stack(Module):
+    def __init__(
+        self,
+        config: T5Config,
+        embed_tokens: nn.Embedding | None = None,
+    ):
+        """Construct a T5 stack.
+
+        Args:
+            config: T5 configuration.
+            embed_tokens: Embedding module.
+        """
+        super().__init__()
+        self.config = config
+        self.embed_tokens = embed_tokens
+        self.is_decoder = config.is_decoder
+
+        self.block = nn.LayerList(
+            [
+                T5Block(
+                    config,
+                    has_relative_attention_bias=bool(i == 0),
+                    layer_idx=i,
+                )
+                for i in range(config.num_layers)
+            ]
+        )
+        self.final_layer_norm = T5LayerNorm(
+            config.d_model,
+            eps=config.layer_norm_epsilon,
+            device=config.device,
+            dtype=config.dtype,
+        )
+        self.dropout = config.dropout_rate
+        self.device = config.device
+        self.dtype = config.dtype
+
+    def __call__(
+        self,
+        input_ids: TensorValue | None = None,
+        attention_mask: TensorValue | None = None,
+        inputs_embeds: TensorValue | None = None,
+        encoder_hidden_states: TensorValue | None = None,
+        encoder_attention_mask: TensorValue | None = None,
+        encoder_decoder_position_bias: TensorValue | None = None,
+        cross_attn_layer_head_mask: TensorValue | None = None,
+        layer_head_mask: TensorValue | None = None,
+        past_key_values: TensorValue | None = None,
+        use_cache: bool = False,
+        output_attentions: bool = False,
+        cache_position: TensorValue | None = None,
+    ) -> TensorValue:
+        """Process input through the T5 stack.
+
+        Args:
+            input_ids: Input IDs tensor of shape (batch_size, seq_length).
+            attention_mask: Attention mask tensor of shape (batch_size, seq_length).
+            inputs_embeds: Input embeddings tensor of shape (batch_size, seq_length, hidden_size).
+            encoder_hidden_states: Encoder hidden states (not implemented).
+            encoder_attention_mask: Encoder attention mask (not implemented).
+            encoder_decoder_position_bias: Encoder-decoder position bias (not implemented).
+            cross_attn_layer_head_mask: Cross attention layer head mask (not implemented).
+            layer_head_mask: Mask for attention heads.
+            past_key_values: Past key values for caching (not implemented).
+            use_cache: Whether to use cache (not implemented).
+            output_attentions: Whether to return attention weights.
+            cache_position: Cache position.
+
+        Returns:
+            TensorValue: Output tensor of shape (batch_size, seq_length, hidden_size).
+        """
+        use_cache = (
+            use_cache if use_cache is not None else self.config.use_cache
+        )
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+        if input_ids is not None:
+            inputs_embeds = self.embed_tokens(input_ids)
+        elif inputs_embeds is None:
+            raise ValueError(
+                "You have to specify either input_ids or inputs_embeds"
+            )
+
+        if self.is_decoder or use_cache:
+            raise NotImplementedError("T5 decoder is not implemented yet.")
+
+        hidden_states = inputs_embeds
+
+        if attention_mask is not None:
+            causal_mask = (
+                1.0 - ops.cast(attention_mask, hidden_states.dtype)
+            ) * DType.finfo(hidden_states.dtype).min
+            causal_mask = ops.unsqueeze(causal_mask, 1)
+            causal_mask = ops.unsqueeze(causal_mask, 1)
+        else:
+            causal_mask = None
+        encoder_extended_attention_mask = None
+
+        position_bias = None
+        for layer_module in self.block:
+            layer_outputs = layer_module(
+                hidden_states,
+                attention_mask=causal_mask,
+                position_bias=position_bias,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=encoder_extended_attention_mask,
+                encoder_decoder_position_bias=encoder_decoder_position_bias,
+                cross_attn_layer_head_mask=cross_attn_layer_head_mask,
+                layer_head_mask=layer_head_mask,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                cache_position=cache_position,
+            )
+            hidden_states = layer_outputs[0]
+            position_bias = layer_outputs[1]
+            if output_attentions:
+                all_attentions = all_attentions + (layer_outputs[2],)
+
+        hidden_states = self.final_layer_norm(hidden_states)
+        return hidden_states
+
+
+class T5EncoderModel(Module):
+    def __init__(
+        self,
+        config: T5Config,
+    ):
+        """Construct a T5 encoder model.
+
+        Args:
+            config: T5 configuration for vocabulary size, layer counts, and
+                device/dtype settings.
+        """
+        super().__init__()
+        act_info = config.feed_forward_proj.split("-")
+        config.dense_act_fn = act_info[-1]
+        config.is_gated_act = act_info[0] == "gated"
+
+        self.shared = nn.Embedding(
+            config.vocab_size,
+            config.d_model,
+            device=config.device,
+            dtype=config.dtype,
+        )
+
+        encoder_config = config
+        encoder_config.is_decoder = False
+        encoder_config.use_cache = False
+        encoder_config.is_encoder_decoder = False
+
+        self.encoder = T5Stack(encoder_config, self.shared)
+        self.device = config.device
+        self.dtype = config.dtype
+
+    def input_types(self) -> tuple[TensorType, ...]:
+        """Get input types for the model.
+
+        Returns:
+            tuple[TensorType, ...]: Input types.
+        """
+        return (
+            TensorType(
+                DType.int64,
+                shape=["batch_size", "sequence_length"],
+                device=self.device,
+            ),
+        )
+
+    def __call__(
+        self,
+        input_ids: TensorValue | None = None,
+        attention_mask: TensorValue | None = None,
+    ) -> TensorValue:
+        """Process input through the T5 encoder model.
+
+        Args:
+            input_ids: Input IDs tensor of shape (batch_size, seq_length).
+            attention_mask: Attention mask tensor of shape (batch_size, seq_length).
+
+        Returns:
+            TensorValue: Output tensor of shape (batch_size, seq_length, hidden_size).
+        """
+        return self.encoder(input_ids=input_ids, attention_mask=attention_mask)

--- a/max/python/max/pipelines/lib/interfaces/max_model.py
+++ b/max/python/max/pipelines/lib/interfaces/max_model.py
@@ -1,0 +1,45 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+from max.driver import Device
+from max.engine import Model
+from max.graph.weights import Weights
+
+if TYPE_CHECKING:
+    from max.pipelines.lib import SupportedEncoding
+
+
+class MaxModel(ABC):
+    """Base interface for pipeline models with weight-backed execution."""
+
+    def __init__(
+        self,
+        config: dict,
+        encoding: SupportedEncoding,
+        devices: list[Device],
+        weights: Weights,
+    ) -> None:
+        self.config = config
+        self.encoding = encoding
+        self.devices = devices
+        self.weights = weights
+
+    @abstractmethod
+    def load_model(self) -> Model:
+        """Load and return a runtime model instance."""
+        ...


### PR DESCRIPTION
This PR adds the model-side building blocks needed to run the Flux1 diffusion pipeline in MAX. It introduces MAX implementations for the FLUX transformer, its text encoders (CLIP + T5), and the VAE decoder.

- Adds `flux1_arch` as a `SupportedArchitecture` for `PipelineTask.IMAGE_GENERATION`, pointing to `FluxPipeline`. This serves as a registration point for all the components. So, other remaining components don't have `arch.py` defined.
- Adds model implementations for each component: clip, t5, flux, and autoencoder.
- Adds BaseModel interface for diffusion sub-models, to restrict the initialization flow. `PipelineModel` is implemented specifically for LLM models, so this simpler base class is introduced.

**NOTES**
Currently, V3 migration is implemented partially in this PR. I'll make updates to V3 migration as soon as possible.