### PR TITLE
[MAX] Add UMT5 text encoder for Wan diffusion

### DIFF
--- a/max/python/max/pipelines/architectures/umt5/__init__.py
+++ b/max/python/max/pipelines/architectures/umt5/__init__.py
@@ -1,0 +1,16 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from .model import UMT5Model
+
+__all__ = ["UMT5Model"]

--- a/max/python/max/pipelines/architectures/umt5/model.py
+++ b/max/python/max/pipelines/architectures/umt5/model.py
@@ -1,0 +1,107 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from typing import Any
+
+from max.driver import Device
+from max.dtype import DType
+from max.engine import InferenceSession, Model
+from max.graph import DeviceRef, Graph, TensorType
+from max.graph.weights import WeightData, Weights
+from max.pipelines.lib import SupportedEncoding
+from max.pipelines.lib.interfaces.component_model import ComponentModel
+
+from .model_config import UMT5Config, UMT5ConfigBase
+from .umt5 import UMT5EncoderModel
+
+
+def _prepare_state_dict(
+    weights: Weights,
+    target_dtype: DType | None = None,
+) -> dict[str, WeightData]:
+    """Convert Weights to a raw state dict, normalizing tied embedding keys.
+
+    HF UMT5 ties ``shared.weight`` and ``encoder.embed_tokens.weight``.
+    Our module owns the embedding as ``shared``, so we normalize to that key
+    and drop the alias to avoid strict-mode validation failures.
+
+    If ``target_dtype`` is provided, all weights are cast to that dtype
+    (e.g. float32 → bfloat16 for Wan 2.1 checkpoints).
+    """
+    state_dict: dict[str, WeightData] = {}
+    for key, value in weights.items():
+        wd = value.data()
+        if target_dtype is not None and wd.dtype != target_dtype:
+            wd = wd.astype(target_dtype)
+        state_dict[key] = wd
+
+    encoder_emb = state_dict.pop("encoder.embed_tokens.weight", None)
+    if "shared.weight" not in state_dict and encoder_emb is not None:
+        state_dict["shared.weight"] = encoder_emb
+
+    return state_dict
+
+
+class UMT5Model(ComponentModel):
+    def __init__(
+        self,
+        config: dict[str, Any],
+        encoding: SupportedEncoding,
+        devices: list[Device],
+        weights: Weights,
+        session: InferenceSession | None = None,
+    ) -> None:
+        super().__init__(config, encoding, devices, weights)
+        self.session = session or InferenceSession(devices=devices)
+        self.config: UMT5ConfigBase = UMT5Config.generate(
+            config,
+            encoding,
+            devices,
+        )
+        self.load_model()
+
+    def load_model(self) -> Model:
+        assert self.weights is not None, "Weights already freed"
+        # Force bfloat16 — some repos (Wan 2.1) declare float32 but
+        # should run in bfloat16 on GPU. Override both config and weights.
+        dtype = DType.bfloat16
+        self.config.dtype = dtype
+        state_dict = _prepare_state_dict(self.weights, target_dtype=dtype)
+        dev = self.devices[0]
+        dev_ref = DeviceRef.from_device(dev)
+
+        # Build module and load weights
+        module = UMT5EncoderModel(self.config, dtype=dtype, device=dev_ref)
+        module.load_state_dict(state_dict, weight_alignment=1, strict=True)
+
+        # Build graph with symbolic sequence length
+        # attention_mask comes in as int64 from the pipeline
+        input_types = [
+            TensorType(DType.int64, ["batch", "seq_len"], device=dev),
+            TensorType(DType.int64, ["batch", "seq_len"], device=dev),
+        ]
+        with Graph("umt5_encoder", input_types=input_types) as graph:
+            input_ids = graph.inputs[0].tensor
+            attention_mask = graph.inputs[1].tensor
+            out = module(input_ids, attention_mask)
+            graph.output(out)
+
+        self.model: Model = self.session.load(
+            graph, weights_registry=module.state_dict()
+        )
+        # Free raw weights after compilation
+        self.weights = None  # type: ignore[assignment]
+        return self.model
+
+    def __call__(self, *args, **kwargs):
+        return self.model(*args, **kwargs)

