### PR TITLE
[MAX] Add Z-Image Pipeline Implementation for Z-Image, Z-Image-Turbo

### DIFF
--- a/max/examples/diffusion/simple_offline_generation.py
+++ b/max/examples/diffusion/simple_offline_generation.py
@@ -162,6 +162,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Guidance scale for classifier-free guidance. Set to 1.0 to disable CFG.",
     )
     parser.add_argument(
+        "--strength",
+        type=float,
+        default=0.6,
+        help="Image-to-image strength in (0, 1]. Ignored for text-to-image.",
+    )
+    parser.add_argument(
+        "--cfg-normalization",
+        action="store_true",
+        help="Enable CFG output renormalization when supported by the selected model.",
+    )
+    parser.add_argument(
+        "--cfg-truncation",
+        type=float,
+        default=1.0,
+        help="CFG truncation threshold in normalized time when supported by the selected model (> 0).",
+    )
+    parser.add_argument(
         "--seed",
         type=int,
         default=42,
@@ -249,7 +266,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--prefer-module-v3",
         action="store_true",
-        help="Use the ModuleV3 FLUX implementation instead of the default architecture.",
+        help="Prefer the ModuleV3 implementation when the selected model provides one.",
     )
 
     args = parser.parse_args(argv)
@@ -264,6 +281,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "num-inference-steps must be a positive integer."
     )
     assert args.guidance_scale > 0.0, "guidance-scale must be positive."
+    assert 0.0 < args.strength <= 1.0, "strength must be in (0, 1]."
+    assert args.cfg_truncation > 0.0, "cfg-truncation must be positive."
     if args.residual_threshold is not None:
         assert args.residual_threshold >= 0.0, (
             "residual-threshold must be non-negative."
@@ -379,7 +398,7 @@ async def generate_image(args: argparse.Namespace) -> None:
         max_length = components_config["tokenizer"]["config_dict"].get(
             "model_max_length", None
         )
-        if arch.name in _FLUX2_ARCH_NAMES:
+        if arch.name in _FLUX2_ARCH_NAMES or arch.name == "ZImagePipeline":
             max_length = 512
         print(f"Using max length: {max_length} for tokenizer")
 
@@ -464,6 +483,9 @@ async def generate_image(args: argparse.Namespace) -> None:
                     width=args.width,
                     steps=args.num_inference_steps,
                     guidance_scale=args.guidance_scale,
+                    strength=args.strength,
+                    cfg_normalization=args.cfg_normalization,
+                    cfg_truncation=args.cfg_truncation,
                 )
             ),
         )
@@ -480,6 +502,9 @@ async def generate_image(args: argparse.Namespace) -> None:
                     width=args.width,
                     steps=args.num_inference_steps,
                     guidance_scale=args.guidance_scale,
+                    strength=args.strength,
+                    cfg_normalization=args.cfg_normalization,
+                    cfg_truncation=args.cfg_truncation,
                 )
             ),
         )
@@ -487,7 +512,9 @@ async def generate_image(args: argparse.Namespace) -> None:
     request = OpenResponsesRequest(request_id=RequestID(), body=body)
 
     print(
-        f"Parameters: steps={args.num_inference_steps}, guidance={args.guidance_scale}"
+        "Parameters: "
+        f"steps={args.num_inference_steps}, guidance={args.guidance_scale}, "
+        f"cfg_norm={args.cfg_normalization}, cfg_trunc={args.cfg_truncation}"
     )
 
     # Step 5: Create a PixelContext object from the request
@@ -546,6 +573,9 @@ async def generate_image(args: argparse.Namespace) -> None:
                     width=args.width,
                     steps=args.num_inference_steps,
                     guidance_scale=args.guidance_scale,
+                    strength=args.strength,
+                    cfg_normalization=args.cfg_normalization,
+                    cfg_truncation=args.cfg_truncation,
                 )
             ),
         )

--- a/max/python/max/interfaces/provider_options/modality/image.py
+++ b/max/python/max/interfaces/provider_options/modality/image.py
@@ -43,9 +43,10 @@ class ImageProviderOptions(BaseModel):
         description=(
             "Guidance scale for classifier-free guidance. "
             "Higher values make the generation follow the prompt more closely. "
-            "Set to 1.0 to disable CFG. Defaults to 3.5."
+            "Set to 1.0 to disable CFG. Some distilled or guidance-light models "
+            "may prefer lower values. Defaults to 3.5."
         ),
-        gt=0.0,
+        ge=0.0,
     )
 
     true_cfg_scale: float = Field(
@@ -83,6 +84,35 @@ class ImageProviderOptions(BaseModel):
         1,
         description="The number of images to generate. Defaults to 1.",
         ge=1,
+    )
+
+    strength: float = Field(
+        0.6,
+        description=(
+            "Image-to-image strength. Must be in (0, 1]. "
+            "Higher values add more noise and preserve less from input image. "
+            "Ignored for text-to-image requests."
+        ),
+        gt=0.0,
+        le=1.0,
+    )
+
+    cfg_normalization: bool = Field(
+        False,
+        description=(
+            "Enable CFG output renormalization when supported by the selected model. "
+            "When enabled, the guided prediction norm is clipped to the positive "
+            "prediction norm."
+        ),
+    )
+
+    cfg_truncation: float = Field(
+        1.0,
+        description=(
+            "CFG truncation threshold in normalized time when supported by the selected model. "
+            "CFG is disabled for steps where t_norm > cfg_truncation."
+        ),
+        gt=0.0,
     )
 
     output_format: str = Field(

--- a/max/python/max/pipelines/architectures/__init__.py
+++ b/max/python/max/pipelines/architectures/__init__.py
@@ -81,6 +81,7 @@ def register_all_models() -> None:
     from .qwen3vl_moe import qwen3vl_arch, qwen3vl_moe_arch
     from .unified_eagle_llama3 import unified_eagle_llama3_arch
     from .unified_mtp_deepseekV3 import unified_mtp_deepseekV3_arch
+    from .z_image_modulev3 import z_image_arch
 
     architectures = [
         exaone_arch,
@@ -133,6 +134,7 @@ def register_all_models() -> None:
         qwen3vl_moe_arch,
         unified_eagle_llama3_arch,
         unified_mtp_deepseekV3_arch,
+        z_image_arch,
     ]
 
     for arch in architectures:

--- a/max/python/max/pipelines/architectures/z_image_modulev3/__init__.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/__init__.py
@@ -1,0 +1,17 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from .arch import z_image_arch
+from .model import ZImageTransformerModel
+
+__all__ = ["ZImageTransformerModel", "z_image_arch"]

--- a/max/python/max/pipelines/architectures/z_image_modulev3/arch.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/arch.py
@@ -1,0 +1,62 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from max.graph.weights import WeightsFormat
+from max.interfaces import PipelineTask
+from max.pipelines.core import PixelContext
+from max.pipelines.lib import PixelGenerationTokenizer, SupportedArchitecture
+from max.pipelines.lib.config import MAXModelConfig, PipelineConfig
+from max.pipelines.lib.interfaces import ArchConfig
+from typing_extensions import Self
+
+from .pipeline_z_image import ZImagePipeline
+
+
+@dataclass(kw_only=True)
+class ZImageArchConfig(ArchConfig):
+    pipeline_config: PipelineConfig
+
+    def get_max_seq_len(self) -> int:
+        return 0
+
+    @classmethod
+    def initialize(
+        cls,
+        pipeline_config: PipelineConfig,
+        model_config: MAXModelConfig | None = None,
+    ) -> Self:
+        model_config = model_config or pipeline_config.model
+        if len(model_config.device_specs) != 1:
+            raise ValueError("Z-Image is only supported on a single device")
+        return cls(pipeline_config=pipeline_config)
+
+
+z_image_arch = SupportedArchitecture(
+    name="ZImagePipeline",
+    task=PipelineTask.PIXEL_GENERATION,
+    default_encoding="bfloat16",
+    supported_encodings={"bfloat16"},
+    example_repo_ids=[
+        "Tongyi-MAI/Z-Image",
+        "Zyphra/Z-Image",
+    ],
+    pipeline_model=ZImagePipeline,  # type: ignore[arg-type]
+    context_type=PixelContext,
+    default_weights_format=WeightsFormat.safetensors,
+    tokenizer=PixelGenerationTokenizer,
+    config=ZImageArchConfig,
+)

--- a/max/python/max/pipelines/architectures/z_image_modulev3/layers/__init__.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/layers/__init__.py
@@ -1,0 +1,17 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from .attention import ZImageAttention
+from .embeddings import RopeEmbedder, TimestepEmbedder
+
+__all__ = ["RopeEmbedder", "TimestepEmbedder", "ZImageAttention"]

--- a/max/python/max/pipelines/architectures/z_image_modulev3/layers/attention.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/layers/attention.py
@@ -1,0 +1,102 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import math
+
+from max.experimental import functional as F
+from max.experimental.nn import Linear, Module
+from max.experimental.nn.norm import RMSNorm
+from max.experimental.nn.sequential import ModuleList
+from max.experimental.tensor import Tensor
+from max.nn.attention.mask_config import MHAMaskVariant
+from max.nn.kernels import flash_attention_gpu as _flash_attention_gpu
+
+from ...flux2_modulev3.layers.embeddings import apply_rotary_emb
+
+flash_attention_gpu = F.functional(_flash_attention_gpu)
+
+
+class ZImageAttention(Module[..., Tensor]):
+    def __init__(
+        self,
+        dim: int,
+        n_heads: int,
+        qk_norm: bool,
+        eps: float,
+    ):
+        self.head_dim = dim // n_heads
+        self.inner_dim = dim
+        self.n_heads = n_heads
+
+        self.to_q = Linear(dim, dim, bias=False)
+        self.to_k = Linear(dim, dim, bias=False)
+        self.to_v = Linear(dim, dim, bias=False)
+
+        self.norm_q = RMSNorm(self.head_dim, eps=eps) if qk_norm else None
+        self.norm_k = RMSNorm(self.head_dim, eps=eps) if qk_norm else None
+
+        # Keep ModuleList naming for diffusers-compatible key loading.
+        self.to_out = ModuleList([Linear(dim, dim, bias=False)])
+
+    def forward(
+        self,
+        hidden_states: Tensor,
+        freqs_cis: tuple[Tensor, Tensor],
+    ) -> Tensor:
+        batch_size = hidden_states.shape[0]
+        seq_len = hidden_states.shape[1]
+
+        query = self.to_q(hidden_states)
+        key = self.to_k(hidden_states)
+        value = self.to_v(hidden_states)
+
+        query = F.reshape(
+            query, [batch_size, seq_len, self.n_heads, self.head_dim]
+        )
+        key = F.reshape(key, [batch_size, seq_len, self.n_heads, self.head_dim])
+        value = F.reshape(
+            value, [batch_size, seq_len, self.n_heads, self.head_dim]
+        )
+
+        if self.norm_q is not None:
+            query = self.norm_q(query)
+        if self.norm_k is not None:
+            key = self.norm_k(key)
+
+        query = apply_rotary_emb(
+            query,
+            freqs_cis,
+            use_real=True,
+            use_real_unbind_dim=-1,
+            sequence_dim=1,
+        )
+        key = apply_rotary_emb(
+            key,
+            freqs_cis,
+            use_real=True,
+            use_real_unbind_dim=-1,
+            sequence_dim=1,
+        )
+        query = query.cast(value.dtype)
+        key = key.cast(value.dtype)
+
+        out = flash_attention_gpu(
+            query,
+            key,
+            value,
+            mask_variant=MHAMaskVariant.NULL_MASK,
+            scale=math.sqrt(1.0 / float(self.head_dim)),
+        )
+
+        out = F.reshape(out, [batch_size, seq_len, self.inner_dim])
+        return self.to_out[0](out)

--- a/max/python/max/pipelines/architectures/z_image_modulev3/layers/embeddings.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/layers/embeddings.py
@@ -1,0 +1,103 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import math
+
+from max.dtype import DType
+from max.experimental import functional as F
+from max.experimental.nn import Linear, Module
+from max.experimental.tensor import Tensor
+
+from ...flux2_modulev3.layers.embeddings import get_1d_rotary_pos_embed
+
+
+class TimestepEmbedder(Module[[Tensor], Tensor]):
+    def __init__(
+        self,
+        out_size: int,
+        mid_size: int | None = None,
+        frequency_embedding_size: int = 256,
+    ) -> None:
+        if mid_size is None:
+            mid_size = out_size
+
+        self.linear_1 = Linear(frequency_embedding_size, mid_size, bias=True)
+        self.linear_2 = Linear(mid_size, out_size, bias=True)
+        self.frequency_embedding_size = frequency_embedding_size
+
+    @staticmethod
+    def timestep_embedding(
+        t: Tensor,
+        dim: int,
+        max_period: float = 10000.0,
+    ) -> Tensor:
+        half = dim // 2
+        freqs = F.arange(0, half, dtype=DType.float32, device=t.device)
+        freqs = F.exp((-math.log(max_period) * freqs) / float(half))
+
+        args = F.cast(t, DType.float32)[:, None] * freqs[None, :]
+        embedding = F.concat([F.cos(args), F.sin(args)], axis=-1)
+
+        if dim % 2:
+            # Avoid Tensor.zeros in the graph path; broadcast a scalar zero like
+            # other normalization blocks (see LayerNorm gamma/beta patterns).
+            zero = F.reshape(
+                F.constant(0.0, embedding.dtype, device=t.device),
+                (1, 1),
+            )
+            zeros_col = F.broadcast_to(zero, (embedding.shape[0], 1))
+            embedding = F.concat([embedding, zeros_col], axis=-1)
+
+        return embedding
+
+    def forward(self, t: Tensor) -> Tensor:
+        t_freq = self.timestep_embedding(t, self.frequency_embedding_size)
+        t_freq = F.cast(t_freq, self.linear_1.weight.dtype)
+        t_emb = self.linear_2(F.silu(self.linear_1(t_freq)))
+        return t_emb
+
+
+class RopeEmbedder(Module[[Tensor], tuple[Tensor, Tensor]]):
+    def __init__(
+        self,
+        theta: float = 256.0,
+        axes_dims: tuple[int, ...] = (32, 48, 48),
+    ) -> None:
+        self.theta = theta
+        self.axes_dims = axes_dims
+
+    def forward(self, ids: Tensor) -> tuple[Tensor, Tensor]:
+        if ids.rank != 2:
+            raise ValueError(f"Expected 2D ids tensor, got rank={ids.rank}")
+
+        if int(ids.shape[-1]) != len(self.axes_dims):
+            raise ValueError(
+                "ids last dimension must match axes_dims length "
+                f"({len(self.axes_dims)}), got {ids.shape[-1]}"
+            )
+
+        pos = ids.cast(DType.float32)
+        cos_out = []
+        sin_out = []
+        for i in range(len(self.axes_dims)):
+            cos_i, sin_i = get_1d_rotary_pos_embed(
+                self.axes_dims[i],
+                pos[:, i],
+                theta=self.theta,
+                use_real=True,
+                repeat_interleave_real=True,
+            )
+            cos_out.append(cos_i)
+            sin_out.append(sin_i)
+
+        return F.concat(cos_out, axis=-1), F.concat(sin_out, axis=-1)

--- a/max/python/max/pipelines/architectures/z_image_modulev3/model.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/model.py
@@ -1,0 +1,124 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from max.driver import Device
+from max.experimental import functional as F
+from max.experimental.tensor import Tensor
+from max.graph.weights import Weights
+from max.pipelines.lib import SupportedEncoding
+from max.pipelines.lib.interfaces.component_model import ComponentModel
+from max.profiler import traced
+
+if TYPE_CHECKING:
+    from max.pipelines.lib.interfaces.cache_mixin import DenoisingCacheConfig
+
+from .model_config import ZImageConfig
+from .weight_adapters import convert_z_image_transformer_state_dict
+from .z_image import ZImageTransformer2DModel
+
+
+class ZImageTransformerModel(ComponentModel):
+    """Component wrapper for the compiled Z-Image transformer graph."""
+
+    model: Callable[..., Any]
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        encoding: SupportedEncoding,
+        devices: list[Device],
+        weights: Weights,
+        *,
+        cache_config: DenoisingCacheConfig | None = None,
+    ) -> None:
+        super().__init__(
+            config,
+            encoding,
+            devices,
+            weights,
+            cache_config=cache_config,
+        )
+        self.config = ZImageConfig.initialize_from_config(
+            config,
+            encoding,
+            devices,
+        )
+        self.load_model()
+
+    @traced(message="ZImageTransformerModel.load_model")
+    def load_model(self) -> None:
+        target_dtype = self.config.dtype
+        state_dict = {}
+        for key, value in self.weights.items():
+            weight = value.data()
+            if weight.dtype != target_dtype:
+                if weight.dtype.is_float() and target_dtype.is_float():
+                    weight = weight.astype(target_dtype)
+            state_dict[key] = weight
+        state_dict = convert_z_image_transformer_state_dict(state_dict)
+
+        with F.lazy():
+            transformer = ZImageTransformer2DModel(
+                self.config,
+                cache_config=self.cache_config,
+            )
+            transformer.to(self.devices[0])
+
+        self.model = transformer.compile(
+            *transformer.input_types(),
+            weights=state_dict,
+        )
+
+    @traced(message="ZImageTransformerModel.__call__")
+    def __call__(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Tensor,
+        timestep: Tensor,
+        img_ids: Tensor,
+        txt_ids: Tensor,
+        prev_residual: Tensor | None = None,
+        prev_output: Tensor | None = None,
+        controlnet_block_samples: Tensor | None = None,
+        siglip_feats: Tensor | None = None,
+        image_noise_mask: Tensor | None = None,
+    ) -> Any:
+        if controlnet_block_samples is not None:
+            raise NotImplementedError(
+                "controlnet_block_samples is not supported in z-image phase 1"
+            )
+        if siglip_feats is not None or image_noise_mask is not None:
+            raise NotImplementedError(
+                "Omni(siglip/image_noise_mask) is not supported in z-image phase 1"
+            )
+
+        model_args: tuple[Any, ...] = (
+            hidden_states,
+            encoder_hidden_states,
+            timestep,
+            img_ids,
+            txt_ids,
+        )
+        if (
+            self.cache_config is not None
+            and self.cache_config.first_block_caching
+            and prev_residual is not None
+            and prev_output is not None
+        ):
+            model_args = (*model_args, prev_residual, prev_output)
+        return self.model(*model_args)

