### PR TITLE
Refine SM100 softmax large-row paths

### DIFF
--- a/max/kernels/benchmarks/autotune/kbench.py
+++ b/max/kernels/benchmarks/autotune/kbench.py
@@ -123,8 +123,9 @@ def run(
     timeout_secs: int | None = None,
     plot: str = "bars",
     use_shared_lib: bool = False,
+    reset_shared_lib_worker_per_binary_group: bool = False,
     cache_dir: Path | None = None,
-) -> None:
+) -> int:
     if yaml_path_list:
         # Load specs from a list of YAML files and join them in 'spec'.
         assert len(yaml_path_list), "There should be at least 1 YAML as input."
@@ -158,6 +159,8 @@ def run(
     if filter_list:
         spec.filter(filter_list)
 
+    executed_spec_count = len(spec)
+
     if verbose:
         for i, s in enumerate(spec):
             logging.debug(f"[{i}]{s}")
@@ -188,6 +191,7 @@ def run(
         output_suffix="output.csv",
         progress=progress,
         use_shared_lib=use_shared_lib,
+        reset_shared_lib_worker_per_binary_group=reset_shared_lib_worker_per_binary_group,
         cache_dir=cache_dir,
     )
 
@@ -216,7 +220,7 @@ def run(
                     f"Number of valid built specs: {num_valid}"
                     f" (out of {num_total})"
                 )
-                return
+                return executed_spec_count
 
             # Only RUN and BUILD_AND_RUN reach here.
             scheduler.execute_all(
@@ -258,6 +262,8 @@ def run(
                 render_results(
                     pkl_data["merged_df"], mode=plot, console=CONSOLE
                 )
+
+    return executed_spec_count
 
 
 def _validate_partition(partition: str) -> list[int]:
@@ -403,7 +409,8 @@ def set_build_opts(
     "cache_dir",
     default=None,
     help="Fixed directory for compiled binaries and cache pickle. "
-    "Enables portable caching for split build/run workflows.",
+    "Stores portable build artifacts for split build/run workflows. "
+    "Reuse still requires --cached or --run-only.",
     type=click.Path(path_type=Path),
 )
 @click.option(
@@ -470,6 +477,12 @@ def set_build_opts(
     multiple=False,
 )
 @click.option(
+    "--reset-shared-lib-worker-per-binary-group",
+    is_flag=True,
+    default=False,
+    help="Respawn the shared-lib worker whenever kbench switches to a new compiled binary group.",
+)
+@click.option(
     "--timeout-secs",
     default=120,
     show_default=True,
@@ -523,6 +536,7 @@ def cli(
     profile: str,
     exec_prefix: str,
     exec_suffix: str,
+    reset_shared_lib_worker_per_binary_group: bool,
     timeout_secs: int | None,
     partition: str,
     plot: str,
@@ -558,7 +572,6 @@ def cli(
     if cache_dir:
         cache_dir = Path(cache_dir).resolve()
         obj_cache = KbenchCache(base_dir=cache_dir)
-        cached = True  # --cache-dir implies --cached
     else:
         obj_cache = KbenchCache()
 
@@ -570,6 +583,12 @@ def cli(
 
     if cached or (mode == KBENCH_MODE.RUN):
         obj_cache.load()
+    elif cache_dir:
+        logging.info(
+            "Using --cache-dir for fresh builds only; pass --cached to "
+            "reuse previous binaries."
+        )
+        obj_cache.activate_empty()
 
     if len(obj_cache.data) == 0 and mode == KBENCH_MODE.RUN:
         log_and_raise_error(
@@ -662,6 +681,14 @@ def cli(
     use_shared_lib = not profile and not exec_prefix and not exec_suffix
     if use_shared_lib:
         logging.info("Using shared library (.so) mode for faster execution")
+    elif reset_shared_lib_worker_per_binary_group:
+        logging.warning(
+            "Ignoring --reset-shared-lib-worker-per-binary-group because shared library mode is disabled."
+        )
+        reset_shared_lib_worker_per_binary_group = False
+
+    if reset_shared_lib_worker_per_binary_group:
+        logging.info("Resetting the shared-lib worker between binary groups")
 
     # Resolve num_cpu sentinel value once before the shape loop.
     if num_cpu == -1:
@@ -673,8 +700,9 @@ def cli(
     shape_idx_ub = min(shape_idx_lb + shapes_per_partition, len(shape_list))
 
     output_dir_path: Path | None = Path(output_dir) if output_dir else None
+    executed_shape_count = 0
     for i in range(shape_idx_lb, shape_idx_ub):
-        run(
+        executed_shape_count += run(
             yaml_path_list=yaml_files,
             obj_cache=obj_cache,
             shape=shape_list[i],
@@ -695,11 +723,12 @@ def cli(
             timeout_secs=timeout_secs,
             plot=plot,
             use_shared_lib=use_shared_lib,
+            reset_shared_lib_worker_per_binary_group=reset_shared_lib_worker_per_binary_group,
             cache_dir=cache_dir,
         )
         if obj_cache.is_active:
             obj_cache.dump()
-    logging.info(f"Number of shapes: {len(shape_list)}")
+    logging.info(f"Number of shapes: {executed_shape_count}")
     return True
 
 

--- a/max/kernels/benchmarks/autotune/kbench_model.py
+++ b/max/kernels/benchmarks/autotune/kbench_model.py
@@ -81,7 +81,7 @@ ScalarValue = str | int | float | bool
 
 _WRAPPER_SOURCE = """\
 from {module_name} import main as _bench_main
-from std.builtin._startup import _ensure_runtime_init
+from std.builtin._startup import _ensure_current_or_global_runtime_init
 
 
 @export
@@ -91,7 +91,7 @@ def benchmark_entry() -> Int32:
     # never registered.  Benchmarks that use CPU parallelism
     # (e.g. elementwise) will abort on a null Runtime* without
     # this.  The call is idempotent — a no-op after the first.
-    _ensure_runtime_init()
+    _ensure_current_or_global_runtime_init()
     try:
         _bench_main()
         return 0
@@ -294,6 +294,11 @@ class KbenchCache:
         """Load cache from file."""
         if self.path.exists():
             self.data = utils.load_pickle(self.path)
+        self.is_active = True
+
+    def activate_empty(self) -> None:
+        """Enable cache writes without loading any existing entries."""
+        self.data = {}
         self.is_active = True
 
     def dump(self) -> None:
@@ -1049,6 +1054,17 @@ def _start_worker(
     return proc
 
 
+def _has_explicit_single_visible_device(
+    visible_device_prefix: str,
+) -> bool:
+    """True when the caller already constrained visibility to one GPU."""
+    if not visible_device_prefix:
+        return False
+    existing = os.environ.get(visible_device_prefix, "")
+    visible_ids = [v.strip() for v in existing.split(",") if v.strip()]
+    return len(visible_ids) == 1
+
+
 def _gpu_worker_loop(
     gpu_id: int | str,
     visible_device_prefix: str,
@@ -1203,6 +1219,7 @@ def _gpu_manager(
     visible_device_prefix: str,
     item_pool: ItemPool,
     timeout_secs: int | None,
+    reset_shared_lib_worker_per_binary_group: bool,
     results_list: list[BuildItem],
     results_lock: threading.Lock,
     progress: Any,
@@ -1217,11 +1234,28 @@ def _gpu_manager(
     proc = _start_worker(
         gpu_id, visible_device_prefix, task_queue, result_queue
     )
+    last_bin_path: Path | None = None
 
     while not shutdown_event.is_set():
         item = item_pool.next_for(gpu_id)
         if item is None:
             break
+
+        current_bin_path = item.build_item.bin_path
+        if (
+            reset_shared_lib_worker_per_binary_group
+            and item.use_shared_lib
+            and last_bin_path is not None
+            and current_bin_path is not None
+            and current_bin_path != last_bin_path
+        ):
+            proc, task_queue, result_queue = _respawn_worker(
+                gpu_id,
+                visible_device_prefix,
+                proc,
+                task_queue,
+                result_queue,
+            )
 
         task_queue.put(item)
         completed_bi, status = _poll_result(result_queue, proc, timeout_secs)
@@ -1253,6 +1287,8 @@ def _gpu_manager(
             f"{status} [{done}/{total}] ({utils._percentage(done, total)}%)"
         )
         completed_bi.exec_output.log()
+        if completed_bi.bin_path is not None:
+            last_bin_path = completed_bi.bin_path
 
         completed_bi.stdout_capture_path.unlink(missing_ok=True)
         completed_bi.stderr_capture_path.unlink(missing_ok=True)
@@ -1345,6 +1381,7 @@ class Scheduler:
         output_suffix: str = "output.csv",
         progress: Progress = Progress(),
         use_shared_lib: bool = False,
+        reset_shared_lib_worker_per_binary_group: bool = False,
         output_dir_list: list[Path] | None = None,
         cache_dir: Path | None = None,
     ) -> None:
@@ -1376,6 +1413,9 @@ class Scheduler:
         self.output_dir = output_dir
         self.run_only = run_only
         self.cache_dir = cache_dir
+        self.reset_shared_lib_worker_per_binary_group = (
+            reset_shared_lib_worker_per_binary_group
+        )
 
         self.build_items = [
             BuildItem(
@@ -1743,9 +1783,20 @@ class Scheduler:
         gpu_ids = self._make_gpu_ids(visible_device_prefix)
 
         # Only isolate GPUs when kbench itself is parallelizing across GPUs
-        # and not using mpirun. Otherwise let benchmarks see all GPUs.
+        # and not using mpirun. Preserve an explicit single visible-device
+        # selection from the caller so shared-lib workers can stay pinned to
+        # that physical GPU.
         use_mpirun = any("mpirun" in p for p in exec_prefix)
-        if len(gpu_ids) <= 1 or use_mpirun:
+        preserve_single_visible_device = (
+            _has_explicit_single_visible_device(visible_device_prefix)
+        )
+        if preserve_single_visible_device:
+            logging.info(
+                f"Preserving explicit {visible_device_prefix}="
+                f"{os.environ[visible_device_prefix]} for single-GPU worker"
+                " isolation"
+            )
+        if (len(gpu_ids) <= 1 and not preserve_single_visible_device) or use_mpirun:
             visible_device_prefix = ""
 
         num_items = num_build_items - no_binary_count
@@ -1776,6 +1827,7 @@ class Scheduler:
                     visible_device_prefix,
                     item_pool,
                     timeout_secs,
+                    self.reset_shared_lib_worker_per_binary_group,
                     self.build_items,
                     results_lock,
                     self.progress,

--- a/max/kernels/benchmarks/autotune/kbench_model.py
+++ b/max/kernels/benchmarks/autotune/kbench_model.py
@@ -81,17 +81,10 @@ ScalarValue = str | int | float | bool
 
 _WRAPPER_SOURCE = """\
 from {module_name} import main as _bench_main
-from std.builtin._startup import _ensure_current_or_global_runtime_init
 
 
 @export
 def benchmark_entry() -> Int32:
-    # Shared libraries don't get the __wrap_and_execute_main
-    # startup that executables do, so the Mojo async runtime is
-    # never registered.  Benchmarks that use CPU parallelism
-    # (e.g. elementwise) will abort on a null Runtime* without
-    # this.  The call is idempotent — a no-op after the first.
-    _ensure_current_or_global_runtime_init()
     try:
         _bench_main()
         return 0

--- a/max/kernels/benchmarks/autotune/tests/test_kbench.py
+++ b/max/kernels/benchmarks/autotune/tests/test_kbench.py
@@ -38,6 +38,7 @@ from kbench_model import (
     Scheduler,
     SpecInstance,
     SupportedLangs,
+    _has_explicit_single_visible_device,
 )
 from kplot import _resolve_ytext_unit
 from kplot import cli as kplot_cli
@@ -116,6 +117,28 @@ def test_kbench() -> None:
 
     pd.testing.assert_series_equal(df["name"], baseline_df["name"])
     pd.testing.assert_series_equal(df["spec"], baseline_df["spec"])
+
+
+def test_kbench_logs_multishape_count_on_dryrun(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    output_path = tmp_path / "dryrun_output"
+    result = CliRunner().invoke(
+        kbench_cli,
+        [
+            "--skip-clock-check",
+            f"{kernel_benchmarks_root}/autotune/test.yaml",
+            "-fv",
+            "--dryrun",
+            "-o",
+            str(output_path),
+        ],
+        env=os.environ.copy(),
+    )
+
+    assert result.exit_code == os.EX_OK, result.output
+    assert "Number of shapes: 5" in caplog.text
+    assert "Number of shapes: 1" not in caplog.text
 
 
 # TODO: resolving mpirun deps in bazel.
@@ -362,6 +385,30 @@ def test_kbench_cache_basic_operations(tmp_path: Path) -> None:
     assert cache.query("nonexistent") is None
 
 
+def test_kbench_cache_activate_empty_starts_fresh(tmp_path: Path) -> None:
+    """cache_dir-only build runs should overwrite stale manifests."""
+    cache = KbenchCache(base_dir=tmp_path)
+    stale_bin = tmp_path / "stale.so"
+    stale_bin.touch()
+    cache.load()
+    cache.store("stale", stale_bin)
+    cache.dump()
+
+    fresh_cache = KbenchCache(base_dir=tmp_path)
+    fresh_cache.activate_empty()
+    assert fresh_cache.query("stale") is None
+
+    fresh_bin = tmp_path / "fresh.so"
+    fresh_bin.touch()
+    fresh_cache.store("fresh", fresh_bin)
+    fresh_cache.dump()
+
+    reloaded = KbenchCache(base_dir=tmp_path)
+    reloaded.load()
+    assert reloaded.query("stale") is None
+    assert reloaded.query("fresh") == str(fresh_bin.resolve())
+
+
 def test_process_output_log() -> None:
     """Test ProcessOutput.log doesn't crash"""
     # Just verify it doesn't raise
@@ -482,6 +529,26 @@ def test_get_gpu_count_nvidia_env_fewer_than_hw(mocker: MockerFixture) -> None:
     )
     mocker.patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "2,3"}, clear=False)
     assert _get_gpu_count("nvidia:sm_90") == 2
+
+
+def test_has_explicit_single_visible_device_nvidia(
+    mocker: MockerFixture,
+) -> None:
+    """Single-GPU shared-lib workers should preserve an explicit one-GPU env."""
+    mocker.patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "1"}, clear=False)
+    assert _has_explicit_single_visible_device("CUDA_VISIBLE_DEVICES")
+
+
+def test_has_explicit_single_visible_device_rejects_multi_gpu_env(
+    mocker: MockerFixture,
+) -> None:
+    """Do not preserve the prefix when the caller exposed multiple GPUs."""
+    mocker.patch.dict(
+        os.environ, {"CUDA_VISIBLE_DEVICES": "1,3"}, clear=False
+    )
+    assert not _has_explicit_single_visible_device(
+        "CUDA_VISIBLE_DEVICES"
+    )
 
 
 def test_get_gpu_count_nvidia_no_smi(mocker: MockerFixture) -> None:

--- a/max/kernels/benchmarks/gpu/nn/bench_softmax.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_softmax.mojo
@@ -15,22 +15,275 @@ from std.random import random_float64
 from std.sys import (
     is_defined,
     get_defined_dtype,
+    get_defined_int,
     get_defined_string,
     simd_width_of,
 )
 
 from std.benchmark import Bench, BenchConfig, Bencher, BenchId
 from std.gpu.host import DeviceContext
-from internal_utils import get_defined_shape, int_list_to_tuple
+from std.runtime.asyncrt import DeviceContextPtr
+from internal_utils import (
+    arg_parse,
+    get_defined_shape,
+    int_list_to_tuple,
+    update_bench_config_args,
+)
 from layout import Coord, TileTensor, row_major
-from nn.softmax import softmax, softmax_with_temperature
+from nn.softmax import (
+    softmax_benchmark_candidate,
+    softmax_benchmark_current,
+    softmax_with_temperature,
+)
 
 from std.utils.index import IndexList
 
 
+@always_inline
+def launch_softmax_current[
+    dtype: DType, rank: Int
+](
+    data_buf: TileTensor[dtype, ...],
+    out_buf: TileTensor[mut=True, dtype, ...],
+    context: DeviceContextPtr,
+) raises:
+    softmax_benchmark_current[dtype, simd_width_of[dtype](), rank](
+        data_buf, out_buf, rank - 1, context
+    )
+
+
+@always_inline
+def benchmark_candidate_uses_variant_one[
+    dtype: DType, rank: Int, shape: IndexList[rank]
+]() -> Bool:
+    comptime if dtype == DType.bfloat16 and rank == 2:
+        return shape[1] == 128256 and (shape[0] == 32 or shape[0] == 128)
+    return False
+
+
+@always_inline
+def launch_softmax_candidate[
+    dtype: DType, rank: Int, shape: IndexList[rank]
+](
+    data_buf: TileTensor[dtype, ...],
+    out_buf: TileTensor[mut=True, dtype, ...],
+    context: DeviceContextPtr,
+) raises:
+    comptime if benchmark_candidate_uses_variant_one[dtype, rank, shape]():
+        softmax_benchmark_candidate[
+            dtype, simd_width_of[dtype](), rank
+        ](
+            data_buf, out_buf, rank - 1, context
+        )
+    else:
+        softmax_benchmark_current[dtype, simd_width_of[dtype](), rank](
+            data_buf, out_buf, rank - 1, context
+        )
+
+
+@always_inline
+def _assert_bench_impl_mode[bench_impl_mode: Int]():
+    comptime assert 0 <= bench_impl_mode and bench_impl_mode <= 2
+
+
+@always_inline
+def bench_impl_name[bench_impl_mode: Int]() -> String:
+    _assert_bench_impl_mode[bench_impl_mode]()
+    comptime if bench_impl_mode == 1:
+        return String("current_only")
+    elif bench_impl_mode == 2:
+        return String("candidate_only")
+    return String("mixed")
+
+
+@always_inline
+def decorate_input_suffix[
+    bench_impl_mode: Int
+](input_suffix: String) -> String:
+    return String(
+        "bench_impl=", bench_impl_name[bench_impl_mode](), "/", input_suffix
+    )
+
+
+@always_inline
+def replay_slot_name(slot_order_mode: Int, slot_position: Int) -> String:
+    if slot_order_mode == 1:
+        if slot_position == 0:
+            return String("candidate_slot")
+        if slot_position == 1:
+            return String("current_post")
+        return String("current_pre")
+    if slot_position == 0:
+        return String("current_pre")
+    if slot_position == 1:
+        return String("candidate_slot")
+    return String("current_post")
+
+
+@always_inline
+def replay_slot_uses_candidate(slot_name: String) -> Bool:
+    return slot_name == "candidate_slot"
+
+
+@always_inline
+def slot_order_mode_name(slot_order_mode: Int) -> String:
+    if slot_order_mode == 1:
+        return String("candidate_first")
+    return String("default")
+
+
+@always_inline
+def launch_bench_softmax_variant[
+    bench_impl_mode: Int,
+    use_candidate: Bool,
+    dtype: DType,
+    rank: Int,
+    shape: IndexList[rank],
+](
+    data_buf: TileTensor[dtype, ...],
+    out_buf: TileTensor[mut=True, dtype, ...],
+    context: DeviceContextPtr,
+) raises:
+    _assert_bench_impl_mode[bench_impl_mode]()
+    comptime if bench_impl_mode == 2:
+        # Keep unchanged control shapes on the exact current wrapper so
+        # current-only and candidate-only split binaries stay
+        # codegen-identical outside the active benchmark-only probe.
+        comptime if benchmark_candidate_uses_variant_one[dtype, rank, shape]():
+            launch_softmax_candidate[dtype, rank, shape](
+                data_buf, out_buf, context
+            )
+        else:
+            launch_softmax_current[dtype, rank](data_buf, out_buf, context)
+    elif bench_impl_mode == 1:
+        launch_softmax_current[dtype, rank](data_buf, out_buf, context)
+    else:
+        # In mixed mode, keep unchanged controls on the exact current wrapper
+        # for both slot types so a same-.so current/candidate/current triplet
+        # only differs on the active benchmark-only candidate path.
+        comptime if use_candidate and benchmark_candidate_uses_variant_one[
+            dtype, rank, shape
+        ]():
+            launch_softmax_candidate[dtype, rank, shape](
+                data_buf, out_buf, context
+            )
+        else:
+            launch_softmax_current[dtype, rank](data_buf, out_buf, context)
+
+
+def register_softmax_variant[
+    rank: Int,
+    //,
+    bench_impl_mode: Int,
+    use_candidate: Bool,
+    dtype: DType,
+    shape: IndexList[rank],
+](
+    mut b: Bench,
+    fn_name: String,
+    data_buf: TileTensor[dtype, ...],
+    out_buf: TileTensor[mut=True, dtype, ...],
+    context: DeviceContextPtr,
+    input_suffix: String,
+) raises:
+    var bench_input_id = String(
+        fn_name, "/", dtype, "/", shape, "/", input_suffix
+    )
+
+    @always_inline
+    @__copy_capture(data_buf, out_buf, context)
+    @parameter
+    def bench_fn(mut b: Bencher) raises:
+        @parameter
+        @always_inline
+        def kernel_launch(ctx: DeviceContext) raises:
+            _ = ctx
+            launch_bench_softmax_variant[
+                bench_impl_mode, use_candidate, dtype, rank, shape
+            ](data_buf, out_buf, context)
+
+        b.iter_custom[kernel_launch](context.get_device_context())
+
+    b.bench_function[bench_fn](BenchId("softmax", input_id=bench_input_id))
+
+
+@always_inline
+def should_register_replay_slot(
+    replay_pass: Int,
+    replay_pass_filter: Int,
+    slot_name: String,
+    slot_filter: String,
+) -> Bool:
+    if replay_pass_filter > 0 and replay_pass != replay_pass_filter:
+        return False
+    if slot_filter != "" and slot_filter != slot_name:
+        return False
+    return True
+
+
+def launch_softmax_variant_once[
+    rank: Int,
+    //,
+    bench_impl_mode: Int,
+    dtype: DType,
+    shape: IndexList[rank],
+](
+    ctx: DeviceContext,
+    variant: String = "current",
+) raises:
+    _assert_bench_impl_mode[bench_impl_mode]()
+    comptime assert (
+        bench_impl_mode != 0
+    ), "profile-once only supports current-only or candidate-only binaries"
+    _ = variant
+    comptime total = shape.flattened_length()
+
+    var data_h = alloc[Scalar[dtype]](total)
+    for i in range(total):
+        data_h[i] = Scalar[dtype](random_float64(-1, 1).cast[dtype]())
+
+    var data_d = ctx.enqueue_create_buffer[dtype](total)
+    var out_d = ctx.enqueue_create_buffer[dtype](total)
+
+    var data_buf = TileTensor(data_d, row_major(Coord(shape)))
+    var out_buf = TileTensor(out_d, row_major(Coord(shape)))
+    var context = DeviceContextPtr(ctx)
+
+    ctx.enqueue_copy(data_d, data_h)
+    # Nsight single-launch debugging should only observe the kernel train for
+    # the requested softmax path, not the staging memcpy.
+    ctx.synchronize()
+
+    comptime if bench_impl_mode == 2:
+        launch_bench_softmax_variant[
+            bench_impl_mode, True, dtype, rank, shape
+        ](data_buf, out_buf, context)
+    else:
+        launch_bench_softmax_variant[
+            bench_impl_mode, False, dtype, rank, shape
+        ](data_buf, out_buf, context)
+    ctx.synchronize()
+
+    _ = data_d
+    _ = out_d
+    data_h.free()
+
+
 def bench_softmax_gpu[
-    rank: Int, //, dtype: DType, shape: IndexList[rank]
-](ctx: DeviceContext, mut b: Bench, fn_name: String) raises:
+    rank: Int, //, bench_impl_mode: Int, dtype: DType, shape: IndexList[rank]
+](
+    ctx: DeviceContext,
+    mut b: Bench,
+    fn_name: String,
+    variant: String = "current",
+    replay_passes: Int = 1,
+    slot_filter: String = "",
+    replay_pass_filter: Int = 0,
+    slot_order_mode: Int = 0,
+) raises:
+    _assert_bench_impl_mode[bench_impl_mode]()
+    if slot_order_mode < 0 or slot_order_mode > 1:
+        raise Error("slot-order-mode must be 0 or 1")
     comptime cols = shape[rank - 1]
     comptime total = shape.flattened_length()
 
@@ -44,25 +297,89 @@ def bench_softmax_gpu[
 
     var data_buf = TileTensor(data_d, row_major(Coord(shape)))
     var out_buf = TileTensor(out_d, row_major(Coord(shape)))
+    var context = DeviceContextPtr(ctx)
 
     ctx.enqueue_copy(data_d, data_h)
 
-    @always_inline
-    @__copy_capture(shape, data_buf, out_buf)
-    @parameter
-    def bench_fn(mut b: Bencher) raises:
-        @parameter
-        @always_inline
-        def kernel_launch(ctx: DeviceContext) raises:
-            softmax[dtype, simd_width_of[dtype](), rank](
-                data_buf, out_buf, rank - 1
+    if replay_passes > 1:
+        for replay_pass in range(1, replay_passes + 1):
+            for slot_position in range(3):
+                var slot_name = replay_slot_name(
+                    slot_order_mode, slot_position
+                )
+                if should_register_replay_slot(
+                    replay_pass,
+                    replay_pass_filter,
+                    slot_name,
+                    slot_filter,
+                ):
+                    if replay_slot_uses_candidate(slot_name):
+                        register_softmax_variant[
+                            bench_impl_mode, True, dtype, shape
+                        ](
+                            b,
+                            fn_name,
+                            data_buf,
+                            out_buf,
+                            context,
+                            decorate_input_suffix[bench_impl_mode](String(
+                                "slot_order_mode=",
+                                slot_order_mode_name(slot_order_mode),
+                                "/slot_position=",
+                                slot_position + 1,
+                                "/replay_pass=",
+                                replay_pass,
+                                "/slot=",
+                                slot_name,
+                            )),
+                        )
+                    else:
+                        register_softmax_variant[
+                            bench_impl_mode, False, dtype, shape
+                        ](
+                            b,
+                            fn_name,
+                            data_buf,
+                            out_buf,
+                            context,
+                            decorate_input_suffix[bench_impl_mode](String(
+                                "slot_order_mode=",
+                                slot_order_mode_name(slot_order_mode),
+                                "/slot_position=",
+                                slot_position + 1,
+                                "/replay_pass=",
+                                replay_pass,
+                                "/slot=",
+                                slot_name,
+                            )),
+                        )
+    else:
+        if variant.startswith("candidate"):
+            register_softmax_variant[
+                bench_impl_mode, True, dtype, shape
+            ](
+                b,
+                fn_name,
+                data_buf,
+                out_buf,
+                context,
+                decorate_input_suffix[bench_impl_mode](String(
+                    "variant=", variant
+                )),
             )
-
-        b.iter_custom[kernel_launch](ctx)
-
-    b.bench_function[bench_fn](
-        BenchId("softmax", input_id=String(fn_name, "/", dtype, "/", shape))
-    )
+        else:
+            register_softmax_variant[
+                bench_impl_mode, False, dtype, shape
+            ](
+                b,
+                fn_name,
+                data_buf,
+                out_buf,
+                context,
+                decorate_input_suffix[bench_impl_mode](String(
+                    "variant=", variant
+                )),
+            )
 
     ctx.synchronize()
 
@@ -128,7 +445,19 @@ def main() raises:
     comptime shape = int_list_to_tuple[
         get_defined_shape["shape", "256x256"]()
     ]()
+    # Benchmark-only no-op define that lets kbench force a new shared-library
+    # build key without changing the measured kernel path.
+    comptime build_nonce = get_defined_int["build_nonce", 0]()
+    _ = build_nonce
+    comptime bench_impl_mode = get_defined_int["bench_impl_mode", 0]()
+    var variant = arg_parse("variant", "current")
+    var replay_passes = arg_parse("replay-passes", 1)
+    var slot_filter = arg_parse("slot-filter", "")
+    var replay_pass_filter = arg_parse("replay-pass-filter", 0)
+    var slot_order_mode = arg_parse("slot-order-mode", 0)
+    var profile_once = arg_parse("profile-once", 0)
     var m = Bench(BenchConfig(num_repetitions=1))
+    update_bench_config_args(m)
     with DeviceContext() as ctx:
         comptime if is_defined["temperature"]():
             var temperature = Float32(
@@ -137,7 +466,38 @@ def main() raises:
             bench_softmax_with_temperature_gpu[dtype, shape](
                 ctx, m, "softmax_with_temperature_gpu", temperature
             )
-        elif len(shape) == 3:
-            bench_softmax_gpu[dtype, shape](ctx, m, "softmax_gpu")
+        else:
+            comptime if bench_impl_mode == 0:
+                if profile_once != 0:
+                    raise Error(
+                        "profile-once only supports current-only or candidate-only binaries"
+                    )
+                bench_softmax_gpu[bench_impl_mode, dtype, shape](
+                    ctx,
+                    m,
+                    "softmax_gpu",
+                    variant,
+                    replay_passes,
+                    slot_filter,
+                    replay_pass_filter,
+                    slot_order_mode,
+                )
+            else:
+                if profile_once != 0:
+                    launch_softmax_variant_once[
+                        bench_impl_mode, dtype, shape
+                    ](ctx, variant)
+                else:
+                    bench_softmax_gpu[bench_impl_mode, dtype, shape](
+                        ctx,
+                        m,
+                        "softmax_gpu",
+                        variant,
+                        replay_passes,
+                        slot_filter,
+                        replay_pass_filter,
+                        slot_order_mode,
+                    )
 
-    m.dump_report()
+    if profile_once == 0:
+        m.dump_report()

--- a/max/kernels/src/nn/softmax.mojo
+++ b/max/kernels/src/nn/softmax.mojo
@@ -676,6 +676,35 @@ def softmax[
     )
 
 
+
+
+def softmax_gpu[
+    dtype: DType,
+    simd_width: Int,
+    rank: Int,
+](
+    ctx: DeviceContext,
+    input: TileTensor[dtype, ...],
+    output: TileTensor[mut=True, dtype, ...],
+    axis: Int,
+) raises:
+    @parameter
+    @always_inline
+    def input_fn[
+        _simd_width: Int, _rank: Int
+    ](coords: IndexList[_rank]) -> SIMD[dtype, _simd_width]:
+        return input.load_linear[width=_simd_width, alignment=1](coords)
+
+    _softmax_gpu[dtype, simd_width, rank, input_fn](
+        rebind[IndexList[rank]](
+            coord_to_index_list(input.layout.shape_coord())
+        ),
+        output,
+        axis,
+        ctx,
+    )
+
+
 def softmax_kernel[
     BLOCK_SIZE: Int,
     input_fn: def[_dtype: DType, _simd_width: Int, _rank: Int](
@@ -693,115 +722,120 @@ def softmax_kernel[
 ](
     shape: IndexList[rank],
     output: TileTensor[dtype, OutputLayoutType, output_origin],
-    sink_weights: LayoutTensor[
-        sink_type, Layout.row_major(UNKNOWN_VALUE), ImmutAnyOrigin
-    ],
+    sink_weights: UnsafePointer[Scalar[sink_type], ImmutAnyOrigin],
 ):
     comptime assert dtype.is_floating_point(), "dtype must be floating point"
     comptime assert (
         accum_type.is_floating_point()
     ), "accum_type must be floating point"
     comptime axis = rank - 1
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
 
     var row_size = UInt(shape[axis])
     var num_rows = UInt(shape.flattened_length()) // row_size
+    var tid = Int(thread_idx.x)
+    var use_vectorized = row_size >= UInt(4 * BLOCK_SPAN)
 
-    var max_buf = tt_stack_allocation[
-        dtype=accum_type, address_space=AddressSpace.SHARED
-    ](row_major[1]())
-    var exp_sum_buf = tt_stack_allocation[
-        dtype=accum_type, address_space=AddressSpace.SHARED
-    ](row_major[1]())
+    with PDL():
+        for row_idx in range(block_idx.x, num_rows, grid_dim.x):
+            var sink_val = Scalar[accum_type].MIN
 
-    @parameter
-    @always_inline
-    def _max[
-        dtype: DType, width: Int
-    ](x: SIMD[dtype, width], y: SIMD[dtype, width]) -> SIMD[dtype, width]:
-        return max(x, y)
+            comptime if sink:
+                sink_val = sink_weights[Int(row_idx % UInt(shape[0]))].cast[
+                    accum_type
+                ]()
 
-    @parameter
-    @always_inline
-    def _sum[
-        dtype: DType, width: Int
-    ](x: SIMD[dtype, width], y: SIMD[dtype, width]) -> SIMD[dtype, width]:
-        return x + y
-
-    var tid = thread_idx.x
-
-    # grid stride loop over rows
-    # each block reduces a row, which is convenient because it requires no partial
-    # reductions across blocks
-    for row_idx in range(block_idx.x, num_rows, grid_dim.x):
-        var sink_val = Scalar[accum_type].MIN
-
-        comptime if sink:
-            sink_val = sink_weights[row_idx % UInt(sink_weights.dim[0]())][
-                0
-            ].cast[accum_type]()
-
-        # Step 1: compute max in row
-        var row_coords = _get_nd_indices_from_flat_index(
-            Int(row_idx), shape, axis
-        )
-        var row_max = row_reduce[
-            BLOCK_SIZE,
-            input_fn,
-            _max,
-            dtype,
-            1,
-            rank,
-            accum_type=accum_type,
-        ](row_coords, axis, Scalar[dtype].MIN, Int(row_size))
-
-        comptime if sink:
-            row_max = max(row_max, sink_val)
-
-        if tid == 0:
-            max_buf[0] = row_max
-        barrier()
-
-        row_max = max_buf[0][0]
-
-        # Step 2: out[i] = exp(in[i] - max) and compute sum of out[i]
-        var exp_sum = Scalar[accum_type](0)
-
-        for row_offset in range(tid, row_size, UInt(BLOCK_SIZE)):
-            row_coords[axis] = Int(row_offset)
-
-            # loads from input_fn twice
-            var val = exp(
-                input_fn[dtype, 1, rank](row_coords).cast[accum_type]()
-                - row_max
+            var row_coords = _get_nd_indices_from_flat_index(
+                Int(row_idx), shape, axis
             )
 
-            # TODO we're writing to and reading from global memory twice
-            # we can reduce the amount of reads by keeping values local here.
-            output.store_linear(row_coords, val.cast[dtype]())
-            exp_sum += val
+            var row_max = Scalar[accum_type].MIN
+            var exp_sum = Scalar[accum_type](0)
 
-        var block_exp_sum = block_reduce[BLOCK_SIZE, _sum](exp_sum, 0)
+            if use_vectorized:
+                for tile_base in range(UInt(0), row_size, UInt(BLOCK_SPAN)):
+                    var lane_base = tile_base + UInt(tid * VEC_WIDTH)
+                    if lane_base < row_size:
+                        var lane_count = min(
+                            Int(row_size - lane_base), VEC_WIDTH
+                        )
 
-        if tid == 0:
-            exp_sum_buf[0] = block_exp_sum
-        barrier()
+                        @always_inline
+                        def online_max_sum[
+                            width: Int
+                        ](offset: Int) unified {mut}:
+                            row_coords[axis] = Int(lane_base) + offset
+                            var v = input_fn[dtype, width, rank](
+                                row_coords
+                            ).cast[accum_type]()
+                            var new_max = max(row_max, v.reduce_max())
+                            exp_sum = exp_sum * exp(
+                                row_max - new_max
+                            ) + exp(
+                                v - SIMD[accum_type, width](new_max)
+                            ).reduce_add()
+                            row_max = new_max
 
-        comptime if sink:
-            block_exp_sum += exp(sink_val - row_max)
+                        vectorize[VEC_WIDTH](lane_count, online_max_sum)
+            else:
+                for col in range(UInt(tid), row_size, UInt(BLOCK_SIZE)):
+                    row_coords[axis] = Int(col)
+                    var v = input_fn[dtype, 1, rank](
+                        row_coords
+                    ).cast[accum_type]()
+                    if v > row_max:
+                        exp_sum *= exp(row_max - v)
+                        row_max = v
+                    exp_sum += exp(v - row_max)
 
-        # Step 3: Normalize output (and apply log for logsoftmax)
-        var block_exp_sum_recip = 1 / exp_sum_buf[0]
-        for row_offset in range(tid, row_size, UInt(BLOCK_SIZE)):
-            row_coords[axis] = Int(row_offset)
-            var normalized = (
-                output.load_linear[width=1](row_coords)
-                * block_exp_sum_recip.cast[dtype]()
-            )
+            comptime if sink:
+                if sink_val > row_max:
+                    exp_sum *= exp(row_max - sink_val)
+                    row_max = sink_val
+                exp_sum += exp(sink_val - row_max)
 
-            comptime if logsoftmax:
-                normalized = log(normalized)
+            var global_max = block.max[block_size=BLOCK_SIZE](row_max)
+            exp_sum *= exp(row_max - global_max)
+            var global_sum = block.sum[block_size=BLOCK_SIZE](exp_sum)
+            var recip = Scalar[accum_type](1) / global_sum
 
-            output.store_linear(row_coords, normalized)
+            if use_vectorized:
+                for tile_base in range(UInt(0), row_size, UInt(BLOCK_SPAN)):
+                    var lane_base = tile_base + UInt(tid * VEC_WIDTH)
+                    if lane_base < row_size:
+                        var lane_count = min(
+                            Int(row_size - lane_base), VEC_WIDTH
+                        )
+
+                        @always_inline
+                        def normalize[
+                            width: Int
+                        ](offset: Int) unified {mut}:
+                            row_coords[axis] = Int(lane_base) + offset
+                            var logit = input_fn[dtype, width, rank](
+                                row_coords
+                            ).cast[accum_type]()
+                            var val = exp(
+                                logit - SIMD[accum_type, width](global_max)
+                            ) * SIMD[accum_type, width](recip)
+                            comptime if logsoftmax:
+                                val = log(val)
+                            output.store_linear[width=width](
+                                row_coords, val.cast[dtype]()
+                            )
+
+                        vectorize[VEC_WIDTH](lane_count, normalize)
+            else:
+                for col in range(UInt(tid), row_size, UInt(BLOCK_SIZE)):
+                    row_coords[axis] = Int(col)
+                    var logit = input_fn[dtype, 1, rank](
+                        row_coords
+                    ).cast[accum_type]()
+                    var val = exp(logit - global_max) * recip
+                    comptime if logsoftmax:
+                        val = log(val)
+                    output.store_linear(row_coords, val.cast[dtype]())
 
 
 def _softmax_gpu[
@@ -834,11 +868,16 @@ def _softmax_gpu[
     ](idx: IndexList[rank]) -> SIMD[_dtype, width]:
         return rebind[SIMD[_dtype, width]](input_fn[width, rank](idx))
 
-    comptime BLOCK_SIZE = 128
+    comptime BLOCK_SIZE = 512
     var num_rows = shape.flattened_length() // shape[axis]
     var sm_count = ctx.get_attribute(DeviceAttribute.MULTIPROCESSOR_COUNT)
-    comptime sm_overprovision_factor = 32  # tunable
+    comptime sm_overprovision_factor = 32
     var num_blocks = min(num_rows, sm_overprovision_factor * sm_count)
+
+    var sink_ptr = UnsafePointer[Scalar[sink_type], ImmutAnyOrigin]()
+    if sink_weights:
+        sink_ptr = sink_weights.value().ptr
+
     comptime kernel = softmax_kernel[
         BLOCK_SIZE,
         input_fn_wrapper,
@@ -853,9 +892,10 @@ def _softmax_gpu[
     ctx.enqueue_function[kernel, kernel](
         shape,
         output,
-        sink_weights.value(),
+        sink_ptr,
         grid_dim=num_blocks,
         block_dim=BLOCK_SIZE,
+        attributes=pdl_launch_attributes(PDLLevel(1)),
     )
 
 

--- a/max/kernels/src/nn/softmax.mojo
+++ b/max/kernels/src/nn/softmax.mojo
@@ -35,11 +35,13 @@ from std.gpu import (
     block_idx_uint as block_idx,
     grid_dim_uint as grid_dim,
     lane_id_int as lane_id,
+    syncwarp,
     thread_idx_uint as thread_idx,
     warp_id_uint as warp_id,
 )
 from std.gpu.host import DeviceAttribute, DeviceContext
 from std.gpu.host.info import is_cpu, is_gpu
+from std.gpu.intrinsics import load_acquire, store_release
 from std.gpu.primitives import block
 from layout._utils import idx2crd
 from layout import (
@@ -53,6 +55,7 @@ from layout import (
     TileTensor,
     UNKNOWN_VALUE,
     coord_to_index_list,
+    flatten_leading,
     row_major,
     stack_allocation as tt_stack_allocation,
 )
@@ -64,6 +67,7 @@ from std.runtime.tracing import Trace, TraceLevel, trace_arg
 from std.utils import IndexList, StaticTuple
 from std.utils.index import product
 from std.utils.numerics import get_accum_type, min_or_neg_inf
+from std.os.atomic import Atomic
 
 # ===-----------------------------------------------------------------------===#
 # Utilities
@@ -113,6 +117,92 @@ def reciprocal(x: SIMD) -> type_of(x):
     return 1 / x
 
 
+@always_inline
+def combine_max_sum[
+    dtype: DType
+](
+    other_max: Scalar[dtype],
+    other_sum: Scalar[dtype],
+    mut running_max: Scalar[dtype],
+    mut running_sum: Scalar[dtype],
+):
+    comptime assert dtype.is_floating_point()
+    var new_max = max(running_max, other_max)
+    running_sum = running_sum * exp(
+        running_max - new_max
+    ) + other_sum * exp(other_max - new_max)
+    running_max = new_max
+
+
+@always_inline
+def warp_reduce_max_sum[
+    dtype: DType
+](
+    thread_max: Scalar[dtype],
+    thread_sum: Scalar[dtype],
+    mut warp_max: Scalar[dtype],
+    mut warp_sum: Scalar[dtype],
+):
+    comptime assert dtype.is_floating_point()
+    warp_max = thread_max
+    warp_sum = thread_sum
+
+    comptime limit = log2_floor(WARP_SIZE)
+    comptime for shift in reversed(range(limit)):
+        var other_max = warp.shuffle_down(warp_max, UInt32(1 << shift))
+        var other_sum = warp.shuffle_down(warp_sum, UInt32(1 << shift))
+        combine_max_sum(other_max, other_sum, warp_max, warp_sum)
+
+
+@always_inline
+def block_reduce_max_sum[
+    dtype: DType, max_warps_per_block: Int
+](thread_max: Scalar[dtype], thread_sum: Scalar[dtype]) -> Tuple[
+    Scalar[dtype], Scalar[dtype]
+]:
+    comptime assert dtype.is_floating_point()
+    var max_shared = stack_allocation[
+        max_warps_per_block, dtype, address_space=AddressSpace.SHARED
+    ]()
+    var sum_shared = stack_allocation[
+        max_warps_per_block, dtype, address_space=AddressSpace.SHARED
+    ]()
+    var max_broadcast = stack_allocation[
+        1, dtype, address_space=AddressSpace.SHARED
+    ]()
+    var sum_broadcast = stack_allocation[
+        1, dtype, address_space=AddressSpace.SHARED
+    ]()
+
+    var lane_idx = lane_id()
+    var warp_idx = warp_id()
+    var warp_max = warp.max(thread_max)
+    var warp_sum = warp.sum(thread_sum * exp(thread_max - warp_max))
+
+    if lane_idx == 0:
+        max_shared[warp_idx] = warp_max
+        sum_shared[warp_idx] = warp_sum
+    barrier()
+
+    if warp_idx == 0:
+        if lane_idx < max_warps_per_block:
+            warp_max = max_shared[lane_idx]
+            warp_sum = sum_shared[lane_idx]
+        else:
+            warp_max = Scalar[dtype].MIN
+            warp_sum = Scalar[dtype](0)
+        syncwarp()
+
+        var block_max = Scalar[dtype]()
+        var block_sum = Scalar[dtype]()
+        warp_reduce_max_sum(warp_max, warp_sum, block_max, block_sum)
+
+        if lane_idx == 0:
+            max_broadcast[0] = block_max
+            sum_broadcast[0] = block_sum
+    barrier()
+
+    return (max_broadcast[0], sum_broadcast[0])
 @always_inline
 def _exp_concrete(x: SIMD) -> type_of(x):
     """The concrete implementation of the exp function.
@@ -655,10 +745,12 @@ def softmax[
     dtype: DType,
     simd_width: Int,
     rank: Int,
+    target: StaticString = "cpu",
 ](
     input: TileTensor[dtype, ...],
     output: TileTensor[mut=True, dtype, ...],
     axis: Int,
+    context: DeviceContextPtr = DeviceContextPtr(),
 ) raises:
     @parameter
     @always_inline
@@ -667,15 +759,929 @@ def softmax[
     ](coords: IndexList[_rank]) -> SIMD[dtype, _simd_width]:
         return input.load_linear[width=_simd_width, alignment=1](coords)
 
-    softmax[dtype, simd_width, rank, input_fn](
-        rebind[IndexList[rank]](
-            coord_to_index_list(input.layout.shape_coord())
-        ),
+    comptime if is_gpu[target]():
+        softmax_gpu[dtype, simd_width, rank](
+            context.get_device_context(), input, output, axis
+        )
+    else:
+        softmax[dtype, simd_width, rank, input_fn, target](
+            rebind[IndexList[rank]](
+                coord_to_index_list(input.layout.shape_coord())
+            ),
+            output,
+            axis,
+            context,
+        )
+
+
+
+
+@always_inline
+def _assert_benchmark_variant[benchmark_variant: Int]():
+    comptime assert benchmark_variant == 0 or benchmark_variant == 1
+
+
+@always_inline
+def store_softmax_row_stats[
+    benchmark_variant: Int,
+    dtype: DType,
+    accum_type: DType,
+](
+    scratch: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    row_idx: Int,
+    batch_size: Int,
+    d: Int,
+    row_max: Scalar[accum_type],
+    row_sum: Scalar[accum_type],
+):
+    comptime assert accum_type.is_floating_point()
+    _ = batch_size
+    _ = d
+    var scratch_base = row_idx * 2
+    scratch[scratch_base] = row_max
+    scratch[scratch_base + 1] = log(row_sum)
+
+
+@always_inline
+def launch_softmax_probe_exact_8192_scan_reduce_pass2[
+    benchmark_variant: Int,
+    dtype: DType,
+    rank: Int,
+](
+    ctx: DeviceContext,
+    input: TileTensor[dtype, ...],
+    output: TileTensor[mut=True, dtype, ...],
+    batch_size: Int,
+    d: Int,
+    sm_count: Int,
+) raises:
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert (
+        benchmark_variant == 1
+    ), "exact-8192 staged probe is benchmark-only"
+    comptime assert dtype == DType.bfloat16, "exact-8192 staged probe is BF16-only"
+    comptime BLOCK_SIZE_SCAN = 256
+    comptime VEC_WIDTH_SCAN = simd_width_of[dtype]()
+    comptime BLOCK_SPAN_SCAN = BLOCK_SIZE_SCAN * VEC_WIDTH_SCAN
+    comptime assert (
+        4 * BLOCK_SPAN_SCAN == 8192
+    ), "exact-8192 staged probe expects four 2048-element tiles"
+    comptime accum_type = get_accum_type[dtype]()
+    comptime sm_overprovision_factor = 32
+
+    if d != 8192 or batch_size < 16 or batch_size > 128:
+        return
+
+    comptime kp1_tiled_scan_8192 = softmax_pass1_tiled_scan_kernel[
+        benchmark_variant,
+        BLOCK_SIZE_SCAN,
+        dtype,
+        rank,
+        input.LayoutType,
+        ImmutOrigin(input.origin),
+    ]
+    comptime kp1_reduce_8192 = softmax_pass1_reduce_partials_kernel[
+        benchmark_variant,
+        WARP_SIZE,
+        dtype,
+    ]
+    comptime kp2_split_row_8192 = softmax_pass2_kernel[
+        benchmark_variant,
+        BLOCK_SIZE_SCAN,
+        dtype,
+        rank,
+        input.LayoutType,
+        ImmutOrigin(input.origin),
+        output.LayoutType,
+        output.origin,
+    ]
+
+    var tiles_per_row_scan = ceildiv(d, BLOCK_SPAN_SCAN)
+    var scratch_buf = ctx.enqueue_create_buffer[accum_type](batch_size * 2)
+    var scratch_ptr = UnsafePointer[Scalar[accum_type], MutAnyOrigin](
+        scratch_buf.unsafe_ptr()
+    )
+    var partials_buf = ctx.enqueue_create_buffer[accum_type](
+        batch_size * tiles_per_row_scan * 2
+    )
+    var partials_ptr = UnsafePointer[Scalar[accum_type], MutAnyOrigin](
+        partials_buf.unsafe_ptr()
+    )
+    var num_blocks_scan = min(
+        batch_size * tiles_per_row_scan, sm_overprovision_factor * sm_count
+    )
+    ctx.enqueue_function[kp1_tiled_scan_8192, kp1_tiled_scan_8192](
+        input.as_immut(),
+        partials_ptr,
+        batch_size,
+        d,
+        tiles_per_row_scan,
+        grid_dim=num_blocks_scan,
+        block_dim=BLOCK_SIZE_SCAN,
+        attributes=pdl_launch_attributes(PDLLevel(1)),
+    )
+    var num_blocks_reduce = min(
+        batch_size, sm_overprovision_factor * sm_count
+    )
+    ctx.enqueue_function[kp1_reduce_8192, kp1_reduce_8192](
+        partials_ptr,
+        scratch_ptr,
+        batch_size,
+        d,
+        tiles_per_row_scan,
+        grid_dim=num_blocks_reduce,
+        block_dim=WARP_SIZE,
+        attributes=pdl_launch_attributes(PDLLevel(1)),
+    )
+    var num_blocks_pass2 = min(
+        batch_size * tiles_per_row_scan, sm_overprovision_factor * sm_count
+    )
+    ctx.enqueue_function[kp2_split_row_8192, kp2_split_row_8192](
+        input.as_immut(),
         output,
-        axis,
+        scratch_ptr,
+        batch_size,
+        d,
+        tiles_per_row_scan,
+        grid_dim=num_blocks_pass2,
+        block_dim=BLOCK_SIZE_SCAN,
+        attributes=pdl_launch_attributes(PDLLevel(1)),
+    )
+
+    _ = partials_buf
+    _ = scratch_buf
+
+
+@always_inline
+def launch_softmax_probe_exact_8192_half_row_clone[
+    benchmark_variant: Int,
+    dtype: DType,
+    rank: Int,
+](
+    ctx: DeviceContext,
+    input: TileTensor[dtype, ...],
+    output: TileTensor[mut=True, dtype, ...],
+    batch_size: Int,
+    d: Int,
+    sm_count: Int,
+) raises:
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert (
+        benchmark_variant == 1
+    ), "exact-8192 half-row clone is benchmark-only"
+    comptime assert (
+        dtype == DType.bfloat16
+    ), "exact-8192 half-row clone is BF16-only"
+    # This host-side launcher should stay in the GPU kernel's compile-time
+    # geometry, not the host `simd_width_of[dtype]()` value.
+    comptime BLOCK_SIZE = 256
+    comptime sm_overprovision_factor = 32
+
+    if d != 8192 or batch_size < 16 or batch_size > 128:
+        return
+
+    comptime kernel = softmax_kernel_probe_exact_8192_half_row_clone_online[
+        benchmark_variant,
+        BLOCK_SIZE,
+        dtype,
+        rank,
+        input.LayoutType,
+        ImmutOrigin(input.origin),
+        output.LayoutType,
+        output.origin,
+    ]
+    var num_blocks = min(
+        batch_size * 2, sm_overprovision_factor * sm_count
+    )
+    ctx.enqueue_function[kernel, kernel](
+        input.as_immut(),
+        output,
+        batch_size,
+        d,
+        grid_dim=num_blocks,
+        block_dim=BLOCK_SIZE,
+        attributes=pdl_launch_attributes(PDLLevel(1)),
     )
 
 
+@always_inline
+def launch_softmax_probe_exact_8192_half_row_nonduplicating[
+    benchmark_variant: Int,
+    dtype: DType,
+    rank: Int,
+](
+    ctx: DeviceContext,
+    input: TileTensor[dtype, ...],
+    output: TileTensor[mut=True, dtype, ...],
+    batch_size: Int,
+    d: Int,
+    sm_count: Int,
+) raises:
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert (
+        benchmark_variant == 1
+    ), "exact-8192 half-row nonduplicating probe is benchmark-only"
+    comptime assert (
+        dtype == DType.bfloat16
+    ), "exact-8192 half-row nonduplicating probe is BF16-only"
+    comptime BLOCK_SIZE = 256
+    # Keep the host-side launcher in the GPU kernel's fixed 2048-element tile
+    # geometry instead of host `simd_width_of[dtype]()` evaluation.
+    comptime accum_type = get_accum_type[dtype]()
+    comptime sm_overprovision_factor = 32
+
+    if d != 8192 or batch_size < 16 or batch_size > 128:
+        return
+
+    comptime kernel = softmax_kernel_probe_exact_8192_half_row_nonduplicating_online[
+        benchmark_variant,
+        BLOCK_SIZE,
+        dtype,
+        rank,
+        input.LayoutType,
+        ImmutOrigin(input.origin),
+        output.LayoutType,
+        output.origin,
+    ]
+
+    var scratch_buf = ctx.enqueue_create_buffer[accum_type](batch_size * 2)
+    var scratch_ptr = UnsafePointer[Scalar[accum_type], MutAnyOrigin](
+        scratch_buf.unsafe_ptr()
+    )
+    var partials_buf = ctx.enqueue_create_buffer[accum_type](batch_size * 4)
+    var partials_ptr = UnsafePointer[Scalar[accum_type], MutAnyOrigin](
+        partials_buf.unsafe_ptr()
+    )
+    var half_ready_buf = ctx.enqueue_create_buffer[DType.int32](batch_size * 2)
+    ctx.enqueue_memset(half_ready_buf, Scalar[DType.int32](0))
+    var half_ready_ptr = UnsafePointer[
+        Scalar[DType.int32], MutAnyOrigin
+    ](half_ready_buf.unsafe_ptr())
+    var row_ready_buf = ctx.enqueue_create_buffer[DType.int32](batch_size)
+    ctx.enqueue_memset(row_ready_buf, Scalar[DType.int32](0))
+    var row_ready_ptr = UnsafePointer[
+        Scalar[DType.int32], MutAnyOrigin
+    ](row_ready_buf.unsafe_ptr())
+
+    var num_blocks = min(
+        batch_size * 2, sm_overprovision_factor * sm_count
+    )
+    ctx.enqueue_function[kernel, kernel](
+        input.as_immut(),
+        output,
+        partials_ptr,
+        scratch_ptr,
+        half_ready_ptr,
+        row_ready_ptr,
+        batch_size,
+        d,
+        grid_dim=num_blocks,
+        block_dim=BLOCK_SIZE,
+        attributes=pdl_launch_attributes(PDLLevel(1)),
+    )
+
+    _ = half_ready_buf
+    _ = row_ready_buf
+    _ = partials_buf
+    _ = scratch_buf
+
+
+@always_inline
+def launch_softmax_probe_exact_8192_single_cta_512[
+    benchmark_variant: Int,
+    dtype: DType,
+    rank: Int,
+](
+    ctx: DeviceContext,
+    input: TileTensor[dtype, ...],
+    output: TileTensor[mut=True, dtype, ...],
+    batch_size: Int,
+    d: Int,
+    sm_count: Int,
+) raises:
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert (
+        benchmark_variant == 1
+    ), "exact-8192 single-CTA-512 probe is benchmark-only"
+    comptime assert (
+        dtype == DType.bfloat16
+    ), "exact-8192 single-CTA-512 probe is BF16-only"
+    comptime BLOCK_SIZE = 512
+    comptime sm_overprovision_factor = 32
+
+    if d != 8192 or batch_size < 16 or batch_size > 128:
+        return
+
+    # Reuse the direct online helper with a 4096-element tile span so each CTA
+    # owns one whole 8192-element row with 16 warps instead of splitting rows
+    # across CTAs or paying staged launch overhead.
+    comptime kernel = softmax_kernel_direct_exact_two_block_span_high_batch_online[
+        benchmark_variant,
+        BLOCK_SIZE,
+        dtype,
+        rank,
+        input.LayoutType,
+        ImmutOrigin(input.origin),
+        output.LayoutType,
+        output.origin,
+    ]
+    var num_blocks = min(batch_size, sm_overprovision_factor * sm_count)
+    ctx.enqueue_function[kernel, kernel](
+        input.as_immut(),
+        output,
+        batch_size,
+        d,
+        grid_dim=num_blocks,
+        block_dim=BLOCK_SIZE,
+        attributes=pdl_launch_attributes(PDLLevel(1)),
+    )
+
+
+@always_inline
+def try_launch_softmax_benchmark_candidate_exact_8192[
+    dtype: DType,
+    rank: Int,
+](
+    ctx: DeviceContext,
+    input: TileTensor[dtype, ...],
+    output: TileTensor[mut=True, dtype, ...],
+    axis: Int,
+) raises -> Bool:
+    if axis != rank - 1:
+        return False
+
+    comptime if dtype == DType.bfloat16:
+        var sm_count = ctx.get_attribute(DeviceAttribute.MULTIPROCESSOR_COUNT)
+        comptime if rank == 2:
+            var shape = coord_to_index_list(input.layout.shape_coord())
+            var batch_size = shape[0]
+            var d = shape[1]
+            if d == 8192 and batch_size >= 16 and batch_size <= 128:
+                launch_softmax_probe_exact_8192_scan_reduce_pass2[
+                    1, dtype, rank
+                ](ctx, input, output, batch_size, d, sm_count)
+                return True
+        elif rank == 3 and type_of(input).is_row_major and type_of(
+            output
+        ).is_row_major:
+            var input_2d = flatten_leading(input)
+            var output_2d = flatten_leading(output)
+            var shape = coord_to_index_list(input_2d.layout.shape_coord())
+            var batch_size = shape[0]
+            var d = shape[1]
+            if d == 8192 and batch_size >= 16 and batch_size <= 128:
+                launch_softmax_probe_exact_8192_scan_reduce_pass2[
+                    1, dtype, 2
+                ](ctx, input_2d, output_2d, batch_size, d, sm_count)
+                return True
+
+    return False
+
+
+def softmax_gpu_impl[
+    benchmark_variant: Int,
+    dtype: DType,
+    simd_width: Int,
+    rank: Int,
+](
+    ctx: DeviceContext,
+    input: TileTensor[dtype, ...],
+    output: TileTensor[mut=True, dtype, ...],
+    axis: Int,
+) raises:
+    _assert_benchmark_variant[benchmark_variant]()
+    if axis != rank - 1:
+        raise Error("softmax not supported on non-inner axis yet")
+
+    comptime if rank == 2:
+        var shape = coord_to_index_list(input.layout.shape_coord())
+        var batch_size = shape[0]
+        var d = shape[1]
+
+        comptime BLOCK_SIZE = 512
+        comptime VEC_WIDTH_DISPATCH = simd_width_of[dtype]()
+        comptime BLOCK_SPAN_DISPATCH = BLOCK_SIZE * VEC_WIDTH_DISPATCH
+        var sm_count = ctx.get_attribute(DeviceAttribute.MULTIPROCESSOR_COUNT)
+        comptime sm_overprovision_factor = 32
+        if d >= 4 * BLOCK_SPAN_DISPATCH and batch_size < sm_count:
+            comptime kp1 = softmax_pass1_kernel[
+                benchmark_variant,
+                BLOCK_SIZE,
+                dtype,
+                rank,
+                input.LayoutType,
+                ImmutOrigin(input.origin),
+            ]
+            comptime kp2 = softmax_pass2_kernel[
+                benchmark_variant,
+                BLOCK_SIZE,
+                dtype,
+                rank,
+                input.LayoutType,
+                ImmutOrigin(input.origin),
+                output.LayoutType,
+                output.origin,
+            ]
+
+            comptime accum_type = get_accum_type[dtype]()
+            var scratch_buf = ctx.enqueue_create_buffer[accum_type](
+                batch_size * 2
+            )
+            var scratch_ptr = UnsafePointer[Scalar[accum_type], MutAnyOrigin](
+                scratch_buf.unsafe_ptr()
+            )
+
+            var tiles_per_row = ceildiv(d, BLOCK_SPAN_DISPATCH)
+            # Tile-parallel pass-1 only helps when serial pass-1 would launch
+            # too few rows to keep the GPU busy. A fixed <=64 cutoff is too
+            # aggressive for low-precision kernels on B200 and pays atomic
+            # overhead on batch-32 workloads. FP32 still benefits at batch-32
+            # because pass-1 remains more compute-heavy.
+            var tiled_pass1_batch_limit = max(1, sm_count // 8)
+            comptime if dtype == DType.float32:
+                tiled_pass1_batch_limit = max(tiled_pass1_batch_limit, 32)
+            else:
+                # The warp-cooperative last-block combine keeps the final
+                # reduction cheap on low-precision large-row paths, so widen
+                # the tiled pass-1 gate as rows fan out into more tiles. Batch
+                # 32 benefits once each row spans enough tiles to create a
+                # useful CTA pool, and batch 128 needs the same treatment once
+                # the vocabulary row expands to 32 tiles; otherwise the serial
+                # pass-1 launch only exposes 128 CTAs on a 148-SM B200.
+                if tiles_per_row >= 32:
+                    tiled_pass1_batch_limit = max(tiled_pass1_batch_limit, 128)
+                elif tiles_per_row >= 8:
+                    tiled_pass1_batch_limit = max(tiled_pass1_batch_limit, 32)
+                comptime if benchmark_variant == 1:
+                    # Benchmark-only probe: keep the live 32x128256 split
+                    # family unchanged and test whether batch-128 vocabulary
+                    # rows improve when they stop using the underfilled serial
+                    # pass1 launch and instead reuse the staged scan/reduce
+                    # route already proven out for batch-32.
+                    if dtype == DType.bfloat16 and d == 128256 and batch_size == 128:
+                        tiled_pass1_batch_limit = max(
+                            tiled_pass1_batch_limit, 128
+                        )
+
+            if batch_size <= tiled_pass1_batch_limit:
+                comptime if dtype == DType.bfloat16:
+                    if batch_size > 1:
+                        comptime BLOCK_SIZE_SCAN = 256
+                        comptime BLOCK_SPAN_SCAN = (
+                            BLOCK_SIZE_SCAN * VEC_WIDTH_DISPATCH
+                        )
+                        comptime BLOCK_SIZE_SCAN_WIDE = 512
+                        comptime BLOCK_SPAN_SCAN_WIDE = (
+                            BLOCK_SIZE_SCAN_WIDE * VEC_WIDTH_DISPATCH
+                        )
+                        var use_batch128_wide_scan = False
+                        comptime if benchmark_variant == 1:
+                            # Probe whether batch-128 large rows benefit when
+                            # pass1 scan CTAs align with the live 512-thread
+                            # exact-pass2 geometry instead of the generic
+                            # 256-thread scan tiles.
+                            if (
+                                dtype == DType.bfloat16
+                                and d == 128256
+                                and batch_size == 128
+                            ):
+                                use_batch128_wide_scan = True
+                        var tiles_per_row_scan = ceildiv(d, BLOCK_SPAN_SCAN)
+                        comptime kp1_tiled_scan = softmax_pass1_tiled_scan_kernel[
+                            benchmark_variant,
+                            BLOCK_SIZE_SCAN,
+                            dtype,
+                            rank,
+                            input.LayoutType,
+                            ImmutOrigin(input.origin),
+                        ]
+                        comptime kp1_tiled_scan_wide = softmax_pass1_tiled_scan_kernel[
+                            benchmark_variant,
+                            BLOCK_SIZE_SCAN_WIDE,
+                            dtype,
+                            rank,
+                            input.LayoutType,
+                            ImmutOrigin(input.origin),
+                        ]
+                        if use_batch128_wide_scan:
+                            tiles_per_row_scan = ceildiv(
+                                d, BLOCK_SPAN_SCAN_WIDE
+                            )
+                        var partials_buf = ctx.enqueue_create_buffer[accum_type](
+                            batch_size * tiles_per_row_scan * 2
+                        )
+                        var partials_ptr = UnsafePointer[
+                            Scalar[accum_type], MutAnyOrigin
+                        ](partials_buf.unsafe_ptr())
+                        var num_blocks_scan = min(
+                            batch_size * tiles_per_row_scan,
+                            sm_overprovision_factor * sm_count,
+                        )
+                        if use_batch128_wide_scan:
+                            ctx.enqueue_function[
+                                kp1_tiled_scan_wide, kp1_tiled_scan_wide
+                            ](
+                                input.as_immut(),
+                                partials_ptr,
+                                batch_size,
+                                d,
+                                tiles_per_row_scan,
+                                grid_dim=num_blocks_scan,
+                                block_dim=BLOCK_SIZE_SCAN_WIDE,
+                                attributes=pdl_launch_attributes(PDLLevel(1)),
+                            )
+                        else:
+                            ctx.enqueue_function[
+                                kp1_tiled_scan, kp1_tiled_scan
+                            ](
+                                input.as_immut(),
+                                partials_ptr,
+                                batch_size,
+                                d,
+                                tiles_per_row_scan,
+                                grid_dim=num_blocks_scan,
+                                block_dim=BLOCK_SIZE_SCAN,
+                                attributes=pdl_launch_attributes(PDLLevel(1)),
+                            )
+                        var num_blocks_reduce = min(
+                            batch_size, sm_overprovision_factor * sm_count
+                        )
+                        comptime kp1_reduce = (
+                            softmax_pass1_reduce_partials_kernel[
+                                benchmark_variant,
+                                WARP_SIZE,
+                                dtype,
+                            ]
+                        )
+                        comptime kp1_reduce_double_warp = (
+                            softmax_pass1_reduce_partials_kernel[
+                                benchmark_variant,
+                                2 * WARP_SIZE,
+                                dtype,
+                            ]
+                        )
+                        if (
+                            benchmark_variant == 1
+                            and dtype == DType.bfloat16
+                            and d == 128256
+                            and batch_size == 32
+                        ):
+                            # With the kept batch-128 exact-shape pass2 in
+                            # place, only the batch-32 staged path still uses
+                            # the double-warp partial reducer. Batch-128 rows
+                            # emit only 16 partials, so a benchmark-only
+                            # single-warp reduce can test whether the 64-thread
+                            # combine is just burning idle lanes there.
+                            ctx.enqueue_function[
+                                kp1_reduce_double_warp, kp1_reduce_double_warp
+                            ](
+                                partials_ptr,
+                                scratch_ptr,
+                                batch_size,
+                                d,
+                                tiles_per_row_scan,
+                                grid_dim=num_blocks_reduce,
+                                block_dim=2 * WARP_SIZE,
+                                attributes=pdl_launch_attributes(PDLLevel(1)),
+                            )
+                        else:
+                            ctx.enqueue_function[kp1_reduce, kp1_reduce](
+                                partials_ptr,
+                                scratch_ptr,
+                                batch_size,
+                                d,
+                                tiles_per_row_scan,
+                                grid_dim=num_blocks_reduce,
+                                block_dim=WARP_SIZE,
+                                attributes=pdl_launch_attributes(PDLLevel(1)),
+                            )
+                        _ = partials_buf
+                    else:
+                        comptime kp1_tiled = softmax_pass1_tiled_kernel[
+                            benchmark_variant,
+                            BLOCK_SIZE,
+                            dtype,
+                            rank,
+                            input.LayoutType,
+                            ImmutOrigin(input.origin),
+                        ]
+                        var partials_buf = ctx.enqueue_create_buffer[accum_type](
+                            batch_size * tiles_per_row * 2
+                        )
+                        var partials_ptr = UnsafePointer[
+                            Scalar[accum_type], MutAnyOrigin
+                        ](partials_buf.unsafe_ptr())
+                        var counters_buf = ctx.enqueue_create_buffer[DType.int32](
+                            batch_size
+                        )
+                        ctx.enqueue_memset(counters_buf, Scalar[DType.int32](0))
+                        var counters_ptr = UnsafePointer[
+                            Scalar[DType.int32], MutAnyOrigin
+                        ](counters_buf.unsafe_ptr())
+                        var num_blocks_p1 = min(
+                            batch_size * tiles_per_row,
+                            sm_overprovision_factor * sm_count,
+                        )
+                        ctx.enqueue_function[kp1_tiled, kp1_tiled](
+                            input.as_immut(),
+                            partials_ptr,
+                            scratch_ptr,
+                            counters_ptr,
+                            batch_size,
+                            d,
+                            tiles_per_row,
+                            grid_dim=num_blocks_p1,
+                            block_dim=BLOCK_SIZE,
+                            attributes=pdl_launch_attributes(PDLLevel(1)),
+                        )
+                        _ = partials_buf
+                        _ = counters_buf
+                else:
+                    comptime kp1_tiled = softmax_pass1_tiled_kernel[
+                        benchmark_variant,
+                        BLOCK_SIZE,
+                        dtype,
+                        rank,
+                        input.LayoutType,
+                        ImmutOrigin(input.origin),
+                    ]
+                    var partials_buf = ctx.enqueue_create_buffer[accum_type](
+                        batch_size * tiles_per_row * 2
+                    )
+                    var partials_ptr = UnsafePointer[
+                        Scalar[accum_type], MutAnyOrigin
+                    ](partials_buf.unsafe_ptr())
+                    var counters_buf = ctx.enqueue_create_buffer[DType.int32](
+                        batch_size
+                    )
+                    ctx.enqueue_memset(counters_buf, Scalar[DType.int32](0))
+                    var counters_ptr = UnsafePointer[
+                        Scalar[DType.int32], MutAnyOrigin
+                    ](counters_buf.unsafe_ptr())
+                    var num_blocks_p1 = min(
+                        batch_size * tiles_per_row,
+                        sm_overprovision_factor * sm_count,
+                    )
+                    ctx.enqueue_function[kp1_tiled, kp1_tiled](
+                        input.as_immut(),
+                        partials_ptr,
+                        scratch_ptr,
+                        counters_ptr,
+                        batch_size,
+                        d,
+                        tiles_per_row,
+                        grid_dim=num_blocks_p1,
+                        block_dim=BLOCK_SIZE,
+                        attributes=pdl_launch_attributes(PDLLevel(1)),
+                    )
+                    _ = partials_buf
+                    _ = counters_buf
+            else:
+                var num_blocks_p1 = min(
+                    batch_size, sm_overprovision_factor * sm_count
+                )
+                ctx.enqueue_function[kp1, kp1](
+                    input.as_immut(),
+                    scratch_ptr,
+                    batch_size,
+                    d,
+                    grid_dim=num_blocks_p1,
+                    block_dim=BLOCK_SIZE,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+            var num_blocks_p2 = min(
+                batch_size * tiles_per_row,
+                sm_overprovision_factor * sm_count,
+            )
+            comptime if benchmark_variant == 1 and dtype == DType.bfloat16:
+                if d == 128256 and (
+                    batch_size == 32 or batch_size == 128
+                ):
+                    # Keep the accepted exact-shape pass2 body for the live
+                    # staged large-row route.
+                    comptime kp2_exact_large_row_full_tile = (
+                        softmax_pass2_kernel_exact_large_row_full_tile[
+                            benchmark_variant,
+                            BLOCK_SIZE,
+                            dtype,
+                            rank,
+                            input.LayoutType,
+                            ImmutOrigin(input.origin),
+                            output.LayoutType,
+                            output.origin,
+                        ]
+                    )
+                    ctx.enqueue_function[
+                        kp2_exact_large_row_full_tile,
+                        kp2_exact_large_row_full_tile,
+                    ](
+                        input.as_immut(),
+                        output,
+                        scratch_ptr,
+                        batch_size,
+                        grid_dim=num_blocks_p2,
+                        block_dim=BLOCK_SIZE,
+                        attributes=pdl_launch_attributes(PDLLevel(1)),
+                    )
+                else:
+                    ctx.enqueue_function[kp2, kp2](
+                        input.as_immut(),
+                        output,
+                        scratch_ptr,
+                        batch_size,
+                        d,
+                        tiles_per_row,
+                        grid_dim=num_blocks_p2,
+                        block_dim=BLOCK_SIZE,
+                        attributes=pdl_launch_attributes(PDLLevel(1)),
+                    )
+            else:
+                ctx.enqueue_function[kp2, kp2](
+                    input.as_immut(),
+                    output,
+                    scratch_ptr,
+                    batch_size,
+                    d,
+                    tiles_per_row,
+                    grid_dim=num_blocks_p2,
+                    block_dim=BLOCK_SIZE,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+
+            _ = scratch_buf
+        else:
+            comptime BLOCK_SIZE_DIRECT = 256
+            comptime VEC_WIDTH_DIRECT = simd_width_of[dtype]()
+            comptime BLOCK_SPAN_DIRECT = BLOCK_SIZE_DIRECT * VEC_WIDTH_DIRECT
+            var num_blocks = min(
+                batch_size, sm_overprovision_factor * sm_count
+            )
+            comptime if dtype == DType.bfloat16:
+                var launched_direct_helper = False
+                var use_exact_two_tile_helper = (
+                    d == 2 * BLOCK_SPAN_DIRECT and batch_size >= 1024
+                )
+                if not launched_direct_helper and use_exact_two_tile_helper:
+                    comptime kernel = (
+                        softmax_kernel_direct_exact_two_block_span_high_batch_online[
+                            benchmark_variant,
+                            BLOCK_SIZE_DIRECT,
+                            dtype,
+                            rank,
+                            input.LayoutType,
+                            ImmutOrigin(input.origin),
+                            output.LayoutType,
+                            output.origin,
+                        ]
+                    )
+                    ctx.enqueue_function[kernel, kernel](
+                        input.as_immut(),
+                        output,
+                        batch_size,
+                        d,
+                        grid_dim=num_blocks,
+                        block_dim=BLOCK_SIZE_DIRECT,
+                        attributes=pdl_launch_attributes(PDLLevel(1)),
+                    )
+                    launched_direct_helper = True
+                # Keep the exact-tile medium fast path available for BF16 2048
+                # rows, but isolate it from the generic direct kernel body.
+                if not launched_direct_helper and d == BLOCK_SPAN_DIRECT:
+                    comptime if benchmark_variant == 1:
+                        if batch_size <= 128:
+                            # Keep the register-live exact-2048 probe on its
+                            # own benchmark-only kernel body so inactive
+                            # 256x2048 rows and remote controls keep the shipped
+                            # helper surface.
+                            comptime kernel = (
+                                softmax_kernel_probe_exact_2048_register_live_online[
+                                    benchmark_variant,
+                                    BLOCK_SIZE_DIRECT,
+                                    dtype,
+                                    rank,
+                                    input.LayoutType,
+                                    ImmutOrigin(input.origin),
+                                    output.LayoutType,
+                                    output.origin,
+                                ]
+                            )
+                            ctx.enqueue_function[kernel, kernel](
+                                input.as_immut(),
+                                output,
+                                batch_size,
+                                d,
+                                grid_dim=num_blocks,
+                                block_dim=BLOCK_SIZE_DIRECT,
+                                attributes=pdl_launch_attributes(PDLLevel(1)),
+                            )
+                        else:
+                            comptime kernel = (
+                                softmax_kernel_direct_exact_block_span_medium[
+                                    benchmark_variant,
+                                    BLOCK_SIZE_DIRECT,
+                                    dtype,
+                                    rank,
+                                    input.LayoutType,
+                                    ImmutOrigin(input.origin),
+                                    output.LayoutType,
+                                    output.origin,
+                                ]
+                            )
+                            ctx.enqueue_function[kernel, kernel](
+                                input.as_immut(),
+                                output,
+                                batch_size,
+                                d,
+                                grid_dim=num_blocks,
+                                block_dim=BLOCK_SIZE_DIRECT,
+                                attributes=pdl_launch_attributes(PDLLevel(1)),
+                            )
+                    else:
+                        comptime kernel = (
+                            softmax_kernel_direct_exact_block_span_medium[
+                                benchmark_variant,
+                                BLOCK_SIZE_DIRECT,
+                                dtype,
+                                rank,
+                                input.LayoutType,
+                                ImmutOrigin(input.origin),
+                                output.LayoutType,
+                                output.origin,
+                            ]
+                        )
+                        ctx.enqueue_function[kernel, kernel](
+                            input.as_immut(),
+                            output,
+                            batch_size,
+                            d,
+                            grid_dim=num_blocks,
+                            block_dim=BLOCK_SIZE_DIRECT,
+                            attributes=pdl_launch_attributes(PDLLevel(1)),
+                        )
+                elif not launched_direct_helper:
+                    comptime kernel = softmax_kernel_direct[
+                        benchmark_variant,
+                        BLOCK_SIZE_DIRECT,
+                        dtype,
+                        rank,
+                        input.LayoutType,
+                        ImmutOrigin(input.origin),
+                        output.LayoutType,
+                        output.origin,
+                    ]
+                    ctx.enqueue_function[kernel, kernel](
+                        input.as_immut(),
+                        output,
+                        batch_size,
+                        d,
+                        grid_dim=num_blocks,
+                        block_dim=BLOCK_SIZE_DIRECT,
+                        attributes=pdl_launch_attributes(PDLLevel(1)),
+                    )
+            else:
+                comptime kernel = softmax_kernel_direct[
+                    benchmark_variant,
+                    BLOCK_SIZE_DIRECT,
+                    dtype,
+                    rank,
+                    input.LayoutType,
+                    ImmutOrigin(input.origin),
+                    output.LayoutType,
+                    output.origin,
+                ]
+                ctx.enqueue_function[kernel, kernel](
+                    input.as_immut(),
+                    output,
+                    batch_size,
+                    d,
+                    grid_dim=num_blocks,
+                    block_dim=BLOCK_SIZE_DIRECT,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+    elif type_of(input).rank == 3 and type_of(input).is_row_major and type_of(
+        output
+    ).is_row_major:
+        var input_2d = flatten_leading(input)
+        var output_2d = flatten_leading(output)
+        softmax_gpu_impl[benchmark_variant, dtype, simd_width, 2](
+            ctx, input_2d, output_2d, 1
+        )
+    else:
+        @parameter
+        @always_inline
+        def input_fn[
+            _simd_width: Int, _rank: Int
+        ](coords: IndexList[_rank]) -> SIMD[dtype, _simd_width]:
+            return input.load_linear[width=_simd_width, alignment=1](coords)
+
+        _softmax_gpu[dtype, simd_width, rank, input_fn](
+            rebind[IndexList[rank]](
+                coord_to_index_list(input.layout.shape_coord())
+            ),
+            output,
+            axis,
+            ctx,
+        )
 
 
 def softmax_gpu[
@@ -688,21 +1694,1830 @@ def softmax_gpu[
     output: TileTensor[mut=True, dtype, ...],
     axis: Int,
 ) raises:
-    @parameter
-    @always_inline
-    def input_fn[
-        _simd_width: Int, _rank: Int
-    ](coords: IndexList[_rank]) -> SIMD[dtype, _simd_width]:
-        return input.load_linear[width=_simd_width, alignment=1](coords)
+    softmax_gpu_impl[0, dtype, simd_width, rank](ctx, input, output, axis)
 
-    _softmax_gpu[dtype, simd_width, rank, input_fn](
-        rebind[IndexList[rank]](
-            coord_to_index_list(input.layout.shape_coord())
-        ),
-        output,
-        axis,
-        ctx,
+
+def softmax_benchmark_current[
+    dtype: DType,
+    simd_width: Int,
+    rank: Int,
+](
+    input: TileTensor[dtype, ...],
+    output: TileTensor[mut=True, dtype, ...],
+    axis: Int,
+    context: DeviceContextPtr = DeviceContextPtr(),
+) raises:
+    softmax_gpu_impl[0, dtype, simd_width, rank](
+        context.get_device_context(), input, output, axis
     )
+
+
+def softmax_benchmark_candidate[
+    dtype: DType,
+    simd_width: Int,
+    rank: Int,
+](
+    input: TileTensor[dtype, ...],
+    output: TileTensor[mut=True, dtype, ...],
+    axis: Int,
+    context: DeviceContextPtr = DeviceContextPtr(),
+) raises:
+    softmax_gpu_impl[1, dtype, simd_width, rank](
+        context.get_device_context(), input, output, axis
+    )
+
+
+def softmax_benchmark_candidate_exact_8192[
+    dtype: DType,
+    simd_width: Int,
+    rank: Int,
+](
+    input: TileTensor[dtype, ...],
+    output: TileTensor[mut=True, dtype, ...],
+    axis: Int,
+    context: DeviceContextPtr = DeviceContextPtr(),
+) raises:
+    var ctx = context.get_device_context()
+    # Bypass the shared candidate dispatch for the active 8K benchmark probe.
+    if try_launch_softmax_benchmark_candidate_exact_8192[dtype, rank](
+        ctx, input, output, axis
+    ):
+        return
+    softmax_gpu_impl[1, dtype, simd_width, rank](ctx, input, output, axis)
+
+
+def softmax_benchmark_candidate_exact_8192_staged_only[
+    dtype: DType,
+    simd_width: Int,
+    rank: Int,
+](
+    input: TileTensor[dtype, ...],
+    output: TileTensor[mut=True, dtype, ...],
+    axis: Int,
+    context: DeviceContextPtr = DeviceContextPtr(),
+) raises:
+    _ = simd_width
+    var ctx = context.get_device_context()
+    if axis != rank - 1:
+        raise Error("softmax not supported on non-inner axis yet")
+
+    comptime assert dtype == DType.bfloat16, (
+        "exact-8192 staged-only benchmark wrapper is BF16-only"
+    )
+    var sm_count = ctx.get_attribute(DeviceAttribute.MULTIPROCESSOR_COUNT)
+
+    comptime if rank == 2:
+        var shape = coord_to_index_list(input.layout.shape_coord())
+        var batch_size = shape[0]
+        var d = shape[1]
+        if d == 8192 and batch_size >= 16 and batch_size <= 128:
+            launch_softmax_probe_exact_8192_scan_reduce_pass2[1, dtype, rank](
+                ctx, input, output, batch_size, d, sm_count
+            )
+            return
+    elif rank == 3 and type_of(input).is_row_major and type_of(
+        output
+    ).is_row_major:
+        var input_2d = flatten_leading(input)
+        var output_2d = flatten_leading(output)
+        var shape = coord_to_index_list(input_2d.layout.shape_coord())
+        var batch_size = shape[0]
+        var d = shape[1]
+        if d == 8192 and batch_size >= 16 and batch_size <= 128:
+            launch_softmax_probe_exact_8192_scan_reduce_pass2[1, dtype, 2](
+                ctx, input_2d, output_2d, batch_size, d, sm_count
+            )
+            return
+
+    raise Error(
+        "exact-8192 staged-only benchmark wrapper requires BF16 row-major last-axis 8192 with rows in [16, 128]"
+    )
+
+
+def softmax_benchmark_candidate_exact_8192_half_row_clone_only[
+    dtype: DType,
+    simd_width: Int,
+    rank: Int,
+](
+    input: TileTensor[dtype, ...],
+    output: TileTensor[mut=True, dtype, ...],
+    axis: Int,
+    context: DeviceContextPtr = DeviceContextPtr(),
+) raises:
+    _ = simd_width
+    var ctx = context.get_device_context()
+    if axis != rank - 1:
+        raise Error("softmax not supported on non-inner axis yet")
+
+    comptime assert dtype == DType.bfloat16, (
+        "exact-8192 half-row clone benchmark wrapper is BF16-only"
+    )
+    var sm_count = ctx.get_attribute(DeviceAttribute.MULTIPROCESSOR_COUNT)
+
+    comptime if rank == 2:
+        var shape = coord_to_index_list(input.layout.shape_coord())
+        var batch_size = shape[0]
+        var d = shape[1]
+        if d == 8192 and batch_size >= 16 and batch_size <= 128:
+            launch_softmax_probe_exact_8192_half_row_clone[1, dtype, rank](
+                ctx, input, output, batch_size, d, sm_count
+            )
+            return
+    elif rank == 3 and type_of(input).is_row_major and type_of(
+        output
+    ).is_row_major:
+        var input_2d = flatten_leading(input)
+        var output_2d = flatten_leading(output)
+        var shape = coord_to_index_list(input_2d.layout.shape_coord())
+        var batch_size = shape[0]
+        var d = shape[1]
+        if d == 8192 and batch_size >= 16 and batch_size <= 128:
+            launch_softmax_probe_exact_8192_half_row_clone[1, dtype, 2](
+                ctx, input_2d, output_2d, batch_size, d, sm_count
+            )
+            return
+
+    raise Error(
+        "exact-8192 half-row clone benchmark wrapper requires BF16 row-major last-axis 8192 with rows in [16, 128]"
+    )
+
+
+def softmax_benchmark_candidate_exact_8192_half_row_nonduplicating_only[
+    dtype: DType,
+    simd_width: Int,
+    rank: Int,
+](
+    input: TileTensor[dtype, ...],
+    output: TileTensor[mut=True, dtype, ...],
+    axis: Int,
+    context: DeviceContextPtr = DeviceContextPtr(),
+) raises:
+    _ = simd_width
+    var ctx = context.get_device_context()
+    if axis != rank - 1:
+        raise Error("softmax not supported on non-inner axis yet")
+
+    comptime assert dtype == DType.bfloat16, (
+        "exact-8192 half-row nonduplicating benchmark wrapper is BF16-only"
+    )
+    var sm_count = ctx.get_attribute(DeviceAttribute.MULTIPROCESSOR_COUNT)
+
+    comptime if rank == 2:
+        var shape = coord_to_index_list(input.layout.shape_coord())
+        var batch_size = shape[0]
+        var d = shape[1]
+        if d == 8192 and batch_size >= 16 and batch_size <= 128:
+            launch_softmax_probe_exact_8192_half_row_nonduplicating[
+                1, dtype, rank
+            ](ctx, input, output, batch_size, d, sm_count)
+            return
+    elif rank == 3 and type_of(input).is_row_major and type_of(
+        output
+    ).is_row_major:
+        var input_2d = flatten_leading(input)
+        var output_2d = flatten_leading(output)
+        var shape = coord_to_index_list(input_2d.layout.shape_coord())
+        var batch_size = shape[0]
+        var d = shape[1]
+        if d == 8192 and batch_size >= 16 and batch_size <= 128:
+            launch_softmax_probe_exact_8192_half_row_nonduplicating[
+                1, dtype, 2
+            ](ctx, input_2d, output_2d, batch_size, d, sm_count)
+            return
+
+    raise Error(
+        "exact-8192 half-row nonduplicating benchmark wrapper requires BF16 row-major last-axis 8192 with rows in [16, 128]"
+    )
+
+
+def softmax_benchmark_candidate_exact_8192_single_cta_512_only[
+    dtype: DType,
+    simd_width: Int,
+    rank: Int,
+](
+    input: TileTensor[dtype, ...],
+    output: TileTensor[mut=True, dtype, ...],
+    axis: Int,
+    context: DeviceContextPtr = DeviceContextPtr(),
+) raises:
+    _ = simd_width
+    var ctx = context.get_device_context()
+    if axis != rank - 1:
+        raise Error("softmax not supported on non-inner axis yet")
+
+    comptime assert dtype == DType.bfloat16, (
+        "exact-8192 single-CTA-512 benchmark wrapper is BF16-only"
+    )
+    var sm_count = ctx.get_attribute(DeviceAttribute.MULTIPROCESSOR_COUNT)
+
+    comptime if rank == 2:
+        var shape = coord_to_index_list(input.layout.shape_coord())
+        var batch_size = shape[0]
+        var d = shape[1]
+        if d == 8192 and batch_size >= 16 and batch_size <= 128:
+            launch_softmax_probe_exact_8192_single_cta_512[1, dtype, rank](
+                ctx, input, output, batch_size, d, sm_count
+            )
+            return
+    elif rank == 3 and type_of(input).is_row_major and type_of(
+        output
+    ).is_row_major:
+        var input_2d = flatten_leading(input)
+        var output_2d = flatten_leading(output)
+        var shape = coord_to_index_list(input_2d.layout.shape_coord())
+        var batch_size = shape[0]
+        var d = shape[1]
+        if d == 8192 and batch_size >= 16 and batch_size <= 128:
+            launch_softmax_probe_exact_8192_single_cta_512[1, dtype, 2](
+                ctx, input_2d, output_2d, batch_size, d, sm_count
+            )
+            return
+
+    raise Error(
+        "exact-8192 single-CTA-512 benchmark wrapper requires BF16 row-major last-axis 8192 with rows in [16, 128]"
+    )
+
+
+def softmax_pass1_tiled_kernel[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    partials: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    scratch: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    counters: UnsafePointer[Scalar[DType.int32], MutAnyOrigin],
+    batch_size: Int,
+    d: Int,
+    tiles_per_row: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype.is_floating_point()
+    comptime assert accum_type.is_floating_point()
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+
+    var tid = Int(thread_idx.x)
+    var flat_block = Int(block_idx.x)
+    var row_idx = flat_block // tiles_per_row
+    var tile_idx = flat_block % tiles_per_row
+    var tile_start = tile_idx * BLOCK_SPAN
+
+    if row_idx >= batch_size:
+        return
+
+    var row_max = Scalar[accum_type].MIN
+    var exp_sum = Scalar[accum_type](0)
+
+    var lane_base = tile_start + tid * VEC_WIDTH
+    if lane_base < d:
+        var lane_count = min(d - lane_base, VEC_WIDTH)
+
+        @always_inline
+        def online_max_sum[
+            width: Int
+        ](offset: Int) unified {mut}:
+            var coords = IndexList[rank](row_idx, lane_base + offset)
+            var v = input.load_linear[width=width](coords).cast[accum_type]()
+            var new_max = max(row_max, v.reduce_max())
+            exp_sum = exp_sum * exp(
+                row_max - new_max
+            ) + exp(
+                v - SIMD[accum_type, width](new_max)
+            ).reduce_add()
+            row_max = new_max
+
+        vectorize[VEC_WIDTH](lane_count, online_max_sum)
+
+    var tile_max, tile_sum = block_reduce_max_sum[
+        max_warps_per_block=BLOCK_SIZE // WARP_SIZE
+    ](row_max, exp_sum)
+
+    comptime if dtype == DType.float32:
+        if tid == 0:
+            var partial_idx = row_idx * tiles_per_row + tile_idx
+            partials[partial_idx * 2] = tile_max
+            partials[partial_idx * 2 + 1] = tile_sum
+
+            var finished = Atomic.fetch_add(counters + row_idx, Scalar[DType.int32](1))
+            if finished == Scalar[DType.int32](tiles_per_row - 1):
+                var global_max = Scalar[accum_type].MIN
+                var global_sum = Scalar[accum_type](0)
+                for t in range(tiles_per_row):
+                    var p_idx = row_idx * tiles_per_row + t
+                    var p_max = partials[p_idx * 2]
+                    var p_sum = partials[p_idx * 2 + 1]
+                    var new_max = max(global_max, p_max)
+                    global_sum = global_sum * exp(
+                        global_max - new_max
+                    ) + p_sum * exp(p_max - new_max)
+                    global_max = new_max
+
+                store_softmax_row_stats[
+                    benchmark_variant, dtype, accum_type
+                ](
+                    scratch,
+                    row_idx,
+                    batch_size,
+                    d,
+                    global_max,
+                    global_sum,
+                )
+    else:
+        var last_block_flag = stack_allocation[
+            1, DType.int32, address_space=AddressSpace.SHARED
+        ]()
+        if tid == 0:
+            var partial_idx = row_idx * tiles_per_row + tile_idx
+            partials[partial_idx * 2] = tile_max
+            partials[partial_idx * 2 + 1] = tile_sum
+
+            last_block_flag[0] = Scalar[DType.int32](0)
+            var finished = Atomic.fetch_add(counters + row_idx, Scalar[DType.int32](1))
+            if finished == Scalar[DType.int32](tiles_per_row - 1):
+                last_block_flag[0] = Scalar[DType.int32](1)
+
+        barrier()
+
+        if (
+            last_block_flag[0] != Scalar[DType.int32](0)
+            and tid < Int(WARP_SIZE)
+        ):
+            var lane = Int(lane_id())
+            var global_max = Scalar[accum_type].MIN
+            var global_sum = Scalar[accum_type](0)
+            for t in range(lane, tiles_per_row, Int(WARP_SIZE)):
+                var p_idx = row_idx * tiles_per_row + t
+                var p_max = partials[p_idx * 2]
+                var p_sum = partials[p_idx * 2 + 1]
+                var new_max = max(global_max, p_max)
+                global_sum = global_sum * exp(
+                    global_max - new_max
+                ) + p_sum * exp(p_max - new_max)
+                global_max = new_max
+
+            var warp_max = global_max
+            var warp_sum = global_sum
+            warp_reduce_max_sum(global_max, global_sum, warp_max, warp_sum)
+
+            if lane == 0:
+                store_softmax_row_stats[
+                    benchmark_variant, dtype, accum_type
+                ](
+                    scratch,
+                    row_idx,
+                    batch_size,
+                    d,
+                    warp_max,
+                    warp_sum,
+                )
+
+
+def softmax_pass1_tiled_scan_kernel[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    partials: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    batch_size: Int,
+    d: Int,
+    tiles_per_row: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype.is_floating_point()
+    comptime assert accum_type.is_floating_point()
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+
+    var tid = Int(thread_idx.x)
+    var flat_block = Int(block_idx.x)
+    var row_idx = flat_block // tiles_per_row
+    var tile_idx = flat_block % tiles_per_row
+    var tile_start = tile_idx * BLOCK_SPAN
+
+    if row_idx >= batch_size:
+        return
+
+    var row_max = Scalar[accum_type].MIN
+    var exp_sum = Scalar[accum_type](0)
+
+    var lane_base = tile_start + tid * VEC_WIDTH
+    if lane_base < d:
+        var use_full_tile_fast_path = False
+        comptime if benchmark_variant == 1 and dtype == DType.bfloat16:
+            use_full_tile_fast_path = (
+                d == 128256 and tile_start + BLOCK_SPAN <= d
+            )
+
+        @always_inline
+        def online_max_sum[
+            width: Int
+        ](offset: Int) unified {mut}:
+            var coords = IndexList[rank](row_idx, lane_base + offset)
+            var v = input.load_linear[width=width](coords).cast[accum_type]()
+            var new_max = max(row_max, v.reduce_max())
+            exp_sum = exp_sum * exp(
+                row_max - new_max
+            ) + exp(
+                v - SIMD[accum_type, width](new_max)
+            ).reduce_add()
+            row_max = new_max
+
+        if use_full_tile_fast_path:
+            online_max_sum[VEC_WIDTH](0)
+        else:
+            var lane_count = min(d - lane_base, VEC_WIDTH)
+            vectorize[VEC_WIDTH](lane_count, online_max_sum)
+
+    var tile_max, tile_sum = block_reduce_max_sum[
+        max_warps_per_block=BLOCK_SIZE // WARP_SIZE
+    ](row_max, exp_sum)
+
+    if tid == 0:
+        var partial_idx = row_idx * tiles_per_row + tile_idx
+        partials[partial_idx * 2] = tile_max
+        partials[partial_idx * 2 + 1] = tile_sum
+
+
+def softmax_pass1_reduce_partials_kernel[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    accum_type: DType = get_accum_type[dtype](),
+](
+    partials: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    scratch: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    batch_size: Int,
+    d: Int,
+    tiles_per_row: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype.is_floating_point()
+    comptime assert accum_type.is_floating_point()
+    comptime assert BLOCK_SIZE % WARP_SIZE == 0
+
+    var tid = Int(thread_idx.x)
+    var row_idx = Int(block_idx.x)
+
+    if row_idx >= batch_size or tid >= BLOCK_SIZE:
+        return
+
+    var row_max = Scalar[accum_type].MIN
+    var exp_sum = Scalar[accum_type](0)
+
+    for t in range(tid, tiles_per_row, BLOCK_SIZE):
+        var p_idx = row_idx * tiles_per_row + t
+        var p_max = partials[p_idx * 2]
+        var p_sum = partials[p_idx * 2 + 1]
+        var new_max = max(row_max, p_max)
+        exp_sum = exp_sum * exp(
+            row_max - new_max
+        ) + p_sum * exp(p_max - new_max)
+        row_max = new_max
+
+    var block_max, block_sum = block_reduce_max_sum[
+        max_warps_per_block=BLOCK_SIZE // WARP_SIZE
+    ](row_max, exp_sum)
+
+    if tid == 0:
+        store_softmax_row_stats[
+            benchmark_variant, dtype, accum_type
+        ](
+            scratch,
+            row_idx,
+            batch_size,
+            d,
+            block_max,
+            block_sum,
+        )
+
+
+def softmax_pass1_reduce_partials_kernel_with_norm_const[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    accum_type: DType = get_accum_type[dtype](),
+](
+    partials: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    scratch: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    batch_size: Int,
+    d: Int,
+    tiles_per_row: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype.is_floating_point()
+    comptime assert accum_type.is_floating_point()
+    comptime assert BLOCK_SIZE % WARP_SIZE == 0
+
+    var tid = Int(thread_idx.x)
+    var row_idx = Int(block_idx.x)
+
+    if row_idx >= batch_size or tid >= BLOCK_SIZE:
+        return
+
+    var row_max = Scalar[accum_type].MIN
+    var exp_sum = Scalar[accum_type](0)
+
+    for t in range(tid, tiles_per_row, BLOCK_SIZE):
+        var p_idx = row_idx * tiles_per_row + t
+        var p_max = partials[p_idx * 2]
+        var p_sum = partials[p_idx * 2 + 1]
+        var new_max = max(row_max, p_max)
+        exp_sum = exp_sum * exp(
+            row_max - new_max
+        ) + p_sum * exp(p_max - new_max)
+        row_max = new_max
+
+    var block_max, block_sum = block_reduce_max_sum[
+        max_warps_per_block=BLOCK_SIZE // WARP_SIZE
+    ](row_max, exp_sum)
+
+    if tid == 0:
+        var scratch_base = row_idx * 3
+        var log_sum = log(block_sum)
+        scratch[scratch_base] = block_max
+        scratch[scratch_base + 1] = log_sum
+        scratch[scratch_base + 2] = block_max + log_sum
+
+
+def softmax_pass1_kernel[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    scratch: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    batch_size: Int,
+    d: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype.is_floating_point()
+    comptime assert accum_type.is_floating_point()
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+
+    var tid = Int(thread_idx.x)
+    var bid = Int(block_idx.x)
+    var gid = Int(grid_dim.x)
+
+    with PDL():
+        for row_idx in range(bid, batch_size, gid):
+            var row_max = Scalar[accum_type].MIN
+            var exp_sum = Scalar[accum_type](0)
+
+            for tile_base in range(0, d, BLOCK_SPAN):
+                var lane_base = tile_base + tid * VEC_WIDTH
+                if lane_base < d:
+                    var lane_count = min(d - lane_base, VEC_WIDTH)
+
+                    @always_inline
+                    def online_max_sum[
+                        width: Int
+                    ](offset: Int) unified {mut}:
+                        var coords = IndexList[rank](row_idx, lane_base + offset)
+                        var v = input.load_linear[width=width](
+                            coords
+                        ).cast[accum_type]()
+                        var new_max = max(row_max, v.reduce_max())
+                        exp_sum = exp_sum * exp(
+                            row_max - new_max
+                        ) + exp(
+                            v - SIMD[accum_type, width](new_max)
+                        ).reduce_add()
+                        row_max = new_max
+
+                    vectorize[VEC_WIDTH](lane_count, online_max_sum)
+
+            var global_max, global_sum = block_reduce_max_sum[
+                max_warps_per_block=BLOCK_SIZE // WARP_SIZE
+            ](row_max, exp_sum)
+
+            if tid == 0:
+                store_softmax_row_stats[
+                    benchmark_variant, dtype, accum_type
+                ](
+                    scratch,
+                    row_idx,
+                    batch_size,
+                    d,
+                    global_max,
+                    global_sum,
+                )
+
+def softmax_pass2_kernel_with_vec_width[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    VEC_WIDTH: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+    *,
+    logsoftmax: Bool = False,
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    scratch: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    batch_size: Int,
+    d: Int,
+    tiles_per_row: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype.is_floating_point()
+    comptime assert accum_type.is_floating_point()
+    comptime assert VEC_WIDTH > 0
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+
+    var tid = Int(thread_idx.x)
+    var flat_block = Int(block_idx.x)
+    var row_idx = flat_block // tiles_per_row
+    var tile_idx = flat_block % tiles_per_row
+    var tile_start = tile_idx * BLOCK_SPAN
+
+    if row_idx >= batch_size:
+        return
+
+    var lane_base = tile_start + tid * VEC_WIDTH
+    if lane_base < d:
+        var use_full_tile_fast_path = False
+        comptime if benchmark_variant == 1 and dtype == DType.bfloat16:
+            use_full_tile_fast_path = (
+                d == 128256 and tile_start + BLOCK_SPAN <= d
+            )
+
+        var global_max = scratch[row_idx * 2]
+        var log_sum = scratch[row_idx * 2 + 1]
+
+        @always_inline
+        def normalize[
+            width: Int
+        ](offset: Int) unified {mut}:
+            var coords = IndexList[rank](row_idx, lane_base + offset)
+            var logit = input.load_linear[width=width](
+                coords
+            ).cast[accum_type]()
+            var val = exp(
+                logit
+                - SIMD[accum_type, width](global_max)
+                - SIMD[accum_type, width](log_sum)
+            )
+            comptime if logsoftmax:
+                val = log(val)
+            output.store_linear[width=width](
+                coords, val.cast[dtype]()
+            )
+
+        if use_full_tile_fast_path:
+            normalize[VEC_WIDTH](0)
+        else:
+            var lane_count = min(d - lane_base, VEC_WIDTH)
+            vectorize[VEC_WIDTH](lane_count, normalize)
+
+
+def softmax_pass2_kernel_exact_large_row_full_tile[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+    *,
+    logsoftmax: Bool = False,
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    scratch: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    batch_size: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert (
+        benchmark_variant == 1
+    ), "exact large-row full-tile pass2 is benchmark-only"
+    comptime assert dtype == DType.bfloat16, "exact large-row full-tile pass2 is BF16-only"
+    comptime assert dtype.is_floating_point()
+    comptime assert accum_type.is_floating_point()
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+    comptime EXACT_ROW_SIZE = 128256
+    comptime FULL_TILES_PER_ROW = EXACT_ROW_SIZE // BLOCK_SPAN
+    comptime TAIL_ELEMS = EXACT_ROW_SIZE % BLOCK_SPAN
+    comptime TAIL_THREADS = TAIL_ELEMS // VEC_WIDTH
+    comptime TOTAL_TILES_PER_ROW = FULL_TILES_PER_ROW + 1
+    comptime assert (
+        TAIL_ELEMS % VEC_WIDTH == 0
+    ), "exact large-row tail must stay vector-aligned"
+
+    var tid = Int(thread_idx.x)
+    var flat_block = Int(block_idx.x)
+    var row_idx = flat_block // TOTAL_TILES_PER_ROW
+    var tile_idx = flat_block % TOTAL_TILES_PER_ROW
+
+    if row_idx >= batch_size:
+        return
+
+    var norm_const = Scalar[accum_type](0)
+    if lane_id() == 0:
+        var scratch_base = row_idx * 2
+        norm_const = scratch[scratch_base] + scratch[scratch_base + 1]
+    norm_const = warp.broadcast(norm_const)
+
+    if tile_idx < FULL_TILES_PER_ROW:
+        var tile_start = tile_idx * BLOCK_SPAN
+        var coords = IndexList[rank](row_idx, tile_start + tid * VEC_WIDTH)
+        var logit = input.load_linear[width=VEC_WIDTH](
+            coords
+        ).cast[accum_type]()
+        comptime if logsoftmax:
+            output.store_linear[width=VEC_WIDTH](
+                coords,
+                (
+                    logit - SIMD[accum_type, VEC_WIDTH](norm_const)
+                ).cast[dtype](),
+            )
+        else:
+            output.store_linear[width=VEC_WIDTH](
+                coords,
+                exp(
+                    logit - SIMD[accum_type, VEC_WIDTH](norm_const)
+                ).cast[dtype](),
+            )
+        return
+
+    if tid >= TAIL_THREADS:
+        return
+
+    var tail_start = FULL_TILES_PER_ROW * BLOCK_SPAN
+    var coords = IndexList[rank](row_idx, tail_start + tid * VEC_WIDTH)
+    var logit = input.load_linear[width=VEC_WIDTH](
+        coords
+    ).cast[accum_type]()
+    comptime if logsoftmax:
+        output.store_linear[width=VEC_WIDTH](
+            coords,
+            (
+                logit - SIMD[accum_type, VEC_WIDTH](norm_const)
+            ).cast[dtype](),
+        )
+    else:
+        output.store_linear[width=VEC_WIDTH](
+            coords,
+            exp(
+                logit - SIMD[accum_type, VEC_WIDTH](norm_const)
+            ).cast[dtype](),
+        )
+
+
+def softmax_pass2_kernel_with_precomputed_norm_const[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+    *,
+    logsoftmax: Bool = False,
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    scratch: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    batch_size: Int,
+    d: Int,
+    tiles_per_row: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype.is_floating_point()
+    comptime assert accum_type.is_floating_point()
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+
+    var tid = Int(thread_idx.x)
+    var flat_block = Int(block_idx.x)
+    var row_idx = flat_block // tiles_per_row
+    var tile_idx = flat_block % tiles_per_row
+    var tile_start = tile_idx * BLOCK_SPAN
+
+    if row_idx >= batch_size:
+        return
+
+    var lane_base = tile_start + tid * VEC_WIDTH
+    if lane_base < d:
+        var use_full_tile_fast_path = (
+            d == 128256 and tile_start + BLOCK_SPAN <= d
+        )
+        var norm_const = scratch[row_idx * 3 + 2]
+
+        @always_inline
+        def normalize[
+            width: Int
+        ](offset: Int) unified {mut}:
+            var coords = IndexList[rank](row_idx, lane_base + offset)
+            var logit = input.load_linear[width=width](
+                coords
+            ).cast[accum_type]()
+            comptime if logsoftmax:
+                output.store_linear[width=width](
+                    coords,
+                    (
+                        logit - SIMD[accum_type, width](norm_const)
+                    ).cast[dtype](),
+                )
+            else:
+                output.store_linear[width=width](
+                    coords,
+                    exp(
+                        logit - SIMD[accum_type, width](norm_const)
+                    ).cast[dtype](),
+                )
+
+        if use_full_tile_fast_path:
+            normalize[VEC_WIDTH](0)
+        else:
+            var lane_count = min(d - lane_base, VEC_WIDTH)
+            vectorize[VEC_WIDTH](lane_count, normalize)
+
+
+def softmax_pass2_kernel[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+    *,
+    logsoftmax: Bool = False,
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    scratch: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    batch_size: Int,
+    d: Int,
+    tiles_per_row: Int,
+):
+    softmax_pass2_kernel_with_vec_width[
+        benchmark_variant,
+        BLOCK_SIZE,
+        simd_width_of[dtype](),
+        dtype,
+        rank,
+        InputLayoutType,
+        input_origin,
+        OutputLayoutType,
+        output_origin,
+        accum_type,
+        logsoftmax=logsoftmax,
+    ](input, output, scratch, batch_size, d, tiles_per_row)
+
+def softmax_kernel_direct_exact_block_span_medium[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+    *,
+    logsoftmax: Bool = False,
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    batch_size: Int,
+    d: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype.is_floating_point(), "dtype must be floating point"
+    comptime assert (
+        accum_type.is_floating_point()
+    ), "accum_type must be floating point"
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+
+    if d != BLOCK_SPAN:
+        return
+
+    var num_rows = batch_size
+    var tid = Int(thread_idx.x)
+    var bid = Int(block_idx.x)
+    var gid = Int(grid_dim.x)
+
+    with PDL():
+        for row_idx in range(bid, num_rows, gid):
+            var coords = IndexList[rank](row_idx, tid * VEC_WIDTH)
+            var logits = input.load_linear[width=VEC_WIDTH](
+                coords
+            ).cast[accum_type]()
+            var row_max = logits.reduce_max()
+            var global_max = block.max[block_size=BLOCK_SIZE](row_max)
+
+            var vals = exp(logits - SIMD[accum_type, VEC_WIDTH](global_max))
+            output.store_linear[width=VEC_WIDTH](coords, vals.cast[dtype]())
+            var exp_sum = vals.reduce_add()
+            var global_sum = block.sum[block_size=BLOCK_SIZE](exp_sum)
+            barrier()
+            var recip = Scalar[accum_type](1) / global_sum
+
+            var normalized = output.load_linear[width=VEC_WIDTH](
+                coords
+            ).cast[accum_type]() * SIMD[accum_type, VEC_WIDTH](recip)
+            comptime if logsoftmax:
+                normalized = log(normalized)
+            output.store_linear[width=VEC_WIDTH](
+                coords, normalized.cast[dtype]()
+            )
+
+
+def softmax_kernel_probe_exact_2048_register_live_online[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+    *,
+    logsoftmax: Bool = False,
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    batch_size: Int,
+    d: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype == DType.bfloat16, "exact-2048 probe is BF16-only"
+    comptime assert (
+        accum_type.is_floating_point()
+    ), "accum_type must be floating point"
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+
+    if d != BLOCK_SPAN:
+        return
+
+    var num_rows = batch_size
+    var tid = Int(thread_idx.x)
+    var bid = Int(block_idx.x)
+    var gid = Int(grid_dim.x)
+
+    with PDL():
+        for row_idx in range(bid, num_rows, gid):
+            var coords = IndexList[rank](row_idx, tid * VEC_WIDTH)
+            var logits = input.load_linear[width=VEC_WIDTH](
+                coords
+            ).cast[accum_type]()
+            var thread_max = logits.reduce_max()
+            var vals = exp(
+                logits - SIMD[accum_type, VEC_WIDTH](thread_max)
+            )
+            var thread_sum = vals.reduce_add()
+            var global_max, global_sum = block_reduce_max_sum[
+                max_warps_per_block=BLOCK_SIZE // WARP_SIZE
+            ](thread_max, thread_sum)
+
+            comptime if logsoftmax:
+                var normalized_log = logits - SIMD[accum_type, VEC_WIDTH](
+                    global_max + log(global_sum)
+                )
+                output.store_linear[width=VEC_WIDTH](
+                    coords, normalized_log.cast[dtype]()
+                )
+            else:
+                var rescale = exp(thread_max - global_max) / global_sum
+                var normalized = vals * SIMD[accum_type, VEC_WIDTH](rescale)
+                output.store_linear[width=VEC_WIDTH](
+                    coords, normalized.cast[dtype]()
+                )
+
+
+def softmax_kernel_direct_exact_two_block_span_high_batch_online[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+    *,
+    logsoftmax: Bool = False,
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    batch_size: Int,
+    d: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype.is_floating_point(), "dtype must be floating point"
+    comptime assert (
+        accum_type.is_floating_point()
+    ), "accum_type must be floating point"
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+    comptime if (
+        benchmark_variant == 1 and dtype == DType.bfloat16 and BLOCK_SIZE == 512
+    ):
+        comptime assert (
+            2 * BLOCK_SPAN == 8192
+        ), "live exact-8192 single-CTA-512 helper expects two 4096-element tiles"
+
+    if d != 2 * BLOCK_SPAN:
+        return
+
+    var num_rows = batch_size
+    var tid = Int(thread_idx.x)
+    var bid = Int(block_idx.x)
+    var gid = Int(grid_dim.x)
+
+    with PDL():
+        for row_idx in range(bid, num_rows, gid):
+            var row_max = Scalar[accum_type].MIN
+            var exp_sum = Scalar[accum_type](0)
+
+            @always_inline
+            def online_max_sum_two_tile[
+                tile_base: Int
+            ]() unified {mut}:
+                var coords = IndexList[rank](
+                    row_idx, tile_base + tid * VEC_WIDTH
+                )
+                var v = input.load_linear[width=VEC_WIDTH](coords).cast[
+                    accum_type
+                ]()
+                var new_max = max(row_max, v.reduce_max())
+                exp_sum = exp_sum * exp(
+                    row_max - new_max
+                ) + exp(
+                    v - SIMD[accum_type, VEC_WIDTH](new_max)
+                ).reduce_add()
+                row_max = new_max
+
+            online_max_sum_two_tile[0]()
+            online_max_sum_two_tile[BLOCK_SPAN]()
+
+            var global_max, global_sum = block_reduce_max_sum[
+                max_warps_per_block=BLOCK_SIZE // WARP_SIZE
+            ](row_max, exp_sum)
+            var norm_const = global_max + log(global_sum)
+
+            @always_inline
+            def normalize_two_tile[
+                tile_base: Int
+            ]() unified {mut}:
+                var coords = IndexList[rank](
+                    row_idx, tile_base + tid * VEC_WIDTH
+                )
+                var logit = input.load_linear[width=VEC_WIDTH](coords).cast[
+                    accum_type
+                ]()
+                var val = exp(
+                    logit - SIMD[accum_type, VEC_WIDTH](norm_const)
+                )
+                comptime if logsoftmax:
+                    val = log(val)
+                output.store_linear[width=VEC_WIDTH](
+                    coords, val.cast[dtype]()
+                )
+
+            normalize_two_tile[0]()
+            normalize_two_tile[BLOCK_SPAN]()
+
+
+def softmax_kernel_direct_exact_two_block_span_half_row_online[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+    *,
+    logsoftmax: Bool = False,
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    batch_size: Int,
+    d: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype.is_floating_point(), "dtype must be floating point"
+    comptime assert (
+        accum_type.is_floating_point()
+    ), "accum_type must be floating point"
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+
+    if d != 2 * BLOCK_SPAN:
+        return
+
+    var num_row_halves = batch_size * 2
+    var tid = Int(thread_idx.x)
+    var bid = Int(block_idx.x)
+    var gid = Int(grid_dim.x)
+
+    with PDL():
+        for row_half_idx in range(bid, num_row_halves, gid):
+            var row_idx = row_half_idx // 2
+            var half_idx = row_half_idx % 2
+            var row_max = Scalar[accum_type].MIN
+            var exp_sum = Scalar[accum_type](0)
+
+            @always_inline
+            def online_half[
+                tile_base: Int
+            ]() unified {mut}:
+                var coords = IndexList[rank](
+                    row_idx, tile_base + tid * VEC_WIDTH
+                )
+                var v = input.load_linear[width=VEC_WIDTH](coords).cast[
+                    accum_type
+                ]()
+                var new_max = max(row_max, v.reduce_max())
+                exp_sum = exp_sum * exp(
+                    row_max - new_max
+                ) + exp(
+                    v - SIMD[accum_type, VEC_WIDTH](new_max)
+                ).reduce_add()
+                row_max = new_max
+
+            online_half[0]()
+            online_half[BLOCK_SPAN]()
+
+            var global_max, global_sum = block_reduce_max_sum[
+                max_warps_per_block=BLOCK_SIZE // WARP_SIZE
+            ](row_max, exp_sum)
+            var norm_const = global_max + log(global_sum)
+
+            var coords = IndexList[rank](
+                row_idx, half_idx * BLOCK_SPAN + tid * VEC_WIDTH
+            )
+            var logit = input.load_linear[width=VEC_WIDTH](coords).cast[
+                accum_type
+            ]()
+            var val = exp(logit - SIMD[accum_type, VEC_WIDTH](norm_const))
+            comptime if logsoftmax:
+                val = log(val)
+            output.store_linear[width=VEC_WIDTH](coords, val.cast[dtype]())
+
+
+def softmax_kernel_direct_exact_four_block_span_quarter_row_online[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+    *,
+    logsoftmax: Bool = False,
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    batch_size: Int,
+    d: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype.is_floating_point(), "dtype must be floating point"
+    comptime assert (
+        accum_type.is_floating_point()
+    ), "accum_type must be floating point"
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+
+    if d != 4 * BLOCK_SPAN:
+        return
+
+    var num_row_quarters = batch_size * 4
+    var tid = Int(thread_idx.x)
+    var bid = Int(block_idx.x)
+    var gid = Int(grid_dim.x)
+
+    with PDL():
+        for row_quarter_idx in range(bid, num_row_quarters, gid):
+            var row_idx = row_quarter_idx // 4
+            var quarter_idx = row_quarter_idx % 4
+            var row_max = Scalar[accum_type].MIN
+            var exp_sum = Scalar[accum_type](0)
+
+            @always_inline
+            def online_quarter[
+                tile_base: Int
+            ]() unified {mut}:
+                var coords = IndexList[rank](
+                    row_idx, tile_base + tid * VEC_WIDTH
+                )
+                var v = input.load_linear[width=VEC_WIDTH](coords).cast[
+                    accum_type
+                ]()
+                var new_max = max(row_max, v.reduce_max())
+                exp_sum = exp_sum * exp(
+                    row_max - new_max
+                ) + exp(
+                    v - SIMD[accum_type, VEC_WIDTH](new_max)
+                ).reduce_add()
+                row_max = new_max
+
+            online_quarter[0]()
+            online_quarter[BLOCK_SPAN]()
+            online_quarter[2 * BLOCK_SPAN]()
+            online_quarter[3 * BLOCK_SPAN]()
+
+            var global_max, global_sum = block_reduce_max_sum[
+                max_warps_per_block=BLOCK_SIZE // WARP_SIZE
+            ](row_max, exp_sum)
+            var norm_const = global_max + log(global_sum)
+
+            var coords = IndexList[rank](
+                row_idx, quarter_idx * BLOCK_SPAN + tid * VEC_WIDTH
+            )
+            var logit = input.load_linear[width=VEC_WIDTH](coords).cast[
+                accum_type
+            ]()
+            var val = exp(logit - SIMD[accum_type, VEC_WIDTH](norm_const))
+            comptime if logsoftmax:
+                val = log(val)
+            output.store_linear[width=VEC_WIDTH](coords, val.cast[dtype]())
+
+
+def softmax_kernel_direct_exact_four_block_span_half_row_online[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+    *,
+    logsoftmax: Bool = False,
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    batch_size: Int,
+    d: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype.is_floating_point(), "dtype must be floating point"
+    comptime assert (
+        accum_type.is_floating_point()
+    ), "accum_type must be floating point"
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+
+    if d != 4 * BLOCK_SPAN:
+        return
+
+    var num_row_halves = batch_size * 2
+    var tid = Int(thread_idx.x)
+    var bid = Int(block_idx.x)
+    var gid = Int(grid_dim.x)
+
+    with PDL():
+        for row_half_idx in range(bid, num_row_halves, gid):
+            var row_idx = row_half_idx // 2
+            var half_idx = row_half_idx % 2
+            var row_max = Scalar[accum_type].MIN
+            var exp_sum = Scalar[accum_type](0)
+
+            @always_inline
+            def online_row[
+                tile_base: Int
+            ]() unified {mut}:
+                var coords = IndexList[rank](
+                    row_idx, tile_base + tid * VEC_WIDTH
+                )
+                var v = input.load_linear[width=VEC_WIDTH](coords).cast[
+                    accum_type
+                ]()
+                var new_max = max(row_max, v.reduce_max())
+                exp_sum = exp_sum * exp(
+                    row_max - new_max
+                ) + exp(
+                    v - SIMD[accum_type, VEC_WIDTH](new_max)
+                ).reduce_add()
+                row_max = new_max
+
+            online_row[0]()
+            online_row[BLOCK_SPAN]()
+            online_row[2 * BLOCK_SPAN]()
+            online_row[3 * BLOCK_SPAN]()
+
+            var global_max, global_sum = block_reduce_max_sum[
+                max_warps_per_block=BLOCK_SIZE // WARP_SIZE
+            ](row_max, exp_sum)
+            var norm_const = global_max + log(global_sum)
+
+            @always_inline
+            def normalize_tile[
+                tile_base: Int
+            ]() unified {mut}:
+                var coords = IndexList[rank](
+                    row_idx, tile_base + tid * VEC_WIDTH
+                )
+                var logit = input.load_linear[width=VEC_WIDTH](coords).cast[
+                    accum_type
+                ]()
+                var val = exp(logit - SIMD[accum_type, VEC_WIDTH](norm_const))
+                comptime if logsoftmax:
+                    val = log(val)
+                output.store_linear[width=VEC_WIDTH](
+                    coords, val.cast[dtype]()
+                )
+
+            if half_idx == 0:
+                normalize_tile[0]()
+                normalize_tile[BLOCK_SPAN]()
+            else:
+                normalize_tile[2 * BLOCK_SPAN]()
+                normalize_tile[3 * BLOCK_SPAN]()
+
+
+def softmax_kernel_probe_exact_8192_half_row_online[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+    *,
+    logsoftmax: Bool = False,
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    batch_size: Int,
+    d: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype == DType.bfloat16, "exact-8192 probe is BF16-only"
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime assert (
+        BLOCK_SIZE * VEC_WIDTH == 2048
+    ), "exact-8192 probe expects 2048-element tiles"
+
+    if d != 8192:
+        return
+
+    softmax_kernel_direct_exact_four_block_span_half_row_online[
+        benchmark_variant,
+        BLOCK_SIZE,
+        dtype,
+        rank,
+        InputLayoutType,
+        input_origin,
+        OutputLayoutType,
+        output_origin,
+        accum_type,
+        logsoftmax=logsoftmax,
+    ](input, output, batch_size, d)
+
+
+def softmax_kernel_probe_exact_8192_half_row_clone_online[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+    *,
+    logsoftmax: Bool = False,
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    batch_size: Int,
+    d: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype == DType.bfloat16, "exact-8192 clone is BF16-only"
+    comptime assert (
+        accum_type.is_floating_point()
+    ), "accum_type must be floating point"
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+    comptime assert (
+        4 * BLOCK_SPAN == 8192
+    ), "exact-8192 clone expects four 2048-element tiles"
+
+    if d != 8192:
+        return
+
+    var num_row_halves = batch_size * 2
+    var tid = Int(thread_idx.x)
+    var bid = Int(block_idx.x)
+    var gid = Int(grid_dim.x)
+
+    with PDL():
+        for row_half_idx in range(bid, num_row_halves, gid):
+            var row_idx = row_half_idx // 2
+            var half_idx = row_half_idx % 2
+            var row_max = Scalar[accum_type].MIN
+            var exp_sum = Scalar[accum_type](0)
+
+            @always_inline
+            def online_row[
+                tile_base: Int
+            ]() unified {mut}:
+                var coords = IndexList[rank](
+                    row_idx, tile_base + tid * VEC_WIDTH
+                )
+                var v = input.load_linear[width=VEC_WIDTH](coords).cast[
+                    accum_type
+                ]()
+                var new_max = max(row_max, v.reduce_max())
+                exp_sum = exp_sum * exp(
+                    row_max - new_max
+                ) + exp(
+                    v - SIMD[accum_type, VEC_WIDTH](new_max)
+                ).reduce_add()
+                row_max = new_max
+
+            online_row[0]()
+            online_row[BLOCK_SPAN]()
+            online_row[2 * BLOCK_SPAN]()
+            online_row[3 * BLOCK_SPAN]()
+
+            var global_max, global_sum = block_reduce_max_sum[
+                max_warps_per_block=BLOCK_SIZE // WARP_SIZE
+            ](row_max, exp_sum)
+            var norm_const = global_max + log(global_sum)
+
+            @always_inline
+            def normalize_tile[
+                tile_base: Int
+            ]() unified {mut}:
+                var coords = IndexList[rank](
+                    row_idx, tile_base + tid * VEC_WIDTH
+                )
+                var logit = input.load_linear[width=VEC_WIDTH](coords).cast[
+                    accum_type
+                ]()
+                var val = exp(logit - SIMD[accum_type, VEC_WIDTH](norm_const))
+                comptime if logsoftmax:
+                    val = log(val)
+                output.store_linear[width=VEC_WIDTH](
+                    coords, val.cast[dtype]()
+                )
+
+            if half_idx == 0:
+                normalize_tile[0]()
+                normalize_tile[BLOCK_SPAN]()
+            else:
+                normalize_tile[2 * BLOCK_SPAN]()
+                normalize_tile[3 * BLOCK_SPAN]()
+
+
+def softmax_kernel_probe_exact_8192_half_row_nonduplicating_online[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+    *,
+    logsoftmax: Bool = False,
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    partials: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    scratch: UnsafePointer[Scalar[accum_type], MutAnyOrigin],
+    half_ready: UnsafePointer[Scalar[DType.int32], MutAnyOrigin],
+    row_ready: UnsafePointer[Scalar[DType.int32], MutAnyOrigin],
+    batch_size: Int,
+    d: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype == DType.bfloat16, (
+        "exact-8192 nonduplicating probe is BF16-only"
+    )
+    comptime assert (
+        accum_type.is_floating_point()
+    ), "accum_type must be floating point"
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+    comptime assert (
+        4 * BLOCK_SPAN == 8192
+    ), "exact-8192 nonduplicating probe expects four 2048-element tiles"
+
+    if d != 8192:
+        return
+
+    var num_row_halves = batch_size * 2
+    var tid = Int(thread_idx.x)
+    var bid = Int(block_idx.x)
+    var gid = Int(grid_dim.x)
+
+    with PDL():
+        for row_half_idx in range(bid, num_row_halves, gid):
+            var row_idx = row_half_idx // 2
+            var half_idx = row_half_idx % 2
+            var half_tile_base = half_idx * 2 * BLOCK_SPAN
+            var row_max = Scalar[accum_type].MIN
+            var exp_sum = Scalar[accum_type](0)
+
+            @always_inline
+            def online_half[
+                tile_offset: Int
+            ]() unified {mut}:
+                var coords = IndexList[rank](
+                    row_idx, half_tile_base + tile_offset + tid * VEC_WIDTH
+                )
+                var v = input.load_linear[width=VEC_WIDTH](coords).cast[
+                    accum_type
+                ]()
+                var new_max = max(row_max, v.reduce_max())
+                exp_sum = exp_sum * exp(
+                    row_max - new_max
+                ) + exp(
+                    v - SIMD[accum_type, VEC_WIDTH](new_max)
+                ).reduce_add()
+                row_max = new_max
+
+            online_half[0]()
+            online_half[BLOCK_SPAN]()
+
+            var half_max, half_sum = block_reduce_max_sum[
+                max_warps_per_block=BLOCK_SIZE // WARP_SIZE
+            ](row_max, exp_sum)
+
+            if tid == 0:
+                var partial_base = row_idx * 4 + half_idx * 2
+                partials[partial_base] = half_max
+                partials[partial_base + 1] = half_sum
+                store_release(
+                    half_ready + row_half_idx, Scalar[DType.int32](1)
+                )
+
+                if half_idx == 1:
+                    while load_acquire(
+                        half_ready + row_idx * 2
+                    ) != Scalar[DType.int32](1):
+                        pass
+
+                    var max0 = partials[row_idx * 4]
+                    var sum0 = partials[row_idx * 4 + 1]
+                    var max1 = partials[row_idx * 4 + 2]
+                    var sum1 = partials[row_idx * 4 + 3]
+                    var global_max = max(max0, max1)
+                    var global_sum = sum0 * exp(
+                        max0 - global_max
+                    ) + sum1 * exp(max1 - global_max)
+                    scratch[row_idx * 2] = global_max
+                    scratch[row_idx * 2 + 1] = log(global_sum)
+                    store_release(
+                        row_ready + row_idx, Scalar[DType.int32](1)
+                    )
+
+            while load_acquire(
+                row_ready + row_idx
+            ) != Scalar[DType.int32](1):
+                pass
+
+            var global_max = scratch[row_idx * 2]
+            var log_sum = scratch[row_idx * 2 + 1]
+
+            @always_inline
+            def normalize_tile[
+                tile_offset: Int
+            ]() unified {mut}:
+                var coords = IndexList[rank](
+                    row_idx, half_tile_base + tile_offset + tid * VEC_WIDTH
+                )
+                var logit = input.load_linear[width=VEC_WIDTH](coords).cast[
+                    accum_type
+                ]()
+                var val = exp(
+                    logit
+                    - SIMD[accum_type, VEC_WIDTH](global_max)
+                    - SIMD[accum_type, VEC_WIDTH](log_sum)
+                )
+                comptime if logsoftmax:
+                    val = log(val)
+                output.store_linear[width=VEC_WIDTH](
+                    coords, val.cast[dtype]()
+                )
+
+            normalize_tile[0]()
+            normalize_tile[BLOCK_SPAN]()
+
+
+
+
+def softmax_kernel_direct[
+    benchmark_variant: Int,
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    rank: Int,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+    *,
+    logsoftmax: Bool = False,
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    batch_size: Int,
+    d: Int,
+):
+    _assert_benchmark_variant[benchmark_variant]()
+    comptime assert dtype.is_floating_point(), "dtype must be floating point"
+    comptime assert (
+        accum_type.is_floating_point()
+    ), "accum_type must be floating point"
+    comptime VEC_WIDTH = simd_width_of[dtype]()
+    comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
+
+    var row_size = d
+    var num_rows = batch_size
+    var tid = Int(thread_idx.x)
+    var bid = Int(block_idx.x)
+    var gid = Int(grid_dim.x)
+    var use_two_pass_medium = row_size <= 4096
+    comptime if dtype == DType.bfloat16:
+        # BF16 4K rows are faster on the existing vectorized direct path.
+        use_two_pass_medium = use_two_pass_medium and row_size != 4096
+    var use_full_tile_vector_path = False
+    var use_two_tile_4096_normalize_partial_unroll = False
+    comptime if dtype == DType.bfloat16:
+        use_full_tile_vector_path = (
+            row_size >= BLOCK_SPAN and row_size % BLOCK_SPAN == 0
+        )
+        # Exact-two-tile 4096 rows keep the accepted normalize-side unroll in
+        # both the shipped and benchmark-only direct bodies.
+        use_two_tile_4096_normalize_partial_unroll = (
+            row_size == 2 * BLOCK_SPAN
+        )
+
+    with PDL():
+        for row_idx in range(bid, num_rows, gid):
+            if use_two_pass_medium:
+                var row_max = Scalar[accum_type].MIN
+                for col in range(tid, row_size, BLOCK_SIZE):
+                    var coords = IndexList[rank](row_idx, col)
+                    var v = input.load_linear[width=1](coords).cast[
+                        accum_type
+                    ]()
+                    row_max = max(row_max, v)
+
+                var global_max = block.max[block_size=BLOCK_SIZE](row_max)
+                var exp_sum = Scalar[accum_type](0)
+                for col in range(tid, row_size, BLOCK_SIZE):
+                    var coords = IndexList[rank](row_idx, col)
+                    var logit = input.load_linear[width=1](coords).cast[
+                        accum_type
+                    ]()
+                    var val = exp(logit - global_max)
+                    output.store_linear(coords, val.cast[dtype]())
+                    exp_sum += val
+
+                var global_sum = block.sum[block_size=BLOCK_SIZE](exp_sum)
+                barrier()
+                var recip = Scalar[accum_type](1) / global_sum
+
+                for col in range(tid, row_size, BLOCK_SIZE):
+                    var coords = IndexList[rank](row_idx, col)
+                    var normalized = output.load_linear[width=1](
+                        coords
+                    ).cast[accum_type]() * recip
+                    comptime if logsoftmax:
+                        normalized = log(normalized)
+                    output.store_linear(
+                        coords, normalized.cast[dtype]()
+                    )
+            else:
+                var row_max = Scalar[accum_type].MIN
+                var exp_sum = Scalar[accum_type](0)
+                for tile_base in range(0, row_size, BLOCK_SPAN):
+                    var lane_base = tile_base + tid * VEC_WIDTH
+                    if use_full_tile_vector_path or lane_base < row_size:
+                        @always_inline
+                        def online_max_sum[
+                            width: Int
+                        ](offset: Int) unified {mut}:
+                            var coords = IndexList[rank](
+                                row_idx, lane_base + offset
+                            )
+                            var v = input.load_linear[width=width](
+                                coords
+                            ).cast[accum_type]()
+                            var new_max = max(row_max, v.reduce_max())
+                            exp_sum = exp_sum * exp(
+                                row_max - new_max
+                            ) + exp(
+                                v - SIMD[accum_type, width](new_max)
+                            ).reduce_add()
+                            row_max = new_max
+
+                        if use_full_tile_vector_path:
+                            online_max_sum[VEC_WIDTH](0)
+                        else:
+                            var lane_count = min(
+                                row_size - lane_base, VEC_WIDTH
+                            )
+                            vectorize[VEC_WIDTH](lane_count, online_max_sum)
+                var reduced = block_reduce_max_sum[
+                    max_warps_per_block=BLOCK_SIZE // WARP_SIZE
+                ](row_max, exp_sum)
+                var global_max = reduced[0]
+                var global_sum = reduced[1]
+                var norm_const = global_max + log(global_sum)
+
+                if use_two_tile_4096_normalize_partial_unroll:
+                    @always_inline
+                    def normalize_two_tile[
+                        tile_base: Int
+                    ]() unified {mut}:
+                        var coords = IndexList[rank](
+                            row_idx, tile_base + tid * VEC_WIDTH
+                        )
+                        var logit = input.load_linear[width=VEC_WIDTH](
+                            coords
+                        ).cast[accum_type]()
+                        var val = exp(
+                            logit
+                            - SIMD[accum_type, VEC_WIDTH](norm_const)
+                        )
+                        comptime if logsoftmax:
+                            val = log(val)
+                        output.store_linear[width=VEC_WIDTH](
+                            coords, val.cast[dtype]()
+                        )
+
+                    normalize_two_tile[0]()
+                    normalize_two_tile[BLOCK_SPAN]()
+                else:
+                    for tile_base in range(0, row_size, BLOCK_SPAN):
+                        var lane_base = tile_base + tid * VEC_WIDTH
+                        if use_full_tile_vector_path or lane_base < row_size:
+                            @always_inline
+                            def normalize[
+                                width: Int
+                            ](offset: Int) unified {mut}:
+                                var coords = IndexList[rank](
+                                    row_idx, lane_base + offset
+                                )
+                                var logit = input.load_linear[width=width](
+                                    coords
+                                ).cast[accum_type]()
+                                var val = exp(
+                                    logit
+                                    - SIMD[accum_type, width](norm_const)
+                                )
+                                comptime if logsoftmax:
+                                    val = log(val)
+                                output.store_linear[width=width](
+                                    coords, val.cast[dtype]()
+                                )
+
+                            if use_full_tile_vector_path:
+                                normalize[VEC_WIDTH](0)
+                            else:
+                                var lane_count = min(
+                                    row_size - lane_base, VEC_WIDTH
+                                )
+                                vectorize[VEC_WIDTH](lane_count, normalize)
+
 
 
 def softmax_kernel[
@@ -735,7 +3550,10 @@ def softmax_kernel[
     var row_size = UInt(shape[axis])
     var num_rows = UInt(shape.flattened_length()) // row_size
     var tid = Int(thread_idx.x)
-    var use_vectorized = row_size >= UInt(4 * BLOCK_SPAN)
+    var use_two_pass_medium = row_size <= UInt(4096)
+    var use_vectorized = not use_two_pass_medium and row_size >= UInt(
+        4 * BLOCK_SPAN
+    )
 
     with PDL():
         for row_idx in range(block_idx.x, num_rows, grid_dim.x):
@@ -753,89 +3571,131 @@ def softmax_kernel[
             var row_max = Scalar[accum_type].MIN
             var exp_sum = Scalar[accum_type](0)
 
-            if use_vectorized:
-                for tile_base in range(UInt(0), row_size, UInt(BLOCK_SPAN)):
-                    var lane_base = tile_base + UInt(tid * VEC_WIDTH)
-                    if lane_base < row_size:
-                        var lane_count = min(
-                            Int(row_size - lane_base), VEC_WIDTH
-                        )
-
-                        @always_inline
-                        def online_max_sum[
-                            width: Int
-                        ](offset: Int) unified {mut}:
-                            row_coords[axis] = Int(lane_base) + offset
-                            var v = input_fn[dtype, width, rank](
-                                row_coords
-                            ).cast[accum_type]()
-                            var new_max = max(row_max, v.reduce_max())
-                            exp_sum = exp_sum * exp(
-                                row_max - new_max
-                            ) + exp(
-                                v - SIMD[accum_type, width](new_max)
-                            ).reduce_add()
-                            row_max = new_max
-
-                        vectorize[VEC_WIDTH](lane_count, online_max_sum)
-            else:
+            if use_two_pass_medium:
                 for col in range(UInt(tid), row_size, UInt(BLOCK_SIZE)):
                     row_coords[axis] = Int(col)
                     var v = input_fn[dtype, 1, rank](
                         row_coords
                     ).cast[accum_type]()
-                    if v > row_max:
-                        exp_sum *= exp(row_max - v)
-                        row_max = v
-                    exp_sum += exp(v - row_max)
+                    row_max = max(row_max, v)
 
-            comptime if sink:
-                if sink_val > row_max:
-                    exp_sum *= exp(row_max - sink_val)
-                    row_max = sink_val
-                exp_sum += exp(sink_val - row_max)
+                comptime if sink:
+                    row_max = max(row_max, sink_val)
 
-            var global_max = block.max[block_size=BLOCK_SIZE](row_max)
-            exp_sum *= exp(row_max - global_max)
-            var global_sum = block.sum[block_size=BLOCK_SIZE](exp_sum)
-            var recip = Scalar[accum_type](1) / global_sum
+                var global_max = block.max[block_size=BLOCK_SIZE](row_max)
 
-            if use_vectorized:
-                for tile_base in range(UInt(0), row_size, UInt(BLOCK_SPAN)):
-                    var lane_base = tile_base + UInt(tid * VEC_WIDTH)
-                    if lane_base < row_size:
-                        var lane_count = min(
-                            Int(row_size - lane_base), VEC_WIDTH
-                        )
-
-                        @always_inline
-                        def normalize[
-                            width: Int
-                        ](offset: Int) unified {mut}:
-                            row_coords[axis] = Int(lane_base) + offset
-                            var logit = input_fn[dtype, width, rank](
-                                row_coords
-                            ).cast[accum_type]()
-                            var val = exp(
-                                logit - SIMD[accum_type, width](global_max)
-                            ) * SIMD[accum_type, width](recip)
-                            comptime if logsoftmax:
-                                val = log(val)
-                            output.store_linear[width=width](
-                                row_coords, val.cast[dtype]()
-                            )
-
-                        vectorize[VEC_WIDTH](lane_count, normalize)
-            else:
                 for col in range(UInt(tid), row_size, UInt(BLOCK_SIZE)):
                     row_coords[axis] = Int(col)
                     var logit = input_fn[dtype, 1, rank](
                         row_coords
                     ).cast[accum_type]()
-                    var val = exp(logit - global_max) * recip
-                    comptime if logsoftmax:
-                        val = log(val)
+                    var val = exp(logit - global_max)
                     output.store_linear(row_coords, val.cast[dtype]())
+                    exp_sum += val
+
+                var global_sum = block.sum[block_size=BLOCK_SIZE](exp_sum)
+                comptime if sink:
+                    global_sum += exp(sink_val - global_max)
+                barrier()
+                var recip = Scalar[accum_type](1) / global_sum
+
+                for col in range(UInt(tid), row_size, UInt(BLOCK_SIZE)):
+                    row_coords[axis] = Int(col)
+                    var normalized = output.load_linear[width=1](
+                        row_coords
+                    ).cast[accum_type]() * recip
+                    comptime if logsoftmax:
+                        normalized = log(normalized)
+                    output.store_linear(row_coords, normalized.cast[dtype]())
+            else:
+                if use_vectorized:
+                    for tile_base in range(
+                        UInt(0), row_size, UInt(BLOCK_SPAN)
+                    ):
+                        var lane_base = tile_base + UInt(tid * VEC_WIDTH)
+                        if lane_base < row_size:
+                            var lane_count = min(
+                                Int(row_size - lane_base), VEC_WIDTH
+                            )
+
+                            @always_inline
+                            def online_max_sum[
+                                width: Int
+                            ](offset: Int) unified {mut}:
+                                row_coords[axis] = Int(lane_base) + offset
+                                var v = input_fn[dtype, width, rank](
+                                    row_coords
+                                ).cast[accum_type]()
+                                var new_max = max(row_max, v.reduce_max())
+                                exp_sum = exp_sum * exp(
+                                    row_max - new_max
+                                ) + exp(
+                                    v - SIMD[accum_type, width](new_max)
+                                ).reduce_add()
+                                row_max = new_max
+
+                            vectorize[VEC_WIDTH](lane_count, online_max_sum)
+                else:
+                    for col in range(UInt(tid), row_size, UInt(BLOCK_SIZE)):
+                        row_coords[axis] = Int(col)
+                        var v = input_fn[dtype, 1, rank](
+                            row_coords
+                        ).cast[accum_type]()
+                        if v > row_max:
+                            exp_sum *= exp(row_max - v)
+                            row_max = v
+                        exp_sum += exp(v - row_max)
+
+                comptime if sink:
+                    if sink_val > row_max:
+                        exp_sum *= exp(row_max - sink_val)
+                        row_max = sink_val
+                    exp_sum += exp(sink_val - row_max)
+
+                var global_max = block.max[block_size=BLOCK_SIZE](row_max)
+                exp_sum *= exp(row_max - global_max)
+                var global_sum = block.sum[block_size=BLOCK_SIZE](exp_sum)
+                var recip = Scalar[accum_type](1) / global_sum
+
+                if use_vectorized:
+                    for tile_base in range(
+                        UInt(0), row_size, UInt(BLOCK_SPAN)
+                    ):
+                        var lane_base = tile_base + UInt(tid * VEC_WIDTH)
+                        if lane_base < row_size:
+                            var lane_count = min(
+                                Int(row_size - lane_base), VEC_WIDTH
+                            )
+
+                            @always_inline
+                            def normalize[
+                                width: Int
+                            ](offset: Int) unified {mut}:
+                                row_coords[axis] = Int(lane_base) + offset
+                                var logit = input_fn[dtype, width, rank](
+                                    row_coords
+                                ).cast[accum_type]()
+                                var val = exp(
+                                    logit
+                                    - SIMD[accum_type, width](global_max)
+                                ) * SIMD[accum_type, width](recip)
+                                comptime if logsoftmax:
+                                    val = log(val)
+                                output.store_linear[width=width](
+                                    row_coords, val.cast[dtype]()
+                                )
+
+                            vectorize[VEC_WIDTH](lane_count, normalize)
+                else:
+                    for col in range(UInt(tid), row_size, UInt(BLOCK_SIZE)):
+                        row_coords[axis] = Int(col)
+                        var logit = input_fn[dtype, 1, rank](
+                            row_coords
+                        ).cast[accum_type]()
+                        var val = exp(logit - global_max) * recip
+                        comptime if logsoftmax:
+                            val = log(val)
+                        output.store_linear(row_coords, val.cast[dtype]())
 
 
 def _softmax_gpu[


### PR DESCRIPTION
## Summary
This change keeps the SM100 large-row softmax path and the supporting benchmark harness updates required to validate that path reliably on the current branch.

## Benchmark Notes
- Fresh exact-branch rerun on the 2x B200 workspace completed all 13 generated benchmark items.
- Current exact-branch latencies:
  - `1x128256`: `15.05568 us`
  - `32x128256`: `13.43296 us`
  - `128x128256`: `29.48159 us`
  - `256x4096`: `4.20064 us`
  - `1024x4096`: `8.46527 us`
  - `fp32 32x128256`: `25.37695 us`
- The merge-base harness no longer fails at wrapper generation after a validation-only compatibility patch, but the key `128x128256` baseline still crashes at runtime on the 2x B200 workspace (`worker died`, exit code `-11`).
- That means there is still no trustworthy fresh merge-base-to-head percentage for the same exact large-row shape.
- Historical branch-note context on this path recorded roughly `+50.4%` on the exact `128x128256` route with effectively flat controls; that remains historical context, not the fresh headline.

## Verification
- Exact-branch `kbench` rerun on the 2x B200 workspace.
- Existing PR checks are green.

## Known Limits
- The exact merge-base softmax baseline can now be coerced into the current benchmark harness, but the large-row baseline still crashes before producing a usable row, so the current rerun evidence is exact branch-head latency rather than a fresh before/after delta.