--- a/max/python/max/pipelines/architectures/umt5/model_config.py
+++ b/max/python/max/pipelines/architectures/umt5/model_config.py
@@ -1,0 +1,73 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from typing import Any
+
+from max.driver import Device
+from max.dtype import DType
+from max.graph import DeviceRef
+from max.pipelines.lib import MAXModelConfigBase, SupportedEncoding
+from max.pipelines.lib.config.config_enums import supported_encoding_dtype
+from pydantic import Field
+
+
+class UMT5ConfigBase(MAXModelConfigBase):
+    vocab_size: int = 256384
+    d_model: int = 4096
+    d_kv: int = 64
+    d_ff: int = 10240
+    num_layers: int = 24
+    num_decoder_layers: int | None = 24
+    num_heads: int = 64
+    relative_attention_num_buckets: int = 32
+    relative_attention_max_distance: int = 128
+    dropout_rate: float = 0.1
+    layer_norm_epsilon: float = 1e-6
+    initializer_factor: float = 1.0
+    feed_forward_proj: str = "gated-gelu"
+    dense_act_fn: str | None = Field(default=None, exclude=True)
+    is_gated_act: bool = Field(default=False, exclude=True)
+    is_decoder: bool = Field(default=False, exclude=True)
+    is_encoder_decoder: bool = True
+    use_cache: bool = True
+    output_past: bool = True
+    pad_token_id: int = 0
+    eos_token_id: int = 1
+    decoder_start_token_id: int = 0
+    classifier_dropout: float = 0.0
+    scalable_attention: bool = True
+    tie_word_embeddings: bool = False
+    tokenizer_class: str = "T5Tokenizer"
+    device: DeviceRef = Field(default_factory=DeviceRef.GPU)
+    dtype: DType = DType.bfloat16
+
+
+class UMT5Config(UMT5ConfigBase):
+    @staticmethod
+    def generate(
+        config_dict: dict[str, Any],
+        encoding: SupportedEncoding,
+        devices: list[Device],
+    ) -> UMT5ConfigBase:
+        init_dict = {
+            key: value
+            for key, value in config_dict.items()
+            if key in UMT5ConfigBase.__annotations__
+        }
+        init_dict.update(
+            {
+                "dtype": supported_encoding_dtype(encoding),
+                "device": DeviceRef.from_device(devices[0]),
+            }
+        )
+        return UMT5ConfigBase(**init_dict)

