### PR TITLE
[Stdlib] explicit Writable repr for Bool

### DIFF
--- a/mojo/stdlib/std/builtin/bool.mojo
+++ b/mojo/stdlib/std/builtin/bool.mojo
@@ -216,17 +216,16 @@ struct Bool(
 
         writer.write("True" if self else "False")
 
-    @no_inline
+    @always_inline
     fn write_repr_to(self, mut writer: Some[Writer]):
-        """Writes the repr of this boolean to a writer.
+        """Explicit non-reflective repr for Bool.
 
-        The repr of a boolean is the same as its string representation:
-        `True` or `False`.
-
-        Args:
-            writer: The object to write to.
+        Writes the literal "True" or "False" to preserve existing repr()
+        behavior and avoid using reflection.
         """
-        self.write_to(writer)
+        writer.write("True" if self else "False")
+
+    # `write_repr_to` implemented above (explicit, non-reflective).
 
     fn __repr__(self) -> String:
         """Get the bool as a string.

--- a/mojo/stdlib/test/builtin/test_bool_repr.mojo
+++ b/mojo/stdlib/test/builtin/test_bool_repr.mojo
@@ -1,0 +1,30 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Focused tests for Bool repr
+# ===----------------------------------------------------------------------=== #
+
+from testing import assert_equal, TestSuite
+
+
+def test_bool_repr_true():
+    assert_equal(repr(True), "True")
+
+
+def test_bool_repr_false():
+    assert_equal(repr(False), "False")
+
+
+def main():
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Add an explicit, non-reflective `write_repr_to` for `Bool` that emits
\"True\" or \"False\" to preserve existing repr() output. Adds a focused
test asserting exact repr output for both cases.

Related issue: #5870 
