### PR TITLE
[tests] Enhance local testing setup and add model download utility

### DIFF
--- a/max/CONTRIBUTING.md
+++ b/max/CONTRIBUTING.md
@@ -26,7 +26,7 @@ document:
   GPU-only targets) and a minimal test matrix for local iteration.
 
 When validating a local MAX change, start with the minimal test matrix in the
-[MAX developer guide](/max/docs/development.md#use-a-minimal-test-matrix)
+[MAX developer guide](/max/docs/development.md#minimal-test-matrix)
 instead of defaulting to `//max/...`, especially if your change does not need
 HF-backed or GPU-backed integration coverage.
 

--- a/max/CONTRIBUTING.md
+++ b/max/CONTRIBUTING.md
@@ -21,7 +21,14 @@ For technical details on developing for MAX and models, see the following
 document:
 
 - [Developing the MAX framework](/max/docs/development.md) covers building,
-  testing, and other information you’ll need to work in the MAX framework.
+  testing, and other information you'll need to work in the MAX framework.
+  It also covers local test prerequisites (`HF_TOKEN`, model downloads,
+  GPU-only targets) and a minimal test matrix for local iteration.
+
+When validating a local MAX change, start with the minimal test matrix in the
+[MAX developer guide](/max/docs/development.md#use-a-minimal-test-matrix)
+instead of defaulting to `//max/...`, especially if your change does not need
+HF-backed or GPU-backed integration coverage.
 
 ### Changes we *accept*
 

--- a/max/docs/development.md
+++ b/max/docs/development.md
@@ -50,6 +50,43 @@ From the repo root, run this `bazelw` command to run all the MAX tests:
 If it's your first time, it starts by installing the Bazel version manager,
 [Bazelisk](https://github.com/bazelbuild/bazelisk), which then installs Bazel.
 
+### Know the local test prerequisites
+
+Not every MAX test has the same local requirements. Before running a broad
+target, check which of these constraints apply:
+
+- **Hugging Face auth**: Some tests exercise gated Hugging Face repos or fetch
+  remote config files. Prefer signing in once with the Hugging Face CLI so the
+  local cache and library calls can reuse the saved credentials:
+
+  ```bash
+  hf auth login
+  ```
+
+  Use `HF_TOKEN` when you need non-interactive auth, or when a specific test
+  target explicitly requires that environment variable to be inherited into the
+  Bazel action:
+
+  ```bash
+  export HF_TOKEN="hf_..."
+  ```
+
+- **Model downloads**: Some integration tests resolve model snapshots through
+  the local Hugging Face cache and expect the snapshot to be present already.
+  On a fresh machine, warm the cache first with:
+
+  ```bash
+  bazel run //max/tests/integration/tools:download_models_for_testing -- \
+    meta-llama/Llama-3.2-1B-Instruct
+  ```
+
+- **GPU requirements**: Many integration targets are tagged `gpu` and will not
+  run successfully on a CPU-only machine. Prefer CPU or pure unit targets if
+  your change does not touch GPU execution.
+- **Networked tests**: Targets tagged `requires-network` may contact Hugging
+  Face or other remote endpoints and are more likely to fail in restricted or
+  offline environments.
+
 ### Test a subset of the MAX framework
 
 You can run all the tests within a specific subdirectory by simply
@@ -66,6 +103,29 @@ To find all the test targets, you can run:
 ./bazelw query 'tests(//max/tests/...)'
 ```
 
+### Minimal test matrix
+
+For local iteration, start with a small target set that matches your change,
+then expand to the full relevant suites before sending a PR. The following
+commands are good local starting points, not a substitute for broader test
+coverage:
+
+| Change type                                                      | Suggested command                                                                                                                       | Typical prerequisites                             |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Core Python logic and lightweight local regression               | `./bazelw test //max/tests/tests:cpu_local_tests`                                                                                       | No GPU; usually no `HF_TOKEN`                     |
+| Serve process-control unit tests                                 | `./bazelw test //max/tests/tests/serve/unit:tests`                                                                                      | CPU-only, but slower than the default local suite |
+| Pipeline library or architecture logic that should stay CPU-safe | `./bazelw test //max/tests/tests/pipelines/... //max/tests/integration/pipelines:tests`                                                 | Network may be needed for some pipeline tests     |
+| Tokenization or HF-backed pipeline integration                   | `./bazelw test //max/tests/integration/pipelines/tokenization:tests //max/tests/integration/architectures/internvl_network_tests:tests` | Hugging Face auth, network, and a GPU-capable machine |
+| GPU runtime, graph, or kernel-facing changes                     | `./bazelw test //max/tests/tests:test_interpreter_ops_gpu //max/tests/integration/pipelines:tests_gpu`                                  | GPU required; network often required              |
+
+If you are unsure whether a target needs network or GPUs, inspect its Bazel
+rule for tags such as `gpu` or `requires-network`, or for `env_inherit =
+["HF_TOKEN"]`.
+
+When adding new CPU-safe tests with lightweight local prerequisites, prefer
+including them in `//max/tests/tests:cpu_local_tests` so contributors have a
+fast, shared baseline suite for local iteration.
+
 ## Run a MAX pipeline
 
 When developing a new model architecture, or testing MAX API changes against
@@ -73,12 +133,14 @@ existing models, you can use the following Bazel commands to run inference.
 
 > [!NOTE]
 > Some models require Hugging Face authentication to load model weights, so
-> you should set your [HF access token](https://huggingface.co/settings/tokens)
-> as an environment variable:
+> prefer signing in once with the Hugging Face CLI:
 >
-> ```sh
-> export HF_TOKEN="hf_..."
+> ```bash
+> hf auth login
 > ```
+>
+> If you need non-interactive auth in CI or a shell session dedicated to Bazel,
+> you can still export `HF_TOKEN` instead.
 
 For example, this `entrypoints:pipelines generate` command is equivalent to
 running inference with [`max

--- a/max/python/max/pipelines/lib/hf_utils.py
+++ b/max/python/max/pipelines/lib/hf_utils.py
@@ -680,8 +680,10 @@ def is_diffusion_pipeline(repo: HuggingFaceRepo) -> bool:
 def generate_local_model_path(repo_id: str, revision: str) -> str:
     """Generate the local filesystem path where a Hugging Face model repo is cached.
 
-    This function uses Hugging Face's official snapshot_download with local_files_only=True
-    to resolve the local cache path for a model repository.
+    This function resolves the model from the local Hugging Face cache only.
+    Missing snapshots should be pre-downloaded explicitly so tests without the
+    ``requires-network`` tag do not silently fetch remote artifacts at runtime.
+    network-free do not silently fetch remote artifacts at runtime.
 
     Args:
         repo_id: The Hugging Face repository ID in the format "org/model"
@@ -692,7 +694,7 @@ def generate_local_model_path(repo_id: str, revision: str) -> str:
         str: The absolute path to the cached model files for the specified revision.
 
     Raises:
-        FileNotFoundError: If the model is not found in the local cache
+        FileNotFoundError: If the model is not found in the local cache.
     """
     try:
         return huggingface_hub.snapshot_download(
@@ -700,8 +702,15 @@ def generate_local_model_path(repo_id: str, revision: str) -> str:
             revision=revision,
             local_files_only=True,
         )
-    except huggingface_hub.utils.LocalEntryNotFoundError as e:
+    except huggingface_hub.errors.LocalEntryNotFoundError as local_error:
         raise FileNotFoundError(
             f"Model path does not exist: HF cache for '{repo_id}' "
-            f"(revision: {revision}) not found."
-        ) from e
+            f"(revision: {revision}) not found"
+            + (
+                " while HF_HUB_OFFLINE is enabled."
+                if huggingface_hub.constants.HF_HUB_OFFLINE
+                else "."
+            )
+            + " Configure HF_TOKEN for gated repos and pre-download the model with "
+            "'//max/tests/integration/tools:download_models_for_testing'."
+        ) from local_error

--- a/max/python/max/pipelines/lib/hf_utils.py
+++ b/max/python/max/pipelines/lib/hf_utils.py
@@ -683,7 +683,6 @@ def generate_local_model_path(repo_id: str, revision: str) -> str:
     This function resolves the model from the local Hugging Face cache only.
     Missing snapshots should be pre-downloaded explicitly so tests without the
     ``requires-network`` tag do not silently fetch remote artifacts at runtime.
-    network-free do not silently fetch remote artifacts at runtime.
 
     Args:
         repo_id: The Hugging Face repository ID in the format "org/model"

--- a/max/tests/integration/tools/BUILD.bazel
+++ b/max/tests/integration/tools/BUILD.bazel
@@ -153,6 +153,20 @@ pycross_wheel_library(
 )
 
 modular_py_binary(
+    name = "download_models_for_testing",
+    testonly = True,
+    srcs = ["download_models_for_testing.py"],
+    imports = ["."],
+    main = "download_models_for_testing.py",
+    tags = ["no-pydeps"],
+    deps = [
+        "//max/tests/integration:hf_repo_lock",
+        requirement("click"),
+        requirement("huggingface-hub"),
+    ],
+)
+
+modular_py_binary(
     name = "generate_llm_logits",
     testonly = True,
     srcs = [

--- a/max/tests/integration/tools/README.md
+++ b/max/tests/integration/tools/README.md
@@ -6,6 +6,38 @@ pipelines.
 For a complete walkthrough of debugging model accuracy issues, see the
 [accuracy debugging guide](/max/docs/accuracy-debugging.md).
 
+## `download_models_for_testing.py`
+
+Downloads one or more Hugging Face model repos into the local cache. This is
+useful before running integration tests that resolve models through
+`generate_local_model_path()`, especially on a fresh machine where the cache
+has not been populated yet.
+
+**Basic usage:**
+
+```bash
+# Use the pinned revision from hf-repo-lock.tsv when available
+bazel run //max/tests/integration/tools:download_models_for_testing -- \
+    modularai/Llama-3.1-8B-Instruct-GGUF
+
+# Download multiple repos in one run
+bazel run //max/tests/integration/tools:download_models_for_testing -- \
+    meta-llama/Llama-3.2-1B-Instruct \
+    openai/whisper-large-v3
+
+# Override the revision explicitly
+bazel run //max/tests/integration/tools:download_models_for_testing -- \
+    meta-llama/Llama-3.2-1B-Instruct@main
+```
+
+**Notes:**
+
+- If `HF_TOKEN` is unset, public repos can still download, but gated/private
+  repos will fail.
+- When a repo appears in `max/tests/integration/hf-repo-lock.tsv`, the tool
+  uses that pinned revision by default.
+- Downloaded snapshots land in the standard Hugging Face cache used by tests.
+
 ## `debug_model.py`
 
 The primary tool for inspecting intermediate tensors during model execution.

--- a/max/tests/integration/tools/download_models_for_testing.py
+++ b/max/tests/integration/tools/download_models_for_testing.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import click
+import huggingface_hub
+from max.tests.integration.hf_repo_lock import revision_for_hf_repo
+
+
+@dataclass(frozen=True)
+class RepoDownloadRequest:
+    repo_id: str
+    revision: str | None
+    revision_source: str
+
+
+def parse_repo_spec(repo_spec: str) -> tuple[str, str | None]:
+    repo_id, separator, revision = repo_spec.rpartition("@")
+    if not separator:
+        return repo_spec, None
+    if not repo_id or not revision:
+        raise click.ClickException(
+            f"Invalid repo spec {repo_spec!r}. "
+            "Use 'org/model' or 'org/model@revision'."
+        )
+    return repo_id, revision
+
+
+def resolve_download_request(repo_spec: str) -> RepoDownloadRequest:
+    repo_id, explicit_revision = parse_repo_spec(repo_spec)
+    if explicit_revision is not None:
+        return RepoDownloadRequest(
+            repo_id=repo_id,
+            revision=explicit_revision,
+            revision_source="explicit revision",
+        )
+
+    locked_revision = revision_for_hf_repo(repo_id)
+    if locked_revision is not None:
+        return RepoDownloadRequest(
+            repo_id=repo_id,
+            revision=locked_revision,
+            revision_source="hf-repo-lock.tsv",
+        )
+
+    return RepoDownloadRequest(
+        repo_id=repo_id,
+        revision=None,
+        revision_source="default branch",
+    )
+
+
+def download_repo(
+    request: RepoDownloadRequest,
+    *,
+    force_download: bool,
+) -> str:
+    return huggingface_hub.snapshot_download(
+        repo_id=request.repo_id,
+        force_download=force_download,
+        revision=request.revision,
+    )
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.argument("repo_specs", nargs=-1, required=True)
+@click.option(
+    "--force-download",
+    is_flag=True,
+    help="Redownload snapshots even if the requested revision is already cached.",
+)
+def main(repo_specs: tuple[str, ...], force_download: bool) -> None:
+    """Download one or more Hugging Face model repos into the local cache."""
+    if (
+        not os.getenv("HF_TOKEN")
+        and not huggingface_hub.constants.HF_HUB_OFFLINE
+    ):
+        click.echo(
+            "HF_TOKEN is not set. Public repos may still work, but gated repos "
+            "will fail.",
+            err=True,
+        )
+
+    failures: list[str] = []
+    for repo_spec in repo_specs:
+        request = resolve_download_request(repo_spec)
+        revision_display = request.revision or "default branch"
+        click.echo(
+            f"Downloading {request.repo_id} "
+            f"(revision: {revision_display}, "
+            f"source: {request.revision_source})..."
+        )
+        try:
+            snapshot_path = download_repo(
+                request,
+                force_download=force_download,
+            )
+        except Exception as error:
+            failures.append(
+                f"{request.repo_id} (revision: {revision_display}): {error}"
+            )
+            continue
+
+        click.echo(f"Cached at {snapshot_path}")
+
+    if failures:
+        raise click.ClickException("\n".join(failures))
+
+
+if __name__ == "__main__":
+    main()

--- a/max/tests/integration/unorganized/test_huggingface_utilities.py
+++ b/max/tests/integration/unorganized/test_huggingface_utilities.py
@@ -15,10 +15,14 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from huggingface_hub import constants as hf_hub_constants
 from huggingface_hub import errors as hf_hub_errors
 from max.graph.weights import WeightsFormat
 from max.pipelines.lib import HuggingFaceRepo
-from max.pipelines.lib.hf_utils import validate_hf_repo_access
+from max.pipelines.lib.hf_utils import (
+    generate_local_model_path,
+    validate_hf_repo_access,
+)
 
 
 def test_huggingface_repo__local_path() -> None:
@@ -355,3 +359,60 @@ class TestValidateHfRepoAccess:
                 error_msg = str(exc_info.value)
                 assert f"Repository '{repo_id}' not found" in error_msg
                 assert f"revision '{revision}' exists" in error_msg
+
+
+class TestGenerateLocalModelPath:
+    def test_uses_cached_snapshot_when_available(self) -> None:
+        with patch(
+            "max.pipelines.lib.hf_utils.huggingface_hub.snapshot_download",
+            return_value="/tmp/cached-model",
+        ) as mock_snapshot_download:
+            model_path = generate_local_model_path("org/model", "abc123")
+
+        assert model_path == "/tmp/cached-model"
+        mock_snapshot_download.assert_called_once_with(
+            repo_id="org/model",
+            revision="abc123",
+            local_files_only=True,
+        )
+
+    def test_raises_when_cache_is_missing(self) -> None:
+        with (
+            patch.object(hf_hub_constants, "HF_HUB_OFFLINE", False),
+            patch(
+                "max.pipelines.lib.hf_utils.huggingface_hub.snapshot_download",
+                side_effect=hf_hub_errors.LocalEntryNotFoundError("cache miss"),
+            ) as mock_snapshot_download,
+        ):
+            with pytest.raises(
+                FileNotFoundError,
+                match="pre-download the model",
+            ) as exc_info:
+                generate_local_model_path("org/model", "abc123")
+
+        assert "Configure HF_TOKEN for gated repos" in str(exc_info.value)
+        mock_snapshot_download.assert_called_once_with(
+            repo_id="org/model",
+            revision="abc123",
+            local_files_only=True,
+        )
+
+    def test_raises_when_cache_is_missing_in_offline_mode(self) -> None:
+        with (
+            patch.object(hf_hub_constants, "HF_HUB_OFFLINE", True),
+            patch(
+                "max.pipelines.lib.hf_utils.huggingface_hub.snapshot_download",
+                side_effect=hf_hub_errors.LocalEntryNotFoundError("cache miss"),
+            ) as mock_snapshot_download,
+        ):
+            with pytest.raises(
+                FileNotFoundError,
+                match="HF_HUB_OFFLINE is enabled",
+            ):
+                generate_local_model_path("org/model", "abc123")
+
+        mock_snapshot_download.assert_called_once_with(
+            repo_id="org/model",
+            revision="abc123",
+            local_files_only=True,
+        )

--- a/max/tests/tests/BUILD.bazel
+++ b/max/tests/tests/BUILD.bazel
@@ -108,3 +108,24 @@ modular_py_test(
         requirement("torch"),
     ],
 )
+
+# Keep this suite fast and broadly runnable. New CPU-safe tests with no special
+# local prerequisites should prefer to join this target.
+test_suite(
+    name = "cpu_local_tests",
+    tests = [
+        ":max_tests",
+        ":test_interpreter",
+        ":test_interpreter_ops",
+        "//max/tests/tests/_core_mojo:tests",
+        "//max/tests/tests/benchmark:tests",
+        "//max/tests/tests/driver:tests",
+        "//max/tests/tests/graph:multi_version_tests",
+        "//max/tests/tests/graph:tests",
+        "//max/tests/tests/mojo-importer",
+        "//max/tests/tests/nn:cpu_tests",
+        "//max/tests/tests/profiler:tests",
+        "//max/tests/tests/serve:parser_tests",
+        "//max/tests/tests/support:tests",
+    ],
+)

--- a/max/tests/tests/nn/BUILD.bazel
+++ b/max/tests/tests/nn/BUILD.bazel
@@ -14,6 +14,12 @@ _MACOS_INCOMPATIBLE_TESTS = [
     "test_sampling_gpu.py",
 ]
 
+# CPU-only local suites should not pull in the dedicated GPU test target.
+_CPU_TEST_SRCS = glob(
+    ["test_*.py"],
+    exclude = ["*_gpu.py"],
+)
+
 # Tests that need a longer timeout on remote GPU CI.
 _LONG_TIMEOUT_TESTS = [
     "test_sampling_gpu.py",
@@ -46,9 +52,20 @@ _LONG_TIMEOUT_TESTS = [
             "//max/python/max/graph",
             "//max/python/max/mlir",
             "//max/python/max/nn",
-            "//max/python/max/pipelines/lib",
             requirement("numpy"),
-        ],
+        ] + (
+            # pipelines/lib is only needed by the GPU sampling test; keep it
+            # out of the default dep list so cpu_tests stays lightweight.
+            ["//max/python/max/pipelines/lib"] if src == "test_sampling_gpu.py" else []
+        ),
     )
     for src in glob(["test_*.py"])
 ]
+
+test_suite(
+    name = "cpu_tests",
+    tests = [
+        ":" + src.replace(".py", "")
+        for src in _CPU_TEST_SRCS
+    ],
+)


### PR DESCRIPTION
Re-submission of #6189 for proper Copybara `!sync` import. All credit to @frostming.

#6189 was accidentally squash-merged via the GitHub merge button instead of `!sync`, so the changes existed on public main but were never imported internally. The squash merge was reverted in #6285, and this PR re-introduces the same changes with @frostming as commit author for proper attribution and sync.

---

**Original description:**

- Updated CONTRIBUTING.md and development.md to clarify local test prerequisites and usage of a minimal test matrix.
- Introduced `download_models_for_testing.py` script for downloading Hugging Face models into the local cache.
- Added tests for model path generation and download functionality.
- Updated BUILD.bazel files to include new test suites and dependencies.

Signed-off-by: Frost Ming <me@frostming.com>