### PR TITLE
[MAX] Propose to Add LTX-2's Audio Autoencoder

### DIFF
--- a/max/python/max/experimental/nn/__init__.py
+++ b/max/python/max/experimental/nn/__init__.py
@@ -15,7 +15,7 @@
 from .conv import Conv2d
 from .dropout import Dropout
 from .embedding import Embedding
-from .linear import Linear
+from .linear import Identity, Linear
 from .module import Module, module_dataclass
 from .norm import GemmaRMSNorm, GroupNorm, LayerNorm, RMSNorm
 from .rope import RotaryEmbedding, TransposedRotaryEmbedding
@@ -27,6 +27,7 @@ __all__ = [
     "Embedding",
     "GemmaRMSNorm",
     "GroupNorm",
+    "Identity",
     "LayerNorm",
     "Linear",
     "Module",

--- a/max/python/max/experimental/nn/__init__.py
+++ b/max/python/max/experimental/nn/__init__.py
@@ -13,6 +13,7 @@
 """Module implementation using eager tensors."""
 
 from .conv import Conv2d
+from .dropout import Dropout
 from .embedding import Embedding
 from .linear import Linear
 from .module import Module, module_dataclass
@@ -22,6 +23,7 @@ from .sequential import ModuleList, Sequential
 
 __all__ = [
     "Conv2d",
+    "Dropout",
     "Embedding",
     "GemmaRMSNorm",
     "GroupNorm",

--- a/max/python/max/experimental/nn/dropout.py
+++ b/max/python/max/experimental/nn/dropout.py
@@ -14,8 +14,9 @@
 
 from __future__ import annotations
 
-from max.experimental.nn import Module
 from max.experimental.tensor import Tensor
+
+from .module import Module
 
 
 class Dropout(Module[[Tensor], Tensor]):

--- a/max/python/max/experimental/nn/dropout.py
+++ b/max/python/max/experimental/nn/dropout.py
@@ -1,0 +1,50 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""A Module for dropout layers."""
+
+from __future__ import annotations
+
+from max.experimental.nn import Module
+from max.experimental.tensor import Tensor
+
+
+class Dropout(Module[[Tensor], Tensor]):
+    """Dropout module for regularization.
+
+    During inference (which is the primary use case in MAX), this module
+    acts as a pass-through and returns the input unchanged.
+
+    Args:
+        p: Probability of an element to be zeroed during training.
+    """
+
+    def __init__(self, p: float = 0.5) -> None:
+        """Initialize Dropout module.
+
+        Args:
+            p: Dropout probability (unused during inference).
+        """
+        super().__init__()
+        self.p = p
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Apply dropout (no-op during inference).
+
+        Args:
+            x: Input tensor.
+
+        Returns:
+            The input tensor unchanged during inference.
+        """
+        # During inference, dropout is a no-op
+        return x

--- a/max/python/max/experimental/nn/linear.py
+++ b/max/python/max/experimental/nn/linear.py
@@ -97,3 +97,17 @@ class Linear(Module[[Tensor], Tensor]):
             The result of applying the linear transformation to the tensor.
         """
         return x @ self.weight.T + self.bias
+
+
+class Identity(Module[[Tensor], Tensor]):
+    """A placeholder module that returns the input as-is."""
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Returns the input tensor as-is.
+
+        Args:
+            x: The input tensor
+        Returns:
+            The input tensor as-is.
+        """
+        return x

--- a/max/python/max/pipelines/architectures/autoencoders/__init__.py
+++ b/max/python/max/pipelines/architectures/autoencoders/__init__.py
@@ -13,3 +13,4 @@
 
 from .autoencoder_kl import AutoencoderKLModel
 from .autoencoder_kl_flux2 import AutoencoderKLFlux2Model
+from .autoencoder_kl_ltx2_audio import AutoencoderKLLTX2AudioModel

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -827,10 +827,11 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
         )
 
     def load_model(self) -> Any:
-        """Load and compile the decoder and encoder models with BatchNorm statistics.
+        """Load and compile the decoder model with latent normalization statistics.
 
-        Extracts BatchNorm statistics (latents_mean, latents_std) which are specific to LTX2, then
-        delegates to base class for weight loading and model compilation.
+        Extracts latent normalization statistics (latents_mean, latents_std) which
+        are specific to LTX2 audio, then delegates to base class for weight loading
+        and model compilation.
 
         Returns:
             Compiled decoder model callable.

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -793,8 +793,10 @@ class PostprocessAndDecode(nn.Module[[Tensor], Tensor]):
         self,
         latents_bclm: Tensor,
     ) -> Tensor:
-        # Denormalization
-        latents = latents_bclm * self.latents_std + self.latents_mean
+        # Denormalization: reshape [C] stats to [1, C, 1, 1] for broadcasting over [B, C, T, F]
+        std = self.latents_std.reshape((1, self._num_channels, 1, 1))
+        mean = self.latents_mean.reshape((1, self._num_channels, 1, 1))
+        latents = latents_bclm * std + mean
 
         decoded = self.decoder(latents)
         # TODO: Add vocoder here too?

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -692,7 +692,7 @@ class AutoencoderKLLTX2Audio(nn.Module[[Tensor], Tensor]):
         return self.decoder(z)
 
 
-class PostprocessAndDecode(nn.Module[[Tensor, Tensor, Tensor], Tensor]):
+class PostprocessAndDecode(nn.Module[[Tensor], Tensor]):
     """Fused BN-denorm + VAE decode in a single compiled graph.
 
     Eliminates the inter-graph boundary and intermediate tensor materialization
@@ -728,27 +728,15 @@ class PostprocessAndDecode(nn.Module[[Tensor, Tensor, Tensor], Tensor]):
         return decoded
 
     def input_types(self) -> tuple[TensorType, ...]:
-        return (
-            TensorType(
-                self._dtype,
-                shape=[
-                    "batch_size",
-                    self._num_channels,
-                    "audio_num_frames",
-                    "num_mel_bins",
-                ],
-                device=self._device,
-            ),
-            TensorType(
-                self._dtype,
-                shape=[self._num_channels],
-                device=self._device,
-            ),
-            TensorType(
-                self._dtype,
-                shape=[self._num_channels],
-                device=self._device,
-            ),
+        return TensorType(
+            self._dtype,
+            shape=[
+                "batch_size",
+                self._num_channels,
+                "audio_num_frames",
+                "num_mel_bins",
+            ],
+            device=self._device,
         )
 
 
@@ -862,7 +850,7 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
                 fused_weights["latents_std"] = weight_data
 
         with F.lazy():
-            autoencoder = AutoencoderKLFlux2(self.config)
+            autoencoder = AutoencoderKLLTX2Audio(self.config)
             fused = PostprocessAndDecode(
                 decoder=autoencoder.decoder,
                 bn_mean=self.bn_running_mean,

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -376,7 +376,7 @@ class LTX2AudioUpsample(nn.Module[[Tensor], Tensor]):
                 )
 
     def forward(self, x: Tensor) -> Tensor:
-        x = interpolate_2d_nearest(x, scale_factor=2)
+        x = interpolate_2d_nearest(x, scale_factor=2)  # type: ignore[assignment]
         if self.with_conv:
             x = self.conv(x)
             if self.causality_axis is None or self.causality_axis == "none":

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -600,29 +600,6 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
                 permute=True,
             )
 
-    def input_types(self) -> tuple[TensorType, ...]:
-        if self.dtype is None:
-            raise ValueError("dtype must be set for input_types")
-        if self.device is None:
-            raise ValueError("device must be set for input_types")
-
-        # Hardcoded for num_frames=121, frame_rate=24:
-        #   latent_channels     = 8
-        #   audio_num_frames    = round((121/24) * (16000/160/4)) = 126
-        #   latent_mel_bins     = 64 // 4 = 16
-        return (
-            TensorType(
-                self.dtype,
-                shape=[
-                    "batch_size",
-                    self.latent_channels,
-                    "audio_num_frames",
-                    "latent_mel_bins",
-                ],
-                device=self.device,
-            ),
-        )
-
     def forward(
         self,
         sample: Tensor,
@@ -716,7 +693,7 @@ class AutoencoderKLLTX2Audio(nn.Module[[Tensor], Tensor]):
 
 
 class PostprocessAndDecode(nn.Module[[Tensor, Tensor, Tensor], Tensor]):
-    """Fused BN-denorm + unpatchify + VAE decode in a single compiled graph.
+    """Fused BN-denorm + VAE decode in a single compiled graph.
 
     Eliminates the inter-graph boundary and intermediate tensor materialization
     that previously existed between _postprocess_latents and vae.decode().
@@ -725,12 +702,16 @@ class PostprocessAndDecode(nn.Module[[Tensor, Tensor, Tensor], Tensor]):
     def __init__(
         self,
         decoder: LTX2AudioDecoder,
+        bn_mean: Tensor,
+        bn_var: Tensor,
         num_channels: int,
         device: DeviceRef,
         dtype: DType,
     ) -> None:
         super().__init__()
         self.decoder = decoder
+        self.bn_mean = bn_mean
+        self.bn_var = bn_var
         self._num_channels = num_channels
         self._device = device
         self._dtype = dtype
@@ -738,11 +719,9 @@ class PostprocessAndDecode(nn.Module[[Tensor, Tensor, Tensor], Tensor]):
     def forward(
         self,
         latents_bclm: Tensor,
-        latents_mean: Tensor,
-        latents_std: Tensor,
     ) -> Tensor:
         # Denormalization
-        latents = latents_bclm * latents_std + latents_mean
+        latents = latents_bclm * self.bn_var + self.bn_mean
 
         decoded = self.decoder(latents)
         # TODO: Add vocoder here too?
@@ -774,7 +753,15 @@ class PostprocessAndDecode(nn.Module[[Tensor, Tensor, Tensor], Tensor]):
 
 
 class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
-    """ComponentModel wrapper for LTX2 Audio Autoencoder."""
+    """ComponentModel wrapper for AutoencoderKLLTX2Audio.
+
+    This class provides the ComponentModel interface for AutoencoderKLLTX2Audio,
+    handling configuration, weight loading, model compilation, and BatchNorm
+    statistics for LTX2Audio's latent patchification.
+    """
+
+    bn_running_mean: Tensor
+    bn_running_var: Tensor
 
     def __init__(
         self,
@@ -783,9 +770,14 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
         devices: list[Device],
         weights: Weights,
     ) -> None:
-        self.latents_mean: Tensor | None = None
-        self.latents_std: Tensor | None = None
+        """Initialize AutoencoderKLLTX2AudioModel.
 
+        Args:
+            config: Model configuration dictionary.
+            encoding: Supported encoding for the model.
+            devices: List of devices to use.
+            weights: Model weights.
+        """
         super().__init__(
             config=config,
             encoding=encoding,
@@ -798,7 +790,7 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
     def load_model(self) -> Any:
         """Load and compile the decoder and encoder models with BatchNorm statistics.
 
-        Extracts BatchNorm statistics (bn.*) which are specific to Flux2, then
+        Extracts BatchNorm statistics (latents_mean, latents_std) which are specific to LTX2, then
         delegates to base class for weight loading and model compilation.
 
         Returns:
@@ -819,17 +811,20 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
         bn_mean_data = bn_stats.get("latents_mean")
         bn_var_data = bn_stats.get("latents_std")
 
+        if bn_mean_data is None or bn_var_data is None:
+            raise ValueError(
+                "Latents statistics (latents_mean, latents_std) not loaded. "
+                "Make sure the model weights contain 'latents_mean' and 'latents_std'."
+            )
+
         super().load_model()
 
-        if bn_mean_data is not None or bn_var_data is not None:
-            if bn_mean_data is not None:
-                self.latents_mean = Tensor.from_dlpack(bn_mean_data).to(
-                    self.devices[0]
-                )
-            if bn_var_data is not None:
-                self.latents_std = Tensor.from_dlpack(bn_var_data).to(
-                    self.devices[0]
-                )
+        self.bn_running_mean = Tensor.from_dlpack(bn_mean_data).to(
+            self.devices[0]
+        )
+        self.bn_running_var = Tensor.from_dlpack(bn_var_data).to(
+            self.devices[0]
+        )
 
         return self.model
 
@@ -838,17 +833,13 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
     ) -> Callable[..., Any]:
         """Build a fused postprocess + VAE decode compiled graph.
 
-        Combines BN denormalization, unpatchify, and VAE decoding into a single
-        compiled graph, eliminating the intermediate tensor and device sync
-        between the two previously separate compiled graphs.
-
         Args:
             device: Target device for the compiled graph.
-            num_channels: Number of latent channels (bn.running_mean shape[0]).
+            num_channels: Number of latent channels (latents_mean shape[0]).
 
         Returns:
-            Compiled callable taking (latents_bhwc, bn_mean, bn_var) and
-            returning the decoded image tensor.
+            Compiled callable taking (latents_bsc, h_carrier, w_carrier)
+            and returning the decoded image tensor.
         """
         dtype = self.config.dtype
         device_ref = DeviceRef.from_device(device)
