### PR TITLE
[MAX] Fix MinPSampler inline comment (min_p)

### DIFF
--- a/max/python/max/nn/sampling/min_p.py
+++ b/max/python/max/nn/sampling/min_p.py
@@ -47,7 +47,7 @@ class MinPSampler(Module):
         self, input: TensorValue, min_p: TensorValueLike = 0.0
     ) -> TensorValue:
         batch_size = input.shape[0]
-        # Handle top_p parameter - can be scalar or tensor
+        # Handle min_p parameter - can be scalar or tensor
         if isinstance(min_p, float | int):
             if float(min_p) < 0.0 or float(min_p) > 1.0:
                 raise ValueError(f"expected min_p to be in [0, 1], got {min_p}")


### PR DESCRIPTION
## Summary

Corrects a misleading comment in `MinPSampler.forward`: it referred to `top_p` while the parameter is `min_p`.

## Change

- Single-line comment fix in `max/python/max/nn/sampling/min_p.py`.

BEGIN_PUBLIC
[MAX] Fix MinPSampler inline comment (min_p)

The MinPSampler forward path documents min_p handling; the comment incorrectly referred to top_p. Align the comment with the actual parameter name.
END_PUBLIC