### PR TITLE
[Stdlib] Add assert_in() and assert_not_in() to testing module

### DIFF
--- a/mojo/docs/nightly-changelog.md
+++ b/mojo/docs/nightly-changelog.md
@@ -355,6 +355,16 @@ This version is still a work in progress.
   `lane_group_sum_and_broadcast()`, `lane_group_max_and_broadcast()` functions
   are deprecated — use the short names instead.
 
+- Added `assert_in(value, container)` and `assert_not_in(value, container)` to
+  the `testing` module. Both produce rich error messages showing the value and
+  container, unlike `assert_true(x in container)` which only shows `False`:
+
+  ```mojo
+  assert_in(2, [1, 2, 3])   # passes
+  assert_in(99, [1, 2, 3])  # AssertionError: value 99 not found in [1, 2, 3]
+  assert_not_in(99, [1, 2, 3])  # passes
+  ```
+
 - `Bool` no longer conforms to the `Indexer` trait. Previously, `Bool` could be
   used to index into collections (e.g., `nums[True]`), which is not desirable
   behavior for a strongly-typed language. Use `Int(my_bool)` to explicitly

--- a/mojo/stdlib/std/testing/__init__.mojo
+++ b/mojo/stdlib/std/testing/__init__.mojo
@@ -27,9 +27,11 @@ from .testing import (
     assert_equal,
     assert_equal_pyobj,
     assert_false,
+    assert_in,
     assert_is,
     assert_is_not,
     assert_not_equal,
+    assert_not_in,
     assert_raises,
     assert_true,
 )

