### PR TITLE
[Stdlib] Fix LinkedList.reverse() not updating prev pointers

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -363,3 +363,6 @@ what we publish.
 - `StringSlice.find`: Fixed integer overflow bug in SIMD string search that
   caused searches to fail when searching for strings longer than
   `simd_width_of[DType.bool]()` and haystacks larger than UInt16.MAX.
+
+- `LinkedList.reverse()`: Fixed missing `prev` pointer updates, which caused
+  `__reversed__()` to produce wrong results after reversing.

--- a/mojo/stdlib/std/collections/linked_list.mojo
+++ b/mojo/stdlib/std/collections/linked_list.mojo
@@ -309,6 +309,7 @@ struct LinkedList[ElementType: Copyable & ImplicitlyDestructible](
         while curr:
             var next = curr[].next
             curr[].next = prev
+            curr[].prev = next
             prev = curr
             curr = next
         self._tail = self._head

--- a/mojo/stdlib/test/collections/test_linked_list.mojo
+++ b/mojo/stdlib/test/collections/test_linked_list.mojo
@@ -96,6 +96,18 @@ def test_reverse():
     assert_equal(l1[2], 1)
 
 
+def test_reverse_prev_pointers():
+    var l1 = LinkedList[Int](1, 2, 3)
+    l1.reverse()
+
+    # After reverse, forward order is [3, 2, 1].
+    # Backward iteration via __reversed__ should yield [1, 2, 3].
+    var riter = l1.__reversed__()
+    assert_equal(riter.__next__(), 1)
+    assert_equal(riter.__next__(), 2)
+    assert_equal(riter.__next__(), 3)
+
+
 def test_pop():
     var l1 = LinkedList[Int](1, 2, 3)
     assert_equal(l1.pop(), 3)


### PR DESCRIPTION
## Summary

`reverse()` only swapped `next` pointers, leaving `prev` pointers stale. This caused `__reversed__()` to produce wrong results after a `reverse()`.