### PR TITLE
[stdlib] fix: Outdated ascii_rjust and ascii_ljust docs

### DIFF
--- a/mojo/stdlib/std/collections/string/string.mojo
+++ b/mojo/stdlib/std/collections/string/string.mojo
@@ -2038,9 +2038,9 @@ struct String(
 
         ```mojo
         var s = String("hello")
-        print(s.rjust(10))        # "     hello"
-        print(s.rjust(10, "*"))   # "*****hello"
-        print(s.rjust(3))         # "hello" (no padding)
+        print(s.ascii_rjust(10))        # "     hello"
+        print(s.ascii_rjust(10, "*"))   # "*****hello"
+        print(s.ascii_rjust(3))         # "hello" (no padding)
         ```
         """
         return self.as_string_slice().ascii_rjust(width, fillchar)
@@ -2068,9 +2068,9 @@ struct String(
 
         ```mojo
         var s = String("hello")
-        print(s.ljust(10))        # "hello     "
-        print(s.ljust(10, "*"))   # "hello*****"
-        print(s.ljust(3))         # "hello" (no padding)
+        print(s.ascii_ljust(10))        # "hello     "
+        print(s.ascii_ljust(10, "*"))   # "hello*****"
+        print(s.ascii_ljust(3))         # "hello" (no padding)
         ```
         """
         return self.as_string_slice().ascii_ljust(width, fillchar)


### PR DESCRIPTION
Docs were referencing eferencing the old rjust and ljust methods.


