### PR TITLE
[Kernels] Apply SM-aware block scaling to _topk_gpu default

### DIFF
--- a/max/kernels/src/nn/topk.mojo
+++ b/max/kernels/src/nn/topk.mojo
@@ -1294,10 +1294,17 @@ def _topk_gpu[
     if batch_size == 0:
         return
 
-    # Define the number of blocks per grid
-    var num_blocks_per_input_: Int = ceildiv(
-        N, block_size
-    ) if not num_blocks_per_input else num_blocks_per_input.value()
+    # Define the number of blocks per grid.
+    # Target enough total blocks to saturate the GPU's SMs.
+    var num_blocks_per_input_: Int
+    if num_blocks_per_input:
+        num_blocks_per_input_ = num_blocks_per_input.value()
+    else:
+        comptime target_total_blocks = 128
+        num_blocks_per_input_ = min(
+            ceildiv(N, block_size),
+            max(ceildiv(target_total_blocks, batch_size), 1),
+        )
     # Calculate largest num bytes of shmem for each stage
     if block_size % WARP_SIZE != 0:
         # TODO: Need to pad in this case


### PR DESCRIPTION
[Kernels] Apply SM-aware block scaling to _topk_gpu default

BEGIN_PUBLIC
[Kernels] Apply SM-aware block scaling to _topk_gpu default

Apply the same SM-aware num_blocks_per_input heuristic to the internal
_topk_gpu function, which previously defaulted to ceildiv(N, block_size)
(potentially 1000+ blocks). The new default targets 128 total blocks,
matching the topk_gpu public API behavior.
END_PUBLIC

Signed-off-by: PRAGMA Agent <pragma-agent@modular.com>