### PR TITLE
[Stdlib] Add List.sort() in-place sort method

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -209,6 +209,9 @@ what we publish.
 
 ### Library changes
 
+- `List` now has a `sort()` method for in-place sorting, with overloads for
+  `Comparable` types and custom comparison functions.
+
 - `Set.pop()` now uses `Dict.popitem()` directly, avoiding a redundant rehash.
   Order changes from FIFO to LIFO, matching Python's unordered `set.pop()`.
 

--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -1380,6 +1380,47 @@ struct List[T: Copyable](
                 count += 1
         return count
 
+    fn sort[
+        _T: Copyable & Comparable, //
+    ](mut self: List[_T, ...]):
+        """Sorts the list in-place in ascending order.
+
+        Parameters:
+            _T: The type of the elements in the list. Must implement the
+                traits `Copyable` and `Comparable`.
+
+        Examples:
+
+        ```mojo
+        var numbers = [3, 1, 4, 1, 5]
+        numbers.sort()
+        print(numbers)  # [1, 1, 3, 4, 5]
+        ```
+        """
+        sort(self)
+
+    fn sort[
+        _T: Copyable,
+        //,
+        cmp_fn: fn(_T, _T) capturing[_] -> Bool,
+    ](mut self: List[_T, ...]):
+        """Sorts the list in-place using a custom comparison function.
+
+        Parameters:
+            _T: The type of the elements in the list.
+            cmp_fn: The comparison function that returns True if the first
+                argument should be ordered before the second.
+
+        Examples:
+
+        ```mojo
+        var numbers = [3, 1, 4, 1, 5]
+        numbers.sort[cmp_fn = lambda a, b: a > b]()  # descending
+        print(numbers)  # [5, 4, 3, 1, 1]
+        ```
+        """
+        sort[cmp_fn](self)
+
     fn swap_elements(mut self, elt_idx_1: Int, elt_idx_2: Int):
         """Swaps elements at the specified indexes if they are different.
 

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -822,6 +822,48 @@ def test_list_count():
     assert_equal(0, list2.count(1))
 
 
+def test_list_sort():
+    # Basic ascending sort.
+    var numbers = [3, 1, 4, 1, 5, 9, 2, 6]
+    numbers.sort()
+    assert_equal(numbers, [1, 1, 2, 3, 4, 5, 6, 9])
+
+    # Already sorted.
+    var sorted_list = [1, 2, 3, 4, 5]
+    sorted_list.sort()
+    assert_equal(sorted_list, [1, 2, 3, 4, 5])
+
+    # Reverse sorted.
+    var reversed_list = [5, 4, 3, 2, 1]
+    reversed_list.sort()
+    assert_equal(reversed_list, [1, 2, 3, 4, 5])
+
+    # Single element.
+    var single = [42]
+    single.sort()
+    assert_equal(single, [42])
+
+    # Empty list.
+    var empty = List[Int]()
+    empty.sort()
+    assert_equal(len(empty), 0)
+
+    # Duplicates.
+    var dups = [3, 3, 3, 1, 1, 2]
+    dups.sort()
+    assert_equal(dups, [1, 1, 2, 3, 3, 3])
+
+    # Custom comparison (descending).
+    var desc = [3, 1, 4, 1, 5]
+
+    @parameter
+    fn cmp_desc(a: Int, b: Int) -> Bool:
+        return a > b
+
+    desc.sort[cmp_fn=cmp_desc]()
+    assert_equal(desc, [5, 4, 3, 1, 1])
+
+
 def test_list_add():
     var a = [1, 2, 3]
     var b = [4, 5, 6]


### PR DESCRIPTION
## Summary

- Add `List.sort()` method for `Comparable` types (ascending order).
- Add `List.sort[cmp_fn]()` overload for custom comparison functions.
- Both delegate to the existing `sort()` free function.