--- a/max/python/max/pipelines/architectures/umt5/umt5.py
+++ b/max/python/max/pipelines/architectures/umt5/umt5.py
@@ -1,0 +1,542 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""UMT5 encoder implementation aligned with Hugging Face UMT5 behavior.
+
+Uses module_v2 (nn.layer.Module / ops) API exclusively.
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+
+from max.dtype import DType
+from max.graph import DeviceRef, Dim, TensorValue, Weight, ops
+from max.nn.embedding import Embedding
+from max.nn.layer import LayerList, Module
+from max.nn.linear import Linear
+
+from .model_config import UMT5ConfigBase
+
+
+class UMT5LayerNorm(Module):
+    """T5-style RMSNorm (no bias, no mean subtraction)."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        *,
+        dtype: DType = DType.float32,
+        device: DeviceRef = DeviceRef.GPU(),
+    ) -> None:
+        super().__init__()
+        self.weight = Weight("weight", dtype, [hidden_size], device)
+        self.variance_epsilon = eps
+        self._dtype = dtype
+
+    def __call__(self, hidden_states: TensorValue) -> TensorValue:
+        x = ops.cast(hidden_states, DType.float32)
+        variance = ops.mean(x * x, axis=-1)
+        x = x * ops.rsqrt(variance + self.variance_epsilon)
+        if self._dtype in (DType.float16, DType.bfloat16):
+            x = ops.cast(x, self._dtype)
+        return ops.cast(self.weight, x.dtype) * x
+
+
+class UMT5DenseActDense(Module):
+    def __init__(
+        self,
+        config: UMT5ConfigBase,
+        *,
+        dtype: DType,
+        device: DeviceRef,
+    ) -> None:
+        super().__init__()
+        self.wi = Linear(
+            in_dim=config.d_model,
+            out_dim=config.d_ff,
+            dtype=dtype,
+            device=device,
+            has_bias=False,
+        )
+        self.wo = Linear(
+            in_dim=config.d_ff,
+            out_dim=config.d_model,
+            dtype=dtype,
+            device=device,
+            has_bias=False,
+        )
+        act_name = config.dense_act_fn
+        if act_name == "relu":
+            self._act = "relu"
+        elif act_name in ("gelu_new", "gelu"):
+            self._act = act_name
+        else:
+            raise ValueError(f"Unsupported UMT5 dense_act_fn: {act_name}")
+
+    def __call__(self, hidden_states: TensorValue) -> TensorValue:
+        hidden_states = self.wi(hidden_states)
+        if self._act == "relu":
+            hidden_states = ops.relu(hidden_states)
+        elif self._act == "gelu_new":
+            hidden_states = ops.gelu(hidden_states, approximate="tanh")
+        else:
+            hidden_states = ops.gelu(hidden_states)
+        return self.wo(hidden_states)
+
+
+class UMT5DenseGatedActDense(Module):
+    def __init__(
+        self,
+        config: UMT5ConfigBase,
+        *,
+        dtype: DType,
+        device: DeviceRef,
+    ) -> None:
+        super().__init__()
+        self.wi_0 = Linear(
+            in_dim=config.d_model,
+            out_dim=config.d_ff,
+            dtype=dtype,
+            device=device,
+            has_bias=False,
+        )
+        self.wi_1 = Linear(
+            in_dim=config.d_model,
+            out_dim=config.d_ff,
+            dtype=dtype,
+            device=device,
+            has_bias=False,
+        )
+        self.wo = Linear(
+            in_dim=config.d_ff,
+            out_dim=config.d_model,
+            dtype=dtype,
+            device=device,
+            has_bias=False,
+        )
+        act_name = config.dense_act_fn
+        if act_name == "relu":
+            self._act = "relu"
+        elif act_name in ("gelu_new", "gelu"):
+            self._act = act_name
+        else:
+            raise ValueError(f"Unsupported UMT5 dense_act_fn: {act_name}")
+
+    def __call__(self, hidden_states: TensorValue) -> TensorValue:
+        gated = self.wi_0(hidden_states)
+        if self._act == "relu":
+            gated = ops.relu(gated)
+        elif self._act == "gelu_new":
+            gated = ops.gelu(gated, approximate="tanh")
+        else:
+            gated = ops.gelu(gated)
+        linear = self.wi_1(hidden_states)
+        return self.wo(gated * linear)
+
+
+class UMT5LayerFF(Module):
+    def __init__(
+        self,
+        config: UMT5ConfigBase,
+        *,
+        dtype: DType,
+        device: DeviceRef,
+    ) -> None:
+        super().__init__()
+        if config.is_gated_act:
+            self.DenseReluDense: UMT5DenseGatedActDense | UMT5DenseActDense = (
+                UMT5DenseGatedActDense(config, dtype=dtype, device=device)
+            )
+        else:
+            self.DenseReluDense = UMT5DenseActDense(
+                config, dtype=dtype, device=device
+            )
+        self.layer_norm = UMT5LayerNorm(
+            config.d_model,
+            eps=config.layer_norm_epsilon,
+            dtype=config.dtype,
+            device=device,
+        )
+
+    def __call__(self, hidden_states: TensorValue) -> TensorValue:
+        forwarded = self.layer_norm(hidden_states)
+        forwarded = self.DenseReluDense(forwarded)
+        return hidden_states + forwarded
+
+
+class UMT5Attention(Module):
+    def __init__(
+        self,
+        config: UMT5ConfigBase,
+        has_relative_attention_bias: bool = False,
+        *,
+        dtype: DType,
+        device: DeviceRef,
+    ) -> None:
+        super().__init__()
+        self.is_decoder = config.is_decoder
+        self.has_relative_attention_bias = has_relative_attention_bias
+        self.relative_attention_num_buckets = (
+            config.relative_attention_num_buckets
+        )
+        self.relative_attention_max_distance = (
+            config.relative_attention_max_distance
+        )
+        self.d_model = config.d_model
+        self.key_value_proj_dim = config.d_kv
+        self.n_heads = config.num_heads
+        self.inner_dim = self.n_heads * self.key_value_proj_dim
+        self._dtype = config.dtype
+        self._device = device
+
+        self.q = Linear(
+            in_dim=self.d_model,
+            out_dim=self.inner_dim,
+            dtype=dtype,
+            device=device,
+            has_bias=False,
+        )
+        self.k = Linear(
+            in_dim=self.d_model,
+            out_dim=self.inner_dim,
+            dtype=dtype,
+            device=device,
+            has_bias=False,
+        )
+        self.v = Linear(
+            in_dim=self.d_model,
+            out_dim=self.inner_dim,
+            dtype=dtype,
+            device=device,
+            has_bias=False,
+        )
+        self.o = Linear(
+            in_dim=self.inner_dim,
+            out_dim=self.d_model,
+            dtype=dtype,
+            device=device,
+            has_bias=False,
+        )
+
+        if self.has_relative_attention_bias:
+            self.relative_attention_bias = Embedding(
+                vocab_size=self.relative_attention_num_buckets,
+                hidden_dim=self.n_heads,
+                dtype=dtype,
+                device=device,
+            )
+
+    def _relative_position_bucket(
+        self,
+        relative_position: TensorValue,
+    ) -> TensorValue:
+        num_buckets = self.relative_attention_num_buckets
+        max_distance = self.relative_attention_max_distance
+
+        dev = self._device
+        relative_buckets = ops.constant(0, dtype=DType.int32, device=dev)
+        relative_buckets = ops.broadcast_to(
+            relative_buckets, relative_position.shape
+        )
+
+        if not self.is_decoder:
+            num_buckets = num_buckets // 2
+            is_positive = ops.greater(relative_position, 0)
+            relative_buckets = relative_buckets + (
+                ops.cast(is_positive, DType.int32) * num_buckets
+            )
+            relative_position = ops.abs(relative_position)
+        else:
+            relative_position = -ops.min(relative_position, 0)
+
+        max_exact = num_buckets // 2
+        is_small = ops.greater(
+            ops.constant(max_exact, dtype=DType.int32, device=dev).broadcast_to(
+                relative_position.shape
+            ),
+            relative_position,
+        )
+
+        scale = (num_buckets - max_exact) / math.log(max_distance / max_exact)
+        rel_pos_float = ops.cast(relative_position, DType.float32)
+        val_log = ops.log(rel_pos_float / float(max_exact))
+        relative_position_if_large = (
+            ops.cast(val_log * scale, DType.int32) + max_exact
+        )
+        max_val = ops.constant(
+            num_buckets - 1, dtype=DType.int32, device=dev
+        ).broadcast_to(relative_position_if_large.shape)
+        relative_position_if_large = ops.where(
+            ops.greater(relative_position_if_large, max_val),
+            max_val,
+            relative_position_if_large,
+        )
+
+        return relative_buckets + ops.where(
+            is_small, relative_position, relative_position_if_large
+        )
+
+    def _compute_bias(
+        self,
+        query_length: int | Dim,
+        key_length: int | Dim,
+    ) -> TensorValue:
+        context_position = ops.range(
+            0,
+            query_length,
+            1,
+            dtype=DType.int32,
+            device=self._device,
+        )
+        context_position = ops.unsqueeze(context_position, 1)
+
+        memory_position = ops.range(
+            0,
+            key_length,
+            1,
+            dtype=DType.int32,
+            device=self._device,
+        )
+        memory_position = ops.unsqueeze(memory_position, 0)
+        relative_position = memory_position - context_position
+
+        relative_position_bucket = self._relative_position_bucket(
+            relative_position
+        )
+        values = self.relative_attention_bias(relative_position_bucket)
+        # values: [query_length, key_length, n_heads]
+        values = ops.permute(values, [2, 0, 1])
+        values = ops.unsqueeze(values, 0)
+        # values: [1, n_heads, query_length, key_length]
+        return values
+
+    def __call__(
+        self,
+        hidden_states: TensorValue,
+        attention_mask: TensorValue | None = None,
+    ) -> TensorValue:
+        batch_size = hidden_states.shape[0]
+        seq_length = hidden_states.shape[1]
+
+        query_states = self.q(hidden_states)
+        key_states = self.k(hidden_states)
+        value_states = self.v(hidden_states)
+
+        query_states = ops.reshape(
+            query_states,
+            [batch_size, seq_length, self.n_heads, self.key_value_proj_dim],
+        )
+        key_states = ops.reshape(
+            key_states,
+            [batch_size, seq_length, self.n_heads, self.key_value_proj_dim],
+        )
+        value_states = ops.reshape(
+            value_states,
+            [batch_size, seq_length, self.n_heads, self.key_value_proj_dim],
+        )
+
+        # [B, S, H, D] -> [B, H, S, D]
+        query_states = ops.permute(query_states, [0, 2, 1, 3])
+        key_states = ops.permute(key_states, [0, 2, 1, 3])
+        value_states = ops.permute(value_states, [0, 2, 1, 3])
+
+        # scores: [B, H, S, S]
+        scores = query_states @ ops.permute(key_states, [0, 1, 3, 2])
+
+        if self.has_relative_attention_bias:
+            position_bias = self._compute_bias(seq_length, seq_length)
+            scores = scores + position_bias
+
+        if attention_mask is not None:
+            scores = scores + attention_mask
+
+        attn_weights = ops.softmax(ops.cast(scores, DType.float32))
+        attn_weights = ops.cast(attn_weights, self._dtype)
+        attn_output = attn_weights @ value_states
+
+        # [B, H, S, D] -> [B, S, H, D] -> [B, S, inner_dim]
+        attn_output = ops.permute(attn_output, [0, 2, 1, 3])
+        attn_output = ops.reshape(
+            attn_output, [batch_size, seq_length, self.inner_dim]
+        )
+        return self.o(attn_output)
+
+
+class UMT5LayerSelfAttention(Module):
+    def __init__(
+        self,
+        config: UMT5ConfigBase,
+        layer_idx: int | None = None,
+        *,
+        dtype: DType,
+        device: DeviceRef,
+    ) -> None:
+        super().__init__()
+        del layer_idx
+        self.SelfAttention = UMT5Attention(
+            config,
+            has_relative_attention_bias=True,
+            dtype=dtype,
+            device=device,
+        )
+        self.layer_norm = UMT5LayerNorm(
+            config.d_model,
+            eps=config.layer_norm_epsilon,
+            dtype=config.dtype,
+            device=device,
+        )
+
+    def __call__(
+        self,
+        hidden_states: TensorValue,
+        attention_mask: TensorValue | None = None,
+    ) -> TensorValue:
+        normed = self.layer_norm(hidden_states)
+        attn_output = self.SelfAttention(normed, attention_mask)
+        return hidden_states + attn_output
+
+
+class UMT5Block(Module):
+    def __init__(
+        self,
+        config: UMT5ConfigBase,
+        layer_idx: int | None = None,
+        *,
+        dtype: DType,
+        device: DeviceRef,
+    ) -> None:
+        super().__init__()
+        # Use LayerList with index 0 = self-attn, index 1 = FF
+        # to match HF weight key paths: block.{i}.layer.0 / block.{i}.layer.1
+        self.layer = LayerList(
+            [
+                UMT5LayerSelfAttention(
+                    config, layer_idx=layer_idx, dtype=dtype, device=device
+                ),
+                UMT5LayerFF(config, dtype=dtype, device=device),
+            ]
+        )
+
+    def __call__(
+        self,
+        hidden_states: TensorValue,
+        attention_mask: TensorValue | None = None,
+    ) -> TensorValue:
+        hidden_states = self.layer[0](hidden_states, attention_mask)
+        hidden_states = self.layer[1](hidden_states)
+        return hidden_states
+
+
+class UMT5Stack(Module):
+    def __init__(
+        self,
+        config: UMT5ConfigBase,
+        embed_tokens: Embedding,
+        *,
+        dtype: DType,
+        device: DeviceRef,
+    ) -> None:
+        super().__init__()
+        self.embed_tokens = embed_tokens
+        self.block = LayerList(
+            [
+                UMT5Block(config, layer_idx=i, dtype=dtype, device=device)
+                for i in range(config.num_layers)
+            ]
+        )
+        self.final_layer_norm = UMT5LayerNorm(
+            config.d_model,
+            eps=config.layer_norm_epsilon,
+            dtype=config.dtype,
+            device=device,
+        )
+        self._dtype = config.dtype
+
+    def __call__(
+        self,
+        input_ids: TensorValue,
+        attention_mask: TensorValue | None = None,
+    ) -> TensorValue:
+        hidden_states = self.embed_tokens(input_ids)
+
+        # Build causal mask from attention_mask [B, S]
+        causal_mask: TensorValue | None = None
+        if attention_mask is not None:
+            # (1 - mask) * dtype_min → masked positions get large negative
+            _DTYPE_MIN: dict[DType, float] = {
+                DType.float16: -65504.0,
+                DType.bfloat16: -3.3895314e38,
+                DType.float32: -3.4028235e38,
+            }
+            mask_min = _DTYPE_MIN.get(self._dtype, -3.4028235e38)
+            mask_float = ops.cast(attention_mask, hidden_states.dtype)
+            causal_mask = (1.0 - mask_float) * mask_min
+            # [B, S] -> [B, 1, 1, S] for broadcasting with [B, H, S, S]
+            causal_mask = ops.unsqueeze(ops.unsqueeze(causal_mask, 1), 1)
+
+        for block in self.block:
+            hidden_states = block(hidden_states, causal_mask)
+
+        hidden_states = self.final_layer_norm(hidden_states)
+        return hidden_states
+
+
+class UMT5EncoderModel(Module):
+    """UMT5 encoder using module_v2 (ops-based) API."""
+
+    def __init__(
+        self,
+        config: UMT5ConfigBase,
+        *,
+        dtype: DType,
+        device: DeviceRef,
+    ) -> None:
+        super().__init__()
+        # Parse feed_forward config
+        act_info = config.feed_forward_proj.split("-")
+        config.dense_act_fn = act_info[-1]
+        config.is_gated_act = act_info[0] == "gated"
+        if (len(act_info) > 1 and act_info[0] != "gated") or len(act_info) > 2:
+            raise ValueError(
+                f"`feed_forward_proj`: {config.feed_forward_proj} is not valid."
+            )
+        if config.feed_forward_proj == "gated-gelu":
+            config.dense_act_fn = "gelu_new"
+
+        self.shared = Embedding(
+            vocab_size=config.vocab_size,
+            hidden_dim=config.d_model,
+            dtype=dtype,
+            device=device,
+        )
+
+        encoder_config = copy.deepcopy(config)
+        encoder_config.is_decoder = False
+        encoder_config.use_cache = False
+        encoder_config.is_encoder_decoder = False
+        self.encoder = UMT5Stack(
+            encoder_config, self.shared, dtype=dtype, device=device
+        )
+
+    def __call__(
+        self,
+        input_ids: TensorValue,
+        attention_mask: TensorValue | None = None,
+    ) -> TensorValue:
+        return self.encoder(input_ids, attention_mask)
+
+
+__all__ = ["UMT5EncoderModel"]

--- a/max/python/max/pipelines/architectures/umt5/weight_adapters.py
+++ b/max/python/max/pipelines/architectures/umt5/weight_adapters.py
@@ -1,0 +1,61 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Weight adapters for UMT5 models."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from max.graph.weights import WeightData
+
+
+def _clone_weight(weight: WeightData, new_name: str) -> WeightData:
+    return WeightData(
+        data=weight.data,
+        name=new_name,
+        dtype=weight.dtype,
+        shape=weight.shape,
+        quantization_encoding=weight.quantization_encoding,
+    )
+
+
+def convert_safetensor_state_dict(
+    state_dict: Mapping[str, WeightData],
+) -> dict[str, WeightData]:
+    """Ensure shared UMT5 embeddings are available under MAX expected names.
+
+    Hugging Face UMT5 ties `encoder.embed_tokens.weight` to `shared.weight`.
+    Some checkpoints include only one of these keys, so this adapter duplicates
+    the available embedding to whichever name is missing.
+    """
+    new_state_dict = dict(state_dict)
+    shared_weight = new_state_dict.get("shared.weight")
+    encoder_weight = new_state_dict.get("encoder.embed_tokens.weight")
+
+    if shared_weight is None and encoder_weight is None:
+        raise ValueError(
+            "Missing UMT5 embedding weights. Expected one of "
+            "`shared.weight` or `encoder.embed_tokens.weight` to be present."
+        )
+
+    if shared_weight is None and encoder_weight is not None:
+        new_state_dict["shared.weight"] = _clone_weight(
+            encoder_weight, "shared.weight"
+        )
+
+    if encoder_weight is None and shared_weight is not None:
+        new_state_dict["encoder.embed_tokens.weight"] = _clone_weight(
+            shared_weight, "encoder.embed_tokens.weight"
+        )
+
+    return new_state_dict


### PR DESCRIPTION
## Summary

Add a MAX-native UMT5 text encoder for Wan diffusion pipelines.

## Description

- Implements the UMT5 encoder architecture using `max.nn` (Module V2 graph API)
- Supports float32 → bfloat16 weight casting via `WeightData.astype()` for Wan checkpoints that store text encoder weights in float32
- Includes T5-style relative position bias and gated GeLU feed-forward
- Handles diffusers weight key remapping (e.g. `shared.weight` alias dedup)

UMT5 is the text encoder used by all Wan 2.1/2.2 models. It produces 4096-dim text embeddings consumed by the Wan transformer.

## Dependencies

None — can be merged independently.

## Checklist

- [x] PR is small and focused
- [x] I ran `./bazelw run format` to format my changes

Assisted-by: Claude Code