### PR TITLE
[Stdlib] Add explicit Writable repr for Counter

### DIFF
--- a/mojo/stdlib/std/collections/counter.mojo
+++ b/mojo/stdlib/std/collections/counter.mojo
@@ -295,6 +295,12 @@ struct Counter[V: KeyElement, H: Hasher = default_hasher](
                 writer.write(", ")
         writer.write("})")
 
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        writer.write("Counter(")
+        trait_downcast[Writable](self._data).write_repr_to(writer)
+        writer.write(")")
+
     # ===------------------------------------------------------------------=== #
     # Comparison operators
     # ===------------------------------------------------------------------=== #

--- a/mojo/stdlib/test/collections/test_counter.mojo
+++ b/mojo/stdlib/test/collections/test_counter.mojo
@@ -413,6 +413,18 @@ def test_counter_setitem():
     assert_equal(c[2], 2)
     assert_equal(c[3], 0)
 
+def test_repr():
+    var c = Counter[String]()
+    c["a"] = 1
+    c["b"] = 2
+    var s = String()
+    c.write_repr_to(s)
+    assert_equal(s, "Counter(Dict[String, Int]({'a': Int(1), 'b': Int(2)}))")
+
+    var empty = Counter[String]()
+    var s2 = String()
+    empty.write_repr_to(s2)
+    assert_equal(s2, "Counter(Dict[String, Int]({}))")
 
 def test_neg():
     var c = Counter[String]()


### PR DESCRIPTION
Implemented explicit write_repr_to() for Counter to provide clear and consistent debug output. 
This ensures that Counter's representation includes type parameters and element counts, matching the new Writable trait requirements. Added a unit test for write_repr_to().

Related Issue: #5870 