### PR TITLE
[Kernel] Reuse eager custom-op models

### DIFF
--- a/max/python/max/experimental/functional.py
+++ b/max/python/max/experimental/functional.py
@@ -211,6 +211,11 @@ def functional(op: Op[..., Any]) -> Op[..., Any]:
                 )
                 stack.enter_context(ctx)
                 stack.enter_context(tensor.realization_context(ctx))
+            if isinstance(
+                tensor.current_realization_context(None),
+                rc.EagerRealizationContext,
+            ):
+                rc._clear_eager_model_cache_key(Graph.current)
             return op(*args, **kwargs)
 
     return wrapped
@@ -390,6 +395,32 @@ def _load_custom_extensions(
     graph._import_kernels(paths)
 
 
+def _eager_custom_model_cache_key(
+    name: str,
+    device: driver.Device | DeviceRef,
+    values: Sequence[Value[Any]],
+    out_types: Sequence[Type[Any]],
+    parameters: Mapping[str, bool | int | str | DType] | None,
+    custom_extensions: CustomExtensionsType | None,
+) -> tuple[object, ...] | None:
+    ctx = tensor.current_realization_context(None)
+    if (
+        not isinstance(ctx, rc.EagerRealizationContext)
+        or custom_extensions is None
+    ):
+        return None
+
+    graph = Graph.current
+    return (
+        name,
+        DeviceRef.from_device(device),
+        tuple(TensorValue(value).type for value in values),
+        tuple(out_types),
+        tuple(sorted((parameters or {}).items())),
+        tuple(str(path.resolve()) for path in graph.kernel_libraries_paths),
+    )
+
+
 @functional
 def custom(
     name: str,
@@ -450,6 +481,15 @@ def custom(
     """
     graph = Graph.current
     _load_custom_extensions(graph, custom_extensions)
+    if key := _eager_custom_model_cache_key(
+        name,
+        device,
+        values,
+        out_types,
+        parameters,
+        custom_extensions,
+    ):
+        graph._eager_model_cache_key = key
     return ops.custom(
         name=name,
         device=device,

--- a/max/python/max/experimental/realization_context.py
+++ b/max/python/max/experimental/realization_context.py
@@ -50,8 +50,8 @@ import os
 import threading
 import weakref
 from collections import OrderedDict
+from concurrent.futures import Future
 from contextvars import ContextVar
-from pathlib import Path
 from types import TracebackType
 from typing import Any, TypeVar
 
@@ -75,11 +75,18 @@ Ex = TypeVar("Ex", bound=BaseException)
 _SESSION: ContextVar[engine.api.InferenceSession] = ContextVar("_SESSION")
 _SEED: Tensor | None = None
 _EAGER_MODEL_CACHE_MAX_SIZE = 128
-_EAGER_MODEL_CACHE_LOCK = threading.Lock()
-_EAGER_MODEL_CACHE: OrderedDict[
-    tuple[int, str, tuple[str, ...]],
-    engine.Model,
-] = OrderedDict()
+_EAGER_MODEL_CACHES_LOCK = threading.Lock()
+
+
+class _SessionModelCache:
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.models: OrderedDict[object, Future[engine.Model]] = OrderedDict()
+
+
+_EAGER_MODEL_CACHES: weakref.WeakKeyDictionary[
+    engine.api.InferenceSession, _SessionModelCache
+] = weakref.WeakKeyDictionary()
 
 # Environment variable to control interpreter usage.
 # Set to "0" or "false" to disable the interpreter (always compile).
@@ -169,41 +176,78 @@ def _session() -> engine.api.InferenceSession:
     return session
 
 
-def _eager_model_cache_key(
-    session: engine.api.InferenceSession, graph: Graph
-) -> tuple[int, str, tuple[str, ...]]:
-    module_asm = graph._module.operation.get_asm(
-        assume_verified=True,
-        enable_debug_info=False,
-        pretty_debug_info=False,
-        use_local_scope=True,
-    )
-    return (
-        id(session),
-        module_asm,
-        tuple(
-            str(Path(path).resolve()) for path in graph.kernel_libraries_paths
-        ),
-    )
+def _clear_eager_model_cache_key(graph: Graph) -> None:
+    if hasattr(graph, "_eager_model_cache_key"):
+        delattr(graph, "_eager_model_cache_key")
+
+
+def _clear_eager_model_cache() -> None:
+    with _EAGER_MODEL_CACHES_LOCK:
+        caches = list(_EAGER_MODEL_CACHES.values())
+        _EAGER_MODEL_CACHES.clear()
+    for cache in caches:
+        with cache.lock:
+            cache.models.clear()
+
+
+def _session_model_cache(
+    session: engine.api.InferenceSession,
+) -> _SessionModelCache:
+    with _EAGER_MODEL_CACHES_LOCK:
+        if cache := _EAGER_MODEL_CACHES.get(session):
+            return cache
+        cache = _SessionModelCache()
+        _EAGER_MODEL_CACHES[session] = cache
+        return cache
+
+
+def _trim_session_model_cache(cache: _SessionModelCache) -> None:
+    while len(cache.models) > _EAGER_MODEL_CACHE_MAX_SIZE:
+        oldest_key, oldest_future = next(iter(cache.models.items()))
+        if not oldest_future.done():
+            break
+        del cache.models[oldest_key]
 
 
 def _load_eager_model(graph: Graph) -> engine.Model:
     """Reuses compiled eager models for identical custom-extension graphs."""
     session = _session()
-    if not graph.kernel_libraries_paths:
+    if (
+        not (key := getattr(graph, "_eager_model_cache_key", None))
+        or not graph.kernel_libraries_paths
+    ):
         return session.load(graph)
 
-    key = _eager_model_cache_key(session, graph)
-    with _EAGER_MODEL_CACHE_LOCK:
-        if model := _EAGER_MODEL_CACHE.get(key):
-            _EAGER_MODEL_CACHE.move_to_end(key)
-            return model
+    cache = _session_model_cache(session)
+    should_compile = False
 
-        model = session.load(graph)
-        _EAGER_MODEL_CACHE[key] = model
-        if len(_EAGER_MODEL_CACHE) > _EAGER_MODEL_CACHE_MAX_SIZE:
-            _EAGER_MODEL_CACHE.popitem(last=False)
-        return model
+    with cache.lock:
+        if model_future := cache.models.get(key):
+            cache.models.move_to_end(key)
+        else:
+            model_future = Future()
+            cache.models[key] = model_future
+            should_compile = True
+
+    if should_compile:
+        try:
+            model = session.load(graph)
+        except BaseException as exc:
+            model_future.set_exception(exc)
+            with cache.lock:
+                if cache.models.get(key) is model_future:
+                    del cache.models[key]
+            raise
+        else:
+            model_future.set_result(model)
+            with cache.lock:
+                if cache.models.get(key) is model_future:
+                    cache.models.move_to_end(key)
+                else:
+                    cache.models[key] = model_future
+                _trim_session_model_cache(cache)
+
+    return model_future.result()
 
 
 class EagerRealizationContext(RealizationContext):

--- a/max/python/max/experimental/realization_context.py
+++ b/max/python/max/experimental/realization_context.py
@@ -47,8 +47,11 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import weakref
+from collections import OrderedDict
 from contextvars import ContextVar
+from pathlib import Path
 from types import TracebackType
 from typing import Any, TypeVar
 
@@ -71,6 +74,12 @@ Ex = TypeVar("Ex", bound=BaseException)
 
 _SESSION: ContextVar[engine.api.InferenceSession] = ContextVar("_SESSION")
 _SEED: Tensor | None = None
+_EAGER_MODEL_CACHE_MAX_SIZE = 128
+_EAGER_MODEL_CACHE_LOCK = threading.Lock()
+_EAGER_MODEL_CACHE: OrderedDict[
+    tuple[int, str, tuple[str, ...]],
+    engine.Model,
+] = OrderedDict()
 
 # Environment variable to control interpreter usage.
 # Set to "0" or "false" to disable the interpreter (always compile).
@@ -158,6 +167,43 @@ def _session() -> engine.api.InferenceSession:
     if not (session := _SESSION.get(None)):
         _SESSION.set(session := engine.api.InferenceSession(devices=devices))
     return session
+
+
+def _eager_model_cache_key(
+    session: engine.api.InferenceSession, graph: Graph
+) -> tuple[int, str, tuple[str, ...]]:
+    module_asm = graph._module.operation.get_asm(
+        assume_verified=True,
+        enable_debug_info=False,
+        pretty_debug_info=False,
+        use_local_scope=True,
+    )
+    return (
+        id(session),
+        module_asm,
+        tuple(
+            str(Path(path).resolve()) for path in graph.kernel_libraries_paths
+        ),
+    )
+
+
+def _load_eager_model(graph: Graph) -> engine.Model:
+    """Reuses compiled eager models for identical custom-extension graphs."""
+    session = _session()
+    if not graph.kernel_libraries_paths:
+        return session.load(graph)
+
+    key = _eager_model_cache_key(session, graph)
+    with _EAGER_MODEL_CACHE_LOCK:
+        if model := _EAGER_MODEL_CACHE.get(key):
+            _EAGER_MODEL_CACHE.move_to_end(key)
+            return model
+
+        model = session.load(graph)
+        _EAGER_MODEL_CACHE[key] = model
+        if len(_EAGER_MODEL_CACHE) > _EAGER_MODEL_CACHE_MAX_SIZE:
+            _EAGER_MODEL_CACHE.popitem(last=False)
+        return model
 
 
 class EagerRealizationContext(RealizationContext):
@@ -299,7 +345,7 @@ class EagerRealizationContext(RealizationContext):
                 )
         if not use_interpreter:
             # Compile and execute graph
-            model = _session().load(graph)
+            model = _load_eager_model(graph)
             # Inputs may have been removed by optimization
             inputs = [self.sources[input._mlir_value] for input in graph.inputs]
             # This will become an await when `model` supports it

--- a/max/tests/integration/tensor/test_functional_custom.py
+++ b/max/tests/integration/tensor/test_functional_custom.py
@@ -18,11 +18,13 @@ They don't otherwise make any attempt at coverage, edge cases, or correctness.
 
 import os
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from max.driver import CPU, Accelerator, accelerator_count
 from max.dtype import DType
 from max.experimental import functional as F
+from max.experimental import realization_context as rc
 from max.experimental.tensor import Tensor
 from max.nn import kernels
 
@@ -123,29 +125,44 @@ def test_custom_with_string_path(kernel_verification_ops_path: Path) -> None:
 def test_custom_extensions_cached_across_calls(
     kernel_verification_ops_path: Path,
 ) -> None:
-    """Test that custom_extensions are cached and not reloaded on every call."""
-    x = Tensor.ones([64], dtype=DType.float32, device=CPU())
-    y = Tensor.ones([64], dtype=DType.float32, device=CPU())
+    """Test that identical eager custom op calls reuse compiled models."""
+    x = Tensor.ones([65], dtype=DType.float32, device=CPU())
+    y = Tensor.ones([65], dtype=DType.float32, device=CPU())
 
-    # First call
-    result1 = F.custom(
-        "my_add",
-        device=CPU(),
-        values=[x, y],
-        out_types=[x.type],
-        custom_extensions=kernel_verification_ops_path,
-    )
-    assert result1[0].real
+    session = rc._session()
+    real_load = session.load
+    load_count = 0
+    with rc._EAGER_MODEL_CACHE_LOCK:
+        rc._EAGER_MODEL_CACHE.clear()
 
-    # Second call - should use cached extension
-    result2 = F.custom(
-        "my_add",
-        device=CPU(),
-        values=[x, y],
-        out_types=[x.type],
-        custom_extensions=kernel_verification_ops_path,
-    )
-    assert result2[0].real
+    def counted_load(*args, **kwargs):  # noqa: ANN202
+        nonlocal load_count
+        load_count += 1
+        return real_load(*args, **kwargs)
+
+    with (
+        mock.patch.dict(os.environ, {"MAX_USE_EAGER_INTERPRETER": "0"}),
+        mock.patch.object(session, "load", side_effect=counted_load),
+    ):
+        result1 = F.custom(
+            "my_add",
+            device=CPU(),
+            values=[x, y],
+            out_types=[x.type],
+            custom_extensions=kernel_verification_ops_path,
+        )
+        assert result1[0].real
+
+        result2 = F.custom(
+            "my_add",
+            device=CPU(),
+            values=[x, y],
+            out_types=[x.type],
+            custom_extensions=kernel_verification_ops_path,
+        )
+        assert result2[0].real
+
+    assert load_count == 1
 
 
 def test_custom_helper_function_pattern(

--- a/max/tests/integration/tensor/test_functional_custom.py
+++ b/max/tests/integration/tensor/test_functional_custom.py
@@ -17,6 +17,9 @@ They don't otherwise make any attempt at coverage, edge cases, or correctness.
 """
 
 import os
+import threading
+from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest import mock
 
@@ -37,6 +40,13 @@ scatter_set_constant = F.functional(kernels.scatter_set_constant)
 @pytest.fixture
 def kernel_verification_ops_path() -> Path:
     return Path(os.environ["MODULAR_KERNEL_VERIFICATION_OPS_PATH"])
+
+
+@pytest.fixture(autouse=True)
+def clear_eager_model_cache() -> Generator[None]:
+    rc._clear_eager_model_cache()
+    yield
+    rc._clear_eager_model_cache()
 
 
 @pytest.mark.skipif(
@@ -126,14 +136,12 @@ def test_custom_extensions_cached_across_calls(
     kernel_verification_ops_path: Path,
 ) -> None:
     """Test that identical eager custom op calls reuse compiled models."""
-    x = Tensor.ones([65], dtype=DType.float32, device=CPU())
-    y = Tensor.ones([65], dtype=DType.float32, device=CPU())
+    x = Tensor.ones([64], dtype=DType.float32, device=CPU())
+    y = Tensor.ones([64], dtype=DType.float32, device=CPU())
 
     session = rc._session()
     real_load = session.load
     load_count = 0
-    with rc._EAGER_MODEL_CACHE_LOCK:
-        rc._EAGER_MODEL_CACHE.clear()
 
     def counted_load(*args, **kwargs):  # noqa: ANN202
         nonlocal load_count
@@ -161,6 +169,99 @@ def test_custom_extensions_cached_across_calls(
             custom_extensions=kernel_verification_ops_path,
         )
         assert result2[0].real
+
+    assert load_count == 1
+
+
+def test_custom_extensions_cache_key_distinguishes_ops_and_parameters(
+    kernel_verification_ops_path: Path,
+) -> None:
+    """Test that distinct custom op signatures compile separately."""
+    session = rc._session()
+    real_load = session.load
+    load_count = 0
+
+    def counted_load(*args, **kwargs):  # noqa: ANN202
+        nonlocal load_count
+        load_count += 1
+        return real_load(*args, **kwargs)
+
+    with (
+        mock.patch.dict(os.environ, {"MAX_USE_EAGER_INTERPRETER": "0"}),
+        mock.patch.object(session, "load", side_effect=counted_load),
+    ):
+        x = Tensor.ones([64], dtype=DType.float32, device=CPU())
+        y = Tensor.ones([64], dtype=DType.float32, device=CPU())
+
+        result = F.custom(
+            "my_add",
+            device=CPU(),
+            values=[x, y],
+            out_types=[x.type],
+            custom_extensions=kernel_verification_ops_path,
+        )
+        assert result[0].real
+
+        result = F.custom(
+            "my_add",
+            device=CPU(),
+            values=[x, y],
+            out_types=[x.type],
+            custom_extensions=kernel_verification_ops_path,
+        )
+        assert result[0].real
+
+        for parameter in (1, 1, 2):
+            result = F.custom(
+                "op_with_int_parameter",
+                device=CPU(),
+                values=[x],
+                out_types=[x.type],
+                parameters={"IntParameter": parameter},
+                custom_extensions=kernel_verification_ops_path,
+            )
+            assert result[0].real
+
+    assert load_count == 3
+
+
+def test_custom_extensions_cache_is_thread_safe(
+    kernel_verification_ops_path: Path,
+) -> None:
+    """Test that concurrent identical eager custom op calls compile once."""
+    session = rc._session()
+    real_load = session.load
+    load_count = 0
+    load_count_lock = threading.Lock()
+    barrier = threading.Barrier(2)
+
+    def counted_load(*args, **kwargs):  # noqa: ANN202
+        nonlocal load_count
+        with load_count_lock:
+            load_count += 1
+        return real_load(*args, **kwargs)
+
+    def invoke() -> None:
+        x = Tensor.ones([64], dtype=DType.float32, device=CPU())
+        y = Tensor.ones([64], dtype=DType.float32, device=CPU())
+        barrier.wait()
+        result = F.custom(
+            "my_add",
+            device=CPU(),
+            values=[x, y],
+            out_types=[x.type],
+            custom_extensions=kernel_verification_ops_path,
+        )
+        assert result[0].real
+
+    with (
+        mock.patch.dict(os.environ, {"MAX_USE_EAGER_INTERPRETER": "0"}),
+        mock.patch.object(session, "load", side_effect=counted_load),
+        ThreadPoolExecutor(max_workers=2) as executor,
+    ):
+        futures = [executor.submit(invoke) for _ in range(2)]
+        for future in futures:
+            future.result()
 
     assert load_count == 1
 


### PR DESCRIPTION
## Summary
- cache compiled eager models for graphs with custom extensions, keyed by the eager session, stable MLIR, and resolved kernel-library paths
- route the eager compile path through that cache so repeated identical `F.custom(...)` calls reuse the compiled model instead of recompiling
- add a deterministic regression test that patches `session.load()` and asserts two identical eager custom-op calls only load once

## Validation
- `./bazelw run format`
- `CUDA_VISIBLE_DEVICES= HIP_VISIBLE_DEVICES= ./bazelw test //max/tests/integration/tensor:test_functional_custom --test_output=errors`
- `./bazelw test //max/tests/integration/tensor:test_functional_custom --test_filter=test_custom_extensions_cached_across_calls --test_output=errors`
- `./bazelw test //max/tests/integration/tensor:test_functional_custom --test_filter=test_custom_with_custom_extensions --test_output=errors`