### PR TITLE
[bazel] Bump rules_mojo

### DIFF
--- a/bazel/common.MODULE.bazel
+++ b/bazel/common.MODULE.bazel
@@ -29,10 +29,10 @@ bazel_dep(name = "buildifier_prebuilt", version = "8.2.1", dev_dependency = True
 
 archive_override(
     module_name = "rules_mojo",
-    integrity = "sha256-Nn4tQofKQBkapa2fRXTp7mwd+nSphWni+D5B+Ccd2YQ=",
-    strip_prefix = "rules_mojo-3b5c2b7f72dbf94f0e5bcce331255dc41871b19b",
+    integrity = "sha256-1MF8VA2cwncymsAXmhaF1F9ao3XbpyujUkff3Ra33d0=",
+    strip_prefix = "rules_mojo-759634edb91c3acc6328de2264f9330e55c88204",
     urls = [
-        "https://github.com/modular/rules_mojo/archive/3b5c2b7f72dbf94f0e5bcce331255dc41871b19b.tar.gz",
+        "https://github.com/modular/rules_mojo/archive/759634edb91c3acc6328de2264f9330e55c88204.tar.gz",
     ],
 )
 

--- a/bazel/mojo.MODULE.bazel
+++ b/bazel/mojo.MODULE.bazel
@@ -6,7 +6,7 @@ BASE_URL = "https://whl.modular.com/nightly"
 
 mojo = use_extension("@rules_mojo//mojo:extensions.bzl", "mojo")
 mojo.toolchain(
-    base_url = BASE_URL + "/",
+    base_url = BASE_URL,
     use_prebuilt_packages = False,
     version = "0." + PACKAGE_VERSION,
 )


### PR DESCRIPTION
We assume the base URL doesn't contain a trailing slash, this is consistent with other places where we override this.
