### PR TITLE
[Stdlib] Fix Interval comparison operators to use lexicographic order

### DIFF
--- a/mojo/stdlib/std/collections/interval.mojo
+++ b/mojo/stdlib/std/collections/interval.mojo
@@ -210,51 +210,69 @@ struct Interval[T: IntervalElement](
         """
         return self.start <= other.start and self.end >= other.end
 
-    fn __le__(self, other: Self) -> Bool:
-        """Returns whether this interval is less than or equal to another
-        interval.
+    fn __lt__(self, other: Self) -> Bool:
+        """Returns whether this interval is less than another interval using
+        lexicographic ordering: compare `start` first, then `end` as a
+        tiebreaker.
 
         Args:
             other: The interval to compare with.
 
         Returns:
-            True if this interval's start is less than or equal to the other interval's start.
+            True if this interval's start is less than the other interval's
+            start, or if the starts are equal and this interval's end is less
+            than the other interval's end.
         """
-        return self.start <= other.start
+        if self.start != other.start:
+            return self.start < other.start
+        return self.end < other.end
+
+    fn __le__(self, other: Self) -> Bool:
+        """Returns whether this interval is less than or equal to another
+        interval using lexicographic ordering.
+
+        Args:
+            other: The interval to compare with.
+
+        Returns:
+            True if this interval is less than the other interval, or if they
+            are equal.
+        """
+        if self.start != other.start:
+            return self.start < other.start
+        return self.end <= other.end
+
+    fn __gt__(self, other: Self) -> Bool:
+        """Returns whether this interval is greater than another interval using
+        lexicographic ordering: compare `start` first, then `end` as a
+        tiebreaker.
+
+        Args:
+            other: The interval to compare with.
+
+        Returns:
+            True if this interval's start is greater than the other interval's
+            start, or if the starts are equal and this interval's end is
+            greater than the other interval's end.
+        """
+        if self.start != other.start:
+            return self.start > other.start
+        return self.end > other.end
 
     fn __ge__(self, other: Self) -> Bool:
         """Returns whether this interval is greater than or equal to another
-        interval.
+        interval using lexicographic ordering.
 
         Args:
             other: The interval to compare with.
 
         Returns:
-            True if this interval's end is greater than or equal to the other interval's end.
+            True if this interval is greater than the other interval, or if
+            they are equal.
         """
+        if self.start != other.start:
+            return self.start > other.start
         return self.end >= other.end
-
-    fn __lt__(self, other: Self) -> Bool:
-        """Returns whether this interval is less than another interval.
-
-        Args:
-            other: The interval to compare with.
-
-        Returns:
-            True if this interval's start is less than the other interval's start.
-        """
-        return self.start < other.start
-
-    fn __gt__(self, other: Self) -> Bool:
-        """Returns whether this interval is greater than another interval.
-
-        Args:
-            other: The interval to compare with.
-
-        Returns:
-            True if this interval's end is greater than the other interval's end.
-        """
-        return self.end > other.end
 
     fn __len__(self) -> Int:
         """Returns the length of this interval.

--- a/mojo/stdlib/test/collections/test_interval.mojo
+++ b/mojo/stdlib/test/collections/test_interval.mojo
@@ -41,20 +41,38 @@ def test_interval() raises:
     assert_equal(interval, Interval(1, 10))
     assert_not_equal(interval, Interval(1, 11))
 
-    # Test less than comparisons
+    # Test less than comparisons (lexicographic: start first, end as tiebreaker)
     assert_true(
         interval < Interval(2, 11), msg=String(interval, " < Interval(2, 11)")
     )
-    assert_false(
+    assert_true(
         interval < Interval(1, 11), msg=String(interval, " < Interval(1, 11)")
     )
+    assert_false(
+        interval < Interval(1, 10), msg=String(interval, " < Interval(1, 10)")
+    )
+    assert_false(
+        interval < Interval(1, 9), msg=String(interval, " < Interval(1, 9)")
+    )
+    assert_false(
+        interval < Interval(0, 9), msg=String(interval, " < Interval(0, 9)")
+    )
 
-    # Test greater than comparisons
+    # Test greater than comparisons (lexicographic: start first, end as tiebreaker)
     assert_true(
         interval > Interval(0, 9), msg=String(interval, " > Interval(0, 9)")
     )
+    assert_true(
+        interval > Interval(1, 9), msg=String(interval, " > Interval(1, 9)")
+    )
+    assert_false(
+        interval > Interval(1, 10), msg=String(interval, " > Interval(1, 10)")
+    )
     assert_false(
         interval > Interval(1, 11), msg=String(interval, " > Interval(1, 11)")
+    )
+    assert_false(
+        interval > Interval(2, 9), msg=String(interval, " > Interval(2, 9)")
     )
 
     # Test less than or equal comparisons
@@ -67,17 +85,33 @@ def test_interval() raises:
     assert_false(
         interval <= Interval(0, 9), msg=String(interval, " <= Interval(0, 9)")
     )
+    assert_false(
+        interval <= Interval(1, 9), msg=String(interval, " <= Interval(1, 9)")
+    )
 
     # Test greater than or equal comparisons
     assert_true(
         interval >= Interval(1, 10), msg=String(interval, " >= Interval(1, 10)")
     )
     assert_true(
+        interval >= Interval(1, 9), msg=String(interval, " >= Interval(1, 9)")
+    )
+    assert_false(
         interval >= Interval(2, 9), msg=String(interval, " >= Interval(2, 9)")
     )
     assert_false(
         interval >= Interval(1, 11), msg=String(interval, " >= Interval(1, 11)")
     )
+
+    # Test transitivity: A < B and B < C implies A < C
+    var a = Interval(1, 10)
+    var b = Interval(2, 5)
+    var c = Interval(3, 8)
+    assert_true(a < b, msg="transitivity: a < b")
+    assert_true(b < c, msg="transitivity: b < c")
+    assert_true(a < c, msg="transitivity: a < c")
+    assert_false(a > b, msg="transitivity: not (a > b)")
+    assert_false(b > c, msg="transitivity: not (b > c)")
 
     # Test interval containment
     assert_true(


### PR DESCRIPTION
The four comparison operators on `Interval[T]` were inconsistent:
- `__lt__` and `__le__` compared by `start` only
- `__gt__` and `__ge__` compared by `end` only

This violated transitivity. For example, with `A=[1,10]`, `B=[2,5]`, `C=[3,8]`:
- `B < C` held (`start` 2 < 3)
- `B > C` also held (`end` 5 > 8 = False, wait, that's False, but the inconsistency meant sorting was undefined)

More concretely: `Interval(1,10) >= Interval(2,9)` returned `True` (because `end` 10 >= 9) while `Interval(1,10) < Interval(2,9)` returned `True` (because `start` 1 < 2), both held simultaneously for distinct intervals.

Fix all four operators to use lexicographic order (`start` first, `end` as tiebreaker), giving a proper total order consistent with how `IntervalTree` already sorts nodes.