### PR TITLE
[docs] Wrong folder path in the tutorial of official mojo documentation.

### DIFF
--- a/mojo/docs/manual/install.mdx
+++ b/mojo/docs/manual/install.mdx
@@ -322,7 +322,7 @@ language and its standard library. Here's how to download and use them.
    automation:
 
     ```sh
-    cd modular/examples/mojo/life
+    cd modular/mojo/examples/life
     ```
 
 3. Use `pixi` to download and install the dependencies for the project and to


### PR DESCRIPTION
- **Summary.** Fix wrong folder path in the documentation
- **Description.** Previously, in the Try some examples, it said `cd modular/examples/mojo/life` which does not exist. I changed to the correct location.
- **Environment details.**
  - Documentation fix
- **Severity/frequency.** Less severe.