### PR TITLE
[Stdlib] Add tests and changelog example for variadic pack forwarding

### DIFF
--- a/mojo/docs/nightly-changelog.md
+++ b/mojo/docs/nightly-changelog.md
@@ -23,7 +23,7 @@ This version is still a work in progress.
   def forwarder[*Ts: Writable](*args: *Ts):
       callee(*args)
 
-  forwarder(1, "hello", 3.14)  # prints 1, hello, 3.14
+  forwarder(1, "hello", 3.14)  # prints each value on a separate line
   ```
 
 ## Language changes

--- a/mojo/docs/nightly-changelog.md
+++ b/mojo/docs/nightly-changelog.md
@@ -15,6 +15,17 @@ This version is still a work in progress.
 - Variadic packs can be forwarded through runtime calls with `*pack` when the
   callee takes a compatible variadic pack parameter.
 
+  ```mojo
+  def callee[*Ts: Writable](*args: *Ts):
+      comptime for i in range(args.__len__()):
+          print(args[i])
+
+  def forwarder[*Ts: Writable](*args: *Ts):
+      callee(*args)
+
+  forwarder(1, "hello", 3.14)  # prints 1, hello, 3.14
+  ```
+
 ## Language changes
 
 - Mojo now warns on uses of the legacy `fn` keyword. Please move to `def` as

--- a/mojo/stdlib/test/builtin/test_variadic.mojo
+++ b/mojo/stdlib/test/builtin/test_variadic.mojo
@@ -492,6 +492,20 @@ def test_variadic_pack_forwarding_single_element() raises:
     forwarder(42)
 
 
+def test_variadic_pack_forwarding_empty() raises:
+    """Test forwarding an empty variadic pack."""
+
+    def callee[*Ts: Writable](*args: *Ts) raises:
+        var s = String()
+        args.write_to(s)
+        assert_equal(s, "()")
+
+    def forwarder[*Ts: Writable](*args: *Ts) raises:
+        callee(*args)
+
+    forwarder()
+
+
 def test_variadic_pack_forwarding_through_two_levels() raises:
     """Test forwarding a variadic pack through two levels of indirection."""
 

--- a/mojo/stdlib/test/builtin/test_variadic.mojo
+++ b/mojo/stdlib/test/builtin/test_variadic.mojo
@@ -464,5 +464,50 @@ def test_variadic_pack_write_repr_to() raises:
     helper(1, "hello", True)
 
 
+def test_variadic_pack_forwarding() raises:
+    """Test that variadic packs can be forwarded with *pack syntax."""
+
+    def callee[*Ts: Writable](*args: *Ts) raises:
+        var s = String()
+        args.write_to(s)
+        assert_equal(s, "(1, hello, 3.14)")
+
+    def forwarder[*Ts: Writable](*args: *Ts) raises:
+        callee(*args)
+
+    forwarder(1, "hello", 3.14)
+
+
+def test_variadic_pack_forwarding_single_element() raises:
+    """Test forwarding a single-element variadic pack."""
+
+    def callee[*Ts: Writable](*args: *Ts) raises:
+        var s = String()
+        args.write_to(s)
+        assert_equal(s, "(42)")
+
+    def forwarder[*Ts: Writable](*args: *Ts) raises:
+        callee(*args)
+
+    forwarder(42)
+
+
+def test_variadic_pack_forwarding_through_two_levels() raises:
+    """Test forwarding a variadic pack through two levels of indirection."""
+
+    def callee[*Ts: Writable](*args: *Ts) raises:
+        var s = String()
+        args.write_to(s)
+        assert_equal(s, "(a, True)")
+
+    def middle[*Ts: Writable](*args: *Ts) raises:
+        callee(*args)
+
+    def outer[*Ts: Writable](*args: *Ts) raises:
+        middle(*args)
+
+    outer("a", True)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
- Add unit tests for the new `*pack` forwarding syntax (heterogeneous pack, single element, two-level indirection)
- Add a minimal code example to the changelog entry

Assisted-by: AI