### PR TITLE
[Kernels] Migrate `kernels/src/nn` core ops off LegacyUnsafePointer (part 1)

### DIFF
--- a/max/kernels/src/nn/mla.mojo
+++ b/max/kernels/src/nn/mla.mojo
@@ -16,9 +16,6 @@ from collections import OptionalReg
 from math import ceildiv, recip
 from nn.mha_utils import DynamicInt
 from math.constants import log2e
-from memory import LegacyUnsafePointer
-
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys import (
     align_of,
     has_nvidia_gpu_accelerator,
@@ -277,7 +274,7 @@ fn flare_mla_decoding[
     var valid_length = LayoutTensor[
         DType.uint32, Layout.row_major(UNKNOWN_VALUE)
     ](
-        UnsafePointer[UInt32](),
+        UnsafePointer[UInt32, MutExternalOrigin](),
         RuntimeLayout[Layout.row_major(UNKNOWN_VALUE)].row_major(Index(0)),
     )
 
@@ -483,7 +480,9 @@ fn flare_mla_decoding_dispatch[
             decoding_warp_split_k=decoding_warp_split_k,
         ]
 
-        comptime nullptr = UnsafePointer[Scalar[accum_type]]()
+        comptime nullptr = UnsafePointer[
+            Scalar[accum_type], MutExternalOrigin
+        ]()
 
         var num_partitions_value: Int = 1
         var q_device = DeviceBuffer[q.dtype](ctx, q.ptr, q.size(), owning=False)
@@ -545,11 +544,11 @@ fn mla_decoding[
     _is_cache_length_accurate: Bool = False,
     decoding_warp_split_k: Bool = False,
 ](
-    q_ptr: UnsafePointer[Scalar[q_type]],
+    q_ptr: UnsafePointer[Scalar[q_type], MutAnyOrigin],
     k: k_t,
-    output_ptr: UnsafePointer[Scalar[output_type]],
-    exp_sum_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()]],
-    qk_max_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()]],
+    output_ptr: UnsafePointer[Scalar[output_type], MutAnyOrigin],
+    exp_sum_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()], MutAnyOrigin],
+    qk_max_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()], MutAnyOrigin],
     scale: Float32,
     batch_size: Int,
     num_partitions: Int,
@@ -709,11 +708,11 @@ fn mla_decoding_single_batch[
     use_score_mod: Bool = False,
     decoding_warp_split_k: Bool = False,
 ](
-    q_ptr: UnsafePointer[Scalar[q_type]],
+    q_ptr: UnsafePointer[Scalar[q_type], MutAnyOrigin],
     k: k_t,
-    output_ptr: UnsafePointer[Scalar[output_type]],
-    exp_sum_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()]],
-    qk_max_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()]],
+    output_ptr: UnsafePointer[Scalar[output_type], MutAnyOrigin],
+    exp_sum_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()], MutAnyOrigin],
+    qk_max_ptr: UnsafePointer[Scalar[get_accum_type[q_type]()], MutAnyOrigin],
     scale: Float32,
     num_keys: UInt,
     num_partitions: UInt,
