### PR TITLE
[stdlib] Add `Writable.estimate_bytes_to_write()` with a default implementation

### DIFF
--- a/mojo/stdlib/benchmarks/README.md
+++ b/mojo/stdlib/benchmarks/README.md
@@ -21,7 +21,7 @@ If you want to just compile and run all the benchmarks as-is,
 we need to execute the following command:
 
 ```bash
-./bazelw test mojo/stdlib/benchmarks/... --local_test_jobs=1 --test_output=all
+./bazelw test mojo/stdlib/benchmarks/... --local_test_jobs=1 --test_output=all --cache_test_results=no
 ```
 
 This script builds the open source `std.mojopkg` and then executes

--- a/mojo/stdlib/benchmarks/collections/bench_string.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_string.mojo
@@ -391,6 +391,30 @@ fn bench_string_repr[
 
 
 # ===-----------------------------------------------------------------------===#
+# Benchmark string write int
+# ===-----------------------------------------------------------------------===#
+
+
+@parameter
+fn bench_string_write_int[short: Bool](mut b: Bencher) raises:
+    @always_inline
+    fn call_fn() unified {read}:
+        for _ in range(1000 if not short else 1_000_000):
+            # NOTE: we are keeping the string allocation in the loop to take
+            # that overhead into account
+            var res: String
+
+            @parameter
+            if short:
+                res = String.write(UInt8(123))
+            else:  # more than 24 bytes
+                res = String.write(UInt64.MAX)
+            keep(res)
+
+    b.iter(call_fn)
+
+
+# ===-----------------------------------------------------------------------===#
 # Benchmark Main
 # ===-----------------------------------------------------------------------===#
 def main():
@@ -495,6 +519,12 @@ def main():
     )
     m.bench_function[bench_string_join[False]](
         BenchId(String("bench_string_join_long"))
+    )
+    m.bench_function[bench_string_write_int[True]](
+        BenchId(String("bench_string_write_int_short"))
+    )
+    m.bench_function[bench_string_write_int[False]](
+        BenchId(String("bench_string_write_int_long"))
     )
 
     # NOTE: do not delete this. This is supposed to measure the average for

