### PR TITLE
[Stdlib] Add format spec support to String.format()

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -357,6 +357,18 @@ what we publish.
 
 ### Library changes
 
+- `String.format()`, `StringSlice.format()`, and format string literals now
+  support format specifiers with the `[[fill]align][width]` mini-language,
+  matching Python's format spec syntax:
+
+  ```mojo
+  "{:>10}".format(42)     # "        42"  (right-align)
+  "{:<10}".format("hi")   # "hi        "  (left-align)
+  "{:^10}".format("hi")   # "    hi    "  (center)
+  "{:*^10}".format("hi")  # "****hi****"  (custom fill char)
+  "{!r:>10}".format(42)   # "   Int(42)"  (conversion + spec)
+  ```
+
 - `Set.pop()` now uses `Dict.popitem()` directly, avoiding a redundant rehash.
   Order changes from FIFO to LIFO, matching Python's unordered `set.pop()`.
 

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -1413,8 +1413,8 @@ def test_format_conversion_flags():
     with assert_raises(contains='Conversion flag "x" not recognized.'):
         _ = String("{0!x}").format(1)
 
-    with assert_raises(contains='Conversion flag "r:d" not recognized.'):
-        _ = String("{!r:d}").format(1)
+    # "{!r:d}" is now valid: "!r" = repr conversion, ":d" = format spec with no width
+    assert_equal(String("{!r:d}").format(1), "Int(1)")
 
 
 def test_float_conversion():

--- a/mojo/stdlib/test/format/test_format.mojo
+++ b/mojo/stdlib/test/format/test_format.mojo
@@ -164,6 +164,48 @@ struct NullWriter(Writer):
 comptime ALLOC_FUNC = "KGEN_CompilerRT_AlignedAlloc"
 
 
+def test_format_spec_alignment():
+    # Right-align (default when align char given without fill)
+    assert_equal("{:>10}".format(42), "        42")
+    assert_equal("{:>10}".format("hi"), "        hi")
+
+    # Left-align
+    assert_equal("{:<10}".format(42), "42        ")
+    assert_equal("{:<10}".format("hi"), "hi        ")
+
+    # Center
+    assert_equal("{:^10}".format("hi"), "    hi    ")
+    assert_equal("{:^11}".format("hi"), "    hi     ")  # extra padding on right
+
+    # Custom fill character
+    assert_equal("{:*>10}".format(42), "********42")
+    assert_equal("{:*<10}".format("hi"), "hi********")
+    assert_equal("{:*^10}".format("hi"), "****hi****")
+
+    # Value longer than width: no truncation
+    assert_equal("{:>3}".format("hello"), "hello")
+
+    # Exact width: no padding
+    assert_equal("{:>5}".format("hello"), "hello")
+
+
+def test_format_spec_with_conversion():
+    # Conversion flag combined with format spec
+    assert_equal("{!r:>10}".format(42), "   Int(42)")
+    assert_equal("{0!r:<10}".format(42), "Int(42)   ")
+
+
+def test_format_spec_with_manual_index():
+    assert_equal("{0:>8}".format(42), "      42")
+    assert_equal("{1:<8}".format("x", "hi"), "hi      ")
+    assert_equal("{0:^9}".format("abc"), "   abc   ")
+
+
+def test_format_spec_auto_and_manual_mix():
+    # Auto-index with spec
+    assert_equal("{:>5} {:>5}".format(1, 2), "    1     2")
+
+
 def test_format_runtime_does_allocate():
     def runtime_format[
         *Ts: Writable,


### PR DESCRIPTION
Add `[[fill]align][width]` format specifier support to `String.format()`, matching Python's format mini-language.

Supported syntax: `{:[fill]align[width]}` where fill is any char, align is `<`/`>`/`^`, and width is an integer.

```mojo
"{:>10}".format(42)      # "        42"
"{:<10}".format("hi")   # "hi        "
"{:*^10}".format("hi")  # "****hi****"
"{!r:>10}".format(42)   # "   Int(42)"
```

The implementation uses a two-pass allocation-free approach (`_CountingWriter`) to avoid heap allocation.