### PR TITLE
[MAX] Add Z-Image Verification Support

### DIFF
--- a/max/python/max/interfaces/pipeline_variants/pixel_generation.py
+++ b/max/python/max/interfaces/pipeline_variants/pixel_generation.py
@@ -124,8 +124,43 @@ class PixelGenerationContext(BaseContext, Protocol):
         ...
 
     @property
+    def mask(self) -> npt.NDArray[np.bool_] | None:
+        """Optional attention mask for the primary text encoder."""
+        ...
+
+    @property
+    def negative_tokens(self) -> TokenBuffer | None:
+        """Optional negative prompt tokens for CFG-style conditioning."""
+        ...
+
+    @property
+    def negative_mask(self) -> npt.NDArray[np.bool_] | None:
+        """Optional attention mask for the negative text encoder path."""
+        ...
+
+    @property
+    def explicit_negative_prompt(self) -> bool:
+        """Whether the request explicitly supplied a negative prompt."""
+        ...
+
+    @property
     def latents(self) -> npt.NDArray[np.float32]:
         """The latents for the context."""
+        ...
+
+    @property
+    def timesteps(self) -> npt.NDArray[np.float32]:
+        """The denoising timestep schedule for the context."""
+        ...
+
+    @property
+    def sigmas(self) -> npt.NDArray[np.float32]:
+        """The denoising sigma schedule for the context."""
+        ...
+
+    @property
+    def latent_image_ids(self) -> npt.NDArray[np.float32]:
+        """Optional latent image IDs / positional identifiers."""
         ...
 
     @property
@@ -151,6 +186,11 @@ class PixelGenerationContext(BaseContext, Protocol):
     @property
     def num_images_per_prompt(self) -> int:
         """Number of images to generate."""
+        ...
+
+    @property
+    def input_image(self) -> npt.NDArray[np.uint8] | None:
+        """Optional input image for image-to-image generation."""
         ...
 
 

