### PR TITLE
[MAX] Add Z-Image DiT Modules for Z-Image Pipeline

### DIFF
--- a/max/python/max/pipelines/architectures/z_image_modulev3/__init__.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/__init__.py
@@ -1,0 +1,16 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from .model import ZImageTransformerModel
+
+__all__ = ["ZImageTransformerModel"]

--- a/max/python/max/pipelines/architectures/z_image_modulev3/layers/__init__.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/layers/__init__.py
@@ -1,0 +1,17 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from .attention import ZImageAttention
+from .embeddings import RopeEmbedder, TimestepEmbedder
+
+__all__ = ["RopeEmbedder", "TimestepEmbedder", "ZImageAttention"]

--- a/max/python/max/pipelines/architectures/z_image_modulev3/layers/attention.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/layers/attention.py
@@ -1,0 +1,102 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import math
+
+from max.experimental import functional as F
+from max.experimental.nn import Linear, Module
+from max.experimental.nn.norm import RMSNorm
+from max.experimental.nn.sequential import ModuleList
+from max.experimental.tensor import Tensor
+from max.nn.attention.mask_config import MHAMaskVariant
+from max.nn.kernels import flash_attention_gpu as _flash_attention_gpu
+
+from ...flux2_modulev3.layers.embeddings import apply_rotary_emb
+
+flash_attention_gpu = F.functional(_flash_attention_gpu)
+
+
+class ZImageAttention(Module[..., Tensor]):
+    def __init__(
+        self,
+        dim: int,
+        n_heads: int,
+        qk_norm: bool,
+        eps: float,
+    ):
+        self.head_dim = dim // n_heads
+        self.inner_dim = dim
+        self.n_heads = n_heads
+
+        self.to_q = Linear(dim, dim, bias=False)
+        self.to_k = Linear(dim, dim, bias=False)
+        self.to_v = Linear(dim, dim, bias=False)
+
+        self.norm_q = RMSNorm(self.head_dim, eps=eps) if qk_norm else None
+        self.norm_k = RMSNorm(self.head_dim, eps=eps) if qk_norm else None
+
+        # Keep ModuleList naming for diffusers-compatible key loading.
+        self.to_out = ModuleList([Linear(dim, dim, bias=False)])
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        freqs_cis: tuple[Tensor, Tensor],
+    ) -> Tensor:
+        batch_size = hidden_states.shape[0]
+        seq_len = hidden_states.shape[1]
+
+        query = self.to_q(hidden_states)
+        key = self.to_k(hidden_states)
+        value = self.to_v(hidden_states)
+
+        query = F.reshape(
+            query, [batch_size, seq_len, self.n_heads, self.head_dim]
+        )
+        key = F.reshape(key, [batch_size, seq_len, self.n_heads, self.head_dim])
+        value = F.reshape(
+            value, [batch_size, seq_len, self.n_heads, self.head_dim]
+        )
+
+        if self.norm_q is not None:
+            query = self.norm_q(query)
+        if self.norm_k is not None:
+            key = self.norm_k(key)
+
+        query = apply_rotary_emb(
+            query,
+            freqs_cis,
+            use_real=True,
+            use_real_unbind_dim=-1,
+            sequence_dim=1,
+        )
+        key = apply_rotary_emb(
+            key,
+            freqs_cis,
+            use_real=True,
+            use_real_unbind_dim=-1,
+            sequence_dim=1,
+        )
+        query = query.cast(value.dtype)
+        key = key.cast(value.dtype)
+
+        out = flash_attention_gpu(
+            query,
+            key,
+            value,
+            mask_variant=MHAMaskVariant.NULL_MASK,
+            scale=math.sqrt(1.0 / float(self.head_dim)),
+        )
+
+        out = F.reshape(out, [batch_size, seq_len, self.inner_dim])
+        return self.to_out[0](out)

