### PR TITLE
[Models] Optimize and fix bug on Flux2-Klein pipeline to avoid recompilation

### DIFF
--- a/max/python/max/pipelines/architectures/flux2_modulev3/pipeline_flux2_klein.py
+++ b/max/python/max/pipelines/architectures/flux2_modulev3/pipeline_flux2_klein.py
@@ -17,8 +17,11 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
+from max.dtype import DType
 from max.experimental.tensor import Tensor
+from max.graph import TensorType
 from max.pipelines.core import PixelContext
+from max.pipelines.lib.interfaces.diffusion_pipeline import max_compile
 from max.profiler import Tracer, traced
 
 from ..qwen3.text_encoder import Qwen3TextEncoderKleinModel
@@ -57,6 +60,49 @@ class Flux2KleinPipeline(Flux2Pipeline):
         "text_encoder": Qwen3TextEncoderKleinModel,
         "transformer": Flux2Pipeline.components["transformer"],
     }
+
+    def init_remaining_components(self) -> None:
+        """Initialize derived attributes, including the compiled CFG combine."""
+        super().init_remaining_components()
+        self.build_cfg_combine()
+
+    def build_cfg_combine(self) -> None:
+        """Compile the CFG combine formula with symbolic shapes."""
+        dtype = self.transformer.config.dtype
+        device = self.transformer.devices[0]
+        self.__dict__["cfg_combine"] = max_compile(
+            self.cfg_combine,
+            input_types=[
+                TensorType(
+                    dtype,
+                    shape=["batch", "seq", "channels"],
+                    device=device,
+                ),
+                TensorType(
+                    dtype,
+                    shape=["batch", "seq", "channels"],
+                    device=device,
+                ),
+                TensorType(DType.float32, shape=[], device=device),
+            ],
+        )
+
+    def cfg_combine(
+        self,
+        noise_pred: Tensor,
+        neg_noise_pred: Tensor,
+        guidance_scale: Tensor,
+    ) -> Tensor:
+        """Apply CFG formula: neg + scale * (pos - neg).
+
+        Computation is done in f32 (promoted by guidance_scale) and
+        the result is cast back to the input dtype (typically bf16).
+        """
+        input_dtype = noise_pred.dtype
+        diff = noise_pred - neg_noise_pred
+        scaled = guidance_scale * diff
+        result = neg_noise_pred + scaled
+        return result.cast(input_dtype)
 
     @traced
     def prepare_inputs(self, context: PixelContext) -> Flux2KleinModelInputs:  # type: ignore[override]
@@ -175,7 +221,17 @@ class Flux2KleinPipeline(Flux2Pipeline):
             if hasattr(dts_seq, "driver_tensor"):
                 dts_seq = dts_seq.driver_tensor
 
-        # 5) Denoising loop.
+        # 5) Prepare guidance scale tensor for compiled CFG combine.
+        guidance_scale_tensor: Tensor | None = None
+        if do_cfg:
+            guidance_scale_tensor = Tensor.full(
+                [],
+                model_inputs.guidance_scale,
+                device=self.transformer.devices[0],
+                dtype=DType.float32,
+            )
+
+        # 6) Denoising loop.
         is_img2img = image_latents is not None
         with Tracer("denoising_loop"):
             for i in range(model_inputs.num_inference_steps):
@@ -220,18 +276,18 @@ class Flux2KleinPipeline(Flux2Pipeline):
                                 negative_text_ids,
                                 guidance,
                             )[0]
-                        neg_noise_pred = Tensor.from_dlpack(neg_noise_pred)
-                        noise_pred = Tensor.from_dlpack(noise_pred)
-                        noise_pred = (
-                            neg_noise_pred
-                            + model_inputs.guidance_scale
-                            * (noise_pred - neg_noise_pred)
-                        )
+                        with Tracer("cfg_combine"):
+                            assert guidance_scale_tensor is not None
+                            noise_pred = self.cfg_combine(
+                                noise_pred,
+                                neg_noise_pred,
+                                guidance_scale_tensor,
+                            )
 
                     with Tracer("scheduler_step"):
                         latents = self.scheduler_step(latents, noise_pred, dt)
 
