### PR TITLE
[MAX] Add UMT5 Encoder Architecture

### DIFF
--- a/max/python/max/pipelines/architectures/umt5/__init__.py
+++ b/max/python/max/pipelines/architectures/umt5/__init__.py
@@ -1,0 +1,16 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from .model import UMT5Model
+
+__all__ = ["UMT5Model"]

--- a/max/python/max/pipelines/architectures/umt5/model.py
+++ b/max/python/max/pipelines/architectures/umt5/model.py
@@ -1,0 +1,57 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from typing import Any
+
+from max import functional as F
+from max.driver import Device
+from max.engine import Model
+from max.graph.weights import Weights
+from max.pipelines.lib import SupportedEncoding
+from max.pipelines.lib.interfaces.component_model import ComponentModel
+
+from .model_config import UMT5Config, UMT5ConfigBase
+from .umt5 import UMT5EncoderModel
+from .weight_adapters import convert_safetensor_state_dict
+
+
+class UMT5Model(ComponentModel):
+    def __init__(
+        self,
+        config: dict[str, Any],
+        encoding: SupportedEncoding,
+        devices: list[Device],
+        weights: Weights,
+    ) -> None:
+        super().__init__(config, encoding, devices, weights)
+        self.config: UMT5ConfigBase = UMT5Config.generate(
+            config,
+            encoding,
+            devices,
+        )
+        self.load_model()
+
+    def load_model(self) -> Model:
+        state_dict = {key: value.data() for key, value in self.weights.items()}
+        state_dict = convert_safetensor_state_dict(state_dict)
+        with F.lazy():
+            umt5 = UMT5EncoderModel(self.config)  # type: ignore[arg-type]
+            umt5.to(self.devices[0])
+        self.model: Model = umt5.compile(  # type: ignore[assignment]
+            *umt5.input_types(),
+            weights=state_dict,
+        )
+        return self.model
+
+    def __call__(self, *args, **kwargs):
+        return self.model(*args, **kwargs)

--- a/max/python/max/pipelines/architectures/umt5/model_config.py
+++ b/max/python/max/pipelines/architectures/umt5/model_config.py
@@ -1,0 +1,72 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from typing import Any
+
+from max.driver import Device
+from max.dtype import DType
+from max.graph import DeviceRef
+from max.pipelines.lib import MAXModelConfigBase, SupportedEncoding
+from pydantic import Field
+
+
+class UMT5ConfigBase(MAXModelConfigBase):
+    vocab_size: int = 256384
+    d_model: int = 4096
+    d_kv: int = 64
+    d_ff: int = 10240
+    num_layers: int = 24
+    num_decoder_layers: int | None = 24
+    num_heads: int = 64
+    relative_attention_num_buckets: int = 32
+    relative_attention_max_distance: int = 128
+    dropout_rate: float = 0.1
+    layer_norm_epsilon: float = 1e-6
+    initializer_factor: float = 1.0
+    feed_forward_proj: str = "gated-gelu"
+    dense_act_fn: str | None = Field(default=None, exclude=True)
+    is_gated_act: bool = Field(default=False, exclude=True)
+    is_decoder: bool = Field(default=False, exclude=True)
+    is_encoder_decoder: bool = True
+    use_cache: bool = True
+    output_past: bool = True
+    pad_token_id: int = 0
+    eos_token_id: int = 1
+    decoder_start_token_id: int = 0
+    classifier_dropout: float = 0.0
+    scalable_attention: bool = True
+    tie_word_embeddings: bool = False
+    tokenizer_class: str = "T5Tokenizer"
+    device: DeviceRef = Field(default_factory=DeviceRef.GPU)
+    dtype: DType = DType.bfloat16
+
+
+class UMT5Config(UMT5ConfigBase):
+    @staticmethod
+    def generate(
+        config_dict: dict[str, Any],
+        encoding: SupportedEncoding,
+        devices: list[Device],
+    ) -> UMT5ConfigBase:
+        init_dict = {
+            key: value
+            for key, value in config_dict.items()
+            if key in UMT5ConfigBase.__annotations__
+        }
+        init_dict.update(
+            {
+                "dtype": encoding.dtype,
+                "device": DeviceRef.from_device(devices[0]),
+            }
+        )
+        return UMT5ConfigBase(**init_dict)