--- a/max/python/max/pipelines/architectures/z_image_modulev3/layers/embeddings.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/layers/embeddings.py
@@ -1,0 +1,103 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import math
+
+from max.dtype import DType
+from max.experimental import functional as F
+from max.experimental.nn import Linear, Module
+from max.experimental.tensor import Tensor
+
+from ...flux2_modulev3.layers.embeddings import get_1d_rotary_pos_embed
+
+
+class TimestepEmbedder(Module[[Tensor], Tensor]):
+    def __init__(
+        self,
+        out_size: int,
+        mid_size: int | None = None,
+        frequency_embedding_size: int = 256,
+    ) -> None:
+        if mid_size is None:
+            mid_size = out_size
+
+        self.linear_1 = Linear(frequency_embedding_size, mid_size, bias=True)
+        self.linear_2 = Linear(mid_size, out_size, bias=True)
+        self.frequency_embedding_size = frequency_embedding_size
+
+    @staticmethod
+    def timestep_embedding(
+        t: Tensor,
+        dim: int,
+        max_period: float = 10000.0,
+    ) -> Tensor:
+        half = dim // 2
+        freqs = F.arange(0, half, dtype=DType.float32, device=t.device)
+        freqs = F.exp((-math.log(max_period) * freqs) / float(half))
+
+        args = F.cast(t, DType.float32)[:, None] * freqs[None, :]
+        embedding = F.concat([F.cos(args), F.sin(args)], axis=-1)
+
+        if dim % 2:
+            # Avoid Tensor.zeros in the graph path; broadcast a scalar zero like
+            # other normalization blocks (see LayerNorm gamma/beta patterns).
+            zero = F.reshape(
+                F.constant(0.0, embedding.dtype, device=t.device),
+                (1, 1),
+            )
+            zeros_col = F.broadcast_to(zero, (embedding.shape[0], 1))
+            embedding = F.concat([embedding, zeros_col], axis=-1)
+
+        return embedding
+
+    def forward(self, t: Tensor) -> Tensor:
+        t_freq = self.timestep_embedding(t, self.frequency_embedding_size)
+        t_freq = F.cast(t_freq, self.linear_1.weight.dtype)
+        t_emb = self.linear_2(F.silu(self.linear_1(t_freq)))
+        return t_emb
+
+
+class RopeEmbedder(Module[[Tensor], tuple[Tensor, Tensor]]):
+    def __init__(
+        self,
+        theta: float = 256.0,
+        axes_dims: tuple[int, ...] = (32, 48, 48),
+    ) -> None:
+        self.theta = theta
+        self.axes_dims = axes_dims
+
+    def forward(self, ids: Tensor) -> tuple[Tensor, Tensor]:
+        if ids.rank != 2:
+            raise ValueError(f"Expected 2D ids tensor, got rank={ids.rank}")
+
+        if int(ids.shape[-1]) != len(self.axes_dims):
+            raise ValueError(
+                "ids last dimension must match axes_dims length "
+                f"({len(self.axes_dims)}), got {ids.shape[-1]}"
+            )
+
+        pos = ids.cast(DType.float32)
+        cos_out = []
+        sin_out = []
+        for i in range(len(self.axes_dims)):
+            cos_i, sin_i = get_1d_rotary_pos_embed(
+                self.axes_dims[i],
+                pos[:, i],
+                theta=self.theta,
+                use_real=True,
+                repeat_interleave_real=True,
+            )
+            cos_out.append(cos_i)
+            sin_out.append(sin_i)
+
+        return F.concat(cos_out, axis=-1), F.concat(sin_out, axis=-1)

