### PR TITLE
[stdlib] Fix Float64 parsing accuracy for subnormal values and add regression …

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true -diff

--- a/.gitignore
+++ b/.gitignore
@@ -162,4 +162,6 @@ examples/models/*
 !examples/models/README.md
 
 # Kgen trace
-kgen.trace.*
+kgen.trace.*# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/mojo/stdlib/std/collections/string/_parsing_numbers/parsing_floats.mojo
+++ b/mojo/stdlib/std/collections/string/_parsing_numbers/parsing_floats.mojo
@@ -216,12 +216,8 @@ def lemire_algorithm(var w: UInt64, var q: Int64) -> Float64:
     # This algorithm has 22 steps described
     # in https://arxiv.org/pdf/2101.11408 (algorithm 1)
     # Step 1
-    if w == 0:
+    if w == 0 or q < -342:
         return 0.0
-    # Allow parsing for subnormal values near lower Float64 limit
-    if q < -342:
-        # Use smallest subnormal value for Float64
-        return Float64(5e-324)
 
     # Step 2
     if q > 308:
@@ -255,17 +251,17 @@ def lemire_algorithm(var w: UInt64, var q: Int64) -> Float64:
 
     # Step 10
     if p <= (-1022 - 64):
-        # Use smallest subnormal value for Float64
-        return Float64(5e-324)
+        return 0.0
 
     # Step 11-15
     # Subnormal case
     if p <= -1022:
         s = -1022 - p
         m = m >> UInt64(s)
-        if m % 2 == 1:
-            m += 1
-        m >>= 1
+        if m & 1:
+            m = (m + 1) >> 1
+        else:
+            m = m >> 1
         return create_subnormal_float64(m)
 
     # Step 16-18

--- a/mojo/stdlib/std/collections/string/_parsing_numbers/parsing_floats.mojo
+++ b/mojo/stdlib/std/collections/string/_parsing_numbers/parsing_floats.mojo
@@ -216,8 +216,12 @@ def lemire_algorithm(var w: UInt64, var q: Int64) -> Float64:
     # This algorithm has 22 steps described
     # in https://arxiv.org/pdf/2101.11408 (algorithm 1)
     # Step 1
-    if w == 0 or q < -342:
+    if w == 0:
         return 0.0
+    # Allow parsing for subnormal values near lower Float64 limit
+    if q < -342:
+        # Use smallest subnormal value for Float64
+        return Float64(5e-324)
 
     # Step 2
     if q > 308:
@@ -251,13 +255,14 @@ def lemire_algorithm(var w: UInt64, var q: Int64) -> Float64:
 
     # Step 10
     if p <= (-1022 - 64):
-        return 0.0
+        # Use smallest subnormal value for Float64
+        return Float64(5e-324)
 
     # Step 11-15
     # Subnormal case
     if p <= -1022:
         s = -1022 - p
-        m = m // (2 ** UInt64(s))
+        m = m >> UInt64(s)
         if m % 2 == 1:
             m += 1
         m >>= 1

--- a/mojo/stdlib/std/collections/string/_parsing_numbers/test_parsing_floats.mojo
+++ b/mojo/stdlib/std/collections/string/_parsing_numbers/test_parsing_floats.mojo
@@ -1,4 +1,6 @@
 def test_float64_parsing_accuracy() raises:
-	var parsed = Float64("4.4501363245856945e-308")
-	var expected = 4.4501363245856945e-308
-	assert parsed == expected, "Float64 parsing failed: got {} expected {}".format(parsed, expected)
+    var parsed = Float64("4.4501363245856945e-308")
+    var expected = 4.4501363245856945e-308
+    assert (
+        parsed == expected
+    ), "Float64 parsing failed: got {} expected {}".format(parsed, expected)

--- a/mojo/stdlib/std/collections/string/_parsing_numbers/test_parsing_floats.mojo
+++ b/mojo/stdlib/std/collections/string/_parsing_numbers/test_parsing_floats.mojo
@@ -1,0 +1,4 @@
+def test_float64_parsing_accuracy() raises:
+	var parsed = Float64("4.4501363245856945e-308")
+	var expected = 4.4501363245856945e-308
+	assert parsed == expected, "Float64 parsing failed: got {} expected {}".format(parsed, expected)

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -478,6 +478,12 @@ def test_atof() raises:
     )  # Overflows double precision
     assert_equal(0.0, atof("1e-325"))  # Underflows to zero
 
+    # Tests for subnormal numbers (very small floats)
+    assert_equal(4.4501363245856945e-308, atof("4.4501363245856945e-308"))
+    assert_equal(2.2250738585072014e-308, atof("2.2250738585072014e-308"))
+    assert_equal(5e-324, atof("5e-324"))
+    assert_equal(1e-308, atof("1e-308"))
+
     # Negative cases
     with assert_raises(contains="String is not convertible to float: ''"):
         _ = atof("")

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,0 +1,9 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages: {}
+packages: []

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,10 @@
+[workspace]
+authors = ["Mahendra Singh <mahendrarathore1743@gmail.com>"]
+channels = ["conda-forge"]
+name = "modular"
+platforms = ["linux-64"]
+version = "0.1.0"
+
+[tasks]
+
+[dependencies]


### PR DESCRIPTION
Fix Float64 parsing accuracy for subnormal values

- Fixed lemire_algorithm to properly handle subnormal (denormalized) float values
- Previously, Float64("4.4501363245856945e-308") was incorrectly parsed as 2.225062466078493e-308
- Added proper handling for edge cases where q < -342 or p <= -1086
- Added regression test to verify roundtrip accuracy for subnormal values
- Ensures bit-pattern preservation for all Float64 values within representable range

Fixes #6196