### PR TITLE
[Stdlib] Use Dict.popitem() in Set.pop() to avoid redundant rehash

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -328,6 +328,9 @@ what we publish.
 
 ### Library changes
 
+- `Set.pop()` now uses `Dict.popitem()` directly, avoiding a redundant rehash.
+  Order changes from FIFO to LIFO, matching Python's unordered `set.pop()`.
+
 - `Set.__gt__()` and `Set.__lt__()` now use an O(1) `len()` check plus a single
   `issubset()` traversal instead of two full traversals.
 

--- a/mojo/stdlib/std/collections/set.mojo
+++ b/mojo/stdlib/std/collections/set.mojo
@@ -418,9 +418,8 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
     fn pop(mut self) raises -> Self.T:
         """Remove any one item from the set, and return it.
 
-        As an implementation detail this will remove the first item
-        according to insertion order. This is practically useful
-        for breadth-first search implementations.
+        As an implementation detail this will remove the last item
+        according to insertion order.
 
         Returns:
             The element which was removed from the set.
@@ -428,12 +427,10 @@ struct Set[T: KeyElement, H: Hasher = default_hasher](
         Raises:
             If the set is empty.
         """
-        if not self:
+        try:
+            return self._data.popitem().key.copy()
+        except:
             raise "Pop on empty set"
-        var iter = self.__iter__()
-        var first = iter.__next__().copy()
-        self.remove(first)
-        return first^
 
     fn union(self, other: Self) -> Self:
         """Set union.

--- a/mojo/stdlib/test/collections/test_set.mojo
+++ b/mojo/stdlib/test/collections/test_set.mojo
@@ -269,18 +269,18 @@ def test_remove():
 
 def test_pop_insertion_order():
     var s = {1, 2, 3}
-    assert_equal(s.pop(), 1)
-    assert_equal(s, {2, 3})
+    assert_equal(s.pop(), 3)
+    assert_equal(s, {1, 2})
 
     s.add(4)
 
-    assert_equal(s.pop(), 2)
-    assert_equal(s, {3, 4})
-
-    assert_equal(s.pop(), 3)
-    assert_equal(s, {4})
-
     assert_equal(s.pop(), 4)
+    assert_equal(s, {1, 2})
+
+    assert_equal(s.pop(), 2)
+    assert_equal(s, {1})
+
+    assert_equal(s.pop(), 1)
     assert_equal(s, {})
 
     with assert_raises():


### PR DESCRIPTION
## Summary

Previously `Set.pop()` iterated to find the first element, copied it, then called `remove()` which rehashed to find it again. Now delegates to `Dict.popitem()` which removes directly from the slot. Order changes from FIFO to LIFO, matching Python's unordered `set.pop()` semantics.