### PR TITLE
[Kernels] Extend exact-shape RMSNorm tuning

### DIFF
--- a/max/kernels/benchmarks/gpu/nn/bench_normalization.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_normalization.mojo
@@ -73,9 +73,9 @@ def bench_layer_norm_gpu[
     @parameter
     def input_pair_fn_rank2_direct[
         width: Int
-    ](
-        row: Int, col0: Int, col1: Int
-    ) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
+    ](row: Int, col0: Int, col1: Int) -> Tuple[
+        SIMD[dtype, width], SIMD[dtype, width]
+    ]:
         comptime a = align_of[SIMD[dtype, width]]()
         var row_offset = row * cols
         return (
@@ -86,9 +86,7 @@ def bench_layer_norm_gpu[
     @always_inline
     @__copy_capture(data_buf)
     @parameter
-    def input_fn_flat_direct[
-        width: Int
-    ](flat: Int) -> SIMD[dtype, width]:
+    def input_fn_flat_direct[width: Int](flat: Int) -> SIMD[dtype, width]:
         comptime a = align_of[SIMD[dtype, width]]()
         return data_buf.ptr.load[width=width, alignment=a](flat)
 
@@ -97,9 +95,7 @@ def bench_layer_norm_gpu[
     @parameter
     def input_pair_fn_flat_direct[
         width: Int
-    ](
-        flat0: Int, flat1: Int
-    ) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
+    ](flat0: Int, flat1: Int) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
         comptime a = align_of[SIMD[dtype, width]]()
         return (
             data_buf.ptr.load[width=width, alignment=a](flat0),
@@ -200,9 +196,9 @@ def bench_rms_norm_gpu[
     @parameter
     def input_pair_fn_rank2_direct[
         width: Int
-    ](
-        row: Int, col0: Int, col1: Int
-    ) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
+    ](row: Int, col0: Int, col1: Int) -> Tuple[
+        SIMD[dtype, width], SIMD[dtype, width]
+    ]:
         comptime a = align_of[SIMD[dtype, width]]()
         var row_offset = row * cols
         return (
@@ -213,9 +209,7 @@ def bench_rms_norm_gpu[
     @always_inline
     @__copy_capture(data_buf)
     @parameter
-    def input_fn_flat_direct[
-        width: Int
-    ](flat: Int) -> SIMD[dtype, width]:
+    def input_fn_flat_direct[width: Int](flat: Int) -> SIMD[dtype, width]:
         comptime a = align_of[SIMD[dtype, width]]()
         return data_buf.ptr.load[width=width, alignment=a](flat)
 
@@ -224,9 +218,7 @@ def bench_rms_norm_gpu[
     @parameter
     def input_pair_fn_flat_direct[
         width: Int
-    ](
-        flat0: Int, flat1: Int
-    ) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
+    ](flat0: Int, flat1: Int) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
         comptime a = align_of[SIMD[dtype, width]]()
         return (
             data_buf.ptr.load[width=width, alignment=a](flat0),
@@ -268,9 +260,7 @@ def bench_rms_norm_gpu[
         @parameter
         @always_inline
         def kernel_launch(ctx: DeviceContext) raises:
-            comptime if get_defined_bool[
-                "disable_public_direct_io", False
-            ]():
+            comptime if get_defined_bool["disable_public_direct_io", False]():
                 rms_norm[
                     dtype,
                     rank,
@@ -353,17 +343,17 @@ def main() raises:
             bench_layer_norm_gpu[dtype, shape](ctx, m, "layer_norm_gpu")
         elif len(shape) == 3:
             comptime if disable_public_direct_io:
-                bench_rms_norm_gpu[
-                    dtype, shape
-                ](ctx, m, "rms_norm_gpu_no_public_direct_io")
+                bench_rms_norm_gpu[dtype, shape](
+                    ctx, m, "rms_norm_gpu_no_public_direct_io"
+                )
             elif pair_flat_only_public_direct_io:
-                bench_rms_norm_gpu[
-                    dtype, shape
-                ](ctx, m, "rms_norm_gpu_pair_flat_only_public_direct_io")
+                bench_rms_norm_gpu[dtype, shape](
+                    ctx, m, "rms_norm_gpu_pair_flat_only_public_direct_io"
+                )
             elif rank2_only_public_direct_io:
-                bench_rms_norm_gpu[
-                    dtype, shape
-                ](ctx, m, "rms_norm_gpu_rank2_only_public_direct_io")
+                bench_rms_norm_gpu[dtype, shape](
+                    ctx, m, "rms_norm_gpu_rank2_only_public_direct_io"
+                )
             else:
                 bench_rms_norm_gpu[dtype, shape](ctx, m, "rms_norm_gpu")
 

--- a/max/kernels/benchmarks/gpu/nn/bench_normalization.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_normalization.mojo
@@ -12,13 +12,14 @@
 # ===----------------------------------------------------------------------=== #
 
 from std.random import random_float64
-from std.sys import get_defined_dtype
+from std.sys import get_defined_bool, get_defined_dtype
+from std.sys.info import align_of
 
 from std.benchmark import Bench, BenchConfig, Bencher, BenchId
 from std.gpu.host import DeviceContext
 from internal_utils import get_defined_shape, int_list_to_tuple
 from layout import Coord, Idx, TileTensor, row_major
-from nn.normalization import layer_norm_gpu, rms_norm_gpu
+from nn.normalization import layer_norm_gpu, rms_norm
 
 from std.utils.index import Index, IndexList
 
@@ -64,8 +65,46 @@ def bench_layer_norm_gpu[
         width: Int, _rank: Int
     ](coords: IndexList[_rank]) -> SIMD[dtype, width]:
         var idx = data_buf.layout(Coord(coords))
+        comptime a = align_of[SIMD[dtype, width]]()
+        return data_buf.ptr.load[width=width, alignment=a](idx)
 
-        return data_buf.ptr.load[width=width](idx)
+    @__copy_capture(data_buf, cols)
+    @always_inline
+    @parameter
+    def input_pair_fn_rank2_direct[
+        width: Int
+    ](
+        row: Int, col0: Int, col1: Int
+    ) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
+        comptime a = align_of[SIMD[dtype, width]]()
+        var row_offset = row * cols
+        return (
+            data_buf.ptr.load[width=width, alignment=a](row_offset + col0),
+            data_buf.ptr.load[width=width, alignment=a](row_offset + col1),
+        )
+
+    @always_inline
+    @__copy_capture(data_buf)
+    @parameter
+    def input_fn_flat_direct[
+        width: Int
+    ](flat: Int) -> SIMD[dtype, width]:
+        comptime a = align_of[SIMD[dtype, width]]()
+        return data_buf.ptr.load[width=width, alignment=a](flat)
+
+    @always_inline
+    @__copy_capture(data_buf)
+    @parameter
+    def input_pair_fn_flat_direct[
+        width: Int
+    ](
+        flat0: Int, flat1: Int
+    ) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
+        comptime a = align_of[SIMD[dtype, width]]()
+        return (
+            data_buf.ptr.load[width=width, alignment=a](flat0),
+            data_buf.ptr.load[width=width, alignment=a](flat1),
+        )
 
     @__copy_capture(gamma)
     @always_inline
@@ -153,17 +192,74 @@ def bench_rms_norm_gpu[
         width: Int, _rank: Int
     ](coords: IndexList[_rank]) -> SIMD[dtype, width]:
         var idx = data_buf.layout(Coord(coords))
+        comptime a = align_of[SIMD[dtype, width]]()
+        return data_buf.ptr.load[width=width, alignment=a](idx)
 
-        return data_buf.ptr.load[width=width](idx)
+    @__copy_capture(data_buf, cols)
+    @always_inline
+    @parameter
+    def input_pair_fn_rank2_direct[
+        width: Int
+    ](
+        row: Int, col0: Int, col1: Int
+    ) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
+        comptime a = align_of[SIMD[dtype, width]]()
+        var row_offset = row * cols
+        return (
+            data_buf.ptr.load[width=width, alignment=a](row_offset + col0),
+            data_buf.ptr.load[width=width, alignment=a](row_offset + col1),
+        )
 
     @always_inline
     @__copy_capture(data_buf)
     @parameter
-    def identity_output_fn[
-        width: Int, alignment: Int
-    ](coords: IndexList[rank], val: SIMD[dtype, width]) -> None:
+    def input_fn_flat_direct[
+        width: Int
+    ](flat: Int) -> SIMD[dtype, width]:
+        comptime a = align_of[SIMD[dtype, width]]()
+        return data_buf.ptr.load[width=width, alignment=a](flat)
+
+    @always_inline
+    @__copy_capture(data_buf)
+    @parameter
+    def input_pair_fn_flat_direct[
+        width: Int
+    ](
+        flat0: Int, flat1: Int
+    ) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
+        comptime a = align_of[SIMD[dtype, width]]()
+        return (
+            data_buf.ptr.load[width=width, alignment=a](flat0),
+            data_buf.ptr.load[width=width, alignment=a](flat1),
+        )
+
+    @always_inline
+    @__copy_capture(data_buf)
+    @parameter
+    def identity_output_fn_ranked[
+        width: Int, _rank: Int, alignment: Int
+    ](coords: IndexList[_rank], val: SIMD[dtype, width]) -> None:
         var idx = data_buf.layout(Coord(coords))
         data_buf.ptr.store[width=width, alignment=alignment](idx, val)
+
+    @always_inline
+    @__copy_capture(data_buf, cols)
+    @parameter
+    def output_fn_rank2_direct[
+        width: Int, alignment: Int
+    ](row: Int, col: Int, val: SIMD[dtype, width]) -> None:
+        var row_offset = row * cols
+        data_buf.ptr.store[width=width, alignment=alignment](
+            row_offset + col, val
+        )
+
+    @always_inline
+    @__copy_capture(data_buf)
+    @parameter
+    def output_fn_flat_direct[
+        width: Int, alignment: Int
+    ](flat: Int, val: SIMD[dtype, width]) -> None:
+        data_buf.ptr.store[width=width, alignment=alignment](flat, val)
 
     @always_inline
     @__copy_capture(shape, gamma, epsilon, weight_offset)
@@ -172,9 +268,53 @@ def bench_rms_norm_gpu[
         @parameter
         @always_inline
         def kernel_launch(ctx: DeviceContext) raises:
-            rms_norm_gpu[
-                input_fn, identity_output_fn, multiply_before_cast=True
-            ](shape, gamma, epsilon, weight_offset, ctx)
+            comptime if get_defined_bool[
+                "disable_public_direct_io", False
+            ]():
+                rms_norm[
+                    dtype,
+                    rank,
+                    input_fn,
+                    identity_output_fn_ranked,
+                    target="gpu",
+                    multiply_before_cast=True,
+                ](shape, gamma, epsilon, weight_offset, ctx)
+            elif get_defined_bool["pair_flat_only_public_direct_io", False]():
+                rms_norm[
+                    dtype,
+                    rank,
+                    input_fn,
+                    identity_output_fn_ranked,
+                    target="gpu",
+                    multiply_before_cast=True,
+                    input_pair_fn_flat_direct=input_pair_fn_flat_direct,
+                    output_fn_flat_direct=output_fn_flat_direct,
+                ](shape, gamma, epsilon, weight_offset, ctx)
+            elif get_defined_bool["rank2_only_public_direct_io", False]():
+                rms_norm[
+                    dtype,
+                    rank,
+                    input_fn,
+                    identity_output_fn_ranked,
+                    target="gpu",
+                    multiply_before_cast=True,
+                    input_pair_fn_rank2_direct=input_pair_fn_rank2_direct,
+                    output_fn_rank2_direct=output_fn_rank2_direct,
+                ](shape, gamma, epsilon, weight_offset, ctx)
+            else:
+                rms_norm[
+                    dtype,
+                    rank,
+                    input_fn,
+                    identity_output_fn_ranked,
+                    target="gpu",
+                    multiply_before_cast=True,
+                    input_pair_fn_rank2_direct=input_pair_fn_rank2_direct,
+                    output_fn_rank2_direct=output_fn_rank2_direct,
+                    input_fn_flat_direct=input_fn_flat_direct,
+                    input_pair_fn_flat_direct=input_pair_fn_flat_direct,
+                    output_fn_flat_direct=output_fn_flat_direct,
+                ](shape, gamma, epsilon, weight_offset, ctx)
 
         b.iter_custom[kernel_launch](ctx)
 
@@ -197,12 +337,34 @@ def main() raises:
     comptime shape = int_list_to_tuple[
         get_defined_shape["shape", "256x256"]()
     ]()
+    comptime disable_public_direct_io = get_defined_bool[
+        "disable_public_direct_io", False
+    ]()
+    comptime pair_flat_only_public_direct_io = get_defined_bool[
+        "pair_flat_only_public_direct_io", False
+    ]()
+    comptime rank2_only_public_direct_io = get_defined_bool[
+        "rank2_only_public_direct_io", False
+    ]()
 
     var m = Bench(BenchConfig(num_repetitions=1))
     with DeviceContext() as ctx:
         comptime if len(shape) == 2:
             bench_layer_norm_gpu[dtype, shape](ctx, m, "layer_norm_gpu")
         elif len(shape) == 3:
-            bench_rms_norm_gpu[dtype, shape](ctx, m, "rms_norm_gpu")
+            comptime if disable_public_direct_io:
+                bench_rms_norm_gpu[
+                    dtype, shape
+                ](ctx, m, "rms_norm_gpu_no_public_direct_io")
+            elif pair_flat_only_public_direct_io:
+                bench_rms_norm_gpu[
+                    dtype, shape
+                ](ctx, m, "rms_norm_gpu_pair_flat_only_public_direct_io")
+            elif rank2_only_public_direct_io:
+                bench_rms_norm_gpu[
+                    dtype, shape
+                ](ctx, m, "rms_norm_gpu_rank2_only_public_direct_io")
+            else:
+                bench_rms_norm_gpu[dtype, shape](ctx, m, "rms_norm_gpu")
 
     m.dump_report()

--- a/max/kernels/src/nn/normalization.mojo
+++ b/max/kernels/src/nn/normalization.mojo
@@ -114,8 +114,6 @@ def block_reduce[
     return m2_broadcast[0]
 
 
-
-
 @always_inline
 def block_reduce_one_barrier[
     dtype: DType, max_warps_per_block: Int
@@ -1094,16 +1092,16 @@ def _rms_norm_load_gamma[
     simd_width: Int,
     alignment: Int,
     linear_gamma_indexing: Bool = False,
-](
-    gamma: TileTensor[dtype, LayoutType, origin], idx: UInt
-) -> SIMD[dtype, simd_width]:
+](gamma: TileTensor[dtype, LayoutType, origin], idx: UInt) -> SIMD[
+    dtype, simd_width
+]:
     comptime if linear_gamma_indexing:
-        return gpu_load[
-            width=simd_width, read_only=True, alignment=alignment
-        ](gamma.ptr + Int(idx))
-    return gpu_load[
-        width=simd_width, read_only=True, alignment=alignment
-    ](gamma.ptr + Int(gamma.layout(Idx(idx))))
+        return gpu_load[width=simd_width, read_only=True, alignment=alignment](
+            gamma.ptr + Int(idx)
+        )
+    return gpu_load[width=simd_width, read_only=True, alignment=alignment](
+        gamma.ptr + Int(gamma.layout(Idx(idx)))
+    )
 
 
 def rms_norm_gpu_warp_tiling_aligned[
@@ -1146,10 +1144,12 @@ def rms_norm_gpu_warp_tiling_aligned[
     with PDL():
         var raw_data = input_fn[simd_width](Int(row), Int(idx))
 
-        var thread_m2: Scalar[accum_type] = (raw_data * raw_data).reduce_add().cast[accum_type]()
-        var row_m2 = block_reduce_one_barrier[max_warps_per_block=max_warps_per_block](
-            thread_m2
+        var thread_m2: Scalar[accum_type] = (
+            (raw_data * raw_data).reduce_add().cast[accum_type]()
         )
+        var row_m2 = block_reduce_one_barrier[
+            max_warps_per_block=max_warps_per_block
+        ](thread_m2)
         var norm_factor = sqrt_n * rsqrt(row_m2 + n_eps)
 
         var gamma_val = gpu_load[
@@ -1162,19 +1162,23 @@ def rms_norm_gpu_warp_tiling_aligned[
                 var norm_val = raw_data * (gamma_val * norm_bf16)
                 output_fn[simd_width, align](Int(row), Int(idx), norm_val)
             else:
-                var norm_val = (raw_data.cast[accum_type]() * norm_factor).cast[dtype]() * gamma_val
+                var norm_val = (raw_data.cast[accum_type]() * norm_factor).cast[
+                    dtype
+                ]() * gamma_val
                 output_fn[simd_width, align](Int(row), Int(idx), norm_val)
         else:
             comptime if multiply_before_cast:
                 var gamma_accum = (
                     gamma_val.cast[accum_type]() + weight_offset_accum
                 )
-                var norm_val = (raw_data.cast[accum_type]() * norm_factor * gamma_accum).cast[dtype]()
+                var norm_val = (
+                    raw_data.cast[accum_type]() * norm_factor * gamma_accum
+                ).cast[dtype]()
                 output_fn[simd_width, align](Int(row), Int(idx), norm_val)
             else:
-                var norm_val = (raw_data.cast[accum_type]() * norm_factor).cast[dtype]() * (
-                    gamma_val + weight_offset_accum.cast[dtype]()
-                )
+                var norm_val = (raw_data.cast[accum_type]() * norm_factor).cast[
+                    dtype
+                ]() * (gamma_val + weight_offset_accum.cast[dtype]())
                 output_fn[simd_width, align](Int(row), Int(idx), norm_val)
 
 
@@ -1222,9 +1226,12 @@ def rms_norm_gpu_warp_tiling_aligned_two_tiles[
         var raw_data1 = input_fn[simd_width](Int(row), Int(idx1))
 
         var thread_m2: Scalar[accum_type] = (
-            (raw_data0 * raw_data0).reduce_add().cast[accum_type]()
-            + (raw_data1 * raw_data1).reduce_add().cast[accum_type]()
-        )
+            raw_data0 * raw_data0
+        ).reduce_add().cast[accum_type]() + (
+            raw_data1 * raw_data1
+        ).reduce_add().cast[
+            accum_type
+        ]()
         var row_m2 = block_reduce_one_barrier_lane_group[
             max_warps_per_block=max_warps_per_block
         ](thread_m2)
@@ -1349,9 +1356,12 @@ def rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input[
         var raw_data1 = raw_data_pair[1]
 
         var thread_m2: Scalar[accum_type] = (
-            (raw_data0 * raw_data0).reduce_add().cast[accum_type]()
-            + (raw_data1 * raw_data1).reduce_add().cast[accum_type]()
-        )
+            raw_data0 * raw_data0
+        ).reduce_add().cast[accum_type]() + (
+            raw_data1 * raw_data1
+        ).reduce_add().cast[
+            accum_type
+        ]()
         var row_m2 = block_reduce_one_barrier_warp_sum[
             max_warps_per_block=max_warps_per_block
         ](thread_m2)
@@ -1449,10 +1459,9 @@ def _rms_norm_exact_4096_load_packed_rank2_pair[
     raw_bits0 = bitcast[DType.uint32, packed_width](raw_data0)
     raw_bits1 = bitcast[DType.uint32, packed_width](raw_data1)
 
-    return (
-        (raw_data0 * raw_data0).reduce_add().cast[get_accum_type[dtype]()]()
-        + (raw_data1 * raw_data1).reduce_add().cast[get_accum_type[dtype]()]()
-    )
+    return (raw_data0 * raw_data0).reduce_add().cast[
+        get_accum_type[dtype]()
+    ]() + (raw_data1 * raw_data1).reduce_add().cast[get_accum_type[dtype]()]()
 
 
 def rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input_exact_4096[
@@ -1470,9 +1479,7 @@ def rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input_exact_4096[
         row: Int, col: Int, val: SIMD[dtype, width]
     ) capturing -> None,
     multiply_before_cast: Bool,
-](
-    gamma: TileTensor[dtype, LayoutType, origin], epsilon: Scalar[dtype]
-):
+](gamma: TileTensor[dtype, LayoutType, origin], epsilon: Scalar[dtype]):
     comptime assert dtype == DType.bfloat16, "exact 4096 path is BF16-only"
     comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
     comptime assert gamma.flat_rank >= 1
@@ -1494,10 +1501,12 @@ def rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input_exact_4096[
         var load_row_i = Int(block_idx.x)
         var raw_bits0 = SIMD[DType.uint32, packed_width](0)
         var raw_bits1 = SIMD[DType.uint32, packed_width](0)
-        var thread_m2: Scalar[accum_type] = (
-            _rms_norm_exact_4096_load_packed_rank2_pair[
-                simd_width, packed_width, input_pair_fn
-            ](load_row_i, Int(input_idx0), raw_bits0, raw_bits1)
+        var thread_m2: Scalar[
+            accum_type
+        ] = _rms_norm_exact_4096_load_packed_rank2_pair[
+            simd_width, packed_width, input_pair_fn
+        ](
+            load_row_i, Int(input_idx0), raw_bits0, raw_bits1
         )
         var row_m2 = block_reduce_one_barrier[
             max_warps_per_block=max_warps_per_block
@@ -1518,7 +1527,9 @@ def rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input_exact_4096[
             var row_i1 = Int(block_idx.x)
             var idx1 = input_idx0 + UInt(2048)
             var col1 = Int(idx1)
-            var gamma_val1 = _rms_norm_load_gamma[simd_width, align](gamma, idx1)
+            var gamma_val1 = _rms_norm_load_gamma[simd_width, align](
+                gamma, idx1
+            )
             var norm_val1 = bitcast[dtype, simd_width](raw_bits1) * (
                 gamma_val1 * norm_bf16
             )
@@ -1532,12 +1543,14 @@ def rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input_exact_4096[
                     bitcast[dtype, simd_width](raw_bits0).cast[accum_type]()
                     * norm_factor
                 ).cast[dtype]()
-                    * _rms_norm_load_gamma[simd_width, align](gamma, input_idx0),
+                * _rms_norm_load_gamma[simd_width, align](gamma, input_idx0),
             )
             var row_i1 = Int(block_idx.x)
             var idx1 = input_idx0 + UInt(2048)
             var col1 = Int(idx1)
-            var gamma_val1 = _rms_norm_load_gamma[simd_width, align](gamma, idx1)
+            var gamma_val1 = _rms_norm_load_gamma[simd_width, align](
+                gamma, idx1
+            )
             var norm_val1 = (
                 bitcast[dtype, simd_width](raw_bits1).cast[accum_type]()
                 * norm_factor
@@ -1553,9 +1566,7 @@ def _rms_norm_exact_4096_load_flat_pair[
     input_pair_fn_flat: def[width: Int](
         flat0: Int, flat1: Int
     ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]],
-](
-    flat0: Int
-) -> Tuple[SIMD[dtype, simd_width], SIMD[dtype, simd_width]]:
+](flat0: Int) -> Tuple[SIMD[dtype, simd_width], SIMD[dtype, simd_width]]:
     return input_pair_fn_flat[simd_width](flat0, flat0 + 2048)
 
 
@@ -1619,9 +1630,7 @@ def rms_norm_gpu_warp_tiling_aligned_two_tiles_flat_direct_exact_4096[
         flat: Int, val: SIMD[dtype, width]
     ) capturing -> None,
     multiply_before_cast: Bool,
-](
-    gamma: TileTensor[dtype, LayoutType, origin], epsilon: Scalar[dtype]
-):
+](gamma: TileTensor[dtype, LayoutType, origin], epsilon: Scalar[dtype]):
     comptime assert dtype == DType.bfloat16, "exact 4096 path is BF16-only"
     comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
     comptime assert gamma.flat_rank >= 1
@@ -1649,9 +1658,12 @@ def rms_norm_gpu_warp_tiling_aligned_two_tiles_flat_direct_exact_4096[
         var raw_data1 = raw_data_pair[1]
 
         var thread_m2: Scalar[accum_type] = (
-            (raw_data0 * raw_data0).reduce_add().cast[accum_type]()
-            + (raw_data1 * raw_data1).reduce_add().cast[accum_type]()
-        )
+            raw_data0 * raw_data0
+        ).reduce_add().cast[accum_type]() + (
+            raw_data1 * raw_data1
+        ).reduce_add().cast[
+            accum_type
+        ]()
         var row_m2 = block_reduce_one_barrier_warp_sum[
             max_warps_per_block=max_warps_per_block
         ](thread_m2)
@@ -1713,9 +1725,7 @@ def rms_norm_gpu_warp_tiling_aligned_two_tiles_single_flat_input_exact_4096[
         flat: Int, val: SIMD[dtype, width]
     ) capturing -> None,
     multiply_before_cast: Bool,
-](
-    gamma: TileTensor[dtype, LayoutType, origin], epsilon: Scalar[dtype]
-):
+](gamma: TileTensor[dtype, LayoutType, origin], epsilon: Scalar[dtype]):
     comptime assert dtype == DType.bfloat16, "exact 4096 path is BF16-only"
     comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
     comptime assert gamma.flat_rank >= 1
@@ -1740,9 +1750,12 @@ def rms_norm_gpu_warp_tiling_aligned_two_tiles_single_flat_input_exact_4096[
         var raw_data0 = input_fn_flat[simd_width](flat0)
         var raw_data1 = input_fn_flat[simd_width](flat1)
         var thread_m2: Scalar[accum_type] = (
-            (raw_data0 * raw_data0).reduce_add().cast[accum_type]()
-            + (raw_data1 * raw_data1).reduce_add().cast[accum_type]()
-        )
+            raw_data0 * raw_data0
+        ).reduce_add().cast[accum_type]() + (
+            raw_data1 * raw_data1
+        ).reduce_add().cast[
+            accum_type
+        ]()
         var row_m2 = block_reduce_one_barrier[
             max_warps_per_block=max_warps_per_block
         ](thread_m2)
@@ -1764,16 +1777,16 @@ def rms_norm_gpu_warp_tiling_aligned_two_tiles_single_flat_input_exact_4096[
             var gamma_val0 = _rms_norm_load_gamma[simd_width, align, True](
                 gamma, idx0
             )
-            var norm_val0 = (
-                raw_data0.cast[accum_type]() * norm_factor
-            ).cast[dtype]() * gamma_val0
+            var norm_val0 = (raw_data0.cast[accum_type]() * norm_factor).cast[
+                dtype
+            ]() * gamma_val0
             output_fn_flat[simd_width, align](flat0, norm_val0)
             var gamma_val1 = _rms_norm_load_gamma[simd_width, align, True](
                 gamma, idx1
             )
-            var norm_val1 = (
-                raw_data1.cast[accum_type]() * norm_factor
-            ).cast[dtype]() * gamma_val1
+            var norm_val1 = (raw_data1.cast[accum_type]() * norm_factor).cast[
+                dtype
+            ]() * gamma_val1
             output_fn_flat[simd_width, align](flat1, norm_val1)
 
 
@@ -1825,9 +1838,12 @@ def rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input_lane_group[
         var raw_data1 = raw_data_pair[1]
 
         var thread_m2: Scalar[accum_type] = (
-            (raw_data0 * raw_data0).reduce_add().cast[accum_type]()
-            + (raw_data1 * raw_data1).reduce_add().cast[accum_type]()
-        )
+            raw_data0 * raw_data0
+        ).reduce_add().cast[accum_type]() + (
+            raw_data1 * raw_data1
+        ).reduce_add().cast[
+            accum_type
+        ]()
         var row_m2 = block_reduce_one_barrier_lane_group[
             max_warps_per_block=max_warps_per_block
         ](thread_m2)
@@ -1945,7 +1961,7 @@ def rms_norm_gpu_warp_tiling[
                 accum_type
             ]()
 
-        var thread_m2: Scalar[accum_type] = (vec_data ** 2).reduce_add()
+        var thread_m2: Scalar[accum_type] = (vec_data**2).reduce_add()
         var row_m2 = block_reduce[max_warps_per_block=max_warps_per_block](
             thread_m2
         )
@@ -2093,14 +2109,16 @@ def rms_norm_gpu[
     multiply_before_cast: Bool,
     pdl_level: PDLLevel = PDLLevel(1),
     input_pair_fn_rank2_direct: OptionalReg[
-        def[width: Int](
-            row: Int, col0: Int, col1: Int
-        ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]
+        def[
+            width: Int
+        ](row: Int, col0: Int, col1: Int) capturing -> Tuple[
+            SIMD[dtype, width], SIMD[dtype, width]
+        ]
     ] = None,
     output_fn_rank2_direct: OptionalReg[
-        def[width: Int, alignment: Int](
-            row: Int, col: Int, val: SIMD[dtype, width]
-        ) capturing -> None
+        def[
+            width: Int, alignment: Int
+        ](row: Int, col: Int, val: SIMD[dtype, width]) capturing -> None
     ] = None,
 ](
     shape: IndexList[rank, ...],
@@ -2133,9 +2151,7 @@ def rms_norm_gpu[
                 indices[0] = 0
                 indices[1] = row
                 indices[2] = col
-                output_fn[simd_width, alignment](
-                    indices.canonicalize(), val
-                )
+                output_fn[simd_width, alignment](indices.canonicalize(), val)
                 return
         var indices = _get_start_indices_of_nth_subvolume(row, shape)
         indices[rank - 1] = col
@@ -2189,9 +2205,9 @@ def rms_norm_gpu[
     @always_inline
     def input_pair_fn_2d[
         simd_width: Int
-    ](
-        row: Int, col0: Int, col1: Int
-    ) -> Tuple[SIMD[dtype, simd_width], SIMD[dtype, simd_width]]:
+    ](row: Int, col0: Int, col1: Int) -> Tuple[
+        SIMD[dtype, simd_width], SIMD[dtype, simd_width]
+    ]:
         comptime if rank == 3:
             if shape[0] == 1:
                 var indices = IndexList[rank]()
@@ -2249,11 +2265,19 @@ def rms_norm_gpu[
                 block_dim=block_dim,
                 attributes=pdl_launch_attributes(pdl_level),
             )
-        elif use_doubled and cols % (simd_width * 2) == 0 and cols <= (WARP_SIZE * (simd_width * 2) * max_warps_per_block):
+        elif (
+            use_doubled
+            and cols % (simd_width * 2) == 0
+            and cols <= (WARP_SIZE * (simd_width * 2) * max_warps_per_block)
+        ):
             comptime if rank == 3:
                 if shape[0] == 1:
                     if cols == Int(block_dim) * (simd_width * 2):
-                        if rows >= 4096 and cols == 4096 and dtype == DType.bfloat16:
+                        if (
+                            rows >= 4096
+                            and cols == 4096
+                            and dtype == DType.bfloat16
+                        ):
                             var two_tiles_block_dim = block_dim // 2
                             if weight_offset == Scalar[dtype](0):
                                 comptime if input_pair_fn_rank2_direct:
@@ -2697,6 +2721,7 @@ def rms_norm_gpu[
             attributes=pdl_launch_attributes(pdl_level),
         )
 
+
 def rms_norm_cpu[
     dtype: DType,
     //,
@@ -2995,9 +3020,7 @@ def _rms_norm_gpu_exact_public_rank2_only_via_flat_direct_io[
     @parameter
     def input_pair_fn_flat_from_rank2[
         width: Int
-    ](
-        flat0: Int, flat1: Int
-    ) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
+    ](flat0: Int, flat1: Int) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
         var row = flat0 >> exact_cols_shift
         return input_pair_fn_rank2_direct[width](
             row,
@@ -3026,9 +3049,9 @@ def _rms_norm_gpu_exact_public_rank2_only_via_flat_direct_io[
 def _rms_norm_gpu_exact_public_single_flat_direct_io[
     dtype: DType,
     //,
-    input_fn_flat_direct: def[width: Int](
-        flat: Int
-    ) capturing -> SIMD[dtype, width],
+    input_fn_flat_direct: def[width: Int](flat: Int) capturing -> SIMD[
+        dtype, width
+    ],
     output_fn_flat_direct: def[width: Int, alignment: Int](
         flat: Int, val: SIMD[dtype, width]
     ) capturing -> None,
@@ -3102,27 +3125,31 @@ def _rms_norm_impl[
     target: StaticString = "cpu",
     multiply_before_cast: Bool = True,
     input_pair_fn_rank2_direct: OptionalReg[
-        def[width: Int](
-            row: Int, col0: Int, col1: Int
-        ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]
+        def[
+            width: Int
+        ](row: Int, col0: Int, col1: Int) capturing -> Tuple[
+            SIMD[dtype, width], SIMD[dtype, width]
+        ]
     ] = None,
     output_fn_rank2_direct: OptionalReg[
-        def[width: Int, alignment: Int](
-            row: Int, col: Int, val: SIMD[dtype, width]
-        ) capturing -> None
+        def[
+            width: Int, alignment: Int
+        ](row: Int, col: Int, val: SIMD[dtype, width]) capturing -> None
     ] = None,
     input_fn_flat_direct: OptionalReg[
         def[width: Int](flat: Int) capturing -> SIMD[dtype, width]
     ] = None,
     input_pair_fn_flat_direct: OptionalReg[
-        def[width: Int](
-            flat0: Int, flat1: Int
-        ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]
+        def[
+            width: Int
+        ](flat0: Int, flat1: Int) capturing -> Tuple[
+            SIMD[dtype, width], SIMD[dtype, width]
+        ]
     ] = None,
     output_fn_flat_direct: OptionalReg[
-        def[width: Int, alignment: Int](
-            flat: Int, val: SIMD[dtype, width]
-        ) capturing -> None
+        def[
+            width: Int, alignment: Int
+        ](flat: Int, val: SIMD[dtype, width]) capturing -> None
     ] = None,
 ](
     shape: IndexList[rank],
@@ -3806,8 +3833,7 @@ def rms_norm_fused_residual_add_gpu[
         if (
             use_doubled
             and cols % (simd_width * 2) == 0
-            and cols
-            <= (WARP_SIZE * (simd_width * 2) * max_warps_per_block)
+            and cols <= (WARP_SIZE * (simd_width * 2) * max_warps_per_block)
         ):
             var doubled_block_dim = min(
                 ceildiv(ceildiv(cols, simd_width * 2), WARP_SIZE) * WARP_SIZE,
@@ -4103,27 +4129,31 @@ def rms_norm[
     target: StaticString = "cpu",
     multiply_before_cast: Bool = True,
     input_pair_fn_rank2_direct: OptionalReg[
-        def[width: Int](
-            row: Int, col0: Int, col1: Int
-        ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]
+        def[
+            width: Int
+        ](row: Int, col0: Int, col1: Int) capturing -> Tuple[
+            SIMD[dtype, width], SIMD[dtype, width]
+        ]
     ] = None,
     output_fn_rank2_direct: OptionalReg[
-        def[width: Int, alignment: Int](
-            row: Int, col: Int, val: SIMD[dtype, width]
-        ) capturing -> None
+        def[
+            width: Int, alignment: Int
+        ](row: Int, col: Int, val: SIMD[dtype, width]) capturing -> None
     ] = None,
     input_fn_flat_direct: OptionalReg[
         def[width: Int](flat: Int) capturing -> SIMD[dtype, width]
     ] = None,
     input_pair_fn_flat_direct: OptionalReg[
-        def[width: Int](
-            flat0: Int, flat1: Int
-        ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]
+        def[
+            width: Int
+        ](flat0: Int, flat1: Int) capturing -> Tuple[
+            SIMD[dtype, width], SIMD[dtype, width]
+        ]
     ] = None,
     output_fn_flat_direct: OptionalReg[
-        def[width: Int, alignment: Int](
-            flat: Int, val: SIMD[dtype, width]
-        ) capturing -> None
+        def[
+            width: Int, alignment: Int
+        ](flat: Int, val: SIMD[dtype, width]) capturing -> None
     ] = None,
 ](
     shape: IndexList[rank],

--- a/max/kernels/src/nn/normalization.mojo
+++ b/max/kernels/src/nn/normalization.mojo
@@ -34,7 +34,7 @@ from std.gpu import (
 )
 from std.gpu.host import DeviceContext, FuncAttribute, get_gpu_target
 from std.gpu.host.info import is_cpu, is_gpu
-from std.gpu.memory import external_memory
+from std.gpu.memory import external_memory, load as gpu_load
 from std.sys.info import has_apple_gpu_accelerator, is_apple_gpu
 from std.gpu.primitives import block
 from std.gpu.primitives.grid_controls import (
@@ -1039,34 +1039,41 @@ def rms_norm_gpu_warp_tiling[
     var eps_accum = epsilon.cast[accum_type]()
     var weight_offset_accum = weight_offset.cast[accum_type]()
 
-    var vec_data = SIMD[accum_type, simd_width](0)
     var tid = thread_idx.x
     var row = block_idx.x
     var idx = tid * UInt(simd_width)
 
     with PDL():
-        var gamma_val = SIMD[dtype, simd_width](0)
+        var vec_data = SIMD[accum_type, simd_width](0)
         if idx < UInt(num_cols):
             vec_data = input_fn[simd_width](Int(row), Int(idx)).cast[
                 accum_type
             ]()
-            # Prefetch gamma before reduction to overlap load with compute.
-            gamma_val = gamma.load[width=simd_width, alignment=align](
-                Coord(Idx(idx))
-            )
 
-        var norm_val = _rms_norm_warp_tiling_subkernel[
-            max_warps_per_block, multiply_before_cast
-        ](
-            Int(row),
-            Int(idx),
-            vec_data,
-            gamma_val,
-            eps_accum,
-            weight_offset_accum,
-            num_cols,
+        var thread_m2: Scalar[accum_type] = (vec_data ** 2).reduce_add()
+        var row_m2 = block_reduce[max_warps_per_block=max_warps_per_block](
+            thread_m2
         )
+        var norm_factor = rsqrt(
+            (row_m2 / Scalar[accum_type](num_cols)) + eps_accum
+        )
+
+        var norm_val = SIMD[dtype, simd_width](0)
         if idx < UInt(num_cols):
+            var gamma_val = gpu_load[
+                width=simd_width, read_only=True, alignment=align
+            ](gamma.ptr + Int(gamma.layout(Idx(idx))))
+
+            comptime if multiply_before_cast:
+                var gamma_accum = (
+                    gamma_val.cast[accum_type]() + weight_offset_accum
+                )
+                norm_val = (vec_data * norm_factor * gamma_accum).cast[dtype]()
+            else:
+                norm_val = (vec_data * norm_factor).cast[dtype]() * (
+                    gamma_val + weight_offset_accum.cast[dtype]()
+                )
+
             output_fn[simd_width, align](Int(row), Int(idx), norm_val)
 
 
@@ -1215,7 +1222,16 @@ def rms_norm_gpu[
     def output_fn_2d[
         simd_width: Int, alignment: Int
     ](row: Int, col: Int, val: SIMD[dtype, simd_width]) -> None:
-        # Translate a given 2D index back to the original n-D tensor
+        comptime if rank == 3:
+            if shape[0] == 1:
+                var indices = IndexList[rank]()
+                indices[0] = 0
+                indices[1] = row
+                indices[2] = col
+                output_fn[simd_width, alignment](
+                    indices.canonicalize(), val
+                )
+                return
         var indices = _get_start_indices_of_nth_subvolume(row, shape)
         indices[rank - 1] = col
         output_fn[simd_width, alignment](indices.canonicalize(), val)
@@ -1225,7 +1241,13 @@ def rms_norm_gpu[
     def input_fn_2d[
         simd_width: Int
     ](row: Int, col: Int) -> SIMD[dtype, simd_width]:
-        # Translate a given 2D index back to the original n-D tensor
+        comptime if rank == 3:
+            if shape[0] == 1:
+                var indices = IndexList[rank]()
+                indices[0] = 0
+                indices[1] = row
+                indices[2] = col
+                return input_fn[simd_width](indices.canonicalize())
         var indices = _get_start_indices_of_nth_subvolume(row, shape)
         indices[rank - 1] = col
         return input_fn[simd_width](indices.canonicalize())

--- a/max/kernels/src/nn/normalization.mojo
+++ b/max/kernels/src/nn/normalization.mojo
@@ -11,7 +11,8 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from std.math import align_down, ceildiv, clamp, rsqrt
+from std.collections import OptionalReg
+from std.math import align_down, ceildiv, clamp, rsqrt, sqrt
 from std.sys.info import align_of, simd_width_of, size_of
 
 import std.gpu.primitives.warp as warp
@@ -54,7 +55,7 @@ from layout import (
 )
 from layout.coord import DynamicCoord
 from layout.tile_layout import Layout
-from std.memory import stack_allocation
+from std.memory import bitcast, stack_allocation
 from std.runtime.asyncrt import DeviceContextPtr, parallelism_level
 from std.runtime.tracing import Trace, TraceLevel, trace_arg
 
@@ -111,6 +112,77 @@ def block_reduce[
             m2_broadcast[0] = block_m2
     barrier()
     return m2_broadcast[0]
+
+
+
+
+@always_inline
+def block_reduce_one_barrier[
+    dtype: DType, max_warps_per_block: Int
+](val: Scalar[dtype]) -> Scalar[dtype]:
+    var m2_shared = stack_allocation[
+        max_warps_per_block, dtype, address_space=AddressSpace.SHARED
+    ]()
+
+    var warp_m2 = warp.sum(val)
+
+    var wid = warp_id[broadcast=True]()
+    var lid = lane_id()
+
+    if lid == 0:
+        m2_shared[wid] = warp_m2
+    barrier()
+
+    var block_m2 = Scalar[dtype](0)
+    comptime for i in range(max_warps_per_block):
+        block_m2 += m2_shared[i]
+    return block_m2
+
+
+@always_inline
+def block_reduce_one_barrier_lane_group[
+    dtype: DType, max_warps_per_block: Int
+](val: Scalar[dtype]) -> Scalar[dtype]:
+    var m2_shared = stack_allocation[
+        max_warps_per_block, dtype, address_space=AddressSpace.SHARED
+    ]()
+
+    var warp_m2 = warp.sum(val)
+
+    var wid = warp_id[broadcast=True]()
+    var lid = lane_id()
+
+    if lid == 0:
+        m2_shared[wid] = warp_m2
+    barrier()
+
+    var block_m2 = Scalar[dtype](0)
+    if lid < UInt(max_warps_per_block):
+        block_m2 = m2_shared[lid]
+    return warp.lane_group_sum[num_lanes=max_warps_per_block](block_m2)
+
+
+@always_inline
+def block_reduce_one_barrier_warp_sum[
+    dtype: DType, max_warps_per_block: Int
+](val: Scalar[dtype]) -> Scalar[dtype]:
+    var m2_shared = stack_allocation[
+        max_warps_per_block, dtype, address_space=AddressSpace.SHARED
+    ]()
+
+    var warp_m2 = warp.sum(val)
+
+    var wid = warp_id[broadcast=True]()
+    var lid = lane_id()
+
+    if lid == 0:
+        m2_shared[wid] = warp_m2
+    barrier()
+
+    var block_m2 = Scalar[dtype](0)
+    if lid < UInt(max_warps_per_block):
+        block_m2 = m2_shared[lid]
+    return warp.sum(block_m2)
 
 
 @always_inline
@@ -552,9 +624,12 @@ def layer_norm_gpu[
     comptime simd_width = simd_width_of[dtype, target=get_gpu_target()]()
     comptime max_warps_per_block = ctx.default_device_info.max_thread_block_size // WARP_SIZE
 
+    var use_doubled = rows >= 1024
+    var effective_simd = simd_width * 2 if use_doubled else simd_width
+
     var grid_dim = rows
     var block_dim = min(
-        ceildiv(ceildiv(cols, simd_width), WARP_SIZE) * WARP_SIZE,
+        ceildiv(ceildiv(cols, effective_simd), WARP_SIZE) * WARP_SIZE,
         WARP_SIZE * max_warps_per_block,
     )
 
@@ -1009,6 +1084,826 @@ def rms_norm_gpu_warp_tiling_128[
             output_fn[simd_width, align](Int(row), Int(idx), norm_val)
 
 
+@always_inline
+def _rms_norm_load_gamma[
+    mut: Bool,
+    LayoutType: TensorLayout,
+    origin: Origin[mut=mut],
+    dtype: DType,
+    //,
+    simd_width: Int,
+    alignment: Int,
+    linear_gamma_indexing: Bool = False,
+](
+    gamma: TileTensor[dtype, LayoutType, origin], idx: UInt
+) -> SIMD[dtype, simd_width]:
+    comptime if linear_gamma_indexing:
+        return gpu_load[
+            width=simd_width, read_only=True, alignment=alignment
+        ](gamma.ptr + Int(idx))
+    return gpu_load[
+        width=simd_width, read_only=True, alignment=alignment
+    ](gamma.ptr + Int(gamma.layout(Idx(idx))))
+
+
+def rms_norm_gpu_warp_tiling_aligned[
+    mut: Bool,
+    LayoutType: TensorLayout,
+    origin: Origin[mut=mut],
+    dtype: DType,
+    //,
+    simd_width: Int,
+    max_warps_per_block: Int,
+    input_fn: def[width: Int](row: Int, col: Int) capturing -> SIMD[
+        dtype, width
+    ],
+    output_fn: def[width: Int, alignment: Int](
+        row: Int, col: Int, val: SIMD[dtype, width]
+    ) capturing -> None,
+    multiply_before_cast: Bool,
+    skip_weight_offset: Bool = False,
+](
+    gamma: TileTensor[dtype, LayoutType, origin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    num_cols: Int,
+):
+    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
+    comptime assert gamma.flat_rank >= 1
+
+    comptime align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+
+    var eps_accum = epsilon.cast[accum_type]()
+    var weight_offset_accum = weight_offset.cast[accum_type]()
+    var n_eps = Scalar[accum_type](num_cols) * eps_accum
+    var sqrt_n = sqrt(Scalar[accum_type](num_cols))
+
+    var tid = thread_idx.x
+    var row = block_idx.x
+    var idx = tid * UInt(simd_width)
+
+    with PDL():
+        var raw_data = input_fn[simd_width](Int(row), Int(idx))
+
+        var thread_m2: Scalar[accum_type] = (raw_data * raw_data).reduce_add().cast[accum_type]()
+        var row_m2 = block_reduce_one_barrier[max_warps_per_block=max_warps_per_block](
+            thread_m2
+        )
+        var norm_factor = sqrt_n * rsqrt(row_m2 + n_eps)
+
+        var gamma_val = gpu_load[
+            width=simd_width, read_only=True, alignment=align
+        ](gamma.ptr + Int(gamma.layout(Idx(idx))))
+
+        comptime if skip_weight_offset:
+            comptime if multiply_before_cast:
+                var norm_bf16 = norm_factor.cast[dtype]()
+                var norm_val = raw_data * (gamma_val * norm_bf16)
+                output_fn[simd_width, align](Int(row), Int(idx), norm_val)
+            else:
+                var norm_val = (raw_data.cast[accum_type]() * norm_factor).cast[dtype]() * gamma_val
+                output_fn[simd_width, align](Int(row), Int(idx), norm_val)
+        else:
+            comptime if multiply_before_cast:
+                var gamma_accum = (
+                    gamma_val.cast[accum_type]() + weight_offset_accum
+                )
+                var norm_val = (raw_data.cast[accum_type]() * norm_factor * gamma_accum).cast[dtype]()
+                output_fn[simd_width, align](Int(row), Int(idx), norm_val)
+            else:
+                var norm_val = (raw_data.cast[accum_type]() * norm_factor).cast[dtype]() * (
+                    gamma_val + weight_offset_accum.cast[dtype]()
+                )
+                output_fn[simd_width, align](Int(row), Int(idx), norm_val)
+
+
+def rms_norm_gpu_warp_tiling_aligned_two_tiles[
+    mut: Bool,
+    LayoutType: TensorLayout,
+    origin: Origin[mut=mut],
+    dtype: DType,
+    //,
+    simd_width: Int,
+    max_warps_per_block: Int,
+    input_fn: def[width: Int](row: Int, col: Int) capturing -> SIMD[
+        dtype, width
+    ],
+    output_fn: def[width: Int, alignment: Int](
+        row: Int, col: Int, val: SIMD[dtype, width]
+    ) capturing -> None,
+    multiply_before_cast: Bool,
+    skip_weight_offset: Bool = False,
+](
+    gamma: TileTensor[dtype, LayoutType, origin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    num_cols: Int,
+):
+    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
+    comptime assert gamma.flat_rank >= 1
+
+    comptime align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+
+    var eps_accum = epsilon.cast[accum_type]()
+    var weight_offset_accum = weight_offset.cast[accum_type]()
+    var n_eps = Scalar[accum_type](num_cols) * eps_accum
+    var sqrt_n = sqrt(Scalar[accum_type](num_cols))
+
+    var tid = thread_idx.x
+    var row = block_idx.x
+    var idx0 = tid * UInt(simd_width)
+    var tile_stride = block_dim.x * UInt(simd_width)
+    var idx1 = idx0 + tile_stride
+
+    with PDL():
+        var raw_data0 = input_fn[simd_width](Int(row), Int(idx0))
+        var raw_data1 = input_fn[simd_width](Int(row), Int(idx1))
+
+        var thread_m2: Scalar[accum_type] = (
+            (raw_data0 * raw_data0).reduce_add().cast[accum_type]()
+            + (raw_data1 * raw_data1).reduce_add().cast[accum_type]()
+        )
+        var row_m2 = block_reduce_one_barrier_lane_group[
+            max_warps_per_block=max_warps_per_block
+        ](thread_m2)
+        var norm_factor = sqrt_n * rsqrt(row_m2 + n_eps)
+
+        comptime if skip_weight_offset:
+            comptime if multiply_before_cast:
+                var norm_bf16 = norm_factor.cast[dtype]()
+                var gamma_val0 = gpu_load[
+                    width=simd_width, read_only=True, alignment=align
+                ](gamma.ptr + Int(gamma.layout(Idx(idx0))))
+                var norm_val0 = raw_data0 * (gamma_val0 * norm_bf16)
+                output_fn[simd_width, align](Int(row), Int(idx0), norm_val0)
+                var gamma_val1 = gpu_load[
+                    width=simd_width, read_only=True, alignment=align
+                ](gamma.ptr + Int(gamma.layout(Idx(idx1))))
+                var norm_val1 = raw_data1 * (gamma_val1 * norm_bf16)
+                output_fn[simd_width, align](Int(row), Int(idx1), norm_val1)
+            else:
+                var gamma_val0 = gpu_load[
+                    width=simd_width, read_only=True, alignment=align
+                ](gamma.ptr + Int(gamma.layout(Idx(idx0))))
+                var norm_val0 = (
+                    raw_data0.cast[accum_type]() * norm_factor
+                ).cast[dtype]() * gamma_val0
+                output_fn[simd_width, align](Int(row), Int(idx0), norm_val0)
+                var gamma_val1 = gpu_load[
+                    width=simd_width, read_only=True, alignment=align
+                ](gamma.ptr + Int(gamma.layout(Idx(idx1))))
+                var norm_val1 = (
+                    raw_data1.cast[accum_type]() * norm_factor
+                ).cast[dtype]() * gamma_val1
+                output_fn[simd_width, align](Int(row), Int(idx1), norm_val1)
+        else:
+            comptime if multiply_before_cast:
+                var gamma_val0 = gpu_load[
+                    width=simd_width, read_only=True, alignment=align
+                ](gamma.ptr + Int(gamma.layout(Idx(idx0))))
+                var gamma_accum0 = (
+                    gamma_val0.cast[accum_type]() + weight_offset_accum
+                )
+                var norm_val0 = (
+                    raw_data0.cast[accum_type]() * norm_factor * gamma_accum0
+                ).cast[dtype]()
+                output_fn[simd_width, align](Int(row), Int(idx0), norm_val0)
+                var gamma_val1 = gpu_load[
+                    width=simd_width, read_only=True, alignment=align
+                ](gamma.ptr + Int(gamma.layout(Idx(idx1))))
+                var gamma_accum1 = (
+                    gamma_val1.cast[accum_type]() + weight_offset_accum
+                )
+                var norm_val1 = (
+                    raw_data1.cast[accum_type]() * norm_factor * gamma_accum1
+                ).cast[dtype]()
+                output_fn[simd_width, align](Int(row), Int(idx1), norm_val1)
+            else:
+                var gamma_val0 = gpu_load[
+                    width=simd_width, read_only=True, alignment=align
+                ](gamma.ptr + Int(gamma.layout(Idx(idx0))))
+                var norm_val0 = (
+                    raw_data0.cast[accum_type]() * norm_factor
+                ).cast[dtype]() * (
+                    gamma_val0 + weight_offset_accum.cast[dtype]()
+                )
+                output_fn[simd_width, align](Int(row), Int(idx0), norm_val0)
+                var gamma_val1 = gpu_load[
+                    width=simd_width, read_only=True, alignment=align
+                ](gamma.ptr + Int(gamma.layout(Idx(idx1))))
+                var norm_val1 = (
+                    raw_data1.cast[accum_type]() * norm_factor
+                ).cast[dtype]() * (
+                    gamma_val1 + weight_offset_accum.cast[dtype]()
+                )
+                output_fn[simd_width, align](Int(row), Int(idx1), norm_val1)
+
+
+def rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input[
+    mut: Bool,
+    LayoutType: TensorLayout,
+    origin: Origin[mut=mut],
+    dtype: DType,
+    //,
+    simd_width: Int,
+    max_warps_per_block: Int,
+    input_pair_fn: def[width: Int](
+        row: Int, col0: Int, col1: Int
+    ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]],
+    output_fn: def[width: Int, alignment: Int](
+        row: Int, col: Int, val: SIMD[dtype, width]
+    ) capturing -> None,
+    multiply_before_cast: Bool,
+    skip_weight_offset: Bool = False,
+    linear_gamma_indexing: Bool = False,
+](
+    gamma: TileTensor[dtype, LayoutType, origin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    num_cols: Int,
+):
+    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
+    comptime assert gamma.flat_rank >= 1
+
+    comptime align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+
+    var eps_accum = epsilon.cast[accum_type]()
+    var weight_offset_accum = weight_offset.cast[accum_type]()
+    var n_eps = Scalar[accum_type](num_cols) * eps_accum
+    var sqrt_n = sqrt(Scalar[accum_type](num_cols))
+
+    var tid = thread_idx.x
+    var row = block_idx.x
+    var idx0 = tid * UInt(simd_width)
+    var tile_stride = block_dim.x * UInt(simd_width)
+    var idx1 = idx0 + tile_stride
+
+    with PDL():
+        var raw_data_pair = input_pair_fn[simd_width](
+            Int(row), Int(idx0), Int(idx1)
+        )
+        var raw_data0 = raw_data_pair[0]
+        var raw_data1 = raw_data_pair[1]
+
+        var thread_m2: Scalar[accum_type] = (
+            (raw_data0 * raw_data0).reduce_add().cast[accum_type]()
+            + (raw_data1 * raw_data1).reduce_add().cast[accum_type]()
+        )
+        var row_m2 = block_reduce_one_barrier_warp_sum[
+            max_warps_per_block=max_warps_per_block
+        ](thread_m2)
+        var norm_factor = sqrt_n * rsqrt(row_m2 + n_eps)
+
+        comptime if skip_weight_offset:
+            comptime if multiply_before_cast:
+                var norm_bf16 = norm_factor.cast[dtype]()
+                var gamma_val0 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx0)
+                var norm_val0 = raw_data0 * (gamma_val0 * norm_bf16)
+                output_fn[simd_width, align](Int(row), Int(idx0), norm_val0)
+                var gamma_val1 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx1)
+                var norm_val1 = raw_data1 * (gamma_val1 * norm_bf16)
+                output_fn[simd_width, align](Int(row), Int(idx1), norm_val1)
+            else:
+                var gamma_val0 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx0)
+                var norm_val0 = (
+                    raw_data0.cast[accum_type]() * norm_factor
+                ).cast[dtype]() * gamma_val0
+                output_fn[simd_width, align](Int(row), Int(idx0), norm_val0)
+                var gamma_val1 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx1)
+                var norm_val1 = (
+                    raw_data1.cast[accum_type]() * norm_factor
+                ).cast[dtype]() * gamma_val1
+                output_fn[simd_width, align](Int(row), Int(idx1), norm_val1)
+        else:
+            comptime if multiply_before_cast:
+                var gamma_val0 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx0)
+                var gamma_accum0 = (
+                    gamma_val0.cast[accum_type]() + weight_offset_accum
+                )
+                var norm_val0 = (
+                    raw_data0.cast[accum_type]() * norm_factor * gamma_accum0
+                ).cast[dtype]()
+                output_fn[simd_width, align](Int(row), Int(idx0), norm_val0)
+                var gamma_val1 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx1)
+                var gamma_accum1 = (
+                    gamma_val1.cast[accum_type]() + weight_offset_accum
+                )
+                var norm_val1 = (
+                    raw_data1.cast[accum_type]() * norm_factor * gamma_accum1
+                ).cast[dtype]()
+                output_fn[simd_width, align](Int(row), Int(idx1), norm_val1)
+            else:
+                var gamma_val0 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx0)
+                var norm_val0 = (
+                    raw_data0.cast[accum_type]() * norm_factor
+                ).cast[dtype]() * (
+                    gamma_val0 + weight_offset_accum.cast[dtype]()
+                )
+                output_fn[simd_width, align](Int(row), Int(idx0), norm_val0)
+                var gamma_val1 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx1)
+                var norm_val1 = (
+                    raw_data1.cast[accum_type]() * norm_factor
+                ).cast[dtype]() * (
+                    gamma_val1 + weight_offset_accum.cast[dtype]()
+                )
+                output_fn[simd_width, align](Int(row), Int(idx1), norm_val1)
+
+
+@always_inline
+def _rms_norm_exact_4096_load_packed_rank2_pair[
+    dtype: DType,
+    //,
+    simd_width: Int,
+    packed_width: Int,
+    input_pair_fn: def[width: Int](
+        row: Int, col0: Int, col1: Int
+    ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]],
+](
+    row: Int,
+    col0: Int,
+    mut raw_bits0: SIMD[DType.uint32, packed_width],
+    mut raw_bits1: SIMD[DType.uint32, packed_width],
+) -> Scalar[get_accum_type[dtype]()]:
+    var raw_data_pair = input_pair_fn[simd_width](row, col0, col0 + 2048)
+    var raw_data0 = raw_data_pair[0]
+    var raw_data1 = raw_data_pair[1]
+    raw_bits0 = bitcast[DType.uint32, packed_width](raw_data0)
+    raw_bits1 = bitcast[DType.uint32, packed_width](raw_data1)
+
+    return (
+        (raw_data0 * raw_data0).reduce_add().cast[get_accum_type[dtype]()]()
+        + (raw_data1 * raw_data1).reduce_add().cast[get_accum_type[dtype]()]()
+    )
+
+
+def rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input_exact_4096[
+    mut: Bool,
+    LayoutType: TensorLayout,
+    origin: Origin[mut=mut],
+    dtype: DType,
+    //,
+    simd_width: Int,
+    max_warps_per_block: Int,
+    input_pair_fn: def[width: Int](
+        row: Int, col0: Int, col1: Int
+    ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]],
+    output_fn: def[width: Int, alignment: Int](
+        row: Int, col: Int, val: SIMD[dtype, width]
+    ) capturing -> None,
+    multiply_before_cast: Bool,
+](
+    gamma: TileTensor[dtype, LayoutType, origin], epsilon: Scalar[dtype]
+):
+    comptime assert dtype == DType.bfloat16, "exact 4096 path is BF16-only"
+    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
+    comptime assert gamma.flat_rank >= 1
+    comptime assert (
+        2 * WARP_SIZE * max_warps_per_block * simd_width == 4096
+    ), "exact 4096 path requires a full two-tile CTA"
+    comptime packed_width = simd_width // 2
+    comptime align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+
+    var eps_accum = epsilon.cast[accum_type]()
+    var n_eps = Scalar[accum_type](4096) * eps_accum
+    var sqrt_n = Scalar[accum_type](64)
+
+    var tid = thread_idx.x
+    var input_idx0 = tid * UInt(simd_width)
+
+    with PDL():
+        var load_row_i = Int(block_idx.x)
+        var raw_bits0 = SIMD[DType.uint32, packed_width](0)
+        var raw_bits1 = SIMD[DType.uint32, packed_width](0)
+        var thread_m2: Scalar[accum_type] = (
+            _rms_norm_exact_4096_load_packed_rank2_pair[
+                simd_width, packed_width, input_pair_fn
+            ](load_row_i, Int(input_idx0), raw_bits0, raw_bits1)
+        )
+        var row_m2 = block_reduce_one_barrier[
+            max_warps_per_block=max_warps_per_block
+        ](thread_m2)
+        var norm_factor = sqrt_n * rsqrt(row_m2 + n_eps)
+        comptime if multiply_before_cast:
+            var norm_bf16 = norm_factor.cast[dtype]()
+            var col0 = Int(input_idx0)
+            output_fn[simd_width, align](
+                Int(block_idx.x),
+                col0,
+                bitcast[dtype, simd_width](raw_bits0)
+                * (
+                    _rms_norm_load_gamma[simd_width, align](gamma, input_idx0)
+                    * norm_bf16
+                ),
+            )
+            var row_i1 = Int(block_idx.x)
+            var idx1 = input_idx0 + UInt(2048)
+            var col1 = Int(idx1)
+            var gamma_val1 = _rms_norm_load_gamma[simd_width, align](gamma, idx1)
+            var norm_val1 = bitcast[dtype, simd_width](raw_bits1) * (
+                gamma_val1 * norm_bf16
+            )
+            output_fn[simd_width, align](row_i1, col1, norm_val1)
+        else:
+            var col0 = Int(input_idx0)
+            output_fn[simd_width, align](
+                Int(block_idx.x),
+                col0,
+                (
+                    bitcast[dtype, simd_width](raw_bits0).cast[accum_type]()
+                    * norm_factor
+                ).cast[dtype]()
+                    * _rms_norm_load_gamma[simd_width, align](gamma, input_idx0),
+            )
+            var row_i1 = Int(block_idx.x)
+            var idx1 = input_idx0 + UInt(2048)
+            var col1 = Int(idx1)
+            var gamma_val1 = _rms_norm_load_gamma[simd_width, align](gamma, idx1)
+            var norm_val1 = (
+                bitcast[dtype, simd_width](raw_bits1).cast[accum_type]()
+                * norm_factor
+            ).cast[dtype]() * gamma_val1
+            output_fn[simd_width, align](row_i1, col1, norm_val1)
+
+
+@always_inline
+def _rms_norm_exact_4096_load_flat_pair[
+    dtype: DType,
+    //,
+    simd_width: Int,
+    input_pair_fn_flat: def[width: Int](
+        flat0: Int, flat1: Int
+    ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]],
+](
+    flat0: Int
+) -> Tuple[SIMD[dtype, simd_width], SIMD[dtype, simd_width]]:
+    return input_pair_fn_flat[simd_width](flat0, flat0 + 2048)
+
+
+@always_inline
+def _rms_norm_exact_4096_store_flat_tile[
+    mut: Bool,
+    LayoutType: TensorLayout,
+    origin: Origin[mut=mut],
+    dtype: DType,
+    //,
+    simd_width: Int,
+    output_fn_flat: def[width: Int, alignment: Int](
+        flat: Int, val: SIMD[dtype, width]
+    ) capturing -> None,
+    multiply_before_cast: Bool,
+    tile_offset: Int,
+](
+    gamma: TileTensor[dtype, LayoutType, origin],
+    flat0: Int,
+    idx0: UInt,
+    raw_data: SIMD[dtype, simd_width],
+    norm_factor: Scalar[DType.float32],
+):
+    comptime assert dtype == DType.bfloat16, "exact 4096 path is BF16-only"
+    comptime align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+
+    var idx = idx0 + UInt(tile_offset)
+    var flat = flat0 + tile_offset
+    var norm_factor_accum = rebind[Scalar[accum_type]](norm_factor)
+
+    comptime if multiply_before_cast:
+        var norm_bf16 = norm_factor_accum.cast[dtype]()
+        var gamma_val = _rms_norm_load_gamma[simd_width, align, True](
+            gamma, idx
+        )
+        var norm_val = raw_data * (gamma_val * norm_bf16)
+        output_fn_flat[simd_width, align](flat, norm_val)
+    else:
+        var gamma_val = _rms_norm_load_gamma[simd_width, align, True](
+            gamma, idx
+        )
+        var norm_val = (raw_data.cast[accum_type]() * norm_factor_accum).cast[
+            dtype
+        ]() * gamma_val
+        output_fn_flat[simd_width, align](flat, norm_val)
+
+
+def rms_norm_gpu_warp_tiling_aligned_two_tiles_flat_direct_exact_4096[
+    mut: Bool,
+    LayoutType: TensorLayout,
+    origin: Origin[mut=mut],
+    dtype: DType,
+    //,
+    simd_width: Int,
+    max_warps_per_block: Int,
+    input_pair_fn_flat: def[width: Int](
+        flat0: Int, flat1: Int
+    ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]],
+    output_fn_flat: def[width: Int, alignment: Int](
+        flat: Int, val: SIMD[dtype, width]
+    ) capturing -> None,
+    multiply_before_cast: Bool,
+](
+    gamma: TileTensor[dtype, LayoutType, origin], epsilon: Scalar[dtype]
+):
+    comptime assert dtype == DType.bfloat16, "exact 4096 path is BF16-only"
+    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
+    comptime assert gamma.flat_rank >= 1
+    comptime assert (
+        2 * WARP_SIZE * max_warps_per_block * simd_width == 4096
+    ), "exact 4096 path requires a full two-tile CTA"
+    comptime align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+
+    var eps_accum = epsilon.cast[accum_type]()
+    var n_eps = Scalar[accum_type](4096) * eps_accum
+    var sqrt_n = Scalar[accum_type](64)
+
+    var tid = thread_idx.x
+    var row = block_idx.x
+    var idx0 = tid * UInt(simd_width)
+
+    with PDL():
+        var input_flat0 = Int(row) * 4096 + Int(idx0)
+        var raw_data_pair = _rms_norm_exact_4096_load_flat_pair[
+            simd_width,
+            input_pair_fn_flat,
+        ](input_flat0)
+        var raw_data0 = raw_data_pair[0]
+        var raw_data1 = raw_data_pair[1]
+
+        var thread_m2: Scalar[accum_type] = (
+            (raw_data0 * raw_data0).reduce_add().cast[accum_type]()
+            + (raw_data1 * raw_data1).reduce_add().cast[accum_type]()
+        )
+        var row_m2 = block_reduce_one_barrier_warp_sum[
+            max_warps_per_block=max_warps_per_block
+        ](thread_m2)
+        var norm_factor = sqrt_n * rsqrt(row_m2 + n_eps)
+        var output_flat0 = Int(row) * 4096 + Int(idx0)
+
+        comptime if multiply_before_cast:
+            var norm_factor_f32 = rebind[Scalar[DType.float32]](norm_factor)
+            _rms_norm_exact_4096_store_flat_tile[
+                mut=gamma.mut,
+                LayoutType=gamma.LayoutType,
+                origin=gamma.origin,
+                simd_width,
+                output_fn_flat,
+                multiply_before_cast=multiply_before_cast,
+                tile_offset=0,
+            ](gamma, output_flat0, idx0, raw_data0, norm_factor_f32)
+            _rms_norm_exact_4096_store_flat_tile[
+                mut=gamma.mut,
+                LayoutType=gamma.LayoutType,
+                origin=gamma.origin,
+                simd_width,
+                output_fn_flat,
+                multiply_before_cast=multiply_before_cast,
+                tile_offset=2048,
+            ](gamma, output_flat0, idx0, raw_data1, norm_factor_f32)
+        else:
+            var norm_factor_f32 = rebind[Scalar[DType.float32]](norm_factor)
+            _rms_norm_exact_4096_store_flat_tile[
+                mut=gamma.mut,
+                LayoutType=gamma.LayoutType,
+                origin=gamma.origin,
+                simd_width,
+                output_fn_flat,
+                multiply_before_cast=multiply_before_cast,
+                tile_offset=0,
+            ](gamma, output_flat0, idx0, raw_data0, norm_factor_f32)
+            _rms_norm_exact_4096_store_flat_tile[
+                mut=gamma.mut,
+                LayoutType=gamma.LayoutType,
+                origin=gamma.origin,
+                simd_width,
+                output_fn_flat,
+                multiply_before_cast=multiply_before_cast,
+                tile_offset=2048,
+            ](gamma, output_flat0, idx0, raw_data1, norm_factor_f32)
+
+
+def rms_norm_gpu_warp_tiling_aligned_two_tiles_single_flat_input_exact_4096[
+    mut: Bool,
+    LayoutType: TensorLayout,
+    origin: Origin[mut=mut],
+    dtype: DType,
+    //,
+    simd_width: Int,
+    max_warps_per_block: Int,
+    input_fn_flat: def[width: Int](flat: Int) capturing -> SIMD[dtype, width],
+    output_fn_flat: def[width: Int, alignment: Int](
+        flat: Int, val: SIMD[dtype, width]
+    ) capturing -> None,
+    multiply_before_cast: Bool,
+](
+    gamma: TileTensor[dtype, LayoutType, origin], epsilon: Scalar[dtype]
+):
+    comptime assert dtype == DType.bfloat16, "exact 4096 path is BF16-only"
+    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
+    comptime assert gamma.flat_rank >= 1
+    comptime assert (
+        2 * WARP_SIZE * max_warps_per_block * simd_width == 4096
+    ), "exact 4096 path requires a full two-tile CTA"
+    comptime align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+
+    var eps_accum = epsilon.cast[accum_type]()
+    var n_eps = Scalar[accum_type](4096) * eps_accum
+    var sqrt_n = Scalar[accum_type](64)
+
+    var tid = thread_idx.x
+    var row = block_idx.x
+    var idx0 = tid * UInt(simd_width)
+    var idx1 = idx0 + UInt(2048)
+    with PDL():
+        var row_offset = Int(row) * 4096
+        var flat0 = row_offset + Int(idx0)
+        var flat1 = flat0 + 2048
+        var raw_data0 = input_fn_flat[simd_width](flat0)
+        var raw_data1 = input_fn_flat[simd_width](flat1)
+        var thread_m2: Scalar[accum_type] = (
+            (raw_data0 * raw_data0).reduce_add().cast[accum_type]()
+            + (raw_data1 * raw_data1).reduce_add().cast[accum_type]()
+        )
+        var row_m2 = block_reduce_one_barrier[
+            max_warps_per_block=max_warps_per_block
+        ](thread_m2)
+        var norm_factor = sqrt_n * rsqrt(row_m2 + n_eps)
+
+        comptime if multiply_before_cast:
+            var norm_bf16 = norm_factor.cast[dtype]()
+            var gamma_val0 = _rms_norm_load_gamma[simd_width, align, True](
+                gamma, idx0
+            )
+            var norm_val0 = raw_data0 * (gamma_val0 * norm_bf16)
+            output_fn_flat[simd_width, align](flat0, norm_val0)
+            var gamma_val1 = _rms_norm_load_gamma[simd_width, align, True](
+                gamma, idx1
+            )
+            var norm_val1 = raw_data1 * (gamma_val1 * norm_bf16)
+            output_fn_flat[simd_width, align](flat1, norm_val1)
+        else:
+            var gamma_val0 = _rms_norm_load_gamma[simd_width, align, True](
+                gamma, idx0
+            )
+            var norm_val0 = (
+                raw_data0.cast[accum_type]() * norm_factor
+            ).cast[dtype]() * gamma_val0
+            output_fn_flat[simd_width, align](flat0, norm_val0)
+            var gamma_val1 = _rms_norm_load_gamma[simd_width, align, True](
+                gamma, idx1
+            )
+            var norm_val1 = (
+                raw_data1.cast[accum_type]() * norm_factor
+            ).cast[dtype]() * gamma_val1
+            output_fn_flat[simd_width, align](flat1, norm_val1)
+
+
+def rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input_lane_group[
+    mut: Bool,
+    LayoutType: TensorLayout,
+    origin: Origin[mut=mut],
+    dtype: DType,
+    //,
+    simd_width: Int,
+    max_warps_per_block: Int,
+    input_pair_fn: def[width: Int](
+        row: Int, col0: Int, col1: Int
+    ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]],
+    output_fn: def[width: Int, alignment: Int](
+        row: Int, col: Int, val: SIMD[dtype, width]
+    ) capturing -> None,
+    multiply_before_cast: Bool,
+    skip_weight_offset: Bool = False,
+    linear_gamma_indexing: Bool = False,
+](
+    gamma: TileTensor[dtype, LayoutType, origin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    num_cols: Int,
+):
+    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
+    comptime assert gamma.flat_rank >= 1
+
+    comptime align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+
+    var eps_accum = epsilon.cast[accum_type]()
+    var weight_offset_accum = weight_offset.cast[accum_type]()
+    var n_eps = Scalar[accum_type](num_cols) * eps_accum
+    var sqrt_n = sqrt(Scalar[accum_type](num_cols))
+
+    var tid = thread_idx.x
+    var row = block_idx.x
+    var idx0 = tid * UInt(simd_width)
+    var tile_stride = block_dim.x * UInt(simd_width)
+    var idx1 = idx0 + tile_stride
+
+    with PDL():
+        var raw_data_pair = input_pair_fn[simd_width](
+            Int(row), Int(idx0), Int(idx1)
+        )
+        var raw_data0 = raw_data_pair[0]
+        var raw_data1 = raw_data_pair[1]
+
+        var thread_m2: Scalar[accum_type] = (
+            (raw_data0 * raw_data0).reduce_add().cast[accum_type]()
+            + (raw_data1 * raw_data1).reduce_add().cast[accum_type]()
+        )
+        var row_m2 = block_reduce_one_barrier_lane_group[
+            max_warps_per_block=max_warps_per_block
+        ](thread_m2)
+        var norm_factor = sqrt_n * rsqrt(row_m2 + n_eps)
+
+        comptime if skip_weight_offset:
+            comptime if multiply_before_cast:
+                var norm_bf16 = norm_factor.cast[dtype]()
+                var gamma_val0 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx0)
+                var norm_val0 = raw_data0 * (gamma_val0 * norm_bf16)
+                output_fn[simd_width, align](Int(row), Int(idx0), norm_val0)
+                var gamma_val1 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx1)
+                var norm_val1 = raw_data1 * (gamma_val1 * norm_bf16)
+                output_fn[simd_width, align](Int(row), Int(idx1), norm_val1)
+            else:
+                var gamma_val0 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx0)
+                var norm_val0 = (
+                    raw_data0.cast[accum_type]() * norm_factor
+                ).cast[dtype]() * gamma_val0
+                output_fn[simd_width, align](Int(row), Int(idx0), norm_val0)
+                var gamma_val1 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx1)
+                var norm_val1 = (
+                    raw_data1.cast[accum_type]() * norm_factor
+                ).cast[dtype]() * gamma_val1
+                output_fn[simd_width, align](Int(row), Int(idx1), norm_val1)
+        else:
+            comptime if multiply_before_cast:
+                var gamma_val0 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx0)
+                var gamma_accum0 = (
+                    gamma_val0.cast[accum_type]() + weight_offset_accum
+                )
+                var norm_val0 = (
+                    raw_data0.cast[accum_type]() * norm_factor * gamma_accum0
+                ).cast[dtype]()
+                output_fn[simd_width, align](Int(row), Int(idx0), norm_val0)
+                var gamma_val1 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx1)
+                var gamma_accum1 = (
+                    gamma_val1.cast[accum_type]() + weight_offset_accum
+                )
+                var norm_val1 = (
+                    raw_data1.cast[accum_type]() * norm_factor * gamma_accum1
+                ).cast[dtype]()
+                output_fn[simd_width, align](Int(row), Int(idx1), norm_val1)
+            else:
+                var gamma_val0 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx0)
+                var norm_val0 = (
+                    raw_data0.cast[accum_type]() * norm_factor
+                ).cast[dtype]() * (
+                    gamma_val0 + weight_offset_accum.cast[dtype]()
+                )
+                output_fn[simd_width, align](Int(row), Int(idx0), norm_val0)
+                var gamma_val1 = _rms_norm_load_gamma[
+                    simd_width, align, linear_gamma_indexing
+                ](gamma, idx1)
+                var norm_val1 = (
+                    raw_data1.cast[accum_type]() * norm_factor
+                ).cast[dtype]() * (
+                    gamma_val1 + weight_offset_accum.cast[dtype]()
+                )
+                output_fn[simd_width, align](Int(row), Int(idx1), norm_val1)
+
+
 def rms_norm_gpu_warp_tiling[
     mut: Bool,
     LayoutType: TensorLayout,
@@ -1197,6 +2092,16 @@ def rms_norm_gpu[
     ) capturing -> None,
     multiply_before_cast: Bool,
     pdl_level: PDLLevel = PDLLevel(1),
+    input_pair_fn_rank2_direct: OptionalReg[
+        def[width: Int](
+            row: Int, col0: Int, col1: Int
+        ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]
+    ] = None,
+    output_fn_rank2_direct: OptionalReg[
+        def[width: Int, alignment: Int](
+            row: Int, col: Int, val: SIMD[dtype, width]
+        ) capturing -> None
+    ] = None,
 ](
     shape: IndexList[rank, ...],
     gamma: TileTensor[dtype, ...],
@@ -1252,12 +2157,64 @@ def rms_norm_gpu[
         indices[rank - 1] = col
         return input_fn[simd_width](indices.canonicalize())
 
+    @parameter
+    @always_inline
+    def output_fn_2d_flat[
+        simd_width: Int, alignment: Int
+    ](row: Int, col: Int, val: SIMD[dtype, simd_width]) -> None:
+        comptime if rank != 3:
+            output_fn_2d[simd_width, alignment](row, col, val)
+        else:
+            var indices = IndexList[rank]()
+            indices[0] = 0
+            indices[1] = row
+            indices[2] = col
+            output_fn[simd_width, alignment](indices.canonicalize(), val)
+
+    @parameter
+    @always_inline
+    def input_fn_2d_flat[
+        simd_width: Int
+    ](row: Int, col: Int) -> SIMD[dtype, simd_width]:
+        comptime if rank != 3:
+            return input_fn_2d[simd_width](row, col)
+        else:
+            var indices = IndexList[rank]()
+            indices[0] = 0
+            indices[1] = row
+            indices[2] = col
+            return input_fn[simd_width](indices.canonicalize())
+
+    @parameter
+    @always_inline
+    def input_pair_fn_2d[
+        simd_width: Int
+    ](
+        row: Int, col0: Int, col1: Int
+    ) -> Tuple[SIMD[dtype, simd_width], SIMD[dtype, simd_width]]:
+        comptime if rank == 3:
+            if shape[0] == 1:
+                var indices = IndexList[rank]()
+                indices[0] = 0
+                indices[1] = row
+                indices[2] = col0
+                var raw_data0 = input_fn[simd_width](indices.canonicalize())
+                indices[2] = col1
+                return (raw_data0, input_fn[simd_width](indices.canonicalize()))
+        return (
+            input_fn_2d[simd_width](row, col0),
+            input_fn_2d[simd_width](row, col1),
+        )
+
     comptime simd_width = simd_width_of[dtype, target=get_gpu_target()]()
     comptime max_warps_per_block = ctx.default_device_info.max_thread_block_size // WARP_SIZE
 
+    var use_doubled = rows >= 1024
+    var effective_simd = simd_width * 2 if use_doubled else simd_width
+
     var grid_dim = rows
     var block_dim = min(
-        ceildiv(ceildiv(cols, simd_width), WARP_SIZE) * WARP_SIZE,
+        ceildiv(ceildiv(cols, effective_simd), WARP_SIZE) * WARP_SIZE,
         WARP_SIZE * max_warps_per_block,
     )
 
@@ -1292,26 +2249,390 @@ def rms_norm_gpu[
                 block_dim=block_dim,
                 attributes=pdl_launch_attributes(pdl_level),
             )
+        elif use_doubled and cols % (simd_width * 2) == 0 and cols <= (WARP_SIZE * (simd_width * 2) * max_warps_per_block):
+            comptime if rank == 3:
+                if shape[0] == 1:
+                    if cols == Int(block_dim) * (simd_width * 2):
+                        if rows >= 4096 and cols == 4096 and dtype == DType.bfloat16:
+                            var two_tiles_block_dim = block_dim // 2
+                            if weight_offset == Scalar[dtype](0):
+                                comptime if input_pair_fn_rank2_direct:
+                                    comptime direct_input_pair_fn = (
+                                        input_pair_fn_rank2_direct.value()
+                                    )
+                                    comptime if output_fn_rank2_direct:
+                                        comptime direct_output_fn = (
+                                            output_fn_rank2_direct.value()
+                                        )
+                                        comptime kernel = rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input_lane_group[
+                                            mut=gamma.mut,
+                                            LayoutType=gamma.LayoutType,
+                                            origin=gamma.origin,
+                                            simd_width * 2,
+                                            4,
+                                            direct_input_pair_fn,
+                                            direct_output_fn,
+                                            multiply_before_cast=multiply_before_cast,
+                                            skip_weight_offset=True,
+                                            linear_gamma_indexing=True,
+                                        ]
+                                        ctx.enqueue_function[kernel, kernel](
+                                            gamma,
+                                            epsilon,
+                                            weight_offset,
+                                            cols,
+                                            grid_dim=grid_dim,
+                                            block_dim=two_tiles_block_dim,
+                                            attributes=pdl_launch_attributes(
+                                                pdl_level
+                                            ),
+                                        )
+                                    else:
+                                        comptime kernel = rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input[
+                                            mut=gamma.mut,
+                                            LayoutType=gamma.LayoutType,
+                                            origin=gamma.origin,
+                                            simd_width * 2,
+                                            4,
+                                            direct_input_pair_fn,
+                                            output_fn_2d,
+                                            multiply_before_cast=multiply_before_cast,
+                                            skip_weight_offset=True,
+                                            linear_gamma_indexing=True,
+                                        ]
+                                        ctx.enqueue_function[kernel, kernel](
+                                            gamma,
+                                            epsilon,
+                                            weight_offset,
+                                            cols,
+                                            grid_dim=grid_dim,
+                                            block_dim=two_tiles_block_dim,
+                                            attributes=pdl_launch_attributes(
+                                                pdl_level
+                                            ),
+                                        )
+                                else:
+                                    comptime if output_fn_rank2_direct:
+                                        comptime direct_output_fn = (
+                                            output_fn_rank2_direct.value()
+                                        )
+                                        comptime kernel = rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input[
+                                            mut=gamma.mut,
+                                            LayoutType=gamma.LayoutType,
+                                            origin=gamma.origin,
+                                            simd_width * 2,
+                                            4,
+                                            input_pair_fn_2d,
+                                            direct_output_fn,
+                                            multiply_before_cast=multiply_before_cast,
+                                            skip_weight_offset=True,
+                                            linear_gamma_indexing=True,
+                                        ]
+                                        ctx.enqueue_function[kernel, kernel](
+                                            gamma,
+                                            epsilon,
+                                            weight_offset,
+                                            cols,
+                                            grid_dim=grid_dim,
+                                            block_dim=two_tiles_block_dim,
+                                            attributes=pdl_launch_attributes(
+                                                pdl_level
+                                            ),
+                                        )
+                                    else:
+                                        comptime kernel = rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input[
+                                            mut=gamma.mut,
+                                            LayoutType=gamma.LayoutType,
+                                            origin=gamma.origin,
+                                            simd_width * 2,
+                                            4,
+                                            input_pair_fn_2d,
+                                            output_fn_2d,
+                                            multiply_before_cast=multiply_before_cast,
+                                            skip_weight_offset=True,
+                                            linear_gamma_indexing=True,
+                                        ]
+                                        ctx.enqueue_function[kernel, kernel](
+                                            gamma,
+                                            epsilon,
+                                            weight_offset,
+                                            cols,
+                                            grid_dim=grid_dim,
+                                            block_dim=two_tiles_block_dim,
+                                            attributes=pdl_launch_attributes(
+                                                pdl_level
+                                            ),
+                                        )
+                            else:
+                                comptime kernel = rms_norm_gpu_warp_tiling_aligned_two_tiles[
+                                    mut=gamma.mut,
+                                    LayoutType=gamma.LayoutType,
+                                    origin=gamma.origin,
+                                    simd_width * 2,
+                                    4,
+                                    input_fn_2d,
+                                    output_fn_2d,
+                                    multiply_before_cast=multiply_before_cast,
+                                ]
+                                ctx.enqueue_function[kernel, kernel](
+                                    gamma,
+                                    epsilon,
+                                    weight_offset,
+                                    cols,
+                                    grid_dim=grid_dim,
+                                    block_dim=two_tiles_block_dim,
+                                    attributes=pdl_launch_attributes(pdl_level),
+                                )
+                        elif weight_offset == Scalar[dtype](0):
+                            comptime kernel = rms_norm_gpu_warp_tiling_aligned[
+                                mut=gamma.mut,
+                                LayoutType=gamma.LayoutType,
+                                origin=gamma.origin,
+                                simd_width * 2,
+                                8,
+                                input_fn_2d,
+                                output_fn_2d,
+                                multiply_before_cast=multiply_before_cast,
+                                skip_weight_offset=True,
+                            ]
+                            ctx.enqueue_function[kernel, kernel](
+                                gamma,
+                                epsilon,
+                                weight_offset,
+                                cols,
+                                grid_dim=grid_dim,
+                                block_dim=block_dim,
+                                attributes=pdl_launch_attributes(pdl_level),
+                            )
+                        else:
+                            comptime kernel = rms_norm_gpu_warp_tiling_aligned[
+                                mut=gamma.mut,
+                                LayoutType=gamma.LayoutType,
+                                origin=gamma.origin,
+                                simd_width * 2,
+                                8,
+                                input_fn_2d,
+                                output_fn_2d,
+                                multiply_before_cast=multiply_before_cast,
+                            ]
+                            ctx.enqueue_function[kernel, kernel](
+                                gamma,
+                                epsilon,
+                                weight_offset,
+                                cols,
+                                grid_dim=grid_dim,
+                                block_dim=block_dim,
+                                attributes=pdl_launch_attributes(pdl_level),
+                            )
+                    else:
+                        comptime kernel = rms_norm_gpu_warp_tiling[
+                            mut=gamma.mut,
+                            LayoutType=gamma.LayoutType,
+                            origin=gamma.origin,
+                            simd_width * 2,
+                            max_warps_per_block,
+                            input_fn_2d,
+                            output_fn_2d,
+                            multiply_before_cast=multiply_before_cast,
+                        ]
+                        ctx.enqueue_function[kernel, kernel](
+                            gamma,
+                            epsilon,
+                            weight_offset,
+                            cols,
+                            grid_dim=grid_dim,
+                            block_dim=block_dim,
+                            attributes=pdl_launch_attributes(pdl_level),
+                        )
+                else:
+                    if cols == Int(block_dim) * (simd_width * 2):
+                        if weight_offset == Scalar[dtype](0):
+                            comptime kernel = rms_norm_gpu_warp_tiling_aligned[
+                                mut=gamma.mut,
+                                LayoutType=gamma.LayoutType,
+                                origin=gamma.origin,
+                                simd_width * 2,
+                                8,
+                                input_fn_2d,
+                                output_fn_2d,
+                                multiply_before_cast=multiply_before_cast,
+                                skip_weight_offset=True,
+                            ]
+                            ctx.enqueue_function[kernel, kernel](
+                                gamma,
+                                epsilon,
+                                weight_offset,
+                                cols,
+                                grid_dim=grid_dim,
+                                block_dim=block_dim,
+                                attributes=pdl_launch_attributes(pdl_level),
+                            )
+                        else:
+                            comptime kernel = rms_norm_gpu_warp_tiling_aligned[
+                                mut=gamma.mut,
+                                LayoutType=gamma.LayoutType,
+                                origin=gamma.origin,
+                                simd_width * 2,
+                                8,
+                                input_fn_2d,
+                                output_fn_2d,
+                                multiply_before_cast=multiply_before_cast,
+                            ]
+                            ctx.enqueue_function[kernel, kernel](
+                                gamma,
+                                epsilon,
+                                weight_offset,
+                                cols,
+                                grid_dim=grid_dim,
+                                block_dim=block_dim,
+                                attributes=pdl_launch_attributes(pdl_level),
+                            )
+                    else:
+                        comptime kernel = rms_norm_gpu_warp_tiling[
+                            mut=gamma.mut,
+                            LayoutType=gamma.LayoutType,
+                            origin=gamma.origin,
+                            simd_width * 2,
+                            max_warps_per_block,
+                            input_fn_2d,
+                            output_fn_2d,
+                            multiply_before_cast=multiply_before_cast,
+                        ]
+                        ctx.enqueue_function[kernel, kernel](
+                            gamma,
+                            epsilon,
+                            weight_offset,
+                            cols,
+                            grid_dim=grid_dim,
+                            block_dim=block_dim,
+                            attributes=pdl_launch_attributes(pdl_level),
+                        )
+            else:
+                if cols == Int(block_dim) * (simd_width * 2):
+                    if weight_offset == Scalar[dtype](0):
+                        comptime kernel = rms_norm_gpu_warp_tiling_aligned[
+                            mut=gamma.mut,
+                            LayoutType=gamma.LayoutType,
+                            origin=gamma.origin,
+                            simd_width * 2,
+                            8,
+                            input_fn_2d,
+                            output_fn_2d,
+                            multiply_before_cast=multiply_before_cast,
+                            skip_weight_offset=True,
+                        ]
+                        ctx.enqueue_function[kernel, kernel](
+                            gamma,
+                            epsilon,
+                            weight_offset,
+                            cols,
+                            grid_dim=grid_dim,
+                            block_dim=block_dim,
+                            attributes=pdl_launch_attributes(pdl_level),
+                        )
+                    else:
+                        comptime kernel = rms_norm_gpu_warp_tiling_aligned[
+                            mut=gamma.mut,
+                            LayoutType=gamma.LayoutType,
+                            origin=gamma.origin,
+                            simd_width * 2,
+                            8,
+                            input_fn_2d,
+                            output_fn_2d,
+                            multiply_before_cast=multiply_before_cast,
+                        ]
+                        ctx.enqueue_function[kernel, kernel](
+                            gamma,
+                            epsilon,
+                            weight_offset,
+                            cols,
+                            grid_dim=grid_dim,
+                            block_dim=block_dim,
+                            attributes=pdl_launch_attributes(pdl_level),
+                        )
+                else:
+                    comptime kernel = rms_norm_gpu_warp_tiling[
+                        mut=gamma.mut,
+                        LayoutType=gamma.LayoutType,
+                        origin=gamma.origin,
+                        simd_width * 2,
+                        max_warps_per_block,
+                        input_fn_2d,
+                        output_fn_2d,
+                        multiply_before_cast=multiply_before_cast,
+                    ]
+                    ctx.enqueue_function[kernel, kernel](
+                        gamma,
+                        epsilon,
+                        weight_offset,
+                        cols,
+                        grid_dim=grid_dim,
+                        block_dim=block_dim,
+                        attributes=pdl_launch_attributes(pdl_level),
+                    )
         elif cols <= (WARP_SIZE * simd_width * max_warps_per_block):
-            comptime kernel = rms_norm_gpu_warp_tiling[
-                mut=gamma.mut,
-                LayoutType=gamma.LayoutType,
-                origin=gamma.origin,
-                simd_width,
-                max_warps_per_block,
-                input_fn_2d,
-                output_fn_2d,
-                multiply_before_cast=multiply_before_cast,
-            ]
-            ctx.enqueue_function[kernel, kernel](
-                gamma,
-                epsilon,
-                weight_offset,
-                cols,
-                grid_dim=grid_dim,
-                block_dim=block_dim,
-                attributes=pdl_launch_attributes(pdl_level),
-            )
+            if cols == Int(block_dim) * simd_width:
+                if weight_offset == Scalar[dtype](0):
+                    comptime kernel = rms_norm_gpu_warp_tiling_aligned[
+                        mut=gamma.mut,
+                        LayoutType=gamma.LayoutType,
+                        origin=gamma.origin,
+                        simd_width,
+                        16,
+                        input_fn_2d,
+                        output_fn_2d,
+                        multiply_before_cast=multiply_before_cast,
+                        skip_weight_offset=True,
+                    ]
+                    ctx.enqueue_function[kernel, kernel](
+                        gamma,
+                        epsilon,
+                        weight_offset,
+                        cols,
+                        grid_dim=grid_dim,
+                        block_dim=block_dim,
+                        attributes=pdl_launch_attributes(pdl_level),
+                    )
+                else:
+                    comptime kernel = rms_norm_gpu_warp_tiling_aligned[
+                        mut=gamma.mut,
+                        LayoutType=gamma.LayoutType,
+                        origin=gamma.origin,
+                        simd_width,
+                        16,
+                        input_fn_2d,
+                        output_fn_2d,
+                        multiply_before_cast=multiply_before_cast,
+                    ]
+                    ctx.enqueue_function[kernel, kernel](
+                        gamma,
+                        epsilon,
+                        weight_offset,
+                        cols,
+                        grid_dim=grid_dim,
+                        block_dim=block_dim,
+                        attributes=pdl_launch_attributes(pdl_level),
+                    )
+            else:
+                comptime kernel = rms_norm_gpu_warp_tiling[
+                    mut=gamma.mut,
+                    LayoutType=gamma.LayoutType,
+                    origin=gamma.origin,
+                    simd_width,
+                    max_warps_per_block,
+                    input_fn_2d,
+                    output_fn_2d,
+                    multiply_before_cast=multiply_before_cast,
+                ]
+                ctx.enqueue_function[kernel, kernel](
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    cols,
+                    grid_dim=grid_dim,
+                    block_dim=block_dim,
+                    attributes=pdl_launch_attributes(pdl_level),
+                )
         elif (
             cols <= (WARP_SIZE * (simd_width * 2) * max_warps_per_block)
             and cols % (simd_width * 2) == 0
@@ -1375,7 +2696,6 @@ def rms_norm_gpu[
             block_dim=block_dim,
             attributes=pdl_launch_attributes(pdl_level),
         )
-
 
 def rms_norm_cpu[
     dtype: DType,
@@ -1518,6 +2838,257 @@ def rms_norm_cpu[
 
 
 @always_inline
+def _rms_norm_gpu_exact_public_direct_io[
+    dtype: DType,
+    //,
+    input_pair_fn_rank2_direct: def[width: Int](
+        row: Int, col0: Int, col1: Int
+    ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]],
+    output_fn_rank2_direct: def[width: Int, alignment: Int](
+        row: Int, col: Int, val: SIMD[dtype, width]
+    ) capturing -> None,
+    multiply_before_cast: Bool,
+](
+    shape: IndexList[3],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    ctx: DeviceContext,
+    pdl_level: PDLLevel = PDLLevel(1),
+) raises -> Bool:
+    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
+    comptime if dtype != DType.bfloat16:
+        return False
+
+    var cols = Int(gamma.dim[0]())
+    if cols == 0 or shape[0] != 1:
+        return False
+
+    var rows = shape.flattened_length() // cols
+    if rows < 4096 or cols != 4096:
+        return False
+
+    if weight_offset != Scalar[dtype](0):
+        return False
+
+    comptime simd_width = simd_width_of[dtype, target=get_gpu_target()]()
+    if simd_width != 8:
+        return False
+
+    comptime exact_simd_width = simd_width * 2
+    comptime exact_max_warps_per_block = 4
+    comptime exact_block_dim = WARP_SIZE * exact_max_warps_per_block
+
+    if ctx.default_device_info.max_thread_block_size < exact_block_dim:
+        return False
+
+    comptime kernel = rms_norm_gpu_warp_tiling_aligned_two_tiles_paired_input_exact_4096[
+        mut=gamma.mut,
+        LayoutType=gamma.LayoutType,
+        origin=gamma.origin,
+        exact_simd_width,
+        exact_max_warps_per_block,
+        input_pair_fn_rank2_direct,
+        output_fn_rank2_direct,
+        multiply_before_cast=multiply_before_cast,
+    ]
+    ctx.enqueue_function[kernel, kernel](
+        gamma,
+        epsilon,
+        grid_dim=rows,
+        block_dim=exact_block_dim,
+        attributes=pdl_launch_attributes(pdl_level),
+    )
+    return True
+
+
+@always_inline
+def _rms_norm_gpu_exact_public_flat_direct_io[
+    dtype: DType,
+    //,
+    input_pair_fn_flat_direct: def[width: Int](
+        flat0: Int, flat1: Int
+    ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]],
+    output_fn_flat_direct: def[width: Int, alignment: Int](
+        flat: Int, val: SIMD[dtype, width]
+    ) capturing -> None,
+    multiply_before_cast: Bool,
+](
+    shape: IndexList[3],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    ctx: DeviceContext,
+    pdl_level: PDLLevel = PDLLevel(1),
+) raises -> Bool:
+    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
+    comptime if dtype != DType.bfloat16:
+        return False
+
+    var cols = Int(gamma.dim[0]())
+    if cols == 0 or shape[0] != 1:
+        return False
+
+    var rows = shape.flattened_length() // cols
+    if rows < 4096 or cols != 4096:
+        return False
+
+    if weight_offset != Scalar[dtype](0):
+        return False
+
+    comptime simd_width = simd_width_of[dtype, target=get_gpu_target()]()
+    if simd_width != 8:
+        return False
+
+    comptime exact_simd_width = simd_width * 2
+    comptime exact_max_warps_per_block = 4
+    comptime exact_block_dim = WARP_SIZE * exact_max_warps_per_block
+
+    if ctx.default_device_info.max_thread_block_size < exact_block_dim:
+        return False
+
+    comptime kernel = (
+        rms_norm_gpu_warp_tiling_aligned_two_tiles_flat_direct_exact_4096[
+            mut=gamma.mut,
+            LayoutType=gamma.LayoutType,
+            origin=gamma.origin,
+            exact_simd_width,
+            exact_max_warps_per_block,
+            input_pair_fn_flat_direct,
+            output_fn_flat_direct,
+            multiply_before_cast=multiply_before_cast,
+        ]
+    )
+    ctx.enqueue_function[kernel, kernel](
+        gamma,
+        epsilon,
+        grid_dim=rows,
+        block_dim=exact_block_dim,
+        attributes=pdl_launch_attributes(pdl_level),
+    )
+    return True
+
+
+@always_inline
+def _rms_norm_gpu_exact_public_rank2_only_via_flat_direct_io[
+    dtype: DType,
+    //,
+    input_pair_fn_rank2_direct: def[width: Int](
+        row: Int, col0: Int, col1: Int
+    ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]],
+    output_fn_rank2_direct: def[width: Int, alignment: Int](
+        row: Int, col: Int, val: SIMD[dtype, width]
+    ) capturing -> None,
+    multiply_before_cast: Bool,
+](
+    shape: IndexList[3],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    ctx: DeviceContext,
+    pdl_level: PDLLevel = PDLLevel(1),
+) raises -> Bool:
+    comptime exact_cols_shift = 12
+    comptime exact_cols_mask = (1 << exact_cols_shift) - 1
+
+    @always_inline
+    @parameter
+    def input_pair_fn_flat_from_rank2[
+        width: Int
+    ](
+        flat0: Int, flat1: Int
+    ) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
+        var row = flat0 >> exact_cols_shift
+        return input_pair_fn_rank2_direct[width](
+            row,
+            flat0 & exact_cols_mask,
+            flat1 & exact_cols_mask,
+        )
+
+    @always_inline
+    @parameter
+    def output_fn_flat_from_rank2[
+        width: Int, alignment: Int
+    ](flat: Int, val: SIMD[dtype, width]) -> None:
+        var row = flat >> exact_cols_shift
+        output_fn_rank2_direct[width, alignment](
+            row, flat & exact_cols_mask, val
+        )
+
+    return _rms_norm_gpu_exact_public_flat_direct_io[
+        input_pair_fn_flat_from_rank2,
+        output_fn_flat_from_rank2,
+        multiply_before_cast=multiply_before_cast,
+    ](shape, gamma, epsilon, weight_offset, ctx, pdl_level)
+
+
+@always_inline
+def _rms_norm_gpu_exact_public_single_flat_direct_io[
+    dtype: DType,
+    //,
+    input_fn_flat_direct: def[width: Int](
+        flat: Int
+    ) capturing -> SIMD[dtype, width],
+    output_fn_flat_direct: def[width: Int, alignment: Int](
+        flat: Int, val: SIMD[dtype, width]
+    ) capturing -> None,
+    multiply_before_cast: Bool,
+](
+    shape: IndexList[3],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    ctx: DeviceContext,
+    pdl_level: PDLLevel = PDLLevel(1),
+) raises -> Bool:
+    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
+    comptime if dtype != DType.bfloat16:
+        return False
+
+    var cols = Int(gamma.dim[0]())
+    if cols == 0 or shape[0] != 1:
+        return False
+
+    var rows = shape.flattened_length() // cols
+    if rows < 4096 or cols != 4096:
+        return False
+
+    if weight_offset != Scalar[dtype](0):
+        return False
+
+    comptime simd_width = simd_width_of[dtype, target=get_gpu_target()]()
+    if simd_width != 8:
+        return False
+
+    comptime exact_simd_width = simd_width * 2
+    comptime exact_max_warps_per_block = 4
+    comptime exact_block_dim = WARP_SIZE * exact_max_warps_per_block
+
+    if ctx.default_device_info.max_thread_block_size < exact_block_dim:
+        return False
+
+    comptime kernel = (
+        rms_norm_gpu_warp_tiling_aligned_two_tiles_single_flat_input_exact_4096[
+            mut=gamma.mut,
+            LayoutType=gamma.LayoutType,
+            origin=gamma.origin,
+            exact_simd_width,
+            exact_max_warps_per_block,
+            input_fn_flat_direct,
+            output_fn_flat_direct,
+            multiply_before_cast=multiply_before_cast,
+        ]
+    )
+    ctx.enqueue_function[kernel, kernel](
+        gamma,
+        epsilon,
+        grid_dim=rows,
+        block_dim=exact_block_dim,
+        attributes=pdl_launch_attributes(pdl_level),
+    )
+    return True
+
+
 def _rms_norm_impl[
     dtype: DType,
     rank: Int,
@@ -1530,6 +3101,29 @@ def _rms_norm_impl[
     /,
     target: StaticString = "cpu",
     multiply_before_cast: Bool = True,
+    input_pair_fn_rank2_direct: OptionalReg[
+        def[width: Int](
+            row: Int, col0: Int, col1: Int
+        ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]
+    ] = None,
+    output_fn_rank2_direct: OptionalReg[
+        def[width: Int, alignment: Int](
+            row: Int, col: Int, val: SIMD[dtype, width]
+        ) capturing -> None
+    ] = None,
+    input_fn_flat_direct: OptionalReg[
+        def[width: Int](flat: Int) capturing -> SIMD[dtype, width]
+    ] = None,
+    input_pair_fn_flat_direct: OptionalReg[
+        def[width: Int](
+            flat0: Int, flat1: Int
+        ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]
+    ] = None,
+    output_fn_flat_direct: OptionalReg[
+        def[width: Int, alignment: Int](
+            flat: Int, val: SIMD[dtype, width]
+        ) capturing -> None
+    ] = None,
 ](
     shape: IndexList[rank],
     gamma: TileTensor[dtype, ...],
@@ -1558,8 +3152,88 @@ def _rms_norm_impl[
             input_0_fn, output_fn, multiply_before_cast=multiply_before_cast
         ](shape, gamma, epsilon, weight_offset)
     elif is_gpu[target]():
+        comptime if rank == 3:
+            comptime if input_pair_fn_flat_direct:
+                comptime if output_fn_flat_direct:
+                    comptime direct_input_pair_fn_flat = (
+                        input_pair_fn_flat_direct.value()
+                    )
+                    comptime direct_output_fn_flat = (
+                        output_fn_flat_direct.value()
+                    )
+                    if _rms_norm_gpu_exact_public_flat_direct_io[
+                        direct_input_pair_fn_flat,
+                        direct_output_fn_flat,
+                        multiply_before_cast=multiply_before_cast,
+                    ](
+                        rebind[IndexList[3]](shape),
+                        gamma,
+                        epsilon,
+                        weight_offset,
+                        ctx.get_device_context(),
+                    ):
+                        return
+            comptime if input_fn_flat_direct:
+                comptime if output_fn_flat_direct:
+                    comptime direct_input_fn_flat = (
+                        input_fn_flat_direct.value()
+                    )
+                    comptime direct_output_fn_flat = (
+                        output_fn_flat_direct.value()
+                    )
+                    if _rms_norm_gpu_exact_public_single_flat_direct_io[
+                        direct_input_fn_flat,
+                        direct_output_fn_flat,
+                        multiply_before_cast=multiply_before_cast,
+                    ](
+                        rebind[IndexList[3]](shape),
+                        gamma,
+                        epsilon,
+                        weight_offset,
+                        ctx.get_device_context(),
+                    ):
+                        return
+            comptime if (
+                not input_pair_fn_flat_direct or not output_fn_flat_direct
+            ):
+                comptime if input_pair_fn_rank2_direct:
+                    comptime if output_fn_rank2_direct:
+                        comptime direct_input_pair_fn = (
+                            input_pair_fn_rank2_direct.value()
+                        )
+                        comptime direct_output_fn = (
+                            output_fn_rank2_direct.value()
+                        )
+                        if _rms_norm_gpu_exact_public_direct_io[
+                            direct_input_pair_fn,
+                            direct_output_fn,
+                            multiply_before_cast=multiply_before_cast,
+                        ](
+                            rebind[IndexList[3]](shape),
+                            gamma,
+                            epsilon,
+                            weight_offset,
+                            ctx.get_device_context(),
+                        ):
+                            return
+                        if _rms_norm_gpu_exact_public_rank2_only_via_flat_direct_io[
+                            direct_input_pair_fn,
+                            direct_output_fn,
+                            multiply_before_cast=multiply_before_cast,
+                        ](
+                            rebind[IndexList[3]](shape),
+                            gamma,
+                            epsilon,
+                            weight_offset,
+                            ctx.get_device_context(),
+                        ):
+                            return
         rms_norm_gpu[
-            input_0_fn, output_fn, multiply_before_cast=multiply_before_cast
+            input_0_fn,
+            output_fn,
+            multiply_before_cast=multiply_before_cast,
+            input_pair_fn_rank2_direct=input_pair_fn_rank2_direct,
+            output_fn_rank2_direct=output_fn_rank2_direct,
         ](
             shape,
             gamma,
@@ -2116,9 +3790,12 @@ def rms_norm_fused_residual_add_gpu[
     comptime simd_width = simd_width_of[dtype, target=get_gpu_target()]()
     comptime max_warps_per_block = ctx.default_device_info.max_thread_block_size // WARP_SIZE
 
+    var use_doubled = rows >= 1024
+    var effective_simd = simd_width * 2 if use_doubled else simd_width
+
     var grid_dim = rows
     var block_dim = min(
-        ceildiv(ceildiv(cols, simd_width), WARP_SIZE) * WARP_SIZE,
+        ceildiv(ceildiv(cols, effective_simd), WARP_SIZE) * WARP_SIZE,
         WARP_SIZE * max_warps_per_block,
     )
 
@@ -2126,7 +3803,48 @@ def rms_norm_fused_residual_add_gpu[
         # When the number of columns are less enough that they can be placed in
         # registers we do warp tiling which is a single pass to do mean/var
         # computation and normalization.
-        if cols <= (WARP_SIZE * simd_width * max_warps_per_block):
+        if (
+            use_doubled
+            and cols % (simd_width * 2) == 0
+            and cols
+            <= (WARP_SIZE * (simd_width * 2) * max_warps_per_block)
+        ):
+            var doubled_block_dim = min(
+                ceildiv(ceildiv(cols, simd_width * 2), WARP_SIZE) * WARP_SIZE,
+                WARP_SIZE * max_warps_per_block,
+            )
+            comptime kernel = rms_norm_fused_residual_add_gpu_warp_tiling[
+                mut1=gamma1.mut,
+                LayoutType1=gamma1.LayoutType,
+                origin1=gamma1.origin,
+                mut2=gamma2.mut,
+                LayoutType2=gamma2.LayoutType,
+                origin2=gamma2.origin,
+                simd_width * 2,
+                max_warps_per_block,
+                input_fn_2d,
+                residual_input_fn_2d,
+                output_fn_2d,
+                output_residual_fn_2d,
+                multiply_before_cast=multiply_before_cast,
+            ]
+            ctx.enqueue_function[kernel, kernel](
+                gamma1,
+                epsilon1,
+                weight_offset1,
+                gamma2,
+                epsilon2,
+                weight_offset2,
+                cols,
+                grid_dim=grid_dim,
+                block_dim=doubled_block_dim,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+        elif cols <= (WARP_SIZE * simd_width * max_warps_per_block):
+            var single_block_dim = min(
+                ceildiv(ceildiv(cols, simd_width), WARP_SIZE) * WARP_SIZE,
+                WARP_SIZE * max_warps_per_block,
+            )
             comptime kernel = rms_norm_fused_residual_add_gpu_warp_tiling[
                 mut1=gamma1.mut,
                 LayoutType1=gamma1.LayoutType,
@@ -2151,7 +3869,7 @@ def rms_norm_fused_residual_add_gpu[
                 weight_offset2,
                 cols,
                 grid_dim=grid_dim,
-                block_dim=block_dim,
+                block_dim=single_block_dim,
                 attributes=pdl_launch_attributes(PDLLevel(1)),
             )
         else:
@@ -2384,6 +4102,29 @@ def rms_norm[
     /,
     target: StaticString = "cpu",
     multiply_before_cast: Bool = True,
+    input_pair_fn_rank2_direct: OptionalReg[
+        def[width: Int](
+            row: Int, col0: Int, col1: Int
+        ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]
+    ] = None,
+    output_fn_rank2_direct: OptionalReg[
+        def[width: Int, alignment: Int](
+            row: Int, col: Int, val: SIMD[dtype, width]
+        ) capturing -> None
+    ] = None,
+    input_fn_flat_direct: OptionalReg[
+        def[width: Int](flat: Int) capturing -> SIMD[dtype, width]
+    ] = None,
+    input_pair_fn_flat_direct: OptionalReg[
+        def[width: Int](
+            flat0: Int, flat1: Int
+        ) capturing -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]
+    ] = None,
+    output_fn_flat_direct: OptionalReg[
+        def[width: Int, alignment: Int](
+            flat: Int, val: SIMD[dtype, width]
+        ) capturing -> None
+    ] = None,
 ](
     shape: IndexList[rank],
     gamma: TileTensor[dtype, ...],
@@ -2417,6 +4158,11 @@ def rms_norm[
             output_fn_wrapper,
             target=target,
             multiply_before_cast=multiply_before_cast,
+            input_pair_fn_rank2_direct=input_pair_fn_rank2_direct,
+            output_fn_rank2_direct=output_fn_rank2_direct,
+            input_fn_flat_direct=input_fn_flat_direct,
+            input_pair_fn_flat_direct=input_pair_fn_flat_direct,
+            output_fn_flat_direct=output_fn_flat_direct,
         ](shape, gamma, epsilon, weight_offset, ctx)
 
 

--- a/max/kernels/test/gpu/nn/test_rms_norm.mojo
+++ b/max/kernels/test/gpu/nn/test_rms_norm.mojo
@@ -92,9 +92,9 @@ def run_rms_norm_gpu[
     @parameter
     def input_pair_fn_rank2_direct[
         width: Int
-    ](
-        row: Int, col0: Int, col1: Int
-    ) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
+    ](row: Int, col0: Int, col1: Int) -> Tuple[
+        SIMD[dtype, width], SIMD[dtype, width]
+    ]:
         comptime a = align_of[SIMD[dtype, width]]()
         var row_offset = row * cols
         return (
@@ -105,9 +105,7 @@ def run_rms_norm_gpu[
     @always_inline
     @__copy_capture(data_buf)
     @parameter
-    def input_fn_flat_direct[
-        width: Int
-    ](flat: Int) -> SIMD[dtype, width]:
+    def input_fn_flat_direct[width: Int](flat: Int) -> SIMD[dtype, width]:
         comptime a = align_of[SIMD[dtype, width]]()
         return data_buf.ptr.load[width=width, alignment=a](flat)
 
@@ -116,9 +114,7 @@ def run_rms_norm_gpu[
     @parameter
     def input_pair_fn_flat_direct[
         width: Int
-    ](
-        flat0: Int, flat1: Int
-    ) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
+    ](flat0: Int, flat1: Int) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
         comptime a = align_of[SIMD[dtype, width]]()
         return (
             data_buf.ptr.load[width=width, alignment=a](flat0),

--- a/max/kernels/test/gpu/nn/test_rms_norm.mojo
+++ b/max/kernels/test/gpu/nn/test_rms_norm.mojo
@@ -13,6 +13,7 @@
 
 from std.math import sqrt
 from std.random import rand
+from std.sys.info import align_of
 
 from std.gpu.host import DeviceContext
 from layout import Coord, Idx, TileTensor, row_major
@@ -41,7 +42,14 @@ def compute_rms[
 
 
 def run_rms_norm_gpu[
-    rank: Int, //, dtype: DType, *, static_cols: Int = -1
+    rank: Int,
+    //,
+    dtype: DType,
+    *,
+    static_cols: Int = -1,
+    public_direct_io: Bool = False,
+    pair_flat_only_public_direct_io: Bool = False,
+    rank2_only_public_direct_io: Bool = False,
 ](ctx: DeviceContext, shape: IndexList[rank], rtol: Float64 = 0.01) raises:
     print("== run_rms_norm_gpu")
 
@@ -80,6 +88,44 @@ def run_rms_norm_gpu[
         return data_buf.ptr.load[width=width](idx)
 
     @always_inline
+    @__copy_capture(data_buf, cols)
+    @parameter
+    def input_pair_fn_rank2_direct[
+        width: Int
+    ](
+        row: Int, col0: Int, col1: Int
+    ) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
+        comptime a = align_of[SIMD[dtype, width]]()
+        var row_offset = row * cols
+        return (
+            data_buf.ptr.load[width=width, alignment=a](row_offset + col0),
+            data_buf.ptr.load[width=width, alignment=a](row_offset + col1),
+        )
+
+    @always_inline
+    @__copy_capture(data_buf)
+    @parameter
+    def input_fn_flat_direct[
+        width: Int
+    ](flat: Int) -> SIMD[dtype, width]:
+        comptime a = align_of[SIMD[dtype, width]]()
+        return data_buf.ptr.load[width=width, alignment=a](flat)
+
+    @always_inline
+    @__copy_capture(data_buf)
+    @parameter
+    def input_pair_fn_flat_direct[
+        width: Int
+    ](
+        flat0: Int, flat1: Int
+    ) -> Tuple[SIMD[dtype, width], SIMD[dtype, width]]:
+        comptime a = align_of[SIMD[dtype, width]]()
+        return (
+            data_buf.ptr.load[width=width, alignment=a](flat0),
+            data_buf.ptr.load[width=width, alignment=a](flat1),
+        )
+
+    @always_inline
     @__copy_capture(data_buf)
     @parameter
     def identity_output_fn[
@@ -88,9 +134,75 @@ def run_rms_norm_gpu[
         var idx = data_buf.layout(Coord(coords))
         data_buf.ptr.store[width=width, alignment=alignment](idx, val)
 
-    rms_norm_gpu[input_fn, identity_output_fn, multiply_before_cast=True](
-        shape, gamma, epsilon, weight_offset, ctx
-    )
+    @always_inline
+    @__copy_capture(data_buf)
+    @parameter
+    def identity_output_fn_ranked[
+        width: Int, _rank: Int, alignment: Int
+    ](coords: IndexList[_rank], val: SIMD[dtype, width]) -> None:
+        var idx = data_buf.layout(Coord(coords))
+        data_buf.ptr.store[width=width, alignment=alignment](idx, val)
+
+    @always_inline
+    @__copy_capture(data_buf, cols)
+    @parameter
+    def output_fn_rank2_direct[
+        width: Int, alignment: Int
+    ](row: Int, col: Int, val: SIMD[dtype, width]) -> None:
+        var row_offset = row * cols
+        data_buf.ptr.store[width=width, alignment=alignment](
+            row_offset + col, val
+        )
+
+    @always_inline
+    @__copy_capture(data_buf)
+    @parameter
+    def output_fn_flat_direct[
+        width: Int, alignment: Int
+    ](flat: Int, val: SIMD[dtype, width]) -> None:
+        data_buf.ptr.store[width=width, alignment=alignment](flat, val)
+
+    comptime if public_direct_io:
+        comptime if pair_flat_only_public_direct_io:
+            rms_norm[
+                dtype,
+                rank,
+                input_fn,
+                identity_output_fn_ranked,
+                target="gpu",
+                multiply_before_cast=True,
+                input_pair_fn_flat_direct=input_pair_fn_flat_direct,
+                output_fn_flat_direct=output_fn_flat_direct,
+            ](shape, gamma, epsilon, weight_offset, ctx)
+        elif rank2_only_public_direct_io:
+            rms_norm[
+                dtype,
+                rank,
+                input_fn,
+                identity_output_fn_ranked,
+                target="gpu",
+                multiply_before_cast=True,
+                input_pair_fn_rank2_direct=input_pair_fn_rank2_direct,
+                output_fn_rank2_direct=output_fn_rank2_direct,
+            ](shape, gamma, epsilon, weight_offset, ctx)
+        else:
+            rms_norm[
+                dtype,
+                rank,
+                input_fn,
+                identity_output_fn_ranked,
+                target="gpu",
+                multiply_before_cast=True,
+                input_pair_fn_rank2_direct=input_pair_fn_rank2_direct,
+                output_fn_rank2_direct=output_fn_rank2_direct,
+                input_fn_flat_direct=input_fn_flat_direct,
+                input_pair_fn_flat_direct=input_pair_fn_flat_direct,
+                output_fn_flat_direct=output_fn_flat_direct,
+            ](shape, gamma, epsilon, weight_offset, ctx)
+    else:
+        rms_norm_gpu[input_fn, identity_output_fn, multiply_before_cast=True](
+            shape, gamma, epsilon, weight_offset, ctx
+        )
     ctx.enqueue_copy(res, data_d)
     ctx.synchronize()
 
@@ -135,3 +247,16 @@ def main() raises:
         run_rms_norm_gpu[DType.bfloat16, static_cols=16384](
             ctx, Index(2, 16384), rtol=2e-2
         )
+        run_rms_norm_gpu[DType.bfloat16, public_direct_io=True](
+            ctx, Index(1, 4096, 4096), rtol=2e-2
+        )
+        run_rms_norm_gpu[
+            DType.bfloat16,
+            public_direct_io=True,
+            pair_flat_only_public_direct_io=True,
+        ](ctx, Index(1, 4096, 4096), rtol=2e-2)
+        run_rms_norm_gpu[
+            DType.bfloat16,
+            public_direct_io=True,
+            rank2_only_public_direct_io=True,
+        ](ctx, Index(1, 4096, 4096), rtol=2e-2)

--- a/max/kernels/test/gpu/nn/test_rms_norm_fused_residual_add.mojo
+++ b/max/kernels/test/gpu/nn/test_rms_norm_fused_residual_add.mojo
@@ -262,6 +262,9 @@ def main() raises:
         run_rms_norm_fused_residual_add_gpu[DType.bfloat16](
             ctx, Index(2, 16385)
         )
+        run_rms_norm_fused_residual_add_gpu[DType.bfloat16](
+            ctx, Index(1, 4096, 4096), rtol=2e-2
+        )
 
         # TODO(KERN-1951): the following fails with CUDA_ERROR_INVALID_VALUE, not sure why
         # run_rms_norm_fused_residual_add_gpu[DType.float32](ctx, Index(2, 16384))


### PR DESCRIPTION
## Summary
- extend the exact-shape rank-3 RMSNorm path in `normalization.mojo`
- refresh the benchmark target and GPU tests that cover the tuned exact-4096 route
- keep the latest tile-0 row-index inline change on top of the accepted exact-4096 branch

## Benchmark Notes
- historical branch-note exact-shape A/B on the kept branch:
  - baseline split latency: `7.63199 us`
  - candidate split latency: `7.60191 us`
  - direct delta: `-0.03008 us` (`-0.39%`)
- historical warmed `--run-only` replay average:
  - baseline: `7.615355 us`
  - candidate: `7.597038 us`
  - average delta: `-0.01832 us` (`-0.24%`)
- fresh exact-head B200 rerun on the current PR head produced:
  - `1x1x4096`: `5.67936 us`
  - `1x512x4096`: `3.82495 us`
  - `1x1024x4096`: `4.58303 us`
  - `1x4096x4096`: `12.23072 us`
- the current exact-head rerun therefore does not reproduce the historical `1x4096x4096` exact-shape headline; the earlier numbers should be read as branch-note campaign context
- validation still passes:
  - `//max/kernels/test/gpu/nn:test_rms_norm.mojo.test`
