### PR TITLE
[Kernels] Add variable length causal conv1d and selective scan kernels for Mamba SSM Architecture

### DIFF
--- a/max/kernels/src/state_space/varlen_causal_conv1d.mojo
+++ b/max/kernels/src/state_space/varlen_causal_conv1d.mojo
@@ -1,0 +1,1007 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Causal Conv1D with variable length sequence support (vLLM interface).
+
+This module implements causal 1D convolution operations that support variable
+length sequences using cumulative sequence lengths (cu_seqlens), compatible
+with the vLLM inference interface.
+
+Key Functions:
+    - causal_conv1d_varlen_fwd: Forward pass for varlen sequences
+    - causal_conv1d_varlen_update: Update function for decode
+    - causal_conv1d_varlen_states: Extract states from varlen sequences
+
+vLLM Interface:
+    - x: (dim, cu_seq_len) for varlen - sequences concatenated left to right
+    - query_start_loc: (batch + 1) int32 - cumulative sequence lengths
+    - cache_indices: (batch) int32 - indices into conv_states
+    - has_initial_state: (batch) bool - whether to use initial state
+    - conv_states: (..., dim, width - 1) - states updated in-place
+    - activation: None or "silu" or "swish"
+    - pad_slot_id: int - for identifying padded entries
+"""
+
+from collections import Optional
+from math import ceildiv, exp
+
+from algorithm import vectorize
+from buffer.buffer import NDBuffer
+from buffer.dimlist import Dim, DimList
+
+from gpu.host import DeviceContext
+from gpu import block_dim, block_idx, thread_idx
+
+from memory import UnsafePointer, memcpy
+
+from layout import Layout, LayoutTensor
+from state_space.causal_conv1d import silu
+from tensor import InputTensor, OutputTensor
+
+
+# ============================================================================
+# Constants
+# ============================================================================
+
+comptime PAD_SLOT_ID: Int32 = -1
+
+
+# ============================================================================
+# CPU Reference Implementations
+# ============================================================================
+
+
+fn causal_conv1d_varlen_states_cpu[
+    x_dtype: DType,
+    x_layout: Layout,
+    cu_seqlens_dtype: DType,
+    cu_seqlens_layout: Layout,
+    states_dtype: DType,
+    states_layout: Layout,
+](
+    total_tokens: Int,
+    dim: Int,
+    batch: Int,
+    state_len: Int,
+    x: LayoutTensor[
+        x_dtype, x_layout, MutAnyOrigin
+    ],  # Shape (total_tokens, dim)
+    cu_seqlens: LayoutTensor[
+        cu_seqlens_dtype, cu_seqlens_layout, MutAnyOrigin
+    ],  # Shape (batch + 1,)
+    states: LayoutTensor[
+        states_dtype, states_layout, MutAnyOrigin
+    ],  # Shape (batch, dim, state_len)
+    x_seqlen_stride: UInt32,
+    x_dim_stride: UInt32,
+    states_batch_stride: UInt32,
+    states_dim_stride: UInt32,
+    states_seqlen_stride: UInt32,
+):
+    """Extract the last state_len elements from each variable length sequence.
+
+    For each sequence in the batch, copies the last state_len tokens (or fewer
+    if the sequence is shorter) to the states tensor. If a sequence is shorter
+    than state_len, the earlier positions in states are zero-padded.
+
+    This is the CPU reference implementation for causal_conv1d_varlen_states.
+
+    Parameters:
+        x_dtype: Data type of the input tensor.
+        x_layout: Layout of the input tensor.
+        cu_seqlens_dtype: Data type of the cumulative sequence lengths.
+        cu_seqlens_layout: Layout of the cumulative sequence lengths.
+        states_dtype: Data type of the output states tensor.
+        states_layout: Layout of the output states tensor.
+
+    Args:
+        total_tokens: Total number of tokens across all sequences.
+        dim: Number of channels/dimensions.
+        batch: Number of sequences.
+        state_len: Number of elements to extract per sequence (typically width - 1).
+        x: Input tensor of shape (total_tokens, dim).
+        cu_seqlens: Cumulative sequence lengths of shape (batch + 1,).
+        states: Output states tensor of shape (batch, dim, state_len).
+        x_seqlen_stride: Stride for sequence dimension in x.
+        x_dim_stride: Stride for dimension in x.
+        states_batch_stride: Stride for batch dimension in states.
+        states_dim_stride: Stride for dimension in states.
+        states_seqlen_stride: Stride for sequence dimension in states.
+    """
+    # Initialize states to zero
+    for b in range(batch):
+        for d in range(dim):
+            for s in range(state_len):
+                var states_offset = (
+                    b * states_batch_stride
+                    + d * states_dim_stride
+                    + s * states_seqlen_stride
+                )
+                states.ptr[states_offset] = Scalar[states_dtype](0)
+
+    # Extract states for each sequence
+    for b in range(batch):
+        var end_idx = Int(cu_seqlens.ptr[b + 1])
+        var start_idx_seq = Int(cu_seqlens.ptr[b])
+        var start_idx = max(start_idx_seq, end_idx - state_len)
+        var num_elements = end_idx - start_idx
+
+        # Copy elements from x to states
+        # states[b, :, -(end_idx - start_idx):] = x[start_idx:end_idx].T
+        for i in range(num_elements):
+            var x_seq_idx = start_idx + i
+            var states_seq_idx = state_len - num_elements + i
+
+            for d in range(dim):
+                var x_offset = x_seq_idx * x_seqlen_stride + d * x_dim_stride
+                var states_offset = (
+                    b * states_batch_stride
+                    + d * states_dim_stride
+                    + states_seq_idx * states_seqlen_stride
+                )
+                var val = x.ptr[x_offset]
+                states.ptr[states_offset] = Scalar[states_dtype](val)
+
+
+fn causal_conv1d_varlen_fwd_cpu[
+    x_dtype: DType,
+    x_layout: Layout,
+    weight_dtype: DType,
+    weight_layout: Layout,
+    bias_dtype: DType,
+    bias_layout: Layout,
+    output_dtype: DType,
+    output_layout: Layout,
+    cu_seqlens_dtype: DType,
+    cu_seqlens_layout: Layout,
+    cache_indices_dtype: DType,
+    cache_indices_layout: Layout,
+    has_initial_state_dtype: DType,
+    has_initial_state_layout: Layout,
+    conv_states_dtype: DType,
+    conv_states_layout: Layout,
+](
+    dim: Int,
+    total_seqlen: Int,
+    width: Int,
+    batch: Int,
+    x: LayoutTensor[
+        x_dtype, x_layout, MutAnyOrigin
+    ],  # Shape (dim, total_seqlen) for varlen
+    weight: LayoutTensor[
+        weight_dtype, weight_layout, MutAnyOrigin
+    ],  # Shape (dim, width)
+    bias: LayoutTensor[bias_dtype, bias_layout, MutAnyOrigin],  # Shape (dim,)
+    query_start_loc: LayoutTensor[
+        cu_seqlens_dtype, cu_seqlens_layout, MutAnyOrigin
+    ],  # Shape (batch + 1,)
+    cache_indices: LayoutTensor[
+        cache_indices_dtype, cache_indices_layout, MutAnyOrigin
+    ],  # Shape (batch,)
+    has_initial_state: LayoutTensor[
+        has_initial_state_dtype, has_initial_state_layout, MutAnyOrigin
+    ],  # Shape (batch,)
+    conv_states: LayoutTensor[
+        conv_states_dtype, conv_states_layout, MutAnyOrigin
+    ],  # Shape (..., dim, width - 1)
+    output: LayoutTensor[
+        output_dtype, output_layout, MutAnyOrigin
+    ],  # Shape (dim, total_seqlen)
+    x_dim_stride: UInt32,
+    x_seqlen_stride: UInt32,
+    weight_dim_stride: UInt32,
+    weight_width_stride: UInt32,
+    out_dim_stride: UInt32,
+    out_seqlen_stride: UInt32,
+    conv_states_batch_stride: UInt32,
+    conv_states_dim_stride: UInt32,
+    conv_states_width_stride: UInt32,
+    silu_activation: Bool,
+    pad_slot_id: Int32,
+    has_cache_indices: Bool,
+    has_initial_state_flag: Bool,
+    has_conv_states: Bool,
+    has_bias: Bool,
+):
+    """Forward pass for causal conv1d with variable length sequences.
+
+    Performs causal 1D convolution on variable length sequences that are
+    concatenated together. Uses cumulative sequence lengths to identify
+    sequence boundaries.
+
+    Uses LayoutTensor with MutAnyOrigin for proper memory mutability.
+    """
+    var width_minus_1 = width - 1
+
+    # Process each sequence in the batch
+    for b in range(batch):
+        # Check if this is a padded entry
+        if has_cache_indices:
+            var cache_idx_val = Int32(cache_indices.ptr[b])
+            if cache_idx_val == pad_slot_id:
+                continue
+
+        var seq_start = Int(query_start_loc.ptr[b])
+        var seq_end = Int(query_start_loc.ptr[b + 1])
+        var seqlen = seq_end - seq_start
+
+        # Determine if we should use initial state
+        var use_initial_state = False
+        if has_initial_state_flag:
+            use_initial_state = Bool(has_initial_state.ptr[b])
+
+        # Get cache index for this batch
+        var cache_idx: Int = b
+        if has_cache_indices:
+            cache_idx = Int(cache_indices.ptr[b])
+
+        # Process each channel
+        for d in range(dim):
+            # Load bias
+            var bias_val: Scalar[output_dtype] = 0
+            if has_bias:
+                bias_val = Scalar[output_dtype](bias.ptr[d])
+
+            # Load weights for this channel
+            var weights = List[Scalar[weight_dtype]]()
+            for w_idx in range(width):
+                var weight_offset = (
+                    d * weight_dim_stride + w_idx * weight_width_stride
+                )
+                weights.append(weight.ptr[weight_offset])
+
+            # Process each position in the sequence
+            for l in range(seqlen):
+                var conv_sum = bias_val
+
+                # Convolution sum
+                for w_idx in range(width):
+                    var input_l = l - (width_minus_1 - w_idx)
+                    var input_val: Scalar[x_dtype] = 0
+
+                    if input_l >= 0:
+                        # Within current sequence
+                        var x_offset = (
+                            d * x_dim_stride
+                            + (seq_start + input_l) * x_seqlen_stride
+                        )
+                        input_val = x.ptr[x_offset]
+                    elif use_initial_state and has_conv_states:
+                        # Use initial state from conv_states
+                        var state_idx = (
+                            width_minus_1 + input_l
+                        )  # Maps negative to state index
+                        if state_idx >= 0:
+                            var state_offset = (
+                                cache_idx * conv_states_batch_stride
+                                + d * conv_states_dim_stride
+                                + state_idx * conv_states_width_stride
+                            )
+                            input_val = Scalar[x_dtype](
+                                conv_states.ptr[state_offset]
+                            )
+
+                    conv_sum += Scalar[output_dtype](
+                        input_val * Scalar[x_dtype](weights[w_idx])
+                    )
+
+                # Apply activation
+                var out_val = conv_sum
+                if silu_activation:
+
+                    @parameter
+                    if output_dtype.is_floating_point():
+                        out_val = silu(out_val)
+                    else:
+                        out_val = silu(out_val.cast[DType.float32]()).cast[
+                            output_dtype
+                        ]()
+
+                # Store output
+                var out_offset = (
+                    d * out_dim_stride + (seq_start + l) * out_seqlen_stride
+                )
+                output.ptr[out_offset] = out_val
+
+            # Update conv_states with final state if provided
+            if has_conv_states:
+                # Copy last (width-1) elements to conv_states
+                for s in range(width_minus_1):
+                    var src_l = seqlen - width_minus_1 + s
+                    var val: Scalar[conv_states_dtype] = 0
+
+                    if src_l >= 0:
+                        var x_offset = (
+                            d * x_dim_stride
+                            + (seq_start + src_l) * x_seqlen_stride
+                        )
+                        val = Scalar[conv_states_dtype](x.ptr[x_offset])
+                    elif use_initial_state:
+                        # Carry over from initial state
+                        var state_idx = width_minus_1 + src_l - (width_minus_1)
+                        if state_idx >= 0 and state_idx < width_minus_1:
+                            var state_offset = (
+                                cache_idx * conv_states_batch_stride
+                                + d * conv_states_dim_stride
+                                + state_idx * conv_states_width_stride
+                            )
+                            val = conv_states.ptr[state_offset]
+
+                    var state_offset = (
+                        cache_idx * conv_states_batch_stride
+                        + d * conv_states_dim_stride
+                        + s * conv_states_width_stride
+                    )
+                    conv_states.ptr[state_offset] = val
+
+
+fn causal_conv1d_varlen_update_cpu[
+    x_dtype: DType,
+    x_layout: Layout,
+    weight_dtype: DType,
+    weight_layout: Layout,
+    bias_dtype: DType,
+    bias_layout: Layout,
+    output_dtype: DType,
+    output_layout: Layout,
+    conv_state_dtype: DType,
+    conv_state_layout: Layout,
+    cache_seqlens_dtype: DType,
+    cache_seqlens_layout: Layout,
+    conv_state_indices_dtype: DType,
+    conv_state_indices_layout: Layout,
+](
+    batch: Int,
+    dim: Int,
+    seqlen: Int,
+    width: Int,
+    state_len: Int,
+    x: LayoutTensor[
+        x_dtype, x_layout, MutAnyOrigin
+    ],  # Shape (batch, dim) or (batch, dim, seqlen)
+    weight: LayoutTensor[
+        weight_dtype, weight_layout, MutAnyOrigin
+    ],  # Shape (dim, width)
+    bias: LayoutTensor[bias_dtype, bias_layout, MutAnyOrigin],  # Shape (dim,)
+    conv_state: LayoutTensor[
+        conv_state_dtype, conv_state_layout, MutAnyOrigin
+    ],  # Shape (batch, dim, state_len)
+    cache_seqlens: LayoutTensor[
+        cache_seqlens_dtype, cache_seqlens_layout, MutAnyOrigin
+    ],  # Shape (batch,)
+    conv_state_indices: LayoutTensor[
+        conv_state_indices_dtype, conv_state_indices_layout, MutAnyOrigin
+    ],  # Shape (batch,)
+    output: LayoutTensor[
+        output_dtype, output_layout, MutAnyOrigin
+    ],  # Shape (batch, dim) or (batch, dim, seqlen)
+    x_batch_stride: UInt32,
+    x_dim_stride: UInt32,
+    x_seqlen_stride: UInt32,
+    weight_dim_stride: UInt32,
+    weight_width_stride: UInt32,
+    conv_state_batch_stride: UInt32,
+    conv_state_dim_stride: UInt32,
+    conv_state_seqlen_stride: UInt32,
+    out_batch_stride: UInt32,
+    out_dim_stride: UInt32,
+    out_seqlen_stride: UInt32,
+    silu_activation: Bool,
+    pad_slot_id: Int32,
+    has_conv_state_indices: Bool,
+    has_cache_seqlens: Bool,
+    has_bias: Bool,
+):
+    """Update function for causal conv1d decode.
+
+    Updates the convolution state and computes output for decode steps.
+    Supports circular buffer state management with cache_seqlens.
+
+    Uses LayoutTensor with MutAnyOrigin for proper memory mutability.
+    """
+    var width_minus_1 = width - 1
+
+    for b in range(batch):
+        # Check for padded entry
+        if has_conv_state_indices:
+            var state_idx_val = Int32(conv_state_indices.ptr[b])
+            if state_idx_val == pad_slot_id:
+                continue
+
+        # Determine actual batch index for conv_state
+        var state_batch_idx = b
+        if has_conv_state_indices:
+            state_batch_idx = Int(conv_state_indices.ptr[b])
+
+        for d in range(dim):
+            # Load bias
+            var bias_val: Scalar[output_dtype] = 0
+            if has_bias:
+                bias_val = Scalar[output_dtype](bias.ptr[d])
+
+            # Load weights
+            var weights = List[Scalar[weight_dtype]]()
+            for w_idx in range(width):
+                var weight_offset = (
+                    d * weight_dim_stride + w_idx * weight_width_stride
+                )
+                weights.append(weight.ptr[weight_offset])
+
+            for l in range(seqlen):
+                # Get cache position for circular buffer
+                var cache_offset = 0
+                if has_cache_seqlens:
+                    var cache_seqlen = Int(cache_seqlens.ptr[b])
+                    cache_offset = (cache_seqlen + l) % state_len
+
+                # Gather input values from state and current x
+                var input_vals = List[Scalar[x_dtype]]()
+                for w_idx in range(width):
+                    var input_val: Scalar[x_dtype] = 0
+                    var rel_pos = (
+                        w_idx - width_minus_1
+                    )  # Ranges from -(width-1) to 0
+
+                    if rel_pos + l < 0:
+                        # Read from state
+                        var state_pos: Int
+                        if has_cache_seqlens:
+                            # Circular buffer
+                            var cache_seqlen = Int(cache_seqlens.ptr[b])
+                            state_pos = (
+                                cache_seqlen + rel_pos + l + state_len
+                            ) % state_len
+                        else:
+                            # Linear buffer: position in state
+                            state_pos = width_minus_1 + rel_pos + l
+
+                        if state_pos >= 0 and state_pos < state_len:
+                            var state_offset = (
+                                state_batch_idx * conv_state_batch_stride
+                                + d * conv_state_dim_stride
+                                + state_pos * conv_state_seqlen_stride
+                            )
+                            input_val = Scalar[x_dtype](
+                                conv_state.ptr[state_offset]
+                            )
+                    else:
+                        # Read from current x
+                        var x_l = rel_pos + l
+                        if x_l >= 0 and x_l < seqlen:
+                            var x_offset = (
+                                b * x_batch_stride
+                                + d * x_dim_stride
+                                + x_l * x_seqlen_stride
+                            )
+                            input_val = x.ptr[x_offset]
+
+                    input_vals.append(input_val)
+
+                # Compute convolution
+                var conv_sum = bias_val
+                for w_idx in range(width):
+                    conv_sum += Scalar[output_dtype](
+                        input_vals[w_idx] * Scalar[x_dtype](weights[w_idx])
+                    )
+
+                # Apply activation
+                var out_val = conv_sum
+                if silu_activation:
+
+                    @parameter
+                    if output_dtype.is_floating_point():
+                        out_val = silu(out_val)
+                    else:
+                        out_val = silu(out_val.cast[DType.float32]()).cast[
+                            output_dtype
+                        ]()
+
+                # Store output
+                var out_offset = (
+                    b * out_batch_stride
+                    + d * out_dim_stride
+                    + l * out_seqlen_stride
+                )
+                output.ptr[out_offset] = out_val
+
+            # Update state with new x values
+            for l in range(seqlen):
+                var x_offset = (
+                    b * x_batch_stride + d * x_dim_stride + l * x_seqlen_stride
+                )
+                var x_val = x.ptr[x_offset]
+
+                var state_pos: Int
+                if has_cache_seqlens:
+                    # Circular buffer
+                    var cache_seqlen = Int(cache_seqlens.ptr[b])
+                    state_pos = (cache_seqlen + l) % state_len
+                else:
+                    # Shift state left and add new value at end
+                    if l == 0:
+                        # Shift existing values
+                        for s in range(state_len - seqlen):
+                            var src_offset = (
+                                state_batch_idx * conv_state_batch_stride
+                                + d * conv_state_dim_stride
+                                + (s + seqlen) * conv_state_seqlen_stride
+                            )
+                            var dst_offset = (
+                                state_batch_idx * conv_state_batch_stride
+                                + d * conv_state_dim_stride
+                                + s * conv_state_seqlen_stride
+                            )
+                            var val = conv_state.ptr[src_offset]
+                            conv_state.ptr[dst_offset] = val
+                    state_pos = state_len - seqlen + l
+
+                var state_offset = (
+                    state_batch_idx * conv_state_batch_stride
+                    + d * conv_state_dim_stride
+                    + state_pos * conv_state_seqlen_stride
+                )
+                conv_state.ptr[state_offset] = Scalar[conv_state_dtype](x_val)
+
+
+# ============================================================================
+# GPU Kernel Implementations
+# ============================================================================
+
+
+fn causal_conv1d_varlen_states_gpu[
+    x_dtype: DType,
+    x_layout: Layout,
+    cu_seqlens_dtype: DType,
+    cu_seqlens_layout: Layout,
+    states_dtype: DType,
+    states_layout: Layout,
+    BLOCK_M: Int,
+    BLOCK_N: Int,
+](
+    total_tokens: Int,
+    dim: Int,
+    batch: Int,
+    state_len: Int,
+    x: LayoutTensor[
+        x_dtype, x_layout, MutAnyOrigin
+    ],  # Shape (total_tokens, dim)
+    cu_seqlens: LayoutTensor[
+        cu_seqlens_dtype, cu_seqlens_layout, MutAnyOrigin
+    ],  # Shape (batch + 1,)
+    states: LayoutTensor[
+        states_dtype, states_layout, MutAnyOrigin
+    ],  # Shape (batch, dim, state_len)
+    x_seqlen_stride: UInt32,
+    x_dim_stride: UInt32,
+    states_batch_stride: UInt32,
+    states_dim_stride: UInt32,
+    states_seqlen_stride: UInt32,
+):
+    """GPU kernel for extracting states from variable length sequences.
+
+    Each thread block processes a tile of (BLOCK_M x BLOCK_N) elements.
+    Grid dimensions: (ceildiv(dim, BLOCK_N), ceildiv(state_len, BLOCK_M), batch)
+
+    Parameters:
+        x_dtype: Data type of input.
+        x_layout: Layout of input.
+        cu_seqlens_dtype: Data type of cumulative sequence lengths.
+        cu_seqlens_layout: Layout of cumulative sequence lengths.
+        states_dtype: Data type of output states.
+        states_layout: Layout of output states.
+        BLOCK_M: Tile size for sequence dimension.
+        BLOCK_N: Tile size for channel dimension.
+
+    Args:
+        total_tokens: Total number of tokens.
+        dim: Number of channels.
+        batch: Number of sequences.
+        state_len: State length to extract.
+        x: Input tensor.
+        cu_seqlens: Cumulative sequence lengths.
+        states: Output states tensor.
+        x_seqlen_stride: Stride for sequence in x.
+        x_dim_stride: Stride for dimension in x.
+        states_batch_stride: Stride for batch in states.
+        states_dim_stride: Stride for dimension in states.
+        states_seqlen_stride: Stride for sequence in states.
+    """
+    var batch_idx = Int(block_idx.z)
+    var block_row = Int(block_idx.y)
+    var block_col = Int(block_idx.x)
+    var tid_row = Int(thread_idx.y)
+    var tid_col = Int(thread_idx.x)
+
+    # Load sequence boundaries
+    var end_idx = Int(cu_seqlens.ptr[batch_idx + 1])
+    var start_idx_seq = Int(cu_seqlens.ptr[batch_idx])
+    var start_idx = max(start_idx_seq, end_idx - state_len)
+
+    # Calculate row indices (processing from end backwards)
+    var row = end_idx - (block_row * BLOCK_M + tid_row + 1)
+    var col = block_col * BLOCK_N + tid_col
+
+    # Load value from x if in valid range
+    var val: Scalar[states_dtype] = 0
+    if row >= start_idx and col < dim:
+        var x_offset = row * x_seqlen_stride + col * x_dim_stride
+        val = Scalar[states_dtype](x.ptr[x_offset])
+
+    # Calculate state row index
+    var states_row = state_len - (block_row * BLOCK_M + tid_row + 1)
+
+    # Store to states if in valid range
+    if states_row >= 0 and col < dim:
+        var states_offset = (
+            batch_idx * states_batch_stride
+            + col * states_dim_stride
+            + states_row * states_seqlen_stride
+        )
+        states.ptr[states_offset] = val
+
+
+fn causal_conv1d_varlen_fwd_gpu[
+    x_dtype: DType,
+    x_layout: Layout,
+    weight_dtype: DType,
+    weight_layout: Layout,
+    bias_dtype: DType,
+    bias_layout: Layout,
+    output_dtype: DType,
+    output_layout: Layout,
+    cu_seqlens_dtype: DType,
+    cu_seqlens_layout: Layout,
+    cache_indices_dtype: DType,
+    cache_indices_layout: Layout,
+    has_initial_state_dtype: DType,
+    has_initial_state_layout: Layout,
+    conv_states_dtype: DType,
+    conv_states_layout: Layout,
+    WIDTH: Int,
+    BLOCK_DIM: Int,
+    BLOCK_SEQ: Int,
+](
+    dim: Int,
+    total_seqlen: Int,
+    batch: Int,
+    x: LayoutTensor[x_dtype, x_layout, MutAnyOrigin],
+    weight: LayoutTensor[weight_dtype, weight_layout, MutAnyOrigin],
+    bias: LayoutTensor[bias_dtype, bias_layout, MutAnyOrigin],
+    query_start_loc: LayoutTensor[
+        cu_seqlens_dtype, cu_seqlens_layout, MutAnyOrigin
+    ],
+    cache_indices: LayoutTensor[
+        cache_indices_dtype, cache_indices_layout, MutAnyOrigin
+    ],
+    has_initial_state: LayoutTensor[
+        has_initial_state_dtype, has_initial_state_layout, MutAnyOrigin
+    ],
+    conv_states: LayoutTensor[
+        conv_states_dtype, conv_states_layout, MutAnyOrigin
+    ],
+    output: LayoutTensor[output_dtype, output_layout, MutAnyOrigin],
+    x_dim_stride: UInt32,
+    x_seqlen_stride: UInt32,
+    weight_dim_stride: UInt32,
+    weight_width_stride: UInt32,
+    out_dim_stride: UInt32,
+    out_seqlen_stride: UInt32,
+    conv_states_batch_stride: UInt32,
+    conv_states_dim_stride: UInt32,
+    conv_states_width_stride: UInt32,
+    silu_activation: Int8,
+    pad_slot_id: Int32,
+    has_cache_indices: Int8,
+    has_initial_state_flag: Int8,
+    has_conv_states: Int8,
+    has_bias: Int8,
+):
+    """GPU kernel for causal conv1d forward with variable length sequences.
+
+    Grid: (batch, ceildiv(dim, BLOCK_DIM))
+    Block: (BLOCK_DIM, BLOCK_SEQ)
+
+    Each block processes BLOCK_DIM channels for one sequence.
+    Uses LayoutTensor with MutAnyOrigin for proper GPU memory mutability.
+
+    Note: silu_activation and flag parameters are Int8 (0 or 1) instead of Bool
+    for DevicePassable compatibility on GPU.
+    """
+    var batch_idx = Int(block_idx.x)
+    var dim_block_idx = Int(block_idx.y)
+    var tid = Int(thread_idx.x)
+
+    var d = dim_block_idx * BLOCK_DIM + tid
+
+    # Check for padding
+    if has_cache_indices != 0:
+        var cache_idx_val = Int32(cache_indices.ptr[batch_idx])
+        if cache_idx_val == pad_slot_id:
+            return
+
+    # Get sequence bounds
+    var seq_start = Int(query_start_loc.ptr[batch_idx])
+    var seq_end = Int(query_start_loc.ptr[batch_idx + 1])
+    var seqlen = seq_end - seq_start
+
+    if d >= dim:
+        return
+
+    # Check for initial state
+    var use_initial_state = False
+    if has_initial_state_flag != 0:
+        use_initial_state = Bool(has_initial_state.ptr[batch_idx])
+
+    # Get cache index
+    var cache_idx: Int = batch_idx
+    if has_cache_indices != 0:
+        cache_idx = Int(cache_indices.ptr[batch_idx])
+
+    # Load bias
+    var bias_val: Scalar[output_dtype] = 0
+    if has_bias != 0:
+        bias_val = Scalar[output_dtype](bias.ptr[d])
+
+    # Load weights into registers
+    var weights = SIMD[weight_dtype, 8](0)  # Initialize with zeros
+    for w_idx in range(WIDTH):
+        var weight_offset = d * weight_dim_stride + w_idx * weight_width_stride
+        weights[w_idx] = weight.ptr[weight_offset]
+
+    comptime WIDTH_MINUS_1 = WIDTH - 1
+
+    # Process sequence
+    for l in range(seqlen):
+        var conv_sum = bias_val
+
+        # Gather inputs and compute convolution
+        @parameter
+        for w_idx in range(WIDTH):
+            var input_l = l - (WIDTH_MINUS_1 - w_idx)
+            var input_val: Scalar[x_dtype] = 0
+
+            if input_l >= 0:
+                var x_offset = (
+                    d * x_dim_stride + (seq_start + input_l) * x_seqlen_stride
+                )
+                input_val = x.ptr[x_offset]
+            elif use_initial_state and has_conv_states != 0:
+                var state_idx = WIDTH_MINUS_1 + input_l
+                if state_idx >= 0:
+                    var state_offset = (
+                        cache_idx * conv_states_batch_stride
+                        + d * conv_states_dim_stride
+                        + state_idx * conv_states_width_stride
+                    )
+                    input_val = Scalar[x_dtype](conv_states.ptr[state_offset])
+
+            conv_sum += Scalar[output_dtype](
+                input_val * Scalar[x_dtype](weights[w_idx])
+            )
+
+        # Apply activation
+        var out_val = conv_sum
+        if silu_activation != 0:
+
+            @parameter
+            if output_dtype.is_floating_point():
+                out_val = silu(out_val)
+            else:
+                out_val = silu(out_val.cast[DType.float32]()).cast[
+                    output_dtype
+                ]()
+
+        # Store output
+        var out_offset = (
+            d * out_dim_stride + (seq_start + l) * out_seqlen_stride
+        )
+        output.ptr[out_offset] = out_val
+
+    # Update conv_states
+    if has_conv_states != 0:
+
+        @parameter
+        for s in range(WIDTH_MINUS_1):
+            var src_l = seqlen - WIDTH_MINUS_1 + s
+            var val: Scalar[conv_states_dtype] = 0
+
+            if src_l >= 0:
+                var x_offset = (
+                    d * x_dim_stride + (seq_start + src_l) * x_seqlen_stride
+                )
+                val = Scalar[conv_states_dtype](x.ptr[x_offset])
+
+            var state_offset = (
+                cache_idx * conv_states_batch_stride
+                + d * conv_states_dim_stride
+                + s * conv_states_width_stride
+            )
+            conv_states.ptr[state_offset] = val
+
+
+fn causal_conv1d_varlen_update_gpu[
+    x_dtype: DType,
+    x_layout: Layout,
+    weight_dtype: DType,
+    weight_layout: Layout,
+    bias_dtype: DType,
+    bias_layout: Layout,
+    output_dtype: DType,
+    output_layout: Layout,
+    conv_state_dtype: DType,
+    conv_state_layout: Layout,
+    cache_seqlens_dtype: DType,
+    cache_seqlens_layout: Layout,
+    conv_state_indices_dtype: DType,
+    conv_state_indices_layout: Layout,
+    WIDTH: Int,
+    BLOCK_DIM: Int,
+](
+    batch: Int,
+    dim: Int,
+    seqlen: Int,
+    state_len: Int,
+    x: LayoutTensor[x_dtype, x_layout, MutAnyOrigin],
+    weight: LayoutTensor[weight_dtype, weight_layout, MutAnyOrigin],
+    bias: LayoutTensor[bias_dtype, bias_layout, MutAnyOrigin],
+    conv_state: LayoutTensor[conv_state_dtype, conv_state_layout, MutAnyOrigin],
+    cache_seqlens: LayoutTensor[
+        cache_seqlens_dtype, cache_seqlens_layout, MutAnyOrigin
+    ],
+    conv_state_indices: LayoutTensor[
+        conv_state_indices_dtype, conv_state_indices_layout, MutAnyOrigin
+    ],
+    output: LayoutTensor[output_dtype, output_layout, MutAnyOrigin],
+    x_batch_stride: UInt32,
+    x_dim_stride: UInt32,
+    x_seqlen_stride: UInt32,
+    weight_dim_stride: UInt32,
+    weight_width_stride: UInt32,
+    conv_state_batch_stride: UInt32,
+    conv_state_dim_stride: UInt32,
+    conv_state_seqlen_stride: UInt32,
+    out_batch_stride: UInt32,
+    out_dim_stride: UInt32,
+    out_seqlen_stride: UInt32,
+    silu_activation: Int8,
+    pad_slot_id: Int32,
+    has_conv_state_indices: Int8,
+    has_cache_seqlens: Int8,
+    has_bias: Int8,
+):
+    """GPU kernel for causal conv1d update (decode step).
+
+    Grid: (batch, ceildiv(dim, BLOCK_DIM))
+    Block: (BLOCK_DIM,)
+
+    Uses LayoutTensor with MutAnyOrigin for proper GPU memory mutability.
+
+    Note: silu_activation and flag parameters are Int8 (0 or 1) instead of Bool
+    for DevicePassable compatibility on GPU.
+    """
+    var batch_idx = Int(block_idx.x)
+    var dim_block_idx = Int(block_idx.y)
+    var tid = Int(thread_idx.x)
+
+    var d = dim_block_idx * BLOCK_DIM + tid
+
+    # Check for padding
+    if has_conv_state_indices != 0:
+        var state_idx_val = Int32(conv_state_indices.ptr[batch_idx])
+        if state_idx_val == pad_slot_id:
+            return
+
+    if d >= dim:
+        return
+
+    # Get state batch index
+    var state_batch_idx: Int = batch_idx
+    if has_conv_state_indices != 0:
+        state_batch_idx = Int(conv_state_indices.ptr[batch_idx])
+
+    # Load bias
+    var bias_val: Scalar[output_dtype] = 0
+    if has_bias != 0:
+        bias_val = Scalar[output_dtype](bias.ptr[d])
+
+    # Load weights
+    var weights = SIMD[weight_dtype, 8](0)  # Initialize with zeros
+    for w_idx in range(WIDTH):
+        var weight_offset = d * weight_dim_stride + w_idx * weight_width_stride
+        weights[w_idx] = weight.ptr[weight_offset]
+
+    comptime WIDTH_MINUS_1 = WIDTH - 1
+
+    for l in range(seqlen):
+        # Get cache position
+        var cache_offset = 0
+        if has_cache_seqlens != 0:
+            var cache_seqlen = Int(cache_seqlens.ptr[batch_idx])
+            cache_offset = cache_seqlen
+
+        # Gather inputs and compute
+        var conv_sum = bias_val
+
+        @parameter
+        for w_idx in range(WIDTH):
+            var rel_pos = w_idx - WIDTH_MINUS_1
+            var input_val: Scalar[x_dtype] = 0
+
+            if rel_pos + l < 0:
+                # From state
+                var state_pos: Int
+                if has_cache_seqlens != 0:
+                    state_pos = (
+                        cache_offset + rel_pos + l + state_len
+                    ) % state_len
+                else:
+                    state_pos = WIDTH_MINUS_1 + rel_pos + l
+
+                if state_pos >= 0 and state_pos < state_len:
+                    var state_offset = (
+                        state_batch_idx * conv_state_batch_stride
+                        + d * conv_state_dim_stride
+                        + state_pos * conv_state_seqlen_stride
+                    )
+                    input_val = Scalar[x_dtype](conv_state.ptr[state_offset])
+            else:
+                # From x
+                var x_l = rel_pos + l
+                if x_l >= 0 and x_l < seqlen:
+                    var x_offset = (
+                        batch_idx * x_batch_stride
+                        + d * x_dim_stride
+                        + x_l * x_seqlen_stride
+                    )
+                    input_val = x.ptr[x_offset]
+
+            conv_sum += Scalar[output_dtype](
+                input_val * Scalar[x_dtype](weights[w_idx])
+            )
+        # Apply activation
+        var out_val = conv_sum
+        if silu_activation != 0:
+
+            @parameter
+            if output_dtype.is_floating_point():
+                out_val = silu(out_val)
+            else:
+                out_val = silu(out_val.cast[DType.float32]()).cast[
+                    output_dtype
+                ]()
+
+        # Store output
+        var out_offset = (
+            batch_idx * out_batch_stride
+            + d * out_dim_stride
+            + l * out_seqlen_stride
+        )
+        output.ptr[out_offset] = out_val
+
+        # Update state
+        var x_offset = (
+            batch_idx * x_batch_stride + d * x_dim_stride + l * x_seqlen_stride
+        )
+        var x_val = x.ptr[x_offset]
+
+        var state_pos: Int
+        if has_cache_seqlens != 0:
+            state_pos = (cache_offset + l) % state_len
+        else:
+            state_pos = state_len - seqlen + l
+
+        var state_offset = (
+            state_batch_idx * conv_state_batch_stride
+            + d * conv_state_dim_stride
+            + state_pos * conv_state_seqlen_stride
+        )
+        conv_state.ptr[state_offset] = Scalar[conv_state_dtype](x_val)

--- a/max/kernels/src/state_space/varlen_causal_conv1d.mojo
+++ b/max/kernels/src/state_space/varlen_causal_conv1d.mojo
@@ -217,8 +217,6 @@ fn causal_conv1d_varlen_fwd_cpu[
     Performs causal 1D convolution on variable length sequences that are
     concatenated together. Uses cumulative sequence lengths to identify
     sequence boundaries.
-
-    Uses LayoutTensor with MutAnyOrigin for proper memory mutability.
     """
     var width_minus_1 = width - 1
 
