### PR TITLE
[Kernels] Skip barriers in 1-stage broadcast for single GPU

### DIFF
--- a/max/kernels/broadcast/profiling_config.yaml
+++ b/max/kernels/broadcast/profiling_config.yaml
@@ -1,0 +1,25 @@
+# Nsight Compute Profiling Configuration
+# Kernel: broadcast
+# Target: NVIDIA H100 (SM90)
+
+profiling:
+  tool: ncu-cli
+  sections:
+    - SpeedOfLight
+    - Occupancy
+    - MemoryWorkloadAnalysis
+    - ComputeWorkloadAnalysis
+  target_kernel: "broadcast_kernel"
+  launch_count: 10
+  warmup_count: 5
+  metrics:
+    - sm__throughput.avg.pct_of_peak_sustained_elapsed
+    - dram__throughput.avg.pct_of_peak_sustained_elapsed
+    - gpu__compute_memory_throughput.avg.pct_of_peak_sustained_elapsed
+  architecture: sm_90
+  output_report: "reports/broadcast_profile.ncu-rep"
+
+benchmark:
+  tool: kbench
+  iterations: 100
+  warmup: 10

--- a/max/kernels/src/comm/broadcast.mojo
+++ b/max/kernels/src/comm/broadcast.mojo
@@ -185,7 +185,9 @@ def broadcast_pull_1stage_kernel[
     comptime if pdl_level > PDLLevel.OFF:
         wait_on_dependent_grids()
 
-    _multi_gpu_barrier[ngpus, is_start=True](rank_sigs, my_sig, my_rank)
+    # Skip barriers for single-GPU case (no peers to synchronize with).
+    comptime if ngpus > 1:
+        _multi_gpu_barrier[ngpus, is_start=True](rank_sigs, my_sig, my_rank)
 
     comptime alignment = align_of[SIMD[dtype, simd_width]]()
     var in_ptr = input.ptr.address_space_cast[_target_address_space]()
@@ -210,7 +212,8 @@ def broadcast_pull_1stage_kernel[
         var data = in_ptr.load[width=1, invariant=True](tail_idx)
         out_ptr.store(tail_idx, data)
 
-    _multi_gpu_barrier[ngpus, is_start=False](rank_sigs, my_sig, my_rank)
+    comptime if ngpus > 1:
+        _multi_gpu_barrier[ngpus, is_start=False](rank_sigs, my_sig, my_rank)
 
 
 @__llvm_metadata(


### PR DESCRIPTION
[Kernels] Skip barriers in 1-stage broadcast for single GPU

BEGIN_PUBLIC
[Kernels] Skip barriers in 1-stage broadcast for single GPU

When ngpus=1, the multi-GPU barrier in the 1-stage broadcast kernel
has no peers to synchronize with. The barrier still costs two
__syncthreads() calls and volatile counter operations per kernel
invocation.

Guard the start and end barriers with a compile-time ngpus > 1 check
to eliminate this overhead for single-GPU broadcast.
END_PUBLIC

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: PRAGMA Agent <pragma-agent@modular.com>