### PR TITLE
[Stdlib] Add Writable to sys.intrinsics Prefetch types

### DIFF
--- a/mojo/stdlib/std/sys/intrinsics.mojo
+++ b/mojo/stdlib/std/sys/intrinsics.mojo
@@ -252,7 +252,7 @@ fn scatter[
 # ===-----------------------------------------------------------------------===#
 
 
-struct PrefetchLocality(Stringable, TrivialRegisterPassable, Writable):
+struct PrefetchLocality(Representable, Stringable, TrivialRegisterPassable, Writable):
     """The prefetch locality.
 
     The locality, rw, and cache type correspond to LLVM prefetch intrinsic's
@@ -298,6 +298,26 @@ struct PrefetchLocality(Stringable, TrivialRegisterPassable, Writable):
             writer.write("HIGH")
 
     @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the representation of the prefetch locality to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        writer.write("PrefetchLocality.", self)
+
+    @no_inline
+    fn __repr__(self) -> String:
+        """Returns the representation of the prefetch locality.
+
+        Returns:
+            A string such as `"PrefetchLocality.HIGH"`.
+        """
+        var string = String()
+        self.write_repr_to(string)
+        return string^
+
+    @no_inline
     fn __str__(self) -> String:
         """Returns the string representation of the prefetch locality.
 
@@ -307,7 +327,7 @@ struct PrefetchLocality(Stringable, TrivialRegisterPassable, Writable):
         return String.write(self)
 
 
-struct PrefetchRW(Stringable, TrivialRegisterPassable, Writable):
+struct PrefetchRW(Representable, Stringable, TrivialRegisterPassable, Writable):
     """Prefetch read or write."""
 
     var value: Int32
@@ -352,6 +372,26 @@ struct PrefetchRW(Stringable, TrivialRegisterPassable, Writable):
             writer.write("WRITE")
 
     @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the representation of the prefetch read-write option to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        writer.write("PrefetchRW.", self)
+
+    @no_inline
+    fn __repr__(self) -> String:
+        """Returns the representation of the prefetch read-write option.
+
+        Returns:
+            A string such as `"PrefetchRW.READ"`.
+        """
+        var string = String()
+        self.write_repr_to(string)
+        return string^
+
+    @no_inline
     fn __str__(self) -> String:
         """Returns the string representation of the prefetch read-write option.
 
@@ -362,7 +402,7 @@ struct PrefetchRW(Stringable, TrivialRegisterPassable, Writable):
 
 
 # LLVM prefetch cache type
-struct PrefetchCache(Stringable, TrivialRegisterPassable, Writable):
+struct PrefetchCache(Representable, Stringable, TrivialRegisterPassable, Writable):
     """Prefetch cache type."""
 
     var value: Int32
@@ -395,6 +435,26 @@ struct PrefetchCache(Stringable, TrivialRegisterPassable, Writable):
             writer.write("DATA")
 
     @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the representation of the prefetch cache type to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        writer.write("PrefetchCache.", self)
+
+    @no_inline
+    fn __repr__(self) -> String:
+        """Returns the representation of the prefetch cache type.
+
+        Returns:
+            A string such as `"PrefetchCache.DATA"`.
+        """
+        var string = String()
+        self.write_repr_to(string)
+        return string^
+
+    @no_inline
     fn __str__(self) -> String:
         """Returns the string representation of the prefetch cache type.
 
@@ -404,7 +464,7 @@ struct PrefetchCache(Stringable, TrivialRegisterPassable, Writable):
         return String.write(self)
 
 
-struct PrefetchOptions(Defaultable, Stringable, TrivialRegisterPassable, Writable):
+struct PrefetchOptions(Defaultable, Representable, Stringable, TrivialRegisterPassable, Writable):
     """Collection of configuration parameters for a prefetch intrinsic call.
 
     The op configuration follows similar interface as LLVM intrinsic prefetch
@@ -546,6 +606,34 @@ struct PrefetchOptions(Defaultable, Stringable, TrivialRegisterPassable, Writabl
             self.cache,
             ")",
         )
+
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the representation of the prefetch options to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        writer.write(
+            "PrefetchOptions(rw=",
+            self.rw.__repr__(),
+            ", locality=",
+            self.locality.__repr__(),
+            ", cache=",
+            self.cache.__repr__(),
+            ")",
+        )
+
+    @no_inline
+    fn __repr__(self) -> String:
+        """Returns the representation of the prefetch options.
+
+        Returns:
+            A string such as `"PrefetchOptions(rw=PrefetchRW.READ, locality=PrefetchLocality.HIGH, cache=PrefetchCache.DATA)"`.
+        """
+        var string = String()
+        self.write_repr_to(string)
+        return string^
 
     @no_inline
     fn __str__(self) -> String:

--- a/mojo/stdlib/std/sys/intrinsics.mojo
+++ b/mojo/stdlib/std/sys/intrinsics.mojo
@@ -252,7 +252,7 @@ fn scatter[
 # ===-----------------------------------------------------------------------===#
 
 
-struct PrefetchLocality(TrivialRegisterPassable):
+struct PrefetchLocality(Stringable, TrivialRegisterPassable, Writable):
     """The prefetch locality.
 
     The locality, rw, and cache type correspond to LLVM prefetch intrinsic's
@@ -281,8 +281,33 @@ struct PrefetchLocality(TrivialRegisterPassable):
         """
         self.value = Int32(value)
 
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the prefetch locality to a writer.
 
-struct PrefetchRW(TrivialRegisterPassable):
+        Args:
+            writer: The writer to write to.
+        """
+        if self.value == 0:
+            writer.write("NONE")
+        elif self.value == 1:
+            writer.write("LOW")
+        elif self.value == 2:
+            writer.write("MEDIUM")
+        else:
+            writer.write("HIGH")
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns the string representation of the prefetch locality.
+
+        Returns:
+            A string representation of the locality value.
+        """
+        return String.write(self)
+
+
+struct PrefetchRW(Stringable, TrivialRegisterPassable, Writable):
     """Prefetch read or write."""
 
     var value: Int32
@@ -314,9 +339,30 @@ struct PrefetchRW(TrivialRegisterPassable):
         """
         return self.value == other.value
 
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the prefetch read-write option to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        if self.value == 0:
+            writer.write("READ")
+        else:
+            writer.write("WRITE")
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns the string representation of the prefetch read-write option.
+
+        Returns:
+            A string representation of the read-write value.
+        """
+        return String.write(self)
+
 
 # LLVM prefetch cache type
-struct PrefetchCache(TrivialRegisterPassable):
+struct PrefetchCache(Stringable, TrivialRegisterPassable, Writable):
     """Prefetch cache type."""
 
     var value: Int32
@@ -336,8 +382,29 @@ struct PrefetchCache(TrivialRegisterPassable):
         """
         self.value = Int32(value)
 
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the prefetch cache type to a writer.
 
-struct PrefetchOptions(Defaultable, TrivialRegisterPassable):
+        Args:
+            writer: The writer to write to.
+        """
+        if self.value == 0:
+            writer.write("INSTRUCTION")
+        else:
+            writer.write("DATA")
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns the string representation of the prefetch cache type.
+
+        Returns:
+            A string representation of the cache type.
+        """
+        return String.write(self)
+
+
+struct PrefetchOptions(Defaultable, Stringable, TrivialRegisterPassable, Writable):
     """Collection of configuration parameters for a prefetch intrinsic call.
 
     The op configuration follows similar interface as LLVM intrinsic prefetch
@@ -462,6 +529,32 @@ struct PrefetchOptions(Defaultable, TrivialRegisterPassable):
         var updated = self
         updated.cache = PrefetchCache.INSTRUCTION
         return updated
+
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the prefetch options to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        writer.write(
+            "PrefetchOptions(rw=",
+            self.rw,
+            ", locality=",
+            self.locality,
+            ", cache=",
+            self.cache,
+            ")",
+        )
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns the string representation of the prefetch options.
+
+        Returns:
+            A string representation of the prefetch options.
+        """
+        return String.write(self)
 
 
 @always_inline("nodebug")

--- a/mojo/stdlib/test/sys/test_intrinsics.mojo
+++ b/mojo/stdlib/test/sys/test_intrinsics.mojo
@@ -19,7 +19,15 @@ from sys import (
     strided_load,
     strided_store,
 )
-from sys.intrinsics import assume, likely, unlikely
+from sys.intrinsics import (
+    PrefetchCache,
+    PrefetchLocality,
+    PrefetchOptions,
+    PrefetchRW,
+    assume,
+    likely,
+    unlikely,
+)
 
 from memory import memset_zero
 from testing import assert_equal
@@ -135,6 +143,36 @@ def test_likely_unlikely():
 
 def test_assume():
     assume(True)
+
+
+def test_prefetch_locality_str():
+    assert_equal(String(PrefetchLocality.NONE), "NONE")
+    assert_equal(String(PrefetchLocality.LOW), "LOW")
+    assert_equal(String(PrefetchLocality.MEDIUM), "MEDIUM")
+    assert_equal(String(PrefetchLocality.HIGH), "HIGH")
+
+
+def test_prefetch_rw_str():
+    assert_equal(String(PrefetchRW.READ), "READ")
+    assert_equal(String(PrefetchRW.WRITE), "WRITE")
+
+
+def test_prefetch_cache_str():
+    assert_equal(String(PrefetchCache.INSTRUCTION), "INSTRUCTION")
+    assert_equal(String(PrefetchCache.DATA), "DATA")
+
+
+def test_prefetch_options_str():
+    assert_equal(
+        String(PrefetchOptions()),
+        "PrefetchOptions(rw=READ, locality=HIGH, cache=DATA)",
+    )
+    assert_equal(
+        String(
+            PrefetchOptions().for_write().no_locality().to_instruction_cache()
+        ),
+        "PrefetchOptions(rw=WRITE, locality=NONE, cache=INSTRUCTION)",
+    )
 
 
 def main():

--- a/mojo/stdlib/test/sys/test_intrinsics.mojo
+++ b/mojo/stdlib/test/sys/test_intrinsics.mojo
@@ -175,5 +175,33 @@ def test_prefetch_options_str():
     )
 
 