--- a/max/python/max/pipelines/architectures/z_image_modulev3/model_config.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/model_config.py
@@ -1,0 +1,79 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from typing import Any
+
+from max.driver import Device
+from max.dtype import DType
+from max.graph import DeviceRef
+from max.pipelines.lib import MAXModelConfigBase, SupportedEncoding
+from max.pipelines.lib.config.config_enums import supported_encoding_dtype
+from pydantic import Field
+from typing_extensions import Self
+
+
+class ZImageConfig(MAXModelConfigBase):
+    all_patch_size: tuple[int, ...] = (2,)
+    all_f_patch_size: tuple[int, ...] = (1,)
+    in_channels: int = 16
+    dim: int = 3840
+    n_layers: int = 30
+    n_refiner_layers: int = 2
+    n_heads: int = 30
+    n_kv_heads: int = 30
+    norm_eps: float = 1e-5
+    qk_norm: bool = True
+    cap_feat_dim: int = 2560
+    rope_theta: float = 256.0
+    t_scale: float = 1000.0
+    axes_dims: tuple[int, ...] = (32, 48, 48)
+    axes_lens: tuple[int, ...] = (1024, 512, 512)
+    dtype: DType = DType.bfloat16
+    device: DeviceRef = Field(default_factory=DeviceRef.GPU)
+
+    @classmethod
+    def initialize_from_config(
+        cls,
+        config_dict: dict[str, Any],
+        encoding: SupportedEncoding,
+        devices: list[Device],
+    ) -> Self:
+        init_dict = {
+            key: value
+            for key, value in config_dict.items()
+            if key in cls.model_fields
+        }
+        # Ignore omni-only fields in phase 1 (may appear in full checkpoints).
+        init_dict.pop("siglip_feat_dim", None)
+
+        init_dict.update(
+            {
+                "dtype": supported_encoding_dtype(encoding),
+                "device": DeviceRef.from_device(devices[0]),
+            }
+        )
+        return cls(**init_dict)
+
+    def fbcache_dims(self) -> tuple[int, int]:
+        """(hidden_dim, output_dim) per image token for FBCache / Taylor tensors."""
+        out_dim = (
+            self.all_patch_size[0]
+            * self.all_patch_size[0]
+            * self.all_f_patch_size[0]
+            * self.in_channels
+        )
+        return self.dim, out_dim
+
+
+# Back-compat alias for call sites that refer to the config as a "base" type.
+ZImageConfigBase = ZImageConfig