@@ -405,8 +403,6 @@ fn causal_conv1d_varlen_update_cpu[
 
     Updates the convolution state and computes output for decode steps.
     Supports circular buffer state management with cache_seqlens.
-
-    Uses LayoutTensor with MutAnyOrigin for proper memory mutability.
     """
     var width_minus_1 = width - 1
 
@@ -711,7 +707,6 @@ fn causal_conv1d_varlen_fwd_gpu[
     Block: (BLOCK_DIM, BLOCK_SEQ)
 
     Each block processes BLOCK_DIM channels for one sequence.
-    Uses LayoutTensor with MutAnyOrigin for proper GPU memory mutability.
 
     Note: silu_activation and flag parameters are Int8 (0 or 1) instead of Bool
     for DevicePassable compatibility on GPU.
@@ -882,8 +877,6 @@ fn causal_conv1d_varlen_update_gpu[
 
     Grid: (batch, ceildiv(dim, BLOCK_DIM))
     Block: (BLOCK_DIM,)
-
-    Uses LayoutTensor with MutAnyOrigin for proper GPU memory mutability.
 
     Note: silu_activation and flag parameters are Int8 (0 or 1) instead of Bool
     for DevicePassable compatibility on GPU.

--- a/max/kernels/src/state_space/varlen_causal_conv1d_ops.mojo
+++ b/max/kernels/src/state_space/varlen_causal_conv1d_ops.mojo
@@ -73,9 +73,9 @@ struct CausalConv1DVarlenFwd[activation: StaticString]:
         x: InputTensor[dtype=dtype, rank=2],
         weight: InputTensor[dtype=dtype, rank=2],
         bias: InputTensor[dtype=dtype, rank=1],
-        query_start_loc: InputTensor[dtype=DType.int32, rank=1],
-        cache_indices: InputTensor[dtype=DType.int32, rank=1],
-        has_initial_state: InputTensor[dtype=DType.bool, rank=1],
+        query_start_loc: InputTensor[dtype = DType.int32, rank=1],
+        cache_indices: InputTensor[dtype = DType.int32, rank=1],
+        has_initial_state: InputTensor[dtype = DType.bool, rank=1],
         conv_states: OutputTensor[dtype=dtype, rank=3],
         ctx: DeviceContextPtr,
     ) capturing raises:
@@ -501,9 +501,9 @@ struct CausalConv1DVarlenFwd[activation: StaticString]:
         x: InputTensor[dtype=dtype, rank=2],
         weight: InputTensor[dtype=dtype, rank=2],
         bias: InputTensor[dtype=dtype, rank=1],
-        query_start_loc: InputTensor[dtype=DType.int32, rank=1],
-        cache_indices: InputTensor[dtype=DType.int32, rank=1],
-        has_initial_state: InputTensor[dtype=DType.bool, rank=1],
+        query_start_loc: InputTensor[dtype = DType.int32, rank=1],
+        cache_indices: InputTensor[dtype = DType.int32, rank=1],
+        has_initial_state: InputTensor[dtype = DType.bool, rank=1],
         conv_states: InputTensor[dtype=dtype, rank=3],
     ) -> IndexList[2]:
         return x.shape()
@@ -544,8 +544,8 @@ struct CausalConv1DVarlenUpdate[activation: StaticString]:
         weight: InputTensor[dtype=dtype, rank=2],
         bias: InputTensor[dtype=dtype, rank=1],
         conv_state: OutputTensor[dtype=dtype, rank=3],
-        cache_seqlens: InputTensor[dtype=DType.int32, rank=1],
-        conv_state_indices: InputTensor[dtype=DType.int32, rank=1],
+        cache_seqlens: InputTensor[dtype = DType.int32, rank=1],
+        conv_state_indices: InputTensor[dtype = DType.int32, rank=1],
         ctx: DeviceContextPtr,
     ) capturing raises:
         var batch = x.dim_size(0)
@@ -942,8 +942,8 @@ struct CausalConv1DVarlenUpdate[activation: StaticString]:
         weight: InputTensor[dtype=dtype, rank=2],
         bias: InputTensor[dtype=dtype, rank=1],
         conv_state: InputTensor[dtype=dtype, rank=3],
-        cache_seqlens: InputTensor[dtype=DType.int32, rank=1],
-        conv_state_indices: InputTensor[dtype=DType.int32, rank=1],
+        cache_seqlens: InputTensor[dtype = DType.int32, rank=1],
+        conv_state_indices: InputTensor[dtype = DType.int32, rank=1],
     ) -> IndexList[3]:
         return x.shape()
 
@@ -973,7 +973,7 @@ struct CausalConv1DVarlenStates:
     ](
         states: OutputTensor[dtype=dtype, rank=3],
         x: InputTensor[dtype=dtype, rank=2],
-        cu_seqlens: InputTensor[dtype=DType.int32, rank=1],
+        cu_seqlens: InputTensor[dtype = DType.int32, rank=1],
         ctx: DeviceContextPtr,
     ) capturing raises:
         var total_tokens = x.dim_size(0)
@@ -1065,7 +1065,7 @@ struct CausalConv1DVarlenStates:
         dtype: DType,
     ](
         x: InputTensor[dtype=dtype, rank=2],
-        cu_seqlens: InputTensor[dtype=DType.int32, rank=1],
+        cu_seqlens: InputTensor[dtype = DType.int32, rank=1],
         state_len: Int,
     ) -> IndexList[3]:
         var batch = cu_seqlens.dim_size(0) - 1

--- a/max/kernels/src/state_space/varlen_causal_conv1d_ops.mojo
+++ b/max/kernels/src/state_space/varlen_causal_conv1d_ops.mojo
@@ -1,0 +1,1073 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Varlen Causal Conv1D operation registrations for Mamba SSM.
+
+This module registers operations for variable-length causal 1D convolution:
+- causal_conv1d_varlen_fwd: Forward pass for varlen sequences
+- causal_conv1d_varlen_update: Update for decode/autoregressive inference
+- causal_conv1d_varlen_states: Extract states from varlen sequences
+"""
+
+from math import ceildiv
+
+import compiler_internal as compiler
+from gpu.host import DeviceContext
+from gpu.host.info import is_cpu, is_gpu
+from runtime.asyncrt import DeviceContextPtr
+from tensor import InputTensor, OutputTensor
+from utils.index import IndexList
+
+from state_space.varlen_causal_conv1d import (
+    causal_conv1d_varlen_fwd_cpu,
+    causal_conv1d_varlen_fwd_gpu,
+    causal_conv1d_varlen_update_cpu,
+    causal_conv1d_varlen_update_gpu,
+    causal_conv1d_varlen_states_cpu,
+    causal_conv1d_varlen_states_gpu,
+)
+
+
+# ============================================================================
+# Varlen Causal Conv1D Forward Registration
+# ============================================================================
+
+
+@compiler.register("causal_conv1d_varlen_fwd")
+struct CausalConv1DVarlenFwd[activation: StaticString]:
+    """Varlen causal 1D convolution forward pass.
+
+    Performs causal 1D convolution on variable-length sequences that are
+    concatenated together. Uses cumulative sequence lengths to identify
+    sequence boundaries.
+
+    Parameters:
+        activation: Activation function - "none" or "silu".
+
+    Tensor Shapes:
+        - output: (dim, total_seqlen) - Output tensor
+        - x: (dim, total_seqlen) - Input tensor (concatenated sequences)
+        - weight: (dim, width) - Convolution weights per channel
+        - bias: (dim,) - Per-channel bias
+        - query_start_loc: (batch + 1,) - Cumulative sequence lengths
+        - cache_indices: (batch,) - Indices into conv_states (optional)
+        - has_initial_state: (batch,) - Whether to use initial state (optional)
+        - conv_states: (batch, dim, width - 1) - Conv states (optional, in/out)
+    """
+
+    @staticmethod
+    fn execute[
+        dtype: DType,
+        target: StaticString,
+    ](
+        output: OutputTensor[dtype=dtype, rank=2],
+        x: InputTensor[dtype=dtype, rank=2],
+        weight: InputTensor[dtype=dtype, rank=2],
+        bias: InputTensor[dtype=dtype, rank=1],
+        query_start_loc: InputTensor[dtype=DType.int32, rank=1],
+        cache_indices: InputTensor[dtype=DType.int32, rank=1],
+        has_initial_state: InputTensor[dtype=DType.bool, rank=1],
+        conv_states: OutputTensor[dtype=dtype, rank=3],
+        ctx: DeviceContextPtr,
+    ) capturing raises:
+        var dim = x.dim_size(0)
+        var total_seqlen = x.dim_size(1)
+        var width = weight.dim_size(1)
+        var batch = query_start_loc.dim_size(0) - 1
+
+        var output_lt = output.to_layout_tensor()
+        var x_lt = x.to_layout_tensor()
+        var weight_lt = weight.to_layout_tensor()
+        var bias_lt = bias.to_layout_tensor()
+        var query_start_loc_lt = query_start_loc.to_layout_tensor()
+        var cache_indices_lt = cache_indices.to_layout_tensor()
+        var has_initial_state_lt = has_initial_state.to_layout_tensor()
+        var conv_states_lt = conv_states.to_layout_tensor()
+
+        # Get strides as UInt32
+        var x_strides = x.strides()
+        var weight_strides = weight.strides()
+        var output_strides = output.strides()
+        var conv_states_strides = conv_states.strides()
+
+        var x_dim_stride = UInt32(x_strides[0])
+        var x_seqlen_stride = UInt32(x_strides[1])
+        var weight_dim_stride = UInt32(weight_strides[0])
+        var weight_width_stride = UInt32(weight_strides[1])
+        var out_dim_stride = UInt32(output_strides[0])
+        var out_seqlen_stride = UInt32(output_strides[1])
+
+        var has_conv_states = conv_states.dim_size(0) > 0
+        var conv_states_batch_stride = UInt32(
+            conv_states_strides[0] if has_conv_states else 0
+        )
+        var conv_states_dim_stride = UInt32(
+            conv_states_strides[1] if has_conv_states else 0
+        )
+        var conv_states_width_stride = UInt32(
+            conv_states_strides[2] if has_conv_states else 0
+        )
+
+        var has_cache_indices = cache_indices.dim_size(0) > 0
+        var has_initial_state_flag = has_initial_state.dim_size(0) > 0
+        var has_bias = bias.dim_size(0) > 0
+
+        var silu_activation = Self.activation == "silu"
+        comptime PAD_SLOT_ID: Int32 = -1
+
+        @parameter
+        if is_cpu[target]():
+            causal_conv1d_varlen_fwd_cpu[
+                x_lt.dtype,
+                x_lt.layout,
+                weight_lt.dtype,
+                weight_lt.layout,
+                bias_lt.dtype,
+                bias_lt.layout,
+                output_lt.dtype,
+                output_lt.layout,
+                query_start_loc_lt.dtype,
+                query_start_loc_lt.layout,
+                cache_indices_lt.dtype,
+                cache_indices_lt.layout,
+                has_initial_state_lt.dtype,
+                has_initial_state_lt.layout,
+                conv_states_lt.dtype,
+                conv_states_lt.layout,
+            ](
+                dim,
+                total_seqlen,
+                width,
+                batch,
+                x_lt,
+                weight_lt,
+                bias_lt,
+                query_start_loc_lt,
+                cache_indices_lt,
+                has_initial_state_lt,
+                conv_states_lt,
+                output_lt,
+                x_dim_stride,
+                x_seqlen_stride,
+                weight_dim_stride,
+                weight_width_stride,
+                out_dim_stride,
+                out_seqlen_stride,
+                conv_states_batch_stride,
+                conv_states_dim_stride,
+                conv_states_width_stride,
+                silu_activation,
+                PAD_SLOT_ID,
+                has_cache_indices,
+                has_initial_state_flag,
+                has_conv_states,
+                has_bias,
+            )
+        elif is_gpu[target]():
+            var gpu_ctx = ctx.get_device_context()
+            comptime BLOCK_DIM = 128
+            comptime BLOCK_SEQ = 1
+            var silu_activation_int8 = Int8(silu_activation)
+
+            if width == 1:
+                comptime kWidth = 1
+                var compiled_func = gpu_ctx.compile_function[
+                    causal_conv1d_varlen_fwd_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        query_start_loc_lt.dtype,
+                        query_start_loc_lt.layout,
+                        cache_indices_lt.dtype,
+                        cache_indices_lt.layout,
+                        has_initial_state_lt.dtype,
+                        has_initial_state_lt.layout,
+                        conv_states_lt.dtype,
+                        conv_states_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                        BLOCK_SEQ,
+                    ],
+                    causal_conv1d_varlen_fwd_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        query_start_loc_lt.dtype,
+                        query_start_loc_lt.layout,
+                        cache_indices_lt.dtype,
+                        cache_indices_lt.layout,
+                        has_initial_state_lt.dtype,
+                        has_initial_state_lt.layout,
+                        conv_states_lt.dtype,
+                        conv_states_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                        BLOCK_SEQ,
+                    ],
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_func,
+                    dim,
+                    total_seqlen,
+                    batch,
+                    x_lt,
+                    weight_lt,
+                    bias_lt,
+                    query_start_loc_lt,
+                    cache_indices_lt,
+                    has_initial_state_lt,
+                    conv_states_lt,
+                    output_lt,
+                    x_dim_stride,
+                    x_seqlen_stride,
+                    weight_dim_stride,
+                    weight_width_stride,
+                    out_dim_stride,
+                    out_seqlen_stride,
+                    conv_states_batch_stride,
+                    conv_states_dim_stride,
+                    conv_states_width_stride,
+                    silu_activation_int8,
+                    PAD_SLOT_ID,
+                    Int8(has_cache_indices),
+                    Int8(has_initial_state_flag),
+                    Int8(has_conv_states),
+                    Int8(has_bias),
+                    grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                    block_dim=(BLOCK_DIM, BLOCK_SEQ),
+                )
+            elif width == 2:
+                comptime kWidth = 2
+                var compiled_func = gpu_ctx.compile_function[
+                    causal_conv1d_varlen_fwd_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        query_start_loc_lt.dtype,
+                        query_start_loc_lt.layout,
+                        cache_indices_lt.dtype,
+                        cache_indices_lt.layout,
+                        has_initial_state_lt.dtype,
+                        has_initial_state_lt.layout,
+                        conv_states_lt.dtype,
+                        conv_states_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                        BLOCK_SEQ,
+                    ],
+                    causal_conv1d_varlen_fwd_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        query_start_loc_lt.dtype,
+                        query_start_loc_lt.layout,
+                        cache_indices_lt.dtype,
+                        cache_indices_lt.layout,
+                        has_initial_state_lt.dtype,
+                        has_initial_state_lt.layout,
+                        conv_states_lt.dtype,
+                        conv_states_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                        BLOCK_SEQ,
+                    ],
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_func,
+                    dim,
+                    total_seqlen,
+                    batch,
+                    x_lt,
+                    weight_lt,
+                    bias_lt,
+                    query_start_loc_lt,
+                    cache_indices_lt,
+                    has_initial_state_lt,
+                    conv_states_lt,
+                    output_lt,
+                    x_dim_stride,
+                    x_seqlen_stride,
+                    weight_dim_stride,
+                    weight_width_stride,
+                    out_dim_stride,
+                    out_seqlen_stride,
+                    conv_states_batch_stride,
+                    conv_states_dim_stride,
+                    conv_states_width_stride,
+                    silu_activation_int8,
+                    PAD_SLOT_ID,
+                    Int8(has_cache_indices),
+                    Int8(has_initial_state_flag),
+                    Int8(has_conv_states),
+                    Int8(has_bias),
+                    grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                    block_dim=(BLOCK_DIM, BLOCK_SEQ),
+                )
+            elif width == 3:
+                comptime kWidth = 3
+                var compiled_func = gpu_ctx.compile_function[
+                    causal_conv1d_varlen_fwd_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        query_start_loc_lt.dtype,
+                        query_start_loc_lt.layout,
+                        cache_indices_lt.dtype,
+                        cache_indices_lt.layout,
+                        has_initial_state_lt.dtype,
+                        has_initial_state_lt.layout,
+                        conv_states_lt.dtype,
+                        conv_states_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                        BLOCK_SEQ,
+                    ],
+                    causal_conv1d_varlen_fwd_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        query_start_loc_lt.dtype,
+                        query_start_loc_lt.layout,
+                        cache_indices_lt.dtype,
+                        cache_indices_lt.layout,
+                        has_initial_state_lt.dtype,
+                        has_initial_state_lt.layout,
+                        conv_states_lt.dtype,
+                        conv_states_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                        BLOCK_SEQ,
+                    ],
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_func,
+                    dim,
+                    total_seqlen,
+                    batch,
+                    x_lt,
+                    weight_lt,
+                    bias_lt,
+                    query_start_loc_lt,
+                    cache_indices_lt,
+                    has_initial_state_lt,
+                    conv_states_lt,
+                    output_lt,
+                    x_dim_stride,
+                    x_seqlen_stride,
+                    weight_dim_stride,
+                    weight_width_stride,
+                    out_dim_stride,
+                    out_seqlen_stride,
+                    conv_states_batch_stride,
+                    conv_states_dim_stride,
+                    conv_states_width_stride,
+                    silu_activation_int8,
+                    PAD_SLOT_ID,
+                    Int8(has_cache_indices),
+                    Int8(has_initial_state_flag),
+                    Int8(has_conv_states),
+                    Int8(has_bias),
+                    grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                    block_dim=(BLOCK_DIM, BLOCK_SEQ),
+                )
+            elif width == 4:
+                comptime kWidth = 4
+                var compiled_func = gpu_ctx.compile_function[
+                    causal_conv1d_varlen_fwd_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        query_start_loc_lt.dtype,
+                        query_start_loc_lt.layout,
+                        cache_indices_lt.dtype,
+                        cache_indices_lt.layout,
+                        has_initial_state_lt.dtype,
+                        has_initial_state_lt.layout,
+                        conv_states_lt.dtype,
+                        conv_states_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                        BLOCK_SEQ,
+                    ],
+                    causal_conv1d_varlen_fwd_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        query_start_loc_lt.dtype,
+                        query_start_loc_lt.layout,
+                        cache_indices_lt.dtype,
+                        cache_indices_lt.layout,
+                        has_initial_state_lt.dtype,
+                        has_initial_state_lt.layout,
+                        conv_states_lt.dtype,
+                        conv_states_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                        BLOCK_SEQ,
+                    ],
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_func,
+                    dim,
+                    total_seqlen,
+                    batch,
+                    x_lt,
+                    weight_lt,
+                    bias_lt,
+                    query_start_loc_lt,
+                    cache_indices_lt,
+                    has_initial_state_lt,
+                    conv_states_lt,
+                    output_lt,
+                    x_dim_stride,
+                    x_seqlen_stride,
+                    weight_dim_stride,
+                    weight_width_stride,
+                    out_dim_stride,
+                    out_seqlen_stride,
+                    conv_states_batch_stride,
+                    conv_states_dim_stride,
+                    conv_states_width_stride,
+                    silu_activation_int8,
+                    PAD_SLOT_ID,
+                    Int8(has_cache_indices),
+                    Int8(has_initial_state_flag),
+                    Int8(has_conv_states),
+                    Int8(has_bias),
+                    grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                    block_dim=(BLOCK_DIM, BLOCK_SEQ),
+                )
+            else:
+                raise Error(
+                    "Unsupported kernel width: only widths 1, 2, 3, 4 are"
+                    " supported"
+                )
+        else:
+            raise Error("Unsupported target device")
+
+    @staticmethod
+    fn shape[
+        dtype: DType,
+    ](
+        x: InputTensor[dtype=dtype, rank=2],
+        weight: InputTensor[dtype=dtype, rank=2],
+        bias: InputTensor[dtype=dtype, rank=1],
+        query_start_loc: InputTensor[dtype=DType.int32, rank=1],
+        cache_indices: InputTensor[dtype=DType.int32, rank=1],
+        has_initial_state: InputTensor[dtype=DType.bool, rank=1],
+        conv_states: InputTensor[dtype=dtype, rank=3],
+    ) -> IndexList[2]:
+        return x.shape()
+
+
+# ============================================================================
+# Varlen Causal Conv1D Update Registration
+# ============================================================================
+
+
+@compiler.register("causal_conv1d_varlen_update")
+struct CausalConv1DVarlenUpdate[activation: StaticString]:
+    """Varlen causal conv1d update for autoregressive decoding.
+
+    Performs incremental convolution update for token-by-token generation.
+    Updates the conv_state in-place with new input values.
+
+    Parameters:
+        activation: Activation function - "none" or "silu".
+
+    Tensor Shapes:
+        - output: (batch, dim, seqlen) - Output tensor
+        - x: (batch, dim, seqlen) - Input tensor
+        - weight: (dim, width) - Convolution weights
+        - bias: (dim,) - Per-channel bias
+        - conv_state: (batch, dim, state_len) - Conv state (in/out)
+        - cache_seqlens: (batch,) - Current sequence lengths (optional)
+        - conv_state_indices: (batch,) - Indices into conv_state (optional)
+    """
+
+    @staticmethod
+    fn execute[
+        dtype: DType,
+        target: StaticString,
+    ](
+        output: OutputTensor[dtype=dtype, rank=3],
+        x: InputTensor[dtype=dtype, rank=3],
+        weight: InputTensor[dtype=dtype, rank=2],
+        bias: InputTensor[dtype=dtype, rank=1],
+        conv_state: OutputTensor[dtype=dtype, rank=3],
+        cache_seqlens: InputTensor[dtype=DType.int32, rank=1],
+        conv_state_indices: InputTensor[dtype=DType.int32, rank=1],
+        ctx: DeviceContextPtr,
+    ) capturing raises:
+        var batch = x.dim_size(0)
+        var dim = x.dim_size(1)
+        var seqlen = x.dim_size(2)
+        var width = weight.dim_size(1)
+        var state_len = conv_state.dim_size(2)
+
+        var output_lt = output.to_layout_tensor()
+        var x_lt = x.to_layout_tensor()
+        var weight_lt = weight.to_layout_tensor()
+        var bias_lt = bias.to_layout_tensor()
+        var conv_state_lt = conv_state.to_layout_tensor()
+        var cache_seqlens_lt = cache_seqlens.to_layout_tensor()
+        var conv_state_indices_lt = conv_state_indices.to_layout_tensor()
+
+        var x_strides = x.strides()
+        var weight_strides = weight.strides()
+        var output_strides = output.strides()
+        var conv_state_strides = conv_state.strides()
+
+        var x_batch_stride = UInt32(x_strides[0])
+        var x_dim_stride = UInt32(x_strides[1])
+        var x_seqlen_stride = UInt32(x_strides[2])
+        var weight_dim_stride = UInt32(weight_strides[0])
+        var weight_width_stride = UInt32(weight_strides[1])
+        var conv_state_batch_stride = UInt32(conv_state_strides[0])
+        var conv_state_dim_stride = UInt32(conv_state_strides[1])
+        var conv_state_seqlen_stride = UInt32(conv_state_strides[2])
+        var out_batch_stride = UInt32(output_strides[0])
+        var out_dim_stride = UInt32(output_strides[1])
+        var out_seqlen_stride = UInt32(output_strides[2])
+
+        var has_conv_state_indices = conv_state_indices.dim_size(0) > 0
+        var has_cache_seqlens = cache_seqlens.dim_size(0) > 0
+        var has_bias = bias.dim_size(0) > 0
+
+        var silu_activation = Self.activation == "silu"
+        comptime PAD_SLOT_ID: Int32 = -1
+
+        @parameter
+        if is_cpu[target]():
+            causal_conv1d_varlen_update_cpu[
+                x_lt.dtype,
+                x_lt.layout,
+                weight_lt.dtype,
+                weight_lt.layout,
+                bias_lt.dtype,
+                bias_lt.layout,
+                output_lt.dtype,
+                output_lt.layout,
+                conv_state_lt.dtype,
+                conv_state_lt.layout,
+                cache_seqlens_lt.dtype,
+                cache_seqlens_lt.layout,
+                conv_state_indices_lt.dtype,
+                conv_state_indices_lt.layout,
+            ](
+                batch,
+                dim,
+                seqlen,
+                width,
+                state_len,
+                x_lt,
+                weight_lt,
+                bias_lt,
+                conv_state_lt,
+                cache_seqlens_lt,
+                conv_state_indices_lt,
+                output_lt,
+                x_batch_stride,
+                x_dim_stride,
+                x_seqlen_stride,
+                weight_dim_stride,
+                weight_width_stride,
+                conv_state_batch_stride,
+                conv_state_dim_stride,
+                conv_state_seqlen_stride,
+                out_batch_stride,
+                out_dim_stride,
+                out_seqlen_stride,
+                silu_activation,
+                PAD_SLOT_ID,
+                has_conv_state_indices,
+                has_cache_seqlens,
+                has_bias,
+            )
+        elif is_gpu[target]():
+            var gpu_ctx = ctx.get_device_context()
+            comptime BLOCK_DIM = 128
+            var silu_activation_int8 = Int8(silu_activation)
+
+            if width == 1:
+                comptime kWidth = 1
+                var compiled_func = gpu_ctx.compile_function[
+                    causal_conv1d_varlen_update_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        conv_state_lt.dtype,
+                        conv_state_lt.layout,
+                        cache_seqlens_lt.dtype,
+                        cache_seqlens_lt.layout,
+                        conv_state_indices_lt.dtype,
+                        conv_state_indices_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                    ],
+                    causal_conv1d_varlen_update_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        conv_state_lt.dtype,
+                        conv_state_lt.layout,
+                        cache_seqlens_lt.dtype,
+                        cache_seqlens_lt.layout,
+                        conv_state_indices_lt.dtype,
+                        conv_state_indices_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                    ],
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_func,
+                    batch,
+                    dim,
+                    seqlen,
+                    state_len,
+                    x_lt,
+                    weight_lt,
+                    bias_lt,
+                    conv_state_lt,
+                    cache_seqlens_lt,
+                    conv_state_indices_lt,
+                    output_lt,
+                    x_batch_stride,
+                    x_dim_stride,
+                    x_seqlen_stride,
+                    weight_dim_stride,
+                    weight_width_stride,
+                    conv_state_batch_stride,
+                    conv_state_dim_stride,
+                    conv_state_seqlen_stride,
+                    out_batch_stride,
+                    out_dim_stride,
+                    out_seqlen_stride,
+                    silu_activation_int8,
+                    PAD_SLOT_ID,
+                    Int8(has_conv_state_indices),
+                    Int8(has_cache_seqlens),
+                    Int8(has_bias),
+                    grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                    block_dim=(BLOCK_DIM,),
+                )
+            elif width == 2:
+                comptime kWidth = 2
+                var compiled_func = gpu_ctx.compile_function[
+                    causal_conv1d_varlen_update_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        conv_state_lt.dtype,
+                        conv_state_lt.layout,
+                        cache_seqlens_lt.dtype,
+                        cache_seqlens_lt.layout,
+                        conv_state_indices_lt.dtype,
+                        conv_state_indices_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                    ],
+                    causal_conv1d_varlen_update_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        conv_state_lt.dtype,
+                        conv_state_lt.layout,
+                        cache_seqlens_lt.dtype,
+                        cache_seqlens_lt.layout,
+                        conv_state_indices_lt.dtype,
+                        conv_state_indices_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                    ],
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_func,
+                    batch,
+                    dim,
+                    seqlen,
+                    state_len,
+                    x_lt,
+                    weight_lt,
+                    bias_lt,
+                    conv_state_lt,
+                    cache_seqlens_lt,
+                    conv_state_indices_lt,
+                    output_lt,
+                    x_batch_stride,
+                    x_dim_stride,
+                    x_seqlen_stride,
+                    weight_dim_stride,
+                    weight_width_stride,
+                    conv_state_batch_stride,
+                    conv_state_dim_stride,
+                    conv_state_seqlen_stride,
+                    out_batch_stride,
+                    out_dim_stride,
+                    out_seqlen_stride,
+                    silu_activation_int8,
+                    PAD_SLOT_ID,
+                    Int8(has_conv_state_indices),
+                    Int8(has_cache_seqlens),
+                    Int8(has_bias),
+                    grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                    block_dim=(BLOCK_DIM,),
+                )
+            elif width == 3:
+                comptime kWidth = 3
+                var compiled_func = gpu_ctx.compile_function[
+                    causal_conv1d_varlen_update_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        conv_state_lt.dtype,
+                        conv_state_lt.layout,
+                        cache_seqlens_lt.dtype,
+                        cache_seqlens_lt.layout,
+                        conv_state_indices_lt.dtype,
+                        conv_state_indices_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                    ],
+                    causal_conv1d_varlen_update_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        conv_state_lt.dtype,
+                        conv_state_lt.layout,
+                        cache_seqlens_lt.dtype,
+                        cache_seqlens_lt.layout,
+                        conv_state_indices_lt.dtype,
+                        conv_state_indices_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                    ],
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_func,
+                    batch,
+                    dim,
+                    seqlen,
+                    state_len,
+                    x_lt,
+                    weight_lt,
+                    bias_lt,
+                    conv_state_lt,
+                    cache_seqlens_lt,
+                    conv_state_indices_lt,
+                    output_lt,
+                    x_batch_stride,
+                    x_dim_stride,
+                    x_seqlen_stride,
+                    weight_dim_stride,
+                    weight_width_stride,
+                    conv_state_batch_stride,
+                    conv_state_dim_stride,
+                    conv_state_seqlen_stride,
+                    out_batch_stride,
+                    out_dim_stride,
+                    out_seqlen_stride,
+                    silu_activation_int8,
+                    PAD_SLOT_ID,
+                    Int8(has_conv_state_indices),
+                    Int8(has_cache_seqlens),
+                    Int8(has_bias),
+                    grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                    block_dim=(BLOCK_DIM,),
+                )
+            elif width == 4:
+                comptime kWidth = 4
+                var compiled_func = gpu_ctx.compile_function[
+                    causal_conv1d_varlen_update_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        conv_state_lt.dtype,
+                        conv_state_lt.layout,
+                        cache_seqlens_lt.dtype,
+                        cache_seqlens_lt.layout,
+                        conv_state_indices_lt.dtype,
+                        conv_state_indices_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                    ],
+                    causal_conv1d_varlen_update_gpu[
+                        x_lt.dtype,
+                        x_lt.layout,
+                        weight_lt.dtype,
+                        weight_lt.layout,
+                        bias_lt.dtype,
+                        bias_lt.layout,
+                        output_lt.dtype,
+                        output_lt.layout,
+                        conv_state_lt.dtype,
+                        conv_state_lt.layout,
+                        cache_seqlens_lt.dtype,
+                        cache_seqlens_lt.layout,
+                        conv_state_indices_lt.dtype,
+                        conv_state_indices_lt.layout,
+                        kWidth,
+                        BLOCK_DIM,
+                    ],
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_func,
+                    batch,
+                    dim,
+                    seqlen,
+                    state_len,
+                    x_lt,
+                    weight_lt,
+                    bias_lt,
+                    conv_state_lt,
+                    cache_seqlens_lt,
+                    conv_state_indices_lt,
+                    output_lt,
+                    x_batch_stride,
+                    x_dim_stride,
+                    x_seqlen_stride,
+                    weight_dim_stride,
+                    weight_width_stride,
+                    conv_state_batch_stride,
+                    conv_state_dim_stride,
+                    conv_state_seqlen_stride,
+                    out_batch_stride,
+                    out_dim_stride,
+                    out_seqlen_stride,
+                    silu_activation_int8,
+                    PAD_SLOT_ID,
+                    Int8(has_conv_state_indices),
+                    Int8(has_cache_seqlens),
+                    Int8(has_bias),
+                    grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                    block_dim=(BLOCK_DIM,),
+                )
+            else:
+                raise Error(
+                    "Unsupported kernel width: only widths 1, 2, 3, 4 are"
+                    " supported"
+                )
+        else:
+            raise Error("Unsupported target device")
+
+    @staticmethod
+    fn shape[
+        dtype: DType,
+    ](
+        x: InputTensor[dtype=dtype, rank=3],
+        weight: InputTensor[dtype=dtype, rank=2],
+        bias: InputTensor[dtype=dtype, rank=1],
+        conv_state: InputTensor[dtype=dtype, rank=3],
+        cache_seqlens: InputTensor[dtype=DType.int32, rank=1],
+        conv_state_indices: InputTensor[dtype=DType.int32, rank=1],
+    ) -> IndexList[3]:
+        return x.shape()
+
+
+# ============================================================================
+# Varlen Causal Conv1D States Registration
+# ============================================================================
+
+
+@compiler.register("causal_conv1d_varlen_states")
+struct CausalConv1DVarlenStates:
+    """Extract conv states from variable-length sequences.
+
+    Extracts the last state_len elements from each sequence to initialize
+    conv_state for subsequent autoregressive generation.
+
+    Tensor Shapes:
+        - states: (batch, dim, state_len) - Output states tensor
+        - x: (total_tokens, dim) - Input tensor (concatenated sequences)
+        - cu_seqlens: (batch + 1,) - Cumulative sequence lengths
+    """
+
+    @staticmethod
+    fn execute[
+        dtype: DType,
+        target: StaticString,
+    ](
+        states: OutputTensor[dtype=dtype, rank=3],
+        x: InputTensor[dtype=dtype, rank=2],
+        cu_seqlens: InputTensor[dtype=DType.int32, rank=1],
+        ctx: DeviceContextPtr,
+    ) capturing raises:
+        var total_tokens = x.dim_size(0)
+        var dim = x.dim_size(1)
+        var batch = cu_seqlens.dim_size(0) - 1
+        var state_len = states.dim_size(2)
+
+        var states_lt = states.to_layout_tensor()
+        var x_lt = x.to_layout_tensor()
+        var cu_seqlens_lt = cu_seqlens.to_layout_tensor()
+
+        var x_strides = x.strides()
+        var states_strides = states.strides()
+
+        var x_seqlen_stride = UInt32(x_strides[0])
+        var x_dim_stride = UInt32(x_strides[1])
+        var states_batch_stride = UInt32(states_strides[0])
+        var states_dim_stride = UInt32(states_strides[1])
+        var states_seqlen_stride = UInt32(states_strides[2])
+
+        @parameter
+        if is_cpu[target]():
+            causal_conv1d_varlen_states_cpu[
+                x_lt.dtype,
+                x_lt.layout,
+                cu_seqlens_lt.dtype,
+                cu_seqlens_lt.layout,
+                states_lt.dtype,
+                states_lt.layout,
+            ](
+                total_tokens,
+                dim,
+                batch,
+                state_len,
+                x_lt,
+                cu_seqlens_lt,
+                states_lt,
+                x_seqlen_stride,
+                x_dim_stride,
+                states_batch_stride,
+                states_dim_stride,
+                states_seqlen_stride,
+            )
+        elif is_gpu[target]():
+            var gpu_ctx = ctx.get_device_context()
+            comptime BLOCK_DIM = 128
+            var compiled_func = gpu_ctx.compile_function[
+                causal_conv1d_varlen_states_gpu[
+                    x_lt.dtype,
+                    x_lt.layout,
+                    cu_seqlens_lt.dtype,
+                    cu_seqlens_lt.layout,
+                    states_lt.dtype,
+                    states_lt.layout,
+                    BLOCK_DIM,
+                ],
+                causal_conv1d_varlen_states_gpu[
+                    x_lt.dtype,
+                    x_lt.layout,
+                    cu_seqlens_lt.dtype,
+                    cu_seqlens_lt.layout,
+                    states_lt.dtype,
+                    states_lt.layout,
+                    BLOCK_DIM,
+                ],
+            ]()
+            gpu_ctx.enqueue_function(
+                compiled_func,
+                total_tokens,
+                dim,
+                batch,
+                state_len,
+                x_lt,
+                cu_seqlens_lt,
+                states_lt,
+                x_seqlen_stride,
+                x_dim_stride,
+                states_batch_stride,
+                states_dim_stride,
+                states_seqlen_stride,
+                grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                block_dim=(BLOCK_DIM,),
+            )
+        else:
+            raise Error("Unsupported target device")
+
+    @staticmethod
+    fn shape[
+        dtype: DType,
+    ](
+        x: InputTensor[dtype=dtype, rank=2],
+        cu_seqlens: InputTensor[dtype=DType.int32, rank=1],
+        state_len: Int,
+    ) -> IndexList[3]:
+        var batch = cu_seqlens.dim_size(0) - 1
+        var dim = x.dim_size(1)
+        return IndexList[3](batch, dim, state_len)

