### PR TITLE
[MAX] Optimize Flux1 pipeline and Flux2 I2I pipeline

### DIFF
--- a/max/examples/diffusion/BUILD.bazel
+++ b/max/examples/diffusion/BUILD.bazel
@@ -10,6 +10,7 @@ modular_py_library(
     ],
     deps = [
         "//max/python/max:tensor",  # Provides max.functional and max.tensor.Tensor
+        requirement("torch"),
     ],
 )
 

--- a/max/examples/diffusion/simple_offline_generation.py
+++ b/max/examples/diffusion/simple_offline_generation.py
@@ -421,16 +421,13 @@ async def generate_image(args: argparse.Namespace) -> None:
         for i in range(args.num_warmups):
             print(f"Running warmup {i + 1} of {args.num_warmups}")
             pipeline.execute(inputs_warmup)
-        with profile_execute(
-            pipeline, patch_concat=True, patch_tensor_ops=True
-        ) as prof:
+        with profile_execute(pipeline) as prof:
             for i in range(args.num_profile_iterations):
                 print(
                     f"Running inference {i + 1} of {args.num_profile_iterations}"
                 )
                 outputs = pipeline.execute(inputs)
-        print(f"Method timings:\n{prof.report(unit='ms')}")
-        print(f"Module timings:\n{prof.report_modules(unit='ms')}")
+        prof.report(unit="ms")
     else:
         outputs = pipeline.execute(inputs)
 

--- a/max/python/max/pipelines/architectures/flux1/pipeline_flux.py
+++ b/max/python/max/pipelines/architectures/flux1/pipeline_flux.py
@@ -15,14 +15,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from queue import Queue
-from typing import Literal
+from typing import Any, Literal, cast
 
 import numpy as np
+import numpy.typing as npt
 from max import functional as F
-from max.driver import CPU
+from max.driver import CPU, Device
 from max.dtype import DType
+from max.graph import TensorType
 from max.interfaces import PixelGenerationContext, TokenBuffer
 from max.pipelines.lib.interfaces import DiffusionPipeline, PixelModelInputs
+from max.pipelines.lib.interfaces.diffusion_pipeline import max_compile
 from max.tensor import Tensor
 from tqdm import tqdm
 
@@ -92,59 +95,183 @@ class FluxPipeline(DiffusionPipeline):
             else 8
         )
 
+        self.build_prepare_prompt_embeddings()
+        self.build_preprocess_latents()
+        self.build_prepare_scheduler()
+        self.build_scheduler_step()
+        self.build_decode_latents()
+
+        # Save attributes needed after unwrap.
+        self._transformer_device: Device = self.transformer.devices[0]
+        self._guidance_embeds: bool = self.transformer.config.guidance_embeds
+
+        if unwrapped_transformer := self.transformer.unwrap_model():
+            self.transformer = cast(Any, unwrapped_transformer)
+
+        # Tensor caches.
+        self._cached_guidance: dict[str, Tensor] = {}
+        self._cached_text_ids: dict[str, Tensor] = {}
+        self._cached_sigmas: dict[str, Tensor] = {}
+
     def prepare_inputs(
         self, context: PixelGenerationContext
     ) -> FluxModelInputs:
         return FluxModelInputs.from_context(context)
 
