### PR TITLE
[proposal] Fix and clarify a small typo in Division Semantics proposal

### DIFF
--- a/mojo/proposals/truediv.md
+++ b/mojo/proposals/truediv.md
@@ -59,8 +59,9 @@ Python's float-returning semantics.
 7 // -3  # = -3 (floor toward -infinity)
 
 # Float __floordiv__ follows the same semantics, but still returns Self
-7.0 / 3.0     # = 2.0
-7.0 // -3.0   # = -3.0 (floor toward -infinity)
+7.0 / 3.0     # = 2.333... (regular floating-point division)
+7.0 // 3.0    # = 2.0      (floor toward -infinity)
+7.0 // -3.0   # = -3.0     (floor toward -infinity)
 ```
 
 ### Behavior Summary


### PR DESCRIPTION
The floating point example given is incorrect: regardless of whether the proposal gets applied or not, 7.0 / 3.0 will always be 2.3333...

This patch tweaks the example for complete clarity of intent, with cases for regular division, floordiv with a positive result, and floordiv with a negative result.

Fixes https://github.com/modular/modular/issues/5924
