### PR TITLE
[MAX] Fused RoPE kernel for FLUX.2-dev

### DIFF
--- a/max/kernels/src/nn/fused_qk_rope_vision.mojo
+++ b/max/kernels/src/nn/fused_qk_rope_vision.mojo
@@ -1,0 +1,169 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Fused Q/K RoPE kernel for vision models (no KV cache).
+
+This kernel applies Rotary Position Embedding (RoPE) to both query and key
+tensors in a single fused operation, optimized for BF16 on GPU.
+"""
+
+from runtime.asyncrt import DeviceContextPtr
+from tensor import InputTensor, OutputTensor
+from algorithm.functional import elementwise
+from gpu.host.info import is_cpu
+from register import register_internal
+
+from utils.index import IndexList
+
+
+@always_inline
+fn _rope[
+    dtype: DType,
+    freq_dtype: DType,
+    width: Int,
+](
+    val: SIMD[dtype, width],
+    cos: SIMD[freq_dtype, width],
+    sin: SIMD[freq_dtype, width],
+) -> SIMD[dtype, width]:
+    """Apply RoPE rotation using complex multiplication.
+
+    val is complex (interleaved real/imag), cos/sin are the rotation coefficients.
+    Complex multiplication for rotation:
+        out_re = x_re * cos - x_im * sin
+        out_im = x_re * sin + x_im * cos
+    """
+    var x_complex = val.cast[freq_dtype]().deinterleave()
+    var x_re = x_complex[0]
+    var x_im = x_complex[1]
+
+    # cos/sin are repeated [c0, c0, c1, c1], so deinterleaving gives [c0, c1] in both parts
+    # We need the values corresponding to x_re (even indices) and x_im (odd indices)
+    # Since they are repeated, the even and odd parts are identical.
+    var cos_parts = cos.deinterleave()
+    var sin_parts = sin.deinterleave()
+
+    var cos_half = cos_parts[0]
+    var sin_half = sin_parts[0]
+
+    # Apply rotation
+    var out_re = x_re * cos_half - x_im * sin_half
+    var out_im = x_re * sin_half + x_im * cos_half
+
+    return rebind[SIMD[dtype, width]](out_re.interleave(out_im).cast[dtype]())
+
+
+@register_internal("mo.fused_qk_rope_vision")
+fn fused_qk_rope_vision[
+    target: StaticString,
+](
+    q_out: OutputTensor,
+    k_out: OutputTensor,
+    query: InputTensor[dtype = q_out.dtype, rank = q_out.rank],
+    key: InputTensor[dtype = k_out.dtype, rank = k_out.rank],
+    freqs_cos: InputTensor,
+    freqs_sin: InputTensor,
+    ctx: DeviceContextPtr,
+) raises:
+    """Fused Q/K RoPE for vision models.
+
+    Applies RoPE to query and key tensors simultaneously.
+    Input shapes:
+        - query: [B, S, num_heads, head_dim]
+        - key: [B, S, num_heads, head_dim]
+        - freqs_cos: [S, head_dim]  (cos values, interleaved pairs)
+        - freqs_sin: [S, head_dim]  (sin values, interleaved pairs)
+    Output shapes:
+        - q_out: same as query
+        - k_out: same as key
+    """
+
+    # Extract dimensions
+    var batch_size = query.dim_size(0)
+    var seq_len = query.dim_size(1)
+    var num_q_heads = query.dim_size(2)
+    var head_dim = query.dim_size(3)
+    var num_k_heads = key.dim_size(2)
+
+    debug_assert(head_dim % 2 == 0, "head_dim must be even for RoPE pairs")
+
+    @parameter
+    @__copy_capture(query, freqs_cos, freqs_sin, q_out)
+    @always_inline
+    fn rope_fn_q[
+        width: Int, rank: Int, alignment: Int = 1
+    ](idx: IndexList[rank],):
+        comptime assert rank == 4, "Expected rank 4 for query tensor"
+
+        @parameter
+        if width == 1:
+            return
+        else:
+            var s = idx[1]
+            var v = idx[3]
+            var cos_val = freqs_cos.load[width=width](IndexList[2](s, v))
+            var sin_val = freqs_sin.load[width=width](IndexList[2](s, v))
+            var val = query.load[width=width](idx)
+            var res = _rope(
+                val,
+                cos_val.cast[query.dtype](),
+                sin_val.cast[query.dtype](),
+            )
+            q_out.store[width=width](idx, res)
+
+    @parameter
+    @__copy_capture(key, freqs_cos, freqs_sin, k_out)
+    @always_inline
+    fn rope_fn_k[
+        width: Int, rank: Int, alignment: Int = 1
+    ](idx: IndexList[rank],):
+        comptime assert rank == 4, "Expected rank 4 for key tensor"
+
+        @parameter
+        if width == 1:
+            return
+        else:
+            var s = idx[1]
+            var v = idx[3]
+            var cos_val = freqs_cos.load[width=width](IndexList[2](s, v))
+            var sin_val = freqs_sin.load[width=width](IndexList[2](s, v))
+            var val = key.load[width=width](idx)
+            var res = _rope(
+                val,
+                cos_val.cast[key.dtype](),
+                sin_val.cast[key.dtype](),
+            )
+            k_out.store[width=width](idx, res)
+
+    var q_shape = IndexList[4](batch_size, seq_len, num_q_heads, head_dim)
+    var k_shape = IndexList[4](batch_size, seq_len, num_k_heads, head_dim)
+
+    # Keep SIMD width conservative to work with a wide range of head sizes.
+    comptime kernel_simd_width = 2
+
+    @parameter
+    if is_cpu[target]():
+        elementwise[
+            func=rope_fn_q, simd_width=kernel_simd_width, target=target
+        ](q_shape)
+        elementwise[
+            func=rope_fn_k, simd_width=kernel_simd_width, target=target
+        ](k_shape)
+    else:
+        var dev_ctx = ctx.get_device_context()
+        elementwise[
+            func=rope_fn_q, simd_width=kernel_simd_width, target=target
+        ](q_shape, dev_ctx)
+        elementwise[
+            func=rope_fn_k, simd_width=kernel_simd_width, target=target
+        ](k_shape, dev_ctx)

--- a/max/kernels/test/gpu/nn/BUILD.bazel
+++ b/max/kernels/test/gpu/nn/BUILD.bazel
@@ -131,6 +131,10 @@ _EXTRA_CONSTRAINTS = {
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),  # FIXME: PRDT-506
+    "test_fused_qk_rope_vision.mojo": select({
+        "//:apple_gpu": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 }
 
 _FILECHECK_TESTS = [

--- a/max/kernels/test/gpu/nn/test_fused_qk_rope_vision.mojo
+++ b/max/kernels/test/gpu/nn/test_fused_qk_rope_vision.mojo
@@ -1,3 +1,16 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
 from testing import assert_true
 from math import cos, sin
 

--- a/max/kernels/test/gpu/nn/test_fused_qk_rope_vision.mojo
+++ b/max/kernels/test/gpu/nn/test_fused_qk_rope_vision.mojo
@@ -1,0 +1,152 @@
+from testing import assert_true
+from math import cos, sin
+
+from gpu.host import DeviceContext
+from layout import Layout, LayoutTensor, RuntimeLayout
+from nn.fused_qk_rope_vision import fused_qk_rope_vision
+from runtime.asyncrt import DeviceContextPtr
+from tensor import InputTensor, OutputTensor, StaticTensorSpec
+from utils import IndexList
+
+# Hardcode dtype to bfloat16 as the kernel is specialized for it
+comptime dtype = DType.bfloat16
+
+
+def run_test[freq_dtype: DType](ctx: DeviceContext):
+    # Dimensions
+    comptime batch = 1
+    comptime seq_len = 4
+    comptime num_q_heads = 2
+    comptime num_k_heads = 2
+    comptime head_dim = 16
+
+    # Layouts
+    comptime input_layout = Layout.row_major(
+        batch, seq_len, num_q_heads, head_dim
+    )
+    comptime k_input_layout = Layout.row_major(
+        batch, seq_len, num_k_heads, head_dim
+    )
+    comptime freq_layout = Layout.row_major(seq_len, head_dim)
+
+    # Shapes
+    var input_shape = IndexList[4](batch, seq_len, num_q_heads, head_dim)
+    var k_input_shape = IndexList[4](batch, seq_len, num_k_heads, head_dim)
+    var freq_shape = IndexList[2](seq_len, head_dim)
+
+    # Runtime Layouts
+    var input_rl = RuntimeLayout[input_layout].row_major(input_shape)
+    var k_input_rl = RuntimeLayout[k_input_layout].row_major(k_input_shape)
+    var freq_rl = RuntimeLayout[freq_layout].row_major(freq_shape)
+
+    # Device Allocations
+    var q_dev = ctx.enqueue_create_buffer[dtype](input_shape.flattened_length())
+    var k_dev = ctx.enqueue_create_buffer[dtype](
+        k_input_shape.flattened_length()
+    )
+    var cos_dev = ctx.enqueue_create_buffer[freq_dtype](
+        freq_shape.flattened_length()
+    )
+    var sin_dev = ctx.enqueue_create_buffer[freq_dtype](
+        freq_shape.flattened_length()
+    )
+    var q_out_dev = ctx.enqueue_create_buffer[dtype](
+        input_shape.flattened_length()
+    )
+    var k_out_dev = ctx.enqueue_create_buffer[dtype](
+        k_input_shape.flattened_length()
+    )
+
+    # Initialize Data
+    with q_dev.map_to_host() as ptr:
+        var t = LayoutTensor[dtype, input_layout](ptr, input_rl)
+        for b in range(batch):
+            for s in range(seq_len):
+                for h in range(num_q_heads):
+                    for d in range(head_dim):
+                        var val = Float32(s * 100 + h * 10 + d)
+                        var idx = IndexList[4](b, s, h, d)
+                        t.store(idx, val.cast[dtype]())
+
+    with k_dev.map_to_host() as ptr:
+        var t = LayoutTensor[dtype, k_input_layout](ptr, k_input_rl)
+        for b in range(batch):
+            for s in range(seq_len):
+                for h in range(num_k_heads):
+                    for d in range(head_dim):
+                        var val = Float32(s * 100 + h * 10 + d) + 0.5
+                        var idx = IndexList[4](b, s, h, d)
+                        t.store(idx, val.cast[dtype]())
+
+    with cos_dev.map_to_host() as c_ptr, sin_dev.map_to_host() as s_ptr:
+        var ct = LayoutTensor[freq_dtype, freq_layout](c_ptr, freq_rl)
+        var st = LayoutTensor[freq_dtype, freq_layout](s_ptr, freq_rl)
+        for s in range(seq_len):
+            for d in range(head_dim // 2):
+                var angle = Float32(s) * 0.1 + Float32(d) * 0.5
+                var c = cos(angle)
+                var s_val = sin(angle)
+
+                var idx0 = IndexList[2](s, d * 2)
+                var idx1 = IndexList[2](s, d * 2 + 1)
+
+                ct.store(idx0, c.cast[freq_dtype]())
+                ct.store(idx1, c.cast[freq_dtype]())
+
+                st.store(idx0, s_val.cast[freq_dtype]())
+                st.store(idx1, s_val.cast[freq_dtype]())
+
+    # Create MTS wrappers expected by fused_qk_rope_vision
+    comptime q_spec = StaticTensorSpec[dtype, 4].create_unknown()
+    comptime k_spec = StaticTensorSpec[dtype, 4].create_unknown()
+    comptime freq_spec = StaticTensorSpec[freq_dtype, 2].create_unknown()
+
+    var q = InputTensor[static_spec=q_spec](q_dev.unsafe_ptr(), input_shape)
+    var k = InputTensor[static_spec=k_spec](k_dev.unsafe_ptr(), k_input_shape)
+    var cos_t = InputTensor[static_spec=freq_spec](
+        cos_dev.unsafe_ptr(), freq_shape
+    )
+    var sin_t = InputTensor[static_spec=freq_spec](
+        sin_dev.unsafe_ptr(), freq_shape
+    )
+    var q_out = OutputTensor[static_spec=q_spec](
+        q_out_dev.unsafe_ptr(), input_shape
+    )
+    var k_out = OutputTensor[static_spec=k_spec](
+        k_out_dev.unsafe_ptr(), k_input_shape
+    )
+
+    # Run Kernel
+    var ctx_ptr = DeviceContextPtr(ctx)
+
+    fused_qk_rope_vision[target="gpu"](
+        q_out, k_out, q, k, cos_t, sin_t, ctx_ptr
+    )
+    ctx.synchronize()
+
+    # Verify Output
+    with q_out_dev.map_to_host() as ptr:
+        var t = LayoutTensor[dtype, input_layout](ptr, input_rl)
+        # Check position s=1, h=0, d=0,1 (angle 0.1)
+        # q[0]=100, q[1]=101
+        # cos=cos(0.1)=0.995, sin=sin(0.1)=0.0998
+        # Rotated 0: 100*c - 101*s = 99.5 - 10.08 = 89.42
+        # Rotated 1: 100*s + 101*c = 9.98 + 100.495 = 110.475
+
+        var idx0 = IndexList[4](0, 1, 0, 0)
+        var idx1 = IndexList[4](0, 1, 0, 1)
+
+        # Explicit width=1 to avoid inference error
+        var q0 = t.load[width=1](idx0).cast[DType.float32]()
+        var q1 = t.load[width=1](idx1).cast[DType.float32]()
+
+        # Loose checks for BF16 precision
+        assert_true(q0 > 89.0 and q0 < 90.0)
+        assert_true(q1 > 110.0 and q1 < 111.0)
+
+    print("Test finished successfully")
+
+
+def main():
+    with DeviceContext() as ctx:
+        run_test[DType.float32](ctx)

--- a/max/python/max/nn/rope/__init__.py
+++ b/max/python/max/nn/rope/__init__.py
@@ -12,9 +12,11 @@
 # ===----------------------------------------------------------------------=== #
 """Positional embedding modules and functions."""
 
+from .fused_rope_vision import fused_qk_rope_vision
 from .rope import RotaryEmbedding, TransposedRotaryEmbedding
 
 __all__ = [
     "RotaryEmbedding",
     "TransposedRotaryEmbedding",
+    "fused_qk_rope_vision",
 ]

--- a/max/python/max/nn/rope/fused_rope_vision.py
+++ b/max/python/max/nn/rope/fused_rope_vision.py
@@ -1,0 +1,71 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Fused RoPE kernel for vision models."""
+
+from __future__ import annotations
+
+from max.graph import DeviceRef, TensorType, TensorValue, TensorValueLike, ops
+
+
+def fused_qk_rope_vision(
+    query: TensorValueLike,
+    key: TensorValueLike,
+    cos: TensorValueLike,
+    sin: TensorValueLike,
+    repeat_interleave: bool = True,
+) -> tuple[TensorValue, TensorValue]:
+    """Applies RoPE to query and key tensors using a fused kernel.
+
+    Args:
+        query: Query tensor [batch, seq_len, num_q_heads, head_dim].
+        key: Key tensor [batch, seq_len, num_k_heads, head_dim].
+        cos: Cosine frequency tensor [seq_len, head_dim].
+        sin: Sine frequency tensor [seq_len, head_dim].
+        repeat_interleave: Whether frequencies are repeated (Flux2/LLama3) or
+            interleaved. Flux2 uses repeat-interleave (True).
+
+    Returns:
+        Tuple of (rotated_query, rotated_key).
+    """
+    # Convert TensorValueLike to TensorValue if needed
+    query_val = TensorValue(query)
+    key_val = TensorValue(key)
+    cos_val = TensorValue(cos)
+    sin_val = TensorValue(sin)
+
+    device = DeviceRef.from_device(query_val.device)
+
+    # Define output types (same shapes/dtypes as inputs)
+    out_types = [
+        TensorType(
+            dtype=query_val.dtype,
+            shape=query_val.shape,
+            device=device,
+        ),
+        TensorType(
+            dtype=key_val.dtype,
+            shape=key_val.shape,
+            device=device,
+        ),
+    ]
+
+    # Call the registered internal op
+    # The kernel signature is: (q_out, k_out, query, key, freqs_cos, freqs_sin, ctx)
+    results = ops.custom(
+        name="mo.fused_qk_rope_vision",
+        device=device,
+        values=[query_val, key_val, cos_val, sin_val],
+        out_types=out_types,
+    )
+
+    return results[0].tensor, results[1].tensor

