### PR TITLE
[Stdlib] Use len() check + single issubset() in Set.__gt__/__lt__

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -328,6 +328,9 @@ what we publish.
 
 ### Library changes
 
+- `Set.__gt__()` and `Set.__lt__()` now use an O(1) `len()` check plus a single
+  `issubset()` traversal instead of two full traversals.
+
 - `Dict` internals have been replaced with a Swiss Table implementation using
   SIMD group probing for lookups. This improves lookup, insertion, and deletion
   performance — especially when looking up keys not in the dict — while

--- a/mojo/stdlib/std/collections/set.mojo
+++ b/mojo/stdlib/std/collections/set.mojo
@@ -236,7 +236,7 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
         Returns:
             True if the set is a strict superset of the `other` set, False otherwise.
         """
-        return self >= other and self != other
+        return len(self) > len(other) and other.issubset(self)
 
     fn __lt__(self, other: Self) -> Bool:
         """Overloads the < operator for strict subset comparison of sets.
@@ -247,7 +247,7 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
         Returns:
             True if the set is a strict subset of the `other` set, False otherwise.
         """
-        return self <= other and self != other
+        return len(self) < len(other) and self.issubset(other)
 
     fn __xor__(self, other: Self) -> Self:
         """Overloads the ^ operator for sets. Works like as `symmetric_difference` method.


### PR DESCRIPTION
## Summary

Previously `__gt__`/`__lt__` did two full traversals: `issuperset`/`issubset` + `__ne__`. Now an O(1) `len()` check ensures strictness, followed by a single `issubset()` traversal.