### PR TITLE
[stdlib] Add take_items() method to List

### DIFF
--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -206,8 +206,9 @@ struct _ListTakeIter[
 
         # Destroy remaining elements from current index to original length
         while self._index < self._original_len:
-            (self._list[].unsafe_ptr().bitcast[TDestructible]() + self._index)
-                .destroy_pointee()
+            (
+                self._list[].unsafe_ptr().bitcast[TDestructible]() + self._index
+            ).destroy_pointee()
             self._index += 1
 
     @always_inline

--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -147,6 +147,54 @@ struct _ListIterOwned[T: Copyable](IterableOwned, Iterator, Movable):
         return (iter_len, {iter_len})
 
 
+@fieldwise_init
+struct _ListTakeIter[
+    T: Copyable,
+    origin: MutOrigin,
+](Copyable, Iterable, Iterator):
+    """Iterator over mutable List element references that moves elements out of the list.
+
+    This iterator drains the list as it iterates, moving elements out using
+    `take_pointee()` and updating the list's length accordingly.
+
+    Parameters:
+        T: The type of the elements in the list.
+        origin: The mutable origin of the List.
+    """
+
+    comptime IteratorType[
+        iterable_mut: Bool, //, iterable_origin: Origin[mut=iterable_mut]
+    ]: Iterator = Self
+    comptime Element = Self.T
+
+    var _index: Int
+    var _list: Pointer[List[Self.T], Self.origin]
+
+    def __init__(out self, ref[Self.origin] list: List[Self.T]):
+        self._index = 0
+        self._list = Pointer(to=list)
+
+    @always_inline
+    def __iter__(ref self) -> Self.IteratorType[origin_of(self)]:
+        return self.copy()
+
+    @always_inline
+    def __next__(mut self) raises StopIteration -> Self.Element:
+        if self._index >= len(self._list[]):
+            raise StopIteration()
+
+        # Move the element out and update the list state
+        var element = (self._list[].unsafe_ptr() + self._index).take_pointee()
+        self._index += 1
+        self._list[]._len -= 1
+        return element
+
+    @always_inline
+    def bounds(self) -> Tuple[Int, Optional[Int]]:
+        var iter_len = len(self._list[]) - self._index
+        return (iter_len, {iter_len})
+
+
 struct List[T: Copyable](
     Boolable,
     Copyable,
@@ -673,6 +721,44 @@ struct List[T: Copyable](
         return _ListIter[forward=False](
             index=len(self), src=self.unsafe_ptr(), length=self._len
         )
+
+    def take_items(mut self) -> _ListTakeIter[Self.T, origin_of(self)]:
+        """Iterate over the list's elements and move them out of the list,
+        effectively draining the list.
+
+        This method returns an iterator that moves elements out of the list
+        using `take_pointee()`, updating the list's length as it drains. The
+        list will be empty after complete iteration.
+
+        Returns:
+            An iterator of owned elements that moves them out of the list.
+
+        Examples:
+
+        ```mojo
+        var my_list = List[String]("a", "b", "c")
+
+        for element in my_list.take_items():
+            print(element[])  # prints a, then b, then c
+
+        print(len(my_list))  # prints 0
+        ```
+
+        This is useful for efficiently transferring elements from a list
+        to another data structure without copying:
+
+        ```mojo
+        var keys = List[String]("x", "y", "z")
+        var values = List[Int](1, 2, 3)
+        var dict = Dict[String, Int]()
+
+        # Transfer elements without copying
+        for key in keys.take_items():
+            var value = values.take_items().__next__()
+            dict[key[]] = value[]
+        ```
+        """
+        return _ListTakeIter(self)
 
     # ===-------------------------------------------------------------------===#
     # Trait implementations

--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -151,47 +151,58 @@ struct _ListIterOwned[T: Copyable](IterableOwned, Iterator, Movable):
 struct _ListTakeIter[
     T: Copyable,
     origin: MutOrigin,
-](Copyable, Iterable, Iterator):
-    """Iterator over mutable List element references that moves elements out of the list.
+](Movable, IterableOwned, Iterator):
+    """Iterator over List elements that moves elements out of the list.
 
     This iterator drains the list as it iterates, moving elements out using
-    `take_pointee()` and updating the list's length accordingly.
+    `take_pointee()`. The list's length is set to 0 immediately when the
+    iterator is created to prevent double-free issues. Remaining elements
+    are destroyed by the iterator's destructor if not fully consumed.
 
     Parameters:
         T: The type of the elements in the list.
         origin: The mutable origin of the List.
     """
 
-    comptime IteratorType[
-        iterable_mut: Bool, //, iterable_origin: Origin[mut=iterable_mut]
-    ]: Iterator = Self
+    comptime IteratorType: Iterator = Self
     comptime Element = Self.T
 
     var _index: Int
     var _list: Pointer[List[Self.T], Self.origin]
+    var _original_len: Int
 
     def __init__(out self, ref[Self.origin] list: List[Self.T]):
         self._index = 0
         self._list = Pointer(to=list)
+        # Store original length and immediately set list length to 0
+        # to prevent double-free when list destructor runs
+        self._original_len = len(list)
+        list._len = 0
 
     @always_inline
-    def __iter__(ref self) -> Self.IteratorType[origin_of(self)]:
-        return self.copy()
+    def __iter__(owned self) -> Self:
+        return self^
 
     @always_inline
     def __next__(mut self) raises StopIteration -> Self.Element:
-        if self._index >= len(self._list[]):
+        if self._index >= self._original_len:
             raise StopIteration()
 
-        # Move the element out and update the list state
+        # Move the element out
         var element = (self._list[].unsafe_ptr() + self._index).take_pointee()
         self._index += 1
-        self._list[]._len -= 1
         return element^
+
+    def __del__(deinit self):
+        """Destroy any remaining elements that weren't iterated over."""
+        # Destroy remaining elements from current index to original length
+        while self._index < self._original_len:
+            (self._list[].unsafe_ptr() + self._index).destroy_pointee()
+            self._index += 1
 
     @always_inline
     def bounds(self) -> Tuple[Int, Optional[Int]]:
-        var iter_len = len(self._list[]) - self._index
+        var iter_len = self._original_len - self._index
         return (iter_len, {iter_len})
 
 

--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -149,7 +149,7 @@ struct _ListIterOwned[T: Copyable](IterableOwned, Iterator, Movable):
 
 @fieldwise_init
 struct _ListTakeIter[
-    T: Copyable & ImplicitlyDestructible,
+    T: Copyable,
     origin: MutOrigin,
 ](Movable, IterableOwned, Iterator):
     """Iterator over List elements that moves elements out of the list.
@@ -195,9 +195,19 @@ struct _ListTakeIter[
 
     def __del__(deinit self):
         """Destroy any remaining elements that weren't iterated over."""
+        # Ensure T is ImplicitlyDestructible so we can destroy remaining elements
+        _constrained_conforms_to[
+            conforms_to(Self.T, ImplicitlyDestructible),
+            Parent=Self,
+            Element=Self.T,
+            ParentConformsTo="ImplicitlyDestructible",
+        ]()
+        comptime TDestructible = downcast[Self.T, ImplicitlyDestructible]
+
         # Destroy remaining elements from current index to original length
         while self._index < self._original_len:
-            (self._list[].unsafe_ptr() + self._index).destroy_pointee()
+            (self._list[].unsafe_ptr().bitcast[TDestructible]() + self._index)
+                .destroy_pointee()
             self._index += 1
 
     @always_inline
@@ -733,11 +743,7 @@ struct List[T: Copyable](
             index=len(self), src=self.unsafe_ptr(), length=self._len
         )
 
-    def take_items(
-        mut self,
-    ) -> _ListTakeIter[Self.T, origin_of(self)] where conforms_to(
-        Self.T, ImplicitlyDestructible
-    ):
+    def take_items(mut self) -> _ListTakeIter[Self.T, origin_of(self)]:
         """Iterate over the list's elements and move them out of the list,
         effectively draining the list.
 

--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -151,7 +151,7 @@ struct _ListIterOwned[T: Copyable](IterableOwned, Iterator, Movable):
 struct _ListTakeIter[
     T: Copyable,
     origin: MutOrigin,
-](Movable, IterableOwned, Iterator):
+](IterableOwned, Iterator, Movable):
     """Iterator over List elements that moves elements out of the list.
 
     This iterator drains the list as it iterates, moving elements out using

--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -149,7 +149,7 @@ struct _ListIterOwned[T: Copyable](IterableOwned, Iterator, Movable):
 
 @fieldwise_init
 struct _ListTakeIter[
-    T: Copyable,
+    T: Copyable & ImplicitlyDestructible,
     origin: MutOrigin,
 ](Movable, IterableOwned, Iterator):
     """Iterator over List elements that moves elements out of the list.
@@ -164,7 +164,7 @@ struct _ListTakeIter[
         origin: The mutable origin of the List.
     """
 
-    comptime IteratorType: Iterator = Self
+    comptime IteratorOwnedType = Self
     comptime Element = Self.T
 
     var _index: Int
@@ -180,7 +180,7 @@ struct _ListTakeIter[
         list._len = 0
 
     @always_inline
-    def __iter__(owned self) -> Self:
+    def __iter__(var self) -> Self.IteratorOwnedType:
         return self^
 
     @always_inline

--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -187,7 +187,7 @@ struct _ListTakeIter[
         var element = (self._list[].unsafe_ptr() + self._index).take_pointee()
         self._index += 1
         self._list[]._len -= 1
-        return element
+        return element^
 
     @always_inline
     def bounds(self) -> Tuple[Int, Optional[Int]]:

--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -733,7 +733,11 @@ struct List[T: Copyable](
             index=len(self), src=self.unsafe_ptr(), length=self._len
         )
 
-    def take_items(mut self) -> _ListTakeIter[Self.T, origin_of(self)]:
+    def take_items(
+        mut self,
+    ) -> _ListTakeIter[Self.T, origin_of(self)] where conforms_to(
+        Self.T, ImplicitlyDestructible
+    ):
         """Iterate over the list's elements and move them out of the list,
         effectively draining the list.
 
@@ -747,10 +751,13 @@ struct List[T: Copyable](
         Examples:
 
         ```mojo
-        var my_list = List[String]("a", "b", "c")
+        var my_list = List[String]()
+        my_list.append("a")
+        my_list.append("b")
+        my_list.append("c")
 
         for element in my_list.take_items():
-            print(element[])  # prints a, then b, then c
+            print(element)  # prints a, then b, then c
 
         print(len(my_list))  # prints 0
         ```

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -1187,7 +1187,10 @@ def test_list_hash() raises:
 
 def test_list_take_items() raises:
     """Test that take_items drains the list and moves elements out."""
-    var my_list = List[String]("a", "b", "c")
+    var my_list = List[String]()
+    my_list.append("a")
+    my_list.append("b")
+    my_list.append("c")
     assert_equal(len(my_list), 3)
 
     # Collect elements from take_items iterator
@@ -1218,7 +1221,12 @@ def test_list_take_items_empty() raises:
 
 def test_list_take_items_partial() raises:
     """Test that take_items works correctly when partially consumed."""
-    var my_list = List[Int](1, 2, 3, 4, 5)
+    var my_list = List[Int]()
+    my_list.append(1)
+    my_list.append(2)
+    my_list.append(3)
+    my_list.append(4)
+    my_list.append(5)
     assert_equal(len(my_list), 5)
 
     var iter = my_list.take_items()
@@ -1240,11 +1248,15 @@ def test_list_take_items_partial() raises:
 
 def test_list_take_items_bounds() raises:
     """Test that take_items reports correct bounds."""
-    var iter = List[Int](1, 2, 3).take_items()
+    var my_list = List[Int]()
+    my_list.append(1)
+    my_list.append(2)
+    my_list.append(3)
+    var iter = my_list.take_items()
     for i in range(3, 0, -1):
-        var lower, upper = iter.bounds()
-        assert_equal(lower, i)
-        assert_equal(upper.value(), i)
+        var bounds = iter.bounds()
+        assert_equal(bounds[0], i)
+        assert_equal(bounds[1].value(), i)
         _ = iter.__next__()
 
 

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -1196,7 +1196,7 @@ def test_list_take_items() raises:
     # Collect elements from take_items iterator
     var collected = List[String]()
     for element in my_list.take_items():
-        collected.append(element[])
+        collected.append(element)
 
     # List should be empty after draining
     assert_equal(len(my_list), 0)

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -1221,7 +1221,7 @@ def test_list_take_items_empty() raises:
 
 def test_list_take_items_partial() raises:
     """Test that take_items works correctly when partially consumed.
-    
+
     Note: The list length is set to 0 immediately when take_items() is called
     to prevent double-free. Remaining elements are tracked in the iterator
     and destroyed when the iterator is dropped.
@@ -1256,13 +1256,14 @@ def test_list_take_items_partial() raises:
 
 
 def test_list_take_items_bounds() raises:
-    """Test that take_items reports correct bounds and list is empty immediately."""
+    """Test that take_items reports correct bounds and list is empty immediately.
+    """
     var my_list = List[Int]()
     my_list.append(1)
     my_list.append(2)
     my_list.append(3)
     assert_equal(len(my_list), 3)
-    
+
     var iter = my_list.take_items()
     # List is immediately empty when iterator is created
     assert_equal(len(my_list), 0)

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -1247,9 +1247,9 @@ def test_list_take_items_partial() raises:
     # Iterator now has 3 elements remaining
     assert_equal(iter.bounds()[0], 3)
 
-    # Complete the iteration
+    # Complete the iteration (consume the iterator)
     var count = 0
-    for _ in iter:
+    for _ in iter^:
         count += 1
 
     assert_equal(count, 3)

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -1185,6 +1185,69 @@ def test_list_hash() raises:
     assert_true(conforms_to(List[String], Hashable))
 
 
+def test_list_take_items() raises:
+    """Test that take_items drains the list and moves elements out."""
+    var my_list = List[String]("a", "b", "c")
+    assert_equal(len(my_list), 3)
+
+    # Collect elements from take_items iterator
+    var collected = List[String]()
+    for element in my_list.take_items():
+        collected.append(element[])
+
+    # List should be empty after draining
+    assert_equal(len(my_list), 0)
+    assert_equal(len(collected), 3)
+    assert_equal(collected[0], "a")
+    assert_equal(collected[1], "b")
+    assert_equal(collected[2], "c")
+
+
+def test_list_take_items_empty() raises:
+    """Test take_items on an empty list."""
+    var my_list = List[Int]()
+    assert_equal(len(my_list), 0)
+
+    var count = 0
+    for _ in my_list.take_items():
+        count += 1
+
+    assert_equal(count, 0)
+    assert_equal(len(my_list), 0)
+
+
+def test_list_take_items_partial() raises:
+    """Test that take_items works correctly when partially consumed."""
+    var my_list = List[Int](1, 2, 3, 4, 5)
+    assert_equal(len(my_list), 5)
+
+    var iter = my_list.take_items()
+    # Only consume 2 elements
+    _ = iter.__next__()
+    _ = iter.__next__()
+
+    # List should have 3 elements remaining
+    assert_equal(len(my_list), 3)
+
+    # Complete the iteration
+    var count = 0
+    for _ in iter:
+        count += 1
+
+    assert_equal(count, 3)
+    assert_equal(len(my_list), 0)
+
+
+def test_list_take_items_bounds() raises:
+    """Test that take_items reports correct bounds."""
+    var iter = List[Int](1, 2, 3).take_items()
+    for i in range(3, 0, -1):
+        var lower, upper = iter.bounds()
+        assert_equal(lower, i)
+        assert_equal(upper.value(), i)
+        _ = iter.__next__()
+
+
 # ===-------------------------------------------------------------------===#
 # main
 # ===-------------------------------------------------------------------===#

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -1198,7 +1198,7 @@ def test_list_take_items() raises:
     for element in my_list.take_items():
         collected.append(element)
 
-    # List should be empty after draining
+    # List should be empty (length set to 0 immediately when iterator created)
     assert_equal(len(my_list), 0)
     assert_equal(len(collected), 3)
     assert_equal(collected[0], "a")
@@ -1220,7 +1220,12 @@ def test_list_take_items_empty() raises:
 
 
 def test_list_take_items_partial() raises:
-    """Test that take_items works correctly when partially consumed."""
+    """Test that take_items works correctly when partially consumed.
+    
+    Note: The list length is set to 0 immediately when take_items() is called
+    to prevent double-free. Remaining elements are tracked in the iterator
+    and destroyed when the iterator is dropped.
+    """
     var my_list = List[Int]()
     my_list.append(1)
     my_list.append(2)
@@ -1230,12 +1235,17 @@ def test_list_take_items_partial() raises:
     assert_equal(len(my_list), 5)
 
     var iter = my_list.take_items()
+    # List is immediately empty (length set to 0)
+    assert_equal(len(my_list), 0)
+    # But iterator reports remaining elements
+    assert_equal(iter.bounds()[0], 5)
+
     # Only consume 2 elements
     _ = iter.__next__()
     _ = iter.__next__()
 
-    # List should have 3 elements remaining
-    assert_equal(len(my_list), 3)
+    # Iterator now has 3 elements remaining
+    assert_equal(iter.bounds()[0], 3)
 
     # Complete the iteration
     var count = 0
@@ -1243,16 +1253,20 @@ def test_list_take_items_partial() raises:
         count += 1
 
     assert_equal(count, 3)
-    assert_equal(len(my_list), 0)
 
 
 def test_list_take_items_bounds() raises:
-    """Test that take_items reports correct bounds."""
+    """Test that take_items reports correct bounds and list is empty immediately."""
     var my_list = List[Int]()
     my_list.append(1)
     my_list.append(2)
     my_list.append(3)
+    assert_equal(len(my_list), 3)
+    
     var iter = my_list.take_items()
+    # List is immediately empty when iterator is created
+    assert_equal(len(my_list), 0)
+    # Iterator bounds track remaining elements
     for i in range(3, 0, -1):
         var bounds = iter.bounds()
         assert_equal(bounds[0], i)


### PR DESCRIPTION
This PR implements #5312 by adding a `take_items()` method to `List` that returns an iterator draining the list by moving elements out.

## Motivation

When transferring elements from a `List` to another data structure (like a `Dict`), users currently need to copy elements or consume the entire list with owned iteration. This PR adds `take_items()` similar to `Dict.take_items()` to enable efficient transfer without copying.

## Changes

### Core Implementation
- Added `_ListTakeIter` struct that takes a mutable reference to a List
- Iterator moves elements out using `take_pointee()` and updates `_len`
- Added `List.take_items()` method returning the draining iterator

### Tests
- `test_list_take_items()` - Basic functionality
- `test_list_take_items_empty()` - Empty list edge case
- `test_list_take_items_partial()` - Partial consumption behavior
- `test_list_take_items_bounds()` - Bounds reporting

## Usage Example

```mojo
var my_list = List[String]("a", "b", "c")

for element in my_list.take_items():
    print(element[])  # prints a, b, c

print(len(my_list))  # 0 - list is drained
```

## Comparison

**Owned iteration (consumes list):**
```mojo
for x in my_list^:
    pass
# my_list no longer accessible
```

**take_items() (drains but keeps list accessible):**
```mojo
for x in my_list.take_items():
    pass
# my_list still accessible but empty
```

## Checklist
- [x] Code follows style guidelines
- [x] Tests added and passing
- [x] Documentation added (docstrings with examples)
- [x] Signed-off commits
- [x] Fixes #5312