--- a/max/kernels/src/state_space/varlen_selective_scan.mojo
+++ b/max/kernels/src/state_space/varlen_selective_scan.mojo
@@ -1,0 +1,973 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Variable-Length Selective Scan Kernels
+# ===----------------------------------------------------------------------=== #
+# This file contains GPU kernel implementations for variable-length selective
+# scan operations, compatible with vLLM's mamba_ssm interface.
+#
+# The kernels support:
+# - Variable-length sequences packed together (varlen)
+# - Multi-head SSM with grouped heads (nheads, ngroups)
+# - Cache management for autoregressive inference
+# - Initial state support
+#
+# Reference: vLLM v0.9.2 mamba_ssm.py
+# ===----------------------------------------------------------------------=== #
+
+from gpu import block_dim, block_idx, thread_idx
+from layout import Layout, LayoutTensor
+from utils.index import IndexList
+from memory import UnsafePointer
+from algorithm import sync_parallelize
+import math
+from math import ceildiv, exp2
+from state_space.selective_scan import softplus, sigmoid
+
+# LOG2E constant for converting exp to exp2 (faster on GPU)
+comptime LOG2E = 1.4426950408889634
+comptime MAX_DSTATE = 256  # Larger for Mamba-2 models
+
+# Stride types for passing tensor strides to kernels
+comptime Strides1D = IndexList[1]
+comptime Strides2D = IndexList[2]
+comptime Strides3D = IndexList[3]
+comptime Strides4D = IndexList[4]
+
+
+# Optimized SiLU (Swish): x * sigmoid(x)
+fn silu(val: Float32) -> Float32:
+    return val * sigmoid(val)
+
+
+# ===----------------------------------------------------------------------=== #
+# Selective State Update Kernel (Single Step with Multi-Head Support)
+# ===----------------------------------------------------------------------=== #
+# This kernel matches vLLM's selective_state_update function.
+#
+# Supports:
+# - Multi-head SSM: state (batch, nheads, dim, dstate)
+# - Grouped heads: B, C are (batch, ngroups, dstate) with nheads_ngroups_ratio
+# - State batch indices for non-contiguous state access
+# - Padding slot handling
+#
+# Algorithm:
+#   dt = dt + dt_bias (if has_dt_bias)
+#   dt = softplus(dt) (if dt_softplus)
+#   dA = exp(A * dt)
+#   dB = B * dt
+#   state = state * dA + dB * x
+#   out = sum(state * C, axis=-1)
+#   out += x * D (if has_D)
+#   out *= z * sigmoid(z) (if has_z)
+# ===----------------------------------------------------------------------=== #
+
+
+fn varlen_selective_state_update_gpu[
+    kernel_dtype: DType,
+    state_layout: Layout,
+    x_layout: Layout,
+    dt_layout: Layout,
+    A_layout: Layout,
+    B_layout: Layout,
+    C_layout: Layout,
+    D_layout: Layout,
+    z_layout: Layout,
+    out_layout: Layout,
+    dt_bias_layout: Layout,
+    state_batch_indices_layout: Layout,
+](
+    # Grid dimensions
+    total_threads: Int,  # batch * nheads * dim / BLOCK_SIZE_M
+    batch: Int,
+    nheads: Int,
+    dim: Int,
+    dstate: Int,
+    nheads_ngroups_ratio: Int,
+    pad_slot_id: Int32,
+    dt_softplus: Int8,
+    has_state_batch_indices: Int8,
+    # Tensors
+    state: LayoutTensor[kernel_dtype, state_layout, MutAnyOrigin],
+    x: LayoutTensor[kernel_dtype, x_layout, MutAnyOrigin],
+    dt: LayoutTensor[kernel_dtype, dt_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, A_layout, MutAnyOrigin],
+    B: LayoutTensor[kernel_dtype, B_layout, MutAnyOrigin],
+    C: LayoutTensor[kernel_dtype, C_layout, MutAnyOrigin],
+    D: LayoutTensor[kernel_dtype, D_layout, MutAnyOrigin],
+    z: LayoutTensor[kernel_dtype, z_layout, MutAnyOrigin],
+    output: LayoutTensor[kernel_dtype, out_layout, MutAnyOrigin],
+    dt_bias: LayoutTensor[kernel_dtype, dt_bias_layout, MutAnyOrigin],
+    state_batch_indices: LayoutTensor[
+        DType.int32, state_batch_indices_layout, MutAnyOrigin
+    ],
+    # Strides for state: (batch, nheads, dim, dstate)
+    state_strides: Strides4D,
+    # Strides for x: (batch, nheads, dim)
+    x_strides: Strides3D,
+    # Strides for dt: (batch, nheads, dim)
+    dt_strides: Strides3D,
+    # Strides for dt_bias: (nheads, dim)
+    dt_bias_strides: Strides2D,
+    # Strides for A: (nheads, dim, dstate)
+    A_strides: Strides3D,
+    # Strides for B: (batch, ngroups, dstate)
+    B_strides: Strides3D,
+    # Strides for C: (batch, ngroups, dstate)
+    C_strides: Strides3D,
+    # Strides for D: (nheads, dim)
+    D_strides: Strides2D,
+    # Strides for z: (batch, nheads, dim)
+    z_strides: Strides3D,
+    # Strides for out: (batch, nheads, dim)
+    out_strides: Strides3D,
+):
+    """GPU kernel for selective state update with multi-head support.
+
+    Each thread block processes BLOCK_SIZE_M dim elements for a (batch, head) pair.
+    Matches vLLM's _selective_scan_update_kernel.
+    """
+    comptime BLOCK_SIZE_M = 4  # Process 4 dims per thread
+
+    var pid_m = block_idx.x  # Dim block index
+    var pid_b = block_idx.y  # Batch index
+    var pid_h = block_idx.z  # Head index
+
+    var pid_b_int = Int(pid_b)
+    var pid_h_int = Int(pid_h)
+    var pid_m_int = Int(pid_m)
+
+    if pid_b_int >= batch or pid_h_int >= nheads:
+        return
+
+    # Determine state batch index
+    var state_batch_idx = Int32(pid_b_int)
+    if Bool(Int(has_state_batch_indices) != 0):
+        state_batch_idx = state_batch_indices.ptr[pid_b_int]
+        # Check for padding
+        if state_batch_idx == pad_slot_id:
+            return
+
+    var has_dt_bias = dt_bias.dim(0) > 0
+    var has_D = D.dim(0) > 0
+    var has_z = z.dim(0) > 0
+    var dt_softplus_bool = Bool(Int(dt_softplus) != 0)
+
+    var group_id = pid_h_int // nheads_ngroups_ratio
+
+    # Process BLOCK_SIZE_M dims per thread
+    for local_m in range(BLOCK_SIZE_M):
+        var m = pid_m_int * BLOCK_SIZE_M + local_m
+        if m >= dim:
+            continue
+
+        # Load x value
+        var x_offset = UInt32(
+            pid_b_int * x_strides[0]
+            + pid_h_int * x_strides[1]
+            + m * x_strides[2]
+        )
+        var x_val = Scalar[kernel_dtype](x.ptr[x_offset]).cast[DType.float32]()
+
+        # Load dt value
+        var dt_offset = UInt32(
+            pid_b_int * dt_strides[0]
+            + pid_h_int * dt_strides[1]
+            + m * dt_strides[2]
+        )
+        var dt_val = Scalar[kernel_dtype](dt.ptr[dt_offset]).cast[
+            DType.float32
+        ]()
+
+        # Apply dt_bias if present
+        if has_dt_bias:
+            var dt_bias_offset = UInt32(
+                pid_h_int * dt_bias_strides[0] + m * dt_bias_strides[1]
+            )
+            var bias_val = Scalar[kernel_dtype](
+                dt_bias.ptr[dt_bias_offset]
+            ).cast[DType.float32]()
+            dt_val += bias_val
+
+        # Apply softplus if requested
+        if dt_softplus_bool:
+            dt_val = softplus(dt_val)
+
+        # Check for TIE_HDIM mode (A has zero strides for dim and dstate)
+        # For simplicity, we'll implement the non-tied case
+        var out_val = Float32(0.0)
+
+        # Process each dstate element
+        for n in range(dstate):
+            # Load A value
+            var A_offset = UInt32(
+                pid_h_int * A_strides[0] + m * A_strides[1] + n * A_strides[2]
+            )
+            var A_val = Scalar[kernel_dtype](A.ptr[A_offset]).cast[
+                DType.float32
+            ]()
+
+            # Compute dA = exp(A * dt) using exp2 for faster GPU execution
+            var dA = exp2(A_val * LOG2E * dt_val)
+
+            # Load B value
+            var B_offset = UInt32(
+                pid_b_int * B_strides[0]
+                + group_id * B_strides[1]
+                + n * B_strides[2]
+            )
+            var B_val = Scalar[kernel_dtype](B.ptr[B_offset]).cast[
+                DType.float32
+            ]()
+
+            # Compute dB = B * dt
+            var dB = B_val * dt_val
+
+            # Load current state
+            var state_offset = UInt32(
+                Int(state_batch_idx) * state_strides[0]
+                + pid_h_int * state_strides[1]
+                + m * state_strides[2]
+                + n * state_strides[3]
+            )
+            var state_val = Scalar[kernel_dtype](state.ptr[state_offset]).cast[
+                DType.float32
+            ]()
+
+            # Update state: state = state * dA + dB * x
+            state_val = state_val * dA + dB * x_val
+
+            # Store updated state
+            state.ptr[state_offset] = Scalar[kernel_dtype](
+                state_val.cast[kernel_dtype]()
+            )
+
+            # Load C value
+            var C_offset = UInt32(
+                pid_b_int * C_strides[0]
+                + group_id * C_strides[1]
+                + n * C_strides[2]
+            )
+            var C_val = Scalar[kernel_dtype](C.ptr[C_offset]).cast[
+                DType.float32
+            ]()
+
+            # Accumulate output
+            out_val += state_val * C_val
+
+        # Add skip connection if D is present
+        if has_D:
+            var D_offset = UInt32(pid_h_int * D_strides[0] + m * D_strides[1])
+            var D_val = Scalar[kernel_dtype](D.ptr[D_offset]).cast[
+                DType.float32
+            ]()
+            out_val += x_val * D_val
+
+        # Apply gating if z is present, using optimized silu
+        if has_z:
+            var z_offset = UInt32(
+                pid_b_int * z_strides[0]
+                + pid_h_int * z_strides[1]
+                + m * z_strides[2]
+            )
+            var z_val = Scalar[kernel_dtype](z.ptr[z_offset]).cast[
+                DType.float32
+            ]()
+            out_val *= silu(z_val)
+
+        # Store output
+        var out_offset = UInt32(
+            pid_b_int * out_strides[0]
+            + pid_h_int * out_strides[1]
+            + m * out_strides[2]
+        )
+        output.ptr[out_offset] = Scalar[kernel_dtype](
+            out_val.cast[kernel_dtype]()
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Variable-Length Selective Scan Forward Kernel
+# ===----------------------------------------------------------------------=== #
+# This kernel matches vLLM's selective_scan_fn with varlen support.
+#
+# Supports:
+# - Variable-length sequences via query_start_loc (cumulative lengths)
+# - Cache management via cache_indices
+# - Initial state via has_initial_state
+# - Padding handling via pad_slot_id
+#
+# Tensor layouts for varlen:
+#   u: (dim, total_length)
+#   delta: (dim, total_length)
+#   B: (ngroups, dstate, total_length)
+#   C: (ngroups, dstate, total_length)
+#   ssm_states: (batch, nheads, dim, dstate) or (batch, dim, dstate)
+#
+# query_start_loc: (batch + 1,) - cumulative sequence lengths
+#   Example: [0, 10, 16, 17] means 3 sequences of lengths 10, 6, 1
+# ===----------------------------------------------------------------------=== #
+
+
+fn varlen_selective_scan_fwd_gpu[
+    kernel_dtype: DType,
+    u_layout: Layout,
+    delta_layout: Layout,
+    A_layout: Layout,
+    B_layout: Layout,
+    C_layout: Layout,
+    D_layout: Layout,
+    z_layout: Layout,
+    delta_bias_layout: Layout,
+    ssm_states_layout: Layout,
+    out_layout: Layout,
+    query_start_loc_layout: Layout,
+    cache_indices_layout: Layout,
+    has_initial_state_layout: Layout,
+](
+    # Grid dimensions - now using 2D grid (dim_blocks, batch)
+    dim: Int,
+    dstate: Int,
+    ngroups: Int,
+    batch: Int,
+    pad_slot_id: Int32,
+    delta_softplus: Int8,
+    # Tensors - varlen format: (dim, total_length) for u, delta, z, out
+    u: LayoutTensor[kernel_dtype, u_layout, MutAnyOrigin],
+    delta: LayoutTensor[kernel_dtype, delta_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, A_layout, MutAnyOrigin],
+    B: LayoutTensor[
+        kernel_dtype, B_layout, MutAnyOrigin
+    ],  # (ngroups, dstate, total_length)
+    C: LayoutTensor[
+        kernel_dtype, C_layout, MutAnyOrigin
+    ],  # (ngroups, dstate, total_length)
+    D: LayoutTensor[kernel_dtype, D_layout, MutAnyOrigin],
+    z: LayoutTensor[kernel_dtype, z_layout, MutAnyOrigin],
+    delta_bias: LayoutTensor[kernel_dtype, delta_bias_layout, MutAnyOrigin],
+    ssm_states: LayoutTensor[
+        kernel_dtype, ssm_states_layout, MutAnyOrigin
+    ],  # (batch, dim, dstate)
+    output: LayoutTensor[
+        kernel_dtype, out_layout, MutAnyOrigin
+    ],  # Output written here (or to z if z is present)
+    query_start_loc: LayoutTensor[
+        DType.int32, query_start_loc_layout, MutAnyOrigin
+    ],  # (batch + 1,)
+    cache_indices: LayoutTensor[
+        DType.int32, cache_indices_layout, MutAnyOrigin
+    ],  # (batch,)
+    has_initial_state: LayoutTensor[
+        DType.bool, has_initial_state_layout, MutAnyOrigin
+    ],  # (batch,)
+    # Strides for u: (dim, total_length)
+    u_strides: Strides2D,
+    # Strides for delta: (dim, total_length)
+    delta_strides: Strides2D,
+    # Strides for A: (dim, dstate)
+    A_strides: Strides2D,
+    # Strides for B: (ngroups, dstate, total_length)
+    B_strides: Strides3D,
+    # Strides for C: (ngroups, dstate, total_length)
+    C_strides: Strides3D,
+    # Strides for D: (dim,)
+    D_strides: Strides1D,
+    # Strides for z: (dim, total_length)
+    z_strides: Strides2D,
+    # Strides for delta_bias: (dim,)
+    delta_bias_strides: Strides1D,
+    # Strides for ssm_states: (batch, dim, dstate)
+    ssm_states_strides: Strides3D,
+    # Strides for out: (dim, total_length)
+    out_strides: Strides2D,
+):
+    """GPU kernel for variable-length selective scan.
+
+    Uses 2D grid: (dim_blocks, batch) for parallel processing across sequences.
+    Each thread processes one (batch, dim) pair, iterating over the sequence.
+
+    For each sequence b with length = query_start_loc[b+1] - query_start_loc[b]:
+    - Uses cache_indices[b] to determine which SSM state slot to use
+    - Uses has_initial_state[b] to determine if initial state should be loaded
+    - Processes the sequence and updates the SSM state
+    """
+    # 2D grid: block_idx.x for dim, block_idx.y for batch
+    var d = Int(block_dim.x * block_idx.x + thread_idx.x)
+    var b = Int(block_idx.y)
+
+    if d >= dim or b >= batch:
+        return
+
+    var has_D = D.dim(0) > 0
+    var has_z = z.dim(0) > 0
+    var has_delta_bias = delta_bias.dim(0) > 0
+    var has_cache_indices = cache_indices.dim(0) > 0
+    var has_initial_state_tensor = has_initial_state.dim(0) > 0
+    var delta_softplus_bool = Bool(Int(delta_softplus) != 0)
+
+    # Get sequence start and length
+    var seq_start = Int(query_start_loc.ptr[b])
+    var seq_end = Int(query_start_loc.ptr[b + 1])
+    var seq_len = seq_end - seq_start
+
+    if seq_len <= 0:
+        return
+
+    # Get cache index for this sequence
+    var cache_idx = b
+    if has_cache_indices:
+        cache_idx = Int(cache_indices.ptr[b])
+        if cache_idx == Int(pad_slot_id):
+            return
+
+    # Pre-load D and delta_bias for this dim
+    var D_val = Float32(0.0)
+    if has_D:
+        var D_offset = UInt32(d * D_strides[0])
+        D_val = Scalar[kernel_dtype](D.ptr[D_offset]).cast[DType.float32]()
+
+    var delta_bias_val = Float32(0.0)
+    if has_delta_bias:
+        var bias_offset = UInt32(d * delta_bias_strides[0])
+        delta_bias_val = Scalar[kernel_dtype](delta_bias.ptr[bias_offset]).cast[
+            DType.float32
+        ]()
+
+    # Pre-load A values for this dim and pre-multiply by LOG2E for faster exp2
+    var A_vals = SIMD[DType.float32, MAX_DSTATE](0.0)
+    for n in range(dstate):
+        var A_offset = UInt32(d * A_strides[0] + n * A_strides[1])
+        A_vals[n] = (
+            Scalar[kernel_dtype](A.ptr[A_offset]).cast[DType.float32]() * LOG2E
+        )
+
+    # Determine group for this dim
+    var group_size = dim // ngroups
+    var group_id = d // group_size
+
+    # Initialize state - either from cache or zeros
+    var state = SIMD[DType.float32, MAX_DSTATE](0.0)
+
+    # Load initial state if requested
+    var use_initial_state = False
+    if has_initial_state_tensor:
+        var init_state_val = has_initial_state.ptr[b]
+        use_initial_state = Bool(init_state_val)
+
+    if use_initial_state:
+        for n in range(dstate):
+            var state_offset = UInt32(
+                cache_idx * ssm_states_strides[0]
+                + d * ssm_states_strides[1]
+                + n * ssm_states_strides[2]
+            )
+            state[n] = Scalar[kernel_dtype](ssm_states.ptr[state_offset]).cast[
+                DType.float32
+            ]()
+
+    # Process sequence
+    for t in range(seq_len):
+        var global_t = seq_start + t
+
+        # Load u value
+        var u_offset = UInt32(d * u_strides[0] + global_t * u_strides[1])
+        var u_val = Scalar[kernel_dtype](u.ptr[u_offset]).cast[DType.float32]()
+
+        # Load delta value
+        var delta_offset = UInt32(
+            d * delta_strides[0] + global_t * delta_strides[1]
+        )
+        var delta_val = Scalar[kernel_dtype](delta.ptr[delta_offset]).cast[
+            DType.float32
+        ]()
+
+        # Apply delta_bias
+        if has_delta_bias:
+            delta_val += delta_bias_val
+
+        # Apply softplus
+        if delta_softplus_bool:
+            delta_val = softplus(delta_val)
+
+        var delta_u = delta_val * u_val
+
+        # Load B and C values for this timestep
+        var B_vals = SIMD[DType.float32, MAX_DSTATE](0.0)
+        var C_vals = SIMD[DType.float32, MAX_DSTATE](0.0)
+
+        for n in range(dstate):
+            var B_offset = UInt32(
+                group_id * B_strides[0]
+                + n * B_strides[1]
+                + global_t * B_strides[2]
+            )
+            var C_offset = UInt32(
+                group_id * C_strides[0]
+                + n * C_strides[1]
+                + global_t * C_strides[2]
+            )
+
+            B_vals[n] = Scalar[kernel_dtype](B.ptr[B_offset]).cast[
+                DType.float32
+            ]()
+            C_vals[n] = Scalar[kernel_dtype](C.ptr[C_offset]).cast[
+                DType.float32
+            ]()
+
+        # SSM step: state = state * exp2(A * LOG2E * delta) + B * delta * u
+        var a_t = exp2(A_vals * delta_val)
+        var b_t = B_vals * delta_u
+        state = state * a_t + b_t
+
+        # Compute output: y = sum(state * C) - use SIMD reduce
+        var output_val = (state * C_vals).reduce_add()
+
+        # Add D * u if D is present
+        if has_D:
+            output_val += D_val * u_val
+
+        # Apply gating with z if present, using optimized silu
+        if has_z:
+            var z_offset = UInt32(d * z_strides[0] + global_t * z_strides[1])
+            var z_val = Scalar[kernel_dtype](z.ptr[z_offset]).cast[
+                DType.float32
+            ]()
+            output_val *= silu(z_val)
+
+            # Write to z if z is present (vLLM convention: output written to z)
+            z.ptr[z_offset] = Scalar[kernel_dtype](
+                output_val.cast[kernel_dtype]()
+            )
+        else:
+            # Write to output (or delta in vLLM convention)
+            var out_offset = UInt32(
+                d * out_strides[0] + global_t * out_strides[1]
+            )
+            output.ptr[out_offset] = Scalar[kernel_dtype](
+                output_val.cast[kernel_dtype]()
+            )
+
+    # Store final state to cache
+    for n in range(dstate):
+        var state_offset = UInt32(
+            cache_idx * ssm_states_strides[0]
+            + d * ssm_states_strides[1]
+            + n * ssm_states_strides[2]
+        )
+        ssm_states.ptr[state_offset] = Scalar[kernel_dtype](
+            state[n].cast[kernel_dtype]()
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# CPU Implementations (for testing and fallback)
+# ===----------------------------------------------------------------------=== #
+
+
+fn varlen_selective_state_update_cpu[
+    kernel_dtype: DType,
+    state_layout: Layout,
+    x_layout: Layout,
+    dt_layout: Layout,
+    A_layout: Layout,
+    B_layout: Layout,
+    C_layout: Layout,
+    D_layout: Layout,
+    z_layout: Layout,
+    out_layout: Layout,
+    dt_bias_layout: Layout,
+    state_batch_indices_layout: Layout,
+](
+    batch: Int,
+    nheads: Int,
+    dim: Int,
+    dstate: Int,
+    nheads_ngroups_ratio: Int,
+    pad_slot_id: Int32,
+    dt_softplus: Int8,
+    has_state_batch_indices: Int8,
+    # Tensors
+    state: LayoutTensor[kernel_dtype, state_layout, MutAnyOrigin],
+    x: LayoutTensor[kernel_dtype, x_layout, MutAnyOrigin],
+    dt: LayoutTensor[kernel_dtype, dt_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, A_layout, MutAnyOrigin],
+    B: LayoutTensor[kernel_dtype, B_layout, MutAnyOrigin],
+    C: LayoutTensor[kernel_dtype, C_layout, MutAnyOrigin],
+    D: LayoutTensor[kernel_dtype, D_layout, MutAnyOrigin],
+    z: LayoutTensor[kernel_dtype, z_layout, MutAnyOrigin],
+    output: LayoutTensor[kernel_dtype, out_layout, MutAnyOrigin],
+    dt_bias: LayoutTensor[kernel_dtype, dt_bias_layout, MutAnyOrigin],
+    state_batch_indices: LayoutTensor[
+        DType.int32, state_batch_indices_layout, MutAnyOrigin
+    ],
+    # All strides (same as GPU version)
+    state_strides: Strides4D,
+    x_strides: Strides3D,
+    dt_strides: Strides3D,
+    dt_bias_strides: Strides2D,
+    A_strides: Strides3D,
+    B_strides: Strides3D,
+    C_strides: Strides3D,
+    D_strides: Strides2D,
+    z_strides: Strides3D,
+    out_strides: Strides3D,
+):
+    """CPU kernel for varlen selective state update."""
+    var has_dt_bias = dt_bias.dim(0) > 0
+    var has_D = D.dim(0) > 0
+    var has_z = z.dim(0) > 0
+    var dt_softplus_bool = Bool(Int(dt_softplus) != 0)
+    var has_state_batch_indices_bool = Bool(Int(has_state_batch_indices) != 0)
+
+    @parameter
+    fn worker(idx: Int):
+        var b = idx // (nheads * dim)
+        var remaining = idx % (nheads * dim)
+        var h = remaining // dim
+        var m = remaining % dim
+
+        # Determine state batch index
+        var state_batch_idx = Int32(b)
+        if has_state_batch_indices_bool:
+            state_batch_idx = state_batch_indices.ptr[b]
+            if state_batch_idx == pad_slot_id:
+                return
+
+        var group_id = h // nheads_ngroups_ratio
+
+        # Load x value
+        var x_offset = UInt32(
+            b * x_strides[0] + h * x_strides[1] + m * x_strides[2]
+        )
+        var x_val = Scalar[kernel_dtype](x.ptr[x_offset]).cast[DType.float32]()
+
+        # Load dt value
+        var dt_offset = UInt32(
+            b * dt_strides[0] + h * dt_strides[1] + m * dt_strides[2]
+        )
+        var dt_val = Scalar[kernel_dtype](dt.ptr[dt_offset]).cast[
+            DType.float32
+        ]()
+
+        # Apply dt_bias if present
+        if has_dt_bias:
+            var dt_bias_offset = UInt32(
+                h * dt_bias_strides[0] + m * dt_bias_strides[1]
+            )
+            var bias_val = Scalar[kernel_dtype](
+                dt_bias.ptr[dt_bias_offset]
+            ).cast[DType.float32]()
+            dt_val += bias_val
+
+        # Apply softplus if requested
+        if dt_softplus_bool:
+            dt_val = softplus(dt_val)
+
+        var out_val = Float32(0.0)
+
+        # Process each dstate element
+        for n in range(dstate):
+            # Load A value
+            var A_offset = UInt32(
+                h * A_strides[0] + m * A_strides[1] + n * A_strides[2]
+            )
+            var A_val = Scalar[kernel_dtype](A.ptr[A_offset]).cast[
+                DType.float32
+            ]()
+
+            # Compute dA = exp(A * dt) using exp2 for consistency
+            var dA = exp2(A_val * LOG2E * dt_val)
+
+            # Load B value
+            var B_offset = UInt32(
+                b * B_strides[0] + group_id * B_strides[1] + n * B_strides[2]
+            )
+            var B_val = Scalar[kernel_dtype](B.ptr[B_offset]).cast[
+                DType.float32
+            ]()
+
+            # Compute dB = B * dt
+            var dB = B_val * dt_val
+
+            # Load current state
+            var state_offset = UInt32(
+                Int(state_batch_idx) * state_strides[0]
+                + h * state_strides[1]
+                + m * state_strides[2]
+                + n * state_strides[3]
+            )
+            var state_val = Scalar[kernel_dtype](state.ptr[state_offset]).cast[
+                DType.float32
+            ]()
+
+            # Update state
+            state_val = state_val * dA + dB * x_val
+
+            # Store updated state
+            state.ptr[state_offset] = Scalar[kernel_dtype](
+                state_val.cast[kernel_dtype]()
+            )
+
+            # Load C value
+            var C_offset = UInt32(
+                b * C_strides[0] + group_id * C_strides[1] + n * C_strides[2]
+            )
+            var C_val = Scalar[kernel_dtype](C.ptr[C_offset]).cast[
+                DType.float32
+            ]()
+
+            # Accumulate output
+            out_val += state_val * C_val
+
+        # Add skip connection if D is present
+        if has_D:
+            var D_offset = UInt32(h * D_strides[0] + m * D_strides[1])
+            var D_val = Scalar[kernel_dtype](D.ptr[D_offset]).cast[
+                DType.float32
+            ]()
+            out_val += x_val * D_val
+
+        # Apply gating if z is present, using optimized silu
+        if has_z:
+            var z_offset = UInt32(
+                b * z_strides[0] + h * z_strides[1] + m * z_strides[2]
+            )
+            var z_val = Scalar[kernel_dtype](z.ptr[z_offset]).cast[
+                DType.float32
+            ]()
+            out_val *= silu(z_val)
+
+        # Store output
+        var out_offset = UInt32(
+            b * out_strides[0] + h * out_strides[1] + m * out_strides[2]
+        )
+        output.ptr[out_offset] = Scalar[kernel_dtype](
+            out_val.cast[kernel_dtype]()
+        )
+
+    sync_parallelize[worker](batch * nheads * dim)
+
+
+fn varlen_selective_scan_fwd_cpu[
+    kernel_dtype: DType,
+    u_layout: Layout,
+    delta_layout: Layout,
+    A_layout: Layout,
+    B_layout: Layout,
+    C_layout: Layout,
+    D_layout: Layout,
+    z_layout: Layout,
+    delta_bias_layout: Layout,
+    ssm_states_layout: Layout,
+    out_layout: Layout,
+    query_start_loc_layout: Layout,
+    cache_indices_layout: Layout,
+    has_initial_state_layout: Layout,
+](
+    dim: Int,
+    dstate: Int,
+    ngroups: Int,
+    batch: Int,
+    pad_slot_id: Int32,
+    delta_softplus: Int8,
+    # Tensors
+    u: LayoutTensor[kernel_dtype, u_layout, MutAnyOrigin],
+    delta: LayoutTensor[kernel_dtype, delta_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, A_layout, MutAnyOrigin],
+    B: LayoutTensor[kernel_dtype, B_layout, MutAnyOrigin],
+    C: LayoutTensor[kernel_dtype, C_layout, MutAnyOrigin],
+    D: LayoutTensor[kernel_dtype, D_layout, MutAnyOrigin],
+    z: LayoutTensor[kernel_dtype, z_layout, MutAnyOrigin],
+    delta_bias: LayoutTensor[kernel_dtype, delta_bias_layout, MutAnyOrigin],
+    ssm_states: LayoutTensor[kernel_dtype, ssm_states_layout, MutAnyOrigin],
+    output: LayoutTensor[kernel_dtype, out_layout, MutAnyOrigin],
+    query_start_loc: LayoutTensor[
+        DType.int32, query_start_loc_layout, MutAnyOrigin
+    ],
+    cache_indices: LayoutTensor[
+        DType.int32, cache_indices_layout, MutAnyOrigin
+    ],
+    has_initial_state: LayoutTensor[
+        DType.bool, has_initial_state_layout, MutAnyOrigin
+    ],
+    # Strides (same as GPU version)
+    u_strides: Strides2D,
+    delta_strides: Strides2D,
+    A_strides: Strides2D,
+    B_strides: Strides3D,
+    C_strides: Strides3D,
+    D_strides: Strides1D,
+    z_strides: Strides2D,
+    delta_bias_strides: Strides1D,
+    ssm_states_strides: Strides3D,
+    out_strides: Strides2D,
+):
+    """CPU kernel for variable-length selective scan."""
+    var has_D = D.dim(0) > 0
+    var has_z = z.dim(0) > 0
+    var has_delta_bias = delta_bias.dim(0) > 0
+    var has_cache_indices = cache_indices.dim(0) > 0
+    var has_initial_state_tensor = has_initial_state.dim(0) > 0
+    var delta_softplus_bool = Bool(Int(delta_softplus) != 0)
+    var group_size = dim // ngroups
+
+    @parameter
+    fn worker(d: Int):
+        # Pre-load D and delta_bias for this dim
+        var D_val = Float32(0.0)
+        if has_D:
+            var D_offset = UInt32(d * D_strides[0])
+            D_val = Scalar[kernel_dtype](D.ptr[D_offset]).cast[DType.float32]()
+
+        var delta_bias_val = Float32(0.0)
+        if has_delta_bias:
+            var bias_offset = UInt32(d * delta_bias_strides[0])
+            delta_bias_val = Scalar[kernel_dtype](
+                delta_bias.ptr[bias_offset]
+            ).cast[DType.float32]()
+
+        # Pre-load A values for this dim and pre-multiply by LOG2E for faster exp2
+        var A_vals = SIMD[DType.float32, MAX_DSTATE](0.0)
+        for n in range(dstate):
+            var A_offset = UInt32(d * A_strides[0] + n * A_strides[1])
+            A_vals[n] = (
+                Scalar[kernel_dtype](A.ptr[A_offset]).cast[DType.float32]()
+                * LOG2E
+            )
+        var group_id = d // group_size
+
+        # Process each sequence
+        for b in range(batch):
+            var seq_start = Int(query_start_loc.ptr[b])
+            var seq_end = Int(query_start_loc.ptr[b + 1])
+            var seq_len = seq_end - seq_start
+
+            if seq_len <= 0:
+                continue
+
+            var cache_idx = b
+            if has_cache_indices:
+                cache_idx = Int(cache_indices.ptr[b])
+                if cache_idx == Int(pad_slot_id):
+                    continue
+
+            # Initialize state
+            var state = SIMD[DType.float32, MAX_DSTATE](0.0)
+
+            var use_initial_state = False
+            if has_initial_state_tensor:
+                var init_state_val = has_initial_state.ptr[b]
+                use_initial_state = Bool(init_state_val)
+
+            if use_initial_state:
+                for n in range(dstate):
+                    var state_offset = UInt32(
+                        cache_idx * ssm_states_strides[0]
+                        + d * ssm_states_strides[1]
+                        + n * ssm_states_strides[2]
+                    )
+                    state[n] = Scalar[kernel_dtype](
+                        ssm_states.ptr[state_offset]
+                    ).cast[DType.float32]()
+
+            # Process sequence
+            for t in range(seq_len):
+                var global_t = seq_start + t
+
+                var u_offset = UInt32(
+                    d * u_strides[0] + global_t * u_strides[1]
+                )
+                var u_val = Scalar[kernel_dtype](u.ptr[u_offset]).cast[
+                    DType.float32
+                ]()
+
+                var delta_offset = UInt32(
+                    d * delta_strides[0] + global_t * delta_strides[1]
+                )
+                var out_offset = UInt32(
+                    d * out_strides[0] + global_t * out_strides[1]
+                )
+                var delta_val = Scalar[kernel_dtype](
+                    delta.ptr[delta_offset]
+                ).cast[DType.float32]()
+
+                if has_delta_bias:
+                    delta_val += delta_bias_val
+
+                if delta_softplus_bool:
+                    delta_val = softplus(delta_val)
+
+                var delta_u = delta_val * u_val
+
+                var B_vals = SIMD[DType.float32, MAX_DSTATE](0.0)
+                var C_vals = SIMD[DType.float32, MAX_DSTATE](0.0)
+
+                for n in range(dstate):
+                    var B_offset = UInt32(
+                        group_id * B_strides[0]
+                        + n * B_strides[1]
+                        + global_t * B_strides[2]
+                    )
+                    var C_offset = UInt32(
+                        group_id * C_strides[0]
+                        + n * C_strides[1]
+                        + global_t * C_strides[2]
+                    )
+
+                    B_vals[n] = Scalar[kernel_dtype](B.ptr[B_offset]).cast[
+                        DType.float32
+                    ]()
+                    C_vals[n] = Scalar[kernel_dtype](C.ptr[C_offset]).cast[
+                        DType.float32
+                    ]()
+
+                # SSM step using SIMD exp2 with pre-multiplied LOG2E
+                var a_t = exp2(A_vals * delta_val)
+                var b_t = B_vals * delta_u
+                state = state * a_t + b_t
+
+                # Compute output using SIMD reduce
+                var output_val = (state * C_vals).reduce_add()
+
+                if has_D:
+                    output_val += D_val * u_val
+
+                if has_z:
+                    var z_offset = UInt32(
+                        d * z_strides[0] + global_t * z_strides[1]
+                    )
+                    var z_val = Scalar[kernel_dtype](z.ptr[z_offset]).cast[
+                        DType.float32
+                    ]()
+                    output_val *= silu(z_val)
+                    z.ptr[z_offset] = Scalar[kernel_dtype](
+                        output_val.cast[kernel_dtype]()
+                    )
+                else:
+                    output.ptr[out_offset] = Scalar[kernel_dtype](
+                        output_val.cast[kernel_dtype]()
+                    )
+
+            # Store final state
+            for n in range(dstate):
+                var state_offset = UInt32(
+                    cache_idx * ssm_states_strides[0]
+                    + d * ssm_states_strides[1]
+                    + n * ssm_states_strides[2]
+                )
+                ssm_states.ptr[state_offset] = Scalar[kernel_dtype](
+                    state[n].cast[kernel_dtype]()
+                )
+
+    sync_parallelize[worker](dim)

--- a/max/kernels/src/state_space/varlen_selective_scan.mojo
+++ b/max/kernels/src/state_space/varlen_selective_scan.mojo
@@ -20,7 +20,8 @@ from memory import UnsafePointer
 from algorithm import sync_parallelize
 import math
 from math import ceildiv, exp2
-from state_space.selective_scan import softplus, sigmoid
+from state_space.causal_conv1d import silu
+from state_space.selective_scan import softplus
 
 # LOG2E constant for converting exp to exp2 (faster on GPU)
 comptime LOG2E = 1.4426950408889634
@@ -31,11 +32,6 @@ comptime Strides1D = IndexList[1]
 comptime Strides2D = IndexList[2]
 comptime Strides3D = IndexList[3]
 comptime Strides4D = IndexList[4]
-
-
-# Optimized SiLU (Swish): x * sigmoid(x)
-fn silu(val: Float32) -> Float32:
-    return val * sigmoid(val)
 
 
 fn varlen_selective_state_update_gpu[

--- a/max/kernels/src/state_space/varlen_selective_scan_ops.mojo
+++ b/max/kernels/src/state_space/varlen_selective_scan_ops.mojo
@@ -87,9 +87,9 @@ struct VarlenSelectiveScanFwd[delta_softplus: Bool = False]:
         D: InputTensor[dtype=dtype, rank=1],
         z: OutputTensor[dtype=dtype, rank=2],
         delta_bias: InputTensor[dtype=dtype, rank=1],
-        query_start_loc: InputTensor[dtype=DType.int32, rank=1],
-        cache_indices: InputTensor[dtype=DType.int32, rank=1],
-        has_initial_state: InputTensor[dtype=DType.bool, rank=1],
+        query_start_loc: InputTensor[dtype = DType.int32, rank=1],
+        cache_indices: InputTensor[dtype = DType.int32, rank=1],
+        has_initial_state: InputTensor[dtype = DType.bool, rank=1],
         ctx: DeviceContextPtr,
     ) capturing raises:
         var dim = u.dim_size(0)
@@ -135,9 +135,7 @@ struct VarlenSelectiveScanFwd[delta_softplus: Bool = False]:
             ssm_states.strides()[1],
             ssm_states.strides()[2],
         )
-        var out_strides = Strides2D(
-            output.strides()[0], output.strides()[1]
-        )
+        var out_strides = Strides2D(output.strides()[0], output.strides()[1])
 
         comptime PAD_SLOT_ID: Int32 = -1
         comptime delta_softplus_int8: Int8 = Int8(
@@ -527,9 +525,9 @@ struct VarlenSelectiveScanFwd[delta_softplus: Bool = False]:
         D: InputTensor[dtype=dtype, rank=1],
         z: InputTensor[dtype=dtype, rank=2],
         delta_bias: InputTensor[dtype=dtype, rank=1],
-        query_start_loc: InputTensor[dtype=DType.int32, rank=1],
-        cache_indices: InputTensor[dtype=DType.int32, rank=1],
-        has_initial_state: InputTensor[dtype=DType.bool, rank=1],
+        query_start_loc: InputTensor[dtype = DType.int32, rank=1],
+        cache_indices: InputTensor[dtype = DType.int32, rank=1],
+        has_initial_state: InputTensor[dtype = DType.bool, rank=1],
     ) -> IndexList[2]:
         return u.shape()
 
@@ -578,7 +576,7 @@ struct VarlenSelectiveStateUpdate[dt_softplus: Bool = False]:
         D: InputTensor[dtype=dtype, rank=2],
         z: InputTensor[dtype=dtype, rank=3],
         dt_bias: InputTensor[dtype=dtype, rank=2],
-        state_batch_indices: InputTensor[dtype=DType.int32, rank=1],
+        state_batch_indices: InputTensor[dtype = DType.int32, rank=1],
         ctx: DeviceContextPtr,
     ) capturing raises:
         var batch = x.dim_size(0)
