### PR TITLE
[Stdlib] Add as_span() method to List

### DIFF
--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -1429,6 +1429,19 @@ struct List[T: Copyable](
             .address_space_cast[address_space]()
         )
 
+    fn as_span[
+        origin: Origin, //
+    ](ref[origin] self) -> Span[Self.T, origin]:
+        """Returns a `Span` over the elements of the `List`.
+
+        Parameters:
+            origin: The origin of the `List`.
+
+        Returns:
+            A `Span` pointing to the elements of this `List`.
+        """
+        return Span[Self.T, origin](ptr=self.unsafe_ptr(), length=len(self))
+
     @always_inline
     fn _unsafe_next_uninit_ptr(
         ref self,

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -1080,6 +1080,25 @@ def test_list_can_infer_iterable_element_type():
     )
 
 
+def test_list_as_span():
+    var l = [1, 2, 3]
+    var s = l.as_span()
+    assert_equal(len(s), 3)
+    assert_equal(s[0], 1)
+    assert_equal(s[1], 2)
+    assert_equal(s[2], 3)
+
+    # Mutable span allows modification.
+    var m = l.as_span()
+    m[0] = 10
+    assert_equal(l[0], 10)
+
+    # Empty list.
+    var empty = List[Int]()
+    var es = empty.as_span()
+    assert_equal(len(es), 0)
+
+
 # ===-------------------------------------------------------------------===#
 # main
 # ===-------------------------------------------------------------------===#


### PR DESCRIPTION
## Summary
- Adds `as_span()` method to `List` for explicitly obtaining a `Span` view over the list's elements, matching the pattern used by `HostBuffer.as_span()`.