### PR TITLE
[MAX][config] Auto-default DeepSeek EP/DP for multi-GPU pipeline config

### DIFF
--- a/max/python/max/entrypoints/cli/config.py
+++ b/max/python/max/entrypoints/cli/config.py
@@ -189,8 +189,16 @@ def is_multiple(field_type: Any) -> bool:
     return get_origin(field_type) is list
 
 
+def get_public_field_name(field_name: str, field_info: Any) -> str:
+    alias = getattr(field_info, "alias", None)
+    if isinstance(alias, str):
+        return alias
+    return field_name
+
+
 def get_normalized_flag_name(dataclass_field: Any, field_type: Any) -> str:
-    normalized_name = dataclass_field.name.lower().replace("_", "-")
+    public_name = getattr(dataclass_field, "public_name", dataclass_field.name)
+    normalized_name = public_name.lower().replace("_", "-")
 
     if is_flag(field_type):
         return f"--{normalized_name}/--no-{normalized_name}"
@@ -204,7 +212,8 @@ def create_click_option(
     field_type: Any,
 ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
     # Get Help text.
-    help_text = help_for_fields.get(dataclass_field.name, None)
+    public_name = getattr(dataclass_field, "public_name", dataclass_field.name)
+    help_text = help_for_fields.get(public_name)
 
     # Get help field.
     return click.option(
@@ -243,6 +252,7 @@ def get_fields_from_pydantic_model(
         # Create a simple object that mimics dataclass Field.
         field_obj = SimpleNamespace()
         field_obj.name = field_name
+        field_obj.public_name = get_public_field_name(field_name, field_info)
 
         # Extract default value from Pydantic FieldInfo
         # In Pydantic v2, field_info.default is PydanticUndefined if not set,
@@ -314,7 +324,7 @@ def config_to_flag(
     options: list[tuple[str, Callable[..., Any]]] = []
     param_names: set[str] = set()
     help_text = {
-        field_name: field_info.description
+        get_public_field_name(field_name, field_info): field_info.description
         for field_name, field_info in cls.model_fields.items()
         if field_info.description
     }
@@ -327,28 +337,29 @@ def config_to_flag(
             continue
 
         original_name = _field.name
+        public_name = _field.public_name
         field_type = field_types[original_name]
 
         if prefix:
             # Create a copy of the help text with the prefixed name
-            new_name = f"{prefix}_{original_name}"
+            new_name = f"{prefix}_{public_name}"
 
-            if original_name in help_text:
-                help_text[new_name] = help_text[original_name]
+            if public_name in help_text:
+                help_text[new_name] = help_text[public_name]
 
             # Create a new Field with the modified name by copying all attributes
             from copy import copy
 
             modified_field = copy(_field)
-            modified_field.name = new_name
+            modified_field.public_name = new_name
             new_option = create_click_option(
                 help_text, modified_field, field_type
             )
             param_names.add(new_name)
         else:
-            new_name = original_name
+            new_name = public_name
             new_option = create_click_option(help_text, _field, field_type)
-            param_names.add(original_name)
+            param_names.add(public_name)
         options.append((new_name, new_option))
 
     def apply_flags(func: Callable[_P, _R]) -> Callable[_P, _R]:

--- a/max/python/max/entrypoints/cli/config.py
+++ b/max/python/max/entrypoints/cli/config.py
@@ -447,16 +447,6 @@ def pipeline_config_options(func: Callable[_P, _R]) -> Callable[_P, _R]:
                 and all(isinstance(x, int) for x in value)
             )
 
-        ctx = click.get_current_context(silent=True)
-        if ctx is not None:
-            # Preserve CLI parameter sources so PipelineConfig can distinguish
-            # Click-injected defaults from explicitly provided flags.
-            kwargs["__cli_param_sources__"] = {
-                name: source.name
-                for name in kwargs
-                if (source := ctx.get_parameter_source(name)) is not None
-            }
-
         # Remove the options from kwargs and replace with unified device_specs.
         devices = kwargs.pop("devices")
         draft_devices = kwargs.pop("draft_devices")

--- a/max/python/max/entrypoints/cli/config.py
+++ b/max/python/max/entrypoints/cli/config.py
@@ -447,6 +447,16 @@ def pipeline_config_options(func: Callable[_P, _R]) -> Callable[_P, _R]:
                 and all(isinstance(x, int) for x in value)
             )
 
+        ctx = click.get_current_context(silent=True)
+        if ctx is not None:
+            # Preserve CLI parameter sources so PipelineConfig can distinguish
+            # Click-injected defaults from explicitly provided flags.
+            kwargs["__cli_param_sources__"] = {
+                name: source.name
+                for name in kwargs
+                if (source := ctx.get_parameter_source(name)) is not None
+            }
+
         # Remove the options from kwargs and replace with unified device_specs.
         devices = kwargs.pop("devices")
         draft_devices = kwargs.pop("draft_devices")

--- a/max/python/max/pipelines/architectures/deepseekV3/arch.py
+++ b/max/python/max/pipelines/architectures/deepseekV3/arch.py
@@ -33,6 +33,8 @@ deepseekV3_arch = SupportedArchitecture(
         "float4_e2m1fnx2",
     },
     multi_gpu_supported=True,
+    default_ep_size_to_num_devices=True,
+    default_data_parallel_degree_to_num_devices=True,
     pipeline_model=DeepseekV3Model,
     tokenizer=TextTokenizer,
     context_type=TextContext,

--- a/max/python/max/pipelines/architectures/deepseekV3_2/arch.py
+++ b/max/python/max/pipelines/architectures/deepseekV3_2/arch.py
@@ -33,6 +33,8 @@ deepseekV3_2_arch = SupportedArchitecture(
         "float8_e4m3fn",
     },
     multi_gpu_supported=True,
+    default_ep_size_to_num_devices=True,
+    default_data_parallel_degree_to_num_devices=True,
     pipeline_model=DeepseekV3_2Model,
     tokenizer=TextTokenizer,
     context_type=TextContext,

--- a/max/python/max/pipelines/architectures/deepseekV3_nextn/arch.py
+++ b/max/python/max/pipelines/architectures/deepseekV3_nextn/arch.py
@@ -36,6 +36,8 @@ deepseekV3_nextn_arch = SupportedArchitecture(
         "float4_e2m1fnx2",
     },
     multi_gpu_supported=True,
+    default_ep_size_to_num_devices=True,
+    default_data_parallel_degree_to_num_devices=True,
     pipeline_model=DeepseekV3NextNModel,
     tokenizer=TextTokenizer,
     context_type=TextContext,

--- a/max/python/max/pipelines/lib/config/config.py
+++ b/max/python/max/pipelines/lib/config/config.py
@@ -547,6 +547,53 @@ class PipelineConfig(ConfigFileModel):
                 # We should be able to override this value for all config objects.
                 continue
 
+    @staticmethod
+    def _is_deepseek_arch(architecture: SupportedArchitecture) -> bool:
+        return architecture.name in {
+            "DeepseekV3ForCausalLM",
+            "DeepseekV32ForCausalLM",
+            "DeepseekV3ForCausalLMNextN",
+        }
+
+    def _apply_deepseek_multi_gpu_parallelism_defaults(
+        self,
+        architecture: SupportedArchitecture,
+        model_config: MAXModelConfig,
+        num_devices: int,
+    ) -> None:
+        """Auto-resolve DeepSeek EP/DP defaults for multi-GPU.
+
+        DeepSeek V3/V3.2/NextN require multi-GPU launches to run with
+        expert parallelism and data-parallel attention on all local devices.
+        """
+        assert self._is_deepseek_arch(architecture)
+        if num_devices <= 1:
+            return
+
+        old_ep = self.ep_size
+        old_dp = model_config.data_parallel_degree
+
+        if self.ep_size == 1 and model_config.data_parallel_degree in (
+            1,
+            num_devices,
+        ):
+            self.ep_size = num_devices
+
+        # If user provide an invalid ep_size > 1, we will not fix it here
+        # but let downstream codes to handle it
+        if self.ep_size > 1 and model_config.data_parallel_degree == 1:
+            model_config.data_parallel_degree = num_devices
+
+        if self.ep_size != old_ep or model_config.data_parallel_degree != old_dp:
+            logger.info(
+                "Auto-configured DeepSeek multi-GPU parallelism: "
+                "ep_size %s -> %s, data_parallel_degree %s -> %s",
+                old_ep,
+                self.ep_size,
+                old_dp,
+                model_config.data_parallel_degree,
+            )
+
     def resolve(self) -> None:
         """Validates and resolves the config.
 
@@ -916,6 +963,12 @@ class PipelineConfig(ConfigFileModel):
             )
 
         devices = load_devices(model_config.device_specs)
+        # This resolver runs for both primary and draft models. Apply DeepSeek
+        # EP/DP auto-defaulting only to the primary model pass.
+        if model_config is self.model and self._is_deepseek_arch(arch):
+            self._apply_deepseek_multi_gpu_parallelism_defaults(
+                arch, model_config, len(devices)
+            )
 
         # Validate LoRA support - currently only Llama3 models support LoRA
         if self.lora and self.lora.enable_lora:

--- a/max/python/max/pipelines/lib/config/config.py
+++ b/max/python/max/pipelines/lib/config/config.py
@@ -584,7 +584,10 @@ class PipelineConfig(ConfigFileModel):
         if self.ep_size > 1 and model_config.data_parallel_degree == 1:
             model_config.data_parallel_degree = num_devices
 
-        if self.ep_size != old_ep or model_config.data_parallel_degree != old_dp:
+        if (
+            self.ep_size != old_ep
+            or model_config.data_parallel_degree != old_dp
+        ):
             logger.info(
                 "Auto-configured DeepSeek multi-GPU parallelism: "
                 "ep_size %s -> %s, data_parallel_degree %s -> %s",

--- a/max/python/max/pipelines/lib/config/config.py
+++ b/max/python/max/pipelines/lib/config/config.py
@@ -153,6 +153,13 @@ class PipelineConfig(ConfigFileModel):
     """Temporary storage for unmatched kwargs during initialization.
     This is used to pass unmatched kwargs from the before validator to the after validator."""
 
+    _cli_param_sources: dict[str, str] | None = PrivateAttr(default=None)
+    """Click parameter source metadata passed from CLI entrypoints.
+
+    Keys are parameter names and values are ``click.ParameterSource.name``
+    strings (for example, ``"DEFAULT"`` or ``"COMMANDLINE"``).
+    """
+
     def configure_session(self, session: InferenceSession) -> None:
         """Configures a :class:`~max.engine.InferenceSession` with standard pipeline settings."""
         session.gpu_profiling(self.profiling.gpu_profiling)
@@ -394,6 +401,7 @@ class PipelineConfig(ConfigFileModel):
             return handler(data)
 
         kwargs = data.copy()
+        cli_param_sources = kwargs.pop("__cli_param_sources__", None)
         # Merge config file values before separating pydantic vs unmatched
         # kwargs, so sub-config fields (e.g. model_path) from the YAML are
         # visible to _postprocess_configs.
@@ -416,6 +424,10 @@ class PipelineConfig(ConfigFileModel):
         model = handler(pydantic_kwargs)
         # `_unmatched_kwargs` is a PrivateAttr, so set it on the instance.
         model._unmatched_kwargs = unmatched_kwargs
+        if isinstance(cli_param_sources, dict):
+            model._cli_param_sources = {
+                str(k): str(v) for k, v in cli_param_sources.items()
+            }
         return model
 
     @model_validator(mode="after")
@@ -547,55 +559,72 @@ class PipelineConfig(ConfigFileModel):
                 # We should be able to override this value for all config objects.
                 continue
 
-    @staticmethod
-    def _is_deepseek_arch(architecture: SupportedArchitecture) -> bool:
-        return architecture.name in {
-            "DeepseekV3ForCausalLM",
-            "DeepseekV32ForCausalLM",
-            "DeepseekV3ForCausalLMNextN",
-        }
-
-    def _apply_deepseek_multi_gpu_parallelism_defaults(
+    def _apply_multi_gpu_parallelism_defaults(
         self,
         architecture: SupportedArchitecture,
         model_config: MAXModelConfig,
         num_devices: int,
     ) -> None:
-        """Auto-resolve DeepSeek EP/DP defaults for multi-GPU.
-
-        DeepSeek V3/V3.2/NextN require multi-GPU launches to run with
-        expert parallelism and data-parallel attention on all local devices.
-        """
-        assert self._is_deepseek_arch(architecture)
+        """Auto-resolve architecture-defined EP/DP defaults for multi-GPU."""
         if num_devices <= 1:
             return
 
-        old_ep = self.ep_size
+        ep_was_provided = self._is_param_explicitly_provided(
+            "ep_size", "ep_size" in self.runtime.model_fields_set
+        )
+        dp_was_provided = self._is_param_explicitly_provided(
+            "data_parallel_degree",
+            "data_parallel_degree" in model_config.model_fields_set,
+        )
+
+        old_ep = self.runtime.ep_size
         old_dp = model_config.data_parallel_degree
 
-        if self.ep_size == 1 and model_config.data_parallel_degree in (
-            1,
-            num_devices,
+        if (
+            architecture.default_ep_size_to_num_devices
+            and not ep_was_provided
+            and self.runtime.ep_size == 1
+            and model_config.data_parallel_degree in (1, num_devices)
         ):
-            self.ep_size = num_devices
+            self.runtime.ep_size = num_devices
 
         # If user provide an invalid ep_size > 1, we will not fix it here
-        # but let downstream codes to handle it
-        if self.ep_size > 1 and model_config.data_parallel_degree == 1:
+        # but let downstream codes to handle it.
+        if (
+            architecture.default_data_parallel_degree_to_num_devices
+            and not dp_was_provided
+            and model_config.data_parallel_degree == 1
+        ):
             model_config.data_parallel_degree = num_devices
 
         if (
-            self.ep_size != old_ep
+            self.runtime.ep_size != old_ep
             or model_config.data_parallel_degree != old_dp
         ):
             logger.info(
-                "Auto-configured DeepSeek multi-GPU parallelism: "
+                "Auto-configured %s multi-GPU parallelism defaults: "
                 "ep_size %s -> %s, data_parallel_degree %s -> %s",
+                architecture.name,
                 old_ep,
-                self.ep_size,
+                self.runtime.ep_size,
                 old_dp,
                 model_config.data_parallel_degree,
             )
+
+    def _is_param_explicitly_provided(
+        self, param_name: str, fallback: bool
+    ) -> bool:
+        """Returns whether a parameter was explicitly set by the user.
+
+        ``fallback`` is the non-CLI explicitness signal (typically from
+        ``model_fields_set``) used when Click source metadata is unavailable.
+        """
+        if (
+            self._cli_param_sources is None
+            or param_name not in self._cli_param_sources
+        ):
+            return fallback
+        return self._cli_param_sources[param_name] != "DEFAULT"
 
     def resolve(self) -> None:
         """Validates and resolves the config.
@@ -966,10 +995,10 @@ class PipelineConfig(ConfigFileModel):
             )
 
         devices = load_devices(model_config.device_specs)
-        # This resolver runs for both primary and draft models. Apply DeepSeek
-        # EP/DP auto-defaulting only to the primary model pass.
-        if model_config is self.model and self._is_deepseek_arch(arch):
-            self._apply_deepseek_multi_gpu_parallelism_defaults(
+        # This resolver runs for both primary and draft models. Apply
+        # architecture default parallelism only to the primary model pass.
+        if model_config is self.model:
+            self._apply_multi_gpu_parallelism_defaults(
                 arch, model_config, len(devices)
             )
 

--- a/max/python/max/pipelines/lib/config/config.py
+++ b/max/python/max/pipelines/lib/config/config.py
@@ -557,7 +557,7 @@ class PipelineConfig(ConfigFileModel):
         old_ep = self.runtime.ep_size
         old_dp = model_config.data_parallel_degree
 
-        if self.runtime.ep_size is None:
+        if self.runtime.ep_size == 0:
             if (
                 architecture is not None
                 and num_devices > 1
@@ -567,7 +567,7 @@ class PipelineConfig(ConfigFileModel):
             else:
                 self.runtime.ep_size = 1
 
-        if model_config.data_parallel_degree is None:
+        if model_config.data_parallel_degree == 0:
             if (
                 architecture is not None
                 and num_devices > 1
@@ -597,14 +597,14 @@ class PipelineConfig(ConfigFileModel):
             return
 
         primary_dp = self.model.data_parallel_degree
-        if primary_dp is None:
+        if primary_dp == 0:
             raise AssertionError(
                 "Primary model data_parallel_degree must be resolved before "
                 "draft model defaults are applied."
             )
 
         old_draft_dp = self.draft_model.data_parallel_degree
-        if old_draft_dp is None:
+        if old_draft_dp == 0:
             self.draft_model.data_parallel_degree = primary_dp
             logger.info(
                 "Resolved draft model data_parallel_degree %s -> %s "

--- a/max/python/max/pipelines/lib/config/config.py
+++ b/max/python/max/pipelines/lib/config/config.py
@@ -557,7 +557,7 @@ class PipelineConfig(ConfigFileModel):
         old_ep = self.runtime.ep_size
         old_dp = model_config.data_parallel_degree
 
-        if self.runtime.ep_size == 0:
+        if self.runtime.ep_size is None:
             if (
                 architecture is not None
                 and num_devices > 1
@@ -567,7 +567,7 @@ class PipelineConfig(ConfigFileModel):
             else:
                 self.runtime.ep_size = 1
 
-        if model_config.data_parallel_degree == 0:
+        if model_config.data_parallel_degree is None:
             if (
                 architecture is not None
                 and num_devices > 1
@@ -597,14 +597,14 @@ class PipelineConfig(ConfigFileModel):
             return
 
         primary_dp = self.model.data_parallel_degree
-        if primary_dp == 0:
+        if primary_dp is None:
             raise AssertionError(
                 "Primary model data_parallel_degree must be resolved before "
                 "draft model defaults are applied."
             )
 
         old_draft_dp = self.draft_model.data_parallel_degree
-        if old_draft_dp == 0:
+        if old_draft_dp is None:
             self.draft_model.data_parallel_degree = primary_dp
             logger.info(
                 "Resolved draft model data_parallel_degree %s -> %s "

--- a/max/python/max/pipelines/lib/config/config.py
+++ b/max/python/max/pipelines/lib/config/config.py
@@ -153,13 +153,6 @@ class PipelineConfig(ConfigFileModel):
     """Temporary storage for unmatched kwargs during initialization.
     This is used to pass unmatched kwargs from the before validator to the after validator."""
 
-    _cli_param_sources: dict[str, str] | None = PrivateAttr(default=None)
-    """Click parameter source metadata passed from CLI entrypoints.
-
-    Keys are parameter names and values are ``click.ParameterSource.name``
-    strings (for example, ``"DEFAULT"`` or ``"COMMANDLINE"``).
-    """
-
     def configure_session(self, session: InferenceSession) -> None:
         """Configures a :class:`~max.engine.InferenceSession` with standard pipeline settings."""
         session.gpu_profiling(self.profiling.gpu_profiling)
@@ -401,7 +394,6 @@ class PipelineConfig(ConfigFileModel):
             return handler(data)
 
         kwargs = data.copy()
-        cli_param_sources = kwargs.pop("__cli_param_sources__", None)
         # Merge config file values before separating pydantic vs unmatched
         # kwargs, so sub-config fields (e.g. model_path) from the YAML are
         # visible to _postprocess_configs.
@@ -424,10 +416,6 @@ class PipelineConfig(ConfigFileModel):
         model = handler(pydantic_kwargs)
         # `_unmatched_kwargs` is a PrivateAttr, so set it on the instance.
         model._unmatched_kwargs = unmatched_kwargs
-        if isinstance(cli_param_sources, dict):
-            model._cli_param_sources = {
-                str(k): str(v) for k, v in cli_param_sources.items()
-            }
         return model
 
     @model_validator(mode="after")
@@ -561,70 +549,69 @@ class PipelineConfig(ConfigFileModel):
 
     def _apply_multi_gpu_parallelism_defaults(
         self,
-        architecture: SupportedArchitecture,
+        architecture: SupportedArchitecture | None,
         model_config: MAXModelConfig,
         num_devices: int,
     ) -> None:
-        """Auto-resolve architecture-defined EP/DP defaults for multi-GPU."""
-        if num_devices <= 1:
-            return
-
-        ep_was_provided = self._is_param_explicitly_provided(
-            "ep_size", "ep_size" in self.runtime.model_fields_set
-        )
-        dp_was_provided = self._is_param_explicitly_provided(
-            "data_parallel_degree",
-            "data_parallel_degree" in model_config.model_fields_set,
-        )
-
+        """Resolve primary-model EP/DP defaults to concrete integers."""
         old_ep = self.runtime.ep_size
         old_dp = model_config.data_parallel_degree
 
-        if (
-            architecture.default_ep_size_to_num_devices
-            and not ep_was_provided
-            and self.runtime.ep_size == 1
-            and model_config.data_parallel_degree in (1, num_devices)
-        ):
-            self.runtime.ep_size = num_devices
+        if self.runtime.ep_size is None:
+            if (
+                architecture is not None
+                and num_devices > 1
+                and architecture.default_ep_size_to_num_devices
+            ):
+                self.runtime.ep_size = num_devices
+            else:
+                self.runtime.ep_size = 1
 
-        # If user provide an invalid ep_size > 1, we will not fix it here
-        # but let downstream codes to handle it.
-        if (
-            architecture.default_data_parallel_degree_to_num_devices
-            and not dp_was_provided
-            and model_config.data_parallel_degree == 1
-        ):
-            model_config.data_parallel_degree = num_devices
+        if model_config.data_parallel_degree is None:
+            if (
+                architecture is not None
+                and num_devices > 1
+                and architecture.default_data_parallel_degree_to_num_devices
+            ):
+                model_config.data_parallel_degree = num_devices
+            else:
+                model_config.data_parallel_degree = 1
 
         if (
             self.runtime.ep_size != old_ep
             or model_config.data_parallel_degree != old_dp
         ):
             logger.info(
-                "Auto-configured %s multi-GPU parallelism defaults: "
+                "Resolved %s parallelism defaults: "
                 "ep_size %s -> %s, data_parallel_degree %s -> %s",
-                architecture.name,
+                architecture.name if architecture is not None else "default",
                 old_ep,
                 self.runtime.ep_size,
                 old_dp,
                 model_config.data_parallel_degree,
             )
 
-    def _is_param_explicitly_provided(
-        self, param_name: str, fallback: bool
-    ) -> bool:
-        """Returns whether a parameter was explicitly set by the user.
+    def _apply_draft_data_parallel_default(self) -> None:
+        """Inherit the resolved primary-model DP when draft DP is unset."""
+        if self.draft_model is None:
+            return
 
-        ``fallback`` is the non-CLI explicitness signal (typically from
-        ``model_fields_set``) used when Click source metadata is unavailable.
-        """
-        if (
-            self._cli_param_sources is None
-            or param_name not in self._cli_param_sources
-        ):
-            return fallback
-        return self._cli_param_sources[param_name] != "DEFAULT"
+        primary_dp = self.model.data_parallel_degree
+        if primary_dp is None:
+            raise AssertionError(
+                "Primary model data_parallel_degree must be resolved before "
+                "draft model defaults are applied."
+            )
+
+        old_draft_dp = self.draft_model.data_parallel_degree
+        if old_draft_dp is None:
+            self.draft_model.data_parallel_degree = primary_dp
+            logger.info(
+                "Resolved draft model data_parallel_degree %s -> %s "
+                "(inherited from primary model)",
+                old_draft_dp,
+                self.draft_model.data_parallel_degree,
+            )
 
     def resolve(self) -> None:
         """Validates and resolves the config.
@@ -636,6 +623,17 @@ class PipelineConfig(ConfigFileModel):
         self._import_custom_architectures()
 
         self.model.resolve()
+        primary_arch = PIPELINE_REGISTRY.retrieve_architecture(
+            huggingface_repo=self.model.huggingface_model_repo,
+            prefer_module_v3=self.runtime.prefer_module_v3,
+        )
+        self._apply_multi_gpu_parallelism_defaults(
+            primary_arch,
+            self.model,
+            len(load_devices(self.model.device_specs)),
+        )
+        if self.draft_model is not None:
+            self._apply_draft_data_parallel_default()
 
         # Validation for max_length is handled in MAXModelConfig
 
@@ -995,12 +993,6 @@ class PipelineConfig(ConfigFileModel):
             )
 
         devices = load_devices(model_config.device_specs)
-        # This resolver runs for both primary and draft models. Apply
-        # architecture default parallelism only to the primary model pass.
-        if model_config is self.model:
-            self._apply_multi_gpu_parallelism_defaults(
-                arch, model_config, len(devices)
-            )
 
         # Validate LoRA support - currently only Llama3 models support LoRA
         if self.lora and self.lora.enable_lora:

--- a/max/python/max/pipelines/lib/config/config.py
+++ b/max/python/max/pipelines/lib/config/config.py
@@ -191,7 +191,9 @@ class PipelineConfig(ConfigFileModel):
             field_name = key.replace(key_prefix, "") if strip_prefix else key
 
             # Check if this field exists in the config class (Pydantic model)
-            if field_name in config_class.model_fields:
+            if PipelineConfig._config_class_accepts_key(
+                config_class, field_name
+            ):
                 # Use original key or stripped key as specified
                 extracted_key = field_name if strip_prefix else key
                 extracted[extracted_key] = value
@@ -202,6 +204,18 @@ class PipelineConfig(ConfigFileModel):
             del kwargs[key]
 
         return extracted
+
+    @staticmethod
+    def _config_class_accepts_key(
+        config_class: type[ConfigFileModel], key: str
+    ) -> bool:
+        """Return whether ``key`` matches a field name or alias."""
+        for field_name, field_info in config_class.model_fields.items():
+            if key == field_name:
+                return True
+            if isinstance(field_info.alias, str) and key == field_info.alias:
+                return True
+        return False
 
     def _create_cache_config_if_needed(self, kwargs: dict[str, Any]) -> None:
         """Extract denoising cache kwargs and create DenoisingCacheConfig if any provided."""
@@ -311,7 +325,7 @@ class PipelineConfig(ConfigFileModel):
             kv_cache_kwargs = {}
 
             for key, value in unmatched_kwargs.items():
-                if key in config_class.model_fields:
+                if self._config_class_accepts_key(config_class, key):
                     matched_kwargs[key] = value
                 # Check if this is a KVCache config param
                 elif (
@@ -554,10 +568,10 @@ class PipelineConfig(ConfigFileModel):
         num_devices: int,
     ) -> None:
         """Resolve primary-model EP/DP defaults to concrete integers."""
-        old_ep = self.runtime.ep_size
-        old_dp = model_config.data_parallel_degree
+        old_ep = self.runtime.ep_size_raw
+        old_dp = model_config.data_parallel_degree_raw
 
-        if self.runtime.ep_size is None:
+        if self.runtime.ep_size_raw is None:
             if (
                 architecture is not None
                 and num_devices > 1
@@ -567,7 +581,7 @@ class PipelineConfig(ConfigFileModel):
             else:
                 self.runtime.ep_size = 1
 
-        if model_config.data_parallel_degree is None:
+        if model_config.data_parallel_degree_raw is None:
             if (
                 architecture is not None
                 and num_devices > 1
@@ -578,8 +592,8 @@ class PipelineConfig(ConfigFileModel):
                 model_config.data_parallel_degree = 1
 
         if (
-            self.runtime.ep_size != old_ep
-            or model_config.data_parallel_degree != old_dp
+            self.runtime.ep_size_raw != old_ep
+            or model_config.data_parallel_degree_raw != old_dp
         ):
             logger.info(
                 "Resolved %s parallelism defaults: "
@@ -596,14 +610,14 @@ class PipelineConfig(ConfigFileModel):
         if self.draft_model is None:
             return
 
-        primary_dp = self.model.data_parallel_degree
+        primary_dp = self.model.data_parallel_degree_raw
         if primary_dp is None:
             raise AssertionError(
                 "Primary model data_parallel_degree must be resolved before "
                 "draft model defaults are applied."
             )
 
-        old_draft_dp = self.draft_model.data_parallel_degree
+        old_draft_dp = self.draft_model.data_parallel_degree_raw
         if old_draft_dp is None:
             self.draft_model.data_parallel_degree = primary_dp
             logger.info(

--- a/max/python/max/pipelines/lib/config/model_config.py
+++ b/max/python/max/pipelines/lib/config/model_config.py
@@ -92,11 +92,11 @@ class MAXModelConfig(MAXModelConfigBase):
     )
     """Whether to use subgraphs for the model."""
 
-    data_parallel_degree: int = Field(
-        default=1,
+    data_parallel_degree: int | None = Field(
+        default=None,
         description=(
-            "Data-parallelism parameter. The degree to which the model is "
-            "replicated is dependent on the model type."
+            "Data-parallelism parameter. Default is model-dependent and is "
+            "resolved during pipeline configuration."
         ),
     )
     """The degree of data parallelism for replicating the model."""

--- a/max/python/max/pipelines/lib/config/model_config.py
+++ b/max/python/max/pipelines/lib/config/model_config.py
@@ -76,11 +76,25 @@ class MAXModelConfigBase(ConfigFileModel):
     """
 
     # Allow arbitrary types (like DeviceRef, AutoConfig) to avoid schema generation errors.
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+        serialize_by_alias=True,
+    )
 
 
 class MAXModelConfig(MAXModelConfigBase):
     """Configuration for a pipeline model."""
+
+    def __init__(
+        self, *, data_parallel_degree: int | None = None, **data: Any
+    ) -> None:
+        if (
+            "data_parallel_degree" not in data
+            and data_parallel_degree is not None
+        ):
+            data["data_parallel_degree"] = data_parallel_degree
+        super().__init__(**data)
 
     use_subgraphs: bool = Field(
         default=True,
@@ -92,14 +106,29 @@ class MAXModelConfig(MAXModelConfigBase):
     )
     """Whether to use subgraphs for the model."""
 
-    data_parallel_degree: int | None = Field(
+    data_parallel_degree_raw: int | None = Field(
         default=None,
+        alias="data_parallel_degree",
         description=(
             "Data-parallelism parameter. Default is model-dependent and is "
             "resolved during pipeline configuration."
         ),
     )
-    """The degree of data parallelism for replicating the model."""
+    """The raw degree of data parallelism for replicating the model."""
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def data_parallel_degree(self) -> int:
+        """Return the resolved DP degree, treating an unset value as 1."""
+        return (
+            1
+            if self.data_parallel_degree_raw is None
+            else self.data_parallel_degree_raw
+        )
+
+    @data_parallel_degree.setter
+    def data_parallel_degree(self, value: int | None) -> None:
+        self.data_parallel_degree_raw = value
 
     pool_embeddings: bool = Field(
         default=True, description="Whether to pool embedding outputs."

--- a/max/python/max/pipelines/lib/config/model_config.py
+++ b/max/python/max/pipelines/lib/config/model_config.py
@@ -92,11 +92,12 @@ class MAXModelConfig(MAXModelConfigBase):
     )
     """Whether to use subgraphs for the model."""
 
-    data_parallel_degree: int | None = Field(
-        default=None,
+    data_parallel_degree: int = Field(
+        default=0,
         description=(
-            "Data-parallelism parameter. Default is model-dependent and is "
-            "resolved during pipeline configuration."
+            "Data-parallelism parameter. A value of 0 means this was not "
+            "overridden explicitly and should be resolved during pipeline "
+            "configuration."
         ),
     )
     """The degree of data parallelism for replicating the model."""

--- a/max/python/max/pipelines/lib/config/model_config.py
+++ b/max/python/max/pipelines/lib/config/model_config.py
@@ -92,12 +92,11 @@ class MAXModelConfig(MAXModelConfigBase):
     )
     """Whether to use subgraphs for the model."""
 
-    data_parallel_degree: int = Field(
-        default=0,
+    data_parallel_degree: int | None = Field(
+        default=None,
         description=(
-            "Data-parallelism parameter. A value of 0 means this was not "
-            "overridden explicitly and should be resolved during pipeline "
-            "configuration."
+            "Data-parallelism parameter. Default is model-dependent and is "
+            "resolved during pipeline configuration."
         ),
     )
     """The degree of data parallelism for replicating the model."""

--- a/max/python/max/pipelines/lib/pipeline_runtime_config.py
+++ b/max/python/max/pipelines/lib/pipeline_runtime_config.py
@@ -70,12 +70,12 @@ class PipelineRuntimeConfig(ConfigFileModel):
         ),
     )
 
-    ep_size: int | None = Field(
-        default=None,
+    ep_size: int = Field(
+        default=0,
         description=(
-            "The expert parallelism size. Default is model-dependent and is "
-            "resolved to 1 unless the selected architecture opts into a "
-            "multi-GPU default."
+            "The expert parallelism size. A value of 0 means this was not "
+            "overridden explicitly and should be resolved during pipeline "
+            "configuration."
         ),
     )
 

--- a/max/python/max/pipelines/lib/pipeline_runtime_config.py
+++ b/max/python/max/pipelines/lib/pipeline_runtime_config.py
@@ -70,11 +70,12 @@ class PipelineRuntimeConfig(ConfigFileModel):
         ),
     )
 
-    ep_size: int = Field(
-        default=1,
+    ep_size: int | None = Field(
+        default=None,
         description=(
-            "The expert parallelism size. Needs to be 1 (no expert parallelism) "
-            "or the total number of GPUs across nodes."
+            "The expert parallelism size. Default is model-dependent and is "
+            "resolved to 1 unless the selected architecture opts into a "
+            "multi-GPU default."
         ),
     )
 

--- a/max/python/max/pipelines/lib/pipeline_runtime_config.py
+++ b/max/python/max/pipelines/lib/pipeline_runtime_config.py
@@ -70,12 +70,12 @@ class PipelineRuntimeConfig(ConfigFileModel):
         ),
     )
 
-    ep_size: int = Field(
-        default=0,
+    ep_size: int | None = Field(
+        default=None,
         description=(
-            "The expert parallelism size. A value of 0 means this was not "
-            "overridden explicitly and should be resolved during pipeline "
-            "configuration."
+            "The expert parallelism size. Default is model-dependent and is "
+            "resolved to 1 unless the selected architecture opts into a "
+            "multi-GPU default."
         ),
     )
 

--- a/max/python/max/pipelines/lib/pipeline_runtime_config.py
+++ b/max/python/max/pipelines/lib/pipeline_runtime_config.py
@@ -16,10 +16,11 @@
 from __future__ import annotations
 
 import os
+from typing import Any
 
 from max.config import ConfigFileModel
 from max.serve.worker_interface.zmq_queue import generate_zmq_ipc_path
-from pydantic import Field, PrivateAttr
+from pydantic import ConfigDict, Field, PrivateAttr, computed_field
 
 from .config.config_enums import PipelineRole
 
@@ -33,6 +34,16 @@ class PipelineRuntimeConfig(ConfigFileModel):
     Contains batching, scheduling, and execution configuration that is
     independent of any particular model architecture.
     """
+
+    model_config = ConfigDict(
+        populate_by_name=True,
+        serialize_by_alias=True,
+    )
+
+    def __init__(self, *, ep_size: int | None = None, **data: Any) -> None:
+        if "ep_size" not in data and ep_size is not None:
+            data["ep_size"] = ep_size
+        super().__init__(**data)
 
     pipeline_role: PipelineRole = Field(
         default="prefill_and_decode",
@@ -70,14 +81,25 @@ class PipelineRuntimeConfig(ConfigFileModel):
         ),
     )
 
-    ep_size: int | None = Field(
+    ep_size_raw: int | None = Field(
         default=None,
+        alias="ep_size",
         description=(
             "The expert parallelism size. Default is model-dependent and is "
             "resolved to 1 unless the selected architecture opts into a "
             "multi-GPU default."
         ),
     )
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def ep_size(self) -> int:
+        """Return the resolved EP size, treating an unset value as 1."""
+        return 1 if self.ep_size_raw is None else self.ep_size_raw
+
+    @ep_size.setter
+    def ep_size(self, value: int | None) -> None:
+        self.ep_size_raw = value
 
     ce_delay_ms: float = Field(
         default=0.0,

--- a/max/python/max/pipelines/lib/registry.py
+++ b/max/python/max/pipelines/lib/registry.py
@@ -250,6 +250,12 @@ class SupportedArchitecture:
     multi_gpu_supported: bool = False
     """Whether the architecture supports multi-GPU execution."""
 
+    default_ep_size_to_num_devices: bool = False
+    """Whether expert parallelism should default to local multi-GPU width."""
+
+    default_data_parallel_degree_to_num_devices: bool = False
+    """Whether data parallel attention should default to local multi-GPU width."""
+
     required_arguments: dict[str, bool | int | float] = field(
         default_factory=dict
     )

--- a/max/tests/integration/unorganized/test_config_pure.py
+++ b/max/tests/integration/unorganized/test_config_pure.py
@@ -489,6 +489,15 @@ class TestPipelineConfigUtilityMethods:
         assert config.runtime.ep_size == num_devices
         assert config.model.data_parallel_degree == num_devices
 
+    @mock_pipeline_config_resolve
+    def test_parallelism_defaults_start_unresolved_as_none(self) -> None:
+        config = PipelineConfig(
+            model=MAXModelConfig(model_path="test/model"),
+        )
+
+        assert config.runtime.ep_size is None
+        assert config.model.data_parallel_degree is None
+
     @pytest.mark.parametrize("num_devices", _MULTI_GPU_DEVICE_COUNTS)
     @mock_pipeline_config_resolve
     def test_apply_multi_gpu_defaults_for_enabled_arch_ep_only(
@@ -640,22 +649,19 @@ class TestPipelineConfigUtilityMethods:
 
     @pytest.mark.parametrize("num_devices", _MULTI_GPU_DEVICE_COUNTS)
     @mock_pipeline_config_resolve
-    def test_apply_multi_gpu_defaults_click_default_sources(
+    def test_apply_draft_data_parallel_default_inherits_primary_dp(
         self, num_devices: int
     ) -> None:
-        # Simulate Click passing default-valued flags in kwargs.
         config = PipelineConfig(
             model=MAXModelConfig(
                 model_path="test/model",
                 device_specs=[DeviceSpec.accelerator()] * num_devices,
-                data_parallel_degree=1,
             ),
-            runtime=PipelineRuntimeConfig(ep_size=1),
+            draft_model=MAXModelConfig(
+                model_path="test/draft",
+                device_specs=[DeviceSpec.accelerator()] * num_devices,
+            ),
         )
-        config._cli_param_sources = {
-            "ep_size": "DEFAULT",
-            "data_parallel_degree": "DEFAULT",
-        }
 
         config._apply_multi_gpu_parallelism_defaults(
             self._arch_with_parallel_defaults(
@@ -666,53 +672,32 @@ class TestPipelineConfigUtilityMethods:
             config.model,
             num_devices,
         )
+        config._apply_draft_data_parallel_default()
 
         assert config.runtime.ep_size == num_devices
         assert config.model.data_parallel_degree == num_devices
+        assert config.draft_model is not None
+        assert config.draft_model.data_parallel_degree == num_devices
 
-    @pytest.mark.parametrize("num_devices", _MULTI_GPU_DEVICE_COUNTS)
     @mock_pipeline_config_resolve
-    def test_apply_multi_gpu_defaults_click_commandline_source_wins(
-        self, num_devices: int
+    def test_apply_draft_data_parallel_default_respects_explicit_draft_dp(
+        self,
     ) -> None:
-        # Simulate user explicitly setting --ep-size=1 on CLI.
-        # EP should stay fixed, while DP can still auto-default from DEFAULT.
         config = PipelineConfig(
             model=MAXModelConfig(
                 model_path="test/model",
-                device_specs=[DeviceSpec.accelerator()] * num_devices,
+                data_parallel_degree=8,
+            ),
+            draft_model=MAXModelConfig(
+                model_path="test/draft",
                 data_parallel_degree=1,
             ),
-            runtime=PipelineRuntimeConfig(ep_size=1),
-        )
-        config._cli_param_sources = {
-            "ep_size": "COMMANDLINE",
-            "data_parallel_degree": "DEFAULT",
-        }
-
-        config._apply_multi_gpu_parallelism_defaults(
-            self._arch_with_parallel_defaults(
-                name="DeepseekV3ForCausalLM",
-                default_ep_size_to_num_devices=True,
-                default_data_parallel_degree_to_num_devices=True,
-            ),
-            config.model,
-            num_devices,
         )
 
-        assert config.runtime.ep_size == 1
-        assert config.model.data_parallel_degree == num_devices
+        config._apply_draft_data_parallel_default()
 
-    @mock_pipeline_config_resolve
-    def test_pipeline_config_accepts_cli_param_sources_hidden_kwarg(
-        self,
-    ) -> None:
-        config_kwargs: dict[str, Any] = {
-            "model": MAXModelConfig(model_path="test/model"),
-            "__cli_param_sources__": {"ep_size": "DEFAULT"},
-        }
-        config = PipelineConfig(**config_kwargs)
-        assert config._cli_param_sources == {"ep_size": "DEFAULT"}
+        assert config.draft_model is not None
+        assert config.draft_model.data_parallel_degree == 1
 
 
 class TestDraftModelEncodingDefault:

--- a/max/tests/integration/unorganized/test_config_pure.py
+++ b/max/tests/integration/unorganized/test_config_pure.py
@@ -12,9 +12,9 @@
 # ===----------------------------------------------------------------------=== #
 
 import pickle
-from dataclasses import replace
 from collections.abc import Generator
 from contextlib import contextmanager
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -451,9 +451,7 @@ class TestPipelineConfigUtilityMethods:
         ),
     )
     @mock_pipeline_config_resolve
-    def test_apply_deepseek_defaults_multi_gpu(
-        self, arch_name: str
-    ) -> None:
+    def test_apply_deepseek_defaults_multi_gpu(self, arch_name: str) -> None:
         config = PipelineConfig(
             model=MAXModelConfig(
                 model_path="test/model",

--- a/max/tests/integration/unorganized/test_config_pure.py
+++ b/max/tests/integration/unorganized/test_config_pure.py
@@ -490,13 +490,13 @@ class TestPipelineConfigUtilityMethods:
         assert config.model.data_parallel_degree == num_devices
 
     @mock_pipeline_config_resolve
-    def test_parallelism_defaults_start_unresolved_as_none(self) -> None:
+    def test_parallelism_defaults_start_unresolved_as_zero(self) -> None:
         config = PipelineConfig(
             model=MAXModelConfig(model_path="test/model"),
         )
 
-        assert config.runtime.ep_size is None
-        assert config.model.data_parallel_degree is None
+        assert config.runtime.ep_size == 0
+        assert config.model.data_parallel_degree == 0
 
     @pytest.mark.parametrize("num_devices", _MULTI_GPU_DEVICE_COUNTS)
     @mock_pipeline_config_resolve

--- a/max/tests/integration/unorganized/test_config_pure.py
+++ b/max/tests/integration/unorganized/test_config_pure.py
@@ -90,9 +90,23 @@ class TestClickFlagParsing:
 class TestPipelineConfigUtilityMethods:
     """Test suite for the refactored utility methods in PipelineConfig."""
 
+    _MULTI_GPU_DEVICE_COUNTS = (2, 3, 8)
+
     @staticmethod
-    def _arch_with_name(name: str) -> SupportedArchitecture:
-        return replace(DUMMY_LLAMA_ARCH, name=name)
+    def _arch_with_parallel_defaults(
+        *,
+        name: str = "LlamaForCausalLM",
+        default_ep_size_to_num_devices: bool = False,
+        default_data_parallel_degree_to_num_devices: bool = False,
+    ) -> SupportedArchitecture:
+        return replace(
+            DUMMY_LLAMA_ARCH,
+            name=name,
+            default_ep_size_to_num_devices=default_ep_size_to_num_devices,
+            default_data_parallel_degree_to_num_devices=(
+                default_data_parallel_degree_to_num_devices
+            ),
+        )
 
     @mock_pipeline_config_resolve
     def test_extract_kwargs_for_config_basic(self) -> None:
@@ -450,103 +464,255 @@ class TestPipelineConfigUtilityMethods:
             "DeepseekV3ForCausalLMNextN",
         ),
     )
+    @pytest.mark.parametrize("num_devices", _MULTI_GPU_DEVICE_COUNTS)
     @mock_pipeline_config_resolve
-    def test_apply_deepseek_defaults_multi_gpu(self, arch_name: str) -> None:
+    def test_apply_multi_gpu_defaults_for_enabled_arch(
+        self, arch_name: str, num_devices: int
+    ) -> None:
         config = PipelineConfig(
             model=MAXModelConfig(
                 model_path="test/model",
-                device_specs=[DeviceSpec.accelerator()] * 8,
+                device_specs=[DeviceSpec.accelerator()] * num_devices,
             )
         )
-        config.ep_size = 1
-        config.model.data_parallel_degree = 1
 
-        config._apply_deepseek_multi_gpu_parallelism_defaults(
-            self._arch_with_name(arch_name), config.model, 8
-        )
-
-        assert config.ep_size == 8
-        assert config.model.data_parallel_degree == 8
-
-    @mock_pipeline_config_resolve
-    def test_apply_deepseek_defaults_multi_gpu_ep_only(self) -> None:
-        config = PipelineConfig(
-            model=MAXModelConfig(
-                model_path="test/model",
-                device_specs=[DeviceSpec.accelerator()] * 8,
-            )
-        )
-        config.ep_size = 8
-        config.model.data_parallel_degree = 1
-
-        config._apply_deepseek_multi_gpu_parallelism_defaults(
-            self._arch_with_name("DeepseekV3ForCausalLM"),
+        config._apply_multi_gpu_parallelism_defaults(
+            self._arch_with_parallel_defaults(
+                name=arch_name,
+                default_ep_size_to_num_devices=True,
+                default_data_parallel_degree_to_num_devices=True,
+            ),
             config.model,
-            8,
+            num_devices,
         )
 
-        assert config.ep_size == 8
-        assert config.model.data_parallel_degree == 8
+        assert config.runtime.ep_size == num_devices
+        assert config.model.data_parallel_degree == num_devices
 
+    @pytest.mark.parametrize("num_devices", _MULTI_GPU_DEVICE_COUNTS)
     @mock_pipeline_config_resolve
-    def test_apply_deepseek_defaults_multi_gpu_dp_only(self) -> None:
+    def test_apply_multi_gpu_defaults_for_enabled_arch_ep_only(
+        self, num_devices: int
+    ) -> None:
         config = PipelineConfig(
             model=MAXModelConfig(
                 model_path="test/model",
-                device_specs=[DeviceSpec.accelerator()] * 8,
-            )
+                device_specs=[DeviceSpec.accelerator()] * num_devices,
+            ),
+            runtime=PipelineRuntimeConfig(ep_size=num_devices),
         )
-        config.ep_size = 1
-        config.model.data_parallel_degree = 8
 
-        config._apply_deepseek_multi_gpu_parallelism_defaults(
-            self._arch_with_name("DeepseekV3ForCausalLM"),
+        config._apply_multi_gpu_parallelism_defaults(
+            self._arch_with_parallel_defaults(
+                name="DeepseekV3ForCausalLM",
+                default_ep_size_to_num_devices=True,
+                default_data_parallel_degree_to_num_devices=True,
+            ),
             config.model,
-            8,
+            num_devices,
         )
 
-        assert config.ep_size == 8
-        assert config.model.data_parallel_degree == 8
+        assert config.runtime.ep_size == num_devices
+        assert config.model.data_parallel_degree == num_devices
 
+    @pytest.mark.parametrize("num_devices", _MULTI_GPU_DEVICE_COUNTS)
     @mock_pipeline_config_resolve
-    def test_apply_deepseek_defaults_non_deepseek_unchanged(self) -> None:
+    def test_apply_multi_gpu_defaults_for_enabled_arch_dp_only(
+        self, num_devices: int
+    ) -> None:
         config = PipelineConfig(
             model=MAXModelConfig(
                 model_path="test/model",
-                device_specs=[DeviceSpec.accelerator()] * 8,
+                device_specs=[DeviceSpec.accelerator()] * num_devices,
+                data_parallel_degree=num_devices,
             )
         )
-        config.ep_size = 1
-        config.model.data_parallel_degree = 1
 
-        arch = self._arch_with_name("LlamaForCausalLM")
-        if config._is_deepseek_arch(arch):
-            config._apply_deepseek_multi_gpu_parallelism_defaults(
-                arch, config.model, 8
+        config._apply_multi_gpu_parallelism_defaults(
+            self._arch_with_parallel_defaults(
+                name="DeepseekV3ForCausalLM",
+                default_ep_size_to_num_devices=True,
+                default_data_parallel_degree_to_num_devices=True,
+            ),
+            config.model,
+            num_devices,
+        )
+
+        assert config.runtime.ep_size == num_devices
+        assert config.model.data_parallel_degree == num_devices
+
+    @pytest.mark.parametrize("num_devices", _MULTI_GPU_DEVICE_COUNTS)
+    @mock_pipeline_config_resolve
+    def test_apply_multi_gpu_defaults_for_non_enabled_arch_unchanged(
+        self,
+        num_devices: int,
+    ) -> None:
+        config = PipelineConfig(
+            model=MAXModelConfig(
+                model_path="test/model",
+                device_specs=[DeviceSpec.accelerator()] * num_devices,
             )
+        )
 
-        assert config.ep_size == 1
+        config._apply_multi_gpu_parallelism_defaults(
+            self._arch_with_parallel_defaults(name="LlamaForCausalLM"),
+            config.model,
+            num_devices,
+        )
+
+        assert config.runtime.ep_size == 1
         assert config.model.data_parallel_degree == 1
 
     @mock_pipeline_config_resolve
-    def test_apply_deepseek_defaults_single_gpu_unchanged(self) -> None:
+    def test_apply_multi_gpu_defaults_single_gpu_unchanged(self) -> None:
         config = PipelineConfig(
             model=MAXModelConfig(
                 model_path="test/model",
                 device_specs=[DeviceSpec.accelerator()],
             )
         )
-        config.ep_size = 1
-        config.model.data_parallel_degree = 1
 
-        config._apply_deepseek_multi_gpu_parallelism_defaults(
-            self._arch_with_name("DeepseekV3ForCausalLM"),
+        config._apply_multi_gpu_parallelism_defaults(
+            self._arch_with_parallel_defaults(
+                name="DeepseekV3ForCausalLM",
+                default_ep_size_to_num_devices=True,
+                default_data_parallel_degree_to_num_devices=True,
+            ),
             config.model,
             1,
         )
 
-        assert config.ep_size == 1
+        assert config.runtime.ep_size == 1
         assert config.model.data_parallel_degree == 1
+
+    @pytest.mark.parametrize("num_devices", _MULTI_GPU_DEVICE_COUNTS)
+    @mock_pipeline_config_resolve
+    def test_apply_multi_gpu_defaults_respects_explicit_ep(
+        self, num_devices: int
+    ) -> None:
+        config = PipelineConfig(
+            model=MAXModelConfig(
+                model_path="test/model",
+                device_specs=[DeviceSpec.accelerator()] * num_devices,
+            ),
+            runtime=PipelineRuntimeConfig(ep_size=1),
+        )
+
+        config._apply_multi_gpu_parallelism_defaults(
+            self._arch_with_parallel_defaults(
+                name="DeepseekV3ForCausalLM",
+                default_ep_size_to_num_devices=True,
+                default_data_parallel_degree_to_num_devices=True,
+            ),
+            config.model,
+            num_devices,
+        )
+
+        assert config.runtime.ep_size == 1
+        assert config.model.data_parallel_degree == num_devices
+
+    @pytest.mark.parametrize("num_devices", _MULTI_GPU_DEVICE_COUNTS)
+    @mock_pipeline_config_resolve
+    def test_apply_multi_gpu_defaults_respects_explicit_dp(
+        self, num_devices: int
+    ) -> None:
+        config = PipelineConfig(
+            model=MAXModelConfig(
+                model_path="test/model",
+                device_specs=[DeviceSpec.accelerator()] * num_devices,
+                data_parallel_degree=1,
+            ),
+            runtime=PipelineRuntimeConfig(ep_size=num_devices),
+        )
+
+        config._apply_multi_gpu_parallelism_defaults(
+            self._arch_with_parallel_defaults(
+                name="DeepseekV3ForCausalLM",
+                default_ep_size_to_num_devices=True,
+                default_data_parallel_degree_to_num_devices=True,
+            ),
+            config.model,
+            num_devices,
+        )
+
+        assert config.runtime.ep_size == num_devices
+        assert config.model.data_parallel_degree == 1
+
+    @pytest.mark.parametrize("num_devices", _MULTI_GPU_DEVICE_COUNTS)
+    @mock_pipeline_config_resolve
+    def test_apply_multi_gpu_defaults_click_default_sources(
+        self, num_devices: int
+    ) -> None:
+        # Simulate Click passing default-valued flags in kwargs.
+        config = PipelineConfig(
+            model=MAXModelConfig(
+                model_path="test/model",
+                device_specs=[DeviceSpec.accelerator()] * num_devices,
+                data_parallel_degree=1,
+            ),
+            runtime=PipelineRuntimeConfig(ep_size=1),
+        )
+        config._cli_param_sources = {
+            "ep_size": "DEFAULT",
+            "data_parallel_degree": "DEFAULT",
+        }
+
+        config._apply_multi_gpu_parallelism_defaults(
+            self._arch_with_parallel_defaults(
+                name="DeepseekV3ForCausalLM",
+                default_ep_size_to_num_devices=True,
+                default_data_parallel_degree_to_num_devices=True,
+            ),
+            config.model,
+            num_devices,
+        )
+
+        assert config.runtime.ep_size == num_devices
+        assert config.model.data_parallel_degree == num_devices
+
+    @pytest.mark.parametrize("num_devices", _MULTI_GPU_DEVICE_COUNTS)
+    @mock_pipeline_config_resolve
+    def test_apply_multi_gpu_defaults_click_commandline_source_wins(
+        self, num_devices: int
+    ) -> None:
+        # Simulate user explicitly setting --ep-size=1 on CLI.
+        # EP should stay fixed, while DP can still auto-default from DEFAULT.
+        config = PipelineConfig(
+            model=MAXModelConfig(
+                model_path="test/model",
+                device_specs=[DeviceSpec.accelerator()] * num_devices,
+                data_parallel_degree=1,
+            ),
+            runtime=PipelineRuntimeConfig(ep_size=1),
+        )
+        config._cli_param_sources = {
+            "ep_size": "COMMANDLINE",
+            "data_parallel_degree": "DEFAULT",
+        }
+
+        config._apply_multi_gpu_parallelism_defaults(
+            self._arch_with_parallel_defaults(
+                name="DeepseekV3ForCausalLM",
+                default_ep_size_to_num_devices=True,
+                default_data_parallel_degree_to_num_devices=True,
+            ),
+            config.model,
+            num_devices,
+        )
+
+        assert config.runtime.ep_size == 1
+        assert config.model.data_parallel_degree == num_devices
+
+    @mock_pipeline_config_resolve
+    def test_pipeline_config_accepts_cli_param_sources_hidden_kwarg(
+        self,
+    ) -> None:
+        config_kwargs: dict[str, Any] = {
+            "model": MAXModelConfig(model_path="test/model"),
+            "__cli_param_sources__": {"ep_size": "DEFAULT"},
+        }
+        config = PipelineConfig(**config_kwargs)
+        assert config._cli_param_sources == {"ep_size": "DEFAULT"}
 
 
 class TestDraftModelEncodingDefault:

--- a/max/tests/integration/unorganized/test_config_pure.py
+++ b/max/tests/integration/unorganized/test_config_pure.py
@@ -490,13 +490,15 @@ class TestPipelineConfigUtilityMethods:
         assert config.model.data_parallel_degree == num_devices
 
     @mock_pipeline_config_resolve
-    def test_parallelism_defaults_start_unresolved_as_none(self) -> None:
+    def test_parallelism_defaults_start_with_unset_backing_fields(self) -> None:
         config = PipelineConfig(
             model=MAXModelConfig(model_path="test/model"),
         )
 
-        assert config.runtime.ep_size is None
-        assert config.model.data_parallel_degree is None
+        assert config.runtime.ep_size_raw is None
+        assert config.model.data_parallel_degree_raw is None
+        assert config.runtime.ep_size == 1
+        assert config.model.data_parallel_degree == 1
 
     @pytest.mark.parametrize("num_devices", _MULTI_GPU_DEVICE_COUNTS)
     @mock_pipeline_config_resolve

--- a/max/tests/integration/unorganized/test_config_pure.py
+++ b/max/tests/integration/unorganized/test_config_pure.py
@@ -490,13 +490,13 @@ class TestPipelineConfigUtilityMethods:
         assert config.model.data_parallel_degree == num_devices
 
     @mock_pipeline_config_resolve
-    def test_parallelism_defaults_start_unresolved_as_zero(self) -> None:
+    def test_parallelism_defaults_start_unresolved_as_none(self) -> None:
         config = PipelineConfig(
             model=MAXModelConfig(model_path="test/model"),
         )
 
-        assert config.runtime.ep_size == 0
-        assert config.model.data_parallel_degree == 0
+        assert config.runtime.ep_size is None
+        assert config.model.data_parallel_degree is None
 
     @pytest.mark.parametrize("num_devices", _MULTI_GPU_DEVICE_COUNTS)
     @mock_pipeline_config_resolve

--- a/max/tests/integration/unorganized/test_config_pure.py
+++ b/max/tests/integration/unorganized/test_config_pure.py
@@ -436,6 +436,114 @@ class TestPipelineConfigUtilityMethods:
         assert config.model.kv_cache.cache_dtype == DType.bfloat16
         assert config.draft_model.kv_cache.cache_dtype == DType.bfloat16
 
+    @pytest.mark.parametrize(
+        "arch_name",
+        (
+            "DeepseekV3ForCausalLM",
+            "DeepseekV32ForCausalLM",
+            "DeepseekV3ForCausalLMNextN",
+        ),
+    )
+    @mock_pipeline_config_resolve
+    def test_apply_deepseek_defaults_multi_gpu(
+        self, arch_name: str
+    ) -> None:
+        config = PipelineConfig(
+            model=MAXModelConfig(
+                model_path="test/model",
+                device_specs=[DeviceSpec.accelerator()] * 8,
+            )
+        )
+        config.ep_size = 1
+        config.model.data_parallel_degree = 1
+
+        config._apply_deepseek_multi_gpu_parallelism_defaults(
+            SimpleNamespace(name=arch_name), config.model, 8
+        )
+
+        assert config.ep_size == 8
+        assert config.model.data_parallel_degree == 8
+
+    @mock_pipeline_config_resolve
+    def test_apply_deepseek_defaults_multi_gpu_ep_only(self) -> None:
+        config = PipelineConfig(
+            model=MAXModelConfig(
+                model_path="test/model",
+                device_specs=[DeviceSpec.accelerator()] * 8,
+            )
+        )
+        config.ep_size = 8
+        config.model.data_parallel_degree = 1
+
+        config._apply_deepseek_multi_gpu_parallelism_defaults(
+            SimpleNamespace(name="DeepseekV3ForCausalLM"),
+            config.model,
+            8,
+        )
+
+        assert config.ep_size == 8
+        assert config.model.data_parallel_degree == 8
+
+    @mock_pipeline_config_resolve
+    def test_apply_deepseek_defaults_multi_gpu_dp_only(self) -> None:
+        config = PipelineConfig(
+            model=MAXModelConfig(
+                model_path="test/model",
+                device_specs=[DeviceSpec.accelerator()] * 8,
+            )
+        )
+        config.ep_size = 1
+        config.model.data_parallel_degree = 8
+
+        config._apply_deepseek_multi_gpu_parallelism_defaults(
+            SimpleNamespace(name="DeepseekV3ForCausalLM"),
+            config.model,
+            8,
+        )
+
+        assert config.ep_size == 8
+        assert config.model.data_parallel_degree == 8
+
+    @mock_pipeline_config_resolve
+    def test_apply_deepseek_defaults_non_deepseek_unchanged(self) -> None:
+        config = PipelineConfig(
+            model=MAXModelConfig(
+                model_path="test/model",
+                device_specs=[DeviceSpec.accelerator()] * 8,
+            )
+        )
+        config.ep_size = 1
+        config.model.data_parallel_degree = 1
+
+        arch = SimpleNamespace(name="LlamaForCausalLM")
+        if config._is_deepseek_arch(arch):
+            config._apply_deepseek_multi_gpu_parallelism_defaults(
+                arch, config.model, 8
+            )
+
+        assert config.ep_size == 1
+        assert config.model.data_parallel_degree == 1
+
+    @mock_pipeline_config_resolve
+    def test_apply_deepseek_defaults_single_gpu_unchanged(self) -> None:
+        config = PipelineConfig(
+            model=MAXModelConfig(
+                model_path="test/model",
+                device_specs=[DeviceSpec.accelerator()],
+            )
+        )
+        config.ep_size = 1
+        config.model.data_parallel_degree = 1
+
+        config._apply_deepseek_multi_gpu_parallelism_defaults(
+            SimpleNamespace(name="DeepseekV3ForCausalLM"),
+            config.model,
+            1,
+        )
+
+        assert config.ep_size == 1
+        assert config.model.data_parallel_degree == 1
+
 
 class TestDraftModelEncodingDefault:
     """Tests that draft model quantization_encoding defaults to the target model's encoding."""

--- a/max/tests/integration/unorganized/test_config_pure.py
+++ b/max/tests/integration/unorganized/test_config_pure.py
@@ -12,6 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 
 import pickle
+from dataclasses import replace
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
@@ -32,6 +33,7 @@ from max.pipelines.lib import (
     PipelineConfig,
     PipelineRuntimeConfig,
     SamplingConfig,
+    SupportedArchitecture,
 )
 from max.pipelines.lib.config import AudioGenerationConfig
 from max.pipelines.lib.config.speculative_config import SpeculativeConfig
@@ -87,6 +89,10 @@ class TestClickFlagParsing:
 
 class TestPipelineConfigUtilityMethods:
     """Test suite for the refactored utility methods in PipelineConfig."""
+
+    @staticmethod
+    def _arch_with_name(name: str) -> SupportedArchitecture:
+        return replace(DUMMY_LLAMA_ARCH, name=name)
 
     @mock_pipeline_config_resolve
     def test_extract_kwargs_for_config_basic(self) -> None:
@@ -458,7 +464,7 @@ class TestPipelineConfigUtilityMethods:
         config.model.data_parallel_degree = 1
 
         config._apply_deepseek_multi_gpu_parallelism_defaults(
-            SimpleNamespace(name=arch_name), config.model, 8
+            self._arch_with_name(arch_name), config.model, 8
         )
 
         assert config.ep_size == 8
@@ -476,7 +482,7 @@ class TestPipelineConfigUtilityMethods:
         config.model.data_parallel_degree = 1
 
         config._apply_deepseek_multi_gpu_parallelism_defaults(
-            SimpleNamespace(name="DeepseekV3ForCausalLM"),
+            self._arch_with_name("DeepseekV3ForCausalLM"),
             config.model,
             8,
         )
@@ -496,7 +502,7 @@ class TestPipelineConfigUtilityMethods:
         config.model.data_parallel_degree = 8
 
         config._apply_deepseek_multi_gpu_parallelism_defaults(
-            SimpleNamespace(name="DeepseekV3ForCausalLM"),
+            self._arch_with_name("DeepseekV3ForCausalLM"),
             config.model,
             8,
         )
@@ -515,7 +521,7 @@ class TestPipelineConfigUtilityMethods:
         config.ep_size = 1
         config.model.data_parallel_degree = 1
 
-        arch = SimpleNamespace(name="LlamaForCausalLM")
+        arch = self._arch_with_name("LlamaForCausalLM")
         if config._is_deepseek_arch(arch):
             config._apply_deepseek_multi_gpu_parallelism_defaults(
                 arch, config.model, 8
@@ -536,7 +542,7 @@ class TestPipelineConfigUtilityMethods:
         config.model.data_parallel_degree = 1
 
         config._apply_deepseek_multi_gpu_parallelism_defaults(
-            SimpleNamespace(name="DeepseekV3ForCausalLM"),
+            self._arch_with_name("DeepseekV3ForCausalLM"),
             config.model,
             1,
         )

--- a/max/tests/tests/pipelines/lib/test_cli_config_file_precedence.py
+++ b/max/tests/tests/pipelines/lib/test_cli_config_file_precedence.py
@@ -20,7 +20,7 @@ from typing import Any
 import click
 from click.testing import CliRunner
 from max.config import ConfigFileModel
-from max.entrypoints.cli.config import config_to_flag
+from max.entrypoints.cli.config import config_to_flag, pipeline_config_options
 from pydantic import Field
 
 
@@ -35,6 +35,18 @@ def _make_cli() -> click.Command:
     def cli(**config_kwargs: Any) -> None:
         config = _TestConfig(**config_kwargs)
         click.echo(f"{config.model_path}|{config.device_graph_capture}")
+
+    return cli
+
+
+def _make_pipeline_sources_cli() -> click.Command:
+    @click.command()
+    @pipeline_config_options
+    def cli(**config_kwargs: Any) -> None:
+        sources = config_kwargs.get("__cli_param_sources__", {})
+        click.echo(
+            f"{sources.get('ep_size')}|{sources.get('data_parallel_degree')}"
+        )
 
     return cli
 
@@ -80,3 +92,19 @@ def test_cli_args_override_config_file(tmp_path: Path) -> None:
     )
     assert result.exit_code == 0, result.output
     assert result.output.strip() == "from-cli|True"
+
+
+def test_pipeline_config_options_injects_default_sources() -> None:
+    """Click defaults are preserved in source metadata."""
+    result = CliRunner().invoke(_make_pipeline_sources_cli(), [])
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "DEFAULT|DEFAULT"
+
+
+def test_pipeline_config_options_marks_commandline_sources() -> None:
+    """Explicit flags are marked as COMMANDLINE in source metadata."""
+    result = CliRunner().invoke(
+        _make_pipeline_sources_cli(), ["--ep-size", "1"]
+    )
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == "COMMANDLINE|DEFAULT"

--- a/max/tests/tests/pipelines/lib/test_cli_config_file_precedence.py
+++ b/max/tests/tests/pipelines/lib/test_cli_config_file_precedence.py
@@ -21,6 +21,7 @@ import click
 from click.testing import CliRunner
 from max.config import ConfigFileModel
 from max.entrypoints.cli.config import config_to_flag, pipeline_config_options
+from max.pipelines.lib import MAXModelConfig, PipelineRuntimeConfig
 from pydantic import Field
 
 
@@ -109,3 +110,27 @@ def test_pipeline_config_options_preserves_explicit_parallelism_flags() -> None:
     )
     assert result.exit_code == 0, result.output
     assert result.output.strip() == "1|1"
+
+
+def test_parallelism_backing_fields_preserve_public_api() -> None:
+    runtime = PipelineRuntimeConfig(ep_size=8)
+    model = MAXModelConfig(data_parallel_degree=4)
+
+    assert runtime.ep_size_raw == 8
+    assert runtime.ep_size == 8
+    assert runtime.model_dump()["ep_size"] == 8
+    assert "ep_size_raw" not in runtime.model_dump()
+
+    runtime.ep_size = None
+    assert runtime.ep_size_raw is None
+    assert runtime.ep_size == 1
+
+    assert model.data_parallel_degree_raw == 4
+    assert model.data_parallel_degree == 4
+    model_dump = model.model_dump(include={"data_parallel_degree"})
+    assert model_dump["data_parallel_degree"] == 4
+    assert "data_parallel_degree_raw" not in model_dump
+
+    model.data_parallel_degree = None
+    assert model.data_parallel_degree_raw is None
+    assert model.data_parallel_degree == 1

--- a/max/tests/tests/pipelines/lib/test_cli_config_file_precedence.py
+++ b/max/tests/tests/pipelines/lib/test_cli_config_file_precedence.py
@@ -39,13 +39,13 @@ def _make_cli() -> click.Command:
     return cli
 
 
-def _make_pipeline_sources_cli() -> click.Command:
+def _make_pipeline_parallelism_cli() -> click.Command:
     @click.command()
     @pipeline_config_options
     def cli(**config_kwargs: Any) -> None:
-        sources = config_kwargs.get("__cli_param_sources__", {})
         click.echo(
-            f"{sources.get('ep_size')}|{sources.get('data_parallel_degree')}"
+            f"{config_kwargs.get('ep_size')}|"
+            f"{config_kwargs.get('data_parallel_degree')}"
         )
 
     return cli
@@ -94,17 +94,18 @@ def test_cli_args_override_config_file(tmp_path: Path) -> None:
     assert result.output.strip() == "from-cli|True"
 
 
-def test_pipeline_config_options_injects_default_sources() -> None:
-    """Click defaults are preserved in source metadata."""
-    result = CliRunner().invoke(_make_pipeline_sources_cli(), [])
+def test_pipeline_config_options_preserves_none_defaults() -> None:
+    """Absent EP/DP flags remain unset until config resolution."""
+    result = CliRunner().invoke(_make_pipeline_parallelism_cli(), [])
     assert result.exit_code == 0, result.output
-    assert result.output.strip() == "DEFAULT|DEFAULT"
+    assert result.output.strip() == "None|None"
 
 
-def test_pipeline_config_options_marks_commandline_sources() -> None:
-    """Explicit flags are marked as COMMANDLINE in source metadata."""
+def test_pipeline_config_options_preserves_explicit_parallelism_flags() -> None:
+    """Explicit EP/DP flags are passed through as concrete values."""
     result = CliRunner().invoke(
-        _make_pipeline_sources_cli(), ["--ep-size", "1"]
+        _make_pipeline_parallelism_cli(),
+        ["--ep-size", "1", "--data-parallel-degree", "1"],
     )
     assert result.exit_code == 0, result.output
-    assert result.output.strip() == "COMMANDLINE|DEFAULT"
+    assert result.output.strip() == "1|1"

--- a/max/tests/tests/pipelines/lib/test_cli_config_file_precedence.py
+++ b/max/tests/tests/pipelines/lib/test_cli_config_file_precedence.py
@@ -94,11 +94,11 @@ def test_cli_args_override_config_file(tmp_path: Path) -> None:
     assert result.output.strip() == "from-cli|True"
 
 
-def test_pipeline_config_options_preserves_none_defaults() -> None:
-    """Absent EP/DP flags remain unset until config resolution."""
+def test_pipeline_config_options_preserves_zero_sentinels() -> None:
+    """Absent EP/DP flags keep the unresolved integer sentinel."""
     result = CliRunner().invoke(_make_pipeline_parallelism_cli(), [])
     assert result.exit_code == 0, result.output
-    assert result.output.strip() == "None|None"
+    assert result.output.strip() == "0|0"
 
 
 def test_pipeline_config_options_preserves_explicit_parallelism_flags() -> None:

--- a/max/tests/tests/pipelines/lib/test_cli_config_file_precedence.py
+++ b/max/tests/tests/pipelines/lib/test_cli_config_file_precedence.py
@@ -94,11 +94,11 @@ def test_cli_args_override_config_file(tmp_path: Path) -> None:
     assert result.output.strip() == "from-cli|True"
 
 
-def test_pipeline_config_options_preserves_zero_sentinels() -> None:
-    """Absent EP/DP flags keep the unresolved integer sentinel."""
+def test_pipeline_config_options_preserves_none_defaults() -> None:
+    """Absent EP/DP flags remain unset until config resolution."""
     result = CliRunner().invoke(_make_pipeline_parallelism_cli(), [])
     assert result.exit_code == 0, result.output
-    assert result.output.strip() == "0|0"
+    assert result.output.strip() == "None|None"
 
 
 def test_pipeline_config_options_preserves_explicit_parallelism_flags() -> None:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Please fill out the sections below to help reviewers understand your change.
For guidance on writing a good PR, see our
[contributor guide](../CONTRIBUTING.md).
-->

## Summary

<!-- Describe what this PR does and why. Link to any related issues. -->

This PR adds DeepSeek-specific multi-GPU parallelism defaults during `PipelineConfig.resolve()`. It will assign both EP and DP to the number of GPUs.

Because currently we are only doing special treatment for DeepSeek models in `config.py`, I add helper functions directly. We may consider a rule-table based approach like `[(rule1_pred, rule1_resolve)...]` if more model arch need special treatments so each model arch can add their own parameter defaults to this rule-table.

## Testing

<!--
Describe how you validated your changes. For code changes, this should include
what tests you ran and any relevant results. For documentation changes, describe
how you verified accuracy.
-->
minimal tests:

```
./bazelw test --config=disable-mypy \
  //max/tests/integration/unorganized:test_config_pure \
  --test_arg=-k \
  --test_arg='test_apply_deepseek_defaults'
```

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
