### PR TITLE
[stdlib] add `downcast` parametric alias to stdlib prelude

### DIFF
--- a/mojo/stdlib/std/builtin/device_passable.mojo
+++ b/mojo/stdlib/std/builtin/device_passable.mojo
@@ -12,7 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 
 from sys.intrinsics import _type_is_eq
-from builtin.rebind import downcast
 
 
 trait DevicePassable:

--- a/mojo/stdlib/std/builtin/variadics.mojo
+++ b/mojo/stdlib/std/builtin/variadics.mojo
@@ -16,7 +16,6 @@ These are Mojo built-ins, so you don't need to import them.
 """
 
 from builtin.constrained import _constrained_conforms_to
-from builtin.rebind import downcast
 from sys.intrinsics import _type_is_eq_parse_time
 
 

--- a/mojo/stdlib/std/collections/inline_array.mojo
+++ b/mojo/stdlib/std/collections/inline_array.mojo
@@ -36,7 +36,6 @@ import math
 from collections._index_normalization import normalize_index
 
 from builtin.device_passable import DevicePassable
-from builtin.rebind import downcast
 from builtin.constrained import _constrained_conforms_to
 from builtin.repr import repr
 from compile import get_type_name

--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -17,7 +17,6 @@ These APIs are imported automatically, just like builtins.
 
 
 from builtin.constrained import _constrained_conforms_to
-from builtin.rebind import downcast
 from reflection import get_type_name
 from collections._index_normalization import normalize_index
 from collections._asan_annotations import (

--- a/mojo/stdlib/std/gpu/host/device_context.mojo
+++ b/mojo/stdlib/std/gpu/host/device_context.mojo
@@ -57,7 +57,6 @@ from gpu.host.compile import (
 )
 from memory import stack_allocation
 from memory.unsafe import bitcast
-from builtin.rebind import downcast
 
 from utils import Variant
 from utils._serialize import _serialize_elements

--- a/mojo/stdlib/std/memory/legacy_unsafe_pointer.mojo
+++ b/mojo/stdlib/std/memory/legacy_unsafe_pointer.mojo
@@ -18,7 +18,6 @@ These APIs are imported automatically, just like builtins.
 from sys import align_of, is_gpu, is_nvidia_gpu, size_of
 from sys.intrinsics import gather, scatter, strided_load, strided_store
 
-from builtin.rebind import downcast
 from builtin.simd import _simd_construction_checks
 from builtin.variadics import Variadic
 from format._utils import FormatStruct, Named

--- a/mojo/stdlib/std/memory/owned_pointer.mojo
+++ b/mojo/stdlib/std/memory/owned_pointer.mojo
@@ -20,7 +20,6 @@ from memory import OwnedPointer
 """
 
 from builtin.constrained import _constrained_conforms_to
-from builtin.rebind import downcast, trait_downcast
 from format._utils import Repr, FormatStruct
 from reflection.type_info import _unqualified_type_name
 

--- a/mojo/stdlib/std/memory/unsafe_pointer.mojo
+++ b/mojo/stdlib/std/memory/unsafe_pointer.mojo
@@ -23,7 +23,6 @@ structures.
 from sys import align_of, is_gpu, is_nvidia_gpu, size_of
 from sys.intrinsics import gather, scatter, strided_load, strided_store
 
-from builtin.rebind import downcast
 from builtin.format_int import _write_int
 from builtin.simd import _simd_construction_checks
 from builtin.variadics import Variadic

--- a/mojo/stdlib/std/prelude/__init__.mojo
+++ b/mojo/stdlib/std/prelude/__init__.mojo
@@ -88,6 +88,7 @@ from builtin.rebind import (
     rebind_var,
     trait_downcast,
     trait_downcast_var,
+    downcast,
 )
 from builtin.repr import Representable, repr
 from builtin.reversed import ReversibleRange, reversed

--- a/mojo/stdlib/std/utils/variant.mojo
+++ b/mojo/stdlib/std/utils/variant.mojo
@@ -13,7 +13,6 @@
 """Defines a Variant type."""
 
 from builtin.constrained import _constrained_conforms_to
-from builtin.rebind import downcast
 from builtin.variadics import Variadic
 from os import abort
 from sys.intrinsics import _type_is_eq


### PR DESCRIPTION
I have found the `downcast` alias to be extremely useful during my adventures with the new reflection functionality for calling trait static methods amongst other things. As more people dig into it I believe it would helpful to import it into the prelude to avoid having to explicitly import it all the time.