### PR TITLE
[Stdlib] Add Writable to StridedSlice and ContiguousSlice

### DIFF
--- a/mojo/stdlib/std/builtin/builtin_slice.mojo
+++ b/mojo/stdlib/std/builtin/builtin_slice.mojo
@@ -205,7 +205,7 @@ struct Slice(
         return (start.value(), end.value(), step)
 
 
-struct StridedSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
+struct StridedSlice(ImplicitlyCopyable, Writable):
     """Represents a slice expression that has a stride.
 
     This type is used to support different behavior for strided vs unstrided
@@ -246,35 +246,13 @@ struct StridedSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
     # ===-------------------------------------------------------------------===#
 
     @no_inline
-    fn __str__(self) -> String:
-        """Gets the string representation of the strided slice.
-
-        Returns:
-            The string representation of the strided slice.
-        """
-        var output = String()
-        self.write_to(output)
-        return output
-
-    @no_inline
-    fn __repr__(self) -> String:
-        """Gets the string representation of the strided slice.
-
-        Returns:
-            The string representation of the strided slice.
-        """
-        var output = String()
-        self.write_repr_to(output)
-        return output^
-
-    @no_inline
     fn write_to(self, mut writer: Some[Writer]):
         """Write StridedSlice string representation to a `Writer`.
 
         Args:
             writer: The object to write to.
         """
-        writer.write(self._inner)
+        self._inner.write_to(writer)
 
     @no_inline
     fn write_repr_to(self, mut writer: Some[Writer]):
@@ -298,7 +276,7 @@ struct StridedSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
         return self._inner.indices(length)
 
 
-struct ContiguousSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
+struct ContiguousSlice(ImplicitlyCopyable, Writable):
     """Represents a slice expression without a stride.
 
     This type is used to support different behavior for strided vs unstrided
@@ -334,28 +312,6 @@ struct ContiguousSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
     # ===-------------------------------------------------------------------===#
 
     @no_inline
-    fn __str__(self) -> String:
-        """Gets the string representation of the contiguous slice.
-
-        Returns:
-            The string representation of the contiguous slice.
-        """
-        var output = String()
-        self.write_to(output)
-        return output
-
-    @no_inline
-    fn __repr__(self) -> String:
-        """Gets the string representation of the contiguous slice.
-
-        Returns:
-            The string representation of the contiguous slice.
-        """
-        var output = String()
-        self.write_repr_to(output)
-        return output^
-
-    @no_inline
     fn write_to(self, mut writer: Some[Writer]):
         """Write ContiguousSlice string representation to a `Writer`.
 
@@ -368,13 +324,13 @@ struct ContiguousSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
             if opt:
                 writer.write(repr(opt.value()))
             else:
-                writer.write(repr(None))
+                writer.write_string("None")
 
-        writer.write("slice(")
+        writer.write_string("slice(")
         write_optional(self.start)
-        writer.write(", ")
+        writer.write_string(", ")
         write_optional(self.end)
-        writer.write(", None)")
+        writer.write_string(", None)")
 
     @no_inline
     fn write_repr_to(self, mut writer: Some[Writer]):

--- a/mojo/stdlib/std/builtin/builtin_slice.mojo
+++ b/mojo/stdlib/std/builtin/builtin_slice.mojo
@@ -205,7 +205,7 @@ struct Slice(
         return (start.value(), end.value(), step)
 
 
-struct StridedSlice(ImplicitlyCopyable, Stringable, Writable):
+struct StridedSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
     """Represents a slice expression that has a stride.
 
     This type is used to support different behavior for strided vs unstrided
@@ -255,6 +255,15 @@ struct StridedSlice(ImplicitlyCopyable, Stringable, Writable):
         return String.write(self)
 
     @no_inline
+    fn __repr__(self) -> String:
+        """Gets the string representation of the strided slice.
+
+        Returns:
+            The string representation of the strided slice.
+        """
+        return self.__str__()
+
+    @no_inline
     fn write_to(self, mut writer: Some[Writer]):
         """Write StridedSlice string representation to a `Writer`.
 
@@ -262,6 +271,15 @@ struct StridedSlice(ImplicitlyCopyable, Stringable, Writable):
             writer: The object to write to.
         """
         writer.write(self._inner)
+
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Write StridedSlice debug representation to a `Writer`.
+
+        Args:
+            writer: The object to write to.
+        """
+        self.write_to(writer)
 
     fn indices(self, length: Int) -> Tuple[Int, Int, Int]:
         """Returns a tuple of 3 integers representing start, end, and step
@@ -276,7 +294,7 @@ struct StridedSlice(ImplicitlyCopyable, Stringable, Writable):
         return self._inner.indices(length)
 
 
-struct ContiguousSlice(ImplicitlyCopyable, Stringable, Writable):
+struct ContiguousSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
     """Represents a slice expression without a stride.
 
     This type is used to support different behavior for strided vs unstrided
@@ -321,6 +339,15 @@ struct ContiguousSlice(ImplicitlyCopyable, Stringable, Writable):
         return String.write(self)
 
     @no_inline
+    fn __repr__(self) -> String:
+        """Gets the string representation of the contiguous slice.
+
+        Returns:
+            The string representation of the contiguous slice.
+        """
+        return self.__str__()
+
+    @no_inline
     fn write_to(self, mut writer: Some[Writer]):
         """Write ContiguousSlice string representation to a `Writer`.
 
@@ -340,6 +367,15 @@ struct ContiguousSlice(ImplicitlyCopyable, Stringable, Writable):
         writer.write(", ")
         write_optional(self.end)
         writer.write(", None)")
+
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Write ContiguousSlice debug representation to a `Writer`.
+
+        Args:
+            writer: The object to write to.
+        """
+        self.write_to(writer)
 
     fn indices(self, length: Int) -> Tuple[Int, Int]:
         """Returns a tuple of 2 integers representing the start, and end

--- a/mojo/stdlib/std/builtin/builtin_slice.mojo
+++ b/mojo/stdlib/std/builtin/builtin_slice.mojo
@@ -205,7 +205,7 @@ struct Slice(
         return (start.value(), end.value(), step)
 
 
-struct StridedSlice(ImplicitlyCopyable):
+struct StridedSlice(ImplicitlyCopyable, Stringable, Writable):
     """Represents a slice expression that has a stride.
 
     This type is used to support different behavior for strided vs unstrided
@@ -241,6 +241,28 @@ struct StridedSlice(ImplicitlyCopyable):
 
         self._inner = Slice(start, end, stride)
 
+    # ===-------------------------------------------------------------------===#
+    # Trait implementations
+    # ===-------------------------------------------------------------------===#
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Gets the string representation of the strided slice.
+
+        Returns:
+            The string representation of the strided slice.
+        """
+        return String.write(self)
+
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Write StridedSlice string representation to a `Writer`.
+
+        Args:
+            writer: The object to write to.
+        """
+        writer.write(self._inner)
+
     fn indices(self, length: Int) -> Tuple[Int, Int, Int]:
         """Returns a tuple of 3 integers representing start, end, and step
         of the slice if applied to a container of given length.
@@ -254,7 +276,7 @@ struct StridedSlice(ImplicitlyCopyable):
         return self._inner.indices(length)
 
 
-struct ContiguousSlice(ImplicitlyCopyable):
+struct ContiguousSlice(ImplicitlyCopyable, Stringable, Writable):
     """Represents a slice expression without a stride.
 
     This type is used to support different behavior for strided vs unstrided
@@ -284,6 +306,40 @@ struct ContiguousSlice(ImplicitlyCopyable):
         """
         self.start = start
         self.end = end
+
+    # ===-------------------------------------------------------------------===#
+    # Trait implementations
+    # ===-------------------------------------------------------------------===#
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Gets the string representation of the contiguous slice.
+
+        Returns:
+            The string representation of the contiguous slice.
+        """
+        return String.write(self)
+
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Write ContiguousSlice string representation to a `Writer`.
+
+        Args:
+            writer: The object to write to.
+        """
+
+        @parameter
+        fn write_optional(opt: Optional[Int]):
+            if opt:
+                writer.write(repr(opt.value()))
+            else:
+                writer.write(repr(None))
+
+        writer.write("slice(")
+        write_optional(self.start)
+        writer.write(", ")
+        write_optional(self.end)
+        writer.write(", None)")
 
     fn indices(self, length: Int) -> Tuple[Int, Int]:
         """Returns a tuple of 2 integers representing the start, and end

--- a/mojo/stdlib/std/builtin/builtin_slice.mojo
+++ b/mojo/stdlib/std/builtin/builtin_slice.mojo
@@ -252,7 +252,9 @@ struct StridedSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
         Returns:
             The string representation of the strided slice.
         """
-        return String.write(self)
+        var output = String()
+        self.write_to(output)
+        return output
 
     @no_inline
     fn __repr__(self) -> String:
@@ -261,7 +263,9 @@ struct StridedSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
         Returns:
             The string representation of the strided slice.
         """
-        return self.__str__()
+        var output = String()
+        self.write_repr_to(output)
+        return output^
 
     @no_inline
     fn write_to(self, mut writer: Some[Writer]):
@@ -336,7 +340,9 @@ struct ContiguousSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
         Returns:
             The string representation of the contiguous slice.
         """
-        return String.write(self)
+        var output = String()
+        self.write_to(output)
+        return output
 
     @no_inline
     fn __repr__(self) -> String:
@@ -345,7 +351,9 @@ struct ContiguousSlice(ImplicitlyCopyable, Representable, Stringable, Writable):
         Returns:
             The string representation of the contiguous slice.
         """
-        return self.__str__()
+        var output = String()
+        self.write_repr_to(output)
+        return output^
 
     @no_inline
     fn write_to(self, mut writer: Some[Writer]):

--- a/mojo/stdlib/test/builtin/test_slice.mojo
+++ b/mojo/stdlib/test/builtin/test_slice.mojo
@@ -93,9 +93,16 @@ struct StridedSliceStringable:
 
 def test_strided_slice_stringable():
     var s = StridedSliceStringable()
+    # Positive stride
     assert_equal(s[1:10:2], "slice(1, 10, 2)")
-    assert_equal(s[::3], "slice(None, None, 3)")
+    assert_equal(s[0:5:1], "slice(0, 5, 1)")
+    # Negative stride
     assert_equal(s[2::-1], "slice(2, None, -1)")
+    assert_equal(s[1:-1:2], "slice(1, -1, 2)")
+    # None start or end
+    assert_equal(s[::3], "slice(None, None, 3)")
+    assert_equal(s[:5:2], "slice(None, 5, 2)")
+    assert_equal(s[1::2], "slice(1, None, 2)")
 
 
 struct ContiguousSliceStringable:
@@ -108,9 +115,15 @@ struct ContiguousSliceStringable:
 
 def test_contiguous_slice_stringable():
     var s = ContiguousSliceStringable()
+    # Both bounds present
+    assert_equal(s[1:5], "slice(1, 5, None)")
     assert_equal(s[0:10], "slice(0, 10, None)")
+    # Only end
+    assert_equal(s[:3], "slice(None, 3, None)")
     assert_equal(s[:5], "slice(None, 5, None)")
+    # Only start
     assert_equal(s[3:], "slice(3, None, None)")
+    # Neither
     assert_equal(s[:], "slice(None, None, None)")
 
 
@@ -124,10 +137,16 @@ struct StridedSliceRepresentable:
 
 def test_strided_slice_representable():
     var s = StridedSliceRepresentable()
+    # Verify exact repr output
     assert_equal(s[1:10:2], "slice(1, 10, 2)")
+    assert_equal(s[2::-1], "slice(2, None, -1)")
+    assert_equal(s[1:-1:2], "slice(1, -1, 2)")
     assert_equal(s[::3], "slice(None, None, 3)")
     # repr == str for StridedSlice
-    assert_equal(s[2::-1], String(StridedSlice(2, None, -1)))
+    assert_equal(repr(StridedSlice(1, 10, 2)), String(StridedSlice(1, 10, 2)))
+    assert_equal(
+        repr(StridedSlice(None, None, 3)), String(StridedSlice(None, None, 3))
+    )
 
 
 struct ContiguousSliceRepresentable:
@@ -140,10 +159,20 @@ struct ContiguousSliceRepresentable:
 
 def test_contiguous_slice_representable():
     var s = ContiguousSliceRepresentable()
+    # Verify exact repr output
+    assert_equal(s[1:5], "slice(1, 5, None)")
     assert_equal(s[0:10], "slice(0, 10, None)")
-    assert_equal(s[:5], "slice(None, 5, None)")
+    assert_equal(s[:3], "slice(None, 3, None)")
+    assert_equal(s[3:], "slice(3, None, None)")
+    assert_equal(s[:], "slice(None, None, None)")
     # repr == str for ContiguousSlice
-    assert_equal(s[3:], String(ContiguousSlice(3, None, None)))
+    assert_equal(
+        repr(ContiguousSlice(1, 5, None)), String(ContiguousSlice(1, 5, None))
+    )
+    assert_equal(
+        repr(ContiguousSlice(None, 3, None)),
+        String(ContiguousSlice(None, 3, None)),
+    )
 
 
 def test_slice_eq():

--- a/mojo/stdlib/test/builtin/test_slice.mojo
+++ b/mojo/stdlib/test/builtin/test_slice.mojo
@@ -11,6 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+from builtin.builtin_slice import ContiguousSlice, StridedSlice
 from testing import assert_equal, assert_true, TestSuite
 
 
@@ -80,6 +81,37 @@ def test_slice_stringable():
     assert_equal(s[::4], "slice(None, None, 4)")
     assert_equal(repr(slice(None, 2, 3)), "slice(None, 2, 3)")
     assert_equal(repr(slice(10)), "slice(None, 10, None)")
+
+
+struct StridedSliceStringable:
+    fn __init__(out self):
+        pass
+
+    fn __getitem__(self, a: StridedSlice) -> String:
+        return String(a)
+
+
+def test_strided_slice_stringable():
+    var s = StridedSliceStringable()
+    assert_equal(s[1:10:2], "slice(1, 10, 2)")
+    assert_equal(s[::3], "slice(None, None, 3)")
+    assert_equal(s[2::-1], "slice(2, None, -1)")
+
+
+struct ContiguousSliceStringable:
+    fn __init__(out self):
+        pass
+
+    fn __getitem__(self, a: ContiguousSlice) -> String:
+        return String(a)
+
+
+def test_contiguous_slice_stringable():
+    var s = ContiguousSliceStringable()
+    assert_equal(s[0:10], "slice(0, 10, None)")
+    assert_equal(s[:5], "slice(None, 5, None)")
+    assert_equal(s[3:], "slice(3, None, None)")
+    assert_equal(s[:], "slice(None, None, None)")
 
 
 def test_slice_eq():

--- a/mojo/stdlib/test/builtin/test_slice.mojo
+++ b/mojo/stdlib/test/builtin/test_slice.mojo
@@ -114,6 +114,38 @@ def test_contiguous_slice_stringable():
     assert_equal(s[:], "slice(None, None, None)")
 
 
+struct StridedSliceRepresentable:
+    fn __init__(out self):
+        pass
+
+    fn __getitem__(self, a: StridedSlice) -> String:
+        return repr(a)
+
+
+def test_strided_slice_representable():
+    var s = StridedSliceRepresentable()
+    assert_equal(s[1:10:2], "slice(1, 10, 2)")
+    assert_equal(s[::3], "slice(None, None, 3)")
+    # repr == str for StridedSlice
+    assert_equal(s[2::-1], String(StridedSlice(2, None, -1)))
+
+
+struct ContiguousSliceRepresentable:
+    fn __init__(out self):
+        pass
+
+    fn __getitem__(self, a: ContiguousSlice) -> String:
+        return repr(a)
+
+
+def test_contiguous_slice_representable():
+    var s = ContiguousSliceRepresentable()
+    assert_equal(s[0:10], "slice(0, 10, None)")
+    assert_equal(s[:5], "slice(None, 5, None)")
+    # repr == str for ContiguousSlice
+    assert_equal(s[3:], String(ContiguousSlice(3, None, None)))
+
+
 def test_slice_eq():
     assert_equal(slice(1, 2, 3), slice(1, 2, 3))
     assert_equal(slice(None, 1, None), slice(1))


### PR DESCRIPTION
Add `Writable` trait to `StridedSlice` and `ContiguousSlice`, consistent with `Slice` which already implements it.

- `StridedSlice.write_to` delegates to the inner `Slice`
- `ContiguousSlice.write_to` formats as `slice(start, end, None)` (no step)
- `write_repr_to` delegates to `write_to` for both (repr == str, matching Python)

Tests use `check_write_to`.