### PR TITLE
[pipelines] use the max_model_length from model config for tokenizers

### DIFF
--- a/max/python/max/pipelines/lib/tokenizer.py
+++ b/max/python/max/pipelines/lib/tokenizer.py
@@ -227,6 +227,24 @@ async def run_with_default_executor(
     return await loop.run_in_executor(None, fn, *args, **kwargs)
 
 
+def _resolve_tokenizer_max_length(
+    max_length: int | None, pipeline_config: PipelineConfig | None
+) -> int | None:
+    """Resolve tokenizer max length with pipeline config fallback."""
+    if max_length is not None:
+        return max_length
+
+    if pipeline_config is None:
+        return None
+
+    model_config = getattr(pipeline_config, "model", None)
+    if model_config is None:
+        return None
+
+    model_max_length = getattr(model_config, "max_length", None)
+    return model_max_length if isinstance(model_max_length, int) else None
+
+
 class TextTokenizer(
     PipelineTokenizer[
         TextContext, npt.NDArray[np.integer[Any]], TextGenerationRequest
@@ -259,15 +277,16 @@ class TextTokenizer(
         **unused_kwargs,
     ) -> None:
         self.model_path = model_path
+        resolved_max_length = _resolve_tokenizer_max_length(
+            max_length, pipeline_config
+        )
 
         try:
             self.delegate = AutoTokenizer.from_pretrained(
                 model_path,
                 revision=revision,
                 trust_remote_code=trust_remote_code,
-                # If `max_length` is None, the max length will be taken
-                # from the HuggingFace tokenizer_config.
-                model_max_length=max_length,
+                model_max_length=resolved_max_length,
             )
         except Exception as e:
             raise ValueError(
@@ -279,6 +298,10 @@ class TextTokenizer(
                 "- '--trust-remote-code' is needed but not set\n"
             ) from e
 
+        if resolved_max_length is not None:
+            # Keep delegate warnings/validations aligned with pipeline max_length.
+            self.delegate.model_max_length = resolved_max_length
+
         # Override chat template if provided
         # This will be used by the delegate's apply_chat_template method automatically
         self._custom_template_provided = chat_template is not None
@@ -288,7 +311,7 @@ class TextTokenizer(
                 f"Set custom chat template on tokenizer for {model_path}"
             )
 
-        self.max_length = max_length or self.delegate.model_max_length
+        self.max_length = self.delegate.model_max_length
 
         # configure Llama whitespace fix if needed
         self._enable_llama_whitespace_fix = (
@@ -574,16 +597,20 @@ class TextAndVisionTokenizer(
         **unused_kwargs,
     ) -> None:
         self.model_path = model_path
+        resolved_max_length = _resolve_tokenizer_max_length(
+            max_length, pipeline_config
+        )
 
         self.delegate = AutoTokenizer.from_pretrained(
             model_path,
             revision=revision,
             trust_remote_code=trust_remote_code,
-            # If `max_length` is None, the max length will be taken
-            # from the HuggingFace tokenizer_config.
-            model_max_length=max_length,
+            model_max_length=resolved_max_length,
         )
-        self.max_length = max_length or self.delegate.model_max_length
+        if resolved_max_length is not None:
+            # Keep delegate warnings/validations aligned with pipeline max_length.
+            self.delegate.model_max_length = resolved_max_length
+        self.max_length = self.delegate.model_max_length
 
         # Use the pre-loaded HuggingFace config from pipeline_config
         config = pipeline_config.model.huggingface_config

--- a/max/python/max/pipelines/lib/tokenizer.py
+++ b/max/python/max/pipelines/lib/tokenizer.py
@@ -227,24 +227,6 @@ async def run_with_default_executor(
     return await loop.run_in_executor(None, fn, *args, **kwargs)
 
 
-def _resolve_tokenizer_max_length(
-    max_length: int | None, pipeline_config: PipelineConfig | None
-) -> int | None:
-    """Resolve tokenizer max length with pipeline config fallback."""
-    if max_length is not None:
-        return max_length
-
-    if pipeline_config is None:
-        return None
-
-    model_config = getattr(pipeline_config, "model", None)
-    if model_config is None:
-        return None
-
-    model_max_length = getattr(model_config, "max_length", None)
-    return model_max_length if isinstance(model_max_length, int) else None
-
-
 class TextTokenizer(
     PipelineTokenizer[
         TextContext, npt.NDArray[np.integer[Any]], TextGenerationRequest
@@ -277,9 +259,7 @@ class TextTokenizer(
         **unused_kwargs,
     ) -> None:
         self.model_path = model_path
-        resolved_max_length = _resolve_tokenizer_max_length(
-            max_length, pipeline_config
-        )
+        resolved_max_length = max_length or pipeline_config.model.max_length
 
         try:
             self.delegate = AutoTokenizer.from_pretrained(
@@ -597,9 +577,7 @@ class TextAndVisionTokenizer(
         **unused_kwargs,
     ) -> None:
         self.model_path = model_path
-        resolved_max_length = _resolve_tokenizer_max_length(
-            max_length, pipeline_config
-        )
+        resolved_max_length = max_length or pipeline_config.model.max_length
 
         self.delegate = AutoTokenizer.from_pretrained(
             model_path,

--- a/max/tests/tests/pipelines/lib/test_max_config_basic.py
+++ b/max/tests/tests/pipelines/lib/test_max_config_basic.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import yaml
@@ -27,6 +28,7 @@ from max.pipelines.lib import (
     ProfilingConfig,
     SamplingConfig,
 )
+from max.pipelines.lib.tokenizer import TextAndVisionTokenizer, TextTokenizer
 from pydantic import Field, ValidationError
 
 
@@ -254,6 +256,135 @@ class TestProfilingConfigEnv:
         monkeypatch.setenv("MODULAR_ENABLE_PROFILING", "bad-value")
         config = ProfilingConfig(gpu_profiling="on")
         assert config.gpu_profiling == "on"
+
+
+def _make_text_pipeline_config(max_length: int | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        model=SimpleNamespace(
+            max_length=max_length,
+            huggingface_config=SimpleNamespace(eos_token_id=None),
+        )
+    )
+
+
+def _make_text_and_vision_pipeline_config(
+    max_length: int | None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        model=SimpleNamespace(
+            max_length=max_length,
+            huggingface_config=SimpleNamespace(
+                eos_token_id=None,
+                image_token_id=151667,
+            ),
+            kv_cache=SimpleNamespace(enable_prefix_caching=False),
+        )
+    )
+
+
+class TestTokenizerMaxLengthResolution:
+    def test_text_tokenizer_uses_pipeline_config_max_length_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recorded_kwargs: dict[str, object] = {}
+
+        class FakeTokenizer:
+            model_max_length = 131072
+            eos_token_id = 2
+
+            def decode(self, *_args, **_kwargs) -> str:
+                return "x"
+
+        def _fake_from_pretrained(*_args, **kwargs):  # noqa: ANN202
+            recorded_kwargs.update(kwargs)
+            return FakeTokenizer()
+
+        monkeypatch.setattr(
+            "max.pipelines.lib.tokenizer.AutoTokenizer.from_pretrained",
+            _fake_from_pretrained,
+        )
+
+        tokenizer = TextTokenizer(
+            model_path="fake-model",
+            pipeline_config=_make_text_pipeline_config(max_length=163840),
+        )
+
+        assert recorded_kwargs["model_max_length"] == 163840
+        assert tokenizer.max_length == 163840
+        assert tokenizer.delegate.model_max_length == 163840
+
+    def test_text_tokenizer_prefers_explicit_max_length(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recorded_kwargs: dict[str, object] = {}
+
+        class FakeTokenizer:
+            model_max_length = 131072
+            eos_token_id = 2
+
+            def decode(self, *_args, **_kwargs) -> str:
+                return "x"
+
+        def _fake_from_pretrained(*_args, **kwargs):  # noqa: ANN202
+            recorded_kwargs.update(kwargs)
+            return FakeTokenizer()
+
+        monkeypatch.setattr(
+            "max.pipelines.lib.tokenizer.AutoTokenizer.from_pretrained",
+            _fake_from_pretrained,
+        )
+
+        tokenizer = TextTokenizer(
+            model_path="fake-model",
+            pipeline_config=_make_text_pipeline_config(max_length=163840),
+            max_length=200000,
+        )
+
+        assert recorded_kwargs["model_max_length"] == 200000
+        assert tokenizer.max_length == 200000
+        assert tokenizer.delegate.model_max_length == 200000
+
+    def test_text_and_vision_tokenizer_uses_pipeline_config_max_length_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recorded_kwargs: dict[str, object] = {}
+
+        class FakeTokenizer:
+            model_max_length = 131072
+            eos_token_id = 2
+
+        fake_processor = SimpleNamespace(image_break_token_id=None)
+
+        def _fake_auto_tokenizer_from_pretrained(
+            *_args, **kwargs
+        ):  # noqa: ANN202
+            recorded_kwargs.update(kwargs)
+            return FakeTokenizer()
+
+        def _fake_auto_processor_from_pretrained(
+            *_args, **_kwargs
+        ):  # noqa: ANN202
+            return fake_processor
+
+        monkeypatch.setattr(
+            "max.pipelines.lib.tokenizer.AutoTokenizer.from_pretrained",
+            _fake_auto_tokenizer_from_pretrained,
+        )
+        monkeypatch.setattr(
+            "max.pipelines.lib.tokenizer.AutoProcessor.from_pretrained",
+            _fake_auto_processor_from_pretrained,
+        )
+
+        tokenizer = TextAndVisionTokenizer(
+            model_path="fake-model",
+            pipeline_config=_make_text_and_vision_pipeline_config(
+                max_length=163840
+            ),
+        )
+
+        assert recorded_kwargs["model_max_length"] == 163840
+        assert tokenizer.max_length == 163840
+        assert tokenizer.delegate.model_max_length == 163840
 
 
 class _StrictModel(MAXBaseModel):

--- a/max/tests/tests/pipelines/lib/test_max_config_basic.py
+++ b/max/tests/tests/pipelines/lib/test_max_config_basic.py
@@ -295,7 +295,9 @@ class TestTokenizerMaxLengthResolution:
             def decode(self, *_args, **_kwargs) -> str:
                 return "x"
 
-        def _fake_from_pretrained(*_args, **kwargs):  # noqa: ANN202
+        def _fake_from_pretrained(
+            *_args: object, **kwargs: object
+        ) -> FakeTokenizer:
             recorded_kwargs.update(kwargs)
             return FakeTokenizer()
 
@@ -325,7 +327,9 @@ class TestTokenizerMaxLengthResolution:
             def decode(self, *_args, **_kwargs) -> str:
                 return "x"
 
-        def _fake_from_pretrained(*_args, **kwargs):  # noqa: ANN202
+        def _fake_from_pretrained(
+            *_args: object, **kwargs: object
+        ) -> FakeTokenizer:
             recorded_kwargs.update(kwargs)
             return FakeTokenizer()
 
@@ -356,14 +360,14 @@ class TestTokenizerMaxLengthResolution:
         fake_processor = SimpleNamespace(image_break_token_id=None)
 
         def _fake_auto_tokenizer_from_pretrained(
-            *_args, **kwargs
-        ):  # noqa: ANN202
+            *_args: object, **kwargs: object
+        ) -> FakeTokenizer:
             recorded_kwargs.update(kwargs)
             return FakeTokenizer()
 
         def _fake_auto_processor_from_pretrained(
-            *_args, **_kwargs
-        ):  # noqa: ANN202
+            *_args: object, **_kwargs: object
+        ) -> SimpleNamespace:
             return fake_processor
 
         monkeypatch.setattr(

--- a/max/tests/tests/pipelines/lib/test_max_config_basic.py
+++ b/max/tests/tests/pipelines/lib/test_max_config_basic.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 import yaml
@@ -25,6 +26,7 @@ from max.dtype import DType
 from max.pipelines.lib import (
     KVCacheConfig,
     LoRAConfig,
+    PipelineConfig,
     ProfilingConfig,
     SamplingConfig,
 )
@@ -258,27 +260,33 @@ class TestProfilingConfigEnv:
         assert config.gpu_profiling == "on"
 
 
-def _make_text_pipeline_config(max_length: int | None) -> SimpleNamespace:
-    return SimpleNamespace(
-        model=SimpleNamespace(
-            max_length=max_length,
-            huggingface_config=SimpleNamespace(eos_token_id=None),
-        )
+def _make_text_pipeline_config(max_length: int | None) -> PipelineConfig:
+    return cast(
+        PipelineConfig,
+        SimpleNamespace(
+            model=SimpleNamespace(
+                max_length=max_length,
+                huggingface_config=SimpleNamespace(eos_token_id=None),
+            )
+        ),
     )
 
 
 def _make_text_and_vision_pipeline_config(
     max_length: int | None,
-) -> SimpleNamespace:
-    return SimpleNamespace(
-        model=SimpleNamespace(
-            max_length=max_length,
-            huggingface_config=SimpleNamespace(
-                eos_token_id=None,
-                image_token_id=151667,
-            ),
-            kv_cache=SimpleNamespace(enable_prefix_caching=False),
-        )
+) -> PipelineConfig:
+    return cast(
+        PipelineConfig,
+        SimpleNamespace(
+            model=SimpleNamespace(
+                max_length=max_length,
+                huggingface_config=SimpleNamespace(
+                    eos_token_id=None,
+                    image_token_id=151667,
+                ),
+                kv_cache=SimpleNamespace(enable_prefix_caching=False),
+            )
+        ),
     )
 
 


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

<!--
Thanks for submitting a pull request, 
your contribution is really appreciated!

If possible, add a link to the issue you are 
trying to solve in the pull request description.

If your pull request is big (> 100 lines), consider splitting it
into multiple pull requests as it may accelerate the review process.
-->

Quote:

> In the MAX pipeline, the tokenizer is limiting model_max_length to 131072 based on the value in tokenizer_config.json, even when a higher --max-length (e.g. 163840) is provided and the model supports a larger context.
> 
> This has been observed with DeepSeekV3 and will also affect DeepSeek-R1, since both have model_max_length set to 131072 in their tokenizer configs:
> 
> DeepSeekV3: https://huggingface.co/kathywu95/deepseek-v3-small-random-fp8/blob/main/tokenizer_config.json#L22
> 
> DeepSeek-R1: https://huggingface.co/deepseek-ai/DeepSeek-R1/blob/main/tokenizer_config.json#L22
> 
> The current behavior causes warnings/errors like:
> 
> Token indices sequence length is longer than the specified maximum sequence length for this model (405315 > 131072). Running this sequence through the model will result in indexing errors
> 
> The MAX pipeline tokenizer should obtain the correct model_max_length from the model/config instead of automatically using the value from tokenizer_config.json.
> 