### PR TITLE
[MAX] Align FLUX.2-dev prompt masking with diffusers

### DIFF
--- a/max/python/max/pipelines/architectures/flux2/pipeline_flux2.py
+++ b/max/python/max/pipelines/architectures/flux2/pipeline_flux2.py
@@ -90,6 +90,9 @@ class Flux2ModelInputs:
     input_image: npt.NDArray[np.uint8] | None
     """Optional input image for image-to-image generation (HWC uint8)."""
 
+    attention_mask: np.ndarray
+    """Tokenizer-generated mask for the padded prompt sequence."""
+
     def __post_init__(self) -> None:
         if not isinstance(self.height, int) or self.height <= 0:
             raise ValueError(
@@ -227,6 +230,7 @@ class Flux2Pipeline(DiffusionPipeline):
             tokens=Buffer.from_dlpack(context.tokens.array).to(
                 self.text_encoder.devices[0]
             ),
+            attention_mask=context.mask,
             latents=Buffer.from_dlpack(context.latents).to(device),
             latent_image_ids=Buffer.from_dlpack(context.latent_image_ids).to(
                 device
@@ -615,6 +619,7 @@ class Flux2Pipeline(DiffusionPipeline):
         self,
         tokens: Buffer,
         num_images_per_prompt: int = 1,
+        attention_mask: npt.ArrayLike | None = None,
     ) -> tuple[Buffer, Buffer]:
         """Create prompt embeddings and text position IDs for the transformer.
 
@@ -638,7 +643,7 @@ class Flux2Pipeline(DiffusionPipeline):
         with Tracer("text_encoder"):
             prompt_embeds = cast(
                 Buffer,
-                self.text_encoder(tokens),
+                self.text_encoder(tokens, attention_mask=attention_mask),
             )
 
         with Tracer("post_process"):
@@ -816,6 +821,7 @@ class Flux2Pipeline(DiffusionPipeline):
         prompt_embeds, text_ids = self.prepare_prompt_embeddings(
             tokens=model_inputs.tokens,
             num_images_per_prompt=model_inputs.num_images_per_prompt,
+            attention_mask=model_inputs.attention_mask,
         )
         batch_size = int(prompt_embeds.shape[0])
 

--- a/max/python/max/pipelines/architectures/flux2/pipeline_flux2.py
+++ b/max/python/max/pipelines/architectures/flux2/pipeline_flux2.py
@@ -90,7 +90,7 @@ class Flux2ModelInputs:
     input_image: npt.NDArray[np.uint8] | None
     """Optional input image for image-to-image generation (HWC uint8)."""
 
-    attention_mask: np.ndarray
+    attention_mask: npt.NDArray[np.bool_] | None
     """Tokenizer-generated mask for the padded prompt sequence."""
 
     def __post_init__(self) -> None:

--- a/max/python/max/pipelines/architectures/flux2_modulev3/pipeline_flux2.py
+++ b/max/python/max/pipelines/architectures/flux2_modulev3/pipeline_flux2.py
@@ -84,6 +84,9 @@ class Flux2ModelInputs:
     input_image: npt.NDArray[np.uint8] | None
     """Optional input image for image-to-image generation (HWC uint8)."""
 
+    attention_mask: np.ndarray | None = None
+    """Tokenizer-generated mask for the padded prompt sequence."""
+
     residual_threshold: Tensor | None = None
     """Scalar float32 tensor for FBCache residual threshold, on device.
     None when FBCache is not enabled."""
@@ -243,6 +246,7 @@ class Flux2Pipeline(DiffusionPipeline):
                     self.text_encoder.devices[0]
                 )
             ),
+            attention_mask=context.mask,
             latents=Tensor(
                 storage=Buffer.from_dlpack(context.latents).to(device)
             ),
@@ -735,6 +739,7 @@ class Flux2Pipeline(DiffusionPipeline):
         prompt_embeds, text_ids = self.prepare_prompt_embeddings(
             tokens=model_inputs.tokens,
             num_images_per_prompt=model_inputs.num_images_per_prompt,
+            attention_mask=model_inputs.attention_mask,
         )
         batch_size = int(prompt_embeds.shape[0])
 

--- a/max/python/max/pipelines/architectures/flux2_modulev3/pipeline_flux2.py
+++ b/max/python/max/pipelines/architectures/flux2_modulev3/pipeline_flux2.py
@@ -84,7 +84,7 @@ class Flux2ModelInputs:
     input_image: npt.NDArray[np.uint8] | None
     """Optional input image for image-to-image generation (HWC uint8)."""
 
-    attention_mask: np.ndarray | None = None
+    attention_mask: npt.NDArray[np.bool_] | None = None
     """Tokenizer-generated mask for the padded prompt sequence."""
 
     residual_threshold: Tensor | None = None
@@ -505,7 +505,7 @@ class Flux2Pipeline(DiffusionPipeline):
         self,
         tokens: Tensor,
         num_images_per_prompt: int = 1,
-        attention_mask: Tensor | npt.ArrayLike | None = None,
+        attention_mask: npt.ArrayLike | None = None,
     ) -> tuple[Tensor, Tensor]:
         """Create prompt embeddings and text position IDs for the transformer.
 
@@ -529,13 +529,10 @@ class Flux2Pipeline(DiffusionPipeline):
         batch_size = 1
 
         with Tracer("text_encoder"):
-            if attention_mask is None:
-                prompt_embeds = self.text_encoder(tokens)
-            else:
-                prompt_embeds = self.text_encoder(  # type: ignore[call-arg]
-                    tokens,
-                    attention_mask=attention_mask,
-                )
+            prompt_embeds = self.text_encoder(
+                tokens,
+                attention_mask=attention_mask,
+            )
 
         with Tracer("post_process"):
             if num_images_per_prompt != 1:

--- a/max/python/max/pipelines/architectures/mistral3/text_encoder/attention.py
+++ b/max/python/max/pipelines/architectures/mistral3/text_encoder/attention.py
@@ -17,8 +17,7 @@ from __future__ import annotations
 
 from max.dtype import DType
 from max.graph import DeviceRef, TensorValue, ops
-from max.nn.attention.mask_config import MHAMaskVariant
-from max.nn.kernels import flash_attention_gpu
+from max.nn.kernels import masked_flash_attention_gpu
 from max.nn.layer import Module
 from max.nn.linear import Linear
 from max.nn.rotary_embedding import RotaryEmbedding
@@ -98,7 +97,12 @@ class EncoderAttention(Module):
             [batch_size, seq_len, self.n_kv_heads * n_rep, self.head_dim],
         )
 
