### PR TITLE
[Kernels] Update CLAUDE.md import example to use TileTensor

### DIFF
--- a/max/kernels/CLAUDE.md
+++ b/max/kernels/CLAUDE.md
@@ -95,7 +95,7 @@ bd //KGEN/tools/mojo -- /path/to/file.mojo
 
 ```mojo
 from linalg.matmul import matmul
-from layout import Layout, LayoutTensor
+from layout import TileTensor, row_major
 from gpu.host import DeviceContext
 ```
 


### PR DESCRIPTION
## Summary

Update the canonical import example in `kernels/CLAUDE.md` to use `TileTensor` instead of the deprecated `LayoutTensor`.

`LayoutTensor` is being replaced by `TileTensor` across the kernels codebase. `CLAUDE.md` is used by contributors and AI coding assistants as the reference for how to write kernel code, so having the wrong type here causes new code to be written against the deprecated API.
