### PR TITLE
[Kernels] Use invariant loads in 2-stage allreduce allgather phase

### DIFF
--- a/max/kernels/allreduce/profiling_config.yaml
+++ b/max/kernels/allreduce/profiling_config.yaml
@@ -1,0 +1,25 @@
+# Nsight Compute Profiling Configuration
+# Kernel: allreduce
+# Target: NVIDIA H100 (SM90)
+
+profiling:
+  tool: ncu-cli
+  sections:
+    - SpeedOfLight
+    - Occupancy
+    - MemoryWorkloadAnalysis
+    - ComputeWorkloadAnalysis
+  target_kernel: "allreduce_kernel"
+  launch_count: 10
+  warmup_count: 5
+  metrics:
+    - sm__throughput.avg.pct_of_peak_sustained_elapsed
+    - dram__throughput.avg.pct_of_peak_sustained_elapsed
+    - gpu__compute_memory_throughput.avg.pct_of_peak_sustained_elapsed
+  architecture: sm_90
+  output_report: "reports/allreduce_profile.ncu-rep"
+
+benchmark:
+  tool: kbench
+  iterations: 100
+  warmup: 10

--- a/max/kernels/src/comm/allreduce.mojo
+++ b/max/kernels/src/comm/allreduce.mojo
@@ -484,7 +484,11 @@ def _allreduce_2stage_kernel[
                 result.get_nd_index(dst_idx),
                 tmps[gpu_idx]
                 .address_space_cast[_target_address_space]()
-                .load[width=simd_width, alignment=alignment](idx),
+                .load[
+                    width=simd_width,
+                    alignment=alignment,
+                    invariant=True,
+                ](idx),
             )
 
     # Ragged tail - max 1 simd vector per gpu, spread work between threads
@@ -499,7 +503,11 @@ def _allreduce_2stage_kernel[
                 result.get_nd_index(dst_idx),
                 tmps[global_tid]
                 .address_space_cast[_target_address_space]()
-                .load[width=simd_width, alignment=alignment](idx),
+                .load[
+                    width=simd_width,
+                    alignment=alignment,
+                    invariant=True,
+                ](idx),
             )
 
 


### PR DESCRIPTION
[Kernels] Use invariant loads in 2-stage allreduce allgather phase

BEGIN_PUBLIC
[Kernels] Use invariant loads in 2-stage allreduce allgather phase

Add invariant=True to loads in the all-gather phase of the 2-stage
allreduce kernel. After the barrier with release-acquire semantics,
the reduced partition data in signal payloads is fixed for the
remainder of the kernel. Marking these loads as invariant allows the
compiler to generate non-coherent loads (ld.global.nc on NVIDIA),
which bypass L1 and use the texture cache path for better throughput.
END_PUBLIC

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: PRAGMA Agent <pragma-agent@modular.com>