### PR TITLE
[Stdlib] Optimize `Counter.most_common(n)` with heap-based partial sort for small n

### DIFF
--- a/mojo/stdlib/benchmarks/collections/bench_counter.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_counter.mojo
@@ -37,7 +37,7 @@ def bench_most_common_small_n[total: Int, n: Int](mut b: Bencher) raises:
 
     @always_inline
     def call_fn() unified {read}:
-        var result = black_box(c).most_common(black_box(n))
+        var result = black_box(c).most_common(UInt(black_box(n)))
         keep(result)
 
     b.iter(call_fn)
@@ -53,7 +53,7 @@ def bench_most_common_large_n[total: Int, n: Int](mut b: Bencher) raises:
 
     @always_inline
     def call_fn() unified {read}:
-        var result = black_box(c).most_common(black_box(n))
+        var result = black_box(c).most_common(UInt(black_box(n)))
         keep(result)
 
     b.iter(call_fn)

--- a/mojo/stdlib/benchmarks/collections/bench_counter.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_counter.mojo
@@ -1,0 +1,92 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.collections import Counter
+
+from std.benchmark import Bench, BenchConfig, Bencher, BenchId, black_box, keep
+
+
+# ===-----------------------------------------------------------------------===#
+# Benchmark Data
+# ===-----------------------------------------------------------------------===#
+def make_counter[size: Int]() -> Counter[Int]:
+    """Build a Counter with `size` distinct keys, count[i] = i + 1."""
+    var c = Counter[Int]()
+    for i in range(size):
+        c[i] = i + 1
+    return c^
+
+
+# ===-----------------------------------------------------------------------===#
+# Benchmark most_common — heap path (n << total)
+# ===-----------------------------------------------------------------------===#
+@parameter
+def bench_most_common_small_n[total: Int, n: Int](mut b: Bencher) raises:
+    """Benchmark most_common(n) via the heap path (n < total // 2)."""
+    var c = make_counter[total]()
+
+    @always_inline
+    def call_fn() unified {read}:
+        var result = black_box(c).most_common(black_box(n))
+        keep(result)
+
+    b.iter(call_fn)
+
+
+# ===-----------------------------------------------------------------------===#
+# Benchmark most_common — full sort path (n >= total // 2)
+# ===-----------------------------------------------------------------------===#
+@parameter
+def bench_most_common_large_n[total: Int, n: Int](mut b: Bencher) raises:
+    """Benchmark most_common(n) via the full sort path (n >= total // 2)."""
+    var c = make_counter[total]()
+
+    @always_inline
+    def call_fn() unified {read}:
+        var result = black_box(c).most_common(black_box(n))
+        keep(result)
+
+    b.iter(call_fn)
+
+
+# ===-----------------------------------------------------------------------===#
+# Benchmark Main
+# ===-----------------------------------------------------------------------===#
+def main() raises:
+    var m = Bench(BenchConfig(num_repetitions=10))
+
+    # total=100: heap path (n=5), full sort path (n=80)
+    m.bench_function[bench_most_common_small_n[100, 5]](
+        BenchId("bench_most_common_heap[total=100,n=5]")
+    )
+    m.bench_function[bench_most_common_large_n[100, 80]](
+        BenchId("bench_most_common_sort[total=100,n=80]")
+    )
+
+    # total=1000: heap path (n=10), full sort path (n=800)
+    m.bench_function[bench_most_common_small_n[1000, 10]](
+        BenchId("bench_most_common_heap[total=1000,n=10]")
+    )
+    m.bench_function[bench_most_common_large_n[1000, 800]](
+        BenchId("bench_most_common_sort[total=1000,n=800]")
+    )
+
+    # total=10_000: heap path (n=10), full sort path (n=8000)
+    m.bench_function[bench_most_common_small_n[10_000, 10]](
+        BenchId("bench_most_common_heap[total=10000,n=10]")
+    )
+    m.bench_function[bench_most_common_large_n[10_000, 8_000]](
+        BenchId("bench_most_common_sort[total=10000,n=8000]")
+    )
+
+    print(m)

