### PR TITLE
[stdlib] Add assert for power-of-two capacity in `Deque.__len__()`

### DIFF
--- a/mojo/stdlib/std/collections/deque.mojo
+++ b/mojo/stdlib/std/collections/deque.mojo
@@ -368,11 +368,9 @@ struct Deque[ElementType: Copyable & ImplicitlyDestructible](
         Returns:
             The number of elements in the deque.
         """
-        debug_assert(
-            self._capacity & (self._capacity - 1) == 0,
-            "Deque._capacity must be a power of two, got: ",
-            self._capacity,
-        )
+        assert (
+            self._capacity & (self._capacity - 1) == 0
+        ), "Deque._capacity must be a power of two"
         return (self._tail - self._head) & (self._capacity - 1)
 
     fn __getitem__(ref self, idx: Int) -> ref[self] Self.ElementType:

--- a/mojo/stdlib/std/collections/deque.mojo
+++ b/mojo/stdlib/std/collections/deque.mojo
@@ -368,6 +368,11 @@ struct Deque[ElementType: Copyable & ImplicitlyDestructible](
         Returns:
             The number of elements in the deque.
         """
+        debug_assert(
+            self._capacity & (self._capacity - 1) == 0,
+            "Deque._capacity must be a power of two, got: ",
+            self._capacity,
+        )
         return (self._tail - self._head) & (self._capacity - 1)
 
     fn __getitem__(ref self, idx: Int) -> ref[self] Self.ElementType:

--- a/mojo/stdlib/std/collections/deque.mojo
+++ b/mojo/stdlib/std/collections/deque.mojo
@@ -369,8 +369,8 @@ struct Deque[ElementType: Copyable & ImplicitlyDestructible](
             The number of elements in the deque.
         """
         assert (
-            self._capacity & (self._capacity - 1) == 0
-        ), "Deque._capacity must be a power of two"
+            self._capacity > 0 and self._capacity & (self._capacity - 1) == 0
+        ), "Deque._capacity must be a positive power of two"
         return (self._tail - self._head) & (self._capacity - 1)
 
     fn __getitem__(ref self, idx: Int) -> ref[self] Self.ElementType:


### PR DESCRIPTION
`Deque.__len__` uses `(tail - head) & (capacity - 1)` which is only correct when `_capacity` is a power of two. The invariant is always maintained internally, but there was no assertion guarding it.

Add a `assert` so that any future unsafe mutation that breaks the invariant is caught immediately rather than silently producing a wrong length (and corrupting all callers that rely on it).