### PR TITLE
[Stdlib] Replace O(n^2) pop() loop in Set.clear() with Dict.clear()

### DIFF
--- a/mojo/stdlib/std/collections/set.mojo
+++ b/mojo/stdlib/std/collections/set.mojo
@@ -622,14 +622,4 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
         This method modifies the set in-place, removing all of its elements.
         After calling this method, the set will be empty.
         """
-        for _ in range(len(self)):
-            # Can't fail from an empty set
-            try:
-                _ = self.pop()
-            except:
-                pass
-
-        #! This code below (without using range function) won't pass tests
-        #! It leaves set with one remaining item. Is this a bug?
-        # for _ in self:
-        #     var a = self.pop()
+        self._data.clear()


### PR DESCRIPTION
## Summary

`Set.clear()` called `pop()` in a loop, which restarts iteration from the beginning on each call, resulting in O(n^2) behavior. Delegate to the underlying `Dict.clear()` which is O(n).