### PR TITLE
[Docs] Update variables.mdx with regard to scope of explicit and implicit

### DIFF
--- a/mojo/docs/manual/variables.mdx
+++ b/mojo/docs/manual/variables.mdx
@@ -127,8 +127,7 @@ not compile:
 var user_id: Int = "Sam"
 ```
 
-Explicitly-declared variables follow [lexical scoping](#variable-scopes), unlike
-implicitly-declared variables.
+Explicitly-declared variables have block-level [scope](#variable-scopes).
 
 ## Type annotations
 
@@ -258,10 +257,15 @@ conversion](/mojo/manual/lifecycle/life/#constructors-and-implicit-conversion).
 
 ## Variable scopes
 
-Variables declared with `var` are bound by *lexical scoping*. This
-means that nested code blocks can read and modify variables defined in an
+Variables in Mojo are bound by *lexical scoping*. This
+means that a variable's definition is limited to *where* it is defined
+(as opposed to *when*, during execution, as with dynamic scoping). Nested code
+can read and modify variables defined in an
 outer scope. But an outer scope **cannot** read variables defined in an
 inner scope at all.
+
+Variables [explicitly declared](#explicitly-declared-variables) with `var`
+have **block-level** scope. 
 
 For example, the `if` code block shown here creates an inner scope where outer
 variables are accessible to read/write, but any new variables do not live
@@ -295,11 +299,11 @@ scope variable hides or "shadows" a variable from an outer scope.)
 The lifetime of the inner `num` ends exactly where the `if` code block ends,
 because that's the scope in which the variable was defined.
 
-This is in contrast to implicitly-declared variables (those without the `var`
-keyword), which use **function-level scoping** (consistent with Python variable
-behavior). That means, when you change the value of an implicitly-declared
-variable inside the `if` block, it actually changes the value for the entire
-function.
+This is in contrast to [implicitly-declared](#implicitly-declared-variables)
+variables (those without the `var` keyword), which use **function-level scoping**
+(consistent with Python variable behavior). That means, when you change the
+value of an implicitly-declared variable inside the `if` block, it actually
+changes the value for the entire function.
 
 For example, here's the same code but *without* the `var` declarations:
 
@@ -320,8 +324,8 @@ def function_scopes():
 ```
 
 Now, the last `print()` function sees the updated `num` value from the inner
-scope, because implicitly-declared variables (Python-style variables) use function-level
-scope (instead of lexical scope).
+scope, because implicitly-declared variables are scoped at the function level,
+as in Python, rather than at the block level.
 
 ## Copying and moving values
 


### PR DESCRIPTION
The current descriptions of the distinction between implicitly declared and explicitly declared variables is using "lexical scope" to refer to block-level scope.  But it is lexical scoping in both cases, with the difference being in the granularity, block-level or function-level.

I think a larger edit to better organize these descriptions might be helpful too.