### PR TITLE
[Stdlib] Fix Pipe FD leak when set_close_on_exec fails

### DIFF
--- a/mojo/stdlib/std/os/process.mojo
+++ b/mojo/stdlib/std/os/process.mojo
@@ -124,10 +124,14 @@ struct Pipe:
 
         if in_close_on_exec:
             if not self._set_close_on_exec(pipe_fds[0]):
+                _ = close(pipe_fds[0])
+                _ = close(pipe_fds[1])
                 raise Error("Failed to configure input pipe close on exec")
 
         if out_close_on_exec:
             if not self._set_close_on_exec(pipe_fds[1]):
+                _ = close(pipe_fds[0])
+                _ = close(pipe_fds[1])
                 raise Error("Failed to configure output pipe close on exec")
 
         self.fd_in = FileDescriptor(Int(pipe_fds[0]))


### PR DESCRIPTION
If `_set_close_on_exec()` fails after `pipe()` succeeds, both raw FDs were leaked because `self.fd_in`/`fd_out` are not yet initialized, so `__del__` cannot close them. Close both FDs explicitly before raising.