--- a/mojo/stdlib/std/builtin/simd.mojo
+++ b/mojo/stdlib/std/builtin/simd.mojo
@@ -40,6 +40,7 @@ components, including tensor operations, linear algebra routines, and
 domain-specific libraries for machine learning and scientific computing.
 """
 
+from bit import next_power_of_two
 import math
 from collections import InlineArray
 from hashlib.hasher import Hasher
@@ -73,7 +74,7 @@ from bit import bit_width, byte_swap, pop_count
 from builtin._format_float import _write_float
 from builtin.device_passable import DevicePassable
 from builtin.format_int import _write_int
-from math import DivModable, Powable
+from math import DivModable, Powable, log10, ceil
 from documentation import doc_private
 from memory import bitcast, memcpy, pack_bits
 from python import ConvertibleToPython, Python, PythonObject
@@ -89,6 +90,7 @@ from utils.numerics import max_or_inf as _max_or_inf
 from utils.numerics import min_finite as _min_finite
 from utils.numerics import min_or_neg_inf as _min_or_neg_inf
 from utils.numerics import nan as _nan
+from format._utils import _TotalWritableBytes
 
 from .dtype import (
     _integral_type_of,
@@ -2271,6 +2273,119 @@ struct SIMD[dtype: DType, size: Int](
             _write_scalar(writer, element)
         writer.write_string(")")
 
+    fn estimate_bytes_to_write(self) -> Int:
+        """Estimate the total bytes to write the type into a writer.
+
+        Returns:
+            The estimated bytes needed to write the type into a writer.
+        """
+
+        @parameter
+        if not Self.dtype.is_integral():
+            var total_bytes = _TotalWritableBytes()
+            self.write_to(total_bytes)
+            return total_bytes.size
+        else:
+            comptime extra = (2 * Self.size) if Self.size > 1 else 0
+            comptime is_unsigned = Self.dtype.is_unsigned()
+            comptime MAX = Scalar[Self.dtype].MAX
+            comptime f_MAX = MAX.cast[DType.float64]()
+            comptime log10_f_MAX = Int(ceil(log10(f_MAX)))
+            comptime max_digits_size[offset: Int] = next_power_of_two(
+                log10_f_MAX - offset
+            )
+
+            fn _get_max_digits[
+                offset: Int = 0
+            ](out res: SIMD[Self.dtype, max_digits_size[offset]]):
+                res = {MAX}
+
+                var idx = 0
+
+                for i in range(offset, offset + type_of(res).size):
+                    if log10_f_MAX >= i + 1:
+                        res[idx] = Scalar[Self.dtype](10) ** i - 1
+                        idx += 1
+
+            @parameter
+            fn _full_digits[offset: Int = 0]() -> Int:
+                var abs_v: Self
+
+                @parameter
+                if is_unsigned:
+                    abs_v = self
+                else:
+                    abs_v = abs(self + self.eq(Self.MIN).cast[Self.dtype]())
+
+                var count = offset + extra
+
+                @parameter
+                if bit_width_of[Self.dtype]() <= 64:
+                    comptime max_digits = _get_max_digits[offset]()
+
+                    @parameter
+                    for i in range(Self.size):
+                        count += max_digits.lt(abs_v[i]).reduce_bit_count()
+                else:  # 128 and 256 bit integers would take 1KiB+
+                    var max_digit = Self(10) ** offset
+
+                    @parameter
+                    for i in range(offset, max_digits_size[0]):
+
+                        @parameter
+                        if log10_f_MAX < i + 1:
+                            break
+                        count += max_digit.le(abs_v).reduce_bit_count()
+                        max_digit *= 10
+
+                return count + self.le(0).reduce_bit_count()
+
+            @parameter
+            if bit_width_of[Self.dtype]() <= 16 or Self.size > 1:
+                return _full_digits()
+            else:
+                # NOTE: We can take advantage of 4 facts:
+                # 1. We are human and our measurement systems don't tend towards
+                # numbers bigger than 10_000
+                # 2. They can be casted to [u]int16 and use a size of 4 which
+                # only requires a machine simd width of 64 bits
+                # 3. We can lower latecy by letting the branch predictor do its
+                # job, instead of brute-forcing all possible digits
+                # 4. After this comparison 32bit integers need only 8 digit
+                # comparisons instead of 16 and 64bit need only 16 instead of 32
+                var comp: Bool
+
+                @parameter
+                if is_unsigned:
+                    comp = self < 10_000
+                else:
+                    comp = Self(-10_000) < self < Self(10_000)
+                if not comp:
+                    return _full_digits[4]()
+                else:
+                    comptime dt = DType.uint16 if is_unsigned else DType.int16
+                    comptime max_digits = SIMD[dt, 4](0, 10, 100, 1000)
+                    var vec = self.cast[dt]()
+                    var abs_v: type_of(vec)
+
+                    @parameter
+                    if is_unsigned:
+                        abs_v = vec
+                    else:
+                        abs_v = abs(vec)
+
+                    var count = 0
+
+                    @parameter
+                    for i in range(Self.size):
+                        count += max_digits.le(abs_v[i]).reduce_bit_count()
+
+                    @parameter
+                    if is_unsigned:
+                        return count
+                    else:
+                        return count + vec.lt(0).reduce_bit_count()
+
     @always_inline
     fn to_bits[
         _dtype: DType = _uint_type_of_width[bit_width_of[Self.dtype]()]()
@@ -3051,17 +3166,14 @@ struct SIMD[dtype: DType, size: Int](
         ), "Expected either integral or bool type"
 
         @parameter
-        if Self.dtype == DType.bool:
-
-            @parameter
-            if Self.size == 1:
-                return Int(self)
+        if Self.dtype == DType.bool and Self.size == 1:
+            return Int(self)
+        elif Self.dtype == DType.bool:
+            if is_compile_time():  # FIXME(#5855): remove this workaround
+                return self.cast[DType.uint8]().reduce_bit_count()
             else:
-                var packed_mask = pack_bits(
-                    rebind[SIMD[DType.bool, Self.size]](self)
-                )
-                var count = pop_count(packed_mask)
-                return Int(count)
+                var s = self._refine[DType.bool, Self.size]()
+                return Int(pop_count(pack_bits(s)))
         else:
             return Int(pop_count(self).reduce_add())
 

--- a/mojo/stdlib/std/builtin/variadics.mojo
+++ b/mojo/stdlib/std/builtin/variadics.mojo
@@ -1040,6 +1040,42 @@ struct VariadicPack[
                 self[i].write_to(writer)
         writer.write_string(end)
 
+    fn _estimate_bytes_to_write[
+        O1: ImmutOrigin = StaticConstantOrigin,
+        O2: ImmutOrigin = StaticConstantOrigin,
+        O3: ImmutOrigin = StaticConstantOrigin,
+    ](
+        self: VariadicPack[_, Writable, ...],
+        start: StringSlice[O1] = rebind[StringSlice[O1]](StaticString("")),
+        end: StringSlice[O2] = rebind[StringSlice[O2]](StaticString("")),
+        sep: StringSlice[O3] = rebind[StringSlice[O3]](StaticString(", ")),
+    ) -> Int:
+        """Estimate the total bytes to write the type into a writer.
+
+        Parameters:
+            O1: The origin of the open `StringSlice`.
+            O2: The origin of the close `StringSlice`.
+            O3: The origin of the separator `StringSlice`.
+
+        Args:
+            start: The starting delimiter.
+            end: The ending delimiter.
+            sep: The separator between items.
+
+        Returns:
+            The estimated bytes needed to write the type into a writer.
+        """
+        var res = start.byte_length()
+
+        @parameter
+        if self.__len__() > 1:
+            res += (self.__len__() - 1) * sep.byte_length()
+
+        @parameter
+        for i in range(self.__len__()):
+            res += self[i].estimate_bytes_to_write()
+        return res + end.byte_length()
+
 
 # ===-----------------------------------------------------------------------===#
 # VariadicReduce

--- a/mojo/stdlib/std/format/__init__.mojo
+++ b/mojo/stdlib/std/format/__init__.mojo
@@ -82,7 +82,7 @@ from reflection import (
     get_type_name,
 )
 from reflection.type_info import _unqualified_type_name
-
+from format._utils import _TotalWritableBytes
 
 # ===-----------------------------------------------------------------------===#
 # Writer
@@ -255,6 +255,24 @@ trait Writable(ImplicitlyDestructible):
             field.write_repr_to(writer)
 
         _reflection_write_to[f=call_write_repr_to](self, writer)
+
+    @always_inline
+    fn estimate_bytes_to_write(self) -> Int:
+        """Estimate the total bytes to write the type into a writer.
+
+        Returns:
+            The estimated bytes needed to write the type into a writer.
+
+        Notes:
+            By default this function runs the type's `write_to` function. If
+            doing that is not cheap for a given type, consider writing a faster
+            size estimation function instead.
+            The estimates should be as conservative as possible to avoid
+            over-allocation.
+        """
+        var total_bytes = _TotalWritableBytes()
+        self.write_to(total_bytes)
+        return total_bytes.size
 
 
 @always_inline

--- a/mojo/stdlib/std/format/_utils.mojo
+++ b/mojo/stdlib/std/format/_utils.mojo
@@ -536,6 +536,7 @@ struct _TotalWritableBytes(Writer):
             for i in range(1, length):
                 self.write(sep, values[i])
 
+    @always_inline
     fn write_string(mut self, string: StringSlice):
         self.size += string.byte_length()
 

--- a/mojo/stdlib/std/math/math.mojo
+++ b/mojo/stdlib/std/math/math.mojo
@@ -2198,6 +2198,9 @@ fn log10[
     elif is_apple_gpu():
         return _llvm_unary_fn["llvm.air.log10"](x)
 
+    if is_compile_time():
+        return _llvm_unary_fn["llvm.log10"](x)
+
     return _call_libm["log10"](x)
 
 

--- a/mojo/stdlib/std/memory/unsafe.mojo
+++ b/mojo/stdlib/std/memory/unsafe.mojo
@@ -113,7 +113,8 @@ fn bitcast[
 
 
 @always_inline("builtin")
-fn _uint(n: Int) -> DType:
+fn _uint[n: Int]() -> DType:
+    __comptime_assert n <= 256, "No dtype bigger than 256 is available"
     # fmt: off
     return (
         DType._uint1 if n == 1 else
@@ -151,7 +152,7 @@ fn _llvm_bitwidth(dtype: DType) -> Int:
 fn pack_bits[
     src_width: Int,
     //,
-    dtype: DType = _uint(src_width),
+    dtype: DType = _uint[src_width](),
     width: Int = 1,
 ](val: SIMD[DType.bool, src_width]) -> SIMD[dtype, width]:
     """Packs a SIMD vector of `bool` values into an integer.

