### PR TITLE
[Stdlib] Add Stringable and Writable to StridedSlice and ContiguousSlice

### DIFF
--- a/mojo/stdlib/std/builtin/builtin_slice.mojo
+++ b/mojo/stdlib/std/builtin/builtin_slice.mojo
@@ -205,7 +205,7 @@ struct Slice(
         return (start.value(), end.value(), step)
 
 
-struct StridedSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
+struct StridedSlice(ImplicitlyCopyable, Writable):
     """Represents a slice expression that has a stride.
 
     This type is used to support different behavior for strided vs unstrided
@@ -246,35 +246,13 @@ struct StridedSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
     # ===-------------------------------------------------------------------===#
 
     @no_inline
-    fn __str__(self) -> String:
-        """Gets the string representation of the strided slice.
-
-        Returns:
-            The string representation of the strided slice.
-        """
-        var output = String()
-        self.write_to(output)
-        return output
-
-    @no_inline
-    fn __repr__(self) -> String:
-        """Gets the string representation of the strided slice.
-
-        Returns:
-            The string representation of the strided slice.
-        """
-        var output = String()
-        self.write_repr_to(output)
-        return output^
-
-    @no_inline
     fn write_to(self, mut writer: Some[Writer]):
         """Write StridedSlice string representation to a `Writer`.
 
         Args:
             writer: The object to write to.
         """
-        writer.write(self._inner)
+        self._inner.write_to(writer)
 
     @no_inline
     fn write_repr_to(self, mut writer: Some[Writer]):
@@ -298,7 +276,7 @@ struct StridedSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
         return self._inner.indices(length)
 
 
-struct ContiguousSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
+struct ContiguousSlice(ImplicitlyCopyable, Writable):
     """Represents a slice expression without a stride.
 
     This type is used to support different behavior for strided vs unstrided
@@ -334,28 +312,6 @@ struct ContiguousSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
     # ===-------------------------------------------------------------------===#
 
     @no_inline
-    fn __str__(self) -> String:
-        """Gets the string representation of the contiguous slice.
-
-        Returns:
-            The string representation of the contiguous slice.
-        """
-        var output = String()
-        self.write_to(output)
-        return output
-
-    @no_inline
-    fn __repr__(self) -> String:
-        """Gets the string representation of the contiguous slice.
-
-        Returns:
-            The string representation of the contiguous slice.
-        """
-        var output = String()
-        self.write_repr_to(output)
-        return output^
-
-    @no_inline
     fn write_to(self, mut writer: Some[Writer]):
         """Write ContiguousSlice string representation to a `Writer`.
 
@@ -368,13 +324,13 @@ struct ContiguousSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
             if opt:
                 writer.write(repr(opt.value()))
             else:
-                writer.write(repr(None))
+                writer.write_string("None")
 
-        writer.write("slice(")
+        writer.write_string("slice(")
         write_optional(self.start)
-        writer.write(", ")
+        writer.write_string(", ")
         write_optional(self.end)
-        writer.write(", None)")
+        writer.write_string(", None)")
 
     @no_inline
     fn write_repr_to(self, mut writer: Some[Writer]):

--- a/mojo/stdlib/std/builtin/builtin_slice.mojo
+++ b/mojo/stdlib/std/builtin/builtin_slice.mojo
@@ -205,7 +205,7 @@ struct Slice(
         return (start.value(), end.value(), step)
 
 
-struct StridedSlice(ImplicitlyCopyable, Stringable, Writable):
+struct StridedSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
     """Represents a slice expression that has a stride.
 
     This type is used to support different behavior for strided vs unstrided
@@ -255,6 +255,15 @@ struct StridedSlice(ImplicitlyCopyable, Stringable, Writable):
         return String.write(self)
 
     @no_inline
+    fn __repr__(self) -> String:
+        """Gets the string representation of the strided slice.
+
+        Returns:
+            The string representation of the strided slice.
+        """
+        return self.__str__()
+
+    @no_inline
     fn write_to(self, mut writer: Some[Writer]):
         """Write StridedSlice string representation to a `Writer`.
 
@@ -262,6 +271,15 @@ struct StridedSlice(ImplicitlyCopyable, Stringable, Writable):
             writer: The object to write to.
         """
         writer.write(self._inner)
+
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Write StridedSlice debug representation to a `Writer`.
+
+        Args:
+            writer: The object to write to.
+        """
+        self.write_to(writer)
 
     fn indices(self, length: Int) -> Tuple[Int, Int, Int]:
         """Returns a tuple of 3 integers representing start, end, and step
@@ -276,7 +294,7 @@ struct StridedSlice(ImplicitlyCopyable, Stringable, Writable):
         return self._inner.indices(length)
 
 
-struct ContiguousSlice(ImplicitlyCopyable, Stringable, Writable):
+struct ContiguousSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
     """Represents a slice expression without a stride.
 
     This type is used to support different behavior for strided vs unstrided
@@ -321,6 +339,15 @@ struct ContiguousSlice(ImplicitlyCopyable, Stringable, Writable):
         return String.write(self)
 
     @no_inline
+    fn __repr__(self) -> String:
+        """Gets the string representation of the contiguous slice.
+
+        Returns:
+            The string representation of the contiguous slice.
+        """
+        return self.__str__()
+
+    @no_inline
     fn write_to(self, mut writer: Some[Writer]):
         """Write ContiguousSlice string representation to a `Writer`.
 
@@ -340,6 +367,15 @@ struct ContiguousSlice(ImplicitlyCopyable, Stringable, Writable):
         writer.write(", ")
         write_optional(self.end)
         writer.write(", None)")
+
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Write ContiguousSlice debug representation to a `Writer`.
+
+        Args:
+            writer: The object to write to.
+        """
+        self.write_to(writer)
 
     fn indices(self, length: Int) -> Tuple[Int, Int]:
         """Returns a tuple of 2 integers representing the start, and end

--- a/mojo/stdlib/std/builtin/builtin_slice.mojo
+++ b/mojo/stdlib/std/builtin/builtin_slice.mojo
@@ -205,7 +205,7 @@ struct Slice(
         return (start.value(), end.value(), step)
 
 
-struct StridedSlice(ImplicitlyCopyable):
+struct StridedSlice(ImplicitlyCopyable, Stringable, Writable):
     """Represents a slice expression that has a stride.
 
     This type is used to support different behavior for strided vs unstrided
@@ -241,6 +241,28 @@ struct StridedSlice(ImplicitlyCopyable):
 
         self._inner = Slice(start, end, stride)
 
+    # ===-------------------------------------------------------------------===#
+    # Trait implementations
+    # ===-------------------------------------------------------------------===#
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Gets the string representation of the strided slice.
+
+        Returns:
+            The string representation of the strided slice.
+        """
+        return String.write(self)
+
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Write StridedSlice string representation to a `Writer`.
+
+        Args:
+            writer: The object to write to.
+        """
+        writer.write(self._inner)
+
     fn indices(self, length: Int) -> Tuple[Int, Int, Int]:
         """Returns a tuple of 3 integers representing start, end, and step
         of the slice if applied to a container of given length.
@@ -254,7 +276,7 @@ struct StridedSlice(ImplicitlyCopyable):
         return self._inner.indices(length)
 
 
-struct ContiguousSlice(ImplicitlyCopyable):
+struct ContiguousSlice(ImplicitlyCopyable, Stringable, Writable):
     """Represents a slice expression without a stride.
 
     This type is used to support different behavior for strided vs unstrided
@@ -284,6 +306,40 @@ struct ContiguousSlice(ImplicitlyCopyable):
         """
         self.start = start
         self.end = end
+
+    # ===-------------------------------------------------------------------===#
+    # Trait implementations
+    # ===-------------------------------------------------------------------===#
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Gets the string representation of the contiguous slice.
+
+        Returns:
+            The string representation of the contiguous slice.
+        """
+        return String.write(self)
+
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Write ContiguousSlice string representation to a `Writer`.
+
+        Args:
+            writer: The object to write to.
+        """
+
+        @parameter
+        fn write_optional(opt: Optional[Int]):
+            if opt:
+                writer.write(repr(opt.value()))
+            else:
+                writer.write(repr(None))
+
+        writer.write("slice(")
+        write_optional(self.start)
+        writer.write(", ")
+        write_optional(self.end)
+        writer.write(", None)")
 
     fn indices(self, length: Int) -> Tuple[Int, Int]:
         """Returns a tuple of 2 integers representing the start, and end

--- a/mojo/stdlib/std/builtin/builtin_slice.mojo
+++ b/mojo/stdlib/std/builtin/builtin_slice.mojo
@@ -252,7 +252,9 @@ struct StridedSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
         Returns:
             The string representation of the strided slice.
         """
-        return String.write(self)
+        var output = String()
+        self.write_to(output)
+        return output
 
     @no_inline
     fn __repr__(self) -> String:
@@ -261,7 +263,9 @@ struct StridedSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
         Returns:
             The string representation of the strided slice.
         """
-        return self.__str__()
+        var output = String()
+        self.write_repr_to(output)
+        return output^
 
     @no_inline
     fn write_to(self, mut writer: Some[Writer]):
@@ -336,7 +340,9 @@ struct ContiguousSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
         Returns:
             The string representation of the contiguous slice.
         """
-        return String.write(self)
+        var output = String()
+        self.write_to(output)
+        return output
 
     @no_inline
     fn __repr__(self) -> String:
@@ -345,7 +351,9 @@ struct ContiguousSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
         Returns:
             The string representation of the contiguous slice.
         """
-        return self.__str__()
+        var output = String()
+        self.write_repr_to(output)
+        return output^
 
     @no_inline
     fn write_to(self, mut writer: Some[Writer]):

--- a/mojo/stdlib/std/os/process.mojo
+++ b/mojo/stdlib/std/os/process.mojo
@@ -44,7 +44,7 @@ from sys.os import abort, sep
 # ===----------------------------------------------------------------------=== #
 
 
-struct ProcessStatus(Copyable, ImplicitlyCopyable, Movable):
+struct ProcessStatus(Copyable, ImplicitlyCopyable, Movable, Stringable, Writable):
     """Represents the termination status of a process.
 
     This struct is returned by `poll()` and `wait()`.
@@ -86,6 +86,29 @@ struct ProcessStatus(Copyable, ImplicitlyCopyable, Movable):
             True if the process has terminated, either normally or by a signal.
         """
         return Bool(self.exit_code) or Bool(self.term_signal)
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Constructs a string representation of `ProcessStatus`.
+
+        Returns:
+            A string representation of `ProcessStatus`.
+        """
+        return String.write(self)
+
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Formats this `ProcessStatus` to the provided Writer.
+
+        Args:
+            writer: The object to write to.
+        """
+        if self.exit_code:
+            writer.write("ProcessStatus(exit_code: ", self.exit_code.value(), ")")
+        elif self.term_signal:
+            writer.write("ProcessStatus(term_signal: ", self.term_signal.value(), ")")
+        else:
+            writer.write("ProcessStatus(running)")
 
 
 struct Pipe:

--- a/mojo/stdlib/std/sys/intrinsics.mojo
+++ b/mojo/stdlib/std/sys/intrinsics.mojo
@@ -252,7 +252,7 @@ fn scatter[
 # ===-----------------------------------------------------------------------===#
 
 
-struct PrefetchLocality(TrivialRegisterPassable):
+struct PrefetchLocality(Representable, Stringable, TrivialRegisterPassable, Writable):
     """The prefetch locality.
 
     The locality, rw, and cache type correspond to LLVM prefetch intrinsic's
@@ -281,8 +281,53 @@ struct PrefetchLocality(TrivialRegisterPassable):
         """
         self.value = Int32(value)
 
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the prefetch locality to a writer.
 
-struct PrefetchRW(TrivialRegisterPassable):
+        Args:
+            writer: The writer to write to.
+        """
+        if self.value == 0:
+            writer.write("NONE")
+        elif self.value == 1:
+            writer.write("LOW")
+        elif self.value == 2:
+            writer.write("MEDIUM")
+        else:
+            writer.write("HIGH")
+
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the representation of the prefetch locality to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        writer.write("PrefetchLocality.", self)
+
+    @no_inline
+    fn __repr__(self) -> String:
+        """Returns the representation of the prefetch locality.
+
+        Returns:
+            A string such as `"PrefetchLocality.HIGH"`.
+        """
+        var string = String()
+        self.write_repr_to(string)
+        return string^
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns the string representation of the prefetch locality.
+
+        Returns:
+            A string representation of the locality value.
+        """
+        return String.write(self)
+
+
+struct PrefetchRW(Representable, Stringable, TrivialRegisterPassable, Writable):
     """Prefetch read or write."""
 
     var value: Int32
@@ -314,9 +359,50 @@ struct PrefetchRW(TrivialRegisterPassable):
         """
         return self.value == other.value
 
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the prefetch read-write option to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        if self.value == 0:
+            writer.write("READ")
+        else:
+            writer.write("WRITE")
+
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the representation of the prefetch read-write option to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        writer.write("PrefetchRW.", self)
+
+    @no_inline
+    fn __repr__(self) -> String:
+        """Returns the representation of the prefetch read-write option.
+
+        Returns:
+            A string such as `"PrefetchRW.READ"`.
+        """
+        var string = String()
+        self.write_repr_to(string)
+        return string^
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns the string representation of the prefetch read-write option.
+
+        Returns:
+            A string representation of the read-write value.
+        """
+        return String.write(self)
+
 
 # LLVM prefetch cache type
-struct PrefetchCache(TrivialRegisterPassable):
+struct PrefetchCache(Representable, Stringable, TrivialRegisterPassable, Writable):
     """Prefetch cache type."""
 
     var value: Int32
@@ -336,8 +422,49 @@ struct PrefetchCache(TrivialRegisterPassable):
         """
         self.value = Int32(value)
 
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the prefetch cache type to a writer.
 
-struct PrefetchOptions(Defaultable, TrivialRegisterPassable):
+        Args:
+            writer: The writer to write to.
+        """
+        if self.value == 0:
+            writer.write("INSTRUCTION")
+        else:
+            writer.write("DATA")
+
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the representation of the prefetch cache type to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        writer.write("PrefetchCache.", self)
+
+    @no_inline
+    fn __repr__(self) -> String:
+        """Returns the representation of the prefetch cache type.
+
+        Returns:
+            A string such as `"PrefetchCache.DATA"`.
+        """
+        var string = String()
+        self.write_repr_to(string)
+        return string^
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns the string representation of the prefetch cache type.
+
+        Returns:
+            A string representation of the cache type.
+        """
+        return String.write(self)
+
+
+struct PrefetchOptions(Defaultable, Representable, Stringable, TrivialRegisterPassable, Writable):
     """Collection of configuration parameters for a prefetch intrinsic call.
 
     The op configuration follows similar interface as LLVM intrinsic prefetch
@@ -462,6 +589,60 @@ struct PrefetchOptions(Defaultable, TrivialRegisterPassable):
         var updated = self
         updated.cache = PrefetchCache.INSTRUCTION
         return updated
+
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the prefetch options to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        writer.write(
+            "PrefetchOptions(rw=",
+            self.rw,
+            ", locality=",
+            self.locality,
+            ", cache=",
+            self.cache,
+            ")",
+        )
+
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the representation of the prefetch options to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        writer.write(
+            "PrefetchOptions(rw=",
+            self.rw.__repr__(),
+            ", locality=",
+            self.locality.__repr__(),
+            ", cache=",
+            self.cache.__repr__(),
+            ")",
+        )
+
+    @no_inline
+    fn __repr__(self) -> String:
+        """Returns the representation of the prefetch options.
+
+        Returns:
+            A string such as `"PrefetchOptions(rw=PrefetchRW.READ, locality=PrefetchLocality.HIGH, cache=PrefetchCache.DATA)"`.
+        """
+        var string = String()
+        self.write_repr_to(string)
+        return string^
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns the string representation of the prefetch options.
+
+        Returns:
+            A string representation of the prefetch options.
+        """
+        return String.write(self)
 
 
 @always_inline("nodebug")

--- a/mojo/stdlib/test/builtin/test_slice.mojo
+++ b/mojo/stdlib/test/builtin/test_slice.mojo
@@ -93,9 +93,16 @@ struct StridedSliceStringable:
 
 def test_strided_slice_stringable():
     var s = StridedSliceStringable()
+    # Positive stride
     assert_equal(s[1:10:2], "slice(1, 10, 2)")
-    assert_equal(s[::3], "slice(None, None, 3)")
+    assert_equal(s[0:5:1], "slice(0, 5, 1)")
+    # Negative stride
     assert_equal(s[2::-1], "slice(2, None, -1)")
+    assert_equal(s[1:-1:2], "slice(1, -1, 2)")
+    # None start or end
+    assert_equal(s[::3], "slice(None, None, 3)")
+    assert_equal(s[:5:2], "slice(None, 5, 2)")
+    assert_equal(s[1::2], "slice(1, None, 2)")
 
 
 struct ContiguousSliceStringable:
@@ -108,9 +115,15 @@ struct ContiguousSliceStringable:
 
 def test_contiguous_slice_stringable():
     var s = ContiguousSliceStringable()
+    # Both bounds present
+    assert_equal(s[1:5], "slice(1, 5, None)")
     assert_equal(s[0:10], "slice(0, 10, None)")
+    # Only end
+    assert_equal(s[:3], "slice(None, 3, None)")
     assert_equal(s[:5], "slice(None, 5, None)")
+    # Only start
     assert_equal(s[3:], "slice(3, None, None)")
+    # Neither
     assert_equal(s[:], "slice(None, None, None)")
 
 
@@ -124,10 +137,16 @@ struct StridedSliceRepresentable:
 
 def test_strided_slice_representable():
     var s = StridedSliceRepresentable()
+    # Verify exact repr output
     assert_equal(s[1:10:2], "slice(1, 10, 2)")
+    assert_equal(s[2::-1], "slice(2, None, -1)")
+    assert_equal(s[1:-1:2], "slice(1, -1, 2)")
     assert_equal(s[::3], "slice(None, None, 3)")
     # repr == str for StridedSlice
-    assert_equal(s[2::-1], String(StridedSlice(2, None, -1)))
+    assert_equal(repr(StridedSlice(1, 10, 2)), String(StridedSlice(1, 10, 2)))
+    assert_equal(
+        repr(StridedSlice(None, None, 3)), String(StridedSlice(None, None, 3))
+    )
 
 
 struct ContiguousSliceRepresentable:
@@ -140,10 +159,20 @@ struct ContiguousSliceRepresentable:
 
 def test_contiguous_slice_representable():
     var s = ContiguousSliceRepresentable()
+    # Verify exact repr output
+    assert_equal(s[1:5], "slice(1, 5, None)")
     assert_equal(s[0:10], "slice(0, 10, None)")
-    assert_equal(s[:5], "slice(None, 5, None)")
+    assert_equal(s[:3], "slice(None, 3, None)")
+    assert_equal(s[3:], "slice(3, None, None)")
+    assert_equal(s[:], "slice(None, None, None)")
     # repr == str for ContiguousSlice
-    assert_equal(s[3:], String(ContiguousSlice(3, None, None)))
+    assert_equal(
+        repr(ContiguousSlice(1, 5, None)), String(ContiguousSlice(1, 5, None))
+    )
+    assert_equal(
+        repr(ContiguousSlice(None, 3, None)),
+        String(ContiguousSlice(None, 3, None)),
+    )
 
 
 def test_slice_eq():

--- a/mojo/stdlib/test/builtin/test_slice.mojo
+++ b/mojo/stdlib/test/builtin/test_slice.mojo
@@ -11,6 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+from builtin.builtin_slice import ContiguousSlice, StridedSlice
 from testing import assert_equal, assert_true, TestSuite
 
 
@@ -80,6 +81,37 @@ def test_slice_stringable():
     assert_equal(s[::4], "slice(None, None, 4)")
     assert_equal(repr(slice(None, 2, 3)), "slice(None, 2, 3)")
     assert_equal(repr(slice(10)), "slice(None, 10, None)")
+
+
+struct StridedSliceStringable:
+    fn __init__(out self):
+        pass
+
+    fn __getitem__(self, a: StridedSlice) -> String:
+        return String(a)
+
+
+def test_strided_slice_stringable():
+    var s = StridedSliceStringable()
+    assert_equal(s[1:10:2], "slice(1, 10, 2)")
+    assert_equal(s[::3], "slice(None, None, 3)")
+    assert_equal(s[2::-1], "slice(2, None, -1)")
+
+
+struct ContiguousSliceStringable:
+    fn __init__(out self):
+        pass
+
+    fn __getitem__(self, a: ContiguousSlice) -> String:
+        return String(a)
+
+
+def test_contiguous_slice_stringable():
+    var s = ContiguousSliceStringable()
+    assert_equal(s[0:10], "slice(0, 10, None)")
+    assert_equal(s[:5], "slice(None, 5, None)")
+    assert_equal(s[3:], "slice(3, None, None)")
+    assert_equal(s[:], "slice(None, None, None)")
 
 
 def test_slice_eq():

--- a/mojo/stdlib/test/builtin/test_slice.mojo
+++ b/mojo/stdlib/test/builtin/test_slice.mojo
@@ -114,6 +114,38 @@ def test_contiguous_slice_stringable():
     assert_equal(s[:], "slice(None, None, None)")
 
 
+struct StridedSliceRepresentable:
+    fn __init__(out self):
+        pass
+
+    fn __getitem__(self, a: StridedSlice) -> String:
+        return repr(a)
+
+
+def test_strided_slice_representable():
+    var s = StridedSliceRepresentable()
+    assert_equal(s[1:10:2], "slice(1, 10, 2)")
+    assert_equal(s[::3], "slice(None, None, 3)")
+    # repr == str for StridedSlice
+    assert_equal(s[2::-1], String(StridedSlice(2, None, -1)))
+
+
+struct ContiguousSliceRepresentable:
+    fn __init__(out self):
+        pass
+
+    fn __getitem__(self, a: ContiguousSlice) -> String:
+        return repr(a)
+
+
+def test_contiguous_slice_representable():
+    var s = ContiguousSliceRepresentable()
+    assert_equal(s[0:10], "slice(0, 10, None)")
+    assert_equal(s[:5], "slice(None, 5, None)")
+    # repr == str for ContiguousSlice
+    assert_equal(s[3:], String(ContiguousSlice(3, None, None)))
+
+
 def test_slice_eq():
     assert_equal(slice(1, 2, 3), slice(1, 2, 3))
     assert_equal(slice(None, 1, None), slice(1))

--- a/mojo/stdlib/test/os/test_process.mojo
+++ b/mojo/stdlib/test/os/test_process.mojo
@@ -14,7 +14,7 @@
 from collections import List
 from os.path import exists
 from os import Process
-from os.process import Pipe
+from os.process import Pipe, ProcessStatus
 
 from testing import (
     assert_false,
@@ -81,9 +81,23 @@ def test_process_run_missing():
         _ = Process.run(missing_executable_file, List[String]())
 
 
+def test_processstatus_str():
+    assert_equal(
+        String(ProcessStatus(exit_code=0)), "ProcessStatus(exit_code: 0)"
+    )
+    assert_equal(
+        String(ProcessStatus(exit_code=1)), "ProcessStatus(exit_code: 1)"
+    )
+    assert_equal(
+        String(ProcessStatus(term_signal=15)), "ProcessStatus(term_signal: 15)"
+    )
+    assert_equal(String(ProcessStatus.running()), "ProcessStatus(running)")
+
+
 def main():
     test_process_run()
     test_process_run_missing()
     test_process_wait()
     test_process_kill()
     test_pipe()
+    test_processstatus_str()

--- a/mojo/stdlib/test/sys/test_intrinsics.mojo
+++ b/mojo/stdlib/test/sys/test_intrinsics.mojo
@@ -19,7 +19,15 @@ from sys import (
     strided_load,
     strided_store,
 )
-from sys.intrinsics import assume, likely, unlikely
+from sys.intrinsics import (
+    PrefetchCache,
+    PrefetchLocality,
+    PrefetchOptions,
+    PrefetchRW,
+    assume,
+    likely,
+    unlikely,
+)
 
 from memory import memset_zero
 from testing import assert_equal
@@ -135,6 +143,64 @@ def test_likely_unlikely():
 
 def test_assume():
     assume(True)
+
+
+def test_prefetch_locality_str():
+    assert_equal(String(PrefetchLocality.NONE), "NONE")
+    assert_equal(String(PrefetchLocality.LOW), "LOW")
+    assert_equal(String(PrefetchLocality.MEDIUM), "MEDIUM")
+    assert_equal(String(PrefetchLocality.HIGH), "HIGH")
+
+
+def test_prefetch_rw_str():
+    assert_equal(String(PrefetchRW.READ), "READ")
+    assert_equal(String(PrefetchRW.WRITE), "WRITE")
+
+
+def test_prefetch_cache_str():
+    assert_equal(String(PrefetchCache.INSTRUCTION), "INSTRUCTION")
+    assert_equal(String(PrefetchCache.DATA), "DATA")
+
+
+def test_prefetch_options_str():
+    assert_equal(
+        String(PrefetchOptions()),
+        "PrefetchOptions(rw=READ, locality=HIGH, cache=DATA)",
+    )
+    assert_equal(
+        String(
+            PrefetchOptions().for_write().no_locality().to_instruction_cache()
+        ),
+        "PrefetchOptions(rw=WRITE, locality=NONE, cache=INSTRUCTION)",
+    )
+
+
+def test_prefetch_locality_repr():
+    assert_equal(repr(PrefetchLocality.NONE), "PrefetchLocality.NONE")
+    assert_equal(repr(PrefetchLocality.HIGH), "PrefetchLocality.HIGH")
+
+
+def test_prefetch_rw_repr():
+    assert_equal(repr(PrefetchRW.READ), "PrefetchRW.READ")
+    assert_equal(repr(PrefetchRW.WRITE), "PrefetchRW.WRITE")
+
+
+def test_prefetch_cache_repr():
+    assert_equal(repr(PrefetchCache.INSTRUCTION), "PrefetchCache.INSTRUCTION")
+    assert_equal(repr(PrefetchCache.DATA), "PrefetchCache.DATA")
+
+
+def test_prefetch_options_repr():
+    assert_equal(
+        repr(PrefetchOptions()),
+        "PrefetchOptions(rw=PrefetchRW.READ, locality=PrefetchLocality.HIGH, cache=PrefetchCache.DATA)",
+    )
+    assert_equal(
+        repr(
+            PrefetchOptions().for_write().no_locality().to_instruction_cache()
+        ),
+        "PrefetchOptions(rw=PrefetchRW.WRITE, locality=PrefetchLocality.NONE, cache=PrefetchCache.INSTRUCTION)",
+    )
 
 
 def main():

--- a/mojo/stdlib/test/sys/test_intrinsics.mojo
+++ b/mojo/stdlib/test/sys/test_intrinsics.mojo
@@ -30,6 +30,7 @@ from sys.intrinsics import (
 )
 
 from memory import memset_zero
+from test_utils import check_write_to
 from testing import assert_equal
 from testing import TestSuite
 
@@ -145,63 +146,67 @@ def test_assume():
     assume(True)
 
 
-def test_prefetch_locality_str():
-    assert_equal(String(PrefetchLocality.NONE), "NONE")
-    assert_equal(String(PrefetchLocality.LOW), "LOW")
-    assert_equal(String(PrefetchLocality.MEDIUM), "MEDIUM")
-    assert_equal(String(PrefetchLocality.HIGH), "HIGH")
+def test_prefetch_locality_write_to():
+    check_write_to(PrefetchLocality.NONE, expected="NONE", is_repr=False)
+    check_write_to(PrefetchLocality.LOW, expected="LOW", is_repr=False)
+    check_write_to(PrefetchLocality.MEDIUM, expected="MEDIUM", is_repr=False)
+    check_write_to(PrefetchLocality.HIGH, expected="HIGH", is_repr=False)
 
 
-def test_prefetch_rw_str():
-    assert_equal(String(PrefetchRW.READ), "READ")
-    assert_equal(String(PrefetchRW.WRITE), "WRITE")
+def test_prefetch_rw_write_to():
+    check_write_to(PrefetchRW.READ, expected="READ", is_repr=False)
+    check_write_to(PrefetchRW.WRITE, expected="WRITE", is_repr=False)
 
 
-def test_prefetch_cache_str():
-    assert_equal(String(PrefetchCache.INSTRUCTION), "INSTRUCTION")
-    assert_equal(String(PrefetchCache.DATA), "DATA")
+def test_prefetch_cache_write_to():
+    check_write_to(PrefetchCache.INSTRUCTION, expected="INSTRUCTION", is_repr=False)
+    check_write_to(PrefetchCache.DATA, expected="DATA", is_repr=False)
 
 
-def test_prefetch_options_str():
-    assert_equal(
-        String(PrefetchOptions()),
-        "PrefetchOptions(rw=READ, locality=HIGH, cache=DATA)",
+def test_prefetch_options_write_to():
+    check_write_to(
+        PrefetchOptions(),
+        expected="PrefetchOptions(READ, HIGH, DATA)",
+        is_repr=False,
     )
-    assert_equal(
-        String(
-            PrefetchOptions().for_write().no_locality().to_instruction_cache()
-        ),
-        "PrefetchOptions(rw=WRITE, locality=NONE, cache=INSTRUCTION)",
+    check_write_to(
+        PrefetchOptions().for_write().no_locality().to_instruction_cache(),
+        expected="PrefetchOptions(WRITE, NONE, INSTRUCTION)",
+        is_repr=False,
     )
 
 
-def test_prefetch_locality_repr():
-    assert_equal(repr(PrefetchLocality.NONE), "PrefetchLocality.NONE")
-    assert_equal(repr(PrefetchLocality.LOW), "PrefetchLocality.LOW")
-    assert_equal(repr(PrefetchLocality.MEDIUM), "PrefetchLocality.MEDIUM")
-    assert_equal(repr(PrefetchLocality.HIGH), "PrefetchLocality.HIGH")
-
-
-def test_prefetch_rw_repr():
-    assert_equal(repr(PrefetchRW.READ), "PrefetchRW.READ")
-    assert_equal(repr(PrefetchRW.WRITE), "PrefetchRW.WRITE")
-
-
-def test_prefetch_cache_repr():
-    assert_equal(repr(PrefetchCache.INSTRUCTION), "PrefetchCache.INSTRUCTION")
-    assert_equal(repr(PrefetchCache.DATA), "PrefetchCache.DATA")
-
-
-def test_prefetch_options_repr():
-    assert_equal(
-        repr(PrefetchOptions()),
-        "PrefetchOptions(rw=PrefetchRW.READ, locality=PrefetchLocality.HIGH, cache=PrefetchCache.DATA)",
+def test_prefetch_locality_write_repr_to():
+    check_write_to(PrefetchLocality.NONE, expected="PrefetchLocality(NONE)", is_repr=True)
+    check_write_to(PrefetchLocality.LOW, expected="PrefetchLocality(LOW)", is_repr=True)
+    check_write_to(
+        PrefetchLocality.MEDIUM, expected="PrefetchLocality(MEDIUM)", is_repr=True
     )
-    assert_equal(
-        repr(
-            PrefetchOptions().for_write().no_locality().to_instruction_cache()
-        ),
-        "PrefetchOptions(rw=PrefetchRW.WRITE, locality=PrefetchLocality.NONE, cache=PrefetchCache.INSTRUCTION)",
+    check_write_to(PrefetchLocality.HIGH, expected="PrefetchLocality(HIGH)", is_repr=True)
+
+
+def test_prefetch_rw_write_repr_to():
+    check_write_to(PrefetchRW.READ, expected="PrefetchRW(READ)", is_repr=True)
+    check_write_to(PrefetchRW.WRITE, expected="PrefetchRW(WRITE)", is_repr=True)
+
+
+def test_prefetch_cache_write_repr_to():
+    check_write_to(
+        PrefetchCache.INSTRUCTION, expected="PrefetchCache(INSTRUCTION)", is_repr=True
+    )
+    check_write_to(PrefetchCache.DATA, expected="PrefetchCache(DATA)", is_repr=True)
+
+
+def test_prefetch_options_write_repr_to():
+    check_write_to(
+        PrefetchOptions(),
+        expected="PrefetchOptions(PrefetchRW(READ), PrefetchLocality(HIGH), PrefetchCache(DATA))",
+        is_repr=True,
+    )
+    check_write_to(
+        PrefetchOptions().for_write().no_locality().to_instruction_cache(),
+        expected="PrefetchOptions(PrefetchRW(WRITE), PrefetchLocality(NONE), PrefetchCache(INSTRUCTION))",
+        is_repr=True,
     )
 
 

--- a/mojo/stdlib/test/sys/test_intrinsics.mojo
+++ b/mojo/stdlib/test/sys/test_intrinsics.mojo
@@ -177,6 +177,8 @@ def test_prefetch_options_str():
 
 def test_prefetch_locality_repr():
     assert_equal(repr(PrefetchLocality.NONE), "PrefetchLocality.NONE")
+    assert_equal(repr(PrefetchLocality.LOW), "PrefetchLocality.LOW")
+    assert_equal(repr(PrefetchLocality.MEDIUM), "PrefetchLocality.MEDIUM")
     assert_equal(repr(PrefetchLocality.HIGH), "PrefetchLocality.HIGH")
 
 


### PR DESCRIPTION
`StridedSlice` and `ContiguousSlice` now implement `Stringable` and `Writable`, consistent with `Slice`.

- `StridedSlice.write_to` delegates to its inner `Slice`, producing the same `slice(start, end, step)` format.
- `ContiguousSlice.write_to` produces `slice(start, end, None)` (step is always `None`).

Both types now support `str()` and `print()`.