### PR TITLE
[Stdlib][complex]: add canonical write_repr_to for ComplexSIMD

### DIFF
--- a/mojo/stdlib/std/complex/complex.mojo
+++ b/mojo/stdlib/std/complex/complex.mojo
@@ -22,6 +22,7 @@ from complex import ComplexSIMD
 import math
 from math.math import _Expable
 from sys import llvm_intrinsic
+from format._utils import FormatStruct
 
 comptime ComplexScalar = ComplexSIMD[size=1]
 """Represents a scalar complex value."""
@@ -164,6 +165,10 @@ struct ComplexSIMD[dtype: DType, size: Int](
         @parameter
         if Self.size > 1:
             writer.write("]")
+    
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        FormatStruct(writer, "ComplexSIMD").fields(self)
 
     @always_inline
     fn __abs__(self) -> SIMD[Self.dtype, Self.size]:

--- a/mojo/stdlib/std/complex/complex.mojo
+++ b/mojo/stdlib/std/complex/complex.mojo
@@ -168,6 +168,11 @@ struct ComplexSIMD[dtype: DType, size: Int](
     
     @no_inline
     fn write_repr_to(self, mut writer: Some[Writer]):
+        """Formats the complex value for debug representation.
+
+        Args:
+            writer: The Writer to write the representation to.
+        """
         FormatStruct(writer, "ComplexSIMD").fields(self)
 
     @always_inline

--- a/mojo/stdlib/test/complex/test_complex.mojo
+++ b/mojo/stdlib/test/complex/test_complex.mojo
@@ -16,6 +16,7 @@ import math
 from complex import ComplexFloat32, ComplexFloat64, ComplexSIMD, abs
 from testing import assert_almost_equal, assert_equal
 from testing import TestSuite
+from testing import assert_true
 
 
 def test_init():
@@ -123,6 +124,11 @@ def test_exp():
     var c = math.exp(ComplexFloat64(0, math.pi))
     assert_almost_equal(c.re, -1)
     assert_almost_equal(c.im, 0)
+
+
+def test_complex_repr():
+    var c = ComplexFloat32(1, 2)
+    assert_equal(repr(c), "ComplexSIMD(1.0 + 2.0i)")
 
 
 def main():

--- a/mojo/stdlib/test/complex/test_complex.mojo
+++ b/mojo/stdlib/test/complex/test_complex.mojo
@@ -16,7 +16,7 @@ import math
 from complex import ComplexFloat32, ComplexFloat64, ComplexSIMD, abs
 from testing import assert_almost_equal, assert_equal
 from testing import TestSuite
-from testing import assert_true
+from test_utils import check_write_to
 
 
 def test_init():
@@ -128,7 +128,11 @@ def test_exp():
 
 def test_complex_repr():
     var c = ComplexFloat32(1, 2)
-    assert_equal(repr(c), "ComplexSIMD(1.0 + 2.0i)")
+    check_write_to(
+        c,
+        expected="ComplexSIMD(1.0 + 2.0i)",
+        is_repr=True,
+    )
 
 
 def main():


### PR DESCRIPTION
Adds explicit write_repr_to implementation for ComplexSIMD as part of the stdlib Writable migration.

Uses FormatStruct(...).fields(self) to ensure canonical stdlib formatting
and avoids relying on the default reflection-based implementation.

Adds unit test verifying repr output.

All complex and builtin tests pass locally.
Part of issue: #5870 