### PR TITLE
[MAX] Add TeaCache support for DiffusionPipeline

### DIFF
--- a/max/examples/diffusion/flux2_comparison.py
+++ b/max/examples/diffusion/flux2_comparison.py
@@ -425,6 +425,27 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Taylor expansion order: 1=linear, 2=quadratic (model default if unset).",
     )
     parser.add_argument(
+        "--teacache",
+        action="store_true",
+        help="Enable TeaCache optimization for the MAX pipeline.",
+    )
+    parser.add_argument(
+        "--teacache-rel-l1-thresh",
+        type=float,
+        default=None,
+        help="TeaCache relative-L1 threshold (model default if unset).",
+    )
+    parser.add_argument(
+        "--teacache-coefficients",
+        type=float,
+        action="append",
+        default=None,
+        help=(
+            "TeaCache polynomial coefficients. Repeat this flag once per "
+            "coefficient to override the model defaults (5 for FLUX)."
+        ),
+    )
+    parser.add_argument(
         "--no-output",
         action="store_true",
         help="Skip saving generated images to disk.",
@@ -572,6 +593,12 @@ def _build_image_filename(
         warmup = args.taylorseer_warmup_steps or "default"
         order = args.taylorseer_max_order or "default"
         parts.append(f"taylorseer_i{interval}_w{warmup}_o{order}")
+    if args.teacache:
+        thresh = args.teacache_rel_l1_thresh or "default"
+        coeffs = (
+            "custom" if args.teacache_coefficients is not None else "default"
+        )
+        parts.append(f"teacache_t{thresh}_c{coeffs}")
     return "_".join(parts) + ".png"
 
 
@@ -796,6 +823,9 @@ def _load_max_pipeline(args: argparse.Namespace) -> tuple[Any, Any, Any]:
         taylorseer_cache_interval=args.taylorseer_cache_interval,
         taylorseer_warmup_steps=args.taylorseer_warmup_steps,
         taylorseer_max_order=args.taylorseer_max_order,
+        teacache=args.teacache,
+        teacache_rel_l1_thresh=args.teacache_rel_l1_thresh,
+        teacache_coefficients=args.teacache_coefficients,
     )
 
     pipeline_model = cast(type[DiffusionPipeline], arch.pipeline_model)
@@ -1158,6 +1188,19 @@ def main(argv: list[str] | None = None) -> int:
         print(
             f"  ts max order     : {args.taylorseer_max_order or 'model-default'}"
         )
+    print(f"  teacache         : {args.teacache}")
+    if args.teacache:
+        print(
+            f"  tc rel_l1 thresh : {args.teacache_rel_l1_thresh or 'model-default'}"
+        )
+        print(
+            "  tc coefficients  : "
+            + (
+                "user-specified"
+                if args.teacache_coefficients is not None
+                else "model-default"
+            )
+        )
     print(f"  warmup runs      : {args.num_warmups}")
     print(f"  timed iterations : {len(requests)}")
     print()
@@ -1171,6 +1214,17 @@ def main(argv: list[str] | None = None) -> int:
     if args.enable_fbc:
         caching_parts.append(
             f"first block cache (threshold: {args.residual_threshold})"
+        )
+    if args.taylorseer:
+        caching_parts.append("taylorseer")
+    if args.teacache:
+        caching_parts.append(
+            "teacache"
+            + (
+                f" (threshold: {args.teacache_rel_l1_thresh})"
+                if args.teacache_rel_l1_thresh is not None
+                else " (threshold: model-default)"
+            )
         )
     print(f"    caching        : {', '.join(caching_parts) or 'none'}")
     print()

--- a/max/examples/diffusion/simple_offline_generation.py
+++ b/max/examples/diffusion/simple_offline_generation.py
@@ -247,6 +247,27 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Taylor expansion order: 1=linear, 2=quadratic (model default if unset).",
     )
     parser.add_argument(
+        "--teacache",
+        action="store_true",
+        help="Enable TeaCache optimization for the FLUX.2 transformer.",
+    )
+    parser.add_argument(
+        "--teacache-rel-l1-thresh",
+        type=float,
+        default=None,
+        help="Relative-L1 threshold for TeaCache (model default if unset).",
+    )
+    parser.add_argument(
+        "--teacache-coefficients",
+        type=float,
+        action="append",
+        default=None,
+        help=(
+            "TeaCache polynomial coefficients. Repeat this flag once per "
+            "coefficient to override the model defaults (5 for FLUX)."
+        ),
+    )
+    parser.add_argument(
         "--prefer-module-v3",
         action="store_true",
         help="Use the ModuleV3 FLUX implementation instead of the default architecture.",
@@ -423,6 +444,9 @@ async def generate_image(args: argparse.Namespace) -> None:
         taylorseer_cache_interval=args.taylorseer_cache_interval,
         taylorseer_warmup_steps=args.taylorseer_warmup_steps,
         taylorseer_max_order=args.taylorseer_max_order,
+        teacache=args.teacache,
+        teacache_rel_l1_thresh=args.teacache_rel_l1_thresh,
+        teacache_coefficients=args.teacache_coefficients,
     )
     pipeline = PixelGenerationPipeline[PixelContext](
         pipeline_config=config,
@@ -525,6 +549,18 @@ async def generate_image(args: argparse.Namespace) -> None:
         print(
             f"TaylorSeer enabled: {order_info}, {interval_info}, {warmup_info}."
         )
+    if args.teacache:
+        thresh_info = (
+            f"rel_l1_thresh={args.teacache_rel_l1_thresh}"
+            if args.teacache_rel_l1_thresh is not None
+            else "rel_l1_thresh=model-default"
+        )
+        coeff_info = (
+            "coefficients=user-specified"
+            if args.teacache_coefficients is not None
+            else "coefficients=model-default"
+        )
+        print(f"TeaCache enabled: {thresh_info}, {coeff_info}.")
 
     # Step 6: Prepare inputs for the pipeline
     # Create a batch with a single context

--- a/max/python/max/pipelines/architectures/flux1_modulev3/flux1.py
+++ b/max/python/max/pipelines/architectures/flux1_modulev3/flux1.py
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 from max.dtype import DType
 from max.experimental import functional as F
@@ -39,6 +39,8 @@ logger = logging.getLogger(__name__)
 
 from max.pipelines.lib.interfaces.cache_mixin import (
     fbcache_conditional_execution,
+    teacache_conditional_execution,
+    teacache_rescaled_delta,
 )
 
 
@@ -359,9 +361,17 @@ class FluxTransformer2DModel(Module[..., Sequence[Tensor]]):
         self.joint_attention_dim = joint_attention_dim
         self.pooled_projection_dim = pooled_projection_dim
 
-        # Step-cache config (set before compilation based on cache_config)
-        self._step_cache_enabled: bool = False
+        # Cache routing: pick the forward/input_types path once before
+        # compilation.  model.py sets these based on cache_config.
+        self._forward_impl: Callable[..., tuple[Tensor, ...]] = (
+            self._forward_standard
+        )
+        self._input_types_impl: Callable[..., tuple[TensorType, ...]] = (
+            self._input_types_standard
+        )
         self._rdt_value: float = 0.05
+        self._teacache_rel_l1_thresh: float = 0.2
+        self._teacache_coefficients: tuple[float, ...] = ()
 
     def _fbcache_conditional_execution_output_types(self) -> list[TensorType]:
         """Return [residual_type, output_type] for fbcache_conditional_execution / input_types."""
@@ -381,56 +391,102 @@ class FluxTransformer2DModel(Module[..., Sequence[Tensor]]):
         )
         return [residual_type, output_type]
 
