### PR TITLE
[Stdlib] Fix tanh() float64 accuracy by using expm1-based formula

### DIFF
--- a/mojo/stdlib/std/math/math.mojo
+++ b/mojo/stdlib/std/math/math.mojo
@@ -1141,6 +1141,18 @@ fn tanh[
                 instruction="tanh.approx.f32", constraints="=f,f"
             ](x)
 
+    comptime if dtype == DType.float64 and not is_gpu():
+        # For float64 on CPU, use the expm1-based identity for full accuracy:
+        #   tanh(x) = -expm1(-2|x|) / (expm1(-2|x|) + 2)
+        # expm1 computes e^y - 1 accurately even for small |y|, avoiding the
+        # catastrophic cancellation that occurs in (e^y - 1) computed naively.
+        # This matches the accuracy of FreeBSD/Cephes libm tanh for float64.
+        # Clamp at ±20: tanh(±20) rounds to exactly ±1 in float64.
+        var xc64 = x.clamp(-20, 20)
+        var x_abs = abs(xc64)
+        var e = expm1((-2) * x_abs)
+        return copysign((-e) / (e + 2), xc64)
+
     var xc = x.clamp(-9, 9)
     var x_squared = xc * xc
 

--- a/mojo/stdlib/test/math/test_tanh.mojo
+++ b/mojo/stdlib/test/math/test_tanh.mojo
@@ -191,7 +191,8 @@ def test_tanh_libm() raises:
     _test_tanh_libm[]()
 
 
-def _test_tanh_libm_f64[N: Int = 8192]() raises:
+def test_tanh_libm_f64() raises:
+    comptime N = 8192
     seed(0)
     comptime test_dtype = DType.float64
     var x64 = alloc[Scalar[test_dtype]](N)
@@ -208,9 +209,7 @@ def _test_tanh_libm_f64[N: Int = 8192]() raises:
 
     # Expect near machine-epsilon accuracy after float64 fix.
     # Allow up to 1e-14 absolute and relative error as a conservative bound.
-    var abs_rel_err = SIMD[test_dtype, 4](
-        0.0, 1e-14, 0.0, 1e-14
-    )
+    var abs_rel_err = SIMD[test_dtype, 4](0.0, 1e-14, 0.0, 1e-14)
 
     var err = compare[test_dtype](
         y64, libm_out, N, msg="Compare Mojo float64 vs. LibM tanh"
@@ -222,10 +221,6 @@ def _test_tanh_libm_f64[N: Int = 8192]() raises:
     x64.free()
     y64.free()
     libm_out.free()
-
-
-def test_tanh_libm_f64() raises:
-    _test_tanh_libm_f64[]()
 
 
 def main() raises:

--- a/mojo/stdlib/test/math/test_tanh.mojo
+++ b/mojo/stdlib/test/math/test_tanh.mojo
@@ -191,5 +191,42 @@ def test_tanh_libm() raises:
     _test_tanh_libm[]()
 
 
+def _test_tanh_libm_f64[N: Int = 8192]() raises:
+    seed(0)
+    comptime test_dtype = DType.float64
+    var x64 = alloc[Scalar[test_dtype]](N)
+    randn[test_dtype](x64, N, 0, 9.0)
+    print("For N=", N, " randomly generated float64 vals; mean=0.0, var=9.0")
+
+    var y64 = alloc[Scalar[test_dtype]](N)
+    for i in range(N):
+        y64[i] = tanh(x64[i])
+
+    var libm_out = alloc[Scalar[test_dtype]](N)
+    for i in range(N):
+        libm_out[i] = tanh_libm(x64[i])
+
+    # Expect near machine-epsilon accuracy after float64 fix.
+    # Allow up to 1e-14 absolute and relative error as a conservative bound.
+    var abs_rel_err = SIMD[test_dtype, 4](
+        0.0, 1e-14, 0.0, 1e-14
+    )
+
+    var err = compare[test_dtype](
+        y64, libm_out, N, msg="Compare Mojo float64 vs. LibM tanh"
+    )
+    for i in range(4):
+        if not err[i] <= abs_rel_err[i]:
+            assert_almost_equal(err[i], abs_rel_err[i])
+
+    x64.free()
+    y64.free()
+    libm_out.free()
+
+
+def test_tanh_libm_f64() raises:
+    _test_tanh_libm_f64[]()
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Summary

- `tanh()` used a P6/Q3 Padé polynomial designed for float32 accuracy (~1e-8 relative error). For float64 inputs this produced only ~8 decimal digits instead of the expected ~15.
- For float64 on CPU, switch to the numerically stable identity `tanh(x) = -expm1(-2|x|) / (expm1(-2|x|) + 2)`. `expm1` avoids catastrophic cancellation for small arguments and matches the approach used by FreeBSD libm / Cephes for double-precision tanh.
- GPU float64 continues to use the existing polynomial (no hardware intrinsic available; libm is not accessible on GPU).
- Adds `test_tanh_libm_f64` which compares Mojo float64 tanh against libm with a 1e-14 tolerance (previously the error was ~1e-8).