### PR TITLE
[stdlib] Improve default `write_to` function implementations

### DIFF
--- a/mojo/stdlib/std/builtin/bool.mojo
+++ b/mojo/stdlib/std/builtin/bool.mojo
@@ -107,6 +107,7 @@ struct Bool(
     comptime __del__is_trivial: Bool = True
     comptime __moveinit__is_trivial: Bool = True
     comptime __copyinit__is_trivial: Bool = True
+    comptime _write_self_not_fields = True
 
     # ===-------------------------------------------------------------------===#
     # Life cycle methods
@@ -215,18 +216,6 @@ struct Bool(
         """
 
         writer.write("True" if self else "False")
-
-    @no_inline
-    fn write_repr_to(self, mut writer: Some[Writer]):
-        """Writes the repr of this boolean to a writer.
-
-        The repr of a boolean is the same as its string representation:
-        `True` or `False`.
-
-        Args:
-            writer: The object to write to.
-        """
-        self.write_to(writer)
 
     fn __repr__(self) -> String:
         """Get the bool as a string.

--- a/mojo/stdlib/std/builtin/int.mojo
+++ b/mojo/stdlib/std/builtin/int.mojo
@@ -204,6 +204,8 @@ struct Int(
     # Aliases
     # ===-------------------------------------------------------------------===#
 
+    comptime _write_self_not_fields = True
+
     comptime BITWIDTH: Int = bit_width_of[DType.int]()
     """The bit width of the integer type."""
 
@@ -1003,14 +1005,6 @@ struct Int(
         """
 
         writer.write(Int64(self))
-
-    fn write_repr_to(self, mut writer: Some[Writer]):
-        """Write the string representation of the Int".
-
-        Args:
-            writer: The value to write to.
-        """
-        writer.write("Int(", self, ")")
 
     fn write_padded[W: Writer](self, mut writer: W, width: Int):
         """Write the int right-aligned to a set padding.

--- a/mojo/stdlib/std/builtin/simd.mojo
+++ b/mojo/stdlib/std/builtin/simd.mojo
@@ -525,6 +525,9 @@ struct SIMD[dtype: DType, size: Int](
     # Aliases
     # ===-------------------------------------------------------------------===#
 
+    comptime _type_name = String("SIMD[", Self.dtype, ", ", Self.size, "]")
+    comptime _write_self_not_fields = True
+
     comptime MAX = Self(_max_or_inf[Self.dtype]())
     """Gets the maximum value for the SIMD value, potentially +inf."""
 
@@ -2251,25 +2254,6 @@ struct SIMD[dtype: DType, size: Int](
         @parameter
         if Self.size > 1:
             writer.write("]")
-
-    @no_inline
-    fn write_repr_to(self, mut writer: Some[Writer]):
-        """Write the string representation of the SIMD value".
-
-        Args:
-            writer: The value to write to.
-        """
-        writer.write_string("SIMD[")
-        Self.dtype.write_repr_to(writer)
-        writer.write(", ", Self.size, "](")
-        # Write each element.
-        for i in range(Self.size):
-            var element = self[i]
-            # Write separators between each element.
-            if i != 0:
-                writer.write_string(", ")
-            _write_scalar(writer, element)
-        writer.write_string(")")
 
     @always_inline
     fn to_bits[

--- a/mojo/stdlib/std/builtin/tuple.mojo
+++ b/mojo/stdlib/std/builtin/tuple.mojo
@@ -368,16 +368,7 @@ struct Tuple[*element_types: Movable](ImplicitlyCopyable, Sized, Writable):
         Args:
             writer: The writer to write to.
         """
-        writer.write_string("Tuple[")
-
-        @parameter
-        for i in range(Self.__len__()):
-
-            @parameter
-            if i != 0:
-                writer.write_string(", ")
-            writer.write_string(_unqualified_type_name[Self.element_types[i]]())
-        writer.write_string("]")
+        writer.write_string(Self._type_name)
         self._write_tuple_to[is_repr=True](writer)
 
     @always_inline

--- a/mojo/stdlib/std/collections/inline_array.mojo
+++ b/mojo/stdlib/std/collections/inline_array.mojo
@@ -100,6 +100,7 @@ struct InlineArray[ElementType: Copyable, size: Int,](
     ].__del__is_trivial
     comptime __copyinit__is_trivial: Bool = Self.ElementType.__copyinit__is_trivial
     comptime __moveinit__is_trivial: Bool = Self.ElementType.__moveinit__is_trivial
+    comptime _write_self_not_fields = True
 
     # Fields
     comptime type = __mlir_type[
@@ -648,11 +649,7 @@ struct InlineArray[ElementType: Copyable, size: Int,](
             ElementConformsTo="Representable",
         ]()
 
-        writer.write("InlineArray[")
-        writer.write(get_type_name[Self.ElementType]())
-        writer.write(", ")
-        writer.write(String(Self.size))
-        writer.write("](")
+        writer.write("[")
 
         for i in range(Self.size):
             ref element = self.unsafe_get(i)
@@ -661,7 +658,7 @@ struct InlineArray[ElementType: Copyable, size: Int,](
             if i < Self.size - 1:
                 writer.write(", ")
 
-        writer.write(")")
+        writer.write("]")
 
     @always_inline
     fn __str__(self) -> String:
@@ -681,4 +678,6 @@ struct InlineArray[ElementType: Copyable, size: Int,](
         Returns:
             A string representation of the array.
         """
-        return self.__str__()
+        var res = String()
+        self.write_repr_to(res)
+        return res

--- a/mojo/stdlib/std/memory/legacy_unsafe_pointer.mojo
+++ b/mojo/stdlib/std/memory/legacy_unsafe_pointer.mojo
@@ -84,6 +84,17 @@ struct LegacyUnsafePointer[
         Self.origin,
         address_space = Self.address_space,
     ]
+    # FIXME(#5873): should just use the default, but AddressSpace is wrong
+    comptime _type_name = String(
+        "UnsafePointer[",
+        Self.mut,
+        ", ",
+        _unqualified_type_name[Self.type](),
+        ", ",
+        Self.address_space,
+        "]",
+    )
+    comptime _write_self_not_fields = True
 
     # Fields
     comptime _mlir_type = __mlir_type[
@@ -495,19 +506,6 @@ struct LegacyUnsafePointer[
             writer: The object to write to.
         """
         self.as_unsafe_pointer().write_to(writer)
-
-    @no_inline
-    fn write_repr_to(self, mut writer: Some[Writer]):
-        """Write the string representation of the LegacyUnsafePointer.
-
-        Args:
-            writer: The object to write to.
-        """
-        FormatStruct(writer, "LegacyUnsafePointer").params(
-            Named("mut", Self.mut),
-            _unqualified_type_name[Self.type](),
-            Named("address_space", Self.address_space),
-        ).fields(self)
 
     # ===-------------------------------------------------------------------===#
     # Methods

--- a/mojo/stdlib/std/memory/pointer.mojo
+++ b/mojo/stdlib/std/memory/pointer.mojo
@@ -227,6 +227,18 @@ struct Pointer[
     ]
     comptime _with_origin = Pointer[Self.type, _, Self.address_space]
 
+    # FIXME(#5873): should just use the default, but AddressSpace is wrong
+    comptime _type_name = String(
+        "Pointer[",
+        Self.mut,
+        ", ",
+        _unqualified_type_name[Self.type](),
+        ", ",
+        Self.address_space,
+        "]",
+    )
+    comptime _write_self_not_fields = True
+
     comptime Mutable = Self._with_origin[unsafe_origin_mutcast[Self.origin]]
     """The mutable version of the `Pointer`."""
     comptime Immutable = Self._with_origin[ImmutOrigin(Self.origin)]
@@ -352,18 +364,6 @@ struct Pointer[
             writer: The object to write to.
         """
         UnsafePointer(to=self[]).write_to(writer)
-
-    fn write_repr_to(self, mut writer: Some[Writer]):
-        """Write the string representation of the Pointer.
-
-        Args:
-            writer: The object to write to.
-        """
-        FormatStruct(writer, "Pointer").params(
-            Named("mut", Self.mut),
-            _unqualified_type_name[Self.type](),
-            Named("address_space", Self.address_space),
-        ).fields(self)
 
     @always_inline("nodebug")
     fn __merge_with__[

--- a/mojo/stdlib/std/memory/unsafe_pointer.mojo
+++ b/mojo/stdlib/std/memory/unsafe_pointer.mojo
@@ -302,6 +302,17 @@ struct UnsafePointer[
     # ===-------------------------------------------------------------------===#
 
     comptime _UnsafePointerType = Self
+    # FIXME(#5873): should just use the default, but AddressSpace is wrong
+    comptime _type_name = String(
+        "UnsafePointer[",
+        Self.mut,
+        ", ",
+        _unqualified_type_name[Self.type](),
+        ", ",
+        Self.address_space,
+        "]",
+    )
+    comptime _write_self_not_fields = True
 
     comptime _mlir_type = __mlir_type[
         `!kgen.pointer<`,
@@ -924,19 +935,6 @@ struct UnsafePointer[
             writer: The object to write to.
         """
         _write_int[radix=16](writer, Scalar[DType.int](Int(self)), prefix="0x")
-
-    @no_inline
-    fn write_repr_to(self, mut writer: Some[Writer]):
-        """Write the string representation of the UnsafePointer.
-
-        Args:
-            writer: The object to write to.
-        """
-        FormatStruct(writer, "UnsafePointer").params(
-            Named("mut", Self.mut),
-            _unqualified_type_name[Self.type](),
-            Named("address_space", Self.address_space),
-        ).fields(self)
 
     # ===-------------------------------------------------------------------===#
     # Methods

--- a/mojo/stdlib/test/builtin/test_simd.mojo
+++ b/mojo/stdlib/test/builtin/test_simd.mojo
@@ -328,61 +328,54 @@ fn _test_repr(value: SIMD, expected: String) raises:
 
 def test_simd_repr_and_write_repr_to():
     # Basic integer vectors
+    _test_repr(SIMD[DType.int32, 4](1, 2, 3, 4), "SIMD[int32, 4]([1, 2, 3, 4])")
     _test_repr(
-        SIMD[DType.int32, 4](1, 2, 3, 4),
-        "SIMD[DType.int32, 4](1, 2, 3, 4)",
-    )
-    _test_repr(
-        SIMD[DType.int32, 4](-1, 2, -3, 4),
-        "SIMD[DType.int32, 4](-1, 2, -3, 4)",
+        SIMD[DType.int32, 4](-1, 2, -3, 4), "SIMD[int32, 4]([-1, 2, -3, 4])"
     )
 
     # Size boundary: scalar (size=1)
-    _test_repr(Int32(4), "SIMD[DType.int32, 1](4)")
-    _test_repr(Int32(0), "SIMD[DType.int32, 1](0)")
-    _test_repr(Int32(-42), "SIMD[DType.int32, 1](-42)")
+    _test_repr(Int32(4), "SIMD[int32, 1](4)")
+    _test_repr(Int32(0), "SIMD[int32, 1](0)")
+    _test_repr(Int32(-42), "SIMD[int32, 1](-42)")
 
     # Integer boundary values (min/max for different sizes)
-    _test_repr(Int8.MIN, "SIMD[DType.int8, 1](-128)")
-    _test_repr(Int8.MAX, "SIMD[DType.int8, 1](127)")
-    _test_repr(UInt8.MAX, "SIMD[DType.uint8, 1](255)")
+    _test_repr(Int8.MIN, "SIMD[int8, 1](-128)")
+    _test_repr(Int8.MAX, "SIMD[int8, 1](127)")
+    _test_repr(UInt8.MAX, "SIMD[uint8, 1](255)")
     _test_repr(
         Int64.MIN,
-        "SIMD[DType.int64, 1](-9223372036854775808)",
+        "SIMD[int64, 1](-9223372036854775808)",
     )
     _test_repr(
         SIMD[DType.uint32, 2](0, UInt32.MAX),
-        "SIMD[DType.uint32, 2](0, 4294967295)",
+        "SIMD[uint32, 2](0, 4294967295)",
     )
 
     # Boolean vectors - all patterns
     _test_repr(
         SIMD[DType.bool, 2](True, False),
-        "SIMD[DType.bool, 2](True, False)",
+        "SIMD[bool, 2]([True, False])",
     )
     _test_repr(
         SIMD[DType.bool, 4](True, True, True, True),
-        "SIMD[DType.bool, 4](True, True, True, True)",
+        "SIMD[bool, 4]([True, True, True, True])",
     )
     _test_repr(
         SIMD[DType.bool, 4](False, False, False, False),
-        "SIMD[DType.bool, 4](False, False, False, False)",
+        "SIMD[bool, 4]([False, False, False, False])",
     )
 
     # Float types - different precisions
-    _test_repr(Float16(324), "SIMD[DType.float16, 1](324.0)")
-    _test_repr(Float32(2897239), "SIMD[DType.float32, 1](2897239.0)")
-    _test_repr(
-        Float64(235234523.3452),
-        "SIMD[DType.float64, 1](235234523.3452)",
-    )
+    _test_repr(Float16(324), "SIMD[float16, 1](324.0)")
+    _test_repr(Float32(2897239), "SIMD[float32, 1](2897239.0)")
+    _test_repr(Float64(235234523.3452), "SIMD[float64, 1](235234523.3452)")
 
     # Float special values (inf, -inf, nan, -0.0)
     _test_repr(
         SIMD[DType.float32, 4](
             Float32.MAX, Float32.MIN, -0.0, nan[DType.float32]()
         ),
-        "SIMD[DType.float32, 4](inf, -inf, -0.0, nan)",
+        "SIMD[float32, 4]([inf, -inf, -0.0, nan])",
     )
 
 

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -1328,59 +1328,42 @@ def test_format_conversion_flags():
     assert_equal("{0!s} {0!r}".format(a, "Mojo2"), "Mojo 'Mojo'")
 
     var b = 21.1
-    assert_true(
-        "21.1 SIMD[DType.float64, 1](2" in "{} {!r}".format(b, b),
-    )
-    assert_true(
-        "21.1 SIMD[DType.float64, 1](2" in "{!s} {!r}".format(b, b),
-    )
+    assert_true("21.1 SIMD[float64, 1](2" in "{} {!r}".format(b, b))
+    assert_true("21.1 SIMD[float64, 1](2" in "{!s} {!r}".format(b, b))
 
     var c = 1e100
-    assert_equal(
-        "{} {!r}".format(c, c),
-        "1e+100 SIMD[DType.float64, 1](1e+100)",
-    )
-    assert_equal(
-        "{!s} {!r}".format(c, c),
-        "1e+100 SIMD[DType.float64, 1](1e+100)",
-    )
+    assert_equal("{} {!r}".format(c, c), "1e+100 SIMD[float64, 1](1e+100)")
+    assert_equal("{!s} {!r}".format(c, c), "1e+100 SIMD[float64, 1](1e+100)")
 
     var d = 42
     assert_equal("{} {!r}".format(d, d), "42 42")
     assert_equal("{!s} {!r}".format(d, d), "42 42")
 
     assert_true(
-        "Mojo SIMD[DType.float64, 1](2" in "{} {!r} {} {!r}".format(a, b, c, d)
+        "Mojo SIMD[float64, 1](2" in "{} {!r} {} {!r}".format(a, b, c, d)
     )
     assert_true(
-        "Mojo SIMD[DType.float64, 1](2"
-        in "{!s} {!r} {!s} {!r}".format(a, b, c, d)
+        "Mojo SIMD[float64, 1](2" in "{!s} {!r} {!s} {!r}".format(a, b, c, d)
     )
 
     var e = True
     assert_equal("{} {!r}".format(e, e), "True True")
 
     assert_true(
-        "Mojo SIMD[DType.float64, 1](2"
-        in "{0} {1!r} {2} {3}".format(a, b, c, d)
+        "Mojo SIMD[float64, 1](2" in "{0} {1!r} {2} {3}".format(a, b, c, d)
     )
     assert_true(
-        "Mojo SIMD[DType.float64, 1](2"
-        in "{0!s} {1!r} {2} {3!s}".format(a, b, c, d)
+        "Mojo SIMD[float64, 1](2" in "{0!s} {1!r} {2} {3!s}".format(a, b, c, d)
     )
 
-    assert_equal(
-        "{3} {2} {1} {0}".format(a, d, c, b),
-        "21.1 1e+100 42 Mojo",
-    )
+    assert_equal("{3} {2} {1} {0}".format(a, d, c, b), "21.1 1e+100 42 Mojo")
 
     assert_true(
-        "'Mojo' 42 SIMD[DType.float64, 1](2"
-        in "{0!r} {3} {1!r}".format(a, b, c, d)
+        "'Mojo' 42 SIMD[float64, 1](2" in "{0!r} {3} {1!r}".format(a, b, c, d)
     )
 
     assert_true(
-        "True 'Mojo' 42 SIMD[DType.float64, 1](2"
+        "True 'Mojo' 42 SIMD[float64, 1](2"
         in "{4} {0!r} {3} {1!r}".format(a, b, c, d, True)
     )
 

--- a/mojo/stdlib/test/collections/test_dict.mojo
+++ b/mojo/stdlib/test/collections/test_dict.mojo
@@ -711,10 +711,7 @@ def test_dict_repr_wrap():
     var tmp_dict = {"one": 1.0, "two": 2.0}
     assert_equal(
         repr(tmp_dict),
-        (
-            "{'one': SIMD[DType.float64, 1](1.0), 'two': SIMD[DType.float64,"
-            " 1](2.0)}"
-        ),
+        "{'one': SIMD[float64, 1](1.0), 'two': SIMD[float64, 1](2.0)}",
     )
 
 

--- a/mojo/stdlib/test/collections/test_inline_array.mojo
+++ b/mojo/stdlib/test/collections/test_inline_array.mojo
@@ -324,66 +324,50 @@ def test_move():
     _ = del_counter
 
 
-def test_str_and_repr():
-    """Test __str__ and __repr__ methods."""
-    var array: InlineArray[Int, 3] = [1, 2, 3]
-
-    # Test __str__ method
-    var str_result = array.__str__()
-    assert_equal(str_result, "InlineArray[Int, 3](1, 2, 3)")
-
-    # Test __repr__ method
-    var repr_result = array.__repr__()
-    assert_equal(repr_result, "InlineArray[Int, 3](1, 2, 3)")
-
-    # They should be equal
-    assert_equal(str_result, repr_result)
-
-
 def test_different_types():
     """Test with different element types."""
     # Test with String
     var string_array: InlineArray[String, 2] = ["hello", "world"]
-    var str_result = string_array.__str__()
-    assert_equal(str_result, "InlineArray[String, 2]('hello', 'world')")
+    assert_equal(String(string_array), "['hello', 'world']")
 
     # Test with single element
     var single: InlineArray[Int, 1] = [42]
-    var single_str = single.__str__()
-    assert_equal(single_str, "InlineArray[Int, 1](42)")
+    assert_equal(String(single), "[42]")
 
     # Test with default values
-    var default_array = InlineArray[Int, 3](fill=0)
-    var default_str = default_array.__str__()
-    assert_equal(default_str, "InlineArray[Int, 3](0, 0, 0)")
+    assert_equal(String(InlineArray[Int, 3](fill=0)), "[0, 0, 0]")
 
     # Test with filled array
-    var filled_array = InlineArray[Int, 4](fill=99)
-    var filled_str = filled_array.__str__()
-    assert_equal(filled_str, "InlineArray[Int, 4](99, 99, 99, 99)")
+    assert_equal(String(InlineArray[Int, 4](fill=99)), "[99, 99, 99, 99]")
 
 
 def test_write_to():
     """Test Writable trait implementation."""
-    var array: InlineArray[Int, 3] = [10, 20, 30]
-    var output = String()
-    array.write_to(output)
-
-    assert_equal(output, "InlineArray[Int, 3](10, 20, 30)")
-
-    # Test with different types
+    # Test with String
     var string_array: InlineArray[String, 2] = ["hello", "world"]
-    var string_output = String()
-    string_array.write_to(string_output)
+    assert_equal(String(string_array), "['hello', 'world']")
+    assert_equal(
+        repr(string_array), "InlineArray[String, 2](['hello', 'world'])"
+    )
 
-    assert_equal(string_output, "InlineArray[String, 2]('hello', 'world')")
+    # Test with single element
+    var single: InlineArray[Int, 1] = [42]
+    assert_equal(String(single), "[42]")
+    assert_equal(repr(single), "InlineArray[Int, 1]([42])")
 
+    # Test with default values
+    var default_array = InlineArray[Int, 3](fill=0)
+    assert_equal(String(default_array), "[0, 0, 0]")
+    assert_equal(repr(default_array), "InlineArray[Int, 3]([0, 0, 0])")
+
+    # Test with filled array
+    var filled_array = InlineArray[Int, 4](fill=99)
+    assert_equal(String(filled_array), "[99, 99, 99, 99]")
+    assert_equal(repr(filled_array), "InlineArray[Int, 4]([99, 99, 99, 99])")
     # Test empty array
     var empty_array = InlineArray[Int, 0](fill=0)
-    var empty_output = String()
-    empty_array.write_to(empty_output)
-
-    assert_equal(empty_output, "InlineArray[Int, 0]()")
+    assert_equal(String(empty_array), "[]")
+    assert_equal(repr(empty_array), "InlineArray[Int, 0]([])")
 
 
 def test_inline_array_triviality():

--- a/mojo/stdlib/test/memory/test_pointer.mojo
+++ b/mojo/stdlib/test/memory/test_pointer.mojo
@@ -55,25 +55,19 @@ def test_write_repr_to():
     var n = Int(42)
     check_write_to(
         Pointer(to=n),
-        contains=(
-            "Pointer[mut=True, Int, address_space=AddressSpace.GENERIC](0x"
-        ),
+        contains="Pointer[True, Int, AddressSpace.GENERIC](0x",
         is_repr=True,
     )
     check_write_to(
         Pointer(to=n).get_immutable(),
-        contains=(
-            "Pointer[mut=False, Int, address_space=AddressSpace.GENERIC](0x"
-        ),
+        contains="Pointer[False, Int, AddressSpace.GENERIC](0x",
         is_repr=True,
     )
 
     var s = String("hello")
     check_write_to(
         Pointer(to=s),
-        contains=(
-            "Pointer[mut=True, String, address_space=AddressSpace.GENERIC](0x"
-        ),
+        contains="Pointer[True, String, AddressSpace.GENERIC](0x",
         is_repr=True,
     )
 

--- a/mojo/stdlib/test/memory/unsafe_pointer/test_legacy_unsafe_pointer.mojo
+++ b/mojo/stdlib/test/memory/unsafe_pointer/test_legacy_unsafe_pointer.mojo
@@ -507,31 +507,32 @@ def test_write_to():
 
 def test_write_repr_to():
     check_write_to(
-        LegacyUnsafePointer[Int, origin=MutAnyOrigin](),
-        expected=(
-            "LegacyUnsafePointer[mut=True, Int,"
-            " address_space=AddressSpace.GENERIC](0x0)"
-        ),
+        UnsafePointer[Int, MutAnyOrigin](),
+        expected="UnsafePointer[True, Int, AddressSpace.GENERIC](0x0)",
         is_repr=True,
     )
 
     var x = 42
     check_write_to(
-        LegacyUnsafePointer(to=x),
-        contains=(
-            "LegacyUnsafePointer[mut=True, Int,"
-            " address_space=AddressSpace.GENERIC](0x"
-        ),
+        UnsafePointer(to=x),
+        contains="UnsafePointer[True, Int, AddressSpace.GENERIC](0x",
+        is_repr=True,
+    )
+    check_write_to(
+        UnsafePointer(to=x).as_immutable(),
+        contains="UnsafePointer[False, Int, AddressSpace.GENERIC](0x",
+        is_repr=True,
+    )
+    check_write_to(
+        UnsafePointer(to=x).address_space_cast[AddressSpace.SHARED](),
+        contains="UnsafePointer[True, Int, AddressSpace.SHARED](0x",
         is_repr=True,
     )
 
     var s = String("hello")
     check_write_to(
-        LegacyUnsafePointer(to=s),
-        contains=(
-            "LegacyUnsafePointer[mut=True, String,"
-            " address_space=AddressSpace.GENERIC](0x"
-        ),
+        UnsafePointer(to=s),
+        contains="UnsafePointer[True, String, AddressSpace.GENERIC](0x",
         is_repr=True,
     )
 

--- a/mojo/stdlib/test/memory/unsafe_pointer/test_unsafe_pointer_v2.mojo
+++ b/mojo/stdlib/test/memory/unsafe_pointer/test_unsafe_pointer_v2.mojo
@@ -603,45 +603,31 @@ def test_write_to():
 def test_write_repr_to():
     check_write_to(
         UnsafePointer[Int, MutAnyOrigin](),
-        expected=(
-            "UnsafePointer[mut=True, Int,"
-            " address_space=AddressSpace.GENERIC](0x0)"
-        ),
+        expected="UnsafePointer[True, Int, AddressSpace.GENERIC](0x0)",
         is_repr=True,
     )
 
     var x = 42
     check_write_to(
         UnsafePointer(to=x),
-        contains=(
-            "UnsafePointer[mut=True, Int,"
-            " address_space=AddressSpace.GENERIC](0x"
-        ),
+        contains="UnsafePointer[True, Int, AddressSpace.GENERIC](0x",
         is_repr=True,
     )
     check_write_to(
         UnsafePointer(to=x).as_immutable(),
-        contains=(
-            "UnsafePointer[mut=False, Int,"
-            " address_space=AddressSpace.GENERIC](0x"
-        ),
+        contains="UnsafePointer[False, Int, AddressSpace.GENERIC](0x",
         is_repr=True,
     )
     check_write_to(
         UnsafePointer(to=x).address_space_cast[AddressSpace.SHARED](),
-        contains=(
-            "UnsafePointer[mut=True, Int, address_space=AddressSpace.SHARED](0x"
-        ),
+        contains="UnsafePointer[True, Int, AddressSpace.SHARED](0x",
         is_repr=True,
     )
 
     var s = String("hello")
     check_write_to(
         UnsafePointer(to=s),
-        contains=(
-            "UnsafePointer[mut=True, String,"
-            " address_space=AddressSpace.GENERIC](0x"
-        ),
+        contains="UnsafePointer[True, String, AddressSpace.GENERIC](0x",
         is_repr=True,
     )
 

--- a/mojo/stdlib/test/test_utils/test_utils.mojo
+++ b/mojo/stdlib/test/test_utils/test_utils.mojo
@@ -47,7 +47,10 @@ def check_write_to(value: Some[Writable], *, contains: String, is_repr: Bool):
         value.write_repr_to(string)
     else:
         value.write_to(string)
-    assert_true(contains in string)
+    assert_true(
+        contains in string,
+        String("contains: ", contains, " is not in string: ", string),
+    )
 
 
 @always_inline


### PR DESCRIPTION
Added tests for previously undiscovered bugs: #5871, #5872, #5873.

This should already make several types only need to use the default implementation for #5870

Changes in behavior:
- Slightly change the behavior of the default `write_to` implementation making it not print the name of the fields
- Make the default skip mlir fields
- SIMD now prints e.g. `SIMD[uint8, 2]([1, 2])`
- InlineArray now prints as a list `[1, 2]` and using repr `InlineArray[Int, 2]([1, 2])`

What is missing:
- A proper way to iterate over parameters and getting their write_repr_to/write_to behavior depending on which one was triggered
- A way to have the Writable interface trickle down the information of whether to use write_repr_to or write_to for nested structures, such that we can use it in all colection types in a generic way and provide a default implementation that does this. It would allow types to implement `write_to` only once