### PR TITLE
[Stdlib] Return self.path directly in Path.__fspath__()

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -328,6 +328,9 @@ what we publish.
 
 ### Library changes
 
+- `Path.__fspath__()` now returns `self.path` directly instead of creating an
+  unnecessary copy via `String(self)`.
+
 - `Dict` internals have been replaced with a Swiss Table implementation using
   SIMD group probing for lookups. This improves lookup, insertion, and deletion
   performance — especially when looking up keys not in the dict — while

--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -328,9 +328,6 @@ what we publish.
 
 ### Library changes
 
-- `Path.__fspath__()` now returns `self.path` directly instead of creating an
-  unnecessary copy via `String(self)`.
-
 - `Dict` internals have been replaced with a Swiss Table implementation using
   SIMD group probing for lookups. This improves lookup, insertion, and deletion
   performance — especially when looking up keys not in the dict — while

--- a/mojo/stdlib/std/pathlib/path.mojo
+++ b/mojo/stdlib/std/pathlib/path.mojo
@@ -210,7 +210,7 @@ struct Path(
         Returns:
           A string representation of the path.
         """
-        return String(self)
+        return self.path
 
     fn __repr__(self) -> String:
         """Returns a printable representation of the path.


### PR DESCRIPTION
## Summary

Previously used `String(self)` which went through the `Writable` trait, creating an unnecessary intermediate copy. Now returns `self.path` directly.