### PR TITLE
[MAX] Extend Max registry system to support PixelGenerationPipeline

### DIFF
--- a/max/python/max/pipelines/lib/registry.py
+++ b/max/python/max/pipelines/lib/registry.py
@@ -35,7 +35,7 @@ from max.interfaces import (
     TextGenerationRequest,
 )
 from max.nn.legacy.kv_cache import KVCacheStrategy
-from max.pipelines.core import (
+from max.pipelines.core import (  # type: ignore[attr-defined] #TODO: can be removed once #5816 is merged.
     PixelContext,
     TextAndVisionContext,
     TextContext,
@@ -56,7 +56,10 @@ from .config_enums import RopeType, SupportedEncoding
 from .embeddings_pipeline import EmbeddingsPipeline
 from .hf_utils import HuggingFaceRepo
 from .interfaces import ArchConfig, PipelineModel
-from .pipeline_variants import PixelGenerationPipeline, TextGenerationPipeline
+from .pipeline_variants import (  # type: ignore[attr-defined] #TODO: can be removed once #5835 is merged.
+    PixelGenerationPipeline,
+    TextGenerationPipeline,
+)
 from .pipeline_variants.overlap_text_generation import (
     OverlapTextGenerationPipeline,
 )
@@ -373,7 +376,7 @@ class PipelineRegistry:
         """
         # Check for diffusers-style model first (via pipeline_config)
         if pipeline_config is not None:
-            diffusers_config = pipeline_config.model.diffusers_config
+            diffusers_config = pipeline_config.model.diffusers_config  # type: ignore[attr-defined] #TODO: can be removed once #5849 is merged.
             if diffusers_config is not None:
                 # Use pipeline_class from model_index.json for architecture lookup
                 arch_name = diffusers_config.pipeline_class
@@ -551,7 +554,7 @@ class PipelineRegistry:
                 f"No architecture found for {pipeline_config.model.model_path}"
             )
 
-        is_diffusers = pipeline_config.model.diffusers_config is not None
+        is_diffusers = pipeline_config.model.diffusers_config is not None  # type: ignore[attr-defined] #TODO: can be removed once #5849 is merged.
 
         # Calculate Max Length (skip for diffusers models)
         huggingface_config = (
@@ -567,10 +570,10 @@ class PipelineRegistry:
 
         tokenizer: PipelineTokenizer[Any, Any, Any]
         if is_diffusers:
-            assert pipeline_config.model.diffusers_config is not None
+            assert pipeline_config.model.diffusers_config is not None  # type: ignore[attr-defined] #TODO: can be removed once #5849 is merged.
             subfolder_2 = (
                 "tokenizer_2"
-                if pipeline_config.model.diffusers_config.components.get(
+                if pipeline_config.model.diffusers_config.components.get(  # type: ignore[attr-defined] #TODO: can be removed once #5849 is merged.
                     "tokenizer_2"
                 )
                 else None
@@ -666,7 +669,7 @@ class PipelineRegistry:
             "tokenizer": typed_tokenizer,
         }
 
-        if pipeline_config.model.diffusers_config is not None:
+        if pipeline_config.model.diffusers_config is not None:  # type: ignore[attr-defined] #TODO: can be removed once #5849 is merged.
             factory_kwargs.pop("weight_adapters")
 
         # If using speculative decoding, add draft model-specific parameters

--- a/max/python/max/pipelines/lib/registry.py
+++ b/max/python/max/pipelines/lib/registry.py
@@ -30,11 +30,16 @@ from max.interfaces import (
     Pipeline,
     PipelineTask,
     PipelineTokenizer,
+    PixelGenerationContext,
     TextGenerationContext,
     TextGenerationRequest,
 )
 from max.nn.legacy.kv_cache import KVCacheStrategy
-from max.pipelines.core import TextAndVisionContext, TextContext
+from max.pipelines.core import (
+    PixelContext,
+    TextAndVisionContext,
+    TextContext,
+)
 from transformers import (
     AutoConfig,
     AutoTokenizer,
@@ -51,10 +56,10 @@ from .config_enums import RopeType, SupportedEncoding
 from .embeddings_pipeline import EmbeddingsPipeline
 from .hf_utils import HuggingFaceRepo
 from .interfaces import ArchConfig, PipelineModel
+from .pipeline_variants import PixelGenerationPipeline, TextGenerationPipeline
 from .pipeline_variants.overlap_text_generation import (
     OverlapTextGenerationPipeline,
 )
-from .pipeline_variants.text_generation import TextGenerationPipeline
 from .speculative_decoding import (
     EAGLESpeculativeDecodingPipeline,
     SpeculativeMethod,
@@ -88,7 +93,10 @@ def _infer_task_from_hf_pipeline_tag(
         "feature-extraction": PipelineTask.EMBEDDINGS_GENERATION,
         "sentence-similarity": PipelineTask.EMBEDDINGS_GENERATION,
         "audio-generation": PipelineTask.AUDIO_GENERATION,
-        # Add more mappings as needed
+        # Diffusion/pixel generation tasks
+        "text-to-image": PipelineTask.PIXEL_GENERATION,
+        "image-to-image": PipelineTask.PIXEL_GENERATION,
+        "image-generation": PipelineTask.PIXEL_GENERATION,
     }
 
     return tag_to_task.get(pipeline_tag)
@@ -104,6 +112,7 @@ def get_pipeline_for_task(
     | type[SpeechTokenGenerationPipeline]
     | type[EAGLESpeculativeDecodingPipeline]
     | type[OverlapTextGenerationPipeline[TextContext]]
+    | type[PixelGenerationPipeline[PixelContext]]
 ):
     if (
         task == PipelineTask.TEXT_GENERATION
@@ -136,7 +145,7 @@ def get_pipeline_for_task(
     elif task == PipelineTask.SPEECH_TOKEN_GENERATION:
         return SpeechTokenGenerationPipeline
     elif task == PipelineTask.PIXEL_GENERATION:
-        raise NotImplementedError("Pixel generation not yet implemented")
+        return PixelGenerationPipeline
 
 
 @dataclass(frozen=False)
@@ -204,11 +213,16 @@ class SupportedArchitecture:
     default_weights_format: WeightsFormat
     """The weights format expected by the `pipeline_model`."""
 
-    context_type: type[TextGenerationContext] | type[EmbeddingsContext]
+    context_type: (
+        type[TextGenerationContext]
+        | type[EmbeddingsContext]
+        | type[PixelGenerationContext]
+    )
     """The context class type that this architecture uses for managing request state and inputs.
 
-    This should be a class (not an instance) that implements either the `TextGenerationContext`
-    or `EmbeddingsContext` protocol, defining how the pipeline processes and tracks requests.
+    This should be a class (not an instance) that implements one of the context protocols:
+    TextGenerationContext, EmbeddingsContext, or PixelGenerationContext, defining how
+    the pipeline processes and tracks requests.
     """
 
     config: ArchConfig | None = None
@@ -335,24 +349,49 @@ class PipelineRegistry:
 
     def retrieve_architecture(
         self,
-        huggingface_repo: HuggingFaceRepo,
+        huggingface_repo: HuggingFaceRepo | None = None,
         use_legacy_module: bool = True,
         task: PipelineTask | None = None,
+        pipeline_config: PipelineConfig | None = None,
     ) -> SupportedArchitecture | None:
-        """Retrieve architecture matching the HuggingFace model config.
+        """Retrieve architecture matching the model config.
 
         Args:
             huggingface_repo: The HuggingFace repository to match against.
+                Required for transformers models, optional for diffusers models.
             use_legacy_module: Whether to use legacy Module architecture (default=True).
                 When True, appends "_Legacy" suffix to find legacy graph-based architecture.
                 When False, uses the standard HuggingFace architecture name for new API.
             task: Optional task to disambiguate when multiple architectures share the same name.
                   If not provided and multiple architectures share the same name, the task will
                   be inferred from the HuggingFace Hub's pipeline_tag.
+            pipeline_config: Optional pipeline config for diffusers-style model lookup.
+                When provided, checks for diffusers_config first.
 
         Returns:
             The matching SupportedArchitecture or None if no match found.
         """
+        # Check for diffusers-style model first (via pipeline_config)
+        if pipeline_config is not None:
+            diffusers_config = pipeline_config.model.diffusers_config
+            if diffusers_config is not None:
+                # Use pipeline_class from model_index.json for architecture lookup
+                arch_name = diffusers_config.pipeline_class
+                if arch_name in self.architectures:
+                    return self.architectures[arch_name]
+                logger.debug(
+                    f"Diffusers architecture '{arch_name}' not registered in REGISTRY"
+                )
+                return None
+
+        # Fall back to transformers (HuggingFace AutoConfig)
+        if huggingface_repo is None:
+            logger.debug(
+                "huggingface_repo not provided and no diffusers_config found, "
+                "cannot retrieve architecture"
+            )
+            return None
+
         # Retrieve model architecture names
         hf_config = self.get_active_huggingface_config(
             huggingface_repo=huggingface_repo
@@ -504,21 +543,57 @@ class PipelineRegistry:
             arch = self.retrieve_architecture(
                 huggingface_repo=pipeline_config.model.huggingface_model_repo,
                 use_legacy_module=pipeline_config.use_legacy_module,
+                pipeline_config=pipeline_config,
             )
 
         if arch is None:
             raise ValueError(
-                f"No architecture found for {pipeline_config.model.huggingface_model_repo.repo_id}"
+                f"No architecture found for {pipeline_config.model.model_path}"
             )
 
-        # Calculate Max Length
-        huggingface_config = pipeline_config.model.huggingface_config
-        max_length = arch.pipeline_model.calculate_max_seq_len(
-            pipeline_config, huggingface_config=huggingface_config
+        is_diffusers = pipeline_config.model.diffusers_config is not None
+
+        # Calculate Max Length (skip for diffusers models)
+        huggingface_config = (
+            None if is_diffusers else pipeline_config.model.huggingface_config
+        )
+        max_length = (
+            None
+            if is_diffusers
+            else arch.pipeline_model.calculate_max_seq_len(
+                pipeline_config, huggingface_config=huggingface_config
+            )
         )
 
         tokenizer: PipelineTokenizer[Any, Any, Any]
-        if (
+        if is_diffusers:
+            assert pipeline_config.model.diffusers_config is not None
+            subfolder_2 = (
+                "tokenizer_2"
+                if pipeline_config.model.diffusers_config.components.get(
+                    "tokenizer_2"
+                )
+                else None
+            )
+            tokenizer = arch.tokenizer(
+                model_path=pipeline_config.model.model_path,
+                pipeline_config=pipeline_config,
+                subfolder="tokenizer",
+                subfolder_2=subfolder_2,
+                revision=pipeline_config.model.huggingface_model_revision,
+                trust_remote_code=pipeline_config.model.trust_remote_code,
+                chat_template=pipeline_config.retrieve_chat_template(),
+                context_validators=arch.context_validators,
+            )
+        # Old Mistral model like Mistral-7B-Instruct-v0.3 uses LlamaTokenizer
+        # and suffers from the whitespace decoding bug. So, we enable the fix
+        # for only MistralModel in order to avoid any issues with performance
+        # for rest of the models. This can be applied more generically once
+        # we have more time verifying this for all the models.
+        # More information:
+        # https://linear.app/modularml/issue/AIPIPE-197/add-support-for-mistral-7b-instruct-v03
+        # TODO: remove this pipeline_model.__name__ check
+        elif (
             arch.pipeline_model.__name__ in ("MistralModel", "Phi3Model")
             and arch.tokenizer is TextTokenizer
         ):
@@ -555,7 +630,6 @@ class PipelineRegistry:
 
         pipeline_class = get_pipeline_for_task(task, pipeline_config)
 
-        # MAX pipeline
         arch: SupportedArchitecture | None = None
         if override_architecture:
             arch = self.architectures[override_architecture]
@@ -563,52 +637,18 @@ class PipelineRegistry:
             arch = self.retrieve_architecture(
                 huggingface_repo=pipeline_config.model.huggingface_model_repo,
                 use_legacy_module=pipeline_config.use_legacy_module,
-                task=task,
+                pipeline_config=pipeline_config,
             )
 
-        # Load HuggingFace Config
-        huggingface_config = pipeline_config.model.huggingface_config
+        if arch is None:
+            raise ValueError(
+                f"No architecture found for {pipeline_config.model.model_path}"
+            )
 
-        # Architecture should not be None here, as the engine is MAX.
-        assert arch is not None
-
-        max_length = arch.pipeline_model.calculate_max_seq_len(
-            pipeline_config, huggingface_config=huggingface_config
+        tokenizer = self.retrieve_tokenizer(
+            pipeline_config, override_architecture
         )
 
-        # Old Mistral model like Mistral-7B-Instruct-v0.3 uses LlamaTokenizer
-        # and suffers from the whitespace decoding bug. So, we enable the fix
-        # for only MistralModel in order to avoid any issues with performance
-        # for rest of the models. This can be applied more generically once
-        # we have more time verifying this for all the models.
-        # More information:
-        # https://linear.app/modularml/issue/AIPIPE-197/add-support-for-mistral-7b-instruct-v03
-        # TODO: remove this pipeline_model.__name__ check
-        if (
-            arch.pipeline_model.__name__ in ("MistralModel", "Phi3Model")
-            and arch.tokenizer is TextTokenizer
-        ):
-            text_tokenizer = cast(type[TextTokenizer], arch.tokenizer)
-            tokenizer = text_tokenizer(
-                pipeline_config.model.model_path,
-                pipeline_config=pipeline_config,
-                revision=pipeline_config.model.huggingface_model_revision,
-                max_length=max_length,
-                trust_remote_code=pipeline_config.model.trust_remote_code,
-                enable_llama_whitespace_fix=True,
-                chat_template=pipeline_config.retrieve_chat_template(),
-                context_validators=arch.context_validators,
-            )
-        else:
-            tokenizer = arch.tokenizer(
-                model_path=pipeline_config.model.model_path,
-                pipeline_config=pipeline_config,
-                revision=pipeline_config.model.huggingface_model_revision,
-                max_length=max_length,
-                trust_remote_code=pipeline_config.model.trust_remote_code,
-                chat_template=pipeline_config.retrieve_chat_template(),
-                context_validators=arch.context_validators,
-            )
         # Cast tokenizer to the proper type for text generation pipeline compatibility
         typed_tokenizer = cast(
             PipelineTokenizer[
@@ -625,6 +665,9 @@ class PipelineRegistry:
             "weight_adapters": arch.weight_adapters,
             "tokenizer": typed_tokenizer,
         }
+
+        if pipeline_config.model.diffusers_config is not None:
+            factory_kwargs.pop("weight_adapters")
 
         # If using speculative decoding, add draft model-specific parameters
         if pipeline_config.draft_model is not None:
@@ -657,56 +700,62 @@ class PipelineRegistry:
 
     def retrieve_context_type(
         self, pipeline_config: PipelineConfig
-    ) -> type[TextGenerationContext] | type[EmbeddingsContext]:
+    ) -> (
+        type[TextGenerationContext]
+        | type[EmbeddingsContext]
+        | type[PixelGenerationContext]
+    ):
         """Retrieve the context class type associated with the architecture for the given pipeline configuration.
 
         The context type defines how the pipeline manages request state and inputs during
         model execution. Different architectures may use different context implementations
-        that adhere to either the TextGenerationContext or EmbeddingsContext protocol.
+        that adhere to the TextGenerationContext, EmbeddingsContext, or PixelGenerationContext
+        protocol.
 
         Args:
             pipeline_config: The configuration for the pipeline.
 
         Returns:
             The context class type associated with the architecture, which implements
-            either the TextGenerationContext or EmbeddingsContext protocol.
+            one of the supported context protocols.
 
         Raises:
-            ValueError: If no supported architecture is found for the given model repository.
+            ValueError: If no supported architecture is found for the given model.
         """
         if arch := self.retrieve_architecture(
             huggingface_repo=pipeline_config.model.huggingface_model_repo,
             use_legacy_module=pipeline_config.use_legacy_module,
+            pipeline_config=pipeline_config,
         ):
             return arch.context_type
 
         raise ValueError(
-            f"MAX Optimized architecture not supported for {pipeline_config.model.huggingface_model_repo.repo_id}"
+            f"MAX Optimized architecture not supported for {pipeline_config.model.model_path}"
         )
 
     def retrieve_pipeline_task(
         self, pipeline_config: PipelineConfig
     ) -> PipelineTask:
-        """
-        Retrieve the pipeline task associated with the architecture for the given pipeline configuration.
+        """Retrieve the pipeline task associated with the architecture for the given pipeline configuration.
 
         Args:
-            pipeline_config (PipelineConfig): The configuration for the pipeline.
+            pipeline_config: The configuration for the pipeline.
 
         Returns:
             PipelineTask: The task associated with the architecture.
 
         Raises:
-            ValueError: If no supported architecture is found for the given model repository.
+            ValueError: If no supported architecture is found for the given model.
         """
         if arch := self.retrieve_architecture(
             huggingface_repo=pipeline_config.model.huggingface_model_repo,
             use_legacy_module=pipeline_config.use_legacy_module,
+            pipeline_config=pipeline_config,
         ):
             return arch.task
 
         raise ValueError(
-            f"MAX Optimized architecture not supported for {pipeline_config.model.huggingface_model_repo.repo_id}"
+            f"MAX Optimized architecture not supported for {pipeline_config.model.model_path}"
         )
 
     def retrieve(

--- a/max/python/max/serve/scheduler/queues.py
+++ b/max/python/max/serve/scheduler/queues.py
@@ -28,6 +28,7 @@ from max.interfaces import (
     PipelineOutput,
     PipelineOutputType,
     PipelineTask,
+    PixelGenerationContext,
     RequestID,
     SchedulerResult,
     TextGenerationContext,
@@ -43,7 +44,9 @@ class SchedulerZmqConfigs:
     def __init__(
         self,
         pipeline_task: PipelineTask,
-        context_type: type[TextGenerationContext] | type[EmbeddingsContext],
+        context_type: type[TextGenerationContext]
+        | type[EmbeddingsContext]
+        | type[PixelGenerationContext],
     ) -> None:
         response_type = pipeline_task.output_type
 

--- a/max/tests/tests/pipelines/lib/test_registry_diffusers.py
+++ b/max/tests/tests/pipelines/lib/test_registry_diffusers.py
@@ -1,0 +1,225 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2025, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Tests for PipelineRegistry with diffusers models."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from max.graph.weights import WeightsFormat
+from max.interfaces import PipelineTask
+from max.nn.legacy.kv_cache import KVCacheStrategy
+from max.pipelines.lib import (
+    PixelGenerationConfig,
+    SupportedEncoding,
+)
+from max.pipelines.lib.config_enums import RopeType
+from max.pipelines.lib.registry import (
+    PipelineRegistry,
+    SupportedArchitecture,
+)
+
+
+def create_diffusers_model_structure(
+    tmp_path: Path,
+    pipeline_class: str = "FluxPipeline",
+) -> Path:
+    """Create a mock diffusers model directory structure."""
+    model_index: dict[str, Any] = {
+        "_class_name": pipeline_class,
+        "_diffusers_version": "0.30.0",
+        "transformer": ["diffusers", "FluxTransformer2DModel"],
+        "vae": ["diffusers", "AutoencoderKL"],
+        "tokenizer": ["transformers", "CLIPTokenizer"],
+    }
+    (tmp_path / "model_index.json").write_text(json.dumps(model_index))
+
+    for component_name in ["transformer", "vae", "tokenizer"]:
+        (tmp_path / component_name).mkdir(exist_ok=True)
+
+    return tmp_path
+
+
+def create_mock_architecture(
+    name: str,
+    task: PipelineTask = PipelineTask.TEXT_GENERATION,
+) -> SupportedArchitecture:
+    """Create a mock SupportedArchitecture for testing."""
+    mock_pipeline_model = MagicMock()
+    mock_pipeline_model.calculate_max_seq_len = MagicMock(return_value=2048)
+
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.return_value = MagicMock(eos=49407)
+
+    return SupportedArchitecture(
+        name=name,
+        example_repo_ids=[f"test/{name.lower()}"],
+        default_encoding=SupportedEncoding.bfloat16,
+        supported_encodings={
+            SupportedEncoding.bfloat16: [KVCacheStrategy.PAGED],
+        },
+        pipeline_model=mock_pipeline_model,
+        task=task,
+        tokenizer=mock_tokenizer,
+        context_type=MagicMock(),
+        default_weights_format=WeightsFormat.safetensors,
+        rope_type=RopeType.none,
+    )
+
+
+def test_retrieve_architecture_with_diffusers_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test that retrieve_architecture uses diffusers_config when available."""
+    monkeypatch.setenv("MODULAR_PIPELINE_DEFER_RESOLVE", "true")
+    create_diffusers_model_structure(tmp_path, pipeline_class="FluxPipeline")
+
+    flux_arch = create_mock_architecture(
+        "FluxPipeline", task=PipelineTask.PIXEL_GENERATION
+    )
+    registry = PipelineRegistry([flux_arch])
+
+    config = PixelGenerationConfig(model={"model_path": str(tmp_path)})
+
+    arch = registry.retrieve_architecture(pipeline_config=config)
+
+    assert arch is not None
+    assert arch.name == "FluxPipeline"
+    assert arch.task == PipelineTask.PIXEL_GENERATION
+
+
+def test_retrieve_pipeline_task_returns_pixel_generation_for_diffusers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test retrieve_pipeline_task returns PIXEL_GENERATION for diffusers."""
+    monkeypatch.setenv("MODULAR_PIPELINE_DEFER_RESOLVE", "true")
+    create_diffusers_model_structure(tmp_path, pipeline_class="FluxPipeline")
+
+    flux_arch = create_mock_architecture(
+        "FluxPipeline", task=PipelineTask.PIXEL_GENERATION
+    )
+    registry = PipelineRegistry([flux_arch])
+
+    config = PixelGenerationConfig(model={"model_path": str(tmp_path)})
+
+    task = registry.retrieve_pipeline_task(config)
+
+    assert task == PipelineTask.PIXEL_GENERATION
+
+
+def test_retrieve_context_type_for_diffusers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test retrieve_context_type returns correct context for diffusers models."""
+    monkeypatch.setenv("MODULAR_PIPELINE_DEFER_RESOLVE", "true")
+    create_diffusers_model_structure(tmp_path, pipeline_class="FluxPipeline")
+
+    mock_context_type = MagicMock()
+    flux_arch = create_mock_architecture(
+        "FluxPipeline", task=PipelineTask.PIXEL_GENERATION
+    )
+    # Override the context_type with the mock
+    flux_arch.context_type = mock_context_type
+
+    registry = PipelineRegistry([flux_arch])
+
+    config = PixelGenerationConfig(model={"model_path": str(tmp_path)})
+
+    context_type = registry.retrieve_context_type(config)
+
+    assert context_type is mock_context_type
+
+
+def test_retrieve_factory_returns_tokenizer_from_architecture_for_diffusers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test retrieve_factory returns tokenizer from architecture for diffusers."""
+    monkeypatch.setenv("MODULAR_PIPELINE_DEFER_RESOLVE", "true")
+    create_diffusers_model_structure(tmp_path, pipeline_class="FluxPipeline")
+
+    # Create a mock tokenizer that the architecture will provide
+    expected_tokenizer = MagicMock()
+    expected_tokenizer.eos = 49407
+
+    flux_arch = create_mock_architecture(
+        "FluxPipeline", task=PipelineTask.PIXEL_GENERATION
+    )
+    # Override the tokenizer to return our expected tokenizer
+    flux_arch.tokenizer = MagicMock(return_value=expected_tokenizer)
+
+    registry = PipelineRegistry([flux_arch])
+
+    config = PixelGenerationConfig(model={"model_path": str(tmp_path)})
+
+    tokenizer, factory = registry.retrieve_factory(
+        config, task=PipelineTask.PIXEL_GENERATION
+    )
+
+    # Tokenizer should be the one returned by arch.tokenizer
+    assert tokenizer is expected_tokenizer
+    # Factory should be callable
+    assert callable(factory)
+    # Verify arch.tokenizer was called with expected arguments
+    flux_arch.tokenizer.assert_called_once()
+
+
+def test_retrieve_factory_returns_pixel_generation_pipeline_for_diffusers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test retrieve_factory returns PixelGenerationPipeline for diffusers."""
+    from functools import partial
+
+    monkeypatch.setenv("MODULAR_PIPELINE_DEFER_RESOLVE", "true")
+    create_diffusers_model_structure(tmp_path, pipeline_class="FluxPipeline")
+
+    flux_arch = create_mock_architecture(
+        "FluxPipeline", task=PipelineTask.PIXEL_GENERATION
+    )
+    registry = PipelineRegistry([flux_arch])
+
+    config = PixelGenerationConfig(model={"model_path": str(tmp_path)})
+
+    _, factory = registry.retrieve_factory(
+        config, task=PipelineTask.PIXEL_GENERATION
+    )
+
+    # Factory should be a partial function wrapping PixelGenerationPipeline
+    assert isinstance(factory, partial)
+    # The func should be PixelGenerationPipeline (with type parameter)
+    assert factory.func.__name__ == "PixelGenerationPipeline"
+
+
+def test_retrieve_architecture_returns_none_for_unregistered_diffusers(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Test retrieve_architecture returns None for unregistered diffusers arch."""
+    monkeypatch.setenv("MODULAR_PIPELINE_DEFER_RESOLVE", "true")
+    create_diffusers_model_structure(
+        tmp_path, pipeline_class="UnregisteredPipeline"
+    )
+
+    # Register a different architecture
+    flux_arch = create_mock_architecture(
+        "FluxPipeline", task=PipelineTask.PIXEL_GENERATION
+    )
+    registry = PipelineRegistry([flux_arch])
+
+    config = PixelGenerationConfig(model={"model_path": str(tmp_path)})
+
+    arch = registry.retrieve_architecture(pipeline_config=config)
+
+    assert arch is None

--- a/max/tests/tests/pipelines/lib/test_registry_diffusers.py
+++ b/max/tests/tests/pipelines/lib/test_registry_diffusers.py
@@ -23,7 +23,7 @@ import pytest
 from max.graph.weights import WeightsFormat
 from max.interfaces import PipelineTask
 from max.nn.legacy.kv_cache import KVCacheStrategy
-from max.pipelines.lib import (
+from max.pipelines.lib import (  # type: ignore[attr-defined]
     PixelGenerationConfig,
     SupportedEncoding,
 )


### PR DESCRIPTION
## Overview
This PR extends the Registry system to support `PixelGenerationPipeline`, including updated registry logic.

## Changes
- Update registry handling to accommodate `PixelGenerationPipeline`
- Add comprehensive tests in max/tests/tests/pipelines/lib/test_registry_diffusers.py

## Usage Example
```
pipeline_config = PixelGenerationConfig(model_path=model_id_for_diffusers_model)
pipeline_task = PIPELINE_REGISTRY.retrieve_pipeline_task(pipeline_config)
tokenizer, model_factory = PIPELINE_REGISTRY.retrieve_factory(
    pipeline_config,
    task=pipeline_task,
)
pixel_generation_pipeline = model_factory()
```