### PR TITLE
[Stdlib] Add String.__iadd__ overload for Writable types

### DIFF
--- a/mojo/stdlib/std/collections/string/string.mojo
+++ b/mojo/stdlib/std/collections/string/string.mojo
@@ -982,6 +982,20 @@ struct String(
         """
         self._iadd(other.as_bytes())
 
+    fn __iadd__[T: Writable](mut self, other: T):
+        """Appends any writable value to this string.
+
+        This overload allows appending any type that implements `Writable`,
+        such as t-strings, integers, or other formattable types.
+
+        Parameters:
+            T: The type of the value to append, which must implement `Writable`.
+
+        Args:
+            other: The writable value to append.
+        """
+        self.write(other)
+
     @deprecated("Use `str.codepoints()` or `str.codepoint_slices()` instead.")
     fn __iter__(self) -> CodepointSliceIter[origin_of(self)]:
         """Iterate over the string, returning immutable references.

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -1817,5 +1817,34 @@ def test_append_codepoint() raises:
     assert_equal(s.byte_length(), 8)
 
 
+def test_iadd_writable() raises:
+    # t-strings
+    var s = String("hello")
+    s += t" {42}"
+    assert_equal(s, "hello 42")
+
+    # integers
+    var s2 = String("count=")
+    s2 += 7
+    assert_equal(s2, "count=7")
+
+    # existing StringSlice overload still works
+    var s3 = String("abc")
+    s3 += StringSlice("def")
+    assert_equal(s3, "abcdef")
+
+    # String += String still works
+    var s4 = String("foo")
+    s4 += String("bar")
+    assert_equal(s4, "foobar")
+
+    # chained appends via t-strings
+    var s5 = String("x=")
+    var x = 10
+    s5 += t"{x}"
+    s5 += t", y={x * 2}"
+    assert_equal(s5, "x=10, y=20")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Add a generic `__iadd__[T: Writable]` overload to `String` so that any `Writable` value can be appended with `+=`, including t-strings (`s += t"{x}"`), integers, and other formattable types.

The existing `StringSlice` overload is preserved as the fast path (direct `memcpy` via `_iadd`). Mojo's overload resolution prefers the concrete `StringSlice` overload for `StringSlice` and `String` arguments, so there is no ambiguity or performance regression.