--- a/max/tests/integration/nn/module_v3/rope/test_fused_rope_vision.py
+++ b/max/tests/integration/nn/module_v3/rope/test_fused_rope_vision.py
@@ -1,0 +1,80 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Tests for fused_qk_rope_vision kernel."""
+
+from __future__ import annotations
+
+from max.driver import CPU, Accelerator, accelerator_count
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Graph, TensorType
+from max.nn.rope import fused_qk_rope_vision
+from max.tensor import Tensor
+
+
+def test_fused_rope_vision_import() -> None:
+    """Test that fused_qk_rope_vision is properly exported from max.nn.rope."""
+    assert callable(fused_qk_rope_vision)
+
+
+def test_fused_rope_vision_execution() -> None:
+    """Test that the kernel can be compiled and executed via MAX graph."""
+
+    # shapes
+    batch = 1
+    seq_len = 8
+    num_q_heads = 2
+    num_k_heads = 2
+    head_dim = 64  # mult of 2
+
+    # Q/K: [B, S, H, D]
+    input_shape = (batch, seq_len, num_q_heads, head_dim)
+    # Cos/Sin: [S, D]
+    freq_shape = (seq_len, head_dim)
+
+    # Select device
+    device = CPU() if accelerator_count() == 0 else Accelerator()
+    device_ref = DeviceRef.from_device(device)
+
+    # Define graph with custom_extensions
+    graph = Graph(
+        name="fused_rope_test",
+        forward=lambda q, k, cos, sin: fused_qk_rope_vision(
+            q, k, cos, sin, repeat_interleave=True
+        ),
+        input_types=[
+            TensorType(DType.bfloat16, input_shape, device=device_ref),
+            TensorType(DType.bfloat16, input_shape, device=device_ref),
+            TensorType(DType.float32, freq_shape, device=device_ref),
+            TensorType(DType.float32, freq_shape, device=device_ref),
+        ],
+    )
+
+    # Load and compile
+    session = InferenceSession(devices=[device])
+    model = session.load(graph)
+
+    # Create dummy inputs
+    q = Tensor.zeros(input_shape, dtype=DType.bfloat16).to(device)
+    k = Tensor.zeros(input_shape, dtype=DType.bfloat16).to(device)
+    cos = Tensor.ones(freq_shape, dtype=DType.float32).to(device)
+    sin = Tensor.ones(freq_shape, dtype=DType.float32).to(device)
+
+    # Execute
+    results = model.execute(q, k, cos, sin)
+    q_out = results[0]
+    k_out = results[1]
+
+    # Basic output check
+    assert q_out.shape == input_shape
+    assert k_out.shape == input_shape


### PR DESCRIPTION
## Context
Flux2 attention currently applies rotary embeddings to Q and K through separate steps. That creates extra launch and memory traffic overhead in a latency-sensitive path. This change introduces a fused Q/K vision RoPE op and wires Flux2 to use it, with coverage at both kernel and integration levels.

## What This PR Changes

1. Adds a fused vision RoPE kernel (Mojo)
- New file: `max/kernels/src/nn/fused_qk_rope_vision.mojo`
- Implements a fused operator that rotates both query and key tensors in one kernel flow.
- Expected tensor shapes:
    - query: [B, S, num_q_heads, head_dim]
    - key: [B, S, num_k_heads, head_dim]
    - freqs_cos: [S, head_dim]
    - freqs_sin: [S, head_dim]
- Produces:
    - q_out: same shape as query
    - k_out: same shape as key

2. Registers the op in the kernel API layer
- Updated: `max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo`
- Adds registration for `mo.fused_qk_rope_vision` and execution plumbing so the op is callable from graph/custom-op paths.

3. Adds Python API wrapper for graph users
- New file: `max/python/max/nn/rope/fused_rope_vision.py`
- Exports helper `fused_qk_rope_vision(...)` that issues `ops.custom(name="mo.fused_qk_rope_vision", ...)`.
- Updated exports in `max/python/max/nn/rope/__init__.py`.

4. Integrates fused op into Flux2 attention
- Updated: `max/python/max/pipelines/architectures/flux2/layers/flux2_attention.py`
- Switches relevant attention path to use the fused Q/K RoPE op rather than separate transformations.

5. Adds test coverage
- New kernel test (with simple golden output): `max/kernels/test/gpu/nn/test_fused_qk_rope_vision.mojo`
- BUILD wiring: `max/kernels/test/gpu/nn/BUILD.bazel`
- New integration test (compilation test only): `max/tests/integration/nn/module_v3/rope/test_fused_rope_vision.py`

## Validation Performed
- Functional tests:
    - `./bazelw test --verbose_failures --test_output=errors //max/kernels/test/gpu/nn:test_fused_qk_rope_vision.mojo.test //max/tests/integration/nn/module_v3:rope/test_fused_rope_vision`
    - Result: both tests passed.

## Benchmark Results (B200, 1024x1024, 50 steps, t2i, FLUX.2-dev)
### Command
`./bazelw run //max/examples/diffusion:simple_offline_generation -- --model black-forest-labs/FLUX.2-dev --prompt "A cat holding a sign that says hello world" --num-inference-steps 50 --guidance-scale 4.0 --seed 42 --profile-timing`
### As-is (#5974)
```
Method timings:
section                          calls        total          avg (ms)
E2E execute                          3    45725.297    15241.766
component/vae.decode                 3     1438.910      479.637
component/transformer              150      648.512        4.323
tensor/to                            9      550.072       61.119
decode/to_numpy                      3      375.833      125.278
component/text_encoder               3      315.667      105.222
tensor/cast                          3      184.898       61.633
tensor/from_dlpack                 321        1.126        0.004
prompt/prepare_embeddings            3        0.889        0.296
Module timings:
module                           calls        total          avg (ms)
pipeline/Flux2Pipeline               9    46102.020     5122.447
component/vae.decode                 3     1438.910      479.637
tensor/ops                         333      736.096        2.210
component/transformer              150      648.512        4.323
component/text_encoder               3      315.667      105.222
Generation complete!
```
### To-be
```
Method timings:
section                          calls        total          avg (ms)
E2E execute                          3    42291.829    14097.276
component/vae.decode                 3     1446.888      482.296
tensor/to                            9      595.852       66.206
component/transformer              150      554.179        3.695
decode/to_numpy                      3      416.293      138.764
component/text_encoder               3      334.824      111.608
tensor/cast                          3      207.996       69.332
tensor/from_dlpack                 321        1.298        0.004
prompt/prepare_embeddings            3        0.975        0.325
Module timings:
module                           calls        total          avg (ms)
pipeline/Flux2Pipeline               9    42709.097     4745.455
component/vae.decode                 3     1446.888      482.296
tensor/ops                         333      805.145        2.418
component/transformer              150      554.179        3.695
component/text_encoder               3      334.824      111.608
Generation complete!
```