### PR TITLE
[stdlib] Add `Writable` conformance to `Batch`

### DIFF
--- a/mojo/stdlib/std/benchmark/benchmark.mojo
+++ b/mojo/stdlib/std/benchmark/benchmark.mojo
@@ -139,6 +139,8 @@ Note that benchmarking continues until `min_runtime_secs` has
 elapsed and either `max_runtime_secs` OR `max_iters` is achieved.
 """
 
+import std.format._utils as fmt
+
 from std.time import time_function
 from std.testing import assert_true
 from std.utils.numerics import max_finite, min_finite
@@ -148,7 +150,7 @@ from std.utils.numerics import max_finite, min_finite
 # Batch
 # ===-----------------------------------------------------------------------===#
 @fieldwise_init
-struct Batch(TrivialRegisterPassable):
+struct Batch(TrivialRegisterPassable, Writable):
     """
     A batch of benchmarks, the benchmark.run() function works out how many
     iterations to run in each batch based the how long the previous iterations
@@ -176,6 +178,34 @@ struct Batch(TrivialRegisterPassable):
             Float64(self.duration)
             / Float64(self.iterations)
             / Float64(Unit._divisor(unit))
+        )
+
+    fn write_to(self, mut writer: Some[Writer]):
+        """Formats this `Batch` to the provided Writer.
+
+        Args:
+            writer: The object to write to.
+        """
+        writer.write(
+            "Batch(duration=",
+            self.duration,
+            "ns, iterations=",
+            self.iterations,
+            ", significant=",
+            self._is_significant,
+            ")",
+        )
+
+    fn write_repr_to(self, mut writer: Some[Writer]):
+        """Writes the string representation of this `Batch` to a writer.
+
+        Args:
+            writer: The object to write to.
+        """
+        fmt.FormatStruct(writer, "Batch").fields(
+            fmt.Named("duration", self.duration),
+            fmt.Named("iterations", self.iterations),
+            fmt.Named("_is_significant", self._is_significant),
         )
 
 

--- a/mojo/stdlib/std/benchmark/benchmark.mojo
+++ b/mojo/stdlib/std/benchmark/benchmark.mojo
@@ -196,8 +196,9 @@ struct Batch(TrivialRegisterPassable, Writable):
             ")",
         )
 
+    @no_inline
     fn write_repr_to(self, mut writer: Some[Writer]):
-        """Writes the string representation of this `Batch` to a writer.
+        """Writes the repr of this `Batch` to a writer.
 
         Args:
             writer: The object to write to.

--- a/mojo/stdlib/test/benchmark/test_benchmark.mojo
+++ b/mojo/stdlib/test/benchmark/test_benchmark.mojo
@@ -14,8 +14,10 @@
 from std.time import sleep, time_function
 
 from std.benchmark import Report, clobber_memory, keep, run
+from std.benchmark.benchmark import Batch
 from std.benchmark.bencher import BenchMetric, Format, ThroughputMeasure
 from std.testing import TestSuite, assert_equal, assert_true
+from test_utils import check_write_to
 
 
 def test_stopping_criteria() raises:
@@ -180,6 +182,24 @@ def test_throughput_measure_write_repr_to() raises:
     assert_true(s.startswith("ThroughputMeasure("))
     assert_true("metric=" in s)
     assert_true("value=1024" in s)
+
+
+def test_batch_write_to() raises:
+    var b = Batch(duration=1000, iterations=10, _is_significant=True)
+    check_write_to(
+        b,
+        expected="Batch(duration=1000ns, iterations=10, significant=True)",
+        is_repr=False,
+    )
+
+
+def test_batch_write_repr_to() raises:
+    var b = Batch(duration=2000, iterations=5, _is_significant=False)
+    check_write_to(
+        b,
+        expected="Batch(duration=2000, iterations=5, _is_significant=False)",
+        is_repr=True,
+    )
 
 
 def main() raises:

--- a/mojo/stdlib/test/benchmark/test_benchmark.mojo
+++ b/mojo/stdlib/test/benchmark/test_benchmark.mojo
@@ -13,8 +13,7 @@
 
 from std.time import sleep, time_function
 
-from std.benchmark import Report, clobber_memory, keep, run
-from std.benchmark.benchmark import Batch
+from std.benchmark import Batch, Report, clobber_memory, keep, run
 from std.benchmark.bencher import BenchMetric, Format, ThroughputMeasure
 from std.testing import TestSuite, assert_equal, assert_true
 from test_utils import check_write_to


### PR DESCRIPTION
`Batch` in `benchmark.mojo` was `TrivialRegisterPassable` but not `Writable`, unlike the other benchmark types (`BenchMetric`, `ThroughputMeasure`, `Format`, `Bench`) which all implement `Writable`.

This adds `write_to()` and `write_repr_to()` to `Batch`, making it printable directly.

- `write_to` produces: `Batch(duration=1000ns, iterations=10, significant=True)`
- `write_repr_to` produces: `Batch(duration=1000, iterations=5, _is_significant=False)`

---

Assisted-by: AI