--- a/mojo/stdlib/std/testing/testing.mojo
+++ b/mojo/stdlib/std/testing/testing.mojo
@@ -577,8 +577,10 @@ fn assert_in[
         raise _assert_error(
             String(
                 "`value in container` assertion failed",
-                "\n  value: ", value,
-                "\n  container: ", container,
+                "\n  value: ",
+                value,
+                "\n  container: ",
+                container,
                 ("\n  reason: " + msg) if msg else "",
             ),
             location.or_else(call_location()),
@@ -621,8 +623,10 @@ fn assert_not_in[
         raise _assert_error(
             String(
                 "`value not in container` assertion failed",
-                "\n  value: ", value,
-                "\n  container: ", container,
+                "\n  value: ",
+                value,
+                "\n  container: ",
+                container,
                 ("\n  reason: " + msg) if msg else "",
             ),
             location.or_else(call_location()),

--- a/mojo/stdlib/std/testing/testing.mojo
+++ b/mojo/stdlib/std/testing/testing.mojo
@@ -540,6 +540,95 @@ fn _assert_cmp_error[
     return _assert_error(err, loc)
 
 
+@always_inline
+fn assert_in[
+    T: Equatable & Copyable & Writable, //
+](
+    value: T,
+    container: List[T, ...],
+    msg: String = "",
+    *,
+    location: Optional[SourceLocation] = None,
+) raises:
+    """Asserts that `value` is a member of `container`. If not, raises an Error.
+
+    Parameters:
+        T: The element type. Must be `Equatable`, `Copyable`, and `Writable`.
+
+    Args:
+        value: The value to search for.
+        container: The list to search in.
+        msg: An optional message to include if the assertion fails.
+        location: The location of the error (defaults to `call_location`).
+
+    Raises:
+        An Error if `value` is not in `container`.
+
+    Example:
+
+    ```mojo
+    from std.testing import assert_in
+    assert_in(2, [1, 2, 3])         # passes
+    assert_in("b", ["a", "b", "c"]) # passes
+    assert_in(99, [1, 2, 3])        # raises AssertionError
+    ```
+    """
+    if value not in container:
+        raise _assert_error(
+            String(
+                "`value in container` assertion failed",
+                "\n  value: ", value,
+                "\n  container: ", container,
+                ("\n  reason: " + msg) if msg else "",
+            ),
+            location.or_else(call_location()),
+        )
+
+
+@always_inline
+fn assert_not_in[
+    T: Equatable & Copyable & Writable, //
+](
+    value: T,
+    container: List[T, ...],
+    msg: String = "",
+    *,
+    location: Optional[SourceLocation] = None,
+) raises:
+    """Asserts that `value` is not a member of `container`. If it is, raises an Error.
+
+    Parameters:
+        T: The element type. Must be `Equatable`, `Copyable`, and `Writable`.
+
+    Args:
+        value: The value to search for.
+        container: The list to search in.
+        msg: An optional message to include if the assertion fails.
+        location: The location of the error (defaults to `call_location`).
+
+    Raises:
+        An Error if `value` is in `container`.
+
+    Example:
+
+    ```mojo
+    from std.testing import assert_not_in
+    assert_not_in(99, [1, 2, 3])        # passes
+    assert_not_in(2, [1, 2, 3])         # raises AssertionError
+    ```
+    """
+    if value in container:
+        raise _assert_error(
+            String(
+                "`value not in container` assertion failed",
+                "\n  value: ", value,
+                "\n  container: ", container,
+                ("\n  reason: " + msg) if msg else "",
+            ),
+            location.or_else(call_location()),
+        )
+
+
 struct assert_raises:
     """Context manager that asserts that the block raises an exception.
 

--- a/mojo/stdlib/test/testing/test_assertion.mojo
+++ b/mojo/stdlib/test/testing/test_assertion.mojo
@@ -17,7 +17,9 @@ from std.testing import (
     assert_almost_equal,
     assert_equal,
     assert_false,
+    assert_in,
     assert_not_equal,
+    assert_not_in,
     assert_raises,
     assert_true,
     TestSuite,
@@ -289,6 +291,54 @@ def test_assert_equal_with_unicode() raises:
     # Mixed ASCII and Unicode
     with assert_raises():
         assert_equal("abc中文def", "abc英文def")
+
+
+def test_assert_in_passes() raises:
+    """assert_in succeeds when the value is in the container."""
+    assert_in(2, [1, 2, 3])
+    assert_in("b", ["a", "b", "c"])
+
+
+def test_assert_in_fails() raises:
+    """assert_in raises AssertionError when the value is not in the container."""
+    with assert_raises(contains="AssertionError"):
+        assert_in(99, [1, 2, 3])
+
+
+def test_assert_in_error_message() raises:
+    """assert_in error message contains value and container."""
+    with assert_raises(contains="value in container"):
+        assert_in(99, [1, 2, 3])
+
+
+def test_assert_in_custom_msg() raises:
+    """assert_in includes the custom message on failure."""
+    with assert_raises(contains="not there"):
+        assert_in(99, [1, 2, 3], msg="not there")
+
+
+def test_assert_not_in_passes() raises:
+    """assert_not_in succeeds when the value is not in the container."""
+    assert_not_in(99, [1, 2, 3])
+    assert_not_in("z", ["a", "b", "c"])
+
+
+def test_assert_not_in_fails() raises:
+    """Raises AssertionError when the value is in the container."""
+    with assert_raises(contains="AssertionError"):
+        assert_not_in(2, [1, 2, 3])
+
+
+def test_assert_not_in_error_message() raises:
+    """Error message contains value and container on failure."""
+    with assert_raises(contains="value not in container"):
+        assert_not_in(2, [1, 2, 3])
+
+
+def test_assert_not_in_custom_msg() raises:
+    """Custom message is included in the error on failure."""
+    with assert_raises(contains="unexpected"):
+        assert_not_in(2, [1, 2, 3], msg="unexpected")
 
 
 def main() raises:

--- a/mojo/stdlib/test/testing/test_assertion.mojo
+++ b/mojo/stdlib/test/testing/test_assertion.mojo
@@ -294,31 +294,31 @@ def test_assert_equal_with_unicode() raises:
 
 
 def test_assert_in_passes() raises:
-    """assert_in succeeds when the value is in the container."""
+    """Succeeds when the value is in the container."""
     assert_in(2, [1, 2, 3])
     assert_in("b", ["a", "b", "c"])
 
 
 def test_assert_in_fails() raises:
-    """assert_in raises AssertionError when the value is not in the container."""
+    """Raises AssertionError when the value is not in the container."""
     with assert_raises(contains="AssertionError"):
         assert_in(99, [1, 2, 3])
 
 
 def test_assert_in_error_message() raises:
-    """assert_in error message contains value and container."""
+    """Error message contains value and container."""
     with assert_raises(contains="value in container"):
         assert_in(99, [1, 2, 3])
 
 
 def test_assert_in_custom_msg() raises:
-    """assert_in includes the custom message on failure."""
+    """Includes the custom message on failure."""
     with assert_raises(contains="not there"):
         assert_in(99, [1, 2, 3], msg="not there")
 
 
 def test_assert_not_in_passes() raises:
-    """assert_not_in succeeds when the value is not in the container."""
+    """Succeeds when the value is not in the container."""
     assert_not_in(99, [1, 2, 3])
     assert_not_in("z", ["a", "b", "c"])
 


### PR DESCRIPTION
Adds `assert_in(value, container)` and `assert_not_in(value, container)` for richer membership assertions.

`assert_true(x in collection)` only shows `False` on failure. The new helpers show the value and container:
```
AssertionError: `value in container` assertion failed
  value: 99
  container: [1, 2, 3]
```