--- a/max/python/max/support/networked_data.py
+++ b/max/python/max/support/networked_data.py
@@ -25,16 +25,6 @@ def fetch_bytes_from_s3(s3_path: str) -> bytes:
         ImportError: If boto3 is not installed. Install with `pip install boto3`
             or use the benchmark extras: `pip install max[benchmark]`
     """
-    import io
-
-    try:
-        import boto3  # type: ignore[import-not-found]
-    except ImportError as e:
-        raise ImportError(
-            "boto3 is required for S3 operations. "
-            "Install it with `pip install boto3` or use `pip install max[benchmark]`"
-        ) from e
-
     if not s3_path.startswith("s3://"):
         raise ValueError(f"Invalid S3 path: {s3_path}")
 
@@ -43,9 +33,41 @@ def fetch_bytes_from_s3(s3_path: str) -> bytes:
     if len(path_parts) != 2:
         raise ValueError(f"Invalid S3 path format: {s3_path}")
 
-    bucket, key = path_parts
-    s3 = boto3.client("s3")
+    import io
 
-    buffer = io.BytesIO()
-    s3.download_fileobj(bucket, key, buffer)
-    return buffer.getvalue()
+    try:
+        import boto3  # type: ignore[import-not-found]
+        from botocore import UNSIGNED  # type: ignore[import-not-found]
+        from botocore.client import Config  # type: ignore[import-not-found]
+        from botocore.exceptions import (  # type: ignore[import-not-found]
+            NoCredentialsError,
+            SSOTokenLoadError,
+            UnauthorizedSSOTokenError,
+        )
+    except ImportError as e:
+        raise ImportError(
+            "boto3 is required for S3 operations. "
+            "Install it with `pip install boto3` or use `pip install max[benchmark]`"
+        ) from e
+
+    bucket, key = path_parts
+
+    def _download_bytes(*, anonymous: bool = False) -> bytes:
+        buffer = io.BytesIO()
+        client_kwargs = (
+            {"config": Config(signature_version=UNSIGNED)} if anonymous else {}
+        )
+        s3 = boto3.client("s3", **client_kwargs)
+        s3.download_fileobj(bucket, key, buffer)
+        return buffer.getvalue()
+
+    try:
+        return _download_bytes()
+    except (
+        NoCredentialsError,
+        SSOTokenLoadError,
+        UnauthorizedSSOTokenError,
+    ):
+        # Public test artifacts are readable without credentials; fall back to
+        # unsigned requests when the local AWS credential chain is unavailable.
+        return _download_bytes(anonymous=True)

--- a/max/tests/integration/accuracy/logit_verification/logit_verification_config.yaml
+++ b/max/tests/integration/accuracy/logit_verification/logit_verification_config.yaml
@@ -947,3 +947,44 @@ logit_verification_pipelines:
     ssim_threshold: 0.60
     lpips_threshold: 0.35
     timeout: 3600
+
+  Tongyi-MAI/Z-Image-t2i-bfloat16:
+    pre_submit_agents: []
+    post_submit_agents: []
+    pipeline: "Tongyi-MAI/Z-Image-t2i"
+    compatible_with: [gpu]
+    encoding: bfloat16
+    tags: [nvidia-only, image-generation, manual]
+    ssim_threshold: 0.60
+    lpips_threshold: 0.35
+
+  Tongyi-MAI/Z-Image-negative-prompt-t2i-bfloat16:
+    pre_submit_agents: []
+    post_submit_agents: []
+    pipeline: "Tongyi-MAI/Z-Image-negative-prompt-t2i"
+    compatible_with: [gpu]
+    encoding: bfloat16
+    tags: [nvidia-only, image-generation, manual]
+    ssim_threshold: 0.60
+    lpips_threshold: 0.35
+
+  Tongyi-MAI/Z-Image-Turbo-t2i-bfloat16:
+    pre_submit_agents: []
+    post_submit_agents: []
+    pipeline: "Tongyi-MAI/Z-Image-Turbo-t2i"
+    compatible_with: [gpu]
+    encoding: bfloat16
+    tags: [nvidia-only, image-generation, manual]
+    ssim_threshold: 0.60
+    lpips_threshold: 0.35
+
+  Tongyi-MAI/Z-Image-i2i-bfloat16:
+    pre_submit_agents: []
+    post_submit_agents: []
+    pipeline: "Tongyi-MAI/Z-Image-i2i"
+    compatible_with: [gpu]
+    encoding: bfloat16
+    tags: [nvidia-only, image-generation, manual]
+    ssim_threshold: 0.60
+    lpips_threshold: 0.35
+    timeout: 3600

--- a/max/tests/integration/test_common/test_data.py
+++ b/max/tests/integration/test_common/test_data.py
@@ -176,6 +176,9 @@ class MockPixelGenerationRequest:
     input_image: str | None = None
     """Optional input image URI for image-to-image generation."""
 
+    strength: float | None = None
+    """img2img strength in (0, 1]. When None, API defaults (0.6) apply."""
+
     model_name: str = ""
     """Model name for the request."""
 
@@ -194,6 +197,7 @@ class MockPixelGenerationRequest:
         true_cfg_scale: float = 1.0,
         seed: int | None = None,
         input_image: str | None = None,
+        strength: float | None = None,
         model_name: str = "",
     ) -> MockPixelGenerationRequest:
         """Creates a pixel generation request from a prompt."""
@@ -209,6 +213,7 @@ class MockPixelGenerationRequest:
             true_cfg_scale=true_cfg_scale,
             seed=seed,
             input_image=input_image,
+            strength=strength,
             model_name=model_name,
         )
 
@@ -230,6 +235,9 @@ class MockPixelGenerationRequest:
                     steps=self.num_inference_steps,
                     guidance_scale=self.guidance_scale,
                     true_cfg_scale=self.true_cfg_scale,
+                    strength=(
+                        self.strength if self.strength is not None else 0.6
+                    ),
                 )
             ),
         )
@@ -365,6 +373,51 @@ DEFAULT_PIXEL_GENERATION = [
     for prompt in DEFAULT_PIXEL_GENERATION_PROMPTS
 ]
 
+# Tongyi-MAI/Z-Image (base): align torch reference with diffusers / ZImageModelInputs
+# defaults (guidance_scale=5.0, 50 steps).
+DEFAULT_Z_IMAGE_PIXEL_GENERATION = [
+    MockPixelGenerationRequest.from_prompt(
+        prompt=prompt, seed=42, guidance_scale=5.0
+    )
+    for prompt in DEFAULT_PIXEL_GENERATION_PROMPTS
+]
+
+# Z-Image-Turbo (distilled): few steps, no CFG — matches diffusers Turbo examples
+# (guidance_scale=0) and MAX (CFG only when guidance_scale > 1).
+DEFAULT_Z_IMAGE_TURBO_PIXEL_GENERATION = [
+    MockPixelGenerationRequest.from_prompt(
+        prompt=prompt,
+        seed=42,
+        num_inference_steps=8,
+        guidance_scale=0.0,
+    )
+    for prompt in DEFAULT_PIXEL_GENERATION_PROMPTS
+]
+
+# Z-Image base: keep the existing 5 prompts/settings, but add tailored
+# negative prompts so we can verify negative_prompt parity independently.
+DEFAULT_Z_IMAGE_NEGATIVE_PROMPTS = [
+    "blurry, low quality, cartoon, duplicate panther, extra limbs, distorted animal anatomy, oversaturated, text, watermark",
+    "blurry, low quality, duplicate cow, extra legs, deformed anatomy, duplicate subject, watermark, oversaturated, distorted proportions",
+    "blurry, low quality, deformed hands, extra fingers, extra limbs, bad anatomy, distorted face, duplicate person, text, watermark",
+    "blurry, low quality, deformed face, extra limbs, bad anatomy, duplicate person, cropped, text, watermark",
+    "blurry, low quality, malformed text, misspelled words, wrong quadrants, duplicate labels, extra objects, watermark, cropped",
+]
+
+DEFAULT_Z_IMAGE_NEGATIVE_PROMPT_PIXEL_GENERATION = [
+    MockPixelGenerationRequest.from_prompt(
+        prompt=prompt,
+        seed=42,
+        guidance_scale=5.0,
+        negative_prompt=negative_prompt,
+    )
+    for prompt, negative_prompt in zip(
+        DEFAULT_PIXEL_GENERATION_PROMPTS,
+        DEFAULT_Z_IMAGE_NEGATIVE_PROMPTS,
+        strict=True,
+    )
+]
+
 # The prompt contains Kimi-specific media tokens for the vLLM path, which
 # uses it directly.  The messages are the clean (no special tokens) version
 # that the MAX tokenizer runs through the HuggingFace chat template.
@@ -406,5 +459,29 @@ FLUX2_PIXEL_GENERATION_I2I = [
         input_image=MULTIMODAL_IMAGE,
         height=1024,
         width=1024,
+    ),
+]
+
+# Tongyi-MAI/Z-Image img2img: same two i2i scenarios as FLUX.2-dev-i2i, with
+# Z-Image base CFG defaults (guidance_scale=5.0, 50 steps) and explicit strength
+# so MAX torch_utils agree on the flow-matching schedule trim.
+DEFAULT_Z_IMAGE_PIXEL_GENERATION_I2I = [
+    MockPixelGenerationRequest.from_prompt(
+        prompt="Transform this image into a cinematic nighttime scene with neon reflections, wet streets, and dramatic contrast.",
+        seed=42,
+        input_image=MULTIMODAL_IMAGE,
+        height=1024,
+        width=1024,
+        guidance_scale=5.0,
+        strength=0.6,
+    ),
+    MockPixelGenerationRequest.from_prompt(
+        prompt="Restyle this image as a watercolor painting with soft edges, visible brush texture, and warm afternoon light.",
+        seed=42,
+        input_image=MULTIMODAL_IMAGE,
+        height=1024,
+        width=1024,
+        guidance_scale=5.0,
+        strength=0.6,
     ),
 ]

--- a/max/tests/integration/test_common/torch_utils.py
+++ b/max/tests/integration/test_common/torch_utils.py
@@ -343,6 +343,128 @@ def _is_flux2_pipeline(pipeline: Any) -> bool:
     return config_class_name == "Flux2Pipeline"
 
 
+def _is_z_image_pipeline(pipeline: Any) -> bool:
+    """Detect diffusers Z-Image pipelines (latents are BCHW, full transformer.in_channels)."""
+    class_name = pipeline.__class__.__name__
+    if class_name in ("ZImagePipeline", "ZImageImg2ImgPipeline"):
+        return True
+
+    config = getattr(pipeline, "config", None)
+    if config is None:
+        return False
+
+    config_class_name = None
+    if isinstance(config, dict):
+        config_class_name = config.get("_class_name")
+    elif hasattr(config, "get"):
+        config_class_name = config.get("_class_name")
+    else:
+        config_class_name = getattr(config, "_class_name", None)
+
+    return config_class_name in ("ZImagePipeline", "ZImageImg2ImgPipeline")
+
+
+def _is_z_image_img2img_pipeline(pipeline: Any) -> bool:
+    """True when the torch reference is diffusers ``ZImageImg2ImgPipeline``."""
+    if pipeline.__class__.__name__ == "ZImageImg2ImgPipeline":
+        return True
+    config = getattr(pipeline, "config", None)
+    if config is None:
+        return False
+    if isinstance(config, dict):
+        return config.get("_class_name") == "ZImageImg2ImgPipeline"
+    if hasattr(config, "get"):
+        return config.get("_class_name") == "ZImageImg2ImgPipeline"
+    return getattr(config, "_class_name", None) == "ZImageImg2ImgPipeline"
+
+
+def _z_image_img2img_starting_latents(
+    pipeline: Any,
+    *,
+    input_image: Image.Image,
+    height: int,
+    width: int,
+    num_inference_steps: int,
+    strength: float,
+    seed: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Match MAX ``prepare_img2img_latents``: VAE mode + numpy noise + scheduler.scale_noise.
+
+    ``ZImageImg2ImgPipeline.prepare_latents`` skips image encoding when ``latents``
+    is passed; we precompute the same noisy latents diffusers would build so the
+    noise tensor matches ``_canonical_randn_tensor`` (and MAX).
+    """
+    from diffusers.pipelines.z_image.pipeline_z_image_img2img import (
+        calculate_shift,
+        retrieve_latents,
+        retrieve_timesteps,
+    )
+
+    vae_scale = int(pipeline.vae_scale_factor) * 2
+    if height % vae_scale != 0 or width % vae_scale != 0:
+        raise ValueError(
+            f"Height and width must be divisible by {vae_scale}; got {height}x{width}"
+        )
+
+    latent_height = 2 * (int(height) // (pipeline.vae_scale_factor * 2))
+    latent_width = 2 * (int(width) // (pipeline.vae_scale_factor * 2))
+    num_channels_latents = int(pipeline.transformer.config.in_channels)
+    image_seq_len = (latent_height // 2) * (latent_width // 2)
+
+    init_image = pipeline.image_processor.preprocess(
+        input_image,
+        height=height,
+        width=width,
+    )
+    init_image = init_image.to(device=device, dtype=torch.float32)
+
+    encode_dtype = next(pipeline.vae.parameters()).dtype
+    image_tensor = init_image.to(dtype=encode_dtype)
+    encoder_output = pipeline.vae.encode(image_tensor)
+    image_latents = retrieve_latents(
+        encoder_output, generator=None, sample_mode="argmax"
+    )
+    shift = float(getattr(pipeline.vae.config, "shift_factor", 0.0) or 0.0)
+    scale = float(pipeline.vae.config.scaling_factor)
+    image_latents = (image_latents - shift) * scale
+    image_latents = image_latents.to(device=device, dtype=torch.float32)
+
+    sch_cfg = pipeline.scheduler.config
+    mu = calculate_shift(
+        image_seq_len,
+        getattr(sch_cfg, "base_image_seq_len", 256),
+        getattr(sch_cfg, "max_image_seq_len", 4096),
+        getattr(sch_cfg, "base_shift", 0.5),
+        getattr(sch_cfg, "max_shift", 1.15),
+    )
+    pipeline.scheduler.sigma_min = 0.0
+    retrieve_timesteps(
+        pipeline.scheduler,
+        num_inference_steps,
+        device,
+        sigmas=None,
+        mu=mu,
+    )
+    timesteps, _ = pipeline.get_timesteps(num_inference_steps, strength, device)
+    if timesteps.shape[0] < 1:
+        raise ValueError(
+            "After strength adjustment, num_inference_steps is < 1 for Z-Image img2img."
+        )
+    batch_size = int(init_image.shape[0])
+    latent_timestep = timesteps[:1].repeat(batch_size)
+
+    latents_np = _canonical_randn_tensor(
+        batch_size,
+        num_channels_latents,
+        latent_height,
+        latent_width,
+        seed,
+    )
+    noise = torch.from_numpy(latents_np).to(device=device, dtype=torch.float32)
+    return pipeline.scheduler.scale_noise(image_latents, latent_timestep, noise)
+
+
 def _load_input_image(image_uri: str) -> Image.Image:
     """Load an input image for image-to-image generation."""
     if image_uri.startswith("s3://"):
@@ -380,6 +502,8 @@ def run_image_generation(
 
     pipeline.to(device)  # type: ignore[attr-defined]
     is_flux2 = _is_flux2_pipeline(pipeline)
+    is_z_image = _is_z_image_pipeline(pipeline)
+    is_z_image_img2img = _is_z_image_img2img_pipeline(pipeline)
 
     for mock_request in requests:
         prompt = mock_request.prompt
@@ -403,17 +527,39 @@ def run_image_generation(
             if mock_request.input_image is not None
             else None
         )
+        strength = (
+            float(mock_request.strength)
+            if mock_request.strength is not None
+            else 0.6
+        )
 
         # Prepare latents using the same approach as MAX pipeline
         # This ensures deterministic and comparable outputs
-        num_channels_latents = pipeline.transformer.config.in_channels // 4  # type: ignore[attr-defined]
+        transformer_in_ch = pipeline.transformer.config.in_channels  # type: ignore[attr-defined]
+        num_channels_latents = (
+            transformer_in_ch if is_z_image else transformer_in_ch // 4
+        )
         vae_scale_factor = pipeline.vae_scale_factor  # type: ignore[attr-defined]
         latent_height = 2 * (height // (vae_scale_factor * 2))
         latent_width = 2 * (width // (vae_scale_factor * 2))
 
+        # Z-Image img2img: diffusers ignores the input image when ``latents`` is set.
+        # Build the same flow-matching noisy latents as MAX (VAE mode + canonical noise).
+        if is_z_image_img2img and input_image is not None:
+            latents = _z_image_img2img_starting_latents(
+                pipeline,
+                input_image=input_image,
+                height=height,
+                width=width,
+                num_inference_steps=inference_steps,
+                strength=strength,
+                seed=seed,
+                device=device,
+            )
         # Generate latents using numpy RandomState (same as MAX).
         # Flux2 expects patchified latents shaped (B, C*4, H//2, W//2).
-        if is_flux2:
+        # Z-Image matches MAX pixel_tokenizer: (B, in_channels, H, W), no packing.
+        elif is_flux2:
             latents_np = _canonical_randn_tensor(
                 batch_size=1,
                 num_channels_latents=num_channels_latents,
@@ -422,6 +568,15 @@ def run_image_generation(
                 seed=seed,
             )
             latents_np = _patchify_latents_numpy(latents_np)
+            latents = torch.from_numpy(latents_np)
+        elif is_z_image:
+            latents_np = _canonical_randn_tensor(
+                batch_size=1,
+                num_channels_latents=num_channels_latents,
+                latent_height=latent_height,
+                latent_width=latent_width,
+                seed=seed,
+            )
             latents = torch.from_numpy(latents_np)
         else:
             latents = torch.from_numpy(
@@ -449,6 +604,8 @@ def run_image_generation(
 
         if input_image is not None:
             pipeline_kwargs["image"] = input_image
+            if is_z_image_img2img:
+                pipeline_kwargs["strength"] = strength
 
         # Add negative prompt if provided
         if mock_request.negative_prompt:

--- a/max/tests/integration/tools/create_pipelines.py
+++ b/max/tests/integration/tools/create_pipelines.py
@@ -48,6 +48,9 @@ from max.pipelines.architectures.flux2_modulev3.pipeline_flux2_klein import (
     Flux2KleinPipeline,
 )
 from max.pipelines.architectures.internvl.tokenizer import InternVLProcessor
+from max.pipelines.architectures.z_image_modulev3.pipeline_z_image import (
+    ZImagePipeline,
+)
 from max.pipelines.core import PixelContext
 from max.pipelines.lib import (
     PipelineRuntimeConfig,
@@ -1124,10 +1127,15 @@ class LoRAOracle(PipelineOracle):
 
 
 class ImageGenerationOracle(PipelineOracle):
-    """Pipeline oracle for FLUX image generation."""
+    """Pipeline oracle for FLUX and Z-Image text-to-image generation."""
 
     num_steps: int
     """Number of denoising steps."""
+
+    @staticmethod
+    def _is_z_image_model(model_path: str) -> bool:
+        p = model_path.lower().replace("_", "-")
+        return "z-image" in p
 
     def __init__(
         self,
@@ -1158,7 +1166,7 @@ class ImageGenerationOracle(PipelineOracle):
         encoding: pipelines.SupportedEncoding,
         device_specs: list[driver.DeviceSpec],
     ) -> MaxPipelineAndTokenizer:
-        """Create MAX FLUX pixel generation pipeline."""
+        """Create MAX pixel generation pipeline (FLUX or Z-Image)."""
 
         config = pipelines.PipelineConfig(
             model=pipelines.MAXModelConfig(
@@ -1168,7 +1176,9 @@ class ImageGenerationOracle(PipelineOracle):
             runtime=PipelineRuntimeConfig(prefer_module_v3=True),
         )
 
-        if self.model_path.startswith("black-forest-labs/FLUX.2"):
+        is_flux2 = self.model_path.startswith("black-forest-labs/FLUX.2")
+        is_z_image = self._is_z_image_model(self.model_path)
+        if is_flux2:
             pipeline_model_cls = (
                 Flux2KleinPipeline
                 if self.model_path.startswith("black-forest-labs/FLUX.2-klein")
@@ -1183,6 +1193,17 @@ class ImageGenerationOracle(PipelineOracle):
             pipeline = PixelGenerationPipeline[PixelContext](
                 pipeline_config=config,
                 pipeline_model=pipeline_model_cls,
+            )
+        elif is_z_image:
+            tokenizer = PixelGenerationTokenizer(
+                model_path=self.model_path,
+                pipeline_config=config,
+                subfolder="tokenizer",
+                max_length=512,
+            )
+            pipeline = PixelGenerationPipeline[PixelContext](
+                pipeline_config=config,
+                pipeline_model=ZImagePipeline,
             )
         else:
             tokenizer = PixelGenerationTokenizer(
@@ -1209,17 +1230,31 @@ class ImageGenerationOracle(PipelineOracle):
         encoding: pipelines.SupportedEncoding | None,
         device: torch.device,
     ) -> TorchModelAndDataProcessor:
-        """Create diffusers FLUX pipeline."""
+        """Create a diffusers image pipeline (FLUX, Z-Image, etc.)."""
 
         revision = hf_repo_lock.revision_for_hf_repo(self.model_path)
 
-        # Load the exact pipeline class from model config instead of relying on
-        # auto-pipeline resolution.
-        pipeline = diffusers.DiffusionPipeline.from_pretrained(
-            self.model_path,
-            revision=revision,
-            torch_dtype=ENCODING_TO_TORCH_DTYPE.get(encoding, torch.bfloat16),  # type: ignore
+        # Load the exact pipeline class from model config.
+        # AutoPipelineForText2Image in diffusers==0.36.0 cannot resolve FLUX2.
+        is_z_image = self._is_z_image_model(self.model_path)
+        needs_z_image_img2img = is_z_image and any(
+            getattr(r, "input_image", None) for r in self._inputs
         )
+        torch_dtype = (
+            ENCODING_TO_TORCH_DTYPE[encoding] if encoding else torch.bfloat16
+        )
+        if needs_z_image_img2img:
+            pipeline = diffusers.ZImageImg2ImgPipeline.from_pretrained(
+                self.model_path,
+                revision=revision,
+                torch_dtype=torch_dtype,
+            )
+        else:
+            pipeline = diffusers.DiffusionPipeline.from_pretrained(
+                self.model_path,
+                revision=revision,
+                torch_dtype=torch_dtype,
+            )
         pipeline = pipeline.to(device)
 
         # Return pipeline as "model" and None as data_processor (not needed for diffusers)
@@ -1236,7 +1271,7 @@ class ImageGenerationOracle(PipelineOracle):
         num_steps: int,
         inputs: list[Any],
     ) -> list[dict[str, Any]]:
-        """Run image generation using diffusers FLUX."""
+        """Run image generation using diffusers (FLUX, Z-Image, etc.)."""
 
         return torch_utils.run_image_generation(
             pipeline=torch_pipeline_and_tokenizer.model,
@@ -1763,6 +1798,23 @@ PIPELINE_ORACLES: Mapping[str, PipelineOracle] = {
     "black-forest-labs/FLUX.2-dev-i2i": ImageGenerationOracle(
         "black-forest-labs/FLUX.2-dev",
         requests=test_data.FLUX2_PIXEL_GENERATION_I2I,
+    ),
+    "Tongyi-MAI/Z-Image-t2i": ImageGenerationOracle(
+        "Tongyi-MAI/Z-Image",
+        requests=test_data.DEFAULT_Z_IMAGE_PIXEL_GENERATION,
+    ),
+    "Tongyi-MAI/Z-Image-negative-prompt-t2i": ImageGenerationOracle(
+        "Tongyi-MAI/Z-Image",
+        requests=test_data.DEFAULT_Z_IMAGE_NEGATIVE_PROMPT_PIXEL_GENERATION,
+    ),
+    "Tongyi-MAI/Z-Image-Turbo-t2i": ImageGenerationOracle(
+        "Tongyi-MAI/Z-Image-Turbo",
+        num_steps=8,
+        requests=test_data.DEFAULT_Z_IMAGE_TURBO_PIXEL_GENERATION,
+    ),
+    "Tongyi-MAI/Z-Image-i2i": ImageGenerationOracle(
+        "Tongyi-MAI/Z-Image",
+        requests=test_data.DEFAULT_Z_IMAGE_PIXEL_GENERATION_I2I,
     ),
     "black-forest-labs/FLUX.2-klein-4B": ImageGenerationOracle(
         "black-forest-labs/FLUX.2-klein-4B",


### PR DESCRIPTION
## Summary

- This PR depends on `add/z-image-module` #6063  and `add/z-image-pipeline-integration` #6065  . It should be reviewed and tested together only after those PRs are merged first.

- It contains the remaining Z-Image validation and harness-side follow-ups, including updates to the verification config and shared integration helpers, plus the small supporting typing fixes that those checks depend on.

- adds `Tongyi-MAI/Z-Image`, `Tongyi-MAI/Z-Image-Turbo` to the accuracy verification path, including Flux2KleinPipeline selection and switching back to the standard transformer before denoising

## Testing

- Z-Image (T2I)
```./bazelw run //max/tests/integration/accuracy:verify_pipelines -- --pipeline Tongyi-MAI/Z-Image-t2i-bfloat16  --devices gpu:0 --pixel-results-dir ../results```
- Z-Image (T2I with negative prompt)
```./bazelw run //max/tests/integration/accuracy:verify_pipelines -- --pipeline Tongyi-MAI/Z-Image-negative-prompt-t2i-bfloat16  --devices gpu:0 --pixel-results-dir ../results```
- Z-Image (I2I)
```./bazelw run //max/tests/integration/accuracy:verify_pipelines -- --pipeline Tongyi-MAI/Z-Image-i2i-bfloat16  --devices gpu:0 --pixel-results-dir ../results```
- Z-Image-Turbo (T2I)
```./bazelw run //max/tests/integration/accuracy:verify_pipelines -- --pipeline Tongyi-MAI/Z-Image-Turbo-t2i-bfloat16  --devices gpu:0 --pixel-results-dir ../results```

- Sample Results (diffusers / MAX)
<img width="1024" height="1024" alt="004" src="https://github.com/user-attachments/assets/ef6ac71e-9874-4707-a0d6-e1e2ca3b2db0" />
<img width="1024" height="1024" alt="004" src="https://github.com/user-attachments/assets/f1aabc36-bbc4-42ec-8f31-bc514bf298c8" />

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))

`Assisted-by: AI`