### PR TITLE
[stdlib] [docs] Fixed comment of _atanh_float32() to match the real (and correct) implementation

### DIFF
--- a/mojo/stdlib/std/math/math.mojo
+++ b/mojo/stdlib/std/math/math.mojo
@@ -1893,7 +1893,7 @@ def _atanh_float32(x: SIMD) -> type_of(x) where x.dtype.is_floating_point():
     ](x2)
     p = x3.fma(p, x)
 
-    # For |x| in the range [0.5, 1), we use the identity:
+    # For |x| in the range (0.5, 1), we use the identity:
     # atanh(x) = 0.5 * log((1 + x) / (1 - x))
     var r = 0.5 * log((1 + x) / (1 - x))
 

--- a/mojo/stdlib/std/math/math.mojo
+++ b/mojo/stdlib/std/math/math.mojo
@@ -1897,10 +1897,9 @@ def _atanh_float32(x: SIMD) -> type_of(x) where x.dtype.is_floating_point():
     # atanh(x) = 0.5 * log((1 + x) / (1 - x))
     var r = 0.5 * log((1 + x) / (1 - x))
 
-    # If If x is >= 1, NaN is returned.
-    # If x is 1, then the result is +infinity if x is negative, and -infinity
-    # if x is positive. If x is >= 1, NaN is returned. Otherwise, if x is >= 0.5,
-    # we use the r approximation, otherwise we use the p polynomial approximation.
+    # If x is 1, then the result is +infinity, and -infinity if x is -1.
+    # If |x| > 1, NaN is returned. Otherwise, if |x| >= 0.5, we use the r
+    # approximation, otherwise we use the p polynomial approximation.
     return x_abs.eq(1).select(
         is_neg.select(neg_inf_val, inf_val),
         x_abs.ge(1).select(

--- a/mojo/stdlib/std/math/math.mojo
+++ b/mojo/stdlib/std/math/math.mojo
@@ -1898,7 +1898,7 @@ def _atanh_float32(x: SIMD) -> type_of(x) where x.dtype.is_floating_point():
     var r = 0.5 * log((1 + x) / (1 - x))
 
     # If x is 1, then the result is +infinity, and -infinity if x is -1.
-    # If |x| > 1, NaN is returned. Otherwise, if |x| >= 0.5, we use the r
+    # If |x| > 1, NaN is returned. Otherwise, if |x| > 0.5, we use the r
     # approximation, otherwise we use the p polynomial approximation.
     return x_abs.eq(1).select(
         is_neg.select(neg_inf_val, inf_val),


### PR DESCRIPTION

## Summary

the comment in _atanh_float32() did not match the implementation of the function and as also misleading (double if if etc)
this fix clarifies semantic and also matches the real and correct implementation
I have also verified the implementation in mojo against the initial eigen lib version

## Testing

no code changes.
docs or comment now reflects the verified implementation

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [ ] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
