### PR TITLE
[MAX] Add DType.bool support to interpreter reduce ops

### DIFF
--- a/max/python/max/_interpreter_ops/reduce_ops.mojo
+++ b/max/python/max/_interpreter_ops/reduce_ops.mojo
@@ -226,6 +226,42 @@ def _reduce_mul[
 # =============================================================================
 
 
+def _normalize_reduce_shape(
+    in_buffer: PythonObject,
+    axis: PythonObject,
+) raises -> IndexList[3]:
+    """Compute normalized rank-3 shape for reduction along an axis.
+
+    Collapses an N-dimensional tensor shape into three dimensions:
+    - dim0: product of dims before the reduction axis
+    - dim1: the reduction axis dimension
+    - dim2: product of dims after the reduction axis
+
+    Args:
+        in_buffer: The input buffer object (must have a .shape attribute).
+        axis: The axis along which to reduce (integer).
+
+    Returns:
+        An IndexList[3] with [dim0, dim1, dim2].
+    """
+    var axis_val = Int(py=axis)
+    var in_shape_py = in_buffer.shape
+    var rank = Int(py=len(in_shape_py))
+    var in_shape = _get_shape(in_shape_py, rank)
+
+    var dim0 = 1
+    for i in range(axis_val):
+        dim0 *= in_shape[i]
+
+    var dim1 = in_shape[axis_val]
+
+    var dim2 = 1
+    for i in range(axis_val + 1, rank):
+        dim2 *= in_shape[i]
+
+    return IndexList[3](dim0, dim1, dim2)
+
+
 def reduce_dispatcher[
     reduce_fn: ReduceFn
 ](
@@ -247,28 +283,8 @@ def reduce_dispatcher[
         device_context_ptr: Device context pointer (must be null for CPU).
     """
     var dtype = _get_dtype(in_buffer)
-    var axis_val = Int(py=axis)
     var ctx = _get_ctx(device_context_ptr)
-
-    # Extract input shape and compute normalized rank-3 shape:
-    # dim0: product of dims before axis
-    # dim1: the reduction axis dimension
-    # dim2: product of dims after axis
-    var in_shape_py = in_buffer.shape
-    var rank = Int(py=len(in_shape_py))
-    var in_shape = _get_shape(in_shape_py, rank)
-
-    var dim0 = 1
-    for i in range(axis_val):
-        dim0 *= in_shape[i]
-
-    var dim1 = in_shape[axis_val]
-
-    var dim2 = 1
-    for i in range(axis_val + 1, rank):
-        dim2 *= in_shape[i]
-
-    var normalized_shape = IndexList[3](dim0, dim1, dim2)
+    var normalized_shape = _normalize_reduce_shape(in_buffer, axis)
 
     # Float types
     if dtype == DType.float16:
@@ -464,15 +480,44 @@ def reduce_op[
 # reduce_dispatcher[_reduce_max] directly (parametric def type can't be inferred).
 
 
+def _reduce_bool_dispatcher[
+    reduce_fn: ReduceFn
+](
+    out_buffer: PythonObject,
+    in_buffer: PythonObject,
+    axis: PythonObject,
+    device_context_ptr: PythonObject,
+) raises:
+    """Handle DType.bool reduction for max/min only.
+
+    Bool is not numeric so it cannot go through the generic
+    reduce_dispatcher (sum/mean/mul would fail the SIMD numeric
+    constraint). This helper dispatches directly for bool buffers.
+    """
+    var ctx = _get_ctx(device_context_ptr)
+    var normalized_shape = _normalize_reduce_shape(in_buffer, axis)
+    reduce_op[DType.bool, reduce_fn](
+        _get_buffer_ptr[DType.bool](out_buffer),
+        _get_buffer_ptr[DType.bool](in_buffer),
+        normalized_shape,
+        ctx,
+    )
+
+
 def reduce_max_dispatcher(
     out_buffer: PythonObject,
     in_buffer: PythonObject,
     axis: PythonObject,
     device_context_ptr: PythonObject,
 ) raises:
-    reduce_dispatcher[_reduce_max](
-        out_buffer, in_buffer, axis, device_context_ptr
-    )
+    if _get_dtype(in_buffer) == DType.bool:
+        _reduce_bool_dispatcher[_reduce_max](
+            out_buffer, in_buffer, axis, device_context_ptr
+        )
+    else:
+        reduce_dispatcher[_reduce_max](
+            out_buffer, in_buffer, axis, device_context_ptr
+        )
 
 
 def reduce_min_dispatcher(
@@ -481,9 +526,14 @@ def reduce_min_dispatcher(
     axis: PythonObject,
     device_context_ptr: PythonObject,
 ) raises:
-    reduce_dispatcher[_reduce_min](
-        out_buffer, in_buffer, axis, device_context_ptr
-    )
+    if _get_dtype(in_buffer) == DType.bool:
+        _reduce_bool_dispatcher[_reduce_min](
+            out_buffer, in_buffer, axis, device_context_ptr
+        )
+    else:
+        reduce_dispatcher[_reduce_min](
+            out_buffer, in_buffer, axis, device_context_ptr
+        )
 
 
 def reduce_sum_dispatcher(

--- a/max/tests/tests/test_interpreter_ops.py
+++ b/max/tests/tests/test_interpreter_ops.py
@@ -1908,6 +1908,180 @@ class TestReduceOps:
         expected = np.prod(x_np, axis=-1, keepdims=True)
         np.testing.assert_array_almost_equal(np.from_dlpack(y), expected)
 
+    # --- Bool reduce tests (issue #6067) ---
+
+    def test_reduce_max_bool(self) -> None:
+        """Test reduce_max on a bool tensor (logical OR)."""
+        x_np = np.array(
+            [[True, False, True], [False, False, False]], dtype=np.bool_
+        )
+
+        x = Tensor.from_dlpack(x_np)
+        with (
+            rc.EagerRealizationContext(use_interpreter=True) as ctx,
+            realization_context(ctx),
+        ):
+            y = x.max(axis=-1)
+
+        expected = np.max(x_np, axis=-1, keepdims=True)
+        np.testing.assert_array_equal(np.from_dlpack(y), expected)
+
+    def test_reduce_min_bool(self) -> None:
+        """Test reduce_min on a bool tensor (logical AND)."""
+        x_np = np.array(
+            [[True, False, True], [True, True, True]], dtype=np.bool_
+        )
+
+        x = Tensor.from_dlpack(x_np)
+        with (
+            rc.EagerRealizationContext(use_interpreter=True) as ctx,
+            realization_context(ctx),
+        ):
+            y = x.min(axis=-1)
+
+        expected = np.min(x_np, axis=-1, keepdims=True)
+        np.testing.assert_array_equal(np.from_dlpack(y), expected)
+
+    def test_reduce_max_bool_first_axis(self) -> None:
+        """Test reduce_max on a bool tensor along the first axis."""
+        x_np = np.array(
+            [[False, True, False], [False, False, True]], dtype=np.bool_
+        )
+
+        x = Tensor.from_dlpack(x_np)
+        with (
+            rc.EagerRealizationContext(use_interpreter=True) as ctx,
+            realization_context(ctx),
+        ):
+            y = x.max(axis=0)
+
+        expected = np.max(x_np, axis=0, keepdims=True)
+        np.testing.assert_array_equal(np.from_dlpack(y), expected)
+
+    def test_reduce_max_bool_all_false(self) -> None:
+        """Test reduce_max on an all-False bool tensor."""
+        x_np = np.zeros((2, 3), dtype=np.bool_)
+
+        x = Tensor.from_dlpack(x_np)
+        with (
+            rc.EagerRealizationContext(use_interpreter=True) as ctx,
+            realization_context(ctx),
+        ):
+            y = x.max(axis=-1)
+
+        expected = np.max(x_np, axis=-1, keepdims=True)
+        np.testing.assert_array_equal(np.from_dlpack(y), expected)
+
+    def test_reduce_max_bool_all_true(self) -> None:
+        """Test reduce_max on an all-True bool tensor."""
+        x_np = np.ones((2, 3), dtype=np.bool_)
+
+        x = Tensor.from_dlpack(x_np)
+        with (
+            rc.EagerRealizationContext(use_interpreter=True) as ctx,
+            realization_context(ctx),
+        ):
+            y = x.max(axis=-1)
+
+        expected = np.max(x_np, axis=-1, keepdims=True)
+        np.testing.assert_array_equal(np.from_dlpack(y), expected)
+
+    # --- Additional tests requested in PR review ---
+
+    def test_reduce_min_bool_all_false(self) -> None:
+        """Test reduce_min on an all-False bool tensor."""
+        x_np = np.zeros((2, 3), dtype=np.bool_)
+
+        x = Tensor.from_dlpack(x_np)
+        with (
+            rc.EagerRealizationContext(use_interpreter=True) as ctx,
+            realization_context(ctx),
+        ):
+            y = x.min(axis=-1)
+
+        expected = np.min(x_np, axis=-1, keepdims=True)
+        np.testing.assert_array_equal(np.from_dlpack(y), expected)
+
+    def test_reduce_min_bool_all_true(self) -> None:
+        """Test reduce_min on an all-True bool tensor."""
+        x_np = np.ones((2, 3), dtype=np.bool_)
+
+        x = Tensor.from_dlpack(x_np)
+        with (
+            rc.EagerRealizationContext(use_interpreter=True) as ctx,
+            realization_context(ctx),
+        ):
+            y = x.min(axis=-1)
+
+        expected = np.min(x_np, axis=-1, keepdims=True)
+        np.testing.assert_array_equal(np.from_dlpack(y), expected)
+
+    def test_reduce_bool_3d(self) -> None:
+        """Test reduce max/min on a 3D bool tensor across each axis."""
+        x_np = np.array(
+            [
+                [[True, False], [False, True], [True, True]],
+                [[False, False], [True, False], [False, True]],
+            ],
+            dtype=np.bool_,
+        )  # shape (2, 3, 2)
+
+        for axis in range(3):
+            for op_fn, np_fn in [
+                (Tensor.max, np.max),
+                (Tensor.min, np.min),
+            ]:
+                x = Tensor.from_dlpack(x_np)
+                with (
+                    rc.EagerRealizationContext(use_interpreter=True) as ctx,
+                    realization_context(ctx),
+                ):
+                    y = op_fn(x, axis=axis)
+
+                expected = np_fn(x_np, axis=axis, keepdims=True)
+                np.testing.assert_array_equal(np.from_dlpack(y), expected)
+
+    def test_reduce_bool_4d(self) -> None:
+        """Test reduce max/min on a 4D bool tensor across each axis."""
+        x_np = (
+            np.random.default_rng(42)
+            .choice([True, False], size=(2, 2, 3, 2))
+            .astype(np.bool_)
+        )
+
+        for axis in range(4):
+            for op_fn, np_fn in [
+                (Tensor.max, np.max),
+                (Tensor.min, np.min),
+            ]:
+                x = Tensor.from_dlpack(x_np)
+                with (
+                    rc.EagerRealizationContext(use_interpreter=True) as ctx,
+                    realization_context(ctx),
+                ):
+                    y = op_fn(x, axis=axis)
+
+                expected = np_fn(x_np, axis=axis, keepdims=True)
+                np.testing.assert_array_equal(np.from_dlpack(y), expected)
+
+    def test_reduce_bool_single_element_axis(self) -> None:
+        """Test reduce max/min on a bool tensor with a size-1 axis."""
+        x_np = np.array([[True], [False], [True]], dtype=np.bool_)  # (3, 1)
+
+        for op_fn, np_fn in [
+            (Tensor.max, np.max),
+            (Tensor.min, np.min),
+        ]:
+            x = Tensor.from_dlpack(x_np)
+            with (
+                rc.EagerRealizationContext(use_interpreter=True) as ctx,
+                realization_context(ctx),
+            ):
+                y = op_fn(x, axis=1)
+
+            expected = np_fn(x_np, axis=1, keepdims=True)
+            np.testing.assert_array_equal(np.from_dlpack(y), expected)
+
 
 def _numpy_softmax(x: np.ndarray, axis: int = -1) -> np.ndarray:
     """Numerically stable softmax reference implementation."""


### PR DESCRIPTION
## Summary

- Fixes `"Unsupported dtype for reduce: bool"` when calling `F.max()` / `F.min()` on a `DType.bool` tensor under the eager interpreter (`MAX_USE_EAGER_INTERPRETER=1`).
- The identity values (`max_finite[DType.bool]()` → `True`, `min_finite[DType.bool]()` → `False`) were already correctly defined in `numerics.mojo` — only the dispatch was missing.
- Bool cannot go through the generic `reduce_dispatcher` because `reduce_sum`/`reduce_mean`/`reduce_mul` instantiate SIMD operations that require numeric types, failing a compile-time constraint. Instead, a dedicated `_reduce_bool_dispatcher` helper handles bool in `reduce_max_dispatcher` and `reduce_min_dispatcher` only.
- Adds 5 bool-specific reduce tests (max, min, first axis, all-false, all-true edge cases).

Fixes #6067

## Test plan

- [ ] `test_reduce_max_bool` — mixed True/False tensor, last axis
- [ ] `test_reduce_min_bool` — logical AND semantics, last axis
- [ ] `test_reduce_max_bool_first_axis` — reduction along axis 0
- [ ] `test_reduce_max_bool_all_false` — edge case: identity value check
- [ ] `test_reduce_max_bool_all_true` — edge case: all-True tensor