### PR TITLE
[bazel][POC] Bazel target to run Mojo

### DIFF
--- a/bazel/internal/BUILD.bazel
+++ b/bazel/internal/BUILD.bazel
@@ -151,3 +151,11 @@ toolchain(
     toolchain = ":_mojo_copts_toolchain",
     toolchain_type = "@rules_mojo//:copts_toolchain_type",
 )
+
+modular_py_binary(
+    name = "run_mojo",
+    srcs = ["run_mojo.py"],
+    deps = [
+        "@mojo//:python",
+    ],
+)

--- a/bazel/internal/run_mojo.py
+++ b/bazel/internal/run_mojo.py
@@ -1,0 +1,5 @@
+import sys
+
+from mojo.run import subprocess_run_mojo
+
+subprocess_run_mojo(sys.argv[1:])

--- a/main.mojo
+++ b/main.mojo
@@ -1,0 +1,2 @@
+fn main():
+    print("Hello, world!")


### PR DESCRIPTION
Can try it out with
```
./bazelw run bazel/internal:run_mojo -- run $(pwd)/main.mojo
```

Note the $(pwd), maybe we can find a way to avoid that. Also need a better place for the target.

Also note that the debugging stuff isn't here, we would need to pull more stuff for that.