### PR TITLE
[Stdlib] Add LinkedList.index() method

### DIFF
--- a/mojo/docs/nightly-changelog.md
+++ b/mojo/docs/nightly-changelog.md
@@ -359,6 +359,10 @@ This version is still a work in progress.
   `lane_group_sum_and_broadcast()`, `lane_group_max_and_broadcast()` functions
   are deprecated — use the short names instead.
 
+- `LinkedList` now has an `index(value, start=0, stop=None)` method returning
+  the position of the first occurrence of `value`, consistent with `List.index()`.
+  Raises `ValueError` if the value is not found.
+
 - `Bool` no longer conforms to the `Indexer` trait. Previously, `Bool` could be
   used to index into collections (e.g., `nums[True]`), which is not desirable
   behavior for a strongly-typed language. Use `Int(my_bool)` to explicitly

--- a/mojo/stdlib/std/collections/linked_list.mojo
+++ b/mojo/stdlib/std/collections/linked_list.mojo
@@ -613,7 +613,9 @@ struct LinkedList[ElementType: Copyable & ImplicitlyDestructible](
         var n = len(self)
         var start_norm = max(start if start >= 0 else start + n, 0)
         var stop_val = stop.value() if stop else n
-        var stop_norm = min(max(stop_val if stop_val >= 0 else stop_val + n, 0), n)
+        var stop_norm = min(
+            max(stop_val if stop_val >= 0 else stop_val + n, 0), n
+        )
 
         # Advance to start_norm without unnecessary comparisons in the hot loop
         var current = self._head

--- a/mojo/stdlib/std/collections/linked_list.mojo
+++ b/mojo/stdlib/std/collections/linked_list.mojo
@@ -611,17 +611,20 @@ struct LinkedList[ElementType: Copyable & ImplicitlyDestructible](
         ```
         """
         var n = len(self)
-        var start_norm = start if start >= 0 else max(start + n, 0)
-        var stop_norm = (
-            n if stop is None else (stop.value() if stop.value() >= 0 else max(stop.value() + n, 0))
-        )
-        start_norm = min(start_norm, n)
-        stop_norm = min(stop_norm, n)
+        var start_norm = max(start if start >= 0 else start + n, 0)
+        var stop_val = stop.value() if stop else n
+        var stop_norm = min(max(stop_val if stop_val >= 0 else stop_val + n, 0), n)
 
+        # Advance to start_norm without unnecessary comparisons in the hot loop
         var current = self._head
-        var idx = 0
+        for _ in range(start_norm):
+            if not current:
+                break
+            current = current[].next
+
+        var idx = start_norm
         while current and idx < stop_norm:
-            if idx >= start_norm and current[].value == value:
+            if current[].value == value:
                 return idx
             current = current[].next
             idx += 1

--- a/mojo/stdlib/std/collections/linked_list.mojo
+++ b/mojo/stdlib/std/collections/linked_list.mojo
@@ -570,6 +570,64 @@ struct LinkedList[ElementType: Copyable & ImplicitlyDestructible](
 
         return UInt(count)
 
+    fn index[
+        _ElementType: Equatable & Copyable, //
+    ](
+        self: LinkedList[_ElementType],
+        read value: _ElementType,
+        start: Int = 0,
+        stop: Optional[Int] = None,
+    ) raises -> Int:
+        """Returns the index of the first occurrence of `value` in the list.
+
+        Parameters:
+            _ElementType: The list element type, used to conditionally enable
+                the function.
+
+        Args:
+            value: The value to search for.
+            start: The index to start searching from (default 0). Negative
+                values are treated as offsets from the end of the list.
+            stop: The index to stop searching at (exclusive). Defaults to the
+                end of the list. Negative values are treated as offsets from
+                the end of the list.
+
+        Returns:
+            The index of the first occurrence of `value` in the range
+            `[start, stop)`.
+
+        Raises:
+            ValueError: If the value is not found in the specified range.
+
+        Notes:
+            Time Complexity: O(n) in len(self) traversals.
+
+        Example:
+
+        ```mojo
+        var ll = LinkedList[Int](1, 2, 3, 2, 1)
+        print(ll.index(2))  # 1
+        print(ll.index(2, start=2))  # 3
+        ```
+        """
+        var n = len(self)
+        var start_norm = start if start >= 0 else max(start + n, 0)
+        var stop_norm = (
+            n if stop is None else (stop.value() if stop.value() >= 0 else max(stop.value() + n, 0))
+        )
+        start_norm = min(start_norm, n)
+        stop_norm = min(stop_norm, n)
+
+        var current = self._head
+        var idx = 0
+        while current and idx < stop_norm:
+            if idx >= start_norm and current[].value == value:
+                return idx
+            current = current[].next
+            idx += 1
+
+        raise Error("ValueError: value is not in list")
+
     fn __contains__[
         _ElementType: Equatable & Copyable, //
     ](self: LinkedList[_ElementType], value: _ElementType) -> Bool:

--- a/mojo/stdlib/test/collections/test_linked_list.mojo
+++ b/mojo/stdlib/test/collections/test_linked_list.mojo
@@ -669,5 +669,48 @@ def test_linked_list_conditional_conformances() raises:
     assert_true(conforms_to(LinkedList[Int], Hashable))
 
 
+def test_index_basic() raises:
+    """Returns the index of the first occurrence."""
+    var ll = LinkedList[Int](1, 2, 3)
+    assert_equal(ll.index(1), 0)
+    assert_equal(ll.index(2), 1)
+    assert_equal(ll.index(3), 2)
+
+
+def test_index_first_occurrence() raises:
+    """Returns the first occurrence when there are duplicates."""
+    var ll = LinkedList[Int](1, 2, 3, 2, 1)
+    assert_equal(ll.index(2), 1)
+    assert_equal(ll.index(1), 0)
+
+
+def test_index_with_start() raises:
+    """Respects the start bound."""
+    var ll = LinkedList[Int](1, 2, 3, 2, 1)
+    assert_equal(ll.index(2, start=2), 3)
+
+
+def test_index_with_stop() raises:
+    """Respects the stop bound (exclusive)."""
+    var ll = LinkedList[Int](1, 2, 3, 2, 1)
+    assert_equal(ll.index(2, stop=3), 1)
+    with assert_raises(contains="ValueError"):
+        _ = ll.index(3, stop=2)
+
+
+def test_index_negative_bounds() raises:
+    """Negative start/stop are normalized from the end."""
+    var ll = LinkedList[Int](1, 2, 3, 2, 1)
+    assert_equal(ll.index(2, start=-4), 1)
+    assert_equal(ll.index(2, start=-3, stop=-1), 3)
+
+
+def test_index_not_found() raises:
+    """Raises ValueError when the value is not present."""
+    var ll = LinkedList[Int](1, 2, 3)
+    with assert_raises(contains="ValueError"):
+        _ = ll.index(99)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Adds `index(value, start=0, stop=None)` to `LinkedList`, making it consistent with `List.index()`.

Traverses the list once up to `stop`, returning the index of the first match at or after `start`. Negative `start`/`stop` values are normalized from the end of the list. Raises `ValueError` if not found.