### PR TITLE
[Stdlib] Add Equatable and Writable to benchmark Mode

### DIFF
--- a/mojo/docs/nightly-changelog.md
+++ b/mojo/docs/nightly-changelog.md
@@ -95,6 +95,10 @@ This version is still a work in progress.
   To provide a gradual migration path, explicitly typed aliases are
   available temporarily.
 
+- `BenchConfig` and `Mode` in `std.benchmark.bencher` now conform to `Writable`,
+  enabling use with `String()`, `print()`, and any `Writer`-based formatting.
+  `Mode` also conforms to `Equatable`, supporting `==` and `!=` comparisons.
+
   | Base         | `UInt` Accessor   | `Int` Accessor    |
   |--------------|-------------------|-------------------|
   | `thread_idx` | `thread_idx_uint` | `thread_idx_int`  |

--- a/mojo/stdlib/std/benchmark/bencher.mojo
+++ b/mojo/stdlib/std/benchmark/bencher.mojo
@@ -459,16 +459,11 @@ struct BenchConfig(Copyable, Writable):
             writer: The writer to write to.
         """
 
-        @parameter
-        fn fields(mut w: Some[Writer]):
-            w.write_string("min_runtime_secs=")
-            w.write(self.min_runtime_secs)
-            w.write_string(", max_runtime_secs=")
-            w.write(self.max_runtime_secs)
-            w.write_string(", max_iters=")
-            w.write(self.max_iters)
-
-        fmt.FormatStruct(writer, "BenchConfig").fields[FieldsFn=fields]()
+        fmt.FormatStruct(writer, "BenchConfig").fields(
+            fmt.Named("min_runtime_secs", self.min_runtime_secs),
+            fmt.Named("max_runtime_secs", self.max_runtime_secs),
+            fmt.Named("max_iters", self.max_iters),
+        )
 
 
 @fieldwise_init

--- a/mojo/stdlib/std/benchmark/bencher.mojo
+++ b/mojo/stdlib/std/benchmark/bencher.mojo
@@ -515,7 +515,7 @@ struct BenchmarkInfo(Copyable):
 
 
 @fieldwise_init
-struct Mode(ImplicitlyCopyable):
+struct Mode(Equatable, ImplicitlyCopyable, Writable):
     """Defines a Benchmark Mode to distinguish between test runs and actual benchmarks.
     """
 
@@ -539,6 +539,27 @@ struct Mode(ImplicitlyCopyable):
         """
 
         return self.value == other.value
