### PR TITLE
[MAX] Dual Ragged RoPE kernel for FLUX.2-dev

### DIFF
--- a/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
@@ -6979,6 +6979,90 @@ struct Struct_rope_ragged_paged[interleaved: Bool]:
             )
 
 
+@compiler.register("mo.rope.ragged.with_position_id")
+struct Struct_rope_ragged_paged_with_position_id[interleaved: Bool]:
+    @always_inline
+    @staticmethod
+    fn execute[
+        dtype: DType,
+        freq_dtype: DType,
+        //,
+        target: StaticString,
+    ](
+        output: FusedOutputTensor[dtype=dtype, rank=3],
+        x: InputTensor[dtype=dtype, rank=3],
+        input_row_offsets: InputTensor[dtype = DType.uint32, rank=1],
+        start_pos: InputTensor[dtype = DType.uint32, rank=1],
+        freqs_cis: InputTensor[dtype=freq_dtype, rank=2],
+        position_ids: InputTensor[dtype = DType.uint32, rank=2],
+        ctx: DeviceContextPtr,
+    ) capturing raises:
+        @always_inline
+        @parameter
+        fn description_fn() -> String:
+            return String(";").join(
+                Span(
+                    [
+                        trace_arg("output", output.shape()),
+                        trace_arg("x", x.shape()),
+                        trace_arg(
+                            "input_row_offsets", input_row_offsets.shape()
+                        ),
+                        trace_arg("start_pos", start_pos.shape()),
+                        trace_arg("freqs_cis", freqs_cis.shape()),
+                        trace_arg("position_ids", position_ids.shape()),
+                        "interleaved=" + String(Self.interleaved),
+                        "target=" + String(target),
+                    ]
+                )
+            )
+
+        @always_inline
+        @parameter
+        fn output_fn[
+            width: Int, alignment: Int
+        ](idx: IndexList[3], val: SIMD[dtype, width]) capturing -> None:
+            output._lambda_store[width=width, element_alignment=alignment](
+                idx,
+                rebind[SIMD[dtype, width]](val),
+            )
+
+        var device_ctx: Optional[DeviceContext] = None
+
+        @parameter
+        if is_gpu[target]():
+            device_ctx = ctx.get_device_context()
+
+        with Trace[TraceLevel.OP, target=target](
+            "mo.rope.ragged.with_position_id",
+            Trace[TraceLevel.OP]._get_detail_str[description_fn](),
+        ):
+            var x_tensor = x.to_tile_tensor[DType.int64]()
+            var row_offsets_tensor = input_row_offsets.to_tile_tensor[
+                DType.int64
+            ]()
+            var start_tensor = start_pos.to_tile_tensor[DType.int64]()
+            var freqs_cis_tensor = freqs_cis.to_tile_tensor[DType.int64]()
+            var position_ids_tensor = position_ids.to_tile_tensor[DType.int64]()
+            comptime assert row_offsets_tensor.flat_rank == 1
+            comptime assert start_tensor.flat_rank == 1
+            comptime assert freqs_cis_tensor.flat_rank == 2
+            comptime assert position_ids_tensor.flat_rank == 2
+
+            rope_ragged[
+                interleaved = Self.interleaved,
+                target=target,
+                output_fn=output_fn,
+            ](
+                x_tensor,
+                row_offsets_tensor,
+                start_tensor,
+                freqs_cis_tensor,
+                device_ctx,
+                position_ids=position_ids_tensor.as_any_origin().as_immut(),
+            )
+
+
 # ===-----------------------------------------------------------------------===#
 # MHA
 #

--- a/max/kernels/src/nn/rope.mojo
+++ b/max/kernels/src/nn/rope.mojo
@@ -28,7 +28,7 @@ from layout import (
     TileTensor,
     coord,
 )
-from layout._layout import Layout, _RowMajor
+from layout._layout import TensorLayout, RowMajorLayout
 from nn._ragged_utils import get_batch_from_row_offsets
 
 from std.utils import IndexList
@@ -130,6 +130,9 @@ fn rope_ragged[
         CoordLike
     ],
     mrope_section: Optional[Coord[*mrope_types]] = None,