--- a/mojo/stdlib/benchmarks/collections/bench_counter.mojo
+++ b/mojo/stdlib/benchmarks/collections/bench_counter.mojo
@@ -28,10 +28,10 @@ def make_counter[size: Int]() -> Counter[Int]:
 
 
 # ===-----------------------------------------------------------------------===#
-# Benchmark most_common — heap path (n << total)
+# Benchmark most_common — heap path (n < total // 2)
 # ===-----------------------------------------------------------------------===#
 @parameter
-def bench_most_common_small_n[total: Int, n: Int](mut b: Bencher) raises:
+def bench_most_common_heap[total: Int, n: Int](mut b: Bencher) raises:
     """Benchmark most_common(n) via the heap path (n < total // 2)."""
     var c = make_counter[total]()
 
@@ -47,7 +47,7 @@ def bench_most_common_small_n[total: Int, n: Int](mut b: Bencher) raises:
 # Benchmark most_common — full sort path (n >= total // 2)
 # ===-----------------------------------------------------------------------===#
 @parameter
-def bench_most_common_large_n[total: Int, n: Int](mut b: Bencher) raises:
+def bench_most_common_sort[total: Int, n: Int](mut b: Bencher) raises:
     """Benchmark most_common(n) via the full sort path (n >= total // 2)."""
     var c = make_counter[total]()
 
@@ -65,28 +65,56 @@ def bench_most_common_large_n[total: Int, n: Int](mut b: Bencher) raises:
 def main() raises:
     var m = Bench(BenchConfig(num_repetitions=10))
 