@@ -1014,6 +1012,6 @@ struct VarlenSelectiveStateUpdate[dt_softplus: Bool = False]:
         D: InputTensor[dtype=dtype, rank=2],
         z: InputTensor[dtype=dtype, rank=3],
         dt_bias: InputTensor[dtype=dtype, rank=2],
-        state_batch_indices: InputTensor[dtype=DType.int32, rank=1],
+        state_batch_indices: InputTensor[dtype = DType.int32, rank=1],
     ) -> Tuple[IndexList[4], IndexList[3]]:
         return (state.shape(), x.shape())

--- a/max/kernels/src/state_space/varlen_selective_scan_ops.mojo
+++ b/max/kernels/src/state_space/varlen_selective_scan_ops.mojo
@@ -1,0 +1,1019 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Varlen selective scan operation registrations for Mamba SSM.
+
+This module registers operations for variable-length selective scan:
+- varlen_selective_scan_fwd: Forward pass for varlen sequences
+- varlen_selective_state_update: State update for decode/autoregressive inference
+"""
+
+from math import ceildiv
+
+import compiler_internal as compiler
+from gpu.host import DeviceContext
+from gpu.host.info import is_cpu, is_gpu
+from runtime.asyncrt import DeviceContextPtr
+from tensor import InputTensor, OutputTensor
+from utils.index import IndexList
+
+from state_space.varlen_selective_scan import (
+    varlen_selective_scan_fwd_cpu,
+    varlen_selective_scan_fwd_gpu,
+    varlen_selective_state_update_cpu,
+    varlen_selective_state_update_gpu,
+)
+
+# Stride types for kernel calls
+comptime Strides1D = IndexList[1]
+comptime Strides2D = IndexList[2]
+comptime Strides3D = IndexList[3]
+comptime Strides4D = IndexList[4]
+
+
+# ============================================================================
+# Varlen Selective Scan Forward Registration
+# ============================================================================
+
+
+@compiler.register("varlen_selective_scan_fwd")
+struct VarlenSelectiveScanFwd[delta_softplus: Bool = False]:
+    """Variable-length selective scan forward pass.
+
+    Performs the selective scan computation for variable-length sequences
+    that are concatenated together. Uses cumulative sequence lengths to
+    identify sequence boundaries.
+
+    Parameters:
+        delta_softplus: If True, applies softplus activation to delta values.
+
+    Tensor Shapes:
+        - output: (dim, total_length) - Output tensor (or written to z if present)
+        - ssm_states: (batch, dim, dstate) - SSM states (in/out)
+        - u: (dim, total_length) - Input tensor
+        - delta: (dim, total_length) - Time step tensor
+        - A: (dim, dstate) - State transition matrix
+        - B: (ngroups, dstate, total_length) - Input projection
+        - C: (ngroups, dstate, total_length) - Output projection
+        - D: (dim,) - Skip connection (optional, can be empty)
+        - z: (dim, total_length) - Gating tensor (optional, can be empty)
+        - delta_bias: (dim,) - Delta bias (optional, can be empty)
+        - query_start_loc: (batch + 1,) - Cumulative sequence lengths
+        - cache_indices: (batch,) - Indices into ssm_states (optional)
+        - has_initial_state: (batch,) - Whether to use initial state (optional)
+    """
+
+    @staticmethod
+    fn execute[
+        dtype: DType,
+        target: StaticString,
+    ](
+        output: OutputTensor[dtype=dtype, rank=2],
+        ssm_states: OutputTensor[dtype=dtype, rank=3],
+        u: InputTensor[dtype=dtype, rank=2],
+        delta: InputTensor[dtype=dtype, rank=2],
+        A: InputTensor[dtype=dtype, rank=2],
+        B: InputTensor[dtype=dtype, rank=3],
+        C: InputTensor[dtype=dtype, rank=3],
+        D: InputTensor[dtype=dtype, rank=1],
+        z: OutputTensor[dtype=dtype, rank=2],
+        delta_bias: InputTensor[dtype=dtype, rank=1],
+        query_start_loc: InputTensor[dtype=DType.int32, rank=1],
+        cache_indices: InputTensor[dtype=DType.int32, rank=1],
+        has_initial_state: InputTensor[dtype=DType.bool, rank=1],
+        ctx: DeviceContextPtr,
+    ) capturing raises:
+        var dim = u.dim_size(0)
+        var total_length = u.dim_size(1)
+        var dstate = A.dim_size(1)
+        var ngroups = B.dim_size(0)
+        var batch = query_start_loc.dim_size(0) - 1
+
+        var output_lt = output.to_layout_tensor()
+        var ssm_states_lt = ssm_states.to_layout_tensor()
+        var u_lt = u.to_layout_tensor()
+        var delta_lt = delta.to_layout_tensor()
+        var A_lt = A.to_layout_tensor()
+        var B_lt = B.to_layout_tensor()
+        var C_lt = C.to_layout_tensor()
+        var D_lt = D.to_layout_tensor()
+        var z_lt = z.to_layout_tensor()
+        var delta_bias_lt = delta_bias.to_layout_tensor()
+        var query_start_loc_lt = query_start_loc.to_layout_tensor()
+        var cache_indices_lt = cache_indices.to_layout_tensor()
+        var has_initial_state_lt = has_initial_state.to_layout_tensor()
+
+        # Get strides
+        var u_strides = Strides2D(u.strides()[0], u.strides()[1])
+        var delta_strides = Strides2D(delta.strides()[0], delta.strides()[1])
+        var A_strides = Strides2D(A.strides()[0], A.strides()[1])
+        var B_strides = Strides3D(
+            B.strides()[0], B.strides()[1], B.strides()[2]
+        )
+        var C_strides = Strides3D(
+            C.strides()[0], C.strides()[1], C.strides()[2]
+        )
+        var D_strides = Strides1D(D.strides()[0] if D.dim_size(0) > 0 else 1)
+        var z_strides = Strides2D(
+            z.strides()[0] if z.dim_size(0) > 0 else 1,
+            z.strides()[1] if z.dim_size(0) > 0 else 1,
+        )
+        var delta_bias_strides = Strides1D(
+            delta_bias.strides()[0] if delta_bias.dim_size(0) > 0 else 1
+        )
+        var ssm_states_strides = Strides3D(
+            ssm_states.strides()[0],
+            ssm_states.strides()[1],
+            ssm_states.strides()[2],
+        )
+        var out_strides = Strides2D(
+            output.strides()[0], output.strides()[1]
+        )
+
+        comptime PAD_SLOT_ID: Int32 = -1
+        comptime delta_softplus_int8: Int8 = Int8(
+            1
+        ) if Self.delta_softplus else Int8(0)
+
+        if dstate != 4 and dstate != 8 and dstate != 16:
+            raise Error(
+                "Unsupported dstate: "
+                + String(dstate)
+                + ". Expected 4, 8, or 16."
+            )
+
+        @parameter
+        if is_cpu[target]():
+            if dstate == 16:
+                varlen_selective_scan_fwd_cpu[
+                    dtype,
+                    16,
+                    u_lt.layout,
+                    delta_lt.layout,
+                    A_lt.layout,
+                    B_lt.layout,
+                    C_lt.layout,
+                    D_lt.layout,
+                    z_lt.layout,
+                    delta_bias_lt.layout,
+                    ssm_states_lt.layout,
+                    output_lt.layout,
+                    query_start_loc_lt.layout,
+                    cache_indices_lt.layout,
+                    has_initial_state_lt.layout,
+                ](
+                    dim,
+                    ngroups,
+                    batch,
+                    PAD_SLOT_ID,
+                    delta_softplus_int8,
+                    u_lt,
+                    delta_lt,
+                    A_lt,
+                    B_lt,
+                    C_lt,
+                    D_lt,
+                    z_lt,
+                    delta_bias_lt,
+                    ssm_states_lt,
+                    output_lt,
+                    query_start_loc_lt,
+                    cache_indices_lt,
+                    has_initial_state_lt,
+                    u_strides,
+                    delta_strides,
+                    A_strides,
+                    B_strides,
+                    C_strides,
+                    D_strides,
+                    z_strides,
+                    delta_bias_strides,
+                    ssm_states_strides,
+                    out_strides,
+                )
+            elif dstate == 8:
+                varlen_selective_scan_fwd_cpu[
+                    dtype,
+                    8,
+                    u_lt.layout,
+                    delta_lt.layout,
+                    A_lt.layout,
+                    B_lt.layout,
+                    C_lt.layout,
+                    D_lt.layout,
+                    z_lt.layout,
+                    delta_bias_lt.layout,
+                    ssm_states_lt.layout,
+                    output_lt.layout,
+                    query_start_loc_lt.layout,
+                    cache_indices_lt.layout,
+                    has_initial_state_lt.layout,
+                ](
+                    dim,
+                    ngroups,
+                    batch,
+                    PAD_SLOT_ID,
+                    delta_softplus_int8,
+                    u_lt,
+                    delta_lt,
+                    A_lt,
+                    B_lt,
+                    C_lt,
+                    D_lt,
+                    z_lt,
+                    delta_bias_lt,
+                    ssm_states_lt,
+                    output_lt,
+                    query_start_loc_lt,
+                    cache_indices_lt,
+                    has_initial_state_lt,
+                    u_strides,
+                    delta_strides,
+                    A_strides,
+                    B_strides,
+                    C_strides,
+                    D_strides,
+                    z_strides,
+                    delta_bias_strides,
+                    ssm_states_strides,
+                    out_strides,
+                )
+            else:  # dstate == 4
+                varlen_selective_scan_fwd_cpu[
+                    dtype,
+                    4,
+                    u_lt.layout,
+                    delta_lt.layout,
+                    A_lt.layout,
+                    B_lt.layout,
+                    C_lt.layout,
+                    D_lt.layout,
+                    z_lt.layout,
+                    delta_bias_lt.layout,
+                    ssm_states_lt.layout,
+                    output_lt.layout,
+                    query_start_loc_lt.layout,
+                    cache_indices_lt.layout,
+                    has_initial_state_lt.layout,
+                ](
+                    dim,
+                    ngroups,
+                    batch,
+                    PAD_SLOT_ID,
+                    delta_softplus_int8,
+                    u_lt,
+                    delta_lt,
+                    A_lt,
+                    B_lt,
+                    C_lt,
+                    D_lt,
+                    z_lt,
+                    delta_bias_lt,
+                    ssm_states_lt,
+                    output_lt,
+                    query_start_loc_lt,
+                    cache_indices_lt,
+                    has_initial_state_lt,
+                    u_strides,
+                    delta_strides,
+                    A_strides,
+                    B_strides,
+                    C_strides,
+                    D_strides,
+                    z_strides,
+                    delta_bias_strides,
+                    ssm_states_strides,
+                    out_strides,
+                )
+        elif is_gpu[target]():
+            var gpu_ctx = ctx.get_device_context()
+            comptime BLOCK_SIZE = 128
+            var num_dim_blocks = ceildiv(dim, BLOCK_SIZE)
+
+            if dstate == 16:
+                comptime DSTATE_VAL = 16
+                var compiled_kernel = gpu_ctx.compile_function[
+                    varlen_selective_scan_fwd_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        u_lt.layout,
+                        delta_lt.layout,
+                        A_lt.layout,
+                        B_lt.layout,
+                        C_lt.layout,
+                        D_lt.layout,
+                        z_lt.layout,
+                        delta_bias_lt.layout,
+                        ssm_states_lt.layout,
+                        output_lt.layout,
+                        query_start_loc_lt.layout,
+                        cache_indices_lt.layout,
+                        has_initial_state_lt.layout,
+                    ],
+                    varlen_selective_scan_fwd_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        u_lt.layout,
+                        delta_lt.layout,
+                        A_lt.layout,
+                        B_lt.layout,
+                        C_lt.layout,
+                        D_lt.layout,
+                        z_lt.layout,
+                        delta_bias_lt.layout,
+                        ssm_states_lt.layout,
+                        output_lt.layout,
+                        query_start_loc_lt.layout,
+                        cache_indices_lt.layout,
+                        has_initial_state_lt.layout,
+                    ],
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_kernel,
+                    dim,
+                    ngroups,
+                    batch,
+                    PAD_SLOT_ID,
+                    delta_softplus_int8,
+                    u_lt,
+                    delta_lt,
+                    A_lt,
+                    B_lt,
+                    C_lt,
+                    D_lt,
+                    z_lt,
+                    delta_bias_lt,
+                    ssm_states_lt,
+                    output_lt,
+                    query_start_loc_lt,
+                    cache_indices_lt,
+                    has_initial_state_lt,
+                    u_strides,
+                    delta_strides,
+                    A_strides,
+                    B_strides,
+                    C_strides,
+                    D_strides,
+                    z_strides,
+                    delta_bias_strides,
+                    ssm_states_strides,
+                    out_strides,
+                    grid_dim=(num_dim_blocks, batch, 1),
+                    block_dim=(BLOCK_SIZE, 1, 1),
+                )
+            elif dstate == 8:
+                comptime DSTATE_VAL = 8
+                var compiled_kernel = gpu_ctx.compile_function[
+                    varlen_selective_scan_fwd_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        u_lt.layout,
+                        delta_lt.layout,
+                        A_lt.layout,
+                        B_lt.layout,
+                        C_lt.layout,
+                        D_lt.layout,
+                        z_lt.layout,
+                        delta_bias_lt.layout,
+                        ssm_states_lt.layout,
+                        output_lt.layout,
+                        query_start_loc_lt.layout,
+                        cache_indices_lt.layout,
+                        has_initial_state_lt.layout,
+                    ],
+                    varlen_selective_scan_fwd_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        u_lt.layout,
+                        delta_lt.layout,
+                        A_lt.layout,
+                        B_lt.layout,
+                        C_lt.layout,
+                        D_lt.layout,
+                        z_lt.layout,
+                        delta_bias_lt.layout,
+                        ssm_states_lt.layout,
+                        output_lt.layout,
+                        query_start_loc_lt.layout,
+                        cache_indices_lt.layout,
+                        has_initial_state_lt.layout,
+                    ],
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_kernel,
+                    dim,
+                    ngroups,
+                    batch,
+                    PAD_SLOT_ID,
+                    delta_softplus_int8,
+                    u_lt,
+                    delta_lt,
+                    A_lt,
+                    B_lt,
+                    C_lt,
+                    D_lt,
+                    z_lt,
+                    delta_bias_lt,
+                    ssm_states_lt,
+                    output_lt,
+                    query_start_loc_lt,
+                    cache_indices_lt,
+                    has_initial_state_lt,
+                    u_strides,
+                    delta_strides,
+                    A_strides,
+                    B_strides,
+                    C_strides,
+                    D_strides,
+                    z_strides,
+                    delta_bias_strides,
+                    ssm_states_strides,
+                    out_strides,
+                    grid_dim=(num_dim_blocks, batch, 1),
+                    block_dim=(BLOCK_SIZE, 1, 1),
+                )
+            else:  # dstate == 4
+                comptime DSTATE_VAL = 4
+                var compiled_kernel = gpu_ctx.compile_function[
+                    varlen_selective_scan_fwd_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        u_lt.layout,
+                        delta_lt.layout,
+                        A_lt.layout,
+                        B_lt.layout,
+                        C_lt.layout,
+                        D_lt.layout,
+                        z_lt.layout,
+                        delta_bias_lt.layout,
+                        ssm_states_lt.layout,
+                        output_lt.layout,
+                        query_start_loc_lt.layout,
+                        cache_indices_lt.layout,
+                        has_initial_state_lt.layout,
+                    ],
+                    varlen_selective_scan_fwd_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        u_lt.layout,
+                        delta_lt.layout,
+                        A_lt.layout,
+                        B_lt.layout,
+                        C_lt.layout,
+                        D_lt.layout,
+                        z_lt.layout,
+                        delta_bias_lt.layout,
+                        ssm_states_lt.layout,
+                        output_lt.layout,
+                        query_start_loc_lt.layout,
+                        cache_indices_lt.layout,
+                        has_initial_state_lt.layout,
+                    ],
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_kernel,
+                    dim,
+                    ngroups,
+                    batch,
+                    PAD_SLOT_ID,
+                    delta_softplus_int8,
+                    u_lt,
+                    delta_lt,
+                    A_lt,
+                    B_lt,
+                    C_lt,
+                    D_lt,
+                    z_lt,
+                    delta_bias_lt,
+                    ssm_states_lt,
+                    output_lt,
+                    query_start_loc_lt,
+                    cache_indices_lt,
+                    has_initial_state_lt,
+                    u_strides,
+                    delta_strides,
+                    A_strides,
+                    B_strides,
+                    C_strides,
+                    D_strides,
+                    z_strides,
+                    delta_bias_strides,
+                    ssm_states_strides,
+                    out_strides,
+                    grid_dim=(num_dim_blocks, batch, 1),
+                    block_dim=(BLOCK_SIZE, 1, 1),
+                )
+        else:
+            raise Error("Unsupported target device")
+
+    @staticmethod
+    fn shape[
+        dtype: DType,
+    ](
+        u: InputTensor[dtype=dtype, rank=2],
+        delta: InputTensor[dtype=dtype, rank=2],
+        A: InputTensor[dtype=dtype, rank=2],
+        B: InputTensor[dtype=dtype, rank=3],
+        C: InputTensor[dtype=dtype, rank=3],
+        D: InputTensor[dtype=dtype, rank=1],
+        z: InputTensor[dtype=dtype, rank=2],
+        delta_bias: InputTensor[dtype=dtype, rank=1],
+        query_start_loc: InputTensor[dtype=DType.int32, rank=1],
+        cache_indices: InputTensor[dtype=DType.int32, rank=1],
+        has_initial_state: InputTensor[dtype=DType.bool, rank=1],
+    ) -> IndexList[2]:
+        return u.shape()
+
+
+# ============================================================================
+# Varlen Selective State Update Registration
+# ============================================================================
+
+
+@compiler.register("varlen_selective_state_update")
+struct VarlenSelectiveStateUpdate[dt_softplus: Bool = False]:
+    """Varlen selective state update for autoregressive inference.
+
+    Performs a single step of the SSM recurrence for incremental token
+    generation with multi-head support.
+
+    Parameters:
+        dt_softplus: If True, applies softplus activation to dt values.
+
+    Tensor Shapes:
+        - state: (batch, nheads, dim, dstate) - SSM state (in/out)
+        - output: (batch, nheads, dim) - Output tensor
+        - x: (batch, nheads, dim) - Input tensor
+        - dt: (batch, nheads, dim) - Time delta tensor
+        - A: (nheads, dim, dstate) - State transition matrix
+        - B: (batch, ngroups, dstate) - Input matrix
+        - C: (batch, ngroups, dstate) - Output matrix
+        - D: (nheads, dim) - Skip connection (optional, can be empty)
+        - z: (batch, nheads, dim) - Gating tensor (optional, can be empty)
+        - dt_bias: (nheads, dim) - Time delta bias (optional, can be empty)
+        - state_batch_indices: (batch,) - Indices into state batch (optional)
+    """
+
+    @staticmethod
+    fn execute[
+        dtype: DType,
+        target: StaticString,
+    ](
+        state: OutputTensor[dtype=dtype, rank=4],
+        output: OutputTensor[dtype=dtype, rank=3],
+        x: InputTensor[dtype=dtype, rank=3],
+        dt: InputTensor[dtype=dtype, rank=3],
+        A: InputTensor[dtype=dtype, rank=3],
+        B: InputTensor[dtype=dtype, rank=3],
+        C: InputTensor[dtype=dtype, rank=3],
+        D: InputTensor[dtype=dtype, rank=2],
+        z: InputTensor[dtype=dtype, rank=3],
+        dt_bias: InputTensor[dtype=dtype, rank=2],
+        state_batch_indices: InputTensor[dtype=DType.int32, rank=1],
+        ctx: DeviceContextPtr,
+    ) capturing raises:
+        var batch = x.dim_size(0)
+        var nheads = x.dim_size(1)
+        var dim = x.dim_size(2)
+        var dstate = state.dim_size(3)
+        var ngroups = B.dim_size(1)
+        var nheads_ngroups_ratio = nheads // ngroups
+
+        var state_lt = state.to_layout_tensor()
+        var output_lt = output.to_layout_tensor()
+        var x_lt = x.to_layout_tensor()
+        var dt_lt = dt.to_layout_tensor()
+        var A_lt = A.to_layout_tensor()
+        var B_lt = B.to_layout_tensor()
+        var C_lt = C.to_layout_tensor()
+        var D_lt = D.to_layout_tensor()
+        var z_lt = z.to_layout_tensor()
+        var dt_bias_lt = dt_bias.to_layout_tensor()
+        var state_batch_indices_lt = state_batch_indices.to_layout_tensor()
+
+        # Get strides
+        var state_strides = Strides4D(
+            state.strides()[0],
+            state.strides()[1],
+            state.strides()[2],
+            state.strides()[3],
+        )
+        var x_strides = Strides3D(
+            x.strides()[0], x.strides()[1], x.strides()[2]
+        )
+        var dt_strides = Strides3D(
+            dt.strides()[0], dt.strides()[1], dt.strides()[2]
+        )
+        var dt_bias_strides = Strides2D(
+            dt_bias.strides()[0] if dt_bias.dim_size(0) > 0 else 1,
+            dt_bias.strides()[1] if dt_bias.dim_size(0) > 0 else 1,
+        )
+        var A_strides = Strides3D(
+            A.strides()[0], A.strides()[1], A.strides()[2]
+        )
+        var B_strides = Strides3D(
+            B.strides()[0], B.strides()[1], B.strides()[2]
+        )
+        var C_strides = Strides3D(
+            C.strides()[0], C.strides()[1], C.strides()[2]
+        )
+        var D_strides = Strides2D(
+            D.strides()[0] if D.dim_size(0) > 0 else 1,
+            D.strides()[1] if D.dim_size(0) > 0 else 1,
+        )
+        var z_strides = Strides3D(
+            z.strides()[0] if z.dim_size(0) > 0 else 1,
+            z.strides()[1] if z.dim_size(0) > 0 else 1,
+            z.strides()[2] if z.dim_size(0) > 0 else 1,
+        )
+        var out_strides = Strides3D(
+            output.strides()[0], output.strides()[1], output.strides()[2]
+        )
+
+        var has_state_batch_indices = state_batch_indices.dim_size(0) > 0
+        comptime PAD_SLOT_ID: Int32 = -1
+        comptime dt_softplus_int8: Int8 = Int8(1) if Self.dt_softplus else Int8(
+            0
+        )
+
+        if dstate != 4 and dstate != 8 and dstate != 16:
+            raise Error(
+                "Unsupported dstate: "
+                + String(dstate)
+                + ". Expected 4, 8, or 16."
+            )
+
+        @parameter
+        if is_cpu[target]():
+            if dstate == 16:
+                varlen_selective_state_update_cpu[
+                    dtype,
+                    16,
+                    state_lt.layout,
+                    x_lt.layout,
+                    dt_lt.layout,
+                    A_lt.layout,
+                    B_lt.layout,
+                    C_lt.layout,
+                    D_lt.layout,
+                    z_lt.layout,
+                    output_lt.layout,
+                    dt_bias_lt.layout,
+                    state_batch_indices_lt.layout,
+                ](
+                    batch,
+                    nheads,
+                    dim,
+                    nheads_ngroups_ratio,
+                    PAD_SLOT_ID,
+                    dt_softplus_int8,
+                    Int8(has_state_batch_indices),
+                    state_lt,
+                    x_lt,
+                    dt_lt,
+                    A_lt,
+                    B_lt,
+                    C_lt,
+                    D_lt,
+                    z_lt,
+                    output_lt,
+                    dt_bias_lt,
+                    state_batch_indices_lt,
+                    state_strides,
+                    x_strides,
+                    dt_strides,
+                    dt_bias_strides,
+                    A_strides,
+                    B_strides,
+                    C_strides,
+                    D_strides,
+                    z_strides,
+                    out_strides,
+                )
+            elif dstate == 8:
+                varlen_selective_state_update_cpu[
+                    dtype,
+                    8,
+                    state_lt.layout,
+                    x_lt.layout,
+                    dt_lt.layout,
+                    A_lt.layout,
+                    B_lt.layout,
+                    C_lt.layout,
+                    D_lt.layout,
+                    z_lt.layout,
+                    output_lt.layout,
+                    dt_bias_lt.layout,
+                    state_batch_indices_lt.layout,
+                ](
+                    batch,
+                    nheads,
+                    dim,
+                    nheads_ngroups_ratio,
+                    PAD_SLOT_ID,
+                    dt_softplus_int8,
+                    Int8(has_state_batch_indices),
+                    state_lt,
+                    x_lt,
+                    dt_lt,
+                    A_lt,
+                    B_lt,
+                    C_lt,
+                    D_lt,
+                    z_lt,
+                    output_lt,
+                    dt_bias_lt,
+                    state_batch_indices_lt,
+                    state_strides,
+                    x_strides,
+                    dt_strides,
+                    dt_bias_strides,
+                    A_strides,
+                    B_strides,
+                    C_strides,
+                    D_strides,
+                    z_strides,
+                    out_strides,
+                )
+            else:  # dstate == 4
+                varlen_selective_state_update_cpu[
+                    dtype,
+                    4,
+                    state_lt.layout,
+                    x_lt.layout,
+                    dt_lt.layout,
+                    A_lt.layout,
+                    B_lt.layout,
+                    C_lt.layout,
+                    D_lt.layout,
+                    z_lt.layout,
+                    output_lt.layout,
+                    dt_bias_lt.layout,
+                    state_batch_indices_lt.layout,
+                ](
+                    batch,
+                    nheads,
+                    dim,
+                    nheads_ngroups_ratio,
+                    PAD_SLOT_ID,
+                    dt_softplus_int8,
+                    Int8(has_state_batch_indices),
+                    state_lt,
+                    x_lt,
+                    dt_lt,
+                    A_lt,
+                    B_lt,
+                    C_lt,
+                    D_lt,
+                    z_lt,
+                    output_lt,
+                    dt_bias_lt,
+                    state_batch_indices_lt,
+                    state_strides,
+                    x_strides,
+                    dt_strides,
+                    dt_bias_strides,
+                    A_strides,
+                    B_strides,
+                    C_strides,
+                    D_strides,
+                    z_strides,
+                    out_strides,
+                )
+        elif is_gpu[target]():
+            var gpu_ctx = ctx.get_device_context()
+            comptime BLOCK_SIZE_M = 4
+            var total_threads = batch * nheads * ceildiv(dim, BLOCK_SIZE_M)
+
+            if dstate == 16:
+                comptime DSTATE_VAL = 16
+                var compiled_kernel = gpu_ctx.compile_function[
+                    varlen_selective_state_update_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        state_lt.layout,
+                        x_lt.layout,
+                        dt_lt.layout,
+                        A_lt.layout,
+                        B_lt.layout,
+                        C_lt.layout,
+                        D_lt.layout,
+                        z_lt.layout,
+                        output_lt.layout,
+                        dt_bias_lt.layout,
+                        state_batch_indices_lt.layout,
+                    ],
+                    varlen_selective_state_update_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        state_lt.layout,
+                        x_lt.layout,
+                        dt_lt.layout,
+                        A_lt.layout,
+                        B_lt.layout,
+                        C_lt.layout,
+                        D_lt.layout,
+                        z_lt.layout,
+                        output_lt.layout,
+                        dt_bias_lt.layout,
+                        state_batch_indices_lt.layout,
+                    ],
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_kernel,
+                    total_threads,
+                    batch,
+                    nheads,
+                    dim,
+                    nheads_ngroups_ratio,
+                    PAD_SLOT_ID,
+                    dt_softplus_int8,
+                    Int8(has_state_batch_indices),
+                    state_lt,
+                    x_lt,
+                    dt_lt,
+                    A_lt,
+                    B_lt,
+                    C_lt,
+                    D_lt,
+                    z_lt,
+                    output_lt,
+                    dt_bias_lt,
+                    state_batch_indices_lt,
+                    state_strides,
+                    x_strides,
+                    dt_strides,
+                    dt_bias_strides,
+                    A_strides,
+                    B_strides,
+                    C_strides,
+                    D_strides,
+                    z_strides,
+                    out_strides,
+                    grid_dim=(ceildiv(dim, BLOCK_SIZE_M), batch, nheads),
+                    block_dim=(1,),
+                )
+            elif dstate == 8:
+                comptime DSTATE_VAL = 8
+                var compiled_kernel = gpu_ctx.compile_function[
+                    varlen_selective_state_update_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        state_lt.layout,
+                        x_lt.layout,
+                        dt_lt.layout,
+                        A_lt.layout,
+                        B_lt.layout,
+                        C_lt.layout,
+                        D_lt.layout,
+                        z_lt.layout,
+                        output_lt.layout,
+                        dt_bias_lt.layout,
+                        state_batch_indices_lt.layout,
+                    ],
+                    varlen_selective_state_update_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        state_lt.layout,
+                        x_lt.layout,
+                        dt_lt.layout,
+                        A_lt.layout,
+                        B_lt.layout,
+                        C_lt.layout,
+                        D_lt.layout,
+                        z_lt.layout,
+                        output_lt.layout,
+                        dt_bias_lt.layout,
+                        state_batch_indices_lt.layout,
+                    ],
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_kernel,
+                    total_threads,
+                    batch,
+                    nheads,
+                    dim,
+                    nheads_ngroups_ratio,
+                    PAD_SLOT_ID,
+                    dt_softplus_int8,
+                    Int8(has_state_batch_indices),
+                    state_lt,
+                    x_lt,
+                    dt_lt,
+                    A_lt,
+                    B_lt,
+                    C_lt,
+                    D_lt,
+                    z_lt,
+                    output_lt,
+                    dt_bias_lt,
+                    state_batch_indices_lt,
+                    state_strides,
+                    x_strides,
+                    dt_strides,
+                    dt_bias_strides,
+                    A_strides,
+                    B_strides,
+                    C_strides,
+                    D_strides,
+                    z_strides,
+                    out_strides,
+                    grid_dim=(ceildiv(dim, BLOCK_SIZE_M), batch, nheads),
+                    block_dim=(1,),
+                )
+            else:  # dstate == 4
+                comptime DSTATE_VAL = 4
+                var compiled_kernel = gpu_ctx.compile_function[
+                    varlen_selective_state_update_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        state_lt.layout,
+                        x_lt.layout,
+                        dt_lt.layout,
+                        A_lt.layout,
+                        B_lt.layout,
+                        C_lt.layout,
+                        D_lt.layout,
+                        z_lt.layout,
+                        output_lt.layout,
+                        dt_bias_lt.layout,
+                        state_batch_indices_lt.layout,
+                    ],
+                    varlen_selective_state_update_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        state_lt.layout,
+                        x_lt.layout,
+                        dt_lt.layout,
+                        A_lt.layout,
+                        B_lt.layout,
+                        C_lt.layout,
+                        D_lt.layout,
+                        z_lt.layout,
+                        output_lt.layout,
+                        dt_bias_lt.layout,
+                        state_batch_indices_lt.layout,
+                    ],
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_kernel,
+                    total_threads,
+                    batch,
+                    nheads,
+                    dim,
+                    nheads_ngroups_ratio,
+                    PAD_SLOT_ID,
+                    dt_softplus_int8,
+                    Int8(has_state_batch_indices),
+                    state_lt,
+                    x_lt,
+                    dt_lt,
+                    A_lt,
+                    B_lt,
+                    C_lt,
+                    D_lt,
+                    z_lt,
+                    output_lt,
+                    dt_bias_lt,
+                    state_batch_indices_lt,
+                    state_strides,
+                    x_strides,
+                    dt_strides,
+                    dt_bias_strides,
+                    A_strides,
+                    B_strides,
+                    C_strides,
+                    D_strides,
+                    z_strides,
+                    out_strides,
+                    grid_dim=(ceildiv(dim, BLOCK_SIZE_M), batch, nheads),
+                    block_dim=(1,),
+                )
+        else:
+            raise Error("Unsupported target device")
+
+    @staticmethod
+    fn shape[
+        dtype: DType,
+    ](
+        state: InputTensor[dtype=dtype, rank=4],
+        x: InputTensor[dtype=dtype, rank=3],
+        dt: InputTensor[dtype=dtype, rank=3],
+        A: InputTensor[dtype=dtype, rank=3],
+        B: InputTensor[dtype=dtype, rank=3],
+        C: InputTensor[dtype=dtype, rank=3],
+        D: InputTensor[dtype=dtype, rank=2],
+        z: InputTensor[dtype=dtype, rank=3],
+        dt_bias: InputTensor[dtype=dtype, rank=2],
+        state_batch_indices: InputTensor[dtype=DType.int32, rank=1],
+    ) -> Tuple[IndexList[4], IndexList[3]]:
+        return (state.shape(), x.shape())

--- a/max/kernels/src/state_space/varlen_selective_scan_ops.mojo
+++ b/max/kernels/src/state_space/varlen_selective_scan_ops.mojo
@@ -79,13 +79,13 @@ struct VarlenSelectiveScanFwd[delta_softplus: Bool = False]:
     ](
         output: OutputTensor[dtype=dtype, rank=2],
         ssm_states: OutputTensor[dtype=dtype, rank=3],
+        z: OutputTensor[dtype=dtype, rank=2],
         u: InputTensor[dtype=dtype, rank=2],
         delta: InputTensor[dtype=dtype, rank=2],
         A: InputTensor[dtype=dtype, rank=2],
         B: InputTensor[dtype=dtype, rank=3],
         C: InputTensor[dtype=dtype, rank=3],
         D: InputTensor[dtype=dtype, rank=1],
-        z: OutputTensor[dtype=dtype, rank=2],
         delta_bias: InputTensor[dtype=dtype, rank=1],
         query_start_loc: InputTensor[dtype = DType.int32, rank=1],
         cache_indices: InputTensor[dtype = DType.int32, rank=1],
@@ -523,7 +523,6 @@ struct VarlenSelectiveScanFwd[delta_softplus: Bool = False]:
         B: InputTensor[dtype=dtype, rank=3],
         C: InputTensor[dtype=dtype, rank=3],
         D: InputTensor[dtype=dtype, rank=1],
-        z: InputTensor[dtype=dtype, rank=2],
         delta_bias: InputTensor[dtype=dtype, rank=1],
         query_start_loc: InputTensor[dtype = DType.int32, rank=1],
         cache_indices: InputTensor[dtype = DType.int32, rank=1],
@@ -1003,7 +1002,6 @@ struct VarlenSelectiveStateUpdate[dt_softplus: Bool = False]:
     fn shape[
         dtype: DType,
     ](
-        state: InputTensor[dtype=dtype, rank=4],
         x: InputTensor[dtype=dtype, rank=3],
         dt: InputTensor[dtype=dtype, rank=3],
         A: InputTensor[dtype=dtype, rank=3],
@@ -1014,4 +1012,8 @@ struct VarlenSelectiveStateUpdate[dt_softplus: Bool = False]:
         dt_bias: InputTensor[dtype=dtype, rank=2],
         state_batch_indices: InputTensor[dtype = DType.int32, rank=1],
     ) -> Tuple[IndexList[4], IndexList[3]]:
-        return (state.shape(), x.shape())
+        var batch = x.dim_size(0)
+        var nheads = x.dim_size(1)
+        var dim = x.dim_size(2)
+        var dstate = A.dim_size(2)
+        return (IndexList[4](batch, nheads, dim, dstate), x.shape())

--- a/max/kernels/test/gpu/state_space/BUILD.bazel
+++ b/max/kernels/test/gpu/state_space/BUILD.bazel
@@ -12,6 +12,14 @@ _EXTRA_CONSTRAINTS = {
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    "test_varlen_causal_conv1d.mojo": select({
+        "//:apple_gpu": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    "test_varlen_selective_scan.mojo": select({
+        "//:apple_gpu": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 }
 
 [

--- a/max/kernels/test/gpu/state_space/test_varlen_causal_conv1d.mojo
+++ b/max/kernels/test/gpu/state_space/test_varlen_causal_conv1d.mojo
@@ -1,0 +1,1254 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from math import ceildiv, exp
+from sys.info import simd_width_of
+
+from gpu.host import DeviceContext
+from layout import (
+    UNKNOWN_VALUE,
+    Layout,
+    LayoutTensor,
+    RuntimeTuple,
+    RuntimeLayout,
+)
+from random import rand
+from memory import alloc
+from state_space.varlen_causal_conv1d import (
+    causal_conv1d_varlen_fwd_cpu,
+    causal_conv1d_varlen_update_cpu,
+    causal_conv1d_varlen_states_cpu,
+    causal_conv1d_varlen_fwd_gpu,
+    causal_conv1d_varlen_update_gpu,
+    causal_conv1d_varlen_states_gpu,
+)
+from testing import assert_almost_equal
+
+from utils.index import Index, IndexList
+
+
+# Constants
+comptime PAD_SLOT_ID: Int32 = -1
+
+
+@always_inline
+fn silu_ref[dtype: DType](x: Scalar[dtype]) -> Scalar[dtype]:
+    """Reference SiLU implementation: x * sigmoid(x) = x / (1 + exp(-x))."""
+    var x_f32 = x.cast[DType.float32]()
+    var neg_x = -x_f32
+    var exp_neg_x = exp(neg_x)
+    var one = Scalar[DType.float32](1.0)
+    var sigmoid_x = one / (one + exp_neg_x)
+    return (x_f32 * sigmoid_x).cast[dtype]()
+
+
+fn run_varlen_causal_conv1d_fwd_gpu[
+    dtype: DType,
+    activation: StaticString,
+](
+    batch: Int,
+    dim: Int,
+    seq_lengths: IndexList,
+    width: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test varlen causal conv1d forward GPU kernel against CPU reference."""
+    # Calculate total_seqlen (sum of all sequence lengths)
+    var total_seqlen = 0
+    for i in range(batch):
+        total_seqlen += seq_lengths[i]
+
+    # Allocate host memory
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_2d = Layout.row_major[2]()
+    comptime layout_1d = Layout(UNKNOWN_VALUE)
+
+    # x: (dim, total_seqlen) for varlen - sequences concatenated
+    var x_heap = alloc[Scalar[dtype]](dim * total_seqlen)
+    var x_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        x_heap, RuntimeLayout[layout_2d].row_major(Index(dim, total_seqlen))
+    )
+
+    # weight: (dim, width)
+    var weight_heap = alloc[Scalar[dtype]](dim * width)
+    var weight_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        weight_heap, RuntimeLayout[layout_2d].row_major(Index(dim, width))
+    )
+
+    # bias: (dim,)
+    var bias_heap = alloc[Scalar[dtype]](dim)
+    var bias_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        bias_heap, RuntimeLayout[layout_1d].row_major(Index(dim))
+    )
+
+    # query_start_loc: (batch + 1,) - cumulative sequence lengths
+    var query_start_loc_heap = alloc[Scalar[DType.int32]](batch + 1)
+    var query_start_loc_h = LayoutTensor[DType.int32, layout_1d, MutAnyOrigin](
+        query_start_loc_heap,
+        RuntimeLayout[layout_1d].row_major(Index(batch + 1)),
+    )
+    var cumsum = 0
+    query_start_loc_h.ptr.store(0, Scalar[DType.int32](0))
+    for i in range(batch):
+        cumsum += seq_lengths[i]
+        query_start_loc_h.ptr.store(i + 1, Scalar[DType.int32](cumsum))
+
+    # cache_indices: (batch,) - identity mapping
+    var cache_indices_heap = alloc[Scalar[DType.int32]](batch)
+    var cache_indices_h = LayoutTensor[DType.int32, layout_1d, MutAnyOrigin](
+        cache_indices_heap, RuntimeLayout[layout_1d].row_major(Index(batch))
+    )
+    for i in range(batch):
+        cache_indices_h.ptr.store(i, Scalar[DType.int32](i))
+
+    # has_initial_state: (batch,) - all False
+    var has_initial_state_heap = alloc[Scalar[DType.bool]](batch)
+    var has_initial_state_h = LayoutTensor[DType.bool, layout_1d, MutAnyOrigin](
+        has_initial_state_heap, RuntimeLayout[layout_1d].row_major(Index(batch))
+    )
+    for i in range(batch):
+        has_initial_state_h.ptr.store(i, Scalar[DType.bool](False))
+
+    # conv_states: (batch, dim, width - 1)
+    var state_len = width - 1
+    var conv_states_heap = alloc[Scalar[dtype]](batch * dim * state_len)
+    var conv_states_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        conv_states_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, state_len)),
+    ).fill(0)
+
+    # output: (dim, total_seqlen)
+    var output_gpu_heap = alloc[Scalar[dtype]](dim * total_seqlen)
+    var output_gpu_h = LayoutTensor[dtype, layout_2d](
+        output_gpu_heap,
+        RuntimeLayout[layout_2d].row_major(Index(dim, total_seqlen)),
+    ).fill(0)
+
+    var output_cpu_heap = alloc[Scalar[dtype]](dim * total_seqlen)
+    var output_cpu_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        output_cpu_heap,
+        RuntimeLayout[layout_2d].row_major(Index(dim, total_seqlen)),
+    ).fill(0)
+
+    # Initialize input data
+    rand[dtype](x_h.ptr, x_h.size())
+    rand[dtype](weight_h.ptr, weight_h.size())
+    rand[dtype](bias_h.ptr, bias_h.size())
+
+    var x_buf = x_h
+    var weight_buf = weight_h
+    var bias_buf = bias_h
+    var query_start_loc_buf = query_start_loc_h
+    var cache_indices_buf = cache_indices_h
+    var has_initial_state_buf = has_initial_state_h
+    var conv_states_buf = conv_states_h
+    var output_gpu_buf = output_gpu_h
+    var output_cpu_buf = output_cpu_h
+
+    # Strides for row-major layout
+    var x_dim_stride: UInt32 = total_seqlen
+    var x_seqlen_stride: UInt32 = 1
+    var weight_dim_stride: UInt32 = width
+    var weight_width_stride: UInt32 = 1
+    var out_dim_stride: UInt32 = total_seqlen
+    var out_seqlen_stride: UInt32 = 1
+    var conv_states_batch_stride: UInt32 = dim * state_len
+    var conv_states_dim_stride: UInt32 = state_len
+    var conv_states_width_stride: UInt32 = 1
+
+    var silu_activation = activation == "silu"
+    var silu_activation_int8 = Int8(silu_activation)
+
+    # Allocate device buffers
+    var x_device = ctx.enqueue_create_buffer[dtype](dim * total_seqlen)
+    var weight_device = ctx.enqueue_create_buffer[dtype](dim * width)
+    var bias_device = ctx.enqueue_create_buffer[dtype](dim)
+    var query_start_loc_device = ctx.enqueue_create_buffer[DType.int32](
+        batch + 1
+    )
+    var cache_indices_device = ctx.enqueue_create_buffer[DType.int32](batch)
+    var has_initial_state_device = ctx.enqueue_create_buffer[DType.bool](batch)
+    var conv_states_device = ctx.enqueue_create_buffer[dtype](
+        batch * dim * state_len
+    )
+    var output_device = ctx.enqueue_create_buffer[dtype](dim * total_seqlen)
+
+    # Copy data to device
+    with ctx.push_context():
+        ctx.enqueue_copy(x_device, x_buf.ptr)
+        ctx.enqueue_copy(weight_device, weight_buf.ptr)
+        ctx.enqueue_copy(bias_device, bias_buf.ptr)
+        ctx.enqueue_copy(query_start_loc_device, query_start_loc_buf.ptr)
+        ctx.enqueue_copy(cache_indices_device, cache_indices_buf.ptr)
+        ctx.enqueue_copy(has_initial_state_device, has_initial_state_buf.ptr)
+        ctx.enqueue_copy(conv_states_device, conv_states_buf.ptr)
+
+    # Create device LayoutTensors
+    var x_device_tensor = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        x_device.unsafe_ptr(),
+        RuntimeLayout[layout_2d].row_major(Index(dim, total_seqlen)),
+    )
+    var weight_device_tensor = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        weight_device.unsafe_ptr(),
+        RuntimeLayout[layout_2d].row_major(Index(dim, width)),
+    )
+    var bias_device_tensor = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        bias_device.unsafe_ptr(),
+        RuntimeLayout[layout_1d].row_major(Index(dim)),
+    )
+    var query_start_loc_device_tensor = LayoutTensor[
+        DType.int32, layout_1d, MutAnyOrigin
+    ](
+        query_start_loc_device.unsafe_ptr(),
+        RuntimeLayout[layout_1d].row_major(Index(batch + 1)),
+    )
+    var cache_indices_device_tensor = LayoutTensor[
+        DType.int32, layout_1d, MutAnyOrigin
+    ](
+        cache_indices_device.unsafe_ptr(),
+        RuntimeLayout[layout_1d].row_major(Index(batch)),
+    )
+    var has_initial_state_device_tensor = LayoutTensor[
+        DType.bool, layout_1d, MutAnyOrigin
+    ](
+        has_initial_state_device.unsafe_ptr(),
+        RuntimeLayout[layout_1d].row_major(Index(batch)),
+    )
+    var conv_states_device_tensor = LayoutTensor[
+        dtype, layout_3d, MutAnyOrigin
+    ](
+        conv_states_device.unsafe_ptr(),
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, state_len)),
+    )
+    var output_device_tensor = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        output_device.unsafe_ptr(),
+        RuntimeLayout[layout_2d].row_major(Index(dim, total_seqlen)),
+    )
+
+    # Run GPU kernel
+    comptime BLOCK_DIM = 128
+    comptime BLOCK_SEQ = 1
+
+    if width == 1:
+        comptime kWidth = 1
+        var compiled_func = ctx.compile_function[
+            causal_conv1d_varlen_fwd_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                query_start_loc_device_tensor.dtype,
+                query_start_loc_device_tensor.layout,
+                cache_indices_device_tensor.dtype,
+                cache_indices_device_tensor.layout,
+                has_initial_state_device_tensor.dtype,
+                has_initial_state_device_tensor.layout,
+                conv_states_device_tensor.dtype,
+                conv_states_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+                BLOCK_SEQ,
+            ],
+            causal_conv1d_varlen_fwd_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                query_start_loc_device_tensor.dtype,
+                query_start_loc_device_tensor.layout,
+                cache_indices_device_tensor.dtype,
+                cache_indices_device_tensor.layout,
+                has_initial_state_device_tensor.dtype,
+                has_initial_state_device_tensor.layout,
+                conv_states_device_tensor.dtype,
+                conv_states_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+                BLOCK_SEQ,
+            ],
+        ]()
+        with ctx.push_context():
+            ctx.enqueue_function(
+                compiled_func,
+                dim,
+                total_seqlen,
+                batch,
+                x_device_tensor,
+                weight_device_tensor,
+                bias_device_tensor,
+                query_start_loc_device_tensor,
+                cache_indices_device_tensor,
+                has_initial_state_device_tensor,
+                conv_states_device_tensor,
+                output_device_tensor,
+                x_dim_stride,
+                x_seqlen_stride,
+                weight_dim_stride,
+                weight_width_stride,
+                out_dim_stride,
+                out_seqlen_stride,
+                conv_states_batch_stride,
+                conv_states_dim_stride,
+                conv_states_width_stride,
+                silu_activation_int8,
+                PAD_SLOT_ID,
+                Int8(1),  # has_cache_indices
+                Int8(1),  # has_initial_state_flag
+                Int8(1),  # has_conv_states
+                Int8(1),  # has_bias
+                grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                block_dim=(BLOCK_DIM, BLOCK_SEQ),
+            )
+    elif width == 2:
+        comptime kWidth = 2
+        var compiled_func = ctx.compile_function[
+            causal_conv1d_varlen_fwd_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                query_start_loc_device_tensor.dtype,
+                query_start_loc_device_tensor.layout,
+                cache_indices_device_tensor.dtype,
+                cache_indices_device_tensor.layout,
+                has_initial_state_device_tensor.dtype,
+                has_initial_state_device_tensor.layout,
+                conv_states_device_tensor.dtype,
+                conv_states_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+                BLOCK_SEQ,
+            ],
+            causal_conv1d_varlen_fwd_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                query_start_loc_device_tensor.dtype,
+                query_start_loc_device_tensor.layout,
+                cache_indices_device_tensor.dtype,
+                cache_indices_device_tensor.layout,
+                has_initial_state_device_tensor.dtype,
+                has_initial_state_device_tensor.layout,
+                conv_states_device_tensor.dtype,
+                conv_states_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+                BLOCK_SEQ,
+            ],
+        ]()
+        with ctx.push_context():
+            ctx.enqueue_function(
+                compiled_func,
+                dim,
+                total_seqlen,
+                batch,
+                x_device_tensor,
+                weight_device_tensor,
+                bias_device_tensor,
+                query_start_loc_device_tensor,
+                cache_indices_device_tensor,
+                has_initial_state_device_tensor,
+                conv_states_device_tensor,
+                output_device_tensor,
+                x_dim_stride,
+                x_seqlen_stride,
+                weight_dim_stride,
+                weight_width_stride,
+                out_dim_stride,
+                out_seqlen_stride,
+                conv_states_batch_stride,
+                conv_states_dim_stride,
+                conv_states_width_stride,
+                silu_activation_int8,
+                PAD_SLOT_ID,
+                Int8(1),  # has_cache_indices
+                Int8(1),  # has_initial_state_flag
+                Int8(1),  # has_conv_states
+                Int8(1),  # has_bias
+                grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                block_dim=(BLOCK_DIM, BLOCK_SEQ),
+            )
+    elif width == 3:
+        comptime kWidth = 3
+        var compiled_func = ctx.compile_function[
+            causal_conv1d_varlen_fwd_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                query_start_loc_device_tensor.dtype,
+                query_start_loc_device_tensor.layout,
+                cache_indices_device_tensor.dtype,
+                cache_indices_device_tensor.layout,
+                has_initial_state_device_tensor.dtype,
+                has_initial_state_device_tensor.layout,
+                conv_states_device_tensor.dtype,
+                conv_states_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+                BLOCK_SEQ,
+            ],
+            causal_conv1d_varlen_fwd_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                query_start_loc_device_tensor.dtype,
+                query_start_loc_device_tensor.layout,
+                cache_indices_device_tensor.dtype,
+                cache_indices_device_tensor.layout,
+                has_initial_state_device_tensor.dtype,
+                has_initial_state_device_tensor.layout,
+                conv_states_device_tensor.dtype,
+                conv_states_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+                BLOCK_SEQ,
+            ],
+        ]()
+        with ctx.push_context():
+            ctx.enqueue_function(
+                compiled_func,
+                dim,
+                total_seqlen,
+                batch,
+                x_device_tensor,
+                weight_device_tensor,
+                bias_device_tensor,
+                query_start_loc_device_tensor,
+                cache_indices_device_tensor,
+                has_initial_state_device_tensor,
+                conv_states_device_tensor,
+                output_device_tensor,
+                x_dim_stride,
+                x_seqlen_stride,
+                weight_dim_stride,
+                weight_width_stride,
+                out_dim_stride,
+                out_seqlen_stride,
+                conv_states_batch_stride,
+                conv_states_dim_stride,
+                conv_states_width_stride,
+                silu_activation_int8,
+                PAD_SLOT_ID,
+                Int8(1),  # has_cache_indices
+                Int8(1),  # has_initial_state_flag
+                Int8(1),  # has_conv_states
+                Int8(1),  # has_bias
+                grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                block_dim=(BLOCK_DIM, BLOCK_SEQ),
+            )
+    elif width == 4:
+        comptime kWidth = 4
+        var compiled_func = ctx.compile_function[
+            causal_conv1d_varlen_fwd_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                query_start_loc_device_tensor.dtype,
+                query_start_loc_device_tensor.layout,
+                cache_indices_device_tensor.dtype,
+                cache_indices_device_tensor.layout,
+                has_initial_state_device_tensor.dtype,
+                has_initial_state_device_tensor.layout,
+                conv_states_device_tensor.dtype,
+                conv_states_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+                BLOCK_SEQ,
+            ],
+            causal_conv1d_varlen_fwd_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                query_start_loc_device_tensor.dtype,
+                query_start_loc_device_tensor.layout,
+                cache_indices_device_tensor.dtype,
+                cache_indices_device_tensor.layout,
+                has_initial_state_device_tensor.dtype,
+                has_initial_state_device_tensor.layout,
+                conv_states_device_tensor.dtype,
+                conv_states_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+                BLOCK_SEQ,
+            ],
+        ]()
+        with ctx.push_context():
+            ctx.enqueue_function(
+                compiled_func,
+                dim,
+                total_seqlen,
+                batch,
+                x_device_tensor,
+                weight_device_tensor,
+                bias_device_tensor,
+                query_start_loc_device_tensor,
+                cache_indices_device_tensor,
+                has_initial_state_device_tensor,
+                conv_states_device_tensor,
+                output_device_tensor,
+                x_dim_stride,
+                x_seqlen_stride,
+                weight_dim_stride,
+                weight_width_stride,
+                out_dim_stride,
+                out_seqlen_stride,
+                conv_states_batch_stride,
+                conv_states_dim_stride,
+                conv_states_width_stride,
+                silu_activation_int8,
+                PAD_SLOT_ID,
+                Int8(1),  # has_cache_indices
+                Int8(1),  # has_initial_state_flag
+                Int8(1),  # has_conv_states
+                Int8(1),  # has_bias
+                grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                block_dim=(BLOCK_DIM, BLOCK_SEQ),
+            )
+    else:
+        raise Error(
+            "Unsupported kernel width: only widths 1, 2, 3, 4 are supported"
+        )
+
+    # Copy GPU results back to host
+    with ctx.push_context():
+        ctx.enqueue_copy(output_gpu_buf.ptr, output_device)
+    ctx.synchronize()
+
+    # Run CPU reference
+    causal_conv1d_varlen_fwd_cpu[
+        x_buf.dtype,
+        x_buf.layout,
+        weight_buf.dtype,
+        weight_buf.layout,
+        bias_buf.dtype,
+        bias_buf.layout,
+        output_cpu_buf.dtype,
+        output_cpu_buf.layout,
+        query_start_loc_buf.dtype,
+        query_start_loc_buf.layout,
+        cache_indices_buf.dtype,
+        cache_indices_buf.layout,
+        has_initial_state_buf.dtype,
+        has_initial_state_buf.layout,
+        conv_states_buf.dtype,
+        conv_states_buf.layout,
+    ](
+        dim,
+        total_seqlen,
+        width,
+        batch,
+        x_buf,
+        weight_buf,
+        bias_buf,
+        query_start_loc_buf,
+        cache_indices_buf,
+        has_initial_state_buf,
+        conv_states_buf,
+        output_cpu_buf,
+        x_dim_stride,
+        x_seqlen_stride,
+        weight_dim_stride,
+        weight_width_stride,
+        out_dim_stride,
+        out_seqlen_stride,
+        conv_states_batch_stride,
+        conv_states_dim_stride,
+        conv_states_width_stride,
+        silu_activation,
+        PAD_SLOT_ID,
+        True,  # has_cache_indices
+        True,  # has_initial_state_flag
+        True,  # has_conv_states
+        True,  # has_bias
+    )
+
+    # Compare results
+    var flattened_size = dim * total_seqlen
+    for i in range(flattened_size):
+        assert_almost_equal(
+            output_gpu_h.ptr[i],
+            output_cpu_h.ptr[i],
+            rtol=rtol,
+        )
+
+    # Cleanup
+    x_heap.free()
+    weight_heap.free()
+    bias_heap.free()
+    query_start_loc_heap.free()
+    cache_indices_heap.free()
+    has_initial_state_heap.free()
+    conv_states_heap.free()
+    output_gpu_heap.free()
+    output_cpu_heap.free()
+
+
+fn run_varlen_causal_conv1d_update_gpu[
+    dtype: DType,
+    activation: StaticString,
+](
+    batch: Int,
+    dim: Int,
+    seqlen: Int,
+    width: Int,
+    state_len: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test varlen causal conv1d update GPU kernel against CPU reference."""
+    # Allocate host memory
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_2d = Layout.row_major[2]()
+    comptime layout_1d = Layout(UNKNOWN_VALUE)
+
+    # x: (batch, dim, seqlen)
+    var x_heap = alloc[Scalar[dtype]](batch * dim * seqlen)
+    var x_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        x_heap, RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen))
+    )
+
+    # weight: (dim, width)
+    var weight_heap = alloc[Scalar[dtype]](dim * width)
+    var weight_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        weight_heap, RuntimeLayout[layout_2d].row_major(Index(dim, width))
+    )
+
+    # bias: (dim,)
+    var bias_heap = alloc[Scalar[dtype]](dim)
+    var bias_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        bias_heap, RuntimeLayout[layout_1d].row_major(Index(dim))
+    )
+
+    # conv_state: (batch, dim, state_len)
+    var conv_state_heap = alloc[Scalar[dtype]](batch * dim * state_len)
+    var conv_state_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        conv_state_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, state_len)),
+    )
+
+    # cache_seqlens: (batch,) - all zeros
+    var cache_seqlens_heap = alloc[Scalar[DType.int32]](batch)
+    var cache_seqlens_h = LayoutTensor[DType.int32, layout_1d, MutAnyOrigin](
+        cache_seqlens_heap, RuntimeLayout[layout_1d].row_major(Index(batch))
+    )
+    for i in range(batch):
+        cache_seqlens_h.ptr.store(i, Scalar[DType.int32](0))
+
+    # conv_state_indices: (batch,) - identity mapping
+    var conv_state_indices_heap = alloc[Scalar[DType.int32]](batch)
+    var conv_state_indices_h = LayoutTensor[
+        DType.int32, layout_1d, MutAnyOrigin
+    ](conv_state_indices_heap, RuntimeLayout[layout_1d].row_major(Index(batch)))
+    for i in range(batch):
+        conv_state_indices_h.ptr.store(i, Scalar[DType.int32](i))
+
+    # output: (batch, dim, seqlen)
+    var output_gpu_heap = alloc[Scalar[dtype]](batch * dim * seqlen)
+    var output_gpu_h = LayoutTensor[dtype, layout_3d](
+        output_gpu_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    ).fill(0)
+
+    var output_cpu_heap = alloc[Scalar[dtype]](batch * dim * seqlen)
+    var output_cpu_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        output_cpu_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    ).fill(0)
+
+    # Copy of conv_state for CPU and GPU
+    var conv_state_cpu_heap = alloc[Scalar[dtype]](batch * dim * state_len)
+    var conv_state_cpu_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        conv_state_cpu_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, state_len)),
+    )
+
+    var conv_state_gpu_heap = alloc[Scalar[dtype]](batch * dim * state_len)
+    var conv_state_gpu_h = LayoutTensor[dtype, layout_3d](
+        conv_state_gpu_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, state_len)),
+    )
+
+    # Initialize input data
+    rand[dtype](x_h.ptr, x_h.size())
+    rand[dtype](conv_state_h.ptr, conv_state_h.size())
+    rand[dtype](weight_h.ptr, weight_h.size())
+    rand[dtype](bias_h.ptr, bias_h.size())
+
+    # Copy conv_state for CPU and GPU
+    for i in range(batch * dim * state_len):
+        conv_state_cpu_h.ptr[i] = conv_state_h.ptr[i]
+        conv_state_gpu_h.ptr[i] = conv_state_h.ptr[i]
+
+    var x_buf = x_h
+    var weight_buf = weight_h
+    var bias_buf = bias_h
+    var conv_state_cpu_buf = conv_state_cpu_h
+    var conv_state_gpu_buf = conv_state_gpu_h
+    var cache_seqlens_buf = cache_seqlens_h
+    var conv_state_indices_buf = conv_state_indices_h
+    var output_gpu_buf = output_gpu_h
+    var output_cpu_buf = output_cpu_h
+
+    # Strides for row-major layout
+    var x_batch_stride: UInt32 = dim * seqlen
+    var x_dim_stride: UInt32 = seqlen
+    var x_seqlen_stride: UInt32 = 1
+    var weight_dim_stride: UInt32 = width
+    var weight_width_stride: UInt32 = 1
+    var conv_state_batch_stride: UInt32 = dim * state_len
+    var conv_state_dim_stride: UInt32 = state_len
+    var conv_state_seqlen_stride: UInt32 = 1
+    var out_batch_stride: UInt32 = dim * seqlen
+    var out_dim_stride: UInt32 = seqlen
+    var out_seqlen_stride: UInt32 = 1
+
+    var silu_activation = activation == "silu"
+    var silu_activation_int8 = Int8(silu_activation)
+
+    # Allocate device buffers
+    var x_device = ctx.enqueue_create_buffer[dtype](batch * dim * seqlen)
+    var weight_device = ctx.enqueue_create_buffer[dtype](dim * width)
+    var bias_device = ctx.enqueue_create_buffer[dtype](dim)
+    var conv_state_device = ctx.enqueue_create_buffer[dtype](
+        batch * dim * state_len
+    )
+    var cache_seqlens_device = ctx.enqueue_create_buffer[DType.int32](batch)
+    var conv_state_indices_device = ctx.enqueue_create_buffer[DType.int32](
+        batch
+    )
+    var output_device = ctx.enqueue_create_buffer[dtype](batch * dim * seqlen)
+
+    # Copy data to device
+    with ctx.push_context():
+        ctx.enqueue_copy(x_device, x_buf.ptr)
+        ctx.enqueue_copy(weight_device, weight_buf.ptr)
+        ctx.enqueue_copy(bias_device, bias_buf.ptr)
+        ctx.enqueue_copy(conv_state_device, conv_state_gpu_buf.ptr)
+        ctx.enqueue_copy(cache_seqlens_device, cache_seqlens_buf.ptr)
+        ctx.enqueue_copy(conv_state_indices_device, conv_state_indices_buf.ptr)
+
+    # Create device LayoutTensors
+    var x_device_tensor = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        x_device.unsafe_ptr(),
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var weight_device_tensor = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        weight_device.unsafe_ptr(),
+        RuntimeLayout[layout_2d].row_major(Index(dim, width)),
+    )
+    var bias_device_tensor = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        bias_device.unsafe_ptr(),
+        RuntimeLayout[layout_1d].row_major(Index(dim)),
+    )
+    var conv_state_device_tensor = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        conv_state_device.unsafe_ptr(),
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, state_len)),
+    )
+    var cache_seqlens_device_tensor = LayoutTensor[
+        DType.int32, layout_1d, MutAnyOrigin
+    ](
+        cache_seqlens_device.unsafe_ptr(),
+        RuntimeLayout[layout_1d].row_major(Index(batch)),
+    )
+    var conv_state_indices_device_tensor = LayoutTensor[
+        DType.int32, layout_1d, MutAnyOrigin
+    ](
+        conv_state_indices_device.unsafe_ptr(),
+        RuntimeLayout[layout_1d].row_major(Index(batch)),
+    )
+    var output_device_tensor = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        output_device.unsafe_ptr(),
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+
+    # Run GPU kernel
+    comptime BLOCK_DIM = 128
+
+    if width == 1:
+        comptime kWidth = 1
+        var compiled_func = ctx.compile_function[
+            causal_conv1d_varlen_update_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                conv_state_device_tensor.dtype,
+                conv_state_device_tensor.layout,
+                cache_seqlens_device_tensor.dtype,
+                cache_seqlens_device_tensor.layout,
+                conv_state_indices_device_tensor.dtype,
+                conv_state_indices_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+            ],
+            causal_conv1d_varlen_update_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                conv_state_device_tensor.dtype,
+                conv_state_device_tensor.layout,
+                cache_seqlens_device_tensor.dtype,
+                cache_seqlens_device_tensor.layout,
+                conv_state_indices_device_tensor.dtype,
+                conv_state_indices_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+            ],
+        ]()
+        with ctx.push_context():
+            ctx.enqueue_function(
+                compiled_func,
+                batch,
+                dim,
+                seqlen,
+                state_len,
+                x_device_tensor,
+                weight_device_tensor,
+                bias_device_tensor,
+                conv_state_device_tensor,
+                cache_seqlens_device_tensor,
+                conv_state_indices_device_tensor,
+                output_device_tensor,
+                x_batch_stride,
+                x_dim_stride,
+                x_seqlen_stride,
+                weight_dim_stride,
+                weight_width_stride,
+                conv_state_batch_stride,
+                conv_state_dim_stride,
+                conv_state_seqlen_stride,
+                out_batch_stride,
+                out_dim_stride,
+                out_seqlen_stride,
+                silu_activation_int8,
+                PAD_SLOT_ID,
+                Int8(1),  # has_conv_state_indices
+                Int8(1),  # has_cache_seqlens
+                Int8(1),  # has_bias
+                grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                block_dim=(BLOCK_DIM),
+            )
+    elif width == 2:
+        comptime kWidth = 2
+        var compiled_func = ctx.compile_function[
+            causal_conv1d_varlen_update_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                conv_state_device_tensor.dtype,
+                conv_state_device_tensor.layout,
+                cache_seqlens_device_tensor.dtype,
+                cache_seqlens_device_tensor.layout,
+                conv_state_indices_device_tensor.dtype,
+                conv_state_indices_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+            ],
+            causal_conv1d_varlen_update_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                conv_state_device_tensor.dtype,
+                conv_state_device_tensor.layout,
+                cache_seqlens_device_tensor.dtype,
+                cache_seqlens_device_tensor.layout,
+                conv_state_indices_device_tensor.dtype,
+                conv_state_indices_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+            ],
+        ]()
+        with ctx.push_context():
+            ctx.enqueue_function(
+                compiled_func,
+                batch,
+                dim,
+                seqlen,
+                state_len,
+                x_device_tensor,
+                weight_device_tensor,
+                bias_device_tensor,
+                conv_state_device_tensor,
+                cache_seqlens_device_tensor,
+                conv_state_indices_device_tensor,
+                output_device_tensor,
+                x_batch_stride,
+                x_dim_stride,
+                x_seqlen_stride,
+                weight_dim_stride,
+                weight_width_stride,
+                conv_state_batch_stride,
+                conv_state_dim_stride,
+                conv_state_seqlen_stride,
+                out_batch_stride,
+                out_dim_stride,
+                out_seqlen_stride,
+                silu_activation_int8,
+                PAD_SLOT_ID,
+                Int8(1),  # has_conv_state_indices
+                Int8(1),  # has_cache_seqlens
+                Int8(1),  # has_bias
+                grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                block_dim=(BLOCK_DIM),
+            )
+    elif width == 3:
+        comptime kWidth = 3
+        var compiled_func = ctx.compile_function[
+            causal_conv1d_varlen_update_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                conv_state_device_tensor.dtype,
+                conv_state_device_tensor.layout,
+                cache_seqlens_device_tensor.dtype,
+                cache_seqlens_device_tensor.layout,
+                conv_state_indices_device_tensor.dtype,
+                conv_state_indices_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+            ],
+            causal_conv1d_varlen_update_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                conv_state_device_tensor.dtype,
+                conv_state_device_tensor.layout,
+                cache_seqlens_device_tensor.dtype,
+                cache_seqlens_device_tensor.layout,
+                conv_state_indices_device_tensor.dtype,
+                conv_state_indices_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+            ],
+        ]()
+        with ctx.push_context():
+            ctx.enqueue_function(
+                compiled_func,
+                batch,
+                dim,
+                seqlen,
+                state_len,
+                x_device_tensor,
+                weight_device_tensor,
+                bias_device_tensor,
+                conv_state_device_tensor,
+                cache_seqlens_device_tensor,
+                conv_state_indices_device_tensor,
+                output_device_tensor,
+                x_batch_stride,
+                x_dim_stride,
+                x_seqlen_stride,
+                weight_dim_stride,
+                weight_width_stride,
+                conv_state_batch_stride,
+                conv_state_dim_stride,
+                conv_state_seqlen_stride,
+                out_batch_stride,
+                out_dim_stride,
+                out_seqlen_stride,
+                silu_activation_int8,
+                PAD_SLOT_ID,
+                Int8(1),  # has_conv_state_indices
+                Int8(1),  # has_cache_seqlens
+                Int8(1),  # has_bias
+                grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                block_dim=(BLOCK_DIM),
+            )
+    elif width == 4:
+        comptime kWidth = 4
+        var compiled_func = ctx.compile_function[
+            causal_conv1d_varlen_update_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                conv_state_device_tensor.dtype,
+                conv_state_device_tensor.layout,
+                cache_seqlens_device_tensor.dtype,
+                cache_seqlens_device_tensor.layout,
+                conv_state_indices_device_tensor.dtype,
+                conv_state_indices_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+            ],
+            causal_conv1d_varlen_update_gpu[
+                x_device_tensor.dtype,
+                x_device_tensor.layout,
+                weight_device_tensor.dtype,
+                weight_device_tensor.layout,
+                bias_device_tensor.dtype,
+                bias_device_tensor.layout,
+                output_device_tensor.dtype,
+                output_device_tensor.layout,
+                conv_state_device_tensor.dtype,
+                conv_state_device_tensor.layout,
+                cache_seqlens_device_tensor.dtype,
+                cache_seqlens_device_tensor.layout,
+                conv_state_indices_device_tensor.dtype,
+                conv_state_indices_device_tensor.layout,
+                kWidth,
+                BLOCK_DIM,
+            ],
+        ]()
+        with ctx.push_context():
+            ctx.enqueue_function(
+                compiled_func,
+                batch,
+                dim,
+                seqlen,
+                state_len,
+                x_device_tensor,
+                weight_device_tensor,
+                bias_device_tensor,
+                conv_state_device_tensor,
+                cache_seqlens_device_tensor,
+                conv_state_indices_device_tensor,
+                output_device_tensor,
+                x_batch_stride,
+                x_dim_stride,
+                x_seqlen_stride,
+                weight_dim_stride,
+                weight_width_stride,
+                conv_state_batch_stride,
+                conv_state_dim_stride,
+                conv_state_seqlen_stride,
+                out_batch_stride,
+                out_dim_stride,
+                out_seqlen_stride,
+                silu_activation_int8,
+                PAD_SLOT_ID,
+                Int8(1),  # has_conv_state_indices
+                Int8(1),  # has_cache_seqlens
+                Int8(1),  # has_bias
+                grid_dim=(batch, ceildiv(dim, BLOCK_DIM)),
+                block_dim=(BLOCK_DIM),
+            )
+    else:
+        raise Error(
+            "Unsupported kernel width: only widths 1, 2, 3, 4 are supported"
+        )
+
+    # Copy results back from device
+    with ctx.push_context():
+        ctx.enqueue_copy(output_gpu_buf.ptr, output_device)
+        ctx.enqueue_copy(conv_state_gpu_buf.ptr, conv_state_device)
+    ctx.synchronize()
+
+    # Run CPU reference
+    causal_conv1d_varlen_update_cpu[
+        x_buf.dtype,
+        x_buf.layout,
+        weight_buf.dtype,
+        weight_buf.layout,
+        bias_buf.dtype,
+        bias_buf.layout,
+        output_cpu_buf.dtype,
+        output_cpu_buf.layout,
+        conv_state_cpu_buf.dtype,
+        conv_state_cpu_buf.layout,
+        cache_seqlens_buf.dtype,
+        cache_seqlens_buf.layout,
+        conv_state_indices_buf.dtype,
+        conv_state_indices_buf.layout,
+    ](
+        batch,
+        dim,
+        seqlen,
+        width,
+        state_len,
+        x_buf,
+        weight_buf,
+        bias_buf,
+        conv_state_cpu_buf,
+        cache_seqlens_buf,
+        conv_state_indices_buf,
+        output_cpu_buf,
+        x_batch_stride,
+        x_dim_stride,
+        x_seqlen_stride,
+        weight_dim_stride,
+        weight_width_stride,
+        conv_state_batch_stride,
+        conv_state_dim_stride,
+        conv_state_seqlen_stride,
+        out_batch_stride,
+        out_dim_stride,
+        out_seqlen_stride,
+        silu_activation,
+        PAD_SLOT_ID,
+        True,  # has_conv_state_indices
+        True,  # has_cache_seqlens
+        True,  # has_bias
+    )
+
+    # Compare results
+    var flattened_size = batch * dim * seqlen
+    for i in range(flattened_size):
+        assert_almost_equal(
+            output_gpu_h.ptr[i],
+            output_cpu_h.ptr[i],
+            rtol=rtol,
+        )
+
+    # Compare conv_state updates
+    var conv_state_size = batch * dim * state_len
+    for i in range(conv_state_size):
+        assert_almost_equal(
+            conv_state_gpu_h.ptr[i],
+            conv_state_cpu_h.ptr[i],
+            rtol=rtol,
+        )
+
+    # Cleanup
+    x_heap.free()
+    weight_heap.free()
+    bias_heap.free()
+    conv_state_heap.free()
+    conv_state_cpu_heap.free()
+    conv_state_gpu_heap.free()
+    cache_seqlens_heap.free()
+    conv_state_indices_heap.free()
+    output_gpu_heap.free()
+    output_cpu_heap.free()
+
+
+def main():
+    var ctx = DeviceContext()
+    if not ctx.is_compatible():
+        print("GPU not available, skipping GPU tests")
+        return
+
+    # Test varlen_causal_conv1d_fwd with equal-length sequences
+    run_varlen_causal_conv1d_fwd_gpu[DType.float32, "none"](
+        batch=2, dim=4, seq_lengths=Index(8, 8), width=3, ctx=ctx
+    )
+    print("✓ GPU varlen causal conv1d fwd (equal lengths) test passed")
+
+    # Test varlen_causal_conv1d_fwd with variable-length sequences
+    run_varlen_causal_conv1d_fwd_gpu[DType.float32, "none"](
+        batch=3, dim=4, seq_lengths=Index(10, 6, 1), width=3, ctx=ctx
+    )
+    print("✓ GPU varlen causal conv1d fwd (variable lengths) test passed")
+
+    # Test with SiLU activation
+    run_varlen_causal_conv1d_fwd_gpu[DType.float32, "silu"](
+        batch=2, dim=4, seq_lengths=Index(8, 8), width=3, ctx=ctx
+    )
+    print("✓ GPU varlen causal conv1d fwd with SiLU test passed")
+
+    # Test various widths
+    run_varlen_causal_conv1d_fwd_gpu[DType.float32, "none"](
+        batch=2, dim=4, seq_lengths=Index(8, 8), width=2, ctx=ctx
+    )
+    run_varlen_causal_conv1d_fwd_gpu[DType.float32, "none"](
+        batch=2, dim=4, seq_lengths=Index(8, 8), width=4, ctx=ctx
+    )
+    print("✓ GPU varlen causal conv1d fwd various widths test passed")
+
+    # Test varlen_causal_conv1d_update
+    run_varlen_causal_conv1d_update_gpu[DType.float32, "none"](
+        batch=2, dim=4, seqlen=1, width=3, state_len=4, ctx=ctx
+    )
+    print("✓ GPU varlen causal conv1d update test passed")
+
+    # Test update with SiLU
+    run_varlen_causal_conv1d_update_gpu[DType.float32, "silu"](
+        batch=2, dim=4, seqlen=1, width=3, state_len=4, ctx=ctx
+    )
+    print("✓ GPU varlen causal conv1d update with SiLU test passed")
+
+    # Test update with seqlen > 1
+    run_varlen_causal_conv1d_update_gpu[DType.float32, "none"](
+        batch=2, dim=4, seqlen=4, width=3, state_len=4, ctx=ctx
+    )
+    print("✓ GPU varlen causal conv1d update with seqlen > 1 test passed")
+
+    # Test various widths for update
+    run_varlen_causal_conv1d_update_gpu[DType.float32, "none"](
+        batch=2, dim=4, seqlen=1, width=2, state_len=3, ctx=ctx
+    )
+    run_varlen_causal_conv1d_update_gpu[DType.float32, "none"](
+        batch=2, dim=4, seqlen=1, width=4, state_len=5, ctx=ctx
+    )
+    print("✓ GPU varlen causal conv1d update various widths test passed")

--- a/max/kernels/test/gpu/state_space/test_varlen_causal_conv1d.mojo
+++ b/max/kernels/test/gpu/state_space/test_varlen_causal_conv1d.mojo
@@ -32,7 +32,7 @@ from state_space.varlen_causal_conv1d import (
     causal_conv1d_varlen_update_gpu,
     causal_conv1d_varlen_states_gpu,
 )
-from testing import assert_almost_equal
+from testing import TestSuite, assert_almost_equal
 
 from utils.index import Index, IndexList
 
@@ -1193,62 +1193,101 @@ fn run_varlen_causal_conv1d_update_gpu[
     output_cpu_heap.free()
 
 
-def main():
+# =============================================================================
+# Test functions for varlen causal conv1d forward on GPU
+# =============================================================================
+
+
+fn test_varlen_causal_conv1d_fwd_gpu_equal_lengths() raises:
+    """Test varlen causal conv1d forward GPU with equal-length sequences."""
     var ctx = DeviceContext()
     if not ctx.is_compatible():
-        print("GPU not available, skipping GPU tests")
         return
-
-    # Test varlen_causal_conv1d_fwd with equal-length sequences
     run_varlen_causal_conv1d_fwd_gpu[DType.float32, "none"](
         batch=2, dim=4, seq_lengths=Index(8, 8), width=3, ctx=ctx
     )
-    print("✓ GPU varlen causal conv1d fwd (equal lengths) test passed")
 
-    # Test varlen_causal_conv1d_fwd with variable-length sequences
+
+fn test_varlen_causal_conv1d_fwd_gpu_variable_lengths() raises:
+    """Test varlen causal conv1d forward GPU with variable-length sequences."""
+    var ctx = DeviceContext()
+    if not ctx.is_compatible():
+        return
     run_varlen_causal_conv1d_fwd_gpu[DType.float32, "none"](
         batch=3, dim=4, seq_lengths=Index(10, 6, 1), width=3, ctx=ctx
     )
-    print("✓ GPU varlen causal conv1d fwd (variable lengths) test passed")
 
-    # Test with SiLU activation
+
+fn test_varlen_causal_conv1d_fwd_gpu_with_silu() raises:
+    """Test varlen causal conv1d forward GPU with SiLU activation."""
+    var ctx = DeviceContext()
+    if not ctx.is_compatible():
+        return
     run_varlen_causal_conv1d_fwd_gpu[DType.float32, "silu"](
         batch=2, dim=4, seq_lengths=Index(8, 8), width=3, ctx=ctx
     )
-    print("✓ GPU varlen causal conv1d fwd with SiLU test passed")
 
-    # Test various widths
+
+fn test_varlen_causal_conv1d_fwd_gpu_various_widths() raises:
+    """Test varlen causal conv1d forward GPU with various kernel widths."""
+    var ctx = DeviceContext()
+    if not ctx.is_compatible():
+        return
     run_varlen_causal_conv1d_fwd_gpu[DType.float32, "none"](
         batch=2, dim=4, seq_lengths=Index(8, 8), width=2, ctx=ctx
     )
     run_varlen_causal_conv1d_fwd_gpu[DType.float32, "none"](
         batch=2, dim=4, seq_lengths=Index(8, 8), width=4, ctx=ctx
     )
-    print("✓ GPU varlen causal conv1d fwd various widths test passed")
 
-    # Test varlen_causal_conv1d_update
+
+# =============================================================================
+# Test functions for varlen causal conv1d update on GPU
+# =============================================================================
+
+
+fn test_varlen_causal_conv1d_update_gpu_basic() raises:
+    """Test basic varlen causal conv1d update on GPU."""
+    var ctx = DeviceContext()
+    if not ctx.is_compatible():
+        return
     run_varlen_causal_conv1d_update_gpu[DType.float32, "none"](
         batch=2, dim=4, seqlen=1, width=3, state_len=4, ctx=ctx
     )
-    print("✓ GPU varlen causal conv1d update test passed")
 
-    # Test update with SiLU
+
+fn test_varlen_causal_conv1d_update_gpu_with_silu() raises:
+    """Test varlen causal conv1d update GPU with SiLU activation."""
+    var ctx = DeviceContext()
+    if not ctx.is_compatible():
+        return
     run_varlen_causal_conv1d_update_gpu[DType.float32, "silu"](
         batch=2, dim=4, seqlen=1, width=3, state_len=4, ctx=ctx
     )
-    print("✓ GPU varlen causal conv1d update with SiLU test passed")
 
-    # Test update with seqlen > 1
+
+fn test_varlen_causal_conv1d_update_gpu_seqlen_gt_1() raises:
+    """Test varlen causal conv1d update GPU with seqlen > 1."""
+    var ctx = DeviceContext()
+    if not ctx.is_compatible():
+        return
     run_varlen_causal_conv1d_update_gpu[DType.float32, "none"](
         batch=2, dim=4, seqlen=4, width=3, state_len=4, ctx=ctx
     )
-    print("✓ GPU varlen causal conv1d update with seqlen > 1 test passed")
 
-    # Test various widths for update
+
+fn test_varlen_causal_conv1d_update_gpu_various_widths() raises:
+    """Test varlen causal conv1d update GPU with various kernel widths."""
+    var ctx = DeviceContext()
+    if not ctx.is_compatible():
+        return
     run_varlen_causal_conv1d_update_gpu[DType.float32, "none"](
         batch=2, dim=4, seqlen=1, width=2, state_len=3, ctx=ctx
     )
     run_varlen_causal_conv1d_update_gpu[DType.float32, "none"](
         batch=2, dim=4, seqlen=1, width=4, state_len=5, ctx=ctx
     )
-    print("✓ GPU varlen causal conv1d update various widths test passed")
+
+
+def main():
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/gpu/state_space/test_varlen_selective_scan.mojo
+++ b/max/kernels/test/gpu/state_space/test_varlen_selective_scan.mojo
@@ -28,7 +28,7 @@ from state_space.varlen_selective_scan import (
     varlen_selective_state_update_cpu,
     varlen_selective_state_update_gpu,
 )
-from testing import assert_almost_equal
+from testing import TestSuite, assert_almost_equal
 
 from utils.index import Index, IndexList
 
@@ -481,11 +481,16 @@ fn run_varlen_selective_scan_fwd_gpu[
     has_initial_state_h.free()
 
 
-def main():
+# =============================================================================
+# Test functions for varlen selective scan forward on GPU
+# =============================================================================
+
+
+fn test_varlen_selective_scan_fwd_gpu_equal_lengths() raises:
+    """Test varlen selective scan forward GPU with equal-length sequences."""
     with DeviceContext() as ctx:
         if not ctx.is_compatible():
             return
-        # Test varlen_selective_scan_fwd with equal-length sequences
         run_varlen_selective_scan_fwd_gpu[
             DType.float32,
             4,
@@ -494,9 +499,13 @@ def main():
             has_delta_bias=True,
             delta_softplus=False,
         ](batch=2, dim=4, ngroups=1, seq_lengths=Index(8, 8), ctx=ctx)
-        print("✓ Varlen selective scan fwd GPU (equal lengths) test passed")
 
-        # Test with variable-length sequences
+
+fn test_varlen_selective_scan_fwd_gpu_variable_lengths() raises:
+    """Test varlen selective scan forward GPU with variable-length sequences."""
+    with DeviceContext() as ctx:
+        if not ctx.is_compatible():
+            return
         run_varlen_selective_scan_fwd_gpu[
             DType.float32,
             4,
@@ -511,9 +520,13 @@ def main():
             seq_lengths=Index(10, 6, 1),
             ctx=ctx,
         )
-        print("✓ Varlen selective scan fwd GPU (variable lengths) test passed")
 
-        # Test without D
+
+fn test_varlen_selective_scan_fwd_gpu_without_D() raises:
+    """Test varlen selective scan forward GPU without D tensor."""
+    with DeviceContext() as ctx:
+        if not ctx.is_compatible():
+            return
         run_varlen_selective_scan_fwd_gpu[
             DType.float32,
             4,
@@ -522,9 +535,13 @@ def main():
             has_delta_bias=True,
             delta_softplus=False,
         ](batch=2, dim=4, ngroups=1, seq_lengths=Index(8, 8), ctx=ctx)
-        print("✓ Varlen selective scan fwd GPU without D test passed")
 
-        # Test without z
+
+fn test_varlen_selective_scan_fwd_gpu_without_z() raises:
+    """Test varlen selective scan forward GPU without z tensor."""
+    with DeviceContext() as ctx:
+        if not ctx.is_compatible():
+            return
         run_varlen_selective_scan_fwd_gpu[
             DType.float32,
             4,
@@ -533,9 +550,13 @@ def main():
             has_delta_bias=True,
             delta_softplus=False,
         ](batch=2, dim=4, ngroups=1, seq_lengths=Index(8, 8), ctx=ctx)
-        print("✓ Varlen selective scan fwd GPU without z test passed")
 
-        # Test with delta_softplus
+
+fn test_varlen_selective_scan_fwd_gpu_with_delta_softplus() raises:
+    """Test varlen selective scan forward GPU with delta softplus activation."""
+    with DeviceContext() as ctx:
+        if not ctx.is_compatible():
+            return
         run_varlen_selective_scan_fwd_gpu[
             DType.float32,
             4,
@@ -544,4 +565,7 @@ def main():
             has_delta_bias=True,
             delta_softplus=True,
         ](batch=2, dim=4, ngroups=1, seq_lengths=Index(8, 8), ctx=ctx)
-        print("✓ Varlen selective scan fwd GPU with delta_softplus test passed")
+
+
+def main():
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/gpu/state_space/test_varlen_selective_scan.mojo
+++ b/max/kernels/test/gpu/state_space/test_varlen_selective_scan.mojo
@@ -1,0 +1,541 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from memory import LegacyUnsafePointer
+
+comptime UnsafePointer = LegacyUnsafePointer[mut=True, *_, **_]
+from gpu.host import DeviceContext
+from layout import (
+    UNKNOWN_VALUE,
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+)
+from random import rand
+from state_space.varlen_selective_scan import (
+    varlen_selective_scan_fwd_cpu,
+    varlen_selective_scan_fwd_gpu,
+    varlen_selective_state_update_cpu,
+    varlen_selective_state_update_gpu,
+)
+from testing import assert_almost_equal
+
+from utils.index import Index, IndexList
+
+
+fn run_varlen_selective_scan_fwd_gpu[
+    dtype: DType,
+    has_D: Bool = True,
+    has_z: Bool = True,
+    has_delta_bias: Bool = True,
+    delta_softplus: Bool = False,
+](
+    batch: Int,
+    dim: Int,
+    dstate: Int,
+    ngroups: Int,
+    seq_lengths: IndexList,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test varlen selective scan forward GPU kernel against CPU reference."""
+    if dstate > 256:
+        return  # Skip if dstate exceeds kernel limit
+
+    # Calculate total_length
+    var total_length = 0
+    for i in range(batch):
+        total_length += seq_lengths[i]
+
+    # Allocate host memory
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_2d = Layout.row_major[2]()
+    comptime layout_1d = Layout(UNKNOWN_VALUE)
+
+    var ssm_states_cpu_h = UnsafePointer[Scalar[dtype]].alloc(
+        batch * dim * dstate
+    )
+    var ssm_states_gpu_h = UnsafePointer[Scalar[dtype]].alloc(
+        batch * dim * dstate
+    )
+    var output_cpu_h = UnsafePointer[Scalar[dtype]].alloc(dim * total_length)
+    var output_gpu_h = UnsafePointer[Scalar[dtype]].alloc(dim * total_length)
+    var u_h = UnsafePointer[Scalar[dtype]].alloc(dim * total_length)
+    var delta_h = UnsafePointer[Scalar[dtype]].alloc(dim * total_length)
+    var A_h = UnsafePointer[Scalar[dtype]].alloc(dim * dstate)
+    var B_h = UnsafePointer[Scalar[dtype]].alloc(
+        ngroups * dstate * total_length
+    )
+    var C_h = UnsafePointer[Scalar[dtype]].alloc(
+        ngroups * dstate * total_length
+    )
+    var D_size = dim if has_D else 0
+    var D_h = UnsafePointer[Scalar[dtype]].alloc(max(D_size, 1))
+    var z_size = dim * total_length if has_z else 0
+    var z_cpu_h = UnsafePointer[Scalar[dtype]].alloc(max(z_size, 1))
+    var z_gpu_h = UnsafePointer[Scalar[dtype]].alloc(max(z_size, 1))
+    var delta_bias_size = dim if has_delta_bias else 0
+    var delta_bias_h = UnsafePointer[Scalar[dtype]].alloc(
+        max(delta_bias_size, 1)
+    )
+    var query_start_loc_h = UnsafePointer[Scalar[DType.int32]].alloc(batch + 1)
+    var cache_indices_h = UnsafePointer[Scalar[DType.int32]].alloc(batch)
+    var has_initial_state_h = UnsafePointer[Scalar[DType.bool]].alloc(batch)
+
+    # Create LayoutTensors for initialization
+    var u_init = LayoutTensor[dtype, layout_2d](
+        u_h, RuntimeLayout[layout_2d].row_major(Index(dim, total_length))
+    )
+    var delta_init = LayoutTensor[dtype, layout_2d](
+        delta_h, RuntimeLayout[layout_2d].row_major(Index(dim, total_length))
+    )
+    var A_init = LayoutTensor[dtype, layout_2d](
+        A_h, RuntimeLayout[layout_2d].row_major(Index(dim, dstate))
+    )
+    var B_init = LayoutTensor[dtype, layout_3d](
+        B_h,
+        RuntimeLayout[layout_3d].row_major(
+            Index(ngroups, dstate, total_length)
+        ),
+    )
+    var C_init = LayoutTensor[dtype, layout_3d](
+        C_h,
+        RuntimeLayout[layout_3d].row_major(
+            Index(ngroups, dstate, total_length)
+        ),
+    )
+    var D_init = LayoutTensor[dtype, layout_1d](
+        D_h, RuntimeLayout[layout_1d].row_major(Index(D_size))
+    )
+    var z_init = LayoutTensor[dtype, layout_2d](
+        z_cpu_h,
+        RuntimeLayout[layout_2d].row_major(
+            Index(dim if has_z else 0, total_length if has_z else 0)
+        ),
+    )
+    var delta_bias_init = LayoutTensor[dtype, layout_1d](
+        delta_bias_h, RuntimeLayout[layout_1d].row_major(Index(delta_bias_size))
+    )
+
+    # Initialize input data
+    rand(u_init.ptr, u_init.size())
+    rand(delta_init.ptr, delta_init.size())
+    rand(A_init.ptr, A_init.size())
+    rand(B_init.ptr, B_init.size())
+    rand(C_init.ptr, C_init.size())
+    if has_D:
+        rand(D_init.ptr, D_init.size())
+    if has_z:
+        rand(z_init.ptr, z_init.size())
+    if has_delta_bias:
+        rand(delta_bias_init.ptr, delta_bias_init.size())
+
+    # Scale A to be negative for stability
+    for i in range(dim * dstate):
+        var val = A_h.load(i)
+        A_h.store(i, Scalar[dtype](Float32(val) * -0.5))
+
+    # Scale delta to be positive
+    for i in range(dim * total_length):
+        var val = delta_h.load(i)
+        delta_h.store(i, Scalar[dtype](abs(Float32(val)) * 0.5))
+
+    # Initialize query_start_loc (cumulative lengths)
+    var cumsum = 0
+    query_start_loc_h.store(0, Scalar[DType.int32](0))
+    for i in range(batch):
+        cumsum += seq_lengths[i]
+        query_start_loc_h.store(i + 1, Scalar[DType.int32](cumsum))
+
+    # Initialize cache_indices (identity mapping)
+    for i in range(batch):
+        cache_indices_h.store(i, Scalar[DType.int32](i))
+
+    # Initialize has_initial_state (all False)
+    for i in range(batch):
+        has_initial_state_h.store(i, Scalar[DType.bool](False))
+
+    # Copy z for GPU
+    if has_z:
+        for i in range(dim * total_length):
+            z_gpu_h.store(i, z_cpu_h.load(i))
+
+    # Copy ssm_states for GPU
+    for i in range(batch * dim * dstate):
+        ssm_states_gpu_h.store(i, ssm_states_cpu_h.load(i))
+
+    # Create LayoutTensors for CPU kernel
+    var ssm_states_cpu = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        ssm_states_cpu_h,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, dstate)),
+    )
+    var output_cpu = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        output_cpu_h,
+        RuntimeLayout[layout_2d].row_major(Index(dim, total_length)),
+    )
+    var u_cpu = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        u_h, RuntimeLayout[layout_2d].row_major(Index(dim, total_length))
+    )
+    var delta_cpu = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        delta_h, RuntimeLayout[layout_2d].row_major(Index(dim, total_length))
+    )
+    var A_cpu = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        A_h, RuntimeLayout[layout_2d].row_major(Index(dim, dstate))
+    )
+    var B_cpu = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        B_h,
+        RuntimeLayout[layout_3d].row_major(
+            Index(ngroups, dstate, total_length)
+        ),
+    )
+    var C_cpu = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        C_h,
+        RuntimeLayout[layout_3d].row_major(
+            Index(ngroups, dstate, total_length)
+        ),
+    )
+    var D_cpu = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        D_h, RuntimeLayout[layout_1d].row_major(Index(D_size))
+    )
+    var z_cpu = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        z_cpu_h,
+        RuntimeLayout[layout_2d].row_major(
+            Index(dim if has_z else 0, total_length if has_z else 0)
+        ),
+    )
+    var delta_bias_cpu = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        delta_bias_h, RuntimeLayout[layout_1d].row_major(Index(delta_bias_size))
+    )
+    var query_start_loc_cpu = LayoutTensor[
+        DType.int32, layout_1d, MutAnyOrigin
+    ](query_start_loc_h, RuntimeLayout[layout_1d].row_major(Index(batch + 1)))
+    var cache_indices_cpu = LayoutTensor[DType.int32, layout_1d, MutAnyOrigin](
+        cache_indices_h, RuntimeLayout[layout_1d].row_major(Index(batch))
+    )
+    var has_initial_state_cpu = LayoutTensor[
+        DType.bool, layout_1d, MutAnyOrigin
+    ](has_initial_state_h, RuntimeLayout[layout_1d].row_major(Index(batch)))
+
+    # Strides for row-major layout using IndexList types
+    var u_strides = IndexList[2](total_length, 1)
+    var delta_strides = IndexList[2](total_length, 1)
+    var A_strides = IndexList[2](dstate, 1)
+    var B_strides = IndexList[3](dstate * total_length, total_length, 1)
+    var C_strides = IndexList[3](dstate * total_length, total_length, 1)
+    var D_strides = IndexList[1](1)
+    var z_strides = IndexList[2](total_length, 1)
+    var delta_bias_strides = IndexList[1](1)
+    var ssm_states_strides = IndexList[3](dim * dstate, dstate, 1)
+    var out_strides = IndexList[2](total_length, 1)
+
+    # Run CPU kernel
+    varlen_selective_scan_fwd_cpu[
+        dtype,
+        u_cpu.layout,
+        delta_cpu.layout,
+        A_cpu.layout,
+        B_cpu.layout,
+        C_cpu.layout,
+        D_cpu.layout,
+        z_cpu.layout,
+        delta_bias_cpu.layout,
+        ssm_states_cpu.layout,
+        output_cpu.layout,
+        query_start_loc_cpu.layout,
+        cache_indices_cpu.layout,
+        has_initial_state_cpu.layout,
+    ](
+        dim,
+        dstate,
+        ngroups,
+        batch,
+        Int32(-1),  # pad_slot_id
+        Int8(1) if delta_softplus else Int8(0),
+        u_cpu,
+        delta_cpu,
+        A_cpu,
+        B_cpu,
+        C_cpu,
+        D_cpu,
+        z_cpu,
+        delta_bias_cpu,
+        ssm_states_cpu,
+        output_cpu,
+        query_start_loc_cpu,
+        cache_indices_cpu,
+        has_initial_state_cpu,
+        u_strides,
+        delta_strides,
+        A_strides,
+        B_strides,
+        C_strides,
+        D_strides,
+        z_strides,
+        delta_bias_strides,
+        ssm_states_strides,
+        out_strides,
+    )
+
+    # Allocate device memory
+    var ssm_states_gpu_d = ctx.enqueue_create_buffer[dtype](
+        batch * dim * dstate
+    )
+    var output_gpu_d = ctx.enqueue_create_buffer[dtype](dim * total_length)
+    var u_d = ctx.enqueue_create_buffer[dtype](dim * total_length)
+    var delta_d = ctx.enqueue_create_buffer[dtype](dim * total_length)
+    var A_d = ctx.enqueue_create_buffer[dtype](dim * dstate)
+    var B_d = ctx.enqueue_create_buffer[dtype](ngroups * dstate * total_length)
+    var C_d = ctx.enqueue_create_buffer[dtype](ngroups * dstate * total_length)
+    var D_d = ctx.enqueue_create_buffer[dtype](max(D_size, 1))
+    var z_d = ctx.enqueue_create_buffer[dtype](max(z_size, 1))
+    var delta_bias_d = ctx.enqueue_create_buffer[dtype](max(delta_bias_size, 1))
+    var query_start_loc_d = ctx.enqueue_create_buffer[DType.int32](batch + 1)
+    var cache_indices_d = ctx.enqueue_create_buffer[DType.int32](batch)
+    var has_initial_state_d = ctx.enqueue_create_buffer[DType.bool](batch)
+
+    # Copy to device
+    ctx.enqueue_copy(u_d, u_h)
+    ctx.enqueue_copy(delta_d, delta_h)
+    ctx.enqueue_copy(A_d, A_h)
+    ctx.enqueue_copy(B_d, B_h)
+    ctx.enqueue_copy(C_d, C_h)
+    if has_D:
+        ctx.enqueue_copy(D_d, D_h)
+    if has_z:
+        ctx.enqueue_copy(z_d, z_gpu_h)
+    if has_delta_bias:
+        ctx.enqueue_copy(delta_bias_d, delta_bias_h)
+    ctx.enqueue_copy(query_start_loc_d, query_start_loc_h)
+    ctx.enqueue_copy(cache_indices_d, cache_indices_h)
+    ctx.enqueue_copy(has_initial_state_d, has_initial_state_h)
+    ctx.enqueue_copy(ssm_states_gpu_d, ssm_states_gpu_h)
+
+    # Create LayoutTensors for GPU kernel
+    var ssm_states_gpu_lt = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        ssm_states_gpu_d,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, dstate)),
+    )
+    var output_gpu_lt = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        output_gpu_d,
+        RuntimeLayout[layout_2d].row_major(Index(dim, total_length)),
+    )
+    var u_gpu_lt = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        u_d, RuntimeLayout[layout_2d].row_major(Index(dim, total_length))
+    )
+    var delta_gpu_lt = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        delta_d, RuntimeLayout[layout_2d].row_major(Index(dim, total_length))
+    )
+    var A_gpu_lt = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        A_d, RuntimeLayout[layout_2d].row_major(Index(dim, dstate))
+    )
+    var B_gpu_lt = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        B_d,
+        RuntimeLayout[layout_3d].row_major(
+            Index(ngroups, dstate, total_length)
+        ),
+    )
+    var C_gpu_lt = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        C_d,
+        RuntimeLayout[layout_3d].row_major(
+            Index(ngroups, dstate, total_length)
+        ),
+    )
+    var D_gpu_lt = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        D_d, RuntimeLayout[layout_1d].row_major(Index(D_size))
+    )
+    var z_gpu_lt = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        z_d,
+        RuntimeLayout[layout_2d].row_major(
+            Index(dim if has_z else 0, total_length if has_z else 0)
+        ),
+    )
+    var delta_bias_gpu_lt = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        delta_bias_d, RuntimeLayout[layout_1d].row_major(Index(delta_bias_size))
+    )
+    var query_start_loc_gpu_lt = LayoutTensor[
+        DType.int32, layout_1d, MutAnyOrigin
+    ](query_start_loc_d, RuntimeLayout[layout_1d].row_major(Index(batch + 1)))
+    var cache_indices_gpu_lt = LayoutTensor[
+        DType.int32, layout_1d, MutAnyOrigin
+    ](cache_indices_d, RuntimeLayout[layout_1d].row_major(Index(batch)))
+    var has_initial_state_gpu_lt = LayoutTensor[
+        DType.bool, layout_1d, MutAnyOrigin
+    ](has_initial_state_d, RuntimeLayout[layout_1d].row_major(Index(batch)))
+
+    # Launch GPU kernel
+    comptime BLOCK_SIZE = 128
+    var num_dim_blocks = (dim + BLOCK_SIZE - 1) // BLOCK_SIZE
+
+    var compiled_kernel = ctx.compile_function[
+        varlen_selective_scan_fwd_gpu[
+            dtype,
+            u_gpu_lt.layout,
+            delta_gpu_lt.layout,
+            A_gpu_lt.layout,
+            B_gpu_lt.layout,
+            C_gpu_lt.layout,
+            D_gpu_lt.layout,
+            z_gpu_lt.layout,
+            delta_bias_gpu_lt.layout,
+            ssm_states_gpu_lt.layout,
+            output_gpu_lt.layout,
+            query_start_loc_gpu_lt.layout,
+            cache_indices_gpu_lt.layout,
+            has_initial_state_gpu_lt.layout,
+        ],
+        varlen_selective_scan_fwd_gpu[
+            dtype,
+            u_gpu_lt.layout,
+            delta_gpu_lt.layout,
+            A_gpu_lt.layout,
+            B_gpu_lt.layout,
+            C_gpu_lt.layout,
+            D_gpu_lt.layout,
+            z_gpu_lt.layout,
+            delta_bias_gpu_lt.layout,
+            ssm_states_gpu_lt.layout,
+            output_gpu_lt.layout,
+            query_start_loc_gpu_lt.layout,
+            cache_indices_gpu_lt.layout,
+            has_initial_state_gpu_lt.layout,
+        ],
+    ]()
+
+    ctx.enqueue_function(
+        compiled_kernel,
+        dim,
+        dstate,
+        ngroups,
+        batch,
+        Int32(-1),  # pad_slot_id
+        Int8(1) if delta_softplus else Int8(0),
+        u_gpu_lt,
+        delta_gpu_lt,
+        A_gpu_lt,
+        B_gpu_lt,
+        C_gpu_lt,
+        D_gpu_lt,
+        z_gpu_lt,
+        delta_bias_gpu_lt,
+        ssm_states_gpu_lt,
+        output_gpu_lt,
+        query_start_loc_gpu_lt,
+        cache_indices_gpu_lt,
+        has_initial_state_gpu_lt,
+        u_strides,
+        delta_strides,
+        A_strides,
+        B_strides,
+        C_strides,
+        D_strides,
+        z_strides,
+        delta_bias_strides,
+        ssm_states_strides,
+        out_strides,
+        grid_dim=(num_dim_blocks, batch, 1),
+        block_dim=(BLOCK_SIZE, 1, 1),
+    )
+
+    # Copy results back
+    var output_to_check = z_d if has_z else output_gpu_d
+    var output_to_check_host = z_gpu_h if has_z else output_gpu_h
+    ctx.enqueue_copy(output_to_check_host, output_to_check)
+
+    # Compare outputs
+    var output_to_check_cpu = z_cpu_h if has_z else output_cpu_h
+    var output_size = dim * total_length
+
+    for i in range(output_size):
+        var cpu_val = Float32(output_to_check_cpu.load(i))
+        var gpu_val = Float32(output_to_check_host.load(i))
+        assert_almost_equal(cpu_val, gpu_val, rtol=rtol)
+
+    # Cleanup
+    u_h.free()
+    delta_h.free()
+    A_h.free()
+    B_h.free()
+    C_h.free()
+    D_h.free()
+    z_cpu_h.free()
+    z_gpu_h.free()
+    delta_bias_h.free()
+    ssm_states_cpu_h.free()
+    ssm_states_gpu_h.free()
+    output_cpu_h.free()
+    output_gpu_h.free()
+    query_start_loc_h.free()
+    cache_indices_h.free()
+    has_initial_state_h.free()
+
+
+def main():
+    with DeviceContext() as ctx:
+        if not ctx.is_compatible():
+            return
+        # Test varlen_selective_scan_fwd with equal-length sequences
+        run_varlen_selective_scan_fwd_gpu[
+            DType.float32,
+            has_D=True,
+            has_z=True,
+            has_delta_bias=True,
+            delta_softplus=False,
+        ](batch=2, dim=4, dstate=4, ngroups=1, seq_lengths=Index(8, 8), ctx=ctx)
+        print("✓ Varlen selective scan fwd GPU (equal lengths) test passed")
+
+        # Test with variable-length sequences
+        run_varlen_selective_scan_fwd_gpu[
+            DType.float32,
+            has_D=True,
+            has_z=True,
+            has_delta_bias=True,
+            delta_softplus=False,
+        ](
+            batch=3,
+            dim=4,
+            dstate=4,
+            ngroups=1,
+            seq_lengths=Index(10, 6, 1),
+            ctx=ctx,
+        )
+        print("✓ Varlen selective scan fwd GPU (variable lengths) test passed")
+
+        # Test without D
+        run_varlen_selective_scan_fwd_gpu[
+            DType.float32,
+            has_D=False,
+            has_z=True,
+            has_delta_bias=True,
+            delta_softplus=False,
+        ](batch=2, dim=4, dstate=4, ngroups=1, seq_lengths=Index(8, 8), ctx=ctx)
+        print("✓ Varlen selective scan fwd GPU without D test passed")
+
+        # Test without z
+        run_varlen_selective_scan_fwd_gpu[
+            DType.float32,
+            has_D=True,
+            has_z=False,
+            has_delta_bias=True,
+            delta_softplus=False,
+        ](batch=2, dim=4, dstate=4, ngroups=1, seq_lengths=Index(8, 8), ctx=ctx)
+        print("✓ Varlen selective scan fwd GPU without z test passed")
+
+        # Test with delta_softplus
+        run_varlen_selective_scan_fwd_gpu[
+            DType.float32,
+            has_D=True,
+            has_z=True,
+            has_delta_bias=True,
+            delta_softplus=True,
+        ](batch=2, dim=4, dstate=4, ngroups=1, seq_lengths=Index(8, 8), ctx=ctx)
+        print("✓ Varlen selective scan fwd GPU with delta_softplus test passed")

