### PR TITLE
Add SM121 (GB10 DGX Spark) support for FP4 kernels

### DIFF
--- a/max/kernels/src/linalg/fp4_quantization.mojo
+++ b/max/kernels/src/linalg/fp4_quantization.mojo
@@ -95,7 +95,7 @@ fn quantize_dynamic_scaled_fp4[
     tensor_sf: Float32 = 1.0,  # tensor-wise scale factor
 ) raises:
     __comptime_assert (
-        ctx.default_device_info.compute == B200.compute
+        ctx.default_device_info.compute >= B200.compute
     ), "This kernel is only supported on SM100"
     __comptime_assert in_dtype in (
         DType.bfloat16,
@@ -340,7 +340,7 @@ fn block_scales_interleave_fp4[
     ],
 ) raises:
     __comptime_assert (
-        ctx.default_device_info.compute == B200.compute
+        ctx.default_device_info.compute >= B200.compute
     ), "This kernel is only supported on SM100"
     __comptime_assert scales_dtype in (
         NVFP4_SF_DTYPE,
@@ -634,7 +634,7 @@ fn quantize_dynamic_block_scaled[
     ctx: DeviceContext,
 ) raises:
     __comptime_assert (
-        ctx.default_device_info.compute == B200.compute
+        ctx.default_device_info.compute >= B200.compute
     ), "This kernel is only supported on SM100"
     __comptime_assert in_dtype in (
         DType.bfloat16,
@@ -691,7 +691,7 @@ fn block_scales_interleave[
     ctx: DeviceContext,
 ) raises:
     __comptime_assert (
-        ctx.default_device_info.compute == B200.compute
+        ctx.default_device_info.compute >= B200.compute
     ), "This kernel is only supported on SM100"
     __comptime_assert scales_dtype in (
         NVFP4_SF_DTYPE,
@@ -1134,7 +1134,7 @@ fn block_scaled_matmul[
     ctx: DeviceContext,
 ) raises:
     __comptime_assert (
-        ctx.default_device_info.compute == B200.compute
+        ctx.default_device_info.compute >= B200.compute
     ), "This kernel is only supported on SM100"
 
     __comptime_assert transpose_b, "Only support transposed B"
@@ -1223,7 +1223,7 @@ fn block_scaled_matmul_with_epilogue[
     """
 
     __comptime_assert (
-        ctx.default_device_info.compute == B200.compute
+        ctx.default_device_info.compute >= B200.compute
     ), "This kernel is only supported on SM100"
 
     __comptime_assert transpose_b, "Only support transposed B"

--- a/mojo/stdlib/std/gpu/primitives/warp.mojo
+++ b/mojo/stdlib/std/gpu/primitives/warp.mojo
@@ -42,7 +42,7 @@ from sys import (
     _RegisterPackType,
 )
 from sys._assembly import inlined_assembly
-from sys.info import _is_sm_100x_or_newer, _cdna_4_or_newer
+from sys.info import _is_sm_100x_or_newer, _is_sm_100x, _is_sm_101x, _cdna_4_or_newer
 
 from bit import log2_floor
 from builtin.math import max as _max
@@ -942,7 +942,8 @@ fn prefix_sum[
 
 @always_inline("nodebug")
 fn _has_redux_f32_support[dtype: DType, simd_width: Int]() -> Bool:
-    return _is_sm_100x_or_newer() and dtype == DType.float32 and simd_width == 1
+    # redux.f32 only supported on SM100/SM101 server Blackwell, not SM120/SM121
+    return (_is_sm_100x() or _is_sm_101x()) and dtype == DType.float32 and simd_width == 1
 
 
 @always_inline("nodebug")

--- a/mojo/stdlib/std/sys/info.mojo
+++ b/mojo/stdlib/std/sys/info.mojo
@@ -492,6 +492,12 @@ fn _is_sm_120x() -> Bool:
 
 
 @always_inline("nodebug")
+fn _is_sm_121x() -> Bool:
+    """Returns True for NVIDIA GB10 (DGX Spark) SM121 Blackwell GPU."""
+    return is_nvidia_gpu["sm_121"]() or is_nvidia_gpu["sm_121a"]()
+
+
+@always_inline("nodebug")
 fn _has_blackwell_tcgen05() -> Bool:
     return is_nvidia_gpu["sm_100a"]() or is_nvidia_gpu["sm_101a"]()
 
@@ -518,7 +524,7 @@ fn _is_sm_110x_or_newer() -> Bool:
 
 @always_inline("nodebug")
 fn _is_sm_120x_or_newer() -> Bool:
-    return _is_sm_120x()
+    return _is_sm_120x() or _is_sm_121x()
 
 
 @always_inline("nodebug")


### PR DESCRIPTION
## Summary

This PR enables FP4 tensor core acceleration on NVIDIA GB10 (SM121) GPUs, specifically the DGX Spark.

## Changes

**mojo/stdlib/std/sys/info.mojo:**
- Add `_is_sm_121x()` detection for GB10 DGX Spark
- Update `_is_sm_120x_or_newer()` to include SM121

**mojo/stdlib/std/gpu/primitives/warp.mojo:**
- Exclude SM120/SM121 from `redux.f32` support (instruction only available on SM100/SM101 server Blackwell)

**max/kernels/src/linalg/fp4_quantization.mojo:**
- Change FP4 kernel constraints from `== B200.compute` to `>= B200.compute`

## Testing

All FP4 tests pass on SM121 GB10:

```
============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-8.2.2

test_dynamic_block_scaled_1d1d_matmul_fp4 PASSED
test_quantize_dynamic_block_scaled_fp4 PASSED  
test_block_scales_interleave PASSED

============================== 3 passed in 4.59s ===============================
```

## Hardware

- **GPU**: NVIDIA GB10 (DGX Spark)
- **Compute Capability**: 12.1 (SM121)
- **Theoretical FP4**: ~312 TFLOPS

## Context

Related to issue #5707. While that issue focuses on SM120 (RTX 5090), SM121 (GB10) shares the same FP4 tensor core architecture as SM100/SM101 (B100/B200 server GPUs) and should support these kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)