### PR TITLE
[Kernels][GPU] Use architecture-specific block dispatch for reducescatter

### DIFF
--- a/max/kernels/reducescatter/profiling_config.yaml
+++ b/max/kernels/reducescatter/profiling_config.yaml
@@ -1,0 +1,25 @@
+# Nsight Compute Profiling Configuration
+# Kernel: reducescatter
+# Target: NVIDIA H100 (SM90)
+
+profiling:
+  tool: ncu-cli
+  sections:
+    - SpeedOfLight
+    - Occupancy
+    - MemoryWorkloadAnalysis
+    - ComputeWorkloadAnalysis
+  target_kernel: "reducescatter_kernel"
+  launch_count: 10
+  warmup_count: 5
+  metrics:
+    - sm__throughput.avg.pct_of_peak_sustained_elapsed
+    - dram__throughput.avg.pct_of_peak_sustained_elapsed
+    - gpu__compute_memory_throughput.avg.pct_of_peak_sustained_elapsed
+  architecture: sm_90
+  output_report: "reports/reducescatter_profile.ncu-rep"
+
+benchmark:
+  tool: kbench
+  iterations: 100
+  warmup: 10

--- a/max/kernels/src/comm/reducescatter.mojo
+++ b/max/kernels/src/comm/reducescatter.mojo
@@ -41,10 +41,10 @@ from std.gpu.intrinsics import (
 )
 from std.math import ceildiv
 from std.sys import simd_width_of, align_of, is_amd_gpu
+from .device_query import _dispatch_max_num_blocks, get_sm_version
 
 from .sync import (
     MAX_GPUS,
-    MAX_NUM_BLOCKS_UPPER_BOUND,
     Signal,
     _multi_gpu_barrier,
     circular_add,
@@ -584,7 +584,7 @@ def reducescatter[
         rank_sigs: Signal pointers for synchronization between GPUs.
         ctx: Device context for THIS GPU.
         _max_num_blocks: Optional maximum number of thread blocks to launch.
-            If not specified, uses MAX_NUM_BLOCKS_UPPER_BOUND.
+            If not specified, uses architecture-specific dispatch table.
 
     Raises:
         Error: If P2P access is not available between GPUs.
@@ -688,8 +688,11 @@ def reducescatter[
                 + ")"
             )
 
-    var max_num_blocks = (
-        _max_num_blocks.value() if _max_num_blocks else MAX_NUM_BLOCKS_UPPER_BOUND
+    comptime sm_version = get_sm_version()
+    var max_num_blocks = _max_num_blocks.or_else(
+        _dispatch_max_num_blocks[ngpus, sm_version](
+            input_buffers[0].bytecount()
+        )
     )
 
     # Default epilogue: store directly to output buffer


### PR DESCRIPTION
PRAGMA optimization: use architecture-specific block dispatch (264 blocks for H100 = exactly 2 full waves) instead of MAX_NUM_BLOCKS_UPPER_BOUND (512 = 3.88 waves, wasted SMs). Mirrors the allreduce kernel. Signed-off-by: PRAGMA Agent