### PR TITLE
[Kernels] Increase reduce_kernel default BLOCK_SIZE from 128 to 256

### DIFF
--- a/mojo/stdlib/std/algorithm/backend/gpu/reduction.mojo
+++ b/mojo/stdlib/std/algorithm/backend/gpu/reduction.mojo
@@ -759,7 +759,7 @@ def reduce_launch[
     # multiple warps within a block to reduce rows and save shared memory sync
     else:
         comptime BLOCK_SIZE = get_defined_int[
-            "MOJO_REDUCTION_BLOCK_SIZE", 128
+            "MOJO_REDUCTION_BLOCK_SIZE", 256
         ]()
         if shape[axis] < WARP_SIZE:
             comptime for ax in range(rank):


### PR DESCRIPTION
PRAGMA-guided optimization of the GPU reduction kernel default block size.

## Summary

Increase the default  from 128 to 256 for the GPU reduction kernel.

**Problem**: For latency-bound reduction workloads with few rows relative to SM count (common in LLM decode/generation), the default BLOCK_SIZE of 128 resulted in poor SM occupancy (~12% on H100 with 256 rows). With only 4 warps per block and limited block count, most of the GPU was idle.

**Fix**: Increasing BLOCK_SIZE to 256 (8 warps per block) doubles the active warps per SM, improving occupancy from ~12% to ~24% and saturating the streaming multiprocessors on common LLM shapes.

## Benchmark Results (H100, MAX nightly 26.3.0.dev2026031822)

| Shape | Axis | Dtype | Baseline | Optimized | Speedup |
|---|---|---|---|---|---|
| (1, 256, 4096) | 2 | float16 | 42.3 us | 26.4 us | **1.6x** |
| (8, 256, 4096) | 2 | float16 | 48.1 us | 31.5 us | **1.53x** |
| (1, 2048, 4096) | 2 | float16 | 91.2 us | 85.6 us | 1.07x |

The optimization specifically targets the latency-bound path (small M, large N along reduction axis). Large reduction workloads are unaffected.

## Changes

- mojo/stdlib/std/algorithm/backend/gpu/reduction.mojo: default BLOCK_SIZE 128 -> 256

## Test Plan

-  - PASSED
-  - PASSED

Co-Authored-By: modular-kernel-agent <modular@speedtrain.co>
