### PR TITLE
[Kernels] Remove redundant barrier and prefetch gamma in RMS norm

### DIFF
--- a/max/kernels/src/nn/mla_graph.mojo
+++ b/max/kernels/src/nn/mla_graph.mojo
@@ -16,6 +16,7 @@ from std.collections import OptionalReg
 from std.math import align_up, ceildiv
 
 from std.sys import simd_width_of, size_of
+from std.sys.info import align_of
 from std.utils.index import Index, IndexList
 
 from std.algorithm.functional import _elementwise_impl_gpu
@@ -195,6 +196,7 @@ fn fused_rope_rmsnorm_kernel[
                 ), "kv_norm_dim should be divisible by k_width"
 
                 var vec_data = SIMD[accum_type, k_width](0)
+                var gamma_val = SIMD[gamma_dtype, k_width](0)
 
                 var idx = Int(thread_idx.x) * k_width
                 if idx < kv_norm_dim:
@@ -204,6 +206,11 @@ fn fused_rope_rmsnorm_kernel[
                         post_seq_idx,
                         idx,
                     ).cast[accum_type]()
+                    # Prefetch gamma before reduction.
+                    gamma_val = gamma.load[
+                        width=k_width,
+                        alignment = align_of[SIMD[gamma_dtype, k_width]](),
+                    ](Coord(Idx(idx)))
 
                 var norm_val = _rms_norm_warp_tiling_subkernel[
                     warps_per_block,
@@ -212,7 +219,7 @@ fn fused_rope_rmsnorm_kernel[
                     global_token_idx,
                     idx,
                     vec_data,
-                    gamma,
+                    gamma_val,
                     epsilon.cast[accum_type](),
                     0.0,
                     kv_norm_dim,

--- a/max/kernels/src/nn/mla_graph.mojo
+++ b/max/kernels/src/nn/mla_graph.mojo
@@ -376,12 +376,18 @@ fn fused_rope_rmsnorm_quantization_kernel[
                 ), "kv_norm_dim should be divisible by k_width"
 
                 var vec_data = SIMD[accum_type, k_width](0)
+                var gamma_val = SIMD[gamma_dtype, k_width](0)
 
                 var idx = Int(thread_idx.x) * k_width
                 if idx < kv_norm_dim:
                     vec_data = kv.load[width=k_width](
                         (Idx(global_token_idx), Idx(idx))
                     ).cast[accum_type]()
+                    # Prefetch gamma before reduction.
+                    gamma_val = gamma.load[
+                        width=k_width,
+                        alignment = align_of[SIMD[gamma_dtype, k_width]](),
+                    ](Coord(Idx(idx)))
 
                 var norm_val = _rms_norm_warp_tiling_subkernel[
                     warps_per_block,
@@ -390,7 +396,7 @@ fn fused_rope_rmsnorm_quantization_kernel[
                     global_token_idx,
                     idx,
                     vec_data,
-                    gamma,
+                    gamma_val,
                     epsilon.cast[accum_type](),
                     0.0,
                     kv_norm_dim,

--- a/max/kernels/src/nn/normalization.mojo
+++ b/max/kernels/src/nn/normalization.mojo
@@ -832,14 +832,11 @@ fn _rms_norm_warp_tiling_subkernel[
     row: Int,
     idx: Int,
     vec_data: SIMD[accum_type, simd_width],
-    gamma: TileTensor[dtype, ...],
+    gamma_val: SIMD[dtype, simd_width],
     epsilon: Scalar[accum_type],
     weight_offset: Scalar[accum_type],
     num_cols: Int,
 ) -> SIMD[dtype, simd_width]:
-    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
-    comptime align = align_of[SIMD[dtype, simd_width]]()
-
     # To utilize simd vector load.
     var thread_m2: Scalar[accum_type] = (vec_data**2).reduce_add()
 
@@ -856,10 +853,6 @@ fn _rms_norm_warp_tiling_subkernel[
     var norm_factor = rsqrt((row_m2 / Scalar[accum_type](num_cols)) + epsilon)
     var norm_val: SIMD[dtype, simd_width] = 0
     if idx < num_cols:
-        var gamma_val = gamma.load[width=simd_width, alignment=align](
-            Coord(Idx(idx))
-        )
-
         comptime if multiply_before_cast:
             var gamma_accum = gamma_val.cast[accum_type]() + weight_offset
             norm_val = (vec_data * norm_factor * gamma_accum).cast[dtype]()
@@ -913,10 +906,15 @@ fn rms_norm_gpu_warp_tiling_128[
     var idx = local_tid * UInt(simd_width)
 
     with PDL():
+        var gamma_val = SIMD[dtype, simd_width](0)
         if row < UInt(num_rows) and idx < UInt(num_cols):
             vec_data = input_fn[simd_width](Int(row), Int(idx)).cast[
                 accum_type
             ]()
+            # Prefetch gamma before reduction to overlap load with compute.
+            gamma_val = gamma.load[width=simd_width, alignment=align](
+                Coord(Idx(idx))
+            )
 
         var norm_val = _rms_norm_warp_tiling_subkernel[
             warps_per_block, multiply_before_cast, rows_per_warp=2
@@ -924,7 +922,7 @@ fn rms_norm_gpu_warp_tiling_128[
             Int(row),
             Int(idx),
             vec_data,
-            gamma,
+            gamma_val,
             eps_accum,
             weight_offset_accum,
             num_cols,
@@ -968,10 +966,15 @@ fn rms_norm_gpu_warp_tiling[
     var idx = tid * UInt(simd_width)
 
     with PDL():
+        var gamma_val = SIMD[dtype, simd_width](0)
         if idx < UInt(num_cols):
             vec_data = input_fn[simd_width](Int(row), Int(idx)).cast[
                 accum_type
             ]()
+            # Prefetch gamma before reduction to overlap load with compute.
+            gamma_val = gamma.load[width=simd_width, alignment=align](
+                Coord(Idx(idx))
+            )
 
         var norm_val = _rms_norm_warp_tiling_subkernel[
             max_warps_per_block, multiply_before_cast
@@ -979,7 +982,7 @@ fn rms_norm_gpu_warp_tiling[
             Int(row),
             Int(idx),
             vec_data,
-            gamma,
+            gamma_val,
             eps_accum,
             weight_offset_accum,
             num_cols,
@@ -1498,7 +1501,9 @@ fn rms_norm_fused_residual_add_gpu_warp_tiling[
     num_cols: Int,
 ):
     comptime assert gamma1.rank == 1, "gamma1 must have rank 1"
+    comptime assert gamma1.flat_rank == 1, "gamma1 must have flat_rank 1"
     comptime assert gamma2.rank == 1, "gamma2 must have rank 1"
+    comptime assert gamma2.flat_rank == 1, "gamma2 must have flat_rank 1"
 
     comptime align = align_of[SIMD[dtype, simd_width]]()
     comptime accum_type = get_accum_type[dtype]()
@@ -1514,8 +1519,13 @@ fn rms_norm_fused_residual_add_gpu_warp_tiling[
     var idx = tid * UInt(simd_width)
 
     with PDL():
+        var gamma1_val = SIMD[dtype, simd_width](0)
         if idx < UInt(num_cols):
             vec_data = input_fn[simd_width](Int(row), Int(idx))
+            # Prefetch gamma1 before reduction to overlap load with compute.
+            gamma1_val = gamma1.load[width=simd_width, alignment=align](
+                Coord(Idx(idx))
+            )
 
         var norm1_val = _rms_norm_warp_tiling_subkernel[
             max_warps_per_block, multiply_before_cast
@@ -1523,15 +1533,20 @@ fn rms_norm_fused_residual_add_gpu_warp_tiling[
             Int(row),
             Int(idx),
             vec_data.cast[accum_type](),
-            gamma1,
+            gamma1_val,
             eps_accum1,
             weight_offset_accum1,
             num_cols,
         )
 
+        var gamma2_val = SIMD[dtype, simd_width](0)
         if idx < UInt(num_cols):
             norm1_val += residual_input_fn[simd_width](Int(row), Int(idx))
             output_residual_fn[simd_width, align](Int(row), Int(idx), norm1_val)
+            # Prefetch gamma2 before second reduction.
+            gamma2_val = gamma2.load[width=simd_width, alignment=align](
+                Coord(Idx(idx))
+            )
 
         var norm2_val = _rms_norm_warp_tiling_subkernel[
             max_warps_per_block, multiply_before_cast
@@ -1539,7 +1554,7 @@ fn rms_norm_fused_residual_add_gpu_warp_tiling[
             Int(row),
             Int(idx),
             norm1_val.cast[accum_type](),
-            gamma2,
+            gamma2_val,
             eps_accum2,
             weight_offset_accum2,
             num_cols,

--- a/max/kernels/src/nn/normalization.mojo
+++ b/max/kernels/src/nn/normalization.mojo
@@ -75,17 +75,9 @@ fn block_reduce[
         1, dtype, address_space = AddressSpace.SHARED
     ]()
 
-    var tid = thread_idx.x
-    for i in range(tid, max_warps_per_block, block_dim.x):
-        m2_shared[i] = 0
-
-    if tid == 0:
-        m2_broadcast[0] = 0
-
-    barrier()
-
     var warp_m2 = warp.sum(val)
 
+    var tid = thread_idx.x
     var warp_id = warp.broadcast(tid // UInt(WARP_SIZE))
     var lane_idx = lane_id()
 
@@ -96,7 +88,9 @@ fn block_reduce[
     if warp_id == 0:
         var block_m2 = Scalar[dtype](0)
 
-        if lane_idx < UInt(max_warps_per_block):
+        # Only read lanes corresponding to active warps to avoid
+        # reading uninitialized shared memory.
+        if lane_idx < block_dim.x // UInt(WARP_SIZE):
             block_m2 = m2_shared[lane_idx]
 
         # On some GPUs, the warp-level reduction implicitly requires all lanes

--- a/max/kernels/src/nn/normalization.mojo
+++ b/max/kernels/src/nn/normalization.mojo
@@ -895,6 +895,7 @@ fn rms_norm_gpu_warp_tiling_128[
     var weight_offset_accum = weight_offset.cast[accum_type]()
 
     var vec_data = SIMD[accum_type, simd_width](0)
+    var gamma_val = SIMD[dtype, simd_width](0)
     var tid = thread_idx.x
     # Each warp handles 2 rows, so total rows per block is warps_per_block * 2
     var block_row = block_idx.x * UInt(warps_per_block * 2)
@@ -906,7 +907,6 @@ fn rms_norm_gpu_warp_tiling_128[
     var idx = local_tid * UInt(simd_width)
 
     with PDL():
-        var gamma_val = SIMD[dtype, simd_width](0)
         if row < UInt(num_rows) and idx < UInt(num_cols):
             vec_data = input_fn[simd_width](Int(row), Int(idx)).cast[
                 accum_type
@@ -961,12 +961,12 @@ fn rms_norm_gpu_warp_tiling[
     var weight_offset_accum = weight_offset.cast[accum_type]()
 
     var vec_data = SIMD[accum_type, simd_width](0)
+    var gamma_val = SIMD[dtype, simd_width](0)
     var tid = thread_idx.x
     var row = block_idx.x
     var idx = tid * UInt(simd_width)
 
     with PDL():
-        var gamma_val = SIMD[dtype, simd_width](0)
         if idx < UInt(num_cols):
             vec_data = input_fn[simd_width](Int(row), Int(idx)).cast[
                 accum_type
@@ -1514,12 +1514,12 @@ fn rms_norm_fused_residual_add_gpu_warp_tiling[
     var weight_offset_accum2 = weight_offset2.cast[accum_type]()
 
     var vec_data = SIMD[dtype, simd_width](0)
+    var gamma1_val = SIMD[dtype, simd_width](0)
     var tid = thread_idx.x
     var row = block_idx.x
     var idx = tid * UInt(simd_width)
 
     with PDL():
-        var gamma1_val = SIMD[dtype, simd_width](0)
         if idx < UInt(num_cols):
             vec_data = input_fn[simd_width](Int(row), Int(idx))
             # Prefetch gamma1 before reduction to overlap load with compute.


### PR DESCRIPTION
## Summary

Two optimizations to the RMS norm GPU kernel:

1. **Remove redundant barrier and init loop from `block_reduce`** — The shared memory initialization loop and first barrier are unnecessary when all active warps write before the reduction reads. Changed warp 0's read condition to `block_dim.x // WARP_SIZE` instead of compile-time `max_warps_per_block`.

2. **Prefetch gamma before `block_reduce`** — Moved gamma load before the block_reduce synchronization so gamma memory latency overlaps with the block reduction compute (barriers + warp shuffles). Updated `_rms_norm_warp_tiling_subkernel` signature to accept pre-loaded SIMD gamma, and updated the caller in `mla_graph.mojo`.

## Benchmark Results (H100, MAX nightly 26.2.0.dev2026021805, driver 570)

**Shape:** 1x4096x4096, bfloat16

| Metric | Baseline | Optimized | Change |
|--------|----------|-----------|--------|
| Duration | 36.64 µs | 33.59 µs | **-8.3%** |
| SM Throughput | 65.36% | 68.07% | +2.7pp |
| DRAM Throughput | 36.31% | 37.54% | +1.2pp |
| Long Scoreboard Stall | 20.59% | 19.48% | -1.1pp |
| Barrier Stall | 14.11% | 13.77% | -0.3pp |

## Changes

- `max/kernels/src/nn/normalization.mojo` — barrier removal + gamma prefetch
- `max/kernels/src/nn/mla_graph.mojo` — updated caller for new subkernel signature

## Test Plan

- [x] Kernel builds successfully
- [x] Benchmarked with verified speedup via NCU profiling
- [x] `./bazelw test //max/kernels/test/gpu/nn:test_rms_norm.mojo.test` — PASSED
- [x] `./bazelw test //max/kernels/test/gpu/nn:test_mla.mojo.test` — PASSED

Co-Authored-By: modular-kernel-agent <modular@speedtrain.co>