### PR TITLE
[Stdlib] Add explicit Writable repr for Codepoint

### DIFF
--- a/mojo/stdlib/std/collections/string/codepoint.mojo
+++ b/mojo/stdlib/std/collections/string/codepoint.mojo
@@ -314,6 +314,11 @@ struct Codepoint(
         """
         w.write(self.__str__())
 
+    fn write_repr_to(self, mut w: Some[Writer]):
+        w.write("Codepoint(")
+        w.write(Int(self._scalar_value))
+        w.write(")")
+
     # ===-------------------------------------------------------------------===#
     # Methods
     # ===-------------------------------------------------------------------===#

--- a/mojo/stdlib/test/collections/test_codepoint.mojo
+++ b/mojo/stdlib/test/collections/test_codepoint.mojo
@@ -86,6 +86,18 @@ def test_char_writable():
     assert_equal(buffer, String("a"))
 
 
+def test_char_write_repr():
+    var c1 = Codepoint(97)
+    var buffer = String()
+    c1.write_repr_to(buffer)
+    assert_equal(buffer, "Codepoint(97)")
+
+    var c2 = Codepoint.from_u32(0x1F642).value()
+    var buffer2 = String()
+    c2.write_repr_to(buffer2)
+    assert_equal(buffer2, "Codepoint(128578)")
+
+
 def test_char_properties():
     assert_true(Codepoint.from_u32(0).value().is_ascii())
     # Last ASCII codepoint.


### PR DESCRIPTION
This change adds a `write_repr_to` method to the `Codepoint` type, providing a clear and consistent string representation for debugging and logging purposes. A corresponding test was also added.

Related Issue: #5870 