### PR TITLE
[Kernels] Use invariant loads in broadcast kernels + add kbench YAML

### DIFF
--- a/max/kernels/benchmarks/gpu/bench_broadcast.yaml
+++ b/max/kernels/benchmarks/gpu/bench_broadcast.yaml
@@ -1,0 +1,31 @@
+##===----------------------------------------------------------------------===##
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##===----------------------------------------------------------------------===##
+
+name: bench_broadcast
+file: $KERNEL_BENCHMARKS_ROOT/gpu/bench_broadcast.mojo
+
+commons: &commons
+  dtype: [DType.bfloat16, DType.float32]
+  num_gpus: [2, 4, 8]
+  rank: [1]
+  $num_bytes: "[2**i for i in range(14, 28)]"
+  TUNE_MAX_NUM_BLOCKS: [0]
+
+params:
+- <<: *commons
+  use_multimem: [False, True]
+  use_vendor_ccl: [False]
+
+- <<: *commons
+  use_multimem: [False]
+  use_vendor_ccl: [True]


### PR DESCRIPTION
## Summary

Use raw pointer operations with `invariant=True` loads in both the 1-stage and multimem broadcast kernels. The invariant hint tells the compiler that the source data won't change during kernel execution, enabling better codegen (instruction scheduling, caching hints).

Also adds a `bench_broadcast.yaml` kbench configuration file with representative parameter sweeps for multi-GPU benchmarking.

> Per review feedback on #6023: this PR contains only the invariant load optimization. The 1-GPU dispatch changes, block size tuning, and barrier skip have been removed.

## Changes

- `max/kernels/src/comm/broadcast.mojo` — raw pointer + `invariant=True` loads in both 1-stage and multimem kernels
- `max/kernels/benchmarks/gpu/bench_broadcast.yaml` — kbench config (bf16/f32, 2/4/8 GPUs, 16KB–128MB, multimem + vendor CCL)

## Note

The invariant load optimization improves codegen quality but the performance impact requires multi-GPU hardware to measure (broadcast is a collective operation). The YAML file enables benchmarking across GPU counts and message sizes via kbench.

Benchmarked on H100 with MAX nightly 26.2.0.dev2026021805, driver 570.

## Test Plan

- [x] Kernel builds successfully
- [ ] `./bazelw test //max/kernels/test/gpu/comm:test_broadcast.mojo.test` (requires multi-GPU)

Co-Authored-By: modular-kernel-agent <modular@speedtrain.co>