@@ -1789,11 +1788,11 @@ fn mla_prefill[
     use_score_mod: Bool = False,
     _ndbuffer_mha_operand: Bool = False,
 ](
-    q_ptr: UnsafePointer[Scalar[q_type]],
+    q_ptr: UnsafePointer[Scalar[q_type], MutAnyOrigin],
     k: k_t,
     v: v_t,
     k_rope: k_rope_t,
-    output_ptr: UnsafePointer[Scalar[output_type]],
+    output_ptr: UnsafePointer[Scalar[output_type], MutAnyOrigin],
     scale: Float32,
     batch_size: Int,
     seq_len_arg: Int,
@@ -1918,11 +1917,11 @@ fn mla_prefill_single_batch[
     cache_depth: Int = 576,
     use_score_mod: Bool = False,
 ](
-    q_ptr: UnsafePointer[Scalar[q_type]],
+    q_ptr: UnsafePointer[Scalar[q_type], MutAnyOrigin],
     k: k_t,
     v: v_t,
     k_rope: k_rope_t,
-    output_ptr: UnsafePointer[Scalar[output_type]],
+    output_ptr: UnsafePointer[Scalar[output_type], MutAnyOrigin],
     scale: Float32,
     seq_len: Int,  # valid sequence length i.e. w/o padding.
     max_seq_len: Int,  # sequence length after padding.

--- a/max/kernels/src/nn/softmax.mojo
+++ b/max/kernels/src/nn/softmax.mojo
@@ -12,10 +12,8 @@
 # ===----------------------------------------------------------------------=== #
 
 from math import align_down, ceildiv, exp, exp2, log
-from memory import LegacyUnsafePointer
 from collections import OptionalReg
 
-comptime UnsafePointer = LegacyUnsafePointer[mut=True, ...]
 from sys import align_of, is_amd_gpu, is_nvidia_gpu, simd_width_of
 
 import gpu.primitives.warp as warp
@@ -1133,8 +1131,8 @@ fn _online_softmax_iter_for_mma_output[
     output_reg_tile: LayoutTensor[mut=True, dtype, ...],
     score_reg_tile: LayoutTensor[mut=True, dtype, ...],
     warp_scratch: LayoutTensor[mut=True, dtype, ...],
-    rowmax: UnsafePointer[Scalar[dtype], ...],
-    rowsum: UnsafePointer[Scalar[dtype], ...],
+    rowmax: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    rowsum: UnsafePointer[Scalar[dtype], MutAnyOrigin],
 ):
     comptime num_colwise_warps = block_layout_by_warp.shape[0].value()
     comptime num_rowwise_warps = block_layout_by_warp.shape[1].value()
@@ -1547,10 +1545,12 @@ fn _online_softmax_iter_for_mma_output_split_warp_reduce[
         mut=True, dtype, address_space = AddressSpace.SHARED, ...
     ],
     o_smem_ptr_base: UnsafePointer[
-        Scalar[dtype], address_space = AddressSpace.SHARED, ...
+        Scalar[dtype],
+        MutAnyOrigin,
+        address_space = AddressSpace.SHARED,
     ],
-    rowmax: UnsafePointer[Scalar[dtype], ...],
-    rowsum: UnsafePointer[Scalar[dtype], ...],
+    rowmax: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    rowsum: UnsafePointer[Scalar[dtype], MutAnyOrigin],
 ):
     # Here, we use naming conventions aligning with MHA's
     comptime num_m_mmas = score_layout_by_mma_unit.shape[0].value()

--- a/max/kernels/src/nn/topk.mojo
+++ b/max/kernels/src/nn/topk.mojo
@@ -1216,11 +1216,7 @@ fn _topk_stage2[
         @parameter
         if sampling:
             # Storing the top-K logits in shmem for sampling
-            s_id = (
-                (idxs_sram + vals_smem_size).bitcast[Int]()
-                # comes from external_memory via vals_sram
-                .unsafe_origin_cast[MutExternalOrigin]()
-            )
+            s_id = (idxs_sram + vals_smem_size).bitcast[Int]()
             # The 2* below is for warp align safety
             s_val2 = (s_id + 2 * k_batch).bitcast[Scalar[T]]()
 


### PR DESCRIPTION
Partially fix https://github.com/modular/modular/issues/5675

Already migrated on `main` [57f2f860](https://github.com/modular/modular/commit/57f2f860e509339dd8f4d805bba97c09c778036a):
- broadcast.mojo
- concat.mojo
- irfft.mojo
- normalization.mojo
- pad_gpu.mojo
- pad.mojo
- resize.mojo
- toppminp.mojo

Migrated in this PR:
- moe.mojo
- softmax.mojo
- topk_fi.mojo
- topk.mojo
- toppminp_gpu.mojo
- mla_graph.mojo
- mla.mojo

To migrate in [next PR](https://github.com/modular/modular/pull/5826):
- conv_transpose.mojo
- conv.mojo