-    def input_types(self) -> tuple[TensorType, ...]:
-        """Define input tensor types for the model.
-
-        Returns:
-            Tuple of TensorType specifications for all model inputs.
-        """
-        hidden_states_type = TensorType(
+    def _teacache_output_types(self) -> list[TensorType]:
+        """Return TeaCache output types for updated cache state + output."""
+        image_hidden_type = TensorType(
             self.max_dtype,
-            shape=["batch_size", "image_seq_len", self.in_channels],
+            shape=["batch_size", "image_seq_len", self.inner_dim],
             device=self.device,
         )
-        encoder_hidden_states_type = TensorType(
+        accum_type = TensorType(DType.float32, shape=[1], device=self.device)
+        output_type = TensorType(
             self.max_dtype,
-            shape=["batch_size", "text_seq_len", self.joint_attention_dim],
+            shape=[
+                "batch_size",
+                "image_seq_len",
+                self.patch_size * self.patch_size * self.out_channels,
+            ],
             device=self.device,
         )
-        pooled_projections_type = TensorType(
-            self.max_dtype,
-            shape=["batch_size", self.pooled_projection_dim],
-            device=self.device,
+        return [image_hidden_type, image_hidden_type, accum_type, output_type]
+
+    def _teacache_modulated_input(
+        self,
+        hidden_states: Tensor,
+        temb: Tensor,
+    ) -> Tensor:
+        """Compute TeaCache's modulated input from the first block's AdaLN."""
+        norm_hidden_states, _gate, _shift, _scale, _gate2 = (
+            self.transformer_blocks[0].norm1(hidden_states, emb=temb)
         )
-        timestep_type = TensorType(
-            DType.float32, shape=["batch_size"], device=self.device
-        )
-        img_ids_type = TensorType(
-            self.max_dtype, shape=["image_seq_len", 3], device=self.device
-        )
-        txt_ids_type = TensorType(
-            self.max_dtype, shape=["text_seq_len", 3], device=self.device
-        )
-        guidance_type = TensorType(
-            self.max_dtype, shape=["batch_size"], device=self.device
+        return norm_hidden_states
+
+    def _base_input_types(self) -> tuple[TensorType, ...]:
+        """Return the base input types shared by all forward paths."""
+        return (
+            TensorType(
+                self.max_dtype,
+                shape=["batch_size", "image_seq_len", self.in_channels],
+                device=self.device,
+            ),
+            TensorType(
+                self.max_dtype,
+                shape=[
+                    "batch_size",
+                    "text_seq_len",
+                    self.joint_attention_dim,
+                ],
+                device=self.device,
+            ),
+            TensorType(
+                self.max_dtype,
+                shape=["batch_size", self.pooled_projection_dim],
+                device=self.device,
+            ),
+            TensorType(DType.float32, shape=["batch_size"], device=self.device),
+            TensorType(
+                self.max_dtype,
+                shape=["image_seq_len", 3],
+                device=self.device,
+            ),
+            TensorType(
+                self.max_dtype,
+                shape=["text_seq_len", 3],
+                device=self.device,
+            ),
+            TensorType(
+                self.max_dtype, shape=["batch_size"], device=self.device
+            ),
         )
 
-        base_types = (
-            hidden_states_type,
-            encoder_hidden_states_type,
-            pooled_projections_type,
-            timestep_type,
-            img_ids_type,
-            txt_ids_type,
-            guidance_type,
-        )
+    def _input_types_standard(self) -> tuple[TensorType, ...]:
+        return self._base_input_types()
 
-        if not self._step_cache_enabled:
-            return base_types
-
-        return base_types + tuple(
+    def _input_types_fbcache(self) -> tuple[TensorType, ...]:
+        return self._base_input_types() + tuple(
             self._fbcache_conditional_execution_output_types()
         )
+
+    def _input_types_teacache(self) -> tuple[TensorType, ...]:
+        image_hidden_type = TensorType(
+            self.max_dtype,
+            shape=["batch_size", "image_seq_len", self.inner_dim],
+            device=self.device,
+        )
+        accum_type = TensorType(DType.float32, shape=[1], device=self.device)
+        force_compute_type = TensorType(
+            DType.bool, shape=[1], device=self.device
+        )
+        return self._base_input_types() + (
+            image_hidden_type,  # prev_modulated_input
+            image_hidden_type,  # prev_residual
+            accum_type,  # accumulated_rel_l1
+            force_compute_type,  # force_compute
+        )
+
+    def input_types(self) -> tuple[TensorType, ...]:
+        """Define input tensor types for the model."""
+        return self._input_types_impl()
 
     def _run_first_block(
         self,
@@ -458,10 +514,10 @@ class FluxTransformer2DModel(Module[..., Sequence[Tensor]]):
         temb: Tensor,
         image_rotary_emb: tuple[Tensor, Tensor],
     ) -> Tensor:
-        """Run remaining dual-stream blocks, single-stream blocks, norm, and proj.
+        """Run remaining dual-stream blocks 1..N and single-stream blocks.
 
         Returns:
-            Output tensor of shape [B, image_seq_len, patch_size² * out_channels].
+            Pre-postamble image hidden states [B, image_seq_len, inner_dim].
         """
         for rem_block in self.transformer_blocks[1:]:
             encoder_hidden_states, hidden_states = rem_block(
@@ -477,10 +533,13 @@ class FluxTransformer2DModel(Module[..., Sequence[Tensor]]):
                 temb=temb,
                 image_rotary_emb=image_rotary_emb,
             )
-        hidden_states = self.norm_out(hidden_states, temb)
-        return self.proj_out(hidden_states)
+        return hidden_states
 
-    def forward(
+    def _forward_postamble(self, hidden_states: Tensor, temb: Tensor) -> Tensor:
+        """Final norm and projection after the transformer backbone."""
+        return self.proj_out(self.norm_out(hidden_states, temb))
+
+    def _forward_preamble(
         self,
         hidden_states: Tensor,
         encoder_hidden_states: Tensor,
@@ -489,27 +548,13 @@ class FluxTransformer2DModel(Module[..., Sequence[Tensor]]):
         img_ids: Tensor,
         txt_ids: Tensor,
         guidance: Tensor | None = None,
-        prev_residual: Tensor | None = None,
-        prev_output: Tensor | None = None,
-    ) -> tuple[Tensor] | tuple[Tensor, Tensor]:
-        """Apply Flux Transformer 2D model forward pass.
-
-        Args:
-            hidden_states: Input latent hidden states.
-            encoder_hidden_states: Text encoder hidden states.
-            pooled_projections: Pooled text embeddings.
-            timestep: Diffusion timestep.
-            img_ids: Image position IDs.
-            txt_ids: Text position IDs.
-            guidance: Guidance scale values.
-            prev_residual: First-block residual from previous step.
-            prev_output: Previous step output for cache reuse.
+    ) -> tuple[Tensor, Tensor, Tensor, tuple[Tensor, Tensor]]:
+        """Embeddings, projection, RoPE.
 
         Returns:
-            If step-cache is disabled, returns (output,).
-            If step-cache is enabled, returns (output, first_block_residual).
+            (projected_hidden_states, encoder_hidden_states, temb,
+             image_rotary_emb).
         """
-
         hidden_states = self.x_embedder(hidden_states)
 
         timestep = F.cast(timestep, hidden_states.dtype)
@@ -519,7 +564,8 @@ class FluxTransformer2DModel(Module[..., Sequence[Tensor]]):
 
         if self.guidance_embeds:
             assert isinstance(
-                self.time_text_embed, CombinedTimestepGuidanceTextProjEmbeddings
+                self.time_text_embed,
+                CombinedTimestepGuidanceTextProjEmbeddings,
             )
             assert isinstance(guidance, Tensor)
             temb = self.time_text_embed(timestep, guidance, pooled_projections)
@@ -534,31 +580,66 @@ class FluxTransformer2DModel(Module[..., Sequence[Tensor]]):
         ids = F.concat((txt_ids, img_ids), axis=0)
         image_rotary_emb = self.pos_embed(ids)
 
-        # Run first block (shared between standard and step-cache paths).
-        first_encoder_hidden_states, first_hidden_states = (
-            self._run_first_block(
+        return (hidden_states, encoder_hidden_states, temb, image_rotary_emb)
+
+    def _forward_standard(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Tensor,
+        pooled_projections: Tensor,
+        timestep: Tensor,
+        img_ids: Tensor,
+        txt_ids: Tensor,
+        guidance: Tensor | None = None,
+    ) -> tuple[Tensor]:
+        """Standard forward pass (no step-cache)."""
+        projected, encoder_hidden_states, temb, image_rotary_emb = (
+            self._forward_preamble(
                 hidden_states,
                 encoder_hidden_states,
-                temb,
-                image_rotary_emb,
+                pooled_projections,
+                timestep,
+                img_ids,
+                txt_ids,
+                guidance,
             )
         )
+        first_encoder, first_hidden = self._run_first_block(
+            projected, encoder_hidden_states, temb, image_rotary_emb
+        )
+        image_hidden = self._run_remaining_blocks(
+            first_hidden, first_encoder, temb, image_rotary_emb
+        )
+        return (self._forward_postamble(image_hidden, temb),)
 
-        if not self._step_cache_enabled:
-            # Standard path: run remaining blocks sequentially.
-            output = self._run_remaining_blocks(
-                first_hidden_states,
-                first_encoder_hidden_states,
-                temb,
-                image_rotary_emb,
+    def _forward_fbcache(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Tensor,
+        pooled_projections: Tensor,
+        timestep: Tensor,
+        img_ids: Tensor,
+        txt_ids: Tensor,
+        guidance: Tensor | None,
+        prev_residual: Tensor,
+        prev_output: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        """Step-cache forward pass with F.cond branching for cache reuse."""
+        projected, encoder_hidden_states, temb, image_rotary_emb = (
+            self._forward_preamble(
+                hidden_states,
+                encoder_hidden_states,
+                pooled_projections,
+                timestep,
+                img_ids,
+                txt_ids,
+                guidance,
             )
-            return (output,)
-
-        # Step-cache path: F.cond branching for cache reuse.
-        assert prev_residual is not None
-        assert prev_output is not None
-
-        first_block_residual = first_hidden_states - hidden_states
+        )
+        first_encoder, first_hidden = self._run_first_block(
+            projected, encoder_hidden_states, temb, image_rotary_emb
+        )
+        first_block_residual = first_hidden - projected
 
         return fbcache_conditional_execution(
             first_block_residual,
@@ -567,10 +648,76 @@ class FluxTransformer2DModel(Module[..., Sequence[Tensor]]):
             self._rdt_value,
             self._run_remaining_blocks,
             dict(
-                hidden_states=first_hidden_states,
-                encoder_hidden_states=first_encoder_hidden_states,
+                hidden_states=first_hidden,
+                encoder_hidden_states=first_encoder,
                 temb=temb,
                 image_rotary_emb=image_rotary_emb,
             ),
+            self._forward_postamble,
+            temb,
             self._fbcache_conditional_execution_output_types(),
         )
+
+    def _forward_teacache(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Tensor,
+        pooled_projections: Tensor,
+        timestep: Tensor,
+        img_ids: Tensor,
+        txt_ids: Tensor,
+        guidance: Tensor | None,
+        prev_modulated_input: Tensor,
+        prev_residual: Tensor,
+        accumulated_rel_l1: Tensor,
+        force_compute: Tensor,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        """TeaCache forward pass: skip decision gates the entire DiT backbone."""
+        projected, encoder_hidden_states, temb, image_rotary_emb = (
+            self._forward_preamble(
+                hidden_states,
+                encoder_hidden_states,
+                pooled_projections,
+                timestep,
+                img_ids,
+                txt_ids,
+                guidance,
+            )
+        )
+        modulated_input = self._teacache_modulated_input(projected, temb)
+
+        delta = teacache_rescaled_delta(
+            modulated_input,
+            prev_modulated_input,
+            self._teacache_coefficients,
+        )
+        next_accumulated = accumulated_rel_l1 + delta
+
+        return teacache_conditional_execution(
+            modulated_input=modulated_input,
+            next_accumulated=next_accumulated,
+            accumulated_rel_l1=accumulated_rel_l1,
+            force_compute=force_compute,
+            rel_l1_thresh=self._teacache_rel_l1_thresh,
+            projected_hidden_states=projected,
+            prev_residual=prev_residual,
+            temb=temb,
+            run_first_block=self._run_first_block,
+            first_block_kwargs=dict(
+                hidden_states=projected,
+                encoder_hidden_states=encoder_hidden_states,
+                temb=temb,
+                image_rotary_emb=image_rotary_emb,
+            ),
+            run_remaining_blocks=self._run_remaining_blocks,
+            remaining_blocks_kwargs=dict(
+                temb=temb,
+                image_rotary_emb=image_rotary_emb,
+            ),
+            run_postamble=self._forward_postamble,
+            output_types=self._teacache_output_types(),
+        )
+
+    def forward(self, *args: Tensor) -> tuple[Tensor, ...]:
+        """Forward pass, dispatched to standard or step-cache impl."""
+        return self._forward_impl(*args)

--- a/max/python/max/pipelines/architectures/flux1_modulev3/model.py
+++ b/max/python/max/pipelines/architectures/flux1_modulev3/model.py
@@ -69,10 +69,20 @@ class Flux1TransformerModel(ComponentModel):
             and self.cache_config.first_block_caching
         ):
             assert self.cache_config.residual_threshold is not None
-            flux._step_cache_enabled = True
             flux._rdt_value = self.cache_config.residual_threshold
-        else:
-            flux._step_cache_enabled = False
+            flux._forward_impl = flux._forward_fbcache
+            flux._input_types_impl = flux._input_types_fbcache
+        elif self.cache_config is not None and self.cache_config.teacache:
+            assert self.cache_config.teacache_rel_l1_thresh is not None
+            assert self.cache_config.teacache_coefficients is not None
+            flux._teacache_rel_l1_thresh = (
+                self.cache_config.teacache_rel_l1_thresh
+            )
+            flux._teacache_coefficients = tuple(
+                self.cache_config.teacache_coefficients
+            )
+            flux._forward_impl = flux._forward_teacache
+            flux._input_types_impl = flux._input_types_teacache
 
         self.model = flux.compile(
             *flux.input_types(),
@@ -90,6 +100,10 @@ class Flux1TransformerModel(ComponentModel):
         guidance: Tensor | None,
         prev_residual: Tensor | None = None,
         prev_output: Tensor | None = None,
+        teacache_prev_modulated_input: Tensor | None = None,
+        teacache_cached_residual: Tensor | None = None,
+        teacache_accumulated_rel_l1: Tensor | None = None,
+        force_compute: Tensor | None = None,
     ) -> Any:
         args: tuple[Any, ...] = (
             hidden_states,
@@ -100,6 +114,14 @@ class Flux1TransformerModel(ComponentModel):
             txt_ids,
             guidance,
         )
-        if prev_residual is not None:
+        if teacache_prev_modulated_input is not None:
+            args = (
+                *args,
+                teacache_prev_modulated_input,
+                teacache_cached_residual,
+                teacache_accumulated_rel_l1,
+                force_compute,
+            )
+        elif prev_residual is not None:
             args = (*args, prev_residual, prev_output)
         return self.model(*args)

--- a/max/python/max/pipelines/architectures/flux1_modulev3/pipeline_flux.py
+++ b/max/python/max/pipelines/architectures/flux1_modulev3/pipeline_flux.py
@@ -19,7 +19,7 @@ from typing import Any, Literal
 
 import numpy as np
 import numpy.typing as npt
-from max.driver import CPU, Device
+from max.driver import CPU, Buffer, Device
 from max.dtype import DType
 from max.experimental import functional as F
 from max.experimental.tensor import Tensor
@@ -381,7 +381,7 @@ class FluxPipeline(DiffusionPipeline):
         cache_state: DenoisingCacheState,
         **kwargs: Any,
     ) -> tuple[Tensor, ...]:
-        return self.transformer(
+        base_args = (
             kwargs["latents"],
             kwargs["prompt_embeds"],
             kwargs["pooled_prompt_embeds"],
@@ -389,9 +389,22 @@ class FluxPipeline(DiffusionPipeline):
             kwargs["latent_image_ids"],
             kwargs["text_ids"],
             kwargs["guidance"],
-            prev_residual=cache_state.prev_residual,
-            prev_output=cache_state.prev_output,
         )
+        if self.cache_config.teacache:
+            return self.transformer(
+                *base_args,
+                teacache_prev_modulated_input=cache_state.teacache_prev_modulated_input,
+                teacache_cached_residual=cache_state.teacache_cached_residual,
+                teacache_accumulated_rel_l1=cache_state.teacache_accumulated_rel_l1,
+                force_compute=kwargs["force_compute"],
+            )
+        if self.cache_config.first_block_caching:
+            return self.transformer(
+                *base_args,
+                prev_residual=cache_state.prev_residual,
+                prev_output=cache_state.prev_output,
+            )
+        return self.transformer(*base_args)
 
     def execute(  # type: ignore[override]
         self,
@@ -485,14 +498,13 @@ class FluxPipeline(DiffusionPipeline):
             else None
         )
 
+        is_teacache = self.cache_config.teacache
+
         for i in range(num_timesteps):
             timestep = timesteps_seq[i : i + 1]
             dt = dts_seq[i : i + 1]
 
-            noise_pred = self.run_denoising_step(
-                step=i,
-                cache_state=cache_pos,
-                device=dev,
+            step_kwargs: dict[str, Any] = dict(
                 latents=latents,
                 prompt_embeds=prompt_embeds,
                 pooled_prompt_embeds=pooled_prompt_embeds,
@@ -501,6 +513,23 @@ class FluxPipeline(DiffusionPipeline):
                 text_ids=text_ids,
                 guidance=guidance,
             )
+            if is_teacache:
+                step_kwargs["force_compute"] = Tensor(
+                    storage=Buffer.from_dlpack(
+                        np.array(
+                            [i == 0 or i == num_timesteps - 1],
+                            dtype=bool,
+                        )
+                    ).to(dev)
+                )
+                step_kwargs["num_inference_steps"] = num_timesteps
+
+            noise_pred = self.run_denoising_step(
+                step=i,
+                cache_state=cache_pos,
+                device=dev,
+                **step_kwargs,
+            )
 
             if model_inputs.do_true_cfg:
                 assert negative_prompt_embeds is not None
@@ -508,10 +537,7 @@ class FluxPipeline(DiffusionPipeline):
                 assert negative_text_ids is not None
                 assert cache_neg is not None
 
-                neg_noise_pred = self.run_denoising_step(
-                    step=i,
-                    cache_state=cache_neg,
-                    device=dev,
+                neg_step_kwargs = dict(
                     latents=latents,
                     prompt_embeds=negative_prompt_embeds,
                     pooled_prompt_embeds=negative_pooled_prompt_embeds,
@@ -519,6 +545,18 @@ class FluxPipeline(DiffusionPipeline):
                     latent_image_ids=latent_image_ids,
                     text_ids=negative_text_ids,
                     guidance=guidance,
+                )
+                if is_teacache:
+                    neg_step_kwargs["force_compute"] = step_kwargs[
+                        "force_compute"
+                    ]
+                    neg_step_kwargs["num_inference_steps"] = num_timesteps
+
+                neg_noise_pred = self.run_denoising_step(
+                    step=i,
+                    cache_state=cache_neg,
+                    device=dev,
+                    **neg_step_kwargs,
                 )
                 noise_pred = neg_noise_pred + model_inputs.true_cfg_scale * (
                     noise_pred - neg_noise_pred

--- a/max/python/max/pipelines/architectures/flux2_modulev3/flux2.py
+++ b/max/python/max/pipelines/architectures/flux2_modulev3/flux2.py
@@ -27,6 +27,8 @@ from max.nn.quant_config import QuantConfig
 from max.pipelines.lib.interfaces.cache_mixin import (
     DenoisingCacheConfig,
     fbcache_conditional_execution,
+    teacache_conditional_execution,
+    teacache_rescaled_delta,
 )
 
 from .layers.embeddings import TimestepEmbedding, Timesteps
@@ -557,11 +559,22 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
             self._input_types_standard
         )
         self._rdt_value: float = 0.05
+        self._teacache_rel_l1_thresh: float = 0.4
+        self._teacache_coefficients: tuple[float, ...] = ()
         if cache_config is not None and cache_config.first_block_caching:
             assert cache_config.residual_threshold is not None
             self._rdt_value = cache_config.residual_threshold
-            self._forward_impl = self._forward_step_cache
-            self._input_types_impl = self._input_types_step_cache
+            self._forward_impl = self._forward_fbcache
+            self._input_types_impl = self._input_types_fbcache
+        elif cache_config is not None and cache_config.teacache:
+            assert cache_config.teacache_rel_l1_thresh is not None
+            assert cache_config.teacache_coefficients is not None
+            self._teacache_rel_l1_thresh = cache_config.teacache_rel_l1_thresh
+            self._teacache_coefficients = tuple(
+                cache_config.teacache_coefficients
+            )
+            self._forward_impl = self._forward_teacache
+            self._input_types_impl = self._input_types_teacache
 
     def _fbcache_conditional_execution_output_types(self) -> list[TensorType]:
         """Return [residual_type, output_type] for fbcache_conditional_execution / input_types."""
@@ -580,6 +593,25 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
             device=self.device,
         )
         return [residual_type, output_type]
+
+    def _teacache_output_types(self) -> list[TensorType]:
+        """Return TeaCache output types for updated cache state + output."""
+        image_hidden_type = TensorType(
+            self.max_dtype,
+            shape=["batch_size", "image_seq_len", self.inner_dim],
+            device=self.device,
+        )
+        accum_type = TensorType(DType.float32, shape=[1], device=self.device)
+        output_type = TensorType(
+            self.max_dtype,
+            shape=[
+                "batch_size",
+                "image_seq_len",
+                self.patch_size * self.patch_size * self.out_channels,
+            ],
+            device=self.device,
+        )
+        return [image_hidden_type, image_hidden_type, accum_type, output_type]
 
     def _base_input_types(self) -> tuple[TensorType, ...]:
         """Return the base input types shared by both forward paths."""
@@ -621,9 +653,26 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
     def _input_types_standard(self) -> tuple[TensorType, ...]:
         return self._base_input_types()
 
-    def _input_types_step_cache(self) -> tuple[TensorType, ...]:
+    def _input_types_fbcache(self) -> tuple[TensorType, ...]:
         return self._base_input_types() + tuple(
             self._fbcache_conditional_execution_output_types()
+        )
+
+    def _input_types_teacache(self) -> tuple[TensorType, ...]:
+        image_hidden_type = TensorType(
+            self.max_dtype,
+            shape=["batch_size", "image_seq_len", self.inner_dim],
+            device=self.device,
+        )
+        accum_type = TensorType(DType.float32, shape=[1], device=self.device)
+        force_compute_type = TensorType(
+            DType.bool, shape=[1], device=self.device
+        )
+        return self._base_input_types() + (
+            image_hidden_type,  # prev_modulated_input
+            image_hidden_type,  # prev_residual
+            accum_type,  # accumulated_rel_l1
+            force_compute_type,  # force_compute
         )
 
     def input_types(self) -> tuple[TensorType, ...]:
@@ -661,7 +710,6 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
         self,
         hidden_states: Tensor,
         encoder_hidden_states: Tensor,
-        temb: Tensor,
         double_stream_mod_img: tuple[
             tuple[Tensor, Tensor, Tensor], tuple[Tensor, Tensor, Tensor]
         ],
@@ -673,13 +721,13 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
         position_ids: Tensor,
         num_txt_tokens: int | Dim,
     ) -> Tensor:
-        """Run remaining dual-stream blocks, single-stream blocks, norm, and proj.
+        """Run dual-stream blocks 1..N and all single-stream blocks.
 
         Returns:
-            Output tensor of shape [B, image_seq_len, patch_size² * out_channels].
+            Pre-tail image hidden states [B, image_seq_len, inner_dim].
         """
-        for rest_block in self.transformer_blocks[1:]:
-            encoder_hidden_states, hidden_states = rest_block(
+        for block in self.transformer_blocks[1:]:
+            encoder_hidden_states, hidden_states = block(
                 hidden_states=hidden_states,
                 encoder_hidden_states=encoder_hidden_states,
                 temb_mod_params_img=double_stream_mod_img,
@@ -700,9 +748,20 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
                 position_ids=position_ids,
                 split_hidden_states=False,
             )
-        hidden_states = hidden_states[:, num_txt_tokens:, :]
-        hidden_states = self.norm_out(hidden_states, temb)
-        return self.proj_out(hidden_states)
+        return hidden_states[:, num_txt_tokens:, :]
+
+    def _teacache_modulated_input(
+        self,
+        hidden_states: Tensor,
+        double_stream_mod_img: tuple[
+            tuple[Tensor, Tensor, Tensor], tuple[Tensor, Tensor, Tensor]
+        ],
+    ) -> Tensor:
+        """Compute TeaCache's image-stream modulated input for the first block."""
+        (shift_msa, scale_msa, _gate_msa), _ = double_stream_mod_img
+        block0 = self.transformer_blocks[0]
+        norm_hidden_states = block0.norm1(hidden_states)
+        return (1 + scale_msa) * norm_hidden_states + shift_msa
 
     def _forward_preamble(
         self,
@@ -716,7 +775,6 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
         Tensor,
         Tensor,
         Tensor,
-        Tensor,
         tuple[tuple[Tensor, Tensor, Tensor], tuple[Tensor, Tensor, Tensor]],
         tuple[tuple[Tensor, Tensor, Tensor], tuple[Tensor, Tensor, Tensor]],
         tuple[Tensor, Tensor, Tensor],
@@ -724,13 +782,13 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
         Tensor,
         int | Dim,
     ]:
-        """Shared preamble: embeddings, modulation, projection, RoPE, first block.
+        """Embeddings, modulation, projection, RoPE.
 
         Returns:
-            (hidden_states, first_hidden_states, first_encoder_hidden_states,
+            (projected_hidden_states, encoder_hidden_states,
              temb, double_stream_mod_img, double_stream_mod_txt,
-             single_stream_mod, image_rotary_emb, position_ids, num_txt_tokens).
-            Note: hidden_states is the projected value (after x_embedder).
+             single_stream_mod, image_rotary_emb, position_ids,
+             num_txt_tokens).
         """
         # Handle batch dimension in ids (squeeze if needed)
         if img_ids.rank == 3:
@@ -773,22 +831,9 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
             [hidden_states.shape[0], ids.shape[0]],
         )
 
-        # Run first block
-        first_encoder_hidden_states, first_hidden_states = (
-            self._run_first_block(
-                hidden_states,
-                encoder_hidden_states,
-                double_stream_mod_img,
-                double_stream_mod_txt,
-                image_rotary_emb,
-                position_ids,
-            )
-        )
-
         return (
             hidden_states,
-            first_hidden_states,
-            first_encoder_hidden_states,
+            encoder_hidden_states,
             temb,
             double_stream_mod_img,
             double_stream_mod_txt,
@@ -797,6 +842,10 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
             position_ids,
             num_txt_tokens,
         )
+
+    def _forward_postamble(self, hidden_states: Tensor, temb: Tensor) -> Tensor:
+        """Final norm and projection after the transformer backbone."""
+        return self.proj_out(self.norm_out(hidden_states, temb))
 
     def _forward_standard(
         self,
@@ -809,9 +858,8 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
     ) -> tuple[Tensor]:
         """Standard forward pass (no step-cache)."""
         (
-            _hidden_states,
-            first_hidden_states,
-            first_encoder_hidden_states,
+            projected,
+            encoder_hidden_states,
             temb,
             double_stream_mod_img,
             double_stream_mod_txt,
@@ -827,10 +875,17 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
             txt_ids,
             guidance,
         )
-        output = self._run_remaining_blocks(
-            first_hidden_states,
-            first_encoder_hidden_states,
-            temb,
+        first_encoder, first_hidden = self._run_first_block(
+            projected,
+            encoder_hidden_states,
+            double_stream_mod_img,
+            double_stream_mod_txt,
+            image_rotary_emb,
+            position_ids,
+        )
+        image_hidden = self._run_remaining_blocks(
+            first_hidden,
+            first_encoder,
             double_stream_mod_img,
             double_stream_mod_txt,
             single_stream_mod,
@@ -838,9 +893,9 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
             position_ids,
             num_txt_tokens,
         )
-        return (output,)
+        return (self._forward_postamble(image_hidden, temb),)
 
-    def _forward_step_cache(
+    def _forward_fbcache(
         self,
         hidden_states: Tensor,
         encoder_hidden_states: Tensor,
@@ -854,8 +909,7 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
         """Step-cache forward pass with F.cond branching for cache reuse."""
         (
             projected_hidden_states,
-            first_hidden_states,
-            first_encoder_hidden_states,
+            encoder_hidden_states,
             temb,
             double_stream_mod_img,
             double_stream_mod_txt,
@@ -872,7 +926,15 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
             guidance,
         )
 
-        first_block_residual = first_hidden_states - projected_hidden_states
+        first_encoder, first_hidden = self._run_first_block(
+            projected_hidden_states,
+            encoder_hidden_states,
+            double_stream_mod_img,
+            double_stream_mod_txt,
+            image_rotary_emb,
+            position_ids,
+        )
+        first_block_residual = first_hidden - projected_hidden_states
 
         return fbcache_conditional_execution(
             first_block_residual,
@@ -881,9 +943,8 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
             self._rdt_value,
             self._run_remaining_blocks,
             dict(
-                hidden_states=first_hidden_states,
-                encoder_hidden_states=first_encoder_hidden_states,
-                temb=temb,
+                hidden_states=first_hidden,
+                encoder_hidden_states=first_encoder,
                 double_stream_mod_img=double_stream_mod_img,
                 double_stream_mod_txt=double_stream_mod_txt,
                 single_stream_mod=single_stream_mod,
@@ -891,7 +952,85 @@ class Flux2Transformer2DModel(Module[..., Sequence[Tensor]]):
                 position_ids=position_ids,
                 num_txt_tokens=num_txt_tokens,
             ),
+            self._forward_postamble,
+            temb,
             self._fbcache_conditional_execution_output_types(),
+        )
+
+    def _forward_teacache(
+        self,
+        hidden_states: Tensor,
+        encoder_hidden_states: Tensor,
+        timestep: Tensor,
+        img_ids: Tensor,
+        txt_ids: Tensor,
+        guidance: Tensor,
+        prev_modulated_input: Tensor,
+        prev_residual: Tensor,
+        accumulated_rel_l1: Tensor,
+        force_compute: Tensor,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        """TeaCache forward pass: skip decision gates the entire DiT backbone."""
+        (
+            projected_hidden_states,
+            encoder_hidden_states,
+            temb,
+            double_stream_mod_img,
+            double_stream_mod_txt,
+            single_stream_mod,
+            image_rotary_emb,
+            position_ids,
+            num_txt_tokens,
+        ) = self._forward_preamble(
+            hidden_states,
+            encoder_hidden_states,
+            timestep,
+            img_ids,
+            txt_ids,
+            guidance,
+        )
+
+        modulated_input = self._teacache_modulated_input(
+            projected_hidden_states,
+            double_stream_mod_img,
+        )
+
+        delta = teacache_rescaled_delta(
+            modulated_input,
+            prev_modulated_input,
+            self._teacache_coefficients,
+        )
+        next_accumulated = accumulated_rel_l1 + delta
+
+        return teacache_conditional_execution(
+            modulated_input=modulated_input,
+            next_accumulated=next_accumulated,
+            accumulated_rel_l1=accumulated_rel_l1,
+            force_compute=force_compute,
+            rel_l1_thresh=self._teacache_rel_l1_thresh,
+            projected_hidden_states=projected_hidden_states,
+            prev_residual=prev_residual,
+            temb=temb,
+            run_first_block=self._run_first_block,
+            first_block_kwargs=dict(
+                hidden_states=projected_hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                double_stream_mod_img=double_stream_mod_img,
+                double_stream_mod_txt=double_stream_mod_txt,
+                image_rotary_emb=image_rotary_emb,
+                position_ids=position_ids,
+            ),
+            run_remaining_blocks=self._run_remaining_blocks,
+            remaining_blocks_kwargs=dict(
+                double_stream_mod_img=double_stream_mod_img,
+                double_stream_mod_txt=double_stream_mod_txt,
+                single_stream_mod=single_stream_mod,
+                image_rotary_emb=image_rotary_emb,
+                position_ids=position_ids,
+                num_txt_tokens=num_txt_tokens,
+            ),
+            run_postamble=self._forward_postamble,
+            output_types=self._teacache_output_types(),
         )
 
     def forward(self, *args: Tensor) -> tuple[Tensor, ...]:

--- a/max/python/max/pipelines/architectures/flux2_modulev3/model.py
+++ b/max/python/max/pipelines/architectures/flux2_modulev3/model.py
@@ -155,6 +155,10 @@ class Flux2TransformerModel(ComponentModel):
         guidance: Tensor,
         prev_residual: Tensor | None = None,
         prev_output: Tensor | None = None,
+        teacache_prev_modulated_input: Tensor | None = None,
+        teacache_cached_residual: Tensor | None = None,
+        teacache_accumulated_rel_l1: Tensor | None = None,
+        force_compute: Tensor | None = None,
     ) -> Any:
         args: tuple[Any, ...] = (
             hidden_states,
@@ -164,6 +168,14 @@ class Flux2TransformerModel(ComponentModel):
             txt_ids,
             guidance,
         )
-        if prev_residual is not None:
+        if teacache_prev_modulated_input is not None:
+            args = (
+                *args,
+                teacache_prev_modulated_input,
+                teacache_cached_residual,
+                teacache_accumulated_rel_l1,
+                force_compute,
+            )
+        elif prev_residual is not None:
             args = (*args, prev_residual, prev_output)
         return self.model(*args)

--- a/max/python/max/pipelines/architectures/flux2_modulev3/pipeline_flux2.py
+++ b/max/python/max/pipelines/architectures/flux2_modulev3/pipeline_flux2.py
@@ -698,16 +698,29 @@ class Flux2Pipeline(DiffusionPipeline):
         cache_state: DenoisingCacheState,
         **kwargs: Any,
     ) -> tuple[Tensor, ...]:
-        return self.transformer(
+        base_args = (
             kwargs["latents"],
             kwargs["prompt_embeds"],
             kwargs["timestep"],
             kwargs["latent_image_ids"],
             kwargs["text_ids"],
             kwargs["guidance"],
-            prev_residual=cache_state.prev_residual,
-            prev_output=cache_state.prev_output,
         )
+        if self.cache_config.teacache:
+            return self.transformer(
+                *base_args,
+                teacache_prev_modulated_input=cache_state.teacache_prev_modulated_input,
+                teacache_cached_residual=cache_state.teacache_cached_residual,
+                teacache_accumulated_rel_l1=cache_state.teacache_accumulated_rel_l1,
+                force_compute=kwargs["force_compute"],
+            )
+        if self.cache_config.first_block_caching:
+            return self.transformer(
+                *base_args,
+                prev_residual=cache_state.prev_residual,
+                prev_output=cache_state.prev_output,
+            )
+        return self.transformer(*base_args)
 
     @traced(message="Flux2Pipeline.execute")
     def execute(  # type: ignore[override]
@@ -765,7 +778,10 @@ class Flux2Pipeline(DiffusionPipeline):
         if image_latents is not None:
             seq_len_for_cache += int(image_latents.shape[1])
         cache = self.create_cache_state(
-            batch_size, seq_len_for_cache, self.transformer.config
+            batch_size,
+            seq_len_for_cache,
+            self.transformer.config,
+            text_seq_len=int(prompt_embeds.shape[1]),
         )
 
         with Tracer("denoising_loop"):
@@ -789,16 +805,32 @@ class Flux2Pipeline(DiffusionPipeline):
                         latents_concat = latents
                         latent_image_ids_concat = latent_image_ids
 
-                    noise_pred = self.run_denoising_step(
-                        step=i,
-                        cache_state=cache,
-                        device=device,
+                    step_kwargs: dict[str, Any] = dict(
                         latents=latents_concat,
                         prompt_embeds=prompt_embeds,
                         timestep=timestep,
                         latent_image_ids=latent_image_ids_concat,
                         text_ids=text_ids,
                         guidance=guidance,
+                    )
+                    if self.cache_config.teacache:
+                        step_kwargs["force_compute"] = Tensor(
+                            storage=Buffer.from_dlpack(
+                                np.array(
+                                    [
+                                        i == 0
+                                        or i
+                                        == model_inputs.num_inference_steps - 1
+                                    ],
+                                    dtype=bool,
+                                )
+                            ).to(device)
+                        )
+                    noise_pred = self.run_denoising_step(
+                        step=i,
+                        cache_state=cache,
+                        device=device,
+                        **step_kwargs,
                     )
 
                     with Tracer("scheduler_step"):

--- a/max/python/max/pipelines/lib/interfaces/__init__.py
+++ b/max/python/max/pipelines/lib/interfaces/__init__.py
@@ -21,6 +21,7 @@ from .cache_mixin import (
     DenoisingCacheConfig,
     DenoisingCacheState,
     fbcache_conditional_execution,
+    teacache_conditional_execution,
 )
 from .component_model import ComponentModel
 from .diffusion_pipeline import DiffusionPipeline, PixelModelInputs
@@ -50,4 +51,5 @@ __all__ = [
     "PixelModelInputs",
     "fbcache_conditional_execution",
     "get_paged_manager",
+    "teacache_conditional_execution",
 ]

--- a/max/python/max/pipelines/lib/interfaces/cache_mixin.py
+++ b/max/python/max/pipelines/lib/interfaces/cache_mixin.py
@@ -24,7 +24,7 @@ from max.dtype import DType
 from max.experimental import functional as F
 from max.experimental.tensor import Tensor
 from max.graph import TensorType, TensorValue
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, model_validator
 
 
 class DenoisingCacheConfig(ConfigFileModel):
@@ -88,6 +88,73 @@ class DenoisingCacheConfig(ConfigFileModel):
         ),
     )
 
+    teacache: bool = Field(
+        default=False,
+        description=(
+            "Enable TeaCache cache optimization. Uses the timestep-aware "
+            "modulated input change to decide when the FLUX.2 transformer "
+            "backbone can be skipped."
+        ),
+    )
+
+    teacache_rel_l1_thresh: float | None = Field(
+        default=None,
+        description=(
+            "Relative-L1 threshold used by TeaCache. "
+            "None uses the model-specific default."
+        ),
+    )
+
+    teacache_coefficients: list[float] | None = Field(
+        default=None,
+        description=(
+            "Polynomial coefficients used to rescale TeaCache's relative-L1 "
+            "metric. None uses the model-specific default coefficients."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_cache_mode(self) -> DenoisingCacheConfig:
+        if (
+            self.residual_threshold is not None
+            and self.residual_threshold < 0.0
+        ):
+            raise ValueError("residual_threshold must be non-negative.")
+        if (
+            self.taylorseer_cache_interval is not None
+            and self.taylorseer_cache_interval < 1
+        ):
+            raise ValueError("taylorseer_cache_interval must be >= 1.")
+        if (
+            self.taylorseer_warmup_steps is not None
+            and self.taylorseer_warmup_steps < 1
+        ):
+            raise ValueError("taylorseer_warmup_steps must be >= 1.")
+        if self.taylorseer_max_order is not None and (
+            self.taylorseer_max_order not in (1, 2)
+        ):
+            raise ValueError("taylorseer_max_order must be 1 or 2.")
+        if self.teacache and self.first_block_caching:
+            raise ValueError(
+                "TeaCache cannot be enabled together with first_block_caching."
+            )
+        if self.teacache and self.taylorseer:
+            raise ValueError(
+                "TeaCache cannot be enabled together with taylorseer."
+            )
+        if (
+            self.teacache_rel_l1_thresh is not None
+            and self.teacache_rel_l1_thresh < 0.0
+        ):
+            raise ValueError("teacache_rel_l1_thresh must be non-negative.")
+        if self.teacache_coefficients is not None and (
+            len(self.teacache_coefficients) < 1
+        ):
+            raise ValueError(
+                "teacache_coefficients must contain at least 1 coefficient."
+            )
+        return self
+
 
 @dataclass
 class DenoisingCacheState:
@@ -107,6 +174,11 @@ class DenoisingCacheState:
     taylor_factor_2: Tensor | None = None
     taylor_last_compute_step: int | None = None
 
+    # TeaCache state
+    teacache_prev_modulated_input: Tensor | None = None
+    teacache_cached_residual: Tensor | None = None
+    teacache_accumulated_rel_l1: Tensor | None = None
+
 
 def fbcache_conditional_execution(
     first_block_residual: Tensor,
@@ -115,31 +187,21 @@ def fbcache_conditional_execution(
     rdt_value: float,
     run_remaining_blocks: Callable[..., Tensor],
     run_remaining_kwargs: dict[str, Any],
+    run_postamble: Callable[[Tensor, Tensor], Tensor],
+    temb: Tensor,
     output_types: list[TensorType],
 ) -> tuple[Tensor, Tensor]:
     """Handle FBCache F.cond branching pattern shared across DiT models.
 
-    This is only called from the step-cache graph path (where step-cache is
-    always enabled), so there is no outer ``F.cond`` on a cache-enabled flag.
-    The single ``F.cond`` checks the RDT (relative difference threshold) to
-    decide whether to reuse the cached output or run the remaining blocks.
-
-    The caller provides:
-    - first_block_residual: computed as ``new_hidden_states - hidden_states``
-      after running the first transformer block.
-    - rdt_value: the relative difference threshold as a Python float.
-    - run_remaining_blocks: model-specific callable that runs remaining
-      blocks + norm + proj.  Called with ``**run_remaining_kwargs`` and must
-      return a single output ``Tensor``.
-    - run_remaining_kwargs: keyword arguments forwarded to
-      *run_remaining_blocks*.
-    - output_types: ``[residual_type, output_type]`` passed directly to
-      ``F.cond``.
+    The caller provides atomic DiT methods:
+    - *run_remaining_blocks*: runs blocks 1..N + single-stream blocks,
+      returns pre-tail hidden states.
+    - *run_postamble*: applies final norm + projection.
 
     Returns:
         (first_block_residual, output) tensors.
     """
-    use_step_cache = can_use_step_cache(
+    use_fbcache = can_use_fbcache(
         first_block_residual, prev_residual, rdt_value
     )
 
@@ -155,11 +217,12 @@ def fbcache_conditional_execution(
     def else_fn(
         _fbr: Tensor = first_block_residual,
     ) -> tuple[TensorValue, TensorValue]:
-        out = run_remaining_blocks(**run_remaining_kwargs)
+        hidden_states = run_remaining_blocks(**run_remaining_kwargs)
+        out = run_postamble(hidden_states, temb)
         return (TensorValue(_fbr), TensorValue(out))
 
     result = F.cond(
-        use_step_cache,
+        use_fbcache,
         output_types,
         then_fn,
         else_fn,
@@ -167,7 +230,7 @@ def fbcache_conditional_execution(
     return (result[0], result[1])
 
 
-def can_use_step_cache(
+def can_use_fbcache(
     intermediate_residual: Tensor,
     prev_intermediate_residual: Tensor | None,
     rdt_value: float,
@@ -191,3 +254,122 @@ def can_use_step_cache(
     rdt = F.constant(rdt_value, relative_diff.dtype, device=dev)
     pred = relative_diff < rdt
     return F.squeeze(pred, 0)
+
+
+def teacache_rescaled_delta(
+    modulated_input: Tensor,
+    prev_modulated_input: Tensor,
+    coefficients: tuple[float, ...],
+) -> Tensor:
+    """Compute the polynomial-rescaled relative-L1 delta for TeaCache.
+
+    Uses Horner's method to evaluate the polynomial defined by *coefficients*
+    (descending degree order, matching ``np.poly1d`` convention) on the
+    relative-L1 distance between consecutive modulated inputs.
+
+    Args:
+        modulated_input: Current timestep-modulated hidden states.
+        prev_modulated_input: Previous step's modulated hidden states.
+        coefficients: Polynomial coefficients in descending degree order.
+
+    Returns:
+        Scalar float32 tensor (shape ``[1]``) with the rescaled delta.
+    """
+    mean_diff_rows = F.mean(
+        F.abs(modulated_input - prev_modulated_input), axis=-1
+    )
+    mean_prev_rows = F.mean(F.abs(prev_modulated_input), axis=-1)
+    mean_diff = F.mean(mean_diff_rows, axis=None)
+    mean_prev = F.mean(mean_prev_rows, axis=None)
+    eps = F.constant(1e-9, mean_diff.dtype, device=mean_diff.device)
+    relative_diff = mean_diff / (mean_prev + eps)
+    relative_diff_f32 = F.cast(relative_diff, DType.float32)
+
+    # Horner's method: ((((c0 * x + c1) * x + c2) * x + c3) * x + c4)
+    x = F.constant(coefficients[0], DType.float32, device=relative_diff.device)
+    for coeff in coefficients[1:]:
+        coeff_tensor = F.constant(coeff, DType.float32, device=x.device)
+        x = x * relative_diff_f32 + coeff_tensor
+    return F.reshape(x, [1])
+
+
+def teacache_conditional_execution(
+    modulated_input: Tensor,
+    next_accumulated: Tensor,
+    accumulated_rel_l1: Tensor,
+    force_compute: Tensor,
+    rel_l1_thresh: float,
+    projected_hidden_states: Tensor,
+    prev_residual: Tensor,
+    temb: Tensor,
+    run_first_block: Callable[..., tuple[Tensor, Tensor]],
+    first_block_kwargs: dict[str, Any],
+    run_remaining_blocks: Callable[..., Tensor],
+    remaining_blocks_kwargs: dict[str, Any],
+    run_postamble: Callable[[Tensor, Tensor], Tensor],
+    output_types: list[TensorType],
+) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    """Handle TeaCache F.cond branching pattern shared across DiT models.
+
+    Parallel to ``fbcache_conditional_execution``: the shared utility
+    constructs the then/else closures internally.
+
+    Args:
+        modulated_input: Current step's timestep-modulated proxy signal.
+        next_accumulated: Accumulated rescaled delta including this step.
+        accumulated_rel_l1: Accumulated rescaled delta before this step
+            (used to produce the zero-reset value on compute steps).
+        force_compute: Scalar bool tensor.  When True (first/last step),
+            the transformer always runs regardless of the accumulated delta.
+        rel_l1_thresh: Threshold for skipping; skip when accumulated < thresh.
+        projected_hidden_states: Output of ``x_embedder`` (pre-block input).
+        prev_residual: Cached residual from the last compute step.
+        temb: Timestep embedding for the current step.
+        run_first_block: Runs dual-stream block 0, returns
+            ``(encoder_hidden, image_hidden)``.
+        first_block_kwargs: Keyword arguments forwarded to *run_first_block*.
+        run_remaining_blocks: Runs dual-stream blocks 1..N + single-stream
+            blocks, returns pre-postamble image hidden states.
+        remaining_blocks_kwargs: Keyword arguments forwarded to
+            *run_remaining_blocks* (excluding ``hidden_states`` and
+            ``encoder_hidden_states``, which come from *run_first_block*).
+        run_postamble: Applies final norm + projection,
+            ``(hidden_states, temb) -> output``.
+        output_types: Tensor types for ``F.cond`` output specification.
+
+    Returns:
+        ``(modulated_input, residual_or_prev, accumulated_rel_l1, output)``
+    """
+    thresh = F.constant(
+        rel_l1_thresh, DType.float32, device=next_accumulated.device
+    )
+    should_skip = F.squeeze(~force_compute & (next_accumulated < thresh), 0)
+
+    def then_fn() -> tuple[TensorValue, TensorValue, TensorValue, TensorValue]:
+        output = run_postamble(projected_hidden_states + prev_residual, temb)
+        return (
+            TensorValue(modulated_input),
+            TensorValue(prev_residual),
+            TensorValue(next_accumulated),
+            TensorValue(output),
+        )
+
+    def else_fn() -> tuple[TensorValue, TensorValue, TensorValue, TensorValue]:
+        first_encoder, first_hidden = run_first_block(**first_block_kwargs)
+        hidden_states = run_remaining_blocks(
+            hidden_states=first_hidden,
+            encoder_hidden_states=first_encoder,
+            **remaining_blocks_kwargs,
+        )
+        residual = hidden_states - projected_hidden_states
+        output = run_postamble(hidden_states, temb)
+        zero_accumulated = accumulated_rel_l1 - accumulated_rel_l1
+        return (
+            TensorValue(modulated_input),
+            TensorValue(residual),
+            TensorValue(zero_accumulated),
+            TensorValue(output),
+        )
+
+    result = F.cond(should_skip, output_types, then_fn, else_fn)
+    return (result[0], result[1], result[2], result[3])

--- a/max/python/max/pipelines/lib/interfaces/diffusion_pipeline.py
+++ b/max/python/max/pipelines/lib/interfaces/diffusion_pipeline.py
@@ -99,6 +99,22 @@ class DiffusionPipeline(ABC):
     Used when ``DenoisingCacheConfig.taylorseer_max_order`` is ``None``.
     """
 
+    default_teacache_rel_l1_thresh: float = 0.4
+    """Model-specific default for the TeaCache relative-L1 threshold.
+
+    Subclasses may override this to provide a model-appropriate default.
+    Used when ``DenoisingCacheConfig.teacache_rel_l1_thresh`` is ``None``.
+    """
+
+    default_teacache_coefficients: tuple[float, ...] = (
+        4.98651651e02,
+        -2.83781631e02,
+        5.58554382e01,
+        -3.82021401e00,
+        2.64230861e-01,
+    )
+    """Default TeaCache polynomial coefficients for FLUX-style rescaling."""
+
     def __init__(
         self,
         pipeline_config: PipelineConfig,
@@ -142,6 +158,10 @@ class DiffusionPipeline(ABC):
             cc.taylorseer_warmup_steps = self.default_taylorseer_warmup_steps
         if cc.taylorseer_max_order is None:
             cc.taylorseer_max_order = self.default_taylorseer_max_order
+        if cc.teacache_rel_l1_thresh is None:
+            cc.teacache_rel_l1_thresh = self.default_teacache_rel_l1_thresh
+        if cc.teacache_coefficients is None:
+            cc.teacache_coefficients = list(self.default_teacache_coefficients)
 
     @abstractmethod
     def init_remaining_components(self) -> None:
@@ -338,6 +358,7 @@ class DiffusionPipeline(ABC):
         batch_size: int,
         seq_len: int,
         transformer_config: Any,
+        text_seq_len: int = 0,
     ) -> DenoisingCacheState:
         """Create per-request cache state with fresh tensors.
 
@@ -347,6 +368,8 @@ class DiffusionPipeline(ABC):
             transformer_config: Transformer config carrying dimension info.
                 Must have ``num_attention_heads``, ``attention_head_dim``,
                 ``patch_size``, ``out_channels``, and ``in_channels`` attributes.
+            text_seq_len: Text sequence length. Reserved for cache modes that
+                require text-aware allocations.
         """
         from .cache_mixin import DenoisingCacheState
 
@@ -400,6 +423,19 @@ class DiffusionPipeline(ABC):
                     attr,
                     _device_zeros((batch_size, seq_len, output_dim)),
                 )
+
+        if self.cache_config.teacache:
+            state.teacache_prev_modulated_input = _device_zeros(
+                (batch_size, seq_len, residual_dim)
+            )
+            state.teacache_cached_residual = _device_zeros(
+                (batch_size, seq_len, residual_dim)
+            )
+            state.teacache_accumulated_rel_l1 = Tensor(
+                storage=Buffer.from_dlpack(
+                    np.array([0.0], dtype=np.float32)
+                ).to(self._cache_device)
+            )
 
         return state
 
@@ -585,7 +621,14 @@ class DiffusionPipeline(ABC):
 
         # 4. Full compute path
         result = self.run_transformer(cache_state, **kwargs)
-        if cache_config.first_block_caching:
+        if cache_config.teacache:
+            (
+                cache_state.teacache_prev_modulated_input,
+                cache_state.teacache_cached_residual,
+                cache_state.teacache_accumulated_rel_l1,
+                noise_pred,
+            ) = result
+        elif cache_config.first_block_caching:
             new_residual, noise_pred = result
             cache_state.prev_residual = new_residual
             cache_state.prev_output = noise_pred


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Please fill out the sections below to help reviewers understand your change.
For guidance on writing a good PR, see our
[contributor guide](../CONTRIBUTING.md).
-->

# Add TeaCache support for Diffusion pipeline

## Summary

This PR adds [TeaCache](https://arxiv.org/abs/2411.19108) (Timestep Embedding Aware Cache) support to the FLUX.2 and FLUX.1 pipelines. TeaCache is a training-free inference acceleration method that dynamically decides — at each denoising step — whether to reuse a cached residual from a previous step or recompute the entire transformer backbone, based on a polynomial-rescaled L1 distance between consecutive timestep-modulated hidden states.

### How it works

1. **Probe**: At each step, compute the timestep-modulated input (norm + modulation applied to the projected hidden states) — this is cheap (no transformer blocks).
2. **Delta**: Compute the relative L1 distance between the current and previous modulated inputs, rescaled by a fitted polynomial (Horner's method, coefficients from the reference implementation).
3. **Decide**: Accumulate the rescaled delta. If the accumulated value exceeds a threshold, run the full transformer and reset the accumulator. Otherwise, skip the transformer and reuse the cached residual. First and last steps always compute.
4. **Skip path**: Add the cached residual to the projected hidden states, then apply `norm_out` + `proj_out` with the current step's `temb`.
5. **Compute path**: Run all transformer blocks, compute `residual = pre_tail_hidden - projected`, cache it, then apply `norm_out` + `proj_out`.

### Architecture

The DiT forward is decomposed into four atomic methods with mutually exclusive execution paths:

| Method | Responsibility |
|---|---|
| `_forward_preamble` | Embeddings, modulation, projection, RoPE |
| `_run_first_block` | Dual-stream transformer block 0 |
| `_run_remaining_blocks` | Dual-stream blocks 1..N + single-stream blocks (pre-tail) |
| `_forward_postamble` | Final norm + projection |

Each forward path composes them differently:

- **Standard**: preamble → first_block → remaining_blocks → postamble
- **FBCache**: preamble → first_block → `fbcache_conditional_execution(remaining_blocks, postamble)`
- **TeaCache**: preamble → `teacache_conditional_execution(first_block, remaining_blocks, postamble)`

## Results

**Setup**: FLUX.2-dev, 1024x1024, 50 denoising steps on **H200**.

| | E2E latency (ms) | Speedup |
|---|---|---|
| **Without TeaCache** | 22,203 | 1.00x |
| **With TeaCache** (threshold=0.4) | 9,035 | **2.45x** |
| **With TeaCache** (threshold=0.6) | 6,827 | **3.25x** |

### Output comparison

<table>
<tr>
<th width="33%">Without TeaCache</th>
<th width="33%">With TeaCache(0.4)</th>
<th width="33%">With TeaCache(0.6)</th>
</tr>
<tr>
<td><img width="100%" alt="baseline" src="https://github.com/user-attachments/assets/d5b59ea8-9498-4d76-a63f-661d9f027f6f" /></td>
<td><img width="100%" alt="teacache_0.4" src="https://github.com/user-attachments/assets/5cf26090-88b3-4134-861d-dc4def10a525" /></td>
<td><img width="100%" alt="teacache_0.6" src="https://github.com/user-attachments/assets/8271b049-0c99-4872-ad84-c38afd6c115f" /></td>
</tr>
</table>

## Testing

```bash
# Basic usage (default threshold=0.4, Flux polynomial coefficients)
./bazelw run //max/examples/diffusion:simple_offline_generation -- \
  --model black-forest-labs/FLUX.2-dev \
  --prompt "dog dancing near the sun" \
  --num-inference-steps 50 \
  --prefer-module-v3 \
  --teacache

# Custom threshold (higher = more aggressive caching)
  --teacache --teacache-rel-l1-thresh 0.6
```

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))

`Assisted-by: Claude`