### PR TITLE
[Serve] Export speculative decoding metrics to OTEL/Prometheus

### DIFF
--- a/max/python/max/pipelines/lib/speculative_decoding/utils.py
+++ b/max/python/max/pipelines/lib/speculative_decoding/utils.py
@@ -82,6 +82,14 @@ class SpeculativeDecodingMetrics:
         self.draft_tokens_accepted += metrics.draft_tokens_accepted
         self.draft_tokens_generated += metrics.draft_tokens_generated
 
+    def reset(self) -> None:
+        """Reset all counters to zero."""
+        self.bonus_tokens_used = 0
+        self.draft_tokens_accepted = 0
+        self.draft_tokens_generated = 0
+        self.total_acceptance_lengths = 0
+        self.num_generations = 0
+
     @property
     def acceptance_rate(self) -> float:
         """Get the acceptance rate."""

--- a/max/python/max/pipelines/lib/speculative_decoding/utils.py
+++ b/max/python/max/pipelines/lib/speculative_decoding/utils.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
@@ -76,19 +76,30 @@ class SpeculativeDecodingMetrics:
             draft_tokens_generated=0,
         )
 
+    # Snapshot of the counters at the time of the last publish_delta() call,
+    # used to compute per-batch deltas for additive OTEL counters without
+    # losing the cumulative totals that console logs display.
+    _published_accepted: int = field(init=False, default=0, repr=False)
+    _published_generated: int = field(init=False, default=0, repr=False)
+
     def update(self, metrics: SpeculativeDecodingMetrics) -> None:
         """Update metrics with results from a batch."""
         assert metrics.num_speculative_tokens == self.num_speculative_tokens
         self.draft_tokens_accepted += metrics.draft_tokens_accepted
         self.draft_tokens_generated += metrics.draft_tokens_generated
 
-    def reset(self) -> None:
-        """Reset all counters to zero."""
-        self.bonus_tokens_used = 0
-        self.draft_tokens_accepted = 0
-        self.draft_tokens_generated = 0
-        self.total_acceptance_lengths = 0
-        self.num_generations = 0
+    def publish_delta(self) -> tuple[int, int]:
+        """Return (draft_tokens_generated, draft_tokens_accepted) delta since
+        the last call and advance the snapshot. Cumulative counters remain
+        intact so ``pretty_format`` can show lifetime totals while OTEL
+        counters receive per-batch increments."""
+        delta_generated = (
+            self.draft_tokens_generated - self._published_generated
+        )
+        delta_accepted = self.draft_tokens_accepted - self._published_accepted
+        self._published_generated = self.draft_tokens_generated
+        self._published_accepted = self.draft_tokens_accepted
+        return delta_generated, delta_accepted
 
     @property
     def acceptance_rate(self) -> float:

--- a/max/python/max/serve/scheduler/utils.py
+++ b/max/python/max/serve/scheduler/utils.py
@@ -79,6 +79,7 @@ class BatchMetrics:
     draft_tokens_accepted: int
     avg_acceptance_length: float
     max_acceptance_length: int
+    bonus_tokens_used: int
 
     nixl_read_latency_avg_ms: float
     nixl_write_latency_avg_ms: float
@@ -196,6 +197,7 @@ class BatchMetrics:
         draft_tokens_accepted = 0
         avg_acceptance_length = 0.0
         max_acceptance_length = 0
