### PR TITLE
[Stdlib] Change _unsafe_strlen max parameter to Optional[UInt]

### DIFF
--- a/mojo/stdlib/std/collections/string/string_slice.mojo
+++ b/mojo/stdlib/std/collections/string/string_slice.mojo
@@ -2657,7 +2657,11 @@ fn _unsafe_strlen(
 
     Args:
         ptr: The null-terminated pointer to the string.
-        max: The maximum size of the string.
+        max: The maximum number of bytes to scan. Defaults to `UInt.MAX`,
+             which means the scan is unbounded and relies on the string
+             being null-terminated. Pass an explicit value to cap the scan
+             (e.g. when reading from a fixed-size buffer such as a dirent
+             name field).
 
     Returns:
         The length of the null terminated string without the null terminator.
@@ -2679,11 +2683,16 @@ fn _unsafe_strlen_impl(
     """SIMD-accelerated helper for `_unsafe_strlen`.
 
     Scans for a null byte using SIMD-width blocks, then a scalar tail for any
-    remaining bytes within `max`.
+    remaining bytes within `max`. When `max == UInt.MAX` the scan is
+    unbounded; all other values cap the scan to at most `max` bytes.
+
+    The SIMD width matches `_memchr_impl` (`simd_width_of[DType.bool]()`),
+    keeping SIMD behaviour consistent across stdlib string search helpers.
     """
     comptime bool_mask_width = simd_width_of[DType.bool]()
     var zero = SIMD[DType.uint8, bool_mask_width](0)
 
+    # UInt.MAX is the sentinel for "no bound" (see _unsafe_strlen docstring).
     if max == UInt.MAX:
         # Unbounded scan: the string is guaranteed to be null-terminated, so
         # a null byte will always be found. Load SIMD-width blocks until one

--- a/mojo/stdlib/std/collections/string/string_slice.mojo
+++ b/mojo/stdlib/std/collections/string/string_slice.mojo
@@ -2651,15 +2651,15 @@ fn _to_string_list[
 
 @always_inline
 fn _unsafe_strlen(
-    ptr: UnsafePointer[mut=False, Byte], max: UInt = UInt.MAX
+    ptr: UnsafePointer[mut=False, Byte], max: Optional[UInt] = None
 ) -> UInt:
     """Get the length of a null-terminated string from a pointer.
 
     Args:
         ptr: The null-terminated pointer to the string.
-        max: The maximum number of bytes to scan. Defaults to `UInt.MAX`,
-             which means the scan is unbounded and relies on the string
-             being null-terminated. Pass an explicit value to cap the scan
+        max: The maximum number of bytes to scan. If `None` (the default),
+             the scan is unbounded and relies on the string being
+             null-terminated. Pass an explicit value to cap the scan
              (e.g. when reading from a fixed-size buffer such as a dirent
              name field).
 
@@ -2669,12 +2669,13 @@ fn _unsafe_strlen(
     Notes:
         The length does NOT include the null terminator.
     """
+    var bound = max.or_else(UInt.MAX)
     if is_compile_time():
         var offset = UInt(0)
-        while offset < max and ptr[offset]:
+        while offset < bound and ptr[offset]:
             offset += 1
         return offset
-    return _unsafe_strlen_impl(ptr, max)
+    return _unsafe_strlen_impl(ptr, bound)
 
 
 fn _unsafe_strlen_impl(

--- a/mojo/stdlib/std/ffi/cstring.mojo
+++ b/mojo/stdlib/std/ffi/cstring.mojo
@@ -16,7 +16,7 @@ from std.collections.string.string_slice import _unsafe_strlen
 
 @always_inline
 fn _validate_bytes(slice: Span[Byte]) raises:
-    var length = Int(_unsafe_strlen(slice.unsafe_ptr(), UInt(len(slice))))
+    var length = Int(_unsafe_strlen(slice.unsafe_ptr(), Optional(UInt(len(slice)))))
     if length == len(slice) - 1:
         return
     elif length == 0 or length == len(slice):

--- a/mojo/stdlib/std/os/os.mojo
+++ b/mojo/stdlib/std/os/os.mojo
@@ -145,7 +145,7 @@ struct _DirHandle:
             var name_str = StringSlice[origin_of(name)](
                 ptr=name_ptr,
                 length=Int(
-                    _unsafe_strlen(name_ptr, _dirent_linux.MAX_NAME_SIZE)
+                    _unsafe_strlen(name_ptr, Optional(UInt(_dirent_linux.MAX_NAME_SIZE)))
                 ),
             )
             if name_str == "." or name_str == "..":
@@ -173,7 +173,7 @@ struct _DirHandle:
             var name_str = StringSlice[origin_of(name)](
                 ptr=name_ptr,
                 length=Int(
-                    _unsafe_strlen(name_ptr, _dirent_macos.MAX_NAME_SIZE)
+                    _unsafe_strlen(name_ptr, Optional(UInt(_dirent_macos.MAX_NAME_SIZE)))
                 ),
             )
             if name_str == "." or name_str == "..":

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -13,6 +13,7 @@
 
 from std.collections.string.string_slice import (
     _to_string_list,
+    _unsafe_strlen,
     get_static_string,
 )
 from std.sys.info import size_of, simd_width_of
@@ -1174,6 +1175,63 @@ def test_string_slice_codepoint_slices_reversed() raises:
     for v in s.codepoint_slices_reversed():
         concat += v
     assert_equal(concat, "")
+
+
+def test_unsafe_strlen():
+    comptime simd_width = simd_width_of[DType.bool]()
+
+    # Empty string: just a null terminator.
+    var empty = List[Byte](capacity=1)
+    empty.append(0)
+    assert_equal(_unsafe_strlen(empty.unsafe_ptr()), UInt(0))
+
+    # Short string, well below one SIMD block.
+    var short_buf = List[Byte](capacity=3)
+    short_buf.append(Byte(ord("h")))
+    short_buf.append(Byte(ord("i")))
+    short_buf.append(0)
+    assert_equal(_unsafe_strlen(short_buf.unsafe_ptr()), UInt(2))
+
+    # String exactly (simd_width - 1) bytes long (fits within one SIMD block).
+    var sub_block = List[Byte](capacity=simd_width)
+    for _ in range(simd_width - 1):
+        sub_block.append(Byte(ord("x")))
+    sub_block.append(0)
+    assert_equal(_unsafe_strlen(sub_block.unsafe_ptr()), UInt(simd_width - 1))
+
+    # String that spans more than one SIMD block.
+    var multi_block_len = simd_width * 3 + 7
+    var multi_block = List[Byte](capacity=multi_block_len + 1)
+    for _ in range(multi_block_len):
+        multi_block.append(Byte(ord("a")))
+    multi_block.append(0)
+    assert_equal(
+        _unsafe_strlen(multi_block.unsafe_ptr()), UInt(multi_block_len)
+    )
+
+    # Bounded scan: max smaller than the actual string length.
+    var long_buf = List[Byte](capacity=6)
+    long_buf.append(Byte(ord("a")))
+    long_buf.append(Byte(ord("b")))
+    long_buf.append(Byte(ord("c")))
+    long_buf.append(Byte(ord("d")))
+    long_buf.append(Byte(ord("e")))
+    long_buf.append(0)
+    assert_equal(_unsafe_strlen(long_buf.unsafe_ptr(), UInt(3)), UInt(3))
+
+    # Bounded scan: max exactly equal to the string length.
+    assert_equal(_unsafe_strlen(long_buf.unsafe_ptr(), UInt(5)), UInt(5))
+
+    # Bounded scan: max larger than the string length — returns actual length.
+    assert_equal(_unsafe_strlen(long_buf.unsafe_ptr(), UInt(100)), UInt(5))
+
+    # Unicode bytes: UTF-8 is treated as raw bytes, all non-zero.
+    # "é" encodes as two bytes: 0xC3, 0xA9.
+    var unicode_buf = List[Byte](capacity=3)
+    unicode_buf.append(Byte(0xC3))
+    unicode_buf.append(Byte(0xA9))
+    unicode_buf.append(0)
+    assert_equal(_unsafe_strlen(unicode_buf.unsafe_ptr()), UInt(2))
 
 
 def main() raises:

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -1217,13 +1217,13 @@ def test_unsafe_strlen():
     long_buf.append(Byte(ord("d")))
     long_buf.append(Byte(ord("e")))
     long_buf.append(0)
-    assert_equal(_unsafe_strlen(long_buf.unsafe_ptr(), UInt(3)), UInt(3))
+    assert_equal(_unsafe_strlen(long_buf.unsafe_ptr(), Optional(UInt(3))), UInt(3))
 
     # Bounded scan: max exactly equal to the string length.
-    assert_equal(_unsafe_strlen(long_buf.unsafe_ptr(), UInt(5)), UInt(5))
+    assert_equal(_unsafe_strlen(long_buf.unsafe_ptr(), Optional(UInt(5))), UInt(5))
 
     # Bounded scan: max larger than the string length — returns actual length.
-    assert_equal(_unsafe_strlen(long_buf.unsafe_ptr(), UInt(100)), UInt(5))
+    assert_equal(_unsafe_strlen(long_buf.unsafe_ptr(), Optional(UInt(100))), UInt(5))
 
     # Unicode bytes: UTF-8 is treated as raw bytes, all non-zero.
     # "é" encodes as two bytes: 0xC3, 0xA9.


### PR DESCRIPTION
Replace the `UInt.MAX` magic number sentinel with `Optional[UInt] = None` for the `max` parameter of `_unsafe_strlen`. `None` means unbounded (scan until the null terminator); an explicit value caps the scan.

Follows up on review feedback in #6044.