--- a/max/python/max/pipelines/architectures/umt5/umt5.py
+++ b/max/python/max/pipelines/architectures/umt5/umt5.py
@@ -1,0 +1,556 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""UMT5 encoder implementation aligned with Hugging Face UMT5 behavior."""
+
+from __future__ import annotations
+
+import copy
+import math
+from collections.abc import Callable
+
+import numpy as np
+from max import functional as F
+from max.driver import Device
+from max.dtype import DType
+from max.graph import Dim, TensorType
+from max.nn import Embedding, Linear, Module
+from max.nn.sequential import ModuleList
+from max.tensor import Tensor
+
+from .model_config import UMT5ConfigBase
+
+
+def _get_act_fn(name: str) -> Callable[[Tensor], Tensor]:
+    if name == "relu":
+        return F.relu
+    if name == "gelu_new":
+        return lambda x: F.gelu(x, approximate="tanh")
+    if name == "gelu":
+        return F.gelu
+    raise ValueError(
+        f"Unsupported UMT5 dense activation '{name}'. "
+        "Expected one of: relu, gelu, gelu_new."
+    )
+
+
+class UMT5LayerNorm(Module[..., Tensor]):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        dtype: DType = DType.float32,
+    ):
+        super().__init__()
+        self.weight = Tensor.ones([hidden_size])
+        self.variance_epsilon = eps
+        self.dtype = dtype
+
+    def forward(self, hidden_states: Tensor) -> Tensor:
+        hidden_states_f32 = F.cast(hidden_states, DType.float32)
+        variance = F.mean(F.pow(hidden_states_f32, 2), axis=-1)
+        hidden_states = hidden_states * F.rsqrt(
+            variance + self.variance_epsilon
+        )
+
+        if self.dtype in (DType.float16, DType.bfloat16):
+            hidden_states = F.cast(hidden_states, self.dtype)
+        return self.weight * hidden_states
+
+
+class UMT5DenseActDense(Module[..., Tensor]):
+    def __init__(self, config: UMT5ConfigBase):
+        super().__init__()
+        self.wi = Linear(config.d_model, config.d_ff, bias=False)
+        self.wo = Linear(config.d_ff, config.d_model, bias=False)
+        if config.dense_act_fn is None:
+            raise ValueError("UMT5 dense_act_fn is not initialized.")
+        self.act_fn = _get_act_fn(config.dense_act_fn)
+
+    def forward(self, hidden_states: Tensor) -> Tensor:
+        hidden_states = self.wi(hidden_states)
+        hidden_states = self.act_fn(hidden_states)
+        hidden_states = self.wo(hidden_states)
+        return hidden_states
+
+
+class UMT5DenseGatedActDense(Module[..., Tensor]):
+    def __init__(self, config: UMT5ConfigBase):
+        super().__init__()
+        self.wi_0 = Linear(config.d_model, config.d_ff, bias=False)
+        self.wi_1 = Linear(config.d_model, config.d_ff, bias=False)
+        self.wo = Linear(config.d_ff, config.d_model, bias=False)
+        if config.dense_act_fn is None:
+            raise ValueError("UMT5 dense_act_fn is not initialized.")
+        self.act_fn = _get_act_fn(config.dense_act_fn)
+
+    def forward(self, hidden_states: Tensor) -> Tensor:
+        hidden_gated = self.act_fn(self.wi_0(hidden_states))
+        hidden_linear = self.wi_1(hidden_states)
+        hidden_states = hidden_gated * hidden_linear
+        hidden_states = self.wo(hidden_states)
+        return hidden_states
+
+
+class UMT5LayerFF(Module[..., Tensor]):
+    def __init__(self, config: UMT5ConfigBase):
+        super().__init__()
+        if config.is_gated_act:
+            self.DenseReluDense: UMT5DenseGatedActDense | UMT5DenseActDense = (
+                UMT5DenseGatedActDense(config)
+            )
+        else:
+            self.DenseReluDense = UMT5DenseActDense(config)
+        self.layer_norm = UMT5LayerNorm(
+            config.d_model,
+            eps=config.layer_norm_epsilon,
+            dtype=config.dtype,
+        )
+
+    def forward(self, hidden_states: Tensor) -> Tensor:
+        forwarded_states = self.layer_norm(hidden_states)
+        forwarded_states = self.DenseReluDense(forwarded_states)
+        return hidden_states + forwarded_states
+
+
+class UMT5Attention(Module[..., tuple[Tensor, Tensor]]):
+    def __init__(
+        self,
+        config: UMT5ConfigBase,
+        has_relative_attention_bias: bool = False,
+        layer_idx: int | None = None,
+    ):
+        super().__init__()
+        del layer_idx
+        self.is_decoder = config.is_decoder
+        self.has_relative_attention_bias = has_relative_attention_bias
+        self.relative_attention_num_buckets = (
+            config.relative_attention_num_buckets
+        )
+        self.relative_attention_max_distance = (
+            config.relative_attention_max_distance
+        )
+        self.d_model = config.d_model
+        self.key_value_proj_dim = config.d_kv
+        self.n_heads = config.num_heads
+        self.dropout = config.dropout_rate
+        self.inner_dim = self.n_heads * self.key_value_proj_dim
+        self.dtype = config.dtype
+
+        self.q = Linear(self.d_model, self.inner_dim, bias=False)
+        self.k = Linear(self.d_model, self.inner_dim, bias=False)
+        self.v = Linear(self.d_model, self.inner_dim, bias=False)
+        self.o = Linear(self.inner_dim, self.d_model, bias=False)
+
+        if self.has_relative_attention_bias:
+            self.relative_attention_bias = Embedding(
+                self.relative_attention_num_buckets,
+                dim=self.n_heads,
+            )
+
+    def _relative_position_bucket(self, relative_position: Tensor) -> Tensor:
+        relative_buckets = Tensor.constant(
+            0, dtype=DType.int32, device=relative_position.device
+        )
+        num_buckets = self.relative_attention_num_buckets
+        max_distance = self.relative_attention_max_distance
+
+        if not self.is_decoder:
+            num_buckets = num_buckets // 2
+            is_positive = F.greater(relative_position, 0)
+            relative_buckets = relative_buckets + (
+                F.cast(is_positive, DType.int32) * num_buckets
+            )
+            relative_position = F.abs(relative_position)
+        else:
+            relative_position = -F.min(relative_position, 0)
+
+        max_exact = num_buckets // 2
+        is_small = F.greater(max_exact, relative_position)
+
+        scale = (num_buckets - max_exact) / math.log(max_distance / max_exact)
+        rel_pos_float = F.cast(relative_position, DType.float32)
+        val_log = F.log(rel_pos_float / float(max_exact))
+        relative_position_if_large = max_exact + F.cast(
+            val_log * scale, DType.int32
+        )
+        relative_position_if_large = F.min(
+            relative_position_if_large, num_buckets - 1
+        )
+
+        return relative_buckets + F.where(
+            is_small, relative_position, relative_position_if_large
+        )
+
+    def compute_bias(
+        self,
+        query_length: int | Dim,
+        key_length: int | Dim,
+        device: Device,
+        cache_position: Tensor | None = None,
+    ) -> Tensor:
+        if cache_position is None:
+            context_position = F.arange(
+                0, query_length, step=1, dtype=DType.int32, device=device
+            )
+        else:
+            context_position = cache_position
+        context_position = F.unsqueeze(context_position, 1)
+
+        memory_position = F.arange(
+            0, key_length, step=1, dtype=DType.int32, device=device
+        )
+        memory_position = F.unsqueeze(memory_position, 0)
+        relative_position = memory_position - context_position
+
+        relative_position_bucket = self._relative_position_bucket(
+            relative_position
+        )
+        values = self.relative_attention_bias(relative_position_bucket)
+        values = F.permute(values, (2, 0, 1))
+        values = F.unsqueeze(values, 0)
+        return values
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Tensor | None = None,
+        past_key_values: Tensor | None = None,
+        attention_mask: Tensor | None = None,
+        cache_position: Tensor | None = None,
+        output_attentions: bool = False,
+    ) -> tuple[Tensor, Tensor]:
+        del output_attentions
+        if past_key_values is not None:
+            raise NotImplementedError(
+                "UMT5 cache is not implemented for MAX yet."
+            )
+
+        batch_size, seq_length = hidden_states.shape[:2]
+        source_states = (
+            encoder_hidden_states
+            if encoder_hidden_states is not None
+            else hidden_states
+        )
+        source_seq_length = source_states.shape[1]
+
+        query_states = self.q(hidden_states)
+        key_states = self.k(source_states)
+        value_states = self.v(source_states)
+
+        query_states = F.reshape(
+            query_states,
+            (batch_size, seq_length, self.n_heads, self.key_value_proj_dim),
+        )
+        key_states = F.reshape(
+            key_states,
+            (
+                batch_size,
+                source_seq_length,
+                self.n_heads,
+                self.key_value_proj_dim,
+            ),
+        )
+        value_states = F.reshape(
+            value_states,
+            (
+                batch_size,
+                source_seq_length,
+                self.n_heads,
+                self.key_value_proj_dim,
+            ),
+        )
+
+        query_states = F.permute(query_states, (0, 2, 1, 3))
+        key_states = F.permute(key_states, (0, 2, 1, 3))
+        value_states = F.permute(value_states, (0, 2, 1, 3))
+
+        scores = F.matmul(query_states, F.permute(key_states, (0, 1, 3, 2)))
+
+        if self.has_relative_attention_bias:
+            position_bias = self.compute_bias(
+                seq_length,
+                source_seq_length,
+                hidden_states.device,
+                cache_position=cache_position,
+            )
+            scores = scores + position_bias
+
+        if attention_mask is not None:
+            scores = scores + attention_mask
+
+        attn_weights = F.softmax(F.cast(scores, DType.float32), axis=-1)
+        attn_weights = F.cast(attn_weights, self.dtype)
+        attn_output = F.matmul(attn_weights, value_states)
+        attn_output = F.permute(attn_output, (0, 2, 1, 3))
+        attn_output = F.reshape(
+            attn_output,
+            (batch_size, seq_length, self.inner_dim),
+        )
+        attn_output = self.o(attn_output)
+        return attn_output, attn_weights
+
+
+class UMT5LayerSelfAttention(
+    Module[..., tuple[Tensor] | tuple[Tensor, Tensor]]
+):
+    def __init__(self, config: UMT5ConfigBase, layer_idx: int | None = None):
+        super().__init__()
+        self.SelfAttention = UMT5Attention(
+            config,
+            has_relative_attention_bias=True,
+            layer_idx=layer_idx,
+        )
+        self.layer_norm = UMT5LayerNorm(
+            config.d_model,
+            eps=config.layer_norm_epsilon,
+            dtype=config.dtype,
+        )
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Tensor | None = None,
+        past_key_values: Tensor | None = None,
+        cache_position: Tensor | None = None,
+        output_attentions: bool = False,
+    ) -> tuple[Tensor] | tuple[Tensor, Tensor]:
+        normed_hidden_states = self.layer_norm(hidden_states)
+        attention_output = self.SelfAttention(
+            normed_hidden_states,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            cache_position=cache_position,
+            output_attentions=output_attentions,
+        )
+        hidden_states = hidden_states + attention_output[0]
+        if output_attentions:
+            return hidden_states, attention_output[1]
+        return (hidden_states,)
+
+
+class UMT5Block(Module[..., tuple[Tensor] | tuple[Tensor, Tensor]]):
+    def __init__(self, config: UMT5ConfigBase, layer_idx: int | None = None):
+        super().__init__()
+        self.is_decoder = config.is_decoder
+        self.layer = ModuleList(
+            [
+                UMT5LayerSelfAttention(config, layer_idx=layer_idx),
+                UMT5LayerFF(config),
+            ]
+        )
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        attention_mask: Tensor | None = None,
+        encoder_hidden_states: Tensor | None = None,
+        encoder_attention_mask: Tensor | None = None,
+        past_key_values: Tensor | None = None,
+        use_cache: bool = False,
+        output_attentions: bool = False,
+        cache_position: Tensor | None = None,
+    ) -> tuple[Tensor] | tuple[Tensor, Tensor]:
+        del encoder_attention_mask
+        del use_cache
+
+        self_attention_outputs = self.layer[0](
+            hidden_states,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            cache_position=cache_position,
+            output_attentions=output_attentions,
+        )
+        hidden_states = self_attention_outputs[0]
+        self_attn_weights = (
+            self_attention_outputs[1]
+            if len(self_attention_outputs) > 1
+            else None
+        )
+
+        if hidden_states.dtype == DType.float16:
+            clamp_value = float(np.finfo(np.float16).max) - 1000
+            hidden_states = hidden_states.clip(
+                min=-clamp_value, max=clamp_value
+            )
+
+        do_cross_attention = (
+            self.is_decoder and encoder_hidden_states is not None
+        )
+        if do_cross_attention:
+            raise NotImplementedError(
+                "UMT5 decoder cross attention is not implemented in MAX."
+            )
+
+        hidden_states = self.layer[-1](hidden_states)
+        if hidden_states.dtype == DType.float16:
+            clamp_value = float(np.finfo(np.float16).max) - 1000
+            hidden_states = hidden_states.clip(
+                min=-clamp_value, max=clamp_value
+            )
+
+        if output_attentions and self_attn_weights is not None:
+            return hidden_states, self_attn_weights
+        return (hidden_states,)
+
+
+class UMT5Stack(Module[..., Tensor]):
+    def __init__(
+        self,
+        config: UMT5ConfigBase,
+        embed_tokens: Embedding | None = None,
+    ):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = embed_tokens
+        self.is_decoder = config.is_decoder
+        self.block = ModuleList(
+            [UMT5Block(config, layer_idx=i) for i in range(config.num_layers)]
+        )
+        self.final_layer_norm = UMT5LayerNorm(
+            config.d_model,
+            eps=config.layer_norm_epsilon,
+            dtype=config.dtype,
+        )
+        self.dtype = config.dtype
+
+    def forward(
+        self,
+        input_ids: Tensor | None = None,
+        attention_mask: Tensor | None = None,
+        inputs_embeds: Tensor | None = None,
+        encoder_hidden_states: Tensor | None = None,
+        encoder_attention_mask: Tensor | None = None,
+        past_key_values: Tensor | None = None,
+        use_cache: bool = False,
+        output_attentions: bool = False,
+        cache_position: Tensor | None = None,
+    ) -> Tensor:
+        del encoder_attention_mask
+        del past_key_values
+        del cache_position
+
+        use_cache = (
+            use_cache if use_cache is not None else self.config.use_cache
+        )
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+
+        if input_ids is not None:
+            if input_ids.rank == 1:
+                input_ids = F.unsqueeze(input_ids, 0)
+            if self.embed_tokens is None:
+                raise ValueError(
+                    "embed_tokens must be provided when input_ids is used"
+                )
+            inputs_embeds = self.embed_tokens(input_ids)
+        elif inputs_embeds is None:
+            raise ValueError(
+                "You have to specify either input_ids or inputs_embeds"
+            )
+        elif inputs_embeds.rank == 2:
+            inputs_embeds = F.unsqueeze(inputs_embeds, 0)
+
+        if self.is_decoder or use_cache:
+            raise NotImplementedError("UMT5 decoder is not implemented yet.")
+
+        hidden_states = inputs_embeds
+        if attention_mask is not None:
+            if attention_mask.rank == 1:
+                attention_mask = F.unsqueeze(attention_mask, 0)
+            try:
+                dtype_np = hidden_states.dtype.to_numpy()
+            except (AttributeError, ValueError):
+                dtype_np = np.float32
+            mask_multiplier = F.constant(
+                float(np.finfo(dtype_np).min),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+            causal_mask = (
+                F.constant(
+                    1.0,
+                    dtype=hidden_states.dtype,
+                    device=hidden_states.device,
+                )
+                - F.cast(attention_mask, hidden_states.dtype)
+            ) * mask_multiplier
+            causal_mask = F.unsqueeze(causal_mask, 1)
+            causal_mask = F.unsqueeze(causal_mask, 1)
+        else:
+            causal_mask = None
+
+        all_attentions: tuple[Tensor, ...] = ()
+        for layer_module in self.block:
+            layer_outputs = layer_module(
+                hidden_states,
+                attention_mask=causal_mask,
+                encoder_hidden_states=encoder_hidden_states,
+                output_attentions=output_attentions,
+            )
+            hidden_states = layer_outputs[0]
+            if output_attentions and len(layer_outputs) > 1:
+                all_attentions = all_attentions + (layer_outputs[1],)
+
+        hidden_states = self.final_layer_norm(hidden_states)
+        return hidden_states
+
+
+class UMT5EncoderModel(Module[..., Tensor]):
+    def __init__(self, config: UMT5ConfigBase):
+        super().__init__()
+        act_info = config.feed_forward_proj.split("-")
+        config.dense_act_fn = act_info[-1]
+        config.is_gated_act = act_info[0] == "gated"
+        if (len(act_info) > 1 and act_info[0] != "gated") or len(act_info) > 2:
+            raise ValueError(
+                f"`feed_forward_proj`: {config.feed_forward_proj} is not valid."
+            )
+        if config.feed_forward_proj == "gated-gelu":
+            config.dense_act_fn = "gelu_new"
+
+        self.shared = Embedding(config.vocab_size, dim=config.d_model)
+
+        encoder_config = copy.deepcopy(config)
+        encoder_config.is_decoder = False
+        encoder_config.use_cache = False
+        encoder_config.is_encoder_decoder = False
+        self.encoder = UMT5Stack(encoder_config, self.shared)
+        self.device = config.device
+
+    def input_types(self) -> tuple[TensorType, ...]:
+        return (
+            TensorType(
+                DType.int64,
+                shape=["batch_size", "sequence_length"],
+                device=self.device,
+            ),
+            TensorType(
+                DType.int64,
+                shape=["batch_size", "sequence_length"],
+                device=self.device,
+            ),
+        )
+
+    def forward(
+        self,
+        input_ids: Tensor | None = None,
+        attention_mask: Tensor | None = None,
+    ) -> Tensor:
+        return self.encoder(input_ids=input_ids, attention_mask=attention_mask)
+
+
+__all__ = ["UMT5EncoderModel"]

--- a/max/python/max/pipelines/architectures/umt5/weight_adapters.py
+++ b/max/python/max/pipelines/architectures/umt5/weight_adapters.py
@@ -1,0 +1,61 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Weight adapters for UMT5 models."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from max.graph.weights import WeightData
+
+
+def _clone_weight(weight: WeightData, new_name: str) -> WeightData:
+    return WeightData(
+        data=weight.data,
+        name=new_name,
+        dtype=weight.dtype,
+        shape=weight.shape,
+        quantization_encoding=weight.quantization_encoding,
+    )
+
+
+def convert_safetensor_state_dict(
+    state_dict: Mapping[str, WeightData],
+) -> dict[str, WeightData]:
+    """Ensure shared UMT5 embeddings are available under MAX expected names.
+
+    Hugging Face UMT5 ties `encoder.embed_tokens.weight` to `shared.weight`.
+    Some checkpoints include only one of these keys, so this adapter duplicates
+    the available embedding to whichever name is missing.
+    """
+    new_state_dict = dict(state_dict)
+    shared_weight = new_state_dict.get("shared.weight")
+    encoder_weight = new_state_dict.get("encoder.embed_tokens.weight")
+
+    if shared_weight is None and encoder_weight is None:
+        raise ValueError(
+            "Missing UMT5 embedding weights. Expected one of "
+            "`shared.weight` or `encoder.embed_tokens.weight` to be present."
+        )
+
+    if shared_weight is None and encoder_weight is not None:
+        new_state_dict["shared.weight"] = _clone_weight(
+            encoder_weight, "shared.weight"
+        )
+
+    if encoder_weight is None and shared_weight is not None:
+        new_state_dict["encoder.embed_tokens.weight"] = _clone_weight(
+            shared_weight, "encoder.embed_tokens.weight"
+        )
+
+    return new_state_dict

--- a/max/tests/integration/architectures/umt5/BUILD.bazel
+++ b/max/tests/integration/architectures/umt5/BUILD.bazel
@@ -1,0 +1,38 @@
+load("//bazel:api.bzl", "modular_py_test", "requirement")
+
+package(default_visibility = [
+    "//:__pkg__",
+    "//SDK/integration-test:__subpackages__",
+    "//max/tests:__subpackages__",
+    "//oss/modular/max/tests:__subpackages__",
+])
+
+modular_py_test(
+    name = "umt5",
+    size = "large",
+    srcs = glob(["test_*.py"]),
+    env = {
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.4",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "2",
+    },
+    gpu_constraints = ["//:has_gpu"] + select({
+        "//:apple_gpu": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    tags = [
+        "gpu",
+        "no-sandbox",
+    ],
+    deps = [
+        "//max/python/max:tensor",
+        "//max/python/max/driver",
+        "//max/python/max/dtype",
+        "//max/python/max/graph",
+        "//max/python/max/pipelines/architectures",
+        requirement("numpy"),
+        requirement("torch"),
+        requirement("transformers"),
+    ],
+)

--- a/max/tests/integration/architectures/umt5/test_encoder.py
+++ b/max/tests/integration/architectures/umt5/test_encoder.py
@@ -1,0 +1,232 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import max.driver as md
+import pytest
+import torch
+from max import functional as F
+from max.driver import Accelerator
+from max.dtype import DType
+from max.graph import DeviceRef
+from max.pipelines.architectures.umt5.model_config import UMT5ConfigBase
+from max.pipelines.architectures.umt5.umt5 import UMT5EncoderModel
+from max.tensor import Tensor
+from torch.utils.dlpack import from_dlpack
+from transformers import UMT5Config
+from transformers.models.umt5.modeling_umt5 import UMT5EncoderModel as HfUMT5
+
+
+def _tiny_umt5_config_dict() -> dict[str, int | float | str]:
+    return {
+        "vocab_size": 32128,
+        "d_model": 64,
+        "d_kv": 16,
+        "d_ff": 128,
+        "num_layers": 2,
+        "num_decoder_layers": 2,
+        "num_heads": 4,
+        "relative_attention_num_buckets": 32,
+        "relative_attention_max_distance": 128,
+        "dropout_rate": 0.0,
+        "layer_norm_epsilon": 1e-6,
+        "initializer_factor": 1.0,
+        "feed_forward_proj": "gated-gelu",
+    }
+
+
+def _adapt_hf_weights_for_max(
+    hf_state_dict: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    weights = dict(hf_state_dict)
+    shared = weights.get("shared.weight")
+    embed = weights.get("encoder.embed_tokens.weight")
+
+    # MAX registers both keys, while some HF checkpoints may only carry one.
+    if shared is None and embed is not None:
+        weights["shared.weight"] = embed
+    if embed is None and shared is not None:
+        weights["encoder.embed_tokens.weight"] = shared
+    return weights
+
+
+def _diffusers_like_get_t5_prompt_embeds_from_hidden(
+    hidden_states: torch.Tensor,
+    attention_mask: torch.Tensor,
+    num_videos_per_prompt: int,
+    max_sequence_length: int,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Mirror diffusers WanPipeline._get_t5_prompt_embeds postprocessing."""
+    prompt_embeds = hidden_states.to(dtype=dtype, device=hidden_states.device)
+    seq_lens = attention_mask.gt(0).sum(dim=1).long()
+    prompt_embeds = [
+        u[:v] for u, v in zip(prompt_embeds, seq_lens, strict=False)
+    ]
+    prompt_embeds = torch.stack(
+        [
+            torch.cat(
+                [
+                    u,
+                    u.new_zeros(
+                        max_sequence_length - u.size(0),
+                        u.size(1),
+                    ),
+                ]
+            )
+            for u in prompt_embeds
+        ],
+        dim=0,
+    )
+
+    batch_size, seq_len, _ = prompt_embeds.shape
+    prompt_embeds = prompt_embeds.repeat(1, num_videos_per_prompt, 1)
+    prompt_embeds = prompt_embeds.view(
+        batch_size * num_videos_per_prompt, seq_len, -1
+    )
+    return prompt_embeds
+
+
+def _diffusers_like_get_t5_prompt_embeds_from_encoder(
+    encoder_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor],
+    input_ids: torch.Tensor,
+    attention_mask: torch.Tensor,
+    num_videos_per_prompt: int,
+    max_sequence_length: int,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Mirror WanPipeline._get_t5_prompt_embeds including encoder call."""
+    hidden_states = encoder_fn(input_ids, attention_mask)
+    return _diffusers_like_get_t5_prompt_embeds_from_hidden(
+        hidden_states=hidden_states,
+        attention_mask=attention_mask,
+        num_videos_per_prompt=num_videos_per_prompt,
+        max_sequence_length=max_sequence_length,
+        dtype=dtype,
+    )
+
+
+@torch.no_grad()
+def test_umt5_encoder_matches_transformers() -> None:
+    if md.accelerator_api() != "cuda":
+        pytest.skip("NVIDIA GPUs are required for this test.")
+
+    torch.manual_seed(42)
+    cfg = _tiny_umt5_config_dict()
+
+    hf_model = HfUMT5(UMT5Config(**cfg)).to(torch.bfloat16).to("cuda").eval()
+    hf_state = {
+        key: value.detach().to(torch.bfloat16).to("cuda")
+        for key, value in hf_model.state_dict().items()
+    }
+    max_weights = _adapt_hf_weights_for_max(hf_state)
+
+    max_config = UMT5ConfigBase(
+        **cfg,
+        dtype=DType.bfloat16,
+        device=DeviceRef.GPU(),
+    )
+
+    with F.lazy():
+        max_model = UMT5EncoderModel(max_config)
+        max_model.to(Accelerator())
+
+    required_weight_keys = {name for name, _ in max_model.parameters}
+    missing = sorted(required_weight_keys - set(max_weights.keys()))
+    assert not missing, f"Missing weights for MAX UMT5: {missing[:8]}"
+
+    max_model.load_state_dict(max_weights, strict=False)
+    compiled = max_model.compile(*max_model.input_types())
+
+    input_ids = torch.randint(
+        0,
+        int(cfg["vocab_size"]),
+        (2, 10),
+        dtype=torch.int64,
+        device="cuda",
+    )
+    attention_mask = torch.tensor(
+        [
+            [1, 1, 1, 1, 1, 1, 0, 0, 0, 0],
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 0],
+        ],
+        dtype=torch.int64,
+        device="cuda",
+    )
+    hf_output = hf_model(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+    ).last_hidden_state
+    max_output = compiled(
+        Tensor.from_dlpack(input_ids),
+        Tensor.from_dlpack(attention_mask),
+    )
+    max_output_torch = from_dlpack(max_output).to(torch.bfloat16)
+
+    assert bool(torch.isfinite(hf_output).all()), "HF output contains NaN/Inf."
+    assert bool(torch.isfinite(max_output_torch).all()), (
+        "MAX output contains NaN/Inf."
+    )
+
+    abs_diff = (
+        hf_output.to(torch.float32) - max_output_torch.to(torch.float32)
+    ).abs()
+    max_abs_diff = float(abs_diff.max().item())
+    mean_abs_diff = float(abs_diff.mean().item())
+
+    assert max_abs_diff < 0.2, f"max_abs_diff too large: {max_abs_diff:.6f}"
+    assert mean_abs_diff < 0.04, f"mean_abs_diff too large: {mean_abs_diff:.6f}"
+
+    # WanPipeline._get_t5_prompt_embeds-like parity check:
+    # encoder(input_ids, attention_mask) + trim/pad/repeat.
+    num_videos_per_prompt = 3
+    max_sequence_length = int(input_ids.shape[1])
+    hf_prompt_embeds = _diffusers_like_get_t5_prompt_embeds_from_encoder(
+        encoder_fn=lambda ids, mask: hf_model(
+            input_ids=ids, attention_mask=mask
+        ).last_hidden_state,
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        num_videos_per_prompt=num_videos_per_prompt,
+        max_sequence_length=max_sequence_length,
+        dtype=torch.bfloat16,
+    )
+    max_prompt_embeds = _diffusers_like_get_t5_prompt_embeds_from_encoder(
+        encoder_fn=lambda ids, mask: from_dlpack(
+            compiled(
+                Tensor.from_dlpack(ids),
+                Tensor.from_dlpack(mask),
+            )
+        ).to(torch.bfloat16),
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        num_videos_per_prompt=num_videos_per_prompt,
+        max_sequence_length=max_sequence_length,
+        dtype=torch.bfloat16,
+    )
+
+    prompt_abs_diff = (
+        hf_prompt_embeds.to(torch.float32) - max_prompt_embeds.to(torch.float32)
+    ).abs()
+    prompt_max_abs_diff = float(prompt_abs_diff.max().item())
+    prompt_mean_abs_diff = float(prompt_abs_diff.mean().item())
+
+    assert prompt_max_abs_diff < 0.2, (
+        f"diffusers_like_prompt max_abs_diff too large: {prompt_max_abs_diff:.6f}"
+    )
+    assert prompt_mean_abs_diff < 0.04, (
+        f"diffusers_like_prompt mean_abs_diff too large: {prompt_mean_abs_diff:.6f}"
+    )

--- a/max/tests/integration/architectures/umt5/test_weight_adapters.py
+++ b/max/tests/integration/architectures/umt5/test_weight_adapters.py
@@ -1,0 +1,110 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+import numpy as np
+from max.graph.weights import WeightData
+from max.pipelines.architectures.umt5.model_config import UMT5ConfigBase
+from max.pipelines.architectures.umt5.weight_adapters import (
+    convert_safetensor_state_dict,
+)
+
+
+def _embedding_weight(name: str) -> WeightData:
+    return WeightData.from_numpy(np.ones((4, 8), dtype=np.float32), name)
+
+
+def test_convert_safetensor_state_dict_adds_shared_weight() -> None:
+    encoder_weight = _embedding_weight("encoder.embed_tokens.weight")
+
+    new_state_dict = convert_safetensor_state_dict(
+        {"encoder.embed_tokens.weight": encoder_weight}
+    )
+
+    assert "encoder.embed_tokens.weight" in new_state_dict
+    assert "shared.weight" in new_state_dict
+    assert new_state_dict["shared.weight"].name == "shared.weight"
+    assert new_state_dict["shared.weight"].dtype == encoder_weight.dtype
+    assert new_state_dict["shared.weight"].shape == encoder_weight.shape
+
+
+def test_convert_safetensor_state_dict_adds_encoder_weight() -> None:
+    shared_weight = _embedding_weight("shared.weight")
+
+    new_state_dict = convert_safetensor_state_dict(
+        {"shared.weight": shared_weight}
+    )
+
+    assert "shared.weight" in new_state_dict
+    assert "encoder.embed_tokens.weight" in new_state_dict
+    assert (
+        new_state_dict["encoder.embed_tokens.weight"].name
+        == "encoder.embed_tokens.weight"
+    )
+    assert (
+        new_state_dict["encoder.embed_tokens.weight"].dtype
+        == shared_weight.dtype
+    )
+    assert (
+        new_state_dict["encoder.embed_tokens.weight"].shape
+        == shared_weight.shape
+    )
+
+
+def test_convert_safetensor_state_dict_raises_without_embeddings() -> None:
+    non_embedding_weight = _embedding_weight(
+        "encoder.block.0.layer.0.SelfAttention.q.weight"
+    )
+    try:
+        convert_safetensor_state_dict(
+            {
+                "encoder.block.0.layer.0.SelfAttention.q.weight": (
+                    non_embedding_weight
+                )
+            }
+        )
+    except ValueError as exc:
+        assert "Missing UMT5 embedding weights" in str(exc)
+        assert "shared.weight" in str(exc)
+        assert "encoder.embed_tokens.weight" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for missing UMT5 embeddings.")
+
+
+def test_umt5_config_defaults_match_wan_text_encoder() -> None:
+    # Wan2.2-T2V-A14B-Diffusers text_encoder/config.json defaults.
+    config = UMT5ConfigBase()
+    assert config.classifier_dropout == 0.0
+    assert config.vocab_size == 256384
+    assert config.d_model == 4096
+    assert config.d_kv == 64
+    assert config.d_ff == 10240
+    assert config.num_layers == 24
+    assert config.num_decoder_layers == 24
+    assert config.num_heads == 64
+    assert config.relative_attention_num_buckets == 32
+    assert config.relative_attention_max_distance == 128
+    assert config.dropout_rate == 0.1
+    assert config.layer_norm_epsilon == 1e-6
+    assert config.initializer_factor == 1.0
+    assert config.feed_forward_proj == "gated-gelu"
+    assert config.use_cache is True
+    assert config.output_past is True
+    assert config.is_encoder_decoder is True
+    assert config.decoder_start_token_id == 0
+    assert config.pad_token_id == 0
+    assert config.eos_token_id == 1
+    assert config.tokenizer_class == "T5Tokenizer"
+    assert config.tie_word_embeddings is False
+    assert config.scalable_attention is True


### PR DESCRIPTION
## Summary
This PR adds a new `umt5` architecture under `max/python/max/pipelines/architectures/umt5` for Wan text encoding use cases, aligned with Hugging Face UMT5 behavior and Wan2.2 text-encoder defaults.

It includes:
- A MAX UMT5 encoder implementation.
- UMT5 config defaults matching `Wan-AI/Wan2.2-T2V-A14B-Diffusers` text encoder config.
- Weight adapter utilities for shared/encoder embedding compatibility.
- Integration tests comparing MAX outputs against Transformers UMT5 outputs.
- A diffusers-like prompt embedding parity test path (mirroring `_get_t5_prompt_embeds` post-processing behavior).

## Motivation
Wan pipelines rely on UMT5 text encoding and specific prompt embedding post-processing.  
To support Wan-compatible behavior in MAX, we need a dedicated UMT5 architecture with validated HF parity and Wan-like embedding flow checks.

## What Changed

### New architecture: `architectures/umt5`
- Added:
  - `max/python/max/pipelines/architectures/umt5/__init__.py`
  - `max/python/max/pipelines/architectures/umt5/model.py`
  - `max/python/max/pipelines/architectures/umt5/model_config.py`
  - `max/python/max/pipelines/architectures/umt5/umt5.py`
  - `max/python/max/pipelines/architectures/umt5/weight_adapters.py`

### UMT5 config defaults (Wan-aligned)
- `model_config.py` defaults were set to Wan text-encoder-compatible values, including:
  - `vocab_size=256384`
  - `d_model=4096`
  - `d_ff=10240`
  - `num_layers=24`
  - `num_heads=64`
  - `feed_forward_proj="gated-gelu"`
  - `tokenizer_class="T5Tokenizer"`
  - `tie_word_embeddings=False`
  - plus other matching fields from Wan text encoder config.

### HF compatibility and behavior
- Implemented UMT5 encoder components (attention, FFN, layer norm, stack, encoder model).
- Added support for expected input signature `(input_ids, attention_mask)`.
- Added embedding-key adaptation for checkpoints that include only one of:
  - `shared.weight`
  - `encoder.embed_tokens.weight`

### Tests
`./bazelw test --cache_test_results=no //max/tests/integration/architectures/umt5:umt5`
- Added:
  - `max/tests/integration/architectures/umt5/BUILD.bazel`
  - `max/tests/integration/architectures/umt5/test_weight_adapters.py`
  - `max/tests/integration/architectures/umt5/test_encoder.py`
- `test_encoder.py` validates:
  - MAX UMT5 vs HF `transformers` UMT5 hidden-state parity.
  - NaN/Inf safety checks.
  - diffusers-like prompt embedding path parity:
    - trim by attention-mask length
    - pad to max sequence length
    - repeat for `num_videos_per_prompt`

## Notes
- Current implementation targets encoder behavior for Wan text encoding workflows.
- Decoder/caching paths are intentionally not implemented in this change.
