### PR TITLE
[stdlib] Add CDNA2 Float64 transcendental function tests

### DIFF
--- a/mojo/stdlib/test/math/gpu/BUILD.bazel
+++ b/mojo/stdlib/test/math/gpu/BUILD.bazel
@@ -3,6 +3,9 @@ load("//bazel:api.bzl", "lit_tests", "mojo_test")
 package(default_visibility = ["//visibility:private"])
 
 _LIT_TESTS = [
+    "test_f64_hyperbolic_amd_xfail.mojo",
+    "test_f64_special_amd_xfail.mojo",
+    "test_f64_trig_amd_xfail.mojo",
     "test_sin_cos_f64.mojo",
 ]
 
@@ -38,6 +41,7 @@ lit_tests(
     srcs = _LIT_TESTS,
     mojo_deps = [
         "@mojo//:std",
+        "@mojo//:test_utils",
     ],
     target_compatible_with = select({
         "//:asan": ["@platforms//:incompatible"],

--- a/mojo/stdlib/test/math/gpu/test_f64_hyperbolic_amd_xfail.mojo
+++ b/mojo/stdlib/test/math/gpu/test_f64_hyperbolic_amd_xfail.mojo
@@ -1,0 +1,74 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# REQUIRES: AMD-GPU
+# XFAIL: *
+# RUN: %bare-mojo --target-accelerator=mi250x %s
+
+from test_utils import ulp_distance
+
+from std.gpu.host import DeviceContext
+from std.math import acosh, asinh, atanh, sinh, tanh
+from std.testing import assert_true, TestSuite
+
+
+fn check_unary[
+    name: StaticString,
+    kernel_fn: fn(Float64) capturing -> Float64,
+](val: Float64, ctx: DeviceContext) raises:
+    var out = ctx.enqueue_create_buffer[DType.float64](1)
+    var expected = kernel_fn(val)
+
+    @parameter
+    fn kernel(
+        out_dev: UnsafePointer[Scalar[DType.float64], MutAnyOrigin],
+        x: Float64,
+    ):
+        out_dev[0] = kernel_fn(x)
+
+    ctx.enqueue_function_experimental[kernel](out, val, grid_dim=1, block_dim=1)
+    with out.map_to_host() as out_host:
+        var ulp = ulp_distance(out_host[0], expected)
+        assert_true(ulp <= 10, String(name, " ulp=", ulp))
+
+
+def test_f64_hyperbolic_amd() raises:
+    @parameter
+    fn sinh_fn(x: Float64) -> Float64:
+        return sinh(x)
+
+    @parameter
+    fn tanh_fn(x: Float64) -> Float64:
+        return tanh(x)
+
+    @parameter
+    fn asinh_fn(x: Float64) -> Float64:
+        return asinh(x)
+
+    @parameter
+    fn acosh_fn(x: Float64) -> Float64:
+        return acosh(x)
+
+    @parameter
+    fn atanh_fn(x: Float64) -> Float64:
+        return atanh(x)
+
+    with DeviceContext() as ctx:
+        check_unary["sinh", sinh_fn](0.5, ctx)
+        check_unary["tanh", tanh_fn](0.5, ctx)
+        check_unary["asinh", asinh_fn](0.5, ctx)
+        check_unary["acosh", acosh_fn](2.0, ctx)
+        check_unary["atanh", atanh_fn](0.5, ctx)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/mojo/stdlib/test/math/gpu/test_f64_special_amd_xfail.mojo
+++ b/mojo/stdlib/test/math/gpu/test_f64_special_amd_xfail.mojo
@@ -1,0 +1,132 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# REQUIRES: AMD-GPU
+# XFAIL: *
+# RUN: %bare-mojo --target-accelerator=mi250x %s
+
+from test_utils import ulp_distance
+
+from std.gpu.host import DeviceContext
+from std.math import cbrt, erf, erfc, expm1, gamma, hypot, j0, j1, lgamma, log10, logb, y0, y1
+from std.testing import assert_true, TestSuite
+
+
+fn check_unary[
+    name: StaticString,
+    kernel_fn: fn(Float64) capturing -> Float64,
+](val: Float64, ctx: DeviceContext) raises:
+    var out = ctx.enqueue_create_buffer[DType.float64](1)
+    var expected = kernel_fn(val)
+
+    @parameter
+    fn kernel(
+        out_dev: UnsafePointer[Scalar[DType.float64], MutAnyOrigin],
+        x: Float64,
+    ):
+        out_dev[0] = kernel_fn(x)
+
+    ctx.enqueue_function_experimental[kernel](out, val, grid_dim=1, block_dim=1)
+    with out.map_to_host() as out_host:
+        var ulp = ulp_distance(out_host[0], expected)
+        assert_true(ulp <= 10, String(name, " ulp=", ulp))
+
+
+fn check_binary[
+    name: StaticString,
+    kernel_fn: fn(Float64, Float64) capturing -> Float64,
+](lhs: Float64, rhs: Float64, ctx: DeviceContext) raises:
+    var out = ctx.enqueue_create_buffer[DType.float64](1)
+    var expected = kernel_fn(lhs, rhs)
+
+    @parameter
+    fn kernel(
+        out_dev: UnsafePointer[Scalar[DType.float64], MutAnyOrigin],
+        x: Float64,
+        y: Float64,
+    ):
+        out_dev[0] = kernel_fn(x, y)
+
+    ctx.enqueue_function_experimental[kernel](
+        out, lhs, rhs, grid_dim=1, block_dim=1
+    )
+    with out.map_to_host() as out_host:
+        var ulp = ulp_distance(out_host[0], expected)
+        assert_true(ulp <= 10, String(name, " ulp=", ulp))
+
+
+def test_f64_special_amd() raises:
+    @parameter
+    fn expm1_fn(x: Float64) -> Float64:
+        return expm1(x)
+
+    @parameter
+    fn log10_fn(x: Float64) -> Float64:
+        return log10(x)
+
+    @parameter
+    fn erfc_fn(x: Float64) -> Float64:
+        return erfc(x)
+
+    @parameter
+    fn cbrt_fn(x: Float64) -> Float64:
+        return cbrt(x)
+
+    @parameter
+    fn gamma_fn(x: Float64) -> Float64:
+        return gamma(x)
+
+    @parameter
+    fn lgamma_fn(x: Float64) -> Float64:
+        return lgamma(x)
+
+    @parameter
+    fn logb_fn(x: Float64) -> Float64:
+        return logb(x)
+
+    @parameter
+    fn j0_fn(x: Float64) -> Float64:
+        return j0(x)
+
+    @parameter
+    fn j1_fn(x: Float64) -> Float64:
+        return j1(x)
+
+    @parameter
+    fn y0_fn(x: Float64) -> Float64:
+        return y0(x)
+
+    @parameter
+    fn y1_fn(x: Float64) -> Float64:
+        return y1(x)
+
+    @parameter
+    fn hypot_fn(x: Float64, y: Float64) -> Float64:
+        return hypot(x, y)
+
+    with DeviceContext() as ctx:
+        check_unary["expm1", expm1_fn](0.5, ctx)
+        check_unary["log10", log10_fn](10.0, ctx)
+        check_unary["erfc", erfc_fn](0.5, ctx)
+        check_unary["cbrt", cbrt_fn](8.0, ctx)
+        check_unary["gamma", gamma_fn](5.0, ctx)
+        check_unary["lgamma", lgamma_fn](5.0, ctx)
+        check_unary["logb", logb_fn](8.0, ctx)
+        check_unary["j0", j0_fn](0.5, ctx)
+        check_unary["j1", j1_fn](0.5, ctx)
+        check_unary["y0", y0_fn](0.5, ctx)
+        check_unary["y1", y1_fn](0.5, ctx)
+        check_binary["hypot", hypot_fn](3.0, 4.0, ctx)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/mojo/stdlib/test/math/gpu/test_f64_special_amd_xfail.mojo
+++ b/mojo/stdlib/test/math/gpu/test_f64_special_amd_xfail.mojo
@@ -17,7 +17,21 @@
 from test_utils import ulp_distance
 
 from std.gpu.host import DeviceContext
-from std.math import cbrt, erf, erfc, expm1, gamma, hypot, j0, j1, lgamma, log10, logb, y0, y1
+from std.math import (
+    cbrt,
+    erf,
+    erfc,
+    expm1,
+    gamma,
+    hypot,
+    j0,
+    j1,
+    lgamma,
+    log10,
+    logb,
+    y0,
+    y1,
+)
 from std.testing import assert_true, TestSuite
 
 

--- a/mojo/stdlib/test/math/gpu/test_f64_transcendentals_amd.mojo
+++ b/mojo/stdlib/test/math/gpu/test_f64_transcendentals_amd.mojo
@@ -1,0 +1,156 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from test_utils import ulp_distance
+
+from std.math import cosh, erf, exp, exp2, log, log1p, log2, pow
+from std.gpu.host import DeviceContext
+from std.sys import is_amd_gpu
+from std.testing import assert_true, TestSuite
+
+
+fn check_unary_ulp[
+    name: StaticString,
+    kernel_fn: fn(Float64) capturing -> Float64,
+](
+    val: Float64,
+    ctx: DeviceContext,
+) raises:
+    var out = ctx.enqueue_create_buffer[DType.float64](1)
+    var expected = kernel_fn(val)
+
+    @parameter
+    fn kernel(
+        out_dev: UnsafePointer[Scalar[DType.float64], MutAnyOrigin],
+        x: Float64,
+    ):
+        out_dev[0] = kernel_fn(x)
+
+    ctx.enqueue_function_experimental[kernel](out, val, grid_dim=1, block_dim=1)
+    with out.map_to_host() as out_host:
+        var ulp = ulp_distance(out_host[0], expected)
+        assert_true(
+            ulp <= 10,
+            String(
+                name,
+                "(",
+                val,
+                ") exceeded 10 ULP on AMD gfx90a: gpu=",
+                out_host[0],
+                " expected=",
+                expected,
+                " ulp=",
+                ulp,
+            ),
+        )
+
+
+fn check_binary_ulp[
+    name: StaticString,
+    kernel_fn: fn(Float64, Float64) capturing -> Float64,
+](
+    lhs: Float64,
+    rhs: Float64,
+    ctx: DeviceContext,
+) raises:
+    var out = ctx.enqueue_create_buffer[DType.float64](1)
+    var expected = kernel_fn(lhs, rhs)
+
+    @parameter
+    fn kernel(
+        out_dev: UnsafePointer[Scalar[DType.float64], MutAnyOrigin],
+        x: Float64,
+        y: Float64,
+    ):
+        out_dev[0] = kernel_fn(x, y)
+
+    ctx.enqueue_function_experimental[kernel](
+        out, lhs, rhs, grid_dim=1, block_dim=1
+    )
+    with out.map_to_host() as out_host:
+        var ulp = ulp_distance(out_host[0], expected)
+        assert_true(
+            ulp <= 10,
+            String(
+                name,
+                "(",
+                lhs,
+                ", ",
+                rhs,
+                ") exceeded 10 ULP on AMD gfx90a: gpu=",
+                out_host[0],
+                " expected=",
+                expected,
+                " ulp=",
+                ulp,
+            ),
+        )
+
+
+def test_f64_transcendentals_amd() raises:
+    comptime if not is_amd_gpu["gfx90a"]():
+        return
+
+    @parameter
+    fn exp_fn(x: Float64) -> Float64:
+        return exp(x)
+
+    @parameter
+    fn exp2_fn(x: Float64) -> Float64:
+        return exp2(x)
+
+    @parameter
+    fn log_fn(x: Float64) -> Float64:
+        return log(x)
+
+    @parameter
+    fn log2_fn(x: Float64) -> Float64:
+        return log2(x)
+
+    @parameter
+    fn log1p_fn(x: Float64) -> Float64:
+        return log1p(x)
+
+    @parameter
+    fn cosh_fn(x: Float64) -> Float64:
+        return cosh(x)
+
+    @parameter
+    fn erf_fn(x: Float64) -> Float64:
+        return erf(x)
+
+    @parameter
+    fn pow_fn(x: Float64, y: Float64) -> Float64:
+        return pow(x, y)
+
+    with DeviceContext() as ctx:
+        check_unary_ulp["exp", exp_fn](0.5, ctx)
+        check_unary_ulp["exp", exp_fn](2.0, ctx)
+        check_unary_ulp["exp2", exp2_fn](0.5, ctx)
+        check_unary_ulp["exp2", exp2_fn](4.0, ctx)
+        check_unary_ulp["log", log_fn](0.5, ctx)
+        check_unary_ulp["log", log_fn](2.0, ctx)
+        check_unary_ulp["log2", log2_fn](0.5, ctx)
+        check_unary_ulp["log2", log2_fn](8.0, ctx)
+        check_unary_ulp["log1p", log1p_fn](1e-6, ctx)
+        check_unary_ulp["log1p", log1p_fn](0.5, ctx)
+        check_unary_ulp["cosh", cosh_fn](0.5, ctx)
+        check_unary_ulp["cosh", cosh_fn](2.0, ctx)
+        check_unary_ulp["erf", erf_fn](0.5, ctx)
+        check_unary_ulp["erf", erf_fn](1.5, ctx)
+        check_binary_ulp["pow", pow_fn](2.0, 3.0, ctx)
+        check_binary_ulp["pow", pow_fn](0.5, 2.0, ctx)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/mojo/stdlib/test/math/gpu/test_f64_transcendentals_amd.mojo
+++ b/mojo/stdlib/test/math/gpu/test_f64_transcendentals_amd.mojo
@@ -22,10 +22,7 @@ from std.testing import assert_true, TestSuite
 fn check_unary_ulp[
     name: StaticString,
     kernel_fn: fn(Float64) capturing -> Float64,
-](
-    val: Float64,
-    ctx: DeviceContext,
-) raises:
+](val: Float64, ctx: DeviceContext,) raises:
     var out = ctx.enqueue_create_buffer[DType.float64](1)
     var expected = kernel_fn(val)
 
@@ -58,11 +55,7 @@ fn check_unary_ulp[
 fn check_binary_ulp[
     name: StaticString,
     kernel_fn: fn(Float64, Float64) capturing -> Float64,
-](
-    lhs: Float64,
-    rhs: Float64,
-    ctx: DeviceContext,
-) raises:
+](lhs: Float64, rhs: Float64, ctx: DeviceContext,) raises:
     var out = ctx.enqueue_create_buffer[DType.float64](1)
     var expected = kernel_fn(lhs, rhs)
 

--- a/mojo/stdlib/test/math/gpu/test_f64_trig_amd_xfail.mojo
+++ b/mojo/stdlib/test/math/gpu/test_f64_trig_amd_xfail.mojo
@@ -1,0 +1,107 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# REQUIRES: AMD-GPU
+# XFAIL: *
+# RUN: %bare-mojo --target-accelerator=mi250x %s
+
+from test_utils import ulp_distance
+
+from std.gpu.host import DeviceContext
+from std.math import acos, asin, atan, atan2, cos, sin, tan
+from std.testing import assert_true, TestSuite
+
+
+fn check_unary[
+    name: StaticString,
+    kernel_fn: fn(Float64) capturing -> Float64,
+](val: Float64, ctx: DeviceContext) raises:
+    var out = ctx.enqueue_create_buffer[DType.float64](1)
+    var expected = kernel_fn(val)
+
+    @parameter
+    fn kernel(
+        out_dev: UnsafePointer[Scalar[DType.float64], MutAnyOrigin],
+        x: Float64,
+    ):
+        out_dev[0] = kernel_fn(x)
+
+    ctx.enqueue_function_experimental[kernel](out, val, grid_dim=1, block_dim=1)
+    with out.map_to_host() as out_host:
+        var ulp = ulp_distance(out_host[0], expected)
+        assert_true(ulp <= 10, String(name, " ulp=", ulp))
+
+
+fn check_binary[
+    name: StaticString,
+    kernel_fn: fn(Float64, Float64) capturing -> Float64,
+](lhs: Float64, rhs: Float64, ctx: DeviceContext) raises:
+    var out = ctx.enqueue_create_buffer[DType.float64](1)
+    var expected = kernel_fn(lhs, rhs)
+
+    @parameter
+    fn kernel(
+        out_dev: UnsafePointer[Scalar[DType.float64], MutAnyOrigin],
+        x: Float64,
+        y: Float64,
+    ):
+        out_dev[0] = kernel_fn(x, y)
+
+    ctx.enqueue_function_experimental[kernel](
+        out, lhs, rhs, grid_dim=1, block_dim=1
+    )
+    with out.map_to_host() as out_host:
+        var ulp = ulp_distance(out_host[0], expected)
+        assert_true(ulp <= 10, String(name, " ulp=", ulp))
+
+
+def test_f64_trig_amd() raises:
+    @parameter
+    fn sin_fn(x: Float64) -> Float64:
+        return sin(x)
+
+    @parameter
+    fn cos_fn(x: Float64) -> Float64:
+        return cos(x)
+
+    @parameter
+    fn tan_fn(x: Float64) -> Float64:
+        return tan(x)
+
+    @parameter
+    fn asin_fn(x: Float64) -> Float64:
+        return asin(x)
+
+    @parameter
+    fn acos_fn(x: Float64) -> Float64:
+        return acos(x)
+
+    @parameter
+    fn atan_fn(x: Float64) -> Float64:
+        return atan(x)
+
+    @parameter
+    fn atan2_fn(x: Float64, y: Float64) -> Float64:
+        return atan2(x, y)
+
+    with DeviceContext() as ctx:
+        check_unary["sin", sin_fn](0.5, ctx)
+        check_unary["cos", cos_fn](0.5, ctx)
+        check_unary["tan", tan_fn](0.5, ctx)
+        check_unary["asin", asin_fn](0.5, ctx)
+        check_unary["acos", acos_fn](0.5, ctx)
+        check_unary["atan", atan_fn](0.5, ctx)
+        check_binary["atan2", atan2_fn](0.5, 2.0, ctx)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Please fill out the sections below to help reviewers understand your change.
For guidance on writing a good PR, see our
[contributor guide](../CONTRIBUTING.md).
-->

## Summary

This adds lit tests for Float64 transcendental math functions for CDNA2 targets:
* The set of functions that works now with 0 ULP error (`cosh`, `erf`, `exp`, `exp2`, `log`, `log1p`, `log2`, `pow`) is added as an expected-pass test
* The functions that fail due to either missing support (acosh, asinh, atanh, sinh, cbrt, erf, erfc, expm1, gamma, hypot, j0, j1, lgamma, log10, logb, y0, y1, acos, asin, atan, atan2, cos, sin, tan) or wrong answers (`tanh`) are added as XFAIL tests. The XFAIL tests are grouped into lit tests for i) trigonometric functions, ii) hyperbolic functions, or iii) other transcendental functions.

Depends on: https://github.com/modular/modular/pull/6126.

Assisted-by: AI [Codex CLI]

## Testing

I manually ran it on a MI250X machine and verified that the tests pass (or XFAIL as expected).

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
