### PR TITLE
[Stdlib] Remove misleading TODO in `LinkedList.insert()` index normalization

### DIFF
--- a/mojo/stdlib/std/collections/linked_list.mojo
+++ b/mojo/stdlib/std/collections/linked_list.mojo
@@ -454,7 +454,9 @@ struct LinkedList[ElementType: Copyable & ImplicitlyDestructible](
             Time Complexity: O(n) in len(self).
         """
 
-        # TODO: use normalize_index
+        # `insert` follows Python's list.insert() semantics: out-of-range
+        # negative indices clamp to 0 (head) rather than raising, so
+        # normalize_index (which asserts bounds) cannot be used here.
         var i = index(idx)
         i = max(i if i >= 0 else i + len(self), 0)
 


### PR DESCRIPTION
`LinkedList.insert()` had a `# TODO: use normalize_index` comment, but `normalize_index` asserts bounds and cannot implement Python's `list.insert()` clamping semantics, where out-of-range negative indices silently clamp to 0 (head) rather than raising. Replacing the comment with one explaining the intentional difference.

---

Assisted-by: AI