### PR TITLE
[stdlib] Add `Hashable` conformance to `ArcPointer`

### DIFF
--- a/mojo/docs/nightly-changelog.md
+++ b/mojo/docs/nightly-changelog.md
@@ -38,6 +38,11 @@ This version is still a work in progress.
 - `alloc[T](count, alignment)` will now `abort` if the underlying allocation
   failed.
 
+- `ArcPointer` now conforms to the `Hashable` trait, enabling its use as a
+  `Dict` key or `Set` element. The hash is based on the allocation address,
+  consistent with pointer-identity semantics (`a is b` implies
+  `hash(a) == hash(b)`).
+
 ## Tooling changes
 
 - The Mojo debugger now displays scalar types (e.g. `UInt8`, `Float32`) as

--- a/mojo/stdlib/std/memory/arc_pointer.mojo
+++ b/mojo/stdlib/std/memory/arc_pointer.mojo
@@ -282,20 +282,7 @@ struct ArcPointer[T: Movable & ImplicitlyDestructible](
             True if the two `ArcPointer` instances point at the same object and
             False otherwise.
         """
-        return self._inner == rhs._inner
-
-    def __ne__(self, rhs: Self) -> Bool:
-        """Returns True if the two `ArcPointer` instances point at different
-        objects.
-
-        Args:
-            rhs: The other `ArcPointer`.
-
-        Returns:
-            True if the two `ArcPointer` instances point at different objects
-            and False otherwise.
-        """
-        return self._inner != rhs._inner
+        return self is rhs
 
     def __hash__[H: Hasher](self, mut hasher: H):
         """Hash this pointer by its address.

--- a/mojo/stdlib/std/memory/arc_pointer.mojo
+++ b/mojo/stdlib/std/memory/arc_pointer.mojo
@@ -70,6 +70,7 @@ struct _ArcPointerInner[T: Movable & ImplicitlyDestructible]:
 
 
 struct ArcPointer[T: Movable & ImplicitlyDestructible](
+    Equatable,
     Hashable,
     Identifiable,
     ImplicitlyCopyable,
@@ -266,6 +267,35 @@ struct ArcPointer[T: Movable & ImplicitlyDestructible](
             False otherwise.
         """
         return self._inner == rhs._inner
+
+    def __eq__(self, rhs: Self) -> Bool:
+        """Returns True if the two `ArcPointer` instances point at the same
+        object (pointer equality).
+
+        Two `ArcPointer` values are equal if and only if they refer to the same
+        heap allocation, consistent with `__hash__` and `__is__`.
+
+        Args:
+            rhs: The other `ArcPointer`.
+
+        Returns:
+            True if the two `ArcPointer` instances point at the same object and
+            False otherwise.
+        """
+        return self._inner == rhs._inner
+
+    def __ne__(self, rhs: Self) -> Bool:
+        """Returns True if the two `ArcPointer` instances point at different
+        objects.
+
+        Args:
+            rhs: The other `ArcPointer`.
+
+        Returns:
+            True if the two `ArcPointer` instances point at different objects
+            and False otherwise.
+        """
+        return self._inner != rhs._inner
 
     def __hash__[H: Hasher](self, mut hasher: H):
         """Hash this pointer by its address.

--- a/mojo/stdlib/std/memory/arc_pointer.mojo
+++ b/mojo/stdlib/std/memory/arc_pointer.mojo
@@ -26,6 +26,7 @@ from std.format._utils import (
     FormatStruct,
     TypeNames,
 )
+from std.hashlib.hasher import Hasher
 
 
 struct _ArcPointerInner[T: Movable & ImplicitlyDestructible]:
@@ -69,6 +70,7 @@ struct _ArcPointerInner[T: Movable & ImplicitlyDestructible]:
 
 
 struct ArcPointer[T: Movable & ImplicitlyDestructible](
+    Hashable,
     Identifiable,
     ImplicitlyCopyable,
     RegisterPassable,
@@ -264,6 +266,20 @@ struct ArcPointer[T: Movable & ImplicitlyDestructible](
             False otherwise.
         """
         return self._inner == rhs._inner
+
+    def __hash__[H: Hasher](self, mut hasher: H):
+        """Hash this pointer by its address.
+
+        Two `ArcPointer` instances that point to the same object (i.e. `a is b`)
+        will always produce the same hash value.
+
+        Parameters:
+            H: The hasher type.
+
+        Args:
+            hasher: The hasher instance to update.
+        """
+        hasher.update(Int(self._inner))
 
     def write_to(
         self, mut writer: Some[Writer]

--- a/mojo/stdlib/test/memory/test_arc.mojo
+++ b/mojo/stdlib/test/memory/test_arc.mojo
@@ -124,13 +124,28 @@ def test_hash() raises:
     var p = ArcPointer(42)
     var q = p  # same allocation
 
-    # Two pointers to the same object hash identically
+    # Two pointers to the same object hash identically.
     assert_equal(hash(p), hash(q))
 
-    # A pointer to a different allocation hashes differently (with overwhelmingly
-    # high probability — same address would mean two live allocations overlap)
+    # A distinct allocation is a different pointer: its address differs, so its
+    # hash value differs (hash is the raw address, so no collision is possible
+    # for two simultaneously live allocations).
     var r = ArcPointer(42)
     assert_true(hash(p) != hash(r))
+
+
+def test_eq() raises:
+    var p = ArcPointer(42)
+    var q = p  # same allocation
+
+    # Same allocation: equal.
+    assert_true(p == q)
+    assert_false(p != q)
+
+    # Different allocations: not equal.
+    var r = ArcPointer(42)
+    assert_false(p == r)
+    assert_true(p != r)
 
 
 def main() raises:

--- a/mojo/stdlib/test/memory/test_arc.mojo
+++ b/mojo/stdlib/test/memory/test_arc.mojo
@@ -120,5 +120,18 @@ def test_write_repr_to() raises:
     )
 
 
+def test_hash() raises:
+    var p = ArcPointer(42)
+    var q = p  # same allocation
+
+    # Two pointers to the same object hash identically
+    assert_equal(hash(p), hash(q))
+
+    # A pointer to a different allocation hashes differently (with overwhelmingly
+    # high probability — same address would mean two live allocations overlap)
+    var r = ArcPointer(42)
+    assert_true(hash(p) != hash(r))
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
`ArcPointer` already implements `Identifiable` (pointer-identity semantics via `__is__`/`__isnot__`), but had no `__hash__()` or `__eq__()`. Without them, `ArcPointer` values cannot be stored in `Dict` or `Set`.

`Equatable` and `Hashable` are both based on the inner allocation address, consistent with identity: two `ArcPointer` instances pointing to the same object (`a is b`) are equal and hash identically.

```mojo
var p = ArcPointer(42)
var q = p          # same allocation
print(p == q)      # True
print(hash(p) == hash(q))  # True

var d = Dict[ArcPointer[Int], String]()
d[p] = "hello"
print(d[q])        # "hello"
```

---

Assisted-by: AI