+
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the mode name to a writer.
+
+        Args:
+            writer: The writer to write the `Mode` to.
+        """
+        if self.value == Self.Benchmark.value:
+            writer.write_string("Benchmark")
+        else:
+            writer.write_string("Test")
+
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the repr of this `Mode` to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        writer.write_string("Mode.")
+        self.write_to(writer)
 
 
 struct Bench(Writable):

--- a/mojo/stdlib/std/benchmark/bencher.mojo
+++ b/mojo/stdlib/std/benchmark/bencher.mojo
@@ -299,7 +299,7 @@ struct Format(ImplicitlyCopyable, Writable):
 
 
 @fieldwise_init
-struct BenchConfig(Copyable):
+struct BenchConfig(Copyable, Writable):
     """Defines a benchmark configuration struct to control
     execution times and frequency.
     """
@@ -434,6 +434,41 @@ struct BenchConfig(Copyable):
                     self.out_file = Path(env_outfile)
 
         argparse()
+
+    fn write_to(self, mut writer: Some[Writer]):
+        """Writes the benchmark configuration to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+        writer.write(
+            "BenchConfig(min_runtime_secs=",
+            self.min_runtime_secs,
+            ", max_runtime_secs=",
+            self.max_runtime_secs,
+            ", max_iters=",
+            self.max_iters,
+            ")",
+        )
+
+    @no_inline
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the repr of this `BenchConfig` to a writer.
+
+        Args:
+            writer: The writer to write to.
+        """
+
+        @parameter
+        fn fields(mut w: Some[Writer]):
+            w.write_string("min_runtime_secs=")
+            w.write(self.min_runtime_secs)
+            w.write_string(", max_runtime_secs=")
+            w.write(self.max_runtime_secs)
+            w.write_string(", max_iters=")
+            w.write(self.max_iters)
+
+        fmt.FormatStruct(writer, "BenchConfig").fields[FieldsFn=fields]()
 
 
 @fieldwise_init

--- a/mojo/stdlib/test/benchmark/test_benchmark.mojo
+++ b/mojo/stdlib/test/benchmark/test_benchmark.mojo
@@ -319,7 +319,9 @@ def test_bench_function_no_arg_unified() raises:
 
 
 def test_bench_config_write_to() raises:
-    var cfg = BenchConfig(min_runtime_secs=0.5, max_runtime_secs=2.0, max_iters=1000)
+    var cfg = BenchConfig(
+        min_runtime_secs=0.5, max_runtime_secs=2.0, max_iters=1000
+    )
     var s = String()
     cfg.write_to(s)
     assert_true("min_runtime_secs=0.5" in s)
@@ -328,7 +330,9 @@ def test_bench_config_write_to() raises:
 
 
 def test_bench_config_write_repr_to() raises:
-    var cfg = BenchConfig(min_runtime_secs=0.5, max_runtime_secs=2.0, max_iters=1000)
+    var cfg = BenchConfig(
+        min_runtime_secs=0.5, max_runtime_secs=2.0, max_iters=1000
+    )
     var s = String()
     cfg.write_repr_to(s)
     assert_true(s.startswith("BenchConfig("))

--- a/mojo/stdlib/test/benchmark/test_benchmark.mojo
+++ b/mojo/stdlib/test/benchmark/test_benchmark.mojo
@@ -318,6 +318,26 @@ def test_bench_function_no_arg_unified() raises:
     assert_true(count > 0)
 
 
+def test_bench_config_write_to() raises:
+    var cfg = BenchConfig(min_runtime_secs=0.5, max_runtime_secs=2.0, max_iters=1000)
+    var s = String()
+    cfg.write_to(s)
+    assert_true("min_runtime_secs=0.5" in s)
+    assert_true("max_runtime_secs=2.0" in s)
+    assert_true("max_iters=1000" in s)
+
+
+def test_bench_config_write_repr_to() raises:
+    var cfg = BenchConfig(min_runtime_secs=0.5, max_runtime_secs=2.0, max_iters=1000)
+    var s = String()
+    cfg.write_repr_to(s)
+    assert_true(s.startswith("BenchConfig("))
+    assert_true(s.endswith(")"))
+    assert_true("min_runtime_secs=0.5" in s)
+    assert_true("max_runtime_secs=2.0" in s)
+    assert_true("max_iters=1000" in s)
+
+
 def test_mode_equatable() raises:
     assert_true(Mode.Benchmark == Mode.Benchmark)
     assert_true(Mode.Test == Mode.Test)

--- a/mojo/stdlib/test/benchmark/test_benchmark.mojo
+++ b/mojo/stdlib/test/benchmark/test_benchmark.mojo
@@ -21,9 +21,10 @@ from std.benchmark.bencher import (
     BenchId,
     BenchMetric,
     Format,
+    Mode,
     ThroughputMeasure,
 )
-from std.testing import TestSuite, assert_equal, assert_true
+from std.testing import TestSuite, assert_equal, assert_false, assert_true
 from test_utils import check_write_to
 
 
@@ -315,6 +316,34 @@ def test_bench_function_no_arg_unified() raises:
 
     bench.bench_function(my_func, BenchId("test_noarg_unified"))
     assert_true(count > 0)
+
+
+def test_mode_equatable() raises:
+    assert_true(Mode.Benchmark == Mode.Benchmark)
+    assert_true(Mode.Test == Mode.Test)
+    assert_false(Mode.Benchmark == Mode.Test)
+    assert_true(Mode.Benchmark != Mode.Test)
+    assert_false(Mode.Benchmark != Mode.Benchmark)
+
+
+def test_mode_write_to() raises:
+    var s = String()
+    Mode.Benchmark.write_to(s)
+    assert_equal(s, "Benchmark")
+
+    s = String()
+    Mode.Test.write_to(s)
+    assert_equal(s, "Test")
+
+
+def test_mode_write_repr_to() raises:
+    var s = String()
+    Mode.Benchmark.write_repr_to(s)
+    assert_equal(s, "Mode.Benchmark")
+
+    s = String()
+    Mode.Test.write_repr_to(s)
+    assert_equal(s, "Mode.Test")
 
 
 def main() raises:


### PR DESCRIPTION
## Summary

- Add `Equatable` and `Writable` to `Mode` trait list
- `write_to` outputs `"Benchmark"` or `"Test"`
- `write_repr_to` outputs `"Mode.Benchmark"` or `"Mode.Test"`
- `__ne__` is not needed — `Equatable` provides a default implementation

---

Assisted-by: AI