### PR TITLE
[Stdlib] Add zfill() to String and StringSlice

### DIFF
--- a/mojo/docs/nightly-changelog.md
+++ b/mojo/docs/nightly-changelog.md
@@ -391,6 +391,10 @@ This version is still a work in progress.
   `k > n`. `perm(n, k)` computes permutations P(n, k); omitting `k` (default
   `-1`) returns `n!`.
 
+- `String` and `StringSlice` now have a `zfill()` method, matching Python's
+  string API. It pads the string on the left with zeros, placing zeros after a
+  leading `+` or `-` sign character.
+
 - `Set.pop()` now uses `Dict.popitem()` directly, avoiding a redundant rehash.
   Order changes from FIFO to LIFO, matching Python's unordered `set.pop()`.
 

--- a/mojo/stdlib/std/collections/string/string.mojo
+++ b/mojo/stdlib/std/collections/string/string.mojo
@@ -1974,6 +1974,31 @@ struct String(
         """
         return StringSlice(self).ascii_center(width, fillchar)
 
+    fn zfill(self, width: Int) -> String:
+        """Pads the string on the left with zeros to fill a field of the given
+        width.
+
+        If the string starts with a sign character (`+` or `-`), the zeros are
+        inserted after the sign. If the string is already at least as wide as
+        `width`, it is returned unchanged.
+
+        Args:
+            width: The total width (in bytes) of the resulting string.
+
+        Returns:
+            A zero-padded string of (byte) length `width`, or the original
+            string if it is already at least as wide.
+
+        Examples:
+
+        ```mojo
+        print(String("42").zfill(5))   # "00042"
+        print(String("-42").zfill(5))  # "-0042"
+        print(String("+42").zfill(5))  # "+0042"
+        ```
+        """
+        return StringSlice(self).zfill(width)
+
     fn resize(mut self, length: Int, fill_byte: UInt8 = 0):
         """Resize the string to a new length. Panics if new_len does not
         lie on a codepoint boundary or if fill_byte is non-ascii (>=128).

--- a/mojo/stdlib/std/collections/string/string_slice.mojo
+++ b/mojo/stdlib/std/collections/string/string_slice.mojo
@@ -2433,6 +2433,49 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
         """
         return self._justify(width - len(self) >> 1, width, fillchar)
 
+    fn zfill(self, width: Int) -> String:
+        """Pads the string on the left with zeros to fill a field of the given
+        width.
+
+        If the string starts with a sign character (`+` or `-`), the zeros are
+        inserted after the sign. If the string is already at least as wide as
+        `width`, it is returned unchanged.
+
+        Args:
+            width: The total width (in bytes) of the resulting string.
+
+        Returns:
+            A zero-padded string of (byte) length `width`, or the original
+            string if it is already at least as wide.
+
+        Examples:
+
+        ```mojo
+        print(StringSlice("42").zfill(5))   # "00042"
+        print(StringSlice("-42").zfill(5))  # "-0042"
+        print(StringSlice("+42").zfill(5))  # "+0042"
+        ```
+        """
+        var length = len(self)
+        if length >= width:
+            return String(self)
+        var padding = width - length
+        var result = String(capacity=width)
+        if length > 0:
+            var first = self.unsafe_ptr()[]
+            if first == UInt8(ord("+")) or first == UInt8(ord("-")):
+                result += StringSlice(ptr=self.unsafe_ptr(), length=1)
+                for _ in range(padding):
+                    result += "0"
+                result += StringSlice(
+                    ptr=self.unsafe_ptr() + 1, length=length - 1
+                )
+                return result^
+        for _ in range(padding):
+            result += "0"
+        result += self
+        return result^
+
     fn _justify(self, start: Int, width: Int, fillchar: StaticString) -> String:
         """Internal helper function to justify a string with padding.
 

--- a/mojo/stdlib/std/collections/string/string_slice.mojo
+++ b/mojo/stdlib/std/collections/string/string_slice.mojo
@@ -2456,7 +2456,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
         print(StringSlice("+42").zfill(5))  # "+0042"
         ```
         """
-        var length = len(self)
+        var length = self.byte_length()
         if length >= width:
             return String(self)
         var padding = width - length
@@ -2500,7 +2500,7 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
             padding the original string, or the original string if it's already
             at least as wide as the requested width.
         """
-        if len(self) >= width:
+        if self.byte_length() >= width:
             return String(self)
         assert len(fillchar) == 1, "fill char needs to be a one byte literal"
 

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -1795,5 +1795,15 @@ def test_append_codepoint() raises:
     assert_equal(s.byte_length(), 8)
 
 
+def test_zfill():
+    assert_equal(String("42").zfill(5), "00042")
+    assert_equal(String("42").zfill(2), "42")
+    assert_equal(String("-42").zfill(5), "-0042")
+    assert_equal(String("+42").zfill(5), "+0042")
+    assert_equal(String("").zfill(3), "000")
+    assert_equal(String("hello").zfill(8), "000hello")
+    assert_equal(String("hello").zfill(3), "hello")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -952,6 +952,22 @@ def test_ascii_center() raises:
     assert_equal(StringSlice("hello").ascii_center(8, "*"), "*hello**")
 
 
+def test_zfill():
+    # Basic zero padding
+    assert_equal(StringSlice("42").zfill(5), "00042")
+    assert_equal(StringSlice("42").zfill(2), "42")
+    assert_equal(StringSlice("42").zfill(1), "42")
+    # Sign handling
+    assert_equal(StringSlice("-42").zfill(5), "-0042")
+    assert_equal(StringSlice("+42").zfill(5), "+0042")
+    # Edge cases
+    assert_equal(StringSlice("").zfill(3), "000")
+    assert_equal(StringSlice("hello").zfill(8), "000hello")
+    assert_equal(StringSlice("hello").zfill(3), "hello")
+    # Sign at exact width
+    assert_equal(StringSlice("-42").zfill(3), "-42")
+
+
 def test_count() raises:
     var str = StringSlice("Hello world")
 


### PR DESCRIPTION
Add `zfill()` to `String` and `StringSlice`, matching Python's string API. Pads with zeros on the left, inserting zeros after a leading `+` or `-` sign character.