### PR TITLE
[stdlib] Replace uses of `constrained[False, ...]()` with `comptime assert "" != "", ...`

### DIFF
--- a/max/kernels/src/Mogg/MOGGKernelAPI/logprobs.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/logprobs.mojo
@@ -200,7 +200,7 @@ struct LogProbabilitiesRagged:
                 block_dim=block_size,
             )
         else:
-            constrained[False, "unsupported target"]()
+            comptime assert "" != "", "unsupported target"
 
     @staticmethod
     fn shape[

--- a/max/kernels/src/layout/_coord.mojo
+++ b/max/kernels/src/layout/_coord.mojo
@@ -122,7 +122,7 @@ struct ComptimeInt[val: Int](CoordLike, TrivialRegisterPassable):
 
     @always_inline("nodebug")
     fn tuple(var self) -> Coord[*Self.VariadicType]:
-        constrained[False, "ComptimeInt is not a tuple type"]()
+        comptime assert "" != "", "ComptimeInt is not a tuple type"
         return rebind[Coord[*Self.VariadicType]](self)
 
 
@@ -176,7 +176,7 @@ struct RuntimeInt[dtype: DType = DType.int](CoordLike, TrivialRegisterPassable):
 
     @always_inline("nodebug")
     fn tuple(var self) -> Coord[*Self.VariadicType]:
-        constrained[False, "RuntimeInt is not a tuple type"]()
+        comptime assert "" != "", "RuntimeInt is not a tuple type"
         return rebind[Coord[*Self.VariadicType]](self)
 
 
@@ -421,7 +421,7 @@ struct Coord[*element_types: CoordLike](CoordLike, Sized, Writable):
 
     @always_inline("nodebug")
     fn value(self) -> Int:
-        constrained[False, "Coord is not a value type"]()
+        comptime assert "" != "", "Coord is not a value type"
         abort()
 
     @always_inline("nodebug")
@@ -1110,7 +1110,7 @@ fn _get_flattened_helper[
 
     @parameter
     if i >= Coord[*element_types].__len__():
-        constrained[False, "flat_idx out of bounds"]()
+        comptime assert "" != "", "flat_idx out of bounds"
         abort()
 
     comptime T = element_types[i]

--- a/max/kernels/src/layout/swizzle.mojo
+++ b/max/kernels/src/layout/swizzle.mojo
@@ -563,7 +563,7 @@ fn make_swizzle[dtype: DType, mode: TensorMapSwizzle]() -> Swizzle:
     ):
         return Swizzle(Int(mode), log2_floor(16 // type_size), 3)
     else:
-        constrained[False, "Only support 32B, 64B, 128B, or no swizzle"]()
+        comptime assert "" != "", "Only support 32B, 64B, 128B, or no swizzle"
         return Swizzle(0, 0, 0)
 
 

--- a/max/kernels/src/layout/tensor_core.mojo
+++ b/max/kernels/src/layout/tensor_core.mojo
@@ -286,7 +286,7 @@ struct TensorCore[
         elif _out_type == DType.float64 and _in_type == DType.float64:
             return [shape_8x8x4, shape_16x8x4, shape_16x8x8, shape_16x8x16]
         else:
-            constrained[False, "No valid shape of mma"]()
+            comptime assert "" != "", "No valid shape of mma"
             return [shape_null]
 
     # need always_inline, otherwise the stack allocated LayoutTensor will not be valid
@@ -655,7 +655,7 @@ struct TensorCore[
             var b_ram_frags = b.distribute[warp_layout](lane_id())
             b_reg_tile.copy_from(b_ram_frags)
         else:
-            constrained[False, "No valid type to load matrix fragment b"]()
+            comptime assert "" != "", "No valid type to load matrix fragment b"
         return b_reg_tile
 
     # need always_inline, otherwise the stack allocated LayoutTensor will not be valid
@@ -701,7 +701,7 @@ struct TensorCore[
             )
             c_reg_tile.vectorize[1, 4]().copy_from(c_ram_frags)
         else:
-            constrained[False, "No valid type to load matrix fragment c"]()
+            comptime assert "" != "", "No valid type to load matrix fragment c"
         return c_reg_tile
 
     @always_inline
@@ -732,7 +732,7 @@ struct TensorCore[
             ](lane_id())
             c_reg_tile.vectorize[1, 2]().copy_from(c_ram_frags)
         else:
-            constrained[False, "No valid type to load matrix fragment c"]()
+            comptime assert "" != "", "No valid type to load matrix fragment c"
         return c_reg_tile
 
     @always_inline
@@ -788,7 +788,7 @@ struct TensorCore[
                 )
                 dst.copy_from(d_src.vectorize[1, 4]())
         else:
-            constrained[False, "No valid type to store to LayoutTensor d"]()
+            comptime assert "" != "", "No valid type to store to LayoutTensor d"
 
     @always_inline
     fn _store_d_nvidia(
@@ -824,7 +824,7 @@ struct TensorCore[
             ).copy_from(d_src.vectorize[1, 2]())
 
         else:
-            constrained[False, "No valid type to store to LayoutTensor d"]()
+            comptime assert "" != "", "No valid type to store to LayoutTensor d"
 
     # need always_inline, otherwise the stack allocated LayoutTensor will not be valid
     @always_inline
@@ -1465,7 +1465,7 @@ fn get_mma_shape[
         ):
             return shape_16x8x32
         else:
-            constrained[False, "Unsupported mma shape."]()
+            comptime assert "" != "", "Unsupported mma shape."
             return shape_null
     else:
 
@@ -1508,7 +1508,7 @@ fn get_mma_shape[
             elif accum_type == DType.int32 and (input_type == DType._uint4):
                 return shape_16x16x16
             else:
-                constrained[False, "Unsupported RDNA mma shape."]()
+                comptime assert "" != "", "Unsupported RDNA mma shape."
                 return shape_null
         else:
 
@@ -1520,7 +1520,7 @@ fn get_mma_shape[
             elif accum_type == DType.float32 and input_type.is_float8():
                 return shape_16x16x32
             else:
-                constrained[False, "Unsupported CDNA mma shape."]()
+                comptime assert "" != "", "Unsupported CDNA mma shape."
                 return shape_null
 
 

--- a/max/kernels/src/linalg/arch/cpu/neon_intrinsics.mojo
+++ b/max/kernels/src/linalg/arch/cpu/neon_intrinsics.mojo
@@ -41,7 +41,7 @@ fn _neon_dotprod[
     elif a_type == DType.int8 and b_type == DType.int8:
         return call_intrinsic["llvm.aarch64.neon.sdot.v4i32.v16i8"]()
     else:
-        constrained[False, "unsupported A and B types"]()
+        comptime assert "" != "", "unsupported A and B types"
         return SIMD[c_type, width]()
 
 
@@ -97,5 +97,5 @@ fn _neon_matmul[
     elif a_type == DType.int8 and b_type == DType.int8:
         return call_intrinsic["llvm.aarch64.neon.smmla.v4i32.v16i8"]()
     else:
-        constrained[False, "unsupported A and B types"]()
+        comptime assert "" != "", "unsupported A and B types"
         return SIMD[c_type, width]()

--- a/max/kernels/src/linalg/arch/sm100/_tma.mojo
+++ b/max/kernels/src/linalg/arch/sm100/_tma.mojo
@@ -399,5 +399,5 @@ fn to_swizzle[dtype: DType, mode: SwizzleMode]() -> Swizzle:
     ):
         return Swizzle(Int(mode), log2_floor(16 // type_size), 3)
     else:
-        constrained[False, "Only support 32B, 64B, 128B, or no swizzle"]()
+        comptime assert "" != "", "Only support 32B, 64B, 128B, or no swizzle"
         return Swizzle(0, 0, 0)

--- a/max/kernels/src/linalg/arch/sm100/mma.mojo
+++ b/max/kernels/src/linalg/arch/sm100/mma.mojo
@@ -85,7 +85,7 @@ fn max_contiguous_tile_shape[
         # TODO: for MN = swizzle_bytes // sizeof,  tile_shape[0] may be the max
         return IntTuple(8, swizzle_mode.bytes() // size_of[dtype]())
     else:
-        constrained[False, "Invalid major"]()
+        comptime assert "" != "", "Invalid major"
         return IntTuple()
 
 

--- a/max/kernels/src/linalg/matmul/cpu/apple_accelerate.mojo
+++ b/max/kernels/src/linalg/matmul/cpu/apple_accelerate.mojo
@@ -416,7 +416,7 @@ fn apple_matmul[
             elementwise[epilogue_on_col_chunk, simd_size](IndexList[2](m, n))
         return
     else:
-        constrained[False, "unsupported type in apple accelerate"]()
+        comptime assert "" != "", "unsupported type in apple accelerate"
 
 
 # apple_matmul used by all matmuls except apple_batched_matmul
@@ -436,7 +436,7 @@ fn apple_matmul[
 
         return
     else:
-        constrained[False, "unsupported type in apple accelerate"]()
+        comptime assert "" != "", "unsupported type in apple accelerate"
 
 
 # ===-----------------------------------------------------------------------===#

--- a/max/kernels/src/linalg/matmul/cpu/impl.mojo
+++ b/max/kernels/src/linalg/matmul/cpu/impl.mojo
@@ -762,7 +762,7 @@ fn matmul[
                 num_threads,
             )
         else:
-            constrained[False, "no _run_inner_loop implementation"]()
+            comptime assert "" != "", "no _run_inner_loop implementation"
 
     var shape = GemmShape.get[transpose_b](c, a, b)
     var n = shape.N
@@ -900,4 +900,4 @@ fn _submatmul_sequential_sync[
             sub_matrix_offset,
         )
     else:
-        constrained[False, "no _run_inner_loop implementation"]()
+        comptime assert "" != "", "no _run_inner_loop implementation"

--- a/max/kernels/src/nn/mha_utils.mojo
+++ b/max/kernels/src/nn/mha_utils.mojo
@@ -693,7 +693,7 @@ fn dispatch_mask_and_score_mod[
         ), "You must specify local_window_size for ChunkedCausalMask"
         return outer_wrapper(ChunkedCausalMask[local_window_size]())
     else:
-        constrained[False, "Unsupported mask type: " + mask_type]()
+        comptime assert "" != "", String("Unsupported mask type: ", mask_type)
 
 
 @always_inline
@@ -745,7 +745,9 @@ fn _dispatch_score_mod[
     elif score_mod_type == IdentityScoreMod.name_str:
         return wrapper(IdentityScoreMod())
     else:
-        constrained[False, "Unsupported score mod type: " + score_mod_type]()
+        comptime assert "" != "", String(
+            "Unsupported score mod type: ", score_mod_type
+        )
 
 
 # The motivation here is to be able to pass `StaticInt[1]()`

--- a/max/kernels/src/nn/normalization.mojo
+++ b/max/kernels/src/nn/normalization.mojo
@@ -802,7 +802,7 @@ fn layer_norm[
                 ctx=ctx.get_device_context(),
             )
         else:
-            constrained[False, "unsupported target " + target]()
+            comptime assert "" != "", String("unsupported target ", target)
 
 
 @always_inline
@@ -1483,7 +1483,7 @@ fn _rms_norm_impl[
             ctx.get_device_context(),
         )
     else:
-        constrained[False, "unsupported target " + target]()
+        comptime assert "" != "", String("unsupported target ", target)
 
 
 fn rms_norm_fused_residual_add_gpu_warp_tiling[

--- a/max/kernels/src/nn/pool.mojo
+++ b/max/kernels/src/nn/pool.mojo
@@ -1094,7 +1094,7 @@ fn avg_pool[
             ctx, input, filter, strides, dilations, paddings, output, ceil_mode
         )
     else:
-        constrained[False, "Unknown target " + target]()
+        comptime assert "" != "", String("Unknown target ", target)
 
 
 @always_inline
@@ -1123,4 +1123,4 @@ fn max_pool[
             ctx, input, filter, strides, dilations, paddings, output, ceil_mode
         )
     else:
-        constrained[False, "Unknown target " + target]()
+        comptime assert "" != "", String("Unknown target ", target)

--- a/max/kernels/src/nn/resize.mojo
+++ b/max/kernels/src/nn/resize.mojo
@@ -73,7 +73,9 @@ fn coord_transform[
     elif mode == CoordinateTransformationMode.Asymmetric:
         return out_coord_f32 / scale
     else:
-        constrained[False, "coordinate_transformation_mode not implemented"]()
+        comptime assert (
+            "" != ""
+        ), "coordinate_transformation_mode not implemented"
         return 0
 
 
@@ -123,7 +125,7 @@ struct Interpolator[mode: InterpolationMode](
         if Self.mode == InterpolationMode.Linear:
             return 1
         else:
-            constrained[False, "InterpolationMode not supported"]()
+            comptime assert "" != "", "InterpolationMode not supported"
             return -1
 
     @always_inline
@@ -132,7 +134,7 @@ struct Interpolator[mode: InterpolationMode](
         if Self.mode == InterpolationMode.Linear:
             return linear_filter(x)
         else:
-            constrained[False, "InterpolationMode not supported"]()
+            comptime assert "" != "", "InterpolationMode not supported"
             return -1
 
 
@@ -166,7 +168,7 @@ fn resize_nearest_neighbor[
         elif round_mode == RoundMode.Ceil:
             return ceil(val)
         else:
-            constrained[False, "round_mode not implemented"]()
+            comptime assert "" != "", "round_mode not implemented"
             return val
 
     @__copy_capture(scales)

--- a/max/kernels/src/nn/rope.mojo
+++ b/max/kernels/src/nn/rope.mojo
@@ -195,7 +195,7 @@ fn rope_ragged[
 
         @parameter
         if width == 1:
-            # constrained[False, "ROPE SIMD_WIDTH=1, We should never be here"]()
+            # copmtime assert "" != "", "ROPE SIMD_WIDTH=1, We should never be here"
             return
         else:
             var idx = rebind[IndexList[3]](idx_arg)

--- a/max/kernels/src/nn/softmax.mojo
+++ b/max/kernels/src/nn/softmax.mojo
@@ -889,7 +889,7 @@ fn softmax[
                 context.get_device_context(),
             )
         else:
-            constrained[False, "unsupported target ", target]()
+            comptime assert "" != "", String("unsupported target ", target)
 
 
 # ===----------------------------------------------------------------------=== #

--- a/max/kernels/src/nn/toppminp_gpu.mojo
+++ b/max/kernels/src/nn/toppminp_gpu.mojo
@@ -236,7 +236,7 @@ fn normalize(
     elif dtype == DType.bfloat16:
         return normalize(rebind[BFloat16](value)).cast[result.dtype]()
     else:
-        constrained[False, "unhandled normalize type"]()
+        comptime assert "" != "", "unhandled normalize type"
         return 0
 
 

--- a/max/kernels/src/quantization/qmatmul.mojo
+++ b/max/kernels/src/quantization/qmatmul.mojo
@@ -1343,4 +1343,4 @@ fn matmul_qint4[
     elif CompilationTarget.has_neon_int8_dotprod():
         kernel_dispatch[_MatmulQInt4Kernel_neon_dotprod]()
     else:
-        constrained[False, "unsupported architecture"]()
+        comptime assert "" != "", "unsupported architecture"

--- a/max/kernels/src/quantization/qmatmul_k.mojo
+++ b/max/kernels/src/quantization/qmatmul_k.mojo
@@ -228,7 +228,7 @@ struct _packed_bit_array[bit_width: Int, block_m: Int, block_n: Int]:
         elif Self.bit_width == 6:
             return self._pack_int6(src_ptr)
         else:
-            constrained[False, "unsupported bit width"]()
+            comptime assert "" != "", "unsupported bit width"
 
     @always_inline
     fn unpack[
@@ -244,7 +244,7 @@ struct _packed_bit_array[bit_width: Int, block_m: Int, block_n: Int]:
         elif Self.bit_width == 6:
             return self._unpack_int6[zero_point](dst_ptr)
         else:
-            constrained[False, "unsupported bit width"]()
+            comptime assert "" != "", "unsupported bit width"
 
 
 struct _block_Q4_K_packed[block_n: Int = 1]:
@@ -517,7 +517,7 @@ fn _pack_block_Q4_K[
                 q_mins_reorder_buf[reorder_idx + 0] = q_mins_row_0_val
                 q_mins_reorder_buf[reorder_idx + split_width] = q_mins_row_1_val
             else:
-                constrained[False, "unsupported architecture"]()
+                comptime assert "" != "", "unsupported architecture"
 
     dst_ptr[].q_scales_and_mins.pack(q_scales_and_mins_buf.unsafe_ptr())
     dst_ptr[].q_bits.pack(q_bits_block_buf.unsafe_ptr())
@@ -761,7 +761,7 @@ fn _matmul_group_stream[
             a_q_bits_ptr, c_int32_group
         )
     else:
-        constrained[False, "unsupported architecture"]()
+        comptime assert "" != "", "unsupported architecture"
 
 
 @always_inline
@@ -912,7 +912,7 @@ fn _apply_zero_point_correction[
                     )
 
         else:
-            constrained[False, "unsupported architecture"]()
+            comptime assert "" != "", "unsupported architecture"
 
     # Scale the correction value by the shared base minimum and update the
     # float accumulator.

--- a/max/kernels/test/gpu/layout/test_tensor_core_amd_utils.mojo
+++ b/max/kernels/test/gpu/layout/test_tensor_core_amd_utils.mojo
@@ -139,7 +139,7 @@ fn _arange(tensor: LayoutTensor[mut=True, ...]):
                     Float32(0.1 * Float64(i) + 0.2 * Float64(j))
                 )
     else:
-        constrained[False, "Unsupported dtype"]()
+        comptime assert "" != "", "Unsupported dtype"
 
 
 def test_load_and_mma_and_multiply_operands[

--- a/max/kernels/test/linalg/test_matmul_inner.mojo
+++ b/max/kernels/test/linalg/test_matmul_inner.mojo
@@ -110,7 +110,7 @@ fn _matmul_inner_loop[
             skip_boundary_check,
         )
     else:
-        constrained[False, "no _run_inner_loop implementation"]()
+        comptime assert "" != "", "no _run_inner_loop implementation"
 
 
 fn matmul_inner_loop[

--- a/max/tests/integration/Inputs/test_user_op/user_invalid.mojo
+++ b/max/tests/integration/Inputs/test_user_op/user_invalid.mojo
@@ -21,4 +21,4 @@ struct FailsToElaborate:
     fn execute(
         output: OutputTensor[dtype = DType.int32, rank=1],
     ):
-        constrained[False, "oops"]()
+        comptime assert "" != "", "oops"

--- a/mojo/stdlib/std/builtin/dtype.mojo
+++ b/mojo/stdlib/std/builtin/dtype.mojo
@@ -723,7 +723,7 @@ struct DType(
         elif dtype == DType.float64:
             return 1024
         else:
-            constrained[False, "unsupported float type"]()
+            comptime assert "" != "", "unsupported float type"
             return {}
 
     @staticmethod
@@ -753,7 +753,7 @@ struct DType(
         elif dtype == DType.float64:
             return 11
         else:
-            constrained[False, "unsupported float type"]()
+            comptime assert "" != "", "unsupported float type"
             return {}
 
     @staticmethod
@@ -1117,6 +1117,6 @@ fn _get_dtype_printf_format[dtype: DType]() -> StaticString:
         return "%.17g"
 
     else:
-        constrained[False, "invalid dtype"]()
+        comptime assert "" != "", "invalid dtype"
 
     return ""

--- a/mojo/stdlib/std/builtin/simd.mojo
+++ b/mojo/stdlib/std/builtin/simd.mojo
@@ -3209,7 +3209,9 @@ fn _pshuf_or_tbl1(lookup_table: U8x16, indices: U8x16) -> U8x16:
         return _tbl1(lookup_table, indices)
     else:
         # TODO: Change the error message when we allow SSE3
-        constrained[False, "To call _pshuf_or_tbl1() you need sse4 or neon."]()
+        comptime assert (
+            "" != ""
+        ), "To call _pshuf_or_tbl1() you need sse4 or neon."
         return {}
 
 
@@ -3283,7 +3285,7 @@ fn _pow[
         for i in range(width):
             result[i] = _powi(base[i], exp[i].cast[DType.int32]())
     else:
-        constrained[False, "unsupported type combination"]()
+        comptime assert "" != "", "unsupported type combination"
         return {}
 
 

--- a/mojo/stdlib/std/builtin/variadics.mojo
+++ b/mojo/stdlib/std/builtin/variadics.mojo
@@ -749,6 +749,22 @@ struct VariadicListMem[
 # VariadicPack
 # ===-----------------------------------------------------------------------===#
 
+comptime Several[
+    elt_is_mutable: Bool,
+    origin: Origin[mut=elt_is_mutable],
+    //,
+    T: AnyType,
+    element_trait: type_of(AnyType) = type_of(T),
+    *element_types: element_trait,
+    is_owned: Bool = False,
+] = VariadicPack[
+    elt_is_mutable=elt_is_mutable,
+    origin=origin,
+    is_owned,
+    element_trait,
+    *element_types,
+]
+
 
 struct VariadicPack[
     elt_is_mutable: Bool,

--- a/mojo/stdlib/std/ffi/__init__.mojo
+++ b/mojo/stdlib/std/ffi/__init__.mojo
@@ -150,7 +150,7 @@ fn _c_long_dtype[unsigned: Bool = False]() -> DType:
         # ILP32: long is 32-bit on 32-bit systems (e.g. x86 or RISC-V 32bit)
         return DType.uint32 if unsigned else DType.int32
     else:
-        constrained[False, "size of C `long` is unknown on this target"]()
+        comptime assert "" != "", "size of C `long` is unknown on this target"
         abort()
 
 
@@ -162,7 +162,9 @@ fn _c_long_long_dtype[unsigned: Bool = False]() -> DType:
     if is_64bit() or is_32bit():
         return DType.uint64 if unsigned else DType.int64
     else:
-        constrained[False, "size of C `long long` is unknown on this target"]()
+        comptime assert (
+            "" != ""
+        ), "size of C `long long` is unknown on this target"
         abort()
 
 

--- a/mojo/stdlib/std/gpu/compute/arch/mma_nvidia_sm100.mojo
+++ b/mojo/stdlib/std/gpu/compute/arch/mma_nvidia_sm100.mojo
@@ -241,7 +241,9 @@ fn _get_f16_mma_shape[
 
             return IndexList[3, element_type = DType.uint32](mma_m, mma_n, 16)
         else:
-            constrained[False, String("Invalid MMA shape: ", mma_m, mma_n)]()
+            comptime assert "" != "", String(
+                "Invalid MMA shape: ", mma_m, mma_n
+            )
 
             abort("MMA shape not supported.")
 
@@ -275,7 +277,9 @@ fn _get_f16_mma_shape[
 
             return IndexList[3, element_type = DType.uint32](mma_m, mma_n, 16)
         else:
-            constrained[False, String("Invalid MMA shape: ", mma_m, mma_n)]()
+            comptime assert "" != "", String(
+                "Invalid MMA shape: ", mma_m, mma_n
+            )
 
             abort("MMA shape not supported.")
 
@@ -326,7 +330,9 @@ fn _get_tf32_mma_shape[
 
             return IndexList[3, element_type = DType.uint32](mma_m, mma_n, 8)
         else:
-            constrained[False, String("Invalid MMA shape: ", mma_m, mma_n)]()
+            comptime assert "" != "", String(
+                "Invalid MMA shape: ", mma_m, mma_n
+            )
 
             abort("MMA shape not supported.")
     else:
@@ -359,7 +365,9 @@ fn _get_tf32_mma_shape[
 
             return IndexList[3, element_type = DType.uint32](mma_m, mma_n, 8)
         else:
-            constrained[False, String("Invalid MMA shape: ", mma_m, mma_n)]()
+            comptime assert "" != "", String(
+                "Invalid MMA shape: ", mma_m, mma_n
+            )
 
             abort("MMA shape not supported.")
 
@@ -411,7 +419,9 @@ fn _get_f8f6f4_mma_shape[
             return IndexList[3, element_type = DType.uint32](mma_m, mma_n, 32)
 
         else:
-            constrained[False, String("Invalid MMA shape: ", mma_m, mma_n)]()
+            comptime assert "" != "", String(
+                "Invalid MMA shape: ", mma_m, mma_n
+            )
 
             abort("MMA shape not supported.")
 
@@ -445,7 +455,9 @@ fn _get_f8f6f4_mma_shape[
 
             return IndexList[3, element_type = DType.uint32](mma_m, mma_n, 32)
         else:
-            constrained[False, String("Invalid MMA shape: ", mma_m, mma_n)]()
+            comptime assert "" != "", String(
+                "Invalid MMA shape: ", mma_m, mma_n
+            )
 
             return IndexList[3, element_type = DType.uint32](0, 0, 0)
 
@@ -487,7 +499,9 @@ fn _get_mxf8f6f4_mma_shape[
             return IndexList[3, element_type = DType.uint32](mma_m, mma_n, 32)
 
         else:
-            constrained[False, String("Invalid MMA shape: ", mma_m, mma_n)]()
+            comptime assert "" != "", String(
+                "Invalid MMA shape: ", mma_m, mma_n
+            )
 
             abort("MMA shape not supported.")
 
@@ -521,7 +535,9 @@ fn _get_mxf8f6f4_mma_shape[
 
             return IndexList[3, element_type = DType.uint32](mma_m, mma_n, 32)
         else:
-            constrained[False, String("Invalid MMA shape: ", mma_m, mma_n)]()
+            comptime assert "" != "", String(
+                "Invalid MMA shape: ", mma_m, mma_n
+            )
 
             return IndexList[3, element_type = DType.uint32](0, 0, 0)
 
@@ -1106,7 +1122,9 @@ struct MMASmemDescriptor(MMAOperandDescriptor, TrivialRegisterPassable):
             elif mode == TensorMapSwizzle.SWIZZLE_128B:
                 return 2
             else:
-                constrained[False, String("Unsupported swizzle mode: ", mode)]()
+                comptime assert "" != "", String(
+                    "Unsupported swizzle mode: ", mode
+                )
                 return 0
 
         comptime swizzle = _convert_swizzle_enum[swizzle_mode._value]()
@@ -1267,7 +1285,9 @@ struct MMASmemDescriptorPair(TrivialRegisterPassable):
             elif mode == TensorMapSwizzle.SWIZZLE_128B:
                 return 2
             else:
-                constrained[False, String("Unsupported swizzle mode: ", mode)]()
+                comptime assert "" != "", String(
+                    "Unsupported swizzle mode: ", mode
+                )
                 return 0
 
         comptime swizzle = _convert_swizzle_enum[swizzle_mode._value]()
@@ -1416,7 +1436,7 @@ fn mma[
             masks[7],
         )
     else:
-        constrained[False, String("Unsupported cta group: ", cta_group)]()
+        comptime assert "" != "", String("Unsupported cta group: ", cta_group)
 
 
 @always_inline
@@ -1513,7 +1533,7 @@ fn mma[
             sfb_tmem,
         )
     else:
-        constrained[False, String("Unsupported cta group: ", cta_group)]()
+        comptime assert "" != "", String("Unsupported cta group: ", cta_group)
 
 
 @always_inline
@@ -1601,7 +1621,7 @@ fn mma[
             masks[7],
         )
     else:
-        constrained[False, String("Unsupported cta group: ", cta_group)]()
+        comptime assert "" != "", String("Unsupported cta group: ", cta_group)
 
 
 @always_inline
@@ -1688,7 +1708,7 @@ fn mma[
             masks[7],
         )
     else:
-        constrained[False, String("Unsupported cta group: ", cta_group)]()
+        comptime assert "" != "", String("Unsupported cta group: ", cta_group)
 
 
 @always_inline
@@ -1780,7 +1800,7 @@ fn mma[
             masks[7],
         )
     else:
-        constrained[False, String("Unsupported cta group: ", cta_group)]()
+        comptime assert "" != "", String("Unsupported cta group: ", cta_group)
 
 
 # ===----------------------------------------------------------------------=== #

--- a/mojo/stdlib/std/gpu/compute/arch/tcgen05.mojo
+++ b/mojo/stdlib/std/gpu/compute/arch/tcgen05.mojo
@@ -296,7 +296,7 @@ fn tcgen05_ld[
             ]
         ]()
     else:
-        constrained[False, "width must be a power of 2 in the range [1, 128]."]()
+        comptime assert "" != "", "width must be a power of 2 in the range [1, 128]."
         abort()
     # fmt: on
 

--- a/mojo/stdlib/std/gpu/compute/mma.mojo
+++ b/mojo/stdlib/std/gpu/compute/mma.mojo
@@ -1277,12 +1277,12 @@ fn wgmma_async[
                 )
             )
         else:
-            constrained[False, "the n value '", String(n), "' is not valid"]()
+            comptime assert "" != "", String("the n value '", n, "' is not valid")
             return c
         # fmt: on
 
     else:
-        constrained[False, "unsupported config"]()
+        comptime assert "" != "", "unsupported config"
         return c
 
 

--- a/mojo/stdlib/std/gpu/compute/tensor_ops.mojo
+++ b/mojo/stdlib/std/gpu/compute/tensor_ops.mojo
@@ -226,10 +226,10 @@ fn _tc_reduce_vector[
             return tmp.reduce_add()
 
         else:
-            constrained[False, "unsupported simd_width for BF16"]()
+            comptime assert "" != "", "unsupported simd_width for BF16"
             return val[0].cast[out_type]()
     else:
-        constrained[False, "unsupported input/output type"]()
+        comptime assert "" != "", "unsupported input/output type"
         return val[0].cast[out_type]()
 
 

--- a/mojo/stdlib/std/gpu/intrinsics.mojo
+++ b/mojo/stdlib/std/gpu/intrinsics.mojo
@@ -651,7 +651,7 @@ fn _get_air_atomic_suffix[dtype: DType]() -> StaticString:
     elif dtype in (DType.int32, DType.uint32):
         return "i32"
     else:
-        constrained[False, "unsupported dtype for air atomic intrinsics"]()
+        comptime assert "" != "", "unsupported dtype for air atomic intrinsics"
         return ""
 
 

--- a/mojo/stdlib/std/gpu/primitives/warp.mojo
+++ b/mojo/stdlib/std/gpu/primitives/warp.mojo
@@ -124,7 +124,7 @@ fn _shuffle[
         ).cast[dtype]()
 
     else:
-        constrained[False, "unhandled shuffle dtype"]()
+        comptime assert "" != "", "unhandled shuffle dtype"
         return 0
 
 
@@ -158,7 +158,7 @@ fn _shuffle_amd_helper[
             var result = shuffle1.interleave(shuffle2)
             return bitcast[dtype, simd_width](result)
         else:
-            constrained[False, "unhandled shuffle dtype"]()
+            comptime assert "" != "", "unhandled shuffle dtype"
             return 0
 
 

--- a/mojo/stdlib/std/gpu/sync/sync.mojo
+++ b/mojo/stdlib/std/gpu/sync/sync.mojo
@@ -281,7 +281,9 @@ fn schedule_barrier(
     if is_amd_gpu():
         llvm_intrinsic["llvm.amdgcn.sched.barrier", NoneType](Int32(Int(mask)))
     else:
-        constrained[False, "schedule_barrier is only supported on AMDGPU."]()
+        comptime assert (
+            "" != ""
+        ), "schedule_barrier is only supported on AMDGPU."
 
 
 @always_inline("nodebug")
@@ -516,7 +518,7 @@ fn _mbarrier_impl[
             address.address_space_cast[AddressSpace.GENERIC]().address
         )
     else:
-        constrained[False, "invalid address space"]()
+        comptime assert "" != "", "invalid address space"
 
 
 @always_inline("nodebug")

--- a/mojo/stdlib/std/math/math.mojo
+++ b/mojo/stdlib/std/math/math.mojo
@@ -3508,7 +3508,7 @@ fn _get_amdgcn_type_suffix[dtype: DType]() -> StaticString:
     elif dtype == DType.float64:
         return "f64"
     else:
-        constrained[False, "Extend to support additional dtypes."]()
+        comptime assert "" != "", "Extend to support additional dtypes."
         return ""
 
 

--- a/mojo/stdlib/std/prelude/__init__.mojo
+++ b/mojo/stdlib/std/prelude/__init__.mojo
@@ -153,6 +153,7 @@ from builtin.variadics import (
     VariadicList,
     VariadicListMem,
     VariadicPack,
+    Several,
 )
 from documentation import doc_private
 from iter import (

--- a/mojo/stdlib/std/python/_python_func.mojo
+++ b/mojo/stdlib/std/python/_python_func.mojo
@@ -1295,7 +1295,7 @@ struct PyObjectFunction[
 
         @parameter
         if _type_is_eq[Self.self_type, NoneType]():
-            constrained[False, "Cannot get self arg for NoneType"]()
+            comptime assert "" != "", "Cannot get self arg for NoneType"
             # This line should never be reached due to the constraint
             abort("Unreachable code")
         else:
@@ -1501,7 +1501,7 @@ struct PyObjectFunction[
             elif self._has_type[Self._0]():
                 return PO(rebind[Self._0](self._func)())
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(1):
             check_arguments_arity(1, py_args)
@@ -1517,7 +1517,7 @@ struct PyObjectFunction[
             elif self._has_type[Self._1]():
                 return PO(rebind[Self._1](self._func)(arg0))
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(2):
             check_arguments_arity(2, py_args)
@@ -1534,7 +1534,7 @@ struct PyObjectFunction[
             elif self._has_type[Self._2]():
                 return PO(rebind[Self._2](self._func)(arg0, arg1))
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(3):
             check_arguments_arity(3, py_args)
@@ -1552,7 +1552,7 @@ struct PyObjectFunction[
             elif self._has_type[Self._3]():
                 return PO(rebind[Self._3](self._func)(arg0, arg1, arg2))
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(4):
             check_arguments_arity(4, py_args)
@@ -1571,7 +1571,7 @@ struct PyObjectFunction[
             elif self._has_type[Self._4]():
                 return PO(rebind[Self._4](self._func)(arg0, arg1, arg2, arg3))
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(5):
             check_arguments_arity(5, py_args)
@@ -1599,7 +1599,7 @@ struct PyObjectFunction[
                     rebind[Self._5](self._func)(arg0, arg1, arg2, arg3, arg4)
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(6):
             check_arguments_arity(6, py_args)
@@ -1632,10 +1632,10 @@ struct PyObjectFunction[
                     )
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         else:
-            constrained[False, "unsupported arity"]()
+            comptime assert "" != "", "unsupported arity"
             return PO()
 
     @always_inline("nodebug")
@@ -1659,7 +1659,7 @@ struct PyObjectFunction[
             elif self._has_type[Self._0_kwargs]():
                 return PO(rebind[Self._0_kwargs](self._func)(kwargs))
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(1):
             check_arguments_arity(1, py_args)
@@ -1675,7 +1675,7 @@ struct PyObjectFunction[
             elif self._has_type[Self._1_kwargs]():
                 return PO(rebind[Self._1_kwargs](self._func)(arg0, kwargs))
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(2):
             check_arguments_arity(2, py_args)
@@ -1696,7 +1696,7 @@ struct PyObjectFunction[
                     rebind[Self._2_kwargs](self._func)(arg0, arg1, kwargs)
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(3):
             check_arguments_arity(3, py_args)
@@ -1724,7 +1724,7 @@ struct PyObjectFunction[
                     rebind[Self._3_kwargs](self._func)(arg0, arg1, arg2, kwargs)
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(4):
             check_arguments_arity(4, py_args)
@@ -1755,7 +1755,7 @@ struct PyObjectFunction[
                     )
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(5):
             check_arguments_arity(5, py_args)
@@ -1787,7 +1787,7 @@ struct PyObjectFunction[
                     )
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(6):
             check_arguments_arity(6, py_args)
@@ -1820,10 +1820,10 @@ struct PyObjectFunction[
                     )
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         else:
-            constrained[False, "unsupported arity"]()
+            comptime assert "" != "", "unsupported arity"
             return PO()
 
     @always_inline("nodebug")
@@ -1856,7 +1856,7 @@ struct PyObjectFunction[
                 var self_arg = Self._get_self_arg(py_self)
                 return PO(rebind[Self._1_self](self._func)(self_arg))
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(2):
             check_arguments_arity(1, py_args)
@@ -1884,7 +1884,7 @@ struct PyObjectFunction[
                 var self_arg = Self._get_self_arg(py_self)
                 return PO(rebind[Self._2_self](self._func)(self_arg, arg0))
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(3):
             check_arguments_arity(2, py_args)
@@ -1917,7 +1917,7 @@ struct PyObjectFunction[
                     rebind[Self._3_self](self._func)(self_arg, arg0, arg1)
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(4):
             check_arguments_arity(3, py_args)
@@ -1961,7 +1961,7 @@ struct PyObjectFunction[
                     rebind[Self._4_self](self._func)(self_arg, arg0, arg1, arg2)
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(5):
             check_arguments_arity(4, py_args)
@@ -2014,7 +2014,7 @@ struct PyObjectFunction[
                     )
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(6):
             check_arguments_arity(5, py_args)
@@ -2070,10 +2070,10 @@ struct PyObjectFunction[
                     )
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         else:
-            constrained[False, "unsupported arity"]()
+            comptime assert "" != "", "unsupported arity"
             return PO()
 
     @always_inline("nodebug")
@@ -2118,7 +2118,7 @@ struct PyObjectFunction[
                     rebind[Self._1_self_kwargs](self._func)(self_arg, kwargs)
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(2):
             check_arguments_arity(1, py_args)
@@ -2166,7 +2166,7 @@ struct PyObjectFunction[
                     )
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(3):
             check_arguments_arity(2, py_args)
@@ -2219,7 +2219,7 @@ struct PyObjectFunction[
                     )
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(4):
             check_arguments_arity(3, py_args)
@@ -2273,7 +2273,7 @@ struct PyObjectFunction[
                     )
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(5):
             check_arguments_arity(4, py_args)
@@ -2328,7 +2328,7 @@ struct PyObjectFunction[
                     )
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         elif Self._has_arity(6):
             check_arguments_arity(5, py_args)
@@ -2384,8 +2384,8 @@ struct PyObjectFunction[
                     )
                 )
             else:
-                constrained[False, "unsupported signature"]()
+                comptime assert "" != "", "unsupported signature"
                 return PO()
         else:
-            constrained[False, "unsupported arity"]()
+            comptime assert "" != "", "unsupported arity"
             return PO()

--- a/mojo/stdlib/std/python/python_object.mojo
+++ b/mojo/stdlib/std/python/python_object.mojo
@@ -1933,4 +1933,4 @@ __extension SIMD:
             self = Scalar[dtype](Int(py=py))
         else:
             self = Scalar[dtype]()
-            constrained[False, "unsupported dtype"]()
+            comptime assert "" != "", "unsupported dtype"

--- a/mojo/stdlib/std/sys/info.mojo
+++ b/mojo/stdlib/std/sys/info.mojo
@@ -72,15 +72,11 @@ struct CompilationTarget[value: _TargetType = _current_target()](
 
         @parameter
         if operation:
-            constrained[
-                False,
-                String(msg, " operation: ", operation.value(), ".", note_text),
-            ]()
+            comptime assert "" != "", String(
+                msg, " operation: ", operation.value(), ".", note_text
+            )
         else:
-            constrained[
-                False,
-                String(msg, " this operation.", note_text),
-            ]()
+            comptime assert "" != "", String(msg, " this operation.", note_text)
 
         os.abort()
 

--- a/mojo/stdlib/std/utils/numerics.mojo
+++ b/mojo/stdlib/std/utils/numerics.mojo
@@ -524,7 +524,7 @@ fn nan[dtype: DType]() -> Scalar[dtype]:
             __mlir_attr.`#pop.simd<"nan"> : !pop.scalar<f64>`,
         )
     else:
-        constrained[False, "unsupported float type"]()
+        comptime assert "" != "", "unsupported float type"
         return {}
 
 
@@ -629,7 +629,7 @@ fn inf[dtype: DType]() -> Scalar[dtype]:
             __mlir_attr.`#pop.simd<"inf"> : !pop.scalar<f64>`,
         )
     else:
-        constrained[False, "unsupported float type"]()
+        comptime assert "" != "", "unsupported float type"
         return {}
 
 
@@ -689,7 +689,7 @@ fn neg_inf[dtype: DType]() -> Scalar[dtype]:
             __mlir_attr.`#pop.simd<"-inf"> : !pop.scalar<f64>`,
         )
     else:
-        constrained[False, "unsupported float type"]()
+        comptime assert "" != "", "unsupported float type"
         return {}
 
 
@@ -736,7 +736,7 @@ fn max_finite[dtype: DType]() -> Scalar[dtype]:
     elif dtype == DType.bool:
         return Scalar(True)._refine[dtype]()
     else:
-        constrained[False, "max_finite() called on unsupported dtype"]()
+        comptime assert "" != "", "max_finite() called on unsupported dtype"
         return {}
 
 
@@ -767,7 +767,7 @@ fn min_finite[dtype: DType]() -> Scalar[dtype]:
     elif dtype == DType.bool:
         return Scalar(False)._refine[dtype]()
     else:
-        constrained[False, "min_finite() called on unsupported dtype"]()
+        comptime assert "" != "", "min_finite() called on unsupported dtype"
         return {}
 
 

--- a/mojo/stdlib/test/builtin/test_variadic.mojo
+++ b/mojo/stdlib/test/builtin/test_variadic.mojo
@@ -375,5 +375,26 @@ def test_variadic_list_linear_type():
     take_owned_linear(ExplicitDelOnly(5), ExplicitDelOnly(10))
 
 
+def test_several():
+    def test_trivial_type(a: Several[Int]):
+        @parameter
+        for i in range(a.__len__()):
+            assert_equal(a[i], 0)
+
+    def test_non_trivial_type(a: Several[String]):
+        @parameter
+        for i in range(a.__len__()):
+            assert_equal(a[i], "")
+
+    def test_trait(a: Several[_, Boolable]):
+        @parameter
+        for i in range(a.__len__()):
+            assert_false(a[i])
+
+    test_trivial_type(0, 0, 0)
+    test_non_trivial_type("", "", "")
+    test_trait("", 0, False, [])
+
+
 def main():
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/mojo/stdlib/test/sys/test_ffi.mojo
+++ b/mojo/stdlib/test/sys/test_ffi.mojo
@@ -283,7 +283,7 @@ def test_errno_message():
     elif CompilationTarget.is_macos():
         _test_errno_message[error_message_macos]()
     else:
-        constrained[False, "test not implemented for the platform"]()
+        comptime assert "" != "", "test not implemented for the platform"
 
 
 def test_errno():


### PR DESCRIPTION
Replace uses of `constrained[False, ...]()` with `comptime assert "" != "", ...`. This is a workaround until we can have expressions that always evaluate to false at some sooner stage in the compilation pipeline