### PR TITLE
[Kernels] migrate-nn-modules-to-UnsafePointer

### DIFF
--- a/max/kernels/src/nn/attention/gpu/amd/attention.mojo
+++ b/max/kernels/src/nn/attention/gpu/amd/attention.mojo
@@ -14,9 +14,7 @@
 from collections import OptionalReg
 from math import ceildiv, recip
 from math.constants import log2e
-from memory import LegacyUnsafePointer
 
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys import size_of, simd_width_of
 from sys.info import _cdna_4_or_newer
 from sys.intrinsics import _type_is_eq
@@ -427,7 +425,7 @@ struct Attention[
     var smem_manager: Self.SharedMemoryManagerType
 
     var q_buffer: Self.QRegisterBufferType
-    var output_ptr: UnsafePointer[Scalar[Self.output_type],]
+    var output_ptr: UnsafePointer[Scalar[Self.output_type], MutAnyOrigin]
 
     var batch_idx: Int
 
@@ -672,8 +670,8 @@ struct Attention[
     fn __init__(
         out self,
         attention_config: Self.attention_config_t,
-        output_ptr: UnsafePointer[Scalar[Self.output_type],],
-        q: UnsafePointer[Scalar[Self.q_type]],
+        output_ptr: UnsafePointer[Scalar[Self.output_type], MutAnyOrigin],
+        q: UnsafePointer[Scalar[Self.q_type], MutAnyOrigin],
         k: Self.k_t,
         v: Self.v_t,
         mask: Self.mask_t,
@@ -846,8 +844,12 @@ struct Attention[
     fn store_partition_info(
         self,
         num_partitions: Int,
-        exp_sum_ptr: UnsafePointer[Scalar[get_accum_type[Self.q_type]()]],
-        qk_max_ptr: UnsafePointer[Scalar[get_accum_type[Self.q_type]()]],
+        exp_sum_ptr: UnsafePointer[
+            Scalar[get_accum_type[Self.q_type]()], MutAnyOrigin
+        ],
+        qk_max_ptr: UnsafePointer[
+            Scalar[get_accum_type[Self.q_type]()], MutAnyOrigin
+        ],
     ):
         @parameter
         if not Self.token_gen:

--- a/max/kernels/src/nn/attention/gpu/amd/buffers.mojo
+++ b/max/kernels/src/nn/attention/gpu/amd/buffers.mojo
@@ -302,7 +302,6 @@ struct KVBufferImpl[
             Scalar[Self.dtype],
             MutAnyOrigin,
             address_space = AddressSpace.SHARED,
-            ...,
         ],
     ):
         # __comptime_assert
@@ -566,7 +565,6 @@ struct VBufferTransposeLoads[
             Scalar[Self.dtype],
             MutAnyOrigin,
             address_space = AddressSpace.SHARED,
-            ...,
         ],
     ):
         __comptime_assert Self.depth in (
@@ -975,7 +973,6 @@ struct PRegisterBuffer[
             Scalar[Self.dtype],
             MutAnyOrigin,
             address_space = AddressSpace.SHARED,
-            ...,
         ],
     ):
         self.reg_tile = Self.RegisterTileType_.stack_allocation()

--- a/max/kernels/src/nn/attention/gpu/amd/buffers.mojo
+++ b/max/kernels/src/nn/attention/gpu/amd/buffers.mojo
@@ -13,9 +13,6 @@
 
 from collections import OptionalReg
 from math import ceildiv, recip
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys import simd_width_of
 from sys.intrinsics import readfirstlane
 
@@ -303,6 +300,7 @@ struct KVBufferImpl[
         num_b_rows: OptionalReg[Int],
         shared_ptr: UnsafePointer[
             Scalar[Self.dtype],
+            MutAnyOrigin,
             address_space = AddressSpace.SHARED,
             ...,
         ],
@@ -566,6 +564,7 @@ struct VBufferTransposeLoads[
         global_tile: Self.GlobalTensorType,
         shared_ptr: UnsafePointer[
             Scalar[Self.dtype],
+            MutAnyOrigin,
             address_space = AddressSpace.SHARED,
             ...,
         ],
@@ -973,7 +972,10 @@ struct PRegisterBuffer[
     fn __init__(
         out self,
         shared_ptr: UnsafePointer[
-            Scalar[Self.dtype], address_space = AddressSpace.SHARED, ...
+            Scalar[Self.dtype],
+            MutAnyOrigin,
+            address_space = AddressSpace.SHARED,
+            ...,
         ],
     ):
         self.reg_tile = Self.RegisterTileType_.stack_allocation()

--- a/max/kernels/src/nn/attention/gpu/amd/mha_gfx942.mojo
+++ b/max/kernels/src/nn/attention/gpu/amd/mha_gfx942.mojo
@@ -12,9 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 
 from collections import OptionalReg
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys.info import _cdna_4_or_newer
 from sys import env_get_bool
 
@@ -228,8 +225,12 @@ __extension Attention:
     @always_inline
     fn mha_decoding(
         mut self,
-        exp_sum_ptr: UnsafePointer[Scalar[get_accum_type[Self.q_type]()]],
-        qk_max_ptr: UnsafePointer[Scalar[get_accum_type[Self.q_type]()]],
+        exp_sum_ptr: UnsafePointer[
+            Scalar[get_accum_type[Self.q_type]()], MutAnyOrigin
+        ],
+        qk_max_ptr: UnsafePointer[
+            Scalar[get_accum_type[Self.q_type]()], MutAnyOrigin
+        ],
         num_partitions: Int,
     ):
         __comptime_assert Self.BK == 32, "BK must be 32"

--- a/max/kernels/src/nn/attention/gpu/amd/mla.mojo
+++ b/max/kernels/src/nn/attention/gpu/amd/mla.mojo
@@ -12,9 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 
 from collections import OptionalReg
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys import simd_width_of
 
 from gpu import barrier, block_idx, lane_id
@@ -261,8 +258,12 @@ __extension Attention:
     @always_inline
     fn mla_decoding(
         mut self,
-        exp_sum_ptr: UnsafePointer[Scalar[get_accum_type[Self.q_type]()]],
-        qk_max_ptr: UnsafePointer[Scalar[get_accum_type[Self.q_type]()]],
+        exp_sum_ptr: UnsafePointer[
+            Scalar[get_accum_type[Self.q_type]()], MutAnyOrigin
+        ],
+        qk_max_ptr: UnsafePointer[
+            Scalar[get_accum_type[Self.q_type]()], MutAnyOrigin
+        ],
         num_partitions: Int,
     ):
         self.mha_decoding(exp_sum_ptr, qk_max_ptr, num_partitions)

--- a/max/kernels/src/nn/flash_attention.mojo
+++ b/max/kernels/src/nn/flash_attention.mojo
@@ -1003,7 +1003,7 @@ fn _flash_attention[
         coords: IndexList[rank],
     ) -> UnsafePointer[Scalar[dtype], ImmutAnyOrigin]:
         var idx = q._offset(coords)
-        return rebind[UnsafePointer[Scalar[dtype], ImmutAnyOrigin]](q.ptr + idx)
+        return (q.ptr + idx).as_unsafe_pointer()
 
     @always_inline
     @parameter
@@ -1011,9 +1011,7 @@ fn _flash_attention[
         coords: IndexList[rank],
     ) -> UnsafePointer[Scalar[dtype], MutAnyOrigin]:
         var idx = output._offset(coords)
-        return rebind[UnsafePointer[Scalar[dtype], MutAnyOrigin]](
-            output.ptr + idx
-        )
+        return (output.ptr + idx).as_unsafe_pointer()
 
     @always_inline
     @parameter
@@ -1290,7 +1288,7 @@ fn _flash_attention_kv_cache[
         coords: IndexList[4],
     ) -> UnsafePointer[Scalar[dtype], ImmutAnyOrigin]:
         var idx = q._offset(coords)
-        return rebind[UnsafePointer[Scalar[dtype], ImmutAnyOrigin]](q.ptr + idx)
+        return (q.ptr + idx).as_unsafe_pointer()
 
     @always_inline
     @parameter
@@ -1298,9 +1296,7 @@ fn _flash_attention_kv_cache[
         coords: IndexList[4],
     ) -> UnsafePointer[Scalar[dtype], MutAnyOrigin]:
         var idx = output._offset(coords)
-        return rebind[UnsafePointer[Scalar[dtype], MutAnyOrigin]](
-            output.ptr + idx
-        )
+        return (output.ptr + idx).as_unsafe_pointer()
 
     @always_inline
     @__copy_capture(max_seq_len)
@@ -1538,9 +1534,7 @@ fn flash_attention_kv_cache[
         var q_start = Int(q_input_row_offsets[bs]) + tok_idx
         var flat_idx = IndexList[3](q_start, idx[2], idx[3])
         var out_idx = q._offset(flat_idx)
-        return rebind[UnsafePointer[Scalar[dtype], ImmutAnyOrigin]](
-            q.ptr + out_idx
-        )
+        return (q.ptr + out_idx).as_unsafe_pointer()
 
     @always_inline
     @parameter
@@ -1552,9 +1546,7 @@ fn flash_attention_kv_cache[
         var q_start = Int(q_input_row_offsets[bs]) + tok_idx
         var flat_idx = IndexList[3](q_start, idx[2], idx[3])
         var out_idx = output._offset(flat_idx)
-        return rebind[UnsafePointer[Scalar[dtype], MutAnyOrigin]](
-            output.ptr + out_idx
-        )
+        return (output.ptr + out_idx).as_unsafe_pointer()
 
     comptime mask_rank = 4
     var num_batches = q_input_row_offsets.dim[0]() - 1

--- a/max/kernels/src/nn/flash_attention.mojo
+++ b/max/kernels/src/nn/flash_attention.mojo
@@ -13,9 +13,7 @@
 
 from collections import OptionalReg
 from math import align_down, align_up, ceildiv, exp
-from memory import LegacyUnsafePointer
 
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from os import abort
 from sys import align_of, simd_width_of
 from sys.info import CompilationTarget
@@ -203,7 +201,7 @@ struct _Matmul[dtype: DType, simd_width: Int]:
         a_ptr: UnsafePointer[Scalar[Self.dtype]],
         a_stride: Int,
         b_ptr: UnsafePointer[Scalar[Self.dtype]],
-        c_ptr: UnsafePointer[Scalar[Self.dtype]],
+        c_ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
         c_stride: Int,
         accumulate: Bool = False,
     ):
@@ -248,6 +246,10 @@ struct _Matmul[dtype: DType, simd_width: Int]:
             am_ptr += tile_m * a_stride
             cm_ptr += tile_m * c_stride
 
+            # TODO(MOCO-2074): Suppress false positive unused var warning.
+            _ = bn_ptr
+            _ = cn_ptr
+
         tile[process_rows, Self._matmul_config.row_sizes](0, M)
         # TODO(MOCO-2074): Suppress false positive unused var warning.
         _ = am_ptr
@@ -257,7 +259,11 @@ struct _Matmul[dtype: DType, simd_width: Int]:
     @staticmethod
     fn _pack_buffer_transposed[
         input_b_fn: Self._input_fn_type, static_k: Int
-    ](packed_ptr: UnsafePointer[Scalar[Self.dtype]], N: Int, dynamic_k: Int):
+    ](
+        packed_ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
+        N: Int,
+        dynamic_k: Int,
+    ):
         var K = static_k if static_k != UNKNOWN_VALUE else dynamic_k
 
         var aligned_n = align_up(N, Self.simd_width)
@@ -324,7 +330,11 @@ struct _Matmul[dtype: DType, simd_width: Int]:
     @staticmethod
     fn _pack_buffer[
         input_b_fn: Self._input_fn_type
-    ](packed_ptr: UnsafePointer[Scalar[Self.dtype]], N: Int, K: Int):
+    ](
+        packed_ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
+        N: Int,
+        K: Int,
+    ):
         var output_ptr = packed_ptr
         var aligned_n = align_up(N, Self.simd_width)
 
@@ -351,7 +361,7 @@ struct _Matmul[dtype: DType, simd_width: Int]:
         N: Int,
         dynamic_k: Int,
         a_ptr: UnsafePointer[Scalar[Self.dtype]],
-        c_ptr: UnsafePointer[Scalar[Self.dtype]],
+        c_ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
     ):
         var K = static_k if static_k != UNKNOWN_VALUE else dynamic_k
         var cn_ptr = c_ptr
@@ -427,7 +437,7 @@ struct _Matmul[dtype: DType, simd_width: Int]:
         N: Int,
         K: Int,
         a_ptr: UnsafePointer[Scalar[Self.dtype]],
-        c_ptr: UnsafePointer[Scalar[Self.dtype]],
+        c_ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
         accumulate: Bool = False,
     ):
         var cn_ptr = c_ptr
@@ -464,8 +474,8 @@ struct _Matmul[dtype: DType, simd_width: Int]:
         K: Int,
         a_ptr: UnsafePointer[Scalar[Self.dtype]],
         a_stride: Int,
-        packed_ptr: UnsafePointer[Scalar[Self.dtype]],
-        c_ptr: UnsafePointer[Scalar[Self.dtype]],
+        packed_ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
+        c_ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
         c_stride: Int,
         accumulate: Bool = False,
     ) raises:
@@ -502,9 +512,9 @@ struct _Matmul[dtype: DType, simd_width: Int]:
                 c_stride,
                 Float32(1.0),
                 Float32(1.0) if accumulate else Float32(0.0),
-                rebind[UnsafePointer[Float32]](c_ptr),
-                rebind[UnsafePointer[Float32]](a_ptr),
-                rebind[UnsafePointer[Float32]](packed_ptr),
+                rebind[UnsafePointer[Float32, MutAnyOrigin]](c_ptr),
+                rebind[UnsafePointer[Float32, ImmutAnyOrigin]](a_ptr),
+                rebind[UnsafePointer[Float32, MutAnyOrigin]](packed_ptr),
             )
 
         Self._matmul_packed(
@@ -562,7 +572,7 @@ struct _FlashAttention[
     rank: Int,
     //,
     input_q_ptr_fn: fn (IndexList[rank]) capturing -> UnsafePointer[
-        Scalar[dtype]
+        Scalar[dtype], ImmutAnyOrigin
     ],
     input_k_fn: fn[simd_width: Int, rank: Int] (
         idx: IndexList[rank]
@@ -577,7 +587,7 @@ struct _FlashAttention[
     ) capturing -> SIMD[dtype, simd_width],
     mask_rank: Int,
     output_ptr_fn: fn (IndexList[rank]) capturing -> UnsafePointer[
-        Scalar[dtype]
+        Scalar[dtype], MutAnyOrigin
     ],
     q_length_fn: fn (batch: Int) capturing -> Int,
     kv_length_fn: fn (batch: Int) capturing -> Int,
@@ -598,10 +608,10 @@ struct _FlashAttention[
             m: Int, n: Int, score_vec: SIMD[Self.dtype, simd_width]
         ) capturing -> SIMD[Self.dtype, simd_width],
     ](
-        qk_block_ptr: UnsafePointer[Scalar[Self.dtype]],
-        o_block_ptr: UnsafePointer[Scalar[Self.dtype]],
-        max_vals: UnsafePointer[Scalar[Self.dtype]],
-        sum_vals: UnsafePointer[Scalar[Self.dtype]],
+        qk_block_ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
+        o_block_ptr: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
+        max_vals: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
+        sum_vals: UnsafePointer[Scalar[Self.dtype], MutAnyOrigin],
         count_m: Int,
         count_n: Int,
         kv_seq_cnt: Int,
@@ -763,9 +773,11 @@ struct _FlashAttention[
             ](uninitialized=True)
             var sum_vals = LayoutTensor[Self.dtype, layout](sum_vals_stack)
 
-            var packed_ptr = UnsafePointer[Scalar[Self.dtype]]()
+            var packed_ptr = UnsafePointer[
+                Scalar[Self.dtype], MutExternalOrigin
+            ]()
             if max_seq_len != 1:
-                packed_ptr = packed_ptr.alloc(
+                packed_ptr = alloc[Scalar[Self.dtype]](
                     packed_size,
                     alignment=align_of[SIMD[Self.dtype, Self.simd_width]](),
                 )
@@ -887,8 +899,12 @@ struct _FlashAttention[
                     Self._online_softmax[mask_2d_fn](
                         qk_block_ptr,
                         o_block_ptr,
-                        max_vals.ptr,
-                        sum_vals.ptr,
+                        rebind[UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]](
+                            max_vals.ptr
+                        ),
+                        rebind[UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]](
+                            sum_vals.ptr
+                        ),
                         count_m,
                         count_n,
                         kv_seq_cnt,
@@ -983,15 +999,21 @@ fn _flash_attention[
 
     @always_inline
     @parameter
-    fn input_q_ptr_fn(coords: IndexList[rank]) -> UnsafePointer[Scalar[dtype]]:
+    fn input_q_ptr_fn(
+        coords: IndexList[rank],
+    ) -> UnsafePointer[Scalar[dtype], ImmutAnyOrigin]:
         var idx = q._offset(coords)
-        return q.ptr + idx
+        return rebind[UnsafePointer[Scalar[dtype], ImmutAnyOrigin]](q.ptr + idx)
 
     @always_inline
     @parameter
-    fn output_ptr_fn(coords: IndexList[rank]) -> UnsafePointer[Scalar[dtype]]:
+    fn output_ptr_fn(
+        coords: IndexList[rank],
+    ) -> UnsafePointer[Scalar[dtype], MutAnyOrigin]:
         var idx = output._offset(coords)
-        return output.ptr + idx
+        return rebind[UnsafePointer[Scalar[dtype], MutAnyOrigin]](
+            output.ptr + idx
+        )
 
     @always_inline
     @parameter
@@ -1264,15 +1286,21 @@ fn _flash_attention_kv_cache[
 
     @always_inline
     @parameter
-    fn input_q_ptr_fn(coords: IndexList[4]) -> UnsafePointer[Scalar[dtype]]:
+    fn input_q_ptr_fn(
+        coords: IndexList[4],
+    ) -> UnsafePointer[Scalar[dtype], ImmutAnyOrigin]:
         var idx = q._offset(coords)
-        return q.ptr + idx
+        return rebind[UnsafePointer[Scalar[dtype], ImmutAnyOrigin]](q.ptr + idx)
 
     @always_inline
     @parameter
-    fn output_ptr_fn(coords: IndexList[4]) -> UnsafePointer[Scalar[dtype]]:
+    fn output_ptr_fn(
+        coords: IndexList[4],
+    ) -> UnsafePointer[Scalar[dtype], MutAnyOrigin]:
         var idx = output._offset(coords)
-        return output.ptr + idx
+        return rebind[UnsafePointer[Scalar[dtype], MutAnyOrigin]](
+            output.ptr + idx
+        )
 
     @always_inline
     @__copy_capture(max_seq_len)
@@ -1297,8 +1325,12 @@ fn _flash_attention_kv_cache[
     dtype: DType,
     cache_t: KVCacheT,
     //,
-    input_q_ptr_fn: fn (IndexList[4]) capturing -> UnsafePointer[Scalar[dtype]],
-    output_ptr_fn: fn (IndexList[4]) capturing -> UnsafePointer[Scalar[dtype]],
+    input_q_ptr_fn: fn (IndexList[4]) capturing -> UnsafePointer[
+        Scalar[dtype], ImmutAnyOrigin
+    ],
+    output_ptr_fn: fn (IndexList[4]) capturing -> UnsafePointer[
+        Scalar[dtype], MutAnyOrigin
+    ],
     q_length_fn: fn (batch: Int) capturing -> Int,
     kv_length_fn: fn (batch: Int) capturing -> Int,
     mask_fn: fn[simd_width: Int, mask_rank: Int] (
@@ -1498,23 +1530,31 @@ fn flash_attention_kv_cache[
 
     @always_inline
     @parameter
-    fn input_q_ptr_fn(idx: IndexList[4]) -> UnsafePointer[Scalar[dtype]]:
+    fn input_q_ptr_fn(
+        idx: IndexList[4],
+    ) -> UnsafePointer[Scalar[dtype], ImmutAnyOrigin]:
         var bs = idx[0]
         var tok_idx = idx[1]
         var q_start = Int(q_input_row_offsets[bs]) + tok_idx
         var flat_idx = IndexList[3](q_start, idx[2], idx[3])
         var out_idx = q._offset(flat_idx)
-        return q.ptr + out_idx
+        return rebind[UnsafePointer[Scalar[dtype], ImmutAnyOrigin]](
+            q.ptr + out_idx
+        )
 
     @always_inline
     @parameter
-    fn output_ptr_fn(idx: IndexList[4]) -> UnsafePointer[Scalar[dtype]]:
+    fn output_ptr_fn(
+        idx: IndexList[4],
+    ) -> UnsafePointer[Scalar[dtype], MutAnyOrigin]:
         var bs = idx[0]
         var tok_idx = idx[1]
         var q_start = Int(q_input_row_offsets[bs]) + tok_idx
         var flat_idx = IndexList[3](q_start, idx[2], idx[3])
         var out_idx = output._offset(flat_idx)
-        return output.ptr + out_idx
+        return rebind[UnsafePointer[Scalar[dtype], MutAnyOrigin]](
+            output.ptr + out_idx
+        )
 
     comptime mask_rank = 4
     var num_batches = q_input_row_offsets.dim[0]() - 1

--- a/max/kernels/src/nn/kv_cache.mojo
+++ b/max/kernels/src/nn/kv_cache.mojo
@@ -11,9 +11,6 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 from collections import OptionalReg
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys.intrinsics import _type_is_eq
 
 from algorithm.functional import unswitch
@@ -428,7 +425,7 @@ fn _matmul_common[
 
     @parameter
     if is_cpu[target]():
-        var c_ptr = UnsafePointer[Scalar[dtype]].alloc(BS * SEQ_LEN * N)
+        var c_ptr = alloc[Scalar[dtype]](BS * SEQ_LEN * N)
 
         c_nd = LayoutTensor[dtype, c_layout, MutAnyOrigin](
             c_ptr,
@@ -436,7 +433,7 @@ fn _matmul_common[
         )
     else:
         c_nd = LayoutTensor[dtype, c_layout, MutAnyOrigin](
-            UnsafePointer[Scalar[dtype]](),
+            UnsafePointer[Scalar[dtype], MutExternalOrigin](),
             RuntimeLayout[c_layout].row_major(IndexList[2](BS * SEQ_LEN, N)),
         )
 
@@ -1371,9 +1368,7 @@ def print_kv_cache_cont_batch_generic_gpu[
     is_print_compact: Bool,
     context: DeviceContextPtr,
 ):
-    var blocks_ptr = UnsafePointer[Scalar[dtype]].alloc(
-        kv_collection.blocks.size()
-    )
+    var blocks_ptr = alloc[Scalar[dtype]](kv_collection.blocks.size())
     var blocks_host_nd = LayoutTensor[
         type_of(kv_collection.blocks).dtype, Layout.row_major[6](), MutAnyOrigin
     ](
@@ -1389,9 +1384,7 @@ def print_kv_cache_cont_batch_generic_gpu[
         kv_collection.blocks.size(),
     )
 
-    var cache_lengths_ptr = UnsafePointer[UInt32].alloc(
-        kv_collection.cache_lengths.size()
-    )
+    var cache_lengths_ptr = alloc[UInt32](kv_collection.cache_lengths.size())
     var cache_lengths_host_nd = type_of(kv_collection.cache_lengths)(
         cache_lengths_ptr,
         RuntimeLayout[type_of(kv_collection.cache_lengths).layout].row_major(
@@ -1404,9 +1397,7 @@ def print_kv_cache_cont_batch_generic_gpu[
         kv_collection.cache_lengths.size(),
     )
 
-    var lookup_table_ptr = UnsafePointer[UInt32].alloc(
-        kv_collection.lookup_table.size()
-    )
+    var lookup_table_ptr = alloc[UInt32](kv_collection.lookup_table.size())
     var lookup_table_host_nd = type_of(kv_collection.lookup_table)(
         lookup_table_ptr,
         RuntimeLayout[type_of(kv_collection.lookup_table).layout].row_major(
@@ -1427,9 +1418,7 @@ def print_kv_cache_cont_batch_generic_gpu[
         kv_collection.max_cache_length,
     )
 
-    var valid_lengths_host_ptr = UnsafePointer[UInt32].alloc(
-        valid_lengths.size()
-    )
+    var valid_lengths_host_ptr = alloc[UInt32](valid_lengths.size())
     var valid_lengths_host_nd = LayoutTensor[
         valid_lengths.dtype, valid_lengths.layout
     ](
@@ -1486,9 +1475,7 @@ def print_kv_cache_paged_generic_gpu[
     is_print_compact: Bool,
     context: DeviceContextPtr,
 ):
-    var blocks_ptr = UnsafePointer[Scalar[dtype]].alloc(
-        kv_collection.blocks.size()
-    )
+    var blocks_ptr = alloc[Scalar[dtype]](kv_collection.blocks.size())
     var blocks_host_nd = LayoutTensor[
         type_of(kv_collection.blocks).dtype, Layout.row_major[6](), MutAnyOrigin
     ](
@@ -1503,9 +1490,7 @@ def print_kv_cache_paged_generic_gpu[
         kv_collection.blocks.ptr,
         kv_collection.blocks.size(),
     )
-    var cache_lengths_ptr = UnsafePointer[UInt32].alloc(
-        kv_collection.cache_lengths.size()
-    )
+    var cache_lengths_ptr = alloc[UInt32](kv_collection.cache_lengths.size())
     var cache_lengths_host_nd = type_of(kv_collection.cache_lengths)(
         cache_lengths_ptr,
         RuntimeLayout[type_of(kv_collection.cache_lengths).layout].row_major(
@@ -1517,9 +1502,7 @@ def print_kv_cache_paged_generic_gpu[
         kv_collection.cache_lengths.ptr,
         kv_collection.cache_lengths.size(),
     )
-    var lookup_table_ptr = UnsafePointer[UInt32].alloc(
-        kv_collection.lookup_table.size()
-    )
+    var lookup_table_ptr = alloc[UInt32](kv_collection.lookup_table.size())
     var lookup_table_host_nd = type_of(kv_collection.lookup_table)(
         lookup_table_ptr,
         RuntimeLayout[type_of(kv_collection.lookup_table).layout].row_major(
@@ -1538,9 +1521,7 @@ def print_kv_cache_paged_generic_gpu[
         kv_collection.max_seq_length,
         kv_collection.max_cache_length,
     )
-    var valid_lengths_host_ptr = UnsafePointer[UInt32].alloc(
-        valid_lengths.size()
-    )
+    var valid_lengths_host_ptr = alloc[UInt32](valid_lengths.size())
     var valid_lengths_host_nd = LayoutTensor[
         valid_lengths.dtype, valid_lengths.layout
     ](

--- a/max/kernels/src/nn/kv_cache_ragged.mojo
+++ b/max/kernels/src/nn/kv_cache_ragged.mojo
@@ -12,9 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 
 from collections import OptionalReg
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys.info import _current_target, simd_width_of
 from sys.intrinsics import _type_is_eq
 
@@ -1136,7 +1133,7 @@ fn _matmul_common[
         # The CPU matmul codepath uses the C buffer as a workspace
         # even if an epilogue is provided, here we just allocate
         # something to ensure we don't segfault.
-        var c_ptr = UnsafePointer[Scalar[output_dtype]].alloc(TOTAL_SEQ_LEN * N)
+        var c_ptr = alloc[Scalar[output_dtype]](TOTAL_SEQ_LEN * N)
 
         c_nd = {
             c_ptr,
@@ -1146,7 +1143,7 @@ fn _matmul_common[
         }
     else:
         c_nd = {
-            UnsafePointer[Scalar[output_dtype]](),
+            UnsafePointer[Scalar[output_dtype], MutExternalOrigin](),
             RuntimeLayout[c_nd.layout].row_major(
                 IndexList[2](TOTAL_SEQ_LEN, N)
             ),
@@ -1189,7 +1186,7 @@ fn _qmatmul_common[
     ]
 
     c_nd = {
-        UnsafePointer[Scalar[dtype]](),
+        UnsafePointer[Scalar[dtype], MutAnyOrigin](),
         RuntimeLayout[c_nd.layout].row_major(IndexList[2](TOTAL_SEQ_LEN, N)),
     }
 
@@ -1241,7 +1238,7 @@ fn _matmul_blockwise_scaled_fp8_common[
     ]
 
     c_nd = {
-        UnsafePointer[Scalar[output_dtype]](),
+        UnsafePointer[Scalar[output_dtype], MutAnyOrigin](),
         RuntimeLayout[c_nd.layout].row_major(IndexList[2](TOTAL_SEQ_LEN, N)),
     }
 
@@ -2176,7 +2173,7 @@ fn _qmatmul_gguf_quantized_alloc_output[
     # The CPU matmul codepath uses the C buffer as a workspace
     # even if an epilogue is provided, here we just allocate
     # something to ensure we don't segfault.
-    var c_ptr = UnsafePointer[Float32].alloc(TOTAL_SEQ_LEN * N)
+    var c_ptr = alloc[Float32](TOTAL_SEQ_LEN * N)
 
     c_nd = {
         c_ptr,

--- a/max/kernels/src/nn/mha.mojo
+++ b/max/kernels/src/nn/mha.mojo
@@ -14,9 +14,6 @@
 from collections import OptionalReg
 from math import ceildiv, recip
 from math.constants import log2e
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys import (
     CompilationTarget,
     align_of,
@@ -822,7 +819,9 @@ fn flash_attention_dispatch[
                                 sink_weights,
                             )
                     else:
-                        comptime nullptr = UnsafePointer[Scalar[accum_type]]()
+                        comptime nullptr = UnsafePointer[
+                            Scalar[accum_type], MutAnyOrigin
+                        ]()
 
                         var nullptr_device = DeviceBuffer[accum_type](
                             ctx, nullptr, 0, owning=False
@@ -1342,10 +1341,10 @@ fn mha[
     _is_cache_length_accurate: Bool = False,
     _padded_ndbuffer: Bool = False,
 ](
-    q_ptr: UnsafePointer[Scalar[q_type]],
+    q_ptr: UnsafePointer[Scalar[q_type], MutAnyOrigin],
     k: k_t,
     v: v_t,
-    output_ptr: UnsafePointer[Scalar[output_type]],
+    output_ptr: UnsafePointer[Scalar[output_type], MutAnyOrigin],
     scale: Float32,
     batch_size: Int,
     seq_len_arg: Int,
@@ -1544,10 +1543,10 @@ fn mha_single_batch[
     use_score_mod: Bool = False,
     sink: Bool = False,
 ](
-    q_ptr: UnsafePointer[Scalar[q_type]],
+    q_ptr: UnsafePointer[Scalar[q_type], MutAnyOrigin],
     k: k_t,
     v: v_t,
-    output_ptr: UnsafePointer[Scalar[output_type]],
+    output_ptr: UnsafePointer[Scalar[output_type], MutAnyOrigin],
     scale: Float32,
     seq_len: Int,  # valid sequence length i.e. w/o padding.
     max_seq_len: Int,  # sequence length after padding.
@@ -2303,10 +2302,10 @@ fn mha_single_batch_pipelined[
     use_score_mod: Bool = False,
     sink: Bool = False,
 ](
-    q_ptr: UnsafePointer[Scalar[q_type]],
+    q_ptr: UnsafePointer[Scalar[q_type], MutAnyOrigin],
     k: k_t,
     v: v_t,
-    output_ptr: UnsafePointer[Scalar[output_type]],
+    output_ptr: UnsafePointer[Scalar[output_type], MutAnyOrigin],
     scale: Float32,
     seq_len: Int,  # valid sequence length i.e. w/o padding.
     max_seq_len: Int,  # sequence length after padding.
@@ -3032,12 +3031,12 @@ fn mha_decoding[
     _is_cache_length_accurate: Bool = False,
     decoding_warp_split_k: Bool = False,
 ](
-    q_ptr: UnsafePointer[Scalar[q_type]],
+    q_ptr: UnsafePointer[Scalar[q_type], MutAnyOrigin],
     k: k_t,
     v: v_t,
-    output_ptr: UnsafePointer[Scalar[output_type]],
-    exp_sum_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()]],
-    qk_max_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()]],
+    output_ptr: UnsafePointer[Scalar[output_type], MutAnyOrigin],
+    exp_sum_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()], MutAnyOrigin],
+    qk_max_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()], MutAnyOrigin],
     scale: Float32,
     batch_size: Int,
     num_partitions: Int,
@@ -3363,12 +3362,12 @@ fn mha_decoding_single_batch[
     decoding_warp_split_k: Bool = False,
     sink: Bool = False,
 ](
-    q_ptr: UnsafePointer[Scalar[q_type]],
+    q_ptr: UnsafePointer[Scalar[q_type], MutAnyOrigin],
     k: k_t,
     v: v_t,
-    output_ptr: UnsafePointer[Scalar[output_type]],
-    exp_sum_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()]],
-    qk_max_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()]],
+    output_ptr: UnsafePointer[Scalar[output_type], MutAnyOrigin],
+    exp_sum_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()], MutAnyOrigin],
+    qk_max_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()], MutAnyOrigin],
     scale: Float32,
     num_keys: UInt,
     num_partitions: UInt,
@@ -4078,12 +4077,12 @@ fn mha_decoding_single_batch_pipelined[
     decoding_warp_split_k: Bool = False,
     sink: Bool = False,
 ](
-    q_ptr: UnsafePointer[Scalar[q_type]],
+    q_ptr: UnsafePointer[Scalar[q_type], MutAnyOrigin],
     k: k_t,
     v: v_t,
-    output_ptr: UnsafePointer[Scalar[output_type]],
-    exp_sum_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()]],
-    qk_max_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()]],
+    output_ptr: UnsafePointer[Scalar[output_type], MutAnyOrigin],
+    exp_sum_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()], MutAnyOrigin],
+    qk_max_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()], MutAnyOrigin],
     scale: Float32,
     num_keys: UInt,
     num_partitions: UInt,
@@ -4544,10 +4543,14 @@ fn mha_splitk_reduce[
     group: UInt = 1,
     use_exp2: Bool = False,
 ](
-    intermediate_ptr: UnsafePointer[Scalar[output_type]],
-    output_ptr: UnsafePointer[Scalar[output_type]],
-    exp_sum_ptr: UnsafePointer[Scalar[get_accum_type[output_type]()]],
-    qk_max_ptr: UnsafePointer[Scalar[get_accum_type[output_type]()]],
+    intermediate_ptr: UnsafePointer[Scalar[output_type], ImmutAnyOrigin],
+    output_ptr: UnsafePointer[Scalar[output_type], MutAnyOrigin],
+    exp_sum_ptr: UnsafePointer[
+        Scalar[get_accum_type[output_type]()], MutAnyOrigin
+    ],
+    qk_max_ptr: UnsafePointer[
+        Scalar[get_accum_type[output_type]()], MutAnyOrigin
+    ],
     batch_size: Int,
     num_partitions: Int,
 ):
@@ -4835,8 +4838,8 @@ fn _bmm0_bs[
     _use_valid_length: Bool = False,
     _is_cache_length_accurate: Bool = False,
 ](
-    p_ptr: UnsafePointer[Scalar[p_type]],
-    q_ptr: UnsafePointer[Scalar[q_type]],
+    p_ptr: UnsafePointer[Scalar[p_type], MutAnyOrigin],
+    q_ptr: UnsafePointer[Scalar[q_type], MutAnyOrigin],
     k: k_t,
     valid_length: LayoutTensor[
         DType.uint32,
@@ -4971,8 +4974,8 @@ fn _bmm1_bs[
     _use_valid_length: Bool = False,
     _is_cache_length_accurate: Bool = False,
 ](
-    output_ptr: UnsafePointer[Scalar[output_type]],
-    p_ptr: UnsafePointer[Scalar[p_type]],
+    output_ptr: UnsafePointer[Scalar[output_type], MutAnyOrigin],
+    p_ptr: UnsafePointer[Scalar[p_type], MutAnyOrigin],
     v: v_t,
     valid_length: LayoutTensor[
         DType.uint32,
@@ -5161,7 +5164,7 @@ fn mha_gpu_naive[
     var null_valid_length = LayoutTensor[
         DType.uint32, Layout.row_major(UNKNOWN_VALUE), MutAnyOrigin
     ](
-        UnsafePointer[UInt32](),
+        UnsafePointer[UInt32, MutAnyOrigin](),
         RuntimeLayout[Layout.row_major(UNKNOWN_VALUE)].row_major(Index(0)),
     )
 
@@ -5276,14 +5279,14 @@ fn _naive_attention_with_transpose[
     var depth = q.dim[3]()
 
     # Q, K, V transposed
-    var qt_ptr = UnsafePointer[Scalar[dtype]].alloc(q.size())
-    var kt_ptr = UnsafePointer[Scalar[dtype]].alloc(k.size())
-    var vt_ptr = UnsafePointer[Scalar[dtype]].alloc(v.size())
+    var qt_ptr = alloc[Scalar[dtype]](q.size())
+    var kt_ptr = alloc[Scalar[dtype]](k.size())
+    var vt_ptr = alloc[Scalar[dtype]](v.size())
     # Score = softmax(Q * K)
     var score_size = batch_size * num_heads * seq_len * num_keys
-    var score_ptr = UnsafePointer[Scalar[dtype]].alloc(score_size)
+    var score_ptr = alloc[Scalar[dtype]](score_size)
     # O = Score * V. It's transposed and will be transposed back to output.
-    var ot_ptr = UnsafePointer[Scalar[dtype]].alloc(output.size())
+    var ot_ptr = alloc[Scalar[dtype]](output.size())
 
     var qt = NDBuffer[dtype, 4](
         qt_ptr, Index(batch_size, num_heads, seq_len, depth)
@@ -5420,7 +5423,7 @@ fn _naive_attention[
 
     # Allocate intermediate memory buffer.
     var score_size = batch_size * num_heads * seq_len * num_keys
-    var score_ptr = UnsafePointer[Scalar[dtype]].alloc(score_size)
+    var score_ptr = alloc[Scalar[dtype]](score_size)
     var score = NDBuffer[dtype, 4](
         score_ptr, Index(batch_size, num_heads, seq_len, num_keys)
     )

--- a/max/kernels/src/nn/mha_cross.mojo
+++ b/max/kernels/src/nn/mha_cross.mojo
@@ -12,9 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 
 from math import ceildiv
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys import align_of, simd_width_of
 
 from algorithm.functional import vectorize
@@ -40,8 +37,8 @@ fn _bmm0_bs[
     q_type: DType,
     p_type: DType,
 ](
-    p_ptr: UnsafePointer[Scalar[p_type]],
-    q_ptr: UnsafePointer[Scalar[q_type]],
+    p_ptr: UnsafePointer[Scalar[p_type], MutAnyOrigin],
+    q_ptr: UnsafePointer[Scalar[q_type], ImmutAnyOrigin],
     k_cache: cache_t,
     q_input_row_offsets: LayoutTensor[DType.uint32, q_layout, MutAnyOrigin],
     kv_input_row_offsets: LayoutTensor[DType.uint32, kv_layout, MutAnyOrigin],
@@ -145,8 +142,8 @@ fn _bmm1_bs[
     p_type: DType,
     output_type: DType,
 ](
-    output_ptr: UnsafePointer[Scalar[output_type]],
-    p_ptr: UnsafePointer[Scalar[p_type]],
+    output_ptr: UnsafePointer[Scalar[output_type], MutAnyOrigin],
+    p_ptr: UnsafePointer[Scalar[p_type], ImmutAnyOrigin],
     v_cache: cache_t,
     q_input_row_offsets: LayoutTensor[DType.uint32, q_layout, MutAnyOrigin],
     kv_input_row_offsets: LayoutTensor[DType.uint32, kv_layout, MutAnyOrigin],

--- a/max/kernels/src/nn/mha_operand.mojo
+++ b/max/kernels/src/nn/mha_operand.mojo
@@ -22,12 +22,6 @@ from layout.tma_async import (
     RaggedTMA3DTile,
 )
 
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
-comptime OpaquePointer = LegacyUnsafePointer[
-    mut=True, NoneType, origin=MutAnyOrigin
-]
 from utils import Index, IndexList
 
 from builtin.device_passable import DevicePassable
@@ -50,7 +44,7 @@ trait MHAOperand(DevicePassable):
         start_tok_idx: UInt32,
         head_idx: UInt32,
         head_dim_idx: UInt32 = 0,
-    ) -> UnsafePointer[Scalar[Self.dtype]]:
+    ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]:
         ...
 
     @always_inline
@@ -144,7 +138,7 @@ struct KVCacheMHAOperand[
         start_tok_idx: UInt32,
         head_idx: UInt32,
         head_dim_idx: UInt32 = 0,
-    ) -> UnsafePointer[Scalar[Self.dtype]]:
+    ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]:
         return self.cache.block_paged_ptr[tile_size](
             Int(batch_idx), Int(start_tok_idx), Int(head_idx), Int(head_dim_idx)
         )
@@ -251,7 +245,7 @@ struct LayoutTensorMHAOperand[dtype_: DType, layout: Layout](MHAOperand):
         start_tok_idx: UInt32,
         head_idx: UInt32,
         head_dim_idx: UInt32 = 0,
-    ) -> UnsafePointer[Scalar[Self.dtype]]:
+    ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]:
         var ret_ptr = self.buffer.ptr + self.buffer._offset(
             IndexList[self.layout.rank()](
                 Int(batch_idx),
@@ -260,7 +254,7 @@ struct LayoutTensorMHAOperand[dtype_: DType, layout: Layout](MHAOperand):
                 Int(head_dim_idx),
             )
         )
-        return rebind[UnsafePointer[Scalar[Self.dtype]]](ret_ptr)
+        return ret_ptr
 
     @always_inline
     fn cache_length(self, batch_idx: Int) -> Int:
@@ -386,7 +380,7 @@ struct RaggedMHAOperand[dtype_: DType, layout: Layout, cache_layout: Layout](
         start_tok_idx: UInt32,
         head_idx: UInt32,
         head_dim_idx: UInt32 = 0,
-    ) -> UnsafePointer[Scalar[Self.dtype]]:
+    ) -> UnsafePointer[Scalar[Self.dtype], MutAnyOrigin]:
         global_token_idx = Int(
             self.cache_row_offsets[Int(batch_idx)] + start_tok_idx
         )
@@ -397,7 +391,7 @@ struct RaggedMHAOperand[dtype_: DType, layout: Layout, cache_layout: Layout](
                 Int(head_dim_idx),
             )
         )
-        return rebind[UnsafePointer[Scalar[Self.dtype]]](ret_ptr)
+        return ret_ptr
 
     @always_inline
     fn cache_length(self, batch_idx: Int) -> Int:

--- a/max/kernels/src/nn/mha_sm100_1q.mojo
+++ b/max/kernels/src/nn/mha_sm100_1q.mojo
@@ -14,9 +14,7 @@
 from collections import OptionalReg
 from math import ceildiv, exp2, recip, align_up
 from math.constants import log2e
-from memory import LegacyUnsafePointer
 
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys import align_of, simd_width_of, size_of
 
 from gpu import warp_id
@@ -274,7 +272,9 @@ fn local_tensor_type[
     ]
 ):
     dummy_arg = {
-        UnsafePointer[Scalar[dtype], address_space = AddressSpace.LOCAL]()
+        UnsafePointer[
+            Scalar[dtype], MutAnyOrigin, address_space = AddressSpace.LOCAL
+        ]()
     }
 
 
@@ -850,7 +850,9 @@ struct SM100TensorAccumulatorSS[
     comptime num_m_blocks_per_warp = 2 * Self.BM // Self.num_softmax_threads
 
     comptime smem_ptr_t = UnsafePointer[
-        Scalar[Self.operand_t], address_space = AddressSpace.SHARED
+        Scalar[Self.operand_t],
+        MutAnyOrigin,
+        address_space = AddressSpace.SHARED,
     ]
 
     comptime a_offset = MMAOperandOffsetFn[
@@ -893,7 +895,7 @@ struct SM100TensorAccumulatorSS[
     ]
 
     var mbar: UnsafePointer[
-        SharedMemBarrier, address_space = AddressSpace.SHARED
+        SharedMemBarrier, MutAnyOrigin, address_space = AddressSpace.SHARED
     ]
     var pipeline: PipelineState[Self.pipeline_stages]
 
@@ -919,7 +921,7 @@ struct SM100TensorAccumulatorSS[
     fn __init__(
         out self,
         smem: UnsafePointer[
-            SharedMemBarrier, address_space = AddressSpace.SHARED
+            SharedMemBarrier, MutAnyOrigin, address_space = AddressSpace.SHARED
         ],
     ):
         Self.check_constraints()
@@ -939,10 +941,10 @@ struct SM100TensorAccumulatorSS[
         dtype_a: DType, dtype_b: DType
     ](
         p_a: UnsafePointer[
-            Scalar[dtype_a], address_space = AddressSpace.SHARED
+            Scalar[dtype_a], MutAnyOrigin, address_space = AddressSpace.SHARED
         ],
         p_b: UnsafePointer[
-            Scalar[dtype_b], address_space = AddressSpace.SHARED
+            Scalar[dtype_b], MutAnyOrigin, address_space = AddressSpace.SHARED
         ],
     ) -> Self.ab_t:
         Self.check_constraints()
@@ -1082,7 +1084,9 @@ struct SM100TensorAccumulatorTS[
 
     comptime MMA_K = 16
     comptime smem_ptr_t = UnsafePointer[
-        Scalar[Self.operand_t], address_space = AddressSpace.SHARED
+        Scalar[Self.operand_t],
+        MutAnyOrigin,
+        address_space = AddressSpace.SHARED,
     ]
 
     comptime num_m_mmas = Self.BM // Self.MMA_M
@@ -1130,7 +1134,7 @@ struct SM100TensorAccumulatorTS[
     ]()
 
     var mbar: UnsafePointer[
-        SharedMemBarrier, address_space = AddressSpace.SHARED
+        SharedMemBarrier, MutAnyOrigin, address_space = AddressSpace.SHARED
     ]
     var phase: UInt32
 
@@ -1151,7 +1155,7 @@ struct SM100TensorAccumulatorTS[
     fn __init__(
         out self,
         smem: UnsafePointer[
-            SharedMemBarrier, address_space = AddressSpace.SHARED
+            SharedMemBarrier, MutAnyOrigin, address_space = AddressSpace.SHARED
         ],
     ):
         Self.check_constraints()
@@ -1175,7 +1179,7 @@ struct SM100TensorAccumulatorTS[
         dtype_b: DType
     ](
         p_b: UnsafePointer[
-            Scalar[dtype_b], address_space = AddressSpace.SHARED
+            Scalar[dtype_b], MutAnyOrigin, address_space = AddressSpace.SHARED
         ],
     ) -> Self.ab_t.b_t:
         Self.check_constraints()
@@ -1337,7 +1341,7 @@ fn mha_sm100_dispatch[
     __comptime_assert (
         config.dtype == KVType.dtype and config.dtype == q_type
     ), "config, kv, and q types must all match for FA3."
-    q = rebind[UnsafePointer[Scalar[KVType.dtype]]](q_arg)
+    q = rebind[UnsafePointer[Scalar[KVType.dtype], MutAnyOrigin]](q_arg)
 
     # Persistent kernels not currently supported with partitioning
     # This doesn't seem useful: we partition to make SMs more busy,
@@ -1399,7 +1403,7 @@ fn mha_sm100_dispatch[
     if sink:
         comptime SinkType = NonNullPointer[KVType.dtype]
         var sink_ptr: SinkType = {
-            rebind[UnsafePointer[Scalar[KVType.dtype]]](
+            rebind[UnsafePointer[Scalar[KVType.dtype], ImmutAnyOrigin]](
                 sink_weights.value().ptr
             )
         }
@@ -1933,7 +1937,7 @@ fn _mha_sm100[
         BN = Int(config.block_n()),
         BK = Int(config.padded_depth),
     ],
-    o_ptr_arg: UnsafePointer[Scalar[output_type]],
+    o_ptr_arg: UnsafePointer[Scalar[output_type], MutAnyOrigin],
     kv_lut: KVLUTType,
     scale: Float32,
     batch_size: UInt32,
@@ -2202,13 +2206,13 @@ fn _mha_sm100[
     comptime ragged = not ValidLengthType.is_null
 
     # Handle sink_weights
-    var sink_weights_ptr = UnsafePointer[Scalar[kv_type]]()
+    var sink_weights_ptr = UnsafePointer[Scalar[kv_type], ImmutAnyOrigin]()
 
     @parameter
     if not SinkType.is_null:
-        sink_weights_ptr = rebind[UnsafePointer[Scalar[kv_type]]](
-            sink_weights.value()
-        )
+        sink_weights_ptr = rebind[
+            UnsafePointer[Scalar[kv_type], ImmutAnyOrigin]
+        ](sink_weights.value())
 
     # actually 16 byte alignment
     produced_mbar_kv = (kv_smem + kv_smem_size).bitcast[SharedMemBarrier]()
@@ -2661,7 +2665,9 @@ fn _mha_sm100[
                 for col in range(num_cols_output):
                     vout[row, col] = vout[row, col] * rs_inv
 
-            var output_ptr: UnsafePointer[Scalar[output_type]] = o_ptr_arg
+            var output_ptr: UnsafePointer[
+                Scalar[output_type], MutAnyOrigin
+            ] = o_ptr_arg
 
             @parameter
             if decoding and PartitionType.do_partition:

--- a/max/kernels/src/nn/mha_sm100_2q.mojo
+++ b/max/kernels/src/nn/mha_sm100_2q.mojo
@@ -11,9 +11,6 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from collections import OptionalReg
 from math import ceildiv, exp2, recip, align_up, align_down, gcd, iota
 from math.constants import log2e
@@ -147,7 +144,7 @@ comptime SharedMemTensor[dtype: DType, layout: Layout] = LayoutTensor[
     alignment=128,
 ]
 comptime SharedMemPointer[type: AnyType] = UnsafePointer[
-    type, address_space = AddressSpace.SHARED
+    type, MutAnyOrigin, address_space = AddressSpace.SHARED
 ]
 comptime MBarType = SharedMemPointer[SharedMemBarrier]
 
@@ -486,7 +483,7 @@ struct TMemTile[
         comptime load_dtype = DType.uint32
         # alias load_dtype = Self.dtype if Self.dtype_size == 4 else DType.uint32
         var ptr: UnsafePointer[
-            Scalar[load_dtype], address_space = AddressSpace.LOCAL
+            Scalar[load_dtype], MutAnyOrigin, address_space = AddressSpace.LOCAL
         ]
 
         ptr = rebind[type_of(ptr)](dst.ptr)
@@ -1390,7 +1387,7 @@ fn mha_sm100_dispatch[
     comptime BM = fa4_config.BM
     comptime BN = fa4_config.BN
     comptime num_threads = fa4_config.num_threads
-    q = rebind[UnsafePointer[Scalar[KVType.dtype]]](q_arg)
+    q = rebind[UnsafePointer[Scalar[KVType.dtype], MutAnyOrigin]](q_arg)
 
     var max_cache_valid_length: UInt32 = UInt32(max_cache_valid_length_arg)
     var batch_size: UInt32 = UInt32(batch_size_arg)
@@ -1440,7 +1437,7 @@ fn mha_sm100_dispatch[
     if sink:
         comptime SinkType = NonNullPointer[KVType.dtype]
         var sink_ptr: SinkType = {
-            rebind[UnsafePointer[Scalar[KVType.dtype]]](
+            rebind[UnsafePointer[Scalar[KVType.dtype], ImmutAnyOrigin]](
                 sink_weights.value().ptr
             )
         }
@@ -3663,21 +3660,25 @@ struct SM100MHA2Q[
                             mask_strategy = mask_strategies[2]
                         ](kv_row)
                         mask_iters[2] -= 1
-        var sink_weights_ptr = UnsafePointer[Scalar[Self.qkv_type]]()
+        var sink_weights_ptr = UnsafePointer[
+            Scalar[Self.qkv_type], ImmutAnyOrigin
+        ]()
         var sink_weight: Scalar[Self.accum_type]
 
         @parameter
         if not Self.SinkType.is_null:
-            sink_weights_ptr = rebind[UnsafePointer[Scalar[Self.qkv_type]]](
-                sink_weights.value()
-            )
+            sink_weights_ptr = rebind[
+                UnsafePointer[Scalar[Self.qkv_type], ImmutAnyOrigin]
+            ](sink_weights.value())
             var head_idx: UInt32 = seq_info.head_idx
             sink_weight = (
                 sink_weights_ptr[head_idx].cast[Self.accum_type]() * log2e
             )
             row_max = max(row_max, sink_weight)
         else:
-            sink_weights_ptr = UnsafePointer[Scalar[Self.qkv_type]]()
+            sink_weights_ptr = UnsafePointer[
+                Scalar[Self.qkv_type], ImmutAnyOrigin
+            ]()
             sink_weight = 0.0
 
         var row_sum: f32x2 = store_exp[False](row_max)

--- a/max/kernels/src/nn/mha_sm90.mojo
+++ b/max/kernels/src/nn/mha_sm90.mojo
@@ -14,9 +14,6 @@
 from collections import OptionalReg
 from math import ceildiv, exp2, recip
 from math.constants import log2e
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys import align_of, env_get_int, simd_width_of, size_of
 
 import gpu.primitives.warp as warp
@@ -148,7 +145,7 @@ fn mha_sm90_dispatch[
         config.dtype == KVType.dtype and config.dtype == q_type
     ), "config, kv, and q types must all match for FA3."
     comptime swizzle_mode = TensorMapSwizzle.SWIZZLE_128B
-    q = rebind[UnsafePointer[Scalar[KVType.dtype]]](q_arg)
+    q = rebind[UnsafePointer[Scalar[KVType.dtype], MutAnyOrigin]](q_arg)
     comptime decoding: Bool = MaxPromptLenType.static_value.or_else(0) == 1
     comptime new_config = MHAConfig[config.dtype](
         config.num_heads,
@@ -947,7 +944,7 @@ fn _mha_sm90[
         BN = Int(config.block_n()),
         BK = Int(config.padded_depth),
     ],
-    o_ptr_arg: UnsafePointer[Scalar[output_type]],
+    o_ptr_arg: UnsafePointer[Scalar[output_type], MutAnyOrigin],
     kv_lut: KVLUTType,
     scale: Float32,
     batch_size: UInt32,
@@ -1178,13 +1175,13 @@ fn _mha_sm90[
     comptime mma_thread_layout = Layout.row_major(8, 4)
 
     # Handle sink_weights
-    var sink_weights_ptr = UnsafePointer[Scalar[kv_type]]()
+    var sink_weights_ptr = UnsafePointer[Scalar[kv_type], ImmutAnyOrigin]()
 
     @parameter
     if not SinkType.is_null:
-        sink_weights_ptr = rebind[UnsafePointer[Scalar[kv_type]]](
-            sink_weights.value()
-        )
+        sink_weights_ptr = rebind[
+            UnsafePointer[Scalar[kv_type], ImmutAnyOrigin]
+        ](sink_weights.value())
 
     produced_mbar_kv = (kv_smem + kv_smem_size).bitcast[SharedMemBarrier]()
     consumed_mbar_kv = produced_mbar_kv + pipeline_stages
@@ -1601,7 +1598,9 @@ fn _mha_sm90[
                 for col in range(num_cols_output):
                     vout[row, col] = vout[row, col] * rs_inv
 
-            var output_ptr: UnsafePointer[Scalar[output_type]] = o_ptr_arg
+            var output_ptr: UnsafePointer[
+                Scalar[output_type], MutAnyOrigin
+            ] = o_ptr_arg
 
             @parameter
             if decoding and PartitionType.do_partition:

--- a/max/kernels/src/nn/mha_utils.mojo
+++ b/max/kernels/src/nn/mha_utils.mojo
@@ -11,12 +11,8 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-
 from collections import OptionalReg
 from math import align_up, ceildiv
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys import (
     CompilationTarget,
     align_of,
@@ -812,7 +808,7 @@ trait MHAPartitionScheme(Copyable):
     @always_inline
     fn get_exp_sum_qk_max_pointer(
         self,
-    ) -> UnsafePointer[Scalar[Self.accum_dtype]]:
+    ) -> UnsafePointer[Scalar[Self.accum_dtype], MutAnyOrigin]:
         ...
 
 
@@ -834,24 +830,26 @@ struct NoPartition[dtype: DType](
     @always_inline
     fn get_exp_sum_qk_max_pointer(
         self,
-    ) -> UnsafePointer[Scalar[Self.accum_dtype]]:
-        return UnsafePointer[Scalar[Self.accum_dtype]]()
+    ) -> UnsafePointer[Scalar[Self.accum_dtype], MutAnyOrigin]:
+        return UnsafePointer[Scalar[Self.accum_dtype], MutAnyOrigin]()
 
 
 @register_passable("trivial")
 struct SplitKPartition[dtype: DType](ImplicitlyCopyable, MHAPartitionScheme):
     comptime do_partition: Bool = True
     comptime accum_dtype: DType = Self.dtype
-    var ptr: UnsafePointer[Scalar[Self.accum_dtype]]
+    var ptr: UnsafePointer[Scalar[Self.accum_dtype], MutAnyOrigin]
     var num_partitions_value: UInt32
 
     @always_inline
     fn __init__(
         out self,
-        ptr: UnsafePointer[Scalar[Self.accum_dtype]],
+        ptr: UnsafePointer[Scalar[Self.accum_dtype], MutAnyOrigin],
         num_partitions_value: UInt32,
     ):
-        debug_assert(ptr != UnsafePointer[Scalar[Self.accum_dtype]]())
+        debug_assert(
+            ptr != UnsafePointer[Scalar[Self.accum_dtype], MutAnyOrigin]()
+        )
         self.ptr = ptr
         self.num_partitions_value = num_partitions_value
 
@@ -862,5 +860,5 @@ struct SplitKPartition[dtype: DType](ImplicitlyCopyable, MHAPartitionScheme):
     @always_inline
     fn get_exp_sum_qk_max_pointer(
         self,
-    ) -> UnsafePointer[Scalar[Self.accum_dtype]]:
+    ) -> UnsafePointer[Scalar[Self.accum_dtype], MutAnyOrigin]:
         return self.ptr

--- a/max/kernels/src/nn/mla_decode_sm100.mojo
+++ b/max/kernels/src/nn/mla_decode_sm100.mojo
@@ -766,7 +766,7 @@ struct OffsetPosition[
         out self,
         k: Self.KVLUTType,
         valid_length: UnsafePointer[
-            Scalar[Self.ValidLengthType.dtype], origin=MutAnyOrigin
+            Scalar[Self.ValidLengthType.dtype], origin=ImmutAnyOrigin
         ],
         max_seq_len: Int,
     ):

--- a/max/kernels/src/nn/mla_prefill_sm100.mojo
+++ b/max/kernels/src/nn/mla_prefill_sm100.mojo
@@ -11,9 +11,6 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys import align_of, simd_width_of, size_of
 from math import ceildiv, exp2, recip
 from math.constants import log2e
@@ -973,21 +970,25 @@ struct SM100MLA[
                             mask_strategy = mask_strategies[2]
                         ](kv_row)
                         mask_iters[2] -= 1
-        var sink_weights_ptr = UnsafePointer[Scalar[Self.qkv_type]]()
+        var sink_weights_ptr = UnsafePointer[
+            Scalar[Self.qkv_type], ImmutAnyOrigin
+        ]()
         var sink_weight: Scalar[Self.accum_type]
 
         @parameter
         if not Self.SinkType.is_null:
-            sink_weights_ptr = rebind[UnsafePointer[Scalar[Self.qkv_type]]](
-                sink_weights.value()
-            )
+            sink_weights_ptr = rebind[
+                UnsafePointer[Scalar[Self.qkv_type], ImmutAnyOrigin]
+            ](sink_weights.value())
             var head_idx: UInt32 = seq_info.head_idx
             sink_weight = (
                 sink_weights_ptr[head_idx].cast[Self.accum_type]() * log2e
             )
             row_max = max(row_max, sink_weight)
         else:
-            sink_weights_ptr = UnsafePointer[Scalar[Self.qkv_type]]()
+            sink_weights_ptr = UnsafePointer[
+                Scalar[Self.qkv_type], ImmutAnyOrigin
+            ]()
             sink_weight = 0.0
 
         @parameter
@@ -1755,7 +1756,9 @@ fn mla_sm100_prefill[
     comptime SinkType = NullPointer[output_type]
     comptime KVRowOffsetsNull = NullPointer[DType.uint32]
     comptime PartitionType = NoPartition[get_accum_type[q.dtype]()]
-    var valid_len: ValidLengthType = {valid_length.ptr}
+    var valid_len: ValidLengthType = {
+        rebind[UnsafePointer[UInt32, ImmutAnyOrigin]](valid_length.ptr)
+    }
 
     comptime SM100MLAType = SM100MLA[
         KVType,
@@ -1791,7 +1794,11 @@ fn mla_sm100_prefill[
         q_num_heads = fa4_config.num_q_heads,
         group = fa4_config.group,
         decoding=False,
-    ](ctx, q.ptr, num_rows_q)
+    ](
+        ctx,
+        rebind[UnsafePointer[Scalar[q.dtype], MutAnyOrigin]](q.ptr),
+        num_rows_q,
+    )
 
     # [batch_size * num_keys, num_heads, kv_depth]
     k_tma_op = k.create_tma_tile[


### PR DESCRIPTION
## Summary
migrates the following files off of `LegacyUnsafePointer`:

```
max/kernels/src/nn/attention/gpu/amd/attention.mojo
max/kernels/src/nn/attention/gpu/amd/buffers.mojo
max/kernels/src/nn/attention/gpu/amd/mha_gfx942.mojo
max/kernels/src/nn/attention/gpu/amd/mla.mojo
max/kernels/src/nn/attention/gpu/amd/utils.mojo
max/kernels/src/nn/flash_attention.mojo
max/kernels/src/nn/kv_cache.mojo
max/kernels/src/nn/kv_cache_ragged.mojo
max/kernels/src/nn/mha.mojo
max/kernels/src/nn/mha_cross.mojo
max/kernels/src/nn/mha_fa3_utils.mojo
max/kernels/src/nn/mha_operand.mojo
max/kernels/src/nn/mha_sm100_1q.mojo
max/kernels/src/nn/mha_sm100_2q.mojo
max/kernels/src/nn/mha_sm90.mojo
max/kernels/src/nn/mha_tile_scheduler.mojo
max/kernels/src/nn/mha_utils.mojo
max/kernels/src/nn/mla_decode_sm100.mojo
max/kernels/src/nn/mla_prefill_sm100.mojo
```

- removes legacy imports/aliases
- adds explicit origins (except in some places where can be inferred)
- adds rebinds at tensor boundaries where ptr/origin conversion is not implicit

## Test Summary

`./bazelw build //max/kernels/src/nn:nn`  : builds
`./bazelw test  //max/kernels/test/nn/...`: passes

`./bazelw build //max/kernels/...`     : builds
`./bazelw test  //max/kernels/test/...`: passes

contributes to: #5674 

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