--- a/max/python/max/pipelines/architectures/z_image_modulev3/model.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/model.py
@@ -1,0 +1,124 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from max.driver import Device
+from max.experimental import functional as F
+from max.experimental.tensor import Tensor
+from max.graph.weights import Weights
+from max.pipelines.lib import SupportedEncoding
+from max.pipelines.lib.interfaces.component_model import ComponentModel
+from max.profiler import traced
+
+if TYPE_CHECKING:
+    from max.pipelines.lib.interfaces.cache_mixin import DenoisingCacheConfig
+
+from .model_config import ZImageConfig
+from .weight_adapters import convert_z_image_transformer_state_dict
+from .z_image import ZImageTransformer2DModel
+
+
+class ZImageTransformerModel(ComponentModel):
+    """Component wrapper for the compiled Z-Image transformer graph."""
+
+    model: Callable[..., Any]
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        encoding: SupportedEncoding,
+        devices: list[Device],
+        weights: Weights,
+        *,
+        cache_config: DenoisingCacheConfig | None = None,
+    ) -> None:
+        super().__init__(
+            config,
+            encoding,
+            devices,
+            weights,
+            cache_config=cache_config,
+        )
+        self.config = ZImageConfig.initialize_from_config(
+            config,
+            encoding,
+            devices,
+        )
+        self.load_model()
+
+    @traced(message="ZImageTransformerModel.load_model")
+    def load_model(self) -> None:
+        target_dtype = self.config.dtype
+        state_dict = {}
+        for key, value in self.weights.items():
+            weight = value.data()
+            if weight.dtype != target_dtype:
+                if weight.dtype.is_float() and target_dtype.is_float():
+                    weight = weight.astype(target_dtype)
+            state_dict[key] = weight
+        state_dict = convert_z_image_transformer_state_dict(state_dict)
+
+        with F.lazy():
+            transformer = ZImageTransformer2DModel(
+                self.config,
+                cache_config=self.cache_config,
+            )
+            transformer.to(self.devices[0])
+
+        self.model = transformer.compile(
+            *transformer.input_types(),
+            weights=state_dict,
+        )
+
+    @traced(message="ZImageTransformerModel.__call__")
+    def __call__(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Tensor,
+        timestep: Tensor,
+        img_ids: Tensor,
+        txt_ids: Tensor,
+        prev_residual: Tensor | None = None,
+        prev_output: Tensor | None = None,
+        controlnet_block_samples: Tensor | None = None,
+        siglip_feats: Tensor | None = None,
+        image_noise_mask: Tensor | None = None,
+    ) -> Any:
+        if controlnet_block_samples is not None:
+            raise NotImplementedError(
+                "controlnet_block_samples is not supported in z-image phase 1"
+            )
+        if siglip_feats is not None or image_noise_mask is not None:
+            raise NotImplementedError(
+                "Omni(siglip/image_noise_mask) is not supported in z-image phase 1"
+            )
+
+        model_args: tuple[Any, ...] = (
+            hidden_states,
+            encoder_hidden_states,
+            timestep,
+            img_ids,
+            txt_ids,
+        )
+        if (
+            self.cache_config is not None
+            and self.cache_config.first_block_caching
+            and prev_residual is not None
+            and prev_output is not None
+        ):
+            model_args = (*model_args, prev_residual, prev_output)
+        return self.model(*model_args)

