### PR TITLE
[Stdlib] Add comparison operators to StaticTuple

### DIFF
--- a/mojo/docs/changelog.md
+++ b/mojo/docs/changelog.md
@@ -320,6 +320,11 @@ what we publish.
 
 ### Library changes
 
+- `StaticTuple` now supports comparison operators. `__eq__`/`__ne__` are
+  available when `element_type: Equatable`, and `__lt__`/`__le__`/`__gt__`/
+  `__ge__` are available when `element_type: Comparable`. All use
+  lexicographic ordering with compile-time unrolled loops.
+
 - `lane_group_sum()`, `lane_group_max()`, and `lane_group_min()` in
   `std.gpu.primitives.warp` now always broadcast the reduction result to all
   participating lanes, using optimized hardware-specific paths (AMD DPP,

--- a/mojo/stdlib/std/utils/static_tuple.mojo
+++ b/mojo/stdlib/std/utils/static_tuple.mojo
@@ -268,7 +268,9 @@ struct StaticTuple[element_type: TrivialRegisterPassable, size: Int](
     @always_inline
     fn __eq__[
         _E: Equatable & TrivialRegisterPassable, //
-    ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
+    ](
+        self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]
+    ) -> Bool:
         """Returns `True` if all elements are equal.
 
         Parameters:
@@ -289,7 +291,9 @@ struct StaticTuple[element_type: TrivialRegisterPassable, size: Int](
     @always_inline
     fn __ne__[
         _E: Equatable & TrivialRegisterPassable, //
-    ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
+    ](
+        self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]
+    ) -> Bool:
         """Returns `True` if any element differs.
 
         Parameters:
@@ -307,7 +311,9 @@ struct StaticTuple[element_type: TrivialRegisterPassable, size: Int](
     @always_inline
     fn __lt__[
         _E: Comparable & TrivialRegisterPassable, //
-    ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
+    ](
+        self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]
+    ) -> Bool:
         """Returns `True` if `self` is lexicographically less than `other`.
 
         Parameters:
@@ -330,7 +336,9 @@ struct StaticTuple[element_type: TrivialRegisterPassable, size: Int](
     @always_inline
     fn __le__[
         _E: Comparable & TrivialRegisterPassable, //
-    ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
+    ](
+        self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]
+    ) -> Bool:
         """Returns `True` if `self` is lexicographically less than or equal to
         `other`.
 
@@ -349,7 +357,9 @@ struct StaticTuple[element_type: TrivialRegisterPassable, size: Int](
     @always_inline
     fn __gt__[
         _E: Comparable & TrivialRegisterPassable, //
-    ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
+    ](
+        self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]
+    ) -> Bool:
         """Returns `True` if `self` is lexicographically greater than `other`.
 
         Parameters:
@@ -367,7 +377,9 @@ struct StaticTuple[element_type: TrivialRegisterPassable, size: Int](
     @always_inline
     fn __ge__[
         _E: Comparable & TrivialRegisterPassable, //
-    ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
+    ](
+        self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]
+    ) -> Bool:
         """Returns `True` if `self` is lexicographically greater than or equal
         to `other`.
 

--- a/mojo/stdlib/std/utils/static_tuple.mojo
+++ b/mojo/stdlib/std/utils/static_tuple.mojo
@@ -264,3 +264,116 @@ struct StaticTuple[element_type: TrivialRegisterPassable, size: Int](
         ](val, self._mlir_value)
 
         return Self(mlir_value=array)
+
+    fn __eq__[
+        _E: Equatable & TrivialRegisterPassable, //
+    ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
+        """Returns `True` if all elements are equal.
+
+        Parameters:
+            _E: The element type, must be `Equatable` and
+                `TrivialRegisterPassable`.
+
+        Args:
+            other: The tuple to compare with.
+
+        Returns:
+            True if all corresponding elements are equal.
+        """
+        comptime for i in range(Self.size):
+            if self[i] != other[i]:
+                return False
+        return True
+
+    fn __ne__[
+        _E: Equatable & TrivialRegisterPassable, //
+    ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
+        """Returns `True` if any element differs.
+
+        Parameters:
+            _E: The element type, must be `Equatable` and
+                `TrivialRegisterPassable`.
+
+        Args:
+            other: The tuple to compare with.
+
+        Returns:
+            True if any corresponding elements differ.
+        """
+        return not (self == other)
+
+    fn __lt__[
+        _E: Comparable & TrivialRegisterPassable, //
+    ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
+        """Returns `True` if `self` is lexicographically less than `other`.
+
+        Parameters:
+            _E: The element type, must be `Comparable` and
+                `TrivialRegisterPassable`.
+
+        Args:
+            other: The tuple to compare with.
+
+        Returns:
+            True if `self` is lexicographically less than `other`.
+        """
+        comptime for i in range(Self.size):
+            if self[i] < other[i]:
+                return True
+            if self[i] != other[i]:
+                return False
+        return False
+
+    fn __le__[
+        _E: Comparable & TrivialRegisterPassable, //
+    ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
+        """Returns `True` if `self` is lexicographically less than or equal to
+        `other`.
+
+        Parameters:
+            _E: The element type, must be `Comparable` and
+                `TrivialRegisterPassable`.
+
+        Args:
+            other: The tuple to compare with.
+
+        Returns:
+            True if `self` is lexicographically less than or equal to `other`.
+        """
+        return not (other < self)
+
+    fn __gt__[
+        _E: Comparable & TrivialRegisterPassable, //
+    ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
+        """Returns `True` if `self` is lexicographically greater than `other`.
+
+        Parameters:
+            _E: The element type, must be `Comparable` and
+                `TrivialRegisterPassable`.
+
+        Args:
+            other: The tuple to compare with.
+
+        Returns:
+            True if `self` is lexicographically greater than `other`.
+        """
+        return other < self
+
+    fn __ge__[
+        _E: Comparable & TrivialRegisterPassable, //
+    ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
+        """Returns `True` if `self` is lexicographically greater than or equal
+        to `other`.
+
+        Parameters:
+            _E: The element type, must be `Comparable` and
+                `TrivialRegisterPassable`.
+
+        Args:
+            other: The tuple to compare with.
+
+        Returns:
+            True if `self` is lexicographically greater than or equal to
+            `other`.
+        """
+        return not (self < other)

--- a/mojo/stdlib/std/utils/static_tuple.mojo
+++ b/mojo/stdlib/std/utils/static_tuple.mojo
@@ -265,6 +265,7 @@ struct StaticTuple[element_type: TrivialRegisterPassable, size: Int](
 
         return Self(mlir_value=array)
 
+    @always_inline
     fn __eq__[
         _E: Equatable & TrivialRegisterPassable, //
     ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
@@ -285,6 +286,7 @@ struct StaticTuple[element_type: TrivialRegisterPassable, size: Int](
                 return False
         return True
 
+    @always_inline
     fn __ne__[
         _E: Equatable & TrivialRegisterPassable, //
     ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
@@ -302,6 +304,7 @@ struct StaticTuple[element_type: TrivialRegisterPassable, size: Int](
         """
         return not (self == other)
 
+    @always_inline
     fn __lt__[
         _E: Comparable & TrivialRegisterPassable, //
     ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
@@ -324,6 +327,7 @@ struct StaticTuple[element_type: TrivialRegisterPassable, size: Int](
                 return False
         return False
 
+    @always_inline
     fn __le__[
         _E: Comparable & TrivialRegisterPassable, //
     ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
@@ -342,6 +346,7 @@ struct StaticTuple[element_type: TrivialRegisterPassable, size: Int](
         """
         return not (other < self)
 
+    @always_inline
     fn __gt__[
         _E: Comparable & TrivialRegisterPassable, //
     ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:
@@ -359,6 +364,7 @@ struct StaticTuple[element_type: TrivialRegisterPassable, size: Int](
         """
         return other < self
 
+    @always_inline
     fn __ge__[
         _E: Comparable & TrivialRegisterPassable, //
     ](self: StaticTuple[_E, Self.size], other: StaticTuple[_E, Self.size]) -> Bool:

--- a/mojo/stdlib/test/utils/test_static_tuple.mojo
+++ b/mojo/stdlib/test/utils/test_static_tuple.mojo
@@ -11,7 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from std.testing import TestSuite, assert_equal
+from std.testing import TestSuite, assert_equal, assert_true, assert_false
 
 from std.utils import StaticTuple
 
@@ -49,6 +49,56 @@ def test_setitem() raises:
     comptime idx: Int = 0
     t.__setitem__[idx](400)
     assert_equal(t[0], 400)
+
+
+def test_equality() raises:
+    var a = StaticTuple[Int, 3](1, 2, 3)
+    var b = StaticTuple[Int, 3](1, 2, 3)
+    var c = StaticTuple[Int, 3](1, 2, 4)
+
+    assert_true(a == b)
+    assert_false(a == c)
+    assert_false(a != b)
+    assert_true(a != c)
+
+
+def test_comparison() raises:
+    var a = StaticTuple[Int, 3](1, 2, 3)
+    var b = StaticTuple[Int, 3](1, 2, 4)
+    var c = StaticTuple[Int, 3](1, 2, 3)
+    var d = StaticTuple[Int, 3](2, 0, 0)
+
+    # Less than
+    assert_true(a < b)
+    assert_false(b < a)
+    assert_false(a < c)
+
+    # First element dominates
+    assert_true(a < d)
+    assert_false(d < a)
+
+    # Less than or equal
+    assert_true(a <= c)
+    assert_true(a <= b)
+    assert_false(b <= a)
+
+    # Greater than
+    assert_true(b > a)
+    assert_false(a > b)
+    assert_false(a > c)
+
+    # Greater than or equal
+    assert_true(a >= c)
+    assert_true(b >= a)
+    assert_false(a >= b)
+
+    # Empty tuple
+    var e1 = StaticTuple[Int, 0]()
+    var e2 = StaticTuple[Int, 0]()
+    assert_true(e1 == e2)
+    assert_false(e1 < e2)
+    assert_true(e1 <= e2)
+    assert_true(e1 >= e2)
 
 
 def main() raises:


### PR DESCRIPTION
## Summary

- Add `__eq__`/`__ne__` conditional on `element_type: Equatable & TrivialRegisterPassable`
- Add `__lt__`/`__le__`/`__gt__`/`__ge__` conditional on `element_type: Comparable & TrivialRegisterPassable`
- All use lexicographic ordering with compile-time unrolled loops via `comptime for`