### PR TITLE
[docs] fix: wrong v0.26.1 release date in changelog-released.md

### DIFF
--- a/mojo/docs/changelog-released.md
+++ b/mojo/docs/changelog-released.md
@@ -16,7 +16,7 @@ This version is still a work in progress.
 
 <!-- INSERT HERE : This line is required for post-process-docs.py -->
 
-## v0.26.1 (2025-01-29)
+## v0.26.1 (2026-01-29)
 
 ### Documentation {#26-1-documentation}
 


### PR DESCRIPTION
Here the year is entered as 2025 which is wrong:
https://github.com/modular/modular/blob/main/mojo/docs/changelog-released.md#v0261-2025-01-29