### PR TITLE
[kernels] Replace uses of `constrained[boolean_expression]` with `comptime assert` in kernels

### DIFF
--- a/max/kernels/benchmarks/gpu/bench_grouped_matmul.mojo
+++ b/max/kernels/benchmarks/gpu/bench_grouped_matmul.mojo
@@ -270,10 +270,9 @@ fn bench_grouped_matmul[
 
     @parameter
     if is_fp4e2m1:
-        constrained[
-            scaling_kind_str == "nvfp4",
-            "Only support nvfp4 scaling kind for float4-e2m1fn",
-        ]()
+        comptime assert (
+            scaling_kind_str == "nvfp4"
+        ), "Only support nvfp4 scaling kind for float4-e2m1fn"
 
         var a_scale_offsets_dev_buffer = ctx.enqueue_create_buffer[
             DType.uint32
@@ -471,10 +470,9 @@ fn bench_grouped_matmul[
         expert_scales_host_ptr.free()
 
     elif in_type == DType.float8_e4m3fn:
-        constrained[
-            scaling_kind_str == "1d2d",
-            "Only support 1d2d scaling kind for float8_e4m3fn",
-        ]()
+        comptime assert (
+            scaling_kind_str == "1d2d"
+        ), "Only support 1d2d scaling kind for float8_e4m3fn"
         comptime BLOCK_SCALE_K = 128
         comptime static_a_scales_shape = DimList(K // BLOCK_SCALE_K, Dim())
         var a_scales_size = (K // BLOCK_SCALE_K) * total_num_tokens

--- a/max/kernels/benchmarks/gpu/bench_mla.mojo
+++ b/max/kernels/benchmarks/gpu/bench_mla.mojo
@@ -67,7 +67,7 @@ fn bench_decode[
     mode: String,
     ctx: DeviceContext,
 ) raises:
-    constrained[mask_rank in (3, 4), "MLA only supports rank 3 or 4."]()
+    comptime assert mask_rank in (3, 4), "MLA only supports rank 3 or 4."
 
     # Query, key, value dimensions.
     comptime scale = Float32(0.125)  # rsqrt[type, 1](Float32(depth))

--- a/max/kernels/benchmarks/gpu/bench_reducescatter.mojo
+++ b/max/kernels/benchmarks/gpu/bench_reducescatter.mojo
@@ -82,8 +82,8 @@ fn bench_reducescatter[
     max_num_blocks: Optional[Int],
     ragged: Bool,
 ) raises:
-    constrained[ngpus in (2, 4, 8), "ngpus must be 2, 4, or 8"]()
-    constrained[rank == 1, "this test code currently assumes rank 1"]()
+    comptime assert ngpus in (2, 4, 8), "ngpus must be 2, 4, or 8"
+    comptime assert rank == 1, "this test code currently assumes rank 1"
 
     var name = String(
         _get_test_str[dtype, use_multimem, cache_busting](

--- a/max/kernels/src/comm/allreduce.mojo
+++ b/max/kernels/src/comm/allreduce.mojo
@@ -838,10 +838,9 @@ fn allreduce[
       - The `use_multimem` parameter requires P2P access between GPUs to be enabled.
     """
 
-    constrained[
-        not (use_multimem and use_quickreduce),
-        "Quickreduce is incompatible with multimem.",
-    ]()
+    comptime assert not (
+        use_multimem and use_quickreduce
+    ), "Quickreduce is incompatible with multimem."
     # Return early, if the input buffer is empty
     var num_elements = input_buffers[0].num_elements()
     if num_elements == 0:

--- a/max/kernels/src/comm/reducescatter.mojo
+++ b/max/kernels/src/comm/reducescatter.mojo
@@ -128,7 +128,7 @@ struct ReduceScatterConfig[
         num_elements: Int,
         threads_per_gpu: Int,
     ):
-        constrained[Self.ngpus > 1, "ngpus must be greater than 1"]()
+        comptime assert Self.ngpus > 1, "ngpus must be greater than 1"
         self.stride = threads_per_gpu * Self.simd_width
         # --- Data Partitioning ---
         # Data are divided as evenly as possible amongst ngpus.

--- a/max/kernels/src/extensibility/tensor/managed_tensor_slice.mojo
+++ b/max/kernels/src/extensibility/tensor/managed_tensor_slice.mojo
@@ -1259,12 +1259,11 @@ struct ManagedTensorSlice[
             ),
         ],
     ):
-        constrained[
+        comptime assert (
             not Self.static_spec.in_lambda
             and not Self.static_spec.out_lambda
-            and not Self.static_spec.out_compute_lambda,
-            "The tensor is already bound to a lambda",
-        ]()
+            and not Self.static_spec.out_compute_lambda
+        ), "The tensor is already bound to a lambda"
         return {self._ptr, self._spec, self._runtime_strides}
 
     @doc_private
@@ -1282,12 +1281,11 @@ struct ManagedTensorSlice[
             ),
         ],
     ):
-        constrained[
+        comptime assert (
             not Self.static_spec.in_lambda
             and not Self.static_spec.out_lambda
-            and not Self.static_spec.out_compute_lambda,
-            "The tensor is already bound to a lambda",
-        ]()
+            and not Self.static_spec.out_compute_lambda
+        ), "The tensor is already bound to a lambda"
         return {self._ptr, self._spec, self._runtime_strides}
 
     @doc_private
@@ -1305,12 +1303,11 @@ struct ManagedTensorSlice[
             ),
         ],
     ):
-        constrained[
+        comptime assert (
             not Self.static_spec.in_lambda
             and not Self.static_spec.out_lambda
-            and not Self.static_spec.out_compute_lambda,
-            "The tensor is already bound to a lambda",
-        ]()
+            and not Self.static_spec.out_compute_lambda
+        ), "The tensor is already bound to a lambda"
         return {self._ptr, self._spec, self._runtime_strides}
 
     @doc_private
@@ -1328,12 +1325,11 @@ struct ManagedTensorSlice[
             ),
         ],
     ):
-        constrained[
+        comptime assert (
             not Self.static_spec.in_lambda
             and not Self.static_spec.out_lambda
-            and not Self.static_spec.out_compute_lambda,
-            "The tensor is already bound to a lambda",
-        ]()
+            and not Self.static_spec.out_compute_lambda
+        ), "The tensor is already bound to a lambda"
         return {self._ptr, self._spec, self._runtime_strides}
 
     @always_inline

--- a/max/kernels/src/kv_cache/types.mojo
+++ b/max/kernels/src/kv_cache/types.mojo
@@ -541,10 +541,9 @@ struct ContinuousBatchingKVCache[
         swizzle_mode,
     ]:
         """Creates a TMA tile for this KV cache."""
-        constrained[
-            (BK % swizzle_granularity[Self.dtype, swizzle_mode]()) == 0,
-            "BK must be a multiple of swizzle granularity",
-        ]()
+        comptime assert (
+            BK % swizzle_granularity[Self.dtype, swizzle_mode]()
+        ) == 0, "BK must be a multiple of swizzle granularity"
         # The continuous cache is laid out as [num_blocks, num_layers, seq_len, num_heads, head_size]
         # We create a view of the data as a flattened 2D tensor
         var total_blocks = self.blocks.dim[0]()
@@ -587,10 +586,9 @@ struct ContinuousBatchingKVCache[
             BN=BK,
         ],
     ) raises:
-        constrained[
-            (BK % swizzle_granularity[Self.dtype, swizzle_mode]()) == 0,
-            "BK must be a multiple of swizzle granularity",
-        ]()
+        comptime assert (
+            BK % swizzle_granularity[Self.dtype, swizzle_mode]()
+        ) == 0, "BK must be a multiple of swizzle granularity"
         var total_blocks = self.blocks.dim[0]()
         var rows = UInt32(total_blocks - 1) * self._stride() + UInt32(
             self.blocks.dim[1]()
@@ -826,10 +824,9 @@ struct PagedKVCache[
         swizzle_mode,
     ]:
         """Creates a TMA tile for this KV cache."""
-        constrained[
-            (BK % swizzle_granularity[Self.dtype, swizzle_mode]()) == 0,
-            "BK must be a multiple of swizzle granularity",
-        ]()
+        comptime assert (
+            BK % swizzle_granularity[Self.dtype, swizzle_mode]()
+        ) == 0, "BK must be a multiple of swizzle granularity"
         # Paged cache collection is (where `$idx` means subsetting that idx):
         # [total_num_blocks, $kv_idx, $layer_idx, page_size, num_heads, head_size]
         #
@@ -874,10 +871,9 @@ struct PagedKVCache[
             BN=BK,
         ],
     ) raises:
-        constrained[
-            (BK % swizzle_granularity[Self.dtype, swizzle_mode]()) == 0,
-            "BK must be a multiple of swizzle granularity",
-        ]()
+        comptime assert (
+            BK % swizzle_granularity[Self.dtype, swizzle_mode]()
+        ) == 0, "BK must be a multiple of swizzle granularity"
         var total_blocks = self.blocks.dim[0]()
         var rows = UInt32(total_blocks - 1) * self._stride() + UInt32(
             Self.page_size

--- a/max/kernels/src/layout/layout_tensor.mojo
+++ b/max/kernels/src/layout/layout_tensor.mojo
@@ -2057,15 +2057,16 @@ struct LayoutTensor[
         """
         comptime arg_count = args.__len__()
 
-        constrained[
-            Self.rank == arg_count or Self.num_strides == arg_count,
-            "Indexed with "
-            + String(arg_count)
-            + " dims, but Self.rank, Self.num_strides = "
-            + String(Self.rank)
-            + ", "
-            + String(self.num_strides),
-        ]()
+        comptime assert (
+            Self.rank == arg_count or Self.num_strides == arg_count
+        ), String(
+            "Indexed with ",
+            arg_count,
+            " dims, but Self.rank, Self.num_strides = ",
+            Self.rank,
+            ", ",
+            self.num_strides,
+        )
 
         var index_list = Self.idx_list_t[arg_count](fill=0)
 

--- a/max/kernels/src/linalg/fp4_utils.mojo
+++ b/max/kernels/src/linalg/fp4_utils.mojo
@@ -196,10 +196,9 @@ fn set_scale_factor[
     col_idx: Int,
     scale_value: SIMD[scales_dtype, width],
 ):
-    constrained[
-        scales_tensor.rank == 5,
-        "scales_tensor must be 5D for non-batched scales tensor",
-    ]()
+    comptime assert (
+        scales_tensor.rank == 5
+    ), "scales_tensor must be 5D for non-batched scales tensor"
     comptime assert (
         width <= SF_ATOM_K
     ), "width must be less than or equal to SF_ATOM_K"
@@ -227,10 +226,9 @@ fn get_scale_factor[
     row_idx: Int,
     col_idx: Int,
 ) -> Scalar[scales_dtype]:
-    constrained[
-        scales_tensor.rank == 5,
-        "scales_tensor must be 5D for non-batched scales tensor",
-    ]()
+    comptime assert (
+        scales_tensor.rank == 5
+    ), "scales_tensor must be 5D for non-batched scales tensor"
 
     return rebind[Scalar[scales_dtype]](
         scales_tensor[
@@ -255,10 +253,9 @@ fn set_batched_scale_factor[
     col_idx: Int,
     scale_value: Scalar[scales_dtype],
 ):
-    constrained[
-        scales_tensor.rank == 6,
-        "scales_tensor must be 6D for batched scales tensor",
-    ]()
+    comptime assert (
+        scales_tensor.rank == 6
+    ), "scales_tensor must be 6D for batched scales tensor"
 
     scales_tensor[
         batch_idx,
@@ -281,10 +278,9 @@ fn get_batched_scale_factor[
     row_idx: Int,
     col_idx: Int,
 ) -> Scalar[scales_dtype]:
-    constrained[
-        scales_tensor.rank == 6,
-        "scales_tensor must be 6D for batched scales tensor",
-    ]()
+    comptime assert (
+        scales_tensor.rank == 6
+    ), "scales_tensor must be 6D for batched scales tensor"
 
     return rebind[Scalar[scales_dtype]](
         scales_tensor[

--- a/max/kernels/src/linalg/grouped_matmul_sm100_1d1d.mojo
+++ b/max/kernels/src/linalg/grouped_matmul_sm100_1d1d.mojo
@@ -1146,10 +1146,9 @@ fn blackwell_block_scaled_matmul_tma_umma_warp_specialized[
         address_space = b_device.address_space,
     ](b_device.ptr)
 
-    constrained[
-        sfb_layout.shape[0].value() == num_experts,
-        "num_experts must be equal to _sfb_layout.shape[0]",
-    ]()
+    comptime assert (
+        sfb_layout.shape[0].value() == num_experts
+    ), "num_experts must be equal to _sfb_layout.shape[0]"
     comptime flat_sfb_layout = Layout.row_major(
         sfb_layout.shape[0].value() * sfb_layout.shape[1].value(),
         sfb_layout.shape[2].value(),
@@ -1289,10 +1288,7 @@ fn _blackwell_block_scaled_matmul_tma_umma_warp_specialized[
     #   - Swapped A↔B when config.AB_swapped is True
     # So here a_layout and b_layout are both 2D, and sfa_layout and
     # sfb_layout are both 5D.
-    constrained[
-        transpose_b,
-        "Only support transposed B",
-    ]()
+    comptime assert transpose_b, "Only support transposed B"
 
     comptime assert (
         sfa_dtype == sfb_dtype
@@ -1302,8 +1298,8 @@ fn _blackwell_block_scaled_matmul_tma_umma_warp_specialized[
         " scales"
     )
 
-    constrained[a_scales.rank == 5, "a_scales must be 5D tensors"]()
-    constrained[b_scales.rank == 5, "b_scales must be 5D tensors"]()
+    comptime assert a_scales.rank == 5, "a_scales must be 5D tensors"
+    comptime assert b_scales.rank == 5, "b_scales must be 5D tensors"
 
     comptime MMA_M = config.mma_shape[0]
     comptime MMA_N = config.mma_shape[1]
@@ -1313,75 +1309,65 @@ fn _blackwell_block_scaled_matmul_tma_umma_warp_specialized[
     comptime BN = MMA_N // config.cta_group
     comptime BK = config.block_tile_shape[2]
 
-    constrained[
-        config.cta_group in (1, 2), "Only support cta_group == 1 or 2"
-    ]()
+    comptime assert config.cta_group in (
+        1,
+        2,
+    ), "Only support cta_group == 1 or 2"
+    comptime assert config.k_group_size == 1, "Only support k_group_size == 1"
 
-    constrained[
-        config.k_group_size == 1,
-        "Only support k_group_size == 1",
-    ]()
+    comptime assert config.num_split_k == 1, "Only support split_k == 1"
 
-    constrained[
-        config.num_split_k == 1,
-        "Only support split_k == 1",
-    ]()
+    comptime assert (
+        config.num_pipeline_stages % config.k_group_size == 0
+    ), "num_pipeline_stages must be a multiple of k_group_size"
 
-    constrained[
-        config.num_pipeline_stages % config.k_group_size == 0,
-        "num_pipeline_stages must be a multiple of k_group_size",
-    ]()
+    comptime assert (
+        config.num_pipeline_stages % config.k_group_size == 0
+    ), "num_pipeline_stages must be a multiple of k_group_size"
 
-    constrained[
+    comptime assert (
         sfa_layout.shape[2].value()
         == sfb_layout.shape[2].value()
-        == SF_ATOM_M[0],
-        "",
-    ]()
-    constrained[
+        == SF_ATOM_M[0]
+    )
+    comptime assert (
         sfa_layout.shape[3].value()
         == sfb_layout.shape[3].value()
-        == SF_ATOM_M[1],
-        "",
-    ]()
-    constrained[
-        sfa_layout.shape[4].value() == sfb_layout.shape[4].value() == SF_ATOM_K,
-        "",
-    ]()
+        == SF_ATOM_M[1]
+    )
+    comptime assert (
+        sfa_layout.shape[4].value() == sfb_layout.shape[4].value() == SF_ATOM_K
+    )
 
     @parameter
     if config.cta_group == 2:
-        constrained[
-            MMA_M == 256 and MMA_N in (128, 256),
-            "Only support cta_group == 2 with MMA_M == 256",
-        ]()
+        comptime assert MMA_M == 256 and MMA_N in (
+            128,
+            256,
+        ), "Only support cta_group == 2 with MMA_M == 256"
 
     else:
-        constrained[
-            MMA_M == 128 and MMA_N in (128, 256),
-            (
-                "Only support MMA_M == 128 and MMA_N in (128, 256) when"
-                " cta_group == 1"
-            ),
-        ]()
+        comptime assert MMA_M == 128 and MMA_N in (128, 256), (
+            "Only support MMA_M == 128 and MMA_N in (128, 256) when"
+            " cta_group == 1"
+        )
 
     comptime cluster_shape = config.cluster_shape
 
     comptime N = c_layout.shape[1].value()
     comptime expert_n = N
     comptime K = a_layout.shape[1].value()
-    comptime assert K % 16 == 0, (
-        "Due to TMA limitations, K must be a multiple of 16 bytes"
-        + " but got K = "
-        + String(K)
+    comptime assert K % 16 == 0, String(
+        "Due to TMA limitations, K must be a multiple of 16 bytes",
+        " but got K = ",
+        K,
     )
 
     var M = c_device.dim[0]()
 
-    constrained[
-        ceildiv(K, BK) % config.k_group_size == 0,
-        "K iterations must be a multiple of k_group_size",
-    ]()
+    comptime assert (
+        ceildiv(K, BK) % config.k_group_size == 0
+    ), "K iterations must be a multiple of k_group_size"
 
     a_tma_op = create_tensor_tile[
         Index(BM // cluster_shape[1], BK), swizzle_mode = config.a_swizzle
@@ -1654,8 +1640,8 @@ fn blackwell_block_scaled_tma_umma_warp_specialized_kernel[
     mnk: StaticTuple[UInt32, 3],
     workspace: Span[UInt64, MutAnyOrigin],
 ):
-    constrained[c_type != DType.float32, "c_type cannot be float32"]()
-    constrained[transpose_b, "only support k-major B"]()
+    comptime assert c_type != DType.float32, "c_type cannot be float32"
+    comptime assert transpose_b, "only support k-major B"
 
     comptime num_output_warps = 4
 
@@ -1683,12 +1669,11 @@ fn blackwell_block_scaled_tma_umma_warp_specialized_kernel[
     comptime SFB_NUM_COLS = config.num_sf_k_tiles * (MMA_N // 32)
     comptime stage_stride_cols = config.mma_shape[1]
 
-    constrained[
+    comptime assert (
         config.num_accum_pipeline_stages * MMA_N
         + (SFA_NUM_COLS + SFB_NUM_COLS) * config.num_pipeline_stages
-        <= NUM_TMEM_COLS,
-        "sfa_tmem and sfb_tmem exceed tmem_cols",
-    ]()
+        <= NUM_TMEM_COLS
+    ), "sfa_tmem and sfb_tmem exceed tmem_cols"
 
     comptime num_m_mmas = BM // (config.mma_shape[0] // config.cta_group)
     comptime num_n_mmas = BN // (config.mma_shape[1] // config.cta_group)

--- a/max/kernels/src/linalg/matmul/gpu/__init__.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/__init__.mojo
@@ -456,10 +456,9 @@ fn _matmul_gpu[
         if elementwise_compute_lambda_fn:
             comptime compute_lambda = elementwise_compute_lambda_fn.value()
             var output = compute_lambda(coords, val)
-            constrained[
-                output.dtype == c.type,
-                "compute epilogue lambda output and c type mismatch",
-            ]()
+            comptime assert (
+                output.dtype == c.type
+            ), "compute epilogue lambda output and c type mismatch"
             c.store[alignment = alignment * size_of[c.type]()](
                 coords, rebind[SIMD[c.type, _width]](output)
             )

--- a/max/kernels/src/linalg/matmul/gpu/_multistage_gemm_gpu.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/_multistage_gemm_gpu.mojo
@@ -381,10 +381,9 @@ fn multistage_mma[
     comptime num_k_mma_iters: UInt = num_k_mmas // k_group_size
     comptime num_m_mmas = WM // MMA_M
     comptime num_n_mmas = WN // MMA_N
-    constrained[
-        num_k_mmas % UInt(2 * Int(k_group_size)) == 0,
-        "num_k_mmas must be an integer multiple of 2*k_group_size",
-    ]()
+    comptime assert (
+        num_k_mmas % UInt(2 * Int(k_group_size)) == 0
+    ), "num_k_mmas must be an integer multiple of 2*k_group_size"
 
     comptime accum_type = get_accum_type[a_type]()
     comptime frag_size = get_fragment_size[mma_shape]()
@@ -457,14 +456,13 @@ fn multistage_mma[
 
     @parameter
     if static_num_iters.has_value():
-        constrained[
+        comptime assert (
             a_iter.address_space == AddressSpace.SHARED
-            or a_iter.address_space == AddressSpace.LOCAL,
-            (
-                "Using input in registers or shared memory requires static"
-                " iteration bound.\n"
-            ),
-        ]()
+            or a_iter.address_space == AddressSpace.LOCAL
+        ), (
+            "Using input in registers or shared memory requires static"
+            " iteration bound.\n"
+        )
 
         @parameter
         for k_tile_id in range(static_num_iters.get()):
@@ -764,15 +762,13 @@ fn multistage_gemm_kernel[
     ],
 ):
     # Hold on adding fp16 because it could have different precisions than bf16.
-    constrained[
-        (a_type in (DType.float32, DType.bfloat16) and a_type == b_type)
-        or (
-            a_type in (DType.float8_e4m3fn, DType.float8_e5m2)
-            and a_type == b_type
-            and c_type == DType.float32
-        ),
-        "Pipeline gemm only supports tf32, BF16, E4M3, and E5M2 mma",
-    ]()
+    comptime assert (
+        a_type in (DType.float32, DType.bfloat16) and a_type == b_type
+    ) or (
+        a_type in (DType.float8_e4m3fn, DType.float8_e5m2)
+        and a_type == b_type
+        and c_type == DType.float32
+    ), "Pipeline gemm only supports tf32, BF16, E4M3, and E5M2 mma"
     comptime simd_size = simd_width_of[c_type]()
 
     var M = UInt(c.dim[0]())
@@ -945,10 +941,9 @@ fn multistage_gemm_kernel[
         # This block is identical to the one used for f32 case
         # but putting this in a lambda function leads to test failures
         # TODO: Refactor to remove code duplication
-        constrained[
-            elementwise_lambda_fn is not None,
-            "elementwise_lambda_fn is not valid",
-        ]()
+        comptime assert (
+            elementwise_lambda_fn is not None
+        ), "elementwise_lambda_fn is not valid"
         comptime thread_layout = Layout.row_major(
             8, 4
         ) if is_nvidia_gpu() else Layout.row_major(4, 16)

--- a/max/kernels/src/linalg/matmul/gpu/amd/matmul.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/amd/matmul.mojo
@@ -294,8 +294,8 @@ fn gemm_kernel_amd[
         b: Input matrix B (must be transposed).
     """
     # Validate input constraints
-    constrained[transpose_b, "Transpose b must be true"]()
-    constrained[a_type == b_type, "a and b must have same type"]()
+    comptime assert transpose_b, "Transpose b must be true"
+    comptime assert a_type == b_type, "a and b must have same type"
 
     # Type and shape aliases
     comptime accum_type = get_accum_type[a_type]()
@@ -339,19 +339,19 @@ fn gemm_kernel_amd[
     var M = a.dim[0]()
 
     comptime N = b.shape[0]() if transpose_b else b.shape[1]()
-    constrained[N != UNKNOWN_VALUE, "N should be known at compile time"]()
+    comptime assert N != UNKNOWN_VALUE, "N should be known at compile time"
 
     var K = b.dim[1 if transpose_b else 0]()
 
     comptime stride = b.stride[0]() if transpose_b else b.stride[1]()
-    constrained[
-        stride != UNKNOWN_VALUE, "stride should be known at compile time"
-    ]()
+    comptime assert (
+        stride != UNKNOWN_VALUE
+    ), "stride should be known at compile time"
 
     comptime c_stride = c.stride[0]()
-    constrained[
-        c_stride != UNKNOWN_VALUE, "c_stride should be known at compile time"
-    ]()
+    comptime assert (
+        c_stride != UNKNOWN_VALUE
+    ), "c_stride should be known at compile time"
 
     # Thread and warp indices
     var warp_id = Int(warp_id())
@@ -696,10 +696,9 @@ fn gemm_kernel_amd[
         MMA_M, MMA_N // c_frag_size
     )
 
-    constrained[
-        c_warp_tile.layout.all_dims_known(),
-        "c_warp_tile layout must be fully static",
-    ]()
+    comptime assert (
+        c_warp_tile.layout.all_dims_known()
+    ), "c_warp_tile layout must be fully static"
 
     @parameter
     if Bool(elementwise_lambda_fn) or (N % BN != 0):
@@ -810,10 +809,9 @@ fn write_output_fragments[
             @parameter
             if elementwise_lambda_fn:
                 # Apply custom elementwise operation to each output element
-                constrained[
-                    elementwise_lambda_fn is not None,
-                    "elementwise_lambda_fn is not valid",
-                ]()
+                comptime assert (
+                    elementwise_lambda_fn is not None
+                ), "elementwise_lambda_fn is not valid"
                 comptime epilogue_fn = elementwise_lambda_fn.value()
 
                 # Compute global coordinates

--- a/max/kernels/src/linalg/matmul/gpu/amd/pingpong_kernel.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/amd/pingpong_kernel.mojo
@@ -461,54 +461,45 @@ fn load_lds_fragment[
     # =========================================================================
 
     # mma_access_layout maps lane_id (0..63) to LDS offsets within one iteration
-    constrained[
-        mma_access_layout.size() == WARP_SIZE,
-        String(
-            "mma_access_layout must map exactly ",
-            WARP_SIZE,
-            " threads, got ",
-            mma_access_layout.size(),
-        ),
-    ]()
+    comptime assert mma_access_layout.size() == WARP_SIZE, String(
+        "mma_access_layout must map exactly ",
+        WARP_SIZE,
+        " threads, got ",
+        mma_access_layout.size(),
+    )
 
     # smem must have enough elements for all iterations
     # Each iteration: WARP_SIZE threads × frag_width elements per thread
     comptime smem_elements = smem_layout.size() * smem_element_layout.size()
     comptime required_smem = num_iterations * WARP_SIZE * frag_width
-    constrained[
-        smem_elements >= required_smem,
-        String(
-            "smem has ",
-            smem_elements,
-            " elements but loading requires ",
-            required_smem,
-            " (iterations=",
-            num_iterations,
-            " × WARP_SIZE=",
-            WARP_SIZE,
-            " × width=",
-            frag_width,
-            ")",
-        ),
-    ]()
+    comptime assert smem_elements >= required_smem, String(
+        "smem has ",
+        smem_elements,
+        " elements but loading requires ",
+        required_smem,
+        " (iterations=",
+        num_iterations,
+        " × WARP_SIZE=",
+        WARP_SIZE,
+        " × width=",
+        frag_width,
+        ")",
+    )
 
     # frag must hold all loaded elements
     comptime frag_elements = frag_layout.size() * frag_element_layout.size()
     comptime required_frag = num_iterations * frag_width
-    constrained[
-        frag_elements == required_frag,
-        String(
-            "frag has ",
-            frag_elements,
-            " elements but expects ",
-            required_frag,
-            " (iterations=",
-            num_iterations,
-            " × width=",
-            frag_width,
-            ")",
-        ),
-    ]()
+    comptime assert frag_elements == required_frag, String(
+        "frag has ",
+        frag_elements,
+        " elements but expects ",
+        required_frag,
+        " (iterations=",
+        num_iterations,
+        " × width=",
+        frag_width,
+        ")",
+    )
 
     # =========================================================================
 
@@ -769,10 +760,10 @@ struct MmaOp[
     @always_inline
     fn __init__(out self):
         """Initialize MMA operation with register tiles."""
-        constrained[Self.WM % Self.MMA_M == 0]()
-        constrained[Self.WN % Self.MMA_N == 0]()
-        constrained[Self.BK % Self.MMA_K == 0]()
-        constrained[(Self.MMA_M * Self.MMA_N) % WARP_SIZE == 0]()
+        comptime assert Self.WM % Self.MMA_M == 0
+        comptime assert Self.WN % Self.MMA_N == 0
+        comptime assert Self.BK % Self.MMA_K == 0
+        comptime assert (Self.MMA_M * Self.MMA_N) % WARP_SIZE == 0
 
         self.a_reg_tile = Self.ARegTile.stack_allocation()
         self.b_reg_tile = Self.BRegTile.stack_allocation()
@@ -1065,14 +1056,12 @@ struct TileBuffers[
         """Initialize LDS tiles and loaders. Layouts inferred from a and b tensors.
         """
         # Validate configuration
-        constrained[
-            Self.loading_warps == 4 or Self.loading_warps == 8,
-            "loading_warps must be 4 or 8",
-        ]()
-        constrained[
-            Self.load_width == simd_width_of[Self.in_type](),
-            "load_width must match simd_width_of[in_type]()",
-        ]()
+        comptime assert (
+            Self.loading_warps == 4 or Self.loading_warps == 8
+        ), "loading_warps must be 4 or 8"
+        comptime assert (
+            Self.load_width == simd_width_of[Self.in_type]()
+        ), "load_width must match simd_width_of[in_type]()"
         # Allocate half-tiles: [stage][warp_group]
         # A: 2 stages × 2 warp_m groups (half_BM == WM, so 1:1 mapping)
         var a_s0_g0 = Self.AHalfTile.stack_allocation()  # stage 0, warp_id_m=0
@@ -1358,31 +1347,30 @@ struct AMDPingPongMatmul[
     @staticmethod
     fn validate_config():
         """Validate the kernel configuration."""
-        constrained[
-            Self.BM % Self.WM == 0, "Block M must be divisible by Warp M"
-        ]()
-        constrained[
-            Self.BN % Self.WN == 0, "Block N must be divisible by Warp N"
-        ]()
-        constrained[
-            Self.BK % Self.WK == 0, "Block K must be divisible by Warp K"
-        ]()
-        constrained[
-            Self.WM % Self.MMA_M == 0, "Warp M must be divisible by MMA M"
-        ]()
-        constrained[
-            Self.WN % Self.MMA_N == 0, "Warp N must be divisible by MMA N"
-        ]()
-        constrained[
-            Self.WK % Self.MMA_K == 0, "Warp K must be divisible by MMA K"
-        ]()
-        constrained[
-            Self.total_warps == 8, "Ping-pong kernel requires exactly 8 warps"
-        ]()
-        constrained[
-            Self.num_warps_m == 2,
-            "Ping-pong kernel requires 2 warps in M dimension",
-        ]()
+        comptime assert (
+            Self.BM % Self.WM == 0
+        ), "Block M must be divisible by Warp M"
+        comptime assert (
+            Self.BN % Self.WN == 0
+        ), "Block N must be divisible by Warp N"
+        comptime assert (
+            Self.BK % Self.WK == 0
+        ), "Block K must be divisible by Warp K"
+        comptime assert (
+            Self.WM % Self.MMA_M == 0
+        ), "Warp M must be divisible by MMA M"
+        comptime assert (
+            Self.WN % Self.MMA_N == 0
+        ), "Warp N must be divisible by MMA N"
+        comptime assert (
+            Self.WK % Self.MMA_K == 0
+        ), "Warp K must be divisible by MMA K"
+        comptime assert (
+            Self.total_warps == 8
+        ), "Ping-pong kernel requires exactly 8 warps"
+        comptime assert (
+            Self.num_warps_m == 2
+        ), "Ping-pong kernel requires 2 warps in M dimension"
 
     @__llvm_metadata(
         MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](
@@ -1416,9 +1404,9 @@ struct AMDPingPongMatmul[
         comptime N = b.layout.shape[0].value()
         comptime K = a.layout.shape[1].value()
 
-        constrained[
-            Self.a_type == Self.b_type, "A and B must have the same type"
-        ]()
+        comptime assert (
+            Self.a_type == Self.b_type
+        ), "A and B must have the same type"
 
         comptime in_type = Self.a_type
 
@@ -2166,11 +2154,10 @@ fn ping_pong_matmul[
     c_device_tensor: LayoutTensor[c_type, c_layout],
     ctx: DeviceContext,
 ) raises:
-    constrained[a_type == b_type, "A and B must have the same type"]()
-    constrained[
-        a_type == DType.bfloat16 or a_type == DType.float8_e4m3fn,
-        "A must be bfloat16 or float8_e4m3fn",
-    ]()
+    comptime assert a_type == b_type, "A and B must have the same type"
+    comptime assert (
+        a_type == DType.bfloat16 or a_type == DType.float8_e4m3fn
+    ), "A must be bfloat16 or float8_e4m3fn"
 
     # Select kernel based on input dtype
     comptime is_fp8 = a_type == DType.float8_e4m3fn

--- a/max/kernels/src/linalg/matmul/gpu/amd/ring_buffer.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/amd/ring_buffer.mojo
@@ -402,13 +402,10 @@ struct RingBuffer[
 
     @always_inline
     fn __init__(out self):
-        constrained[
-            Self.total_tiles <= 32,
-            (
-                "total_tiles must be less than or equal to 32 for AMD atomic"
-                " limitations"
-            ),
-        ]()
+        comptime assert Self.total_tiles <= 32, (
+            "total_tiles must be less than or equal to 32 for AMD atomic"
+            " limitations"
+        )
 
         var smem_buffer = Self.SmemBufferType()
         self.smem_buffers = StaticTuple[

--- a/max/kernels/src/linalg/matmul/gpu/amd/structured.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/amd/structured.mojo
@@ -84,7 +84,7 @@ struct ThreadRole(Enum, Stringable, Writable):
 @parameter
 @always_inline
 fn pipeline_layout[layout: Layout, pipeline_stages: Int]() -> Layout:
-    constrained[layout.rank() == 2]()
+    comptime assert layout.rank() == 2
     return blocked_product(
         materialize[layout](),
         Layout.row_major(1, pipeline_stages),
@@ -118,24 +118,16 @@ struct SMemBuffer[
 
     @always_inline
     fn __init__(out self):
-        constrained[
-            Self.layout.rank() == 2,
-            "layout must be 2D",
-        ]()
+        comptime assert Self.layout.rank() == 2, "layout must be 2D"
 
-        constrained[
+        comptime assert (
             prod(Self.layout.shape[0]) == Self.BM
-            and prod(Self.layout.shape[1]) == Self.BN,
-            (
-                "shared memory rows must match block_rows and columns must"
-                " match BN"
-            ),
-        ]()
+            and prod(Self.layout.shape[1]) == Self.BN
+        ), "shared memory rows must match block_rows and columns must match BN"
 
-        constrained[
-            Self.BM % Self.WM == 0 and Self.BN % Self.WN == 0,
-            "BM and BN must be a multiple of WM and WN",
-        ]()
+        comptime assert (
+            Self.BM % Self.WM == 0 and Self.BN % Self.WN == 0
+        ), "BM and BN must be a multiple of WM and WN"
 
         self.buffer = Self.SMemTile.stack_allocation()
 
@@ -354,24 +346,21 @@ struct AmdTileOperator[
 
     @always_inline
     fn __init__(out self):
-        constrained[
+        comptime assert (
             Self.simd_width >= Self._registers_per_thread_a
-            and Self.simd_width >= Self._registers_per_thread_b,
-            (
-                "simd_width must be greater than or equal to required mma"
-                " fragments size"
-            ),
-        ]()
+            and Self.simd_width >= Self._registers_per_thread_b
+        ), (
+            "simd_width must be greater than or equal to required mma"
+            " fragments size"
+        )
 
-        constrained[
-            Self.num_k_tiles % Self.k_group_size_a == 0,
-            "num_k_tiles must be divisible by k_group_size",
-        ]()
+        comptime assert (
+            Self.num_k_tiles % Self.k_group_size_a == 0
+        ), "num_k_tiles must be divisible by k_group_size"
 
-        constrained[
-            Self._k_tiles_per_simd_a == Self._k_tiles_per_simd_b,
-            "k_tiles_per_simd must be equal for A and B",
-        ]()
+        comptime assert (
+            Self._k_tiles_per_simd_a == Self._k_tiles_per_simd_b
+        ), "k_tiles_per_simd must be equal for A and B"
 
         self._a_reg_tile = Self.ARegTile.stack_allocation()
         self._b_reg_tile = Self.BRegTile.stack_allocation()

--- a/max/kernels/src/linalg/matmul/gpu/amd/warp_spec_matmul.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/amd/warp_spec_matmul.mojo
@@ -88,37 +88,32 @@ fn validate_config[
 ]():
     """Validates the configuration parameters for the matrix multiplication kernel.
     """
-    constrained[
-        BM % WM == 0 and BN % WN == 0,
-        "Block dims must be divisible by warp dims",
-    ]()
-    constrained[
-        m_warps % producer_a == 0,
-        "M warps must be divisible by A producers: "
-        + String(m_warps)
-        + " % "
-        + String(producer_a)
-        + " == 0",
-    ]()
-    constrained[
-        n_warps % producer_b == 0,
-        "N warps must be divisible by B producers: "
-        + String(n_warps)
-        + " % "
-        + String(producer_b)
-        + " == 0",
-    ]()
-    constrained[
-        m_warps * n_warps % consumer == 0,
-        "Total warps must be divisible by consumers",
-    ]()
-    constrained[
-        consumer >= producer_a and consumer >= producer_b,
-        "Need enough consumers",
-    ]()
-    constrained[
-        consumer.is_power_of_two(), "Consumer warps must be power of 2"
-    ]()
+    comptime assert (
+        BM % WM == 0 and BN % WN == 0
+    ), "Block dims must be divisible by warp dims"
+    comptime assert m_warps % producer_a == 0, String(
+        "M warps must be divisible by A producers: ",
+        m_warps,
+        " % ",
+        producer_a,
+        " == 0",
+    )
+    comptime assert n_warps % producer_b == 0, String(
+        "N warps must be divisible by B producers: ",
+        n_warps,
+        " % ",
+        producer_b,
+        " == 0",
+    )
+    comptime assert (
+        m_warps * n_warps % consumer == 0
+    ), "Total warps must be divisible by consumers"
+    comptime assert (
+        consumer >= producer_a and consumer >= producer_b
+    ), "Need enough consumers"
+    comptime assert (
+        consumer.is_power_of_two()
+    ), "Consumer warps must be power of 2"
 
 
 @always_inline
@@ -171,10 +166,9 @@ fn smem_tile_layout[
     # └─────────────────────────────────────────────────────────────────────────┘
     # stride between blocks = block_rows x k_tile_size = 64 x 32 = 2048
 
-    constrained[
-        block_cols % k_tile_size == 0,
-        "block_cols must be a multiple of k_tile_size",
-    ]()
+    comptime assert (
+        block_cols % k_tile_size == 0
+    ), "block_cols must be a multiple of k_tile_size"
 
     comptime base_layout = Layout.row_major(block_rows, k_tile_size)
     comptime num_repeats = block_cols // k_tile_size
@@ -213,22 +207,20 @@ fn get_producer_warp_thread_layout[
 
     comptime num_repeats_col = block_cols // k_tile_size
 
-    constrained[
-        num_repeats_col < (WARP_SIZE // inner_block_size),
-        "not enough threads per warp to cover block k dimension: "
-        + String(num_repeats_col)
-        + " < "
-        + String(WARP_SIZE)
-        + " // "
-        + String(inner_block_size),
-    ]()
+    comptime assert num_repeats_col < (WARP_SIZE // inner_block_size), String(
+        "not enough threads per warp to cover block k dimension: ",
+        num_repeats_col,
+        " < ",
+        WARP_SIZE,
+        " // ",
+        inner_block_size,
+    )
     comptime outer_block_size = num_repeats_col * inner_block_size
     comptime num_repeats_row = WARP_SIZE // outer_block_size
 
-    constrained[
-        block_rows % (inner_block_rows * num_repeats_row) == 0,
-        "shared block size is not evenly distributable among threads",
-    ]()
+    comptime assert (
+        block_rows % (inner_block_rows * num_repeats_row) == 0
+    ), "shared block size is not evenly distributable among threads"
 
     comptime tiler_layout = Layout.row_major(
         num_repeats_row,

--- a/max/kernels/src/linalg/matmul/gpu/sm100/blockwise_fp8.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100/blockwise_fp8.mojo
@@ -93,15 +93,14 @@ fn matmul_sm100_blockwise_scaled_fp8_1d2d_kernel[
     b_scales: LayoutTensor[b_scales_type, b_scales_layout, MutAnyOrigin],
     num_iters: UInt,
 ):
-    constrained[transpose_b, "Only support transposed B"]()
-    constrained[num_threads == 128]()
+    comptime assert transpose_b, "Only support transposed B"
+    comptime assert num_threads == 128
 
     comptime accum_type = get_accum_type[a_type]()
 
-    constrained[
-        b_scales_type == a_scales_type == accum_type == DType.float32,
-        "Only support float32 for a_scales and b_scales",
-    ]()
+    comptime assert (
+        b_scales_type == a_scales_type == accum_type == DType.float32
+    ), "Only support float32 for a_scales and b_scales"
 
     comptime N = c_layout.shape[1].value()
     comptime K = a_layout.shape[2].value()
@@ -117,11 +116,10 @@ fn matmul_sm100_blockwise_scaled_fp8_1d2d_kernel[
     comptime num_n_mmas = BN // MMA_N
     comptime num_k_mmas = BK // MMA_K
 
-    constrained[N % BN == 0, "N must be divisible by BN"]()
-    constrained[
-        BN <= BK or gcd(BN, BK) == BN - BK,
-        "BN <= BK or gcd(BN, BK) == BN - BK",
-    ]()
+    comptime assert N % BN == 0, "N must be divisible by BN"
+    comptime assert (
+        BN <= BK or gcd(BN, BK) == BN - BK
+    ), "BN <= BK or gcd(BN, BK) == BN - BK"
 
     # make sure A and B scales are compatible
     comptime b_scales_n = b_scales_layout.shape[0].value()
@@ -203,16 +201,15 @@ fn matmul_sm100_blockwise_scaled_fp8_1d2d_kernel[
     comptime b_size = b_smem_layout.size()
     comptime a_scales_size = a_scales_smem_layout.size()
 
-    constrained[
-        ((a_size * size_of[a_type]()) % 128) == 0, "preserve alignment"
-    ]()
-    constrained[
-        ((b_size * size_of[b_type]()) % 128) == 0, "preserve alignment"
-    ]()
-    constrained[
-        ((a_scales_size * size_of[a_scales_type]()) % 16) == 0,
-        "preserve alignment",
-    ]()
+    comptime assert (
+        (a_size * size_of[a_type]()) % 128
+    ) == 0, "preserve alignment"
+    comptime assert (
+        (b_size * size_of[b_type]()) % 128
+    ) == 0, "preserve alignment"
+    comptime assert (
+        (a_scales_size * size_of[a_scales_type]()) % 16
+    ) == 0, "preserve alignment"
 
     var b_smem = (a_smem + a_size).bitcast[Scalar[b_type]]()
     var a_scales_smem = (b_smem + b_size).bitcast[Scalar[a_scales_type]]()
@@ -282,9 +279,9 @@ fn matmul_sm100_blockwise_scaled_fp8_1d2d_kernel[
     comptime repeat = 1  # a higher repeat will probably get us better performance, but it will increase register pressure
     comptime temp_cfrags_size = 4 * repeat
 
-    constrained[
-        total_repeat % repeat == 0, "total_repeat must be divisible by repeat"
-    ]()
+    comptime assert (
+        total_repeat % repeat == 0
+    ), "total_repeat must be divisible by repeat"
     var c_frag_temp = SIMD[accum_type, temp_cfrags_size]()
 
     for k_iter in range(num_iters):
@@ -572,20 +569,15 @@ fn matmul_sm100_blockwise_scaled_fp8[
     b_scales: LayoutTensor[b_scales_type, b_scales_layout, ...],
     ctx: DeviceContext,
 ) raises:
-    constrained[
-        transpose_b,
-        "Only support transposed B",
-    ]()
+    comptime assert transpose_b, "Only support transposed B"
 
-    constrained[
-        a_type == b_type and a_type == DType.float8_e4m3fn,
-        "Only support float8_e4m3fn",
-    ]()
+    comptime assert (
+        a_type == b_type and a_type == DType.float8_e4m3fn
+    ), "Only support float8_e4m3fn"
 
-    constrained[
-        a_scales_type == b_scales_type and a_scales_type == DType.float32,
-        "Only support float32 for scales",
-    ]()
+    comptime assert (
+        a_scales_type == b_scales_type and a_scales_type == DType.float32
+    ), "Only support float32 for scales"
 
     comptime a_layout_tensor_3D = LayoutTensor[
         a_type,
@@ -648,7 +640,7 @@ fn matmul_sm100_blockwise_scaled_fp8[
     comptime BN = block_tile_shape[1]
     comptime BK = block_tile_shape[2]
 
-    constrained[BK == 128, "blockwise scaled fp8 only works with BK = 128"]()
+    comptime assert BK == 128, "blockwise scaled fp8 only works with BK = 128"
 
     var M = c.dim(0)
     var N = c.dim(1)

--- a/max/kernels/src/linalg/matmul/gpu/sm100/matmul.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100/matmul.mojo
@@ -100,7 +100,7 @@ struct WarpRole[has_scheduler: Bool = True](TrivialRegisterPassable):
     @staticmethod
     @always_inline
     fn is_scheduler() -> Bool:
-        constrained[Self.has_scheduler, "Scheduler warp is not enabled"]()
+        comptime assert Self.has_scheduler, "Scheduler warp is not enabled"
         return Self.Scheduler == warp_id()
 
 

--- a/max/kernels/src/linalg/matmul/gpu/sm100/tile_scheduler.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100/tile_scheduler.mojo
@@ -113,10 +113,13 @@ struct TileScheduler[
             SharedMemBarrier, address_space = AddressSpace.SHARED
         ],
     ):
-        constrained[
-            Self.block_swizzle_size in [0, 1, 2, 4, 8],
-            "block_swizzle_size must be 0, 1, 2, 4, or 8",
-        ]()
+        comptime assert Self.block_swizzle_size in [
+            0,
+            1,
+            2,
+            4,
+            8,
+        ], "block_swizzle_size must be 0, 1, 2, 4, or 8"
 
         self.cluster_dim = cluster_dim
         self.log_cluster_dim_m = FastDiv[DType.uint32](Int(cluster_dim[0]))

--- a/max/kernels/src/linalg/matmul/gpu/sm100/warp_specialized_blockwise_fp8.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100/warp_specialized_blockwise_fp8.mojo
@@ -100,7 +100,7 @@ fn _get_accumulator_size[
     comptime num_m_mmas = BM // (mma_shape[0] // cta_group)
     comptime num_n_mmas = BN // (mma_shape[1] // cta_group)
 
-    constrained[num_m_mmas == 1 and num_n_mmas == 1]()
+    comptime assert num_m_mmas == 1 and num_n_mmas == 1
 
     comptime stageN = c_smem_layout.shape[1].value()
     comptime cg2_num_stages = MMA_N // stageN if MMA_M == 256 else MMA_N // stageN // 2
@@ -298,7 +298,7 @@ fn multi_stage_reg_epilogue[
     comptime num_m_mmas = BM // (mma_shape[0] // cta_group)
     comptime num_n_mmas = BN // (mma_shape[1] // cta_group)
 
-    constrained[num_m_mmas == 1 and num_n_mmas == 1]()
+    comptime assert num_m_mmas == 1 and num_n_mmas == 1
 
     comptime num_stages = accum_layout.shape[0].value()
     comptime num_elements = accum_layout.shape[1].value()
@@ -467,12 +467,11 @@ fn promote_accumulators[
     comptime num_m_mmas = BM // (mma_shape[0] // cta_group)
     comptime num_n_mmas = BN // (mma_shape[1] // cta_group)
 
-    constrained[num_m_mmas == 1 and num_n_mmas == 1]()
+    comptime assert num_m_mmas == 1 and num_n_mmas == 1
 
-    constrained[
-        a_scales_type == b_scales_type and accum_type == DType.float32,
-        "Only support float32 for a_scales, b_scales, and accum_type",
-    ]()
+    comptime assert (
+        a_scales_type == b_scales_type and accum_type == DType.float32
+    ), "Only support float32 for a_scales, b_scales, and accum_type"
     # Rows each warp is responsible for:
     # warp_id 0 -> 0-15 upper, 16-31 lower
     # warp_id 1 -> 32-47 upper, 48-63 lower
@@ -489,7 +488,7 @@ fn promote_accumulators[
     comptime bits = 256
     comptime num_elements_per_load = bits // 32  # each element in tmem is 4 bytes, 32 bits
     comptime fragment_size = (data_paths * num_elements_per_load) // WARP_SIZE
-    constrained[fragment_size == 4, "fragment_size must be 4"]()
+    comptime assert fragment_size == 4, "fragment_size must be 4"
     comptime repeats = num_elements // fragment_size
     comptime stageN = repeats * (bits // 32)
     comptime load_width = 2
@@ -507,14 +506,13 @@ fn promote_accumulators[
 
     @parameter
     if MMA_N != BK:
-        constrained[
-            stageN <= gcd(MMA_N, BK) and (gcd(MMA_N, BK) % stageN == 0),
-            (
-                "gcd(MMA_N, BK) must be divisible by stageN. If not then this"
-                " step should be updated to support non-divisible case"
-                " accordingly"
-            ),
-        ]()
+        comptime assert stageN <= gcd(MMA_N, BK) and (
+            gcd(MMA_N, BK) % stageN == 0
+        ), (
+            "gcd(MMA_N, BK) must be divisible by stageN. If not then this"
+            " step should be updated to support non-divisible case"
+            " accordingly"
+        )
 
         var global_bn_start = bn * UInt(MMA_N)
         var begin_n = min(
@@ -777,11 +775,10 @@ fn blackwell_tma_umma_warp_specialized_blockwise_fp8_kernel[
 
     comptime accum_type = get_accum_type[a_type]()
 
-    constrained[
-        b_scales_type == a_scales_type and accum_type == DType.float32,
-        "Only support float32 for a_scales and b_scales",
-    ]()
-    constrained[transpose_b, "only support k-major B"]()
+    comptime assert (
+        b_scales_type == a_scales_type and accum_type == DType.float32
+    ), "Only support float32 for a_scales and b_scales"
+    comptime assert transpose_b, "only support k-major B"
 
     comptime SCHEDULER_THREADS = WARP_SIZE
     comptime TMA_LOAD_THREADS = WARP_SIZE
@@ -810,14 +807,13 @@ fn blackwell_tma_umma_warp_specialized_blockwise_fp8_kernel[
     comptime MMA_N = config.mma_shape[1]
     comptime MMA_K = config.mma_shape[2]
 
-    constrained[BK == 128, "Only support BK = 128"]()
-    constrained[
-        MMA_N <= BK or gcd(MMA_N, BK) == MMA_N - BK,
-        "MMA_N <= BK or gcd(MMA_N, BK) == MMA_N - BK. MMA_N="
-        + String(MMA_N)
-        + ", GCD="
-        + String(gcd(MMA_N, BK)),
-    ]()
+    comptime assert BK == 128, "Only support BK = 128"
+    comptime assert MMA_N <= BK or gcd(MMA_N, BK) == MMA_N - BK, String(
+        "MMA_N <= BK or gcd(MMA_N, BK) == MMA_N - BK. MMA_N=",
+        MMA_N,
+        ", GCD=",
+        gcd(MMA_N, BK),
+    )
 
     comptime num_m_mmas = BM // (config.mma_shape[0] // config.cta_group)
     comptime num_n_mmas = BN // (config.mma_shape[1] // config.cta_group)
@@ -1327,20 +1323,15 @@ fn sm100_warp_specialized_blockwise_fp8[
     b_scales: LayoutTensor[b_scales_type, b_scales_layout, ...],
     ctx: DeviceContext,
 ) raises:
-    constrained[
-        transpose_b,
-        "Only support transposed B",
-    ]()
+    comptime assert transpose_b, "Only support transposed B"
 
-    constrained[
-        a_type == b_type and a_type == DType.float8_e4m3fn,
-        "Only support float8_e4m3fn",
-    ]()
+    comptime assert (
+        a_type == b_type and a_type == DType.float8_e4m3fn
+    ), "Only support float8_e4m3fn"
 
-    constrained[
-        a_scales_type == b_scales_type,
-        "Only support float32 for scales",
-    ]()
+    comptime assert (
+        a_scales_type == b_scales_type
+    ), "Only support float32 for scales"
 
     if (a_scales.dim(1) * size_of[a_scales_type]()) % 16 != 0:
         raise Error(
@@ -1355,11 +1346,8 @@ fn sm100_warp_specialized_blockwise_fp8[
     comptime BN = MMA_N // config.cta_group
     comptime BK = config.block_tile_shape[2]
 
-    constrained[config.cta_group in (1, 2), "Only support cta_group == 2"]()
-    constrained[
-        (not config.AB_swapped),
-        "Swapped AB is not supported",
-    ]()
+    comptime assert config.cta_group in (1, 2), "Only support cta_group == 2"
+    comptime assert not config.AB_swapped, "Swapped AB is not supported"
 
     var M = c.dim(0)
     var N = c.dim(1)
@@ -1450,10 +1438,9 @@ fn sm100_warp_specialized_blockwise_fp8[
         smem_leftover // producer_consumer_smem_per_stage
     )
 
-    constrained[
-        max_pipeline_stages >= 1,
-        "not enough smem even for one pipeline stage!",
-    ]()
+    comptime assert (
+        max_pipeline_stages >= 1
+    ), "not enough smem even for one pipeline stage!"
 
     comptime producer_consumer_smem = producer_consumer_smem_per_stage * Int(
         max_pipeline_stages

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/block_scaled/block_scaled_matmul_kernel.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/block_scaled/block_scaled_matmul_kernel.mojo
@@ -766,19 +766,17 @@ struct BlackwellBlockScaledMatmulKernel[
     @staticmethod
     fn validate_config():
         """Validate configuration constraints at compile time."""
-        constrained[Self.transpose_b, "Only support transposed B"]()
-        constrained[
-            Self.sfa_dtype == Self.sfb_dtype,
-            "sfa_dtype and sfb_dtype must match",
-        ]()
-        constrained[
-            Self.cta_group in (1, 2),
-            "Only support cta_group == 1 or 2",
-        ]()
-        constrained[
-            Self.config.k_group_size == 1,
-            "Only support k_group_size == 1 for block-scaled",
-        ]()
+        comptime assert Self.transpose_b, "Only support transposed B"
+        comptime assert (
+            Self.sfa_dtype == Self.sfb_dtype
+        ), "sfa_dtype and sfb_dtype must match"
+        comptime assert Self.cta_group in (
+            1,
+            2,
+        ), "Only support cta_group == 1 or 2"
+        comptime assert (
+            Self.config.k_group_size == 1
+        ), "Only support k_group_size == 1 for block-scaled"
 
     # ========== Kernel Entry Point ==========
 

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/blockwise_fp8/blockwise_fp8_accumulator.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/blockwise_fp8/blockwise_fp8_accumulator.mojo
@@ -70,7 +70,7 @@ fn get_accumulator_dims[
     comptime num_m_mmas = BM // (mma_shape[0] // cta_group)
     comptime num_n_mmas = BN // (mma_shape[1] // cta_group)
 
-    constrained[num_m_mmas == 1 and num_n_mmas == 1]()
+    comptime assert num_m_mmas == 1 and num_n_mmas == 1
 
     comptime stageN = c_smem_dim1
     comptime cg2_num_stages = MMA_N // stageN if MMA_M == 256 else MMA_N // stageN // 2
@@ -223,11 +223,10 @@ struct BlockwiseFP8Accumulator[
         # Type aliases for readability
         comptime a_scales_type = a_scales_dtype
 
-        constrained[
+        comptime assert (
             a_scales_dtype == b_scales_dtype
-            and Self.accum_type == DType.float32,
-            "Only support float32 for a_scales, b_scales, and accum_type",
-        ]()
+            and Self.accum_type == DType.float32
+        ), "Only support float32 for a_scales, b_scales, and accum_type"
 
         var M = problem_shape[0]
         var N = problem_shape[1]
@@ -246,11 +245,9 @@ struct BlockwiseFP8Accumulator[
 
         @parameter
         if Self.MMA_N != Self.BK:
-            constrained[
-                Self.stageN <= gcd(Self.MMA_N, Self.BK)
-                and (gcd(Self.MMA_N, Self.BK) % Self.stageN == 0),
-                "gcd(MMA_N, BK) must be divisible by stageN",
-            ]()
+            comptime assert Self.stageN <= gcd(Self.MMA_N, Self.BK) and (
+                gcd(Self.MMA_N, Self.BK) % Self.stageN == 0
+            ), "gcd(MMA_N, BK) must be divisible by stageN"
 
             var global_bn_start = bn * UInt(Self.MMA_N)
             var begin_n = min(

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/blockwise_fp8/blockwise_fp8_matmul.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/blockwise_fp8/blockwise_fp8_matmul.mojo
@@ -101,15 +101,13 @@ fn blockwise_fp8_matmul[
         ](c, a, b, a_scales, b_scales, ctx)
         return
 
-    constrained[transpose_b, "Only support transposed B"]()
-    constrained[
-        a_type == b_type and a_type == DType.float8_e4m3fn,
-        "Only support float8_e4m3fn",
-    ]()
-    constrained[
-        a_scales_type == b_scales_type,
-        "Only support float32 for scales",
-    ]()
+    comptime assert transpose_b, "Only support transposed B"
+    comptime assert (
+        a_type == b_type and a_type == DType.float8_e4m3fn
+    ), "Only support float8_e4m3fn"
+    comptime assert (
+        a_scales_type == b_scales_type
+    ), "Only support float32 for scales"
 
     if (a_scales.dim(1) * size_of[a_scales_type]()) % 16 != 0:
         raise Error(
@@ -124,10 +122,11 @@ fn blockwise_fp8_matmul[
     comptime BN = MMA_N // config.cta_group
     comptime BK = config.block_tile_shape[2]
 
-    constrained[
-        config.cta_group in (1, 2), "Only support cta_group == 1 or 2"
-    ]()
-    constrained[not config.AB_swapped, "Swapped AB is not supported"]()
+    comptime assert config.cta_group in (
+        1,
+        2,
+    ), "Only support cta_group == 1 or 2"
+    comptime assert not config.AB_swapped, "Swapped AB is not supported"
 
     # ==== Compute correct max_pipeline_stages for blockwise FP8 ====
     # MatmulConfig._maximize_pipeline_stages_by_default() doesn't account for

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/blockwise_fp8/blockwise_fp8_matmul_kernel.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/blockwise_fp8/blockwise_fp8_matmul_kernel.mojo
@@ -614,16 +614,15 @@ struct BlackwellBlockwiseFP8MatmulKernel[
     @staticmethod
     fn validate_config():
         """Validate configuration constraints at compile time."""
-        constrained[Self.transpose_b, "Only support transposed B"]()
-        constrained[
-            Self.a_scales_type == Self.b_scales_type,
-            "a_scales_type and b_scales_type must match",
-        ]()
-        constrained[
-            Self.cta_group in (1, 2),
-            "Only support cta_group == 1 or 2",
-        ]()
-        constrained[Self.BK == 128, "Only support BK = 128"]()
+        comptime assert Self.transpose_b, "Only support transposed B"
+        comptime assert (
+            Self.a_scales_type == Self.b_scales_type
+        ), "a_scales_type and b_scales_type must match"
+        comptime assert Self.cta_group in (
+            1,
+            2,
+        ), "Only support cta_group == 1 or 2"
+        comptime assert Self.BK == 128, "Only support BK = 128"
 
     # ========== Kernel Entry Point ==========
 

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/blockwise_fp8_1d2d/blockwise_fp8_1d2d_matmul.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/blockwise_fp8_1d2d/blockwise_fp8_1d2d_matmul.mojo
@@ -98,19 +98,18 @@ fn grouped_matmul_1d2d_blockwise_fp8[
         num_active_experts: Number of active experts.
         ctx: Device context.
     """
-    constrained[transpose_b, "Only support transposed B"]()
-    constrained[
-        a_type == b_type and a_type == DType.float8_e4m3fn,
-        "Only support float8_e4m3fn",
-    ]()
-    constrained[
-        a_scales_type == b_scales_type,
-        "a_scales_type and b_scales_type must match",
-    ]()
-    constrained[
-        config.cta_group in (1, 2), "Only support cta_group == 1 or 2"
-    ]()
-    constrained[not config.AB_swapped, "Swapped AB is not supported"]()
+    comptime assert transpose_b, "Only support transposed B"
+    comptime assert (
+        a_type == b_type and a_type == DType.float8_e4m3fn
+    ), "Only support float8_e4m3fn"
+    comptime assert (
+        a_scales_type == b_scales_type
+    ), "a_scales_type and b_scales_type must match"
+    comptime assert config.cta_group in (
+        1,
+        2,
+    ), "Only support cta_group == 1 or 2"
+    comptime assert not config.AB_swapped, "Swapped AB is not supported"
 
     comptime MMA_M = config.mma_shape[0]
     comptime MMA_N = config.mma_shape[1]
@@ -120,7 +119,7 @@ fn grouped_matmul_1d2d_blockwise_fp8[
     comptime BN = MMA_N // config.cta_group
     comptime BK = config.block_tile_shape[2]
 
-    constrained[BK == 128, "Only support BK = 128"]()
+    comptime assert BK == 128, "Only support BK = 128"
 
     comptime num_experts = b_layout.shape[0].value()
     comptime N = c_layout.shape[1].value()

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/blockwise_fp8_1d2d/blockwise_fp8_1d2d_matmul_kernel.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/blockwise_fp8_1d2d/blockwise_fp8_1d2d_matmul_kernel.mojo
@@ -352,16 +352,15 @@ struct BlockwiseFP8_1D2DMatmulKernel[
     @staticmethod
     fn validate_config():
         """Compile-time validation of kernel configuration."""
-        constrained[Self.transpose_b, "Only support transposed B"]()
-        constrained[
-            Self.a_scales_type == Self.b_scales_type,
-            "a_scales_type and b_scales_type must match",
-        ]()
-        constrained[
-            Self.cta_group in (1, 2),
-            "Only support cta_group == 1 or 2",
-        ]()
-        constrained[Self.BK == 128, "Only support BK = 128"]()
+        comptime assert Self.transpose_b, "Only support transposed B"
+        comptime assert (
+            Self.a_scales_type == Self.b_scales_type
+        ), "a_scales_type and b_scales_type must match"
+        comptime assert Self.cta_group in (
+            1,
+            2,
+        ), "Only support cta_group == 1 or 2"
+        comptime assert Self.BK == 128, "Only support BK = 128"
 
     # ========== Kernel Parameter TileTensor Types ==========
 

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/default/dispatch.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/default/dispatch.mojo
@@ -81,7 +81,7 @@ fn matmul_dispatch_sm100[
     b: NDBuffer[b_type, 2, _, _],
     ctx: DeviceContext,
 ) raises:
-    constrained[a_type == b_type, "a_type and b_type must be the same"]()
+    comptime assert a_type == b_type, "a_type and b_type must be the same"
 
     var m = c.dim[0]()
     comptime static_N = c.shape.get[1]()
@@ -1374,10 +1374,10 @@ fn heuristic_and_outliers_dispatch[
     comptime static_N = c.shape.get[1]()
     comptime static_K = a.shape.get[1]()
 
-    constrained[
-        a_type == b_type and a_type in (DType.bfloat16, DType.float8_e4m3fn),
-        "Only support bfloat16 and float8_e4m3fn input types",
-    ]()
+    comptime assert a_type == b_type and a_type in (
+        DType.bfloat16,
+        DType.float8_e4m3fn,
+    ), "Only support bfloat16 and float8_e4m3fn input types"
 
     comptime MMA_K = 32 if a_type == DType.float8_e4m3fn else 16
     comptime BK = (TensorMapSwizzle.SWIZZLE_128B.bytes() // size_of[a_type]())
@@ -2095,10 +2095,9 @@ fn _matmul_dispatch_sm100[
     var a_tensor = from_ndbuffer_row_major(a)
     var b_tensor = from_ndbuffer_row_major(b)
 
-    constrained[
-        elementwise_lambda_fn is None or elementwise_compute_lambda_fn is None,
-        "Either the epilogue lambda or the compute lambda can be used",
-    ]()
+    comptime assert (
+        elementwise_lambda_fn is None or elementwise_compute_lambda_fn is None
+    ), "Either the epilogue lambda or the compute lambda can be used"
 
     @parameter
     if not elementwise_lambda_fn:

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/default/matmul_kernels.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/default/matmul_kernels.mojo
@@ -633,30 +633,24 @@ struct BlackwellMatmulSM100Kernel[
     @always_inline
     fn validate_constraints():
         """Validate parameter constraints at compile time."""
-        constrained[
-            Self.c_type != DType.float32,
-            "c_type cannot be float32",
-        ]()
-        constrained[
-            Self.transpose_b,
-            "Only support transposed B (K-major)",
-        ]()
-        constrained[
-            Self.cta_group in (1, 2),
-            "Only support cta_group == 1 or 2",
-        ]()
+        comptime assert Self.c_type != DType.float32, "c_type cannot be float32"
+        comptime assert Self.transpose_b, "Only support transposed B (K-major)"
+        comptime assert Self.cta_group in (
+            1,
+            2,
+        ), "Only support cta_group == 1 or 2"
 
         @parameter
         if Self.cta_group == 2:
-            constrained[
-                Self.MMA_M in (128, 256),
-                "cta_group=2 requires MMA_M == 128 or 256",
-            ]()
+            comptime assert Self.MMA_M in (
+                128,
+                256,
+            ), "cta_group=2 requires MMA_M == 128 or 256"
         else:
-            constrained[
-                Self.MMA_M in (64, 128),
-                "cta_group=1 requires MMA_M == 64 or 128",
-            ]()
+            comptime assert Self.MMA_M in (
+                64,
+                128,
+            ), "cta_group=1 requires MMA_M == 64 or 128"
 
     # ========== Static Helper Methods ==========
 
@@ -1436,15 +1430,13 @@ struct BlackwellMatmulSM100FallbackKernel[
     @always_inline
     fn validate_constraints():
         """Validate compile-time constraints for this kernel configuration."""
-        constrained[Self.num_threads == 128 or Self.num_threads == 256]()
-        constrained[
-            ((Self.a_size * size_of[Self.a_type]()) % 128) == 0,
-            "preserve alignment",
-        ]()
-        constrained[
-            ((Self.b_size * size_of[Self.b_type]()) % 16) == 0,
-            "preserve alignment",
-        ]()
+        comptime assert Self.num_threads == 128 or Self.num_threads == 256
+        comptime assert (
+            (Self.a_size * size_of[Self.a_type]()) % 128
+        ) == 0, "preserve alignment"
+        comptime assert (
+            (Self.b_size * size_of[Self.b_type]()) % 16
+        ) == 0, "preserve alignment"
 
     # ========== Kernel Entry Point ==========
     @staticmethod

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/grouped_block_scaled/grouped_block_scaled_matmul_kernel.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/grouped_block_scaled/grouped_block_scaled_matmul_kernel.mojo
@@ -974,23 +974,18 @@ struct GroupedBlockScaledMatmulKernel[
     @staticmethod
     fn validate_config():
         """Compile-time validation of kernel configuration."""
-        constrained[
-            Self.a_type == Self.b_type,
-            "A and B types must match for block-scaled GEMM",
-        ]()
-        constrained[
-            Self.sfa_dtype == Self.sfb_dtype,
-            "SFA and SFB types must match",
-        ]()
-        constrained[
-            Self.cta_group in (1, 2),
-            "Only support cta_group == 1 or 2",
-        ]()
-        constrained[
-            Self.max_groups >= 1,
-            "max_groups must be at least 1",
-        ]()
-        constrained[Self.transpose_b, "Only support transposed B"]()
+        comptime assert (
+            Self.a_type == Self.b_type
+        ), "A and B types must match for block-scaled GEMM"
+        comptime assert (
+            Self.sfa_dtype == Self.sfb_dtype
+        ), "SFA and SFB types must match"
+        comptime assert Self.cta_group in (
+            1,
+            2,
+        ), "Only support cta_group == 1 or 2"
+        comptime assert Self.max_groups >= 1, "max_groups must be at least 1"
+        comptime assert Self.transpose_b, "Only support transposed B"
 
     # ========== TMA Update Helper ==========
 

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/grouped_block_scaled_1d1d/grouped_1d1d_matmul_kernel.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/grouped_block_scaled_1d1d/grouped_1d1d_matmul_kernel.mojo
@@ -499,19 +499,17 @@ struct Grouped1D1DMatmulKernel[
     @staticmethod
     fn validate_config():
         """Compile-time validation of kernel configuration."""
-        constrained[
-            Self.a_type == Self.b_type,
-            "A and B types must match for block-scaled GEMM",
-        ]()
-        constrained[
-            Self.sfa_dtype == Self.sfb_dtype,
-            "SFA and SFB types must match",
-        ]()
-        constrained[
-            Self.cta_group in (1, 2),
-            "Only support cta_group == 1 or 2",
-        ]()
-        constrained[Self.transpose_b, "Only support transposed B"]()
+        comptime assert (
+            Self.a_type == Self.b_type
+        ), "A and B types must match for block-scaled GEMM"
+        comptime assert (
+            Self.sfa_dtype == Self.sfb_dtype
+        ), "SFA and SFB types must match"
+        comptime assert Self.cta_group in (
+            1,
+            2,
+        ), "Only support cta_group == 1 or 2"
+        comptime assert Self.transpose_b, "Only support transposed B"
 
     # ========== Kernel Entry Point ==========
 

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/structured_kernels/config.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/structured_kernels/config.mojo
@@ -241,7 +241,7 @@ struct MatmulConfig[
         num_clc_pipeline_stages: Int = 2,
         extra_smem_per_stage: Int = 0,
     ):
-        constrained[Self.a_type == Self.b_type]()
+        comptime assert Self.a_type == Self.b_type
 
         self.cta_group = cta_group
         self.mma_shape = mma_shape
@@ -343,7 +343,7 @@ fn choose_config[
     c_type: DType,
     transpose_b: Bool = True,
 ](M: Int, N: Int, K: Int) -> MatmulConfig[a_type, b_type, c_type, transpose_b]:
-    constrained[a_type == b_type, "a_type and b_type must be the same"]()
+    comptime assert a_type == b_type, "a_type and b_type must be the same"
 
     comptime num_SMs = B200.sm_count
     # Nvidia mma instruction process 32B in K.
@@ -547,7 +547,7 @@ struct BlockScaledMatmulConfig[
         num_accum_pipeline_stages: Int = 2,
         num_clc_pipeline_stages: Int = 2,
     ):
-        constrained[Self.a_type == Self.b_type]()
+        comptime assert Self.a_type == Self.b_type
 
         self.cta_group = cta_group
         self.mma_shape = mma_shape

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/structured_kernels/epilogue_components.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/structured_kernels/epilogue_components.mojo
@@ -1758,7 +1758,7 @@ fn shared_memory_epilogue_transpose[
     if warp_dim == 2:
         # Use new Layout for idx2crd operations
         comptime layout_3d = row_major[2, Int(stageN), swizzle_dim]()
-        constrained[c_smem_layout.rank() == 4, "c_smem_layout must be 4D"]()
+        comptime assert c_smem_layout.rank() == 4, "c_smem_layout must be 4D"
         comptime thread_layout = Layout.row_major(1, 8, 1, 4)
         comptime result = zipped_divide(
             upcast(c_smem_layout, simd_size), thread_layout
@@ -1837,7 +1837,7 @@ fn shared_memory_epilogue_transpose[
                     )
     else:
         # Layout F: https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-data-path-layout-f
-        constrained[c_smem_layout.rank() == 3, "c_smem_layout must be 3D"]()
+        comptime assert c_smem_layout.rank() == 3, "c_smem_layout must be 3D"
         comptime thread_layout = Layout.row_major(min(16, Int(stageN)), 1, 2)
         comptime thread_bound = UInt(thread_layout.cosize())
         var lane = lane_id()

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/structured_kernels/output_writer.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/structured_kernels/output_writer.mojo
@@ -181,10 +181,9 @@ struct TileWriter[
     @always_inline
     fn __init__(out self, c_tma_op: Self.TmaOpPtr):
         """Initialize with pointer to TMA descriptor."""
-        constrained[
-            Self.stage_stride_cols > 0,
-            "stage_stride_cols must be positive",
-        ]()
+        comptime assert (
+            Self.stage_stride_cols > 0
+        ), "stage_stride_cols must be positive"
         self.c_tma_op = c_tma_op
 
     # ========== Public Write Methods ==========
@@ -456,10 +455,9 @@ struct TileWriter[
                 or not Self.elementwise_compute_lambda_fn
             ):
                 comptime expected_size = SMEMWriter.Config.fragment_size * Self.rep
-                constrained[
-                    Self.rep_frag_size == expected_size,
-                    "Fragment sizes must match",
-                ]()
+                comptime assert (
+                    Self.rep_frag_size == expected_size
+                ), "Fragment sizes must match"
                 smem_writer.write_fragments[Self.rep](
                     rebind[SIMD[Self.c_type, expected_size]](
                         upper_frag_casted.cast[Self.c_type]()
@@ -1041,10 +1039,9 @@ struct TileWriter[
                 or not Self.elementwise_compute_lambda_fn
             ):
                 comptime expected_size = SMEMWriter.Config.fragment_size * Self.rep
-                constrained[
-                    Self.rep_frag_size == expected_size,
-                    "Fragment sizes must match",
-                ]()
+                comptime assert (
+                    Self.rep_frag_size == expected_size
+                ), "Fragment sizes must match"
                 smem_writer.write_fragments[Self.rep](
                     rebind[SIMD[Self.c_type, expected_size]](
                         upper_frag_casted.cast[Self.c_type]()

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/structured_kernels/tile_scheduler.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/structured_kernels/tile_scheduler.mojo
@@ -468,10 +468,13 @@ struct TileScheduler[
         clc_throttle: Self.ThrottleBarrierArray,
     ):
         """Initialize from typed barrier arrays."""
-        constrained[
-            Self.block_swizzle_size in [0, 1, 2, 4, 8],
-            "block_swizzle_size must be 0, 1, 2, 4, or 8",
-        ]()
+        comptime assert Self.block_swizzle_size in [
+            0,
+            1,
+            2,
+            4,
+            8,
+        ], "block_swizzle_size must be 0, 1, 2, 4, or 8"
 
         self.cluster_dim = cluster_dim
         self.log_cluster_dim_m = FastDiv[DType.uint32](Int(cluster_dim[0]))

--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/structured_kernels/tmem.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/structured_kernels/tmem.mojo
@@ -755,19 +755,17 @@ struct BlockScaledTmem[
     @always_inline
     fn __init__(out self, base_addr: Int):
         """Create TMEM region view at the given base address."""
-        constrained[
-            Self.used_cols <= Self.total_cols,
-            "Block-scaled TMEM region exceeds capacity",
-        ]()
+        comptime assert (
+            Self.used_cols <= Self.total_cols
+        ), "Block-scaled TMEM region exceeds capacity"
         self.base_addr = base_addr
 
     @always_inline
     fn __init__(out self, addr: TmemAddress):
         """Create TMEM region view from a TmemAddress."""
-        constrained[
-            Self.used_cols <= Self.total_cols,
-            "Block-scaled TMEM region exceeds capacity",
-        ]()
+        comptime assert (
+            Self.used_cols <= Self.total_cols
+        ), "Block-scaled TMEM region exceeds capacity"
         self.base_addr = Int(addr.addr)
 
     @always_inline
@@ -775,10 +773,9 @@ struct BlockScaledTmem[
         cta: Int, max_cols: Int
     ](out self, alloc: TmemAllocation[cta, max_cols]):
         """Create TMEM region view from a TmemAllocation."""
-        constrained[
-            Self.used_cols <= Self.total_cols,
-            "Block-scaled TMEM region exceeds capacity",
-        ]()
+        comptime assert (
+            Self.used_cols <= Self.total_cols
+        ), "Block-scaled TMEM region exceeds capacity"
         self.base_addr = Int(alloc.addr)
 
     @always_inline

--- a/max/kernels/src/linalg/matmul/gpu/sm90/config.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm90/config.mojo
@@ -88,9 +88,9 @@ struct MatmulConfig[
             consumer_groups: The number of consumer groups.
             swapAB: Whether to swap A and B.
         """
-        constrained[
-            Self.a_type == Self.b_type, "a_type and b_type must be the same"
-        ]()
+        comptime assert (
+            Self.a_type == Self.b_type
+        ), "a_type and b_type must be the same"
 
         var M = n if swapAB else m
         var N = m if swapAB else n

--- a/max/kernels/src/linalg/matmul/gpu/sm90/dispatch.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm90/dispatch.mojo
@@ -2239,15 +2239,14 @@ fn matmul_dispatch_sm90_bf16_fp32[
                 comptime GRID_DIM_X = H100.sm_count
                 comptime GRID_DIM_Y = 1
 
-                constrained[
+                comptime assert (
                     SCHEDULE_TYPE != MatmulSchedule.DS_SCHEDULER
                     or (
                         CLUSTER_DIM_X == 1
                         and CLUSTER_DIM_Y == 1
                         and (not PARTITIONED_MULTICAST)
-                    ),
-                    "Deepseek scheduler dose not support multicasting",
-                ]()
+                    )
+                ), "Deepseek scheduler dose not support multicasting"
 
                 comptime SMALL_SHAPE_H100_BF16_TUNING_CONFIG_NON_SPLITK = MatmulConfig[
                     a_type,

--- a/max/kernels/src/linalg/matmul/gpu/sm90/matmul.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm90/matmul.mojo
@@ -81,10 +81,9 @@ fn _get_grid_shape[
 fn _is_valid_grid_shape[
     grid_shape: IndexList[2], cluster_shape: IndexList[3]
 ](num_tiles_n: Int) -> Bool:
-    constrained[
-        grid_shape[0] * grid_shape[1] <= H100.sm_count,
-        "Total grid size exceed number of SMs in H100.",
-    ]()
+    comptime assert (
+        grid_shape[0] * grid_shape[1] <= H100.sm_count
+    ), "Total grid size exceed number of SMs in H100."
 
     if not _is_valid_cluster_shape[cluster_shape](grid_shape, num_tiles_n):
         return False
@@ -224,31 +223,28 @@ fn _warp_specialize_gemm_with_multicasting_impl[
 
     comptime k_group_size = Int(config.k_group_size)
 
-    constrained[
-        (a_type == b_type == DType.float8_e4m3fn)
-        or (a_type == b_type and a_type in (DType.bfloat16, DType.float32)),
-        "Unsupported input dtype",
-    ]()
+    comptime assert (a_type == b_type == DType.float8_e4m3fn) or (
+        a_type == b_type and a_type in (DType.bfloat16, DType.float32)
+    ), "Unsupported input dtype"
 
-    constrained[
-        a_type != DType.float8_e4m3fn or BK == 128,
-        "BK must be 128 for fp8 data type for numerical accuracy correctness",
-    ]()
+    comptime assert (
+        a_type != DType.float8_e4m3fn or BK == 128
+    ), "BK must be 128 for fp8 data type for numerical accuracy correctness"
 
-    constrained[
-        elementwise_lambda_fn is None or elementwise_compute_lambda_fn is None,
-        "Either the epilogue lambda or the compute lambda can be used",
-    ]()
+    comptime assert (
+        elementwise_lambda_fn is None or elementwise_compute_lambda_fn is None
+    ), "Either the epilogue lambda or the compute lambda can be used"
 
-    constrained[
-        BM > 64 or (BM == 64 and config.num_consumer == 1),
-        "Only support 1 consumer for BM=64",
-    ]()
+    comptime assert BM > 64 or (
+        BM == 64 and config.num_consumer == 1
+    ), "Only support 1 consumer for BM=64"
 
     comptime k_align = find_K_alignment_upto_16B(K_static * size_of[a_type]())
-    constrained[
-        k_align in (4, 8, 16), "H100 matmul K dim must be multiple of 4B"
-    ]()
+    comptime assert k_align in (
+        4,
+        8,
+        16,
+    ), "H100 matmul K dim must be multiple of 4B"
 
     logger.info("Executing Warp Specialized Gemm with Multicasting")
     logger.info("block_tile_shape:", config.block_tile_shape)
@@ -259,31 +255,26 @@ fn _warp_specialize_gemm_with_multicasting_impl[
     if schedule == MatmulSchedule.NONE:
         pass
     elif schedule == MatmulSchedule.DS_SCHEDULER:
-        constrained[
-            grid_shape is not None,
-            "Grid shape must be provided for DS scheduler",
-        ]()
+        comptime assert (
+            grid_shape is not None
+        ), "Grid shape must be provided for DS scheduler"
         comptime ds_grid_shape = grid_shape.value()
-        constrained[
-            ds_grid_shape[0] <= H100.sm_count and ds_grid_shape[1] == 1,
-            "Deepseek scheduler only accepts grid shape with 1 column",
-        ]()
+        comptime assert (
+            ds_grid_shape[0] <= H100.sm_count and ds_grid_shape[1] == 1
+        ), "Deepseek scheduler only accepts grid shape with 1 column"
 
     elif grid_shape:
-        constrained[
-            _is_valid_grid_shape[grid_shape.value(), config.cluster_shape](
-                ceildiv(N_static, BN)
-            ),
-            String(
-                "grid shape:",
-                grid_shape.value(),
-                "is not compatible with cluster shape:",
-                config.cluster_shape,
-                "and static N:",
-                N_static,
-                sep=" ",
-            ),
-        ]()
+        comptime assert _is_valid_grid_shape[
+            grid_shape.value(), config.cluster_shape
+        ](ceildiv(N_static, BN)), String(
+            "grid shape:",
+            grid_shape.value(),
+            "is not compatible with cluster shape:",
+            config.cluster_shape,
+            "and static N:",
+            N_static,
+            sep=" ",
+        )
 
     comptime grid_shape_adjusted = grid_shape.value() if grid_shape else _get_grid_shape[
         config.cluster_shape
@@ -436,10 +427,9 @@ fn _warp_specialize_gemm_with_multicasting_impl[
 
     comptime smem_size = matmul_kernel_regular[].SMem.storage_size() if not swapAB else matmul_kernel_swapAB.SMem.storage_size()
 
-    constrained[
-        smem_size <= H100.shared_memory_per_multiprocessor - 1024,
-        "requested SMEM size exceeds 227KB limit.",
-    ]()
+    comptime assert (
+        smem_size <= H100.shared_memory_per_multiprocessor - 1024
+    ), "requested SMEM size exceeds 227KB limit."
 
     # TMA requires stride (K) multiple of 16B. If not satisfied,
     # we need to use cp.async.ca for 4B and 8B access, and ld for
@@ -853,10 +843,9 @@ fn warp_specialize_gemm_with_multicasting_splitk[
 
     comptime smem_size = matmul_kernel.SMem.storage_size()
 
-    constrained[
-        smem_size <= H100.shared_memory_per_multiprocessor - 1024,
-        "requested SMEM size exceeds 227KB limit.",
-    ]()
+    comptime assert (
+        smem_size <= H100.shared_memory_per_multiprocessor - 1024
+    ), "requested SMEM size exceeds 227KB limit."
 
     comptime kernel = matmul_kernel.run_splitk[
         a_tma_op.layout,

--- a/max/kernels/src/linalg/matmul/gpu/sm90/matmul_kernel_persistent.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm90/matmul_kernel_persistent.mojo
@@ -235,9 +235,9 @@ __extension HopperMatmulSM90Kernel:
             )
         else:
             # Consumer warp groups
-            constrained[
-                Self.num_consumer <= 2, "Only support 1 or 2 consumer"
-            ]()
+            comptime assert (
+                Self.num_consumer <= 2
+            ), "Only support 1 or 2 consumer"
             warpgroup_reg_alloc[232]()
 
             var local_warp_group_idx = warp_group_idx - 1

--- a/max/kernels/src/linalg/matmul/gpu/sm90/matmul_kernels.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm90/matmul_kernels.mojo
@@ -1009,7 +1009,7 @@ struct HopperMatmulSM90Kernel[
         comptime num_k_iters = K // Self.BK
 
         # FIXME: this seems to trip some logits tests
-        # constrained[(K % Self.BK) == 0, "K must be divisible by BK"]()
+        # comptime assert (K % Self.BK) == 0, "K must be divisible by BK"
 
         # Initialize WgmmaOp and SMem first
         var wgmma_op = Self.WgmmaOp()
@@ -1196,7 +1196,7 @@ struct HopperMatmulSM90Kernel[
         comptime num_k_iters = K // Self.BK
 
         # FIXME: this seems to trip some logits tests
-        # constrained[(K % Self.BK) == 0, "K must be divisible by BK"]()
+        # comptime assert (K % Self.BK) == 0, "K must be divisible by BK"
 
         # Initialize WgmmaOp and SMem first
         var wgmma_op = Self.WgmmaOp()
@@ -1493,14 +1493,13 @@ struct HopperMatmulSM90Kernel[
             c_reg_tile: Current accumulation from tensor cores.
             final_c_reg_tile: Higher-precision accumulator (updated in place).
         """
-        constrained[
-            c_reg_tile.dtype in (DType.float32, DType.float16),
-            "Only support fp32 and fp16 data type in CUDA Core promotion",
-        ]()
-        constrained[
-            len(c_reg_tile.layout) == 2,
-            "Only support 2D layout in CUDA Core promotion",
-        ]()
+        comptime assert c_reg_tile.dtype in (
+            DType.float32,
+            DType.float16,
+        ), "Only support fp32 and fp16 data type in CUDA Core promotion"
+        comptime assert (
+            len(c_reg_tile.layout) == 2
+        ), "Only support 2D layout in CUDA Core promotion"
 
         comptime num_mma = c_reg_tile.layout.shape[0].value()
         comptime c_frag_size = c_reg_tile.layout.shape[1].value()

--- a/max/kernels/src/linalg/matmul/gpu/sm90/matmul_output.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm90/matmul_output.mojo
@@ -303,13 +303,14 @@ struct MatmulTileWriter[
 
         comptime needs_x2 = needs_x2_swapAB if Self.swapAB else needs_x2_regular
 
-        constrained[
-            needs_x2 == (Self.frag_size % 4 == 0 and Self.frag_size % 8 != 0),
-            "stmatrix and wgmma register count conflict: needs_x2 = "
-            + String(needs_x2)
-            + " frag_size ="
-            + String(Self.frag_size),
-        ]()
+        comptime assert needs_x2 == (
+            Self.frag_size % 4 == 0 and Self.frag_size % 8 != 0
+        ), String(
+            "stmatrix and wgmma register count conflict: needs_x2 = ",
+            needs_x2,
+            " frag_size =",
+            Self.frag_size,
+        )
 
         comptime fragment_writer_type[
             sub_wg_id: Int, half_tile: Bool

--- a/max/kernels/src/linalg/matmul/gpu/sm90/testbed.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm90/testbed.mojo
@@ -231,13 +231,10 @@ fn test_matmul_sm90[
         ctx,
     )
 
-    constrained[
-        a_type != DType.float8_e4m3fn or transpose_b,
-        (
-            "Testing is only supported for transposed_b==True when"
-            " a_type==float8_e4m3fn. Add the non-transposed case if needed."
-        ),
-    ]()
+    comptime assert a_type != DType.float8_e4m3fn or transpose_b, (
+        "Testing is only supported for transposed_b==True when"
+        " a_type==float8_e4m3fn. Add the non-transposed case if needed."
+    )
 
     vendor_matmul(
         ctx,

--- a/max/kernels/src/linalg/matmul/gpu/sm90/tile_loader.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm90/tile_loader.mojo
@@ -419,28 +419,26 @@ fn async_copy_with_bound_check[
         src: Source tensor fragment in global memory.
         dst: Destination tensor fragment in shared memory.
     """
-    constrained[src.layout.rank() == 2, "Global memory tile must be rank 2."]()
+    comptime assert src.layout.rank() == 2, "Global memory tile must be rank 2."
 
-    constrained[
-        src_layout.shape == dst_layout.shape,
-        "Global memory tile must match source layout: "
-        + String(src_layout)
-        + " != "
-        + String(dst_layout),
-    ]()
+    comptime assert src_layout.shape == dst_layout.shape, String(
+        "Global memory tile must match source layout: ",
+        src_layout,
+        " != ",
+        dst_layout,
+    )
 
     # Validate swizzle pattern alignment with tile dimensions
     comptime src_shape1 = src.layout.shape[1].value()
     comptime swizzle_bytes = swizzle_mode.bytes()
-    constrained[
-        src_shape1 * src.element_size * size_of[src.dtype]() == swizzle_bytes,
-        String(
-            "Global memory tile shape-1 ",
-            src_shape1 * src.element_size,
-            "must match swizzle bytes.",
-            swizzle_bytes,
-        ),
-    ]()
+    comptime assert (
+        src_shape1 * src.element_size * size_of[src.dtype]() == swizzle_bytes
+    ), String(
+        "Global memory tile shape-1 ",
+        src_shape1 * src.element_size,
+        "must match swizzle bytes.",
+        swizzle_bytes,
+    )
 
     # Distribute work across threads according to thread_layout
     var src_frag = src.distribute[thread_layout](thread_idx.x)

--- a/max/kernels/src/linalg/matmul/gpu/sm90/tile_writer.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm90/tile_writer.mojo
@@ -706,10 +706,9 @@ struct RegisterToGMemWriter[
             tile_coords: Optional tile coordinates for epilogue processing.
             max_row: Optional maximum valid M coordinate (for epilogue).
         """
-        constrained[
-            (Self.epilogue_fn is None) or (Self.compute_lambda_fn is None),
-            "Only one of epilogue_fn or compute_lambda_fn should be set",
-        ]()
+        comptime assert (Self.epilogue_fn is None) or (
+            Self.compute_lambda_fn is None
+        ), "Only one of epilogue_fn or compute_lambda_fn should be set"
 
         # Store destination tensor
         self.dst = dst

--- a/max/kernels/src/linalg/matmul/gpu/tile_scheduler.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/tile_scheduler.mojo
@@ -167,19 +167,14 @@ struct TileScheduler[
     fn __init__(out self, prob_shape: IndexList[3]):
         @parameter
         if Self.schedule == MatmulSchedule.TILE2D:
-            constrained[
-                _check_cluster(Self.cluster, Self.raster_dim),
-                "Only support block cluster in along raster dimension.",
-            ]()
+            comptime assert _check_cluster(
+                Self.cluster, Self.raster_dim
+            ), "Only support block cluster in along raster dimension."
 
         if Self.schedule == MatmulSchedule.DS_SCHEDULER:
-            constrained[
-                Self.cluster[0] == Self.cluster[1] == Self.cluster[2] == 1,
-                (
-                    "Currently multicasting is not supported for DeepSeek"
-                    " Scheduler"
-                ),
-            ]()
+            comptime assert (
+                Self.cluster[0] == Self.cluster[1] == Self.cluster[2] == 1
+            ), "Currently multicasting is not supported for DeepSeek Scheduler"
 
         self.prob_shape = prob_shape
         self.num_waves_m = UInt32(

--- a/max/kernels/src/linalg/matmul/gpu/tile_scheduler_splitk.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/tile_scheduler_splitk.mojo
@@ -46,23 +46,18 @@ fn _check_scheduler_constraints[
 ]():
     comptime num_k_iters = ceildiv(prob_shape_nk[1], tile_shape[2])
 
-    constrained[
-        reduction_mode == ReductionMode.Deterministic,
-        "Currently SplitK only supports Deterministic reduction",
-    ]()
-
-    constrained[
-        splits <= UInt32(H100.sm_count),
-        "splits must be less than or equal to the number of SMs",
-    ]()
-
-    constrained[
-        splits <= UInt32(num_k_iters),
-        "splits must be less than or equal to the number of output tiles",
-    ]()
-    constrained[
-        (UInt32(num_k_iters) % splits) == 0, "BK must be divisible by splits"
-    ]()
+    comptime assert (
+        reduction_mode == ReductionMode.Deterministic
+    ), "Currently SplitK only supports Deterministic reduction"
+    comptime assert splits <= UInt32(
+        H100.sm_count
+    ), "splits must be less than or equal to the number of SMs"
+    comptime assert splits <= UInt32(
+        num_k_iters
+    ), "splits must be less than or equal to the number of output tiles"
+    comptime assert (
+        UInt32(num_k_iters) % splits
+    ) == 0, "BK must be divisible by splits"
 
 
 @fieldwise_init
@@ -452,10 +447,9 @@ struct SplitKTileScheduler[
         dyn_tile_shape: IndexList[3],
         dyn_cluster_shape: IndexList[2],
     ) -> Int:
-        constrained[
-            accum_type == DType.float32,
-            "Only support float32 accumulator type",
-        ]()
+        comptime assert (
+            accum_type == DType.float32
+        ), "Only support float32 accumulator type"
 
         var num_output_tiles = Self.get_num_tiles(
             problem_shape, dyn_tile_shape, dyn_cluster_shape
@@ -672,10 +666,9 @@ struct SplitKTileScheduler[
         comptime BM = workspace_layout.shape[1].value()
         comptime BN = workspace_layout.shape[2].value()
 
-        constrained[
-            accum_type == DType.float32,
-            "Only support float32 accumulator type",
-        ]()
+        comptime assert (
+            accum_type == DType.float32
+        ), "Only support float32 accumulator type"
 
         comptime num_mma = c_reg_tile.layout.shape[0].value()
         comptime c_frag_size = c_reg_tile.layout.shape[1].value()
@@ -723,10 +716,9 @@ struct SplitKTileScheduler[
         comptime BM = workspace_layout.shape[1].value()
         comptime BN = workspace_layout.shape[2].value()
 
-        constrained[
-            accum_type == DType.float32,
-            "Only support float32 accumulator type",
-        ]()
+        comptime assert (
+            accum_type == DType.float32
+        ), "Only support float32 accumulator type"
 
         comptime num_mma = c_reg_tile.layout.shape[0].value()
         comptime c_frag_size = c_reg_tile.layout.shape[1].value()

--- a/max/kernels/src/nn/mha.mojo
+++ b/max/kernels/src/nn/mha.mojo
@@ -4712,11 +4712,10 @@ fn mha_splitk_reduce[
     var inv_global_exp_sum = 1.0 / exp_sum
 
     comptime width = next_power_of_two(ceildiv(depth, num_threads))
-    constrained[depth % width == 0, "depth must be divisible by width"]()
-    constrained[
-        width * num_threads >= depth,
-        "width * num_threads must be greater than or equal to depth",
-    ]()
+    comptime assert depth % width == 0, "depth must be divisible by width"
+    comptime assert (
+        width * num_threads >= depth
+    ), "width * num_threads must be greater than or equal to depth"
 
     var acc = SIMD[accum_type, Int(width)](0)
     # Kahan summation compensation for improved precision with many partitions

--- a/max/kernels/src/nn/mha_operand.mojo
+++ b/max/kernels/src/nn/mha_operand.mojo
@@ -169,9 +169,9 @@ struct KVCacheMHAOperand[
         """Creates a TMA tile for efficient GPU memory transfers."""
         # Forward to the underlying cache's implementation
         # TODO: remove `comptime assert` when the `where` clause is enough
-        constrained[
-            (BK % swizzle_granularity[Self.dtype, swizzle_mode]()) == 0
-        ]()
+        comptime assert (
+            BK % swizzle_granularity[Self.dtype, swizzle_mode]()
+        ) == 0
         tma = rebind[type_of(tma)](
             self.cache.create_tma_tile[swizzle_mode, BN=BN, BK=BK](ctx)
         )
@@ -194,14 +194,12 @@ struct KVCacheMHAOperand[
         ],
     ) raises:
         # Forward to the underlying cache's implementation
-        constrained[
-            depth == Int(Self.cache_t.kv_params.head_size),
-            "depth must match kv_params.head_size",
-        ]()
-        constrained[
-            (BK % swizzle_granularity[Self.dtype, swizzle_mode]()) == 0,
-            "BK must be a multiple of swizzle granularity",
-        ]()
+        comptime assert depth == Int(
+            Self.cache_t.kv_params.head_size
+        ), "depth must match kv_params.head_size"
+        comptime assert (
+            BK % swizzle_granularity[Self.dtype, swizzle_mode]()
+        ) == 0, "BK must be a multiple of swizzle granularity"
         tma = rebind[type_of(tma)](
             self.cache.create_ragged_tma_tile[swizzle_mode, BN=BN, BK=BK](ctx)
         )
@@ -284,9 +282,9 @@ struct LayoutTensorMHAOperand[dtype_: DType, layout: Layout](
     ) raises:
         """Creates a TMA tile for efficient GPU memory transfers."""
         # View the 4D buffer as a 2D matrix [batch*seq, heads*head_dim]
-        constrained[
-            (BK % swizzle_granularity[Self.dtype, swizzle_mode]()) == 0
-        ]()
+        comptime assert (
+            BK % swizzle_granularity[Self.dtype, swizzle_mode]()
+        ) == 0
         var rows = self.buffer.dim[0]() * self.buffer.dim[1]()
         comptime smem_shape = IndexList[3](BN, 1, BK)
         comptime gmem_shape = IndexList[3](UNKNOWN_VALUE, UNKNOWN_VALUE, depth)
@@ -314,9 +312,9 @@ struct LayoutTensorMHAOperand[dtype_: DType, layout: Layout](
             BN=BK,
         ],
     ) raises:
-        constrained[
-            (BK % swizzle_granularity[Self.dtype, swizzle_mode]()) == 0
-        ]()
+        comptime assert (
+            BK % swizzle_granularity[Self.dtype, swizzle_mode]()
+        ) == 0
         var rows = self.buffer.dim[0]() * self.buffer.dim[1]()
         var num_heads = self.buffer.dim[2]()
         tma = type_of(tma).create[depth=depth](
@@ -418,9 +416,9 @@ struct RaggedMHAOperand[dtype_: DType, layout: Layout, cache_layout: Layout](
     ) raises:
         """Creates a TMA tile for efficient GPU memory transfers."""
         # View as [total_tokens, heads*head_dim]
-        constrained[
-            (BK % swizzle_granularity[Self.dtype, swizzle_mode]()) == 0
-        ]()
+        comptime assert (
+            BK % swizzle_granularity[Self.dtype, swizzle_mode]()
+        ) == 0
         var rows = self.buffer.dim[0]()  # total tokens
         comptime smem_shape = IndexList[3](BN, 1, BK)
         comptime gmem_shape = IndexList[3](UNKNOWN_VALUE, UNKNOWN_VALUE, depth)
@@ -448,9 +446,9 @@ struct RaggedMHAOperand[dtype_: DType, layout: Layout, cache_layout: Layout](
             BN=BK,
         ],
     ) raises:
-        constrained[
-            (BK % swizzle_granularity[Self.dtype, swizzle_mode]()) == 0
-        ]()
+        comptime assert (
+            BK % swizzle_granularity[Self.dtype, swizzle_mode]()
+        ) == 0
         var rows = self.buffer.dim[0]()  # total tokens
         var num_heads = self.buffer.dim[1]()
         tma = type_of(tma).create[depth=depth](

--- a/max/kernels/src/nn/mha_sm100_2q.mojo
+++ b/max/kernels/src/nn/mha_sm100_2q.mojo
@@ -2615,10 +2615,9 @@ struct RolePipeline[
         Parameters:
             sub_stage_idx: Sub-stage index (0 to producer_sub_stages-1).
         """
-        constrained[
-            sub_stage_idx < Self.producer_sub_stages,
-            "sub_stage_idx out of range",
-        ]()
+        comptime assert (
+            sub_stage_idx < Self.producer_sub_stages
+        ), "sub_stage_idx out of range"
         return (
             self.producer_mbar_base
             + self.state.index() * UInt32(Self.producer_sub_stages)
@@ -2632,10 +2631,9 @@ struct RolePipeline[
         Parameters:
             sub_stage_idx: Sub-stage index (0 to consumer_sub_stages-1).
         """
-        constrained[
-            sub_stage_idx < Self.consumer_sub_stages,
-            "sub_stage_idx out of range",
-        ]()
+        comptime assert (
+            sub_stage_idx < Self.consumer_sub_stages
+        ), "sub_stage_idx out of range"
         return (
             self.consumer_mbar_base
             + self.state.index() * UInt32(Self.consumer_sub_stages)
@@ -3110,7 +3108,9 @@ struct FA4MiscMBars[
     @always_inline("nodebug")
     fn get_v_mbars(self) -> MBarType:
         """Returns base pointer for V pipeline barriers (MHA only)."""
-        constrained[Self.separate_kv, "Use get_kv_mbars for unified pipeline"]()
+        comptime assert (
+            Self.separate_kv
+        ), "Use get_kv_mbars for unified pipeline"
         return self.mbar_base + Self.V_offset
 
     @always_inline("nodebug")

--- a/max/kernels/src/nn/shard_and_stack.mojo
+++ b/max/kernels/src/nn/shard_and_stack.mojo
@@ -48,8 +48,8 @@ fn _validate_shard_and_stack[
         outputs: Output tensors, one per device/shard.
         inputs: Input tensors to be sharded, all with identical shapes.
     """
-    constrained[inputs.size > 0, "must have one or more inputs"]()
-    constrained[0 <= axis < inputs.rank, "axis must be in [0, inputs.rank)"]()
+    comptime assert inputs.size > 0, "must have one or more inputs"
+    comptime assert 0 <= axis < inputs.rank, "axis must be in [0, inputs.rank)"
 
     var input_shape = inputs[0].shape()
     var row_major_strides = _row_major_strides(input_shape)

--- a/max/kernels/test/gpu/comm/test_allreduce.mojo
+++ b/max/kernels/test/gpu/comm/test_allreduce.mojo
@@ -421,9 +421,9 @@ fn run_allreduce_sweep[
 
         # Some checks for raggedness
         comptime simd_width = simd_width_of[dtype, get_gpu_target()]()
-        constrained[
-            length % simd_width == 0, "Length must be multiple of simd_width"
-        ]()
+        comptime assert (
+            length % simd_width == 0
+        ), "Length must be multiple of simd_width"
         comptime quickreduce_tile_shape = simd_width * 8 * 256
         if use_quickreduce and (length % quickreduce_tile_shape != 0):
             # Quickreduce requires full tiles (a quickreduce specific concept)

--- a/max/kernels/test/gpu/comm/test_reducescatter.mojo
+++ b/max/kernels/test/gpu/comm/test_reducescatter.mojo
@@ -57,8 +57,8 @@ fn reducescatter_test[
     Each GPU receives 1/ngpus of the reduced data in its output partition.
     When use_custom_epilogue is True, tests with a negating epilogue.
     """
-    constrained[ngpus in (2, 4, 8), "ngpus must be 2, 4, or 8"]()
-    constrained[rank == 1, "this test code currently assumes rank 1"]()
+    comptime assert ngpus in (2, 4, 8), "ngpus must be 2, 4, or 8"
+    comptime assert rank == 1, "this test code currently assumes rank 1"
 
     print(
         String(

--- a/max/kernels/test/gpu/linalg/test_grouped_matmul_sm100_mxfp8.mojo
+++ b/max/kernels/test/gpu/linalg/test_grouped_matmul_sm100_mxfp8.mojo
@@ -503,13 +503,10 @@ def test_blackwell_block_scaled_matmul_tma_umma_warp_specialized[
         ctx,
     )
 
-    constrained[
-        a_type != DType.float8_e4m3fn or transpose_b,
-        (
-            "Testing is only supported for transposed_b==True when"
-            " a_type==float8_e4m3fn. Add the non-transposed case if needed."
-        ),
-    ]()
+    comptime assert a_type != DType.float8_e4m3fn or transpose_b, (
+        "Testing is only supported for transposed_b==True when"
+        " a_type==float8_e4m3fn. Add the non-transposed case if needed."
+    )
 
     comptime new_c_layout = Layout.row_major(UNKNOWN_VALUE, expert_shape[0])
     comptime new_a_layout = Layout.row_major(UNKNOWN_VALUE, expert_shape[1])

--- a/max/kernels/test/gpu/linalg/test_grouped_matmul_sm100_nvfp4.mojo
+++ b/max/kernels/test/gpu/linalg/test_grouped_matmul_sm100_nvfp4.mojo
@@ -500,13 +500,10 @@ def test_blackwell_block_scaled_matmul_tma_umma_warp_specialized[
         ctx,
     )
 
-    constrained[
-        a_type != DType.float8_e4m3fn or transpose_b,
-        (
-            "Testing is only supported for transposed_b==True when"
-            " a_type==float8_e4m3fn. Add the non-transposed case if needed."
-        ),
-    ]()
+    comptime assert a_type != DType.float8_e4m3fn or transpose_b, (
+        "Testing is only supported for transposed_b==True when"
+        " a_type==float8_e4m3fn. Add the non-transposed case if needed."
+    )
 
     comptime new_c_layout = Layout.row_major(UNKNOWN_VALUE, expert_shape[0])
     comptime new_a_layout = Layout.row_major(

--- a/max/kernels/test/gpu/linalg/test_matmul_sm100_batched_block_scaled_mxfp8_1sm.mojo
+++ b/max/kernels/test/gpu/linalg/test_matmul_sm100_batched_block_scaled_mxfp8_1sm.mojo
@@ -395,13 +395,10 @@ def test_blackwell_block_scaled_matmul_tma_umma_warp_specialized[
         ctx,
     )
 
-    constrained[
-        a_type != DType.float8_e4m3fn or transpose_b,
-        (
-            "Testing is only supported for transposed_b==True when"
-            " a_type==float8_e4m3fn. Add the non-transposed case if needed."
-        ),
-    ]()
+    comptime assert a_type != DType.float8_e4m3fn or transpose_b, (
+        "Testing is only supported for transposed_b==True when"
+        " a_type==float8_e4m3fn. Add the non-transposed case if needed."
+    )
 
     @parameter
     fn _reshape_to_2d[layout: Layout]() -> Layout:

--- a/max/kernels/test/gpu/linalg/test_matmul_sm100_batched_block_scaled_mxfp8_2sm.mojo
+++ b/max/kernels/test/gpu/linalg/test_matmul_sm100_batched_block_scaled_mxfp8_2sm.mojo
@@ -395,13 +395,10 @@ def test_blackwell_block_scaled_matmul_tma_umma_warp_specialized[
         ctx,
     )
 
-    constrained[
-        a_type != DType.float8_e4m3fn or transpose_b,
-        (
-            "Testing is only supported for transposed_b==True when"
-            " a_type==float8_e4m3fn. Add the non-transposed case if needed."
-        ),
-    ]()
+    comptime assert a_type != DType.float8_e4m3fn or transpose_b, (
+        "Testing is only supported for transposed_b==True when"
+        " a_type==float8_e4m3fn. Add the non-transposed case if needed."
+    )
 
     @parameter
     fn _reshape_to_2d[layout: Layout]() -> Layout:

--- a/max/kernels/test/gpu/state_space/test_selective_scan.mojo
+++ b/max/kernels/test/gpu/state_space/test_selective_scan.mojo
@@ -58,7 +58,7 @@ fn run_selective_scan_gpu[
     rtol: Float64 = 0.01,
 ) raises:
     """Test selective scan GPU kernel against CPU reference."""
-    constrained[DSTATE <= 16, "DSTATE exceeds kernel limit"]()
+    comptime assert DSTATE <= 16, "DSTATE exceeds kernel limit"
     comptime dstate = DSTATE
 
     var group_size = dim // n_groups
@@ -500,7 +500,7 @@ fn run_selective_scan_update_gpu[
     rtol: Float64 = 0.01,
 ) raises:
     """Test selective scan update GPU kernel against CPU reference."""
-    constrained[DSTATE <= 16, "DSTATE exceeds kernel limit"]()
+    comptime assert DSTATE <= 16, "DSTATE exceeds kernel limit"
     comptime dstate = DSTATE
 
     var group_size = dim // n_groups

--- a/max/kernels/test/gpu/state_space/test_ssd_combined.mojo
+++ b/max/kernels/test/gpu/state_space/test_ssd_combined.mojo
@@ -67,7 +67,7 @@ fn run_ssd_combined_gpu[
     rtol: Float64 = 0.01,
 ) raises:
     """Test SSD combined GPU kernel against CPU reference."""
-    constrained[DSTATE <= 16, "DSTATE exceeds kernel limit"]()
+    comptime assert DSTATE <= 16, "DSTATE exceeds kernel limit"
     comptime dstate = DSTATE
 
     var group_size = dim // n_groups

--- a/max/kernels/test/layout/test_layout_tensor_load_scalar.mojo
+++ b/max/kernels/test/layout/test_layout_tensor_load_scalar.mojo
@@ -151,10 +151,9 @@ fn test_load_scalar_vectorized_element_size_gt_1() raises:
     var vec_tensor = tensor.vectorize[1, 4]()
 
     # Verify element_size > 1
-    constrained[
-        vec_tensor.element_size == 4,
-        "Expected element_size == 4 for vectorized tensor",
-    ]()
+    comptime assert (
+        vec_tensor.element_size == 4
+    ), "Expected element_size == 4 for vectorized tensor"
 
     # __getitem__ returns SIMD[float32, 4], load_scalar returns just the 0th lane
     # For position (0, 0): the element contains [0, 1, 2, 3], load_scalar returns 0

--- a/max/kernels/test/nn/test_conv2d_winograd.mojo
+++ b/max/kernels/test/nn/test_conv2d_winograd.mojo
@@ -31,7 +31,7 @@ fn matmul[
     A: NDBuffer[dtype, 2, _, _],
     B: NDBuffer[dtype, 2, _, _],
 ):
-    # TODO: Add constrained[]?
+    # TODO: Add comptime assert?
     @parameter
     if transpose_b:
         for i in range(N):

--- a/max/kernels/test/state_space/test_selective_scan.mojo
+++ b/max/kernels/test/state_space/test_selective_scan.mojo
@@ -86,7 +86,7 @@ fn run_selective_scan_fwd[
     rtol: Float64 = 0.01,
 ) raises:
     """Test selective scan forward kernel against reference implementation."""
-    constrained[DSTATE <= MAX_DSTATE, "DSTATE exceeds kernel limit"]()
+    comptime assert DSTATE <= MAX_DSTATE, "DSTATE exceeds kernel limit"
     comptime dstate = DSTATE
 
     var group_size = dim // n_groups
@@ -336,7 +336,7 @@ fn run_selective_scan_update[
     delta_softplus: Bool = False,
 ](batch: Int, dim: Int, n_groups: Int, rtol: Float64 = 0.01,) raises:
     """Test selective scan update kernel against reference implementation."""
-    constrained[DSTATE <= MAX_DSTATE, "DSTATE exceeds kernel limit"]()
+    comptime assert DSTATE <= MAX_DSTATE, "DSTATE exceeds kernel limit"
     comptime dstate = DSTATE
 
     var group_size = dim // n_groups

--- a/max/kernels/test/state_space/test_ssd_combined.mojo
+++ b/max/kernels/test/state_space/test_ssd_combined.mojo
@@ -62,7 +62,7 @@ fn run_ssd_combined[
     rtol: Float64 = 0.01,
 ) raises:
     """Test SSD combined kernel against reference implementation."""
-    constrained[DSTATE <= MAX_DSTATE, "DSTATE exceeds kernel limit"]()
+    comptime assert DSTATE <= MAX_DSTATE, "DSTATE exceeds kernel limit"
     comptime dstate = DSTATE
 
     var group_size = dim // n_groups


### PR DESCRIPTION
Replace uses of `constrained[boolean_expression]` with `comptime assert` in kernels