--- a/max/python/max/pipelines/architectures/z_image_modulev3/pipeline_z_image.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/pipeline_z_image.py
@@ -1,0 +1,1104 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Z-Image diffusion pipeline (ModuleV3).
+
+Wires together the Qwen3 text encoder, Z-Image transformer denoiser, and
+standard AutoencoderKL VAE. Follows the shared diffusion-pipeline structure
+used by the image generation architectures in this directory, including
+tracing, module docstrings, and flat weight path assignment.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import MISSING, dataclass, fields
+from typing import Any, Literal
+
+import numpy as np
+from max.driver import CPU, Buffer, Device
+from max.dtype import DType
+from max.experimental import functional as F
+from max.experimental.tensor import Tensor
+from max.graph import TensorType
+from max.interfaces import PixelGenerationContext
+from max.pipelines.lib.interfaces import (
+    DenoisingCacheState,
+    DiffusionPipeline,
+    PixelModelInputs,
+)
+from max.pipelines.lib.interfaces.diffusion_pipeline import max_compile
+from max.profiler import Tracer, traced
+
+from ..autoencoders import AutoencoderKLModel
+from ..qwen3.text_encoder import Qwen3TextEncoderZImageModel
+from .model import ZImageTransformerModel
+
+_DEVICE_TENSOR_FIELDS = frozenset(
+    {
+        "tokens_tensor",
+        "negative_tokens_tensor",
+        "txt_ids_tensor",
+        "img_ids_tensor",
+        "negative_txt_ids_tensor",
+        "negative_img_ids_tensor",
+        "input_image_tensor",
+        "latents_tensor",
+        "sigmas_tensor",
+        "h_carrier",
+        "w_carrier",
+    }
+)
+
+
+def _validate_z_image_context(context: PixelGenerationContext) -> None:
+    """Fail fast before device uploads."""
+    if context.latents.size == 0:
+        raise ValueError(
+            "ZImagePipeline requires non-empty latents in PixelGenerationContext."
+        )
+    for name in ("latent_image_ids", "sigmas", "timesteps"):
+        if not hasattr(context, name):
+            raise TypeError(
+                f"ZImagePipeline requires PixelGenerationContext with attribute "
+                f"{name!r} (e.g. max.pipelines.core.PixelContext); "
+                f"{type(context).__name__} has no {name!r}."
+            )
+        arr = getattr(context, name)
+        if not isinstance(arr, np.ndarray) or arr.size == 0:
+            raise ValueError(
+                f"ZImagePipeline requires non-empty {name} in PixelGenerationContext."
+            )
+
+
+@dataclass(kw_only=True)
+class ZImageModelInputs(PixelModelInputs):
+    """Z-Image execution inputs with device tensors and host metadata.
+
+    Scalar and NumPy fields are populated from :class:`PixelGenerationContext`
+    (concrete type :class:`~max.pipelines.core.PixelContext`) via
+    :meth:`kwargs_from_context`; ``latents_tensor``, ``sigmas_tensor``, and
+    shape carriers are required device tensors supplied by
+    :meth:`ZImagePipeline.prepare_inputs` in one shot.
+    """
+
+    width: int = 1024
+    height: int = 1024
+    guidance_scale: float = 5.0
+    num_inference_steps: int = 50
+    num_images_per_prompt: int = 1
+    explicit_negative_prompt: bool = False
+    do_cfg: bool = False
+    tokens_tensor: Tensor
+    negative_tokens_tensor: Tensor | None = None
+    txt_ids_tensor: Tensor
+    img_ids_tensor: Tensor
+    negative_txt_ids_tensor: Tensor | None = None
+    negative_img_ids_tensor: Tensor | None = None
+    input_image_tensor: Tensor | None = None
+    latents_tensor: Tensor
+    sigmas_tensor: Tensor
+    h_carrier: Tensor
+    w_carrier: Tensor
+
+    @classmethod
+    def kwargs_from_context(
+        cls, context: PixelGenerationContext
+    ) -> dict[str, Any]:
+        """Build kwargs for all fields except device tensors."""
+        kwargs: dict[str, Any] = {}
+        for dataclass_field in fields(cls):
+            name = dataclass_field.name
+            if name in _DEVICE_TENSOR_FIELDS:
+                continue
+            if not hasattr(context, name):
+                continue
+            v = getattr(context, name)
+            if v is None:
+                if dataclass_field.default is not MISSING:
+                    kwargs[name] = dataclass_field.default
+                elif dataclass_field.default_factory is not MISSING:
+                    kwargs[name] = dataclass_field.default_factory()
+                else:
+                    kwargs[name] = None
+            else:
+                kwargs[name] = v
+        return kwargs
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.sigmas.size == 0:
+            raise ValueError(
+                "ZImagePipeline requires non-empty sigmas in context."
+            )
+        if self.latent_image_ids.size == 0:
+            raise ValueError(
+                "ZImagePipeline requires non-empty latent image ids in context."
+            )
+
+
+@dataclass
+class ZImagePipelineOutput:
+    """Container for Z-Image pipeline results.
+
+    Attributes:
+        images:
+            Decoded image data as a NumPy array or MAX :class:`~max.experimental.tensor.Tensor`,
+            depending on decode path and ``output_type``.
+    """
+
+    images: np.ndarray | Tensor
+
+
+class ZImagePipeline(DiffusionPipeline):
+    """Diffusion pipeline for Z-Image generation (Qwen3 + transformer + VAE)."""
+
+    unprefixed_weight_component = "transformer"
+    default_num_inference_steps = 50
+    default_residual_threshold = 0.06
+
+    vae: AutoencoderKLModel
+    text_encoder: Qwen3TextEncoderZImageModel
+    transformer: ZImageTransformerModel
+
+    components = {
+        "vae": AutoencoderKLModel,
+        "text_encoder": Qwen3TextEncoderZImageModel,
+        "transformer": ZImageTransformerModel,
+    }
+
+    @traced(message="ZImagePipeline.init_remaining_components")
+    def init_remaining_components(self) -> None:
+        """Initialize derived attributes and compiled subgraphs."""
+        self.vae_scale_factor = (
+            2 ** (len(self.vae.config.block_out_channels) - 1)
+            if getattr(self, "vae", None)
+            else 8
+        )
+
+        self.build_preprocess_latents()
+        self.build_prepare_scheduler()
+        self.build_scheduler_step()
+        self.build_decode_latents()
+
+        self._init_cache_state(
+            dtype=self.transformer.config.dtype,
+            device=self.transformer.devices[0],
+        )
+
+        self._cached_text_ids: dict[str, Tensor] = {}
+        self._cached_sigmas: dict[str, Tensor] = {}
+        self._cached_img_ids: dict[str, Tensor] = {}
+        self._cached_img_ids_base_np: dict[str, np.ndarray] = {}
+        self._cached_shape_carriers: dict[int, Tensor] = {}
+        self._cached_timesteps_batched: dict[str, Tensor] = {}
+        self._cached_timesteps_host: dict[str, np.ndarray] = {}
+        self._cached_prompt_token_tensors: dict[str, Tensor] = {}
+        self._cached_prompt_padding: dict[str, Tensor] = {}
+
+    @traced(message="ZImagePipeline.prepare_inputs")
+    def prepare_inputs(
+        self, context: PixelGenerationContext
+    ) -> ZImageModelInputs:
+        """Convert a :class:`PixelGenerationContext` into model inputs with device tensors."""
+        _validate_z_image_context(context)
+        kwargs = ZImageModelInputs.kwargs_from_context(context)
+        device = self.transformer.devices[0]
+        text_device = self.text_encoder.devices[0]
+
+        # Keep host NumPy fields aligned with the tensors we upload.
+        kwargs["latents"] = np.asarray(context.latents)
+        kwargs["sigmas"] = np.asarray(context.sigmas)
+        kwargs["latent_image_ids"] = np.asarray(context.latent_image_ids)
+
+        latents_np = np.ascontiguousarray(kwargs["latents"])
+        latent_h = int(latents_np.shape[-2])
+        latent_w = int(latents_np.shape[-1])
+        packed_h = int(latent_h // 2)
+        packed_w = int(latent_w // 2)
+        image_seq_len = int(np.asarray(context.latent_image_ids).shape[-2])
+
+        tokens_np = self._select_tokens_for_text_encoder(
+            context.tokens.array, context.mask
+        )
+        tokens_tensor = self._token_tensor_from_numpy(tokens_np, text_device)
+        txt_ids_tensor, img_ids_tensor = self._prepare_conditioning_ids(
+            text_seq_len=int(tokens_np.shape[0]),
+            image_seq_len=image_seq_len,
+            latent_image_ids=np.asarray(context.latent_image_ids),
+            height=int(context.height),
+            width=int(context.width),
+            device=device,
+        )
+
+        negative_tokens_tensor: Tensor | None = None
+        negative_txt_ids_tensor: Tensor | None = None
+        negative_img_ids_tensor: Tensor | None = None
+        if context.negative_tokens is not None:
+            negative_tokens_np = self._select_tokens_for_text_encoder(
+                context.negative_tokens.array,
+                context.negative_mask,
+            )
+            negative_tokens_tensor = self._token_tensor_from_numpy(
+                negative_tokens_np, text_device
+            )
+            if context.explicit_negative_prompt:
+                (
+                    negative_txt_ids_tensor,
+                    negative_img_ids_tensor,
+                ) = self._prepare_conditioning_ids(
+                    text_seq_len=int(negative_tokens_np.shape[0]),
+                    image_seq_len=image_seq_len,
+                    latent_image_ids=np.asarray(context.latent_image_ids),
+                    height=int(context.height),
+                    width=int(context.width),
+                    device=device,
+                )
+        do_cfg = (
+            float(context.guidance_scale) > 0.0
+            and negative_tokens_tensor is not None
+        )
+
+        input_image_tensor: Tensor | None = None
+        if context.input_image is not None:
+            input_image_tensor = self._image_to_tensor(
+                image=np.ascontiguousarray(
+                    context.input_image.astype(np.uint8, copy=False)
+                ),
+                batch_size=int(context.num_images_per_prompt),
+                dtype=self.vae.config.dtype,
+            )
+
+        latents_tensor = Tensor(
+            storage=Buffer.from_dlpack(latents_np).to(device)
+        )
+
+        for n in (packed_h, packed_w):
+            if n not in self._cached_shape_carriers:
+                carrier = np.ascontiguousarray(np.empty(n, dtype=np.float32))
+                self._cached_shape_carriers[n] = Tensor(
+                    storage=Buffer.from_dlpack(carrier).to(device)
+                )
+        h_carrier = self._cached_shape_carriers[packed_h]
+        w_carrier = self._cached_shape_carriers[packed_w]
+
+        num_steps = int(context.num_inference_steps)
+        sigmas_key = f"sigmas::{num_steps}::{latent_h}x{latent_w}"
+        if sigmas_key in self._cached_sigmas:
+            sigmas_tensor = self._cached_sigmas[sigmas_key]
+        else:
+            sigmas_tensor = Tensor(
+                storage=Buffer.from_dlpack(
+                    np.ascontiguousarray(context.sigmas)
+                ).to(device)
+            )
+            self._cached_sigmas[sigmas_key] = sigmas_tensor
+
+        return ZImageModelInputs(
+            **kwargs,
+            do_cfg=do_cfg,
+            tokens_tensor=tokens_tensor,
+            negative_tokens_tensor=negative_tokens_tensor,
+            txt_ids_tensor=txt_ids_tensor,
+            img_ids_tensor=img_ids_tensor,
+            negative_txt_ids_tensor=negative_txt_ids_tensor,
+            negative_img_ids_tensor=negative_img_ids_tensor,
+            input_image_tensor=input_image_tensor,
+            latents_tensor=latents_tensor,
+            sigmas_tensor=sigmas_tensor,
+            h_carrier=h_carrier,
+            w_carrier=w_carrier,
+        )
+
+    def create_cache_state(
+        self,
+        batch_size: int,
+        seq_len: int,
+        transformer_config: Any,
+    ) -> DenoisingCacheState:
+        """Allocate FBCache / Taylor tensors using Z-Image output layout."""
+        cfg = transformer_config
+        residual_dim, output_dim = cfg.fbcache_dims()
+        state = DenoisingCacheState()
+
+        def _device_zeros(shape: tuple[int, ...]) -> Tensor:
+            return Tensor(
+                storage=Buffer.zeros(
+                    shape, self._cache_dtype, device=self._cache_device
+                )
+            )
+
+        if self.cache_config.first_block_caching:
+            state.prev_residual = _device_zeros(
+                (batch_size, seq_len, residual_dim)
+            )
+            state.prev_output = _device_zeros((batch_size, seq_len, output_dim))
+
+        if self.cache_config.taylorseer:
+            for attr in (
+                "taylor_factor_0",
+                "taylor_factor_1",
+                "taylor_factor_2",
+            ):
+                setattr(
+                    state,
+                    attr,
+                    _device_zeros((batch_size, seq_len, output_dim)),
+                )
+
+        return state
+
+    def run_transformer(
+        self,
+        cache_state: DenoisingCacheState,
+        **kwargs: Any,
+    ) -> tuple[Tensor, ...]:
+        return self.transformer(
+            kwargs["latents"],
+            kwargs["prompt_embeds"],
+            kwargs["timestep"],
+            kwargs["img_ids"],
+            kwargs["txt_ids"],
+            prev_residual=cache_state.prev_residual,
+            prev_output=cache_state.prev_output,
+        )
+
+    def build_preprocess_latents(self) -> None:
+        device = self.transformer.devices[0]
+        self.__dict__["_pack_latents_from_6d"] = max_compile(
+            self._pack_latents_from_6d,
+            input_types=[
+                TensorType(
+                    DType.float32,
+                    shape=[
+                        "batch",
+                        "channels",
+                        "height",
+                        2,
+                        "width",
+                        2,
+                    ],
+                    device=device,
+                ),
+            ],
+        )
+
+    def build_prepare_scheduler(self) -> None:
+        self.__dict__["prepare_scheduler"] = max_compile(
+            self.prepare_scheduler,
+            input_types=[
+                TensorType(
+                    DType.float32,
+                    shape=["num_sigmas"],
+                    device=self.transformer.devices[0],
+                ),
+            ],
+        )
+
+    def build_scheduler_step(self) -> None:
+        dtype = self.transformer.config.dtype
+        device = self.transformer.devices[0]
+        self.__dict__["scheduler_step"] = max_compile(
+            self.scheduler_step,
+            input_types=[
+                TensorType(
+                    dtype, shape=["batch", "seq", "channels"], device=device
+                ),
+                TensorType(
+                    dtype, shape=["batch", "seq", "channels"], device=device
+                ),
+                TensorType(DType.float32, shape=[1], device=device),
+            ],
+        )
+
+    def build_decode_latents(self) -> None:
+        dtype = self.transformer.config.dtype
+        device = self.transformer.devices[0]
+        self.__dict__["_postprocess_latents"] = max_compile(
+            self._postprocess_latents,
+            input_types=[
+                TensorType(
+                    dtype,
+                    shape=[
+                        "batch",
+                        "half_h",
+                        "half_w",
+                        2,
+                        2,
+                        "ch_4",
+                    ],
+                    device=device,
+                ),
+            ],
+        )
+
+    @staticmethod
+    def _pack_latents(latents: Tensor) -> Tensor:
+        batch_size, num_channels, height, width = map(int, latents.shape)
+        latents = F.reshape(
+            latents,
+            (
+                batch_size,
+                num_channels,
+                height // 2,
+                2,
+                width // 2,
+                2,
+            ),
+        )
+        latents = F.permute(latents, (0, 2, 4, 3, 5, 1))
+        latents = F.reshape(
+            latents,
+            (
+                batch_size,
+                (height // 2) * (width // 2),
+                num_channels * 4,
+            ),
+        )
+        return latents
+
+    @staticmethod
+    def _pack_latents_from_6d(latents: Tensor) -> Tensor:
+        batch_size = latents.shape[0]
+        num_channels = latents.shape[1]
+        height = latents.shape[2]
+        width = latents.shape[4]
+        latents = F.permute(latents, (0, 2, 4, 3, 5, 1))
+        latents = F.reshape(
+            latents,
+            (
+                batch_size,
+                height * width,
+                num_channels * 4,
+            ),
+        )
+        return latents
+
+    @staticmethod
+    def _unpack_latents(
+        latents: Tensor,
+        height: int,
+        width: int,
+        vae_scale_factor: int,
+    ) -> Tensor:
+        batch_size = int(latents.shape[0])
+        ch_size = int(latents.shape[2])
+
+        height = 2 * (height // (vae_scale_factor * 2))
+        width = 2 * (width // (vae_scale_factor * 2))
+
+        h2 = height // 2
+        w2 = width // 2
+        latents = F.reshape(
+            latents,
+            (batch_size, h2, w2, 2, 2, ch_size // 4),
+        )
+        latents = F.permute(latents, (0, 5, 1, 3, 2, 4))
+        latents = F.reshape(
+            latents,
+            (batch_size, ch_size // 4, height, width),
+        )
+        return latents
+
+    @traced(message="ZImagePipeline.prepare_prompt_embeddings")
+    def prepare_prompt_embeddings(
+        self,
+        tokens: Tensor,
+        num_images_per_prompt: int,
+    ) -> Tensor:
+        """Encode prompt tokens into text embeddings."""
+        prompt_embeds = self.text_encoder(tokens)
+        if prompt_embeds.rank == 2:
+            prompt_embeds = F.unsqueeze(prompt_embeds, axis=0)
+        elif prompt_embeds.rank != 3:
+            raise ValueError(
+                f"Unexpected prompt_embeds rank={prompt_embeds.rank}; expected 2 or 3."
+            )
+        if num_images_per_prompt > 1:
+            batch = int(prompt_embeds.shape[0])
+            seq = int(prompt_embeds.shape[1])
+            hidden = int(prompt_embeds.shape[2])
+            if batch == 1:
+                prompt_embeds = F.broadcast_to(
+                    prompt_embeds,
+                    [num_images_per_prompt, seq, hidden],
+                )
+            else:
+                prompt_embeds = F.concat(
+                    [prompt_embeds] * num_images_per_prompt,
+                    axis=0,
+                )
+
+        return prompt_embeds
+
+    @staticmethod
+    def _select_tokens_for_text_encoder(
+        tokens: np.ndarray,
+        mask: np.ndarray | None,
+    ) -> np.ndarray:
+        if tokens.ndim == 2:
+            tokens = tokens[0]
+
+        selected_tokens = tokens
+        if mask is not None:
+            if mask.ndim == 2:
+                mask = mask[0]
+            if mask.shape[0] != tokens.shape[0]:
+                raise ValueError(
+                    f"ZImage mask length mismatch: mask={mask.shape[0]}, "
+                    f"tokens={tokens.shape[0]}."
+                )
+            selected_mask = mask.astype(np.bool_, copy=False)
+            if not np.any(selected_mask):
+                raise ValueError("ZImage mask cannot exclude all tokens.")
+            if not np.all(selected_mask):
+                selected_tokens = tokens[selected_mask]
+
+        return np.ascontiguousarray(
+            selected_tokens.astype(np.int64, copy=False)
+        )
+
+    def _token_tensor_from_numpy(
+        self,
+        tokens: np.ndarray,
+        device: Device,
+    ) -> Tensor:
+        token_digest = hashlib.sha1(tokens.tobytes()).hexdigest()
+        token_key = (
+            f"prompt_tokens::{tokens.shape[0]}::{token_digest}::{device}"
+        )
+        if token_key in self._cached_prompt_token_tensors:
+            return self._cached_prompt_token_tensors[token_key]
+
+        text_input_ids = Tensor(storage=Buffer.from_dlpack(tokens).to(device))
+        self._cached_prompt_token_tensors[token_key] = text_input_ids
+        return text_input_ids
+
+    def _prepare_conditioning_ids(
+        self,
+        text_seq_len: int,
+        image_seq_len: int,
+        latent_image_ids: np.ndarray,
+        height: int,
+        width: int,
+        device: Device,
+    ) -> tuple[Tensor, Tensor]:
+        text_seq_len_padded = text_seq_len + (-text_seq_len % 32)
+        img_ids_base_key = f"img_ids_base::{image_seq_len}_{height}x{width}"
+        if img_ids_base_key in self._cached_img_ids_base_np:
+            img_ids_base_np = self._cached_img_ids_base_np[img_ids_base_key]
+        else:
+            img_ids_base_np = np.asarray(latent_image_ids, dtype=np.int64)
+            if img_ids_base_np.ndim == 3:
+                img_ids_base_np = img_ids_base_np[0]
+            img_ids_base_np = np.ascontiguousarray(img_ids_base_np)
+            self._cached_img_ids_base_np[img_ids_base_key] = img_ids_base_np
+
+        img_ids_key = (
+            f"img_ids::{text_seq_len_padded}_{image_seq_len}_{height}x{width}"
+        )
+        if img_ids_key in self._cached_img_ids:
+            img_ids_tensor = self._cached_img_ids[img_ids_key]
+        else:
+            img_ids_np = img_ids_base_np.copy()
+            img_ids_np[:, 0] = img_ids_np[:, 0] + text_seq_len_padded + 1
+            img_ids_tensor = Tensor(
+                storage=Buffer.from_dlpack(np.ascontiguousarray(img_ids_np)).to(
+                    device
+                )
+            )
+            self._cached_img_ids[img_ids_key] = img_ids_tensor
+
+        text_ids_key = f"text_ids::{text_seq_len}"
+        if text_ids_key in self._cached_text_ids:
+            txt_ids_tensor = self._cached_text_ids[text_ids_key]
+        else:
+            txt_ids_tensor = self._prepare_text_ids(text_seq_len, device)
+            self._cached_text_ids[text_ids_key] = txt_ids_tensor
+
+        return txt_ids_tensor, img_ids_tensor
+
+    def _align_prompt_seq_len(
+        self,
+        embeds: Tensor,
+        target_seq_len: int,
+    ) -> Tensor:
+        cur_len = int(embeds.shape[1])
+        if cur_len == target_seq_len:
+            return embeds
+        if cur_len > target_seq_len:
+            return embeds[:, :target_seq_len, :]
+
+        pad_len = target_seq_len - cur_len
+        pad_key = (
+            f"prompt_pad::{int(embeds.shape[0])}::{pad_len}::"
+            f"{int(embeds.shape[2])}::{embeds.dtype}::{embeds.device}"
+        )
+        if pad_key in self._cached_prompt_padding:
+            pad = self._cached_prompt_padding[pad_key]
+        else:
+            pad = Tensor(
+                storage=Buffer.zeros(
+                    (int(embeds.shape[0]), pad_len, int(embeds.shape[2])),
+                    embeds.dtype,
+                    device=embeds.device,
+                )
+            )
+            self._cached_prompt_padding[pad_key] = pad
+        return F.concat([embeds, pad], axis=1)
+
+    @staticmethod
+    def _prepare_text_ids(
+        seq_len: int,
+        device: Device,
+    ) -> Tensor:
+        """Build text position IDs in [1, 2, ..., seq_len] format."""
+        text_ids = np.zeros((seq_len, 3), dtype=np.int64)
+        text_ids[:, 0] = np.arange(1, seq_len + 1, dtype=np.int64)
+        return Tensor(
+            storage=Buffer.from_dlpack(np.ascontiguousarray(text_ids)).to(
+                device
+            )
+        )
+
+    @traced(message="ZImagePipeline.decode_latents")
+    def decode_latents(
+        self,
+        latents: Tensor,
+        h_carrier: Tensor,
+        w_carrier: Tensor,
+        output_type: Literal["np", "latent", "pil"] = "np",
+    ) -> Tensor | np.ndarray:
+        """Decode packed latents into image output."""
+        latent_h = int(h_carrier.shape[0]) * 2
+        latent_w = int(w_carrier.shape[0]) * 2
+        if output_type == "latent":
+            return latents
+
+        batch_size = int(latents.shape[0])
+        ch_size = int(latents.shape[2])
+        latents = F.reshape(
+            latents,
+            (
+                batch_size,
+                latent_h // 2,
+                latent_w // 2,
+                2,
+                2,
+                ch_size // 4,
+            ),
+        )
+
+        latents = self._postprocess_latents(latents)
+        return self._to_numpy(self.vae.decode(latents))
+
+    def _postprocess_latents(self, latents: Tensor) -> Tensor:
+        batch_size = latents.shape[0]
+        half_h = latents.shape[1]
+        half_w = latents.shape[2]
+        c_quarter = latents.shape[5]
+
+        latents = F.permute(latents, (0, 5, 1, 3, 2, 4))
+        latents = F.reshape(
+            latents, (batch_size, c_quarter, half_h * 2, half_w * 2)
+        )
+        latents = (latents / float(self.vae.config.scaling_factor)) + float(
+            self.vae.config.shift_factor or 0.0
+        )
+        return latents
+
+    @staticmethod
+    def _to_numpy(image: Tensor) -> np.ndarray:
+        cpu_image: Tensor = image.cast(DType.float32).to(CPU())
+        return np.from_dlpack(cpu_image)
+
+    @staticmethod
+    def _vector_norm_per_sample(x: Tensor) -> Tensor:
+        """Compute per-sample norm for [B, S, C] embeddings."""
+        squared = x * x
+        squared = F.sum(squared, axis=2)
+        squared = F.sum(squared, axis=1)
+        return F.sqrt(squared + 1e-12)
+
+    @classmethod
+    def _apply_cfg_renormalization(
+        cls,
+        pos: Tensor,
+        pred: Tensor,
+        cfg_normalization: bool,
+    ) -> Tensor:
+        if not cfg_normalization:
+            return pred
+
+        ori_pos_norm = cls._vector_norm_per_sample(pos)
+        new_pos_norm = cls._vector_norm_per_sample(pred)
+        while ori_pos_norm.rank > 1:
+            ori_pos_norm = F.squeeze(ori_pos_norm, axis=-1)
+        while new_pos_norm.rank > 1:
+            new_pos_norm = F.squeeze(new_pos_norm, axis=-1)
+        max_new_norm = ori_pos_norm
+        # Avoid divide-by-zero and clip only when required.
+        safe_new_norm = F.where(
+            new_pos_norm > 1e-12,
+            new_pos_norm,
+            1e-12,
+        )
+        ratio = max_new_norm / safe_new_norm
+        ratio = F.where(new_pos_norm > max_new_norm, ratio, 1.0)
+        ratio = F.unsqueeze(F.unsqueeze(ratio, 1), 2)
+        return pred * ratio
+
+    @staticmethod
+    def scheduler_step(
+        latents: Tensor,
+        noise_pred: Tensor,
+        dt: Tensor,
+    ) -> Tensor:
+        latents_dtype = latents.dtype
+        latents = latents.cast(DType.float32)
+        latents = latents + dt * noise_pred
+        latents = latents.cast(latents_dtype)
+        return latents
+
+    @staticmethod
+    def prepare_scheduler(sigmas: Tensor) -> tuple[Tensor, Tensor]:
+        """Precompute denoising timesteps and step deltas."""
+        sigmas_curr = F.slice_tensor(sigmas, [slice(0, -1)])
+        sigmas_next = F.slice_tensor(sigmas, [slice(1, None)])
+        all_dt = sigmas_next - sigmas_curr
+        all_timesteps = sigmas_curr.cast(DType.float32)
+        return all_timesteps, all_dt
+
+    @traced(message="ZImagePipeline.preprocess_latents")
+    def preprocess_latents(self, latents: Tensor, dtype: DType) -> Tensor:
+        """Patchify and pack latents before denoising."""
+        with Tracer("host_to_device_latents"):
+            latents = latents.to(self.transformer.devices[0]).cast(
+                DType.float32
+            )
+
+        with Tracer("patchify_and_pack"):
+            batch, channels, height, width = map(int, latents.shape)
+            latents = F.reshape(
+                latents,
+                (
+                    batch,
+                    channels,
+                    height // 2,
+                    2,
+                    width // 2,
+                    2,
+                ),
+            )
+            latents = self._pack_latents_from_6d(latents)
+
+        return latents.cast(dtype)
+
+    def _image_to_tensor(
+        self,
+        image: np.ndarray,
+        batch_size: int,
+        dtype: DType,
+    ) -> Tensor:
+        if image.ndim != 3 or image.shape[2] != 3:
+            raise ValueError(
+                f"Expected input image shape [H, W, 3], got {image.shape}."
+            )
+
+        height, width, _ = image.shape
+        vae_scale = self.vae_scale_factor * 2
+        if height % vae_scale != 0 or width % vae_scale != 0:
+            raise ValueError(
+                f"Input image dimensions must be divisible by {vae_scale}, "
+                f"got {height}x{width}."
+            )
+
+        image_f32 = image.astype(np.float32) / 127.5 - 1.0
+        image_chw = np.transpose(image_f32, (2, 0, 1))
+        image_bchw = np.expand_dims(image_chw, axis=0)
+        image_bchw = np.ascontiguousarray(image_bchw)
+
+        image_tensor = Tensor(
+            storage=Buffer.from_dlpack(image_bchw).to(self.vae.devices[0])
+        ).cast(dtype)
+        if batch_size > 1:
+            image_tensor = F.broadcast_to(
+                image_tensor,
+                [batch_size, 3, height, width],
+            )
+        return image_tensor
+
+    @traced(message="ZImagePipeline.prepare_img2img_latents")
+    def prepare_img2img_latents(
+        self,
+        noise_latents: Tensor,
+        image_tensor: Tensor,
+        sigmas: Tensor,
+    ) -> Tensor:
+        noise_latents = noise_latents.to(self.transformer.devices[0])
+
+        encoder_output = self.vae.encode(image_tensor, return_dict=True)
+        posterior = (
+            encoder_output["latent_dist"]
+            if isinstance(encoder_output, dict)
+            else encoder_output
+        )
+        if not hasattr(posterior, "mode"):
+            raise ValueError("VAE encoder output must expose mode().")
+
+        image_latents = posterior.mode()
+        image_latents = (
+            image_latents - float(self.vae.config.shift_factor or 0.0)
+        ) * float(self.vae.config.scaling_factor)
+        image_latents = image_latents.to(self.transformer.devices[0]).cast(
+            noise_latents.dtype
+        )
+
+        sigma = sigmas[0]
+        latents = sigma * noise_latents + (1.0 - sigma) * image_latents
+        return latents.cast(noise_latents.dtype)
+
+    def _prepare_timestep_broadcast(
+        self,
+        timesteps: np.ndarray,
+        device: Device,
+        cache_key: str | None = None,
+    ) -> tuple[Tensor, np.ndarray]:
+        transformed_timesteps = (1.0 - timesteps).astype(np.float32, copy=False)
+
+        if cache_key is None:
+            num_timesteps = int(transformed_timesteps.shape[0])
+            first_t = (
+                float(transformed_timesteps[0]) if num_timesteps > 0 else 0.0
+            )
+            last_t = (
+                float(transformed_timesteps[-1]) if num_timesteps > 0 else 0.0
+            )
+            cache_key = (
+                f"timesteps::{num_timesteps}::{first_t:.8f}::{last_t:.8f}"
+            )
+
+        if (
+            cache_key in self._cached_timesteps_batched
+            and cache_key in self._cached_timesteps_host
+        ):
+            return (
+                self._cached_timesteps_batched[cache_key],
+                self._cached_timesteps_host[cache_key],
+            )
+
+        transformed_timesteps = np.ascontiguousarray(transformed_timesteps)
+
+        timesteps_tensor = Tensor(
+            storage=Buffer.from_dlpack(transformed_timesteps).to(device)
+        )
+        self._cached_timesteps_batched[cache_key] = timesteps_tensor
+        self._cached_timesteps_host[cache_key] = transformed_timesteps
+        return timesteps_tensor, transformed_timesteps
+
+    def _prepare_scheduler_inputs(
+        self,
+        model_inputs: ZImageModelInputs,
+        sigmas: Tensor,
+        device: Device,
+    ) -> tuple[Any, Any, np.ndarray]:
+        _, all_dts = self.prepare_scheduler(sigmas)
+        dts_seq: Any = all_dts
+        if hasattr(dts_seq, "driver_tensor"):
+            dts_seq = dts_seq.driver_tensor
+
+        timesteps = model_inputs.timesteps
+        num_timesteps = timesteps.shape[0]
+        timesteps_key = (
+            f"timesteps::{num_timesteps}::{model_inputs.height}x"
+            f"{model_inputs.width}::{int(model_inputs.input_image is not None)}::"
+            f"{model_inputs.num_inference_steps}::{model_inputs.strength:.4f}::"
+            f"{float(getattr(self, '_scheduler_shift', 1.0)):.4f}"
+        )
+        timesteps_seq, transformed_timesteps = self._prepare_timestep_broadcast(
+            timesteps=timesteps,
+            device=device,
+            cache_key=timesteps_key,
+        )
+        timesteps_seq_any: Any = timesteps_seq
+        if hasattr(timesteps_seq_any, "driver_tensor"):
+            timesteps_seq_any = timesteps_seq_any.driver_tensor
+
+        return timesteps_seq_any, dts_seq, transformed_timesteps
+
+    @traced(message="ZImagePipeline.execute")
+    def execute(  # type: ignore[override]
+        self,
+        model_inputs: ZImageModelInputs,
+        output_type: Literal["np", "latent", "pil"] = "np",
+    ) -> ZImagePipelineOutput:
+        """Run the Z-Image denoising loop and decode outputs."""
+
+        # 1) Encode prompt embeddings.
+        with Tracer("prepare_prompt_embeddings"):
+            prompt_embeds = self.prepare_prompt_embeddings(
+                tokens=model_inputs.tokens_tensor,
+                num_images_per_prompt=model_inputs.num_images_per_prompt,
+            )
+
+            negative_prompt_embeds: Tensor | None = None
+            if (
+                model_inputs.do_cfg
+                and model_inputs.negative_tokens_tensor is not None
+            ):
+                negative_prompt_embeds = self.prepare_prompt_embeddings(
+                    tokens=model_inputs.negative_tokens_tensor,
+                    num_images_per_prompt=model_inputs.num_images_per_prompt,
+                )
+                if not model_inputs.explicit_negative_prompt:
+                    negative_prompt_embeds = self._align_prompt_seq_len(
+                        negative_prompt_embeds,
+                        int(prompt_embeds.shape[1]),
+                    )
+
+        dtype = prompt_embeds.dtype
+        latents = model_inputs.latents_tensor
+        sigmas = model_inputs.sigmas_tensor
+        h_carrier = model_inputs.h_carrier
+        w_carrier = model_inputs.w_carrier
+
+        timesteps: np.ndarray = model_inputs.timesteps
+        batch_size = int(prompt_embeds.shape[0])
+        num_timesteps = timesteps.shape[0]
+        if num_timesteps < 1:
+            raise ValueError("No timesteps were provided for denoising.")
+
+        # 2) Prepare latents and conditioning tensors.
+        device = self.transformer.devices[0]
+        img_ids = model_inputs.img_ids_tensor
+        txt_ids = model_inputs.txt_ids_tensor
+
+        if model_inputs.input_image_tensor is not None:
+            latents = self.prepare_img2img_latents(
+                noise_latents=latents,
+                image_tensor=model_inputs.input_image_tensor,
+                sigmas=sigmas,
+            )
+        latents = self.preprocess_latents(latents, dtype)
+
+        image_seq_len = int(latents.shape[1])
+        cache_pos = self.create_cache_state(
+            batch_size,
+            image_seq_len,
+            self.transformer.config,
+        )
+        cache_neg = (
+            self.create_cache_state(
+                batch_size,
+                image_seq_len,
+                self.transformer.config,
+            )
+            if model_inputs.do_cfg
+            else None
+        )
+
+        # 3) Prepare scheduler tensors.
+        with Tracer("prepare_scheduler"):
+            timesteps_seq, dts_seq, transformed_timesteps = (
+                self._prepare_scheduler_inputs(
+                    model_inputs=model_inputs,
+                    sigmas=sigmas,
+                    device=device,
+                )
+            )
+
+        cfg_active: np.ndarray | None = None
+        if model_inputs.do_cfg:
+            if model_inputs.cfg_truncation <= 1.0:
+                cfg_active = (
+                    transformed_timesteps <= model_inputs.cfg_truncation
+                )
+            else:
+                cfg_active = np.ones(num_timesteps, dtype=np.bool_)
+
+        # 4) Denoising loop.
+        with Tracer("denoising_loop"):
+            for i in range(num_timesteps):
+                with Tracer(f"denoising_step_{i}"):
+                    timestep = timesteps_seq[i : i + 1]
+                    apply_cfg = bool(
+                        model_inputs.do_cfg
+                        and cfg_active is not None
+                        and cfg_active[i]
+                    )
+                    current_guidance_scale = (
+                        model_inputs.guidance_scale if apply_cfg else 0.0
+                    )
+
+                    with Tracer("transformer"):
+                        noise_pred = self.run_denoising_step(
+                            step=i,
+                            cache_state=cache_pos,
+                            device=device,
+                            latents=latents,
+                            prompt_embeds=prompt_embeds,
+                            timestep=timestep,
+                            img_ids=img_ids,
+                            txt_ids=txt_ids,
+                        )
+
+                    if apply_cfg:
+                        assert negative_prompt_embeds is not None
+                        assert cache_neg is not None
+                        neg_img_ids = img_ids
+                        neg_txt_ids = txt_ids
+                        if model_inputs.explicit_negative_prompt:
+                            assert (
+                                model_inputs.negative_img_ids_tensor is not None
+                            )
+                            assert (
+                                model_inputs.negative_txt_ids_tensor is not None
+                            )
+                            neg_img_ids = model_inputs.negative_img_ids_tensor
+                            neg_txt_ids = model_inputs.negative_txt_ids_tensor
+                        with Tracer("cfg_transformer"):
+                            neg_noise_pred = self.run_denoising_step(
+                                step=i,
+                                cache_state=cache_neg,
+                                device=device,
+                                latents=latents,
+                                prompt_embeds=negative_prompt_embeds,
+                                timestep=timestep,
+                                img_ids=neg_img_ids,
+                                txt_ids=neg_txt_ids,
+                            )
+                        pos_noise_pred = noise_pred
+                        noise_delta = F.sub(noise_pred, neg_noise_pred)
+                        noise_pred = F.add(
+                            pos_noise_pred,
+                            F.mul(noise_delta, current_guidance_scale),
+                        )
+                        noise_pred = self._apply_cfg_renormalization(
+                            pos_noise_pred,
+                            noise_pred,
+                            model_inputs.cfg_normalization,
+                        )
+
+                    with Tracer("scheduler_step"):
+                        noise_pred = F.mul(noise_pred, -1.0)
+                        dt = dts_seq[i : i + 1]
+                        latents = self.scheduler_step(latents, noise_pred, dt)
+
+        with Tracer("decode_outputs"):
+            outputs = self.decode_latents(
+                latents,
+                h_carrier,
+                w_carrier,
+                output_type=output_type,
+            )
+
+        return ZImagePipelineOutput(images=outputs)

--- a/max/python/max/pipelines/architectures/z_image_modulev3/weight_adapters.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/weight_adapters.py
@@ -1,0 +1,94 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+from max.graph.weights import WeightData
+
+
+def _replace_prefix(key: str, old: str, new: str) -> str:
+    if key.startswith(old):
+        return new + key[len(old) :]
+    return key
+
+
+def convert_z_image_transformer_state_dict(
+    state_dict: dict[str, WeightData],
+) -> dict[str, WeightData]:
+    converted: dict[str, WeightData] = {}
+
+    dropped_prefixes = (
+        "x_pad_token",
+        "cap_pad_token",
+        "siglip_",
+    )
+
+    for original_key, value in state_dict.items():
+        key = original_key
+
+        if key.startswith(dropped_prefixes):
+            continue
+
+        key = _replace_prefix(key, "all_x_embedder.2-1.", "x_embedder.")
+        key = _replace_prefix(key, "all_final_layer.2-1.", "final_layer.")
+        key = _replace_prefix(key, "t_embedder.mlp.0.", "t_embedder.linear_1.")
+        key = _replace_prefix(key, "t_embedder.mlp.2.", "t_embedder.linear_2.")
+        key = _replace_prefix(key, "cap_embedder.0.", "cap_norm.")
+        key = _replace_prefix(key, "cap_embedder.1.", "cap_proj.")
+        key = key.replace("adaLN_modulation.0.", "adaLN_modulation.")
+        key = _replace_prefix(
+            key,
+            "final_layer.adaLN_modulation.1.",
+            "final_layer.adaLN_modulation.",
+        )
+
+        converted[key] = value
+
+    required_prefixes = (
+        "x_embedder.",
+        "t_embedder.",
+        "cap_norm.",
+        "cap_proj.",
+        "noise_refiner.0.",
+        "context_refiner.0.",
+        "layers.0.",
+        "final_layer.",
+    )
+    for prefix in required_prefixes:
+        if not any(k.startswith(prefix) for k in converted):
+            raise ValueError(
+                f"Missing required z-image transformer weights with prefix '{prefix}'"
+            )
+
+    allowed_prefixes = (
+        "x_embedder.",
+        "noise_refiner.",
+        "context_refiner.",
+        "t_embedder.",
+        "cap_norm.",
+        "cap_proj.",
+        "layers.",
+        "final_layer.",
+    )
+    unexpected_keys = [
+        k
+        for k in converted
+        if not any(k.startswith(p) for p in allowed_prefixes)
+    ]
+    if unexpected_keys:
+        sample = ", ".join(unexpected_keys[:8])
+        raise ValueError(
+            f"Unexpected z-image transformer keys in phase-1 adapter: {sample}"
+        )
+
+    return converted

--- a/max/python/max/pipelines/architectures/z_image_modulev3/z_image.py
+++ b/max/python/max/pipelines/architectures/z_image_modulev3/z_image.py
@@ -1,0 +1,452 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from max.dtype import DType
+from max.experimental import functional as F
+from max.experimental.nn import Linear, Module
+from max.experimental.nn.norm import LayerNorm, RMSNorm
+from max.experimental.nn.sequential import ModuleList
+from max.experimental.tensor import Tensor
+from max.graph import TensorType
+from max.pipelines.lib.interfaces.cache_mixin import (
+    DenoisingCacheConfig,
+    fbcache_conditional_execution,
+)
+
+from .layers.attention import ZImageAttention
+from .layers.embeddings import RopeEmbedder, TimestepEmbedder
+from .model_config import ZImageConfig
+
+ADALN_EMBED_DIM = 256
+
+
+class FeedForward(Module[[Tensor], Tensor]):
+    def __init__(self, dim: int, hidden_dim: int):
+        self.w1 = Linear(dim, hidden_dim, bias=False)
+        self.w2 = Linear(hidden_dim, dim, bias=False)
+        self.w3 = Linear(dim, hidden_dim, bias=False)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+
+class ZImageTransformerBlock(Module[..., Tensor]):
+    def __init__(
+        self,
+        layer_id: int,
+        dim: int,
+        n_heads: int,
+        n_kv_heads: int,
+        norm_eps: float,
+        qk_norm: bool,
+        modulation: bool = True,
+    ):
+        del n_kv_heads
+
+        self.layer_id = layer_id
+        self.modulation = modulation
+
+        self.attention = ZImageAttention(
+            dim=dim,
+            n_heads=n_heads,
+            qk_norm=qk_norm,
+            eps=norm_eps,
+        )
+        self.feed_forward = FeedForward(dim=dim, hidden_dim=int(dim / 3 * 8))
+
+        self.attention_norm1 = RMSNorm(dim, eps=norm_eps)
+        self.ffn_norm1 = RMSNorm(dim, eps=norm_eps)
+
+        self.attention_norm2 = RMSNorm(dim, eps=norm_eps)
+        self.ffn_norm2 = RMSNorm(dim, eps=norm_eps)
+
+        self.adaLN_modulation = (
+            Linear(min(dim, ADALN_EMBED_DIM), 4 * dim, bias=True)
+            if modulation
+            else None
+        )
+
+    def forward(
+        self,
+        x: Tensor,
+        freqs_cis: tuple[Tensor, Tensor],
+        adaln_input: Tensor | None = None,
+    ) -> Tensor:
+        if self.modulation:
+            if adaln_input is None:
+                raise ValueError("adaln_input is required when modulation=True")
+            if self.adaLN_modulation is None:
+                raise ValueError("adaLN_modulation is not initialized")
+
+            mod = self.adaLN_modulation(adaln_input)
+            mod = F.unsqueeze(mod, 1)
+            scale_msa, gate_msa, scale_mlp, gate_mlp = F.chunk(mod, 4, axis=2)
+
+            gate_msa = F.tanh(gate_msa)
+            gate_mlp = F.tanh(gate_mlp)
+            scale_msa = 1.0 + scale_msa
+            scale_mlp = 1.0 + scale_mlp
+
+            attn_out = self.attention(
+                self.attention_norm1(x) * scale_msa,
+                freqs_cis=freqs_cis,
+            )
+            x = x + gate_msa * self.attention_norm2(attn_out)
+
+            ffn_out = self.feed_forward(self.ffn_norm1(x) * scale_mlp)
+            x = x + gate_mlp * self.ffn_norm2(ffn_out)
+        else:
+            attn_out = self.attention(
+                self.attention_norm1(x), freqs_cis=freqs_cis
+            )
+            x = x + self.attention_norm2(attn_out)
+            x = x + self.ffn_norm2(self.feed_forward(self.ffn_norm1(x)))
+
+        return x
+
+
+class FinalLayer(Module[..., Tensor]):
+    def __init__(self, hidden_size: int, out_channels: int):
+        self.norm_final = LayerNorm(
+            hidden_size,
+            eps=1e-6,
+            elementwise_affine=False,
+            use_bias=False,
+        )
+        self.linear = Linear(hidden_size, out_channels, bias=True)
+        self.adaLN_modulation = Linear(
+            min(hidden_size, ADALN_EMBED_DIM),
+            hidden_size,
+            bias=True,
+        )
+
+    def forward(self, x: Tensor, c: Tensor) -> Tensor:
+        scale = 1.0 + self.adaLN_modulation(F.silu(c))
+        x = self.norm_final(x) * F.unsqueeze(scale, 1)
+        return self.linear(x)
+
+
+class ZImageTransformer2DModel(Module[..., Sequence[Tensor]]):
+    def __init__(
+        self,
+        config: ZImageConfig,
+        cache_config: DenoisingCacheConfig | None = None,
+    ):
+        self.in_channels = config.in_channels
+        self.out_channels = config.in_channels
+        self.dim = config.dim
+        self.n_heads = config.n_heads
+        self.t_scale = config.t_scale
+        self.axes_dims = config.axes_dims
+        self.axes_lens = config.axes_lens
+
+        if len(config.all_patch_size) != len(config.all_f_patch_size):
+            raise ValueError("all_patch_size and all_f_patch_size must align")
+
+        self.patch_size = config.all_patch_size[0]
+        self.f_patch_size = config.all_f_patch_size[0]
+        self.packed_channels = (
+            self.f_patch_size
+            * self.patch_size
+            * self.patch_size
+            * self.in_channels
+        )
+
+        self.x_embedder = Linear(
+            self.packed_channels,
+            self.dim,
+            bias=True,
+        )
+
+        self.final_layer = FinalLayer(
+            self.dim,
+            self.patch_size
+            * self.patch_size
+            * self.f_patch_size
+            * self.out_channels,
+        )
+
+        self.noise_refiner: ModuleList[ZImageTransformerBlock] = ModuleList(
+            [
+                ZImageTransformerBlock(
+                    1000 + layer_id,
+                    self.dim,
+                    config.n_heads,
+                    config.n_kv_heads,
+                    config.norm_eps,
+                    config.qk_norm,
+                    modulation=True,
+                )
+                for layer_id in range(config.n_refiner_layers)
+            ]
+        )
+
+        self.context_refiner: ModuleList[ZImageTransformerBlock] = ModuleList(
+            [
+                ZImageTransformerBlock(
+                    layer_id,
+                    self.dim,
+                    config.n_heads,
+                    config.n_kv_heads,
+                    config.norm_eps,
+                    config.qk_norm,
+                    modulation=False,
+                )
+                for layer_id in range(config.n_refiner_layers)
+            ]
+        )
+
+        self.t_embedder = TimestepEmbedder(
+            min(self.dim, ADALN_EMBED_DIM),
+            mid_size=1024,
+        )
+        self.cap_norm = RMSNorm(config.cap_feat_dim, eps=config.norm_eps)
+        self.cap_proj = Linear(config.cap_feat_dim, self.dim, bias=True)
+
+        self.layers: ModuleList[ZImageTransformerBlock] = ModuleList(
+            [
+                ZImageTransformerBlock(
+                    layer_id,
+                    self.dim,
+                    config.n_heads,
+                    config.n_kv_heads,
+                    config.norm_eps,
+                    config.qk_norm,
+                    modulation=True,
+                )
+                for layer_id in range(config.n_layers)
+            ]
+        )
+
+        head_dim = self.dim // self.n_heads
+        if head_dim != sum(self.axes_dims):
+            raise ValueError(
+                f"head_dim ({head_dim}) must equal sum(axes_dims) ({sum(self.axes_dims)})"
+            )
+
+        self.rope_embedder = RopeEmbedder(
+            theta=config.rope_theta,
+            axes_dims=config.axes_dims,
+        )
+
+        self.max_device = config.device
+        self.max_dtype = config.dtype
+        self.cap_feat_dim = config.cap_feat_dim
+
+        self._forward_impl: Callable[..., tuple[Tensor, ...]] = (
+            self._forward_standard
+        )
+        self._input_types_impl: Callable[..., tuple[TensorType, ...]] = (
+            self._input_types_standard
+        )
+        self._rdt_value: float = 0.05
+        if cache_config is not None and cache_config.first_block_caching:
+            assert cache_config.residual_threshold is not None
+            self._rdt_value = cache_config.residual_threshold
+            self._forward_impl = self._forward_step_cache
+            self._input_types_impl = self._input_types_step_cache
+
+    def _fbcache_conditional_execution_output_types(self) -> list[TensorType]:
+        residual_type = TensorType(
+            self.max_dtype,
+            shape=["batch_size", "image_seq_len", self.dim],
+            device=self.max_device,
+        )
+        out_ch = (
+            self.patch_size
+            * self.patch_size
+            * self.f_patch_size
+            * self.out_channels
+        )
+        output_type = TensorType(
+            self.max_dtype,
+            shape=["batch_size", "image_seq_len", out_ch],
+            device=self.max_device,
+        )
+        return [residual_type, output_type]
+
+    def _base_input_types(self) -> tuple[TensorType, ...]:
+        hidden_states_type = TensorType(
+            self.max_dtype,
+            shape=["batch_size", "image_seq_len", self.packed_channels],
+            device=self.max_device,
+        )
+        encoder_hidden_states_type = TensorType(
+            self.max_dtype,
+            shape=["batch_size", "text_seq_len", self.cap_feat_dim],
+            device=self.max_device,
+        )
+        timestep_type = TensorType(
+            DType.float32,
+            shape=["batch_size"],
+            device=self.max_device,
+        )
+        img_ids_type = TensorType(
+            DType.int64,
+            shape=["image_seq_len", len(self.axes_dims)],
+            device=self.max_device,
+        )
+        txt_ids_type = TensorType(
+            DType.int64,
+            shape=["text_seq_len", len(self.axes_dims)],
+            device=self.max_device,
+        )
+        return (
+            hidden_states_type,
+            encoder_hidden_states_type,
+            timestep_type,
+            img_ids_type,
+            txt_ids_type,
+        )
+
+    def _input_types_standard(self) -> tuple[TensorType, ...]:
+        return self._base_input_types()
+
+    def _input_types_step_cache(self) -> tuple[TensorType, ...]:
+        return self._base_input_types() + tuple(
+            self._fbcache_conditional_execution_output_types()
+        )
+
+    def input_types(self) -> tuple[TensorType, ...]:
+        return self._input_types_impl()
+
+    def _forward_preamble(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Tensor,
+        timestep: Tensor,
+        img_ids: Tensor,
+        txt_ids: Tensor,
+    ) -> tuple[Tensor, Any, Tensor, tuple[Tensor, Tensor]]:
+        """Embed inputs, run refiners, return unified seq before main ``layers[0]``."""
+        x = self.x_embedder(hidden_states)
+        t_emb = self.t_embedder(timestep * self.t_scale).cast(x.dtype)
+
+        cap = self.cap_proj(self.cap_norm(encoder_hidden_states))
+
+        if txt_ids.rank == 3:
+            txt_ids = txt_ids[0]
+        if img_ids.rank == 3:
+            img_ids = img_ids[0]
+
+        txt_freqs = self.rope_embedder(txt_ids)
+        img_freqs = self.rope_embedder(img_ids)
+        unified_freqs = (
+            F.concat([img_freqs[0], txt_freqs[0]], axis=0),
+            F.concat([img_freqs[1], txt_freqs[1]], axis=0),
+        )
+
+        for layer in self.noise_refiner:
+            x = layer(x, freqs_cis=img_freqs, adaln_input=t_emb)
+
+        for layer in self.context_refiner:
+            cap = layer(cap, freqs_cis=txt_freqs)
+
+        img_len = x.shape[1]
+        unified0 = F.concat([x, cap], axis=1)
+        return unified0, img_len, t_emb, unified_freqs
+
+    def _run_first_main_layer(
+        self,
+        unified0: Tensor,
+        t_emb: Tensor,
+        unified_freqs: tuple[Tensor, Tensor],
+    ) -> Tensor:
+        return self.layers[0](
+            unified0,
+            freqs_cis=unified_freqs,
+            adaln_input=t_emb,
+        )
+
+    def _run_remaining_after_first(
+        self,
+        unified: Tensor,
+        *,
+        img_len: Any,
+        t_emb: Tensor,
+        freqs_cis: tuple[Tensor, Tensor],
+    ) -> Tensor:
+        u = unified
+        for i in range(1, len(self.layers)):
+            u = self.layers[i](
+                u,
+                freqs_cis=freqs_cis,
+                adaln_input=t_emb,
+            )
+        u = self.final_layer(u, c=t_emb)
+        return u[:, :img_len, :]
+
+    def _forward_standard(self, *args: Tensor) -> tuple[Tensor]:
+        hidden_states, encoder_hidden_states, timestep, img_ids, txt_ids = args[
+            :5
+        ]
+        unified0, img_len, t_emb, unified_freqs = self._forward_preamble(
+            hidden_states,
+            encoder_hidden_states,
+            timestep,
+            img_ids,
+            txt_ids,
+        )
+        u1 = self._run_first_main_layer(unified0, t_emb, unified_freqs)
+        out = self._run_remaining_after_first(
+            u1,
+            img_len=img_len,
+            t_emb=t_emb,
+            freqs_cis=unified_freqs,
+        )
+        return (out,)
+
+    def _forward_step_cache(self, *args: Tensor) -> tuple[Tensor, Tensor]:
+        (
+            hidden_states,
+            encoder_hidden_states,
+            timestep,
+            img_ids,
+            txt_ids,
+            prev_residual,
+            prev_output,
+        ) = args
+        unified0, img_len, t_emb, unified_freqs = self._forward_preamble(
+            hidden_states,
+            encoder_hidden_states,
+            timestep,
+            img_ids,
+            txt_ids,
+        )
+        unified1 = self._run_first_main_layer(unified0, t_emb, unified_freqs)
+        first_block_residual = (
+            unified1[:, :img_len, :] - unified0[:, :img_len, :]
+        )
+
+        return fbcache_conditional_execution(
+            first_block_residual,
+            prev_residual,
+            prev_output,
+            self._rdt_value,
+            self._run_remaining_after_first,
+            dict(
+                unified=unified1,
+                img_len=img_len,
+                t_emb=t_emb,
+                freqs_cis=unified_freqs,
+            ),
+            self._fbcache_conditional_execution_output_types(),
+        )
+
+    def forward(self, *args: Tensor) -> tuple[Tensor, ...]:
+        return self._forward_impl(*args)

--- a/max/python/max/pipelines/core/context.py
+++ b/max/python/max/pipelines/core/context.py
@@ -671,7 +671,7 @@ class PixelContext:
         num_inference_steps: Number of denoising steps.
         guidance_scale: Guidance scale for classifier-free guidance.
         num_images_per_prompt: Number of images/videos to generate per prompt.
-        input_image: Optional input image for image-to-image generation (PIL.Image.Image).
+        input_image: Optional HWC uint8 numpy array for image-to-image generation.
         model_name: Name of the model being used.
     """
 
@@ -699,6 +699,9 @@ class PixelContext:
     negative_tokens_2: TokenBuffer | None = field(default=None)
     """Negative tokens for secondary encoder. None for single-encoder models."""
 
+    explicit_negative_prompt: bool = field(default=False)
+    """Whether the request explicitly supplied a negative prompt."""
+
     # Precomputed tensors
     timesteps: npt.NDArray[np.float32] = field(
         default_factory=lambda: np.array([], dtype=np.float32)
@@ -725,6 +728,9 @@ class PixelContext:
     num_inference_steps: int = field(default=50)
     guidance_scale: float = field(default=3.5)
     true_cfg_scale: float = field(default=1.0)
+    strength: float = field(default=0.6)
+    cfg_normalization: bool = field(default=False)
+    cfg_truncation: float = field(default=1.0)
     num_warmup_steps: int = field(default=0)
     num_images_per_prompt: int = field(default=1)
     input_image: npt.NDArray[np.uint8] | None = field(default=None)

--- a/max/python/max/pipelines/lib/diffusion_schedulers/scheduling_flow_match_euler_discrete.py
+++ b/max/python/max/pipelines/lib/diffusion_schedulers/scheduling_flow_match_euler_discrete.py
@@ -147,6 +147,7 @@ class FlowMatchEulerDiscreteScheduler:
         image_seq_len: int,
         num_inference_steps: int,
         reverse: bool = False,
+        sigma_min: float | None = None,
     ) -> tuple[npt.NDArray[np.float32], npt.NDArray[np.float32]]:
         """Retrieve timesteps and sigmas for the diffusion process.
 
@@ -154,14 +155,21 @@ class FlowMatchEulerDiscreteScheduler:
             image_seq_len: Length of image sequence (H*W after packing).
             num_inference_steps: Number of inference steps.
             reverse: Whether to reverse the timesteps and sigmas.
+            sigma_min: Optional terminal sigma for the base schedule before
+                shifting. If None, defaults to legacy behavior (1 / steps).
 
         Returns:
             Tuple of timesteps and sigmas.
         """
         if not self._use_flow_sigmas:
+            min_sigma = (
+                float(sigma_min)
+                if sigma_min is not None
+                else 1.0 / num_inference_steps
+            )
             sigmas = np.linspace(
                 1.0,
-                1.0 / num_inference_steps,
+                min_sigma,
                 num_inference_steps,
                 dtype=np.float32,
             )

--- a/max/python/max/pipelines/lib/interfaces/diffusion_pipeline.py
+++ b/max/python/max/pipelines/lib/interfaces/diffusion_pipeline.py
@@ -784,9 +784,38 @@ class PixelModelInputs:
     - Must be > 0.
     - For video generation, the naming may still be used for historical compatibility.
     """
-    input_image: Image.Image | None = None
+    input_image: Image.Image | npt.NDArray[np.uint8] | None = None
     """
-    Optional input image for image-to-image generation (PIL.Image.Image).
+    Optional input image for image-to-image generation.
+
+    Pixel/tokenizer paths typically supply HWC ``uint8`` :class:`numpy.ndarray`
+    (see :class:`~max.pipelines.core.PixelContext`). A :class:`PIL.Image.Image`
+    is still accepted for callers that construct inputs without a pixel context.
+    """
+
+    strength: float = 0.6
+    """
+    Image-to-image denoising strength in (0, 1].
+
+    - Higher values preserve less of the input image and behave closer to text-to-image.
+    - Ignored when `input_image` is None.
+    """
+
+    cfg_normalization: bool = False
+    """
+    Whether to apply Z-Image CFG renormalization.
+
+    - Matches diffusers Z-Image behavior where guided prediction norm can be
+      clipped against the positive prediction norm.
+    - Ignored by non Z-Image pipelines.
+    """
+
+    cfg_truncation: float = 1.0
+    """
+    Z-Image CFG truncation threshold in normalized time.
+
+    - If `cfg_truncation <= 1.0`, guidance is disabled when `t_norm > cfg_truncation`.
+    - Ignored by non Z-Image pipelines.
     """
 
     def __post_init__(self) -> None:
@@ -825,6 +854,23 @@ class PixelModelInputs:
         ):
             raise ValueError(
                 f"num_images_per_prompt must be > 0. Got {self.num_images_per_prompt!r}"
+            )
+        if not isinstance(self.strength, (int, float)) or not (
+            0.0 < float(self.strength) <= 1.0
+        ):
+            raise ValueError(
+                f"strength must be in (0, 1]. Got {self.strength!r}"
+            )
+        if not isinstance(self.cfg_normalization, bool):
+            raise ValueError(
+                "cfg_normalization must be a bool. "
+                f"Got {type(self.cfg_normalization).__name__}"
+            )
+        if not isinstance(self.cfg_truncation, (int, float)) or not (
+            float(self.cfg_truncation) > 0.0
+        ):
+            raise ValueError(
+                f"cfg_truncation must be > 0. Got {self.cfg_truncation!r}"
             )
 
         required_arrays = {

--- a/max/python/max/pipelines/lib/pixel_tokenizer.py
+++ b/max/python/max/pipelines/lib/pixel_tokenizer.py
@@ -243,7 +243,10 @@ class PixelGenerationTokenizer(
 
         # Store static model dimensions
         self._default_sample_size = 128
-        self._num_channels_latents = transformer_config["in_channels"] // 4
+        if self._pipeline_class_name == PipelineClassName.ZIMAGE:
+            self._num_channels_latents = transformer_config["in_channels"]
+        else:
+            self._num_channels_latents = transformer_config["in_channels"] // 4
 
         # Create scheduler
         scheduler_class_name = components.get("scheduler", {}).get(
@@ -258,6 +261,7 @@ class PixelGenerationTokenizer(
             class_name=scheduler_class_name,
             config_dict=scheduler_cfg,
         )
+        self._scheduler_shift = float(scheduler_cfg.get("shift", 1.0))
 
         self._max_pixel_size = None
         if self._pipeline_class_name in (
@@ -344,6 +348,10 @@ class PixelGenerationTokenizer(
     def _preprocess_input_image(
         self,
         image: PIL.Image.Image | npt.NDArray[np.uint8],
+        *,
+        target_height: int | None = None,
+        target_width: int | None = None,
+        preserve_aspect_ratio: bool = True,
     ) -> PIL.Image.Image:
         """Preprocess input image for image-to-image generation.
 
@@ -354,6 +362,10 @@ class PixelGenerationTokenizer(
 
         Args:
             image: PIL Image or numpy array (uint8) to preprocess.
+            target_height: Optional requested output height before latent prep.
+            target_width: Optional requested output width before latent prep.
+            preserve_aspect_ratio: Whether to keep the source aspect ratio when
+                resizing. When false, resize directly to the target dimensions.
 
         Returns:
             Preprocessed PIL Image with adjusted dimensions.
@@ -377,7 +389,7 @@ class PixelGenerationTokenizer(
                 image = image.resize(
                     (new_width, new_height), PIL.Image.Resampling.LANCZOS
                 )
-                image_width, image_height = image.size
+            image_width, image_height = image.size
 
         image_width = max(
             (image_width // multiple_of) * multiple_of, multiple_of
@@ -386,10 +398,25 @@ class PixelGenerationTokenizer(
             (image_height // multiple_of) * multiple_of, multiple_of
         )
 
-        if image.size != (image_width, image_height):
-            image = self._resize_with_center_crop(
-                image, image_width, image_height
+        if target_width is not None:
+            image_width = max(
+                (int(target_width) // multiple_of) * multiple_of, multiple_of
             )
+        if target_height is not None:
+            image_height = max(
+                (int(target_height) // multiple_of) * multiple_of, multiple_of
+            )
+
+        if image.size != (image_width, image_height):
+            if preserve_aspect_ratio:
+                image = self._resize_with_center_crop(
+                    image, image_width, image_height
+                )
+            else:
+                image = image.resize(
+                    (image_width, image_height),
+                    resample=PIL.Image.Resampling.LANCZOS,
+                )
 
         return image
 
@@ -604,6 +631,26 @@ class PixelGenerationTokenizer(
                     add_special_tokens=add_special_tokens,
                     return_attention_mask=True,
                 )
+            elif self._pipeline_class_name == PipelineClassName.ZIMAGE:
+                # For Z-Image, use Qwen chat-template formatting.
+                messages = [{"role": "user", "content": prompt_str}]
+                if not hasattr(delegate, "apply_chat_template"):
+                    raise ValueError(
+                        "Z-Image requires tokenizer.apply_chat_template, "
+                        "but the loaded tokenizer does not provide it."
+                    )
+                return delegate.apply_chat_template(
+                    messages,
+                    enable_thinking=True,
+                    add_generation_prompt=True,
+                    tokenize=True,
+                    return_dict=True,
+                    padding="max_length",
+                    truncation=True,
+                    max_length=max_sequence_length,
+                    return_length=False,
+                    return_overflowing_tokens=False,
+                )
             else:
                 # Validate prompt length before truncation.
                 # The tokenizer's truncation=True silently drops
@@ -631,73 +678,73 @@ class PixelGenerationTokenizer(
 
         tokenizer_output = await run_with_default_executor(_encode_fn, prompt)
 
-        # Extract input_ids and attention_mask.
-        if isinstance(tokenizer_output, dict):
+        # Extract input_ids and attention_mask from both dict-like and object-like
+        # tokenizer outputs (e.g. BatchEncoding).
+        input_ids: Any
+        attention_mask: Any | None
+        if hasattr(tokenizer_output, "__getitem__") and (
+            hasattr(tokenizer_output, "keys")
+            and "input_ids" in tokenizer_output
+        ):
             input_ids = tokenizer_output["input_ids"]
             attention_mask = tokenizer_output.get("attention_mask", None)
-        else:
+        elif hasattr(tokenizer_output, "input_ids"):
             input_ids = tokenizer_output.input_ids
-            attention_mask = tokenizer_output.attention_mask
+            attention_mask = getattr(tokenizer_output, "attention_mask", None)
+        else:
+            raise ValueError(
+                "Tokenizer output does not contain `input_ids`; cannot build PixelContext."
+            )
 
         input_ids_array = np.asarray(input_ids, dtype=np.int64)
+        if input_ids_array.ndim == 1:
+            input_ids_array = input_ids_array[None, :]
+
         if attention_mask is None:
             attention_mask_array = np.ones_like(input_ids_array, dtype=np.bool_)
         else:
             attention_mask_array = np.asarray(attention_mask, dtype=np.bool_)
+            if attention_mask_array.ndim == 1:
+                attention_mask_array = attention_mask_array[None, :]
 
-        # Tokenizers can return a batch dimension for a single prompt.
-        if input_ids_array.ndim == 2:
-            if input_ids_array.shape[0] != 1:
-                raise ValueError(
-                    "Expected one prompt during tokenization, got "
-                    f"batch size {input_ids_array.shape[0]}."
-                )
-            input_ids_array = input_ids_array[0]
-        elif input_ids_array.ndim != 1:
+        if input_ids_array.shape != attention_mask_array.shape:
             raise ValueError(
-                "Expected rank-1 or rank-2 input_ids, got "
-                f"shape {input_ids_array.shape}."
+                "Tokenizer produced mismatched `input_ids` and `attention_mask` shapes: "
+                f"{input_ids_array.shape} vs {attention_mask_array.shape}."
             )
 
-        if attention_mask_array.ndim == 2:
-            if attention_mask_array.shape[0] != 1:
-                raise ValueError(
-                    "Expected one prompt attention_mask, got "
-                    f"batch size {attention_mask_array.shape[0]}."
-                )
-            attention_mask_array = attention_mask_array[0]
-        elif attention_mask_array.ndim != 1:
-            raise ValueError(
-                "Expected rank-1 or rank-2 attention_mask, got "
-                f"shape {attention_mask_array.shape}."
-            )
-
-        if attention_mask_array.shape[0] != input_ids_array.shape[0]:
-            raise ValueError(
-                "input_ids and attention_mask must have the same sequence "
-                f"length ({input_ids_array.shape[0]} != {attention_mask_array.shape[0]})."
-            )
-
-        # FLUX.2 uses compact token IDs; FLUX.2-Klein keeps full tokenizer output.
+        # Flux2 text encoder path currently does not consume an explicit
+        # attention mask. Strip padded tokens here and keep a dense mask.
+        # FLUX2_KLEIN/Z-Image consume attention_mask directly.
         if self._pipeline_class_name == PipelineClassName.FLUX2:
-            input_ids_array = input_ids_array[attention_mask_array]
-            attention_mask_array = np.ones(
-                input_ids_array.shape[0], dtype=np.bool_
+            token_row = input_ids_array[0]
+            mask_row = attention_mask_array[0]
+            real_token_ids = token_row[mask_row]
+            if real_token_ids.size == 0:
+                raise ValueError(
+                    f"{self._pipeline_class_name.value} tokenization produced "
+                    "an empty effective prompt after attention masking."
+                )
+            input_ids_array = np.expand_dims(
+                real_token_ids.astype(np.int64, copy=False), axis=0
             )
+            attention_mask_array = np.ones_like(input_ids_array, dtype=np.bool_)
 
         if (
-            max_sequence_length
-            and input_ids_array.shape[0] > max_sequence_length
+            max_sequence_length is not None
+            and input_ids_array.shape[1] > max_sequence_length
         ):
             raise ValueError(
                 "Input string is larger than tokenizer's max length "
-                f"({input_ids_array.shape[0]} > {max_sequence_length})."
+                f"({input_ids_array.shape[1]} > {max_sequence_length})."
             )
 
-        encoded_prompt = input_ids_array.astype(np.int64, copy=False)
-        attention_mask_array = attention_mask_array.astype(np.bool_, copy=False)
+        encoded_prompt = input_ids_array[0].astype(np.int64, copy=False)
+        attention_mask_flat = attention_mask_array[0].astype(
+            np.bool_, copy=False
+        )
 
-        return encoded_prompt, attention_mask_array
+        return encoded_prompt, attention_mask_flat
 
     async def decode(
         self,
@@ -867,6 +914,10 @@ class PixelGenerationTokenizer(
                 "falling back to standard generation."
             )
 
+        do_zimage_cfg = (
+            self._pipeline_class_name == PipelineClassName.ZIMAGE
+            and image_options.guidance_scale > 0.0
+        )
         if self._pipeline_class_name == PipelineClassName.FLUX2_KLEIN:
             is_distilled_klein = bool(
                 self.diffusers_config.get("is_distilled", False)
@@ -899,14 +950,14 @@ class PixelGenerationTokenizer(
             token_ids_2,
             _attn_mask_2,
             negative_token_ids,
-            _negative_attn_mask,
+            negative_attn_mask,
             negative_token_ids_2,
         ) = await self._generate_tokens_ids(
             prompt,
             image_options.secondary_prompt,
             image_options.negative_prompt,
             image_options.secondary_negative_prompt,
-            do_true_cfg,
+            do_true_cfg or do_zimage_cfg,
             images=images_for_tokenization,
         )
 
@@ -935,7 +986,14 @@ class PixelGenerationTokenizer(
         # 2. Preprocess input image if provided
         preprocessed_image_array = None
         if input_image is not None:
-            preprocessed_image = self._preprocess_input_image(input_image)
+            preprocessed_image = self._preprocess_input_image(
+                input_image,
+                target_height=image_options.height,
+                target_width=image_options.width,
+                preserve_aspect_ratio=(
+                    self._pipeline_class_name != PipelineClassName.ZIMAGE
+                ),
+            )
             height = image_options.height or preprocessed_image.height
             width = image_options.width or preprocessed_image.width
             preprocessed_image_array = np.array(
@@ -959,9 +1017,42 @@ class PixelGenerationTokenizer(
             if "steps" in image_options.model_fields_set
             else self._default_num_inference_steps
         )
-        timesteps, sigmas = self._scheduler.retrieve_timesteps_and_sigmas(
-            image_seq_len, num_inference_steps
+        sigma_min = (
+            0.0
+            if self._pipeline_class_name == PipelineClassName.ZIMAGE
+            else None
         )
+        timesteps, sigmas = self._scheduler.retrieve_timesteps_and_sigmas(
+            image_seq_len, num_inference_steps, sigma_min=sigma_min
+        )
+        if (
+            self._pipeline_class_name == PipelineClassName.ZIMAGE
+            and self._scheduler_shift != 1.0
+        ):
+            # Match diffusers FlowMatchEulerDiscreteScheduler static shift behavior.
+            # Z-Image scheduler config uses shift=6.0.
+            shifted_timesteps = (
+                self._scheduler_shift
+                * timesteps
+                / (1.0 + (self._scheduler_shift - 1.0) * timesteps)
+            ).astype(np.float32)
+            timesteps = shifted_timesteps
+            sigmas = np.append(shifted_timesteps, np.float32(0.0))
+
+        # Z-Image img2img follows diffusers strength behavior by starting
+        # denoising from a later timestep.
+        if (
+            self._pipeline_class_name == PipelineClassName.ZIMAGE
+            and input_image is not None
+        ):
+            init_timestep = min(
+                num_inference_steps * image_options.strength,
+                float(num_inference_steps),
+            )
+            t_start = int(max(num_inference_steps - init_timestep, 0.0))
+            timesteps = timesteps[t_start:]
+            sigmas = sigmas[t_start:]
+            num_inference_steps = int(timesteps.shape[0])
 
         num_warmup_steps: int = max(
             len(timesteps) - num_inference_steps * self._scheduler.order, 0
@@ -982,8 +1073,9 @@ class PixelGenerationTokenizer(
             mask=attn_mask,
             tokens_2=token_buffer_2,
             negative_tokens=negative_token_buffer,
-            negative_mask=_negative_attn_mask,
+            negative_mask=negative_attn_mask,
             negative_tokens_2=negative_token_buffer_2,
+            explicit_negative_prompt=image_options.negative_prompt is not None,
             timesteps=timesteps,
             sigmas=sigmas,
             latents=latents,
@@ -994,6 +1086,9 @@ class PixelGenerationTokenizer(
             guidance_scale=image_options.guidance_scale,
             num_images_per_prompt=image_options.num_images,
             true_cfg_scale=image_options.true_cfg_scale,
+            strength=image_options.strength,
+            cfg_normalization=image_options.cfg_normalization,
+            cfg_truncation=image_options.cfg_truncation,
             num_warmup_steps=num_warmup_steps,
             model_name=request.body.model,
             input_image=preprocessed_image_array,  # Pass numpy array instead of PIL.Image

--- a/max/python/max/pipelines/lib/registry.py
+++ b/max/python/max/pipelines/lib/registry.py
@@ -810,6 +810,8 @@ class PipelineRegistry:
                 "revision": pipeline_config.model.huggingface_model_revision,
                 "trust_remote_code": pipeline_config.model.trust_remote_code,
             }
+            if arch.name in ("Flux2Pipeline", "ZImagePipeline"):
+                tokenizer_kwargs["max_length"] = 512
 
             if has_tokenizer_2:
                 tokenizer_kwargs["subfolder_2"] = "tokenizer_2"


### PR DESCRIPTION
## Summary

- This PR is a **stacked follow-up on** #6063  and focuses on **Z-Image pipeline/runtime integration**.
- Once the preceding PRs #6064 , #6063 , and #6062  are merged together, the Z-Image, Z-Image-Turbo, and FLUX.2-klein families will all work.
- Adds Z-Image pipeline entrypoints:
  - `max/python/max/pipelines/architectures/z_image/arch.py`
  - `max/python/max/pipelines/architectures/z_image/pipeline_z_image.py`
- Wires Z-Image into architecture registration and runtime lookup paths:
  - `max/python/max/pipelines/architectures/__init__.py`
  - `max/python/max/pipelines/lib/registry.py`
- Extends request-to-runtime plumbing so Z-Image generation options are preserved through the full path:
  - `max/python/max/interfaces/provider_options/modality/image.py`
  - `max/python/max/pipelines/core/context.py`
  - `max/python/max/pipelines/lib/interfaces/diffusion_pipeline.py`
- Updates tokenizer/scheduler integration for Z-Image execution flow:
  - `max/python/max/pipelines/lib/pixel_tokenizer.py`
  - `max/python/max/pipelines/lib/diffusion_schedulers/scheduling_flow_match_euler_discrete.py`
- Updates diffusion example wiring for Z-Image options:
  - `max/examples/diffusion/simple_offline_generation.py`

This PR builds on #5604 , #5843  
This model was contributed by [Byungchul Chae (@byungchul-sqzb)](https://github.com/byungchul-sqzb) and [Tolga Cangöz (@tolgacangoz)](https://github.com/tolgacangoz).

## Testing

- `./bazelw run format`

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))

Assisted-by: AI