-    def __call__(self, x: TensorValue, rope: RotaryEmbedding) -> TensorValue:
+    def __call__(
+        self,
+        x: TensorValue,
+        rope: RotaryEmbedding,
+        attention_bias: TensorValue,
+    ) -> TensorValue:
         """Forward pass computing causal self-attention.
 
         Args:
@@ -126,11 +130,11 @@ class EncoderAttention(Module):
             k = self._repeat_kv(k, n_rep)
             v = self._repeat_kv(v, n_rep)
 
-        attn_out = flash_attention_gpu(
+        attn_out = masked_flash_attention_gpu(
             q,
             k,
             v,
-            mask_variant=MHAMaskVariant.CAUSAL_MASK,
+            mask=ops.squeeze(attention_bias, axis=1),
             scale=self.scale,
         )
         attn_out = ops.reshape(attn_out, [total_seq_len, -1])

--- a/max/python/max/pipelines/architectures/mistral3/text_encoder/mistral3.py
+++ b/max/python/max/pipelines/architectures/mistral3/text_encoder/mistral3.py
@@ -116,7 +116,12 @@ class EncoderTransformerBlock(Module):
             multiply_before_cast=False,
         )
 
-    def __call__(self, x: TensorValue, rope: RotaryEmbedding) -> TensorValue:
+    def __call__(
+        self,
+        x: TensorValue,
+        rope: RotaryEmbedding,
+        attention_bias: TensorValue,
+    ) -> TensorValue:
         """Forward pass without KV cache.
 
         Args:
@@ -128,7 +133,7 @@ class EncoderTransformerBlock(Module):
         """
         residual = x
         x = self.input_layernorm(x)
-        x = self.self_attn(x, rope)
+        x = self.self_attn(x, rope, attention_bias)
         x = residual + x
 
         residual = x
@@ -195,13 +200,24 @@ class Mistral3TextEncoderTransformer(Module):
                 shape=["total_seq_len"],
                 device=self.device,
             ),
+            TensorType(
+                DType.float32,
+                shape=[1, 1, "total_seq_len", "total_seq_len"],
+                device=self.device,
+            ),
         )
 
-    def __call__(self, tokens: TensorValue) -> TensorValue:
+    def __call__(
+        self,
+        tokens: TensorValue,
+        attention_bias: TensorValue,
+    ) -> TensorValue:
         """Forward pass returning fused prompt embeddings.
 
         Args:
             tokens: Input token IDs ``[total_seq_len]``.
