### PR TITLE
[Stdlib][FloatLiteral]: implement Writable for FloatLiteral and add tests

### DIFF
--- a/mojo/stdlib/std/builtin/float_literal.mojo
+++ b/mojo/stdlib/std/builtin/float_literal.mojo
@@ -28,6 +28,7 @@ struct FloatLiteral[value: __mlir_type.`!pop.float_literal`](
     Intable,
     Stringable,
     TrivialRegisterPassable,
+    Writable,
 ):
     """Mojo floating point literal type.
 
@@ -168,6 +169,16 @@ struct FloatLiteral[value: __mlir_type.`!pop.float_literal`](
             The Float value.
         """
         return Float64(self)
+    
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the FloatLiteral in string form."""
+        writer.write(String(self))
+
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the FloatLiteral in repr form."""
+        writer.write(String(self))
 
     # ===------------------------------------------------------------------===#
     # Unary Operators

--- a/mojo/stdlib/std/builtin/float_literal.mojo
+++ b/mojo/stdlib/std/builtin/float_literal.mojo
@@ -172,13 +172,21 @@ struct FloatLiteral[value: __mlir_type.`!pop.float_literal`](
     
     @no_inline
     fn write_to(self, mut writer: Some[Writer]):
-        """Writes the FloatLiteral in string form."""
-        writer.write(String(self))
+        """Writes the FloatLiteral in string form.
+
+        Args:
+            writer: The Writer to write the value to.
+        """
+        Float64(self).write_to(writer)
 
     @no_inline
     fn write_repr_to(self, mut writer: Some[Writer]):
-        """Writes the FloatLiteral in repr form."""
-        writer.write(String(self))
+        """Writes the FloatLiteral in repr form.
+
+        Args:
+            writer: The Writer to write the value to.
+        """
+        Float64(self).write_repr_to(writer)
 
     # ===------------------------------------------------------------------===#
     # Unary Operators

--- a/mojo/stdlib/test/builtin/test_float_literal.mojo
+++ b/mojo/stdlib/test/builtin/test_float_literal.mojo
@@ -169,5 +169,16 @@ def test_float_conversion():
     assert_equal((0.0).__float__(), 0.0)
 
 
+def test_float_literal_writable():
+    assert_equal(String(4.5), "4.5")
+    assert_equal(repr(4.5), repr(Float64(4.5)))
+
+    assert_equal(String(0.0), "0.0")
+    assert_equal(repr(0.0), repr(Float64(0.0)))
+
+    assert_equal(String(FloatLiteral.infinity), "inf")
+    assert_equal(String(FloatLiteral.negative_infinity), "-inf")
+
+
 def main():
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Background

As part of the ongoing migration from Stringable/Representable to the unified Writable trait, stdlib types must provide explicit write_to() and write_repr_to() implementations.

While Writable provides a default reflection-based write_repr_to(), this is not suitable for stdlib types, which require consistent and controlled formatting.

Changes

- Added Writable conformance to FloatLiteral
- Implemented explicit write_to()
- Implemented explicit write_repr_to()
- Preserved existing formatting semantics by delegating to String(self)
- Added unit tests to validate Writable behavior

Rationale

FloatLiteral previously relied only on __str__ and did not provide an explicit Writable implementation.

The new implementation:
- Ensures compatibility with the Writable migration
- Avoids reflection-based default formatting
- Keeps output consistent with Float64 formatting
- Adds explicit test coverage for string and repr behavior

Tests

All builtin tests pass locally:
bazel test builtin:all

Part of issue: #5870 