### PR TITLE
[Stdlib] explicit Writable repr for Range

### DIFF
--- a/mojo/stdlib/std/builtin/range.mojo
+++ b/mojo/stdlib/std/builtin/range.mojo
@@ -23,6 +23,7 @@ from sys.intrinsics import unlikely
 from python import PythonObject
 
 from utils._select import _select_register_value as select
+from format._utils import FormatStruct
 
 # ===----------------------------------------------------------------------=== #
 # Utilities
@@ -90,7 +91,12 @@ struct _ZeroStartingRange(
 
 
 struct _SequentialRange(
-    Iterable, Iterator, ReversibleRange, Sized, TrivialRegisterPassable
+    Iterable,
+    Iterator,
+    ReversibleRange,
+    Sized,
+    TrivialRegisterPassable,
+    Writable,
 ):
     comptime IteratorType[
         iterable_mut: Bool, //, iterable_origin: Origin[mut=iterable_mut]
@@ -133,6 +139,11 @@ struct _SequentialRange(
     fn bounds(self) -> Tuple[Int, Optional[Int]]:
         var len = len(self)
         return (len, {len})
+
+    @always_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        # Explicit, non-reflective repr for sequential ranges: `range(start, end)`
+        FormatStruct(writer, "range").fields(self.start, self.end)
 
 
 @fieldwise_init

--- a/mojo/stdlib/test/builtin/BUILD.bazel
+++ b/mojo/stdlib/test/builtin/BUILD.bazel
@@ -116,3 +116,19 @@ lit_tests(
         "//conditions:default": [],
     }),
 )
+
+# Minimal explicit test target for the new focused range repr test
+mojo_test(
+    name = "test_range_repr.test",
+    srcs = ["test_range_repr.mojo"],
+    copts = [
+        "--debug-level",
+        "full",
+    ],
+    data = _DATA + ["test_range_repr.mojo"],
+    target_compatible_with = _PLATFORM_CONSTRAINTS.get("test_range_repr.mojo", []),
+    deps = [
+        "@mojo//:std",
+        "@mojo//:test_utils",
+    ],
+)

--- a/mojo/stdlib/test/builtin/test_range_repr.mojo
+++ b/mojo/stdlib/test/builtin/test_range_repr.mojo
@@ -1,0 +1,28 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from testing import assert_equal, TestSuite
+
+
+def test_range_repr_normal():
+    r = range(2, 5)
+    assert_equal(repr(r), "range(2, 5)")
+
+
+def test_range_repr_empty():
+    r = range(3, 3)
+    assert_equal(repr(r), "range(3, 3)")
+
+
+def main():
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Small changes:
range.mojo
Add Writable to _SequentialRange traits.
Implement fn write_repr_to(self, mut writer: Some[Writer]) using FormatStruct(writer, "range").fields(self.start, self.end).
Add import from format._utils import FormatStruct.
test_range_repr.mojo
New focused test file with two assertions: repr(range(2,5)) == "range(2, 5)" and repr(range(3,3)) == "range(3, 3)".
BUILD.bazel
Add minimal mojo_test target test_range_repr.test so Bazel can run the new test directly.

Related issue: #5870