### PR TITLE
[stdlib] [proposal] Add mmap module

### DIFF
--- a/mojo/proposals/mmap-support.md
+++ b/mojo/proposals/mmap-support.md
@@ -1,0 +1,142 @@
+# Add `mmap` Module
+
+**Status**: Proposed.
+
+This picks up the discussion from #1134 and the earlier proposal in #3218,
+incorporating the review feedback from the stdlib team.
+
+## Problem
+
+Mojo has no way to memory-map files or allocate anonymous mapped regions.
+Users who need this today must manually call `external_call["mmap", ...]`,
+check for `MAP_FAILED`, remember to `munmap` on every exit path, and handle
+the platform constant differences between Linux and macOS.
+
+```mojo
+# What users have to write today:
+var ptr = external_call["mmap", UnsafePointer[UInt8, MutExternalOrigin]](
+    UnsafePointer[UInt8, MutExternalOrigin](),
+    length, c_int(0x1), c_int(0x02), c_int(fd), Int64(0),
+)
+```
+
+## Prior Discussion
+
+The original feature request (#1134) and @KCaverly's proposal (#3218) were
+reviewed by the stdlib team. The feedback was:
+
+- Mode constants should be **numeric bit-flags**, not strings — they need to
+  be OR-able to match POSIX semantics.
+- Include `PROT_NONE`.
+- Avoid "stringly typed" APIs.
+
+This proposal addresses all three points. Plain `comptime Int` constants are
+used (matching the `O_CREAT` / `O_TRUNC` pattern in `io/file.mojo`) and raw
+`prot`/`flags` arguments are accepted rather than a mode enum.
+
+@martinvuyk's suggestion of folding mmap into `FileHandle` as
+`open[memory_mapped=True]()` was also considered. A separate module is
+cleaner: mmap supports anonymous mappings (no file at all), the lifetime of
+a mapping is independent of the fd, and the access pattern (`Span` over
+bytes) is fundamentally different from `FileHandle`'s read/write/seek API.
+
+## Proposal
+
+A new `std/mmap` package with an RAII `MmapRegion` struct and a `mmap_file()`
+convenience function.
+
+### `MmapRegion`
+
+A move-only struct that owns a mapped region and unmaps it on destruction,
+following the same pattern as `FileHandle`:
+
+```mojo
+struct MmapRegion(Movable, Sized):
+    var _ptr: UnsafePointer[UInt8, MutExternalOrigin]
+    var _length: Int
+
+    fn __init__(out self, *, length, prot, flags, fd, offset) raises
+    fn __del__(deinit self)           # munmap, errors silenced
+    fn close(mut self) raises         # munmap, errors raised
+    fn as_bytes(ref self) -> Span[UInt8, __origin_of(self)]
+    fn sync(self, flags: Int = MS_SYNC) raises   # msync
+    fn protect(self, prot: Int) raises            # mprotect
+    fn __len__(self) -> Int
+    fn __enter__(var self) -> Self
+```
+
+Design choices:
+
+- **Move-only** — no `__copyinit__`, prevents double-munmap.
+- **`as_bytes()` returns `Span`** — bounded access without exposing raw
+  pointers in the public API.
+- **Accepts raw `fd: Int`** rather than `FileHandle` — supports anonymous
+  mappings (`fd=-1`) and fds obtained from other sources.
+
+### `mmap_file()`
+
+Covers the common case of mapping an entire file:
+
+```mojo
+fn mmap_file(path: String, *, writable: Bool = False) raises -> MmapRegion
+```
+
+Stats the file for size, opens it, maps it, closes the fd, and returns the
+region.
+
+### Constants
+
+Standard POSIX constants, with `platform_map` where values differ:
+
+```mojo
+comptime PROT_NONE  = 0x0
+comptime PROT_READ  = 0x1
+comptime PROT_WRITE = 0x2
+comptime PROT_EXEC  = 0x4
+
+comptime MAP_SHARED    = 0x01
+comptime MAP_PRIVATE   = 0x02
+comptime MAP_FIXED     = 0x10
+comptime MAP_ANONYMOUS = platform_map[T=Int, "MAP_ANONYMOUS", linux=0x20, macos=0x1000]()
+
+comptime MS_ASYNC      = 0x01
+comptime MS_INVALIDATE = 0x02
+comptime MS_SYNC       = platform_map[T=Int, "MS_SYNC", linux=0x04, macos=0x10]()
+```
+
+## Examples
+
+Map a file for reading:
+
+```mojo
+from mmap import mmap_file
+
+with mmap_file("/path/to/data.bin") as region:
+    var data = region.as_bytes()
+    print("size:", len(region), "first byte:", data[0])
+```
+
+Anonymous scratch region:
+
+```mojo
+from mmap import MmapRegion, PROT_READ, PROT_WRITE, MAP_PRIVATE, MAP_ANONYMOUS
+
+var region = MmapRegion(
+    length=4096,
+    prot=PROT_READ | PROT_WRITE,
+    flags=MAP_PRIVATE | MAP_ANONYMOUS,
+    fd=-1,
+    offset=0,
+)
+var buf = region.as_bytes()
+buf[0] = 42
+```
+
+## Alternatives Considered
+
+- **Python-style `mmap.mmap` with `read()`/`write()`/`seek()`**: Higher-level
+  than needed for a stdlib primitive. Can be built on top of `MmapRegion`.
+- **Folding into `FileHandle`**: Discussed above — mmap's lifetime and access
+  model are too different from fd-based I/O.
+- **Requiring `FileHandle` instead of raw fd**: Would prevent anonymous
+  mappings and limit flexibility when the caller already has an fd.

--- a/mojo/proposals/mmap-support.md
+++ b/mojo/proposals/mmap-support.md
@@ -42,8 +42,16 @@ bytes) is fundamentally different from `FileHandle`'s read/write/seek API.
 
 ## Proposal
 
