### PR TITLE
[stdlib] Make Dict reserve the requested minimum capacity

### DIFF
--- a/mojo/stdlib/std/collections/dict.mojo
+++ b/mojo/stdlib/std/collections/dict.mojo
@@ -41,6 +41,7 @@ from std.compile import get_type_name
 from std.hashlib import Hasher, default_comp_time_hasher, default_hasher
 import std.format._utils as fmt
 from std.sys.intrinsics import likely
+from std.math import ceildiv
 
 from std.bit import count_trailing_zeros, next_power_of_two
 from std.memory import alloc, bitcast, memcpy, memset, pack_bits
@@ -822,9 +823,9 @@ struct Dict[
     def __init__(out self, *, capacity: Int):
         """Initialize an empty dictionary with a pre-reserved capacity.
 
-        The capacity is rounded up to the next power of two (minimum 16)
-        to satisfy internal layout requirements. The usable capacity
-        before resizing is 7/8 of the rounded value.
+        The capacity is defined by `next_power_of_two(ceildiv(capacity * 8, 7))`
+        (minimum 16) to satisfy internal layout requirements. The usable
+        capacity before resizing is `7 // 8` of the rounded value.
 
         Args:
             capacity: The requested minimum number of slots.
@@ -833,10 +834,12 @@ struct Dict[
 
         ```mojo
         var x = Dict[Int, Int](capacity=1000)
-        # Actual capacity is 1024; can hold 896 entries without resizing.
+        # Actual capacity is 2048; can hold 1792 entries without resizing.
         ```
         """
-        self._capacity = max(next_power_of_two(capacity), _INITIAL_CAPACITY)
+        self._capacity = max(
+            next_power_of_two(ceildiv(capacity * 8, 7)), _INITIAL_CAPACITY
+        )
         self._ctrl = alloc[UInt8](self._capacity + _GROUP_WIDTH)
         memset(self._ctrl, _CTRL_EMPTY, self._capacity + _GROUP_WIDTH)
         self._slots = alloc[DictEntry[Self.K, Self.V, Self.H]](self._capacity)

--- a/mojo/stdlib/test/collections/test_dict.mojo
+++ b/mojo/stdlib/test/collections/test_dict.mojo
@@ -617,16 +617,16 @@ def test_clear() raises:
 
 
 def test_init_initial_capacity() raises:
-    var initial_capacity = 16
+    var initial_capacity = 14
     var x = Dict[Int, Int](capacity=initial_capacity)
-    assert_equal(x._reserved(), initial_capacity)
+    assert_equal(x._reserved(), 16)
     for i in range(initial_capacity):
         x[i] = i
     for i in range(initial_capacity):
         assert_equal(i, x[i])
 
     var y = Dict[Int, Int](capacity=64)
-    assert_equal(y._reserved(), 64)
+    assert_equal(y._reserved(), 128)
 
     # Non-power-of-two capacity is rounded up
     var z = Dict[Int, Int](capacity=50)
@@ -980,10 +980,9 @@ def test_tombstone_heavy_no_capacity_growth() raises:
 
 def test_high_load_still_doubles() raises:
     """When most slots are genuinely occupied, resize should still double."""
-    var capacity = 16
-    var max_load = capacity * 7 // 8  # 14
-    var d = Dict[Int, Int](capacity=capacity)
-    var initial_cap = d._reserved()
+    var max_load = 14
+    var d = Dict[Int, Int](capacity=max_load)
+    assert_equal(d._reserved(), 16)
 
     # Fill to capacity without deleting
     for i in range(max_load):
@@ -991,7 +990,7 @@ def test_high_load_still_doubles() raises:
 
     # _len(14) > capacity*7/16(7), so next insert should double
     d[max_load] = max_load
-    assert_equal(d._reserved(), initial_cap * 2)
+    assert_equal(d._reserved(), 32)
 
 
 def test_inplace_rehash_string_keys() raises:


### PR DESCRIPTION
Make Dict reserve the requested minimum capacity

Previously, `Dict(capacity=N)` applied `next_power_of_two(N)` directly, but the usable capacity before resizing is only `7/8` of the internal capacity. So `Dict(capacity=1000)` gave an internal capacity of `1024` but could only hold `1024 * 7 / 8 = 896` entries — less than the requested `1000`. This PR compensates by computing `next_power_of_two(ceildiv(capacity * 8, 7))`, ensuring the usable capacity meets or exceeds the requested amount.