### PR TITLE
[Stdlib] Deduplicate _list_linux/_list_macos in _DirHandle

### DIFF
--- a/mojo/stdlib/std/os/os.mojo
+++ b/mojo/stdlib/std/os/os.mojo
@@ -57,7 +57,9 @@ comptime SEEK_END: UInt8 = 2
 trait _DirentLike(Copyable, ImplicitlyDestructible):
     """Internal trait for platform-specific directory entry types."""
 
-    fn get_name_ptr(ref self) -> UnsafePointer[mut=False, Byte, AnyOrigin[mut=False]]:
+    fn get_name_ptr(
+        ref self,
+    ) -> UnsafePointer[mut=False, Byte, AnyOrigin[mut=False]]:
         """Returns a pointer to the null-terminated name bytes."""
         ...
 
@@ -75,7 +77,9 @@ struct _dirent_linux(_DirentLike):
     var name: InlineArray[c_char, Self.MAX_NAME_SIZE]
     """Name of entry."""
 
-    fn get_name_ptr(ref self) -> UnsafePointer[mut=False, Byte, AnyOrigin[mut=False]]:
+    fn get_name_ptr(
+        ref self,
+    ) -> UnsafePointer[mut=False, Byte, AnyOrigin[mut=False]]:
         return self.name.unsafe_ptr().bitcast[Byte]().as_any_origin()
 
 
@@ -94,7 +98,9 @@ struct _dirent_macos(_DirentLike):
     var name: InlineArray[c_char, Self.MAX_NAME_SIZE]
     """Name of entry."""
 
-    fn get_name_ptr(ref self) -> UnsafePointer[mut=False, Byte, AnyOrigin[mut=False]]:
+    fn get_name_ptr(
+        ref self,
+    ) -> UnsafePointer[mut=False, Byte, AnyOrigin[mut=False]]:
         return self.name.unsafe_ptr().bitcast[Byte]().as_any_origin()
 
 

--- a/mojo/stdlib/std/os/os.mojo
+++ b/mojo/stdlib/std/os/os.mojo
@@ -54,7 +54,15 @@ comptime SEEK_END: UInt8 = 2
 # ===----------------------------------------------------------------------=== #
 
 
-struct _dirent_linux(Copyable):
+trait _DirentLike(Copyable, ImplicitlyDestructible):
+    """Internal trait for platform-specific directory entry types."""
+
+    fn get_name_ptr(ref self) -> UnsafePointer[mut=False, Byte, AnyOrigin[mut=False]]:
+        """Returns a pointer to the null-terminated name bytes."""
+        ...
+
+
+struct _dirent_linux(_DirentLike):
     comptime MAX_NAME_SIZE = 256
     var d_ino: Int64
     """File serial number."""
@@ -67,8 +75,11 @@ struct _dirent_linux(Copyable):
     var name: InlineArray[c_char, Self.MAX_NAME_SIZE]
     """Name of entry."""
 
+    fn get_name_ptr(ref self) -> UnsafePointer[mut=False, Byte, AnyOrigin[mut=False]]:
+        return self.name.unsafe_ptr().bitcast[Byte]().as_any_origin()
 
-struct _dirent_macos(Copyable):
+
+struct _dirent_macos(_DirentLike):
     comptime MAX_NAME_SIZE = 1024
     var d_ino: Int64
     """File serial number."""
@@ -82,6 +93,9 @@ struct _dirent_macos(Copyable):
     """Type of file."""
     var name: InlineArray[c_char, Self.MAX_NAME_SIZE]
     """Name of entry."""
+
+    fn get_name_ptr(ref self) -> UnsafePointer[mut=False, Byte, AnyOrigin[mut=False]]:
+        return self.name.unsafe_ptr().bitcast[Byte]().as_any_origin()
 
 
 struct _DirHandle:
@@ -126,59 +140,26 @@ struct _DirHandle:
         """
 
         comptime if CompilationTarget.is_linux():
-            return self._list_linux()
+            return self._list[_dirent_linux, _dirent_linux.MAX_NAME_SIZE]()
         else:
-            return self._list_macos()
+            return self._list[_dirent_macos, _dirent_macos.MAX_NAME_SIZE]()
 
-    def _list_linux(self) -> List[String]:
-        """Reads all the data from the handle.
-
-        Returns:
-            A string containing the output of running the command.
-        """
+    fn _list[D: _DirentLike, max_name_size: Int](self) -> List[String]:
         var res = List[String]()
 
         while True:
             var ep = external_call[
-                "readdir", _CPointer[_dirent_linux, MutExternalOrigin]
+                "readdir", _CPointer[D, MutExternalOrigin]
             ](self._handle)
             if not ep:
                 break
-            ref name = ep.unsafe_value().take_pointee().name
-            var name_ptr = name.unsafe_ptr().bitcast[Byte]()
-            var name_str = StringSlice[origin_of(name)](
-                ptr=name_ptr,
-                length=Int(
-                    _unsafe_strlen(name_ptr, _dirent_linux.MAX_NAME_SIZE)
-                ),
-            )
-            if name_str == "." or name_str == "..":
-                continue
-            res.append(String(name_str))
-
-        return res^
-
-    def _list_macos(self) -> List[String]:
-        """Reads all the data from the handle.
-
-        Returns:
-            A string containing the output of running the command.
-        """
-        var res = List[String]()
-
-        while True:
-            var ep = external_call[
-                "readdir", _CPointer[_dirent_macos, MutExternalOrigin]
-            ](self._handle)
-            if not ep:
-                break
-            ref name = ep.unsafe_value().take_pointee().name
-            var name_ptr = name.unsafe_ptr().bitcast[Byte]()
-            var name_str = StringSlice[origin_of(name)](
-                ptr=name_ptr,
-                length=Int(
-                    _unsafe_strlen(name_ptr, _dirent_macos.MAX_NAME_SIZE)
-                ),
+            var entry = ep.unsafe_value().take_pointee()
+            var name_ptr = entry.get_name_ptr()
+            var name_str = StringSlice(
+                unsafe_from_utf8=Span(
+                    ptr=name_ptr,
+                    length=Int(_unsafe_strlen(name_ptr, UInt(max_name_size))),
+                )
             )
             if name_str == "." or name_str == "..":
                 continue


### PR DESCRIPTION
`_DirHandle._list_linux` and `_DirHandle._list_macos` were identical except for the dirent type (`_dirent_linux` vs `_dirent_macos`). This PR introduces a `_DirentLike` trait and unifies them into a single `_list[D: _DirentLike, max_name_size: Int]` helper, removing ~20 lines of duplication.