### PR TITLE
[Stdlib] Vectorize Span.fill with SIMD stores for Scalar types

### DIFF
--- a/mojo/stdlib/std/builtin/builtin_slice.mojo
+++ b/mojo/stdlib/std/builtin/builtin_slice.mojo
@@ -205,7 +205,7 @@ struct Slice(
         return (start.value(), end.value(), step)
 
 
-struct StridedSlice(ImplicitlyCopyable):
+struct StridedSlice(ImplicitlyCopyable, Stringable, Writable):
     """Represents a slice expression that has a stride.
 
     This type is used to support different behavior for strided vs unstrided
@@ -241,6 +241,28 @@ struct StridedSlice(ImplicitlyCopyable):
 
         self._inner = Slice(start, end, stride)
 
+    # ===-------------------------------------------------------------------===#
+    # Trait implementations
+    # ===-------------------------------------------------------------------===#
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Gets the string representation of the strided slice.
+
+        Returns:
+            The string representation of the strided slice.
+        """
+        return String.write(self)
+
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Write StridedSlice string representation to a `Writer`.
+
+        Args:
+            writer: The object to write to.
+        """
+        writer.write(self._inner)
+
     fn indices(self, length: Int) -> Tuple[Int, Int, Int]:
         """Returns a tuple of 3 integers representing start, end, and step
         of the slice if applied to a container of given length.
@@ -254,7 +276,7 @@ struct StridedSlice(ImplicitlyCopyable):
         return self._inner.indices(length)
 
 
-struct ContiguousSlice(ImplicitlyCopyable):
+struct ContiguousSlice(ImplicitlyCopyable, Stringable, Writable):
     """Represents a slice expression without a stride.
 
     This type is used to support different behavior for strided vs unstrided
@@ -284,6 +306,40 @@ struct ContiguousSlice(ImplicitlyCopyable):
         """
         self.start = start
         self.end = end
+
+    # ===-------------------------------------------------------------------===#
+    # Trait implementations
+    # ===-------------------------------------------------------------------===#
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Gets the string representation of the contiguous slice.
+
+        Returns:
+            The string representation of the contiguous slice.
+        """
+        return String.write(self)
+
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Write ContiguousSlice string representation to a `Writer`.
+
+        Args:
+            writer: The object to write to.
+        """
+
+        @parameter
+        fn write_optional(opt: Optional[Int]):
+            if opt:
+                writer.write(repr(opt.value()))
+            else:
+                writer.write(repr(None))
+
+        writer.write("slice(")
+        write_optional(self.start)
+        writer.write(", ")
+        write_optional(self.end)
+        writer.write(", None)")
 
     fn indices(self, length: Int) -> Tuple[Int, Int]:
         """Returns a tuple of 2 integers representing the start, and end

--- a/mojo/stdlib/std/gpu/host/info.mojo
+++ b/mojo/stdlib/std/gpu/host/info.mojo
@@ -732,7 +732,7 @@ struct AcceleratorArchitectureFamily(TrivialRegisterPassable):
 
 
 @fieldwise_init
-struct Vendor(Equatable, TrivialRegisterPassable, Writable):
+struct Vendor(Equatable, Stringable, TrivialRegisterPassable, Writable):
     """Represents GPU vendors.
 
     This struct provides identifiers for different GPU vendors and utility

--- a/mojo/stdlib/std/gpu/host/launch_attribute.mojo
+++ b/mojo/stdlib/std/gpu/host/launch_attribute.mojo
@@ -35,7 +35,7 @@ from utils import StaticTuple
 
 
 @fieldwise_init
-struct LaunchAttributeID(Equatable, TrivialRegisterPassable, Writable):
+struct LaunchAttributeID(Equatable, Stringable, TrivialRegisterPassable, Writable):
     """Identifies the type of launch attribute for GPU kernel execution.
 
     This struct represents the various types of launch attributes that can be specified
@@ -257,7 +257,7 @@ struct LaunchAttributeValue(Defaultable, TrivialRegisterPassable):
 
 
 @fieldwise_init
-struct AccessProperty(Equatable, TrivialRegisterPassable, Writable):
+struct AccessProperty(Equatable, Stringable, TrivialRegisterPassable, Writable):
     """Specifies performance hint with AccessPolicyWindow for hit_prop and
     miss_prop fields.
 
@@ -391,7 +391,7 @@ struct LaunchAttribute(Defaultable, TrivialRegisterPassable):
         return res
 
 
-struct AccessPolicyWindow(Defaultable, TrivialRegisterPassable, Writable):
+struct AccessPolicyWindow(Defaultable, Stringable, TrivialRegisterPassable, Writable):
     """Specifies an access policy for a window of memory.
 
     This struct defines a contiguous extent of memory beginning at base_ptr and

--- a/mojo/stdlib/std/gpu/memory/memory.mojo
+++ b/mojo/stdlib/std/gpu/memory/memory.mojo
@@ -70,7 +70,7 @@ from ..intrinsics import Scope
 
 
 @fieldwise_init
-struct CacheOperation(Equatable, TrivialRegisterPassable):
+struct CacheOperation(Equatable, Stringable, TrivialRegisterPassable, Writable):
     """Represents different GPU cache operation policies.
 
     This struct defines various caching behaviors for GPU memory operations,
@@ -186,6 +186,24 @@ struct CacheOperation(Equatable, TrivialRegisterPassable):
 
         return "unknown cache operation"
 
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns a string representation of the cache operation.
+
+        Returns:
+            A string describing the cache operation.
+        """
+        return String.write(self)
+
+    @always_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes a string representation of the cache operation to a writer.
+
+        Args:
+            writer: The writer to output the cache operation to.
+        """
+        writer.write(self.mnemonic())
+
 
 # ===-----------------------------------------------------------------------===#
 # CacheEviction
@@ -193,7 +211,7 @@ struct CacheOperation(Equatable, TrivialRegisterPassable):
 
 
 @fieldwise_init
-struct CacheEviction(Equatable, TrivialRegisterPassable):
+struct CacheEviction(Equatable, Stringable, TrivialRegisterPassable, Writable):
     """Represents cache eviction policies for GPU memory operations.
 
     This struct defines different cache eviction priorities that control how data is
@@ -283,6 +301,24 @@ struct CacheEviction(Equatable, TrivialRegisterPassable):
             return "no_allocate"
         return "unknown cache eviction"
 
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns a string representation of the cache eviction policy.
+
+        Returns:
+            A string describing the cache eviction policy.
+        """
+        return String.write(self)
+
+    @always_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes a string representation of the cache eviction policy to a writer.
+
+        Args:
+            writer: The writer to output the cache eviction policy to.
+        """
+        writer.write(self.mnemonic())
+
 
 # ===-----------------------------------------------------------------------===#
 # Fill
@@ -290,7 +326,7 @@ struct CacheEviction(Equatable, TrivialRegisterPassable):
 
 
 @fieldwise_init
-struct Fill(Equatable, TrivialRegisterPassable):
+struct Fill(Equatable, Stringable, TrivialRegisterPassable, Writable):
     """Represents memory fill patterns for GPU memory operations.
 
     This struct defines different fill patterns that can be used when allocating or
@@ -330,13 +366,23 @@ struct Fill(Equatable, TrivialRegisterPassable):
         Returns:
             A string describing the fill pattern.
         """
+        return String.write(self)
+
+    @always_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes a string representation of the fill pattern to a writer.
+
+        Args:
+            writer: The writer to output the fill pattern to.
+        """
         if self == Self.NONE:
-            return "none"
-        if self == Self.ZERO:
-            return "zero"
-        if self == Self.NAN:
-            return "nan"
-        return "unknown fill"
+            writer.write("none")
+        elif self == Self.ZERO:
+            writer.write("zero")
+        elif self == Self.NAN:
+            writer.write("nan")
+        else:
+            writer.write("unknown fill")
 
 
 # ===-----------------------------------------------------------------------===#
@@ -345,7 +391,7 @@ struct Fill(Equatable, TrivialRegisterPassable):
 
 
 @fieldwise_init
-struct Consistency(Equatable, TrivialRegisterPassable):
+struct Consistency(Equatable, Stringable, TrivialRegisterPassable, Writable):
     """Represents memory consistency models for GPU memory operations.
 
     This struct defines different memory consistency levels that control how memory
@@ -396,7 +442,16 @@ struct Consistency(Equatable, TrivialRegisterPassable):
         Returns:
             A string describing the consistency level.
         """
-        return String(self.mnemonic())
+        return String.write(self)
+
+    @always_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes a string representation of the consistency level to a writer.
+
+        Args:
+            writer: The writer to output the consistency level to.
+        """
+        writer.write(self.mnemonic())
 
     @always_inline
     fn mnemonic(self) -> StaticString:
@@ -423,7 +478,7 @@ struct Consistency(Equatable, TrivialRegisterPassable):
 
 
 @fieldwise_init
-struct ReduceOp(Equatable, TrivialRegisterPassable):
+struct ReduceOp(Equatable, Stringable, TrivialRegisterPassable, Writable):
     """Represents reduction operations for parallel reduction algorithms.
 
     This struct defines different reduction operations that can be performed
@@ -492,7 +547,16 @@ struct ReduceOp(Equatable, TrivialRegisterPassable):
         Returns:
             A string describing the reduction operation.
         """
-        return String(self.mnemonic())
+        return String.write(self)
+
+    @always_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes a string representation of the reduction operation to a writer.
+
+        Args:
+            writer: The writer to output the reduction operation to.
+        """
+        writer.write(self.mnemonic())
 
     @always_inline
     fn mnemonic(self) -> StaticString:

--- a/mojo/stdlib/std/gpu/sync/sync.mojo
+++ b/mojo/stdlib/std/gpu/sync/sync.mojo
@@ -142,7 +142,7 @@ fn barrier():
 
 
 @fieldwise_init
-struct AMDScheduleBarrierMask(Equatable, Intable, TrivialRegisterPassable):
+struct AMDScheduleBarrierMask(Equatable, Intable, Stringable, TrivialRegisterPassable, Writable):
     """Represents different instruction scheduling masks for AMDGPU scheduling instructions.
 
     These masks control which types of instructions can be reordered across a barrier for
@@ -219,30 +219,38 @@ struct AMDScheduleBarrierMask(Equatable, Intable, TrivialRegisterPassable):
         Returns:
             A string representation of the mask, or aborts if the value is invalid.
         """
+        return String.write(self)
+
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes a string representation of the `AMDScheduleBarrierMask` to a writer.
+
+        Args:
+            writer: The writer to output the mask to.
+        """
         if self == Self.NONE:
-            return "NONE"
+            writer.write("NONE")
         elif self == Self.ALL_ALU:
-            return "ALL_ALU"
+            writer.write("ALL_ALU")
         elif self == Self.VALU:
-            return "VALU"
+            writer.write("VALU")
         elif self == Self.SALU:
-            return "SALU"
+            writer.write("SALU")
         elif self == Self.MFMA:
-            return "MFMA"
+            writer.write("MFMA")
         elif self == Self.ALL_VMEM:
-            return "ALL_VMEM"
+            writer.write("ALL_VMEM")
         elif self == Self.VMEM_READ:
-            return "VMEM_READ"
+            writer.write("VMEM_READ")
         elif self == Self.VMEM_WRITE:
-            return "VMEM_WRITE"
+            writer.write("VMEM_WRITE")
         elif self == Self.ALL_DS:
-            return "ALL_DS"
+            writer.write("ALL_DS")
         elif self == Self.DS_READ:
-            return "DS_READ"
+            writer.write("DS_READ")
         elif self == Self.DS_WRITE:
-            return "DS_WRITE"
+            writer.write("DS_WRITE")
         elif self == Self.TRANS:
-            return "TRANS"
+            writer.write("TRANS")
         else:
             abort("invalid AMDScheduleBarrierMask value")
 

--- a/mojo/stdlib/std/memory/span.mojo
+++ b/mojo/stdlib/std/memory/span.mojo
@@ -594,6 +594,33 @@ struct Span[
         for ref element in self:
             element = value.copy()
 
+    fn fill[
+        dtype: DType, _origin: MutOrigin, //
+    ](self: Span[Scalar[dtype], _origin], value: Scalar[dtype]):
+        """Fill the span with `value` using vectorized SIMD stores.
+
+        Parameters:
+            dtype: The DType of the scalar elements.
+            _origin: The inferred mutable origin of the data within the Span.
+
+        Args:
+            value: The scalar value to broadcast and store across the span.
+        """
+        comptime widths = (256, 128, 64, 32, 16, 8, 4)
+        var ptr = self.unsafe_ptr()
+        var length = len(self)
+        var processed = 0
+
+        comptime for i in range(len(widths)):
+            comptime w = widths[i]
+            comptime if simd_width_of[dtype]() >= w:
+                for _ in range((length - processed) // w):
+                    (ptr + processed).store(SIMD[dtype, w](value))
+                    processed += w
+
+        for i in range(length - processed):
+            ptr[processed + i] = value
+
     @always_inline
     fn unsafe_swap_elements(self: Span[mut=True, Self.T], a: Int, b: Int):
         """Swap the values at indices `a` and `b` without performing bounds checking.

--- a/mojo/stdlib/std/os/process.mojo
+++ b/mojo/stdlib/std/os/process.mojo
@@ -117,7 +117,14 @@ struct ProcessStatus(Copyable, ImplicitlyCopyable, Movable, Representable, Strin
         Args:
             writer: The object to write to.
         """
-        self.write_to(writer)
+        writer.write("ProcessStatus(")
+        if self.exit_code:
+            writer.write("exit_code=", self.exit_code.value())
+        elif self.term_signal:
+            writer.write("term_signal=", self.term_signal.value())
+        else:
+            writer.write("running=True")
+        writer.write(")")
 
     @no_inline
     fn __repr__(self) -> String:
@@ -126,7 +133,9 @@ struct ProcessStatus(Copyable, ImplicitlyCopyable, Movable, Representable, Strin
         Returns:
             A string representation of `ProcessStatus`.
         """
-        return String(self)
+        var string = String()
+        self.write_repr_to(string)
+        return string^
 
 
 struct Pipe:

--- a/mojo/stdlib/std/os/process.mojo
+++ b/mojo/stdlib/std/os/process.mojo
@@ -44,7 +44,7 @@ from sys.os import abort, sep
 # ===----------------------------------------------------------------------=== #
 
 
-struct ProcessStatus(Copyable, ImplicitlyCopyable, Movable):
+struct ProcessStatus(Copyable, ImplicitlyCopyable, Movable, Stringable, Writable):
     """Represents the termination status of a process.
 
     This struct is returned by `poll()` and `wait()`.
@@ -86,6 +86,29 @@ struct ProcessStatus(Copyable, ImplicitlyCopyable, Movable):
             True if the process has terminated, either normally or by a signal.
         """
         return Bool(self.exit_code) or Bool(self.term_signal)
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Constructs a string representation of `ProcessStatus`.
+
+        Returns:
+            A string representation of `ProcessStatus`.
+        """
+        return String.write(self)
+
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Formats this `ProcessStatus` to the provided Writer.
+
+        Args:
+            writer: The object to write to.
+        """
+        if self.exit_code:
+            writer.write("ProcessStatus(exit_code: ", self.exit_code.value(), ")")
+        elif self.term_signal:
+            writer.write("ProcessStatus(term_signal: ", self.term_signal.value(), ")")
+        else:
+            writer.write("ProcessStatus(running)")
 
 
 struct Pipe:

--- a/mojo/stdlib/std/os/process.mojo
+++ b/mojo/stdlib/std/os/process.mojo
@@ -44,7 +44,7 @@ from sys.os import abort, sep
 # ===----------------------------------------------------------------------=== #
 
 
-struct ProcessStatus(Copyable, ImplicitlyCopyable, Movable, Stringable, Writable):
+struct ProcessStatus(Copyable, ImplicitlyCopyable, Movable, Representable, Stringable, Writable):
     """Represents the termination status of a process.
 
     This struct is returned by `poll()` and `wait()`.
@@ -109,6 +109,24 @@ struct ProcessStatus(Copyable, ImplicitlyCopyable, Movable, Stringable, Writable
             writer.write("ProcessStatus(term_signal: ", self.term_signal.value(), ")")
         else:
             writer.write("ProcessStatus(running)")
+
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Formats the repr of this `ProcessStatus` to the provided Writer.
+
+        Args:
+            writer: The object to write to.
+        """
+        self.write_to(writer)
+
+    @no_inline
+    fn __repr__(self) -> String:
+        """Constructs a repr of `ProcessStatus`.
+
+        Returns:
+            A string representation of `ProcessStatus`.
+        """
+        return String(self)
 
 
 struct Pipe:

--- a/mojo/stdlib/std/os/process.mojo
+++ b/mojo/stdlib/std/os/process.mojo
@@ -114,12 +114,12 @@ struct ProcessStatus(Copyable, ImplicitlyCopyable, Movable, Writable):
 
         @parameter
         fn fields(mut w: Some[Writer]):
-            if exit_code := self.exit_code:
+            if self.exit_code:
                 w.write_string("exit_code=")
-                w.write(exit_code[])
-            elif term_signal := self.term_signal:
+                w.write(self.exit_code.unsafe_value())
+            elif self.term_signal:
                 w.write_string("term_signal=")
-                w.write(term_signal[])
+                w.write(self.term_signal.unsafe_value())
             else:
                 w.write_string("running=True")
 

--- a/mojo/stdlib/std/sys/intrinsics.mojo
+++ b/mojo/stdlib/std/sys/intrinsics.mojo
@@ -252,7 +252,7 @@ fn scatter[
 # ===-----------------------------------------------------------------------===#
 
 
-struct PrefetchLocality(TrivialRegisterPassable):
+struct PrefetchLocality(Stringable, TrivialRegisterPassable, Writable):
     """The prefetch locality.
 
     The locality, rw, and cache type correspond to LLVM prefetch intrinsic's
@@ -281,8 +281,33 @@ struct PrefetchLocality(TrivialRegisterPassable):
         """
         self.value = Int32(value)
 
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the prefetch locality to a writer.
 
-struct PrefetchRW(TrivialRegisterPassable):
+        Args:
+            writer: The writer to write to.
+        """
+        if self.value == 0:
+            writer.write("NONE")
+        elif self.value == 1:
+            writer.write("LOW")
+        elif self.value == 2:
+            writer.write("MEDIUM")
+        else:
+            writer.write("HIGH")
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns the string representation of the prefetch locality.
+
+        Returns:
+            A string representation of the locality value.
+        """
+        return String.write(self)
+
+
+struct PrefetchRW(Stringable, TrivialRegisterPassable, Writable):
     """Prefetch read or write."""
 
     var value: Int32
@@ -314,9 +339,30 @@ struct PrefetchRW(TrivialRegisterPassable):
         """
         return self.value == other.value
 
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the prefetch read-write option to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        if self.value == 0:
+            writer.write("READ")
+        else:
+            writer.write("WRITE")
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns the string representation of the prefetch read-write option.
+
+        Returns:
+            A string representation of the read-write value.
+        """
+        return String.write(self)
+
 
 # LLVM prefetch cache type
-struct PrefetchCache(TrivialRegisterPassable):
+struct PrefetchCache(Stringable, TrivialRegisterPassable, Writable):
     """Prefetch cache type."""
 
     var value: Int32
@@ -336,8 +382,29 @@ struct PrefetchCache(TrivialRegisterPassable):
         """
         self.value = Int32(value)
 
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the prefetch cache type to a writer.
 
-struct PrefetchOptions(Defaultable, TrivialRegisterPassable):
+        Args:
+            writer: The writer to write to.
+        """
+        if self.value == 0:
+            writer.write("INSTRUCTION")
+        else:
+            writer.write("DATA")
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns the string representation of the prefetch cache type.
+
+        Returns:
+            A string representation of the cache type.
+        """
+        return String.write(self)
+
+
+struct PrefetchOptions(Defaultable, Stringable, TrivialRegisterPassable, Writable):
     """Collection of configuration parameters for a prefetch intrinsic call.
 
     The op configuration follows similar interface as LLVM intrinsic prefetch
@@ -462,6 +529,32 @@ struct PrefetchOptions(Defaultable, TrivialRegisterPassable):
         var updated = self
         updated.cache = PrefetchCache.INSTRUCTION
         return updated
+
+    @no_inline
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the prefetch options to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        writer.write(
+            "PrefetchOptions(rw=",
+            self.rw,
+            ", locality=",
+            self.locality,
+            ", cache=",
+            self.cache,
+            ")",
+        )
+
+    @no_inline
+    fn __str__(self) -> String:
+        """Returns the string representation of the prefetch options.
+
+        Returns:
+            A string representation of the prefetch options.
+        """
+        return String.write(self)
 
 
 @always_inline("nodebug")

--- a/mojo/stdlib/std/sys/intrinsics.mojo
+++ b/mojo/stdlib/std/sys/intrinsics.mojo
@@ -252,7 +252,7 @@ fn scatter[
 # ===-----------------------------------------------------------------------===#
 
 
-struct PrefetchLocality(Stringable, TrivialRegisterPassable, Writable):
+struct PrefetchLocality(Representable, Stringable, TrivialRegisterPassable, Writable):
     """The prefetch locality.
 
     The locality, rw, and cache type correspond to LLVM prefetch intrinsic's
@@ -298,6 +298,24 @@ struct PrefetchLocality(Stringable, TrivialRegisterPassable, Writable):
             writer.write("HIGH")
 
     @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the representation of the prefetch locality to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        self.write_to(writer)
+
+    @no_inline
+    fn __repr__(self) -> String:
+        """Returns the representation of the prefetch locality.
+
+        Returns:
+            A string representation of the locality value.
+        """
+        return String(self)
+
+    @no_inline
     fn __str__(self) -> String:
         """Returns the string representation of the prefetch locality.
 
@@ -307,7 +325,7 @@ struct PrefetchLocality(Stringable, TrivialRegisterPassable, Writable):
         return String.write(self)
 
 
-struct PrefetchRW(Stringable, TrivialRegisterPassable, Writable):
+struct PrefetchRW(Representable, Stringable, TrivialRegisterPassable, Writable):
     """Prefetch read or write."""
 
     var value: Int32
@@ -352,6 +370,24 @@ struct PrefetchRW(Stringable, TrivialRegisterPassable, Writable):
             writer.write("WRITE")
 
     @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the representation of the prefetch read-write option to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        self.write_to(writer)
+
+    @no_inline
+    fn __repr__(self) -> String:
+        """Returns the representation of the prefetch read-write option.
+
+        Returns:
+            A string representation of the read-write value.
+        """
+        return String(self)
+
+    @no_inline
     fn __str__(self) -> String:
         """Returns the string representation of the prefetch read-write option.
 
@@ -362,7 +398,7 @@ struct PrefetchRW(Stringable, TrivialRegisterPassable, Writable):
 
 
 # LLVM prefetch cache type
-struct PrefetchCache(Stringable, TrivialRegisterPassable, Writable):
+struct PrefetchCache(Representable, Stringable, TrivialRegisterPassable, Writable):
     """Prefetch cache type."""
 
     var value: Int32
@@ -395,6 +431,24 @@ struct PrefetchCache(Stringable, TrivialRegisterPassable, Writable):
             writer.write("DATA")
 
     @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the representation of the prefetch cache type to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        self.write_to(writer)
+
+    @no_inline
+    fn __repr__(self) -> String:
+        """Returns the representation of the prefetch cache type.
+
+        Returns:
+            A string representation of the cache type.
+        """
+        return String(self)
+
+    @no_inline
     fn __str__(self) -> String:
         """Returns the string representation of the prefetch cache type.
 
@@ -404,7 +458,7 @@ struct PrefetchCache(Stringable, TrivialRegisterPassable, Writable):
         return String.write(self)
 
 
-struct PrefetchOptions(Defaultable, Stringable, TrivialRegisterPassable, Writable):
+struct PrefetchOptions(Defaultable, Representable, Stringable, TrivialRegisterPassable, Writable):
     """Collection of configuration parameters for a prefetch intrinsic call.
 
     The op configuration follows similar interface as LLVM intrinsic prefetch
@@ -546,6 +600,24 @@ struct PrefetchOptions(Defaultable, Stringable, TrivialRegisterPassable, Writabl
             self.cache,
             ")",
         )
+
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the representation of the prefetch options to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        self.write_to(writer)
+
+    @no_inline
+    fn __repr__(self) -> String:
+        """Returns the representation of the prefetch options.
+
+        Returns:
+            A string representation of the prefetch options.
+        """
+        return String(self)
 
     @no_inline
     fn __str__(self) -> String:

--- a/mojo/stdlib/test/builtin/test_slice.mojo
+++ b/mojo/stdlib/test/builtin/test_slice.mojo
@@ -11,6 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+from builtin.builtin_slice import ContiguousSlice, StridedSlice
 from testing import assert_equal, assert_true, TestSuite
 
 
@@ -80,6 +81,37 @@ def test_slice_stringable():
     assert_equal(s[::4], "slice(None, None, 4)")
     assert_equal(repr(slice(None, 2, 3)), "slice(None, 2, 3)")
     assert_equal(repr(slice(10)), "slice(None, 10, None)")
+
+
+struct StridedSliceStringable:
+    fn __init__(out self):
+        pass
+
+    fn __getitem__(self, a: StridedSlice) -> String:
+        return String(a)
+
+
+def test_strided_slice_stringable():
+    var s = StridedSliceStringable()
+    assert_equal(s[1:10:2], "slice(1, 10, 2)")
+    assert_equal(s[::3], "slice(None, None, 3)")
+    assert_equal(s[2::-1], "slice(2, None, -1)")
+
+
+struct ContiguousSliceStringable:
+    fn __init__(out self):
+        pass
+
+    fn __getitem__(self, a: ContiguousSlice) -> String:
+        return String(a)
+
+
+def test_contiguous_slice_stringable():
+    var s = ContiguousSliceStringable()
+    assert_equal(s[0:10], "slice(0, 10, None)")
+    assert_equal(s[:5], "slice(None, 5, None)")
+    assert_equal(s[3:], "slice(3, None, None)")
+    assert_equal(s[:], "slice(None, None, None)")
 
 
 def test_slice_eq():

--- a/mojo/stdlib/test/memory/test_span.mojo
+++ b/mojo/stdlib/test/memory/test_span.mojo
@@ -191,6 +191,36 @@ def test_fill():
         assert_equal(s[i], 2)
 
 
+def test_fill_simd():
+    # Test SIMD fill overload for various DTypes and lengths
+    # UInt8 (1 byte) — exercises the Byte-width path
+    var bytes: List[UInt8] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    Span(bytes).fill(UInt8(7))
+    for i in range(len(bytes)):
+        assert_equal(bytes[i], UInt8(7))
+
+    # UInt32 — exercises wider SIMD paths
+    var words: List[UInt32] = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+    Span(words).fill(UInt32(42))
+    for i in range(len(words)):
+        assert_equal(words[i], UInt32(42))
+
+    # Non-multiple-of-SIMD-width length (tail handling)
+    var odd: List[Float32] = [0, 0, 0, 0, 0]
+    Span(odd).fill(Float32(1.5))
+    for i in range(len(odd)):
+        assert_equal(odd[i], Float32(1.5))
+
+    # Single element
+    var one: List[Int32] = [0]
+    Span(one).fill(Int32(99))
+    assert_equal(one[0], Int32(99))
+
+    # Empty span — no crash
+    var empty: List[UInt8] = []
+    Span(empty).fill(UInt8(1))
+
+
 def test_ref():
     var l: InlineArray[Int, 3] = [1, 2, 3]
     var s = Span[Int](array=l)

--- a/mojo/stdlib/test/os/test_process.mojo
+++ b/mojo/stdlib/test/os/test_process.mojo
@@ -16,6 +16,7 @@ from os.path import exists
 from os import Process
 from os.process import Pipe, ProcessStatus
 
+from test_utils import check_write_to
 from testing import (
     assert_false,
     assert_raises,
@@ -83,45 +84,75 @@ def test_process_run_missing():
 
 def test_processstatus_str():
     # Common exit codes.
-    assert_equal(
-        String(ProcessStatus(exit_code=0)), "ProcessStatus(exit_code: 0)"
+    check_write_to(
+        ProcessStatus(exit_code=0),
+        expected="ProcessStatus(exit_code: 0)",
+        is_repr=False,
     )
-    assert_equal(
-        String(ProcessStatus(exit_code=1)), "ProcessStatus(exit_code: 1)"
+    check_write_to(
+        ProcessStatus(exit_code=1),
+        expected="ProcessStatus(exit_code: 1)",
+        is_repr=False,
     )
-    assert_equal(
-        String(ProcessStatus(exit_code=127)), "ProcessStatus(exit_code: 127)"
+    check_write_to(
+        ProcessStatus(exit_code=127),
+        expected="ProcessStatus(exit_code: 127)",
+        is_repr=False,
     )
-    assert_equal(
-        String(ProcessStatus(exit_code=128)), "ProcessStatus(exit_code: 128)"
+    check_write_to(
+        ProcessStatus(exit_code=128),
+        expected="ProcessStatus(exit_code: 128)",
+        is_repr=False,
     )
-    assert_equal(
-        String(ProcessStatus(exit_code=255)), "ProcessStatus(exit_code: 255)"
+    check_write_to(
+        ProcessStatus(exit_code=255),
+        expected="ProcessStatus(exit_code: 255)",
+        is_repr=False,
     )
-    assert_equal(
-        String(ProcessStatus(term_signal=15)), "ProcessStatus(term_signal: 15)"
+    check_write_to(
+        ProcessStatus(term_signal=15),
+        expected="ProcessStatus(term_signal: 15)",
+        is_repr=False,
     )
-    assert_equal(String(ProcessStatus.running()), "ProcessStatus(running)")
+    check_write_to(
+        ProcessStatus.running(),
+        expected="ProcessStatus(running)",
+        is_repr=False,
+    )
 
 
 def test_processstatus_repr():
     # exit_code cases.
-    assert_equal(repr(ProcessStatus(exit_code=0)), "ProcessStatus(exit_code=0)")
-    assert_equal(repr(ProcessStatus(exit_code=1)), "ProcessStatus(exit_code=1)")
+    check_write_to(
+        ProcessStatus(exit_code=0),
+        expected="ProcessStatus(exit_code=0)",
+        is_repr=True,
+    )
+    check_write_to(
+        ProcessStatus(exit_code=1),
+        expected="ProcessStatus(exit_code=1)",
+        is_repr=True,
+    )
     # Common signals: SIGHUP=1, SIGKILL=9, SIGTERM=15.
-    assert_equal(
-        repr(ProcessStatus(term_signal=1)), "ProcessStatus(term_signal=1)"
+    check_write_to(
+        ProcessStatus(term_signal=1),
+        expected="ProcessStatus(term_signal=1)",
+        is_repr=True,
     )
-    assert_equal(
-        repr(ProcessStatus(term_signal=9)), "ProcessStatus(term_signal=9)"
+    check_write_to(
+        ProcessStatus(term_signal=9),
+        expected="ProcessStatus(term_signal=9)",
+        is_repr=True,
     )
-    assert_equal(
-        repr(ProcessStatus(term_signal=15)), "ProcessStatus(term_signal=15)"
+    check_write_to(
+        ProcessStatus(term_signal=15),
+        expected="ProcessStatus(term_signal=15)",
+        is_repr=True,
     )
-    assert_equal(repr(ProcessStatus.running()), "ProcessStatus(running=True)")
-    # str uses ': ' format, repr uses '=' format — they must differ.
-    assert_true(
-        String(ProcessStatus(exit_code=0)) != repr(ProcessStatus(exit_code=0))
+    check_write_to(
+        ProcessStatus.running(),
+        expected="ProcessStatus(running=True)",
+        is_repr=True,
     )
 
 

--- a/mojo/stdlib/test/os/test_process.mojo
+++ b/mojo/stdlib/test/os/test_process.mojo
@@ -14,7 +14,7 @@
 from collections import List
 from os.path import exists
 from os import Process
-from os.process import Pipe
+from os.process import Pipe, ProcessStatus
 
 from testing import (
     assert_false,
@@ -81,9 +81,23 @@ def test_process_run_missing():
         _ = Process.run(missing_executable_file, List[String]())
 
 
+def test_processstatus_str():
+    assert_equal(
+        String(ProcessStatus(exit_code=0)), "ProcessStatus(exit_code: 0)"
+    )
+    assert_equal(
+        String(ProcessStatus(exit_code=1)), "ProcessStatus(exit_code: 1)"
+    )
+    assert_equal(
+        String(ProcessStatus(term_signal=15)), "ProcessStatus(term_signal: 15)"
+    )
+    assert_equal(String(ProcessStatus.running()), "ProcessStatus(running)")
+
+
 def main():
     test_process_run()
     test_process_run_missing()
     test_process_wait()
     test_process_kill()
     test_pipe()
+    test_processstatus_str()

--- a/mojo/stdlib/test/os/test_process.mojo
+++ b/mojo/stdlib/test/os/test_process.mojo
@@ -96,12 +96,14 @@ def test_processstatus_str():
 
 def test_processstatus_repr():
     assert_equal(
-        ProcessStatus(exit_code=0).__repr__(), "ProcessStatus(exit_code: 0)"
+        ProcessStatus(exit_code=0).__repr__(), "ProcessStatus(exit_code=0)"
     )
     assert_equal(
-        ProcessStatus(term_signal=15).__repr__(), "ProcessStatus(term_signal: 15)"
+        ProcessStatus(term_signal=15).__repr__(), "ProcessStatus(term_signal=15)"
     )
-    assert_equal(ProcessStatus.running().__repr__(), "ProcessStatus(running)")
+    assert_equal(
+        ProcessStatus.running().__repr__(), "ProcessStatus(running=True)"
+    )
 
 
 def main():

--- a/mojo/stdlib/test/os/test_process.mojo
+++ b/mojo/stdlib/test/os/test_process.mojo
@@ -82,11 +82,21 @@ def test_process_run_missing():
 
 
 def test_processstatus_str():
+    # Common exit codes.
     assert_equal(
         String(ProcessStatus(exit_code=0)), "ProcessStatus(exit_code: 0)"
     )
     assert_equal(
         String(ProcessStatus(exit_code=1)), "ProcessStatus(exit_code: 1)"
+    )
+    assert_equal(
+        String(ProcessStatus(exit_code=127)), "ProcessStatus(exit_code: 127)"
+    )
+    assert_equal(
+        String(ProcessStatus(exit_code=128)), "ProcessStatus(exit_code: 128)"
+    )
+    assert_equal(
+        String(ProcessStatus(exit_code=255)), "ProcessStatus(exit_code: 255)"
     )
     assert_equal(
         String(ProcessStatus(term_signal=15)), "ProcessStatus(term_signal: 15)"
@@ -95,14 +105,23 @@ def test_processstatus_str():
 
 
 def test_processstatus_repr():
+    # exit_code cases.
+    assert_equal(repr(ProcessStatus(exit_code=0)), "ProcessStatus(exit_code=0)")
+    assert_equal(repr(ProcessStatus(exit_code=1)), "ProcessStatus(exit_code=1)")
+    # Common signals: SIGHUP=1, SIGKILL=9, SIGTERM=15.
     assert_equal(
-        ProcessStatus(exit_code=0).__repr__(), "ProcessStatus(exit_code=0)"
+        repr(ProcessStatus(term_signal=1)), "ProcessStatus(term_signal=1)"
     )
     assert_equal(
-        ProcessStatus(term_signal=15).__repr__(), "ProcessStatus(term_signal=15)"
+        repr(ProcessStatus(term_signal=9)), "ProcessStatus(term_signal=9)"
     )
     assert_equal(
-        ProcessStatus.running().__repr__(), "ProcessStatus(running=True)"
+        repr(ProcessStatus(term_signal=15)), "ProcessStatus(term_signal=15)"
+    )
+    assert_equal(repr(ProcessStatus.running()), "ProcessStatus(running=True)")
+    # str uses ': ' format, repr uses '=' format — they must differ.
+    assert_true(
+        String(ProcessStatus(exit_code=0)) != repr(ProcessStatus(exit_code=0))
     )
 
 

--- a/mojo/stdlib/test/os/test_process.mojo
+++ b/mojo/stdlib/test/os/test_process.mojo
@@ -94,6 +94,16 @@ def test_processstatus_str():
     assert_equal(String(ProcessStatus.running()), "ProcessStatus(running)")
 
 
+def test_processstatus_repr():
+    assert_equal(
+        ProcessStatus(exit_code=0).__repr__(), "ProcessStatus(exit_code: 0)"
+    )
+    assert_equal(
+        ProcessStatus(term_signal=15).__repr__(), "ProcessStatus(term_signal: 15)"
+    )
+    assert_equal(ProcessStatus.running().__repr__(), "ProcessStatus(running)")
+
+
 def main():
     test_process_run()
     test_process_run_missing()
@@ -101,3 +111,4 @@ def main():
     test_process_kill()
     test_pipe()
     test_processstatus_str()
+    test_processstatus_repr()

--- a/mojo/stdlib/test/sys/test_intrinsics.mojo
+++ b/mojo/stdlib/test/sys/test_intrinsics.mojo
@@ -19,7 +19,15 @@ from sys import (
     strided_load,
     strided_store,
 )
-from sys.intrinsics import assume, likely, unlikely
+from sys.intrinsics import (
+    PrefetchCache,
+    PrefetchLocality,
+    PrefetchOptions,
+    PrefetchRW,
+    assume,
+    likely,
+    unlikely,
+)
 
 from memory import memset_zero
 from testing import assert_equal
@@ -135,6 +143,36 @@ def test_likely_unlikely():
 
 def test_assume():
     assume(True)
+
+
+def test_prefetch_locality_str():
+    assert_equal(String(PrefetchLocality.NONE), "NONE")
+    assert_equal(String(PrefetchLocality.LOW), "LOW")
+    assert_equal(String(PrefetchLocality.MEDIUM), "MEDIUM")
+    assert_equal(String(PrefetchLocality.HIGH), "HIGH")
+
+
+def test_prefetch_rw_str():
+    assert_equal(String(PrefetchRW.READ), "READ")
+    assert_equal(String(PrefetchRW.WRITE), "WRITE")
+
+
+def test_prefetch_cache_str():
+    assert_equal(String(PrefetchCache.INSTRUCTION), "INSTRUCTION")
+    assert_equal(String(PrefetchCache.DATA), "DATA")
+
+
+def test_prefetch_options_str():
+    assert_equal(
+        String(PrefetchOptions()),
+        "PrefetchOptions(rw=READ, locality=HIGH, cache=DATA)",
+    )
+    assert_equal(
+        String(
+            PrefetchOptions().for_write().no_locality().to_instruction_cache()
+        ),
+        "PrefetchOptions(rw=WRITE, locality=NONE, cache=INSTRUCTION)",
+    )
 
 
 def main():

--- a/mojo/stdlib/test/sys/test_intrinsics.mojo
+++ b/mojo/stdlib/test/sys/test_intrinsics.mojo
@@ -175,5 +175,33 @@ def test_prefetch_options_str():
     )
 
 
+def test_prefetch_locality_repr():
+    assert_equal(repr(PrefetchLocality.NONE), "NONE")
+    assert_equal(repr(PrefetchLocality.HIGH), "HIGH")
+
+
+def test_prefetch_rw_repr():
+    assert_equal(repr(PrefetchRW.READ), "READ")
+    assert_equal(repr(PrefetchRW.WRITE), "WRITE")
+
+
+def test_prefetch_cache_repr():
+    assert_equal(repr(PrefetchCache.INSTRUCTION), "INSTRUCTION")
+    assert_equal(repr(PrefetchCache.DATA), "DATA")
+
+
+def test_prefetch_options_repr():
+    assert_equal(
+        repr(PrefetchOptions()),
+        "PrefetchOptions(rw=READ, locality=HIGH, cache=DATA)",
+    )
+    assert_equal(
+        repr(
+            PrefetchOptions().for_write().no_locality().to_instruction_cache()
+        ),
+        "PrefetchOptions(rw=WRITE, locality=NONE, cache=INSTRUCTION)",
+    )
+
+
 def main():
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Add a specialized `Span.fill` overload for `Span[Scalar[dtype]]` that uses SIMD broadcast stores instead of a scalar element loop.

The value is splatted into SIMD vectors of decreasing width (256 → 4), storing multiple elements per instruction. Remaining elements are handled by a scalar tail loop. Follows the same `comptime widths` pattern used by `Span.apply()`.