-        # 6) Decode final outputs.
+        # 7) Decode final outputs.
         with Tracer("decode_outputs"):
             images = self.decode_latents(
                 latents,

--- a/max/python/max/pipelines/architectures/flux2_modulev3/pipeline_flux2_klein.py
+++ b/max/python/max/pipelines/architectures/flux2_modulev3/pipeline_flux2_klein.py
@@ -15,49 +15,38 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from queue import Queue
-from typing import Any, Literal, cast
+from typing import Any
 
-import numpy as np
-from max.driver import CPU, Buffer
-from max.dtype import DType
-from max.experimental import functional as F
 from max.experimental.tensor import Tensor
-from max.interfaces import TokenBuffer
 from max.pipelines.core import PixelContext
-from max.pipelines.lib.interfaces import PixelModelInputs
-from max.profiler import Tracer
-from PIL import Image
+from max.profiler import Tracer, traced
 
 from ..qwen3.text_encoder import Qwen3TextEncoderKleinModel
-from .pipeline_flux2 import Flux2Pipeline
+from .pipeline_flux2 import Flux2ModelInputs, Flux2Pipeline, Flux2PipelineOutput
 
 logger = logging.getLogger("max.pipelines")
 
 
 @dataclass(kw_only=True)
-class Flux2KleinModelInputs(PixelModelInputs):
-    """Flux2 Klein-specific model inputs."""
+class Flux2KleinModelInputs(Flux2ModelInputs):
+    """Flux2 Klein-specific model inputs extending the base Flux2 inputs."""
 
-    width: int = 1024
-    height: int = 1024
+    negative_tokens: Tensor | None = None
+    """Negative prompt token IDs on device (for classifier-free guidance)."""
+
     guidance_scale: float = 4.0
-    num_inference_steps: int = 50
-    num_images_per_prompt: int = 1
-    input_image: Image.Image | None = None
-    h_carrier: Tensor | None = None
-    w_carrier: Tensor | None = None
+    """Guidance scale for classifier-free guidance."""
+
+    is_distilled: bool = False
+    """Whether the model is distilled (disables CFG)."""
 
     @property
     def do_classifier_free_guidance(self) -> bool:
-        return self.negative_tokens is not None and self.guidance_scale > 1.0
-
-
-@dataclass
-class Flux2KleinPipelineOutput:
-    """Container for Flux2 Klein pipeline results."""
-
-    images: np.ndarray | Tensor
+        return (
+            self.negative_tokens is not None
+            and self.guidance_scale > 1.0
+            and not self.is_distilled
+        )
 
 
 class Flux2KleinPipeline(Flux2Pipeline):
@@ -69,191 +58,115 @@ class Flux2KleinPipeline(Flux2Pipeline):
         "transformer": Flux2Pipeline.components["transformer"],
     }
 
+    @traced
     def prepare_inputs(self, context: PixelContext) -> Flux2KleinModelInputs:  # type: ignore[override]
-        pil_image = None
-        if context.input_image is not None and isinstance(
-            context.input_image, np.ndarray
-        ):
-            pil_image = Image.fromarray(context.input_image.astype(np.uint8))
+        """Convert a PixelContext into Flux2KleinModelInputs.
 
-        original_input_image = context.input_image
-        if pil_image is not None:
-            context.input_image = pil_image  # type: ignore[assignment]
+        Reuses the parent's prepare_inputs logic and adds Klein-specific
+        fields for classifier-free guidance.
+        """
+        base_inputs = super().prepare_inputs(context)
 
-        result = Flux2KleinModelInputs.from_context(context)
+        # Prepare negative tokens on device if present.
+        negative_tokens = None
+        if context.negative_tokens is not None:
+            from max.driver import Buffer
 
