### PR TITLE
[Feature Request] [stdlib] Prettier SIMD scalar printing

### DIFF
--- a/mojo/stdlib/std/builtin/simd.mojo
+++ b/mojo/stdlib/std/builtin/simd.mojo
@@ -103,56 +103,29 @@ from .dtype import (
 
 
 # Compute a scalar alias name for `SIMD[dtype, 1]`.
-# Maps the DType short name to the usual alias (e.g. "uint32" -> "UInt32",
-# "int64" -> "Int64", otherwise Capitalize(first)).  Runs at comptime.
+# Maps the DType string name to a more readable form (e.g. "uint32" -> "UInt32", "float32" -> "Float32")
 @always_inline("nodebug")
 fn _scalar_alias_from_dtype(dtype: DType) -> String:
     var name = String()
     dtype.write_to(name)
 
-    # Prefer explicit aliases for common integral dtypes for readability.
-    if dtype == DType.uint8:
-        return String("UInt8")
-    elif dtype == DType.int8:
-        return String("Int8")
-    elif dtype == DType.uint16:
-        return String("UInt16")
-    elif dtype == DType.int16:
-        return String("Int16")
-    elif dtype == DType.uint32:
-        return String("UInt32")
-    elif dtype == DType.int32:
-        return String("Int32")
-    elif dtype == DType.uint64:
-        return String("UInt64")
-    elif dtype == DType.int64:
-        return String("Int64")
-    elif dtype == DType.uint128:
-        return String("UInt128")
-    elif dtype == DType.int128:
-        return String("Int128")
-    elif dtype == DType.uint256:
-        return String("UInt256")
-    elif dtype == DType.int256:
-        return String("Int256")
-    elif dtype == DType.uint:
+    if len(name) == 0:
+        return name
+
+    if name == "uint":
         return String("UInt")
-    elif dtype == DType.int:
+    elif name == "int":
         return String("Int")
 
-    # Fallback: capitalize the printed dtype name, e.g. "float32" -> "Float32".
-    var s = StringSlice(name)
-    if len(s) > 0:
-        var iter = s.codepoint_slices()
-        var first_slice = iter.peek_next().value()
-        var first_upper = first_slice.upper()
-        var total = s.byte_length()
-        var first_len = first_slice.byte_length()
-        var rest = StringSlice(
-            ptr=s.unsafe_ptr() + first_len, length=total - first_len
-        )
+    var result = name.replace("uint", "UInt").replace("int", "Int")
+
+    if result == name:
+        var first_char = StringSlice(ptr=name.unsafe_ptr(), length=1)
+        var first_upper = first_char.upper()
+        var rest = StringSlice(ptr=name.unsafe_ptr() + 1, length=len(name) - 1)
         return String(first_upper, rest)
-    return String()
+
+    return result
 
 
 comptime Scalar = SIMD[_, size=1]

--- a/mojo/stdlib/std/builtin/simd.mojo
+++ b/mojo/stdlib/std/builtin/simd.mojo
@@ -42,7 +42,7 @@ domain-specific libraries for machine learning and scientific computing.
 
 import std.math
 from std.collections import InlineArray
-from std.collections.string.string import _calc_initial_buffer_size
+from std.collections.string.string import _calc_initial_buffer_size, StringSlice
 from std.hashlib.hasher import Hasher
 from std.math import Ceilable, CeilDivable, Floorable, Truncable
 from std.math.math import _call_ptx_intrinsic, trunc
@@ -100,6 +100,60 @@ from .dtype import (
 # ===----------------------------------------------------------------------=== #
 # Type Aliases
 # ===----------------------------------------------------------------------=== #
+
+
+# Compute a scalar alias name for `SIMD[dtype, 1]`.
+# Maps the DType short name to the usual alias (e.g. "uint32" -> "UInt32",
+# "int64" -> "Int64", otherwise Capitalize(first)).  Runs at comptime.
+@always_inline("nodebug")
+fn _scalar_alias_from_dtype(dtype: DType) -> String:
+    var name = String()
+    dtype.write_to(name)
+
+    # Prefer explicit aliases for common integral dtypes for readability.
+    if dtype == DType.uint8:
+        return String("UInt8")
+    elif dtype == DType.int8:
+        return String("Int8")
+    elif dtype == DType.uint16:
+        return String("UInt16")
+    elif dtype == DType.int16:
+        return String("Int16")
+    elif dtype == DType.uint32:
+        return String("UInt32")
+    elif dtype == DType.int32:
+        return String("Int32")
+    elif dtype == DType.uint64:
+        return String("UInt64")
+    elif dtype == DType.int64:
+        return String("Int64")
+    elif dtype == DType.uint128:
+        return String("UInt128")
+    elif dtype == DType.int128:
+        return String("Int128")
+    elif dtype == DType.uint256:
+        return String("UInt256")
+    elif dtype == DType.int256:
+        return String("Int256")
+    elif dtype == DType.uint:
+        return String("UInt")
+    elif dtype == DType.int:
+        return String("Int")
+
+    # Fallback: capitalize the printed dtype name, e.g. "float32" -> "Float32".
+    var s = StringSlice(name)
+    if len(s) > 0:
+        var iter = s.codepoint_slices()
+        var first_slice = iter.peek_next().value()
+        var first_upper = first_slice.upper()
+        var total = s.byte_length()
+        var first_len = first_slice.byte_length()
+        var rest = StringSlice(
+            ptr=s.unsafe_ptr() + first_len, length=total - first_len
+        )
+        return String(first_upper, rest)
+    return String()
+
 
 comptime Scalar = SIMD[_, size=1]
 """Represents a scalar dtype."""
@@ -2191,6 +2245,14 @@ struct SIMD[dtype: DType, size: Int](
         Args:
             writer: The value to write to.
         """
+
+        comptime if Self.size == 1:
+            writer.write_string(
+                StringSlice(_scalar_alias_from_dtype(Self.dtype))
+            )
+            writer.write("(", self[0], ")")
+            return
+
         writer.write_string("SIMD[")
         Self.dtype.write_repr_to(writer)
         writer.write(", ", Self.size, "](")

--- a/mojo/stdlib/test/builtin/test_simd.mojo
+++ b/mojo/stdlib/test/builtin/test_simd.mojo
@@ -331,19 +331,24 @@ def test_simd_repr_and_write_repr_to() raises:
         SIMD[DType.int32, 4](-1, 2, -3, 4),
         "SIMD[DType.int32, 4](-1, 2, -3, 4)",
     )
+    _test_repr(
+        SIMD[DType.uint32, 4](0, 1, 2, 3),
+        "SIMD[DType.uint32, 4](0, 1, 2, 3)",
+    )
 
-    # Size boundary: scalar (size=1)
-    _test_repr(Int32(4), "SIMD[DType.int32, 1](4)")
-    _test_repr(Int32(0), "SIMD[DType.int32, 1](0)")
-    _test_repr(Int32(-42), "SIMD[DType.int32, 1](-42)")
+    # Size boundary: scalar (size=1) now uses alias names
+    _test_repr(Int32(4), "Int32(4)")
+    _test_repr(Int32(0), "Int32(0)")
+    _test_repr(Int32(-42), "Int32(-42)")
 
-    # Integer boundary values (min/max for different sizes)
-    _test_repr(Int8.MIN, "SIMD[DType.int8, 1](-128)")
-    _test_repr(Int8.MAX, "SIMD[DType.int8, 1](127)")
-    _test_repr(UInt8.MAX, "SIMD[DType.uint8, 1](255)")
+    # Integer boundary values (min/max for different sizes).
+    # the alias is still based on dtype
+    _test_repr(Int8.MIN, "Int8(-128)")
+    _test_repr(Int8.MAX, "Int8(127)")
+    _test_repr(UInt8.MAX, "UInt8(255)")
     _test_repr(
         Int64.MIN,
-        "SIMD[DType.int64, 1](-9223372036854775808)",
+        "Int64(-9223372036854775808)",
     )
     _test_repr(
         SIMD[DType.uint32, 2](0, UInt32.MAX),
@@ -364,12 +369,12 @@ def test_simd_repr_and_write_repr_to() raises:
         "SIMD[DType.bool, 4](False, False, False, False)",
     )
 
-    # Float types - different precisions
-    _test_repr(Float16(324), "SIMD[DType.float16, 1](324.0)")
-    _test_repr(Float32(2897239), "SIMD[DType.float32, 1](2897239.0)")
+    # Float types - different precisions (now alias)
+    _test_repr(Float16(324), "Float16(324.0)")
+    _test_repr(Float32(2897239), "Float32(2897239.0)")
     _test_repr(
         Float64(235234523.3452),
-        "SIMD[DType.float64, 1](235234523.3452)",
+        "Float64(235234523.3452)",
     )
 
     # Float special values (inf, -inf, nan, -0.0)
@@ -378,6 +383,16 @@ def test_simd_repr_and_write_repr_to() raises:
             Float32.MAX, Float32.MIN, -0.0, nan[DType.float32]()
         ),
         "SIMD[DType.float32, 4](inf, -inf, -0.0, nan)",
+    )
+
+    # Additional scalar alias coverage and collections
+    _test_repr(UInt(1), "UInt(1)")
+    _test_repr(Int64(5), "Int64(5)")
+
+    # Collections should reflect alias naming
+    assert_equal(
+        repr([UInt(1)]), 
+        "List[SIMD[DType.uint, 1]]([UInt(1)])",
     )
 
 

--- a/mojo/stdlib/test/builtin/test_simd.mojo
+++ b/mojo/stdlib/test/builtin/test_simd.mojo
@@ -391,7 +391,7 @@ def test_simd_repr_and_write_repr_to() raises:
 
     # Collections should reflect alias naming
     assert_equal(
-        repr([UInt(1)]), 
+        repr([UInt(1)]),
         "List[SIMD[DType.uint, 1]]([UInt(1)])",
     )
 


### PR DESCRIPTION
SIMD.write_repr_to now checks comptime if Self.size == 1 and, in that case, prints the alias name derived from the dtype. A compile‑time helper (_scalar_alias_from_dtype) computes the alias by transforming the short dtype name returned by DType.write_to.
Prefix rules:
- uint… → UInt…
- int… → Int…
- otherwise, capitalize the first letter (so float32→Float32, float8_e4m3fn→Float8_e4m3fn, etc.).

For size > 1 the original SIMD[DType.foo, N](…) output is unchanged. No reflection or runtime hacks were introduced. The change is local to write_repr_to as requested.

Related issue: #5838 

Tests added/modified
File: test_simd.mojo
The scalar expectations were updated and new assertions inserted (including a uint32‑4 test). A new collection test ensures wrappers print nicely. All tests pass.