### PR TITLE
[bazel] Use single clang binary on CI

### DIFF
--- a/bazel/internal/cc-toolchain/tools/BUILD.bazel
+++ b/bazel/internal/cc-toolchain/tools/BUILD.bazel
@@ -17,7 +17,7 @@ cc_tool(
 )
 
 cc_tool(
-    name = "multi-platform-clang++".format(platform),
+    name = "multi-platform-clang++",
     src = ":multi-platform-clang++.sh",
     data = [
         "@clang-linux-aarch64//:bin/clang++",
@@ -28,7 +28,7 @@ cc_tool(
 )
 
 cc_tool(
-    name = "multi-platform-linker_driver".format(platform),
+    name = "multi-platform-linker_driver",
     src = ":linker-driver.sh",
     data = [
         "@clang-linux-aarch64//:bin/clang",

--- a/bazel/internal/cc-toolchain/tools/BUILD.bazel
+++ b/bazel/internal/cc-toolchain/tools/BUILD.bazel
@@ -6,7 +6,7 @@ load(":tools.bzl", "declare_tools")
 package(default_visibility = ["//visibility:public"])
 
 cc_tool(
-    name = "clang",
+    name = "multi-platform-clang",
     src = ":multi-platform-clang.sh",
     data = [
         "@clang-linux-aarch64//:bin/clang",
@@ -17,7 +17,7 @@ cc_tool(
 )
 
 cc_tool(
-    name = "clang++".format(platform),
+    name = "multi-platform-clang++".format(platform),
     src = ":multi-platform-clang++.sh",
     data = [
         "@clang-linux-aarch64//:bin/clang++",
@@ -28,7 +28,7 @@ cc_tool(
 )
 
 cc_tool(
-    name = "linker_driver".format(platform),
+    name = "multi-platform-linker_driver".format(platform),
     src = ":linker-driver.sh",
     data = [
         "@clang-linux-aarch64//:bin/clang",

--- a/bazel/internal/cc-toolchain/tools/tools.bzl
+++ b/bazel/internal/cc-toolchain/tools/tools.bzl
@@ -126,6 +126,7 @@ def _declare_tools(platform):
             "//:modular_config_ci_build": ":{}-single-platform-clang".format(platform),
             "//conditions:default": ":multi-platform-clang",
         }),
+        tags = ["manual"],
     )
 
     cc_tool(
@@ -141,6 +142,7 @@ def _declare_tools(platform):
             "//:modular_config_ci_build": ":{}-single-platform-clang++".format(platform),
             "//conditions:default": ":multi-platform-clang++",
         }),
+        tags = ["manual"],
     )
 
     cc_tool(

--- a/bazel/internal/cc-toolchain/tools/tools.bzl
+++ b/bazel/internal/cc-toolchain/tools/tools.bzl
@@ -22,11 +22,11 @@ def _declare_tools(platform):
         visibility = ["//bazel/internal/cc-toolchain:__subpackages__"],
         tools = {
             "@rules_cc//cc/toolchains/actions:ar_actions": ":{}-llvm-ar".format(platform),
-            "@rules_cc//cc/toolchains/actions:assembly_actions": ":clang",
-            "@rules_cc//cc/toolchains/actions:c_compile": ":clang",
-            "@rules_cc//cc/toolchains/actions:cpp_compile_actions": ":clang++",
-            "@rules_cc//cc/toolchains/actions:link_actions": ":linker_driver",
-            "@rules_cc//cc/toolchains/actions:objc_compile": ":clang",
+            "@rules_cc//cc/toolchains/actions:assembly_actions": ":{}-clang".format(platform),
+            "@rules_cc//cc/toolchains/actions:c_compile": ":{}-clang".format(platform),
+            "@rules_cc//cc/toolchains/actions:cpp_compile_actions": ":{}-clang++".format(platform),
+            "@rules_cc//cc/toolchains/actions:link_actions": ":{}-linker_driver".format(platform),
+            "@rules_cc//cc/toolchains/actions:objc_compile": ":{}-clang".format(platform),
             "@rules_cc//cc/toolchains/actions:objcopy_embed_data": ":{}-llvm-objcopy".format(platform),
             "@rules_cc//cc/toolchains/actions:strip": ":{}-llvm-strip".format(platform),
             "@rules_cc//cc/toolchains/actions:dwp": ":{}-llvm-dwp".format(platform),
@@ -111,4 +111,59 @@ def _declare_tools(platform):
         src = "@clang-{}//:bin/llvm-otool".format(platform),
         data = ["@clang-{}//:bin/llvm-objdump".format(platform)],
         tags = ["manual"],
+    )
+
+    cc_tool(
+        name = "{}-single-platform-clang".format(platform),
+        src = ":multi-platform-clang.sh",
+        data = ["@clang-{}//:bin/clang".format(platform)],
+        tags = ["manual"],
+    )
+
+    native.alias(
+        name = "{}-clang".format(platform),
+        actual = select({
+            "//:modular_config_ci_build": ":{}-single-platform-clang".format(platform),
+            "//conditions:default": ":multi-platform-clang",
+        }),
+    )
+
+    cc_tool(
+        name = "{}-single-platform-clang++".format(platform),
+        src = ":multi-platform-clang++.sh",
+        data = ["@clang-{}//:bin/clang++".format(platform)],
+        tags = ["manual"],
+    )
+
+    native.alias(
+        name = "{}-clang++".format(platform),
+        actual = select({
+            "//:modular_config_ci_build": ":{}-single-platform-clang++".format(platform),
+            "//conditions:default": ":multi-platform-clang++",
+        }),
+    )
+
+    cc_tool(
+        name = "{}-single-platform-linker_driver".format(platform),
+        src = ":multi-platform-linker_driver.sh",
+        data = [
+            "@clang-{}//:bin/clang".format(platform),
+            "@clang-{}//:bin/clang++".format(platform),  # symlink to clang
+            "@clang-{}//:bin/dsymutil".format(platform),
+            "@clang-{}//:ld".format(platform),
+        ],
+        tags = [
+            "manual",
+            # HACK: until our lld contains this fix https://github.com/llvm/llvm-project/commit/9234066476aa82cfac3cee564883a3124df4584e
+            # This tag is meaningless to us but changes this behavior https://github.com/bazelbuild/bazel/blob/4c664d9ba50e7d7aea66a0547a5bac3ca8d264e5/src/main/starlark/builtins_bzl/common/cc/link/finalize_link_action.bzl#L363
+            "requires_darwin",
+        ],
+    )
+
+    native.alias(
+        name = "{}-linker_driver".format(platform),
+        actual = select({
+            "//:modular_config_ci_build": ":{}-single-platform-linker_driver".format(platform),
+            "//conditions:default": ":multi-platform-linker_driver",
+        }),
     )

--- a/bazel/internal/cc-toolchain/tools/tools.bzl
+++ b/bazel/internal/cc-toolchain/tools/tools.bzl
@@ -145,7 +145,7 @@ def _declare_tools(platform):
 
     cc_tool(
         name = "{}-single-platform-linker_driver".format(platform),
-        src = ":multi-platform-linker_driver.sh",
+        src = ":linker-driver.sh",
         data = [
             "@clang-{}//:bin/clang".format(platform),
             "@clang-{}//:bin/clang++".format(platform),  # symlink to clang
@@ -166,4 +166,5 @@ def _declare_tools(platform):
             "//:modular_config_ci_build": ":{}-single-platform-linker_driver".format(platform),
             "//conditions:default": ":multi-platform-linker_driver",
         }),
+        tags = ["manual"],
     )


### PR DESCRIPTION
CI already doesn't share caches with local builds because it uses `-g0` and some other different flags. For local builds we use dynamic execution and potentially a different exec platform with remote execution, so we need multiple clang binaries available, on CI we can be sure only 1 will be used. This saves some upload/download of all these duplicate binaries that would never be called.