### PR TITLE
[stdlib] Optimize the String repr implementation

### DIFF
--- a/mojo/stdlib/std/collections/string/codepoint.mojo
+++ b/mojo/stdlib/std/collections/string/codepoint.mojo
@@ -378,15 +378,32 @@ struct Codepoint(
         comptime ord_z = UInt32(ord("z"))
         return ord_a <= self.to_u32() <= ord_z
 
+    @staticmethod
+    @always_inline
+    fn _is_ascii_printable(codepoint: Scalar) -> Bool:
+        """Determines whether the given character is a printable character.
+
+        Args:
+            codepoint: The codepoint to check.
+
+        Returns:
+            True if the character is a printable character, otherwise False.
+        """
+        __comptime_assert (
+            codepoint.dtype.is_integral()
+        ), "only integral codepoints exist"
+        comptime ` ` = type_of(codepoint)(ord(" "))
+        comptime `~` = type_of(codepoint)(ord("~"))
+        return ` ` <= codepoint <= `~`
+
+    @always_inline
     fn is_ascii_printable(self) -> Bool:
         """Determines whether the given character is a printable character.
 
         Returns:
             True if the character is a printable character, otherwise False.
         """
-        comptime ord_space = UInt32(ord(" "))
-        comptime ord_tilde = UInt32(ord("~"))
-        return ord_space <= self.to_u32() <= ord_tilde
+        return Self._is_ascii_printable(self.to_u32())
 
     @always_inline
     fn is_python_space(self) -> Bool:

--- a/mojo/stdlib/std/collections/string/string.mojo
+++ b/mojo/stdlib/std/collections/string/string.mojo
@@ -1217,10 +1217,15 @@ struct String(
         writer.write_string(self)
 
     fn write_repr_to(self, mut writer: Some[Writer]):
-        """Write the string representation of the string".
+        """Formats this string slice to the provided `Writer`.
 
         Args:
-            writer: The value to write to.
+            writer: The object to write to.
+
+        Notes:
+            Mojo's repr always prints single quotes (`'`) at the start and end
+            of the repr. Any single quote inside a string should be escaped
+            (`\\'`).
         """
         self.as_string_slice().write_repr_to(writer)
 

--- a/mojo/stdlib/std/collections/string/string_slice.mojo
+++ b/mojo/stdlib/std/collections/string/string_slice.mojo
@@ -46,6 +46,7 @@ from memory import (
     pack_bits,
 )
 from python import ConvertibleToPython, Python, PythonObject
+from format._utils import _write_hex
 
 comptime StaticString = StringSlice[StaticConstantOrigin]
 """An immutable static string slice.
@@ -844,31 +845,40 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
 
         Args:
             writer: The object to write to.
+
+        Notes:
+            Mojo's repr always prints single quotes (`'`) at the start and end
+            of the repr. Any single quote inside a string should be escaped
+            (`\\'`).
         """
+        comptime `\\` = Byte(ord("\\"))
+        comptime `'` = Byte(ord("'"))
+        comptime `\t` = Byte(ord("\t"))
+        comptime `\n` = Byte(ord("\n"))
+        comptime `\r` = Byte(ord("\r"))
+
+        # Always start and end with a single quote
         writer.write_string("'")
 
         for s in self.codepoint_slices():
-            if s == "\\":
+            var b0 = s.unsafe_ptr()[0]  # safe
+            # Python escapes backslashes but they are ASCII printable
+            if b0 == `\\`:
                 writer.write_string(r"\\")
-            elif s == "\t":
-                writer.write_string(r"\t")
-            elif s == "\n":
-                writer.write_string(r"\n")
-            elif s == "\r":
-                writer.write_string(r"\r")
-            elif s == "'":
+            elif b0 == `'`:  # escape single quotes
                 writer.write_string(r"\'")
-            else:
-                var codepoint = Codepoint.ord(s)
-                var u32 = codepoint.to_u32()
-                if codepoint.is_ascii_printable():
-                    writer.write_string(s)
-                elif u32 < 0x10:
-                    _write_int[radix=16](writer, u32, prefix=r"\x0")
-                elif u32 < 0x20 or u32 == 0x7F:
-                    _write_int[radix=16](writer, u32, prefix=r"\x")
-                else:  # multi-byte character
-                    writer.write_string(s)
+            elif Codepoint._is_ascii_printable(b0):
+                writer.write_string(s)
+            elif b0 == `\t`:
+                writer.write_string(r"\t")
+            elif b0 == `\n`:
+                writer.write_string(r"\n")
+            elif b0 == `\r`:
+                writer.write_string(r"\r")
+            elif b0 < 0b1000_0000:  # non-printable ASCII
+                _write_hex[amnt_hex_bytes=2](writer, b0)
+            else:  # multi-byte character
+                writer.write_string(s)
 
         writer.write_string("'")
 

--- a/mojo/stdlib/std/format/__init__.mojo
+++ b/mojo/stdlib/std/format/__init__.mojo
@@ -241,6 +241,11 @@ trait Writable:
         fn write_repr_to(self, mut writer: Some[Writer]):
             writer.write("Point: x=", self.x, ", y=", self.y)
         ```
+
+        Notes:
+            Mojo's repr always prints single quotes (`'`) at the start and end
+            of the repr. Any single quote inside a string should be escaped
+            (`\\'`).
         """
 
         @always_inline

--- a/mojo/stdlib/std/format/_utils.mojo
+++ b/mojo/stdlib/std/format/_utils.mojo
@@ -194,10 +194,9 @@ comptime _hex_table = SIMD[DType.uint8, 16](
 
 @always_inline
 fn _hex_digits_to_hex_chars(
-    ptr: UnsafePointer[mut=True, Byte], decimal: Scalar
-):
-    """Write a fixed width hexadecimal value into an uninitialized pointer
-    location, assumed to be large enough for the value to be written.
+    decimal: Scalar,
+) -> SIMD[DType.uint8, size_of[decimal.dtype]() * 2]:
+    """Return a fixed width hexadecimal value according to the scalar dtype.
 
     Examples:
 
@@ -209,28 +208,25 @@ fn _hex_digits_to_hex_chars(
     items: List[Byte] = [0, 0, 0, 0, 0, 0, 0, 0, 0]
     comptime S = StringSlice[origin_of(items)]
     ptr = items.unsafe_ptr()
-    _hex_digits_to_hex_chars(ptr, UInt32(ord("🔥")))
+    ptr.store(_hex_digits_to_hex_chars(UInt32(ord("🔥"))))
     assert_equal("0001f525", S(ptr=ptr, length=8))
-    memset_zero(ptr, len(items))
-    _hex_digits_to_hex_chars(ptr, UInt16(ord("你")))
+    ptr.store(_hex_digits_to_hex_chars(UInt16(ord("你"))))
     assert_equal("4f60", S(ptr=ptr, length=4))
-    memset_zero(ptr, len(items))
-    _hex_digits_to_hex_chars(ptr, UInt8(ord("Ö")))
+    ptr.store(_hex_digits_to_hex_chars(UInt8(ord("Ö"))))
     assert_equal("d6", S(ptr=ptr, length=2))
     ```
     """
     comptime size = size_of[decimal.dtype]()
     var bytes = bitcast[DType.uint8, size](byte_swap(decimal))
     var nibbles = (bytes >> 4).interleave(bytes & 0xF)
-    ptr.store(_hex_table._dynamic_shuffle(nibbles))
+    return _hex_table._dynamic_shuffle(nibbles)
 
 
 @always_inline
 fn _write_hex[
-    amnt_hex_bytes: Int
-](p: UnsafePointer[mut=True, Byte], decimal: Int):
-    """Write a python compliant hexadecimal value into an uninitialized pointer
-    location, assumed to be large enough for the value to be written.
+    *, amnt_hex_bytes: Int
+](mut writer: Some[Writer], decimal: Scalar):
+    """Write a python compliant hexadecimal value into a writer.
 
     Examples:
 
@@ -239,17 +235,16 @@ fn _write_hex[
     %# from testing import assert_equal
     %# from utils import StringSlice
     %# from io.write import _write_hex
-    items: List[Byte] = [0, 0, 0, 0, 0, 0, 0, 0, 0]
-    comptime S = StringSlice[origin_of(items)]
-    ptr = items.unsafe_ptr()
-    _write_hex[8](ptr, ord("🔥"))
-    assert_equal(r"\\U0001f525", S(ptr=ptr, length=10))
-    memset_zero(ptr, len(items))
-    _write_hex[4](ptr, ord("你"))
-    assert_equal(r"\\u4f60", S(ptr=ptr, length=6))
-    memset_zero(ptr, len(items))
-    _write_hex[2](ptr, ord("Ö"))
-    assert_equal(r"\\xd6", S(ptr=ptr, length=4))
+    var s = String()
+    _write_hex[amnt_hex_bytes=8](s, Scalar[DType.int](ord("🔥")))
+    %# # Note we are escaping here in docstrings only to enable correct rendering
+    assert_equal(r"\\U0001f525", s)
+    s = ""
+    _write_hex[amnt_hex_bytes=4](s, Scalar[DType.int](ord("你")))
+    assert_equal(r"\\u4f60", s)
+    s = ""
+    _write_hex[amnt_hex_bytes=2](s, Scalar[DType.int](ord("Ö")))
+    assert_equal(r"\\xd6", s)
     ```
     """
 
@@ -260,15 +255,25 @@ fn _write_hex[
     comptime `u` = Byte(ord("u"))
     comptime `U` = Byte(ord("U"))
 
-    p.init_pointee_move(`\\`)
-
     @parameter
     if amnt_hex_bytes == 2:
-        (p + 1).init_pointee_move(`x`)
-        _hex_digits_to_hex_chars(p + 2, UInt8(decimal))
+        var chars = _hex_digits_to_hex_chars(UInt8(decimal))
+        var buf = InlineArray[Byte, 4](uninitialized=True)
+        buf[0] = `\\`
+        buf[1] = `x`
+        (buf.unsafe_ptr() + 2).store(chars)
+        writer.write_string(StringSlice(unsafe_from_utf8=Span(buf)))
     elif amnt_hex_bytes == 4:
-        (p + 1).init_pointee_move(`u`)
-        _hex_digits_to_hex_chars(p + 2, UInt16(decimal))
+        var chars = _hex_digits_to_hex_chars(UInt16(decimal))
+        var buf = InlineArray[Byte, 6](uninitialized=True)
+        buf[0] = `\\`
+        buf[1] = `u`
+        (buf.unsafe_ptr() + 2).store(chars)
+        writer.write_string(StringSlice(unsafe_from_utf8=Span(buf)))
     else:
-        (p + 1).init_pointee_move(`U`)
-        _hex_digits_to_hex_chars(p + 2, UInt32(decimal))
+        var chars = _hex_digits_to_hex_chars(UInt32(decimal))
+        var buf = InlineArray[Byte, 10](uninitialized=True)
+        buf[0] = `\\`
+        buf[1] = `U`
+        (buf.unsafe_ptr() + 2).store(chars)
+        writer.write_string(StringSlice(unsafe_from_utf8=Span(buf)))

--- a/mojo/stdlib/test/io/test_write.mojo
+++ b/mojo/stdlib/test/io/test_write.mojo
@@ -88,40 +88,38 @@ def test_hex_digits_to_hex_chars():
     items: List[Byte] = [0, 0, 0, 0, 0, 0, 0, 0, 0]
     comptime S = StringSlice[origin_of(items)]
     ptr = items.unsafe_ptr()
-    _hex_digits_to_hex_chars(ptr, UInt32(ord("🔥")))
-    assert_equal("0001f525", String(S(ptr=ptr, length=8)))
+    ptr.store(_hex_digits_to_hex_chars(UInt32(ord("🔥"))))
+    assert_equal("0001f525", S(ptr=ptr, length=8))
     memset_zero(ptr, len(items))
-    _hex_digits_to_hex_chars(ptr, UInt16(ord("你")))
-    assert_equal("4f60", String(S(ptr=ptr, length=4)))
+    ptr.store(_hex_digits_to_hex_chars(UInt16(ord("你"))))
+    assert_equal("4f60", S(ptr=ptr, length=4))
     memset_zero(ptr, len(items))
-    _hex_digits_to_hex_chars(ptr, UInt8(ord("Ö")))
-    assert_equal("d6", String(S(ptr=ptr, length=2)))
-    _hex_digits_to_hex_chars(ptr, UInt8(0))
-    assert_equal("00", String(S(ptr=ptr, length=2)))
-    _hex_digits_to_hex_chars(ptr, UInt16(0))
-    assert_equal("0000", String(S(ptr=ptr, length=4)))
-    _hex_digits_to_hex_chars(ptr, UInt32(0))
-    assert_equal("00000000", String(S(ptr=ptr, length=8)))
-    _hex_digits_to_hex_chars(ptr, ~UInt8(0))
-    assert_equal("ff", String(S(ptr=ptr, length=2)))
-    _hex_digits_to_hex_chars(ptr, ~UInt16(0))
-    assert_equal("ffff", String(S(ptr=ptr, length=4)))
-    _hex_digits_to_hex_chars(ptr, ~UInt32(0))
-    assert_equal("ffffffff", String(S(ptr=ptr, length=8)))
+    ptr.store(_hex_digits_to_hex_chars(UInt8(ord("Ö"))))
+    assert_equal("d6", S(ptr=ptr, length=2))
+    ptr.store(_hex_digits_to_hex_chars(UInt8(0)))
+    assert_equal("00", S(ptr=ptr, length=2))
+    ptr.store(_hex_digits_to_hex_chars(UInt16(0)))
+    assert_equal("0000", S(ptr=ptr, length=4))
+    ptr.store(_hex_digits_to_hex_chars(UInt32(0)))
+    assert_equal("00000000", S(ptr=ptr, length=8))
+    ptr.store(_hex_digits_to_hex_chars(~UInt8(0)))
+    assert_equal("ff", S(ptr=ptr, length=2))
+    ptr.store(_hex_digits_to_hex_chars(~UInt16(0)))
+    assert_equal("ffff", S(ptr=ptr, length=4))
+    ptr.store(_hex_digits_to_hex_chars(~UInt32(0)))
+    assert_equal("ffffffff", S(ptr=ptr, length=8))
 
 
 def test_write_hex():
-    items: List[Byte] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    comptime S = StringSlice[origin_of(items)]
-    ptr = items.unsafe_ptr()
-    _write_hex[8](ptr, ord("🔥"))
-    assert_equal(r"\U0001f525", String(S(ptr=ptr, length=10)))
-    memset_zero(ptr, len(items))
-    _write_hex[4](ptr, ord("你"))
-    assert_equal(r"\u4f60", String(S(ptr=ptr, length=6)))
-    memset_zero(ptr, len(items))
-    _write_hex[2](ptr, ord("Ö"))
-    assert_equal(r"\xd6", String(S(ptr=ptr, length=4)))
+    var s = String()
+    _write_hex[amnt_hex_bytes=8](s, Scalar[DType.int](ord("🔥")))
+    assert_equal(r"\U0001f525", s)
+    s = ""
+    _write_hex[amnt_hex_bytes=4](s, Scalar[DType.int](ord("你")))
+    assert_equal(r"\u4f60", s)
+    s = ""
+    _write_hex[amnt_hex_bytes=2](s, Scalar[DType.int](ord("Ö")))
+    assert_equal(r"\xd6", s)
 
 
 def test_closure_non_capturing():


### PR DESCRIPTION
Optimize the String repr implementation. I also updated the `_write_hex` util to use the safer writer API. And I also added a static method version of the `is_ascii_printable` `Codepoint` method given parsing a codepoint from UTF-8 is not free; all to then just do a byte comparison.

## Benchmark results

CPU: Intel® Core™ i7-7700HQ

|  | old value (ms) | new value (ms) | markdown perc | magnitude|
|-- | -- | -- | -- | --|
|bench_string_repr[10] | 12.53 | 9.26 | 0.26 | 1.35|
|bench_string_repr[30] | 14.05 | 10.67 | 0.24 | 1.32|
|bench_string_repr[50] | 14.64 | 9.92 | 0.32 | 1.48|
|bench_string_repr[100] | 14.20 | 9.22 | 0.35 | 1.54|
|bench_string_repr[1000] | 12.48 | 8.21 | 0.34 | 1.52|
|bench_string_repr[10000] | 11.97 | 7.84 | 0.35 | 1.53|
|bench_string_repr[100000] | 11.89 | 7.73 | 0.35 | 1.54|
|bench_string_repr[1000000] | 11.88 | 7.65 | 0.36 | 1.55|

