### PR TITLE
[Kernels][GPU] Increase MLA prefill BK to 64 for fewer MMA iterations

### DIFF
--- a/max/kernels/src/nn/mla.mojo
+++ b/max/kernels/src/nn/mla.mojo
@@ -1549,6 +1549,7 @@ def flare_mla_prefill[
             UInt(Int(q_layout.shape[rank - 2])),  # num_heads
             UInt(Int(k.layout.shape[rank - 1])),  # depth
             num_keys_per_block=num_keys_per_block,
+            BK=UInt(64),
             WN=num_keys_per_block,
             algorithm=FlashAttentionAlgorithm.FLASH_ATTENTION_2,
         )
@@ -1702,6 +1703,7 @@ def flare_mla_prefill[
             UInt(Int(q_layout.shape[rank - 2])),
             UInt(Int(k.layout.shape[rank - 1])),
             num_keys_per_block=num_keys_per_block,
+            BK=UInt(64),
             WN=num_keys_per_block,
             algorithm=FlashAttentionAlgorithm.FLASH_ATTENTION_2,
         )


### PR DESCRIPTION
[Kernels][GPU] Increase MLA prefill BK to 64 for fewer MMA iterations

BEGIN_PUBLIC
[Kernels][GPU] Increase MLA prefill BK to 64 for fewer MMA iterations

The MLA prefill kernel on NVIDIA GPUs was using BK=32 (the MHAConfig
default), requiring 6 MMA iterations for Q@K (q_depth=192/32=6) and
2 iterations for S@V (BN/BK=64/32=2). By increasing BK to 64, we
halve both to 3 and 1 respectively, reducing loop overhead and
improving instruction-level parallelism. Benchmarks show ~9.5%
improvement in prefill kernel latency.
END_PUBLIC

Signed-off-by: PRAGMA Agent <pragma-agent@modular.com>