### PR TITLE
[Stdlib] Add comparison operators to Optional

### DIFF
--- a/mojo/stdlib/std/collections/optional.mojo
+++ b/mojo/stdlib/std/collections/optional.mojo
@@ -312,6 +312,81 @@ struct Optional[T: Movable](
         """
         return not (self == rhs)
 
+    fn __lt__[
+        _T: Comparable & Copyable
+    ](self: Optional[_T], rhs: Optional[_T]) -> Bool:
+        """Return `True` if this `Optional` is less than `rhs`.
+
+        Uses the total order: `None < Some(x)` for all `x`, and
+        `Some(a) < Some(b)` when `a < b`.
+
+        Parameters:
+            _T: The type of the elements. Must implement the traits
+                `Copyable` and `Comparable`.
+
+        Args:
+            rhs: The value to compare to.
+
+        Returns:
+            True if this `Optional` is less than `rhs`.
+        """
+        if self:
+            if rhs:
+                return self.value() < rhs.value()
+            return False  # Some(x) is not less than None
+        return Bool(rhs)  # None < Some(x) is True; None < None is False
+
+    fn __le__[
+        _T: Comparable & Copyable
+    ](self: Optional[_T], rhs: Optional[_T]) -> Bool:
+        """Return `True` if this `Optional` is less than or equal to `rhs`.
+
+        Parameters:
+            _T: The type of the elements. Must implement the traits
+                `Copyable` and `Comparable`.
+
+        Args:
+            rhs: The value to compare to.
+
+        Returns:
+            True if this `Optional` is less than or equal to `rhs`.
+        """
+        return not (rhs < self)
+
+    fn __gt__[
+        _T: Comparable & Copyable
+    ](self: Optional[_T], rhs: Optional[_T]) -> Bool:
+        """Return `True` if this `Optional` is greater than `rhs`.
+
+        Parameters:
+            _T: The type of the elements. Must implement the traits
+                `Copyable` and `Comparable`.
+
+        Args:
+            rhs: The value to compare to.
+
+        Returns:
+            True if this `Optional` is greater than `rhs`.
+        """
+        return rhs < self
+
+    fn __ge__[
+        _T: Comparable & Copyable
+    ](self: Optional[_T], rhs: Optional[_T]) -> Bool:
+        """Return `True` if this `Optional` is greater than or equal to `rhs`.
+
+        Parameters:
+            _T: The type of the elements. Must implement the traits
+                `Copyable` and `Comparable`.
+
+        Args:
+            rhs: The value to compare to.
+
+        Returns:
+            True if this `Optional` is greater than or equal to `rhs`.
+        """
+        return not (self < rhs)
+
     # ===-------------------------------------------------------------------===#
     # Trait implementations
     # ===-------------------------------------------------------------------===#

--- a/mojo/stdlib/test/collections/test_optional.mojo
+++ b/mojo/stdlib/test/collections/test_optional.mojo
@@ -252,6 +252,50 @@ def test_optional_of_move_only_type() raises:
     assert_equal(val.data, 10)
 
 
+def test_optional_comparison() raises:
+    var a = Optional(1)
+    var b = Optional(2)
+    var c = Optional(1)
+    var none1 = Optional[Int]()
+    var none2 = Optional[Int]()
+
+    # None < Some(x) for all x.
+    assert_true(none1 < a)
+    assert_true(none1 < b)
+
+    # Some(x) is not less than None.
+    assert_false(a < none1)
+    assert_false(b < none1)
+
+    # None is not less than None.
+    assert_false(none1 < none2)
+
+    # Some(a) < Some(b) when a < b.
+    assert_true(a < b)
+    assert_false(b < a)
+    assert_false(a < c)
+
+    # Less than or equal.
+    assert_true(a <= c)
+    assert_true(a <= b)
+    assert_false(b <= a)
+    assert_true(none1 <= none2)
+    assert_true(none1 <= a)
+
+    # Greater than.
+    assert_true(b > a)
+    assert_false(a > b)
+    assert_true(a > none1)
+    assert_false(none1 > a)
+
+    # Greater than or equal.
+    assert_true(a >= c)
+    assert_true(b >= a)
+    assert_false(a >= b)
+    assert_true(none1 >= none2)
+    assert_false(none1 >= a)
+
+
 def test_nicheable_size() raises:
     comptime PointerType = Pointer[Int, AnyOrigin[mut=True]]
 


### PR DESCRIPTION
## Summary

- Add `__lt__`, `__le__`, `__gt__`, `__ge__` to `Optional` conditional on `T: Comparable & Copyable`
- Total order: `None < Some(x)` for all `x`, `Some(a) < Some(b)` when `a < b`

The implemented semantics match Rust, C++, and Haskell exactly, but not Python, which raises a `TypeError` when comparing with `None`. So it may need further discussion.