### PR TITLE
[MAX] Extend Max config system to support PixelGeneration and Diffusers models

### DIFF
--- a/max/python/max/pipelines/lib/config.py
+++ b/max/python/max/pipelines/lib/config.py
@@ -38,6 +38,7 @@ from pydantic import (
 from typing_extensions import Self
 
 from .config_enums import PipelineRole
+from .hf_utils import is_diffusion_pipeline
 from .kv_cache_config import KVCacheConfig
 from .lora_config import LoRAConfig
 from .memory_estimation import MemoryEstimator, to_human_readable_bytes
@@ -1028,6 +1029,11 @@ class PipelineConfig(ConfigFileModel):
         # Resolve final pipeline-specific changes to the config before doing
         # memory estimations.
         arch.pipeline_model.finalize_pipeline_config(self)
+
+        if is_diffusion_pipeline(model_config.huggingface_model_repo):
+            # Skip memory estimation for diffusion pipelines,
+            # since they don't use KV cache.
+            return
 
         MemoryEstimator.estimate_memory_footprint(
             self,

--- a/max/python/max/pipelines/lib/hf_utils.py
+++ b/max/python/max/pipelines/lib/hf_utils.py
@@ -28,7 +28,7 @@ import time
 from dataclasses import dataclass
 from functools import cached_property, lru_cache
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, BinaryIO, cast
 
 import huggingface_hub
 from huggingface_hub import errors as hf_hub_errors
@@ -385,20 +385,18 @@ class HuggingFaceRepo:
 
     @cached_property
     def weight_files(self) -> dict[WeightsFormat, list[str]]:
-        safetensor_search_pattern = "*.safetensors"
-        gguf_search_pattern = "*.gguf"
-        pytorch_search_pattern = "*.bin"
+        safetensor_search_pattern = "**/*.safetensors"
+        gguf_search_pattern = "**/*.gguf"
 
         weight_files = {}
         if self.repo_type == RepoType.local:
             safetensor_paths = glob.glob(
-                os.path.join(self.repo_id, safetensor_search_pattern)
+                os.path.join(self.repo_id, safetensor_search_pattern),
+                recursive=True,
             )
             gguf_paths = glob.glob(
-                os.path.join(self.repo_id, gguf_search_pattern)
-            )
-            pytorch_paths = glob.glob(
-                os.path.join(self.repo_id, pytorch_search_pattern)
+                os.path.join(self.repo_id, gguf_search_pattern),
+                recursive=True,
             )
         elif self.repo_type == RepoType.online:
             fs = huggingface_hub.HfFileSystem()
@@ -408,9 +406,6 @@ class HuggingFaceRepo:
             )
             gguf_paths = cast(
                 list[str], fs.glob(f"{self.repo_id}/{gguf_search_pattern}")
-            )
-            pytorch_paths = cast(
-                list[str], fs.glob(f"{self.repo_id}/{pytorch_search_pattern}")
             )
         else:
             raise ValueError(f"Unsupported repo type: {self.repo_type}")
@@ -465,38 +460,9 @@ class HuggingFaceRepo:
                     ),
                     "rb",
                 ) as file:
-                    # Read the first 8 bytes of the file
-                    length_bytes = file.read(8)
-                    # Interpret the bytes as a little-endian unsigned 64-bit integer
-                    length_of_header = struct.unpack("<Q", length_bytes)[0]
-                    # Read length_of_header bytes
-                    header_bytes = file.read(length_of_header)
-                    # Interpret the bytes as a JSON object
-                    header = json.loads(header_bytes)
-
-                    encoding = None
-                    for weight_value in header.values():
-                        if weight_dtype := weight_value.get("dtype", None):
-                            if weight_dtype == "F32":
-                                supported_encodings.add(
-                                    SupportedEncoding.float32
-                                )
-                            elif weight_dtype == "BF16":
-                                supported_encodings.add(
-                                    SupportedEncoding.bfloat16
-                                )
-                            elif weight_dtype == "F8_E4M3":
-                                supported_encodings.add(
-                                    SupportedEncoding.float8_e4m3fn
-                                )
-                            elif weight_dtype == "U8":
-                                supported_encodings.add(
-                                    SupportedEncoding.float4_e2m1fnx2
-                                )
-                            else:
-                                logger.warning(
-                                    f"unknown dtype found in safetensors file: {weight_dtype}"
-                                )
+                    supported_encodings.update(
+                        self._get_safetensors_encoding(file)
+                    )
 
                 # Workaround for FP8/FP4 models that don't have proper safetensors metadata.
                 # Check the path for fp8/fp4 hints (works for both local paths and HF cache paths
