### PR TITLE
[Models] Add missing normalization to Qwen3 embeddings

### DIFF
--- a/max/python/max/pipelines/architectures/qwen3_embedding/layers/transformer.py
+++ b/max/python/max/pipelines/architectures/qwen3_embedding/layers/transformer.py
@@ -17,10 +17,9 @@ from __future__ import annotations
 from max.dtype import DType
 from max.graph import DeviceRef, TensorType, TensorValue, TensorValueLike, ops
 from max.nn.embedding import Embedding
-from max.nn.layer import Layer, LayerList, Module
+from max.nn.layer import LayerList, Module
 from max.nn.linear import Linear
 from max.nn.rotary_embedding import RotaryEmbedding
-from max.nn.transformer import ReturnHiddenStates
 
 
 class Qwen3EmbeddingTransformerBlock(Module):
@@ -35,9 +34,9 @@ class Qwen3EmbeddingTransformerBlock(Module):
     def __init__(
         self,
         attention: Module,
-        mlp: Layer,
-        attention_norm: Layer,
-        mlp_norm: Layer,
+        mlp: Module,
+        attention_norm: Module,
+        mlp_norm: Module,
         residual_multiplier: float = 1.0,
     ) -> None:
         super().__init__()
@@ -99,11 +98,10 @@ class Qwen3EmbeddingTransformer(Module):
         dim: int,
         n_heads: int,
         layers: list[Qwen3EmbeddingTransformerBlock],
-        norm: Layer,
+        norm: Module,
         output: Linear,  # Still keep for weight sharing, but won't use
         embedding: Embedding,
         rope: RotaryEmbedding,
-        return_hidden_states: ReturnHiddenStates = ReturnHiddenStates.ALL,
         embedding_multiplier: float = 1.0,
         device: DeviceRef = DeviceRef.CPU(),
     ) -> None:
@@ -117,7 +115,6 @@ class Qwen3EmbeddingTransformer(Module):
             output: Output projection (for weight sharing with embedding)
             embedding: Token embedding layer
             rope: Rotary position embedding
-            return_hidden_states: Which hidden states to return
             embedding_multiplier: Multiplier for embeddings (if applicable)
         """
         super().__init__()
@@ -129,7 +126,6 @@ class Qwen3EmbeddingTransformer(Module):
         self.embed_tokens = embedding
         self.embedding_multiplier = embedding_multiplier
         self.rope = rope
-        self.return_hidden_states = return_hidden_states
         self.device = device
 
     def input_types(self) -> tuple[TensorType, ...]:
@@ -155,7 +151,7 @@ class Qwen3EmbeddingTransformer(Module):
         tokens: TensorValueLike,
         input_row_offsets: TensorValue,
         return_n_logits: TensorValue,  # Kept for interface compatibility
-    ) -> tuple[TensorValue, ...]:
+    ) -> TensorValue:
         """Forward pass for embedding generation.
 
         Args:
@@ -164,7 +160,7 @@ class Qwen3EmbeddingTransformer(Module):
             return_n_logits: Number of logits to return (unused for embeddings)
 
         Returns:
-            Tuple containing hidden states based on return_hidden_states setting
+            Hidden states tensor [total_seq_len, hidden_size]
         """
         # Embed tokens
         h = self.embed_tokens(tokens)
@@ -177,19 +173,6 @@ class Qwen3EmbeddingTransformer(Module):
         input_row_offsets_device = input_row_offsets.to(self.device)
         for layer in self.layers:
             h = layer(h, input_row_offsets_device)
-        # For embedding models, we typically return all hidden states
-        # The pooling will be done outside the transformer
-        if self.return_hidden_states == ReturnHiddenStates.ALL:
-            return (h,)
-        elif self.return_hidden_states == ReturnHiddenStates.ALL_NORMALIZED:
-            return (self.norm(h),)
-        elif self.return_hidden_states == ReturnHiddenStates.LAST:
-            # Return last token of each sequence
-            last_h = ops.gather(h, input_row_offsets[1:] - 1, axis=0)
-            return (last_h,)
-        elif self.return_hidden_states == ReturnHiddenStates.LAST_NORMALIZED:
-            last_h = ops.gather(h, input_row_offsets[1:] - 1, axis=0)
-            return (self.norm(last_h),)
-        else:
-            # Default: return all hidden states
-            return (h,)
+        h = self.norm(h)
+
+        return h

--- a/max/python/max/pipelines/architectures/qwen3_embedding/model.py
+++ b/max/python/max/pipelines/architectures/qwen3_embedding/model.py
@@ -32,7 +32,7 @@ from max.nn.kv_cache import KVCacheInputs
 from max.nn.linear import MLP, Linear
 from max.nn.norm import RMSNorm
 from max.nn.rotary_embedding import Llama3RotaryEmbedding
-from max.nn.transformer import ReturnHiddenStates, ReturnLogits
+from max.nn.transformer import ReturnLogits
 from max.pipelines.core import TextContext
 from max.pipelines.lib import (
     CompilationTimer,
@@ -270,7 +270,6 @@ class Qwen3EmbeddingModel(PipelineModel[TextContext]):
             output=output,
             embedding=embedding_layer,
             rope=rope,
-            return_hidden_states=ReturnHiddenStates.ALL,  # Return un-normalized states, pooling+norm happens after
             embedding_multiplier=1.0,
             device=device_refs[0],
         )
@@ -293,15 +292,12 @@ class Qwen3EmbeddingModel(PipelineModel[TextContext]):
         with Graph("qwen3_embedding", input_types=graph_inputs) as graph:
             tokens, input_row_offsets, return_n_logits = graph.inputs
 
-            # Forward pass - returns (hidden_states,)
-            outputs = nn_model(
+            # Forward pass - returns hidden_states
+            hidden_states = nn_model(
                 tokens.tensor,
                 input_row_offsets.tensor,
                 return_n_logits.tensor,
             )
-
-            # Extract hidden states
-            hidden_states = outputs[0]
 
             if self.pipeline_config.model.pool_embeddings:
                 # Apply last token pooling

--- a/max/tests/integration/accuracy/verify_pipelines.py
+++ b/max/tests/integration/accuracy/verify_pipelines.py
@@ -1274,8 +1274,8 @@ PIPELINES = {
             json_file="torch_qwen3_embedding_0.6b_bfloat16_golden.json",
         ),
         relative_tolerance=1.0e-04,
-        absolute_tolerance=4.2e-01,
-        cos_dist_threshold=2.4e-1,
+        absolute_tolerance=4.0e-03,
+        cos_dist_threshold=2.5e-04,
         kl_div_threshold=2.6e-04,
     ),
     # Qwen2.VL-FP8


### PR DESCRIPTION
Small follow-up to #5782 to fix an issue with the Qwen 3 embeddings that I missed in the original PR. The crucial change is calling `norm` on the hidden states before returning them. The other changes are simplifications on the transformer layer as it is specialized for this case.

Applying the norm gets us **much** closer to PyTorch upstream which is reflected in the updated `cos_dist_threshold` values in the verification pipeline going down significantly from `0.24` to `0.00025`.

@k-w-w you might want to have a look as you also reviewed the original PR #5782.

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->