--- a/max/kernels/test/state_space/test_varlen_causal_conv1d.mojo
+++ b/max/kernels/test/state_space/test_varlen_causal_conv1d.mojo
@@ -28,7 +28,7 @@ from state_space.varlen_causal_conv1d import (
     causal_conv1d_varlen_update_cpu,
     causal_conv1d_varlen_states_cpu,
 )
-from testing import assert_almost_equal
+from testing import TestSuite, assert_almost_equal
 
 from utils.index import Index, IndexList
 
@@ -678,60 +678,86 @@ fn run_varlen_causal_conv1d_states[
     states_ref_heap.free()
 
 
-def main():
-    # Test varlen_causal_conv1d_fwd with equal-length sequences
+# =============================================================================
+# Test functions for varlen causal conv1d forward
+# =============================================================================
+
+
+fn test_varlen_causal_conv1d_fwd_equal_lengths() raises:
+    """Test varlen causal conv1d forward with equal-length sequences."""
     run_varlen_causal_conv1d_fwd[DType.float32, "none"](
         batch=2, dim=4, seq_lengths=Index(8, 8), width=3
     )
-    print("✓ Varlen causal conv1d fwd (equal lengths) test passed")
 
-    # Test varlen_causal_conv1d_fwd with variable-length sequences
+
+fn test_varlen_causal_conv1d_fwd_variable_lengths() raises:
+    """Test varlen causal conv1d forward with variable-length sequences."""
     run_varlen_causal_conv1d_fwd[DType.float32, "none"](
         batch=3, dim=4, seq_lengths=Index(10, 6, 1), width=3
     )
-    print("✓ Varlen causal conv1d fwd (variable lengths) test passed")
 
-    # Test with SiLU activation
+
+fn test_varlen_causal_conv1d_fwd_with_silu() raises:
+    """Test varlen causal conv1d forward with SiLU activation."""
     run_varlen_causal_conv1d_fwd[DType.float32, "silu"](
         batch=2, dim=4, seq_lengths=Index(8, 8), width=3
     )
-    print("✓ Varlen causal conv1d fwd with SiLU test passed")
 
-    # Test various widths
+
+fn test_varlen_causal_conv1d_fwd_various_widths() raises:
+    """Test varlen causal conv1d forward with various kernel widths."""
     run_varlen_causal_conv1d_fwd[DType.float32, "none"](
         batch=2, dim=4, seq_lengths=Index(8, 8), width=2
     )
     run_varlen_causal_conv1d_fwd[DType.float32, "none"](
         batch=2, dim=4, seq_lengths=Index(8, 8), width=4
     )
-    print("✓ Varlen causal conv1d fwd various widths test passed")
 
-    # Test varlen_causal_conv1d_update
+
+# =============================================================================
+# Test functions for varlen causal conv1d update
+# =============================================================================
+
+
+fn test_varlen_causal_conv1d_update_basic() raises:
+    """Test basic varlen causal conv1d update."""
     run_varlen_causal_conv1d_update[DType.float32, "none"](
         batch=2, dim=4, seqlen=1, width=3, state_len=4
     )
-    print("✓ Varlen causal conv1d update test passed")
 
-    # Test update with SiLU
+
+fn test_varlen_causal_conv1d_update_with_silu() raises:
+    """Test varlen causal conv1d update with SiLU activation."""
     run_varlen_causal_conv1d_update[DType.float32, "silu"](
         batch=2, dim=4, seqlen=1, width=3, state_len=4
     )
-    print("✓ Varlen causal conv1d update with SiLU test passed")
 
-    # Test update with seqlen > 1
+
+fn test_varlen_causal_conv1d_update_seqlen_gt_1() raises:
+    """Test varlen causal conv1d update with seqlen > 1."""
     run_varlen_causal_conv1d_update[DType.float32, "none"](
         batch=2, dim=4, seqlen=4, width=3, state_len=4
     )
-    print("✓ Varlen causal conv1d update with seqlen > 1 test passed")
 
-    # Test varlen_causal_conv1d_states
+
+# =============================================================================
+# Test functions for varlen causal conv1d states
+# =============================================================================
+
+
+fn test_varlen_causal_conv1d_states_basic() raises:
+    """Test basic varlen causal conv1d states extraction."""
     run_varlen_causal_conv1d_states[DType.float32](
         batch=2, dim=4, seq_lengths=Index(8, 8), state_len=3
     )
-    print("✓ Varlen causal conv1d states test passed")
 
-    # Test states with variable-length sequences
+
+fn test_varlen_causal_conv1d_states_variable_lengths() raises:
+    """Test varlen causal conv1d states with variable-length sequences."""
     run_varlen_causal_conv1d_states[DType.float32](
         batch=3, dim=4, seq_lengths=Index(10, 6, 1), state_len=3
     )
-    print("✓ Varlen causal conv1d states (variable lengths) test passed")
+
+
+def main():
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_varlen_causal_conv1d.mojo
+++ b/max/kernels/test/state_space/test_varlen_causal_conv1d.mojo
@@ -1,0 +1,737 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from math import exp
+from sys.info import simd_width_of
+
+from layout import (
+    UNKNOWN_VALUE,
+    Layout,
+    LayoutTensor,
+    RuntimeTuple,
+    RuntimeLayout,
+)
+from layout._fillers import random
+from memory import alloc
+from state_space.varlen_causal_conv1d import (
+    causal_conv1d_varlen_fwd_cpu,
+    causal_conv1d_varlen_update_cpu,
+    causal_conv1d_varlen_states_cpu,
+)
+from testing import assert_almost_equal
+
+from utils.index import Index, IndexList
+
+
+# Constants
+comptime PAD_SLOT_ID: Int32 = -1
+
+
+@always_inline
+fn silu_ref[dtype: DType](x: Scalar[dtype]) -> Scalar[dtype]:
+    """Reference SiLU implementation: x * sigmoid(x) = x / (1 + exp(-x))."""
+    var x_f32 = x.cast[DType.float32]()
+    var neg_x = -x_f32
+    var exp_neg_x = exp(neg_x)
+    var one = Scalar[DType.float32](1.0)
+    var sigmoid_x = one / (one + exp_neg_x)
+    return (x_f32 * sigmoid_x).cast[dtype]()
+
+
+fn run_varlen_causal_conv1d_fwd[
+    dtype: DType,
+    activation: StaticString,
+](
+    batch: Int,
+    dim: Int,
+    seq_lengths: IndexList,
+    width: Int,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test varlen causal conv1d forward kernel against reference implementation.
+    """
+    # Calculate total_seqlen (sum of all sequence lengths)
+    var total_seqlen = 0
+    for i in range(batch):
+        total_seqlen += seq_lengths[i]
+
+    # Allocate host memory
+    comptime layout_2d = Layout.row_major[2]()
+    comptime layout_1d = Layout(UNKNOWN_VALUE)
+
+    # x: (dim, total_seqlen) for varlen - sequences concatenated
+    var x_heap = alloc[Scalar[dtype]](dim * total_seqlen)
+    var x_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        x_heap, RuntimeLayout[layout_2d].row_major(Index(dim, total_seqlen))
+    )
+
+    # weight: (dim, width)
+    var weight_heap = alloc[Scalar[dtype]](dim * width)
+    var weight_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        weight_heap, RuntimeLayout[layout_2d].row_major(Index(dim, width))
+    )
+
+    # bias: (dim,)
+    var bias_heap = alloc[Scalar[dtype]](dim)
+    var bias_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        bias_heap, RuntimeLayout[layout_1d].row_major(Index(dim))
+    )
+
+    # query_start_loc: (batch + 1,) - cumulative sequence lengths
+    var query_start_loc_heap = alloc[Scalar[DType.int32]](batch + 1)
+    var query_start_loc_h = LayoutTensor[DType.int32, layout_1d, MutAnyOrigin](
+        query_start_loc_heap,
+        RuntimeLayout[layout_1d].row_major(Index(batch + 1)),
+    )
+    var cumsum = 0
+    query_start_loc_h.ptr.store(0, Scalar[DType.int32](0))
+    for i in range(batch):
+        cumsum += seq_lengths[i]
+        query_start_loc_h.ptr.store(i + 1, Scalar[DType.int32](cumsum))
+
+    # cache_indices: (batch,) - identity mapping
+    var cache_indices_heap = alloc[Scalar[DType.int32]](batch)
+    var cache_indices_h = LayoutTensor[DType.int32, layout_1d, MutAnyOrigin](
+        cache_indices_heap, RuntimeLayout[layout_1d].row_major(Index(batch))
+    )
+    for i in range(batch):
+        cache_indices_h.ptr.store(i, Scalar[DType.int32](i))
+
+    # has_initial_state: (batch,) - all False
+    var has_initial_state_heap = alloc[Scalar[DType.bool]](batch)
+    var has_initial_state_h = LayoutTensor[DType.bool, layout_1d, MutAnyOrigin](
+        has_initial_state_heap, RuntimeLayout[layout_1d].row_major(Index(batch))
+    )
+    for i in range(batch):
+        has_initial_state_h.ptr.store(i, Scalar[DType.bool](False))
+
+    # conv_states: (batch, dim, width - 1)
+    var state_len = width - 1
+    var conv_states_heap = alloc[Scalar[dtype]](batch * dim * state_len)
+    var conv_states_h = LayoutTensor[
+        dtype, Layout.row_major[3](), MutAnyOrigin
+    ](
+        conv_states_heap,
+        RuntimeLayout[Layout.row_major[3]()].row_major(
+            Index(batch, dim, state_len)
+        ),
+    ).fill(
+        0
+    )
+
+    # output: (dim, total_seqlen)
+    var output_heap = alloc[Scalar[dtype]](dim * total_seqlen)
+    var output_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        output_heap,
+        RuntimeLayout[layout_2d].row_major(Index(dim, total_seqlen)),
+    ).fill(0)
+
+    # reference output: (dim, total_seqlen)
+    var output_ref_heap = alloc[Scalar[dtype]](dim * total_seqlen)
+    var output_ref_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        output_ref_heap,
+        RuntimeLayout[layout_2d].row_major(Index(dim, total_seqlen)),
+    ).fill(0)
+
+    # Initialize input data
+    random(x_h)
+    random(weight_h)
+    random(bias_h)
+
+    var x_buf = x_h
+    var weight_buf = weight_h
+    var bias_buf = bias_h
+    var query_start_loc_buf = query_start_loc_h
+    var cache_indices_buf = cache_indices_h
+    var has_initial_state_buf = has_initial_state_h
+    var conv_states_buf = conv_states_h
+    var output_buf = output_h
+    var output_ref_buf = output_ref_h
+
+    # Strides for row-major layout
+    var x_dim_stride: UInt32 = total_seqlen
+    var x_seqlen_stride: UInt32 = 1
+    var weight_dim_stride: UInt32 = width
+    var weight_width_stride: UInt32 = 1
+    var out_dim_stride: UInt32 = total_seqlen
+    var out_seqlen_stride: UInt32 = 1
+    var conv_states_batch_stride: UInt32 = dim * state_len
+    var conv_states_dim_stride: UInt32 = state_len
+    var conv_states_width_stride: UInt32 = 1
+
+    var silu_activation = activation == "silu"
+
+    # Test kernel
+    causal_conv1d_varlen_fwd_cpu[
+        x_buf.dtype,
+        x_buf.layout,
+        weight_buf.dtype,
+        weight_buf.layout,
+        bias_buf.dtype,
+        bias_buf.layout,
+        output_buf.dtype,
+        output_buf.layout,
+        query_start_loc_buf.dtype,
+        query_start_loc_buf.layout,
+        cache_indices_buf.dtype,
+        cache_indices_buf.layout,
+        has_initial_state_buf.dtype,
+        has_initial_state_buf.layout,
+        conv_states_buf.dtype,
+        conv_states_buf.layout,
+    ](
+        dim,
+        total_seqlen,
+        width,
+        batch,
+        x_buf,
+        weight_buf,
+        bias_buf,
+        query_start_loc_buf,
+        cache_indices_buf,
+        has_initial_state_buf,
+        conv_states_buf,
+        output_buf,
+        x_dim_stride,
+        x_seqlen_stride,
+        weight_dim_stride,
+        weight_width_stride,
+        out_dim_stride,
+        out_seqlen_stride,
+        conv_states_batch_stride,
+        conv_states_dim_stride,
+        conv_states_width_stride,
+        silu_activation,
+        PAD_SLOT_ID,
+        True,  # has_cache_indices
+        True,  # has_initial_state_flag
+        True,  # has_conv_states
+        True,  # has_bias
+    )
+
+    # Reference implementation
+    var width_minus_1: Int = width - 1
+    for b in range(batch):
+        var seq_start = Int(query_start_loc_buf.ptr.load(b))
+        var seq_end = Int(query_start_loc_buf.ptr.load(b + 1))
+        var seqlen = seq_end - seq_start
+
+        for d in range(dim):
+            var bias_val = bias_buf.ptr.load(d)
+
+            for l in range(seqlen):
+                var conv_sum: Scalar[dtype] = bias_val
+
+                for w_idx in range(width):
+                    var input_l = l - (width_minus_1 - w_idx)
+                    var input_val: Scalar[dtype] = Scalar[dtype](0.0)
+
+                    if input_l >= 0:
+                        var x_offset = (
+                            d * x_dim_stride
+                            + (seq_start + input_l) * x_seqlen_stride
+                        )
+                        input_val = x_buf.ptr.load(x_offset)
+
+                    var weight_offset = (
+                        d * weight_dim_stride + w_idx * weight_width_stride
+                    )
+                    var weight_val = weight_buf.ptr.load(weight_offset)
+                    conv_sum = conv_sum + input_val * weight_val
+
+                var out_val = conv_sum
+                if silu_activation:
+                    out_val = silu_ref[dtype](out_val)
+
+                var out_offset = (
+                    d * out_dim_stride + (seq_start + l) * out_seqlen_stride
+                )
+                output_ref_buf.ptr.store(out_offset, out_val)
+
+    # Compare results
+    var flattened_size = dim * total_seqlen
+    for i in range(flattened_size):
+        assert_almost_equal(
+            output_h.ptr[i],
+            output_ref_h.ptr[i],
+            rtol=rtol,
+        )
+
+    # Cleanup
+    x_heap.free()
+    weight_heap.free()
+    bias_heap.free()
+    query_start_loc_heap.free()
+    cache_indices_heap.free()
+    has_initial_state_heap.free()
+    conv_states_heap.free()
+    output_heap.free()
+    output_ref_heap.free()
+
+
+fn run_varlen_causal_conv1d_update[
+    dtype: DType,
+    activation: StaticString,
+](
+    batch: Int,
+    dim: Int,
+    seqlen: Int,
+    width: Int,
+    state_len: Int,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test varlen causal conv1d update kernel against reference implementation.
+    """
+    # Allocate host memory
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_2d = Layout.row_major[2]()
+    comptime layout_1d = Layout(UNKNOWN_VALUE)
+
+    # x: (batch, dim, seqlen)
+    var x_heap = alloc[Scalar[dtype]](batch * dim * seqlen)
+    var x_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        x_heap, RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen))
+    )
+
+    # weight: (dim, width)
+    var weight_heap = alloc[Scalar[dtype]](dim * width)
+    var weight_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        weight_heap, RuntimeLayout[layout_2d].row_major(Index(dim, width))
+    )
+
+    # bias: (dim,)
+    var bias_heap = alloc[Scalar[dtype]](dim)
+    var bias_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        bias_heap, RuntimeLayout[layout_1d].row_major(Index(dim))
+    )
+
+    # conv_state: (batch, dim, state_len)
+    var conv_state_heap = alloc[Scalar[dtype]](batch * dim * state_len)
+    var conv_state_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        conv_state_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, state_len)),
+    )
+
+    # cache_seqlens: (batch,) - can be empty
+    var cache_seqlens_heap = alloc[Scalar[DType.int32]](batch)
+    var cache_seqlens_h = LayoutTensor[DType.int32, layout_1d, MutAnyOrigin](
+        cache_seqlens_heap, RuntimeLayout[layout_1d].row_major(Index(batch))
+    )
+    for i in range(batch):
+        cache_seqlens_h.ptr.store(i, Scalar[DType.int32](0))
+
+    # conv_state_indices: (batch,) - identity mapping
+    var conv_state_indices_heap = alloc[Scalar[DType.int32]](batch)
+    var conv_state_indices_h = LayoutTensor[
+        DType.int32, layout_1d, MutAnyOrigin
+    ](conv_state_indices_heap, RuntimeLayout[layout_1d].row_major(Index(batch)))
+    for i in range(batch):
+        conv_state_indices_h.ptr.store(i, Scalar[DType.int32](i))
+
+    # output: (batch, dim, seqlen)
+    var output_heap = alloc[Scalar[dtype]](batch * dim * seqlen)
+    var output_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        output_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    ).fill(0)
+
+    # reference output: (batch, dim, seqlen)
+    var output_ref_heap = alloc[Scalar[dtype]](batch * dim * seqlen)
+    var output_ref_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        output_ref_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    ).fill(0)
+
+    # Copy of conv_state for reference
+    var conv_state_ref_heap = alloc[Scalar[dtype]](batch * dim * state_len)
+    var conv_state_ref_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        conv_state_ref_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, state_len)),
+    )
+
+    # Initialize input data
+    random(x_h)
+    random(conv_state_h)
+    random(weight_h)
+    random(bias_h)
+
+    # Copy conv_state for reference
+    for i in range(batch * dim * state_len):
+        conv_state_ref_h.ptr[i] = conv_state_h.ptr[i]
+
+    var x_buf = x_h
+    var weight_buf = weight_h
+    var bias_buf = bias_h
+    var conv_state_buf = conv_state_h
+    var cache_seqlens_buf = cache_seqlens_h
+    var conv_state_indices_buf = conv_state_indices_h
+    var output_buf = output_h
+    var output_ref_buf = output_ref_h
+    var conv_state_ref_buf = conv_state_ref_h
+
+    # Strides for row-major layout
+    var x_batch_stride: UInt32 = dim * seqlen
+    var x_dim_stride: UInt32 = seqlen
+    var x_seqlen_stride: UInt32 = 1
+    var weight_dim_stride: UInt32 = width
+    var weight_width_stride: UInt32 = 1
+    var conv_state_batch_stride: UInt32 = dim * state_len
+    var conv_state_dim_stride: UInt32 = state_len
+    var conv_state_seqlen_stride: UInt32 = 1
+    var out_batch_stride: UInt32 = dim * seqlen
+    var out_dim_stride: UInt32 = seqlen
+    var out_seqlen_stride: UInt32 = 1
+
+    var silu_activation = activation == "silu"
+
+    # Test kernel
+    causal_conv1d_varlen_update_cpu[
+        x_buf.dtype,
+        x_buf.layout,
+        weight_buf.dtype,
+        weight_buf.layout,
+        bias_buf.dtype,
+        bias_buf.layout,
+        output_buf.dtype,
+        output_buf.layout,
+        conv_state_buf.dtype,
+        conv_state_buf.layout,
+        cache_seqlens_buf.dtype,
+        cache_seqlens_buf.layout,
+        conv_state_indices_buf.dtype,
+        conv_state_indices_buf.layout,
+    ](
+        batch,
+        dim,
+        seqlen,
+        width,
+        state_len,
+        x_buf,
+        weight_buf,
+        bias_buf,
+        conv_state_buf,
+        cache_seqlens_buf,
+        conv_state_indices_buf,
+        output_buf,
+        x_batch_stride,
+        x_dim_stride,
+        x_seqlen_stride,
+        weight_dim_stride,
+        weight_width_stride,
+        conv_state_batch_stride,
+        conv_state_dim_stride,
+        conv_state_seqlen_stride,
+        out_batch_stride,
+        out_dim_stride,
+        out_seqlen_stride,
+        silu_activation,
+        PAD_SLOT_ID,
+        True,  # has_conv_state_indices
+        True,  # has_cache_seqlens
+        True,  # has_bias
+    )
+
+    # Reference implementation
+    var width_minus_1: Int = width - 1
+    for b in range(batch):
+        var state_batch_idx = b
+
+        for d in range(dim):
+            var bias_val = bias_buf.ptr.load(d)
+
+            for l in range(seqlen):
+                var conv_sum: Scalar[dtype] = bias_val
+
+                for w_idx in range(width):
+                    var rel_pos = w_idx - width_minus_1
+                    var input_val: Scalar[dtype] = Scalar[dtype](0.0)
+
+                    if rel_pos + l < 0:
+                        # Read from state
+                        var state_pos: Int
+                        # has_cache_seqlens is True in our test, so use circular buffer
+                        var cache_seqlen = Int(cache_seqlens_buf.ptr.load(b))
+                        state_pos = (
+                            cache_seqlen + rel_pos + l + state_len
+                        ) % state_len
+
+                        if state_pos >= 0 and state_pos < state_len:
+                            var state_offset = (
+                                state_batch_idx * conv_state_batch_stride
+                                + d * conv_state_dim_stride
+                                + state_pos * conv_state_seqlen_stride
+                            )
+                            input_val = conv_state_ref_buf.ptr.load(
+                                state_offset
+                            )
+                    else:
+                        # Read from x
+                        var x_l = rel_pos + l
+                        if x_l >= 0 and x_l < seqlen:
+                            var x_offset = (
+                                b * x_batch_stride
+                                + d * x_dim_stride
+                                + x_l * x_seqlen_stride
+                            )
+                            input_val = x_buf.ptr.load(x_offset)
+
+                    var weight_offset = (
+                        d * weight_dim_stride + w_idx * weight_width_stride
+                    )
+                    var weight_val = weight_buf.ptr.load(weight_offset)
+                    conv_sum = conv_sum + input_val * weight_val
+
+                var out_val = conv_sum
+                if silu_activation:
+                    out_val = silu_ref[dtype](out_val)
+
+                var out_offset = (
+                    b * out_batch_stride
+                    + d * out_dim_stride
+                    + l * out_seqlen_stride
+                )
+                output_ref_buf.ptr.store(out_offset, out_val)
+
+            # Update state with new x values
+            # This matches the CPU implementation logic exactly
+            for l in range(seqlen):
+                var x_offset = (
+                    b * x_batch_stride + d * x_dim_stride + l * x_seqlen_stride
+                )
+                var x_val = x_buf.ptr.load(x_offset)
+
+                var state_pos: Int
+                # has_cache_seqlens is True in our test, so use circular buffer
+                var cache_seqlen = Int(cache_seqlens_buf.ptr.load(b))
+                state_pos = (cache_seqlen + l) % state_len
+
+                var state_offset = (
+                    state_batch_idx * conv_state_batch_stride
+                    + d * conv_state_dim_stride
+                    + state_pos * conv_state_seqlen_stride
+                )
+                conv_state_ref_buf.ptr.store(state_offset, x_val)
+
+    # Compare results
+    var flattened_size = batch * dim * seqlen
+    for i in range(flattened_size):
+        assert_almost_equal(
+            output_h.ptr[i],
+            output_ref_h.ptr[i],
+            rtol=rtol,
+        )
+
+    # Compare conv_state updates
+    var conv_state_size = batch * dim * state_len
+    for i in range(conv_state_size):
+        assert_almost_equal(
+            conv_state_h.ptr[i],
+            conv_state_ref_h.ptr[i],
+            rtol=rtol,
+        )
+
+    # Cleanup
+    x_heap.free()
+    weight_heap.free()
+    bias_heap.free()
+    conv_state_heap.free()
+    conv_state_ref_heap.free()
+    cache_seqlens_heap.free()
+    conv_state_indices_heap.free()
+    output_heap.free()
+    output_ref_heap.free()
+
+
+fn run_varlen_causal_conv1d_states[
+    dtype: DType,
+](
+    batch: Int,
+    dim: Int,
+    seq_lengths: IndexList,
+    state_len: Int,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test varlen causal conv1d states extraction kernel."""
+    # Calculate total_tokens (sum of all sequence lengths)
+    var total_tokens = 0
+    for i in range(batch):
+        total_tokens += seq_lengths[i]
+
+    # Allocate host memory
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_2d = Layout.row_major[2]()
+    comptime layout_1d = Layout(UNKNOWN_VALUE)
+
+    # x: (total_tokens, dim) - sequences concatenated
+    var x_heap = alloc[Scalar[dtype]](total_tokens * dim)
+    var x_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        x_heap, RuntimeLayout[layout_2d].row_major(Index(total_tokens, dim))
+    )
+
+    # cu_seqlens: (batch + 1,) - cumulative sequence lengths
+    var cu_seqlens_heap = alloc[Scalar[DType.int32]](batch + 1)
+    var cu_seqlens_h = LayoutTensor[DType.int32, layout_1d, MutAnyOrigin](
+        cu_seqlens_heap, RuntimeLayout[layout_1d].row_major(Index(batch + 1))
+    )
+    var cumsum = 0
+    cu_seqlens_h.ptr.store(0, Scalar[DType.int32](0))
+    for i in range(batch):
+        cumsum += seq_lengths[i]
+        cu_seqlens_h.ptr.store(i + 1, Scalar[DType.int32](cumsum))
+
+    # states: (batch, dim, state_len)
+    var states_heap = alloc[Scalar[dtype]](batch * dim * state_len)
+    var states_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        states_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, state_len)),
+    ).fill(0)
+
+    # reference states: (batch, dim, state_len)
+    var states_ref_heap = alloc[Scalar[dtype]](batch * dim * state_len)
+    var states_ref_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        states_ref_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, state_len)),
+    ).fill(0)
+
+    # Initialize input data
+    random(x_h)
+
+    var x_buf = x_h
+    var cu_seqlens_buf = cu_seqlens_h
+    var states_buf = states_h
+    var states_ref_buf = states_ref_h
+
+    # Strides for row-major layout
+    var x_seqlen_stride: UInt32 = dim
+    var x_dim_stride: UInt32 = 1
+    var states_batch_stride: UInt32 = dim * state_len
+    var states_dim_stride: UInt32 = state_len
+    var states_seqlen_stride: UInt32 = 1
+
+    # Test kernel
+    causal_conv1d_varlen_states_cpu[
+        x_buf.dtype,
+        x_buf.layout,
+        cu_seqlens_buf.dtype,
+        cu_seqlens_buf.layout,
+        states_buf.dtype,
+        states_buf.layout,
+    ](
+        total_tokens,
+        dim,
+        batch,
+        state_len,
+        x_buf,
+        cu_seqlens_buf,
+        states_buf,
+        x_seqlen_stride,
+        x_dim_stride,
+        states_batch_stride,
+        states_dim_stride,
+        states_seqlen_stride,
+    )
+
+    # Reference implementation
+    for b in range(batch):
+        var end_idx = Int(cu_seqlens_buf.ptr.load(b + 1))
+        var start_idx_seq = Int(cu_seqlens_buf.ptr.load(b))
+        var start_idx = max(start_idx_seq, end_idx - state_len)
+        var num_elements = end_idx - start_idx
+
+        for i in range(num_elements):
+            var x_seq_idx = start_idx + i
+            var states_seq_idx = state_len - num_elements + i
+
+            for d in range(dim):
+                var x_offset = x_seq_idx * x_seqlen_stride + d * x_dim_stride
+                var states_offset = (
+                    b * states_batch_stride
+                    + d * states_dim_stride
+                    + states_seq_idx * states_seqlen_stride
+                )
+                var val = x_buf.ptr.load(x_offset)
+                states_ref_buf.ptr.store(states_offset, val)
+
+    # Compare results
+    var flattened_size = batch * dim * state_len
+    for i in range(flattened_size):
+        assert_almost_equal(
+            states_h.ptr[i],
+            states_ref_h.ptr[i],
+            rtol=rtol,
+        )
+
+    # Cleanup
+    x_heap.free()
+    cu_seqlens_heap.free()
+    states_heap.free()
+    states_ref_heap.free()
+
+
+def main():
+    # Test varlen_causal_conv1d_fwd with equal-length sequences
+    run_varlen_causal_conv1d_fwd[DType.float32, "none"](
+        batch=2, dim=4, seq_lengths=Index(8, 8), width=3
+    )
+    print("✓ Varlen causal conv1d fwd (equal lengths) test passed")
+
+    # Test varlen_causal_conv1d_fwd with variable-length sequences
+    run_varlen_causal_conv1d_fwd[DType.float32, "none"](
+        batch=3, dim=4, seq_lengths=Index(10, 6, 1), width=3
+    )
+    print("✓ Varlen causal conv1d fwd (variable lengths) test passed")
+
+    # Test with SiLU activation
+    run_varlen_causal_conv1d_fwd[DType.float32, "silu"](
+        batch=2, dim=4, seq_lengths=Index(8, 8), width=3
+    )
+    print("✓ Varlen causal conv1d fwd with SiLU test passed")
+
+    # Test various widths
+    run_varlen_causal_conv1d_fwd[DType.float32, "none"](
+        batch=2, dim=4, seq_lengths=Index(8, 8), width=2
+    )
+    run_varlen_causal_conv1d_fwd[DType.float32, "none"](
+        batch=2, dim=4, seq_lengths=Index(8, 8), width=4
+    )
+    print("✓ Varlen causal conv1d fwd various widths test passed")
+
+    # Test varlen_causal_conv1d_update
+    run_varlen_causal_conv1d_update[DType.float32, "none"](
+        batch=2, dim=4, seqlen=1, width=3, state_len=4
+    )
+    print("✓ Varlen causal conv1d update test passed")
+
+    # Test update with SiLU
+    run_varlen_causal_conv1d_update[DType.float32, "silu"](
+        batch=2, dim=4, seqlen=1, width=3, state_len=4
+    )
+    print("✓ Varlen causal conv1d update with SiLU test passed")
+
+    # Test update with seqlen > 1
+    run_varlen_causal_conv1d_update[DType.float32, "none"](
+        batch=2, dim=4, seqlen=4, width=3, state_len=4
+    )
+    print("✓ Varlen causal conv1d update with seqlen > 1 test passed")
+
+    # Test varlen_causal_conv1d_states
+    run_varlen_causal_conv1d_states[DType.float32](
+        batch=2, dim=4, seq_lengths=Index(8, 8), state_len=3
+    )
+    print("✓ Varlen causal conv1d states test passed")
+
+    # Test states with variable-length sequences
+    run_varlen_causal_conv1d_states[DType.float32](
+        batch=3, dim=4, seq_lengths=Index(10, 6, 1), state_len=3
+    )
+    print("✓ Varlen causal conv1d states (variable lengths) test passed")

--- a/max/kernels/test/state_space/test_varlen_selective_scan.mojo
+++ b/max/kernels/test/state_space/test_varlen_selective_scan.mojo
@@ -26,7 +26,7 @@ from state_space.varlen_selective_scan import (
     varlen_selective_scan_fwd_cpu,
     varlen_selective_state_update_cpu,
 )
-from testing import assert_almost_equal
+from testing import TestSuite, assert_almost_equal
 
 from utils.index import Index, IndexList
 
@@ -571,8 +571,13 @@ fn run_varlen_selective_state_update[
     state_batch_indices_heap.free()
 
 
-def main():
-    # Test varlen_selective_scan_fwd with equal-length sequences
+# =============================================================================
+# Test functions for varlen selective scan forward
+# =============================================================================
+
+
+fn test_varlen_selective_scan_fwd_equal_lengths() raises:
+    """Test varlen selective scan forward with equal-length sequences."""
     run_varlen_selective_scan_fwd[
         DType.float32,
         4,
@@ -581,9 +586,10 @@ def main():
         has_delta_bias=True,
         delta_softplus=False,
     ](batch=2, dim=4, ngroups=1, seq_lengths=Index(8, 8))
-    print("✓ Varlen selective scan fwd (equal lengths) test passed")
 
-    # Test varlen_selective_scan_fwd with variable-length sequences
+
+fn test_varlen_selective_scan_fwd_variable_lengths() raises:
+    """Test varlen selective scan forward with variable-length sequences."""
     run_varlen_selective_scan_fwd[
         DType.float32,
         4,
@@ -592,9 +598,10 @@ def main():
         has_delta_bias=True,
         delta_softplus=False,
     ](batch=3, dim=4, ngroups=1, seq_lengths=Index(10, 6, 1))
-    print("✓ Varlen selective scan fwd (variable lengths) test passed")
 
-    # Test without D
+
+fn test_varlen_selective_scan_fwd_without_D() raises:
+    """Test varlen selective scan forward without D tensor."""
     run_varlen_selective_scan_fwd[
         DType.float32,
         4,
@@ -603,9 +610,10 @@ def main():
         has_delta_bias=True,
         delta_softplus=False,
     ](batch=2, dim=4, ngroups=1, seq_lengths=Index(8, 8))
-    print("✓ Varlen selective scan fwd without D test passed")
 
-    # Test without z
+
+fn test_varlen_selective_scan_fwd_without_z() raises:
+    """Test varlen selective scan forward without z tensor."""
     run_varlen_selective_scan_fwd[
         DType.float32,
         4,
@@ -614,9 +622,10 @@ def main():
         has_delta_bias=True,
         delta_softplus=False,
     ](batch=2, dim=4, ngroups=1, seq_lengths=Index(8, 8))
-    print("✓ Varlen selective scan fwd without z test passed")
 
-    # Test with delta_softplus
+
+fn test_varlen_selective_scan_fwd_with_delta_softplus() raises:
+    """Test varlen selective scan forward with delta softplus activation."""
     run_varlen_selective_scan_fwd[
         DType.float32,
         4,
@@ -625,9 +634,15 @@ def main():
         has_delta_bias=True,
         delta_softplus=True,
     ](batch=2, dim=4, ngroups=1, seq_lengths=Index(8, 8))
-    print("✓ Varlen selective scan fwd with delta_softplus test passed")
 
-    # Test varlen_selective_state_update
+
+# =============================================================================
+# Test functions for varlen selective state update
+# =============================================================================
+
+
+fn test_varlen_selective_state_update_basic() raises:
+    """Test basic varlen selective state update."""
     run_varlen_selective_state_update[
         DType.float32,
         4,
@@ -636,9 +651,10 @@ def main():
         has_dt_bias=True,
         dt_softplus=False,
     ](batch=2, nheads=2, dim=4, ngroups=1)
-    print("✓ Varlen selective state update test passed")
 
-    # Test state update without D
+
+fn test_varlen_selective_state_update_without_D() raises:
+    """Test varlen selective state update without D tensor."""
     run_varlen_selective_state_update[
         DType.float32,
         4,
@@ -647,9 +663,10 @@ def main():
         has_dt_bias=True,
         dt_softplus=False,
     ](batch=2, nheads=2, dim=4, ngroups=1)
-    print("✓ Varlen selective state update without D test passed")
 
-    # Test state update without z
+
+fn test_varlen_selective_state_update_without_z() raises:
+    """Test varlen selective state update without z tensor."""
     run_varlen_selective_state_update[
         DType.float32,
         4,
@@ -658,9 +675,10 @@ def main():
         has_dt_bias=True,
         dt_softplus=False,
     ](batch=2, nheads=2, dim=4, ngroups=1)
-    print("✓ Varlen selective state update without z test passed")
 
-    # Test state update with dt_softplus
+
+fn test_varlen_selective_state_update_with_dt_softplus() raises:
+    """Test varlen selective state update with dt softplus activation."""
     run_varlen_selective_state_update[
         DType.float32,
         4,
@@ -669,4 +687,7 @@ def main():
         has_dt_bias=True,
         dt_softplus=True,
     ](batch=2, nheads=2, dim=4, ngroups=1)
-    print("✓ Varlen selective state update with dt_softplus test passed")
+
+
+def main():
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_varlen_selective_scan.mojo
+++ b/max/kernels/test/state_space/test_varlen_selective_scan.mojo
@@ -1,0 +1,662 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from math import exp, exp2, log
+from sys.info import simd_width_of
+
+from layout import (
+    UNKNOWN_VALUE,
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+)
+from layout._fillers import random
+from memory import alloc
+from state_space.varlen_selective_scan import (
+    varlen_selective_scan_fwd_cpu,
+    varlen_selective_state_update_cpu,
+)
+from testing import assert_almost_equal
+
+from utils.index import Index, IndexList
+
+
+# LOG2E constant for converting exp to exp2
+comptime LOG2E = 1.4426950408889634
+comptime MAX_DSTATE = 256
+
+
+@always_inline
+fn softplus_ref(val: Float32) -> Float32:
+    """Reference softplus implementation: log(1 + exp(x))."""
+    if val > 20.0:
+        return val
+    var exp_val = exp(val)
+    var one = Float32(1.0)
+    return log(one + exp_val)
+
+
+@always_inline
+fn sigmoid_ref(val: Float32) -> Float32:
+    """Reference sigmoid implementation."""
+    if val < -20.0:
+        return 0.0
+    var exp_neg = exp(-val)
+    return 1.0 / (1.0 + exp_neg)
+
+
+@always_inline
+fn silu_ref(val: Float32) -> Float32:
+    """Reference SiLU implementation."""
+    if val < -20.0:
+        return 0.0
+    var exp_neg = exp(-val)
+    return val / (1.0 + exp_neg)
+
+
+fn run_varlen_selective_scan_fwd[
+    dtype: DType,
+    has_D: Bool = True,
+    has_z: Bool = True,
+    has_delta_bias: Bool = True,
+    delta_softplus: Bool = False,
+](
+    batch: Int,
+    dim: Int,
+    dstate: Int,
+    ngroups: Int,
+    seq_lengths: IndexList,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test varlen selective scan forward kernel.
+
+    Args:
+        batch: Number of sequences.
+        dim: Hidden dimension.
+        dstate: State dimension.
+        ngroups: Number of groups.
+        seq_lengths: List of sequence lengths for each batch item.
+        rtol: Relative tolerance for numerical comparisons.
+    """
+    if dstate > MAX_DSTATE:
+        return  # Skip if dstate exceeds kernel limit
+
+    # Calculate total_length (sum of all sequence lengths)
+    var total_length = 0
+    for i in range(batch):
+        total_length += seq_lengths[i]
+
+    # Allocate host memory
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_2d = Layout.row_major[2]()
+    comptime layout_1d = Layout(UNKNOWN_VALUE)
+
+    # u: (dim, total_length)
+    var u_heap = alloc[Scalar[dtype]](dim * total_length)
+    var u_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        u_heap, RuntimeLayout[layout_2d].row_major(Index(dim, total_length))
+    )
+
+    # delta: (dim, total_length) - also used as output if no z
+    var delta_heap = alloc[Scalar[dtype]](dim * total_length)
+    var delta_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        delta_heap, RuntimeLayout[layout_2d].row_major(Index(dim, total_length))
+    )
+
+    # A: (dim, dstate)
+    var A_heap = alloc[Scalar[dtype]](dim * dstate)
+    var A_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        A_heap, RuntimeLayout[layout_2d].row_major(Index(dim, dstate))
+    )
+
+    # B: (ngroups, dstate, total_length)
+    var B_heap = alloc[Scalar[dtype]](ngroups * dstate * total_length)
+    var B_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_3d].row_major(
+            Index(ngroups, dstate, total_length)
+        ),
+    )
+
+    # C: (ngroups, dstate, total_length)
+    var C_heap = alloc[Scalar[dtype]](ngroups * dstate * total_length)
+    var C_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_3d].row_major(
+            Index(ngroups, dstate, total_length)
+        ),
+    )
+
+    # D: (dim,) or empty
+    var D_size = dim if has_D else 0
+    var D_heap = alloc[Scalar[dtype]](max(D_size, 1))
+    var D_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        D_heap, RuntimeLayout[layout_1d].row_major(Index(D_size))
+    )
+
+    # z: (dim, total_length) or empty
+    var z_size = dim * total_length if has_z else 0
+    var z_heap = alloc[Scalar[dtype]](max(z_size, 1))
+    var z_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        z_heap,
+        RuntimeLayout[layout_2d].row_major(
+            Index(dim if has_z else 0, total_length if has_z else 0)
+        ),
+    )
+
+    # delta_bias: (dim,) or empty
+    var delta_bias_size = dim if has_delta_bias else 0
+    var delta_bias_heap = alloc[Scalar[dtype]](max(delta_bias_size, 1))
+    var delta_bias_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        delta_bias_heap,
+        RuntimeLayout[layout_1d].row_major(Index(delta_bias_size)),
+    )
+
+    # ssm_states: (batch, dim, dstate) - in/out
+    var ssm_states_heap = alloc[Scalar[dtype]](batch * dim * dstate)
+    var ssm_states_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        ssm_states_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, dstate)),
+    ).fill(0)
+
+    # output: (dim, total_length) - same as delta
+    var output_heap = alloc[Scalar[dtype]](dim * total_length)
+    var output_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        output_heap,
+        RuntimeLayout[layout_2d].row_major(Index(dim, total_length)),
+    ).fill(0)
+
+    # query_start_loc: (batch + 1,) - cumulative sequence lengths
+    var query_start_loc_heap = alloc[Scalar[DType.int32]](batch + 1)
+    var query_start_loc_h = LayoutTensor[DType.int32, layout_1d, MutAnyOrigin](
+        query_start_loc_heap,
+        RuntimeLayout[layout_1d].row_major(Index(batch + 1)),
+    )
+    var cumsum = 0
+    query_start_loc_h.ptr.store(0, Scalar[DType.int32](0))
+    for i in range(batch):
+        cumsum += seq_lengths[i]
+        query_start_loc_h.ptr.store(i + 1, Scalar[DType.int32](cumsum))
+
+    # cache_indices: (batch,) - can be empty or identity mapping
+    var cache_indices_heap = alloc[Scalar[DType.int32]](batch)
+    var cache_indices_h = LayoutTensor[DType.int32, layout_1d, MutAnyOrigin](
+        cache_indices_heap, RuntimeLayout[layout_1d].row_major(Index(batch))
+    )
+    for i in range(batch):
+        cache_indices_h.ptr.store(i, Scalar[DType.int32](i))
+
+    # has_initial_state: (batch,) - can be empty or all False
+    var has_initial_state_heap = alloc[Scalar[DType.bool]](batch)
+    var has_initial_state_h = LayoutTensor[DType.bool, layout_1d, MutAnyOrigin](
+        has_initial_state_heap, RuntimeLayout[layout_1d].row_major(Index(batch))
+    )
+    for i in range(batch):
+        has_initial_state_h.ptr.store(i, Scalar[DType.bool](False))
+
+    # Initialize input data
+    random(u_h)
+    random(delta_h)
+    random(A_h)
+    random(B_h)
+    random(C_h)
+    if has_D:
+        random(D_h)
+    if has_z:
+        random(z_h)
+    if has_delta_bias:
+        random(delta_bias_h)
+
+    # Scale A to be negative for stability
+    for i in range(dim * dstate):
+        var val = A_h.ptr.load(i)
+        A_h.ptr.store(i, Scalar[dtype](Float32(val) * -0.5))
+
+    # Scale delta to be positive
+    for i in range(dim * total_length):
+        var val = delta_h.ptr.load(i)
+        delta_h.ptr.store(i, Scalar[dtype](abs(Float32(val)) * 0.5))
+
+    var u_buf = u_h
+    var delta_buf = delta_h
+    var A_buf = A_h
+    var B_buf = B_h
+    var C_buf = C_h
+    var D_buf = D_h
+    var z_buf = z_h
+    var delta_bias_buf = delta_bias_h
+    var ssm_states_buf = ssm_states_h
+    var output_buf = output_h
+    var query_start_loc_buf = query_start_loc_h
+    var cache_indices_buf = cache_indices_h
+    var has_initial_state_buf = has_initial_state_h
+
+    # Strides for row-major layout using IndexList types
+    var u_strides = IndexList[2](total_length, 1)
+    var delta_strides = IndexList[2](total_length, 1)
+    var A_strides = IndexList[2](dstate, 1)
+    var B_strides = IndexList[3](dstate * total_length, total_length, 1)
+    var C_strides = IndexList[3](dstate * total_length, total_length, 1)
+    var D_strides = IndexList[1](1)
+    var z_strides = IndexList[2](total_length, 1)
+    var delta_bias_strides = IndexList[1](1)
+    var ssm_states_strides = IndexList[3](dim * dstate, dstate, 1)
+    var out_strides = IndexList[2](total_length, 1)
+
+    # Call kernel
+    varlen_selective_scan_fwd_cpu[
+        dtype,
+        u_buf.layout,
+        delta_buf.layout,
+        A_buf.layout,
+        B_buf.layout,
+        C_buf.layout,
+        D_buf.layout,
+        z_buf.layout,
+        delta_bias_buf.layout,
+        ssm_states_buf.layout,
+        output_buf.layout,
+        query_start_loc_buf.layout,
+        cache_indices_buf.layout,
+        has_initial_state_buf.layout,
+    ](
+        dim,
+        dstate,
+        ngroups,
+        batch,
+        Int32(-1),  # pad_slot_id
+        Int8(1) if delta_softplus else Int8(0),
+        u_buf,
+        delta_buf,
+        A_buf,
+        B_buf,
+        C_buf,
+        D_buf,
+        z_buf,
+        delta_bias_buf,
+        ssm_states_buf,
+        output_buf,
+        query_start_loc_buf,
+        cache_indices_buf,
+        has_initial_state_buf,
+        u_strides,
+        delta_strides,
+        A_strides,
+        B_strides,
+        C_strides,
+        D_strides,
+        z_strides,
+        delta_bias_strides,
+        ssm_states_strides,
+        out_strides,
+    )
+
+    # Basic sanity check: output should not be all zeros
+    var has_nonzero = False
+    var output_to_check = z_buf if has_z else output_buf
+    var output_size = dim * total_length
+    for i in range(output_size):
+        if abs(Float32(output_to_check.ptr.load(i))) > 1e-6:
+            has_nonzero = True
+            break
+
+    if not has_nonzero:
+        raise Error(
+            "Output is all zeros - kernel may not be executing correctly"
+        )
+
+    # Cleanup
+    u_heap.free()
+    delta_heap.free()
+    A_heap.free()
+    B_heap.free()
+    C_heap.free()
+    D_heap.free()
+    z_heap.free()
+    delta_bias_heap.free()
+    ssm_states_heap.free()
+    output_heap.free()
+    query_start_loc_heap.free()
+    cache_indices_heap.free()
+    has_initial_state_heap.free()
+
+
+fn run_varlen_selective_state_update[
+    dtype: DType,
+    has_D: Bool = True,
+    has_z: Bool = True,
+    has_dt_bias: Bool = True,
+    dt_softplus: Bool = False,
+](
+    batch: Int,
+    nheads: Int,
+    dim: Int,
+    dstate: Int,
+    ngroups: Int,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test varlen selective state update kernel (single-step, multi-head SSM).
+    """
+    if dstate > MAX_DSTATE:
+        return  # Skip if dstate exceeds kernel limit
+
+    var nheads_ngroups_ratio = nheads // ngroups
+
+    # Allocate host memory
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_2d = Layout.row_major[2]()
+    comptime layout_1d = Layout(UNKNOWN_VALUE)
+
+    # state: (batch, nheads, dim, dstate) - in/out
+    var state_heap = alloc[Scalar[dtype]](batch * nheads * dim * dstate)
+    var state_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        state_heap,
+        RuntimeLayout[layout_4d].row_major(Index(batch, nheads, dim, dstate)),
+    ).fill(0)
+
+    # output: (batch, nheads, dim)
+    var output_heap = alloc[Scalar[dtype]](batch * nheads * dim)
+    var output_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        output_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, nheads, dim)),
+    ).fill(0)
+
+    # x: (batch, nheads, dim)
+    var x_heap = alloc[Scalar[dtype]](batch * nheads * dim)
+    var x_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        x_heap, RuntimeLayout[layout_3d].row_major(Index(batch, nheads, dim))
+    )
+
+    # dt: (batch, nheads, dim)
+    var dt_heap = alloc[Scalar[dtype]](batch * nheads * dim)
+    var dt_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        dt_heap, RuntimeLayout[layout_3d].row_major(Index(batch, nheads, dim))
+    )
+
+    # A: (nheads, dim, dstate)
+    var A_heap = alloc[Scalar[dtype]](nheads * dim * dstate)
+    var A_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        A_heap, RuntimeLayout[layout_3d].row_major(Index(nheads, dim, dstate))
+    )
+
+    # B: (batch, ngroups, dstate)
+    var B_heap = alloc[Scalar[dtype]](batch * ngroups * dstate)
+    var B_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, ngroups, dstate)),
+    )
+
+    # C: (batch, ngroups, dstate)
+    var C_heap = alloc[Scalar[dtype]](batch * ngroups * dstate)
+    var C_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, ngroups, dstate)),
+    )
+
+    # D: (nheads, dim) or empty
+    var D_size = nheads * dim if has_D else 0
+    var D_heap = alloc[Scalar[dtype]](max(D_size, 1))
+    var D_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        D_heap,
+        RuntimeLayout[layout_2d].row_major(
+            Index(nheads if has_D else 0, dim if has_D else 0)
+        ),
+    )
+
+    # z: (batch, nheads, dim) or empty
+    var z_size = batch * nheads * dim if has_z else 0
+    var z_heap = alloc[Scalar[dtype]](max(z_size, 1))
+    var z_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        z_heap,
+        RuntimeLayout[layout_3d].row_major(
+            Index(
+                batch if has_z else 0,
+                nheads if has_z else 0,
+                dim if has_z else 0,
+            )
+        ),
+    )
+
+    # dt_bias: (nheads, dim) or empty
+    var dt_bias_size = nheads * dim if has_dt_bias else 0
+    var dt_bias_heap = alloc[Scalar[dtype]](max(dt_bias_size, 1))
+    var dt_bias_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        dt_bias_heap,
+        RuntimeLayout[layout_2d].row_major(
+            Index(nheads if has_dt_bias else 0, dim if has_dt_bias else 0)
+        ),
+    )
+
+    # state_batch_indices: (batch,) - can be empty or identity
+    var state_batch_indices_heap = alloc[Scalar[DType.int32]](batch)
+    var state_batch_indices_h = LayoutTensor[
+        DType.int32, layout_1d, MutAnyOrigin
+    ](
+        state_batch_indices_heap,
+        RuntimeLayout[layout_1d].row_major(Index(batch)),
+    )
+    for i in range(batch):
+        state_batch_indices_h.ptr.store(i, Scalar[DType.int32](i))
+
+    # Initialize input data
+    random(x_h)
+    random(dt_h)
+    random(A_h)
+    random(B_h)
+    random(C_h)
+    if has_D:
+        random(D_h)
+    if has_z:
+        random(z_h)
+    if has_dt_bias:
+        random(dt_bias_h)
+
+    # Scale A to be negative for stability
+    for i in range(nheads * dim * dstate):
+        var val = A_h.ptr.load(i)
+        A_h.ptr.store(i, Scalar[dtype](Float32(val) * -0.5))
+
+    # Scale dt to be positive
+    for i in range(batch * nheads * dim):
+        var val = dt_h.ptr.load(i)
+        dt_h.ptr.store(i, Scalar[dtype](abs(Float32(val)) * 0.5))
+
+    var state_buf = state_h
+    var output_buf = output_h
+    var x_buf = x_h
+    var dt_buf = dt_h
+    var A_buf = A_h
+    var B_buf = B_h
+    var C_buf = C_h
+    var D_buf = D_h
+    var z_buf = z_h
+    var dt_bias_buf = dt_bias_h
+    var state_batch_indices_buf = state_batch_indices_h
+
+    # Strides for row-major layout using IndexList types
+    var state_strides = IndexList[4](
+        nheads * dim * dstate, dim * dstate, dstate, 1
+    )
+    var x_strides = IndexList[3](nheads * dim, dim, 1)
+    var dt_strides = IndexList[3](nheads * dim, dim, 1)
+    var dt_bias_strides = IndexList[2](dim, 1)
+    var A_strides = IndexList[3](dim * dstate, dstate, 1)
+    var B_strides = IndexList[3](ngroups * dstate, dstate, 1)
+    var C_strides = IndexList[3](ngroups * dstate, dstate, 1)
+    var D_strides = IndexList[2](dim, 1)
+    var z_strides = IndexList[3](nheads * dim, dim, 1)
+    var out_strides = IndexList[3](nheads * dim, dim, 1)
+
+    # Call kernel
+    varlen_selective_state_update_cpu[
+        dtype,
+        state_buf.layout,
+        x_buf.layout,
+        dt_buf.layout,
+        A_buf.layout,
+        B_buf.layout,
+        C_buf.layout,
+        D_buf.layout,
+        z_buf.layout,
+        output_buf.layout,
+        dt_bias_buf.layout,
+        state_batch_indices_buf.layout,
+    ](
+        batch,
+        nheads,
+        dim,
+        dstate,
+        nheads_ngroups_ratio,
+        Int32(-1),  # pad_slot_id
+        Int8(1) if dt_softplus else Int8(0),
+        Int8(1),  # has_state_batch_indices
+        state_buf,
+        x_buf,
+        dt_buf,
+        A_buf,
+        B_buf,
+        C_buf,
+        D_buf,
+        z_buf,
+        output_buf,
+        dt_bias_buf,
+        state_batch_indices_buf,
+        state_strides,
+        x_strides,
+        dt_strides,
+        dt_bias_strides,
+        A_strides,
+        B_strides,
+        C_strides,
+        D_strides,
+        z_strides,
+        out_strides,
+    )
+
+    # Basic sanity check: output should not be all zeros
+    var has_nonzero = False
+    for i in range(batch * nheads * dim):
+        if abs(Float32(output_h.ptr.load(i))) > 1e-6:
+            has_nonzero = True
+            break
+
+    if not has_nonzero:
+        raise Error(
+            "Output is all zeros - kernel may not be executing correctly"
+        )
+
+    # Cleanup
+    state_heap.free()
+    output_heap.free()
+    x_heap.free()
+    dt_heap.free()
+    A_heap.free()
+    B_heap.free()
+    C_heap.free()
+    D_heap.free()
+    z_heap.free()
+    dt_bias_heap.free()
+    state_batch_indices_heap.free()
+
+
+def main():
+    # Test varlen_selective_scan_fwd with equal-length sequences
+    run_varlen_selective_scan_fwd[
+        DType.float32,
+        has_D=True,
+        has_z=True,
+        has_delta_bias=True,
+        delta_softplus=False,
+    ](batch=2, dim=4, dstate=4, ngroups=1, seq_lengths=Index(8, 8))
+    print("✓ Varlen selective scan fwd (equal lengths) test passed")
+
+    # Test varlen_selective_scan_fwd with variable-length sequences
+    run_varlen_selective_scan_fwd[
+        DType.float32,
+        has_D=True,
+        has_z=True,
+        has_delta_bias=True,
+        delta_softplus=False,
+    ](batch=3, dim=4, dstate=4, ngroups=1, seq_lengths=Index(10, 6, 1))
+    print("✓ Varlen selective scan fwd (variable lengths) test passed")
+
+    # Test without D
+    run_varlen_selective_scan_fwd[
+        DType.float32,
+        has_D=False,
+        has_z=True,
+        has_delta_bias=True,
+        delta_softplus=False,
+    ](batch=2, dim=4, dstate=4, ngroups=1, seq_lengths=Index(8, 8))
+    print("✓ Varlen selective scan fwd without D test passed")
+
+    # Test without z
+    run_varlen_selective_scan_fwd[
+        DType.float32,
+        has_D=True,
+        has_z=False,
+        has_delta_bias=True,
+        delta_softplus=False,
+    ](batch=2, dim=4, dstate=4, ngroups=1, seq_lengths=Index(8, 8))
+    print("✓ Varlen selective scan fwd without z test passed")
+
+    # Test with delta_softplus
+    run_varlen_selective_scan_fwd[
+        DType.float32,
+        has_D=True,
+        has_z=True,
+        has_delta_bias=True,
+        delta_softplus=True,
+    ](batch=2, dim=4, dstate=4, ngroups=1, seq_lengths=Index(8, 8))
+    print("✓ Varlen selective scan fwd with delta_softplus test passed")
+
+    # Test varlen_selective_state_update
+    run_varlen_selective_state_update[
+        DType.float32,
+        has_D=True,
+        has_z=True,
+        has_dt_bias=True,
+        dt_softplus=False,
+    ](batch=2, nheads=2, dim=4, dstate=4, ngroups=1)
+    print("✓ Varlen selective state update test passed")
+
+    # Test state update without D
+    run_varlen_selective_state_update[
+        DType.float32,
+        has_D=False,
+        has_z=True,
+        has_dt_bias=True,
+        dt_softplus=False,
+    ](batch=2, nheads=2, dim=4, dstate=4, ngroups=1)
+    print("✓ Varlen selective state update without D test passed")
+
+    # Test state update without z
+    run_varlen_selective_state_update[
+        DType.float32,
+        has_D=True,
+        has_z=False,
+        has_dt_bias=True,
+        dt_softplus=False,
+    ](batch=2, nheads=2, dim=4, dstate=4, ngroups=1)
+    print("✓ Varlen selective state update without z test passed")
+
+    # Test state update with dt_softplus
+    run_varlen_selective_state_update[
+        DType.float32,
+        has_D=True,
+        has_z=True,
+        has_dt_bias=True,
+        dt_softplus=True,
+    ](batch=2, nheads=2, dim=4, dstate=4, ngroups=1)
+    print("✓ Varlen selective state update with dt_softplus test passed")


### PR DESCRIPTION
  ## Summary
  - Add varlen_causal_conv1d kernel for packed sequences
  - Add varlen_selective_scan kernel with cumulative sequence lengths
  - Add CPU and GPU unit tests

  Part of [Tracking] Mamba SSM Architecture Support for MAX #5772

  Depends on #5821

  ## Test plan
  - [x] `./bazelw run //bazel/lint:lint` - Lint passes
  - [x] `./bazelw build //max/kernels/src/state_space:state_space` - Build passes
  - [x] `./bazelw test //max/kernels/test/state_space/...` - CPU tests pass (5/5)
  - [x] `./bazelw test //max/kernels/test/gpu/state_space/...` - GPU tests pass (5/5)
