### PR TITLE
[MAX] Add FLUX.2-klein i2i pipeline verification

### DIFF
--- a/max/tests/integration/accuracy/logit_verification/logit_verification_config.yaml
+++ b/max/tests/integration/accuracy/logit_verification/logit_verification_config.yaml
@@ -972,7 +972,18 @@ logit_verification_pipelines:
   black-forest-labs/FLUX.2-klein-4B-t2i-bfloat16:
     pre_submit_agents: []
     post_submit_agents: []
-    pipeline: "black-forest-labs/FLUX.2-klein-4B"
+    pipeline: "black-forest-labs/FLUX.2-klein-4B-t2i"
+    compatible_with: [gpu]
+    encoding: bfloat16
+    tags: [nvidia-only, image-generation, manual]
+    ssim_threshold: 0.60
+    lpips_threshold: 0.35
+    timeout: 3600
+
+  black-forest-labs/FLUX.2-klein-4B-i2i-bfloat16:
+    pre_submit_agents: []
+    post_submit_agents: []
+    pipeline: "black-forest-labs/FLUX.2-klein-4B-i2i"
     compatible_with: [gpu]
     encoding: bfloat16
     tags: [nvidia-only, image-generation, manual]

--- a/max/tests/integration/tools/create_pipelines.py
+++ b/max/tests/integration/tools/create_pipelines.py
@@ -1764,8 +1764,13 @@ PIPELINE_ORACLES: Mapping[str, PipelineOracle] = {
         "black-forest-labs/FLUX.2-dev",
         requests=test_data.FLUX2_PIXEL_GENERATION_I2I,
     ),
-    "black-forest-labs/FLUX.2-klein-4B": ImageGenerationOracle(
+    "black-forest-labs/FLUX.2-klein-4B-t2i": ImageGenerationOracle(
         "black-forest-labs/FLUX.2-klein-4B",
         num_steps=4,
+    ),
+    "black-forest-labs/FLUX.2-klein-4B-i2i": ImageGenerationOracle(
+        "black-forest-labs/FLUX.2-klein-4B",
+        num_steps=4,
+        requests=test_data.FLUX2_PIXEL_GENERATION_I2I,
     ),
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Please fill out the sections below to help reviewers understand your change.
For guidance on writing a good PR, see our
[contributor guide](../CONTRIBUTING.md).
-->

## Summary

- add  `black-forest-labs/FLUX.2-klein-4B-i2i` pipeline verification
- rename `black-forest-labs/FLUX.2-klein-4B` pipelines to `black-forest-labs/FLUX.2-klein-4B-t2i`

## Testing

- t2i 
  ```
  ./bazelw run //max/tests/integration/accuracy:verify_pipelines -- \
    --pipeline black-forest-labs/FLUX.2-klein-4B-t2i-bfloat16  \
    --devices gpu:0 \
    --pixel-results-dir ./results
  ```
- i2i
  ```
  ./bazelw run //max/tests/integration/accuracy:verify_pipelines -- \
    --pipeline black-forest-labs/FLUX.2-klein-4B-i2i-bfloat16  \
    --devices gpu:0 \
    --pixel-results-dir ./results
  ```


## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))