### PR TITLE
[Serve] Validate target_endpoint for disaggregated inference requests

### DIFF
--- a/max/python/max/serve/router/openai_routes.py
+++ b/max/python/max/serve/router/openai_routes.py
@@ -1493,6 +1493,30 @@ def get_prompts_from_openai_request(
     raise Exception(f"unknown element type {type(prompt[0])}")
 
 
+def _get_and_verify_target_endpoint(
+    request: Request, completion_request: CreateCompletionRequest
+) -> str | None:
+    target_endpoint = _get_target_endpoint(
+        request, completion_request.target_endpoint
+    )
+    pipeline_config = get_app_pipeline_config(request.app)
+    if (
+        pipeline_config.runtime.pipeline_role == "decode_only"
+        and target_endpoint is None
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "This server is running in disaggregated inference"
+                " mode (pipeline_role='decode_only') and requires a"
+                " target_endpoint to route requests to a prefill"
+                " worker. Provide it via the 'X-Target-Endpoint'"
+                " header or the 'target_endpoint' request body field."
+            ),
+        )
+    return target_endpoint
+
+
 @router.post("/completions", response_model=None)
 async def openai_create_completion(
     request: Request,
@@ -1513,24 +1537,9 @@ async def openai_create_completion(
         )
         assert isinstance(pipeline, TokenGeneratorPipeline)
 
-        target_endpoint = _get_target_endpoint(
-            request, completion_request.target_endpoint
+        target_endpoint = _get_and_verify_target_endpoint(
+            request, completion_request
         )
-        pipeline_config = get_app_pipeline_config(request.app)
-        if (
-            pipeline_config.runtime.pipeline_role == "decode_only"
-            and target_endpoint is None
-        ):
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "This server is running in disaggregated inference"
-                    " mode (pipeline_role='decode_only') and requires a"
-                    " target_endpoint to route requests to a prefill"
-                    " worker. Provide it via the 'X-Target-Endpoint'"
-                    " header or the 'target_endpoint' request body field."
-                ),
-            )
 
         logger.debug(
             "Path: %s, Request: %s%s, Model: %s",

--- a/max/python/max/serve/router/openai_routes.py
+++ b/max/python/max/serve/router/openai_routes.py
@@ -943,24 +943,9 @@ async def openai_create_chat_completion(
                 else 1
             )
 
-        target_endpoint = _get_target_endpoint(
+        target_endpoint = _get_and_verify_target_endpoint(
             request, completion_request.target_endpoint
         )
-        pipeline_config = get_app_pipeline_config(request.app)
-        if (
-            pipeline_config.runtime.pipeline_role == "decode_only"
-            and target_endpoint is None
-        ):
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "This server is running in disaggregated inference"
-                    " mode (pipeline_role='decode_only') and requires a"
-                    " target_endpoint to route requests to a prefill"
-                    " worker. Provide it via the 'X-Target-Endpoint'"
-                    " header or the 'target_endpoint' request body field."
-                ),
-            )
 
         token_request = TextGenerationRequest(
             request_id=RequestID(request_id),
@@ -1494,11 +1479,9 @@ def get_prompts_from_openai_request(
 
 
 def _get_and_verify_target_endpoint(
-    request: Request, completion_request: CreateCompletionRequest
+    request: Request, body_target_endpoint: str | None
 ) -> str | None:
-    target_endpoint = _get_target_endpoint(
-        request, completion_request.target_endpoint
-    )
+    target_endpoint = _get_target_endpoint(request, body_target_endpoint)
     pipeline_config = get_app_pipeline_config(request.app)
     if (
         pipeline_config.runtime.pipeline_role == "decode_only"
@@ -1538,7 +1521,7 @@ async def openai_create_completion(
         assert isinstance(pipeline, TokenGeneratorPipeline)
 
         target_endpoint = _get_and_verify_target_endpoint(
-            request, completion_request
+            request, completion_request.target_endpoint
         )
 
         logger.debug(

--- a/max/python/max/serve/router/openai_routes.py
+++ b/max/python/max/serve/router/openai_routes.py
@@ -943,6 +943,25 @@ async def openai_create_chat_completion(
                 else 1
             )
 
+        target_endpoint = _get_target_endpoint(
+            request, completion_request.target_endpoint
+        )
+        pipeline_config = get_app_pipeline_config(request.app)
+        if (
+            pipeline_config.runtime.pipeline_role == "decode_only"
+            and target_endpoint is None
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "This server is running in disaggregated inference"
+                    " mode (pipeline_role='decode_only') and requires a"
+                    " target_endpoint to route requests to a prefill"
+                    " worker. Provide it via the 'X-Target-Endpoint'"
+                    " header or the 'target_endpoint' request body field."
+                ),
+            )
+
         token_request = TextGenerationRequest(
             request_id=RequestID(request_id),
             model_name=completion_request.model,
@@ -955,9 +974,7 @@ async def openai_create_chat_completion(
             response_format=response_format,
             sampling_params=sampling_params,
             logprobs=logprobs_count,
-            target_endpoint=_get_target_endpoint(
-                request, completion_request.target_endpoint
-            ),
+            target_endpoint=target_endpoint,
             dkv_cache_hint=completion_request.dkv_cache_hint,
             chat_template_options=completion_request.chat_template_kwargs,
         )
@@ -1496,6 +1513,25 @@ async def openai_create_completion(
         )
         assert isinstance(pipeline, TokenGeneratorPipeline)
 
+        target_endpoint = _get_target_endpoint(
+            request, completion_request.target_endpoint
+        )
+        pipeline_config = get_app_pipeline_config(request.app)
+        if (
+            pipeline_config.runtime.pipeline_role == "decode_only"
+            and target_endpoint is None
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "This server is running in disaggregated inference"
+                    " mode (pipeline_role='decode_only') and requires a"
+                    " target_endpoint to route requests to a prefill"
+                    " worker. Provide it via the 'X-Target-Endpoint'"
+                    " header or the 'target_endpoint' request body field."
+                ),
+            )
+
         logger.debug(
             "Path: %s, Request: %s%s, Model: %s",
             request.url.path,
@@ -1543,9 +1579,7 @@ async def openai_create_completion(
                 ),
                 echo=completion_request.echo or False,
                 sampling_params=sampling_params,
-                target_endpoint=_get_target_endpoint(
-                    request, completion_request.target_endpoint
-                ),
+                target_endpoint=target_endpoint,
                 dkv_cache_hint=completion_request.dkv_cache_hint,
             )
             token_requests.append(tgr)

--- a/max/python/max/serve/scheduler/decode_scheduler.py
+++ b/max/python/max/serve/scheduler/decode_scheduler.py
@@ -167,11 +167,12 @@ class DecodeScheduler(Scheduler):
         Raises:
             zmq.ZMQError: If there is an error sending on the socket
         """
-        # TODO: Do not crash the scheduler if a request does not have a target endpoint.
-        #       Instead we should validate this in the frontend.
+        # target_endpoint is validated in reserve_memory_and_send_to_prefill
+        # and in the frontend routes before reaching this point.
         if data.target_endpoint is None:
-            raise ValueError(
-                f"Target endpoint is not specified for the request {request_id}"
+            raise RuntimeError(
+                f"Target endpoint is not specified for request {request_id}."
+                " This should have been validated before reaching this point."
             )
         if data.target_endpoint not in self.remote_endpoints:
             self.dispatcher.send_request_nowait(
@@ -238,6 +239,23 @@ class DecodeScheduler(Scheduler):
             req_id = context.request_id
             del self.pending_reqs[req_id]
 
+            # Validate target_endpoint before allocating resources.
+            # NOTE: The client receives a cancelled response with no error
+            # detail. Frontend route validation should catch this earlier
+            # with a proper 400 error. This guard is a safety net.
+            if context.target_endpoint is None:
+                logger.error(
+                    "Target endpoint is not specified for request %s."
+                    " In disaggregated inference mode, a target_endpoint"
+                    " is required to route to a prefill worker."
+                    " Dropping request.",
+                    req_id,
+                )
+                self.response_queue.put_nowait(
+                    {req_id: SchedulerResult.cancelled()}
+                )
+                continue
+
             # Claim the slot with the paged manager
             replica_idx = self.batch_constructor.get_next_replica_idx(
                 external_requests_per_replica=self.prefill_reqs_per_replica
@@ -288,11 +306,13 @@ class DecodeScheduler(Scheduler):
                 # decode GPU before sending this request to prefill
                 self.kv_cache.release(req_id, replica_idx=dst_replica_idx)
 
-                # TODO: Do not crash the scheduler if a request does not have a target endpoint.
-                #       Instead we should validate this in the frontend.
+                # target_endpoint is validated before requests enter
+                # prefill_reqs, so it should never be None here.
                 if data.target_endpoint is None:
-                    raise ValueError(
-                        f"Target endpoint is not specified for the request {req_id}."
+                    raise RuntimeError(
+                        f"Target endpoint is not specified for request"
+                        f" {req_id}. This should have been validated before"
+                        " reaching this point."
                     )
                 # Send a cancel request to the prefill node
                 self.dispatcher.send_request_nowait(

--- a/max/tests/tests/serve/scheduler/test_di.py
+++ b/max/tests/tests/serve/scheduler/test_di.py
@@ -1400,3 +1400,57 @@ def test_overlap_di_both_sides_minimal_output() -> None:
     # match 42 as decode start_token_id
     assert all_tokens == [99, 42]
     assert FUTURE_TOKEN not in all_tokens
+
+
+def test_missing_target_endpoint_drops_request_gracefully() -> None:
+    """A request without target_endpoint must be dropped gracefully
+    without crashing the scheduler or leaking KV cache blocks.
+
+    The decode scheduler should log an error, send a cancelled result
+    back through the response queue, and continue processing other
+    requests.
+    """
+    decode, _prefill, server_addr, q = create_di_scheduler()
+
+    # Create a context without target_endpoint
+    tokens = TokenBuffer(np.ones(100, dtype=np.int64))
+    bad_ctx = TextContext(
+        request_id=RequestID(),
+        max_length=2048,
+        tokens=tokens,
+        target_endpoint=None,
+    )
+    bad_req_id = bad_ctx.request_id
+
+    # Also create a valid request to ensure processing continues
+    good_ctx = create_text_context(
+        target_endpoint=server_addr, prompt_len=100, output_len=5
+    )
+    good_req_id = good_ctx.request_id
+
+    # Submit both requests
+    q.request_queue.put(bad_ctx)
+    q.request_queue.put(good_ctx)
+
+    # Run the scheduler — should not crash
+    decode.run_iteration()
+
+    # The bad request should get a cancelled result
+    found_bad = False
+    while not q.response_queue.empty():
+        batch = q.response_queue.get()
+        if bad_req_id in batch:
+            found_bad = True
+            assert batch[bad_req_id].result is None  # cancelled
+
+    assert found_bad, (
+        "Expected cancelled result for request without target_endpoint"
+    )
+
+    # The bad request should not have allocated any KV cache blocks
+    # (only the good request should have allocated blocks)
+    assert bad_req_id not in decode.prefill_reqs
+    assert not decode.batch_constructor.contains(bad_req_id)
+
+    # The good request should have been sent to prefill normally
+    assert good_req_id in decode.prefill_reqs


### PR DESCRIPTION
## Summary

Addresses the two TODO comments in `decode_scheduler.py`:

```
# TODO: Do not crash the scheduler if a request does not have a target endpoint.
#       Instead we should validate this in the frontend.
```


When running in disaggregated inference mode (`pipeline_role='decode_only'`),
requests missing a `target_endpoint` can crash the decode scheduler with an
unhandled `ValueError`. This PR adds validation at the two affected endpoints:

- **Frontend routes:** `/v1/chat/completions` and `/v1/completions` return
  HTTP 400 when `target_endpoint` is missing in decode-only mode, with a
  message explaining how to provide it.
- **Scheduler safety net:** `reserve_memory_and_send_to_prefill()` validates
  `target_endpoint` before allocating KV cache blocks. Invalid requests are
  dropped with a cancelled result, preventing both crashes and memory leaks.
- The two existing `raise ValueError` guards are replaced with
  `raise RuntimeError` since they should be unreachable after upstream
  validation.

## Testing

- `test_missing_target_endpoint_drops_request_gracefully` — verifies no
  crash, cancelled result sent back, no KV cache block leak, and a
  subsequent valid request still processes normally.

## Checklist

- [x] PR is small and focused
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description

Assisted-by: AI