### PR TITLE
[stdlib] Add `Iterable` overload for `max`/`min`

### DIFF
--- a/mojo/stdlib/std/math/math.mojo
+++ b/mojo/stdlib/std/math/math.mojo
@@ -3863,6 +3863,50 @@ def max[T: Copyable & Comparable](x: T, *ys: T) -> T:
     return res.copy()
 
 
+fn max[
+    origin: ImmutOrigin, T: Iterable, //
+](
+    ref[origin] seq: T,
+    out max_element: T.IteratorType[origin_of(seq)].Element,
+) raises StopIteration where conforms_to(
+    type_of(max_element), ImplicitlyDestructible & Comparable & Movable
+):
+    """
+    Gets the maximum value from a sequence of values.
+
+    Parameters:
+        origin: The origin of the sequence.
+        T: A type that is both copyable and comparable with greater than.
+
+    Args:
+        seq: The sequence to get the maximum value from.
+
+    Raises:
+        StopIteration: If the sequence is empty.
+
+    Returns:
+        The maximum value from the input sequence.
+    """
+    var it = iter(seq)
+
+    # Will raise on empty container
+    var m = trait_downcast_var[Comparable & Movable & ImplicitlyDestructible](
+        next(it)
+    )
+
+    while True:
+        try:
+            var n = trait_downcast_var[
+                Comparable & Movable & ImplicitlyDestructible
+            ](next(it))
+
+            if n > m:
+                m = n^
+        except:
+            break
+    max_element = m^
+
+
 # ===----------------------------------------------------------------------=== #
 # min
 # ===----------------------------------------------------------------------=== #
@@ -3929,6 +3973,49 @@ def min[T: Copyable & Comparable](x: T, *ys: T) -> T:
         if y < res:
             res = y.copy()
     return res.copy()
+
+
+fn min[
+    origin: ImmutOrigin, T: Iterable, //
+](
+    ref[origin] seq: T,
+    out min_element: T.IteratorType[origin_of(seq)].Element,
+) raises StopIteration where conforms_to(
+    type_of(min_element), ImplicitlyDestructible & Comparable & Movable
+):
+    """Gets the minimum value from a sequence of values.
+
+    Parameters:
+        origin: The origin of the sequence.
+        T: The type to iterate over.
+
+    Args:
+        seq: The sequence of values to find the minimum of.
+
+    Raises:
+        StopIteration: If the sequence is empty.
+
+    Returns:
+        The minimum value from the input sequence.
+    """
+    var it = iter(seq)
+
+    # Will raise on empty container
+    var m = trait_downcast_var[Comparable & Movable & ImplicitlyDestructible](
+        next(it)
+    )
+
+    while True:
+        try:
+            var n = trait_downcast_var[
+                Comparable & Movable & ImplicitlyDestructible
+            ](next(it))
+            if n < m:
+                m = n^
+        except:
+            break
+
+    min_element = m^
 
 
 # ===----------------------------------------------------------------------=== #

--- a/mojo/stdlib/test/math/test_max.mojo
+++ b/mojo/stdlib/test/math/test_max.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 
 from std.testing import TestSuite
-from std.testing import assert_equal
+from std.testing import assert_equal, assert_raises
 
 
 def test_max() raises:
@@ -28,6 +28,22 @@ def test_max() raises:
     )
 
     assert_equal(actual_result, expected_result)
+
+
+def test_max_iterable() raises:
+    var expected_result = 10
+    var l = [1, 2, 10, 4, 5, 6]
+    assert_equal(max(l), expected_result)
+
+    assert_equal(max(range(20)), 19)
+
+    expected_result = 10
+    var t = {1, 2, 8, 4, 10, 6}
+    assert_equal(max(t), expected_result)
+
+    with assert_raises():
+        l = []
+        _ = max(l)
 
 
 def test_max_scalar() raises:

--- a/mojo/stdlib/test/math/test_min.mojo
+++ b/mojo/stdlib/test/math/test_min.mojo
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 
 from std.testing import TestSuite
-from std.testing import assert_equal
+from std.testing import assert_equal, assert_raises
 
 
 def test_min() raises:
@@ -35,6 +35,22 @@ def test_min_scalar() raises:
     assert_equal(min(Bool(False), Bool(True)), Bool(False))
     assert_equal(min(Bool(False), Bool(False)), Bool(False))
     assert_equal(min(Bool(True), Bool(True)), Bool(True))
+
+
+def test_min_iterable() raises:
+    var expected_result = 0
+    var l = [1, 2, 10, 4, 0, 6]
+    assert_equal(min(l), expected_result)
+
+    assert_equal(min(range(20)), 0)
+
+    expected_result = 0
+    var t = {1, 2, 8, 4, 0, 6}
+    assert_equal(min(t), expected_result)
+
+    with assert_raises():
+        l = []
+        _ = min(l)
 
 
 def main() raises:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Please fill out the sections below to help reviewers understand your change.
For guidance on writing a good PR, see our
[contributor guide](../CONTRIBUTING.md).
-->

## Summary

Add `Iterable` overload for the `max`/`min` functions. The implementation is a little messy due to needing to use
a placeholder origin since using the proper origin fails because `seq` _could_ be `RegisterPassable`.

## Testing

<!--
Describe how you validated your changes. For code changes, this should include
what tests you ran and any relevant results. For documentation changes, describe
how you verified accuracy.
-->

Added tests to stdlib test suite. This implementation raises on empty containers which I don't love, but I'm not sure how else to handle it and that does match the Python behaviour.

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [ ] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