@@ -862,11 +853,20 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
             if key.startswith("decoder."):
                 # decoder.X -> decoder.X (PostprocessAndDecode.decoder.X)
                 fused_weights[key] = weight_data
+            elif key.startswith("post_quant_conv."):
+                # post_quant_conv.X -> decoder.post_quant_conv.X
+                fused_weights[f"decoder.{key}"] = weight_data
+            elif key == "latents_mean":
+                fused_weights["latents_mean"] = weight_data
+            elif key == "latents_std":
+                fused_weights["latents_std"] = weight_data
 
         with F.lazy():
-            autoencoder = AutoencoderKLLTX2Audio(self.config)
+            autoencoder = AutoencoderKLFlux2(self.config)
             fused = PostprocessAndDecode(
                 decoder=autoencoder.decoder,
+                bn_mean=self.bn_running_mean,
+                bn_var=self.bn_running_var,
                 num_channels=num_channels,
                 device=device_ref,
                 dtype=dtype,
@@ -887,16 +887,7 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
 
         Returns:
             SimpleNamespace: Object containing running_mean and running_var attributes.
-
-        Raises:
-            ValueError: If BatchNorm statistics are not loaded.
         """
-        if self.latents_mean is None or self.latents_std is None:
-            raise ValueError(
-                "BatchNorm statistics (running_mean, running_var) not loaded. "
-                "Make sure the model weights contain 'latents_mean' and 'latents_std'."
-            )
-
         return SimpleNamespace(
-            running_mean=self.latents_mean, running_var=self.latents_std
+            running_mean=self.bn_running_mean, running_var=self.bn_running_var
         )

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -765,11 +765,15 @@ class AutoencoderKLLTX2Audio(nn.Module[[Tensor], Tensor]):
         return self.decoder(z)
 
 
-class PostprocessAndDecode(nn.Module[[Tensor], Tensor]):
-    """Fused BN-denorm + VAE decode in a single compiled graph.
+class PostprocessAndDecode(nn.Module[..., Tensor]):
+    """Fused latent denorm + unpack + VAE decode in a single compiled graph.
 
     Eliminates the inter-graph boundary and intermediate tensor materialization
-    that previously existed between _postprocess_latents and vae.decode().
+    by fusing the _denormalize_audio_latents, _unpack_audio_latents, and
+    audio_vae.decode steps from the diffusers pipeline.
+
+    Accepts patchified latents in (B, T, D) shape, where
+    D = latent_channels * latent_mel_bins (e.g. 8 * 16 = 128).
     """
 
     def __init__(
@@ -778,6 +782,7 @@ class PostprocessAndDecode(nn.Module[[Tensor], Tensor]):
         latents_mean: Tensor,
         latents_std: Tensor,
         num_channels: int,
+        latent_mel_bins: int,
         device: DeviceRef,
         dtype: DType,
     ) -> None:
@@ -786,32 +791,42 @@ class PostprocessAndDecode(nn.Module[[Tensor], Tensor]):
         self.latents_mean = latents_mean
         self.latents_std = latents_std
         self._num_channels = num_channels
+        self._latent_mel_bins = latent_mel_bins
         self._device = device
         self._dtype = dtype
 
     def forward(
         self,
-        latents_bclm: Tensor,
+        latents_btd: Tensor,
     ) -> Tensor:
-        # Denormalization: reshape [C] stats to [1, C, 1, 1] for broadcasting over [B, C, T, F]
-        std = self.latents_std.reshape((1, self._num_channels, 1, 1))
-        mean = self.latents_mean.reshape((1, self._num_channels, 1, 1))
-        latents = latents_bclm * std + mean
+        """Run latent denorm + unpack + VAE decode in one fused graph.
 
-        decoded = self.decoder(latents)
-        # TODO: Add vocoder here too?
-        return decoded
+        Args:
+            latents_btd: Normalized patchified latent tensor of shape (B, T, D).
+
+        Returns:
+            Decoded mel-spectrogram tensor.
+        """
+        # Denormalization: (B, T, D) * (D,) → element-wise broadcast on last dim
+        latents_btd = latents_btd * self.latents_std + self.latents_mean
+
+        # Unpack patchified (B, T, D) → spatial (B, C, T, M)
+        # D = C * M, where C = latent_channels, M = latent_mel_bins
+        batch = latents_btd.shape[0]
+        t = latents_btd.shape[1]
+        latent_channels = self._num_channels // self._latent_mel_bins
+        latents = F.reshape(
+            latents_btd, (batch, t, latent_channels, self._latent_mel_bins)
+        )
+        latents = F.permute(latents, (0, 2, 1, 3))  # (B, T, C, M) → (B, C, T, M)
+
+        return self.decoder(latents)
 
     def input_types(self) -> tuple[TensorType, ...]:
         return (
             TensorType(
                 self._dtype,
-                shape=[
-                    "batch_size",
-                    self._num_channels,
-                    "audio_num_frames",
-                    "num_mel_bins",
-                ],
+                shape=["batch_size", "audio_num_frames", self._num_channels],
                 device=self._device,
             ),
         )
@@ -890,16 +905,22 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
         return self.model
 
     def build_fused_decode(
-        self, device: Device, num_channels: int
+        self, device: Device, num_channels: int, latent_mel_bins: int
     ) -> Callable[..., Any]:
         """Build a fused postprocess + VAE decode compiled graph.
 
+        Combines latent denormalization, unpacking from patchified (B, T, D)
+        to spatial (B, C, T, M), and VAE decoding into a single compiled graph.
+
         Args:
             device: Target device for the compiled graph.
-            num_channels: Number of latent channels (latents_mean shape[0]).
+            num_channels: Patchified latent feature size D = latent_channels *
+                latent_mel_bins (equals latents_mean.shape[0]).
+            latent_mel_bins: Number of mel bins in the latent space
+                (mel_bins // LATENT_DOWNSAMPLE_FACTOR, typically 16).
 
         Returns:
-            Compiled callable taking a latent tensor ``latents_bclm`` and
+            Compiled callable taking a patchified latent tensor (B, T, D) and
             returning the decoded mel-spectrogram tensor.
         """
         dtype = self.config.dtype
@@ -929,6 +950,7 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
                 latents_mean=self.latents_mean,
                 latents_std=self.latents_std,
                 num_channels=num_channels,
+                latent_mel_bins=latent_mel_bins,
                 device=device_ref,
                 dtype=dtype,
             )

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -762,7 +762,11 @@ class PostprocessAndDecode(nn.Module[[Tensor], Tensor]):
         latents_bclm: Tensor,
     ) -> Tensor:
         # Denormalization
-        latents = latents_bclm * self.latents_std + self.latents_mean
+        # latents_mean/std are typically [128]. Reshape to [1, C, 1, M] to broadcast
+        # across [N, C, F, M].
+        mean = self.latents_mean.reshape([1, self._num_channels, 1, -1])
+        std = self.latents_std.reshape([1, self._num_channels, 1, -1])
+        latents = latents_bclm * std + mean
 
         decoded = self.decoder(latents)
         # TODO: Add vocoder here too?

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -630,14 +630,14 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
         """Returns the expected input types for the decoder."""
         return (
             TensorType(
-                self.dtype or DType.bfloat16,
+                self.dtype,
                 shape=[
                     "batch_size",
                     self.latent_channels,
                     "audio_num_frames",
                     "num_mel_bins",
                 ],
-                device=self.device or DeviceRef.from_device(Device("cpu")),
+                device=self.device,
             ),
         )
 

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -850,12 +850,8 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
 
         super().load_model()
 
-        self.latents_mean = Tensor.from_dlpack(bn_mean_data).to(
-            self.devices[0]
-        )
-        self.latents_std = Tensor.from_dlpack(bn_std_data).to(
-            self.devices[0]
-        )
+        self.latents_mean = Tensor.from_dlpack(bn_mean_data).to(self.devices[0])
+        self.latents_std = Tensor.from_dlpack(bn_std_data).to(self.devices[0])
 
         return self.model
 

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -415,42 +415,6 @@ class LTX2AudioUpsample(nn.Module[[Tensor], Tensor]):
         return x
 
 
-class LTX2AudioAudioPatchifier(nn.Module[[Tensor], Tensor]):
-    """Patchifier for spectrogram/audio latents."""
-
-    def __init__(
-        self,
-        patch_size: int,
-        sample_rate: int = 16000,
-        hop_length: int = 160,
-        audio_latent_downsample_factor: int = 4,
-        is_causal: bool = True,
-    ):
-        self.hop_length = hop_length
-        self.sample_rate = sample_rate
-        self.audio_latent_downsample_factor = audio_latent_downsample_factor
-        self.is_causal = is_causal
-        self._patch_size = (1, patch_size, patch_size)
-
-    def patchify(self, audio_latents: Tensor) -> Tensor:
-        batch, channels, time, freq = audio_latents.shape
-        return audio_latents.permute([0, 2, 1, 3]).reshape(
-            (batch, time, channels * freq)
-        )
-
-    def unpatchify(
-        self, audio_latents: Tensor, channels: int, mel_bins: int
-    ) -> Tensor:
-        batch, time, _ = audio_latents.shape
-        return audio_latents.reshape((batch, time, channels, mel_bins)).permute(
-            [0, 2, 1, 3]
-        )
-
-    @property
-    def patch_size(self) -> tuple[int, int, int]:
-        return self._patch_size
-
-
 class LTX2AudioDecoderMid(nn.Module[..., Any]):
     """Container for the middle block of the LTX2 Audio Decoder."""
 
@@ -504,13 +468,6 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
         self.mel_bins = mel_bins
         self.device = device
         self.dtype = dtype
-        self.patchifier = LTX2AudioAudioPatchifier(
-            patch_size=1,
-            audio_latent_downsample_factor=LATENT_DOWNSAMPLE_FACTOR,
-            sample_rate=sample_rate,
-            hop_length=mel_hop_length,
-            is_causal=is_causal,
-        )
 
         self.base_channels = base_channels
         self.temb_ch = 0

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -818,7 +818,9 @@ class PostprocessAndDecode(nn.Module[..., Tensor]):
         latents = F.reshape(
             latents_btd, (batch, t, latent_channels, self._latent_mel_bins)
         )
-        latents = F.permute(latents, (0, 2, 1, 3))  # (B, T, C, M) → (B, C, T, M)
+        latents = F.permute(
+            latents, (0, 2, 1, 3)
+        )  # (B, T, C, M) → (B, C, T, M)
 
         return self.decoder(latents)
 

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -762,11 +762,7 @@ class PostprocessAndDecode(nn.Module[[Tensor], Tensor]):
         latents_bclm: Tensor,
     ) -> Tensor:
         # Denormalization
-        # latents_mean/std are typically [128]. Reshape to [1, C, 1, M] to broadcast
-        # across [N, C, F, M].
-        mean = self.latents_mean.reshape([1, self._num_channels, 1, -1])
-        std = self.latents_std.reshape([1, self._num_channels, 1, -1])
-        latents = latents_bclm * std + mean
+        latents = latents_bclm * self.latents_std + self.latents_mean
 
         decoded = self.decoder(latents)
         # TODO: Add vocoder here too?

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -431,7 +431,7 @@ class LTX2AudioAudioPatchifier(nn.Module[[Tensor], Tensor]):
         return self._patch_size
 
 
-class LTX2AudioDecoderMid(nn.Module[Any, Any]):
+class LTX2AudioDecoderMid(nn.Module):
     """Container for the middle block of the LTX2 Audio Decoder."""
 
     block_1: LTX2AudioResnetBlock
@@ -439,7 +439,7 @@ class LTX2AudioDecoderMid(nn.Module[Any, Any]):
     block_2: LTX2AudioResnetBlock
 
 