+        bonus_tokens_used = 0
         if speculative_decoding_metrics is not None:
             draft_tokens_generated = (
                 speculative_decoding_metrics.draft_tokens_generated
@@ -209,6 +211,8 @@ class BatchMetrics:
             max_acceptance_length = (
                 speculative_decoding_metrics.num_speculative_tokens
             )
+            bonus_tokens_used = speculative_decoding_metrics.bonus_tokens_used
+            speculative_decoding_metrics.reset()
 
         return cls(
             batch_type=inputs.batch_type,
@@ -241,6 +245,7 @@ class BatchMetrics:
             draft_tokens_accepted=draft_tokens_accepted,
             avg_acceptance_length=avg_acceptance_length,
             max_acceptance_length=max_acceptance_length,
+            bonus_tokens_used=bonus_tokens_used,
             nixl_read_latency_avg_ms=nixl_read_latency_avg_ms,
             nixl_write_latency_avg_ms=nixl_write_latency_avg_ms,
             rpc_acquire_latency_avg_ms=rpc_acquire_latency_avg_ms,
@@ -339,6 +344,15 @@ class BatchMetrics:
             METRICS.dkv_rpc_acquire_latency(self.rpc_acquire_latency_avg_ms)
         if self.rpc_read_latency_avg_ms > 0:
             METRICS.dkv_rpc_read_latency(self.rpc_read_latency_avg_ms)
+
+        if self.draft_tokens_generated > 0:
+            METRICS.speculative_draft_tokens_accepted(
+                self.draft_tokens_accepted
+            )
+            METRICS.speculative_draft_tokens_generated(
+                self.draft_tokens_generated
+            )
+            METRICS.speculative_bonus_tokens_used(self.bonus_tokens_used)
 
 
 class SchedulerLogger:

--- a/max/python/max/serve/scheduler/utils.py
+++ b/max/python/max/serve/scheduler/utils.py
@@ -75,11 +75,15 @@ class BatchMetrics:
     disk_blocks_written: int
     disk_blocks_read: int
 
+    # Cumulative lifetime totals, used by pretty_format for console logs.
     draft_tokens_generated: int
     draft_tokens_accepted: int
     avg_acceptance_length: float
     max_acceptance_length: int
-    bonus_tokens_used: int
+
+    # Per-batch deltas emitted to OTEL counters (which are additive).
+    draft_tokens_generated_delta: int
+    draft_tokens_accepted_delta: int
 
     nixl_read_latency_avg_ms: float
     nixl_write_latency_avg_ms: float
@@ -197,7 +201,8 @@ class BatchMetrics:
         draft_tokens_accepted = 0
         avg_acceptance_length = 0.0
         max_acceptance_length = 0
-        bonus_tokens_used = 0
+        draft_tokens_generated_delta = 0
+        draft_tokens_accepted_delta = 0
         if speculative_decoding_metrics is not None:
             draft_tokens_generated = (
                 speculative_decoding_metrics.draft_tokens_generated
@@ -211,8 +216,10 @@ class BatchMetrics:
             max_acceptance_length = (
                 speculative_decoding_metrics.num_speculative_tokens
             )
-            bonus_tokens_used = speculative_decoding_metrics.bonus_tokens_used
-            speculative_decoding_metrics.reset()
+            (
+                draft_tokens_generated_delta,
+                draft_tokens_accepted_delta,
+            ) = speculative_decoding_metrics.publish_delta()
 
         return cls(
             batch_type=inputs.batch_type,
@@ -245,7 +252,8 @@ class BatchMetrics:
             draft_tokens_accepted=draft_tokens_accepted,
             avg_acceptance_length=avg_acceptance_length,
             max_acceptance_length=max_acceptance_length,
-            bonus_tokens_used=bonus_tokens_used,
+            draft_tokens_generated_delta=draft_tokens_generated_delta,
+            draft_tokens_accepted_delta=draft_tokens_accepted_delta,
             nixl_read_latency_avg_ms=nixl_read_latency_avg_ms,
             nixl_write_latency_avg_ms=nixl_write_latency_avg_ms,
             rpc_acquire_latency_avg_ms=rpc_acquire_latency_avg_ms,
@@ -345,14 +353,13 @@ class BatchMetrics:
         if self.rpc_read_latency_avg_ms > 0:
             METRICS.dkv_rpc_read_latency(self.rpc_read_latency_avg_ms)
 
-        if self.draft_tokens_generated > 0:
+        if self.draft_tokens_generated_delta > 0:
             METRICS.speculative_draft_tokens_accepted(
-                self.draft_tokens_accepted
+                self.draft_tokens_accepted_delta
             )
             METRICS.speculative_draft_tokens_generated(
-                self.draft_tokens_generated
+                self.draft_tokens_generated_delta
             )
-            METRICS.speculative_bonus_tokens_used(self.bonus_tokens_used)
 
 
 class SchedulerLogger:

--- a/max/python/max/serve/telemetry/metrics.py
+++ b/max/python/max/serve/telemetry/metrics.py
@@ -180,11 +180,6 @@ SERVE_METRICS: dict[str, SupportedInstruments] = {
         unit="tokens",
         description="Count of generated draft tokens",
     ),  # type: ignore
-    "maxserve.speculative.bonus_tokens_used": _meter.create_counter(
-        "maxserve.speculative.bonus_tokens_used",
-        unit="tokens",
-        description="Count of bonus tokens used when all draft tokens accepted",
-    ),  # type: ignore
     "maxserve.input_tokens_per_request": _meter.create_histogram(
         "maxserve.input_tokens_per_request",
         unit="tokens",
@@ -555,16 +550,6 @@ class _AsyncMetrics:
         self.client.send_measurement(
             MaxMeasurement(
                 "maxserve.speculative.draft_tokens_generated",
-                value,
-                self.extra_attributes,
-            ),
-            MetricLevel.DETAILED,
-        )
-
-    def speculative_bonus_tokens_used(self, value: int) -> None:
-        self.client.send_measurement(
-            MaxMeasurement(
-                "maxserve.speculative.bonus_tokens_used",
                 value,
                 self.extra_attributes,
             ),

--- a/max/python/max/serve/telemetry/metrics.py
+++ b/max/python/max/serve/telemetry/metrics.py
@@ -170,6 +170,21 @@ SERVE_METRICS: dict[str, SupportedInstruments] = {
         unit="ms",
         description="Audio output length in milliseconds",
     ),  # type: ignore
+    "maxserve.speculative.draft_tokens_accepted": _meter.create_counter(
+        "maxserve.speculative.draft_tokens_accepted",
+        unit="tokens",
+        description="Count of accepted draft tokens",
+    ),  # type: ignore
+    "maxserve.speculative.draft_tokens_generated": _meter.create_counter(
+        "maxserve.speculative.draft_tokens_generated",
+        unit="tokens",
+        description="Count of generated draft tokens",
+    ),  # type: ignore
+    "maxserve.speculative.bonus_tokens_used": _meter.create_counter(
+        "maxserve.speculative.bonus_tokens_used",
+        unit="tokens",
+        description="Count of bonus tokens used when all draft tokens accepted",
+    ),  # type: ignore
     "maxserve.input_tokens_per_request": _meter.create_histogram(
         "maxserve.input_tokens_per_request",
         unit="tokens",
@@ -521,6 +536,36 @@ class _AsyncMetrics:
             MaxMeasurement(
                 "maxserve.tts.audio_output_length",
                 length_ms,
+                self.extra_attributes,
+            ),
+            MetricLevel.DETAILED,
+        )
+
+    def speculative_draft_tokens_accepted(self, value: int) -> None:
+        self.client.send_measurement(
+            MaxMeasurement(
+                "maxserve.speculative.draft_tokens_accepted",
+                value,
+                self.extra_attributes,
+            ),
+            MetricLevel.DETAILED,
+        )
+
+    def speculative_draft_tokens_generated(self, value: int) -> None:
+        self.client.send_measurement(
+            MaxMeasurement(
+                "maxserve.speculative.draft_tokens_generated",
+                value,
+                self.extra_attributes,
+            ),
+            MetricLevel.DETAILED,
+        )
+
+    def speculative_bonus_tokens_used(self, value: int) -> None:
+        self.client.send_measurement(
+            MaxMeasurement(
+                "maxserve.speculative.bonus_tokens_used",
+                value,
                 self.extra_attributes,
             ),
             MetricLevel.DETAILED,

--- a/max/tests/tests/serve/scheduler/test_scheduler_metrics.py
+++ b/max/tests/tests/serve/scheduler/test_scheduler_metrics.py
@@ -11,7 +11,18 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from max.interfaces import BatchType
+import numpy as np
+from max.interfaces import (
+    BatchType,
+    RequestID,
+    TextGenerationInputs,
+    TokenBuffer,
+)
+from max.pipelines.core import TextContext
+from max.pipelines.lib.speculative_decoding.utils import (
+    SpeculativeDecodingMetrics,
+)
+from max.serve.scheduler.config import TokenGenerationSchedulerConfig
 from max.serve.scheduler.utils import BatchMetrics
 
 
@@ -47,6 +58,7 @@ def test_metric_to_string() -> None:
         draft_tokens_accepted=0,
         avg_acceptance_length=0.0,
         max_acceptance_length=0,
+        bonus_tokens_used=0,
         nixl_read_latency_avg_ms=0.0,
         nixl_write_latency_avg_ms=0.0,
         rpc_acquire_latency_avg_ms=0.0,
@@ -73,3 +85,88 @@ def test_metric_to_string() -> None:
         metrics.pretty_format()
         == r"Executed CE batch with 1 reqs | Terminated: 4 reqs, Pending: 5 reqs | Input Tokens: 6/7 toks | Context Tokens: 8/9 toks | Prompt Tput: 12.0 tok/s, Generation Tput: 13.0 tok/s | Batch creation: 10.00s, Execution: 11.00s | Draft Tokens: 5/10 (50.00%) accepted, Acceptance Len: 2.50 / 3 toks | All Preemptions: 14 reqs"
     )
+
+
+def _make_inputs() -> TextGenerationInputs[TextContext]:
+    """Create minimal TextGenerationInputs for BatchMetrics.create()."""
+    ctx = TextContext(
+        request_id=RequestID(),
+        max_length=100,
+        tokens=TokenBuffer(np.ones(10, dtype=np.int64)),
+    )
+    return TextGenerationInputs(batches=[[ctx]], num_steps=1)
+
+
+_SCHEDULER_CONFIG = TokenGenerationSchedulerConfig(
+    max_batch_size=4,
+    max_forward_steps_tg=1,
+    target_tokens_per_batch_ce=32,
+)
+
+
+def test_create_resets_speculative_metrics_between_batches() -> None:
+    """BatchMetrics.create() must reset SpeculativeDecodingMetrics after
+    reading, so consecutive calls emit per-batch values, not cumulative
+    totals that would double-count when added to OTEL counters."""
+    spec_metrics = SpeculativeDecodingMetrics(
+        bonus_tokens_used=0,
+        draft_tokens_accepted=0,
+        draft_tokens_generated=0,
+        total_acceptance_lengths=0,
+        num_generations=0,
+    )
+
+    # Batch 1: pipeline updates metrics with 20 generated, 15 accepted.
+    spec_metrics.update(
+        SpeculativeDecodingMetrics(
+            bonus_tokens_used=3,
+            draft_tokens_accepted=15,
+            draft_tokens_generated=20,
+            total_acceptance_lengths=10,
+            num_generations=2,
+        )
+    )
+
+    batch1 = BatchMetrics.create(
+        sch_config=_SCHEDULER_CONFIG,
+        inputs=_make_inputs(),
+        kv_cache=None,
+        batch_creation_time_s=0.01,
+        batch_execution_time_s=0.05,
+        num_pending_reqs=0,
+        num_terminated_reqs=0,
+        total_preemption_count=0,
+        speculative_decoding_metrics=spec_metrics,
+    )
+
+    assert batch1.draft_tokens_generated == 20
+    assert batch1.draft_tokens_accepted == 15
+    assert batch1.bonus_tokens_used == 3
+
+    # Batch 2: pipeline updates metrics with 10 generated, 8 accepted.
+    spec_metrics.update(
+        SpeculativeDecodingMetrics(
+            bonus_tokens_used=1,
+            draft_tokens_accepted=8,
+            draft_tokens_generated=10,
+            total_acceptance_lengths=5,
+            num_generations=1,
+        )
+    )
+
+    batch2 = BatchMetrics.create(
+        sch_config=_SCHEDULER_CONFIG,
+        inputs=_make_inputs(),
+        kv_cache=None,
+        batch_creation_time_s=0.01,
+        batch_execution_time_s=0.05,
+        num_pending_reqs=0,
+        num_terminated_reqs=0,
+        total_preemption_count=0,
+        speculative_decoding_metrics=spec_metrics,
+    )
+
+    # Must reflect only batch 2's values, not batch 1 + batch 2.
+    assert batch2.draft_tokens_generated == 10
+    assert batch2.draft_tokens_accepted == 8
+    assert batch2.bonus_tokens_used == 1

--- a/max/tests/tests/serve/scheduler/test_scheduler_metrics.py
+++ b/max/tests/tests/serve/scheduler/test_scheduler_metrics.py
@@ -58,7 +58,8 @@ def test_metric_to_string() -> None:
         draft_tokens_accepted=0,
         avg_acceptance_length=0.0,
         max_acceptance_length=0,
-        bonus_tokens_used=0,
+        draft_tokens_generated_delta=0,
+        draft_tokens_accepted_delta=0,
         nixl_read_latency_avg_ms=0.0,
         nixl_write_latency_avg_ms=0.0,
         rpc_acquire_latency_avg_ms=0.0,
@@ -104,26 +105,19 @@ _SCHEDULER_CONFIG = TokenGenerationSchedulerConfig(
 )
 
 
-def test_create_resets_speculative_metrics_between_batches() -> None:
-    """BatchMetrics.create() must reset SpeculativeDecodingMetrics after
-    reading, so consecutive calls emit per-batch values, not cumulative
-    totals that would double-count when added to OTEL counters."""
-    spec_metrics = SpeculativeDecodingMetrics(
-        bonus_tokens_used=0,
-        draft_tokens_accepted=0,
-        draft_tokens_generated=0,
-        total_acceptance_lengths=0,
-        num_generations=0,
-    )
+def test_create_emits_cumulative_totals_and_per_batch_deltas() -> None:
+    """BatchMetrics.create() must expose cumulative draft token counts for
+    console logging while per-batch deltas feed the additive OTEL counters.
+    Without the delta split, consecutive publish_metrics() calls would
+    double-count because OTEL counters aggregate each emitted value."""
+    spec_metrics = SpeculativeDecodingMetrics.empty(num_speculative_tokens=5)
 
-    # Batch 1: pipeline updates metrics with 20 generated, 15 accepted.
+    # Batch 1: pipeline accumulates 20 generated / 15 accepted.
     spec_metrics.update(
         SpeculativeDecodingMetrics(
-            bonus_tokens_used=3,
+            num_speculative_tokens=5,
             draft_tokens_accepted=15,
             draft_tokens_generated=20,
-            total_acceptance_lengths=10,
-            num_generations=2,
         )
     )
 
@@ -141,16 +135,15 @@ def test_create_resets_speculative_metrics_between_batches() -> None:
 
     assert batch1.draft_tokens_generated == 20
     assert batch1.draft_tokens_accepted == 15
-    assert batch1.bonus_tokens_used == 3
+    assert batch1.draft_tokens_generated_delta == 20
+    assert batch1.draft_tokens_accepted_delta == 15
 
-    # Batch 2: pipeline updates metrics with 10 generated, 8 accepted.
+    # Batch 2: pipeline accumulates another 10 generated / 8 accepted on top.
     spec_metrics.update(
         SpeculativeDecodingMetrics(
-            bonus_tokens_used=1,
+            num_speculative_tokens=5,
             draft_tokens_accepted=8,
             draft_tokens_generated=10,
-            total_acceptance_lengths=5,
-            num_generations=1,
         )
     )
 
@@ -166,7 +159,8 @@ def test_create_resets_speculative_metrics_between_batches() -> None:
         speculative_decoding_metrics=spec_metrics,
     )
 
-    # Must reflect only batch 2's values, not batch 1 + batch 2.
-    assert batch2.draft_tokens_generated == 10
-    assert batch2.draft_tokens_accepted == 8
-    assert batch2.bonus_tokens_used == 1
+    # Cumulative totals grow; deltas reflect only this batch's increment.
+    assert batch2.draft_tokens_generated == 30
+    assert batch2.draft_tokens_accepted == 23
+    assert batch2.draft_tokens_generated_delta == 10
+    assert batch2.draft_tokens_accepted_delta == 8


### PR DESCRIPTION
## Summary

The speculative decoding pipeline computes acceptance stats and logs them to
console via `pretty_format()`, but never publishes them to the telemetry
system. This PR bridges that gap by adding three OTEL counters at `DETAILED`
metric level:

- `maxserve.speculative.draft_tokens_generated`
- `maxserve.speculative.draft_tokens_accepted`
- `maxserve.speculative.bonus_tokens_used` — this field already existed on
  `SpeculativeDecodingMetrics` but was never propagated to `BatchMetrics`.
  Adding it required touching the dataclass, `create()`, and the test
  constructor. It could be dropped deriving it from
  the other two counters is preferred.


`BatchMetrics.publish_metrics()` emits these counters only when
`draft_tokens_generated > 0`, avoiding noise when speculative decoding
is not active.

Additionally, `SpeculativeDecodingMetrics` is now reset after each batch in
`BatchMetrics.create()`, matching the existing `kv_cache.reset_metrics()`
pattern. Without this reset, `BatchMetrics.create()` reads cumulative
lifetime totals rather than per-batch deltas. This was already an issue
for `pretty_format()` console logs (which showed ever-growing totals
instead of per-batch stats), and would cause the new OTEL counters to
double-count since counters are additive.

**Note:** This changes the existing `pretty_format()` console log output
from cumulative lifetime stats to per-batch stats (e.g., "Draft Tokens:
15/30" instead of an ever-growing total). Every other metric in the log
line (batch size, throughput, KV cache stats) was already per-batch —
the speculative decoding fields were the only cumulative outlier.

## Testing

- `test_create_resets_speculative_metrics_between_batches` — regression
  test that calls `BatchMetrics.create()` twice with the same
  `SpeculativeDecodingMetrics` object. Verifies the second call returns
  only the new batch's values, not cumulative totals. Fails without the
  `reset()` fix (batch 2 reads 30 instead of 10).

## Checklist

- [x] PR is small and focused
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description

Assisted-by: AI