+    PositionIdsLayoutType: TensorLayout = RowMajorLayout[
+        RuntimeInt[DType.int64], RuntimeInt[DType.int64]
+    ],
 ](
     x: TileTensor[dtype, ...],
     input_row_offsets: TileTensor[DType.uint32, ...],
@@ -137,32 +140,18 @@ fn rope_ragged[
     freqs_cis: TileTensor[freq_dtype, ...],
     context: Optional[DeviceContext],
     position_ids: OptionalReg[
-        TileTensor[
-            DType.uint32,
-            Layout[
-                Variadic.types[
-                    RuntimeInt[DType.int64], RuntimeInt[DType.int64]
-                ],
-                _RowMajor[
-                    *Variadic.types[
-                        RuntimeInt[DType.int64], RuntimeInt[DType.int64]
-                    ]
-                ],
-            ],
-            MutAnyOrigin,
-        ]
+        TileTensor[DType.uint32, PositionIdsLayoutType, ImmutAnyOrigin]
     ] = None,
 ) raises where (
     input_row_offsets.flat_rank == 1
     and start_pos.flat_rank == 1
-    and position_ids.T.flat_rank == 2
     and freqs_cis.flat_rank == 2
 ):
-    comptime assert (
-        freqs_cis.all_dims_known
-    ), "freqs_cis shape must be statically shaped"
-    comptime head_size = x.static_shape[2]
-    comptime rope_dim = freqs_cis.static_shape[1]
+    comptime assert freqs_cis.LayoutType._shape_types[
+        1
+    ].is_static_value, "Need static rope_dim for freqs_cis"
+    comptime head_size = Int(x.static_shape[2])
+    comptime rope_dim = Int(freqs_cis.static_shape[1])
     comptime unroped_dim = head_size - rope_dim
     comptime has_nope = unroped_dim > 0
 
@@ -203,6 +192,8 @@ fn rope_ragged[
 
             var position_ids_idx = Int(post_seq_idx)
             if position_ids:
+                comptime PIdTensor = type_of(position_ids.value())
+                comptime assert PIdTensor.flat_rank == 2
                 comptime if mrope_section:
                     var section_idx = 0
 

--- a/max/kernels/test/gpu/nn/test_rope_ragged.mojo
+++ b/max/kernels/test/gpu/nn/test_rope_ragged.mojo
@@ -18,15 +18,17 @@ from layout._layout import Layout, row_major
 from nn.rope import rope_ragged
 from testdata.fused_qk_rope_goldens import (
     freqs_cis_table_input,
+    position_ids_input,
     q_input,
     q_out_golden,
+    q_out_golden_with_position_ids,
 )
 
 from std.utils import IndexList
 
 
-def test_rope_ragged_gpu[
-    rope_dim: Int, dtype: DType
+def _test_rope_ragged_gpu_impl[
+    rope_dim: Int, dtype: DType, has_position_ids: Bool
 ](ctx: DeviceContext) raises -> None:
     """Verifies rope_ragged GPU kernel against golden values computed with PyTorch.
     """
@@ -47,6 +49,7 @@ def test_rope_ragged_gpu[
     comptime input_row_offsets_layout = row_major[batch_size + 1]()
     comptime start_pos_layout = row_major[batch_size]()
     comptime freqs_cis_layout = row_major[max_seq_len, rope_dim]()
+    comptime position_ids_layout = row_major[1, batch_size * seq_len]()
 
     # ===== Step 1: Create all buffers =====
     # Query tensor buffers
@@ -81,6 +84,14 @@ def test_rope_ragged_gpu[
         freqs_cis_layout.static_product
     )
 
+    # Position ids buffers
+    var position_ids_host_buffer = ctx.enqueue_create_host_buffer[DType.uint32](
+        position_ids_layout.static_product
+    )
+    var position_ids_device_buffer = ctx.enqueue_create_buffer[DType.uint32](
+        position_ids_layout.static_product
+    )
+
     # Output buffers
     var q_out_device_buffer = ctx.enqueue_create_buffer[dtype](
         q_layout.static_product
@@ -103,7 +114,7 @@ def test_rope_ragged_gpu[
         input_row_offsets_host_buffer[i] = UInt32(i * seq_len)
     input_row_offsets_host_buffer[batch_size] = batch_size * seq_len
 
-    # Fill start positions
+    # Fill start positions (ignored when position_ids are passed)
     start_pos_host_buffer[0] = 0
     start_pos_host_buffer[1] = 5
 
@@ -119,6 +130,11 @@ def test_rope_ragged_gpu[
                 seq_idx * rope_dim + rope_idx
             ] = freqs_cis_table_buffer[buffer_offset]
 
+    # Fill explicit position ids
+    position_ids_buffer = position_ids_input[DType.uint32]()
+    for i in range(len(position_ids_buffer)):
+        position_ids_host_buffer[i] = position_ids_buffer[i]
+
     # ===== Step 3: Copy all data to device =====
     ctx.enqueue_copy(q_device_buffer, q_host_buffer)
     ctx.enqueue_copy(
@@ -126,6 +142,7 @@ def test_rope_ragged_gpu[
     )
     ctx.enqueue_copy(start_pos_device_buffer, start_pos_host_buffer)
     ctx.enqueue_copy(freqs_cis_device_buffer, freqs_cis_host_buffer)
+    ctx.enqueue_copy(position_ids_device_buffer, position_ids_host_buffer)
 
     # Synchronize to ensure all copies are complete before kernel execution
     ctx.synchronize()
@@ -141,6 +158,22 @@ def test_rope_ragged_gpu[
     var freqs_cis_device_tensor = TileTensor(
         freqs_cis_device_buffer.unsafe_ptr(), freqs_cis_layout
     )
+    var position_ids_device_tensor_static = TileTensor(
+        position_ids_device_buffer.unsafe_ptr(), position_ids_layout
+    )
+    var position_ids_device_tensor = TileTensor[
+        DType.uint32,
+        _,
+        ImmutAnyOrigin,
+    ](
+        position_ids_device_tensor_static.ptr.as_immutable().unsafe_origin_cast[
+            ImmutAnyOrigin
+        ](),
+        position_ids_device_tensor_static.layout,
+    ).make_dynamic[
+        DType.int64
+    ]()
+
     var q_out_device_tensor = TileTensor(
         q_out_device_buffer.unsafe_ptr(), q_layout
     )
@@ -153,19 +186,35 @@ def test_rope_ragged_gpu[
         q_out_device_tensor.store[width=width](Coord(idx), val)
 
     # Execute rope_ragged kernel on GPU
-    rope_ragged[
-        dtype,
-        dtype,
-        interleaved=True,
-        target = StaticString("gpu"),
-        output_fn=output_fn,
-    ](
-        x=q_device_tensor.as_any_origin(),
-        input_row_offsets=input_row_offsets_device_tensor.as_any_origin(),
-        start_pos=start_pos_device_tensor.as_any_origin(),
-        freqs_cis=freqs_cis_device_tensor.as_any_origin(),
-        context=Optional[DeviceContext](ctx),
-    )
+    comptime if has_position_ids:
+        rope_ragged[
+            dtype,
+            dtype,
+            interleaved=True,
+            target = StaticString("gpu"),
+            output_fn=output_fn,
+        ](
+            x=q_device_tensor.as_any_origin(),
+            input_row_offsets=input_row_offsets_device_tensor.as_any_origin(),
+            start_pos=start_pos_device_tensor.as_any_origin(),
+            freqs_cis=freqs_cis_device_tensor.as_any_origin(),
+            context=Optional[DeviceContext](ctx),
+            position_ids=position_ids_device_tensor,
+        )
+    else:
+        rope_ragged[
+            dtype,
+            dtype,
+            interleaved=True,
+            target = StaticString("gpu"),
+            output_fn=output_fn,
+        ](
+            x=q_device_tensor.as_any_origin(),
+            input_row_offsets=input_row_offsets_device_tensor.as_any_origin(),
+            start_pos=start_pos_device_tensor.as_any_origin(),
+            freqs_cis=freqs_cis_device_tensor.as_any_origin(),
+            context=Optional[DeviceContext](ctx),
+        )
 
     # Copy results back to host for validation
     ctx.enqueue_copy(q_out_host_buffer, q_out_device_buffer)
@@ -176,7 +225,10 @@ def test_rope_ragged_gpu[
         q_layout.static_product
     )
     ctx.synchronize()
-    expected_q_out_buffer = q_out_golden[dtype]()
+    comptime if has_position_ids:
+        expected_q_out_buffer = q_out_golden_with_position_ids[dtype]()
+    else:
+        expected_q_out_buffer = q_out_golden[dtype]()
     for i in range(len(expected_q_out_buffer)):
         expected_q_out_host_buffer[i] = expected_q_out_buffer[i]
 
@@ -221,13 +273,27 @@ def test_rope_ragged_gpu[
                     )
 
 
+def test_rope_ragged_gpu[
+    rope_dim: Int, dtype: DType
+](ctx: DeviceContext) raises -> None:
+    _test_rope_ragged_gpu_impl[rope_dim, dtype, has_position_ids=False](ctx)
+
+
+def test_rope_ragged_gpu_with_position_ids[
+    rope_dim: Int, dtype: DType
+](ctx: DeviceContext) raises -> None:
+    _test_rope_ragged_gpu_impl[rope_dim, dtype, has_position_ids=True](ctx)
+
+
 def execute_rope_ragged_gpu(ctx: DeviceContext) raises -> None:
     """Execute GPU RoPE tests with different rope dimensions."""
     # Full head RoPE
     test_rope_ragged_gpu[8, DType.float32](ctx)
+    test_rope_ragged_gpu_with_position_ids[8, DType.float32](ctx)
 
     # partial RoPE
     test_rope_ragged_gpu[4, DType.float32](ctx)
+    test_rope_ragged_gpu_with_position_ids[4, DType.float32](ctx)
 
 
 def main() raises:

--- a/max/python/max/nn/kernels.py
+++ b/max/python/max/nn/kernels.py
@@ -1472,6 +1472,55 @@ def rope_ragged_with_position_ids(
     interleaved: bool = True,
 ) -> TensorValue:
     """Apply RoPE using explicit position_ids (no KV cache coupling)."""
+    if position_ids.dtype != DType.uint32:
+        raise ValueError(
+            f"expected position_ids to have dtype uint32, was {position_ids.dtype}"
+        )
+    if position_ids.rank == 1:
+        position_ids = ops.unsqueeze(position_ids, 0)
+    if position_ids.rank != 2:
+        raise ValueError(
+            f"expected position_ids to be 1D or 2D, got rank {position_ids.rank}"
+        )
+
+    # Fast path: invoke kernel directly when mrope_section is not used.
+    if mrope_section is None:
+        total_tokens = input.shape[0]
+        row_offsets = ops.range(
+            0,
+            total_tokens + 1,
+            total_tokens,
+            out_dim=2,
+            dtype=DType.uint32,
+            device=input.device,
+        )
+        start_pos = ops.range(
+            0,
+            1,
+            1,
+            out_dim=1,
+            dtype=DType.uint32,
+            device=input.device,
+        )
+        return ops.custom(
+            "mo.rope.ragged.with_position_id",
+            device=input.device,
+            values=[
+                input,
+                row_offsets,
+                start_pos,
+                freqs_cis,
+                position_ids,
+            ],
+            out_types=[
+                TensorType(
+                    dtype=input.dtype, shape=input.shape, device=input.device
+                )
+            ],
+            parameters={"interleaved": interleaved},
+        )[0].tensor
+
+    # Fallback path for mRoPE sections, keep existing graph implementation.
     per_token_freqs = _freqs_cis_from_position_ids(
         freqs_cis,
         position_ids,

--- a/max/python/max/pipelines/architectures/flux2/layers/flux2_attention.py
+++ b/max/python/max/pipelines/architectures/flux2/layers/flux2_attention.py
@@ -72,6 +72,7 @@ def _apply_flux2_qk_rope(
         F.reshape(key_out, [batch_size, seq_len, num_heads, head_dim]),
     )
 
+
 @module_dataclass
 class Flux2SwiGLU(Module[[Tensor], Tensor]):
     def forward(self, x: Tensor) -> Tensor:

--- a/max/python/max/pipelines/architectures/flux2/layers/flux2_attention.py
+++ b/max/python/max/pipelines/architectures/flux2/layers/flux2_attention.py
@@ -16,15 +16,61 @@ from max.experimental import functional as F
 from max.experimental.tensor import Tensor
 from max.nn.attention.mask_config import MHAMaskVariant
 from max.nn.kernels import flash_attention_gpu as _flash_attention_gpu
+from max.nn.kernels import (
+    rope_ragged_with_position_ids as _rope_ragged_with_position_ids,
+)
 from max.nn.module_v3 import Linear, Module, module_dataclass
 from max.nn.module_v3.sequential import ModuleList
 
+from .embeddings import get_1d_rotary_pos_embed
+
 flash_attention_gpu = F.functional(_flash_attention_gpu)
+rope_ragged_with_position_ids = F.functional(_rope_ragged_with_position_ids)
 
 from max.nn.module_v3.norm import RMSNorm
 
-from .embeddings import apply_rotary_emb, get_1d_rotary_pos_embed
 
+def _apply_flux2_qk_rope(
+    query: Tensor,
+    key: Tensor,
+    cos: Tensor,
+    sin: Tensor,
+) -> tuple[Tensor, Tensor]:
+    batch_size = query.shape[0]
+    seq_len = query.shape[1]
+    num_heads = query.shape[2]
+    head_dim = query.shape[3]
+
+    query_ragged = F.reshape(query, [batch_size * seq_len, num_heads, head_dim])
+    key_ragged = F.reshape(key, [batch_size * seq_len, num_heads, head_dim])
+
+    # Convert repeat-interleaved ([cos, cos], [sin, sin]) to [cos, sin] pairs.
+    cos_pairs = F.reshape(cos, [cos.shape[0], cos.shape[1] // 2, 2])[..., 0]
+    sin_pairs = F.reshape(sin, [sin.shape[0], sin.shape[1] // 2, 2])[..., 0]
+    freqs_cis = F.reshape(
+        F.stack([cos_pairs, sin_pairs], axis=-1),
+        [cos.shape[0], cos.shape[1]],
+    )
+    position_ids = F.arange(0, seq_len, dtype=DType.uint32, device=query.device)
+    position_ids = F.tile(position_ids[None, :], (batch_size, 1))
+    position_ids = F.reshape(position_ids, [batch_size * seq_len])
+
+    query_out = rope_ragged_with_position_ids(
+        query_ragged,
+        freqs_cis,
+        position_ids,
+        interleaved=True,
+    )
+    key_out = rope_ragged_with_position_ids(
+        key_ragged,
+        freqs_cis,
+        position_ids,
+        interleaved=True,
+    )
+    return (
+        F.reshape(query_out, [batch_size, seq_len, num_heads, head_dim]),
+        F.reshape(key_out, [batch_size, seq_len, num_heads, head_dim]),
+    )
 
 @module_dataclass
 class Flux2SwiGLU(Module[[Tensor], Tensor]):
@@ -297,26 +343,9 @@ class Flux2Attention(Module[..., Tensor | tuple[Tensor, Tensor]]):
             value = F.concat([encoder_value, value], axis=1)
 
         # Apply rotary embeddings if provided
-        # Store original dtype to cast back after RoPE (which may upcast to float32)
-        original_dtype = query.dtype
         if image_rotary_emb is not None:
-            query = apply_rotary_emb(
-                query,
-                image_rotary_emb,
-                use_real=True,
-                use_real_unbind_dim=-1,
-                sequence_dim=1,
-            )
-            key = apply_rotary_emb(
-                key,
-                image_rotary_emb,
-                use_real=True,
-                use_real_unbind_dim=-1,
-                sequence_dim=1,
-            )
-            # Cast back to original dtype to match value
-            query = query.cast(original_dtype)
-            key = key.cast(original_dtype)
+            cos, sin = image_rotary_emb
+            query, key = _apply_flux2_qk_rope(query, key, cos, sin)
 
         # Scaled dot-product attention
         scale = 1.0 / (self.head_dim**0.5)
@@ -452,26 +481,9 @@ class Flux2ParallelSelfAttention(Module[[Tensor], Tensor]):
         key = self.norm_k(key)
 
         # Apply rotary embeddings
-        # Store original dtype to cast back after RoPE (which may upcast to float32)
-        original_dtype = query.dtype
         if image_rotary_emb is not None:
-            query = apply_rotary_emb(
-                query,
-                image_rotary_emb,
-                use_real=True,
-                use_real_unbind_dim=-1,
-                sequence_dim=1,
-            )
-            key = apply_rotary_emb(
-                key,
-                image_rotary_emb,
-                use_real=True,
-                use_real_unbind_dim=-1,
-                sequence_dim=1,
-            )
-            # Cast back to original dtype to match value
-            query = query.cast(original_dtype)
-            key = key.cast(original_dtype)
+            cos, sin = image_rotary_emb
+            query, key = _apply_flux2_qk_rope(query, key, cos, sin)
 
         # Attention computation
         hidden_states = flash_attention_gpu(


### PR DESCRIPTION
This PR enables FLUX2 vision RoPE using dual rope_ragged_with_position_ids (Q and K). This PR replaces #5987.

## Why this is needed
rope_ragged cannot be used for FLUX.2 vison RoPE since graph compilation fails with symbolic shapes. rope_ragged required: `comptime assert freqs_cis.all_dims_known`.
In graph mode, freqs_cis.shape[0] (token dimension) can be symbolic, so that assert fails even though the kernel only really needs rope_dim (shape[1]) to be static for SIMD selection.

What this PR changes:
- Replaces full static-shape requirement with:
  - freqs_cis.LayoutType._shape_types[1].is_static_value
- Keeps compile-time safety for vectorization/divisibility using static rope_dim.
- Generalizes position_ids typing to runtime row-major dims and validates rank via PIdTensor.flat_rank == 2.

So the PR both:
1. adds explicit position_ids handling in the ragged RoPE path, and
2. fixes the symbolic-shape graph-compile blocker by relaxing the static-shape constraint.

## What changed

- Added new kernel op: mo.rope.ragged.with_position_id
  - max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
- Extended rope_ragged typing/constraints for position-id input and graph-friendly shape handling (static rope_dim requirement retained)
  - max/kernels/src/nn/rope.mojo
- Updated Python wrapper rope_ragged_with_position_ids to call the new custom op fast path when mrope_section is None (existing fallback kept for mRoPE-section case)
  - max/python/max/nn/legacy/kernels.py
- Switched FLUX2 attention RoPE application to dual rope_ragged_with_position_ids
  - max/python/max/pipelines/architectures/flux2/layers/flux2_attention.py

## Benchmark Results (B200, 1024x1024, 50 steps, t2i, FLUX.2-dev)
### As-is (main, commit 2ffbfe882d5125c9911bfeabcfb73dc4d37a573b)
```
Method timings:
section                          calls        total          avg (ms)
E2E execute                          3    50535.349    16845.116
component/transformer              150    42330.125      282.201
component/vae.decode                 3     1450.883      483.628
tensor/to                            9      605.960       67.329
decode/to_numpy                      3      411.398      137.133
component/text_encoder               3      341.790      113.930
tensor/cast                          3      204.760       68.253
tensor/from_dlpack                 321        2.443        0.008
prompt/prepare_embeddings            3        0.642        0.214
Module timings:
module                           calls        total          avg (ms)
pipeline/Flux2Pipeline               9    50947.389     5660.821
component/transformer              150    42330.125      282.201
component/vae.decode                 3     1450.883      483.628
tensor/ops                         333      813.163        2.442
component/text_encoder               3      341.790      113.930
Generation complete!
```
### To-be
```
Method timings:
section                          calls        total          avg (ms)
E2E execute                          3    42859.290    14286.430
component/transformer              150    38515.199      256.768
component/vae.decode                 3     1414.588      471.529
tensor/to                            9      608.845       67.649
decode/to_numpy                      3      400.327      133.442
component/text_encoder               3      337.687      112.562
tensor/cast                          3      197.795       65.932
tensor/from_dlpack                 321        2.346        0.007
prompt/prepare_embeddings            3        0.578        0.193
Module timings:
module                           calls        total          avg (ms)
pipeline/Flux2Pipeline               9    43260.196     4806.688
component/transformer              150    38515.199      256.768
component/vae.decode                 3     1414.588      471.529
tensor/ops                         333      808.986        2.429
component/text_encoder               3      337.687      112.562
Generation complete!
```