### PR TITLE
[Docs] Fix broken Mojo get-started examples

### DIFF
--- a/mojo/docs/manual/get-started.mdx
+++ b/mojo/docs/manual/get-started.mdx
@@ -1041,8 +1041,8 @@ generator](https://en.wikipedia.org/wiki/Pseudorandom_number_generator) used by
 the Mojo standard library currently uses a fixed seed. This means it generates
 the same sequence of numbers unless you provide a different seed, which is
 useful for testing purposes. However, for this application, we want to call
-`std.random.seed()` to set a seed value based on the current time, which gives us a
-unique value every time.
+`std.random.seed()` to set a seed value based on the current time, which gives
+us a unique value every time.
 
 Then we create `data` as an empty `List[List[Int]]`, which we'll populate with a
 random initial state. For each cell, we call

--- a/mojo/docs/manual/get-started.mdx
+++ b/mojo/docs/manual/get-started.mdx
@@ -827,7 +827,7 @@ can accept a value only if its type implements some required behavior—in this
 case, it only accepts types that can generate a `String` representation.
 
 To enforce this, the `String()` constructors require a type to conform to the
-[`Writable`] trait. (This type of function is sometimes referred to as a
+`Writable` trait. (This type of function is sometimes referred to as a
 [*generic* function](/mojo/manual/parameters/#parameters-and-generics).) Each
 trait requires a conforming type to implement a `write_to()` method that writes
 its `String` representation. (To learn more, read
@@ -838,7 +838,7 @@ Notice that `write_to()` takes a `mut writer: Some[Writer]` argument. The
 files, network streams, and so on. By writing to a generic `Writer` instead of
 building and returning a `String`, your type works with any output destination.
 
-Our `grid_str()` method already write our `String` representation, so it looks
+Our `grid_str()` method already writes our `String` representation, so it looks
 like we'll have to rename it to `write_to()` and add the `Writer` argument to
 the function, and remove the `String` return value. We also need to indicate
 which trait `Grid` conforms to. In our case, it must be `Writable`.
@@ -856,7 +856,7 @@ struct Grid(Copyable, Writable):
       for row in range(self.rows):
           # Iterate through columns 0 through cols-1
           for col in range(self.cols):
-              if self[row, col] == 1:
+              if self.data[row][col] == 1:
                   # If cell is populated, write an asterisk
                   writer.write_string("*")
               else:
@@ -1018,7 +1018,7 @@ struct Grid(Copyable, Writable):
     @staticmethod
     def random(rows: Int, cols: Int) -> Self:
         # Seed the random number generator using the current time.
-        random.seed()
+        std.random.seed()
 
         var data: List[List[Int]] = []
 
@@ -1026,7 +1026,7 @@ struct Grid(Copyable, Writable):
             var row_data: List[Int] = []
             for _ in range(cols):
                 # Generate a random 0 or 1 and append it to the row.
-                row_data.append(Int(random.random_si64(0, 1)))
+                row_data.append(Int(std.random.random_si64(0, 1)))
             data.append(row_data^)
 
         return Self(rows, cols, data^)
@@ -1041,12 +1041,12 @@ generator](https://en.wikipedia.org/wiki/Pseudorandom_number_generator) used by
 the Mojo standard library currently uses a fixed seed. This means it generates
 the same sequence of numbers unless you provide a different seed, which is
 useful for testing purposes. However, for this application, we want to call
-`random.seed()` to set a seed value based on the current time, which gives us a
+`std.random.seed()` to set a seed value based on the current time, which gives us a
 unique value every time.
 
 Then we create `data` as an empty `List[List[Int]]`, which we'll populate with a
 random initial state. For each cell, we call
-[`random.random_si64()`](/mojo/std/random/random/random_si64), which returns
+[`std.random.random_si64()`](/mojo/std/random/random/random_si64), which returns
 a random integer value from the provided minimum and maximum values of 0 and 1,
 respectively. This function actually returns a value of type `Int64`, which is a
 signed 64-bit integer value. As described in [Numeric
@@ -1362,7 +1362,7 @@ def run_display(
         pygame.display.flip()
 
         # Pause to let the user appreciate the scene
-        time.sleep(pause)
+        std.time.sleep(pause)
 
         # Next generation
         grid = grid.evolve()


### PR DESCRIPTION
## Summary

Fix the issue-reported broken examples in `mojo/docs/manual/get-started.mdx`.

Closes #6294.

## What changed

- Use `self.data[row][col]` in the section 9 `write_to()` snippet before indexing is introduced
- Fix the nearby section 9 wording issues (`Writable`, `already writes`)
- Qualify the section 11 random calls as `std.random.seed()` and `std.random.random_si64(...)`
- Qualify the section 13 sleep call as `std.time.sleep(pause)`

## Validation

- Ran `~/.pixi/bin/pixi run mojo --version` in `mojo/examples/life` on Mojo `0.26.3.0.dev2026033005`
- Ran `~/.pixi/bin/pixi run test_gridv1` in `mojo/examples/life`
- Ran `~/.pixi/bin/pixi run mojo build lifev1.mojo -o /tmp/lifev1-docs-check` in `mojo/examples/life`
- Re-read section 9 through section 10 to confirm the tutorial progression is internally consistent
- Ran `git diff --check origin/main...HEAD`

## Notes

- Scope is intentionally narrow and docs-only
