### PR TITLE
[Stdlib][GPU] Fix warp.max/warp.min CUDA_ERROR_INVALID_PTX on SM 120

### DIFF
--- a/mojo/stdlib/std/gpu/primitives/warp.mojo
+++ b/mojo/stdlib/std/gpu/primitives/warp.mojo
@@ -1117,7 +1117,11 @@ fn prefix_sum[
 
 @always_inline("nodebug")
 fn _has_redux_f32_support[dtype: DType, simd_width: Int]() -> Bool:
-    return _is_sm_100x_or_newer() and dtype == DType.float32 and simd_width == 1
+    return (
+        (is_nvidia_gpu["sm_100a"]() or is_nvidia_gpu["sm_101a"]())
+        and dtype == DType.float32
+        and simd_width == 1
+    )
 
 
 @always_inline("nodebug")
@@ -1126,7 +1130,7 @@ fn _redux_f32_max_min[direction: StaticString](val: SIMD) -> type_of(val):
     return inlined_assembly[
         instruction + " $0, $1, $2;",
         type_of(val),
-        constraints="=r,r,i",
+        constraints="=f,f,i",
         has_side_effect=True,
     ](val, Int32(_FULL_MASK))
 


### PR DESCRIPTION
## Summary
The `redux.sync.{max,min}.NaN.f32` PTX instruction is only available on SM 100 family GPUs (sm_100a, sm_101a), not on SM 120 (RTX 5090). The `_has_redux_f32_support` guard was using `_is_sm_100x_or_newer()` which incorrectly includes SM 110/120. This caused CUDA_ERROR_INVALID_PTX when calling warp.max or warp.min with Float32 on any SM 120 device (such as an RTX 5090).

This commit:
- Restricts `_has_redux_f32_support` to `sm_100a` and `sm_101a` only, matching the LLVM NVPTX backend's `hasReduxSyncF32()` guard.
- Fixes inline assembly register constraints from `"=r,r,i"` (integer) to `"=f,f,i"` (float), which is correct for f32 operands.

SM 120 devices now fall back to the shuffle-based reduction path which works correctly on all architectures.

Assisted-by: Claude

## Testing

Tests were added in #6048 and these PRs were tested together on an RTX 5090.

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
