### PR TITLE
[Kernels][GPU] Fix CPU eager fallback for flash_attention_gpu no-cache path

### DIFF
--- a/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
@@ -5353,16 +5353,17 @@ struct MaskedFlashAttentionGPU:
 struct FlashAttentionGPU:
     @staticmethod
     def execute[
+        dtype: DType,
         rank: Int,
         //,
         target: StaticString,
         mask_str: StaticString,
         local_window_size: Int = -1,
     ](
-        output: OutputTensor[rank=rank, ...],
-        q: InputTensor[rank=rank, ...],
-        k: InputTensor[rank=rank, ...],
-        v: InputTensor[rank=rank, ...],
+        output: OutputTensor[dtype=dtype, rank=rank, ...],
+        q: InputTensor[dtype=dtype, rank=rank, ...],
+        k: InputTensor[dtype=dtype, rank=rank, ...],
+        v: InputTensor[dtype=dtype, rank=rank, ...],
         scale: Float32,
         ctx: DeviceContextPtr,
     ) raises:
@@ -5406,8 +5407,6 @@ struct FlashAttentionGPU:
         The underlying fusion follows ideas taken from the 2022 FlashAttention paper
         by Tri Dao et al.
         """
-        comptime assert is_gpu[target](), "only valid on GPUs"
-
         var output_buffer = output.to_layout_tensor()
         var q_buffer = q.to_layout_tensor()
         var k_buffer = k.to_layout_tensor()
@@ -5416,15 +5415,58 @@ struct FlashAttentionGPU:
         @parameter
         @__copy_capture(output_buffer, q_buffer, k_buffer, v_buffer)
         def _dispatch_flash_attention[mask_t: MHAMask](mask: mask_t) raises:
-            flash_attention[](
-                output_buffer,
-                q_buffer,
-                k_buffer,
-                v_buffer,
-                mask,
-                scale,
-                ctx[],
-            )
+            comptime if is_cpu[target]():
+
+                @parameter
+                @always_inline
+                def k_input_fn[
+                    width: Int, _rank: Int
+                ](coords: IndexList[_rank]) -> SIMD[q_buffer.dtype, width]:
+                    return rebind[SIMD[q_buffer.dtype, width]](
+                        k_buffer.get_immutable().load[width=width](
+                            rebind[IndexList[rank]](coords)
+                        )
+                    )
+
+                @parameter
+                @always_inline
+                def v_input_fn[
+                    width: Int, _rank: Int
+                ](coords: IndexList[_rank]) -> SIMD[q_buffer.dtype, width]:
+                    return rebind[SIMD[q_buffer.dtype, width]](
+                        v_buffer.get_immutable().load[width=width](
+                            rebind[IndexList[rank]](coords)
+                        )
+                    )
+
+                @parameter
+                @always_inline
+                def mask_input_fn[
+                    width: Int, _rank: Int
+                ](coords: IndexList[_rank]) -> SIMD[q_buffer.dtype, width]:
+                    return mask.mask(
+                        rebind[IndexList[4]](coords),
+                        SIMD[q_buffer.dtype, width](0),
+                    )
+
+                nn_flash_attention[k_input_fn, v_input_fn, mask_input_fn](
+                    q_buffer.get_immutable(),
+                    k.shape(),
+                    v.shape(),
+                    IndexList[4](),
+                    output.to_layout_tensor(),
+                    scale,
+                )
+            else:
+                flash_attention[](
+                    output_buffer,
+                    q_buffer,
+                    k_buffer,
+                    v_buffer,
+                    mask,
+                    scale,
+                    ctx[],
+                )
 
         dispatch_mask[
             mask_str,

--- a/max/python/max/nn/kernels.py
+++ b/max/python/max/nn/kernels.py
@@ -1851,7 +1851,7 @@ def flash_attention_gpu(
     local_window_size: int = -1,
     valid_length: TensorValue | None = None,
 ) -> TensorValue:
-    """Computes flash attention using GPU-optimized kernel.
+    """Computes flash attention using the accelerator kernel or CPU fallback.
 
     Args:
         q: Query tensor of shape [batch, seq_len, num_heads, head_dim]
@@ -1888,8 +1888,12 @@ def flash_attention_gpu(
             f"q: {head_dim}, k: {k.shape[-1]}, v: {v.shape[-1]}"
         )
 
+    assert_same_device(q=q, k=k, v=v)
+
     # Validate valid_length if provided
     if valid_length is not None:
+        assert_same_device(q=q, valid_length=valid_length)
+
         if valid_length.dtype != DType.uint32:
             raise ValueError(
                 f"valid_length must have dtype uint32, got {valid_length.dtype}"
@@ -1904,6 +1908,18 @@ def flash_attention_gpu(
             raise ValueError(
                 f"valid_length batch size ({valid_length.shape[0]}) must match "
                 f"q batch size ({q.shape[0]})"
+            )
+
+        device_type = getattr(q.device, "device_type", None)
+        if device_type is not None:
+            is_host_device = device_type.value == "cpu"
+        else:
+            is_host_device = getattr(q.device, "is_host", False)
+
+        if is_host_device:
+            raise ValueError(
+                "flash_attention_gpu does not support valid_length on CPU; "
+                "padded CPU fallback is not implemented"
             )
 
     parameters = _mha_parameters(

--- a/max/tests/integration/tensor/test_functional_custom.py
+++ b/max/tests/integration/tensor/test_functional_custom.py
@@ -25,6 +25,7 @@ from max.driver import CPU, Accelerator, accelerator_count
 from max.dtype import DType
 from max.experimental import functional as F
 from max.experimental.tensor import Tensor
+from max.graph import TensorValue
 from max.nn import kernels
 
 DEVICE = Accelerator() if accelerator_count() else CPU()
@@ -235,7 +236,9 @@ def test_flash_attention_gpu_cpu_fallback(
     v = Tensor(v_np, device=CPU())
 
     @F.functional
-    def run_attention(q: Tensor, k: Tensor, v: Tensor) -> Tensor:
+    def run_attention(
+        q: TensorValue, k: TensorValue, v: TensorValue
+    ) -> TensorValue:
         return kernels.flash_attention_gpu(
             q,
             k,
@@ -271,11 +274,11 @@ def test_flash_attention_gpu_rejects_valid_length_on_cpu() -> None:
 
     @F.functional
     def run_attention(
-        q: Tensor,
-        k: Tensor,
-        v: Tensor,
-        valid_length: Tensor,
-    ) -> Tensor:
+        q: TensorValue,
+        k: TensorValue,
+        v: TensorValue,
+        valid_length: TensorValue,
+    ) -> TensorValue:
         return kernels.flash_attention_gpu(
             q,
             k,

--- a/max/tests/integration/tensor/test_functional_custom.py
+++ b/max/tests/integration/tensor/test_functional_custom.py
@@ -19,6 +19,7 @@ They don't otherwise make any attempt at coverage, edge cases, or correctness.
 import os
 from pathlib import Path
 
+import numpy as np
 import pytest
 from max.driver import CPU, Accelerator, accelerator_count
 from max.dtype import DType
@@ -30,6 +31,39 @@ DEVICE = Accelerator() if accelerator_count() else CPU()
 
 moe_create_indices = F.functional(kernels.moe_create_indices)
 scatter_set_constant = F.functional(kernels.scatter_set_constant)
+
+
+def _reference_flash_attention(
+    q: np.ndarray,
+    k: np.ndarray,
+    v: np.ndarray,
+    *,
+    mask_variant: kernels.MHAMaskVariant,
+    scale: float,
+) -> np.ndarray:
+    q_heads = np.transpose(q.astype(np.float32), (0, 2, 1, 3))
+    k_heads = np.transpose(k.astype(np.float32), (0, 2, 1, 3))
+    v_heads = np.transpose(v.astype(np.float32), (0, 2, 1, 3))
+
+    scores = np.matmul(q_heads, np.swapaxes(k_heads, -1, -2)) * scale
+
+    if mask_variant == kernels.MHAMaskVariant.CAUSAL_MASK:
+        causal_mask = np.triu(
+            np.ones((q.shape[1], k.shape[1]), dtype=bool),
+            k=1,
+        )
+        scores = np.where(causal_mask[None, None, :, :], -10000.0, scores)
+    elif mask_variant != kernels.MHAMaskVariant.NULL_MASK:
+        raise AssertionError(
+            f"unsupported mask variant in test: {mask_variant}"
+        )
+
+    scores -= np.max(scores, axis=-1, keepdims=True)
+    probs = np.exp(scores)
+    probs /= np.sum(probs, axis=-1, keepdims=True)
+
+    output = np.matmul(probs, v_heads)
+    return np.transpose(output, (0, 2, 1, 3)).astype(q.dtype, copy=False)
 
 
 @pytest.fixture
@@ -170,3 +204,89 @@ def test_custom_helper_function_pattern(
 
     assert result.real
     assert result.shape == x.shape
+
+
+@pytest.mark.parametrize(
+    "mask_variant",
+    [
+        kernels.MHAMaskVariant.NULL_MASK,
+        kernels.MHAMaskVariant.CAUSAL_MASK,
+    ],
+)
+def test_flash_attention_gpu_cpu_fallback(
+    mask_variant: kernels.MHAMaskVariant,
+) -> None:
+    batch, seq_len, num_heads, head_dim = 1, 8, 2, 16
+    scale = 0.25
+
+    rng = np.random.default_rng(42)
+    q_np = rng.standard_normal((batch, seq_len, num_heads, head_dim)).astype(
+        np.float32
+    )
+    k_np = rng.standard_normal((batch, seq_len, num_heads, head_dim)).astype(
+        np.float32
+    )
+    v_np = rng.standard_normal((batch, seq_len, num_heads, head_dim)).astype(
+        np.float32
+    )
+
+    q = Tensor(q_np, device=CPU())
+    k = Tensor(k_np, device=CPU())
+    v = Tensor(v_np, device=CPU())
+
+    @F.functional
+    def run_attention(q: Tensor, k: Tensor, v: Tensor) -> Tensor:
+        return kernels.flash_attention_gpu(
+            q,
+            k,
+            v,
+            mask_variant=mask_variant,
+            scale=scale,
+        )
+
+    output = run_attention(q, k, v)
+
+    assert output.real
+    assert output.shape == q.shape
+    assert output.dtype == q.dtype
+    np.testing.assert_allclose(
+        np.from_dlpack(output),
+        _reference_flash_attention(
+            q_np,
+            k_np,
+            v_np,
+            mask_variant=mask_variant,
+            scale=scale,
+        ),
+        rtol=1e-4,
+        atol=1e-4,
+    )
+
+
+def test_flash_attention_gpu_rejects_valid_length_on_cpu() -> None:
+    q = Tensor.ones([1, 8, 2, 16], dtype=DType.float32, device=CPU())
+    k = Tensor.ones([1, 8, 2, 16], dtype=DType.float32, device=CPU())
+    v = Tensor.ones([1, 8, 2, 16], dtype=DType.float32, device=CPU())
+    valid_length = Tensor([8], dtype=DType.uint32, device=CPU())
+
+    @F.functional
+    def run_attention(
+        q: Tensor,
+        k: Tensor,
+        v: Tensor,
+        valid_length: Tensor,
+    ) -> Tensor:
+        return kernels.flash_attention_gpu(
+            q,
+            k,
+            v,
+            mask_variant=kernels.MHAMaskVariant.NULL_MASK,
+            scale=0.25,
+            valid_length=valid_length,
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="padded CPU fallback is not implemented",
+    ):
+        run_attention(q, k, v, valid_length)


### PR DESCRIPTION
## Summary
- dispatch `mo.mha.no_cache` by device so CPU tensors use the existing CPU flash-attention path instead of the GPU-only custom op
- keep `flash_attention_gpu` stable while adding same-device validation and an explicit CPU error for unsupported `valid_length`
- make the CPU `valid_length` guard work for both eager `Device` and graph `DeviceRef`
- add eager regression coverage for CPU `NULL_MASK` and `CAUSAL_MASK`, plus a CPU `valid_length` rejection test

## Root Cause
`flash_attention_gpu` always routed the no-cache path through the GPU custom op registration, so eager CPU tensors crashed instead of using the existing CPU flash-attention implementation.

## Testing
- `./bazelw run format`
- `./bazelw test //max/tests/tests/nn:test_attention --test_output=errors`
- `/opt/homebrew/bin/python3 -m py_compile max/python/max/nn/kernels.py max/tests/integration/tensor/test_functional_custom.py`
- `./bazelw test --config=disable-mypy //max/tests/integration/tensor:test_functional_custom --test_output=errors`
- `./bazelw test --config=disable-mypy //max/tests/integration/kv_cache/attention:test_padded_attention_gpu --test_output=errors --test_arg=-k --test_arg='test_null_mask_flash_attention_gpu or test_padded_flash_attention_gpu'`

## Notes
- This PR stays scoped to the unpadded CPU fallback path. CPU `valid_length` remains unsupported and now errors explicitly instead of crashing.