### PR TITLE
[Kernels] Enable Mojo matmuls for Flux2-Klein-4B model

### DIFF
--- a/max/kernels/src/linalg/matmul/gpu/sm100_structured/default/dispatch.mojo
+++ b/max/kernels/src/linalg/matmul/gpu/sm100_structured/default/dispatch.mojo
@@ -1494,6 +1494,7 @@ fn matmul_dispatch_sm100_bf16[
     ]
 
     comptime FLUX2_NK = [
+        # Flux2-dev
         Index(6144, 24576),
         Index(55296, 6144),
         Index(6144, 6144),
@@ -1501,6 +1502,15 @@ fn matmul_dispatch_sm100_bf16[
         Index(6144, 18432),
         Index(1024, 5120),
         Index(32768, 5120),
+        # Flux2-Klein-4B
+        Index(3072, 3072),
+        Index(18432, 3072),
+        Index(3072, 9216),
+        Index(9216, 3072),
+        Index(27648, 3072),
+        Index(3072, 12288),
+        Index(3072, 7680),
+        Index(6144, 3072),
     ]
 
     comptime static_NK = Index(static_N, static_K)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Please fill out the sections below to help reviewers understand your change.
For guidance on writing a good PR, see our
[contributor guide](../CONTRIBUTING.md).
-->

## Summary

This PR adds Flux2-Klein-4B matmul shape dispatch entries for SM100 BF16.

## Testing

### Before
Latency of a single execution of whole Flux2 DiT: 43.4ms
<img width="744" height="286" alt="image" src="https://github.com/user-attachments/assets/7958c38d-d73a-4b24-b406-5cd4ae868195" />

### After
Latency of a single execution of whole Flux2 DiT: 41.6ms
<img width="744" height="252" alt="image" src="https://github.com/user-attachments/assets/4c56d6fd-4462-4a87-a84c-212c7fcf5417" />


## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
