### PR TITLE
[Kernels] Fix argmax/argmin input shape validation

### DIFF
--- a/max/kernels/src/nn/argmaxmin.mojo
+++ b/max/kernels/src/nn/argmaxmin.mojo
@@ -55,7 +55,7 @@ def _argn[
 
     comptime for subaxis in range(rank):
         var output_subaxis = output.dim(subaxis)
-        var input_subaxis = output.dim(subaxis)
+        var input_subaxis = input.dim(subaxis)
         if subaxis == canonical_axis:
             if output_subaxis != 1:
                 raise Error("expected axis to have size 1 in output")


### PR DESCRIPTION
## Summary

Fixes the `_argn` dimension validation so the input tensor is compared against the output tensor per subaxis. Previously `output.dim` was used for both sides, so mismatched input shapes were not detected.

## Change

- `input_subaxis`: use `input.dim(subaxis)` instead of `output.dim(subaxis)`.

BEGIN_PUBLIC
[Kernels] Fix argmax/argmin input shape validation

The _argn dimension check used output.dim for both tensors when validating that input and output shapes match outside the reduced axis. Use input.dim for the input side so incorrect input shapes are rejected as intended.
END_PUBLIC