@@ -540,6 +506,18 @@ class HuggingFaceRepo:
                             supported_encodings.add(SupportedEncoding.bfloat16)
                         elif "F32" in params:
                             supported_encodings.add(SupportedEncoding.float32)
+                else:
+                    fs = huggingface_hub.HfFileSystem()
+                    for weight_file in self.weight_files[
+                        WeightsFormat.safetensors
+                    ]:
+                        with fs.open(
+                            f"{self.repo_id}/{weight_file}", "rb"
+                        ) as file:
+                            supported_encodings.update(
+                                self._get_safetensors_encoding(file)
+                            )
+
                 if safetensors_config := self.info.config:
                     if quant_config := safetensors_config.get(
                         "quantization_config"
@@ -550,6 +528,35 @@ class HuggingFaceRepo:
                 raise ValueError(f"Unsupported repo_type: {self.repo_type}")
 
         return list(supported_encodings)
+
+    def _get_safetensors_encoding(self, file: BinaryIO) -> set(
+        SupportedEncoding
+    ):
+        # Read the first 8 bytes of the file
+        length_bytes = file.read(8)
+        # Interpret the bytes as a little-endian unsigned 64-bit integer
+        length_of_header = struct.unpack("<Q", length_bytes)[0]
+        # Read length_of_header bytes
+        header_bytes = file.read(length_of_header)
+        # Interpret the bytes as a JSON object
+        header = json.loads(header_bytes)
+
+        supported_encodings = set([])
+        for weight_value in header.values():
+            if weight_dtype := weight_value.get("dtype", None):
+                if weight_dtype == "F32":
+                    supported_encodings.add(SupportedEncoding.float32)
+                elif weight_dtype == "BF16":
+                    supported_encodings.add(SupportedEncoding.bfloat16)
+                elif weight_dtype == "F8_E4M3":
+                    supported_encodings.add(SupportedEncoding.float8_e4m3fn)
+                elif weight_dtype == "U8":
+                    supported_encodings.add(SupportedEncoding.float4_e2m1fnx2)
+                else:
+                    logger.warning(
+                        f"unknown dtype found in safetensors file: {weight_dtype}"
+                    )
+        return supported_encodings
 
     def _get_gguf_files_for_encoding(
         self, encoding: SupportedEncoding

--- a/max/python/max/pipelines/lib/registry.py
+++ b/max/python/max/pipelines/lib/registry.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
 from .audio_generator_pipeline import AudioGeneratorPipeline
 from .config_enums import RopeType, SupportedEncoding
 from .embeddings_pipeline import EmbeddingsPipeline
-from .hf_utils import HuggingFaceRepo
+from .hf_utils import HuggingFaceRepo, is_diffusion_pipeline
 from .interfaces import ArchConfig, PipelineModel
 from .pipeline_variants.overlap_text_generation import (
     OverlapTextGenerationPipeline,
@@ -357,10 +357,27 @@ class PipelineRegistry:
             The matching SupportedArchitecture or None if no match found.
         """
         # Retrieve model architecture names
-        hf_config = self.get_active_huggingface_config(
-            huggingface_repo=huggingface_repo
-        )
-        architecture_names = getattr(hf_config, "architectures", [])
+        if not is_diffusion_pipeline(huggingface_repo):
+            hf_config = self.get_active_huggingface_config(
+                huggingface_repo=huggingface_repo
+            )
+            architecture_names = getattr(hf_config, "architectures", [])
+        else:
+            diffusers_config = self.get_active_diffusers_config(
+                huggingface_repo=huggingface_repo
+            )
+            if diffusers_config is None:
+                logger.debug(
+                    f"No diffusers_config found for {huggingface_repo.repo_id}"
+                )
+                return None
+            if diffusers_arch := diffusers_config.get("_class_name"):
+                architecture_names = [diffusers_arch]
+            else:
+                logger.debug(
+                    f"No `_class_name` found in diffusers_config for {huggingface_repo.repo_id}"
+                )
+                return None
 
         if not architecture_names:
             logger.debug(


### PR DESCRIPTION
## Overview
This PR extends the existing model_config to allow resolving weight paths for Diffusers models.

## Changes
- Extends `HuggingFaceRepo` to resolve `weight_files` and `supported_encodings` for Diffusers repos.
- Extends `retrieve_architecture` to work with Diffusers models as well.
- Prevents `ValueError` raised when accessing pipeline_config or pipeline_config.model with Diffusers models.