### PR TITLE
[Stdlib] Add `Variadic.permute` and `Tuple.permute`

### DIFF
--- a/mojo/stdlib/std/builtin/tuple.mojo
+++ b/mojo/stdlib/std/builtin/tuple.mojo
@@ -16,6 +16,7 @@ These are Mojo built-ins, so you don't need to import them.
 """
 
 from std.builtin.constrained import _constrained_conforms_to
+from std.builtin.variadics import _is_valid_permutation
 from std.format._utils import (
     write_sequence_to,
     TypeNames,
@@ -566,6 +567,51 @@ struct Tuple[*element_types: Movable](
                     UnsafePointer(
                         to=self[Variadic.size(Self.element_types) - 1 - i]
                     )
+                )
+            )
+
+    @always_inline("nodebug")
+    def permute[
+        perm: Variadic.ValuesOfType[Int] where (
+            Variadic.size(perm) == Self.__len__()
+        )
+    ](
+        deinit self,
+        out result: Tuple[*Variadic.permute[*Self.element_types, perm=perm]],
+    ):
+        """Return a new tuple with the elements reordered according to a
+        permutation.
+
+        Parameters:
+            perm: A variadic of Int indices specifying the permutation.
+                  `perm[i]` is the index in the original tuple that maps to
+                  position `i` in the result.
+
+        Returns:
+            A new tuple with the permuted elements.
+
+        Usage:
+
+        ```mojo
+        var t = ("a", 1, 3.14)
+        var p = t.permute[Variadic.values[2, 0, 1]]()
+        print(p[0], p[1], p[2])  # output: 3.14, a, 1
+        ```
+        """
+        comptime assert _is_valid_permutation[perm, Self.__len__()], (
+            "perm must be a valid permutation of [0, len-1]:"
+            " every index must be in range and appear exactly once"
+        )
+
+        # Mark 'result' as being initialized so we can work on it.
+        __mlir_op.`lit.ownership.mark_initialized`(
+            __get_mvalue_as_litref(result)
+        )
+
+        comptime for i in range(type_of(result).__len__()):
+            UnsafePointer(to=result[i]).init_pointee_move_from(
+                rebind[UnsafePointer[type_of(result[i]), origin_of(self)]](
+                    UnsafePointer(to=self[perm[i]])
                 )
             )
 

--- a/mojo/stdlib/std/builtin/variadics.mojo
+++ b/mojo/stdlib/std/builtin/variadics.mojo
@@ -155,6 +155,49 @@ struct Variadic:
         element_types: The variadic sequence of types to reverse.
     """
 