-A new `std/mmap` package with an RAII `MmapRegion` struct and a `mmap_file()`
-convenience function.
+Two layers, following the existing stdlib pattern (e.g. thin wrappers in
+`sys/_libc.mojo` used internally by `FileHandle`, `Process`, etc.):
+
+1. **Low-level thin wrappers** in `sys/_libc.mojo` — `@always_inline`
+   functions around `mmap`, `munmap`, `msync`, `mprotect`, and `madvise`.
+   Private to the stdlib, matching the existing `close()`, `write()`,
+   `pipe()`, etc. in the same file.
+
+2. **Public RAII API** in a new `std/mmap` package — `MmapRegion` struct
+   and `mmap_file()` convenience function.
 
 ### `MmapRegion`
 
@@ -86,23 +94,14 @@ region.
 
 ### Constants
 
-Standard POSIX constants, with `platform_map` where values differ:
+Standard POSIX constants (`PROT_*`, `MAP_SHARED`, `MAP_PRIVATE`, `MAP_FIXED`,
+`MS_*`), plus Linux-specific flags (`MAP_HUGETLB`, `MAP_LOCKED`,
+`MAP_POPULATE`, etc.) and `MADV_*` constants for `madvise`.
 
-```mojo
-comptime PROT_NONE  = 0x0
-comptime PROT_READ  = 0x1
-comptime PROT_WRITE = 0x2
-comptime PROT_EXEC  = 0x4
-
-comptime MAP_SHARED    = 0x01
-comptime MAP_PRIVATE   = 0x02
-comptime MAP_FIXED     = 0x10
-comptime MAP_ANONYMOUS = platform_map[T=Int, "MAP_ANONYMOUS", linux=0x20, macos=0x1000]()
-
-comptime MS_ASYNC      = 0x01
-comptime MS_INVALIDATE = 0x02
-comptime MS_SYNC       = platform_map[T=Int, "MS_SYNC", linux=0x04, macos=0x10]()
-```
+Platform-differing values use `platform_map`. Linux-only flags use
+`platform_map` with only `linux=` specified (compile error on macOS),
+following the pattern in `sys/_libc_errno.mojo` (e.g. `ECHRNG`,
+`EL2NSYNC`).
 
 ## Examples
 
@@ -136,7 +135,10 @@ buf[0] = 42
 
 - **Python-style `mmap.mmap` with `read()`/`write()`/`seek()`**: Higher-level
   than needed for a stdlib primitive. Can be built on top of `MmapRegion`.
-- **Folding into `FileHandle`**: Discussed above — mmap's lifetime and access
-  model are too different from fd-based I/O.
+- **Folding into `FileHandle`**: mmap's lifetime and access model are too
+  different from fd-based I/O.
 - **Requiring `FileHandle` instead of raw fd**: Would prevent anonymous
   mappings and limit flexibility when the caller already has an fd.
+- **Exposing raw syscall wrappers as public API**: The stdlib keeps thin libc
+  wrappers private (`sys/_libc.mojo`), matching Rust's `memmap2`, Go's
+  `syscall.Mmap`, and Python's `mmap` — all use all-or-nothing RAII.


### PR DESCRIPTION
Proposal for a new `std/mmap` package providing POSIX memory-mapped I/O through an RAII `MmapRegion` struct and `mmap_file()` convenience function.

Picks up the discussion from #1134 and #3218, addressing the stdlib team's review feedback (numeric bit-flag constants, no stringly typed APIs).

Assisted-by: AI (copy-editing)

<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Please fill out the sections below to help reviewers understand your change.
For guidance on writing a good PR, see our
[contributor guide](../CONTRIBUTING.md).
-->

## Summary

<!-- Describe what this PR does and why. Link to any related issues. -->

## Testing

<!--
Describe how you validated your changes. For code changes, this should include
what tests you ran and any relevant results. For documentation changes, describe
how you verified accuracy.
-->

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
