### PR TITLE
[MAX] Fix diffusers config to properly load components configs and to consider local path.

### DIFF
--- a/max/python/max/pipelines/lib/hf_utils.py
+++ b/max/python/max/pipelines/lib/hf_utils.py
@@ -606,6 +606,8 @@ class HuggingFaceRepo:
         return gguf_files
 
     def file_exists(self, filename: str) -> bool:
+        if self.repo_type == RepoType.local:
+            return os.path.exists(os.path.join(self.repo_id, filename))
         return huggingface_hub.file_exists(self.repo_id, filename)
 
     @property

--- a/max/python/max/pipelines/lib/model_config.py
+++ b/max/python/max/pipelines/lib/model_config.py
@@ -507,7 +507,7 @@ class MAXModelConfig(MAXModelConfigBase):
         """
         import json
 
-        from huggingface_hub import hf_hub_download
+        from huggingface_hub import hf_hub_download, list_repo_files
 
         # Extract class name and version
         class_name = model_index.get("_class_name")
@@ -515,6 +515,25 @@ class MAXModelConfig(MAXModelConfigBase):
 
         # Build components dict with loaded configs
         components = {}
+        repo_files = list_repo_files(
+            repo_id=self.huggingface_model_repo.repo_id,
+            revision=self.huggingface_model_repo.revision,
+        )
+        component_configs = {}
+        for file_name in repo_files:
+            if file_name.endswith("config.json") and "/" in file_name:
+                try:
+                    component_name = file_name.split("/")[0]
+                    cfg_path = hf_hub_download(
+                        repo_id=self.huggingface_model_repo.repo_id,
+                        filename=file_name,
+                        revision=self.huggingface_model_repo.revision,
+                    )
+                    with open(cfg_path) as f:
+                        component_configs[component_name] = json.load(f)
+                except Exception as e:
+                    logger.debug(f"Could not load config for {file_name}: {e}")
+
         for component_name, component_info in model_index.items():
             if component_name.startswith("_"):
                 continue
@@ -524,23 +543,10 @@ class MAXModelConfig(MAXModelConfigBase):
 
             library, class_type = component_info
 
-            # Try to load the component's config file
-            component_config = {}
-            try:
-                config_file_path = hf_hub_download(
-                    repo_id=self.huggingface_model_repo.repo_id,
-                    filename=f"{component_name}/config.json",
-                    revision=self.huggingface_model_repo.revision,
-                )
-                with open(config_file_path) as f:
-                    component_config = json.load(f)
-            except Exception as e:
-                logger.debug(f"Could not load config for {component_name}: {e}")
-
             components[component_name] = {
                 "library": library,
                 "class_name": class_type,
-                "config_dict": component_config,
+                "config_dict": component_configs.get(component_name, {}),
             }
 
         # Build the final config structure

--- a/max/python/max/pipelines/lib/registry.py
+++ b/max/python/max/pipelines/lib/registry.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, TypeAlias, cast
@@ -47,7 +48,7 @@ if TYPE_CHECKING:
     from .config import PipelineConfig
 
 from .audio_generator_pipeline import AudioGeneratorPipeline
-from .config_enums import PipelineRole, RopeType, SupportedEncoding
+from .config_enums import PipelineRole, RepoType, RopeType, SupportedEncoding
 from .embeddings_pipeline import EmbeddingsPipeline
 from .hf_utils import HuggingFaceRepo, is_diffusion_pipeline
 from .interfaces import ArchConfig, ArchConfigWithKVCache, PipelineModel
@@ -504,14 +505,19 @@ class PipelineRegistry:
                 # Check if model_index.json exists to identify diffusion pipelines
                 import json
 
-                from huggingface_hub import hf_hub_download
+                if huggingface_repo.repo_type == RepoType.local:
+                    config_path = os.path.join(
+                        huggingface_repo.repo_id, "model_index.json"
+                    )
+                else:
+                    from huggingface_hub import hf_hub_download
 
-                # Try to download model_index.json
-                config_path = hf_hub_download(
-                    repo_id=huggingface_repo.repo_id,
-                    filename="model_index.json",
-                    revision=huggingface_repo.revision,
-                )
+                    # Try to download model_index.json
+                    config_path = hf_hub_download(
+                        repo_id=huggingface_repo.repo_id,
+                        filename="model_index.json",
+                        revision=huggingface_repo.revision,
+                    )
 
                 # Load the config
                 with open(config_path) as f:


### PR DESCRIPTION
This PR fixes two issues that are not properly handled in the current diffusers config implementation.

- loads configs of components having a name different from `config.json`. e.g., `scheduler_config.json`.
- loads configs properly when pre-downloaded local path is given.