### PR TITLE
[Kernels][GPU] Fix shared memory bound calculation in MHA config

### DIFF
--- a/max/kernels/src/nn/mha_utils.mojo
+++ b/max/kernels/src/nn/mha_utils.mojo
@@ -301,22 +301,21 @@ struct MHAConfig[dtype: DType](TrivialRegisterPassable, Writable):
                     get_defined_int["USE_EXPERIMENTAL_KERNELS", 0]() != 0
                 )
                 smem_total = 227000
-                # smem_total >= 2*(BN * depth * pipeline_stages + BM*depth*(1+persistent))
+                # smem_total >= 2*(BN * padded_depth * pipeline_stages
+                #                  + BM*padded_depth*(1+persistent))
                 #                 + 16*pipeline_stages + 40*persistent
-                # smem_total - 2*BM*depth*(1+persistent) - 16*pipeline_stages - 40*persistent
-                #        >= 2*depth*pipeline_stages*BN
-                # BN <= (smem_total//2 - BM*depth*(1+persistent) - 8*pipeline_stages
-                #        - 20*persistent) // (depth*pipeline_stages)
+                # Use padded_depth (not depth) since shared memory tiles
+                # are padded for swizzle alignment.
                 smem_upper_bound = (
                     smem_total // 2
                     - Int(
                         self.num_queries_per_block
-                        * depth
+                        * self.padded_depth
                         * UInt(1 + Int(persistent))
                     )
                     - 8 * Int(num_pipeline_stages)
                     - 20 * Int(persistent)
-                ) // Int(depth * num_pipeline_stages)
+                ) // Int(self.padded_depth * num_pipeline_stages)
                 # divide and multiply by 16 to get a multiple of MMA_K
                 min_upper_bound = 16 * (
                     min(reg_upper_bound, smem_upper_bound) // 16


### PR DESCRIPTION
[Kernels][GPU] Fix shared memory bound calculation in MHA config

BEGIN_PUBLIC
[Kernels][GPU] Fix shared memory bound calculation in MHA config

The BN tile size calculation for SM90 FA3 used depth instead of
padded_depth when computing the shared memory upper bound. For
non-power-of-two depths like 72 (padded to 128), this underestimated
shared memory usage, allowing BN values that exceed available shared
memory when combined with smaller BM values.
END_PUBLIC

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: PRAGMA Agent <pragma-agent@modular.com>