+def test_prefetch_locality_repr():
+    assert_equal(repr(PrefetchLocality.NONE), "PrefetchLocality.NONE")
+    assert_equal(repr(PrefetchLocality.HIGH), "PrefetchLocality.HIGH")
+
+
+def test_prefetch_rw_repr():
+    assert_equal(repr(PrefetchRW.READ), "PrefetchRW.READ")
+    assert_equal(repr(PrefetchRW.WRITE), "PrefetchRW.WRITE")
+
+
+def test_prefetch_cache_repr():
+    assert_equal(repr(PrefetchCache.INSTRUCTION), "PrefetchCache.INSTRUCTION")
+    assert_equal(repr(PrefetchCache.DATA), "PrefetchCache.DATA")
+
+
+def test_prefetch_options_repr():
+    assert_equal(
+        repr(PrefetchOptions()),
+        "PrefetchOptions(rw=PrefetchRW.READ, locality=PrefetchLocality.HIGH, cache=PrefetchCache.DATA)",
+    )
+    assert_equal(
+        repr(
+            PrefetchOptions().for_write().no_locality().to_instruction_cache()
+        ),
+        "PrefetchOptions(rw=PrefetchRW.WRITE, locality=PrefetchLocality.NONE, cache=PrefetchCache.INSTRUCTION)",
+    )
+
+
 def main():
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/mojo/stdlib/test/sys/test_intrinsics.mojo
+++ b/mojo/stdlib/test/sys/test_intrinsics.mojo
@@ -30,6 +30,7 @@ from sys.intrinsics import (
 )
 
 from memory import memset_zero
