### PR TITLE
[stdlib] Take `write_sequence_to` into `VariadicPack` and use it

### DIFF
--- a/mojo/stdlib/std/builtin/variadics.mojo
+++ b/mojo/stdlib/std/builtin/variadics.mojo
@@ -992,6 +992,46 @@ struct VariadicPack[
         """
         return __mlir_op.`kgen.pack.load`(self.get_as_kgen_pack())
 
+    fn write_to[
+        O1: ImmutOrigin = StaticConstantOrigin,
+        O2: ImmutOrigin = StaticConstantOrigin,
+        O3: ImmutOrigin = StaticConstantOrigin,
+    ](
+        self: VariadicPack[_, Writable, ...],
+        mut writer: Some[Writer],
+        start: StringSlice[O1] = rebind[StringSlice[O1]](StaticString("")),
+        end: StringSlice[O2] = rebind[StringSlice[O2]](StaticString("")),
+        sep: StringSlice[O3] = rebind[StringSlice[O3]](StaticString(", ")),
+    ):
+        """Writes a sequence of writable values from a pack to a writer with
+        delimiters.
+
+        This function formats a variadic pack of writable values as a delimited
+        sequence, writing each element separated by the specified separator and
+        enclosed by start and end delimiters.
+
+        Parameters:
+            O1: The origin of the open `StringSlice`.
+            O2: The origin of the close `StringSlice`.
+            O3: The origin of the separator `StringSlice`.
+
+        Args:
+            writer: The writer to write to.
+            start: The starting delimiter.
+            end: The ending delimiter.
+            sep: The separator between items.
+        """
+        writer.write_string(start)
+
+        @parameter
+        for i in range(self.__len__()):
+
+            @parameter
+            if i != 0:
+                writer.write_string(sep)
+            self[i].write_to(writer)
+        writer.write_string(end)
+
 
 # ===-----------------------------------------------------------------------===#
 # VariadicReduce

--- a/mojo/stdlib/std/collections/set.mojo
+++ b/mojo/stdlib/std/collections/set.mojo
@@ -343,7 +343,7 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
             else:
                 trait_downcast[Writable](element).write_to(w)
 
-        write_sequence_to[ElementFn=iterate](writer, open="{", close="}")
+        write_sequence_to[ElementFn=iterate](writer, start="{", end="}")
         _ = iterator^
 
     @no_inline

--- a/mojo/stdlib/std/collections/string/string.mojo
+++ b/mojo/stdlib/std/collections/string/string.mojo
@@ -478,37 +478,15 @@ struct String(
         """
         comptime length = args.__len__()
         var total_bytes = _TotalWritableBytes()
-
-        @parameter
-        for i in range(length):
-            args[i].write_to(total_bytes)
-
-            @parameter
-            if i < length - 1:
-                sep.write_to(total_bytes)
-        end.write_to(total_bytes)
-
-        if total_bytes.size == 0:
-            return String()
-
-        @parameter
-        fn _write[W: Writer](mut writer: W):
-            @parameter
-            for i in range(args.__len__()):
-                args[i].write_to(writer)
-
-                @parameter
-                if i < length - 1:
-                    sep.write_to(writer)
-            end.write_to(writer)
+        args.write_to(total_bytes, end=end, sep=sep)
 
         if total_bytes.size <= Self.INLINE_CAPACITY:
             self = String()
-            _write(self)
+            args.write_to(self, end=end, sep=sep)
         else:
             self = String(capacity=total_bytes.size)
             var buffer = _WriteBufferStack[STACK_BUFFER_BYTES](self)
-            _write(buffer)
+            args.write_to(buffer, end=end, sep=sep)
             buffer.flush()
 
     # TODO(MOCO-1791): Default arguments and param inference aren't powerful
@@ -548,37 +526,15 @@ struct String(
         """
         comptime length = args.__len__()
         var total_bytes = _TotalWritableBytes()
-
-        @parameter
-        for i in range(length):
-            args[i].write_to(total_bytes)
-
-            @parameter
-            if i < length - 1:
-                sep.write_to(total_bytes)
-        end.write_to(total_bytes)
-
-        if total_bytes.size == 0:
-            return String()
-
-        @parameter
-        fn _write[W: Writer](mut writer: W):
-            @parameter
-            for i in range(length):
-                args[i].write_to(writer)
-
-                @parameter
-                if i < length - 1:
-                    sep.write_to(writer)
-            end.write_to(writer)
+        args.write_to(total_bytes, end=end, sep=sep)
 
         if total_bytes.size <= Self.INLINE_CAPACITY:
             self = String()
-            _write(self)
+            args.write_to(self, end=end, sep=sep)
         else:
             self = String(capacity=total_bytes.size)
             var buffer = _WriteBufferStack[STACK_BUFFER_BYTES](self)
-            _write(buffer)
+            args.write_to(buffer, end=end, sep=sep)
             buffer.flush()
 
     @staticmethod
@@ -600,38 +556,16 @@ struct String(
         """
         comptime length = args.__len__()
         var total_bytes = _TotalWritableBytes()
-
-        @parameter
-        for i in range(length):
-            args[i].write_to(total_bytes)
-
-            @parameter
-            if i < length - 1:
-                sep.write_to(total_bytes)
-        end.write_to(total_bytes)
-
-        if total_bytes.size == 0:
-            return String()
-
-        @parameter
-        fn _write[W: Writer](mut writer: W):
-            @parameter
-            for i in range(length):
-                args[i].write_to(writer)
-
-                @parameter
-                if i < length - 1:
-                    sep.write_to(writer)
-            end.write_to(writer)
+        args.write_to(total_bytes, end=end, sep=sep)
 
         if total_bytes.size <= Self.INLINE_CAPACITY:
             var result = String()
-            _write(result)
+            args.write_to(result, end=end, sep=sep)
             return result^
         else:
             var result = String(capacity=total_bytes.size)
             var buffer = _WriteBufferStack[STACK_BUFFER_BYTES](result)
-            _write(buffer)
+            args.write_to(buffer, end=end, sep=sep)
             buffer.flush()
             return result^
 
@@ -647,23 +581,14 @@ struct String(
         comptime length = args.__len__()
         var total_bytes = _TotalWritableBytes()
         total_bytes.size += self.byte_length()
-
-        @parameter
-        for i in range(length):
-            args[i].write_to(total_bytes)
-
-        @parameter
-        fn _write[W: Writer](mut writer: W):
-            @parameter
-            for i in range(length):
-                args[i].write_to(writer)
+        args.write_to(total_bytes, sep="")
 
         if total_bytes.size <= Self.INLINE_CAPACITY:
-            _write(self)
+            args.write_to(self, sep="")
         else:
             self.reserve(total_bytes.size)
             var buffer = _WriteBufferStack[STACK_BUFFER_BYTES](self)
-            _write(buffer)
+            args.write_to(buffer, sep="")
             buffer.flush()
 
     fn write[T: Writable](mut self, value: T):

--- a/mojo/stdlib/test/format/test_format.mojo
+++ b/mojo/stdlib/test/format/test_format.mojo
@@ -146,7 +146,7 @@ def test_write_sequence_to_custom_delimiters():
         index += 1
 
     write_sequence_to[ElementFn=write_items](
-        output, open="{", close="}", sep="; "
+        output, start="{", end="}", sep="; "
     )
     assert_equal(output, "{item0; item1; item2}")
 

--- a/mojo/stdlib/test/format/test_utils.mojo
+++ b/mojo/stdlib/test/format/test_utils.mojo
@@ -45,57 +45,57 @@ struct TestWritable(ImplicitlyCopyable, Writable):
 
 def test_write_sequence_empty():
     var result = String()
-    write_sequence_to(result, open="[", close="]")
+    write_sequence_to(result, start="[", end="]")
     assert_equal(result, "[]")
 
 
 def test_write_sequence_single_element():
     var result = String()
-    write_sequence_to(result, 42, open="[", close="]")
+    write_sequence_to(result, 42, start="[", end="]")
     assert_equal(result, "[42]")
 
 
 def test_write_sequence_multiple_elements():
     var result = String()
-    write_sequence_to(result, 1, 2, 3, open="[", close="]")
+    write_sequence_to(result, 1, 2, 3, start="[", end="]")
     assert_equal(result, "[1, 2, 3]")
 
 
 def test_write_sequence_custom_delimiters():
     var result = String()
-    write_sequence_to(result, 1, 2, 3, open="(", close=")")
+    write_sequence_to(result, 1, 2, 3, start="(", end=")")
     assert_equal(result, "(1, 2, 3)")
 
 
 def test_write_sequence_custom_separator():
     var result = String()
-    write_sequence_to(result, 1, 2, 3, open="[", close="]", sep="; ")
+    write_sequence_to(result, 1, 2, 3, start="[", end="]", sep="; ")
     assert_equal(result, "[1; 2; 3]")
 
 
 def test_write_sequence_custom_all():
     var result = String()
-    write_sequence_to(result, "a", "b", "c", open="<", close=">", sep=" | ")
+    write_sequence_to(result, "a", "b", "c", start="<", end=">", sep=" | ")
     assert_equal(result, "<a | b | c>")
 
 
 def test_write_sequence_writable_objects():
     var result = String()
     write_sequence_to(
-        result, TestWritable(10), TestWritable(20), open="[", close="]"
+        result, TestWritable(10), TestWritable(20), start="[", end="]"
     )
     assert_equal(result, "[TestWritable(10), TestWritable(20)]")
 
 
 def test_write_sequence_mixed_types():
     var result = String()
-    write_sequence_to(result, 1, "hello", TestWritable(42), open="[", close="]")
+    write_sequence_to(result, 1, "hello", TestWritable(42), start="[", end="]")
     assert_equal(result, "[1, hello, TestWritable(42)]")
 
 
 def test_write_sequence_empty_separator():
     var result = String()
-    write_sequence_to(result, 1, 2, 3, open="[", close="]", sep="")
+    write_sequence_to(result, 1, 2, 3, start="[", end="]", sep="")
     assert_equal(result, "[123]")
 
 


### PR DESCRIPTION
Take `write_sequence_to` into `VariadicPack` and use it in several call-sites improving readability :)

Also rename open and close delimiters to start and end to keep nomenclature consistent accross the codebase.

CC: @NathanSWard 