--- a/max/python/max/pipelines/architectures/z_image_modulev3/model_config.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/model_config.py
@@ -1,0 +1,79 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from typing import Any
+
+from max.driver import Device
+from max.dtype import DType
+from max.graph import DeviceRef
+from max.pipelines.lib import MAXModelConfigBase, SupportedEncoding
+from max.pipelines.lib.config.config_enums import supported_encoding_dtype
+from pydantic import Field
+from typing_extensions import Self
+
+
+class ZImageConfig(MAXModelConfigBase):
+    all_patch_size: tuple[int, ...] = (2,)
+    all_f_patch_size: tuple[int, ...] = (1,)
+    in_channels: int = 16
+    dim: int = 3840
+    n_layers: int = 30
+    n_refiner_layers: int = 2
+    n_heads: int = 30
+    n_kv_heads: int = 30
+    norm_eps: float = 1e-5
+    qk_norm: bool = True
+    cap_feat_dim: int = 2560
+    rope_theta: float = 256.0
+    t_scale: float = 1000.0
+    axes_dims: tuple[int, ...] = (32, 48, 48)
+    axes_lens: tuple[int, ...] = (1024, 512, 512)
+    dtype: DType = DType.bfloat16
+    device: DeviceRef = Field(default_factory=DeviceRef.GPU)
+
+    @classmethod
+    def initialize_from_config(
+        cls,
+        config_dict: dict[str, Any],
+        encoding: SupportedEncoding,
+        devices: list[Device],
+    ) -> Self:
+        init_dict = {
+            key: value
+            for key, value in config_dict.items()
+            if key in cls.model_fields
+        }
+        # Ignore omni-only fields in phase 1 (may appear in full checkpoints).
+        init_dict.pop("siglip_feat_dim", None)
+
+        init_dict.update(
+            {
+                "dtype": supported_encoding_dtype(encoding),
+                "device": DeviceRef.from_device(devices[0]),
+            }
+        )
+        return cls(**init_dict)
+
+    def fbcache_dims(self) -> tuple[int, int]:
+        """(hidden_dim, output_dim) per image token for FBCache / Taylor tensors."""
+        out_dim = (
+            self.all_patch_size[0]
+            * self.all_patch_size[0]
+            * self.all_f_patch_size[0]
+            * self.in_channels
+        )
+        return self.dim, out_dim
+
+
+# Back-compat alias for call sites that refer to the config as a "base" type.
+ZImageConfigBase = ZImageConfig

--- a/max/python/max/pipelines/architectures/z_image_modulev3/weight_adapters.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/weight_adapters.py
@@ -1,0 +1,94 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+from max.graph.weights import WeightData
+
+
+def _replace_prefix(key: str, old: str, new: str) -> str:
+    if key.startswith(old):
+        return new + key[len(old) :]
+    return key
+
+
+def convert_z_image_transformer_state_dict(
+    state_dict: dict[str, WeightData],
+) -> dict[str, WeightData]:
+    converted: dict[str, WeightData] = {}
+
+    dropped_prefixes = (
+        "x_pad_token",
+        "cap_pad_token",
+        "siglip_",
+    )
+
+    for original_key, value in state_dict.items():
+        key = original_key
+
+        if key.startswith(dropped_prefixes):
+            continue
+
+        key = _replace_prefix(key, "all_x_embedder.2-1.", "x_embedder.")
+        key = _replace_prefix(key, "all_final_layer.2-1.", "final_layer.")
+        key = _replace_prefix(key, "t_embedder.mlp.0.", "t_embedder.linear_1.")
+        key = _replace_prefix(key, "t_embedder.mlp.2.", "t_embedder.linear_2.")
+        key = _replace_prefix(key, "cap_embedder.0.", "cap_norm.")
+        key = _replace_prefix(key, "cap_embedder.1.", "cap_proj.")
+        key = key.replace("adaLN_modulation.0.", "adaLN_modulation.")
+        key = _replace_prefix(
+            key,
+            "final_layer.adaLN_modulation.1.",
+            "final_layer.adaLN_modulation.",
+        )
+
+        converted[key] = value
+
+    required_prefixes = (
+        "x_embedder.",
+        "t_embedder.",
+        "cap_norm.",
+        "cap_proj.",
+        "noise_refiner.0.",
+        "context_refiner.0.",
+        "layers.0.",
+        "final_layer.",
+    )
+    for prefix in required_prefixes:
+        if not any(k.startswith(prefix) for k in converted):
+            raise ValueError(
+                f"Missing required z-image transformer weights with prefix '{prefix}'"
+            )
+
+    allowed_prefixes = (
+        "x_embedder.",
+        "noise_refiner.",
+        "context_refiner.",
+        "t_embedder.",
+        "cap_norm.",
+        "cap_proj.",
+        "layers.",
+        "final_layer.",
+    )
+    unexpected_keys = [
+        k
+        for k in converted
+        if not any(k.startswith(p) for p in allowed_prefixes)
+    ]
+    if unexpected_keys:
+        sample = ", ".join(unexpected_keys[:8])
+        raise ValueError(
+            f"Unexpected z-image transformer keys in phase-1 adapter: {sample}"
+        )
+
+    return converted