-class LTX2AudioDecoderStage(nn.Module[Any, Any]):
+class LTX2AudioDecoderStage(nn.Module):
     """Container for a single stage (level) of the LTX2 Audio Decoder."""
 
     block: nn.ModuleList[LTX2AudioResnetBlock]

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -630,7 +630,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
         """Returns the expected input types for the decoder."""
         return (
             TensorType(
-                self.dtype,
+                self.dtype if self.dtype is not None else DType.bfloat16,
                 shape=[
                     "batch_size",
                     self.latent_channels,

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -197,7 +197,7 @@ class LTX2AudioAttnBlock(nn.Module[[Tensor], Tensor]):
         return x + self.proj_out(h)
 
 
-class LTX2AudioResnetBlock(nn.Module[[Tensor, Tensor | None], Tensor]):
+class LTX2AudioResnetBlock(nn.Module[..., Tensor]):
     def __init__(
         self,
         in_channels: int,
@@ -431,7 +431,7 @@ class LTX2AudioAudioPatchifier(nn.Module[[Tensor], Tensor]):
         return self._patch_size
 
 
-class LTX2AudioDecoderMid(nn.Module):
+class LTX2AudioDecoderMid(nn.Module[..., Any]):
     """Container for the middle block of the LTX2 Audio Decoder."""
 
     block_1: LTX2AudioResnetBlock
@@ -439,7 +439,7 @@ class LTX2AudioDecoderMid(nn.Module):
     block_2: LTX2AudioResnetBlock
 
 
-class LTX2AudioDecoderStage(nn.Module):
+class LTX2AudioDecoderStage(nn.Module[..., Any]):
     """Container for a single stage (level) of the LTX2 Audio Decoder."""
 
     block: nn.ModuleList[LTX2AudioResnetBlock]

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -878,7 +878,7 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
         Returns:
             Compiled decoder model callable.
         """
-        bn_stats = {}
+        latents_stats = {}
 
         for key, value in self.weights.items():
             if key in ("latents_mean", "latents_std"):
@@ -888,12 +888,12 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
                     if weight_data.dtype.is_float() and target_dtype.is_float():
                         weight_data = weight_data.astype(target_dtype)
                     # Non-float left as-is; running_mean/var are typically float.
-                bn_stats[key] = weight_data.data
+                latents_stats[key] = weight_data.data
 
-        bn_mean_data = bn_stats.get("latents_mean")
-        bn_std_data = bn_stats.get("latents_std")
+        latents_mean_data = latents_stats.get("latents_mean")
+        latents_std_data = latents_stats.get("latents_std")
 
-        if bn_mean_data is None or bn_std_data is None:
+        if latents_mean_data is None or latents_std_data is None:
             raise ValueError(
                 "Latents statistics (latents_mean, latents_std) not loaded. "
                 "Make sure the model weights contain 'latents_mean' and 'latents_std'."
@@ -901,8 +901,12 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
 
         super().load_model()
 
-        self.latents_mean = Tensor.from_dlpack(bn_mean_data).to(self.devices[0])
-        self.latents_std = Tensor.from_dlpack(bn_std_data).to(self.devices[0])
+        self.latents_mean = Tensor.from_dlpack(latents_mean_data).to(
+            self.devices[0]
+        )
+        self.latents_std = Tensor.from_dlpack(latents_std_data).to(
+            self.devices[0]
+        )
 
         return self.model
 
@@ -967,12 +971,12 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
     def bn(self) -> SimpleNamespace:
         """Property to access BatchNorm statistics, compatible with diffusers API.
 
-        Returns a SimpleNamespace with running_mean and running_var attributes
-        for compatibility with pipeline code that accesses self.vae.bn.running_mean.
+        Returns a SimpleNamespace with latents_mean and latents_std attributes
+        for compatibility with pipeline code that accesses self.vae.bn.latents_mean.
 
         Returns:
-            SimpleNamespace: Object containing running_mean and running_var attributes.
+            SimpleNamespace: Object containing latents_mean and latents_std attributes.
         """
         return SimpleNamespace(
-            running_mean=self.latents_mean, running_var=self.latents_std
+            latents_mean=self.latents_mean, latents_std=self.latents_std
         )

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -48,9 +48,11 @@ class LTX2AudioCausalConv2d(nn.Module[[Tensor], Tensor]):
         groups: int = 1,
         bias: bool = True,
         causality_axis: str = "height",
+        dtype: DType | None = None,
     ) -> None:
         super().__init__()
         self.causality_axis = causality_axis
+        self._dtype = dtype
         kernel_size = (
             (kernel_size, kernel_size)
             if isinstance(kernel_size, int)
@@ -109,6 +111,7 @@ class LTX2AudioCausalConv2d(nn.Module[[Tensor], Tensor]):
             num_groups=groups,
             has_bias=bias,
             permute=True,
+            dtype=self._dtype,
         )
 
     def forward(self, x: Tensor) -> Tensor:
@@ -137,6 +140,7 @@ class LTX2AudioAttnBlock(nn.Module[[Tensor], Tensor]):
         self,
         in_channels: int,
         norm_type: str = "group",
+        dtype: DType | None = None,
     ) -> None:
         super().__init__()
         self.in_channels = in_channels
@@ -156,24 +160,28 @@ class LTX2AudioAttnBlock(nn.Module[[Tensor], Tensor]):
             in_channels=in_channels,
             out_channels=in_channels,
             permute=True,
+            dtype=dtype,
         )
         self.k = nn.Conv2d(
             kernel_size=1,
             in_channels=in_channels,
             out_channels=in_channels,
             permute=True,
+            dtype=dtype,
         )
         self.v = nn.Conv2d(
             kernel_size=1,
             in_channels=in_channels,
             out_channels=in_channels,
             permute=True,
+            dtype=dtype,
         )
         self.proj_out = nn.Conv2d(
             kernel_size=1,
             in_channels=in_channels,
             out_channels=in_channels,
             permute=True,
+            dtype=dtype,
         )
 
     def forward(self, x: Tensor) -> Tensor:
@@ -207,6 +215,7 @@ class LTX2AudioResnetBlock(nn.Module[..., Tensor]):
         temb_channels: int = 512,
         norm_type: str = "group",
         causality_axis: str | None = "height",
+        dtype: DType | None = None,
     ) -> None:
         super().__init__()
         self.causality_axis = causality_axis
@@ -242,6 +251,7 @@ class LTX2AudioResnetBlock(nn.Module[..., Tensor]):
                 kernel_size=3,
                 stride=1,
                 causality_axis=causality_axis,
+                dtype=dtype,
             )
         else:
             self.conv1 = nn.Conv2d(
@@ -251,6 +261,7 @@ class LTX2AudioResnetBlock(nn.Module[..., Tensor]):
                 stride=1,
                 padding=1,
                 permute=True,
+                dtype=dtype,
             )
         if temb_channels > 0:
             self.temb_proj = nn.Linear(temb_channels, out_channels)
@@ -272,6 +283,7 @@ class LTX2AudioResnetBlock(nn.Module[..., Tensor]):
                 kernel_size=3,
                 stride=1,
                 causality_axis=causality_axis,
+                dtype=dtype,
             )
         else:
             self.conv2 = nn.Conv2d(
@@ -281,6 +293,7 @@ class LTX2AudioResnetBlock(nn.Module[..., Tensor]):
                 stride=1,
                 padding=1,
                 permute=True,
+                dtype=dtype,
             )
         if self.in_channels != self.out_channels:
             if self.use_conv_shortcut:
@@ -292,6 +305,7 @@ class LTX2AudioResnetBlock(nn.Module[..., Tensor]):
                         kernel_size=3,
                         stride=1,
                         causality_axis=causality_axis,
+                        dtype=dtype,
                     )
                 else:
                     self.conv_shortcut = nn.Conv2d(
@@ -301,6 +315,7 @@ class LTX2AudioResnetBlock(nn.Module[..., Tensor]):
                         stride=1,
                         padding=1,
                         permute=True,
+                        dtype=dtype,
                     )
             else:
                 self.nin_shortcut: nn.Module[[Tensor], Tensor]
@@ -311,6 +326,7 @@ class LTX2AudioResnetBlock(nn.Module[..., Tensor]):
                         kernel_size=1,
                         stride=1,
                         causality_axis=causality_axis,
+                        dtype=dtype,
                     )
                 else:
                     self.nin_shortcut = nn.Conv2d(
@@ -320,6 +336,7 @@ class LTX2AudioResnetBlock(nn.Module[..., Tensor]):
                         stride=1,
                         padding=0,
                         permute=True,
+                        dtype=dtype,
                     )
 
     def forward(self, x: Tensor, temb: Tensor | None = None) -> Tensor:
@@ -351,6 +368,7 @@ class LTX2AudioUpsample(nn.Module[[Tensor], Tensor]):
         in_channels: int,
         with_conv: bool,
         causality_axis: str | None = "height",
+        dtype: DType | None = None,
     ) -> None:
         super().__init__()
         self.with_conv = with_conv
@@ -364,6 +382,7 @@ class LTX2AudioUpsample(nn.Module[[Tensor], Tensor]):
                     kernel_size=3,
                     stride=1,
                     causality_axis=causality_axis,
+                    dtype=dtype,
                 )
             else:
                 self.conv = nn.Conv2d(
@@ -373,6 +392,7 @@ class LTX2AudioUpsample(nn.Module[[Tensor], Tensor]):
                     stride=1,
                     padding=1,
                     permute=True,
+                    dtype=dtype,
                 )
 
     def forward(self, x: Tensor) -> Tensor:
@@ -519,6 +539,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
                 kernel_size=3,
                 stride=1,
                 causality_axis=self.causality_axis,
+                dtype=self.dtype,
             )
         else:
             self.conv_in = nn.Conv2d(
@@ -528,6 +549,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
                 stride=1,
                 padding=1,
                 permute=True,
+                dtype=self.dtype,
             )
         self.non_linearity = activation_function_from_name("silu")
         self.mid = LTX2AudioDecoderMid()
@@ -538,10 +560,11 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
             dropout=dropout,
             norm_type=self.norm_type,
             causality_axis=self.causality_axis,
+            dtype=self.dtype,
         )
         if mid_block_add_attention:
             self.mid.attn_1 = LTX2AudioAttnBlock(
-                base_block_channels, norm_type=self.norm_type
+                base_block_channels, norm_type=self.norm_type, dtype=self.dtype
             )
         else:
             self.mid.attn_1 = nn.Identity()
@@ -552,6 +575,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
             dropout=dropout,
             norm_type=self.norm_type,
             causality_axis=self.causality_axis,
+            dtype=self.dtype,
         )
 
         self.up: nn.ModuleList[LTX2AudioDecoderStage] = nn.ModuleList()
@@ -573,6 +597,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
                         dropout=dropout,
                         norm_type=self.norm_type,
                         causality_axis=self.causality_axis,
+                        dtype=self.dtype,
                     )
                 )
                 block_in = block_out
@@ -580,13 +605,18 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
                     if curr_res in self.attn_resolutions:
                         stage.attn.append(
                             LTX2AudioAttnBlock(
-                                block_in, norm_type=self.norm_type
+                                block_in,
+                                norm_type=self.norm_type,
+                                dtype=self.dtype,
                             )
                         )
 
             if level != 0:
                 stage.upsample = LTX2AudioUpsample(
-                    block_in, True, causality_axis=self.causality_axis
+                    block_in,
+                    True,
+                    causality_axis=self.causality_axis,
+                    dtype=self.dtype,
                 )
                 curr_res *= 2
 
@@ -615,6 +645,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
                 kernel_size=3,
                 stride=1,
                 causality_axis=self.causality_axis,
+                dtype=self.dtype,
             )
         else:
             self.conv_out = nn.Conv2d(
@@ -624,6 +655,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
                 stride=1,
                 padding=1,
                 permute=True,
+                dtype=self.dtype,
             )
 
     def input_types(self) -> tuple[TensorType, ...]:

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -458,7 +458,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
     def __init__(
         self,
         base_channels: int = 128,
-        output_channels: int = 1,
+        out_channels: int = 1,
         num_res_blocks: int = 2,
         attn_resolutions: list[int] | None = None,
         in_channels: int = 2,
@@ -498,7 +498,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
         self.num_res_blocks = num_res_blocks
         self.resolution = resolution
         self.in_channels = in_channels
-        self.out_ch = output_channels
+        self.out_ch = out_channels
         self.give_pre_end = False
         self.tanh_out = False
         self.norm_type = norm_type
@@ -611,7 +611,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
         if self.causality_axis is not None:
             self.conv_out = LTX2AudioCausalConv2d(
                 in_channels=final_block_channels,
-                out_channels=output_channels,
+                out_channels=self.out_ch,
                 kernel_size=3,
                 stride=1,
                 causality_axis=self.causality_axis,
@@ -620,11 +620,26 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
             self.conv_out = nn.Conv2d(
                 kernel_size=3,
                 in_channels=final_block_channels,
-                out_channels=output_channels,
+                out_channels=self.out_ch,
                 stride=1,
                 padding=1,
                 permute=True,
             )
+
+    def input_types(self) -> tuple[TensorType, ...]:
+        """Returns the expected input types for the decoder."""
+        return (
+            TensorType(
+                self.dtype or DType.bfloat16,
+                shape=[
+                    "batch_size",
+                    self.latent_channels,
+                    "audio_num_frames",
+                    "num_mel_bins",
+                ],
+                device=self.device or DeviceRef.from_device(Device("cpu")),
+            ),
+        )
 
     def forward(
         self,
@@ -695,7 +710,7 @@ class AutoencoderKLLTX2Audio(nn.Module[[Tensor], Tensor]):
         super().__init__()
         self.decoder = LTX2AudioDecoder(
             base_channels=config.base_channels,
-            output_channels=config.output_channels,
+            out_channels=config.out_channels,
             num_res_blocks=config.num_res_blocks,
             attn_resolutions=config.attn_resolutions,
             in_channels=config.in_channels,
@@ -728,16 +743,16 @@ class PostprocessAndDecode(nn.Module[[Tensor], Tensor]):
     def __init__(
         self,
         decoder: LTX2AudioDecoder,
-        bn_mean: Tensor,
-        bn_var: Tensor,
+        latents_mean: Tensor,
+        latents_std: Tensor,
         num_channels: int,
         device: DeviceRef,
         dtype: DType,
     ) -> None:
         super().__init__()
         self.decoder = decoder
-        self.bn_mean = bn_mean
-        self.bn_var = bn_var
+        self.latents_mean = latents_mean
+        self.latents_std = latents_std
         self._num_channels = num_channels
         self._device = device
         self._dtype = dtype
@@ -747,7 +762,7 @@ class PostprocessAndDecode(nn.Module[[Tensor], Tensor]):
         latents_bclm: Tensor,
     ) -> Tensor:
         # Denormalization
-        latents = latents_bclm * self.bn_var + self.bn_mean
+        latents = latents_bclm * self.latents_std + self.latents_mean
 
         decoded = self.decoder(latents)
         # TODO: Add vocoder here too?
@@ -776,8 +791,8 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
     statistics for LTX2Audio's latent patchification.
     """
 
-    bn_running_mean: Tensor
-    bn_running_var: Tensor
+    latents_mean: Tensor
+    latents_std: Tensor
 
     def __init__(
         self,
@@ -825,9 +840,9 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
                 bn_stats[key] = weight_data.data
 
         bn_mean_data = bn_stats.get("latents_mean")
-        bn_var_data = bn_stats.get("latents_std")
+        bn_std_data = bn_stats.get("latents_std")
 
-        if bn_mean_data is None or bn_var_data is None:
+        if bn_mean_data is None or bn_std_data is None:
             raise ValueError(
                 "Latents statistics (latents_mean, latents_std) not loaded. "
                 "Make sure the model weights contain 'latents_mean' and 'latents_std'."
@@ -835,10 +850,10 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
 
         super().load_model()
 
-        self.bn_running_mean = Tensor.from_dlpack(bn_mean_data).to(
+        self.latents_mean = Tensor.from_dlpack(bn_mean_data).to(
             self.devices[0]
         )
-        self.bn_running_var = Tensor.from_dlpack(bn_var_data).to(
+        self.latents_std = Tensor.from_dlpack(bn_std_data).to(
             self.devices[0]
         )
 
@@ -854,8 +869,8 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
             num_channels: Number of latent channels (latents_mean shape[0]).
 
         Returns:
-            Compiled callable taking (latents_bsc, h_carrier, w_carrier)
-            and returning the decoded image tensor.
+            Compiled callable taking a latent tensor ``latents_bclm`` and
+            returning the decoded mel-spectrogram tensor.
         """
         dtype = self.config.dtype
         device_ref = DeviceRef.from_device(device)
@@ -881,8 +896,8 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
             autoencoder = AutoencoderKLLTX2Audio(self.config)
             fused = PostprocessAndDecode(
                 decoder=autoencoder.decoder,
-                bn_mean=self.bn_running_mean,
-                bn_var=self.bn_running_var,
+                latents_mean=self.latents_mean,
+                latents_std=self.latents_std,
                 num_channels=num_channels,
                 device=device_ref,
                 dtype=dtype,
@@ -905,5 +920,5 @@ class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
             SimpleNamespace: Object containing running_mean and running_var attributes.
         """
         return SimpleNamespace(
-            running_mean=self.bn_running_mean, running_var=self.bn_running_var
+            running_mean=self.latents_mean, running_var=self.latents_std
         )

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -140,6 +140,7 @@ class LTX2AudioAttnBlock(nn.Module[[Tensor], Tensor]):
     ) -> None:
         super().__init__()
         self.in_channels = in_channels
+        self.norm: nn.Module[[Tensor], Tensor]
 
         if norm_type == "group":
             self.norm = nn.GroupNorm(
@@ -185,7 +186,7 @@ class LTX2AudioAttnBlock(nn.Module[[Tensor], Tensor]):
         q = q.reshape((batch, channels, height * width)).permute([0, 2, 1])
         k = k.reshape((batch, channels, height * width))
 
-        attn = F.matmul(q, k) * (channels ** (-0.5))
+        attn = F.matmul(q, k) * (int(channels) ** (-0.5))
         attn = F.softmax(attn, axis=-1)
 
         v = v.reshape((batch, channels, height * width))
@@ -223,7 +224,7 @@ class LTX2AudioResnetBlock(nn.Module[[Tensor, Tensor | None], Tensor]):
         self.out_channels = out_channels
         self.use_conv_shortcut = conv_shortcut
 
-        self.norm1: nn.Module
+        self.norm1: nn.Module[[Tensor], Tensor]
         if norm_type == "group":
             self.norm1 = nn.GroupNorm(
                 num_groups=32, num_channels=in_channels, eps=1e-6, affine=True
@@ -233,6 +234,7 @@ class LTX2AudioResnetBlock(nn.Module[[Tensor, Tensor | None], Tensor]):
         else:
             raise ValueError(f"Invalid normalization type: {norm_type}")
         self.non_linearity = activation_function_from_name("silu")
+        self.conv1: nn.Module[[Tensor], Tensor]
         if causality_axis is not None:
             self.conv1 = LTX2AudioCausalConv2d(
                 in_channels,
@@ -252,7 +254,7 @@ class LTX2AudioResnetBlock(nn.Module[[Tensor, Tensor | None], Tensor]):
             )
         if temb_channels > 0:
             self.temb_proj = nn.Linear(temb_channels, out_channels)
-        self.norm2: nn.Module
+        self.norm2: nn.Module[[Tensor], Tensor]
         if norm_type == "group":
             self.norm2 = nn.GroupNorm(
                 num_groups=32, num_channels=out_channels, eps=1e-6, affine=True
@@ -262,6 +264,7 @@ class LTX2AudioResnetBlock(nn.Module[[Tensor, Tensor | None], Tensor]):
         else:
             raise ValueError(f"Invalid normalization type: {norm_type}")
         self.dropout = nn.Dropout(dropout)
+        self.conv2: nn.Module[[Tensor], Tensor]
         if causality_axis is not None:
             self.conv2 = LTX2AudioCausalConv2d(
                 out_channels,
@@ -281,6 +284,7 @@ class LTX2AudioResnetBlock(nn.Module[[Tensor, Tensor | None], Tensor]):
             )
         if self.in_channels != self.out_channels:
             if self.use_conv_shortcut:
+                self.conv_shortcut: nn.Module[[Tensor], Tensor]
                 if causality_axis is not None:
                     self.conv_shortcut = LTX2AudioCausalConv2d(
                         in_channels,
@@ -299,6 +303,7 @@ class LTX2AudioResnetBlock(nn.Module[[Tensor, Tensor | None], Tensor]):
                         permute=True,
                     )
             else:
+                self.nin_shortcut: nn.Module[[Tensor], Tensor]
                 if causality_axis is not None:
                     self.nin_shortcut = LTX2AudioCausalConv2d(
                         in_channels,
@@ -350,7 +355,7 @@ class LTX2AudioUpsample(nn.Module[[Tensor], Tensor]):
         super().__init__()
         self.with_conv = with_conv
         self.causality_axis = causality_axis
-        self.conv: nn.Module
+        self.conv: nn.Module[[Tensor], Tensor]
         if self.with_conv:
             if causality_axis is not None:
                 self.conv = LTX2AudioCausalConv2d(
@@ -426,7 +431,7 @@ class LTX2AudioAudioPatchifier(nn.Module[[Tensor], Tensor]):
         return self._patch_size
 
 
-class LTX2AudioDecoderMid(nn.Module):
+class LTX2AudioDecoderMid(nn.Module[Any, Any]):
     """Container for the middle block of the LTX2 Audio Decoder."""
 
     block_1: LTX2AudioResnetBlock
@@ -434,7 +439,7 @@ class LTX2AudioDecoderMid(nn.Module):
     block_2: LTX2AudioResnetBlock
 
 
-class LTX2AudioDecoderStage(nn.Module):
+class LTX2AudioDecoderStage(nn.Module[Any, Any]):
     """Container for a single stage (level) of the LTX2 Audio Decoder."""
 
     block: nn.ModuleList[LTX2AudioResnetBlock]
@@ -506,7 +511,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
         base_resolution = resolution // (2 ** (self.num_resolutions - 1))
         self.z_shape = (1, latent_channels, base_resolution, base_resolution)
 
-        self.conv_in: nn.Module
+        self.conv_in: nn.Module[[Tensor], Tensor]
         if self.causality_axis is not None:
             self.conv_in = LTX2AudioCausalConv2d(
                 latent_channels,
@@ -589,7 +594,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
 
         final_block_channels = block_in
 
-        self.norm_out: nn.Module
+        self.norm_out: nn.Module[[Tensor], Tensor]
         if self.norm_type == "group":
             self.norm_out = nn.GroupNorm(
                 num_groups=32,
@@ -602,7 +607,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
         else:
             raise ValueError(f"Invalid normalization type: {self.norm_type}")
 
-        self.conv_out: nn.Module
+        self.conv_out: nn.Module[[Tensor], Tensor]
         if self.causality_axis is not None:
             self.conv_out = LTX2AudioCausalConv2d(
                 in_channels=final_block_channels,
@@ -748,16 +753,18 @@ class PostprocessAndDecode(nn.Module[[Tensor], Tensor]):
         # TODO: Add vocoder here too?
         return decoded
 
-    def input_types(self) -> TensorType:
-        return TensorType(
-            self._dtype,
-            shape=[
-                "batch_size",
-                self._num_channels,
-                "audio_num_frames",
-                "num_mel_bins",
-            ],
-            device=self._device,
+    def input_types(self) -> tuple[TensorType, ...]:
+        return (
+            TensorType(
+                self._dtype,
+                shape=[
+                    "batch_size",
+                    self._num_channels,
+                    "audio_num_frames",
+                    "num_mel_bins",
+                ],
+                device=self._device,
+            ),
         )
 
 

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -1,0 +1,902 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""LTX2 Audio Autoencoder Architecture."""
+
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import Any
+
+import max.experimental.functional as F
+from max.driver import Device
+from max.dtype import DType
+from max.experimental import nn
+from max.experimental.nn.common_layers.activation import (
+    activation_function_from_name,
+)
+from max.experimental.tensor import Tensor
+from max.graph import DeviceRef, TensorType
+from max.graph.weights import Weights
+from max.pipelines.lib import SupportedEncoding
+
+from .layers.upsampling import interpolate_2d_nearest
+from .model import BaseAutoencoderModel
+from .model_config import AutoencoderKLLTX2AudioConfig
+
+LATENT_DOWNSAMPLE_FACTOR = 4
+
+
+class LTX2AudioCausalConv2d(nn.Module[[Tensor], Tensor]):
+    """A causal 2D convolution that pads asymmetrically along the causal axis."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int | tuple[int, int],
+        stride: int = 1,
+        dilation: int | tuple[int, int] = 1,
+        groups: int = 1,
+        bias: bool = True,
+        causality_axis: str = "height",
+    ) -> None:
+        super().__init__()
+        self.causality_axis = causality_axis
+        kernel_size = (
+            (kernel_size, kernel_size)
+            if isinstance(kernel_size, int)
+            else kernel_size
+        )
+        dilation = (
+            (dilation, dilation) if isinstance(dilation, int) else dilation
+        )
+
+        pad_h = (kernel_size[0] - 1) * dilation[0]
+        pad_w = (kernel_size[1] - 1) * dilation[1]
+
+        if self.causality_axis == "none":
+            self.padding = (
+                0,
+                0,
+                0,
+                0,
+                pad_h // 2,
+                pad_h - pad_h // 2,
+                pad_w // 2,
+                pad_w - pad_w // 2,
+            )
+        elif self.causality_axis in {"width", "width-compatibility"}:
+            self.padding = (
+                0,
+                0,
+                0,
+                0,
+                pad_h // 2,
+                pad_h - pad_h // 2,
+                pad_w,
+                0,
+            )
+        elif self.causality_axis == "height":
+            self.padding = (
+                0,
+                0,
+                0,
+                0,
+                pad_h,
+                0,
+                pad_w // 2,
+                pad_w - pad_w // 2,
+            )
+        else:
+            raise ValueError(f"Invalid causality_axis: {causality_axis}")
+
+        self.conv = nn.Conv2d(
+            kernel_size=kernel_size,
+            in_channels=in_channels,
+            out_channels=out_channels,
+            stride=stride,
+            padding=0,
+            dilation=dilation,
+            num_groups=groups,
+            has_bias=bias,
+            permute=True,
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = F.pad(x, self.padding)
+        return self.conv(x)
+
+
+class LTX2AudioPixelNorm(nn.Module[[Tensor], Tensor]):
+    """Per-pixel (per-location) RMS normalization layer."""
+
+    def __init__(self, dim: int = 1, eps: float = 1e-8) -> None:
+        super().__init__()
+        self.dim = dim
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        mean_sq = F.mean(x**2, axis=self.dim)
+        rms = F.sqrt(mean_sq + self.eps)
+        return x / rms
+
+
+class LTX2AudioAttnBlock(nn.Module[[Tensor], Tensor]):
+    """Attention block for LTX2 Audio."""
+
+    def __init__(
+        self,
+        in_channels: int,
+        norm_type: str = "group",
+    ) -> None:
+        super().__init__()
+        self.in_channels = in_channels
+
+        if norm_type == "group":
+            self.norm = nn.GroupNorm(
+                num_groups=32, num_channels=in_channels, eps=1e-6, affine=True
+            )
+        elif norm_type == "pixel":
+            self.norm = LTX2AudioPixelNorm(dim=1, eps=1e-6)
+        else:
+            raise ValueError(f"Invalid normalization type: {norm_type}")
+
+        self.q = nn.Conv2d(
+            kernel_size=1,
+            in_channels=in_channels,
+            out_channels=in_channels,
+            permute=True,
+        )
+        self.k = nn.Conv2d(
+            kernel_size=1,
+            in_channels=in_channels,
+            out_channels=in_channels,
+            permute=True,
+        )
+        self.v = nn.Conv2d(
+            kernel_size=1,
+            in_channels=in_channels,
+            out_channels=in_channels,
+            permute=True,
+        )
+        self.proj_out = nn.Conv2d(
+            kernel_size=1,
+            in_channels=in_channels,
+            out_channels=in_channels,
+            permute=True,
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        h = self.norm(x)
+        q = self.q(h)
+        k = self.k(h)
+        v = self.v(h)
+
+        batch, channels, height, width = q.shape
+        # Use F.bmm for attention computation
+        q = q.reshape((batch, channels, height * width)).permute((0, 2, 1))
+        k = k.reshape((batch, channels, height * width))
+
+        attn = F.bmm(q, k) * (channels ** (-0.5))
+        attn = F.softmax(attn, axis=-1)
+
+        v = v.reshape((batch, channels, height * width))
+        attn = attn.permute((0, 2, 1))
+
+        h = F.bmm(v, attn).reshape((batch, channels, height, width))
+
+        return x + self.proj_out(h)
+
+
+class LTX2AudioResnetBlock(nn.Module[[Tensor, Tensor | None], Tensor]):
+    def __init__(
+        self,
+        in_channels: int,
+        out_channels: int | None = None,
+        conv_shortcut: bool = False,
+        dropout: float = 0.0,
+        temb_channels: int = 512,
+        norm_type: str = "group",
+        causality_axis: str = "height",
+    ) -> None:
+        super().__init__()
+        self.causality_axis = causality_axis
+
+        if (
+            self.causality_axis is not None
+            and self.causality_axis != "none"
+            and norm_type == "group"
+        ):
+            raise ValueError(
+                "Causal ResnetBlock with GroupNorm is not supported."
+            )
+        self.in_channels = in_channels
+        out_channels = in_channels if out_channels is None else out_channels
+        self.out_channels = out_channels
+        self.use_conv_shortcut = conv_shortcut
+
+        if norm_type == "group":
+            self.norm1 = nn.GroupNorm(
+                num_groups=32, num_channels=in_channels, eps=1e-6, affine=True
+            )
+        elif norm_type == "pixel":
+            self.norm1 = LTX2AudioPixelNorm(dim=1, eps=1e-6)
+        else:
+            raise ValueError(f"Invalid normalization type: {norm_type}")
+        self.non_linearity = activation_function_from_name("silu")
+        if causality_axis is not None:
+            self.conv1 = LTX2AudioCausalConv2d(
+                in_channels,
+                out_channels,
+                kernel_size=3,
+                stride=1,
+                causality_axis=causality_axis,
+            )
+        else:
+            self.conv1 = nn.Conv2d(
+                kernel_size=3,
+                in_channels=in_channels,
+                out_channels=out_channels,
+                stride=1,
+                padding=1,
+                permute=True,
+            )
+        if temb_channels > 0:
+            self.temb_proj = nn.Linear(temb_channels, out_channels)
+        if norm_type == "group":
+            self.norm2 = nn.GroupNorm(
+                num_groups=32, num_channels=out_channels, eps=1e-6, affine=True
+            )
+        elif norm_type == "pixel":
+            self.norm2 = LTX2AudioPixelNorm(dim=1, eps=1e-6)
+        else:
+            raise ValueError(f"Invalid normalization type: {norm_type}")
+        self.dropout = nn.Dropout(dropout)
+        if causality_axis is not None:
+            self.conv2 = LTX2AudioCausalConv2d(
+                out_channels,
+                out_channels,
+                kernel_size=3,
+                stride=1,
+                causality_axis=causality_axis,
+            )
+        else:
+            self.conv2 = nn.Conv2d(
+                kernel_size=3,
+                in_channels=out_channels,
+                out_channels=out_channels,
+                stride=1,
+                padding=1,
+                permute=True,
+            )
+        if self.in_channels != self.out_channels:
+            if self.use_conv_shortcut:
+                if causality_axis is not None:
+                    self.conv_shortcut = LTX2AudioCausalConv2d(
+                        in_channels,
+                        out_channels,
+                        kernel_size=3,
+                        stride=1,
+                        causality_axis=causality_axis,
+                    )
+                else:
+                    self.conv_shortcut = nn.Conv2d(
+                        kernel_size=3,
+                        in_channels=in_channels,
+                        out_channels=out_channels,
+                        stride=1,
+                        padding=1,
+                        permute=True,
+                    )
+            else:
+                if causality_axis is not None:
+                    self.nin_shortcut = LTX2AudioCausalConv2d(
+                        in_channels,
+                        out_channels,
+                        kernel_size=1,
+                        stride=1,
+                        causality_axis=causality_axis,
+                    )
+                else:
+                    self.nin_shortcut = nn.Conv2d(
+                        in_channels=in_channels,
+                        out_channels=out_channels,
+                        kernel_size=1,
+                        stride=1,
+                        padding=0,
+                        permute=True,
+                    )
+
+    def forward(self, x: Tensor, temb: Tensor | None = None) -> Tensor:
+        h = self.norm1(x)
+        h = self.non_linearity(h)
+        h = self.conv1(h)
+
+        if temb is not None:
+            h = h + self.temb_proj(self.non_linearity(temb))[:, :, None, None]
+
+        h = self.norm2(h)
+        h = self.non_linearity(h)
+        h = self.dropout(h)
+        h = self.conv2(h)
+
+        if self.in_channels != self.out_channels:
+            x = (
+                self.conv_shortcut(x)
+                if self.use_conv_shortcut
+                else self.nin_shortcut(x)
+            )
+
+        return x + h
+
+
+class LTX2AudioUpsample(nn.Module[[Tensor], Tensor]):
+    def __init__(
+        self,
+        in_channels: int,
+        with_conv: bool,
+        causality_axis: str | None = "height",
+    ) -> None:
+        super().__init__()
+        self.with_conv = with_conv
+        self.causality_axis = causality_axis
+        if self.with_conv:
+            if causality_axis is not None:
+                self.conv = LTX2AudioCausalConv2d(
+                    in_channels,
+                    in_channels,
+                    kernel_size=3,
+                    stride=1,
+                    causality_axis=causality_axis,
+                )
+            else:
+                self.conv = nn.Conv2d(
+                    kernel_size=3,
+                    in_channels=in_channels,
+                    out_channels=in_channels,
+                    stride=1,
+                    padding=1,
+                    permute=True,
+                )
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = interpolate_2d_nearest(x, scale_factor=2)
+        if self.with_conv:
+            x = self.conv(x)
+            if self.causality_axis is None or self.causality_axis == "none":
+                pass
+            elif self.causality_axis == "height":
+                x = x[:, :, 1:, :]
+            elif self.causality_axis == "width":
+                x = x[:, :, :, 1:]
+            elif self.causality_axis == "width-compatibility":
+                pass
+            else:
+                raise ValueError(
+                    f"Invalid causality_axis: {self.causality_axis}"
+                )
+
+        return x
+
+
+class LTX2AudioAudioPatchifier(nn.Module[[Tensor], Tensor]):
+    """Patchifier for spectrogram/audio latents."""
+
+    def __init__(
+        self,
+        patch_size: int,
+        sample_rate: int = 16000,
+        hop_length: int = 160,
+        audio_latent_downsample_factor: int = 4,
+        is_causal: bool = True,
+    ):
+        self.hop_length = hop_length
+        self.sample_rate = sample_rate
+        self.audio_latent_downsample_factor = audio_latent_downsample_factor
+        self.is_causal = is_causal
+        self._patch_size = (1, patch_size, patch_size)
+
+    def patchify(self, audio_latents: Tensor) -> Tensor:
+        batch, channels, time, freq = audio_latents.shape
+        return audio_latents.permute((0, 2, 1, 3)).reshape(
+            (batch, time, channels * freq)
+        )
+
+    def unpatchify(
+        self, audio_latents: Tensor, channels: int, mel_bins: int
+    ) -> Tensor:
+        batch, time, _ = audio_latents.shape
+        return audio_latents.reshape((batch, time, channels, mel_bins)).permute(
+            (0, 2, 1, 3)
+        )
+
+    @property
+    def patch_size(self) -> tuple[int, int, int]:
+        return self._patch_size
+
+
+class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
+    """
+    Symmetric decoder that reconstructs audio spectrograms from latent features.
+
+    The decoder mirrors the encoder structure with configurable channel multipliers, attention resolutions, and causal
+    convolutions.
+    """
+
+    def __init__(
+        self,
+        base_channels: int = 128,
+        output_channels: int = 1,
+        num_res_blocks: int = 2,
+        attn_resolutions: tuple[int, ...] | None = None,
+        in_channels: int = 2,
+        resolution: int = 256,
+        latent_channels: int = 8,
+        ch_mult: tuple[int, ...] = (1, 2, 4),
+        norm_type: str = "group",
+        causality_axis: str | None = "width",
+        dropout: float = 0.0,
+        mid_block_add_attention: bool = False,
+        sample_rate: int = 16000,
+        mel_hop_length: int = 160,
+        is_causal: bool = True,
+        mel_bins: int | None = 64,
+        device: DeviceRef | None = None,
+        dtype: DType | None = None,
+    ) -> None:
+        super().__init__()
+
+        self.sample_rate = sample_rate
+        self.mel_hop_length = mel_hop_length
+        self.is_causal = is_causal
+        self.mel_bins = mel_bins
+        self.device = device
+        self.dtype = dtype
+        self.patchifier = LTX2AudioAudioPatchifier(
+            patch_size=1,
+            audio_latent_downsample_factor=LATENT_DOWNSAMPLE_FACTOR,
+            sample_rate=sample_rate,
+            hop_length=mel_hop_length,
+            is_causal=is_causal,
+        )
+
+        self.base_channels = base_channels
+        self.temb_ch = 0
+        self.num_resolutions = len(ch_mult)
+        self.num_res_blocks = num_res_blocks
+        self.resolution = resolution
+        self.in_channels = in_channels
+        self.out_ch = output_channels
+        self.give_pre_end = False
+        self.tanh_out = False
+        self.norm_type = norm_type
+        self.latent_channels = latent_channels
+        self.channel_multipliers = ch_mult
+        self.attn_resolutions = attn_resolutions
+        self.causality_axis = causality_axis
+
+        base_block_channels = base_channels * self.channel_multipliers[-1]
+        base_resolution = resolution // (2 ** (self.num_resolutions - 1))
+        self.z_shape = (1, latent_channels, base_resolution, base_resolution)
+
+        if self.causality_axis is not None:
+            self.conv_in = LTX2AudioCausalConv2d(
+                latent_channels,
+                base_block_channels,
+                kernel_size=3,
+                stride=1,
+                causality_axis=self.causality_axis,
+            )
+        else:
+            self.conv_in = nn.Conv2d(
+                kernel_size=3,
+                in_channels=latent_channels,
+                out_channels=base_block_channels,
+                stride=1,
+                padding=1,
+                permute=True,
+            )
+        self.non_linearity = activation_function_from_name("silu")
+        self.mid = nn.Module()
+        self.mid.block_1 = LTX2AudioResnetBlock(
+            in_channels=base_block_channels,
+            out_channels=base_block_channels,
+            temb_channels=self.temb_ch,
+            dropout=dropout,
+            norm_type=self.norm_type,
+            causality_axis=self.causality_axis,
+        )
+        if mid_block_add_attention:
+            self.mid.attn_1 = LTX2AudioAttnBlock(
+                base_block_channels, norm_type=self.norm_type
+            )
+        else:
+            self.mid.attn_1 = nn.Identity()
+        self.mid.block_2 = LTX2AudioResnetBlock(
+            in_channels=base_block_channels,
+            out_channels=base_block_channels,
+            temb_channels=self.temb_ch,
+            dropout=dropout,
+            norm_type=self.norm_type,
+            causality_axis=self.causality_axis,
+        )
+
+        self.up = nn.ModuleList()
+        block_in = base_block_channels
+        curr_res = self.resolution // (2 ** (self.num_resolutions - 1))
+
+        for level in reversed(range(self.num_resolutions)):
+            stage = nn.Module()
+            stage.block = nn.ModuleList()
+            stage.attn = nn.ModuleList()
+            block_out = self.base_channels * self.channel_multipliers[level]
+
+            for _ in range(self.num_res_blocks + 1):
+                stage.block.append(
+                    LTX2AudioResnetBlock(
+                        in_channels=block_in,
+                        out_channels=block_out,
+                        temb_channels=self.temb_ch,
+                        dropout=dropout,
+                        norm_type=self.norm_type,
+                        causality_axis=self.causality_axis,
+                    )
+                )
+                block_in = block_out
+                if self.attn_resolutions:
+                    if curr_res in self.attn_resolutions:
+                        stage.attn.append(
+                            LTX2AudioAttnBlock(
+                                block_in, norm_type=self.norm_type
+                            )
+                        )
+
+            if level != 0:
+                stage.upsample = LTX2AudioUpsample(
+                    block_in, True, causality_axis=self.causality_axis
+                )
+                curr_res *= 2
+
+            self.up.insert(0, stage)
+
+        final_block_channels = block_in
+
+        if self.norm_type == "group":
+            self.norm_out = nn.GroupNorm(
+                num_groups=32,
+                num_channels=final_block_channels,
+                eps=1e-6,
+                affine=True,
+            )
+        elif self.norm_type == "pixel":
+            self.norm_out = LTX2AudioPixelNorm(dim=1, eps=1e-6)
+        else:
+            raise ValueError(f"Invalid normalization type: {self.norm_type}")
+
+        if self.causality_axis is not None:
+            self.conv_out = LTX2AudioCausalConv2d(
+                in_channels=final_block_channels,
+                out_channels=output_channels,
+                kernel_size=3,
+                stride=1,
+                causality_axis=self.causality_axis,
+            )
+        else:
+            self.conv_out = nn.Conv2d(
+                kernel_size=3,
+                in_channels=final_block_channels,
+                out_channels=output_channels,
+                stride=1,
+                padding=1,
+                permute=True,
+            )
+
+    def input_types(self) -> tuple[TensorType, ...]:
+        if self.dtype is None:
+            raise ValueError("dtype must be set for input_types")
+        if self.device is None:
+            raise ValueError("device must be set for input_types")
+
+        # Hardcoded for num_frames=121, frame_rate=24:
+        #   latent_channels     = 8
+        #   audio_num_frames    = round((121/24) * (16000/160/4)) = 126
+        #   latent_mel_bins     = 64 // 4 = 16
+        return (
+            TensorType(
+                self.dtype,
+                shape=[
+                    "batch_size",
+                    self.latent_channels,
+                    "audio_num_frames",
+                    "latent_mel_bins",
+                ],
+                device=self.device,
+            ),
+        )
+
+    def forward(
+        self,
+        sample: Tensor,
+    ) -> Tensor:
+        _, _, frames, mel_bins = sample.shape
+
+        target_frames = frames * LATENT_DOWNSAMPLE_FACTOR
+
+        if self.causality_axis is not None:
+            # frames >= 1 (positive tensor dim), so frames*4 - 3 >= 1 always.
+            # Use Dim arithmetic instead of F.max to keep target_frames as a
+            # Dim expression, which the symbolic rmo.slice path requires.
+            target_frames = target_frames - (LATENT_DOWNSAMPLE_FACTOR - 1)
+
+        target_channels = self.out_ch
+        target_mel_bins = (
+            self.mel_bins if self.mel_bins is not None else mel_bins
+        )
+
+        hidden_features = self.conv_in(sample)
+        hidden_features = self.mid.block_1(hidden_features, temb=None)
+        hidden_features = self.mid.attn_1(hidden_features)
+        hidden_features = self.mid.block_2(hidden_features, temb=None)
+
+        for level in reversed(range(self.num_resolutions)):
+            stage = self.up[level]
+            for block_idx, block in enumerate(stage.block):
+                hidden_features = block(hidden_features, temb=None)
+                if stage.attn:
+                    hidden_features = stage.attn[block_idx](hidden_features)
+
+            if level != 0 and hasattr(stage, "upsample"):
+                hidden_features = stage.upsample(hidden_features)
+
+        if self.give_pre_end:
+            return hidden_features
+
+        hidden = self.norm_out(hidden_features)
+        hidden = self.non_linearity(hidden)
+        decoded_output = self.conv_out(hidden)
+        decoded_output = (
+            F.tanh(decoded_output) if self.tanh_out else decoded_output
+        )
+
+        target_time = target_frames
+        target_freq = target_mel_bins
+
+        # Use a Safe-Pad + Precise-Slice pattern to avoid symbolic Dim
+        # comparisons in Python (which throw TypeError). By padding with a
+        # small constant (8) that is guaranteed to exceed the maximum
+        # architectural discrepancy (2), and then slicing to the exact
+        # symbolic target, we produce a result mathematically identical to
+        # the original "pad deficit then crop" algorithm.
+        decoded_output = F.pad(decoded_output, (0, 0, 0, 0, 0, 8, 0, 8))
+
+        decoded_output = decoded_output[
+            :, :target_channels, :target_time, :target_freq
+        ]
+
+        return decoded_output
+
+
+class AutoencoderKLLTX2Audio(nn.Module[[Tensor], Tensor]):
+    """Refactored LTX2 Audio Autoencoder (Decode-only)."""
+
+    def __init__(self, config: AutoencoderKLLTX2AudioConfig) -> None:
+        super().__init__()
+        self.decoder = LTX2AudioDecoder(
+            base_channels=config.base_channels,
+            output_channels=config.output_channels,
+            num_res_blocks=config.num_res_blocks,
+            attn_resolutions=config.attn_resolutions,
+            in_channels=config.in_channels,
+            resolution=config.resolution,
+            latent_channels=config.latent_channels,
+            ch_mult=config.ch_mult,
+            norm_type=config.norm_type,
+            causality_axis=config.causality_axis,
+            dropout=config.dropout,
+            mid_block_add_attention=config.mid_block_add_attention,
+            sample_rate=config.sample_rate,
+            mel_hop_length=config.mel_hop_length,
+            is_causal=config.is_causal,
+            mel_bins=config.mel_bins,
+            device=config.device,
+            dtype=config.dtype,
+        )
+
+    def forward(self, z: Tensor) -> Tensor:
+        return self.decoder(z)
+
+
+class PostprocessAndDecode(nn.Module[[Tensor, Tensor, Tensor], Tensor]):
+    """Fused BN-denorm + unpatchify + VAE decode in a single compiled graph.
+
+    Eliminates the inter-graph boundary and intermediate tensor materialization
+    that previously existed between _postprocess_latents and vae.decode().
+    """
+
+    def __init__(
+        self,
+        decoder: LTX2AudioDecoder,
+        num_channels: int,
+        device: DeviceRef,
+        dtype: DType,
+    ) -> None:
+        super().__init__()
+        self.decoder = decoder
+        self._num_channels = num_channels
+        self._device = device
+        self._dtype = dtype
+
+    def forward(
+        self,
+        latents_bclm: Tensor,
+        latents_mean: Tensor,
+        latents_std: Tensor,
+    ) -> Tensor:
+        # Denormalization
+        latents = latents_bclm * latents_std + latents_mean
+
+        decoded = self.decoder(latents)
+        # TODO: Add vocoder here too?
+        return decoded
+
+    def input_types(self) -> tuple[TensorType, ...]:
+        return (
+            TensorType(
+                self._dtype,
+                shape=[
+                    "batch_size",
+                    self._num_channels,
+                    "audio_num_frames",
+                    "num_mel_bins",
+                ],
+                device=self._device,
+            ),
+            TensorType(
+                self._dtype,
+                shape=[self._num_channels],
+                device=self._device,
+            ),
+            TensorType(
+                self._dtype,
+                shape=[self._num_channels],
+                device=self._device,
+            ),
+        )
+
+
+class AutoencoderKLLTX2AudioModel(BaseAutoencoderModel):
+    """ComponentModel wrapper for LTX2 Audio Autoencoder."""
+
+    def __init__(
+        self,
+        config: dict[str, Any],
+        encoding: SupportedEncoding,
+        devices: list[Device],
+        weights: Weights,
+    ) -> None:
+        self.latents_mean: Tensor | None = None
+        self.latents_std: Tensor | None = None
+
+        super().__init__(
+            config=config,
+            encoding=encoding,
+            devices=devices,
+            weights=weights,
+            config_class=AutoencoderKLLTX2AudioConfig,
+            autoencoder_class=AutoencoderKLLTX2Audio,
+        )
+
+    def load_model(self) -> Any:
+        """Load and compile the decoder and encoder models with BatchNorm statistics.
+
+        Extracts BatchNorm statistics (bn.*) which are specific to Flux2, then
+        delegates to base class for weight loading and model compilation.
+
+        Returns:
+            Compiled decoder model callable.
+        """
+        bn_stats = {}
+
+        for key, value in self.weights.items():
+            if key in ("latents_mean", "latents_std"):
+                weight_data = value.data()
+                target_dtype = self.config.dtype
+                if weight_data.dtype != target_dtype:
+                    if weight_data.dtype.is_float() and target_dtype.is_float():
+                        weight_data = weight_data.astype(target_dtype)
+                    # Non-float left as-is; running_mean/var are typically float.
+                bn_stats[key] = weight_data.data
+
+        bn_mean_data = bn_stats.get("latents_mean")
+        bn_var_data = bn_stats.get("latents_std")
+
+        super().load_model()
+
+        if bn_mean_data is not None or bn_var_data is not None:
+            if bn_mean_data is not None:
+                self.latents_mean = Tensor.from_dlpack(bn_mean_data).to(
+                    self.devices[0]
+                )
+            if bn_var_data is not None:
+                self.latents_std = Tensor.from_dlpack(bn_var_data).to(
+                    self.devices[0]
+                )
+
+        return self.model
+
+    def build_fused_decode(
+        self, device: Device, num_channels: int
+    ) -> Callable[..., Any]:
+        """Build a fused postprocess + VAE decode compiled graph.
+
+        Combines BN denormalization, unpatchify, and VAE decoding into a single
+        compiled graph, eliminating the intermediate tensor and device sync
+        between the two previously separate compiled graphs.
+
+        Args:
+            device: Target device for the compiled graph.
+            num_channels: Number of latent channels (bn.running_mean shape[0]).
+
+        Returns:
+            Compiled callable taking (latents_bhwc, bn_mean, bn_var) and
+            returning the decoded image tensor.
+        """
+        dtype = self.config.dtype
+        device_ref = DeviceRef.from_device(device)
+
+        fused_weights: dict[str, Any] = {}
+        for key, value in self.weights.items():
+            weight_data = value.data()
+            if weight_data.dtype != dtype:
+                if weight_data.dtype.is_float() and dtype.is_float():
+                    weight_data = weight_data.astype(dtype)
+            if key.startswith("decoder."):
+                # decoder.X -> decoder.X (PostprocessAndDecode.decoder.X)
+                fused_weights[key] = weight_data
+
+        with F.lazy():
+            autoencoder = AutoencoderKLLTX2Audio(self.config)
+            fused = PostprocessAndDecode(
+                decoder=autoencoder.decoder,
+                num_channels=num_channels,
+                device=device_ref,
+                dtype=dtype,
+            )
+            fused.to(device)
+            self._fused_model = fused.compile(
+                *fused.input_types(), weights=fused_weights
+            )
+
+        return self._fused_model
+
+    @property
+    def bn(self) -> SimpleNamespace:
+        """Property to access BatchNorm statistics, compatible with diffusers API.
+
+        Returns a SimpleNamespace with running_mean and running_var attributes
+        for compatibility with pipeline code that accesses self.vae.bn.running_mean.
+
+        Returns:
+            SimpleNamespace: Object containing running_mean and running_var attributes.
+
+        Raises:
+            ValueError: If BatchNorm statistics are not loaded.
+        """
+        if self.latents_mean is None or self.latents_std is None:
+            raise ValueError(
+                "BatchNorm statistics (running_mean, running_var) not loaded. "
+                "Make sure the model weights contain 'latents_mean' and 'latents_std'."
+            )
+
+        return SimpleNamespace(
+            running_mean=self.latents_mean, running_var=self.latents_std
+        )

--- a/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
+++ b/max/python/max/pipelines/architectures/autoencoders/autoencoder_kl_ltx2_audio.py
@@ -182,17 +182,16 @@ class LTX2AudioAttnBlock(nn.Module[[Tensor], Tensor]):
         v = self.v(h)
 
         batch, channels, height, width = q.shape
-        # Use F.bmm for attention computation
-        q = q.reshape((batch, channels, height * width)).permute((0, 2, 1))
+        q = q.reshape((batch, channels, height * width)).permute([0, 2, 1])
         k = k.reshape((batch, channels, height * width))
 
-        attn = F.bmm(q, k) * (channels ** (-0.5))
+        attn = F.matmul(q, k) * (channels ** (-0.5))
         attn = F.softmax(attn, axis=-1)
 
         v = v.reshape((batch, channels, height * width))
-        attn = attn.permute((0, 2, 1))
+        attn = attn.permute([0, 2, 1])
 
-        h = F.bmm(v, attn).reshape((batch, channels, height, width))
+        h = F.matmul(v, attn).reshape((batch, channels, height, width))
 
         return x + self.proj_out(h)
 
@@ -206,7 +205,7 @@ class LTX2AudioResnetBlock(nn.Module[[Tensor, Tensor | None], Tensor]):
         dropout: float = 0.0,
         temb_channels: int = 512,
         norm_type: str = "group",
-        causality_axis: str = "height",
+        causality_axis: str | None = "height",
     ) -> None:
         super().__init__()
         self.causality_axis = causality_axis
@@ -224,6 +223,7 @@ class LTX2AudioResnetBlock(nn.Module[[Tensor, Tensor | None], Tensor]):
         self.out_channels = out_channels
         self.use_conv_shortcut = conv_shortcut
 
+        self.norm1: nn.Module
         if norm_type == "group":
             self.norm1 = nn.GroupNorm(
                 num_groups=32, num_channels=in_channels, eps=1e-6, affine=True
@@ -252,6 +252,7 @@ class LTX2AudioResnetBlock(nn.Module[[Tensor, Tensor | None], Tensor]):
             )
         if temb_channels > 0:
             self.temb_proj = nn.Linear(temb_channels, out_channels)
+        self.norm2: nn.Module
         if norm_type == "group":
             self.norm2 = nn.GroupNorm(
                 num_groups=32, num_channels=out_channels, eps=1e-6, affine=True
@@ -349,6 +350,7 @@ class LTX2AudioUpsample(nn.Module[[Tensor], Tensor]):
         super().__init__()
         self.with_conv = with_conv
         self.causality_axis = causality_axis
+        self.conv: nn.Module
         if self.with_conv:
             if causality_axis is not None:
                 self.conv = LTX2AudioCausalConv2d(
@@ -407,7 +409,7 @@ class LTX2AudioAudioPatchifier(nn.Module[[Tensor], Tensor]):
 
     def patchify(self, audio_latents: Tensor) -> Tensor:
         batch, channels, time, freq = audio_latents.shape
-        return audio_latents.permute((0, 2, 1, 3)).reshape(
+        return audio_latents.permute([0, 2, 1, 3]).reshape(
             (batch, time, channels * freq)
         )
 
@@ -416,12 +418,28 @@ class LTX2AudioAudioPatchifier(nn.Module[[Tensor], Tensor]):
     ) -> Tensor:
         batch, time, _ = audio_latents.shape
         return audio_latents.reshape((batch, time, channels, mel_bins)).permute(
-            (0, 2, 1, 3)
+            [0, 2, 1, 3]
         )
 
     @property
     def patch_size(self) -> tuple[int, int, int]:
         return self._patch_size
+
+
+class LTX2AudioDecoderMid(nn.Module):
+    """Container for the middle block of the LTX2 Audio Decoder."""
+
+    block_1: LTX2AudioResnetBlock
+    attn_1: nn.Module[[Tensor], Tensor]
+    block_2: LTX2AudioResnetBlock
+
+
+class LTX2AudioDecoderStage(nn.Module):
+    """Container for a single stage (level) of the LTX2 Audio Decoder."""
+
+    block: nn.ModuleList[LTX2AudioResnetBlock]
+    attn: nn.ModuleList[LTX2AudioAttnBlock]
+    upsample: LTX2AudioUpsample
 
 
 class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
@@ -437,7 +455,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
         base_channels: int = 128,
         output_channels: int = 1,
         num_res_blocks: int = 2,
-        attn_resolutions: tuple[int, ...] | None = None,
+        attn_resolutions: list[int] | None = None,
         in_channels: int = 2,
         resolution: int = 256,
         latent_channels: int = 8,
@@ -488,6 +506,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
         base_resolution = resolution // (2 ** (self.num_resolutions - 1))
         self.z_shape = (1, latent_channels, base_resolution, base_resolution)
 
+        self.conv_in: nn.Module
         if self.causality_axis is not None:
             self.conv_in = LTX2AudioCausalConv2d(
                 latent_channels,
@@ -506,7 +525,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
                 permute=True,
             )
         self.non_linearity = activation_function_from_name("silu")
-        self.mid = nn.Module()
+        self.mid = LTX2AudioDecoderMid()
         self.mid.block_1 = LTX2AudioResnetBlock(
             in_channels=base_block_channels,
             out_channels=base_block_channels,
@@ -530,12 +549,12 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
             causality_axis=self.causality_axis,
         )
 
-        self.up = nn.ModuleList()
+        self.up: nn.ModuleList[LTX2AudioDecoderStage] = nn.ModuleList()
         block_in = base_block_channels
         curr_res = self.resolution // (2 ** (self.num_resolutions - 1))
 
         for level in reversed(range(self.num_resolutions)):
-            stage = nn.Module()
+            stage = LTX2AudioDecoderStage()
             stage.block = nn.ModuleList()
             stage.attn = nn.ModuleList()
             block_out = self.base_channels * self.channel_multipliers[level]
@@ -570,6 +589,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
 
         final_block_channels = block_in
 
+        self.norm_out: nn.Module
         if self.norm_type == "group":
             self.norm_out = nn.GroupNorm(
                 num_groups=32,
@@ -582,6 +602,7 @@ class LTX2AudioDecoder(nn.Module[[Tensor], Tensor]):
         else:
             raise ValueError(f"Invalid normalization type: {self.norm_type}")
 
+        self.conv_out: nn.Module
         if self.causality_axis is not None:
             self.conv_out = LTX2AudioCausalConv2d(
                 in_channels=final_block_channels,
@@ -727,7 +748,7 @@ class PostprocessAndDecode(nn.Module[[Tensor], Tensor]):
         # TODO: Add vocoder here too?
         return decoded
 
-    def input_types(self) -> tuple[TensorType, ...]:
+    def input_types(self) -> TensorType:
         return TensorType(
             self._dtype,
             shape=[

--- a/max/python/max/pipelines/architectures/autoencoders/model_config.py
+++ b/max/python/max/pipelines/architectures/autoencoders/model_config.py
@@ -108,7 +108,7 @@ class AutoencoderKLFlux2Config(AutoencoderKLConfigBase):
 class AutoencoderKLLTX2AudioConfig(AutoencoderKLConfigBase):
     base_channels: int = 128
     in_channels: int = 2
-    output_channels: int = 2
+    out_channels: int = 2
     ch_mult: tuple[int, ...] = (1, 2, 4)
     num_res_blocks: int = 2
     attn_resolutions: list[int] | None = None
@@ -138,7 +138,6 @@ class AutoencoderKLLTX2AudioConfig(AutoencoderKLConfigBase):
         # Add LTX-2-specific parameters if present
         ltx2_params = [
             "base_channels",
-            "output_channels",
             "ch_mult",
             "num_res_blocks",
             "attn_resolutions",
@@ -155,6 +154,10 @@ class AutoencoderKLLTX2AudioConfig(AutoencoderKLConfigBase):
         for param in ltx2_params:
             if param in config_dict:
                 init_dict[param] = config_dict[param]
+
+        # Map output_channels from HF config to out_channels if out_channels not already set
+        if "output_channels" in config_dict and "out_channels" not in init_dict:
+            init_dict["out_channels"] = config_dict["output_channels"]
         init_dict.update(
             {
                 "dtype": supported_encoding_dtype(encoding),

--- a/max/python/max/pipelines/architectures/autoencoders/model_config.py
+++ b/max/python/max/pipelines/architectures/autoencoders/model_config.py
@@ -64,64 +64,6 @@ class AutoencoderKLConfig(AutoencoderKLConfigBase):
         return AutoencoderKLConfig(**init_dict)
 
 
-class AutoencoderKLLTX2AudioConfig(AutoencoderKLConfigBase):
-    base_channels: int = 128
-    in_channels: int = 2
-    output_channels: int = 2
-    ch_mult: tuple[int, ...] = (1, 2, 4)
-    num_res_blocks: int = 2
-    attn_resolutions: list[int] | None = None
-    resolution: int = 256
-    latent_channels: int = 8
-    norm_type: str = "pixel"
-    causality_axis: str | None = "height"
-    dropout: float = 0.0
-    mid_block_add_attention: bool = False
-    sample_rate: int = 16000
-    mel_hop_length: int = 160
-    is_causal: bool = True
-    mel_bins: int | None = 64
-    double_z: bool = True
-
-    @staticmethod
-    def generate(
-        config_dict: dict[str, Any],
-        encoding: SupportedEncoding,
-        devices: list[Device],
-    ) -> "AutoencoderKLLTX2AudioConfig":
-        init_dict = {
-            key: value
-            for key, value in config_dict.items()
-            if key in AutoencoderKLLTX2AudioConfig.__annotations__
-        }
-        # Add LTX-2-specific parameters if present
-        ltx2_params = [
-            "base_channels",
-            "ch_mult",
-            "num_res_blocks",
-            "attn_resolutions",
-            "resolution",
-            "norm_type",
-            "causality_axis",
-            "dropout",
-            "sample_rate",
-            "mel_hop_length",
-            "is_causal",
-            "mel_bins",
-            "double_z",
-        ]
-        for param in ltx2_params:
-            if param in config_dict:
-                init_dict[param] = config_dict[param]
-        init_dict.update(
-            {
-                "dtype": supported_encoding_dtype(encoding),
-                "device": DeviceRef.from_device(devices[0]),
-            }
-        )
-        return AutoencoderKLLTX2AudioConfig(**init_dict)
-
-
 class AutoencoderKLFlux2Config(AutoencoderKLConfigBase):
     patch_size: tuple[int, int] = (2, 2)
     batch_norm_eps: float = 1e-4
@@ -161,3 +103,62 @@ class AutoencoderKLFlux2Config(AutoencoderKLConfigBase):
             }
         )
         return AutoencoderKLFlux2Config(**init_dict)
+
+
+class AutoencoderKLLTX2AudioConfig(AutoencoderKLConfigBase):
+    base_channels: int = 128
+    in_channels: int = 2
+    output_channels: int = 2
+    ch_mult: tuple[int, ...] = (1, 2, 4)
+    num_res_blocks: int = 2
+    attn_resolutions: list[int] | None = None
+    resolution: int = 256
+    latent_channels: int = 8
+    norm_type: str = "pixel"
+    causality_axis: str | None = "height"
+    dropout: float = 0.0
+    mid_block_add_attention: bool = False
+    sample_rate: int = 16000
+    mel_hop_length: int = 160
+    is_causal: bool = True
+    mel_bins: int | None = 64
+    double_z: bool = True
+
+    @staticmethod
+    def generate(
+        config_dict: dict[str, Any],
+        encoding: SupportedEncoding,
+        devices: list[Device],
+    ) -> "AutoencoderKLLTX2AudioConfig":
+        init_dict = {
+            key: value
+            for key, value in config_dict.items()
+            if key in AutoencoderKLConfigBase.__annotations__
+        }
+        # Add LTX-2-specific parameters if present
+        ltx2_params = [
+            "base_channels",
+            "output_channels",
+            "ch_mult",
+            "num_res_blocks",
+            "attn_resolutions",
+            "resolution",
+            "norm_type",
+            "causality_axis",
+            "dropout",
+            "sample_rate",
+            "mel_hop_length",
+            "is_causal",
+            "mel_bins",
+            "double_z",
+        ]
+        for param in ltx2_params:
+            if param in config_dict:
+                init_dict[param] = config_dict[param]
+        init_dict.update(
+            {
+                "dtype": supported_encoding_dtype(encoding),
+                "device": DeviceRef.from_device(devices[0]),
+            }
+        )
+        return AutoencoderKLLTX2AudioConfig(**init_dict)

--- a/max/python/max/pipelines/architectures/autoencoders/model_config.py
+++ b/max/python/max/pipelines/architectures/autoencoders/model_config.py
@@ -64,6 +64,64 @@ class AutoencoderKLConfig(AutoencoderKLConfigBase):
         return AutoencoderKLConfig(**init_dict)
 
 
+class AutoencoderKLLTX2AudioConfig(AutoencoderKLConfigBase):
+    base_channels: int = 128
+    in_channels: int = 2
+    output_channels: int = 2
+    ch_mult: tuple[int, ...] = (1, 2, 4)
+    num_res_blocks: int = 2
+    attn_resolutions: list[int] | None = None
+    resolution: int = 256
+    latent_channels: int = 8
+    norm_type: str = "pixel"
+    causality_axis: str | None = "height"
+    dropout: float = 0.0
+    mid_block_add_attention: bool = False
+    sample_rate: int = 16000
+    mel_hop_length: int = 160
+    is_causal: bool = True
+    mel_bins: int | None = 64
+    double_z: bool = True
+
+    @staticmethod
+    def generate(
+        config_dict: dict[str, Any],
+        encoding: SupportedEncoding,
+        devices: list[Device],
+    ) -> "AutoencoderKLLTX2AudioConfig":
+        init_dict = {
+            key: value
+            for key, value in config_dict.items()
+            if key in AutoencoderKLLTX2AudioConfig.__annotations__
+        }
+        # Add LTX-2-specific parameters if present
+        ltx2_params = [
+            "base_channels",
+            "ch_mult",
+            "num_res_blocks",
+            "attn_resolutions",
+            "resolution",
+            "norm_type",
+            "causality_axis",
+            "dropout",
+            "sample_rate",
+            "mel_hop_length",
+            "is_causal",
+            "mel_bins",
+            "double_z",
+        ]
+        for param in ltx2_params:
+            if param in config_dict:
+                init_dict[param] = config_dict[param]
+        init_dict.update(
+            {
+                "dtype": supported_encoding_dtype(encoding),
+                "device": DeviceRef.from_device(devices[0]),
+            }
+        )
+        return AutoencoderKLLTX2AudioConfig(**init_dict)
+
+
 class AutoencoderKLFlux2Config(AutoencoderKLConfigBase):
     patch_size: tuple[int, int] = (2, 2)
     batch_norm_eps: float = 1e-4


### PR DESCRIPTION
## Summary

This pull request introduces support for a new audio autoencoder architecture and adds a dropout module to the neural network package. The main changes include the implementation and registration of the `AutoencoderKLLTX2AudioModel`.

## Testing

<details>
<summary>Testing Code</summary>

```py
import json
import os
import subprocess
import sys
from pathlib import Path
from unittest.mock import MagicMock
import torch
import numpy as np
from typing import Any, Dict

# ==============================================================================
# 0. Modal Environment Setup (Optional/Auto-detected)
# ==============================================================================
# These are the settings used on Modal. If running elsewhere, they can be ignored.
MODEL_CLONE_PATH = "/root/modular"
BRANCH = "add-ltx-2-audio-vae"
REMOTE = "https://github.com/tolgacangoz/modular.git"

os.environ["HF_HOME"] = "/mnt/z-image/huggingface"
os.environ["MODULAR_HOME"] = "/mnt/z-image/modular"
os.environ["MODULAR_MAX_DEBUG"] = "True"

# Clone or update the repo first, before touching sys.path or sys.modules.
if not Path(MODEL_CLONE_PATH).exists():
    subprocess.run(["git", "clone", "--branch", BRANCH, REMOTE, MODEL_CLONE_PATH], check=True)
else:
    subprocess.run(["git", "-C", MODEL_CLONE_PATH, "switch", BRANCH], check=True)
    subprocess.run(["git", "-C", MODEL_CLONE_PATH, "pull"], check=True)

# Insert the cloned source at the front of sys.path.
path_to_max = os.path.join(MODEL_CLONE_PATH, "max/python")
if path_to_max not in sys.path:
    sys.path.insert(0, path_to_max)

# Evict any pre-cached max.* entries (Modal pre-imports the installed package).
# This forces a fresh search from sys.path on the next import.
for _mod in list(sys.modules):
    if _mod == "max" or _mod.startswith("max."):
        del sys.modules[_mod]

# Mock the generated protobuf modules missing from the source tree.
sys.modules["max.serve.kvcache_agent.kvcache_agent_service_v1_pb2"] = MagicMock()
sys.modules["max.serve.kvcache_agent.kvcache_agent_service_v1_pb2_grpc"] = MagicMock()

# ==============================================================================
# 1. Imports (from MAX and Diffusers)
# ==============================================================================
from huggingface_hub import hf_hub_download
from max.pipelines.architectures.autoencoders import AutoencoderKLLTX2AudioModel
from max.graph.weights import load_weights
from max.dtype import DType
from max.driver import Accelerator, CPU, accelerator_count
from max.experimental import Tensor
from diffusers import AutoencoderKLLTX2Audio

LATENT_DOWNSAMPLE_FACTOR = 4

# ==============================================================================
# 2. Equivalence Test Logic
# ==============================================================================
def convert_diffusers_config_to_max(diff_config: Dict[str, Any]) -> Dict[str, Any]:
    """Converts a Diffusers VAE config to MAX format."""
    max_cfg = dict(diff_config)
    if "output_channels" in max_cfg:
        max_cfg["out_channels"] = max_cfg.pop("output_channels")
    if "dtype" not in max_cfg:
        max_cfg["dtype"] = "bfloat16"
    return max_cfg

def test_equivalence():
    device = Accelerator() if accelerator_count() > 0 else CPU()
    print(f"Using device: {device}")

    repo_id, subfolder = "Lightricks/LTX-2", "audio_vae"
    hf_home = os.environ.get("HF_HOME")

    # 1. Download config and weights natively (cached after first run)
    print(f"Downloading config and weights from {repo_id}/{subfolder}...")
    config_path = hf_hub_download(
        repo_id, f"{subfolder}/config.json", cache_dir=hf_home
    )
    weights_path = hf_hub_download(
        repo_id,
        f"{subfolder}/diffusion_pytorch_model.safetensors",
        cache_dir=hf_home,
    )
    with open(config_path) as f:
        cfg = convert_diffusers_config_to_max(json.load(f))

    # 2. Initialize MAX Model with native SafetensorWeights
    print("Initializing MAX model with native weights...")
    max_model = AutoencoderKLLTX2AudioModel(
        config=cfg,
        encoding="bfloat16",
        devices=[device],
        weights=load_weights([Path(weights_path)]),
    )

    # 3. Load Diffusers model as reference oracle only
    print(f"Loading Diffusers reference model from {repo_id}/{subfolder}...")
    diff_model = AutoencoderKLLTX2Audio.from_pretrained(
        repo_id,
        subfolder=subfolder,
        torch_dtype=torch.bfloat16,
    ).to('cuda').eval()

    # 4. Compile the Fused Graph
    #
    # PostprocessAndDecode takes patchified latents of shape (B, T, D) where
    #   D = latent_channels * latent_mel_bins  (e.g. 8 * 16 = 128)
    # This mirrors the diffusers pipeline which runs:
    #   _denormalize_audio_latents(latents, ...)  ← on patchified (B, T, D)
    #   _unpack_audio_latents(latents, ...)       ← to (B, C, T, M)
    #   audio_vae.decode(latents)
    print("Compiling MAX fused decode graph...")
    latent_channels = cfg.get("latent_channels", 8)          # 8
    latent_mel_bins = cfg["mel_bins"] // LATENT_DOWNSAMPLE_FACTOR  # 64//4 = 16
    D = latent_channels * latent_mel_bins                    # 128

    fused_forward = max_model.build_fused_decode(device, num_channels=D, latent_mel_bins=latent_mel_bins)

    # 4. Prepare Realistic Inputs
    #
    # Input is patchified audio latents (B, T, D):
    #   T = latent audio frames (126 from the denoising loop)
    #   D = 128 (= latent_channels * latent_mel_bins)
    #
    # Reference shapes from the denoising loop (for context):
    #   audio_latent_model_input: torch.Size([2, 126, 128])
    #   audio_vae's latents (unpacked): torch.Size([1, 8, 126, 16])
    print("Generating test input (patchified latents)...")
    batch_size = 1
    T = 126  # latent audio frames
    z_patchified = torch.randn(batch_size, T, D, dtype=torch.bfloat16).to('cuda')

    # 5. Run Equivalence Test
    print("Running forward pass...")

    # MAX: PostprocessAndDecode handles denorm + unpack + decode internally
    max_input = Tensor.from_dlpack(z_patchified).to(device)
    max_output = fused_forward(max_input)
    max_output_np = np.from_dlpack(max_output.cast(DType.float32).to(CPU()))

    # Diffusers equivalent (mirrors the pipeline's decode path exactly):
    #   1. _denormalize_audio_latents: broadcast (D,) stats over (B, T, D)
    #   2. _unpack_audio_latents: (B, T, D) → (B, C, T, M)
    #   3. audio_vae.decode
    std = diff_model.latents_std   # shape (D,) = (128,)
    mean = diff_model.latents_mean # shape (D,) = (128,)
    z_denormed = z_patchified * std + mean                                     # (B, T, D)
    z_unpacked = z_denormed.unflatten(-1, (latent_channels, latent_mel_bins))  # (B, T, C, M)
    z_unpacked = z_unpacked.permute(0, 2, 1, 3)                               # (B, C, T, M)

    with torch.no_grad():
        diff_output = diff_model.decode(z_unpacked, return_dict=False)[0]
    diff_output_np = diff_output.detach().float().cpu().numpy()

    # Final Comparison
    print(f"Input shape  (patchified): {list(z_patchified.shape)}")
    print(f"Diffusers output shape:    {list(diff_output.shape)}")
    print(f"MAX output shape:          {list(max_output_np.shape)}")

    abs_diff = np.abs(max_output_np - diff_output_np)
    n_total = abs_diff.size
    print(f"Max absolute difference:   {abs_diff.max():.6f}")
    print(f"Mean absolute difference:  {abs_diff.mean():.6f}")
    print(f"Median absolute difference:{np.median(abs_diff):.6f}")
    # bfloat16 ULP at the output scale (~4-8): 0.03125 per ULP.
    # Acceptable threshold for a full bfloat16 decode: 4 ULPs = 0.125.
    BF16_ATOL = 0.125
    BF16_RTOL = 0.02
    n_fail = int(np.sum(
        abs_diff > BF16_ATOL + BF16_RTOL * np.abs(diff_output_np)
    ))
    print(f"Elements outside {BF16_ATOL} + {BF16_RTOL}*|ref|: {n_fail}/{n_total} ({100*n_fail/n_total:.1f}%)")

    try:
        np.testing.assert_allclose(max_output_np, diff_output_np, rtol=BF16_RTOL, atol=BF16_ATOL)
        print("SUCCESS: MAX and Diffusers VAE outputs are equivalent (within bfloat16 tolerance)!")
    except AssertionError as e:
        print(f"FAILURE: Outputs differ beyond bfloat16 tolerance. Error: {e}")

test_equivalence()

"""
Using device: Device(type=gpu,id=0)
Downloading config and weights from Lightricks/LTX-2/audio_vae...
Initializing MAX model with native weights...
Loading Diffusers reference model from Lightricks/LTX-2/audio_vae...
Compiling MAX fused decode graph...
Generating test input (patchified latents)...
Running forward pass...
Input shape  (patchified): [1, 126, 128]
Diffusers output shape:    [1, 2, 501, 64]
MAX output shape:          [1, 2, 501, 64]
Max absolute difference:   0.062500
Mean absolute difference:  0.007654
Median absolute difference:0.000000
Elements outside 0.125 + 0.02*|ref|: 0/64128 (0.0%)
SUCCESS: MAX and Diffusers VAE outputs are equivalent (within bfloat16 tolerance)!
"""
```

</details>

## Checklist

- [X] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [X] I ran `./bazelw run format` to format my changes
- [X] I added or updated tests to cover my changes
- [X] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))


Assisted-by: AI


@KCaverly @katelyncaldwell