### PR TITLE
[docs] Add per-chapter READMEs for PMPP Mojo examples

### DIFF
--- a/max/kernels/examples/pmpp/README.md
+++ b/max/kernels/examples/pmpp/README.md
@@ -1,0 +1,72 @@
+# PMPP Mojo examples
+
+Mojo implementations of the code examples from [Programming Massively Parallel Processors, 5th Edition](https://a.co/d/0bZCoTKY) by David Kirk and Wen-mei W. Hwu.
+
+If you're reading PMPP and want to follow along in Mojo, this is the companion. Each chapter directory contains Mojo files named to match the corresponding figures in the book — `fig5_10.mojo` maps to Figure 5.10 in the text. The original CUDA implementations are in the book itself.
+
+The Mojo versions currently target NVIDIA GPUs. Apple Silicon GPU support is not yet available for these examples (see `BUILD.bazel` for compatibility details).
+
+## Structure
+
+```text
+chapter_5/
+├── BUILD.bazel
+├── fig5_1.mojo
+├── fig5_10.mojo
+├── fig5_14.mojo
+└── dynamic_smem.mojo
+```
+
+## Chapters covered
+
+| Chapter | Topics |
+|---------|--------|
+| 2 | Heterogeneous data parallel computing, vector addition |
+| 3 | Multidimensional grids, image processing |
+| 4 | Compute architecture and scheduling |
+| 5 | Memory architecture, shared memory, tiled matrix multiplication |
+| 7 | Convolution |
+| 8 | Stencil |
+| 9 | Parallel histogram |
+| 10 | Reduction and minimizing thread divergence |
+| 11 | Prefix sum (scan) |
+| 12 | Stream compaction and parallel partition |
+| 13 | Merge sort |
+| 14 | Sorting (odd-even, radix) |
+| 15 | Performance optimizations: register blocking, software pipelining |
+| 16 | Dynamic programming |
+| 17 | Sparse matrix-vector multiplication |
+| 18 | Graph traversal (BFS) |
+| 19 | Convolutional layers |
+| 20 | Softmax and attention |
+| 21 | Electrostatic potential map (Direct Coulomb Summation) |
+
+## Running the examples
+
+Examples are built and tested using Bazel. Each chapter directory has a `BUILD.bazel` file that defines test targets for the Mojo files.
+
+```bash
+# Run a single example via Bazel
+bazel test //max/kernels/examples/pmpp/chapter_5:fig5_10.test --test_tag_filters=gpu
+
+# Run all examples in a chapter
+bazel test //max/kernels/examples/pmpp/chapter_5/... --test_tag_filters=gpu
+```
+
+Not every file is a standalone runnable program. Some are code snippets or utility modules meant to be read alongside the book (for example, `fig2_10.mojo` shows only the kernel function; `vec_add.mojo` is the complete runnable version for that chapter). Each chapter README identifies the runnable files and the recommended reading order.
+
+## Notes on the Mojo implementations
+
+These are direct ports of the CUDA originals, same algorithms and structure. They're written to be readable alongside the book, not to demonstrate idiomatic Mojo GPU programming style.
+
+A few things look different from the CUDA versions:
+
+- Memory management uses Mojo's ownership model instead of `cudaMalloc()`/`cudaFree()`
+- Kernel launches use the `DeviceContext` API
+- Some examples use `LayoutTensor` where it maps cleanly to the memory layout patterns in the chapter
+- A small number of examples note where the Mojo API differs from CUDA (for example, constant memory, grid sync)
+
+For idiomatic GPU programming in Mojo and MAX, see:
+
+- [Mojo GPU Puzzles](https://github.com/modular/mojo-gpu-puzzles): problem sets for learning GPU programming in Mojo; draws from PMPP concepts without reproducing the examples directly
+- [MAX documentation](https://docs.modular.com/max/): higher-level GPU programming with MAX

--- a/max/kernels/examples/pmpp/chapter_10/README.md
+++ b/max/kernels/examples/pmpp/chapter_10/README.md
@@ -1,0 +1,21 @@
+# Chapter 10: Reduction and minimizing divergence
+
+This chapter covers parallel reduction — computing a single value (like a sum) from an array — and the thread divergence problem that naive implementations create. The examples show how to restructure the work to keep threads active and minimize idle lanes, then introduce warp shuffles as a lower-overhead alternative to shared memory.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig10_5.mojo` | Simple sum reduction; naive tree reduction with high thread divergence |
+| `fig10_8.mojo` | Convergent sum reduction; restructured to access contiguous memory and keep active threads together |
+| `fig10_10.mojo` | Shared memory sum reduction; uses shared memory for the reduction tree |
+| `fig10_14.mojo` | Warp-level reduction with shuffle; uses `shuffle_down()` to reduce within a warp without shared memory |
+| `fig10_16.mojo` | Warp reduction combined with shared memory; warp results stored in shared memory for final block-level reduction |
+| `fig10_18.mojo` | Multi-block reduction; each block produces a partial result, accumulated globally via atomic add |
+| `fig10_20.mojo` | Reduction with thread coarsening (coarse factor 4); each thread processes multiple elements before entering the reduction tree |
+
+## Mojo vs. CUDA
+
+Warp shuffles use `shuffle_down()` from `std.gpu.primitives.warp`. `WARP_SIZE` is imported directly from `std.gpu`. Atomic operations use `Atomic` from `std.os`.
+
+Read in order: `fig10_5.mojo` -> `fig10_8.mojo` -> `fig10_10.mojo` -> `fig10_14.mojo` -> `fig10_16.mojo` -> `fig10_18.mojo` -> `fig10_20.mojo`.

--- a/max/kernels/examples/pmpp/chapter_11/README.md
+++ b/max/kernels/examples/pmpp/chapter_11/README.md
@@ -1,0 +1,26 @@
+# Chapter 11: Prefix sum (scan)
+
+This chapter covers parallel prefix sum — computing the running total of an array in parallel. Scan underlies many other algorithms (stream compaction, sorting, histogram). The chapter works through several scan algorithms and shows how to scale from single-block to multi-block inputs.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig11_1.mojo` | Sequential inclusive scan, CPU baseline |
+| `fig11_3.mojo` | Kogge-Stone scan using shared memory; parallel scan within a single block |
+| `fig11_5.mojo` | Kogge-Stone scan with double-buffering; avoids the read-after-write hazard in `fig11_3` by alternating between two shared memory buffers |
+| `fig11_8.mojo` | Warp-level scan using `shuffle_up()`; scan within a single warp without shared memory |
+| `fig11_9.mojo` | Block-level scan built from warp scans; warp results stored in shared memory, then combined |
+| `fig11_10.mojo` | Block-level scan variant; adjusted warp-to-block aggregation |
+| `fig11_12.mojo` | Block scan with thread coarsening (coarse factor 4); each thread handles multiple elements before entering the scan |
+| `fig11_13.mojo` | Coarsened block scan variant; uses a different accumulation strategy |
+| `fig11_17.mojo` | Hierarchical multi-block scan; scans blocks independently, then scans the block sums, then adds the block sum back to each block |
+| `fig11_18.mojo` | Hierarchical scan with thread coarsening; combines multi-block scan with the coarsening from `fig11_12` |
+
+## Mojo vs. CUDA
+
+Warp lane operations use `lane_id()` and `warp_id()` from `std.gpu.primitives.id`, and `shuffle_up()` from `std.gpu.primitives.warp`. Multi-block synchronization uses `Atomic` from `std.os`. Mojo does not yet have a direct equivalent to CUDA's cooperative groups for grid-wide sync, so `fig11_17` uses an atomic-based approach instead.
+
+**Note:** `fig11_15` (three-kernel reduce-scan-scan) has no Mojo port yet. The original CUDA implementation can be found in the PMPP book.
+
+Read in order: `fig11_1.mojo` -> `fig11_3.mojo` -> `fig11_8.mojo` -> `fig11_9.mojo` -> `fig11_12.mojo` -> `fig11_17.mojo`.

--- a/max/kernels/examples/pmpp/chapter_12/README.md
+++ b/max/kernels/examples/pmpp/chapter_12/README.md
@@ -1,0 +1,19 @@
+# Chapter 12: Stream compaction and parallel partition
+
+This chapter covers stream compaction — selecting elements from an array that satisfy a predicate and packing them into a contiguous output. The examples use "keep even numbers" as the predicate. Stream compaction relies on scan (from Chapter 11) and is used in many GPU algorithms that deal with irregular data.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig12_2.mojo` | Basic compaction; sequential scan to compute output positions, then scatter |
+| `fig12_3.mojo` | Warp-vote compaction; uses `vote()` to count matching elements per warp before computing positions |
+| `fig12_4.mojo` | Compaction with atomic positions; threads compute their output index using atomic increments |
+| `fig12_6.mojo` | Compaction with shared memory scan; uses a shared memory prefix sum to compute per-block output positions |
+| `fig12_8.mojo` | Compaction with warp-level scan; uses `shuffle_up()` inside shared memory reduction for better efficiency |
+
+## Mojo vs. CUDA
+
+Warp vote operations use `vote()` from `std.gpu.primitives.warp`. Lane index is from `lane_id()` in `std.gpu.primitives.id`. Atomic position tracking uses `Atomic` from `std.os`.
+
+Read in order: `fig12_2.mojo` -> `fig12_3.mojo` -> `fig12_6.mojo` -> `fig12_8.mojo`.

--- a/max/kernels/examples/pmpp/chapter_13/README.md
+++ b/max/kernels/examples/pmpp/chapter_13/README.md
@@ -1,0 +1,15 @@
+# Chapter 13: Merge sort
+
+This chapter covers parallel merge — combining two sorted arrays into a single sorted output. Merge is more complex than reduction or scan because each output element's position depends on elements from both input arrays. The examples progress from a simple per-thread merge to tiled approaches that use shared memory.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig13_9.mojo` | Basic merge kernel; each thread independently merges a segment of the two input arrays using binary search to find the split point |
+| `fig13_11_12_13.mojo` | Tiled merge kernel; threads in a block cooperate to load input tiles into shared memory before merging; covers Figures 13.11, 13.12, and 13.13 |
+| `fig13_16_18_19_20.mojo` | Circular buffer merge; uses a circular buffer in shared memory to avoid re-loading data across tiles; covers Figures 13.16, 13.18, 13.19, and 13.20 |
+
+## Mojo vs. CUDA
+
+Shared memory loading and barrier usage follow the same patterns as earlier chapters. `min()`/`max()` from `std.math` replace the CUDA equivalents.

--- a/max/kernels/examples/pmpp/chapter_14/README.md
+++ b/max/kernels/examples/pmpp/chapter_14/README.md
@@ -1,0 +1,14 @@
+# Chapter 14: Sorting
+
+This chapter covers two parallel sorting algorithms. Odd-even sort is simple to parallelize but not work-efficient. Radix sort is practical at scale and forms the basis of GPU sorting libraries.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig14_2.mojo` | Parallel odd-even transposition sort; alternating odd and even passes, each thread compares and swaps adjacent elements |
+| `fig14_7.mojo` | Radix sort iteration; one pass of least-significant-digit radix sort, using scan to compute output positions for each bit bucket |
+
+## Mojo vs. CUDA
+
+Both examples use standard `block_idx` and `thread_idx` for indexing. `random_ui64()` from `std.random` generates test data.

--- a/max/kernels/examples/pmpp/chapter_15/README.md
+++ b/max/kernels/examples/pmpp/chapter_15/README.md
@@ -1,0 +1,23 @@
+# Chapter 15: Performance optimizations
+
+This chapter covers register blocking and software pipelining (double buffering) for matrix multiplication. Register blocking keeps partial results in registers across the k-dimension loop instead of writing them back to shared memory each iteration. Double buffering overlaps the load of the next tile with computation on the current tile.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig15_3.mojo` | Tiled matrix multiplication with all prior optimizations combined, the starting baseline for this chapter |
+| `fig15_4.mojo` | Accumulator initialization; `clear()` function for zeroing the register tile |
+| `fig15_5.mojo` | Tile load function; loads a tile from global memory into shared memory with coalesced access |
+| `fig15_6.mojo` | Compute function; multiplies a shared memory tile against a register tile to accumulate results |
+| `fig15_7.mojo` | Write function; stores the register tile back to global memory |
+| `fig15_7_coalesced_exc.mojo` | Write with SIMD vector stores; uses vector-width writes for better memory coalescing |
+| `fig15_9.mojo` | Register blocking; each thread computes a tM x tN submatrix of the output, keeping results in registers across the k-dimension loop |
+| `fig15_14.mojo` | Double buffering (software pipelining); prefetches the next tile into a second shared memory buffer while computing with the current tile |
+| `fig15_14_LayoutTensor.mojo` | Same double buffering kernel using `LayoutTensor`; shows how Mojo's tensor abstraction maps to the tiled memory layout |
+
+## Mojo vs. CUDA
+
+`fig15_14_LayoutTensor.mojo` has no direct CUDA equivalent. It uses `LayoutTensor` from Mojo's layout library to express the same memory access pattern more abstractly. Compare it with `fig15_14.mojo` to see both approaches side by side.
+
+Read in order: `fig15_3.mojo` -> `fig15_9.mojo` -> `fig15_14.mojo` -> `fig15_14_LayoutTensor.mojo`.

--- a/max/kernels/examples/pmpp/chapter_16/README.md
+++ b/max/kernels/examples/pmpp/chapter_16/README.md
@@ -1,0 +1,16 @@
+# Chapter 16: Dynamic programming
+
+This chapter covers parallel dynamic programming — algorithms where each result depends on previously computed subproblems. The examples cover Fibonacci (simple 1D recurrence), Floyd-Warshall (all-pairs shortest path), and Smith-Waterman (local sequence alignment). Each problem has a different dependency structure and maps to GPU execution differently.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig16_1_fibonacci.mojo` | Fibonacci; top-down (memoization) and bottom-up (tabulation) CPU implementations for contrast |
+| `fig16_3_floyd_warshall.mojo` | Floyd-Warshall CPU baseline; all-pairs shortest path with the classic triple-nested loop |
+| `fig16_4_floyd_warshall_gpu.mojo` | Floyd-Warshall GPU kernel; each thread computes one cell per outer iteration, inner two loops parallelized |
+| `fig16_8_9_10_11_12_smith_waterman.mojo` | Smith-Waterman local sequence alignment; GPU kernel using diagonal wavefront parallelism with shared memory tiling; covers Figures 16.8 through 16.12 |
+
+## Notes
+
+Smith-Waterman's anti-diagonal dependency structure (each cell depends on its left, top, and top-left neighbors) requires a wavefront traversal to expose parallelism. The tiled GPU version processes one diagonal tile per kernel launch.

--- a/max/kernels/examples/pmpp/chapter_17/README.md
+++ b/max/kernels/examples/pmpp/chapter_17/README.md
@@ -1,0 +1,17 @@
+# Chapter 17: Sparse matrix-vector multiplication
+
+This chapter covers SpMV — multiplying a sparse matrix by a dense vector. Sparse matrices appear throughout scientific computing, graph algorithms, and machine learning. Performance varies significantly depending on storage format, so the chapter compares four.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `spmv_utils.mojo` | Shared utilities; defines `COOMatrix`, `CSRMatrix`, `ELLMatrix`, and `CSCMatrix` structs, plus `generate_sparse_matrix()`, `spmv_cpu()`, and `verify()` |
+| `fig17_5.mojo` | SpMV with COO (Coordinate) format; each nonzero stored as a (row, col, value) triple, uses atomic adds to accumulate row results |
+| `fig17_9.mojo` | SpMV with CSR (Compressed Sparse Row) format; each thread processes one row, iterating over its nonzeros |
+| `fig17_12.mojo` | SpMV with ELL (ELLPACK) format; padded rows of fixed length enable coalesced access, one thread per row |
+| `fig17_18.mojo` | SpMV with CSC (Compressed Sparse Column) format; each thread processes one column and scatters contributions to output rows via atomics |
+
+## Notes
+
+CSR is the general-purpose format. ELL works well for matrices with regular sparsity patterns. COO and CSC require atomic operations. `spmv_utils.mojo` must be in the same directory as the figure files when compiling.

--- a/max/kernels/examples/pmpp/chapter_18/README.md
+++ b/max/kernels/examples/pmpp/chapter_18/README.md
@@ -1,0 +1,21 @@
+# Chapter 18: Graph traversal
+
+This chapter covers parallel breadth-first search (BFS) on graphs stored in sparse formats. Graph algorithms are irregular: the work per vertex varies, memory access is non-contiguous, and level dependencies complicate parallel execution. The examples cover three fundamental BFS strategies, then show how privatization and frontier queues improve performance.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `graph_utils.mojo` | Shared utilities; `CSRGraph`, `CSCGraph`, and `COOGraph` data structures, plus graph generation and verification functions |
+| `fig18_06.mojo` | Vertex-centric BFS, push-based (CSR); each thread checks one vertex and pushes updates to unvisited neighbors if it was visited last level |
+| `fig18_08.mojo` | Vertex-centric BFS, pull-based (CSC); each unvisited vertex checks whether any incoming neighbor was visited last level |
+| `fig18_10.mojo` | Edge-centric BFS (COO); each thread handles one edge, checking if the source was visited last level and marking the destination if so |
+| `fig18_12.mojo` | Frontier-based BFS (CSR); maintains an explicit queue of active vertices, only frontier vertices are processed each level |
+| `fig18_15.mojo` | Frontier BFS with privatization; each block maintains a private shared memory frontier, merged to global memory at the end |
+| `fig18_17.mojo` | Frontier BFS with privatization, multi-launch; uses separate kernel launches per level instead of grid sync |
+
+## Mojo vs. CUDA
+
+The original `fig18_17` uses CUDA's cooperative groups for grid-wide synchronization. The Mojo version uses multi-launch instead, which is functionally equivalent for level-by-level BFS traversal.
+
+`graph_utils.mojo` must be in the same directory as the figure files when compiling.

--- a/max/kernels/examples/pmpp/chapter_19/README.md
+++ b/max/kernels/examples/pmpp/chapter_19/README.md
@@ -1,0 +1,19 @@
+# Chapter 19: Convolutional layers
+
+This chapter covers GPU implementation of the forward pass of a convolutional layer. The examples start with CPU reference implementations and build up to an optimized GPU kernel that reformulates convolution as matrix multiplication (im2col).
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `conv_utils.mojo` | Shared utilities; 4D tensor indexing helpers, CPU reference convolution, data initialization and verification |
+| `fig19_3.mojo` | CPU forward pass, single image; `X[C, H, W]`, `F[M, C, K, K]` -> `Y[M, H_out, W_out]` |
+| `fig19_4.mojo` | CPU forward pass, batched; `X[N, C, H, W]` -> `Y[N, M, H_out, W_out]` |
+| `fig19_07.mojo` | GPU forward pass kernel; each thread computes one output pixel in one output feature map, direct convolution |
+| `fig19_11.mojo` | Tiled im2col-based convolution; reformulates convolution as `Y = F * X_unrolled` and performs tiled matrix multiplication on the fly without materializing the unrolled input |
+
+## Notes
+
+`fig19_11.mojo` computes the im2col transformation inline as threads load data, avoiding the memory cost of explicitly unrolling `X` first.
+
+`conv_utils.mojo` must be in the same directory as the figure files when compiling.

--- a/max/kernels/examples/pmpp/chapter_2/README.md
+++ b/max/kernels/examples/pmpp/chapter_2/README.md
@@ -1,0 +1,20 @@
+# Chapter 2: Heterogeneous data parallel computing
+
+This chapter introduces the GPU programming model and walks through the first GPU program: vector addition. The examples build from a CPU baseline to a complete GPU implementation with memory management and kernel launch.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig2_4.mojo` | CPU-only vector addition, the sequential baseline before any GPU code |
+| `fig2_8.mojo` | GPU memory management: allocate device buffers, copy host-to-device and device-to-host, free |
+| `fig2_10.mojo` | Vector addition GPU kernel; each thread computes one element of C = A + B |
+| `fig2_12.mojo` | Launch configuration: calculating grid and block dimensions with `ceildiv()` |
+| `fig2_13.mojo` | Complete host function combining memory management and kernel launch |
+| `vec_add.mojo` | Full working example: kernel + host function + correctness verification |
+
+## Mojo vs. CUDA
+
+`DeviceBuffer` and `DeviceContext` replace `cudaMalloc()`, `cudaMemcpy()`, and `cudaFree()`. The kernel itself is nearly identical; `global_idx()` maps to `blockIdx.x * blockDim.x + threadIdx.x`.
+
+Start with `vec_add.mojo` for a runnable end-to-end example for this chapter.

--- a/max/kernels/examples/pmpp/chapter_20/README.md
+++ b/max/kernels/examples/pmpp/chapter_20/README.md
@@ -1,0 +1,16 @@
+# Chapter 20: Softmax and attention
+
+This chapter covers two operations central to transformer models: softmax and scaled dot-product attention. Both require reductions across sequences and draw on the same techniques from earlier chapters — shared memory, warp shuffles, and register blocking.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig20_4.mojo` | Softmax kernel; numerically stable softmax over a sequence, using block reduce for the max and sum passes |
+| `fig20_9.mojo` | Flash Attention forward kernel; tiled attention following the Flash Attention algorithm (Dao et al., 2022), processes Q, K, V in blocks to avoid materializing the full attention matrix |
+
+## Notes
+
+`fig20_9.mojo` is the most complex kernel in the PMPP examples. It combines tiling, warp shuffles (`shuffle_idx()`, `lane_group_max()`, `lane_group_sum()`), and careful tracking of the running max and sum across K/V tiles. The tile dimensions (`B_r`, `B_c`) and model dimension (`D_MODEL`) are compile-time constants.
+
+These examples connect directly to MAX's built-in attention and softmax operations, which handle batching, masking, and multi-head projection on top of the same underlying GPU kernels.

--- a/max/kernels/examples/pmpp/chapter_21/README.md
+++ b/max/kernels/examples/pmpp/chapter_21/README.md
@@ -1,0 +1,22 @@
+# Chapter 21: Electrostatic potential map
+
+This chapter works through Direct Coulomb Summation (DCS) — computing the electrostatic potential at every point on a 3D grid from a set of charged atoms. It's an all-pairs problem (every atom contributes to every grid point) that appears in molecular dynamics and computational chemistry. The chapter uses it to demonstrate thread coarsening and the scatter vs. gather tradeoff.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `dcs_utils.mojo` | Shared utilities; grid dimension struct, atom initialization, and verification functions |
+| `fig21_03.mojo` | CPU baseline (unoptimized); straightforward triple-nested loop: for each grid point, iterate over all atoms |
+| `fig21_04.mojo` | CPU baseline (optimized); reorders the loops to hoist z-related calculations out of the inner loops, reducing redundant work |
+| `fig21_05.mojo` | GPU scatter kernel; each thread handles one atom and adds its contribution to all grid points, requires atomic operations |
+| `fig21_06.mojo` | GPU gather kernel; each thread handles one grid point and accumulates contributions from all atoms, no atomics needed |
+| `fig21_08.mojo` | GPU gather with thread coarsening; each thread handles multiple consecutive grid points (`COARSEN_FACTOR`), reusing atom data across calculations |
+
+## Notes
+
+The scatter pattern (`fig21_05.mojo`) requires atomic operations and has limited parallelism when atom count is low. The gather pattern (`fig21_06.mojo`) is the practical choice: one thread per grid point, no atomics. Thread coarsening in `fig21_08.mojo` improves efficiency further.
+
+**Note:** `fig21_10` (coalesced DCS kernel) has no Mojo port yet. The original CUDA implementation can be found in the PMPP book.
+
+`dcs_utils.mojo` must be in the same directory as the figure files when compiling.

--- a/max/kernels/examples/pmpp/chapter_3/README.md
+++ b/max/kernels/examples/pmpp/chapter_3/README.md
@@ -1,0 +1,15 @@
+# Chapter 3: Multidimensional grids and data
+
+This chapter extends the GPU programming model to 2D grids and data, using image processing and matrix multiplication as the main examples. Each kernel maps a thread to a pixel or matrix element using 2D index calculations.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig3_4.mojo` | Color-to-grayscale conversion; each thread converts one RGB pixel to a luminance value |
+| `fig3_8.mojo` | Box blur; each thread computes the average of a pixel's neighborhood |
+| `fig3_11.mojo` | Basic matrix multiplication; each thread computes one element of the output matrix |
+
+## Mojo vs. CUDA
+
+`global_idx()` returns a struct with `.x` and `.y` components, replacing the 2D index arithmetic from `blockIdx` and `threadIdx` in CUDA. Boundary checking is the same.

--- a/max/kernels/examples/pmpp/chapter_4/README.md
+++ b/max/kernels/examples/pmpp/chapter_4/README.md
@@ -1,0 +1,13 @@
+# Chapter 4: Compute architecture and scheduling
+
+This chapter covers how the GPU hardware schedules warps and executes threads, including the hazards that arise when barrier synchronization is used incorrectly.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig4_4.mojo` | **Incorrect** barrier usage: a conditional `barrier()` that causes deadlock when threads in the same block take different branches |
+
+## Note
+
+This file is an intentional example of broken code. The book uses it to explain why all threads in a block must reach the same barrier. Do not use this pattern.

--- a/max/kernels/examples/pmpp/chapter_5/README.md
+++ b/max/kernels/examples/pmpp/chapter_5/README.md
@@ -1,0 +1,18 @@
+# Chapter 5: Memory architecture and data locality
+
+This chapter introduces shared memory and tiling as tools for reducing global memory traffic. Matrix multiplication is the running example, progressively optimized from a naive implementation to one that handles arbitrary dimensions.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig5_1.mojo` | Matrix multiplication inner loop, a code snippet showing the basic computation before any GPU-specific optimization |
+| `fig5_10.mojo` | Tiled matrix multiplication using shared memory; threads cooperatively load a tile into shared memory before computing |
+| `fig5_14.mojo` | Tiled matrix multiplication with boundary checking; handles matrices whose dimensions are not evenly divisible by the tile width |
+| `dynamic_smem.mojo` | Dynamic shared memory variant; tile width is a runtime parameter rather than a compile-time constant |
+
+## Mojo vs. CUDA
+
+Shared memory allocation uses `external_memory()` with an `AddressSpace` specifier. `FuncAttribute` controls shared memory size at launch, replacing `<<<..., smem_bytes>>>` in CUDA. `barrier()` maps directly to `__syncthreads()`.
+
+Read in order: `fig5_1.mojo` -> `fig5_10.mojo` -> `fig5_14.mojo`.

--- a/max/kernels/examples/pmpp/chapter_7/README.md
+++ b/max/kernels/examples/pmpp/chapter_7/README.md
@@ -1,0 +1,18 @@
+# Chapter 7: Convolution
+
+This chapter uses 2D convolution as a case study for memory optimization, specifically reducing global memory accesses by putting the filter in constant memory and using tiled shared memory for the input.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig7_7.mojo` | Basic 2D convolution with no optimizations; each thread loads all its required input elements from global memory |
+| `fig7_9.mojo` | 2D convolution corresponding to the CUDA constant-memory version; see Mojo vs. CUDA note below |
+| `fig7_12.mojo` | Tiled 2D convolution; threads cooperatively load an input tile into shared memory, filter in constant memory in CUDA |
+| `fig7_15.mojo` | Cached tiled convolution; interior elements come from shared memory, halo elements fall back to global memory |
+
+## Mojo vs. CUDA
+
+CUDA's `__constant__` memory does not have a direct equivalent in the current Mojo API. `fig7_9.mojo` and `fig7_12.mojo` use global memory for the filter instead. The algorithmic structure is otherwise the same.
+
+Read in order: `fig7_7.mojo` -> `fig7_9.mojo` -> `fig7_12.mojo` -> `fig7_15.mojo`.

--- a/max/kernels/examples/pmpp/chapter_8/README.md
+++ b/max/kernels/examples/pmpp/chapter_8/README.md
@@ -1,0 +1,18 @@
+# Chapter 8: Stencil
+
+This chapter applies the tiling and coarsening techniques from earlier chapters to 3D stencil computations, a pattern that appears in finite difference solvers, fluid simulation, and scientific computing.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig8_6.mojo` | Basic 3D stencil kernel; 7-point stencil (center + 6 face neighbors), loads directly from global memory |
+| `fig8_8.mojo` | Tiled 3D stencil with shared memory; threads load an input tile including halo cells, reducing global memory reads for interior elements |
+| `fig8_10.mojo` | Thread coarsening in the z-direction; each thread processes multiple z-layers, reusing the xy-plane data loaded into shared memory |
+| `fig8_12.mojo` | Register tiling; keeps the current z-plane in registers and advances through z, reducing shared memory pressure further |
+
+## Mojo vs. CUDA
+
+Shared memory allocation and barrier usage follow the same pattern as Chapter 5. `FuncAttribute` controls the shared memory size at launch.
+
+Read in order: `fig8_6.mojo` -> `fig8_8.mojo` -> `fig8_10.mojo` -> `fig8_12.mojo`.

--- a/max/kernels/examples/pmpp/chapter_9/README.md
+++ b/max/kernels/examples/pmpp/chapter_9/README.md
@@ -1,0 +1,22 @@
+# Chapter 9: Parallel histogram
+
+This chapter builds a parallel histogram, introducing privatization and aggregation as techniques for handling write contention across threads. The examples start with sequential CPU code and progressively improve the GPU implementation.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `fig9_2.mojo` | Sequential histogram, CPU baseline using a single-threaded loop |
+| `fig9_4.mojo` | Sequential histogram variant, same computation with a different loop structure for comparison |
+| `fig9_6.mojo` | Basic GPU histogram; each thread atomically increments the corresponding bin in global memory |
+| `fig9_9.mojo` | Privatized histogram; each block maintains a private copy of the bins in global memory, merged to the output bins at the end |
+| `fig9_10.mojo` | Privatized histogram with shared memory; each block maintains a private copy of the bins in shared memory, merged to global memory at the end |
+| `fig9_12.mojo` | Privatized histogram with thread coarsening (coarse factor 4); each thread processes multiple input elements |
+| `fig9_14.mojo` | Coarsened histogram with contiguous partitioning; each thread handles a contiguous range of input elements |
+| `fig9_15.mojo` | Coarsened histogram with interleaved partitioning; threads process strided elements for better memory coalescing |
+
+## Mojo vs. CUDA
+
+Atomic operations use `Atomic` from `std.os`. Shared memory via `external_memory()` follows the same pattern as Chapters 5 and 8.
+
+Read in order: `fig9_2.mojo` -> `fig9_6.mojo` -> `fig9_9.mojo` -> `fig9_12.mojo` -> `fig9_14.mojo` or `fig9_15.mojo`.


### PR DESCRIPTION
## Summary
- Add top-level README and 19 per-chapter READMEs to `max/kernels/examples/pmpp/`
- Each chapter README: file table with descriptions, Mojo vs CUDA API callouts, recommended reading order
- Notes missing Mojo ports (fig11_15, fig21_10) and utility file dependencies (ch17, 18, 19, 21)
- Corrected fig9_9/fig9_10 descriptions (global vs shared memory privatization)

Based on the `pmpp-readme-drafts` branch (originally created by @cbronsdon, reviewed by @mdunn-oconnor), adapted for the current repo structure. Context: https://modular-ai.slack.com/archives/C05FH8XUADP/p1772830628051179

Cc @adakkak @ehsanmok  @bradlarson

## Test plan
- [ ] Verify file tables match actual files in each chapter directory
- [ ] Spot-check Mojo vs CUDA callouts against current API
- [ ] Verify chapter titles against PMPP 5th edition table of contents
- [ ] Confirm Bazel test commands in running instructions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)