### PR TITLE
[kernels] Migrate qmatmul_k.mojo to UnsafePointer v2 API

### DIFF
--- a/max/kernels/src/nn/kv_cache_ragged.mojo
+++ b/max/kernels/src/nn/kv_cache_ragged.mojo
@@ -2519,9 +2519,14 @@ fn _qmatmul_gguf_quantized_common[
             output,
         )
     elif quantization_encoding == "q4_k":
+
         @parameter
         if elementwise_lambda_fn:
-            matmul_Q4_K[elementwise_lambda_fn=OptionalReg(elementwise_lambda_fn.value())](
+            matmul_Q4_K[
+                elementwise_lambda_fn = OptionalReg(
+                    elementwise_lambda_fn.value()
+                )
+            ](
                 hidden_state,
                 weight,
                 output,
@@ -2533,9 +2538,14 @@ fn _qmatmul_gguf_quantized_common[
                 output,
             )
     elif quantization_encoding == "q6_k":
+
         @parameter
         if elementwise_lambda_fn:
-            matmul_Q6_K[elementwise_lambda_fn=OptionalReg(elementwise_lambda_fn.value())](
+            matmul_Q6_K[
+                elementwise_lambda_fn = OptionalReg(
+                    elementwise_lambda_fn.value()
+                )
+            ](
                 hidden_state,
                 weight,
                 output,

--- a/max/kernels/src/nn/kv_cache_ragged.mojo
+++ b/max/kernels/src/nn/kv_cache_ragged.mojo
@@ -2522,9 +2522,7 @@ fn _qmatmul_gguf_quantized_common[
 
         @parameter
         if elementwise_lambda_fn:
-            matmul_Q4_K[
-                elementwise_lambda_fn = elementwise_lambda_fn
-            ](
+            matmul_Q4_K[elementwise_lambda_fn=elementwise_lambda_fn](
                 hidden_state,
                 weight,
                 output,
@@ -2539,9 +2537,7 @@ fn _qmatmul_gguf_quantized_common[
 
         @parameter
         if elementwise_lambda_fn:
-            matmul_Q6_K[
-                elementwise_lambda_fn = elementwise_lambda_fn
-            ](
+            matmul_Q6_K[elementwise_lambda_fn=elementwise_lambda_fn](
                 hidden_state,
                 weight,
                 output,

--- a/max/kernels/src/nn/kv_cache_ragged.mojo
+++ b/max/kernels/src/nn/kv_cache_ragged.mojo
@@ -2519,17 +2519,33 @@ fn _qmatmul_gguf_quantized_common[
             output,
         )
     elif quantization_encoding == "q4_k":
-        matmul_Q4_K[elementwise_lambda_fn=elementwise_lambda_fn](
-            hidden_state,
-            weight,
-            output,
-        )
+        @parameter
+        if elementwise_lambda_fn:
+            matmul_Q4_K[elementwise_lambda_fn=OptionalReg(elementwise_lambda_fn.value())](
+                hidden_state,
+                weight,
+                output,
+            )
+        else:
+            matmul_Q4_K[elementwise_lambda_fn=None](
+                hidden_state,
+                weight,
+                output,
+            )
     elif quantization_encoding == "q6_k":
-        matmul_Q6_K[elementwise_lambda_fn=elementwise_lambda_fn](
-            hidden_state,
-            weight,
-            output,
-        )
+        @parameter
+        if elementwise_lambda_fn:
+            matmul_Q6_K[elementwise_lambda_fn=OptionalReg(elementwise_lambda_fn.value())](
+                hidden_state,
+                weight,
+                output,
+            )
+        else:
+            matmul_Q6_K[elementwise_lambda_fn=None](
+                hidden_state,
+                weight,
+                output,
+            )
     else:
         raise Error(
             "Unsupported quantization encoding: ", quantization_encoding

--- a/max/kernels/src/nn/kv_cache_ragged.mojo
+++ b/max/kernels/src/nn/kv_cache_ragged.mojo
@@ -2523,9 +2523,7 @@ fn _qmatmul_gguf_quantized_common[
         @parameter
         if elementwise_lambda_fn:
             matmul_Q4_K[
-                elementwise_lambda_fn = OptionalReg(
-                    elementwise_lambda_fn.value()
-                )
+                elementwise_lambda_fn = elementwise_lambda_fn
             ](
                 hidden_state,
                 weight,
@@ -2542,9 +2540,7 @@ fn _qmatmul_gguf_quantized_common[
         @parameter
         if elementwise_lambda_fn:
             matmul_Q6_K[
-                elementwise_lambda_fn = OptionalReg(
-                    elementwise_lambda_fn.value()
-                )
+                elementwise_lambda_fn = elementwise_lambda_fn
             ](
                 hidden_state,
                 weight,

--- a/max/kernels/src/quantization/qmatmul.mojo
+++ b/max/kernels/src/quantization/qmatmul.mojo
@@ -1221,9 +1221,7 @@ fn _matmul_qint4[
 
     comptime aq_type = kernel.aq_type()
 
-    var a_quant_base_ptr = alloc[Scalar[aq_type]](
-        M * K, alignment=alignment
-    )
+    var a_quant_base_ptr = alloc[Scalar[aq_type]](M * K, alignment=alignment)
     var a_scale_base_ptr = alloc[Float32](M * k_groups)
 
     var a_quant = LayoutTensor[aq_type, Layout.row_major[2]()](

--- a/max/kernels/src/quantization/qmatmul.mojo
+++ b/max/kernels/src/quantization/qmatmul.mojo
@@ -211,8 +211,10 @@ fn _unpack_weights[
     var b_scale_ptr = _b_scale_ptr
     var b_correction_ptr = _b_correction_ptr
 
-    for ko in range(0, batch_k, group_size):
-        comptime for col in range(tile_n):
+    for _ in range(0, batch_k, group_size):
+
+        @parameter
+        for col in range(tile_n):
             var b_scale = (
                 b_packed_ptr.bitcast[Float16]()
                 .load[width=simd_width](col * simd_width)
@@ -227,8 +229,10 @@ fn _unpack_weights[
             fill=0
         )
 
-        for k in range(0, group_size, 8):
-            comptime for col in range(tile_n):
+        for _ in range(0, group_size, 8):
+
+            @parameter
+            for col in range(tile_n):
                 var b_data_packed = b_packed_ptr.load[width = simd_width * 4](
                     col * simd_width * 4
                 ).cast[DType.uint8]()
@@ -1001,7 +1005,7 @@ fn _matmul_qint4_m_1[
             var ak_scale_ptr = a_scale.ptr
             var bk_ptr = b_ptr + n * k_groups * bytes_per_group_int4
 
-            for k in range(0, K, group_size):
+            for _ in range(0, K, group_size):
                 kernel.process_group_packed[group_size](
                     ak_ptr, ak_scale_ptr, bk_ptr, c_float
                 )
@@ -1141,7 +1145,7 @@ fn _matmul_qint4_m_any[
                     var bk_scale_ptr = b_scale_buf
                     var bk_correction_ptr = b_correction_buf
 
-                    for ki in range(0, ko_count, group_size):
+                    for _ in range(0, ko_count, group_size):
                         kernel.process_group_unpacked[group_size](
                             ak_ptr.bitcast[Int8](),
                             ak_scale_ptr,

--- a/max/kernels/src/quantization/qmatmul_k.mojo
+++ b/max/kernels/src/quantization/qmatmul_k.mojo
@@ -1381,7 +1381,7 @@ fn _matmul_Q6_K_columns[
             a_q_bits_ptr: UnsafePointer[Int8],
             mut c_int32_group: _Accumulator[DType.int32, 1, tile_n, simd_width],
         ):
-            _matmul_group_packed_Q6_K[zero_point=b_zero_point](
+            _matmul_group_packed_Q6_K[zero_point = UInt8(b_zero_point)](
                 a_q_bits_ptr, b_q_bits_ptr, c_int32_group
             )
 
@@ -1409,7 +1409,7 @@ fn _matmul_Q6_K_columns[
     var b_q_bits = stack_allocation[
         _block_QK_K.quantized_k * block_n, DType.uint8, alignment=alignment
     ]()
-    b_tile_ptr[].q_bits.unpack[zero_point=b_zero_point](b_q_bits)
+    b_tile_ptr[].q_bits.unpack[zero_point = UInt8(b_zero_point)](b_q_bits)
 
     @parameter
     @__copy_capture(b_tile_ptr, b_q_bits)
@@ -1579,7 +1579,7 @@ fn matmul_Q4_K[
             b_type = _block_Q4_K_packed[],
             columns_fn=_matmul_Q4_K_columns,
             interleave_group_sums=True,
-            elementwise_lambda_fn=OptionalReg(elementwise_lambda_fn.value()),
+            elementwise_lambda_fn = OptionalReg(elementwise_lambda_fn.value()),
         ](a, b, c)
     else:
         _matmul_Qb_K[
@@ -1608,7 +1608,7 @@ fn matmul_Q6_K[
             group_size = _block_Q6_K.group_size,
             b_type = _block_Q6_K_packed[],
             columns_fn=_matmul_Q6_K_columns,
-            elementwise_lambda_fn=OptionalReg(elementwise_lambda_fn.value()),
+            elementwise_lambda_fn = OptionalReg(elementwise_lambda_fn.value()),
         ](a, b, c)
     else:
         _matmul_Qb_K[

--- a/max/kernels/src/quantization/qmatmul_k.mojo
+++ b/max/kernels/src/quantization/qmatmul_k.mojo
@@ -237,8 +237,12 @@ struct _packed_bit_array[bit_width: Int, block_m: Int, block_n: Int]:
     @always_inline
     fn unpack_from_ptr[
         *, zero_point: UInt8 = 0
-    ](self_ptr: UnsafePointer[Self, ...], var dst_ptr: UnsafePointer[mut=True, UInt8]):
-        """Unpacks the local storage to the supplied external buffer using a pointer."""
+    ](
+        self_ptr: UnsafePointer[Self, ...],
+        var dst_ptr: UnsafePointer[mut=True, UInt8],
+    ):
+        """Unpacks the local storage to the supplied external buffer using a pointer.
+        """
         __comptime_assert (Self._packed_stride % Self._simd_width) == 0
 
         var bits_ptr = self_ptr[].bits.unsafe_ptr()
@@ -254,7 +258,10 @@ struct _packed_bit_array[bit_width: Int, block_m: Int, block_n: Int]:
 
     @staticmethod
     @always_inline
-    fn _unpack_int4_static(var bits_ptr: UnsafePointer[UInt8, ...], var dst_ptr: UnsafePointer[mut=True, UInt8]):
+    fn _unpack_int4_static(
+        var bits_ptr: UnsafePointer[UInt8, ...],
+        var dst_ptr: UnsafePointer[mut=True, UInt8],
+    ):
         __comptime_assert Self.bit_width == 4
         __comptime_assert (Self.block_m % (2 * Self._tuple_width)) == 0
 
@@ -276,7 +283,12 @@ struct _packed_bit_array[bit_width: Int, block_m: Int, block_n: Int]:
 
     @staticmethod
     @always_inline
-    fn _unpack_int6_static[zero_point: UInt8](var bits_ptr: UnsafePointer[UInt8, ...], var dst_ptr: UnsafePointer[mut=True, UInt8]):
+    fn _unpack_int6_static[
+        zero_point: UInt8
+    ](
+        var bits_ptr: UnsafePointer[UInt8, ...],
+        var dst_ptr: UnsafePointer[mut=True, UInt8],
+    ):
         __comptime_assert Self.bit_width == 6
         __comptime_assert (Self.block_m % (4 * Self._tuple_width)) == 0
 
@@ -333,7 +345,7 @@ struct _block_Q8_K_packed[group_size: Int, tile_m: Int = 1]:
 fn _quantize_a_Q8_K[
     group_size: Int, dtype: DType, *, interleave_group_sums: Bool = False
 ](a: LayoutTensor[dtype, ...]) -> UnsafePointer[
-    mut = True, _block_Q8_K_packed[group_size], MutExternalOrigin
+    mut=True, _block_Q8_K_packed[group_size], MutExternalOrigin
 ]:
     comptime assert a.rank == 2
     comptime quantized_k = _block_QK_K.quantized_k
@@ -1077,7 +1089,9 @@ fn _matmul_Q4_K_tile[
     ) capturing[_] -> None,
     elementwise_lambda_fn: OptionalReg[elementwise_epilogue_type] = None,
 ](
-    a_ptr: UnsafePointer[_block_Q8_K_packed[_block_Q4_K.group_size], MutAnyOrigin],
+    a_ptr: UnsafePointer[
+        _block_Q8_K_packed[_block_Q4_K.group_size], MutAnyOrigin
+    ],
     b_ptr: UnsafePointer[_block_Q4_K_packed[], MutAnyOrigin],
     b_q_scales_and_mins_buf: UnsafePointer[UInt8, MutAnyOrigin],
     c_ptr: UnsafePointer[Float32, MutAnyOrigin],
@@ -1152,7 +1166,9 @@ fn _matmul_Q4_K_columns[
     simd_width: Int,
     elementwise_lambda_fn: OptionalReg[elementwise_epilogue_type] = None,
 ](
-    var a_ptr: UnsafePointer[_block_Q8_K_packed[_block_Q4_K.group_size], MutAnyOrigin],
+    var a_ptr: UnsafePointer[
+        _block_Q8_K_packed[_block_Q4_K.group_size], MutAnyOrigin
+    ],
     b_ptr: UnsafePointer[_block_Q4_K_packed[], MutAnyOrigin],
     var c_ptr: UnsafePointer[Float32, MutAnyOrigin],
     M: Int,
@@ -1184,14 +1200,14 @@ fn _matmul_Q4_K_columns[
             a_q_bits_ptr: UnsafePointer[Int8],
             mut c_int32_group: _Accumulator[DType.int32, 1, tile_n, simd_width],
         ):
-            _matmul_group_packed_Q4_K(
-                a_q_bits_ptr, b_q_bits_ptr, c_int32_group
-            )
+            _matmul_group_packed_Q4_K(a_q_bits_ptr, b_q_bits_ptr, c_int32_group)
 
         _matmul_Q4_K_tile[
-            tile_m=1, tile_n=tile_n, simd_width=simd_width,
+            tile_m=1,
+            tile_n=tile_n,
+            simd_width=simd_width,
             matmul_group_fn=matmul_group_packed,
-            elementwise_lambda_fn=elementwise_lambda_fn
+            elementwise_lambda_fn=elementwise_lambda_fn,
         ](
             a_ptr,
             b_ptr,
@@ -1231,9 +1247,11 @@ fn _matmul_Q4_K_columns[
             )
 
         _matmul_Q4_K_tile[
-            tile_m=tile_m, tile_n=tile_n, simd_width=simd_width,
+            tile_m=tile_m,
+            tile_n=tile_n,
+            simd_width=simd_width,
             matmul_group_fn=matmul_group_unpacked,
-            elementwise_lambda_fn=elementwise_lambda_fn
+            elementwise_lambda_fn=elementwise_lambda_fn,
         ](
             a_ptr,
             b_ptr,
@@ -1313,7 +1331,9 @@ fn _matmul_Q6_K_tile[
     ) capturing[_] -> None,
     elementwise_lambda_fn: OptionalReg[elementwise_epilogue_type] = None,
 ](
-    a_ptr: UnsafePointer[_block_Q8_K_packed[_block_Q6_K.group_size], MutAnyOrigin],
+    a_ptr: UnsafePointer[
+        _block_Q8_K_packed[_block_Q6_K.group_size], MutAnyOrigin
+    ],
     b_ptr: UnsafePointer[_block_Q6_K_packed[], MutAnyOrigin],
     c_ptr: UnsafePointer[mut=True, Float32, MutAnyOrigin],
     N: Int,
@@ -1396,7 +1416,9 @@ fn _matmul_Q6_K_columns[
     simd_width: Int,
     elementwise_lambda_fn: OptionalReg[elementwise_epilogue_type] = None,
 ](
-    var a_ptr: UnsafePointer[_block_Q8_K_packed[_block_Q6_K.group_size], MutAnyOrigin],
+    var a_ptr: UnsafePointer[
+        _block_Q8_K_packed[_block_Q6_K.group_size], MutAnyOrigin
+    ],
     b_ptr: UnsafePointer[_block_Q6_K_packed[], MutAnyOrigin],
     var c_ptr: UnsafePointer[Float32, MutAnyOrigin],
     M: Int,
@@ -1431,9 +1453,11 @@ fn _matmul_Q6_K_columns[
             )
 
         _matmul_Q6_K_tile[
-            tile_m=1, tile_n=tile_n, simd_width=simd_width,
+            tile_m=1,
+            tile_n=tile_n,
+            simd_width=simd_width,
             matmul_group_fn=matmul_group_packed,
-            elementwise_lambda_fn=elementwise_lambda_fn
+            elementwise_lambda_fn=elementwise_lambda_fn,
         ](
             a_ptr,
             b_ptr,
@@ -1454,7 +1478,6 @@ fn _matmul_Q6_K_columns[
     ]()
     b_tile_ptr[].q_bits.unpack[zero_point=b_zero_point](b_q_bits)
 
-
     @parameter
     @__copy_capture(b_tile_ptr, b_q_bits)
     @always_inline
@@ -1473,9 +1496,11 @@ fn _matmul_Q6_K_columns[
             )
 
         _matmul_Q6_K_tile[
-            tile_m=tile_m, tile_n=tile_n, simd_width=simd_width,
+            tile_m=tile_m,
+            tile_n=tile_n,
+            simd_width=simd_width,
             matmul_group_fn=matmul_group_unpacked,
-            elementwise_lambda_fn=elementwise_lambda_fn
+            elementwise_lambda_fn=elementwise_lambda_fn,
         ](
             a_ptr,
             b_ptr,
@@ -1557,9 +1582,12 @@ fn _matmul_Qb_K[
 
         for k_block in range(k_blocks):
             var bn_packed_ptr = b_packed_ptr + task_n_start
-            var cn_ptr = UnsafePointer[Float32, MutAnyOrigin](
-                unsafe_from_address=Int(c.ptr)
-            ) + task_n_start
+            var cn_ptr = (
+                UnsafePointer[Float32, MutAnyOrigin](
+                    unsafe_from_address=Int(c.ptr)
+                )
+                + task_n_start
+            )
             var accumulate = k_block > 0
 
             # only run epilogue for the last iter of K loop


### PR DESCRIPTION
This PR completes the migration of `max/kernels/src/quantization/qmatmul_k.mojo` from `LegacyUnsafePointer` to the new `UnsafePointer` v2 API.

## Changes
- Replaced all `LegacyUnsafePointer` instances with `UnsafePointer[T, origin]`
- Used `MutAnyOrigin` for all mutable pointer parameters across tile and column functions
- Updated function type signatures to use `OptionalReg` instead of `Optional`
- Added `OptionalReg` import from collections

## Implementation Notes
This migration was particularly challenging due to several issues:

1. **Origin and address space inference**: Initial attempts using `...` syntax failed because it unbinds both origin and address space, causing type mismatches when multiple pointers with different origins are passed to the same function.

2. **Parameter passing**: The `//,` separator requires all subsequent parameters to be passed by name once any keyword argument is used, which caused several "parameter passed both as positional and keyword" errors.

3. **Address space handling**: Early attempts required explicit `address_space_cast` calls, but the final solution uses `MutAnyOrigin` which defaults to `GENERIC` address space, eliminating the need for casts.

4. **Pointer conversion**: Converting between pointer types required explicit construction using `UnsafePointer[T, MutAnyOrigin](unsafe_from_address=Int(ptr))` rather than simple casts.

5. **Merge conflicts**: Rebasing on main required resolving conflicts where upstream had changed `Optional` to `OptionalReg`.

The final approach uses `MutAnyOrigin` throughout, which provides a concrete origin that accepts any mutable pointer source while maintaining type safety.

## Testing
- All builds pass with no errors
- All quantization tests pass successfully

Addresses #5671