+            attention_bias: Additive causal+padding mask bias with shape
+                ``[1, 1, seq_len, seq_len]``.
 
         Returns:
             Tensor of shape ``[1, seq_len, num_layers * hidden_dim]`` with the
@@ -213,7 +229,7 @@ class Mistral3TextEncoderTransformer(Module):
         selected: dict[int, TensorValue] = {}
         max_layer = self._sorted_hidden_state_layers[-1]
         for i, layer in enumerate(self.layers):
-            h = layer(h, self.rope)
+            h = layer(h, self.rope, attention_bias)
             if i in self._hidden_state_layers:
                 selected[i] = h
             if i == max_layer:

--- a/max/python/max/pipelines/architectures/mistral3/text_encoder/model.py
+++ b/max/python/max/pipelines/architectures/mistral3/text_encoder/model.py
@@ -22,10 +22,15 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
+import numpy as np
+import numpy.typing as npt
 from max.driver import Buffer, Device
 from max.engine import InferenceSession, Model
 from max.graph import Graph
 from max.graph.weights import Weights
+from max.pipelines.dataprocessing import (
+    attention_bias_from_attention_mask_array,
+)
 from max.pipelines.lib import SupportedEncoding
 from max.pipelines.lib.interfaces.component_model import ComponentModel
 from max.profiler import traced
@@ -88,9 +93,35 @@ class Mistral3TextEncoderModel(ComponentModel):
         )
         return self.model.execute
 
-    def __call__(self, tokens: Buffer) -> Buffer:
+    def __call__(
+        self,
+        tokens: Buffer,
+        attention_mask: npt.ArrayLike | None = None,
+    ) -> Buffer:
         """Run the compiled text encoder."""
-        outputs = self.model.execute(tokens)
+        if len(tokens.shape) == 2:
+            if int(tokens.shape[0]) != 1:
+                raise ValueError(
+                    "Mistral3TextEncoderModel expects batch_size=1 for 2D token input."
+                )
+            tokens = tokens[0]
+
+        if attention_mask is not None:
+            attention_mask_np = np.asarray(attention_mask)
+            attention_bias_np = attention_bias_from_attention_mask_array(
+                attention_mask_np,
+                expected_seq_len=int(tokens.shape[0]),
+            )
+        else:
+            attention_bias_np = attention_bias_from_attention_mask_array(
+                np.ones((int(tokens.shape[0]),), dtype=np.bool_),
+                expected_seq_len=int(tokens.shape[0]),
+            )
+
+        attention_bias = Buffer.from_numpy(attention_bias_np).to(
+            self.devices[0]
+        )
+        outputs = self.model.execute(tokens, attention_bias)
         if isinstance(outputs, (list, tuple)):
             return outputs[0]
         return outputs

--- a/max/python/max/pipelines/architectures/mistral3_modulev3/text_encoder/attention.py
+++ b/max/python/max/pipelines/architectures/mistral3_modulev3/text_encoder/attention.py
@@ -20,15 +20,16 @@ from typing import TYPE_CHECKING
 from max.experimental import functional as F
 from max.experimental.nn import Linear, Module
 from max.experimental.tensor import Tensor
-from max.nn.attention.mask_config import MHAMaskVariant
-from max.nn.kernels import flash_attention_gpu as _flash_attention_gpu
+from max.nn.kernels import (
+    masked_flash_attention_gpu as _masked_flash_attention_gpu,
+)
 
 if TYPE_CHECKING:
     from max.experimental.nn.common_layers.rotary_embedding import (
         RotaryEmbedding,
     )
 
-flash_attention_gpu = F.functional(_flash_attention_gpu)
+masked_flash_attention_gpu = F.functional(_masked_flash_attention_gpu)
 
 
 class EncoderAttention(Module[..., Tensor]):
@@ -117,7 +118,12 @@ class EncoderAttention(Module[..., Tensor]):
 
         return x
 
