### PR TITLE
perf(weights_registry): O(1) lookup via Dict instead of O(n) linear search

### DIFF
--- a/max/kernels/src/weights_registry/weights_registry.mojo
+++ b/max/kernels/src/weights_registry/weights_registry.mojo
@@ -10,14 +10,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
+"""WeightsRegistry with O(1) lookup.
+
+Performance fix: O(n²) → O(n) for n weights.
+- 14K weights: ~103M comparisons → ~14K lookups
+- Expected speedup: >1000×
+"""
 
 
-@fieldwise_init
 struct WeightsRegistry(ImplicitlyCopyable):
-    """Bag of weights where names[i] names a weight with data weights[i]."""
+    """Bag of weights with O(1) name-based lookup.
 
+    Uses Dict for O(1) lookups instead of O(n) linear search.
+    For 14K weights, this is the difference between minutes and milliseconds.
+    """
+
+    var _lookup: Dict[String, Int]
     var names: List[String]
     var weights: List[OpaquePointer[MutAnyOrigin]]
+
+    fn __init__(out self):
+        """Initialize an empty weights registry."""
+        self._lookup = Dict[String, Int]()
+        self.names = List[String]()
+        self.weights = List[OpaquePointer[MutAnyOrigin]]()
+
+    fn __init__(out self, names: List[String], weights: List[OpaquePointer[MutAnyOrigin]]):
+        """Initialize with existing names and weights.
+
+        Args:
+            names: List of weight names.
+            weights: List of weight pointers.
+        """
+        self._lookup = Dict[String, Int]()
+        self.names = names.copy()
+        self.weights = weights.copy()
+        for i in range(len(self.names)):
+            self._lookup[self.names[i]] = i
 
     fn __copyinit__(out self, existing: Self):
         """Copy an existing weights registry.
@@ -25,12 +54,34 @@ struct WeightsRegistry(ImplicitlyCopyable):
         Args:
             existing: The existing weights registry.
         """
+        self._lookup = Dict[String, Int]()
         self.names = existing.names.copy()
         self.weights = existing.weights.copy()
+        for i in range(len(self.names)):
+            self._lookup[self.names[i]] = i
 
     def __getitem__(self, name: String) -> OpaquePointer[MutAnyOrigin]:
-        for i in range(len(self.names)):
-            if self.names[i] == name:
-                return self.weights[i]
+        """Get weight by name with O(1) lookup.
 
-        raise Error("no weight called " + name + " in weights registry")
+        Args:
+            name: Name of the weight.
+
+        Returns:
+            Pointer to the weight data.
+
+        Raises:
+            Error: If weight name not found.
+        """
+        try:
+            var idx = self._lookup[name]
+            return self.weights[idx]
+        except:
+            raise Error("no weight called " + name + " in weights registry")
+
+    fn __len__(self) -> Int:
+        """Return number of weights."""
+        return len(self.names)
+
+    fn __contains__(self, name: String) -> Bool:
+        """Check if name exists in registry."""
+        return name in self._lookup


### PR DESCRIPTION
## Summary

Replace O(n) linear search in `WeightsRegistry.__getitem__` with O(1) Dict lookup.

**Problem**: With large MoE models (14K+ weights), the O(n²) total complexity caused indefinite hangs during model loading.

**Solution**: Added `Dict[String, Int]` for O(1) name → index lookup while maintaining backward compatibility with existing `names` and `weights` Lists.

## Performance Impact

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Lookup complexity | O(n) | O(1) | - |
| Total for n weights | O(n²) | O(n) | - |
| 14K weights comparisons | ~103M | ~14K | 7,400× |
| Expected load time | minutes/hang | milliseconds | >1000× |

## Testing

- [x] `//max/kernels/src/weights_registry:weights_registry` builds successfully
- [x] `//max/kernels/src/Mogg/MOGGPrimitives:MOGGPrimitives` (dependent module) builds successfully  
- [x] `//max/tests/tests/graph:test_weight` passes
- [x] `//max/tests/tests/nn:test_module` passes
- [x] `//max/tests/tests/nn:test_state_dict` passes

## Breaking Changes

- Removed `@fieldwise_init` decorator (replaced with explicit `__init__` methods)
- The `_lookup` Dict field is now part of the struct

## Context

Fixes #5832

This issue was discovered while attempting to run `nvidia/Qwen3-30B-A3B-NVFP4` (48 layers, 96 experts, 14,355 weights) on DGX Spark (GB10 Blackwell, 128GB unified memory). The model graph built successfully, but `session.load()` hung indefinitely in the weight loading phase.

🤖 Generated with [Claude Code](https://claude.ai/code)