### PR TITLE
[Stdlib] Add Comparable to Interval with lexicographic ordering

### DIFF
--- a/mojo/stdlib/std/collections/interval.mojo
+++ b/mojo/stdlib/std/collections/interval.mojo
@@ -75,7 +75,7 @@ trait IntervalElement(Comparable, Copyable, Intable, Writable):
 
 struct Interval[T: IntervalElement](
     Boolable,
-    Equatable,
+    Comparable,
     ImplicitlyCopyable,
     Sized,
     Writable,
@@ -210,51 +210,20 @@ struct Interval[T: IntervalElement](
         """
         return self.start <= other.start and self.end >= other.end
 
-    fn __le__(self, other: Self) -> Bool:
-        """Returns whether this interval is less than or equal to another
-        interval.
-
-        Args:
-            other: The interval to compare with.
-
-        Returns:
-            True if this interval's start is less than or equal to the other interval's start.
-        """
-        return self.start <= other.start
-
-    fn __ge__(self, other: Self) -> Bool:
-        """Returns whether this interval is greater than or equal to another
-        interval.
-
-        Args:
-            other: The interval to compare with.
-
-        Returns:
-            True if this interval's end is greater than or equal to the other interval's end.
-        """
-        return self.end >= other.end
-
     fn __lt__(self, other: Self) -> Bool:
-        """Returns whether this interval is less than another interval.
+        """Returns whether this interval is less than another interval using
+        lexicographic ordering: compares by start first, then by end as
+        tiebreaker.
 
         Args:
             other: The interval to compare with.
 
         Returns:
-            True if this interval's start is less than the other interval's start.
+            True if this interval is lexicographically less than the other.
         """
-        return self.start < other.start
-
-    fn __gt__(self, other: Self) -> Bool:
-        """Returns whether this interval is greater than another interval.
-
-        Args:
-            other: The interval to compare with.
-
-        Returns:
-            True if this interval's end is greater than the other interval's end.
-        """
-        return self.end > other.end
+        if self.start != other.start:
+            return self.start < other.start
+        return self.end < other.end
 
     fn __len__(self) -> Int:
         """Returns the length of this interval.

--- a/mojo/stdlib/test/collections/test_interval.mojo
+++ b/mojo/stdlib/test/collections/test_interval.mojo
@@ -41,17 +41,26 @@ def test_interval() raises:
     assert_equal(interval, Interval(1, 10))
     assert_not_equal(interval, Interval(1, 11))
 
-    # Test less than comparisons
+    # Test less than comparisons (lexicographic: start first, then end)
     assert_true(
         interval < Interval(2, 11), msg=String(interval, " < Interval(2, 11)")
     )
-    assert_false(
+    assert_true(
         interval < Interval(1, 11), msg=String(interval, " < Interval(1, 11)")
     )
+    assert_false(
+        interval < Interval(1, 10), msg=String(interval, " < Interval(1, 10)")
+    )
+    assert_false(
+        interval < Interval(0, 20), msg=String(interval, " < Interval(0, 20)")
+    )
 
-    # Test greater than comparisons
+    # Test greater than comparisons (lexicographic: start first, then end)
     assert_true(
         interval > Interval(0, 9), msg=String(interval, " > Interval(0, 9)")
+    )
+    assert_true(
+        interval > Interval(1, 9), msg=String(interval, " > Interval(1, 9)")
     )
     assert_false(
         interval > Interval(1, 11), msg=String(interval, " > Interval(1, 11)")
@@ -72,7 +81,7 @@ def test_interval() raises:
     assert_true(
         interval >= Interval(1, 10), msg=String(interval, " >= Interval(1, 10)")
     )
-    assert_true(
+    assert_false(
         interval >= Interval(2, 9), msg=String(interval, " >= Interval(2, 9)")
     )
     assert_false(


### PR DESCRIPTION
## Summary

- Add `Comparable` trait to `Interval`, replacing `Equatable` (which `Comparable` extends).
- Fix broken comparison semantics where `__lt__`/`__le__` compared by `start` while `__gt__`/`__ge__` compared by `end`, violating transitivity.
- Use lexicographic ordering (start first, end as tiebreaker) in `__lt__`, and let `Comparable` derive `__gt__`, `__le__`, `__ge__` consistently.
- Note: this also addresses item 1.2 (comparison semantics bug) from the improvement opportunities, superseding PR #6074.