### PR TITLE
[Stdlib] Add explicit Writable repr for Slice

### DIFF
--- a/mojo/stdlib/std/builtin/builtin_slice.mojo
+++ b/mojo/stdlib/std/builtin/builtin_slice.mojo
@@ -128,6 +128,31 @@ struct Slice(
         write_optional(self.step)
         writer.write(")")
 
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        writer.write("slice(")
+
+        if self.start:
+            self.start.value().write_repr_to(writer)
+        else:
+            writer.write("None")
+
+        writer.write(", ")
+
+        if self.end:
+            self.end.value().write_repr_to(writer)
+        else:
+            writer.write("None")
+
+        writer.write(", ")
+
+        if self.step:
+            self.step.value().write_repr_to(writer)
+        else:
+            writer.write("None")
+
+        writer.write(")")
+
     @always_inline
     fn __eq__(self, other: Self) -> Bool:
         """Compare this slice to the other.

--- a/mojo/stdlib/test/builtin/test_slice.mojo
+++ b/mojo/stdlib/test/builtin/test_slice.mojo
@@ -81,7 +81,10 @@ def test_slice_stringable():
     assert_equal(repr(slice(None, 2, 3)), "slice(None, 2, 3)")
     assert_equal(repr(slice(10)), "slice(None, 10, None)")
 
-
+def test_slice_write_repr_to():
+    assert_equal(repr(slice(1, 5, 2)), "slice(1, 5, 2)")
+    assert_equal(repr(slice(None, None, None)), "slice(None, None, None)")
+    
 def test_slice_eq():
     assert_equal(slice(1, 2, 3), slice(1, 2, 3))
     assert_equal(slice(None, 1, None), slice(1))


### PR DESCRIPTION
Implement explicit Writable::write_repr_to() for Slice to replace the default reflection-based repr and ensure consistent stdlib formatting. Adds unit tests.

Related Issue: #5870 