-    def forward(self, x: Tensor, rope: RotaryEmbedding) -> Tensor:
+    def forward(
+        self,
+        x: Tensor,
+        rope: RotaryEmbedding,
+        attention_bias: Tensor,
+    ) -> Tensor:
         """Forward pass computing causal self-attention.
 
         Args:
@@ -146,16 +152,15 @@ class EncoderAttention(Module[..., Tensor]):
             k = self._repeat_kv(k, n_rep)
             v = self._repeat_kv(v, n_rep)
 
-        # flash_attention_gpu expects [B, S, heads, head_dim]
         q = F.unsqueeze(q, 0)
         k = F.unsqueeze(k, 0)
         v = F.unsqueeze(v, 0)
 
-        attn_out = flash_attention_gpu(
+        attn_out = masked_flash_attention_gpu(
             q,
             k,
             v,
-            mask_variant=MHAMaskVariant.CAUSAL_MASK,
+            mask=F.squeeze(attention_bias, axis=1),
             scale=self.scale,
         )
 

--- a/max/python/max/pipelines/architectures/mistral3_modulev3/text_encoder/mistral3.py
+++ b/max/python/max/pipelines/architectures/mistral3_modulev3/text_encoder/mistral3.py
@@ -76,7 +76,12 @@ class EncoderTransformerBlock(Module[..., Tensor]):
         self.input_layernorm = RMSNorm(hidden_size, eps=rms_norm_eps)
         self.post_attention_layernorm = RMSNorm(hidden_size, eps=rms_norm_eps)
 
-    def forward(self, x: Tensor, rope: RotaryEmbedding) -> Tensor:
+    def forward(
+        self,
+        x: Tensor,
+        rope: RotaryEmbedding,
+        attention_bias: Tensor,
+    ) -> Tensor:
         """Forward pass without KV cache.
 
         Args:
@@ -88,7 +93,7 @@ class EncoderTransformerBlock(Module[..., Tensor]):
         """
         residual = x
         x = self.input_layernorm(x)
-        x = self.self_attn(x, rope)
+        x = self.self_attn(x, rope, attention_bias)
         x = residual + x
 
         residual = x
@@ -150,9 +155,18 @@ class Mistral3TextEncoderTransformer(Module[..., tuple[Tensor, ...]]):
                 shape=["total_seq_len"],
                 device=self.device,
             ),
+            TensorType(
+                DType.float32,
+                shape=[1, 1, "total_seq_len", "total_seq_len"],
+                device=self.device,
+            ),
         )
 
-    def forward(self, tokens: Tensor) -> tuple[Tensor, ...]:
+    def forward(
+        self,
+        tokens: Tensor,
+        attention_bias: Tensor,
+    ) -> tuple[Tensor, ...]:
         """Forward pass returning fused prompt embeddings.
 
         Runs the transformer up to the last configured layer, collects hidden
@@ -161,6 +175,8 @@ class Mistral3TextEncoderTransformer(Module[..., tuple[Tensor, ...]]):
 
         Args:
             tokens: Input token IDs [total_seq_len]
+            attention_bias: Additive causal+padding mask bias with shape
+                [1, 1, seq_len, seq_len].
 
         Returns:
             Tensor of shape [1, seq_len, num_layers * hidden_dim] with the
@@ -172,7 +188,7 @@ class Mistral3TextEncoderTransformer(Module[..., tuple[Tensor, ...]]):
         selected: dict[int, Tensor] = {}
         max_layer = self._sorted_hidden_state_layers[-1]
         for i, layer in enumerate(self.layers):
-            h = layer(h, self.rope)
+            h = layer(h, self.rope, attention_bias)
             if i in self._hidden_state_layers:
                 selected[i] = h
             if i == max_layer:

--- a/max/python/max/pipelines/architectures/mistral3_modulev3/text_encoder/model.py
+++ b/max/python/max/pipelines/architectures/mistral3_modulev3/text_encoder/model.py
@@ -85,7 +85,7 @@ class Mistral3TextEncoderModel(ComponentModel):
     def __call__(
         self,
         tokens: Tensor,
-        attention_mask: npt.ArrayLike,
+        attention_mask: npt.ArrayLike | None = None,
     ) -> Tensor:
         """Run the compiled text encoder."""
         if tokens.rank == 2:
@@ -95,7 +95,13 @@ class Mistral3TextEncoderModel(ComponentModel):
                 )
             tokens = tokens[0]
 
