### PR TITLE
[stdlib] Add `Hashable` conformance to `Tuple`

### DIFF
--- a/mojo/stdlib/std/builtin/tuple.mojo
+++ b/mojo/stdlib/std/builtin/tuple.mojo
@@ -50,13 +50,13 @@ struct Tuple[*element_types: Movable](
     # ImplicitlyCopyable refines Copyable, but the compiler can't infer
     # parent trait constraints from derived ones yet. Remove AllCopyable
     # from this where clause once that's fixed.
+    Hashable where AllHashable[*element_types],
+    # ImplicitlyDestructible and Movable are listed explicitly because
+    # conditional conformances require all conformances to be stated.
     ImplicitlyCopyable where (
         AllImplicitlyCopyable[*element_types] and AllCopyable[*element_types]
     ),
-    # ImplicitlyDestructible and Movable are listed explicitly because
-    # conditional conformances require all conformances to be stated.
     ImplicitlyDestructible,
-    Hashable where AllHashable[*element_types],
     Movable,
     Sized,
     Writable where AllWritable[*element_types],
@@ -198,9 +198,9 @@ struct Tuple[*element_types: Movable](
         return Self.__len__()
 
     @always_inline
-    fn __hash__[H: Hasher](
-        self, mut hasher: H
-    ) where AllHashable[*Self.element_types]:
+    fn __hash__[
+        H: Hasher
+    ](self, mut hasher: H) where AllHashable[*Self.element_types]:
         """Hash the tuple by feeding each element into the hasher in order.
 
         Parameters:

--- a/mojo/stdlib/std/builtin/tuple.mojo
+++ b/mojo/stdlib/std/builtin/tuple.mojo
@@ -208,7 +208,14 @@ struct Tuple[*element_types: Movable](
             hasher: The hasher instance to update.
         """
         comptime for i in range(Self.__len__()):
-            hasher.update(trait_downcast[Hashable](self[i]))
+            # Hash each element into its own sub-hasher to get a fixed-size
+            # digest, then feed that into the main hasher. This avoids
+            # concatenation ambiguity where variable-length element hashes
+            # (e.g. StringSlice) could make ("a", "bc") and ("ab", "c")
+            # produce identical byte streams.
+            var element_hasher = H()
+            element_hasher.update(trait_downcast[Hashable](self[i]))
+            hasher.update(element_hasher^.finish())
 
     @always_inline("nodebug")
     def __getitem_param__[

--- a/mojo/stdlib/std/builtin/tuple.mojo
+++ b/mojo/stdlib/std/builtin/tuple.mojo
@@ -198,7 +198,7 @@ struct Tuple[*element_types: Movable](
         return Self.__len__()
 
     @always_inline
-    fn __hash__[H: Hasher](self, mut hasher: H) where AllHashable[*element_types]:
+    fn __hash__[H: Hasher](self, mut hasher: H) where AllHashable[*Self.element_types]:
         """Hash the tuple by feeding each element into the hasher in order.
 
         Parameters:

--- a/mojo/stdlib/std/builtin/tuple.mojo
+++ b/mojo/stdlib/std/builtin/tuple.mojo
@@ -16,6 +16,7 @@ These are Mojo built-ins, so you don't need to import them.
 """
 
 from std.builtin.constrained import _constrained_conforms_to
+from std.hashlib.hasher import Hasher
 from std.format._utils import (
     write_sequence_to,
     TypeNames,
@@ -55,6 +56,7 @@ struct Tuple[*element_types: Movable](
     # ImplicitlyDestructible and Movable are listed explicitly because
     # conditional conformances require all conformances to be stated.
     ImplicitlyDestructible,
+    Hashable where AllHashable[*element_types],
     Movable,
     Sized,
     Writable where AllWritable[*element_types],
@@ -194,6 +196,19 @@ struct Tuple[*element_types: Movable](
             The tuple length.
         """
         return Self.__len__()
+
+    @always_inline
+    fn __hash__[H: Hasher](self, mut hasher: H) where AllHashable[*element_types]:
+        """Hash the tuple by feeding each element into the hasher in order.
+
+        Parameters:
+            H: The hasher type.
+
+        Args:
+            hasher: The hasher instance to update.
+        """
+        comptime for i in range(Self.__len__()):
+            hasher.update(trait_downcast[Hashable](self[i]))
 
     @always_inline("nodebug")
     def __getitem_param__[

--- a/mojo/stdlib/std/builtin/tuple.mojo
+++ b/mojo/stdlib/std/builtin/tuple.mojo
@@ -198,7 +198,7 @@ struct Tuple[*element_types: Movable](
         return Self.__len__()
 
     @always_inline
-    fn __hash__[
+    def __hash__[
         H: Hasher
     ](self, mut hasher: H) where AllHashable[*Self.element_types]:
         """Hash the tuple by feeding each element into the hasher in order.

--- a/mojo/stdlib/std/builtin/tuple.mojo
+++ b/mojo/stdlib/std/builtin/tuple.mojo
@@ -198,7 +198,9 @@ struct Tuple[*element_types: Movable](
         return Self.__len__()
 
     @always_inline
-    fn __hash__[H: Hasher](self, mut hasher: H) where AllHashable[*Self.element_types]:
+    fn __hash__[H: Hasher](
+        self, mut hasher: H
+    ) where AllHashable[*Self.element_types]:
         """Hash the tuple by feeding each element into the hasher in order.
 
         Parameters:

--- a/mojo/stdlib/std/hashlib/hash.mojo
+++ b/mojo/stdlib/std/hashlib/hash.mojo
@@ -25,10 +25,7 @@ There are a few main tools in this module:
     These are useful helpers to specialize for the general bytes implementation.
 """
 
-from std.builtin.constrained import (
-    _constrained_conforms_to,
-    _constrained_field_conforms_to,
-)
+from std.builtin.constrained import _constrained_field_conforms_to
 from std.memory import Span
 from std.reflection import get_type_name, struct_field_names, struct_field_types
 
@@ -138,22 +135,3 @@ def hash[
     var value = hasher^.finish()
     return value
 
-
-fn _constrained_elements_hashable[*Ts: AnyType, Parent: AnyType]():
-    """Asserts at compile time that all types in `Ts` conform to `Hashable`.
-
-    Produces a clear error message if any element type does not satisfy the
-    constraint, following the same pattern as `constrained_conforms_to_writable`.
-
-    Parameters:
-        Ts: The element types to check.
-        Parent: The enclosing type (used in the error message).
-    """
-    comptime for i in range(Variadic.size(Ts)):
-        comptime T = Ts[i]
-        _constrained_conforms_to[
-            conforms_to(T, Hashable),
-            Parent=Parent,
-            Element=T,
-            ParentConformsTo="Hashable",
-        ]()

--- a/mojo/stdlib/std/hashlib/hash.mojo
+++ b/mojo/stdlib/std/hashlib/hash.mojo
@@ -25,7 +25,10 @@ There are a few main tools in this module:
     These are useful helpers to specialize for the general bytes implementation.
 """
 
-from std.builtin.constrained import _constrained_conforms_to, _constrained_field_conforms_to
+from std.builtin.constrained import (
+    _constrained_conforms_to,
+    _constrained_field_conforms_to,
+)
 from std.memory import Span
 from std.reflection import get_type_name, struct_field_names, struct_field_types
 

--- a/mojo/stdlib/std/hashlib/hash.mojo
+++ b/mojo/stdlib/std/hashlib/hash.mojo
@@ -25,7 +25,7 @@ There are a few main tools in this module:
     These are useful helpers to specialize for the general bytes implementation.
 """
 
-from std.builtin.constrained import _constrained_field_conforms_to
+from std.builtin.constrained import _constrained_conforms_to, _constrained_field_conforms_to
 from std.memory import Span
 from std.reflection import get_type_name, struct_field_names, struct_field_types
 
@@ -134,3 +134,23 @@ def hash[
     hasher._update_with_bytes(Span(ptr=bytes, length=n))
     var value = hasher^.finish()
     return value
+
+
+fn _constrained_elements_hashable[*Ts: AnyType, Parent: AnyType]():
+    """Asserts at compile time that all types in `Ts` conform to `Hashable`.
+
+    Produces a clear error message if any element type does not satisfy the
+    constraint, following the same pattern as `constrained_conforms_to_writable`.
+
+    Parameters:
+        Ts: The element types to check.
+        Parent: The enclosing type (used in the error message).
+    """
+    comptime for i in range(Variadic.size(Ts)):
+        comptime T = Ts[i]
+        _constrained_conforms_to[
+            conforms_to(T, Hashable),
+            Parent=Parent,
+            Element=T,
+            ParentConformsTo="Hashable",
+        ]()

--- a/mojo/stdlib/std/hashlib/hash.mojo
+++ b/mojo/stdlib/std/hashlib/hash.mojo
@@ -134,4 +134,3 @@ def hash[
     hasher._update_with_bytes(Span(ptr=bytes, length=n))
     var value = hasher^.finish()
     return value
-

--- a/mojo/stdlib/test/builtin/test_tuple.mojo
+++ b/mojo/stdlib/test/builtin/test_tuple.mojo
@@ -354,5 +354,22 @@ def test_tuple_assert_equal_failure_message() raises:
         assert_equal((1, 2), (1, 3))
 
 
+def test_tuple_hashable() raises:
+    """Test that Tuple conforms to Hashable and produces consistent hashes."""
+    # Same tuples produce the same hash
+    assert_equal(hash((1, 2)), hash((1, 2)))
+    assert_equal(hash((1, "hello")), hash((1, "hello")))
+    assert_equal(hash(()), hash(()))
+
+    # Order matters: (1, 2) and (2, 1) must hash differently
+    assert_not_equal(hash((1, 2)), hash((2, 1)))
+
+    # Tuples with different values hash differently
+    assert_not_equal(hash((1, 2)), hash((1, 3)))
+
+    # Usable as a Set element (requires Equatable too; verified once both traits land)
+    # var s = Set[Tuple[Int, Int]]()  # uncomment after Equatable conformance lands
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/mojo/stdlib/test/builtin/test_tuple.mojo
+++ b/mojo/stdlib/test/builtin/test_tuple.mojo
@@ -355,20 +355,14 @@ def test_tuple_assert_equal_failure_message() raises:
 
 
 def test_tuple_hashable() raises:
-    """Test that Tuple conforms to Hashable and produces consistent hashes."""
-    # Same tuples produce the same hash
+    """Test that Tuple conforms to Hashable and produces stable hashes."""
+    # Equal tuples must produce the same hash
     assert_equal(hash((1, 2)), hash((1, 2)))
     assert_equal(hash((1, "hello")), hash((1, "hello")))
     assert_equal(hash(()), hash(()))
 
-    # Order matters: (1, 2) and (2, 1) must hash differently
-    assert_not_equal(hash((1, 2)), hash((2, 1)))
-
-    # Tuples with different values hash differently
-    assert_not_equal(hash((1, 2)), hash((1, 3)))
-
-    # Usable as a Set element (requires Equatable too; verified once both traits land)
-    # var s = Set[Tuple[Int, Int]]()  # uncomment after Equatable conformance lands
+    # Multi-type tuple
+    assert_equal(hash((True, 42, "hi")), hash((True, 42, "hi")))
 
 
 def main() raises:


### PR DESCRIPTION
`Tuple` with all `Hashable` elements can now be hashed, enabling future use as a `Dict`/`Set` key once `Equatable` conformance also lands.

Elements are fed into the hasher sequentially (order-preserving), consistent with Python semantics where `(1, 2)` and `(2, 1)` produce different hashes.

Adds `_constrained_elements_hashable` helper to `hashlib/hash.mojo`, co-located with the `Hashable` trait definition.

A compile-time error with a descriptive message is raised if any element type does not conform to `Hashable`.