### PR TITLE
[Stdlib] Add explicit Writable repr for Bitset

### DIFF
--- a/mojo/stdlib/std/collections/bitset.mojo
+++ b/mojo/stdlib/std/collections/bitset.mojo
@@ -449,6 +449,14 @@ struct BitSet[size: Int](
 
         writer.write("}")
 
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        writer.write("BitSet[")
+        writer.write(Self.size)
+        writer.write("](")
+        self.write_to(writer)
+        writer.write(")")
+
     fn __repr__(self) -> String:
         """Returns a developer-friendly string representation of the bitset.
 

--- a/mojo/stdlib/test/collections/test_bitset.mojo
+++ b/mojo/stdlib/test/collections/test_bitset.mojo
@@ -193,6 +193,27 @@ def test_bitset_str_repr():
     )
 
 
+def test_bitset_repr():
+    var bs = BitSet[16]()
+    bs.set(1)
+    bs.set(5)
+
+    var repr_str = repr(bs)
+
+    assert_equal(
+        repr_str,
+        "BitSet[16]({1, 5})",
+        msg="repr should include type parameter and elements",
+    )
+
+    var empty_bs = BitSet[8]()
+    assert_equal(
+        repr(empty_bs),
+        "BitSet[8]({})",
+        msg="repr of empty BitSet should include size",
+    )
+
+
 def test_bitset_edge_cases():
     # Test with minimum size
     var bs_min = BitSet[1]()


### PR DESCRIPTION
Added write_repr_to() for Bitset; no changes to existing write_to(). Added a focused test test_bitset_repr asserting exact repr output.

Related Issue: #5870 