### PR TITLE
[Stdlib] Add `math.prod()` for computing product of a span

### DIFF
--- a/mojo/stdlib/std/math/__init__.mojo
+++ b/mojo/stdlib/std/math/__init__.mojo
@@ -89,6 +89,7 @@ from .math import (
     min,
     modf,
     perm,
+    prod,
     pow,
     recip,
     remainder,

--- a/mojo/stdlib/std/math/math.mojo
+++ b/mojo/stdlib/std/math/math.mojo
@@ -34,7 +34,7 @@ from std.sys._assembly import inlined_assembly
 from std.ffi import _external_call_const
 from std.sys.info import _is_sm_9x_or_newer, is_32bit
 
-from std.algorithm import vectorize
+from std.algorithm import product as _product, vectorize
 from std.bit import count_trailing_zeros
 from std.builtin.dtype import _integral_type_of
 from std.builtin.simd import _modf, _simd_apply
@@ -3140,6 +3140,40 @@ def ulp[
             x2_inf_mask.select(xabs - nextafter(xabs, -inf_val), x2 - xabs),
         ),
     )
+
+
+# ===----------------------------------------------------------------------=== #
+# prod
+# ===----------------------------------------------------------------------=== #
+
+
+def prod[
+    dtype: DType
+](src: Span[Scalar[dtype], _], start: Scalar[dtype] = 1) raises -> Scalar[
+    dtype
+]:
+    """Computes the product of all elements in a buffer, with an optional
+    starting value.
+
+    Equivalent to Python's `math.prod(iterable, start=1)`.
+
+    Parameters:
+        dtype: The dtype of the input elements.
+
+    Args:
+        src: The buffer of elements to multiply.
+        start: The initial value of the product. Defaults to `1`.
+
+    Returns:
+        The product of `start` and all elements of `src`. Returns `start` if
+        `src` is empty.
+
+    Raises:
+        If the reduction fails.
+    """
+    if len(src) == 0:
+        return start
+    return start * _product(src)
 
 
 # ===----------------------------------------------------------------------=== #

--- a/mojo/stdlib/test/math/test_math.mojo
+++ b/mojo/stdlib/test/math/test_math.mojo
@@ -40,6 +40,7 @@ from std.math import (
     log1p,
     log2,
     perm,
+    prod,
     pi,
     rsqrt,
     sin,
@@ -130,6 +131,34 @@ def test_perm() raises:
     assert_equal(perm(5), factorial(5))
     assert_equal(perm(0), 1)
     assert_equal(perm(10, 3), 720)
+
+
+def test_prod() raises:
+    # Empty span returns start (default 1)
+    var empty = List[Int64]()
+    assert_equal(prod(Span[Int64](empty)), Int64(1))
+
+    # Empty span with custom start
+    assert_equal(prod(Span[Int64](empty), start=Int64(5)), Int64(5))
+
+    # Basic int64 product
+    var il: InlineArray[Int64, 5] = [1, 2, 3, 4, 5]
+    assert_equal(prod(Span[Int64](il)), Int64(120))
+
+    # Product with start value
+    assert_equal(prod(Span[Int64](il), start=Int64(2)), Int64(240))
+
+    # Float product
+    var fl: InlineArray[Float64, 3] = [1.5, 2.0, 4.0]
+    assert_almost_equal(prod(Span[Float64](fl)), Float64(12.0))
+
+    # Single element
+    var single: InlineArray[Int64, 1] = [Int64(42)]
+    assert_equal(prod(Span[Int64](single)), Int64(42))
+
+    # Product with a zero element
+    var with_zero: InlineArray[Int64, 3] = [1, 0, 3]
+    assert_equal(prod(Span[Int64](with_zero)), Int64(0))
 
 
 def test_copysign() raises:


### PR DESCRIPTION
Adds `math.prod()` as a Python-compatible function that computes the product of all elements in a `Span[Scalar[dtype]]`, with an optional `start` parameter (defaults to `1`).

Delegates to the existing `algorithm.product()` reduction, adding the `start` multiplier and the empty-span short-circuit.