-    @staticmethod
-    def _pack_latents(
-        latents: Tensor,
-    ) -> Tensor:
-        batch_size, num_channels_latents, height, width = map(
-            int, latents.shape
-        )
-        latents = F.reshape(
-            latents,
-            (batch_size, num_channels_latents, height // 2, 2, width // 2, 2),
-        )
-        latents = F.permute(latents, (0, 2, 4, 1, 3, 5))
-        latents = F.reshape(
-            latents,
-            (
-                batch_size,
-                (height // 2) * (width // 2),
-                num_channels_latents * 4,
+    def build_prepare_prompt_embeddings(self) -> None:
+        input_types = [
+            TensorType(
+                self.text_encoder_2.config.dtype,
+                shape=["batch", "seq_len", "hidden_dim"],
+                device=self.text_encoder_2.devices[0],
             ),
-        )
-        return latents
-
-    @staticmethod
-    def _unpack_latents(
-        latents: Tensor, height: int, width: int, vae_scale_factor: int
-    ) -> Tensor:
-        # TODO: should compile this function for speed up.
-        batch_size = int(latents.shape[0])
-        ch_size = int(latents.shape[2])
-        # VAE applies 8x compression on images but we must also account for packing which requires
-        # latent height and width to be divisible by 2.
-        height = 2 * (height // (vae_scale_factor * 2))
-        width = 2 * (width // (vae_scale_factor * 2))
-
-        latents = F.reshape(
-            latents,
-            (batch_size, height // 2, width // 2, ch_size // 4, 2, 2),
-        )
-        latents = F.permute(latents, (0, 3, 1, 4, 2, 5))
-
-        latents = F.reshape(
-            latents,
-            (batch_size, ch_size // (2 * 2), height, width),
+            TensorType(
+                self.text_encoder_2.config.dtype,
+                shape=["batch", "pooled_dim"],
+                device=self.text_encoder_2.devices[0],
+            ),
+        ]
+        self.__dict__["_prepare_prompt_embeddings"] = max_compile(
+            self._prepare_prompt_embeddings,
+            input_types=input_types,
         )
 
-        return latents
+    def build_preprocess_latents(self) -> None:
+        device = self.transformer.devices[0]
+        input_types = [
+            TensorType(
+                DType.float32,
+                shape=["batch", "channels", "height", 2, "width", 2],
+                device=device,
+            ),
+        ]
+        self.__dict__["_pack_latents"] = max_compile(
+            self._pack_latents,
+            input_types=input_types,
+        )
+
+    def build_prepare_scheduler(self) -> None:
+        input_types = [
+            TensorType(
+                DType.float32,
+                shape=["num_sigmas"],
+                device=self.transformer.devices[0],
+            ),
+        ]
+        self.__dict__["prepare_scheduler"] = max_compile(
+            self.prepare_scheduler,
+            input_types=input_types,
+        )
+
+    def build_scheduler_step(self) -> None:
+        dtype = self.transformer.config.dtype
+        device = self.transformer.devices[0]
+        input_types = [
+            TensorType(
+                dtype, shape=["batch", "seq", "channels"], device=device
+            ),
+            TensorType(
+                dtype,
+                shape=["batch", "seq", "channels"],
+                device=device,
+            ),
+            TensorType(DType.float32, shape=[1], device=device),
+        ]
+        self.__dict__["scheduler_step"] = max_compile(
+            self.scheduler_step,
+            input_types=input_types,
+        )
+
+    def build_decode_latents(self) -> None:
+        dtype = self.transformer.config.dtype
+        device = self.transformer.devices[0]
+        input_types = [
+            TensorType(
+                dtype,
+                shape=["batch", "half_h", "half_w", "ch_4", 2, 2],
+                device=device,
+            ),
+        ]
+        self.__dict__["_postprocess_latents"] = max_compile(
+            self._postprocess_latents,
+            input_types=input_types,
+        )
 
     def _prepare_prompt_embeddings(
+        self,
+        prompt_embeds: Tensor,
+        pooled_prompt_embeds: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        """Fuse dtype casts and device transfers for encoder outputs."""
+        prompt_embeds = prompt_embeds.cast(prompt_embeds.dtype)
+        pooled_prompt_embeds = pooled_prompt_embeds.cast(
+            pooled_prompt_embeds.dtype
+        )
+        return prompt_embeds, pooled_prompt_embeds
+
+    def _pack_latents(self, latents: Tensor) -> Tensor:
+        """Pack 6-D patched latents to sequence format.
+
+        Input:  (B, C, H//2, 2, W//2, 2)
+        Output: (B, H//2*W//2, C*4)
+        """
+        latents = latents.cast(self.transformer.config.dtype)
+        batch = latents.shape[0]
+        c = latents.shape[1]
+        h2 = latents.shape[2]
+        w2 = latents.shape[4]
+        latents = F.permute(latents, (0, 2, 4, 1, 3, 5))
+        latents = F.reshape(latents, (batch, h2 * w2, c * 4))
+        return latents
+
+    def prepare_scheduler(self, sigmas: Tensor) -> tuple[Tensor, Tensor]:
+        """Precompute timesteps and dt values from sigmas.
+
+        Returns:
+            (all_timesteps, all_dts) where timesteps = sigmas[:-1],
+            dts = sigmas[1:] - sigmas[:-1].
+        """
+        sigmas_curr = F.slice_tensor(sigmas, [slice(0, -1)])
+        sigmas_next = F.slice_tensor(sigmas, [slice(1, None)])
+        all_dt = F.sub(sigmas_next, sigmas_curr)
+        all_timesteps = sigmas_curr.cast(DType.float32)
+        return all_timesteps, all_dt
+
+    def scheduler_step(
+        self,
+        latents: Tensor,
+        noise_pred: Tensor,
+        dt: Tensor,
+    ) -> Tensor:
+        """Apply a single Euler update: latents += dt * noise_pred."""
+        latents_dtype = latents.dtype
+        latents = latents.cast(DType.float32)
+        latents = latents + dt * noise_pred
+        return latents.cast(latents_dtype)
+
+    def _postprocess_latents(self, latents: Tensor) -> Tensor:
+        """Unpack 6-D patched latents to (B, C, H, W) and apply VAE
+        scale/shift.
+
+        Input:  (B, H//2, W//2, C//4, 2, 2)
+        Output: (B, C//4, H, W) after scale + shift
+        """
+        scaling_factor = self.vae.config.scaling_factor
+        shift_factor = self.vae.config.shift_factor or 0.0
+
+        batch = latents.shape[0]
+        half_h = latents.shape[1]
+        half_w = latents.shape[2]
+        c_quarter = latents.shape[3]
+
+        latents = F.permute(latents, (0, 3, 1, 4, 2, 5))
+        latents = F.reshape(latents, (batch, c_quarter, half_h * 2, half_w * 2))
+
+        # VAE normalization (constants baked into compiled graph).
+        latents = (latents / scaling_factor) + shift_factor
+        return latents
+
+    def prepare_prompt_embeddings(
         self,
         tokens: TokenBuffer,
         tokens_2: TokenBuffer | None = None,
@@ -152,14 +279,15 @@ class FluxPipeline(DiffusionPipeline):
     ) -> tuple[Tensor, Tensor, Tensor]:
         tokens_2 = tokens_2 or tokens
 
-        # unsqueeze
         if tokens.array.ndim == 1:
             tokens.array = np.expand_dims(tokens.array, axis=0)
         if tokens_2.array.ndim == 1:
             tokens_2.array = np.expand_dims(tokens_2.array, axis=0)
 
         text_input_ids = Tensor.constant(
-            tokens.array, dtype=DType.int64, device=self.text_encoder.devices[0]
+            tokens.array,
+            dtype=DType.int64,
+            device=self.text_encoder.devices[0],
         )
         text_input_ids_2 = Tensor.constant(
             tokens_2.array,
@@ -167,35 +295,40 @@ class FluxPipeline(DiffusionPipeline):
             device=self.text_encoder_2.devices[0],
         )
 
-        # t5 embeddings
+        # T5 embeddings.
         prompt_embeds = self.text_encoder_2(text_input_ids_2)
-
-        # clip embeddings
+        # CLIP embeddings.
         clip_embeddings = self.text_encoder(text_input_ids)
         pooled_prompt_embeds = clip_embeddings[1]
 
-        text_ids = Tensor.zeros(
-            (prompt_embeds.shape[1], 3),
-            device=self.text_encoder_2.devices[0],
-            dtype=prompt_embeds.dtype,
+        prompt_embeds, pooled_prompt_embeds = self._prepare_prompt_embeddings(
+            prompt_embeds, pooled_prompt_embeds
         )
 
-        bs_embed = int(prompt_embeds.shape[0])
-        seq_len = prompt_embeds.shape[1]
+        batch_size, seq_len, _ = map(int, prompt_embeds.shape)
 
-        prompt_embeds = F.tile(prompt_embeds, (1, num_images_per_prompt, 1))
-        prompt_embeds = prompt_embeds.reshape(
-            (bs_embed * num_images_per_prompt, seq_len, -1)
-        )
+        if num_images_per_prompt != 1:
+            prompt_embeds = F.tile(prompt_embeds, (1, num_images_per_prompt, 1))
+            prompt_embeds = prompt_embeds.reshape(
+                (batch_size * num_images_per_prompt, seq_len, -1)
+            )
+            pooled_prompt_embeds = F.tile(
+                pooled_prompt_embeds, (1, num_images_per_prompt)
+            )
+            pooled_prompt_embeds = pooled_prompt_embeds.reshape(
+                (batch_size * num_images_per_prompt, -1)
+            )
 
-        pooled_prompt_embeds = F.tile(
-            pooled_prompt_embeds, (1, num_images_per_prompt)
-        )
-        pooled_prompt_embeds = pooled_prompt_embeds.reshape(
-            (bs_embed * num_images_per_prompt, -1)
-        )
+        batch_size_final = batch_size * num_images_per_prompt
         dtype = prompt_embeds.dtype
         device = prompt_embeds.device
+
+        text_ids_key = f"{batch_size_final}_{seq_len}"
+        if text_ids_key in self._cached_text_ids:
+            text_ids = self._cached_text_ids[text_ids_key]
+        else:
+            text_ids = Tensor.zeros((seq_len, 3), device=device, dtype=dtype)
+            self._cached_text_ids[text_ids_key] = text_ids
 
         return (
             prompt_embeds,
@@ -203,7 +336,22 @@ class FluxPipeline(DiffusionPipeline):
             text_ids.to(device).cast(dtype),
         )
 
-    def _decode_latents(
+    def preprocess_latents(
+        self,
+        latents_np: npt.NDArray[np.float32],
+        latent_image_ids_np: npt.NDArray[np.float32],
+    ) -> tuple[Tensor, Tensor]:
+        """Convert numpy latents to packed MAX tensors on device."""
+        device = self._transformer_device
+        latents = Tensor.from_dlpack(latents_np).to(device)
+        batch, c, h, w = map(int, latents.shape)
+        latents = F.reshape(latents, (batch, c, h // 2, 2, w // 2, 2))
+        latents = self._pack_latents(latents)
+
+        latent_image_ids = Tensor.from_dlpack(latent_image_ids_np).to(device)
+        return latents, latent_image_ids
+
+    def decode_latents(
         self,
         latents: Tensor,
         height: int,
@@ -213,33 +361,21 @@ class FluxPipeline(DiffusionPipeline):
         if output_type == "latent":
             return latents
         latents = Tensor.from_dlpack(latents)
-        latents = self._unpack_latents(
-            latents, height, width, self.vae_scale_factor
+
+        batch_size = int(latents.shape[0])
+        ch_size = int(latents.shape[2])
+        h = 2 * (height // (self.vae_scale_factor * 2))
+        w = 2 * (width // (self.vae_scale_factor * 2))
+        latents = F.reshape(
+            latents, (batch_size, h // 2, w // 2, ch_size // 4, 2, 2)
         )
-        latents = (
-            latents / self.vae.config.scaling_factor
-        ) + self.vae.config.shift_factor
+
+        latents = self._postprocess_latents(latents)
         return self._to_numpy(self.vae.decode(latents))
 
     def _to_numpy(self, image: Tensor) -> np.ndarray:
         cpu_image: Tensor = image.cast(DType.float32).to(CPU())
         return np.from_dlpack(cpu_image)
-
-    def _scheduler_step(
-        self,
-        latents: Tensor,
-        noise_pred: Tensor,
-        sigmas: Tensor,
-        step_index: int,
-    ) -> Tensor:
-        latents_dtype = latents.dtype
-        latents = latents.cast(DType.float32)
-        sigma = sigmas[step_index]
-        sigma_next = sigmas[step_index + 1]
-        dt = sigma_next - sigma
-        latents = latents + dt * noise_pred
-        latents = latents.cast(latents_dtype)
-        return latents
 
     def execute(  # type: ignore[override]
         self,
@@ -248,9 +384,9 @@ class FluxPipeline(DiffusionPipeline):
         output_type: Literal["np", "latent", "pil"] = "np",
     ) -> FluxPipelineOutput:
         """Execute the pipeline."""
-        # 1. Encode prompts
+        # 1. Encode prompts.
         prompt_embeds, pooled_prompt_embeds, text_ids = (
-            self._prepare_prompt_embeddings(
+            self.prepare_prompt_embeddings(
                 tokens=model_inputs.tokens,
                 tokens_2=model_inputs.tokens_2,
                 num_images_per_prompt=model_inputs.num_images_per_prompt,
@@ -266,56 +402,72 @@ class FluxPipeline(DiffusionPipeline):
                 negative_prompt_embeds,
                 negative_pooled_prompt_embeds,
                 negative_text_ids,
-            ) = self._prepare_prompt_embeddings(
+            ) = self.prepare_prompt_embeddings(
                 tokens=model_inputs.negative_tokens,
                 tokens_2=model_inputs.negative_tokens_2,
                 num_images_per_prompt=model_inputs.num_images_per_prompt,
             )
 
-        # 2. Denoise
+        # 2. Prepare latents.
         dtype = prompt_embeds.dtype
-        latents: Tensor = (
-            Tensor.from_dlpack(model_inputs.latents)
-            .to(self.transformer.devices[0])
-            .cast(dtype)
+        latents, latent_image_ids = self.preprocess_latents(
+            model_inputs.latents, model_inputs.latent_image_ids
         )
-        latents = self._pack_latents(latents)
+        latent_image_ids = latent_image_ids.cast(dtype)
 
-        latent_image_ids: Tensor = (
-            Tensor.from_dlpack(model_inputs.latent_image_ids)
-            .to(self.transformer.devices[0])
-            .cast(dtype)
-        )
-
-        if self.transformer.config.guidance_embeds:
-            guidance = Tensor.full(
-                [latents.shape[0]],
-                model_inputs.guidance_scale,
-                device=self.transformer.devices[0],
-                dtype=dtype,
-            )
-        else:
-            guidance = Tensor.zeros(
-                [latents.shape[0]],
-                device=self.transformer.devices[0],
-                dtype=dtype,
-            )
-
-        sigmas = Tensor.from_dlpack(model_inputs.sigmas).to(
-            self.transformer.devices[0]
-        )
+        # 3. Prepare guidance.
+        device = self.transformer.devices[0]
         batch_size = int(prompt_embeds.shape[0])
 
-        timesteps: np.ndarray = model_inputs.timesteps
-        num_timesteps = timesteps.shape[0]
-        timesteps_np = np.broadcast_to(
-            timesteps[:, None], (num_timesteps, batch_size)
-        )
-        timesteps_batched = Tensor.from_dlpack(timesteps_np).to(
-            self.transformer.devices[0]
-        )
+        if self._guidance_embeds:
+            guidance_key = f"{batch_size}_{model_inputs.guidance_scale}"
+            if guidance_key in self._cached_guidance:
+                guidance = self._cached_guidance[guidance_key]
+            else:
+                guidance = Tensor.full(
+                    [latents.shape[0]],
+                    model_inputs.guidance_scale,
+                    device=device,
+                    dtype=dtype,
+                )
+                self._cached_guidance[guidance_key] = guidance
+        else:
+            guidance_key = f"{batch_size}_0"
+            if guidance_key in self._cached_guidance:
+                guidance = self._cached_guidance[guidance_key]
+            else:
+                guidance = Tensor.zeros(
+                    [latents.shape[0]],
+                    device=device,
+                    dtype=dtype,
+                )
+                self._cached_guidance[guidance_key] = guidance
+
+        # 4. Prepare scheduler.
+        num_inference_steps = model_inputs.num_inference_steps
+        image_seq_len = int(latents.shape[1])
+        sigmas_key = f"{num_inference_steps}_{image_seq_len}"
+        if sigmas_key in self._cached_sigmas:
+            sigmas = self._cached_sigmas[sigmas_key]
+        else:
+            sigmas = Tensor.from_dlpack(model_inputs.sigmas).to(device)
+            self._cached_sigmas[sigmas_key] = sigmas
+
+        all_timesteps, all_dts = self.prepare_scheduler(sigmas)
+
+        # Unwrap for faster tensor slicing inside the denoising loop.
+        timesteps_seq: Any = all_timesteps
+        dts_seq: Any = all_dts
+        if hasattr(timesteps_seq, "driver_tensor"):
+            timesteps_seq = timesteps_seq.driver_tensor
+        if hasattr(dts_seq, "driver_tensor"):
+            dts_seq = dts_seq.driver_tensor
+
+        # 5. Denoising loop.
+        num_timesteps = int(model_inputs.timesteps.shape[0])
         for i in tqdm(range(num_timesteps), desc="Denoising"):
-            timestep = timesteps_batched[i]
+            timestep = timesteps_seq[i : i + 1]
+            dt = dts_seq[i : i + 1]
 
             noise_pred = self.transformer(
                 latents,
@@ -346,10 +498,10 @@ class FluxPipeline(DiffusionPipeline):
                 )
 
             # scheduler step
-            latents = self._scheduler_step(latents, noise_pred, sigmas, i)
+            latents = self.scheduler_step(latents, noise_pred, dt)
 
             if callback_queue is not None:
-                image = self._decode_latents(
+                image = self.decode_latents(
                     latents,
                     model_inputs.height,
                     model_inputs.width,
@@ -357,8 +509,8 @@ class FluxPipeline(DiffusionPipeline):
                 )
                 callback_queue.put_nowait(image)
 
-        # 3. Decode
-        outputs = self._decode_latents(
+        # 6. Decode.
+        outputs = self.decode_latents(
             latents,
             model_inputs.height,
             model_inputs.width,

--- a/max/python/max/pipelines/lib/interfaces/diffusion_pipeline.py
+++ b/max/python/max/pipelines/lib/interfaces/diffusion_pipeline.py
@@ -19,7 +19,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from dataclasses import MISSING, dataclass, field, fields
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias, overload
 
 import numpy as np
 import numpy.typing as npt
@@ -487,7 +487,7 @@ class CompileWrapper:
         session = InferenceSession([device])
         self._compiled_model = session.load(compiled_graph)
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Tensor | list[Tensor]:
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """Execute the compiled session with the given arguments.
 
         Args:
@@ -519,6 +519,20 @@ class CompileWrapper:
             return value
         except TypeError:
             return value
+
+
+@overload
+def max_compile(
+    compile_target: CompileTarget,
+    input_types: Iterable[TensorType] | None = ...,
+) -> CompileWrapper: ...
+
+
+@overload
+def max_compile(
+    compile_target: None = ...,
+    input_types: Iterable[TensorType] | None = ...,
+) -> CompileDecorator: ...
 
 
 def max_compile(


### PR DESCRIPTION
This PR focuses on accelerating Flux pipelines by compiling eager ops executions for Flux1/Flux2-I2I.

## Implementation Details
- Flux1 pipeline: compiles multiple previously-eager ops into MAX graphs (prepare_prompt_embeddings, latent pack/unpack, scheduler prep/step, decode postprocess), adds caching for guidance/text ids/sigmas, and restructures the denoising loop to use precomputed timesteps/dt tensors for less per-iteration overhead.
- Flux2 I2I pipeline: compiles image-latent normalization/packing and concatenation for I2I, replaces scatter-based unpack with a fast reshape-based decode path, and tightens image-latent ID creation to use precomputed shapes.
- Flux2 I2I pipeline: simplifies input image handling in prepare_inputs, refactors I2I latent assembly to avoid per-latent Python work, and removes unused helpers (_pack_latents, _patchify_latents, scatter-unpack).
- Profiling tooling: adds CUDA synchronization for accurate timings, splits method vs component timing reports, adds diffusers-mode support, and replaces the previous patch-concat approach with a unified tensor-ops wrapper.

## Results
### Flux1
- Before
```
==================== PROFILING REPORT ====================
Component Timings:
components                       calls        total          avg (ms)
component/transformer              150    16866.494      112.443
component/vae.decode                 3     1374.618      458.206
component/text_encoder_2             3      202.798       67.599
component/text_encoder               3      202.458       67.486

Method Timings:
methods                          calls        total          avg (ms)
E2E execute                          3   105604.455    35201.485
==================== PROFILING REPORT ====================
```
- After
```
==================== PROFILING REPORT ====================
Component Timings:
components                       calls        total          avg (ms)
component/transformer              150    16303.454      108.690
component/vae.decode                 3     1376.540      458.847
component/text_encoder_2             3      224.574       74.858
component/text_encoder               3      213.601       71.200

Method Timings:
methods                          calls        total          avg (ms)
E2E execute                          3    21040.074     7013.358
decode_latents                       3     2062.127      687.376
prepare_embeddings                   3     1761.266      587.089
preprocess_latents                   3      659.716      219.905
scheduler_step                     150       13.599        0.091
prepare_scheduler                    3        0.664        0.221
==================== PROFILING REPORT ====================
```

### Flux2 I2I
- Before
```
==================== PROFILING REPORT ====================
Component Timings:
components                       calls        total          avg (ms)
component/transformer              150    85058.433      567.056
component/vae.encode                 3     1926.643      642.214
component/vae.decode                 3     1413.504      471.168
component/text_encoder               3      340.410      113.470

Method Timings:
methods                          calls        total          avg (ms)
E2E execute                          3   121747.230    40582.410
prepare_image_latents                3     6533.716     2177.905
decode_latents                       3     5274.290     1758.097
preprocess_latents                   3      598.402      199.467
prepare_embeddings                   3      555.026      185.009
scheduler_step                     150       54.326        0.362
prepare_scheduler                    3        0.692        0.231
==================== PROFILING REPORT ====================
```
- After
```
==================== PROFILING REPORT ====================
Component Timings:
components                       calls        total          avg (ms)
component/transformer              150    85239.590      568.264
component/vae.encode                 3     1995.842      665.281
component/vae.decode                 3     1415.105      471.702
component/text_encoder               3      354.493      118.164

Method Timings:
methods                          calls        total          avg (ms)
E2E execute                          3    94384.183    31461.394
decode_latents                       3     2060.916      686.972
preprocess_latents                   3      632.162      210.721
prepare_embeddings                   3      581.302      193.767
scheduler_step                     150       47.194        0.315
concat_image_latents               150       23.226        0.155
==================== PROFILING REPORT ====================
```