-        latent_h = context.height // self.vae_scale_factor
-        latent_w = context.width // self.vae_scale_factor
-        packed_h = latent_h // 2
-        packed_w = latent_w // 2
-        for n in (packed_h, packed_w):
-            if n not in self._cached_shape_carriers:
-                self._cached_shape_carriers[n] = Tensor.from_dlpack(
-                    np.empty(n, dtype=np.float32)
+            negative_tokens = Tensor(
+                storage=Buffer.from_dlpack(context.negative_tokens.array).to(
+                    self.text_encoder.devices[0]
                 )
-        result.h_carrier = self._cached_shape_carriers[packed_h]
-        result.w_carrier = self._cached_shape_carriers[packed_w]
-
-        context.input_image = original_input_image
-        return result
-
-    def prepare_prompt_embeddings(
-        self,
-        tokens: Tensor | TokenBuffer,
-        num_images_per_prompt: int = 1,
-    ) -> tuple[Tensor, Tensor]:
-        if isinstance(tokens, Tensor):
-            text_input_ids = tokens.to(self.text_encoder.devices[0]).cast(
-                DType.int64
-            )
-        else:
-            token_ids = np.asarray(tokens.array, dtype=np.int64)
-            if token_ids.ndim != 1:
-                raise ValueError(
-                    f"Flux2Klein expects 1D tokens, got shape {token_ids.shape}."
-                )
-            text_input_ids = Tensor.constant(
-                token_ids,
-                dtype=DType.int64,
-                device=self.text_encoder.devices[0],
-            )
-        if text_input_ids.rank == 1:
-            # Ensure (seq_len,) -> (1, seq_len) for batch
-            text_input_ids = F.unsqueeze(text_input_ids, axis=0)
-        prompt_embeds = self.text_encoder(text_input_ids)
-        if prompt_embeds.rank == 2:
-            prompt_embeds = F.unsqueeze(prompt_embeds, axis=0)
-        elif prompt_embeds.rank != 3:
-            raise ValueError(
-                f"Unexpected prompt_embeds rank={prompt_embeds.rank}; "
-                "expected 2 or 3."
             )
 
-        prompt_embeds = prompt_embeds.to(self.transformer.devices[0]).cast(
-            self.transformer.config.dtype
+        diff_cfg = self.pipeline_config.model.diffusers_config or {}
+        is_distilled = bool(diff_cfg.get("is_distilled", False))
+
+        if context.guidance_scale > 1.0 and is_distilled:
+            logger.warning(
+                "Guidance scale %s is ignored for distilled Klein models.",
+                context.guidance_scale,
+            )
+
+        return Flux2KleinModelInputs(
+            tokens=base_inputs.tokens,
+            latents=base_inputs.latents,
+            latent_image_ids=base_inputs.latent_image_ids,
+            sigmas=base_inputs.sigmas,
+            guidance=base_inputs.guidance,
+            latent_h=base_inputs.latent_h,
+            latent_w=base_inputs.latent_w,
+            image_seq_len=base_inputs.image_seq_len,
+            h_carrier=base_inputs.h_carrier,
+            w_carrier=base_inputs.w_carrier,
+            height=base_inputs.height,
+            width=base_inputs.width,
+            num_inference_steps=base_inputs.num_inference_steps,
+            num_images_per_prompt=base_inputs.num_images_per_prompt,
+            input_image=base_inputs.input_image,
+            negative_tokens=negative_tokens,
+            guidance_scale=context.guidance_scale,
+            is_distilled=is_distilled,
         )
-        batch_size = int(prompt_embeds.shape[0])
-        seq_len = int(prompt_embeds.shape[1])
 
-        if num_images_per_prompt != 1:
-            prompt_embeds = F.tile(prompt_embeds, (1, num_images_per_prompt, 1))
-            prompt_embeds = prompt_embeds.reshape(
-                (batch_size * num_images_per_prompt, seq_len, -1)
-            )
-
-        batch_size_final = batch_size * num_images_per_prompt
-        text_ids_key = f"{batch_size_final}_{seq_len}"
-        if text_ids_key in self._cached_text_ids:
-            text_ids = self._cached_text_ids[text_ids_key]
-        else:
-            text_ids = Flux2Pipeline._prepare_text_ids(
-                batch_size=batch_size_final,
-                seq_len=seq_len,
-                device=self.text_encoder.devices[0],
-            )
-            self._cached_text_ids[text_ids_key] = text_ids
-        return prompt_embeds, text_ids
-
+    @traced
     def execute(  # type: ignore[override]
         self,
         model_inputs: Flux2KleinModelInputs,
-        callback_queue: Queue[np.ndarray] | None = None,
-        output_type: Literal["np", "latent"] = "np",
-    ) -> Flux2KleinPipelineOutput:
+    ) -> Flux2PipelineOutput:
+        """Run the Flux2 Klein denoising loop with optional CFG.
+
+        Follows the parent Flux2Pipeline execution flow, adding
+        classifier-free guidance support for non-distilled models.
+        """
         # 1) Encode prompts.
-        with Tracer("encode_prompt"):
-            prompt_embeds, text_ids = self.prepare_prompt_embeddings(
-                tokens=model_inputs.tokens,
-                num_images_per_prompt=model_inputs.num_images_per_prompt,
-            )
+        prompt_embeds, text_ids = self.prepare_prompt_embeddings(
+            tokens=model_inputs.tokens,
+            num_images_per_prompt=model_inputs.num_images_per_prompt,
+        )
+        batch_size = int(prompt_embeds.shape[0])
 
-            diff_cfg = self.pipeline_config.model.diffusers_config or {}
-            is_distilled = bool(diff_cfg.get("is_distilled", False))
-            if model_inputs.guidance_scale > 1.0 and is_distilled:
-                logger.warning(
-                    "Guidance scale %s is ignored for distilled Klein models.",
-                    model_inputs.guidance_scale,
-                )
-
-            negative_prompt_embeds: Tensor | None = None
-            negative_text_ids: Tensor | None = None
-            do_cfg = (
-                model_inputs.do_classifier_free_guidance and not is_distilled
-            )
-            if do_cfg and model_inputs.negative_tokens is not None:
-                negative_prompt_embeds, negative_text_ids = (
-                    self.prepare_prompt_embeddings(
-                        tokens=model_inputs.negative_tokens,
-                        num_images_per_prompt=model_inputs.num_images_per_prompt,
-                    )
-                )
-            elif do_cfg:
-                logger.warning(
-                    "CFG requested but negative prompt tokens are missing; "
-                    "running without CFG."
-                )
-                do_cfg = False
-
-        # 2) Prepare latents and conditioning tensors.
-        with Tracer("prepare_latents_and_conditioning"):
-            batch_size = int(prompt_embeds.shape[0])
-            dtype = prompt_embeds.dtype
-            device = self.transformer.devices[0]
-
-            image_latents = None
-            image_latent_ids = None
-            if model_inputs.input_image is not None:
-                image_array = np.array(model_inputs.input_image)
-                if image_array.ndim == 2:
-                    image_array = np.stack([image_array] * 3, axis=-1)
-                image_tensor = self._numpy_image_to_tensor(image_array)
-                image_latents, image_latent_ids = self.prepare_image_latents(
-                    images=[image_tensor],
-                    batch_size=batch_size,
-                    device=self.vae.devices[0],
-                    dtype=self.vae.config.dtype,
-                )
-
-            latents_tensor = Tensor(
-                storage=Buffer.from_dlpack(model_inputs.latents).to(device)
-            )
-            latent_image_ids = Tensor(
-                storage=Buffer.from_dlpack(model_inputs.latent_image_ids).to(
-                    device
+        # Encode negative prompts for CFG.
+        negative_prompt_embeds: Tensor | None = None
+        negative_text_ids: Tensor | None = None
+        do_cfg = model_inputs.do_classifier_free_guidance
+        if do_cfg and model_inputs.negative_tokens is not None:
+            negative_prompt_embeds, negative_text_ids = (
+                self.prepare_prompt_embeddings(
+                    tokens=model_inputs.negative_tokens,
+                    num_images_per_prompt=model_inputs.num_images_per_prompt,
                 )
             )
-            latents = self.preprocess_latents(latents_tensor)
-            guidance_key = f"zero_{batch_size}"
-            if guidance_key in self._cached_guidance:
-                guidance = self._cached_guidance[guidance_key]
-            else:
-                guidance = Tensor.zeros(
-                    [latents.shape[0]],
-                    device=device,
-                    dtype=dtype,
-                )
-                self._cached_guidance[guidance_key] = guidance
+        elif (
+            model_inputs.negative_tokens is None
+            and not model_inputs.is_distilled
+            and model_inputs.guidance_scale > 1.0
+        ):
+            logger.warning(
+                "CFG requested but negative prompt tokens are missing; "
+                "running without CFG."
+            )
+            do_cfg = False
 
-            h_carrier = model_inputs.h_carrier
-            w_carrier = model_inputs.w_carrier
-            if h_carrier is None or w_carrier is None:
-                raise ValueError(
-                    "Missing shape carriers in Flux2KleinModelInputs."
-                )
+        # 2) Prepare image latents (img2img).
+        image_latents = None
+        image_latent_ids = None
+        if model_inputs.input_image is not None:
+            image_tensor = self._numpy_image_to_tensor(model_inputs.input_image)
+            image_latents, image_latent_ids = self.prepare_image_latents(
+                images=[image_tensor],
+                batch_size=batch_size,
+                device=self.vae.devices[0],
+                dtype=self.vae.config.dtype,
+            )
 
-        # 3) Prepare scheduler tensors.
+        # 3) Prepare latents and conditioning tensors.
+        latents = self.preprocess_latents(model_inputs.latents)
+        latent_image_ids = model_inputs.latent_image_ids
+
+        # 4) Prepare scheduler tensors.
         with Tracer("prepare_scheduler"):
-            image_seq_len = int(latents.shape[1])
-            num_inference_steps = model_inputs.num_inference_steps
-            sigmas_key = f"{num_inference_steps}_{image_seq_len}"
-            if sigmas_key in self._cached_sigmas:
-                sigmas = self._cached_sigmas[sigmas_key]
-            else:
-                sigmas = Tensor(
-                    storage=Buffer.from_dlpack(model_inputs.sigmas).to(device)
-                )
-                self._cached_sigmas[sigmas_key] = sigmas
-            all_timesteps, all_dts = self.prepare_scheduler(sigmas)
+            all_timesteps, all_dts = self.prepare_scheduler(model_inputs.sigmas)
+            guidance = model_inputs.guidance
 
             timesteps_seq: Any = all_timesteps
             dts_seq: Any = all_dts
@@ -262,10 +175,10 @@ class Flux2KleinPipeline(Flux2Pipeline):
             if hasattr(dts_seq, "driver_tensor"):
                 dts_seq = dts_seq.driver_tensor
 
-        # 4) Denoising loop.
+        # 5) Denoising loop.
         is_img2img = image_latents is not None
         with Tracer("denoising_loop"):
-            for i in range(num_inference_steps):
+            for i in range(model_inputs.num_inference_steps):
                 with Tracer(f"denoising_step_{i}"):
                     timestep = timesteps_seq[i : i + 1]
                     dt = dts_seq[i : i + 1]
@@ -273,11 +186,13 @@ class Flux2KleinPipeline(Flux2Pipeline):
                     if is_img2img:
                         assert image_latents is not None
                         assert image_latent_ids is not None
-                        latents_concat = F.concat(
-                            [latents, image_latents], axis=1
-                        )
-                        latent_image_ids_concat = F.concat(
-                            [latent_image_ids, image_latent_ids], axis=1
+                        latents_concat, latent_image_ids_concat = (
+                            self.concat_image_latents(
+                                latents,
+                                image_latents,
+                                latent_image_ids,
+                                image_latent_ids,
+                            )
                         )
                     else:
                         latents_concat = latents
@@ -292,12 +207,11 @@ class Flux2KleinPipeline(Flux2Pipeline):
                             text_ids,
                             guidance,
                         )[0]
-                        noise_pred = Tensor.from_dlpack(noise_pred)
 
                     if do_cfg:
                         assert negative_prompt_embeds is not None
                         assert negative_text_ids is not None
-                        with Tracer("transformer_cfg_negative"):
+                        with Tracer("transformer_negative"):
                             neg_noise_pred = self.transformer(
                                 latents_concat,
                                 negative_prompt_embeds,
@@ -306,7 +220,8 @@ class Flux2KleinPipeline(Flux2Pipeline):
                                 negative_text_ids,
                                 guidance,
                             )[0]
-                            neg_noise_pred = Tensor.from_dlpack(neg_noise_pred)
+                        neg_noise_pred = Tensor.from_dlpack(neg_noise_pred)
+                        noise_pred = Tensor.from_dlpack(noise_pred)
                         noise_pred = (
                             neg_noise_pred
                             + model_inputs.guidance_scale
@@ -316,30 +231,12 @@ class Flux2KleinPipeline(Flux2Pipeline):
                     with Tracer("scheduler_step"):
                         latents = self.scheduler_step(latents, noise_pred, dt)
 
-                    if callback_queue is not None:
-                        with Tracer("callback"):
-                            if hasattr(device, "synchronize"):
-                                device.synchronize()
-                            if output_type == "latent":
-                                callback_queue.put_nowait(
-                                    cast(
-                                        np.ndarray,
-                                        np.from_dlpack(latents.to(CPU())),
-                                    )
-                                )
-                            else:
-                                callback_queue.put_nowait(
-                                    cast(
-                                        np.ndarray,
-                                        self.decode_latents(
-                                            latents, h_carrier, w_carrier
-                                        ),
-                                    )
-                                )
-
-        # 5) Decode final outputs for all batch elements in a single pass.
+        # 6) Decode final outputs.
         with Tracer("decode_outputs"):
-            if output_type == "latent":
-                return Flux2KleinPipelineOutput(images=latents)
-            images = self.decode_latents(latents, h_carrier, w_carrier)
-            return Flux2KleinPipelineOutput(images=images)
+            images = self.decode_latents(
+                latents,
+                model_inputs.h_carrier,
+                model_inputs.w_carrier,
+            )
+
+        return Flux2PipelineOutput(images=images)

--- a/max/python/max/pipelines/lib/config/model_config.py
+++ b/max/python/max/pipelines/lib/config/model_config.py
@@ -746,11 +746,21 @@ class MAXModelConfig(MAXModelConfigBase):
                 "config_dict": component_configs.get(component_name, {}),
             }
 
+        # Collect top-level metadata (non-private, non-component keys).
+        metadata: dict[str, Any] = {}
+        for key, value in model_index.items():
+            if key.startswith("_"):
+                continue
+            if isinstance(value, list) and len(value) == 2:
+                continue
+            metadata[key] = value
+
         # Build the final config structure
         return {
             "_class_name": class_name,
             "_diffusers_version": diffusers_version,
             "components": components,
+            **metadata,
         }
 
     @computed_field  # type: ignore[prop-decorator]


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Please fill out the sections below to help reviewers understand your change.
For guidance on writing a good PR, see our
[contributor guide](../CONTRIBUTING.md).
-->

## Summary

- Refactor Flux2KleinPipeline execution to mirror the base Flux2 flow.
- Fix model config parsing to retain top-level metadata fields while building the final config structure. This fixes a bug where `is_distilled` config was not parsed correctly, causing the CFG path to always be taken.
- Compile the CFG combine formula with symbolic shapes to reduce per-step overhead on cfg path.
- Ensure no recompilation is triggered.

## Testing

```
./bazelw run //max/examples/diffusion:simple_offline_generation -- --model black-forest-labs/FLUX.2-klein-4B --prompt "A cat in a garden" --num-inference-steps 4
```

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))

Assisted-by: AI