-        attention_mask_np = np.asarray(attention_mask)
+        if attention_mask is None:
+            attention_mask_np = np.ones(
+                (int(tokens.shape[0]),),
+                dtype=np.bool_,
+            )
+        else:
+            attention_mask_np = np.asarray(attention_mask)
         attention_bias_np = attention_bias_from_attention_mask_array(
             attention_mask_np,
             expected_seq_len=int(tokens.shape[0]),

--- a/max/python/max/pipelines/architectures/mistral3_modulev3/text_encoder/model.py
+++ b/max/python/max/pipelines/architectures/mistral3_modulev3/text_encoder/model.py
@@ -22,10 +22,15 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any
 
-from max.driver import Device
+import numpy as np
+import numpy.typing as npt
+from max.driver import Buffer, Device
 from max.experimental import functional as F
 from max.experimental.tensor import Tensor
 from max.graph.weights import Weights
+from max.pipelines.dataprocessing import (
+    attention_bias_from_attention_mask_array,
+)
 from max.pipelines.lib import SupportedEncoding
 from max.pipelines.lib.interfaces.component_model import ComponentModel
 from max.profiler import traced
@@ -77,9 +82,28 @@ class Mistral3TextEncoderModel(ComponentModel):
         self.model = model.compile(*model.input_types(), weights=state_dict)
         return self.model
 
-    def __call__(self, tokens: Tensor) -> Tensor:
+    def __call__(
+        self,
+        tokens: Tensor,
+        attention_mask: npt.ArrayLike,
+    ) -> Tensor:
         """Run the compiled text encoder."""
-        outputs = self.model(tokens)
+        if tokens.rank == 2:
+            if int(tokens.shape[0]) != 1:
+                raise ValueError(
+                    "Mistral3TextEncoderModel expects batch_size=1 for 2D token input."
+                )
+            tokens = tokens[0]
+
+        attention_mask_np = np.asarray(attention_mask)
+        attention_bias_np = attention_bias_from_attention_mask_array(
+            attention_mask_np,
+            expected_seq_len=int(tokens.shape[0]),
+        )
+        attention_bias = Tensor(
+            storage=Buffer.from_numpy(attention_bias_np).to(self.devices[0])
+        )
+        outputs = self.model(tokens, attention_bias)
         if isinstance(outputs, (list, tuple)):
             return outputs[0]
         return outputs

--- a/max/python/max/pipelines/architectures/qwen3/text_encoder/model.py
+++ b/max/python/max/pipelines/architectures/qwen3/text_encoder/model.py
@@ -166,7 +166,7 @@ class Qwen3TextEncoderModel(ComponentModel):
     def __call__(
         self,
         tokens: Buffer,
-        attention_mask: npt.ArrayLike,
+        attention_mask: npt.ArrayLike | None = None,
         *,
         hidden_state_index: int | None = None,
     ) -> Buffer:
@@ -177,7 +177,13 @@ class Qwen3TextEncoderModel(ComponentModel):
                 )
             tokens = tokens[0]
 
-        attention_mask_np = np.asarray(attention_mask)
+        if attention_mask is None:
+            attention_mask_np = np.ones(
+                (int(tokens.shape[0]),),
+                dtype=np.bool_,
+            )
+        else:
+            attention_mask_np = np.asarray(attention_mask)
         attention_bias_np = attention_bias_from_attention_mask_array(
             attention_mask_np,
             expected_seq_len=int(tokens.shape[0]),

--- a/max/python/max/pipelines/architectures/qwen3/text_encoder/model.py
+++ b/max/python/max/pipelines/architectures/qwen3/text_encoder/model.py
@@ -30,8 +30,8 @@ from max.graph.weights import Weights
 from max.pipelines.architectures.llama3.weight_adapters import (
     LLAMA_SAFETENSOR_MAPPING as QWEN_SAFETENSOR_MAP,
 )
-from max.pipelines.dataprocessing.causal_attention_mask import (
-    causal_attention_mask_with_token_mask,
+from max.pipelines.dataprocessing import (
+    attention_bias_from_attention_mask_array,
 )
 from max.pipelines.lib import SupportedEncoding
 from max.pipelines.lib.interfaces.component_model import ComponentModel
@@ -163,34 +163,10 @@ class Qwen3TextEncoderModel(ComponentModel):
         )
         return self.model.execute
 
-    @staticmethod
-    def attention_bias_from_attention_mask_array(
-        attention_mask: np.ndarray,
-        *,
-        expected_seq_len: int | None = None,
-    ) -> np.ndarray:
-        additive_mask = causal_attention_mask_with_token_mask(
-            [0],
-            attention_mask,
-        )
-        if additive_mask.shape[0] != 1:
-            raise ValueError(
-                f"batch size must be 1, got {additive_mask.shape[0]}."
-            )
-        if (
-            expected_seq_len is not None
-            and additive_mask.shape[1] != expected_seq_len
-        ):
-            raise ValueError(
-                "seq_len must match tokens "
-                f"({additive_mask.shape[1]} != {expected_seq_len})."
-            )
-        return additive_mask[:, np.newaxis, :, :].astype(np.float32, copy=False)
-
     def __call__(
         self,
         tokens: Buffer,
-        attention_mask: npt.ArrayLike | None = None,
+        attention_mask: npt.ArrayLike,
         *,
         hidden_state_index: int | None = None,
     ) -> Buffer:
@@ -201,17 +177,11 @@ class Qwen3TextEncoderModel(ComponentModel):
                 )
             tokens = tokens[0]
 