--- a/mojo/stdlib/test/builtin/test_simd.mojo
+++ b/mojo/stdlib/test/builtin/test_simd.mojo
@@ -1681,8 +1681,12 @@ def test_reduce():
 
 
 def test_reduce_bit_count():
-    var int_0xFFFF = Int32(0xFFFF)
-    assert_equal(int_0xFFFF.reduce_bit_count(), 16)
+    assert_equal(UInt8.MAX.reduce_bit_count(), 8)
+    assert_equal(UInt16.MAX.reduce_bit_count(), 16)
+    assert_equal(UInt32.MAX.reduce_bit_count(), 32)
+    assert_equal(UInt64.MAX.reduce_bit_count(), 64)
+    assert_equal(UInt128.MAX.reduce_bit_count(), 128)
+    assert_equal(UInt256.MAX.reduce_bit_count(), 256)
 
     var int_iota8 = SIMD[DType.int32, 8](0, 1, 2, 3, 4, 5, 6, 7)
     assert_equal(int_iota8.reduce_bit_count(), 12)
@@ -2667,6 +2671,46 @@ def test_float8_e8m0fnu_cast_from_float32():
     randn(h_A.unsafe_ptr(), size=1)
     # Simply verify that cast doesn't error.
     _ = h_A[0].cast[DType.float8_e8m0fnu]()
