### PR TITLE
[MAX] Replace tiled kv repeat in Qwen3 text encoder for FLUX.2-Klein

### DIFF
--- a/max/python/max/pipelines/architectures/qwen3/text_encoder/layers/attention.py
+++ b/max/python/max/pipelines/architectures/qwen3/text_encoder/layers/attention.py
@@ -77,7 +77,7 @@ class EncoderAttention(Module[..., Tensor]):
 
         # [S, H_kv, D] -> [S, H_kv, 1, D] -> [S, H_kv, n_rep, D] -> [S, H, D]
         x = F.unsqueeze(x, 2)
-        x = F.tile(x, [1, 1, n_rep, 1])
+        x = F.concat([x] * n_rep, axis=2)
         x = F.reshape(x, (seq_len, n_kv_heads * n_rep, head_dim))
 
         return x


### PR DESCRIPTION
## Summary

This changes the Qwen3 text encoder KV expansion path used for GQA in Klein.

- replace `F.tile(...)` with `F.concat([x] * n_rep, axis=2)` in `_repeat_kv`
- keep the same input/output shapes and semantics
- reduce overhead in the text encoder attention hot path

## Details

In `max/python/max/pipelines/architectures/qwen3/text_encoder/layers/attention.py`, `_repeat_kv()` previously expanded KV heads with a tiled intermediate:

```python
x = F.unsqueeze(x, 2)
x = F.tile(x, [1, 1, n_rep, 1])
x = F.reshape(x, (seq_len, n_kv_heads * n_rep, head_dim))
```

This change replaces the (currently slow) tile op with concat-based repetition:

```
x = F.unsqueeze(x, 2)
x = F.concat([x] * n_rep, axis=2)
x = F.reshape(x, (seq_len, n_kv_heads * n_rep, head_dim))
```

## Performance
B200, AMD EPYC 9555 64-Core Processor 28vcpu
`./bazelw run //max/examples/diffusion:simple_offline_generation -- --model black-forest-labs/FLUX.2-klein-4B --prompt "A cat holding a sign that says hello world" --num-inference-steps 4 --num-warmups 1 --guidance-scale 1.0 --seed 42 --profile-timings`

### As-is (main, e3e52b0c8b31a74f0e8fd3b02416144c74e43ff0 with some stdlib reverts)
```
==================== PROFILING REPORT ==
Component Timings:
components                       calls        total          avg (ms)
component/transformer               12      447.637       37.303
component/text_encoder               3       70.725       23.575

Method Timings:
methods                          calls        total          avg (ms)
E2E execute                          3      752.485      250.828
component/transformer               12      447.637       37.303
decode_latents                       3      231.710       77.237
prepare_embeddings                   3       70.857       23.619
component/text_encoder               3       70.725       23.575
scheduler_step                      12        1.102        0.092
preprocess_latents                   3        0.349        0.116
prepare_scheduler                    3        0.225        0.075
==========================================
```

### To-be
```
==================== PROFILING REPORT ==
Component Timings:
components                       calls        total          avg (ms)
component/transformer               12      447.069       37.256
component/text_encoder               3       25.241        8.414

Method Timings:
methods                          calls        total          avg (ms)
E2E execute                          3      705.475      235.158
component/transformer               12      447.069       37.256
decode_latents                       3      231.132       77.044
prepare_embeddings                   3       25.392        8.464
component/text_encoder               3       25.241        8.414
scheduler_step                      12        0.879        0.073
preprocess_latents                   3        0.321        0.107
prepare_scheduler                    3        0.174        0.058
==========================================
```