-        if attention_mask is not None:
-            attention_mask_np = np.asarray(attention_mask)
-            attention_bias_np = self.attention_bias_from_attention_mask_array(
-                attention_mask_np,
-                expected_seq_len=int(tokens.shape[0]),
-            )
-        else:
-            attention_bias_np = self.attention_bias_from_attention_mask_array(
-                np.ones((int(tokens.shape[0]),), dtype=np.bool_),
-                expected_seq_len=int(tokens.shape[0]),
-            )
+        attention_mask_np = np.asarray(attention_mask)
+        attention_bias_np = attention_bias_from_attention_mask_array(
+            attention_mask_np,
+            expected_seq_len=int(tokens.shape[0]),
+        )
 
         attention_bias = Buffer.from_numpy(attention_bias_np).to(
             self.devices[0]

--- a/max/python/max/pipelines/architectures/qwen3_modulev3/text_encoder/model.py
+++ b/max/python/max/pipelines/architectures/qwen3_modulev3/text_encoder/model.py
@@ -30,8 +30,8 @@ from max.graph.weights import Weights
 from max.pipelines.architectures.llama3.weight_adapters import (
     LLAMA_SAFETENSOR_MAPPING as QWEN_SAFETENSOR_MAP,
 )
-from max.pipelines.dataprocessing.causal_attention_mask import (
-    causal_attention_mask_with_token_mask,
+from max.pipelines.dataprocessing import (
+    attention_bias_from_attention_mask_array,
 )
 from max.pipelines.lib import SupportedEncoding
 from max.pipelines.lib.interfaces.component_model import ComponentModel
@@ -145,36 +145,10 @@ class Qwen3TextEncoderModel(ComponentModel):
         self.model = model.compile(*model.input_types(), weights=state_dict)
         return self.model
 
-    @staticmethod
-    def attention_bias_from_attention_mask_array(
-        attention_mask: np.ndarray,
-        *,
-        expected_seq_len: int | None = None,
-    ) -> np.ndarray:
-        additive_mask = causal_attention_mask_with_token_mask(
-            [0],
-            attention_mask,
-        )
-        # TODO: Lift this batch_size=1 restriction if the Klein text-encoder
-        # path needs batched prompt-mask handling.
-        if additive_mask.shape[0] != 1:
-            raise ValueError(
-                f"batch size must be 1, got {additive_mask.shape[0]}."
-            )
-        if (
-            expected_seq_len is not None
-            and additive_mask.shape[1] != expected_seq_len
-        ):
-            raise ValueError(
-                "seq_len must match tokens "
-                f"({additive_mask.shape[1]} != {expected_seq_len})."
-            )
-        return additive_mask[:, np.newaxis, :, :].astype(np.float32, copy=False)
-
     def __call__(
         self,
         tokens: Tensor,
-        attention_mask: npt.ArrayLike | None = None,
+        attention_mask: npt.ArrayLike,
         *,
         hidden_state_index: int | None = None,
     ):
@@ -185,17 +159,11 @@ class Qwen3TextEncoderModel(ComponentModel):
                 )
             tokens = tokens[0]
 
-        if attention_mask is not None:
-            attention_mask_np = np.asarray(attention_mask)
-            attention_bias_np = self.attention_bias_from_attention_mask_array(
-                attention_mask_np,
-                expected_seq_len=int(tokens.shape[0]),
-            )
-        else:
-            attention_bias_np = self.attention_bias_from_attention_mask_array(
-                np.ones((int(tokens.shape[0]),), dtype=np.bool_),
-                expected_seq_len=int(tokens.shape[0]),
-            )
+        attention_mask_np = np.asarray(attention_mask)
+        attention_bias_np = attention_bias_from_attention_mask_array(
+            attention_mask_np,
+            expected_seq_len=int(tokens.shape[0]),
+        )
 
         attention_bias = Tensor(
             storage=Buffer.from_numpy(attention_bias_np).to(self.devices[0])

--- a/max/python/max/pipelines/architectures/qwen3_modulev3/text_encoder/model.py
+++ b/max/python/max/pipelines/architectures/qwen3_modulev3/text_encoder/model.py
@@ -148,7 +148,7 @@ class Qwen3TextEncoderModel(ComponentModel):
     def __call__(
         self,
         tokens: Tensor,
-        attention_mask: npt.ArrayLike,
+        attention_mask: npt.ArrayLike | None = None,
         *,
         hidden_state_index: int | None = None,
     ):
@@ -159,7 +159,13 @@ class Qwen3TextEncoderModel(ComponentModel):
                 )
             tokens = tokens[0]
 
-        attention_mask_np = np.asarray(attention_mask)
+        if attention_mask is None:
+            attention_mask_np = np.ones(
+                (int(tokens.shape[0]),),
+                dtype=np.bool_,
+            )
+        else:
+            attention_mask_np = np.asarray(attention_mask)
         attention_bias_np = attention_bias_from_attention_mask_array(
             attention_mask_np,
             expected_seq_len=int(tokens.shape[0]),

--- a/max/python/max/pipelines/dataprocessing/__init__.py
+++ b/max/python/max/pipelines/dataprocessing/__init__.py
@@ -12,6 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 
 from .causal_attention_mask import (
+    attention_bias_from_attention_mask_array,
     causal_attention_mask,
     causal_attention_mask_with_token_mask,
 )
@@ -24,6 +25,7 @@ from .max_tokens_to_generate import max_tokens_to_generate
 
 __all__ = [
     "PaddingDirection",
+    "attention_bias_from_attention_mask_array",
     "batch_padded_tokens_and_mask",
     "causal_attention_mask",
     "causal_attention_mask_with_token_mask",

--- a/max/python/max/pipelines/dataprocessing/causal_attention_mask.py
+++ b/max/python/max/pipelines/dataprocessing/causal_attention_mask.py
@@ -124,3 +124,45 @@ def causal_attention_mask_with_token_mask(
         additive_mask,
         np.float32(FILL_VAL),
     ).astype(np.float32, copy=False)
+
+
+def attention_bias_from_attention_mask_array(
+    attention_mask: npt.ArrayLike,
+    *,
+    expected_seq_len: int | None = None,
+    batch_size: int = 1,
+    start_pos: int = 0,
+    mask_name: str = "attention_mask",
+) -> npt.NDArray[np.float32]:
+    """Converts a token attention mask into a 4D additive attention bias.
+
+    Args:
+        attention_mask: Rank-1 or rank-2 token-validity mask where ``True``
+            marks visible tokens.
+        expected_seq_len: Optional expected sequence length to validate.
+        batch_size: Expected batch size for the materialized bias.
+        start_pos: Start position used when embedding the token mask into a
+            larger causal context.
+        mask_name: Name used in validation errors.
+
+    Returns:
+        Float32 additive attention bias with shape ``[batch, 1, seq_len, seq_len]``.
+    """
+    additive_mask = causal_attention_mask_with_token_mask(
+        [start_pos] * batch_size,
+        attention_mask,
+        mask_name=mask_name,
+    )
+    if additive_mask.shape[0] != batch_size:
+        raise ValueError(
+            f"batch size must be {batch_size}, got {additive_mask.shape[0]}."
+        )
+    if (
+        expected_seq_len is not None
+        and additive_mask.shape[1] != expected_seq_len
+    ):
+        raise ValueError(
+            "seq_len must match tokens "
+            f"({additive_mask.shape[1]} != {expected_seq_len})."
+        )
+    return additive_mask[:, np.newaxis, :, :].astype(np.float32, copy=False)

--- a/max/python/max/pipelines/lib/pixel_tokenizer.py
+++ b/max/python/max/pipelines/lib/pixel_tokenizer.py
@@ -713,23 +713,6 @@ class PixelGenerationTokenizer(
                 f"{input_ids_array.shape} vs {attention_mask_array.shape}."
             )
 
-        # Flux2 text encoder path currently does not consume an explicit
-        # attention mask. Strip padded tokens here and keep a dense mask.
-        # FLUX2_KLEIN/Z-Image consume attention_mask directly.
-        if self._pipeline_class_name == PipelineClassName.FLUX2:
-            token_row = input_ids_array[0]
-            mask_row = attention_mask_array[0]
-            real_token_ids = token_row[mask_row]
-            if real_token_ids.size == 0:
-                raise ValueError(
-                    f"{self._pipeline_class_name.value} tokenization produced "
-                    "an empty effective prompt after attention masking."
-                )
-            input_ids_array = np.expand_dims(
-                real_token_ids.astype(np.int64, copy=False), axis=0
-            )
-            attention_mask_array = np.ones_like(input_ids_array, dtype=np.bool_)
-
         if (
             max_sequence_length is not None
             and input_ids_array.shape[1] > max_sequence_length

--- a/max/tests/integration/tools/create_pipelines.py
+++ b/max/tests/integration/tools/create_pipelines.py
@@ -1134,12 +1134,14 @@ class ImageGenerationOracle(PipelineOracle):
         model_path: str = "black-forest-labs/FLUX.1-dev",
         num_steps: int = 50,
         requests: list[Any] = test_data.DEFAULT_PIXEL_GENERATION,
+        config_params: dict[str, Any] = {},  # noqa: B006
     ) -> None:
         super().__init__()
         self.model_path = model_path
         self.task = PipelineTask.PIXEL_GENERATION
         self.num_steps = num_steps
         self._inputs = requests
+        self.config_params = config_params
 
     @property
     def device_encoding_map(self) -> dict[str, list[str]]:
@@ -1164,8 +1166,9 @@ class ImageGenerationOracle(PipelineOracle):
             model=pipelines.MAXModelConfig(
                 model_path=self.model_path,
                 device_specs=device_specs,
+                quantization_encoding=encoding,
             ),
-            runtime=PipelineRuntimeConfig(prefer_module_v3=True),
+            runtime=PipelineRuntimeConfig(**self.config_params),
         )
 
         if self.model_path.startswith("black-forest-labs/FLUX.2"):


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Please fill out the sections below to help reviewers understand your change.
For guidance on writing a good PR, see our
[contributor guide](../CONTRIBUTING.md).
-->

## Summary

This PR extends the masking approach from PR #6153 to the `FLUX.2-dev`/`Mistral3` text-encoder path.

Instead of compacting padded tokens in `PixelGenerationTokenizer`, we now preserve the padded prompt sequence and pass the tokenizer-generated `attention_mask` through the FLUX.2 pipeline into the Mistral3 text encoder. The text encoder materializes an additive attention bias and uses masked flash attention, matching the same overall masking model already used for FLUX.2-Klein.

## What Changed

- removed the FLUX.2-specific token compaction workaround from `PixelGenerationTokenizer`
- threaded `attention_mask` through `flux2` and `flux2_modulev3` prompt-embedding paths
- added a shared `attention_bias_from_attention_mask_array(...)` helper
- updated graph and modulev3 Mistral3 text encoders to consume additive attention bias
- switched Mistral3 text attention to masked flash attention
- reused the shared helper in the existing Qwen3 text-encoder path for consistency

## Why

Before this change, FLUX.2-dev still relied on a tokenizer-side workaround, while FLUX.2-Klein already had an explicit masking path. This PR removes that inconsistency and makes FLUX.2 prompt masking behavior easier to reason about and maintain across model variants.


## Testing

```
./bazelw run //max/tests/integration/accuracy:verify_pipelines --   --pipeline black-forest-labs/FLUX.2-dev-t2i-bfloat16-v2    --devices gpu:0   --pixel-results-dir ../results
```

<table>
  <tr>
      <td align="center">
      <img width="1024" height="1024" alt="diffusers" src="https://github.com/user-attachments/assets/ca9c3e9e-adb5-4172-937e-f587d93da7b1" />
      <br/>diffusers with same latent
    </td>
    <td align="center">
    <img width="1024" height="1024" alt="max_main" src="https://github.com/user-attachments/assets/c66d1b34-cfe0-4576-9415-e3254d1fbc62" />
      <br/>max main branch
    </td>
    <td align="center">
    <img width="1024" height="1024" alt="max_pr" src="https://github.com/user-attachments/assets/79103a07-aefe-46c9-bdc0-03ed9a4361de" />
    <br/>max current PR
    </td>

  </tr>
</table>

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
`Assisted-by: codex`