+
+
+def test_estimate_bytes_to_write():
+    def _test[dtype: DType]():
+        @parameter
+        for size in [1, 2, 4, 8]:
+            comptime S = SIMD[dtype, size]
+            for i in range(min(Int(Scalar[dtype].MAX), 1000)):
+                assert_equal(
+                    S(i).estimate_bytes_to_write(), String(S(i)).byte_length()
+                )
+
+            comptime length_min = String(S.MIN).byte_length()
+            comptime length_max = String(S.MAX).byte_length()
+
+            assert_equal(
+                S.MAX.estimate_bytes_to_write(), String(S.MAX).byte_length()
+            )
+
+            @parameter
+            if dtype.is_signed():
+                assert_equal(
+                    S(-1).estimate_bytes_to_write(), String(S(-1)).byte_length()
+                )
+                assert_equal(
+                    S.MIN.estimate_bytes_to_write(), String(S.MIN).byte_length()
+                )
+
+    _test[DType.uint8]()
+    _test[DType.int8]()
+    _test[DType.uint16]()
+    _test[DType.int16]()
+    _test[DType.uint32]()
+    _test[DType.int32]()
+    _test[DType.uint64]()
+    _test[DType.int64]()
+    _test[DType.uint128]()
+    _test[DType.int128]()
+    _test[DType.uint256]()
+    _test[DType.int256]()
 
 
 def main():

--- a/mojo/stdlib/test/format/test_format.mojo
+++ b/mojo/stdlib/test/format/test_format.mojo
@@ -190,5 +190,12 @@ def test_format_comptime_does_not_allocate():
     assert_false(ALLOC_FUNC in info)
 
 
+def test_estimate_bytes_to_write():
+    var size = "SimplePoint(x=0, y=9)".byte_length()
+    assert_equal(SimplePoint(0, 9).estimate_bytes_to_write(), size)
+    size = "SimplePoint(x=100, y=999)".byte_length()
+    assert_equal(SimplePoint(100, 999).estimate_bytes_to_write(), size)
+
+
 def main():
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Part of #4249. This will enable every `Writable` type to implement a faster size estimation function in cases where calling `self.write_to(writer)` is expensive. It will also allow other `Writer` types like string to previously reserve the necessary buffer size, enabling equivalent optimizations to what was done by using the `_TotalWritableBytes` internal tool.

This should eventually be extended to enable one to pass the format specification and calculate the necessary buffer size according to it as well.

This also adds integer write size estimation size for `SIMD` as a proof of the improvements this enables

## Benchmark results

CPU: Intel® Core™ i7-7700HQ

|name | old value (ms) | new value (ms) | markdown perc | magnitude|
|-- | -- | -- | -- | -- |
|bench_string_write_int_short | 17.0325 | 17.2421 | -0.0123 | 0.9878|
|bench_string_write_int_long | 37.1422 | 0.0881 | 0.9976 | 421.5114|