+    comptime permute[
+        T: type_of(AnyType),
+        //,
+        *element_types: T,
+        perm: Variadic.ValuesOfType[Int] where (
+            Variadic.size(perm) == Variadic.size(element_types)
+        ),
+    ]: Variadic.TypesOfTrait[T] = _MapVariadicAndIdxToType[
+        To=T,
+        VariadicType=element_types,
+        Mapper=_PermutedVariadic[T, perm, ...],
+    ]
+    """Permute a variadic sequence of types according to the given indices.
+
+    Returns a new variadic where the element at position `i` in the result is
+    `element_types[perm[i]]`.
+
+    Parameters:
+        T: The trait that the types conform to.
+        element_types: The variadic sequence of types to permute.
+        perm: A variadic of Int indices specifying the permutation.
+
+    Constraints:
+        `perm` must be a valid permutation of `[0, len-1]`: its length must
+        equal the length of `element_types`, every index must be in range,
+        and each index must appear exactly once. Out-of-range indices will
+        produce a compile-time error from type indexing.
+
+    Examples:
+
+    ```mojo
+    from std.builtin.variadics import Variadic
+    from std.sys.intrinsics import _type_is_eq
+
+    # Given types [Int, String, Bool], permute with [2, 0, 1]
+    comptime types = Variadic.types[T=AnyType, Int, String, Bool]
+    comptime permuted = Variadic.permute[
+        *types, perm=Variadic.values[2, 0, 1]
+    ]
+    # Result: [Bool, Int, String]
+    ```
+    """
+
     comptime splat_type[
         Trait: type_of(AnyType), //, count: Int, type: Trait
     ]: Variadic.TypesOfTrait[Trait] = Self.tabulate_type[
@@ -1642,6 +1685,51 @@ Parameters:
     element_types: The variadic sequence of types to reverse.
     idx: The index of the type to generate in the reversed sequence.
 """
+
+comptime _PermutedVariadic[
+    T: type_of(AnyType),
+    perm: Variadic.ValuesOfType[Int],
+    element_types: Variadic.TypesOfTrait[T],
+    idx: Int,
+] = element_types[perm[idx]]
+"""A generator that permutes a variadic sequence of types.
+
+Parameters:
+    T: The common trait bound for the variadic types.
+    perm: The permutation indices.
+    element_types: The variadic sequence of types to permute.
+    idx: The index of the type to generate in the permuted sequence.
+"""
+
+
+comptime _IotaTabulator[idx: Int] = idx
+"""A tabulator that returns the index itself, producing [0, 1, 2, ...]."""
+
+comptime _AllIndicesPresentReducer[
+    perm: Variadic.ValuesOfType[Int],
+    Prev: Variadic.ValuesOfType[Bool],
+    From: Variadic.ValuesOfType[Int],
+    idx: Int,
+] = Variadic.values[
+    Prev[0] and Variadic.contains_value[value=From[idx], element_values=perm]
+]
+"""Reducer that checks each index in [0, N) is present in the permutation."""
+
+comptime _is_valid_permutation[
+    perm: Variadic.ValuesOfType[Int],
+    n: Int,
+] = _ReduceValueAndIdxToValue[
+    BaseVal=Variadic.values[True],
+    VariadicType=Variadic.tabulate[n, _IotaTabulator],
+    Reducer=_AllIndicesPresentReducer[perm, ...],
+][
+    0
+]
+"""Check that `perm` is a valid permutation of [0, n).
+
+Given that `size(perm) == n` (enforced separately), this checks that every
+index in `[0, n)` appears in `perm`. By the pigeonhole principle, this
+ensures each index appears exactly once."""
 
 
 comptime _ContainsReducer[

--- a/mojo/stdlib/std/builtin/variadics.mojo
+++ b/mojo/stdlib/std/builtin/variadics.mojo
@@ -159,9 +159,9 @@ struct Variadic:
         T: type_of(AnyType),
         //,
         *element_types: T,
-        perm: Variadic.ValuesOfType[Int] where (
-            Variadic.size(perm) == Variadic.size(element_types)
-        ),
+        perm: Variadic.ValuesOfType[Int] where Variadic.size(
+            perm
+        ) == Variadic.size(element_types),
     ]: Variadic.TypesOfTrait[T] = _MapVariadicAndIdxToType[
         To=T,
         VariadicType=element_types,

--- a/mojo/stdlib/test/builtin/BUILD.bazel
+++ b/mojo/stdlib/test/builtin/BUILD.bazel
@@ -40,6 +40,7 @@ _LIT_TESTS = [
     "test_print_long_string.mojo",
     "test_print_stderr.mojo",
     "test_stdin.mojo",
+    "test_tuple_permute_compile_fail.mojo",
 ]
 
 _MOJO_COMPILE_OPTS = {

--- a/mojo/stdlib/test/builtin/test_tuple.mojo
+++ b/mojo/stdlib/test/builtin/test_tuple.mojo
@@ -198,6 +198,36 @@ def test_tuple_reverse_copy_count() raises:
     assert_equal(t2[0].copy_count, 0)
 
 
+def test_tuple_permute() raises:
+    var t = ("hi", 1, 4.5)
+    var permuted = t^.permute[Variadic.values[2, 0, 1]]()
+    assert_equal(permuted, (4.5, "hi", 1))
+
+
+def test_tuple_permute_identity() raises:
+    var t = ("hi", 1, 4.5)
+    var permuted = t^.permute[Variadic.values[0, 1, 2]]()
+    assert_equal(permuted, ("hi", 1, 4.5))
+
+
+def test_tuple_permute_swap() raises:
+    var t = (Bool(True), Int(42))
+    var permuted = t^.permute[Variadic.values[1, 0]]()
+    assert_equal(permuted, (Int(42), Bool(True)))
+
+
+def test_tuple_permute_single() raises:
+    var t = (Int(42),)
+    var permuted = t^.permute[Variadic.values[0]]()
+    assert_equal(permuted, (Int(42),))
+
+
+def test_tuple_permute_copy_count() raises:
+    var t = (CopyCounter(),)
+    var t2 = t^.permute[Variadic.values[0]]()
+    assert_equal(t2[0].copy_count, 0)
+
+
 def test_tuple_concat() raises:
     var t = ("hi", "hey", 1)
     var t2 = (4.5, "hello")

--- a/mojo/stdlib/test/builtin/test_tuple_permute_compile_fail.mojo
+++ b/mojo/stdlib/test/builtin/test_tuple_permute_compile_fail.mojo
@@ -1,0 +1,33 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# Test that Tuple.permute rejects invalid permutations at compile time.
+
+# RUN: not %mojo -D test=1 %s 2>&1 | FileCheck --check-prefix CHECK_1 %s
+# RUN: not %mojo -D test=2 %s 2>&1 | FileCheck --check-prefix CHECK_2 %s
+
+from std.sys import get_defined_int
+
+
+def main():
+    comptime if get_defined_int["test"]() == 1:
+        # Duplicate indices: [0, 0, 1] is not a valid permutation of [0, 1, 2].
+        # CHECK_1: perm must be a valid permutation of [0, len-1]
+        var t = (1, "hello", 3.14)
+        var p = t.permute[Variadic.values[0, 0, 1]]()
+
+    elif get_defined_int["test"]() == 2:
+        # Out-of-range index: [0, 1, 5] is not a valid permutation of [0, 1, 2].
+        # CHECK_2: perm must be a valid permutation of [0, len-1]
+        var t = (1, "hello", 3.14)
+        var p = t.permute[Variadic.values[0, 1, 5]]()

--- a/mojo/stdlib/test/builtin/test_variadic.mojo
+++ b/mojo/stdlib/test/builtin/test_variadic.mojo
@@ -53,6 +53,47 @@ def test_variadic_reverse_even() raises:
     assert_true(_type_is_eq[ReversedVariadic3[1], Int]())
 
 
+def test_variadic_permute() raises:
+    var _tup = (String("hi"), Int(42), Float32(3.14))
+    comptime Permuted = Variadic.permute[
+        *type_of(_tup).element_types, perm=Variadic.values[2, 0, 1]
+    ]
+    assert_equal(Variadic.size(Permuted), 3)
+    assert_true(_type_is_eq[Permuted[0], Float32]())
+    assert_true(_type_is_eq[Permuted[1], String]())
+    assert_true(_type_is_eq[Permuted[2], Int]())
+
+
+def test_variadic_permute_identity() raises:
+    var _tup = (Int(1), String("a"), Float64(2.0))
+    comptime Permuted = Variadic.permute[
+        *type_of(_tup).element_types, perm=Variadic.values[0, 1, 2]
+    ]
+    assert_equal(Variadic.size(Permuted), 3)
+    assert_true(_type_is_eq[Permuted[0], Int]())
+    assert_true(_type_is_eq[Permuted[1], String]())
+    assert_true(_type_is_eq[Permuted[2], Float64]())
+
+
+def test_variadic_permute_swap() raises:
+    var _tup = (Int(1), String("a"))
+    comptime Permuted = Variadic.permute[
+        *type_of(_tup).element_types, perm=Variadic.values[1, 0]
+    ]
+    assert_equal(Variadic.size(Permuted), 2)
+    assert_true(_type_is_eq[Permuted[0], String]())
+    assert_true(_type_is_eq[Permuted[1], Int]())
+
+
+def test_variadic_permute_single() raises:
+    var _tup = (Int(42),)
+    comptime Permuted = Variadic.permute[
+        *type_of(_tup).element_types, perm=Variadic.values[0]
+    ]
+    assert_equal(Variadic.size(Permuted), 1)
+    assert_true(_type_is_eq[Permuted[0], Int]())
+
+
 def test_variadic_concat_empty() raises:
     var _tup = ()
     comptime ConcattedVariadic = Variadic.concat_types[


### PR DESCRIPTION
## Summary

Add compile-time type permutation (`Variadic.permute`) and runtime value
permutation (`Tuple.permute`).

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))

Assisted-by: Claude Opus 4.6