-    # total=100: heap path (n=5), full sort path (n=80)
-    m.bench_function[bench_most_common_small_n[100, 5]](
-        BenchId("bench_most_common_heap[total=100,n=5]")
+    # --- Crossover comparison: same n on both sides of the total // 2 threshold ---
+    # For each total, n = total//2 - 1 takes the heap path,
+    # n = total//2 takes the sort path. Result counts differ by 1, making
+    # this the fairest apples-to-apples comparison of the two code paths.
+
+    # total=100, threshold=50
+    m.bench_function[bench_most_common_heap[100, 49]](
+        BenchId("bench_most_common_heap[total=100,n=49]")
     )
-    m.bench_function[bench_most_common_large_n[100, 80]](
-        BenchId("bench_most_common_sort[total=100,n=80]")
+    m.bench_function[bench_most_common_sort[100, 50]](
+        BenchId("bench_most_common_sort[total=100,n=50]")
     )
 
-    # total=1000: heap path (n=10), full sort path (n=800)
-    m.bench_function[bench_most_common_small_n[1000, 10]](
-        BenchId("bench_most_common_heap[total=1000,n=10]")
+    # total=1000, threshold=500
+    m.bench_function[bench_most_common_heap[1000, 499]](
+        BenchId("bench_most_common_heap[total=1000,n=499]")
     )
-    m.bench_function[bench_most_common_large_n[1000, 800]](
-        BenchId("bench_most_common_sort[total=1000,n=800]")
+    m.bench_function[bench_most_common_sort[1000, 500]](
+        BenchId("bench_most_common_sort[total=1000,n=500]")
     )
 
-    # total=10_000: heap path (n=10), full sort path (n=8000)
-    m.bench_function[bench_most_common_small_n[10_000, 10]](
+    # total=10_000, threshold=5000
+    m.bench_function[bench_most_common_heap[10_000, 4_999]](
+        BenchId("bench_most_common_heap[total=10000,n=4999]")
+    )
+    m.bench_function[bench_most_common_sort[10_000, 5_000]](
+        BenchId("bench_most_common_sort[total=10000,n=5000]")
+    )
+
+    # --- Small-n scaling: heap path, fixed total=10_000 ---
+    # Shows how the heap path scales as n grows toward the threshold.
+    m.bench_function[bench_most_common_heap[10_000, 10]](
         BenchId("bench_most_common_heap[total=10000,n=10]")
     )
-    m.bench_function[bench_most_common_large_n[10_000, 8_000]](
+    m.bench_function[bench_most_common_heap[10_000, 100]](
+        BenchId("bench_most_common_heap[total=10000,n=100]")
+    )
+    m.bench_function[bench_most_common_heap[10_000, 1_000]](
+        BenchId("bench_most_common_heap[total=10000,n=1000]")
+    )
+
+    # --- Large-n scaling: sort path, fixed total=10_000 ---
+    m.bench_function[bench_most_common_sort[10_000, 5_000]](
+        BenchId("bench_most_common_sort[total=10000,n=5000]")
+    )
+    m.bench_function[bench_most_common_sort[10_000, 8_000]](
         BenchId("bench_most_common_sort[total=10000,n=8000]")
+    )
+    m.bench_function[bench_most_common_sort[10_000, 10_000]](
+        BenchId("bench_most_common_sort[total=10000,n=10000]")
     )
 
     print(m)

--- a/mojo/stdlib/std/collections/counter.mojo
+++ b/mojo/stdlib/std/collections/counter.mojo
@@ -863,6 +863,11 @@ struct Counter[V: KeyElement, H: Hasher = default_hasher](
         """Return a list of the `n` most common elements and their counts from
         the most common to the least.
 
+        Uses a full sort (O(total * log(total))) when `n` is close to the total
+        number of distinct elements, and a min-heap of size `n`
+        (O(total * log(n))) when `n` is much smaller than the total. The
+        heap-based path is taken when `n < total // 2`.
+
         Args:
             n: The number of most common elements to return.
 
@@ -881,6 +886,15 @@ struct Counter[V: KeyElement, H: Hasher = default_hasher](
             # output: 2 4
         ```
         """
+        var total = len(self._data)
+        var want = Int(min(n, UInt(total)))
+
+        # Fast path: use a min-heap of size `want` when n < total // 2.
+        # This runs in O(total * log(n)) instead of O(total * log(total)).
+        if want > 0 and want < total // 2:
+            return _most_common_heap[Self.V, Self.H](self._data, want)
+
+        # Default: collect all items, sort, and truncate.
         var items: List[CountTuple[Self.V]] = List[CountTuple[Self.V]]()
         for item in self._data.items():
             var t = CountTuple[Self.V](item.key, UInt(item.value))
@@ -891,7 +905,7 @@ struct Counter[V: KeyElement, H: Hasher = default_hasher](
             return a < b
 
         sort[comparator](items)
-        items.shrink(Int(n))
+        items.shrink(want)
         return items^
 
     def elements(self) -> List[Self.V]:
@@ -1032,3 +1046,109 @@ struct CountTuple[V: KeyElement](Comparable, Copyable):
             return self._value.copy()
         else:
             return self._count
+
+
+# ===-----------------------------------------------------------------------===#
+# Min-heap helpers for most_common()
+# ===-----------------------------------------------------------------------===#
+
+
+fn _heap_sift_up[V: KeyElement](mut heap: List[CountTuple[V]], i: Int):
+    """Restore the min-heap property by sifting the element at index `i` up.
+
+    The heap is ordered by ascending `_count` (min-heap), so the element with
+    the smallest count sits at index 0.  This is used when a new element is
+    pushed onto the heap.
+
+    Parameters:
+        V: The value type of the `CountTuple` elements.
+
+    Args:
+        heap: The heap list to operate on.
+        i: The index of the element to sift up.
+    """
+    var idx = i
+    while idx > 0:
+        var parent = (idx - 1) // 2
+        if heap[idx]._count < heap[parent]._count:
+            var tmp = heap[idx].copy()
+            heap[idx] = heap[parent].copy()
+            heap[parent] = tmp^
+            idx = parent
+        else:
+            break
+
+
+fn _heap_sift_down[V: KeyElement](
+    mut heap: List[CountTuple[V]], i: Int, size: Int
+):
+    """Restore the min-heap property by sifting the element at index `i` down.
+
+    The heap is ordered by ascending `_count` (min-heap).  This is used after
+    replacing the root with a new element.
+
+    Parameters:
+        V: The value type of the `CountTuple` elements.
+
+    Args:
+        heap: The heap list to operate on.
+        i: The index of the element to sift down.
+        size: The number of valid elements in `heap`.
+    """
+    var idx = i
+    while True:
+        var left = 2 * idx + 1
+        var right = 2 * idx + 2
+        var smallest = idx
+        if left < size and heap[left]._count < heap[smallest]._count:
+            smallest = left
+        if right < size and heap[right]._count < heap[smallest]._count:
+            smallest = right
+        if smallest == idx:
+            break
+        var tmp = heap[idx].copy()
+        heap[idx] = heap[smallest].copy()
+        heap[smallest] = tmp^
+        idx = smallest
+
+
+fn _most_common_heap[
+    V: KeyElement, H: Hasher
+](data: Dict[V, Int, H], n: Int) -> List[CountTuple[V]]:
+    """Return the `n` most common elements using a min-heap of size `n`.
+
+    This runs in O(total * log(n)) time and is called by `Counter.most_common`
+    when `n < total // 2`.
+
+    Parameters:
+        V: The value type stored in the `Counter`.
+        H: The hasher type of the underlying dictionary.
+
+    Args:
+        data: The underlying dictionary of the `Counter`.
+        n: The number of top elements to return.
+
+    Returns:
+        A list of the `n` most common `CountTuple`s, sorted from most to least
+        common.
+    """
+    var heap = List[CountTuple[V]]()
+
+    for item in data.items():
+        var t = CountTuple[V](item.key, UInt(item.value))
+        if len(heap) < n:
+            # Fill the heap until it has n elements.
+            heap.append(t^)
+            _heap_sift_up(heap, len(heap) - 1)
+        elif t._count > heap[0]._count:
+            # New element beats the current minimum: replace root and re-heapify.
+            heap[0] = t^
+            _heap_sift_down(heap, 0, len(heap))
+
+    # Sort the n-element heap in descending order (most common first).
+    @parameter
+    def comparator(a: CountTuple[V], b: CountTuple[V]) -> Bool:
+        return a < b
+
+    sort[comparator](heap)
+    return heap^

--- a/mojo/stdlib/test/collections/test_counter.mojo
+++ b/mojo/stdlib/test/collections/test_counter.mojo
@@ -235,6 +235,23 @@ def test_most_common() raises:
     assert_equal(most_common[1][1][Int], 2)
 
 
+def test_most_common_heap_path() raises:
+    # Build a counter with 20 distinct keys so that requesting n=5 triggers
+    # the heap path (n < total // 2 => 5 < 10).
+    var c = Counter[Int]()
+    for i in range(20):
+        c[i] = i + 1  # key i has count i+1; highest counts are keys 19..15
+
+    var most_common = c.most_common(5)
+    assert_equal(len(most_common), 5)
+    # Keys with the five highest counts: 19 (20), 18 (19), 17 (18), 16 (17), 15 (16)
+    assert_equal(most_common[0][1][Int], 20)
+    assert_equal(most_common[1][1][Int], 19)
+    assert_equal(most_common[2][1][Int], 18)
+    assert_equal(most_common[3][1][Int], 17)
+    assert_equal(most_common[4][1][Int], 16)
+
+
 def test_eq_and_ne() raises:
     var c1 = Counter[String]()
     c1["a"] = 1


### PR DESCRIPTION
When `n < total // 2`, use a min-heap of size `n` to find the top-n elements in O(total · log n) instead of sorting all elements in O(total · log total).

The full sort path is kept for `n >= total // 2` and for the `n is None` case.

Adds private helpers `_heap_sift_up`, `_heap_sift_down`, `_most_common_heap` and a test exercising the heap code path.