+from test_utils import check_write_to
 from testing import assert_equal
 from testing import TestSuite
 
@@ -145,63 +146,67 @@ def test_assume():
     assume(True)
 
 
-def test_prefetch_locality_str():
-    assert_equal(String(PrefetchLocality.NONE), "NONE")
-    assert_equal(String(PrefetchLocality.LOW), "LOW")
-    assert_equal(String(PrefetchLocality.MEDIUM), "MEDIUM")
-    assert_equal(String(PrefetchLocality.HIGH), "HIGH")
+def test_prefetch_locality_write_to():
+    check_write_to(PrefetchLocality.NONE, expected="NONE", is_repr=False)
+    check_write_to(PrefetchLocality.LOW, expected="LOW", is_repr=False)
+    check_write_to(PrefetchLocality.MEDIUM, expected="MEDIUM", is_repr=False)
+    check_write_to(PrefetchLocality.HIGH, expected="HIGH", is_repr=False)
 
 
-def test_prefetch_rw_str():
-    assert_equal(String(PrefetchRW.READ), "READ")
-    assert_equal(String(PrefetchRW.WRITE), "WRITE")
+def test_prefetch_rw_write_to():
+    check_write_to(PrefetchRW.READ, expected="READ", is_repr=False)
+    check_write_to(PrefetchRW.WRITE, expected="WRITE", is_repr=False)
 
 
-def test_prefetch_cache_str():
-    assert_equal(String(PrefetchCache.INSTRUCTION), "INSTRUCTION")
-    assert_equal(String(PrefetchCache.DATA), "DATA")
+def test_prefetch_cache_write_to():
+    check_write_to(PrefetchCache.INSTRUCTION, expected="INSTRUCTION", is_repr=False)
+    check_write_to(PrefetchCache.DATA, expected="DATA", is_repr=False)
 
 
-def test_prefetch_options_str():
-    assert_equal(
-        String(PrefetchOptions()),
-        "PrefetchOptions(rw=READ, locality=HIGH, cache=DATA)",
+def test_prefetch_options_write_to():
+    check_write_to(
+        PrefetchOptions(),
+        expected="PrefetchOptions(READ, HIGH, DATA)",
+        is_repr=False,
     )
-    assert_equal(
-        String(
-            PrefetchOptions().for_write().no_locality().to_instruction_cache()
-        ),
-        "PrefetchOptions(rw=WRITE, locality=NONE, cache=INSTRUCTION)",
+    check_write_to(
+        PrefetchOptions().for_write().no_locality().to_instruction_cache(),
+        expected="PrefetchOptions(WRITE, NONE, INSTRUCTION)",
+        is_repr=False,
     )
 
 
-def test_prefetch_locality_repr():
-    assert_equal(repr(PrefetchLocality.NONE), "PrefetchLocality.NONE")
-    assert_equal(repr(PrefetchLocality.LOW), "PrefetchLocality.LOW")
-    assert_equal(repr(PrefetchLocality.MEDIUM), "PrefetchLocality.MEDIUM")
-    assert_equal(repr(PrefetchLocality.HIGH), "PrefetchLocality.HIGH")
-
-
-def test_prefetch_rw_repr():
-    assert_equal(repr(PrefetchRW.READ), "PrefetchRW.READ")
-    assert_equal(repr(PrefetchRW.WRITE), "PrefetchRW.WRITE")
-
-
-def test_prefetch_cache_repr():
-    assert_equal(repr(PrefetchCache.INSTRUCTION), "PrefetchCache.INSTRUCTION")
-    assert_equal(repr(PrefetchCache.DATA), "PrefetchCache.DATA")
-
-
-def test_prefetch_options_repr():
-    assert_equal(
-        repr(PrefetchOptions()),
-        "PrefetchOptions(rw=PrefetchRW.READ, locality=PrefetchLocality.HIGH, cache=PrefetchCache.DATA)",
+def test_prefetch_locality_write_repr_to():
+    check_write_to(PrefetchLocality.NONE, expected="PrefetchLocality(NONE)", is_repr=True)
+    check_write_to(PrefetchLocality.LOW, expected="PrefetchLocality(LOW)", is_repr=True)
+    check_write_to(
+        PrefetchLocality.MEDIUM, expected="PrefetchLocality(MEDIUM)", is_repr=True
     )
-    assert_equal(
-        repr(
-            PrefetchOptions().for_write().no_locality().to_instruction_cache()
-        ),
-        "PrefetchOptions(rw=PrefetchRW.WRITE, locality=PrefetchLocality.NONE, cache=PrefetchCache.INSTRUCTION)",
+    check_write_to(PrefetchLocality.HIGH, expected="PrefetchLocality(HIGH)", is_repr=True)
+
+
+def test_prefetch_rw_write_repr_to():
+    check_write_to(PrefetchRW.READ, expected="PrefetchRW(READ)", is_repr=True)
+    check_write_to(PrefetchRW.WRITE, expected="PrefetchRW(WRITE)", is_repr=True)
+
+
+def test_prefetch_cache_write_repr_to():
+    check_write_to(
+        PrefetchCache.INSTRUCTION, expected="PrefetchCache(INSTRUCTION)", is_repr=True
+    )
+    check_write_to(PrefetchCache.DATA, expected="PrefetchCache(DATA)", is_repr=True)
+
+
+def test_prefetch_options_write_repr_to():
+    check_write_to(
+        PrefetchOptions(),
+        expected="PrefetchOptions(PrefetchRW(READ), PrefetchLocality(HIGH), PrefetchCache(DATA))",
+        is_repr=True,
+    )
+    check_write_to(
+        PrefetchOptions().for_write().no_locality().to_instruction_cache(),
+        expected="PrefetchOptions(PrefetchRW(WRITE), PrefetchLocality(NONE), PrefetchCache(INSTRUCTION))",
+        is_repr=True,
     )
 
 

--- a/mojo/stdlib/test/sys/test_intrinsics.mojo
+++ b/mojo/stdlib/test/sys/test_intrinsics.mojo
@@ -177,6 +177,8 @@ def test_prefetch_options_str():
 
 def test_prefetch_locality_repr():
     assert_equal(repr(PrefetchLocality.NONE), "PrefetchLocality.NONE")
+    assert_equal(repr(PrefetchLocality.LOW), "PrefetchLocality.LOW")
+    assert_equal(repr(PrefetchLocality.MEDIUM), "PrefetchLocality.MEDIUM")
     assert_equal(repr(PrefetchLocality.HIGH), "PrefetchLocality.HIGH")
 
 


### PR DESCRIPTION
`PrefetchLocality`, `PrefetchRW`, `PrefetchCache`, and `PrefetchOptions` in `sys.intrinsics` now implement `Stringable` and `Writable`, enabling `print()` and `String()` on these types.