### PR TITLE
[docs] fix: broken README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ Highlights include:
 
 - Mojo standard library: [/mojo/stdlib](mojo/stdlib)
 - MAX GPU and CPU kernels: [/max/kernels](max/kernels) (Mojo kernels)
-- MAX inference server: [/max/python/max/serve](max/python/max/serve) (OpenAI-compatible endpoint)
-- MAX model pipelines: [/max/python/max/pipelines](max/python/max/pipelines) (Python-based graphs)
+- MAX inference server: [/max/python/max/serve](max/python/max/serve)
+  (OpenAI-compatible endpoint)
+- MAX model pipelines: [/max/python/max/pipelines](max/python/max/pipelines)
+  (Python-based graphs)
 - Code examples: [/max/examples](max/examples) + [/mojo/examples](mojo/examples)
 
 This repo has two major branches:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Highlights include:
 
 - Mojo standard library: [/mojo/stdlib](mojo/stdlib)
 - MAX GPU and CPU kernels: [/max/kernels](max/kernels) (Mojo kernels)
-- MAX inference server: [/max/serve](max/serve) (OpenAI-compatible endpoint)
+- MAX inference server: [/max/serve](max/python/max/serve) (OpenAI-compatible endpoint)
 - MAX model pipelines: [/max/pipelines](max/pipelines) (Python-based graphs)
 - Code example: [/examples](examples)
 

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Highlights include:
 
 - Mojo standard library: [/mojo/stdlib](mojo/stdlib)
 - MAX GPU and CPU kernels: [/max/kernels](max/kernels) (Mojo kernels)
-- MAX inference server: [/max/serve](max/python/max/serve) (OpenAI-compatible endpoint)
-- MAX model pipelines: [/max/pipelines](max/python/max/pipelines) (Python-based graphs)
+- MAX inference server: [/max/python/max/serve](max/python/max/serve) (OpenAI-compatible endpoint)
+- MAX model pipelines: [/max/python/max/pipelines](max/python/max/pipelines) (Python-based graphs)
 - Code example: [/examples](examples)
 
 This repo has two major branches:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Highlights include:
 - Mojo standard library: [/mojo/stdlib](mojo/stdlib)
 - MAX GPU and CPU kernels: [/max/kernels](max/kernels) (Mojo kernels)
 - MAX inference server: [/max/serve](max/python/max/serve) (OpenAI-compatible endpoint)
-- MAX model pipelines: [/max/pipelines](max/pipelines) (Python-based graphs)
+- MAX model pipelines: [/max/pipelines](max/python/max/pipelines) (Python-based graphs)
 - Code example: [/examples](examples)
 
 This repo has two major branches:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Highlights include:
 - MAX GPU and CPU kernels: [/max/kernels](max/kernels) (Mojo kernels)
 - MAX inference server: [/max/python/max/serve](max/python/max/serve) (OpenAI-compatible endpoint)
 - MAX model pipelines: [/max/python/max/pipelines](max/python/max/pipelines) (Python-based graphs)
-- Code example: [/examples](examples)
+- Code examples: [/max/examples](max/examples) + [/mojo/examples](mojo/examples)
 
 This repo has two major branches:
 


### PR DESCRIPTION
There are a few links in the README (and I believe other files that seem to be broken).

[This commit](https://github.com/modular/modular/commit/7284a57d7f6ea3a310d79d38c073d5037fc0417e0) seemed to move around a fair amount of `.md` files, but I believe it also broke a few links along the way, so this continues the cleanup effort.

closes https://github.com/modular/modular/issues/5795
