### PR TITLE
[Stdlib] Use t-strings for multi-arg String construction in return position

### DIFF
--- a/mojo/stdlib/std/collections/inline_array.mojo
+++ b/mojo/stdlib/std/collections/inline_array.mojo
@@ -297,13 +297,7 @@ struct InlineArray[ElementType: Copyable, size: Int](
         Returns:
             The host type's name.
         """
-        return String(
-            "InlineArray[",
-            get_type_name[Self.ElementType](),
-            ", ",
-            Self.size,
-            "]",
-        )
+        return t"InlineArray[{get_type_name[Self.ElementType]()}, {Self.size}]"
 
     # ===------------------------------------------------------------------===#
     # Life cycle methods

--- a/mojo/stdlib/std/collections/string/string.mojo
+++ b/mojo/stdlib/std/collections/string/string.mojo
@@ -2359,13 +2359,7 @@ def _handle_base_prefix(
 
 
 def _str_to_base_error(base: Int, str_slice: StringSlice) -> String:
-    return String(
-        "String is not convertible to integer with base ",
-        base,
-        ": '",
-        str_slice,
-        "'",
-    )
+    return t"String is not convertible to integer with base {base}: '{str_slice}'"
 
 
 def _identify_base(str_slice: StringSlice, start: Int) -> Tuple[Int, Int]:

--- a/mojo/stdlib/std/collections/string/string.mojo
+++ b/mojo/stdlib/std/collections/string/string.mojo
@@ -2359,7 +2359,9 @@ def _handle_base_prefix(
 
 
 def _str_to_base_error(base: Int, str_slice: StringSlice) -> String:
-    return t"String is not convertible to integer with base {base}: '{str_slice}'"
+    return (
+        t"String is not convertible to integer with base {base}: '{str_slice}'"
+    )
 
 
 def _identify_base(str_slice: StringSlice, start: Int) -> Tuple[Int, Int]:

--- a/mojo/stdlib/std/memory/span.mojo
+++ b/mojo/stdlib/std/memory/span.mojo
@@ -180,11 +180,7 @@ struct Span[
         Returns:
             This type's name.
         """
-        return String(
-            "Span[",
-            get_type_name[Self.T](),
-            "]",
-        )
+        return t"Span[{get_type_name[Self.T]()}]"
 
     # ===------------------------------------------------------------------===#
     # Life cycle methods

--- a/mojo/stdlib/std/memory/unsafe_pointer.mojo
+++ b/mojo/stdlib/std/memory/unsafe_pointer.mojo
@@ -996,15 +996,7 @@ struct UnsafePointer[
         Returns:
             This name of the type.
         """
-        return String(
-            "UnsafePointer[",
-            get_type_name[Self.type](),
-            ", mut=",
-            Self.mut,
-            ", address_space=",
-            Self.address_space,
-            "]",
-        )
+        return t"UnsafePointer[{get_type_name[Self.type]()}, mut={Self.mut}, address_space={Self.address_space}]"
 
     @always_inline("nodebug")
     def swap_pointees[

--- a/mojo/stdlib/std/memory/unsafe_pointer.mojo
+++ b/mojo/stdlib/std/memory/unsafe_pointer.mojo
@@ -996,7 +996,10 @@ struct UnsafePointer[
         Returns:
             This name of the type.
         """
-        return t"UnsafePointer[{get_type_name[Self.type]()}, mut={Self.mut}, address_space={Self.address_space}]"
+        return (
+            t"UnsafePointer[{get_type_name[Self.type]()}, mut={Self.mut},"
+            t" address_space={Self.address_space}]"
+        )
 
     @always_inline("nodebug")
     def swap_pointees[

--- a/mojo/stdlib/std/testing/testing.mojo
+++ b/mojo/stdlib/std/testing/testing.mojo
@@ -520,12 +520,7 @@ def _create_colored_diff(lhs: String, rhs: String) -> String:
     Returns:
         A string containing the colored diff output.
     """
-    return String(
-        "\n   left: ",
-        _colorize_diff_string[Color.RED](lhs, rhs),
-        "\n  right: ",
-        _colorize_diff_string[Color.GREEN](rhs, lhs),
-    )
+    return t"\n   left: {_colorize_diff_string[Color.RED](lhs, rhs)}\n  right: {_colorize_diff_string[Color.GREEN](rhs, lhs)}"
 
 
 def _assert_cmp_error[

--- a/mojo/stdlib/std/testing/testing.mojo
+++ b/mojo/stdlib/std/testing/testing.mojo
@@ -520,7 +520,9 @@ def _create_colored_diff(lhs: String, rhs: String) -> String:
     Returns:
         A string containing the colored diff output.
     """
-    return t"\n   left: {_colorize_diff_string[Color.RED](lhs, rhs)}\n  right: {_colorize_diff_string[Color.GREEN](rhs, lhs)}"
+    var left = _colorize_diff_string[Color.RED](lhs, rhs)
+    var right = _colorize_diff_string[Color.GREEN](rhs, lhs)
+    return t"\n   left: {left}\n  right: {right}"
 
 
 def _assert_cmp_error[

--- a/mojo/stdlib/std/utils/static_tuple.mojo
+++ b/mojo/stdlib/std/utils/static_tuple.mojo
@@ -84,13 +84,7 @@ struct StaticTuple[element_type: _StaticTupleTraits, size: Int](
         Returns:
             A string representation of the type, e.g. "StaticTuple[Int, 3]".
         """
-        return String(
-            "StaticTuple[",
-            get_type_name[Self.element_type](),
-            ", ",
-            Self.size,
-            "]",
-        )
+        return t"StaticTuple[{get_type_name[Self.element_type]()}, {Self.size}]"
 
     @always_inline
     def __init__(out self):


### PR DESCRIPTION
Replace multi-argument `String(...)` variadic constructor calls with t-string syntax in all cases where the result is returned from a `-> String` function.

Affected files: `memory/span.mojo`, `memory/legacy_unsafe_pointer.mojo`, `memory/unsafe_pointer.mojo`, `collections/inline_array.mojo`, `utils/static_tuple.mojo`, `collections/string/string.mojo`, `testing/testing.mojo`.