### PR TITLE
[Kernels][GPU] Reduce MLA prefill BM to 32 for better SM utilization

### DIFF
--- a/max/kernels/src/nn/mla.mojo
+++ b/max/kernels/src/nn/mla.mojo
@@ -1548,6 +1548,7 @@ def flare_mla_prefill[
         comptime mha_config = MHAConfig[dtype](
             UInt(Int(q_layout.shape[rank - 2])),  # num_heads
             UInt(Int(k.layout.shape[rank - 1])),  # depth
+            num_queries_per_block=UInt(32),
             num_keys_per_block=num_keys_per_block,
             WN=num_keys_per_block,
             algorithm=FlashAttentionAlgorithm.FLASH_ATTENTION_2,
@@ -1856,6 +1857,7 @@ def flare_mla_prefill[
         comptime mha_config = MHAConfig[dtype](
             UInt(Int(q_layout.shape[rank - 2])),
             UInt(Int(k.layout.shape[rank - 1])),
+            num_queries_per_block=UInt(32),
             num_keys_per_block=num_keys_per_block,
             WN=num_keys_per_block,
             algorithm=FlashAttentionAlgorithm.FLASH_ATTENTION_2,


### PR DESCRIPTION
[Kernels][GPU] Reduce MLA prefill BM to 32 for better SM utilization

BEGIN_PUBLIC
[Kernels][GPU] Reduce MLA prefill BM to 32 for better SM utilization

Reduce the MLA prefill query block size from 64 to 32 on NVIDIA GPUs.
This halves shared memory usage per block and doubles the number of
thread blocks for small sequence lengths, improving SM occupancy.
Combined with BK=64, this yields ~3% improvement in prefill latency.
END_PUBLIC

Signed-off-by: PRAGMA Agent <pragma-agent@modular.com>