--- a/max/python/max/pipelines/architectures/z_image_modulev3/z_image.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/z_image.py
@@ -1,0 +1,452 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from max.dtype import DType
+from max.experimental import functional as F
+from max.experimental.nn import Linear, Module
+from max.experimental.nn.norm import LayerNorm, RMSNorm
+from max.experimental.nn.sequential import ModuleList
+from max.experimental.tensor import Tensor
+from max.graph import TensorType
+from max.pipelines.lib.interfaces.cache_mixin import (
+    DenoisingCacheConfig,
+    fbcache_conditional_execution,
+)
+
+from .layers.attention import ZImageAttention
+from .layers.embeddings import RopeEmbedder, TimestepEmbedder
+from .model_config import ZImageConfig
+
+ADALN_EMBED_DIM = 256
+
+
+class FeedForward(Module[[Tensor], Tensor]):
+    def __init__(self, dim: int, hidden_dim: int):
+        self.w1 = Linear(dim, hidden_dim, bias=False)
+        self.w2 = Linear(hidden_dim, dim, bias=False)
+        self.w3 = Linear(dim, hidden_dim, bias=False)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+
+class ZImageTransformerBlock(Module[..., Tensor]):
+    def __init__(
+        self,
+        layer_id: int,
+        dim: int,
+        n_heads: int,
+        n_kv_heads: int,
+        norm_eps: float,
+        qk_norm: bool,
+        modulation: bool = True,
+    ):
+        del n_kv_heads
+
+        self.layer_id = layer_id
+        self.modulation = modulation
+
+        self.attention = ZImageAttention(
+            dim=dim,
+            n_heads=n_heads,
+            qk_norm=qk_norm,
+            eps=norm_eps,
+        )
+        self.feed_forward = FeedForward(dim=dim, hidden_dim=int(dim / 3 * 8))
+
+        self.attention_norm1 = RMSNorm(dim, eps=norm_eps)
+        self.ffn_norm1 = RMSNorm(dim, eps=norm_eps)
+
+        self.attention_norm2 = RMSNorm(dim, eps=norm_eps)
+        self.ffn_norm2 = RMSNorm(dim, eps=norm_eps)
+
+        self.adaLN_modulation = (
+            Linear(min(dim, ADALN_EMBED_DIM), 4 * dim, bias=True)
+            if modulation
+            else None
+        )
+
+    def forward(
+        self,
+        x: Tensor,
+        freqs_cis: tuple[Tensor, Tensor],
+        adaln_input: Tensor | None = None,
+    ) -> Tensor:
+        if self.modulation:
+            if adaln_input is None:
+                raise ValueError("adaln_input is required when modulation=True")
+            if self.adaLN_modulation is None:
+                raise ValueError("adaLN_modulation is not initialized")
+
+            mod = self.adaLN_modulation(adaln_input)
+            mod = F.unsqueeze(mod, 1)
+            scale_msa, gate_msa, scale_mlp, gate_mlp = F.chunk(mod, 4, axis=2)
+
+            gate_msa = F.tanh(gate_msa)
+            gate_mlp = F.tanh(gate_mlp)
+            scale_msa = 1.0 + scale_msa
+            scale_mlp = 1.0 + scale_mlp
+
+            attn_out = self.attention(
+                self.attention_norm1(x) * scale_msa,
+                freqs_cis=freqs_cis,
+            )
+            x = x + gate_msa * self.attention_norm2(attn_out)
+
+            ffn_out = self.feed_forward(self.ffn_norm1(x) * scale_mlp)
+            x = x + gate_mlp * self.ffn_norm2(ffn_out)
+        else:
+            attn_out = self.attention(
+                self.attention_norm1(x), freqs_cis=freqs_cis
+            )
+            x = x + self.attention_norm2(attn_out)
+            x = x + self.ffn_norm2(self.feed_forward(self.ffn_norm1(x)))
+
+        return x
+
+
+class FinalLayer(Module[..., Tensor]):
+    def __init__(self, hidden_size: int, out_channels: int):
+        self.norm_final = LayerNorm(
+            hidden_size,
+            eps=1e-6,
+            elementwise_affine=False,
+            use_bias=False,
+        )
+        self.linear = Linear(hidden_size, out_channels, bias=True)
+        self.adaLN_modulation = Linear(
+            min(hidden_size, ADALN_EMBED_DIM),
+            hidden_size,
+            bias=True,
+        )
+
+    def forward(self, x: Tensor, c: Tensor) -> Tensor:
+        scale = 1.0 + self.adaLN_modulation(F.silu(c))
+        x = self.norm_final(x) * F.unsqueeze(scale, 1)
+        return self.linear(x)
+
+
+class ZImageTransformer2DModel(Module[..., Sequence[Tensor]]):
+    def __init__(
+        self,
+        config: ZImageConfig,
+        cache_config: DenoisingCacheConfig | None = None,
+    ):
+        self.in_channels = config.in_channels
+        self.out_channels = config.in_channels
+        self.dim = config.dim
+        self.n_heads = config.n_heads
+        self.t_scale = config.t_scale
+        self.axes_dims = config.axes_dims
+        self.axes_lens = config.axes_lens
+
+        if len(config.all_patch_size) != len(config.all_f_patch_size):
+            raise ValueError("all_patch_size and all_f_patch_size must align")
+
+        self.patch_size = config.all_patch_size[0]
+        self.f_patch_size = config.all_f_patch_size[0]
+        self.packed_channels = (
+            self.f_patch_size
+            * self.patch_size
+            * self.patch_size
+            * self.in_channels
+        )
+
+        self.x_embedder = Linear(
+            self.packed_channels,
+            self.dim,
+            bias=True,
+        )
+
+        self.final_layer = FinalLayer(
+            self.dim,
+            self.patch_size
+            * self.patch_size
+            * self.f_patch_size
+            * self.out_channels,
+        )
+
+        self.noise_refiner: ModuleList[ZImageTransformerBlock] = ModuleList(
+            [
+                ZImageTransformerBlock(
+                    1000 + layer_id,
+                    self.dim,
+                    config.n_heads,
+                    config.n_kv_heads,
+                    config.norm_eps,
+                    config.qk_norm,
+                    modulation=True,
+                )
+                for layer_id in range(config.n_refiner_layers)
+            ]
+        )
+
+        self.context_refiner: ModuleList[ZImageTransformerBlock] = ModuleList(
+            [
+                ZImageTransformerBlock(
+                    layer_id,
+                    self.dim,
+                    config.n_heads,
+                    config.n_kv_heads,
+                    config.norm_eps,
+                    config.qk_norm,
+                    modulation=False,
+                )
+                for layer_id in range(config.n_refiner_layers)
+            ]
+        )
+
+        self.t_embedder = TimestepEmbedder(
+            min(self.dim, ADALN_EMBED_DIM),
+            mid_size=1024,
+        )
+        self.cap_norm = RMSNorm(config.cap_feat_dim, eps=config.norm_eps)
+        self.cap_proj = Linear(config.cap_feat_dim, self.dim, bias=True)
+
+        self.layers: ModuleList[ZImageTransformerBlock] = ModuleList(
+            [
+                ZImageTransformerBlock(
+                    layer_id,
+                    self.dim,
+                    config.n_heads,
+                    config.n_kv_heads,
+                    config.norm_eps,
+                    config.qk_norm,
+                    modulation=True,
+                )
+                for layer_id in range(config.n_layers)
+            ]
+        )
+
+        head_dim = self.dim // self.n_heads
+        if head_dim != sum(self.axes_dims):
+            raise ValueError(
+                f"head_dim ({head_dim}) must equal sum(axes_dims) ({sum(self.axes_dims)})"
+            )
+
+        self.rope_embedder = RopeEmbedder(
+            theta=config.rope_theta,
+            axes_dims=config.axes_dims,
+        )
+
+        self.max_device = config.device
+        self.max_dtype = config.dtype
+        self.cap_feat_dim = config.cap_feat_dim
+
+        self._forward_impl: Callable[..., tuple[Tensor, ...]] = (
+            self._forward_standard
+        )
+        self._input_types_impl: Callable[..., tuple[TensorType, ...]] = (
+            self._input_types_standard
+        )
+        self._rdt_value: float = 0.05
+        if cache_config is not None and cache_config.first_block_caching:
+            assert cache_config.residual_threshold is not None
+            self._rdt_value = cache_config.residual_threshold
+            self._forward_impl = self._forward_step_cache
+            self._input_types_impl = self._input_types_step_cache
+
+    def _fbcache_conditional_execution_output_types(self) -> list[TensorType]:
+        residual_type = TensorType(
+            self.max_dtype,
+            shape=["batch_size", "image_seq_len", self.dim],
+            device=self.max_device,
+        )
+        out_ch = (
+            self.patch_size
+            * self.patch_size
+            * self.f_patch_size
+            * self.out_channels
+        )
+        output_type = TensorType(
+            self.max_dtype,
+            shape=["batch_size", "image_seq_len", out_ch],
+            device=self.max_device,
+        )
+        return [residual_type, output_type]
+
+    def _base_input_types(self) -> tuple[TensorType, ...]:
+        hidden_states_type = TensorType(
+            self.max_dtype,
+            shape=["batch_size", "image_seq_len", self.packed_channels],
+            device=self.max_device,
+        )
+        encoder_hidden_states_type = TensorType(
+            self.max_dtype,
+            shape=["batch_size", "text_seq_len", self.cap_feat_dim],
+            device=self.max_device,
+        )
+        timestep_type = TensorType(
+            DType.float32,
+            shape=["batch_size"],
+            device=self.max_device,
+        )
+        img_ids_type = TensorType(
+            DType.int64,
+            shape=["image_seq_len", len(self.axes_dims)],
+            device=self.max_device,
+        )
+        txt_ids_type = TensorType(
+            DType.int64,
+            shape=["text_seq_len", len(self.axes_dims)],
+            device=self.max_device,
+        )
+        return (
+            hidden_states_type,
+            encoder_hidden_states_type,
+            timestep_type,
+            img_ids_type,
+            txt_ids_type,
+        )
+
+    def _input_types_standard(self) -> tuple[TensorType, ...]:
+        return self._base_input_types()
+
+    def _input_types_step_cache(self) -> tuple[TensorType, ...]:
+        return self._base_input_types() + tuple(
+            self._fbcache_conditional_execution_output_types()
+        )
+
+    def input_types(self) -> tuple[TensorType, ...]:
+        return self._input_types_impl()
+
+    def _forward_preamble(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Tensor,
+        timestep: Tensor,
+        img_ids: Tensor,
+        txt_ids: Tensor,
+    ) -> tuple[Tensor, Any, Tensor, tuple[Tensor, Tensor]]:
+        """Embed inputs, run refiners, return unified seq before main ``layers[0]``."""
+        x = self.x_embedder(hidden_states)
+        t_emb = self.t_embedder(timestep * self.t_scale).cast(x.dtype)
+
+        cap = self.cap_proj(self.cap_norm(encoder_hidden_states))
+
+        if txt_ids.rank == 3:
+            txt_ids = txt_ids[0]
+        if img_ids.rank == 3:
+            img_ids = img_ids[0]
+
+        txt_freqs = self.rope_embedder(txt_ids)
+        img_freqs = self.rope_embedder(img_ids)
+        unified_freqs = (
+            F.concat([img_freqs[0], txt_freqs[0]], axis=0),
+            F.concat([img_freqs[1], txt_freqs[1]], axis=0),
+        )
+
+        for layer in self.noise_refiner:
+            x = layer(x, freqs_cis=img_freqs, adaln_input=t_emb)
+
+        for layer in self.context_refiner:
+            cap = layer(cap, freqs_cis=txt_freqs)
+
+        img_len = x.shape[1]
+        unified0 = F.concat([x, cap], axis=1)
+        return unified0, img_len, t_emb, unified_freqs
+
+    def _run_first_main_layer(
+        self,
+        unified0: Tensor,
+        t_emb: Tensor,
+        unified_freqs: tuple[Tensor, Tensor],
+    ) -> Tensor:
+        return self.layers[0](
+            unified0,
+            freqs_cis=unified_freqs,
+            adaln_input=t_emb,
+        )
+
+    def _run_remaining_after_first(
+        self,
+        unified: Tensor,
+        *,
+        img_len: Any,
+        t_emb: Tensor,
+        freqs_cis: tuple[Tensor, Tensor],
+    ) -> Tensor:
+        u = unified
+        for i in range(1, len(self.layers)):
+            u = self.layers[i](
+                u,
+                freqs_cis=freqs_cis,
+                adaln_input=t_emb,
+            )
+        u = self.final_layer(u, c=t_emb)
+        return u[:, :img_len, :]
+
+    def _forward_standard(self, *args: Tensor) -> tuple[Tensor]:
+        hidden_states, encoder_hidden_states, timestep, img_ids, txt_ids = args[
+            :5
+        ]
+        unified0, img_len, t_emb, unified_freqs = self._forward_preamble(
+            hidden_states,
+            encoder_hidden_states,
+            timestep,
+            img_ids,
+            txt_ids,
+        )
+        u1 = self._run_first_main_layer(unified0, t_emb, unified_freqs)
+        out = self._run_remaining_after_first(
+            u1,
+            img_len=img_len,
+            t_emb=t_emb,
+            freqs_cis=unified_freqs,
+        )
+        return (out,)
+
+    def _forward_step_cache(self, *args: Tensor) -> tuple[Tensor, Tensor]:
+        (
+            hidden_states,
+            encoder_hidden_states,
+            timestep,
+            img_ids,
+            txt_ids,
+            prev_residual,
+            prev_output,
+        ) = args
+        unified0, img_len, t_emb, unified_freqs = self._forward_preamble(
+            hidden_states,
+            encoder_hidden_states,
+            timestep,
+            img_ids,
+            txt_ids,
+        )
+        unified1 = self._run_first_main_layer(unified0, t_emb, unified_freqs)
+        first_block_residual = (
+            unified1[:, :img_len, :] - unified0[:, :img_len, :]
+        )
+
+        return fbcache_conditional_execution(
+            first_block_residual,
+            prev_residual,
+            prev_output,
+            self._rdt_value,
+            self._run_remaining_after_first,
+            dict(
+                unified=unified1,
+                img_len=img_len,
+                t_emb=t_emb,
+                freqs_cis=unified_freqs,
+            ),
+            self._fbcache_conditional_execution_output_types(),
+        )
+
+    def forward(self, *args: Tensor) -> tuple[Tensor, ...]:
+        return self._forward_impl(*args)


### PR DESCRIPTION
## Summary

- Adds the core **Z-Image architecture module** under `max/python/max/pipelines/architectures/z_image/`.
- Introduces model definition, config, and layer implementations:
  - `model.py`
  - `model_config.py`
  - `layers/attention.py`
  - `layers/embeddings.py`
- Adds Z-Image weight mapping/loading adapter:
  - `weight_adapters.py`
- Exposes module entrypoints:
  - `z_image.py`
  - `__init__.py`
  - `layers/__init__.py`
- Scope is intentionally limited to the **module implementation only** (no pipeline/runtime wiring in this PR).

This PR builds on https://github.com/modular/modular/pull/5604 , https://github.com/modular/modular/pull/5843
This model was contributed by [Byungchul Chae (@byungchul-sqzb)](https://github.com/byungchul-sqzb) and [Tolga Cangöz (@tolgacangoz)](https://github.com/tolgacangoz).

## Testing

- `./bazelw run format`

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))

Assisted-by: AI