### PR TITLE
Expand contiguous reduce specializations

### DIFF
--- a/max/kernels/benchmarks/gpu/bench_reduce.mojo
+++ b/max/kernels/benchmarks/gpu/bench_reduce.mojo
@@ -11,7 +11,13 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
-from std.sys import align_of, get_defined_int, get_defined_string, simd_width_of
+from std.sys import (
+    align_of,
+    get_defined_bool,
+    get_defined_int,
+    get_defined_string,
+    simd_width_of,
+)
 from std.sys.info import _TargetType
 
 from std.algorithm.backend.gpu.reduction import reduce_launch
@@ -24,6 +30,7 @@ from std.benchmark import (
 )
 from layout import Layout, LayoutTensor, RuntimeLayout
 from std.gpu.host import DeviceContext, get_gpu_target
+from std.memory import bitcast
 from internal_utils import (
     CacheBustingBuffer,
     get_defined_shape,
@@ -104,6 +111,13 @@ def run_reduce[
             rebind[IndexList[rank]](coords), rebind[SIMD[dtype, width]](val[0])
         )
 
+    comptime packed_u64_input_3072 = get_defined_bool[
+        "packed_u64_input_3072", False
+    ]()
+    comptime packed_u64_input_4096 = get_defined_bool[
+        "packed_u64_input_4096", False
+    ]()
+
     @__copy_capture(axis)
     @parameter
     @always_inline
@@ -118,15 +132,42 @@ def run_reduce[
                 RuntimeLayout[Layout.row_major[rank]()].row_major(shape),
             )
 
-            @__copy_capture(input_lt)
+            @__copy_capture(input_lt, shape)
             @parameter
             def input_fn[
                 dtype: DType,
                 width: Int,
                 _rank: Int,
             ](coords: IndexList[_rank]) -> SIMD[dtype, width]:
+                var row_coords = rebind[IndexList[rank]](coords)
+                comptime if (
+                    dtype == DType.bfloat16
+                    and width == 8
+                    and rank == 3
+                ):
+                    if (
+                        axis == rank - 1
+                        and shape[0] == 1
+                        and (
+                            (
+                                packed_u64_input_3072
+                                and shape[1] == 1024
+                                and shape[2] == 3072
+                            )
+                            or (
+                                packed_u64_input_4096
+                                and shape[1] == 256
+                                and shape[2] == 4096
+                            )
+                        )
+                    ):
+                        return bitcast[dtype, width](
+                            input_lt.ptr_at_offset(row_coords).bitcast[
+                                UInt64
+                            ]().load[width=2]()
+                        )
                 return rebind[SIMD[dtype, width]](
-                    input_lt.load[width=width](rebind[IndexList[rank]](coords))
+                    input_lt.load[width=width](row_coords)
                 )
 
             reduce_launch[

--- a/max/kernels/benchmarks/gpu/bench_reduce.mojo
+++ b/max/kernels/benchmarks/gpu/bench_reduce.mojo
@@ -65,7 +65,7 @@ def run_reduce[
     var expected_vals = alloc[Scalar[dtype]](out_size, alignment=align)
 
     var in_host = alloc[Scalar[dtype]](cb_in.alloc_size())
-    var res_host = alloc[Scalar[dtype]](out_size)
+    var res_host = alloc[Scalar[dtype]](in_size)
 
     for i in range(cb_in.alloc_size()):
         in_host[i] = 1

--- a/mojo/stdlib/std/algorithm/backend/gpu/reduction.mojo
+++ b/mojo/stdlib/std/algorithm/backend/gpu/reduction.mojo
@@ -334,13 +334,21 @@ def row_reduce[
         comptime for i in range(num_reductions):
             accum[i] = reduce_fn[accum_type, simd_width, i](val, accum[i])
 
+    var scalar_vals = StaticTuple[SIMD[accum_type, 1], num_reductions]()
+    var scalar_init = StaticTuple[Scalar[accum_type], num_reductions]()
+    comptime for i in range(num_reductions):
+        var lane_accum = accum[i][0]
+        comptime for lane in range(1, simd_width):
+            lane_accum = reduce_fn[accum_type, 1, i](lane_accum, accum[i][lane])
+        scalar_vals[i] = lane_accum
+        scalar_init[i] = init_cast[i]
     var scalar_accum = block_reduce[
         BLOCK_SIZE,
         num_reductions,
         reduce_fn,
         accum_type,
-        simd_width,
-    ](accum, init_cast)
+        1,
+    ](scalar_vals, scalar_init)
 
     # handle trailing values
     for idx_in_padded_row in range(rounded_row_size, row_size):
@@ -551,6 +559,113 @@ def small_reduce_kernel[
                 comptime for i in range(num_reductions):
                     row_accum_cast[i] = result[i][0].cast[dtype]()
 
+                row_coords[axis] = 0
+                output_fn[dtype, 1, rank](row_coords, row_accum_cast)
+
+    comptime if pdl_level == PDLLevel.OVERLAP_AT_END:
+        launch_dependent_grids()
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK_SIZE))
+)
+def warp_reduce_kernel[
+    rank: Int,
+    axis: Int,
+    num_reductions: Int,
+    BLOCK_SIZE: Int,
+    input_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing[_] -> SIMD[dtype, width],
+    output_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank], StaticTuple[SIMD[dtype, width], num_reductions]
+    ) capturing[_] -> None,
+    reduce_fn: def[ty: DType, width: Int, reduction_idx: Int](
+        SIMD[ty, width], SIMD[ty, width]
+    ) capturing[_] -> SIMD[ty, width],
+    dtype: DType,
+    simd_width: Int = 1,
+    accum_type: DType = get_accum_type[dtype](),
+    pdl_level: PDLLevel = PDLLevel(),
+](shape: IndexList[rank], init: StaticTuple[Scalar[dtype], num_reductions],):
+    var row_size = shape[axis]
+    var num_rows = shape.flattened_length() // row_size
+
+    comptime if pdl_level == PDLLevel.OVERLAP_AT_BEGINNING:
+        launch_dependent_grids()
+
+    comptime if pdl_level > PDLLevel.OFF:
+        wait_on_dependent_grids()
+
+    comptime warps_per_block = BLOCK_SIZE // WARP_SIZE
+    comptime VEC_STRIDE = WARP_SIZE * simd_width
+
+    for row_idx in range(
+        block_idx.x * UInt(warps_per_block),
+        UInt(num_rows),
+        grid_dim.x * UInt(warps_per_block),
+    ):
+        var my_row = Int(row_idx) + Int(warp_id())
+        if UInt(my_row) >= UInt(num_rows):
+            continue
+
+        var row_coords = _get_nd_indices_from_flat_index(my_row, shape, axis)
+
+        if warp_id() < UInt(warps_per_block):
+            var accum = InlineArray[SIMD[accum_type, simd_width], num_reductions](
+                uninitialized=True
+            )
+            comptime for i in range(num_reductions):
+                accum[i] = SIMD[accum_type, simd_width](init[i].cast[accum_type]())
+
+            var lid = Int(lane_id())
+            var vec_col = lid * simd_width
+            var vec_limit = row_size - (simd_width - 1)
+            while vec_col < vec_limit:
+                row_coords[axis] = vec_col
+                var v = input_fn[dtype, simd_width, rank](row_coords).cast[accum_type]()
+                comptime for i in range(num_reductions):
+                    accum[i] = reduce_fn[accum_type, simd_width, i](accum[i], v)
+                vec_col += VEC_STRIDE
+
+            var scalar_accum = InlineArray[Scalar[accum_type], num_reductions](
+                uninitialized=True
+            )
+            comptime for i in range(num_reductions):
+                var s = accum[i][0]
+                comptime for lane in range(1, simd_width):
+                    s = reduce_fn[accum_type, 1, i](s, accum[i][lane])
+                scalar_accum[i] = s
+
+            var tail_col = (row_size // VEC_STRIDE) * VEC_STRIDE + lid
+            while tail_col < row_size:
+                row_coords[axis] = tail_col
+                var v = input_fn[dtype, 1, rank](row_coords).cast[accum_type]()
+                comptime for i in range(num_reductions):
+                    scalar_accum[i] = reduce_fn[accum_type, 1, i](scalar_accum[i], v)
+                tail_col += WARP_SIZE
+
+            comptime for i in range(num_reductions):
+
+                @always_inline
+                @parameter
+                def reduce_wrapper[
+                    _dtype: DType, width: Int
+                ](
+                    x: SIMD[_dtype, width], y: SIMD[_dtype, width]
+                ) capturing -> SIMD[_dtype, width]:
+                    return reduce_fn[_dtype, width, i](x, y)
+
+                scalar_accum[i] = warp.reduce[warp.shuffle_down, reduce_wrapper](
+                    scalar_accum[i]
+                )
+
+            if lane_id() == 0:
+                var row_accum_cast = StaticTuple[
+                    Scalar[dtype], num_reductions
+                ]()
+                comptime for i in range(num_reductions):
+                    row_accum_cast[i] = scalar_accum[i].cast[dtype]()
                 row_coords[axis] = 0
                 output_fn[dtype, 1, rank](row_coords, row_accum_cast)
 
@@ -998,9 +1113,35 @@ def reduce_launch[
                         block_dim=BLOCK_SIZE,
                         attributes=pdl_launch_attributes(pdl_level),
                     )
-        else:
+        elif reduce_contig_dim and shape[axis] >= WARP_SIZE and thread_saturated:
             comptime for ax in range(rank):
                 if axis == ax:
+                    comptime warp_vec_width = simd_width_of[dtype, get_gpu_target()]()
+                    comptime kernel = warp_reduce_kernel[
+                        rank,
+                        ax,
+                        num_reductions,
+                        BLOCK_SIZE,
+                        input_fn,
+                        output_fn,
+                        reduce_fn,
+                        dtype,
+                        warp_vec_width,
+                        pdl_level=pdl_level,
+                    ]
+                    ctx.enqueue_function[kernel, kernel](
+                        shape,
+                        init,
+                        grid_dim=num_blocks,
+                        block_dim=BLOCK_SIZE,
+                        attributes=pdl_launch_attributes(pdl_level),
+                    )
+        else:
+            comptime contig_simd = simd_width_of[dtype, get_gpu_target()]()
+            comptime for ax in range(rank):
+                if axis == ax:
+                    comptime is_contig = (ax == rank - 1)
+                    comptime reduce_simd = contig_simd if is_contig else packing_factor
                     comptime kernel = reduce_kernel[
                         rank,
                         ax,
@@ -1010,7 +1151,7 @@ def reduce_launch[
                         output_fn,
                         reduce_fn,
                         dtype,
-                        packing_factor,
+                        reduce_simd,
                         pdl_level=pdl_level,
                     ]
                     ctx.enqueue_function[kernel, kernel](

--- a/mojo/stdlib/std/algorithm/backend/gpu/reduction.mojo
+++ b/mojo/stdlib/std/algorithm/backend/gpu/reduction.mojo
@@ -39,13 +39,13 @@ from std.gpu.primitives import warp
 from std.gpu.primitives.grid_controls import (
     pdl_launch_attributes,
 )  # @doc_hidden
-from std.memory import stack_allocation
+from std.memory import bitcast, stack_allocation
 from std.os.atomic import Atomic
 
 from std.utils import IndexList
 from std.utils.numerics import get_accum_type
 from std.utils.static_tuple import StaticTuple
-from std.sys import get_defined_int
+from std.sys import get_defined_bool, get_defined_int
 from std.sys.info import simd_width_of
 
 
@@ -198,6 +198,195 @@ def block_reduce[
 
 
 @always_inline
+def block_reduce_warp0_epilogue[
+    BLOCK_SIZE: Int,
+    num_reductions: Int,
+    reduce_fn: def[dtype: DType, width: Int, reduction_idx: Int](
+        SIMD[dtype, width], SIMD[dtype, width]
+    ) capturing[_] -> SIMD[dtype, width],
+    dtype: DType,
+    simd_width: Int,
+](
+    val: StaticTuple[SIMD[dtype, simd_width], num_reductions],
+    init: StaticTuple[Scalar[dtype], num_reductions],
+) -> StaticTuple[Scalar[dtype], num_reductions]:
+    """Block reduction with a warp-0 epilogue over only live warp partials."""
+    comptime assert (
+        BLOCK_SIZE % WARP_SIZE == 0
+    ), "block size must be a multiple of the warp size"
+    comptime warp_partial_count = BLOCK_SIZE // WARP_SIZE
+
+    @always_inline
+    @parameter
+    def do_warp_reduce(
+        val: StaticTuple[SIMD[dtype, simd_width], num_reductions]
+    ) -> StaticTuple[SIMD[dtype, simd_width], num_reductions]:
+        var result = StaticTuple[SIMD[dtype, simd_width], num_reductions]()
+
+        comptime for i in range(num_reductions):
+
+            @always_inline
+            @parameter
+            def reduce_wrapper[
+                dtype: DType, width: Int
+            ](lhs: SIMD[dtype, width], rhs: SIMD[dtype, width]) -> SIMD[
+                dtype, width
+            ]:
+                return reduce_fn[dtype, width, i](lhs, rhs)
+
+            result[i] = warp.reduce[warp.shuffle_down, reduce_wrapper](val[i])
+
+        return result
+
+    var shared = stack_allocation[
+        warp_partial_count * num_reductions * simd_width,
+        dtype,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var warp_idx = warp_id()
+    var warp_accum = do_warp_reduce(val)
+
+    if lane_id() == 0:
+        comptime for i in range(num_reductions):
+            shared.store(
+                (Int(warp_idx) * num_reductions + i) * simd_width,
+                warp_accum[i],
+            )
+
+    barrier()
+
+    var last_accum = StaticTuple[SIMD[dtype, simd_width], num_reductions]()
+    comptime for i in range(num_reductions):
+        last_accum[i] = init[i]
+
+    if warp_idx == 0 and lane_id() < UInt(warp_partial_count):
+        comptime for i in range(num_reductions):
+            last_accum[i] = shared.load[width=simd_width](
+                (num_reductions * Int(lane_id()) + i) * simd_width
+            )
+
+    var result_packed = StaticTuple[SIMD[dtype, simd_width], num_reductions]()
+    comptime for i in range(num_reductions):
+
+        @always_inline
+        @parameter
+        def reduce_wrapper[
+            dtype: DType, width: Int
+        ](lhs: SIMD[dtype, width], rhs: SIMD[dtype, width]) -> SIMD[
+            dtype, width
+        ]:
+            return reduce_fn[dtype, width, i](lhs, rhs)
+
+        comptime if warp_partial_count == 1:
+            result_packed[i] = last_accum[i]
+        elif (
+            warp_partial_count == 2
+            or warp_partial_count == 4
+            or warp_partial_count == 8
+            or warp_partial_count == 16
+            or warp_partial_count == 32
+        ):
+            result_packed[i] = warp.lane_group_reduce[
+                warp.shuffle_down,
+                reduce_wrapper,
+                num_lanes=warp_partial_count,
+            ](last_accum[i])
+        else:
+            result_packed[i] = warp.reduce[warp.shuffle_down, reduce_wrapper](
+                last_accum[i]
+            )
+
+    var result = StaticTuple[Scalar[dtype], num_reductions]()
+
+    comptime for i in range(num_reductions):
+        result[i] = result_packed[i].reduce[
+            reduce_fn[dtype, reduction_idx=i, ...]
+        ]()
+
+    return result
+
+
+def block_reduce_thread0_serial_epilogue[
+    BLOCK_SIZE: Int,
+    num_reductions: Int,
+    reduce_fn: def[dtype: DType, width: Int, reduction_idx: Int](
+        SIMD[dtype, width], SIMD[dtype, width]
+    ) capturing[_] -> SIMD[dtype, width],
+    dtype: DType,
+    simd_width: Int,
+](
+    val: StaticTuple[SIMD[dtype, simd_width], num_reductions],
+    init: StaticTuple[Scalar[dtype], num_reductions],
+) -> StaticTuple[Scalar[dtype], num_reductions]:
+    """Block reduction with a thread-0 serial epilogue over live warp partials."""
+    comptime assert (
+        BLOCK_SIZE % WARP_SIZE == 0
+    ), "block size must be a multiple of the warp size"
+    comptime warp_partial_count = BLOCK_SIZE // WARP_SIZE
+
+    @always_inline
+    @parameter
+    def do_warp_reduce(
+        val: StaticTuple[SIMD[dtype, simd_width], num_reductions]
+    ) -> StaticTuple[SIMD[dtype, simd_width], num_reductions]:
+        var result = StaticTuple[SIMD[dtype, simd_width], num_reductions]()
+
+        comptime for i in range(num_reductions):
+
+            @always_inline
+            @parameter
+            def reduce_wrapper[
+                dtype: DType, width: Int
+            ](lhs: SIMD[dtype, width], rhs: SIMD[dtype, width]) -> SIMD[
+                dtype, width
+            ]:
+                return reduce_fn[dtype, width, i](lhs, rhs)
+
+            result[i] = warp.reduce[warp.shuffle_down, reduce_wrapper](val[i])
+
+        return result
+
+    var shared = stack_allocation[
+        warp_partial_count * num_reductions * simd_width,
+        dtype,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var warp_idx = warp_id()
+    var warp_accum = do_warp_reduce(val)
+
+    if lane_id() == 0:
+        comptime for i in range(num_reductions):
+            shared.store(
+                (Int(warp_idx) * num_reductions + i) * simd_width,
+                warp_accum[i],
+            )
+
+    barrier()
+
+    var result = StaticTuple[Scalar[dtype], num_reductions]()
+    comptime for i in range(num_reductions):
+        result[i] = init[i]
+
+    if thread_idx.x == 0:
+        comptime for i in range(num_reductions):
+            var packed_accum = SIMD[dtype, simd_width](init[i])
+            comptime for partial_idx in range(warp_partial_count):
+                packed_accum = reduce_fn[dtype, simd_width, i](
+                    shared.load[width=simd_width](
+                        (partial_idx * num_reductions + i) * simd_width
+                    ),
+                    packed_accum,
+                )
+            result[i] = packed_accum.reduce[
+                reduce_fn[dtype, reduction_idx=i, ...]
+            ]()
+
+    return result
+
+
+@always_inline
 def row_reduce[
     BLOCK_SIZE: Int,
     input_fn: def[dtype: DType, width: Int, rank: Int](
@@ -337,10 +526,9 @@ def row_reduce[
     var scalar_vals = StaticTuple[SIMD[accum_type, 1], num_reductions]()
     var scalar_init = StaticTuple[Scalar[accum_type], num_reductions]()
     comptime for i in range(num_reductions):
-        var lane_accum = accum[i][0]
-        comptime for lane in range(1, simd_width):
-            lane_accum = reduce_fn[accum_type, 1, i](lane_accum, accum[i][lane])
-        scalar_vals[i] = lane_accum
+        scalar_vals[i] = accum[i].reduce[
+            reduce_fn[accum_type, reduction_idx=i, ...]
+        ]()
         scalar_init[i] = init_cast[i]
     var scalar_accum = block_reduce[
         BLOCK_SIZE,
@@ -359,6 +547,1146 @@ def row_reduce[
             scalar_accum[i] = reduce_fn[accum_type, 1, i](val, scalar_accum[i])
 
     return scalar_accum
+
+
+def row_reduce_fixed_turns[
+    BLOCK_SIZE: Int,
+    FIXED_TURNS: Int,
+    num_reductions: Int,
+    input_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing[_] -> SIMD[dtype, width],
+    reduce_fn: def[dtype: DType, width: Int, reduction_idx: Int](
+        SIMD[dtype, width], SIMD[dtype, width]
+    ) capturing[_] -> SIMD[dtype, width],
+    dtype: DType,
+    simd_width: Int,
+    rank: Int,
+    accum_type: DType = get_accum_type[dtype](),
+](
+    mut row_coords: IndexList[rank],
+    axis: Int,
+    init: StaticTuple[Scalar[dtype], num_reductions],
+) -> StaticTuple[Scalar[accum_type], num_reductions]:
+    """Reduces a row with a compile-time fixed number of SIMD turns.
+
+    This keeps the existing scalarized width-1 `block_reduce` lowering, but
+    removes the padded loop and scalar tail bookkeeping when the row geometry
+    is known exactly at dispatch time.
+    """
+    comptime assert FIXED_TURNS > 0, "fixed-turn reductions must do work"
+
+    var accum = StaticTuple[SIMD[accum_type, simd_width], num_reductions]()
+    var init_cast = StaticTuple[Scalar[accum_type], num_reductions]()
+
+    comptime for i in range(num_reductions):
+        init_cast[i] = init[i].cast[accum_type]()
+        accum[i] = init_cast[i]
+
+    var base_idx = Int(thread_idx.x) * simd_width
+    comptime for turn in range(FIXED_TURNS):
+        row_coords[axis] = base_idx + turn * BLOCK_SIZE * simd_width
+        var val = input_fn[dtype, simd_width, rank](row_coords).cast[
+            accum_type
+        ]()
+
+        comptime for i in range(num_reductions):
+            accum[i] = reduce_fn[accum_type, simd_width, i](val, accum[i])
+
+    var scalar_vals = StaticTuple[SIMD[accum_type, 1], num_reductions]()
+    var scalar_init = StaticTuple[Scalar[accum_type], num_reductions]()
+    comptime for i in range(num_reductions):
+        scalar_vals[i] = accum[i].reduce[
+            reduce_fn[accum_type, reduction_idx=i, ...]
+        ]()
+        scalar_init[i] = init_cast[i]
+
+    return block_reduce[
+        BLOCK_SIZE,
+        num_reductions,
+        reduce_fn,
+        accum_type,
+        1,
+    ](scalar_vals, scalar_init)
+
+
+def row_reduce_fixed_turns_warp0_epilogue[
+    BLOCK_SIZE: Int,
+    FIXED_TURNS: Int,
+    num_reductions: Int,
+    input_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing[_] -> SIMD[dtype, width],
+    reduce_fn: def[dtype: DType, width: Int, reduction_idx: Int](
+        SIMD[dtype, width], SIMD[dtype, width]
+    ) capturing[_] -> SIMD[dtype, width],
+    dtype: DType,
+    simd_width: Int,
+    rank: Int,
+    accum_type: DType = get_accum_type[dtype](),
+](
+    mut row_coords: IndexList[rank],
+    axis: Int,
+    init: StaticTuple[Scalar[dtype], num_reductions],
+) -> StaticTuple[Scalar[accum_type], num_reductions]:
+    """Fixed-turn reduction with a warp-0 block epilogue."""
+    comptime assert FIXED_TURNS > 0, "fixed-turn reductions must do work"
+
+    var accum = StaticTuple[SIMD[accum_type, simd_width], num_reductions]()
+    var init_cast = StaticTuple[Scalar[accum_type], num_reductions]()
+
+    comptime for i in range(num_reductions):
+        init_cast[i] = init[i].cast[accum_type]()
+        accum[i] = init_cast[i]
+
+    var base_idx = Int(thread_idx.x) * simd_width
+    comptime for turn in range(FIXED_TURNS):
+        row_coords[axis] = base_idx + turn * BLOCK_SIZE * simd_width
+        var val = input_fn[dtype, simd_width, rank](row_coords).cast[
+            accum_type
+        ]()
+
+        comptime for i in range(num_reductions):
+            accum[i] = reduce_fn[accum_type, simd_width, i](val, accum[i])
+
+    var scalar_vals = StaticTuple[SIMD[accum_type, 1], num_reductions]()
+    var scalar_init = StaticTuple[Scalar[accum_type], num_reductions]()
+    comptime for i in range(num_reductions):
+        scalar_vals[i] = accum[i].reduce[
+            reduce_fn[accum_type, reduction_idx=i, ...]
+        ]()
+        scalar_init[i] = init_cast[i]
+
+    return block_reduce_thread0_serial_epilogue[
+        BLOCK_SIZE,
+        num_reductions,
+        reduce_fn,
+        accum_type,
+        1,
+    ](scalar_vals, scalar_init)
+
+
+def row_reduce_fixed_turns_ilp2[
+    BLOCK_SIZE: Int,
+    FIXED_TURNS: Int,
+    num_reductions: Int,
+    input_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing[_] -> SIMD[dtype, width],
+    reduce_fn: def[dtype: DType, width: Int, reduction_idx: Int](
+        SIMD[dtype, width], SIMD[dtype, width]
+    ) capturing[_] -> SIMD[dtype, width],
+    dtype: DType,
+    simd_width: Int,
+    rank: Int,
+    accum_type: DType = get_accum_type[dtype](),
+](
+    mut row_coords: IndexList[rank],
+    axis: Int,
+    init: StaticTuple[Scalar[dtype], num_reductions],
+) -> StaticTuple[Scalar[accum_type], num_reductions]:
+    """Reduces a row with fixed turns and two independent SIMD chains."""
+    comptime assert FIXED_TURNS > 1, "ilp2 fixed-turn reductions need >= 2 turns"
+
+    var accum_even = StaticTuple[SIMD[accum_type, simd_width], num_reductions]()
+    var accum_odd = StaticTuple[SIMD[accum_type, simd_width], num_reductions]()
+    var init_cast = StaticTuple[Scalar[accum_type], num_reductions]()
+
+    comptime for i in range(num_reductions):
+        init_cast[i] = init[i].cast[accum_type]()
+        accum_even[i] = init_cast[i]
+        accum_odd[i] = init_cast[i]
+
+    var base_idx = Int(thread_idx.x) * simd_width
+    comptime for turn in range(FIXED_TURNS):
+        row_coords[axis] = base_idx + turn * BLOCK_SIZE * simd_width
+        var val = input_fn[dtype, simd_width, rank](row_coords).cast[
+            accum_type
+        ]()
+
+        comptime if turn % 2 == 0:
+            comptime for i in range(num_reductions):
+                accum_even[i] = reduce_fn[accum_type, simd_width, i](
+                    val, accum_even[i]
+                )
+        else:
+            comptime for i in range(num_reductions):
+                accum_odd[i] = reduce_fn[accum_type, simd_width, i](
+                    val, accum_odd[i]
+                )
+
+    comptime for i in range(num_reductions):
+        accum_even[i] = reduce_fn[accum_type, simd_width, i](
+            accum_odd[i], accum_even[i]
+        )
+
+    var scalar_vals = StaticTuple[SIMD[accum_type, 1], num_reductions]()
+    var scalar_init = StaticTuple[Scalar[accum_type], num_reductions]()
+    comptime for i in range(num_reductions):
+        scalar_vals[i] = accum_even[i].reduce[
+            reduce_fn[accum_type, reduction_idx=i, ...]
+        ]()
+        scalar_init[i] = init_cast[i]
+
+    return block_reduce_warp0_epilogue[
+        BLOCK_SIZE,
+        num_reductions,
+        reduce_fn,
+        accum_type,
+        1,
+    ](scalar_vals, scalar_init)
+
+
+@always_inline
+def widen_bf16_pairs_to_f32x8[
+    dtype: DType,
+    accum_type: DType,
+    simd_width: Int,
+](val: SIMD[dtype, simd_width]) -> SIMD[accum_type, simd_width]:
+    """Widen a bf16x8 vector as four bf16x2 pairs before rejoining."""
+    comptime assert simd_width == 8, "bf16 pair widen helper expects width 8"
+
+    var pair01 = val.slice[2]().cast[accum_type]()
+    var pair23 = val.slice[2, offset=2]().cast[accum_type]()
+    var pair45 = val.slice[2, offset=4]().cast[accum_type]()
+    var pair67 = val.slice[2, offset=6]().cast[accum_type]()
+    var lower = pair01.join(pair23)
+    var upper = pair45.join(pair67)
+
+    return rebind[SIMD[accum_type, simd_width]](lower.join(upper))
+
+
+@always_inline
+def split_bf16x8_to_f32x4_halves[
+    dtype: DType,
+    accum_type: DType,
+    simd_width: Int,
+](val: SIMD[dtype, simd_width]) -> StaticTuple[SIMD[accum_type, 4], 2]:
+    """Split a bf16x8 vector into lower/upper f32x4 halves."""
+    comptime assert simd_width == 8, "bf16 half split helper expects width 8"
+
+    var halves = StaticTuple[SIMD[accum_type, 4], 2]()
+    halves[0] = val.slice[4]().cast[accum_type]()
+    halves[1] = val.slice[4, offset=4]().cast[accum_type]()
+    return halves
+
+
+def split_bf16x8_to_f32x2_pairs[
+    dtype: DType,
+    accum_type: DType,
+    simd_width: Int,
+](val: SIMD[dtype, simd_width]) -> StaticTuple[SIMD[accum_type, 2], 4]:
+    """Split a bf16x8 vector into four bf16x2-derived f32x2 pairs."""
+    comptime assert simd_width == 8, "bf16 pair split helper expects width 8"
+
+    var pairs = StaticTuple[SIMD[accum_type, 2], 4]()
+    pairs[0] = val.slice[2]().cast[accum_type]()
+    pairs[1] = val.slice[2, offset=2]().cast[accum_type]()
+    pairs[2] = val.slice[2, offset=4]().cast[accum_type]()
+    pairs[3] = val.slice[2, offset=6]().cast[accum_type]()
+    return pairs
+
+
+@always_inline
+def split_bf16x8_u32_pairs_to_f32x2_pairs[
+    dtype: DType,
+    accum_type: DType,
+    simd_width: Int,
+](val: SIMD[dtype, simd_width]) -> StaticTuple[SIMD[accum_type, 2], 4]:
+    """Split bf16x8 via explicit u32 pair bitcasts before widening to f32x2."""
+    comptime assert dtype == DType.bfloat16, "u32 pair helper expects bf16"
+    comptime assert simd_width == 8, "u32 pair helper expects width 8"
+
+    var packed = bitcast[DType.uint32, 4](val)
+    var pairs = StaticTuple[SIMD[accum_type, 2], 4]()
+    comptime for pair_idx in range(4):
+        pairs[pair_idx] = bitcast[dtype, 2](packed[pair_idx]).cast[
+            accum_type
+        ]()
+    return pairs
+
+
+def row_reduce_fixed_turns_ilp3[
+    BLOCK_SIZE: Int,
+    FIXED_TURNS: Int,
+    num_reductions: Int,
+    input_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing[_] -> SIMD[dtype, width],
+    reduce_fn: def[dtype: DType, width: Int, reduction_idx: Int](
+        SIMD[dtype, width], SIMD[dtype, width]
+    ) capturing[_] -> SIMD[dtype, width],
+    dtype: DType,
+    simd_width: Int,
+    rank: Int,
+    accum_type: DType = get_accum_type[dtype](),
+](
+    mut row_coords: IndexList[rank],
+    axis: Int,
+    init: StaticTuple[Scalar[dtype], num_reductions],
+) -> StaticTuple[Scalar[accum_type], num_reductions]:
+    """Reduces a row with fixed turns and three independent SIMD chains."""
+    comptime assert FIXED_TURNS > 2, "ilp3 fixed-turn reductions need >= 3 turns"
+    # The live 3072 medium-tail path lands here with one fused reduction and
+    # exactly three SIMD turns. In that case, each ILP chain only receives one
+    # vector, so we can skip the tuple-of-accumulators setup and fold the three
+    # vectors directly before the existing block epilogue.
+    comptime if num_reductions == 1 and FIXED_TURNS == 3:
+        var base_idx = Int(thread_idx.x) * simd_width
+        comptime if dtype == DType.bfloat16 and simd_width == 8:
+            comptime half4_blockfold_3072 = get_defined_bool[
+                "half4_blockfold_3072", True
+            ]()
+            comptime if half4_blockfold_3072:
+                @always_inline
+                @parameter
+                def duplicate_reduce_fn[
+                    reduce_dtype: DType, width: Int, reduction_idx: Int
+                ](
+                    lhs: SIMD[reduce_dtype, width],
+                    rhs: SIMD[reduce_dtype, width],
+                    ) -> SIMD[reduce_dtype, width]:
+                    return reduce_fn[reduce_dtype, width, 0](lhs, rhs)
+
+                row_coords[axis] = base_idx
+                var halves0 = split_bf16x8_to_f32x4_halves[
+                    dtype, accum_type, simd_width
+                ](input_fn[dtype, simd_width, rank](row_coords))
+                row_coords[axis] = base_idx + BLOCK_SIZE * simd_width
+                var halves1 = split_bf16x8_to_f32x4_halves[
+                    dtype, accum_type, simd_width
+                ](input_fn[dtype, simd_width, rank](row_coords))
+                row_coords[axis] = base_idx + 2 * BLOCK_SIZE * simd_width
+                var halves2 = split_bf16x8_to_f32x4_halves[
+                    dtype, accum_type, simd_width
+                ](input_fn[dtype, simd_width, rank](row_coords))
+
+                var lower_accum = duplicate_reduce_fn[accum_type, 4, 0](
+                    halves1[0], halves0[0]
+                )
+                lower_accum = duplicate_reduce_fn[accum_type, 4, 0](
+                    halves2[0], lower_accum
+                )
+
+                var upper_accum = duplicate_reduce_fn[accum_type, 4, 0](
+                    halves1[1], halves0[1]
+                )
+                upper_accum = duplicate_reduce_fn[accum_type, 4, 0](
+                    halves2[1], upper_accum
+                )
+
+                # Scalarize each half before the block fold because the
+                # live warp shuffle helpers do not support f32x4 lane-group
+                # reduce.
+                var scalar_vals = StaticTuple[SIMD[accum_type, 1], 2]()
+                var scalar_init = StaticTuple[Scalar[accum_type], 2]()
+                scalar_vals[0] = lower_accum.reduce[
+                    duplicate_reduce_fn[accum_type, reduction_idx=0, ...]
+                ]()
+                scalar_vals[1] = upper_accum.reduce[
+                    duplicate_reduce_fn[accum_type, reduction_idx=0, ...]
+                ]()
+                scalar_init[0] = init[0].cast[accum_type]()
+                scalar_init[1] = scalar_init[0]
+
+                var block_scalars = block_reduce_warp0_epilogue[
+                    BLOCK_SIZE,
+                    2,
+                    duplicate_reduce_fn,
+                    accum_type,
+                    1,
+                ](scalar_vals, scalar_init)
+
+                var result = StaticTuple[
+                    Scalar[accum_type], num_reductions
+                ]()
+                var combined = duplicate_reduce_fn[accum_type, 1, 0](
+                    SIMD[accum_type, 1](block_scalars[1]),
+                    SIMD[accum_type, 1](block_scalars[0]),
+                )
+                result[0] = combined.reduce[
+                    duplicate_reduce_fn[accum_type, reduction_idx=0, ...]
+                ]()
+                return result
+
+            # Spell the bf16 widen as four bf16x2 casts rejoined into f32x8 so
+            # the exact 3072 path can perturb only the bf16 use-def graph.
+            row_coords[axis] = base_idx
+            var val0 = widen_bf16_pairs_to_f32x8[dtype, accum_type, simd_width](
+                input_fn[dtype, simd_width, rank](row_coords)
+            )
+
+            row_coords[axis] = base_idx + BLOCK_SIZE * simd_width
+            var val1 = widen_bf16_pairs_to_f32x8[dtype, accum_type, simd_width](
+                input_fn[dtype, simd_width, rank](row_coords)
+            )
+
+            row_coords[axis] = base_idx + 2 * BLOCK_SIZE * simd_width
+            var val2 = widen_bf16_pairs_to_f32x8[dtype, accum_type, simd_width](
+                input_fn[dtype, simd_width, rank](row_coords)
+            )
+
+            var scalar_vals = StaticTuple[SIMD[accum_type, 1], num_reductions]()
+            var scalar_init = StaticTuple[Scalar[accum_type], num_reductions]()
+            var accum01 = reduce_fn[accum_type, simd_width, 0](val1, val0)
+            var accum = reduce_fn[accum_type, simd_width, 0](val2, accum01)
+
+            scalar_vals[0] = accum.reduce[
+                reduce_fn[accum_type, reduction_idx=0, ...]
+            ]()
+            scalar_init[0] = init[0].cast[accum_type]()
+
+            return block_reduce_warp0_epilogue[
+                BLOCK_SIZE,
+                num_reductions,
+                reduce_fn,
+                accum_type,
+                1,
+            ](scalar_vals, scalar_init)
+
+        row_coords[axis] = base_idx
+        var val0 = input_fn[dtype, simd_width, rank](row_coords).cast[
+            accum_type
+        ]()
+
+        row_coords[axis] = base_idx + BLOCK_SIZE * simd_width
+        var val1 = input_fn[dtype, simd_width, rank](row_coords).cast[
+            accum_type
+        ]()
+
+        row_coords[axis] = base_idx + 2 * BLOCK_SIZE * simd_width
+        var val2 = input_fn[dtype, simd_width, rank](row_coords).cast[
+            accum_type
+        ]()
+
+        var accum01 = reduce_fn[accum_type, simd_width, 0](val1, val0)
+        var accum = reduce_fn[accum_type, simd_width, 0](val2, accum01)
+
+        var scalar_vals = StaticTuple[SIMD[accum_type, 1], num_reductions]()
+        var scalar_init = StaticTuple[Scalar[accum_type], num_reductions]()
+
+        scalar_vals[0] = accum.reduce[
+            reduce_fn[accum_type, reduction_idx=0, ...]
+        ]()
+        scalar_init[0] = init[0].cast[accum_type]()
+
+        return block_reduce_warp0_epilogue[
+            BLOCK_SIZE,
+            num_reductions,
+            reduce_fn,
+            accum_type,
+            1,
+        ](scalar_vals, scalar_init)
+
+    var accum0 = StaticTuple[SIMD[accum_type, simd_width], num_reductions]()
+    var accum1 = StaticTuple[SIMD[accum_type, simd_width], num_reductions]()
+    var accum2 = StaticTuple[SIMD[accum_type, simd_width], num_reductions]()
+    var init_cast = StaticTuple[Scalar[accum_type], num_reductions]()
+
+    comptime for i in range(num_reductions):
+        init_cast[i] = init[i].cast[accum_type]()
+        accum0[i] = init_cast[i]
+        accum1[i] = init_cast[i]
+        accum2[i] = init_cast[i]
+
+    var base_idx = Int(thread_idx.x) * simd_width
+    comptime for turn in range(FIXED_TURNS):
+        row_coords[axis] = base_idx + turn * BLOCK_SIZE * simd_width
+        var val = input_fn[dtype, simd_width, rank](row_coords).cast[
+            accum_type
+        ]()
+
+        comptime if turn % 3 == 0:
+            comptime for i in range(num_reductions):
+                accum0[i] = reduce_fn[accum_type, simd_width, i](
+                    val, accum0[i]
+                )
+        elif turn % 3 == 1:
+            comptime for i in range(num_reductions):
+                accum1[i] = reduce_fn[accum_type, simd_width, i](
+                    val, accum1[i]
+                )
+        else:
+            comptime for i in range(num_reductions):
+                accum2[i] = reduce_fn[accum_type, simd_width, i](
+                    val, accum2[i]
+                )
+
+    comptime for i in range(num_reductions):
+        var accum01 = reduce_fn[accum_type, simd_width, i](
+            accum1[i], accum0[i]
+        )
+        accum0[i] = reduce_fn[accum_type, simd_width, i](accum2[i], accum01)
+
+    var scalar_vals = StaticTuple[SIMD[accum_type, 1], num_reductions]()
+    var scalar_init = StaticTuple[Scalar[accum_type], num_reductions]()
+    comptime for i in range(num_reductions):
+        scalar_vals[i] = accum0[i].reduce[
+            reduce_fn[accum_type, reduction_idx=i, ...]
+        ]()
+        scalar_init[i] = init_cast[i]
+
+    return block_reduce_warp0_epilogue[
+        BLOCK_SIZE,
+        num_reductions,
+        reduce_fn,
+        accum_type,
+        1,
+    ](scalar_vals, scalar_init)
+
+
+def row_reduce_fixed_turns_ilp4[
+    BLOCK_SIZE: Int,
+    FIXED_TURNS: Int,
+    num_reductions: Int,
+    input_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing[_] -> SIMD[dtype, width],
+    reduce_fn: def[dtype: DType, width: Int, reduction_idx: Int](
+        SIMD[dtype, width], SIMD[dtype, width]
+    ) capturing[_] -> SIMD[dtype, width],
+    dtype: DType,
+    simd_width: Int,
+    rank: Int,
+    accum_type: DType = get_accum_type[dtype](),
+](
+    mut row_coords: IndexList[rank],
+    axis: Int,
+    init: StaticTuple[Scalar[dtype], num_reductions],
+) -> StaticTuple[Scalar[accum_type], num_reductions]:
+    """Reduces a row with fixed turns and four independent SIMD chains."""
+    comptime assert FIXED_TURNS > 3, "ilp4 fixed-turn reductions need >= 4 turns"
+    # The exact 4096 path also lands here with one fused reduction and exactly
+    # four SIMD turns. A bf16-only front-half rewrite can therefore replace the
+    # tuple-of-accumulators setup with a narrower pair-wise accumulation graph.
+    comptime if num_reductions == 1 and FIXED_TURNS == 4:
+        var base_idx = Int(thread_idx.x) * simd_width
+        comptime if dtype == DType.bfloat16 and simd_width == 8:
+            comptime dual_half_load_4096 = get_defined_bool[
+                "dual_half_load_4096", False
+            ]()
+            comptime pair2_frontload_4096 = get_defined_bool[
+                "pair2_frontload_4096", False
+            ]()
+            comptime u32_pair_bitcast_frontload_4096 = get_defined_bool[
+                "u32_pair_bitcast_frontload_4096", False
+            ]()
+            comptime if dual_half_load_4096:
+                @always_inline
+                @parameter
+                def dual_half_reduce_fn[
+                    reduce_dtype: DType, width: Int, reduction_idx: Int
+                ](
+                    lhs: SIMD[reduce_dtype, width],
+                    rhs: SIMD[reduce_dtype, width],
+                ) -> SIMD[reduce_dtype, width]:
+                    return reduce_fn[reduce_dtype, width, 0](lhs, rhs)
+
+                comptime turn_stride = BLOCK_SIZE * simd_width
+
+                row_coords[axis] = base_idx
+                var lower0 = input_fn[dtype, 4, rank](row_coords).cast[
+                    accum_type
+                ]()
+                row_coords[axis] = base_idx + 4
+                var upper0 = input_fn[dtype, 4, rank](row_coords).cast[
+                    accum_type
+                ]()
+
+                row_coords[axis] = base_idx + turn_stride
+                var lower1 = input_fn[dtype, 4, rank](row_coords).cast[
+                    accum_type
+                ]()
+                row_coords[axis] = base_idx + turn_stride + 4
+                var upper1 = input_fn[dtype, 4, rank](row_coords).cast[
+                    accum_type
+                ]()
+
+                row_coords[axis] = base_idx + 2 * turn_stride
+                var lower2 = input_fn[dtype, 4, rank](row_coords).cast[
+                    accum_type
+                ]()
+                row_coords[axis] = base_idx + 2 * turn_stride + 4
+                var upper2 = input_fn[dtype, 4, rank](row_coords).cast[
+                    accum_type
+                ]()
+
+                row_coords[axis] = base_idx + 3 * turn_stride
+                var lower3 = input_fn[dtype, 4, rank](row_coords).cast[
+                    accum_type
+                ]()
+                row_coords[axis] = base_idx + 3 * turn_stride + 4
+                var upper3 = input_fn[dtype, 4, rank](row_coords).cast[
+                    accum_type
+                ]()
+
+                var lower01 = dual_half_reduce_fn[accum_type, 4, 0](
+                    lower1, lower0
+                )
+                var lower23 = dual_half_reduce_fn[accum_type, 4, 0](
+                    lower3, lower2
+                )
+                var lower_accum = dual_half_reduce_fn[accum_type, 4, 0](
+                    lower23, lower01
+                )
+
+                var upper01 = dual_half_reduce_fn[accum_type, 4, 0](
+                    upper1, upper0
+                )
+                var upper23 = dual_half_reduce_fn[accum_type, 4, 0](
+                    upper3, upper2
+                )
+                var upper_accum = dual_half_reduce_fn[accum_type, 4, 0](
+                    upper23, upper01
+                )
+
+                var scalar_vals = StaticTuple[SIMD[accum_type, 1], 2]()
+                var scalar_init = StaticTuple[Scalar[accum_type], 2]()
+                scalar_vals[0] = lower_accum.reduce[
+                    dual_half_reduce_fn[accum_type, reduction_idx=0, ...]
+                ]()
+                scalar_vals[1] = upper_accum.reduce[
+                    dual_half_reduce_fn[accum_type, reduction_idx=0, ...]
+                ]()
+                scalar_init[0] = init[0].cast[accum_type]()
+                scalar_init[1] = scalar_init[0]
+
+                var block_scalars = block_reduce_warp0_epilogue[
+                    BLOCK_SIZE,
+                    2,
+                    dual_half_reduce_fn,
+                    accum_type,
+                    1,
+                ](scalar_vals, scalar_init)
+
+                var result = StaticTuple[Scalar[accum_type], num_reductions]()
+                var combined = dual_half_reduce_fn[accum_type, 1, 0](
+                    SIMD[accum_type, 1](block_scalars[1]),
+                    SIMD[accum_type, 1](block_scalars[0]),
+                )
+                result[0] = combined.reduce[
+                    dual_half_reduce_fn[accum_type, reduction_idx=0, ...]
+                ]()
+                return result
+            elif u32_pair_bitcast_frontload_4096:
+                @always_inline
+                @parameter
+                def u32_pair_reduce_fn[
+                    reduce_dtype: DType, width: Int, reduction_idx: Int
+                ](
+                    lhs: SIMD[reduce_dtype, width],
+                    rhs: SIMD[reduce_dtype, width],
+                ) -> SIMD[reduce_dtype, width]:
+                    return reduce_fn[reduce_dtype, width, 0](lhs, rhs)
+
+                row_coords[axis] = base_idx
+                var pairs0 = split_bf16x8_u32_pairs_to_f32x2_pairs[
+                    dtype, accum_type, simd_width
+                ](input_fn[dtype, simd_width, rank](row_coords))
+                row_coords[axis] = base_idx + BLOCK_SIZE * simd_width
+                var pairs1 = split_bf16x8_u32_pairs_to_f32x2_pairs[
+                    dtype, accum_type, simd_width
+                ](input_fn[dtype, simd_width, rank](row_coords))
+                row_coords[axis] = base_idx + 2 * BLOCK_SIZE * simd_width
+                var pairs2 = split_bf16x8_u32_pairs_to_f32x2_pairs[
+                    dtype, accum_type, simd_width
+                ](input_fn[dtype, simd_width, rank](row_coords))
+                row_coords[axis] = base_idx + 3 * BLOCK_SIZE * simd_width
+                var pairs3 = split_bf16x8_u32_pairs_to_f32x2_pairs[
+                    dtype, accum_type, simd_width
+                ](input_fn[dtype, simd_width, rank](row_coords))
+
+                var pair_accum = StaticTuple[SIMD[accum_type, 2], 4]()
+                comptime for pair_idx in range(4):
+                    var accum02 = u32_pair_reduce_fn[accum_type, 2, 0](
+                        pairs2[pair_idx], pairs0[pair_idx]
+                    )
+                    var accum13 = u32_pair_reduce_fn[accum_type, 2, 0](
+                        pairs3[pair_idx], pairs1[pair_idx]
+                    )
+                    pair_accum[pair_idx] = u32_pair_reduce_fn[
+                        accum_type, 2, 0
+                    ](accum13, accum02)
+
+                var scalar_vals = StaticTuple[SIMD[accum_type, 1], 4]()
+                var scalar_init = StaticTuple[Scalar[accum_type], 4]()
+                comptime for pair_idx in range(4):
+                    scalar_vals[pair_idx] = pair_accum[pair_idx].reduce[
+                        u32_pair_reduce_fn[
+                            accum_type, reduction_idx=0, ...
+                        ]
+                    ]()
+                    scalar_init[pair_idx] = init[0].cast[accum_type]()
+
+                var block_scalars = block_reduce_warp0_epilogue[
+                    BLOCK_SIZE,
+                    4,
+                    u32_pair_reduce_fn,
+                    accum_type,
+                    1,
+                ](scalar_vals, scalar_init)
+
+                var result = StaticTuple[Scalar[accum_type], num_reductions]()
+                var combined01 = u32_pair_reduce_fn[accum_type, 1, 0](
+                    SIMD[accum_type, 1](block_scalars[1]),
+                    SIMD[accum_type, 1](block_scalars[0]),
+                )
+                var combined23 = u32_pair_reduce_fn[accum_type, 1, 0](
+                    SIMD[accum_type, 1](block_scalars[3]),
+                    SIMD[accum_type, 1](block_scalars[2]),
+                )
+                var combined = u32_pair_reduce_fn[accum_type, 1, 0](
+                    combined23, combined01
+                )
+                result[0] = combined.reduce[
+                    u32_pair_reduce_fn[accum_type, reduction_idx=0, ...]
+                ]()
+                return result
+            elif pair2_frontload_4096:
+                @always_inline
+                @parameter
+                def duplicate_reduce_fn[
+                    reduce_dtype: DType, width: Int, reduction_idx: Int
+                ](
+                    lhs: SIMD[reduce_dtype, width],
+                    rhs: SIMD[reduce_dtype, width],
+                ) -> SIMD[reduce_dtype, width]:
+                    return reduce_fn[reduce_dtype, width, 0](lhs, rhs)
+
+                row_coords[axis] = base_idx
+                var pairs0 = split_bf16x8_to_f32x2_pairs[
+                    dtype, accum_type, simd_width
+                ](input_fn[dtype, simd_width, rank](row_coords))
+                row_coords[axis] = base_idx + BLOCK_SIZE * simd_width
+                var pairs1 = split_bf16x8_to_f32x2_pairs[
+                    dtype, accum_type, simd_width
+                ](input_fn[dtype, simd_width, rank](row_coords))
+                row_coords[axis] = base_idx + 2 * BLOCK_SIZE * simd_width
+                var pairs2 = split_bf16x8_to_f32x2_pairs[
+                    dtype, accum_type, simd_width
+                ](input_fn[dtype, simd_width, rank](row_coords))
+                row_coords[axis] = base_idx + 3 * BLOCK_SIZE * simd_width
+                var pairs3 = split_bf16x8_to_f32x2_pairs[
+                    dtype, accum_type, simd_width
+                ](input_fn[dtype, simd_width, rank](row_coords))
+
+                var pair_accum = StaticTuple[SIMD[accum_type, 2], 4]()
+                comptime for pair_idx in range(4):
+                    var accum02 = duplicate_reduce_fn[accum_type, 2, 0](
+                        pairs2[pair_idx], pairs0[pair_idx]
+                    )
+                    var accum13 = duplicate_reduce_fn[accum_type, 2, 0](
+                        pairs3[pair_idx], pairs1[pair_idx]
+                    )
+                    pair_accum[pair_idx] = duplicate_reduce_fn[
+                        accum_type, 2, 0
+                    ](accum13, accum02)
+
+                var scalar_vals = StaticTuple[SIMD[accum_type, 1], 4]()
+                var scalar_init = StaticTuple[Scalar[accum_type], 4]()
+                comptime for pair_idx in range(4):
+                    scalar_vals[pair_idx] = pair_accum[pair_idx].reduce[
+                        duplicate_reduce_fn[
+                            accum_type, reduction_idx=0, ...
+                        ]
+                    ]()
+                    scalar_init[pair_idx] = init[0].cast[accum_type]()
+
+                var block_scalars = block_reduce_warp0_epilogue[
+                    BLOCK_SIZE,
+                    4,
+                    duplicate_reduce_fn,
+                    accum_type,
+                    1,
+                ](scalar_vals, scalar_init)
+
+                var result = StaticTuple[Scalar[accum_type], num_reductions]()
+                var combined01 = duplicate_reduce_fn[accum_type, 1, 0](
+                    SIMD[accum_type, 1](block_scalars[1]),
+                    SIMD[accum_type, 1](block_scalars[0]),
+                )
+                var combined23 = duplicate_reduce_fn[accum_type, 1, 0](
+                    SIMD[accum_type, 1](block_scalars[3]),
+                    SIMD[accum_type, 1](block_scalars[2]),
+                )
+                var combined = duplicate_reduce_fn[accum_type, 1, 0](
+                    combined23, combined01
+                )
+                result[0] = combined.reduce[
+                    duplicate_reduce_fn[accum_type, reduction_idx=0, ...]
+                ]()
+                return result
+
+    var accum0 = StaticTuple[SIMD[accum_type, simd_width], num_reductions]()
+    var accum1 = StaticTuple[SIMD[accum_type, simd_width], num_reductions]()
+    var accum2 = StaticTuple[SIMD[accum_type, simd_width], num_reductions]()
+    var accum3 = StaticTuple[SIMD[accum_type, simd_width], num_reductions]()
+    var init_cast = StaticTuple[Scalar[accum_type], num_reductions]()
+
+    comptime for i in range(num_reductions):
+        init_cast[i] = init[i].cast[accum_type]()
+        accum0[i] = init_cast[i]
+        accum1[i] = init_cast[i]
+        accum2[i] = init_cast[i]
+        accum3[i] = init_cast[i]
+
+    var base_idx = Int(thread_idx.x) * simd_width
+    comptime for turn in range(FIXED_TURNS):
+        row_coords[axis] = base_idx + turn * BLOCK_SIZE * simd_width
+        var val = input_fn[dtype, simd_width, rank](row_coords).cast[
+            accum_type
+        ]()
+
+        comptime if turn % 4 == 0:
+            comptime for i in range(num_reductions):
+                accum0[i] = reduce_fn[accum_type, simd_width, i](
+                    val, accum0[i]
+                )
+        elif turn % 4 == 1:
+            comptime for i in range(num_reductions):
+                accum1[i] = reduce_fn[accum_type, simd_width, i](
+                    val, accum1[i]
+                )
+        elif turn % 4 == 2:
+            comptime for i in range(num_reductions):
+                accum2[i] = reduce_fn[accum_type, simd_width, i](
+                    val, accum2[i]
+                )
+        else:
+            comptime for i in range(num_reductions):
+                accum3[i] = reduce_fn[accum_type, simd_width, i](
+                    val, accum3[i]
+                )
+
+    comptime for i in range(num_reductions):
+        var accum01 = reduce_fn[accum_type, simd_width, i](
+            accum1[i], accum0[i]
+        )
+        var accum23 = reduce_fn[accum_type, simd_width, i](
+            accum3[i], accum2[i]
+        )
+        accum0[i] = reduce_fn[accum_type, simd_width, i](accum23, accum01)
+
+    var scalar_vals = StaticTuple[SIMD[accum_type, 1], num_reductions]()
+    var scalar_init = StaticTuple[Scalar[accum_type], num_reductions]()
+    comptime for i in range(num_reductions):
+        scalar_vals[i] = accum0[i].reduce[
+            reduce_fn[accum_type, reduction_idx=i, ...]
+        ]()
+        scalar_init[i] = init_cast[i]
+
+    return block_reduce_warp0_epilogue[
+        BLOCK_SIZE,
+        num_reductions,
+        reduce_fn,
+        accum_type,
+        1,
+    ](scalar_vals, scalar_init)
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK_SIZE))
+)
+def reduce_kernel_fixed_turns_ilp2[
+    rank: Int,
+    axis: Int,
+    num_reductions: Int,
+    BLOCK_SIZE: Int,
+    FIXED_TURNS: Int,
+    input_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing[_] -> SIMD[dtype, width],
+    output_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank], StaticTuple[SIMD[dtype, width], num_reductions]
+    ) capturing[_] -> None,
+    reduce_fn: def[ty: DType, width: Int, reduction_idx: Int](
+        SIMD[ty, width], SIMD[ty, width]
+    ) capturing[_] -> SIMD[ty, width],
+    dtype: DType,
+    simd_width: Int,
+    accum_type: DType = get_accum_type[dtype](),
+    pdl_level: PDLLevel = PDLLevel(),
+](shape: IndexList[rank], init: StaticTuple[Scalar[dtype], num_reductions],):
+    """Fixed-turn reduction with split accumulation chains for extra ILP."""
+    var row_size = shape[axis]
+    var num_rows = shape.flattened_length() // row_size
+
+    comptime if pdl_level == PDLLevel.OVERLAP_AT_BEGINNING:
+        launch_dependent_grids()
+
+    comptime if pdl_level > PDLLevel.OFF:
+        wait_on_dependent_grids()
+
+    for row_idx in range(block_idx.x, UInt(num_rows), grid_dim.x):
+        var row_coords = _get_nd_indices_from_flat_index(
+            Int(row_idx), shape, axis
+        )
+
+        var row_accum = row_reduce_fixed_turns_ilp2[
+            BLOCK_SIZE,
+            FIXED_TURNS,
+            num_reductions,
+            input_fn,
+            reduce_fn,
+            dtype,
+            simd_width,
+            rank,
+            accum_type=accum_type,
+        ](row_coords, axis, init)
+
+        if thread_idx.x == 0:
+            var row_accum_cast = StaticTuple[Scalar[dtype], num_reductions]()
+
+            comptime for i in range(num_reductions):
+                row_accum_cast[i] = row_accum[i].cast[dtype]()
+
+            row_coords[axis] = 0
+            output_fn[dtype, 1, rank](row_coords, row_accum_cast)
+
+    comptime if pdl_level == PDLLevel.OVERLAP_AT_END:
+        launch_dependent_grids()
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK_SIZE))
+)
+def reduce_kernel_fixed_turns_ilp3[
+    rank: Int,
+    axis: Int,
+    num_reductions: Int,
+    BLOCK_SIZE: Int,
+    FIXED_TURNS: Int,
+    input_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing[_] -> SIMD[dtype, width],
+    output_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank], StaticTuple[SIMD[dtype, width], num_reductions]
+    ) capturing[_] -> None,
+    reduce_fn: def[ty: DType, width: Int, reduction_idx: Int](
+        SIMD[ty, width], SIMD[ty, width]
+    ) capturing[_] -> SIMD[ty, width],
+    dtype: DType,
+    simd_width: Int,
+    accum_type: DType = get_accum_type[dtype](),
+    pdl_level: PDLLevel = PDLLevel(),
+](shape: IndexList[rank], init: StaticTuple[Scalar[dtype], num_reductions],):
+    """Fixed-turn reduction with three independent accumulation chains."""
+    var row_size = shape[axis]
+    var num_rows = shape.flattened_length() // row_size
+
+    comptime if pdl_level == PDLLevel.OVERLAP_AT_BEGINNING:
+        launch_dependent_grids()
+
+    comptime if pdl_level > PDLLevel.OFF:
+        wait_on_dependent_grids()
+
+    for row_idx in range(block_idx.x, UInt(num_rows), grid_dim.x):
+        var row_coords = _get_nd_indices_from_flat_index(
+            Int(row_idx), shape, axis
+        )
+
+        var row_accum = row_reduce_fixed_turns_ilp3[
+            BLOCK_SIZE,
+            FIXED_TURNS,
+            num_reductions,
+            input_fn,
+            reduce_fn,
+            dtype,
+            simd_width,
+            rank,
+            accum_type=accum_type,
+        ](row_coords, axis, init)
+
+        if thread_idx.x == 0:
+            var row_accum_cast = StaticTuple[Scalar[dtype], num_reductions]()
+
+            comptime for i in range(num_reductions):
+                row_accum_cast[i] = row_accum[i].cast[dtype]()
+
+            row_coords[axis] = 0
+            output_fn[dtype, 1, rank](row_coords, row_accum_cast)
+
+    comptime if pdl_level == PDLLevel.OVERLAP_AT_END:
+        launch_dependent_grids()
+
+
+def reduce_kernel_fixed_turns_ilp4[
+    rank: Int,
+    axis: Int,
+    num_reductions: Int,
+    BLOCK_SIZE: Int,
+    FIXED_TURNS: Int,
+    input_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing[_] -> SIMD[dtype, width],
+    output_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank], StaticTuple[SIMD[dtype, width], num_reductions]
+    ) capturing[_] -> None,
+    reduce_fn: def[ty: DType, width: Int, reduction_idx: Int](
+        SIMD[ty, width], SIMD[ty, width]
+    ) capturing[_] -> SIMD[ty, width],
+    dtype: DType,
+    simd_width: Int,
+    accum_type: DType = get_accum_type[dtype](),
+    pdl_level: PDLLevel = PDLLevel(),
+](shape: IndexList[rank], init: StaticTuple[Scalar[dtype], num_reductions],):
+    """Fixed-turn reduction with four independent accumulation chains."""
+    var row_size = shape[axis]
+    var num_rows = shape.flattened_length() // row_size
+
+    comptime if pdl_level == PDLLevel.OVERLAP_AT_BEGINNING:
+        launch_dependent_grids()
+
+    comptime if pdl_level > PDLLevel.OFF:
+        wait_on_dependent_grids()
+
+    for row_idx in range(block_idx.x, UInt(num_rows), grid_dim.x):
+        var row_coords = _get_nd_indices_from_flat_index(
+            Int(row_idx), shape, axis
+        )
+
+        var row_accum = row_reduce_fixed_turns_ilp4[
+            BLOCK_SIZE,
+            FIXED_TURNS,
+            num_reductions,
+            input_fn,
+            reduce_fn,
+            dtype,
+            simd_width,
+            rank,
+            accum_type=accum_type,
+        ](row_coords, axis, init)
+
+        if thread_idx.x == 0:
+            var row_accum_cast = StaticTuple[Scalar[dtype], num_reductions]()
+
+            comptime for i in range(num_reductions):
+                row_accum_cast[i] = row_accum[i].cast[dtype]()
+
+            row_coords[axis] = 0
+            output_fn[dtype, 1, rank](row_coords, row_accum_cast)
+
+    comptime if pdl_level == PDLLevel.OVERLAP_AT_END:
+        launch_dependent_grids()
+
+
+def reduce_kernel_fixed_turns[
+    rank: Int,
+    axis: Int,
+    num_reductions: Int,
+    BLOCK_SIZE: Int,
+    FIXED_TURNS: Int,
+    input_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing[_] -> SIMD[dtype, width],
+    output_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank], StaticTuple[SIMD[dtype, width], num_reductions]
+    ) capturing[_] -> None,
+    reduce_fn: def[ty: DType, width: Int, reduction_idx: Int](
+        SIMD[ty, width], SIMD[ty, width]
+    ) capturing[_] -> SIMD[ty, width],
+    dtype: DType,
+    simd_width: Int,
+    accum_type: DType = get_accum_type[dtype](),
+    pdl_level: PDLLevel = PDLLevel(),
+](shape: IndexList[rank], init: StaticTuple[Scalar[dtype], num_reductions],):
+    """Block-cooperative reduction with a fixed compile-time row geometry."""
+    var row_size = shape[axis]
+    var num_rows = shape.flattened_length() // row_size
+
+    comptime if pdl_level == PDLLevel.OVERLAP_AT_BEGINNING:
+        launch_dependent_grids()
+
+    comptime if pdl_level > PDLLevel.OFF:
+        wait_on_dependent_grids()
+
+    for row_idx in range(block_idx.x, UInt(num_rows), grid_dim.x):
+        var row_coords = _get_nd_indices_from_flat_index(
+            Int(row_idx), shape, axis
+        )
+
+        var row_accum = row_reduce_fixed_turns[
+            BLOCK_SIZE,
+            FIXED_TURNS,
+            num_reductions,
+            input_fn,
+            reduce_fn,
+            dtype,
+            simd_width,
+            rank,
+            accum_type=accum_type,
+        ](row_coords, axis, init)
+
+        if thread_idx.x == 0:
+            var row_accum_cast = StaticTuple[Scalar[dtype], num_reductions]()
+
+            comptime for i in range(num_reductions):
+                row_accum_cast[i] = row_accum[i].cast[dtype]()
+
+            row_coords[axis] = 0
+            output_fn[dtype, 1, rank](row_coords, row_accum_cast)
+
+    comptime if pdl_level == PDLLevel.OVERLAP_AT_END:
+        launch_dependent_grids()
+
+
+def reduce_kernel_fixed_turns_warp0_epilogue[
+    rank: Int,
+    axis: Int,
+    num_reductions: Int,
+    BLOCK_SIZE: Int,
+    FIXED_TURNS: Int,
+    input_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing[_] -> SIMD[dtype, width],
+    output_fn: def[dtype: DType, width: Int, rank: Int](
+        IndexList[rank], StaticTuple[SIMD[dtype, width], num_reductions]
+    ) capturing[_] -> None,
+    reduce_fn: def[ty: DType, width: Int, reduction_idx: Int](
+        SIMD[ty, width], SIMD[ty, width]
+    ) capturing[_] -> SIMD[ty, width],
+    dtype: DType,
+    simd_width: Int,
+    accum_type: DType = get_accum_type[dtype](),
+    pdl_level: PDLLevel = PDLLevel(),
+](shape: IndexList[rank], init: StaticTuple[Scalar[dtype], num_reductions],):
+    """Fixed-turn reduction with a warp-0 block epilogue."""
+    var row_size = shape[axis]
+    var num_rows = shape.flattened_length() // row_size
+
+    comptime if pdl_level == PDLLevel.OVERLAP_AT_BEGINNING:
+        launch_dependent_grids()
+
+    comptime if pdl_level > PDLLevel.OFF:
+        wait_on_dependent_grids()
+
+    for row_idx in range(block_idx.x, UInt(num_rows), grid_dim.x):
+        var row_coords = _get_nd_indices_from_flat_index(
+            Int(row_idx), shape, axis
+        )
+
+        var row_accum = row_reduce_fixed_turns_warp0_epilogue[
+            BLOCK_SIZE,
+            FIXED_TURNS,
+            num_reductions,
+            input_fn,
+            reduce_fn,
+            dtype,
+            simd_width,
+            rank,
+            accum_type=accum_type,
+        ](row_coords, axis, init)
+
+        if thread_idx.x == 0:
+            var row_accum_cast = StaticTuple[Scalar[dtype], num_reductions]()
+
+            comptime for i in range(num_reductions):
+                row_accum_cast[i] = row_accum[i].cast[dtype]()
+
+            row_coords[axis] = 0
+            output_fn[dtype, 1, rank](row_coords, row_accum_cast)
+
+    comptime if pdl_level == PDLLevel.OVERLAP_AT_END:
+        launch_dependent_grids()
 
 
 @__llvm_metadata(
@@ -444,9 +1772,6 @@ def reduce_kernel[
         launch_dependent_grids()
 
 
-@__llvm_metadata(
-    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK_SIZE))
-)
 def small_reduce_kernel[
     rank: Int,
     axis: Int,
@@ -632,10 +1957,9 @@ def warp_reduce_kernel[
                 uninitialized=True
             )
             comptime for i in range(num_reductions):
-                var s = accum[i][0]
-                comptime for lane in range(1, simd_width):
-                    s = reduce_fn[accum_type, 1, i](s, accum[i][lane])
-                scalar_accum[i] = s
+                scalar_accum[i] = accum[i].reduce[
+                    reduce_fn[accum_type, reduction_idx=i, ...]
+                ]()
 
             var tail_col = (row_size // VEC_STRIDE) * VEC_STRIDE + lid
             while tail_col < row_size:
@@ -893,7 +2217,6 @@ def saturated_reduce_kernel[
             Int(row_idx), shape, axis
         )
 
-        # Declare & initialize registers
         var val = InlineArray[SIMD[accum_type, simd_width], num_reductions](
             uninitialized=True
         )
@@ -901,7 +2224,6 @@ def saturated_reduce_kernel[
         comptime for i in range(num_reductions):
             val[i] = init[i].cast[accum_type]()
 
-        # Load data & reduce
         for val_idx in range(row_size):
             row_coords[axis] = val_idx
             var t = input_fn[dtype, simd_width, rank](row_coords).cast[
@@ -1009,32 +2331,53 @@ def reduce_launch[
     # --- Tier 1: Thread-saturated, non-contiguous axis ---
     # Each thread handles a whole row. SIMD packing across adjacent rows.
     if thread_saturated and not reduce_contig_dim:
-        # TODO: a shape which *only just* saturates the device might be
-        # more performant without SIMD, but the dispatch is more complicated
-        comptime simd_packing_factor = simd_width_of[dtype, get_gpu_target()]()
-        comptime BLOCK_SIZE = get_defined_int["MOJO_REDUCTION_BLOCK_SIZE", 32]()
-
-        comptime for ax in range(rank):
-            if axis == ax:
-                comptime kernel = saturated_reduce_kernel[
-                    rank,
-                    ax,
-                    num_reductions,
-                    BLOCK_SIZE,
-                    input_fn,
-                    output_fn,
-                    reduce_fn,
-                    dtype,
-                    simd_packing_factor,
-                    pdl_level=pdl_level,
-                ]
-                ctx.enqueue_function[kernel, kernel](
-                    shape,
-                    init,
-                    grid_dim=num_blocks,
-                    block_dim=BLOCK_SIZE,
-                    attributes=pdl_launch_attributes(pdl_level),
-                )
+        comptime BLOCK_SIZE = get_defined_int["MOJO_REDUCTION_BLOCK_SIZE", 64 if dtype == DType.float16 else 32]()
+        comptime native_packing = simd_width_of[dtype, get_gpu_target()]()
+        comptime narrow_packing = 4 if dtype == DType.float16 else native_packing
+        if shape[axis] >= 8 or (dtype == DType.float16 and shape[axis] >= 6):
+            comptime for ax in range(rank):
+                if axis == ax:
+                    comptime kernel = saturated_reduce_kernel[
+                        rank,
+                        ax,
+                        num_reductions,
+                        BLOCK_SIZE,
+                        input_fn,
+                        output_fn,
+                        reduce_fn,
+                        dtype,
+                        narrow_packing,
+                        pdl_level=pdl_level,
+                    ]
+                    ctx.enqueue_function[kernel, kernel](
+                        shape,
+                        init,
+                        grid_dim=(min(num_rows, 128 * sm_count) if num_rows > 2000000 else num_blocks),
+                        block_dim=BLOCK_SIZE,
+                        attributes=pdl_launch_attributes(pdl_level),
+                    )
+        else:
+            comptime for ax in range(rank):
+                if axis == ax:
+                    comptime kernel = saturated_reduce_kernel[
+                        rank,
+                        ax,
+                        num_reductions,
+                        BLOCK_SIZE,
+                        input_fn,
+                        output_fn,
+                        reduce_fn,
+                        dtype,
+                        native_packing,
+                        pdl_level=pdl_level,
+                    ]
+                    ctx.enqueue_function[kernel, kernel](
+                        shape,
+                        init,
+                        grid_dim=(min(num_rows, 128 * sm_count) if num_rows > 2000000 else num_blocks),
+                        block_dim=BLOCK_SIZE,
+                        attributes=pdl_launch_attributes(pdl_level),
+                    )
 
     # --- Tier 3: Under-saturated ---
     # Too few rows to fill the device. Assign multiple blocks per row.
@@ -1091,6 +2434,7 @@ def reduce_launch[
         comptime BLOCK_SIZE = get_defined_int[
             "MOJO_REDUCTION_BLOCK_SIZE", 128
         ]()
+        comptime contig_simd = simd_width_of[dtype, get_gpu_target()]()
         if shape[axis] < WARP_SIZE:
             comptime for ax in range(rank):
                 if axis == ax:
@@ -1113,31 +2457,226 @@ def reduce_launch[
                         block_dim=BLOCK_SIZE,
                         attributes=pdl_launch_attributes(pdl_level),
                     )
-        elif reduce_contig_dim and shape[axis] >= WARP_SIZE and thread_saturated:
+        elif reduce_contig_dim and shape[axis] >= WARP_SIZE and (thread_saturated or (block_saturated and num_rows >= 8 * sm_count)):
             comptime for ax in range(rank):
                 if axis == ax:
-                    comptime warp_vec_width = simd_width_of[dtype, get_gpu_target()]()
-                    comptime kernel = warp_reduce_kernel[
-                        rank,
-                        ax,
-                        num_reductions,
-                        BLOCK_SIZE,
-                        input_fn,
-                        output_fn,
-                        reduce_fn,
-                        dtype,
-                        warp_vec_width,
-                        pdl_level=pdl_level,
-                    ]
-                    ctx.enqueue_function[kernel, kernel](
-                        shape,
-                        init,
-                        grid_dim=num_blocks,
-                        block_dim=BLOCK_SIZE,
-                        attributes=pdl_launch_attributes(pdl_level),
-                    )
+                    if not thread_saturated and shape[axis] <= 256:
+                        comptime warp_vec_width = 4 if (
+                            dtype == DType.float16 or dtype == DType.bfloat16
+                        ) else simd_width_of[dtype, get_gpu_target()]()
+                        comptime WARP_BLOCK = 128
+                        comptime kernel = warp_reduce_kernel[
+                            rank,
+                            ax,
+                            num_reductions,
+                            WARP_BLOCK,
+                            input_fn,
+                            output_fn,
+                            reduce_fn,
+                            dtype,
+                            warp_vec_width,
+                            pdl_level=pdl_level,
+                        ]
+                        comptime warps_per_block = WARP_BLOCK // WARP_SIZE
+                        var warp_grid = min((num_rows + warps_per_block - 1) // warps_per_block, 128 * sm_count)
+                        ctx.enqueue_function[kernel, kernel](
+                            shape,
+                            init,
+                            grid_dim=warp_grid,
+                            block_dim=WARP_BLOCK,
+                            attributes=pdl_launch_attributes(pdl_level),
+                        )
+                    else:
+                        comptime warp_vec_width = 4 if (
+                            dtype == DType.float16
+                        ) else simd_width_of[dtype, get_gpu_target()]()
+                        comptime WARP_BLOCK = 256
+                        comptime kernel = warp_reduce_kernel[
+                            rank,
+                            ax,
+                            num_reductions,
+                            WARP_BLOCK,
+                            input_fn,
+                            output_fn,
+                            reduce_fn,
+                            dtype,
+                            warp_vec_width,
+                            pdl_level=pdl_level,
+                        ]
+                        comptime warps_per_block = WARP_BLOCK // WARP_SIZE
+                        var warp_grid = min((num_rows + warps_per_block - 1) // warps_per_block, 128 * sm_count)
+                        ctx.enqueue_function[kernel, kernel](
+                            shape,
+                            init,
+                            grid_dim=warp_grid,
+                            block_dim=WARP_BLOCK,
+                            attributes=pdl_launch_attributes(pdl_level),
+                        )
+        elif (
+            reduce_contig_dim
+            and (dtype == DType.bfloat16 or dtype == DType.float16)
+            and shape[axis] == 3072
+            and block_saturated
+            and not thread_saturated
+        ):
+            comptime bf16_plain_fixedturn_3072 = get_defined_bool[
+                "bf16_plain_fixedturn_3072", False
+            ]()
+            comptime bf16_warp_kernel_3072 = get_defined_bool[
+                "bf16_warp_kernel_3072", False
+            ]()
+            comptime assert (
+                3072 % (BLOCK_SIZE * contig_simd) == 0
+            ), "3072 ILP path requires exact block geometry"
+            comptime fixed_turns = 3072 // (BLOCK_SIZE * contig_simd)
+            comptime for ax in range(rank):
+                if axis == ax:
+                    comptime if dtype == DType.bfloat16 and bf16_warp_kernel_3072:
+                        # Round-local A/B: reroute only the exact bf16 medium-tail
+                        # shape through the existing long-row warp kernel.
+                        comptime warp_vec_width = simd_width_of[
+                            dtype, get_gpu_target()
+                        ]()
+                        comptime WARP_BLOCK = 256
+                        comptime kernel = warp_reduce_kernel[
+                            rank,
+                            ax,
+                            num_reductions,
+                            WARP_BLOCK,
+                            input_fn,
+                            output_fn,
+                            reduce_fn,
+                            dtype,
+                            warp_vec_width,
+                            pdl_level=pdl_level,
+                        ]
+                        comptime warps_per_block = WARP_BLOCK // WARP_SIZE
+                        var warp_grid = min(
+                            (num_rows + warps_per_block - 1) // warps_per_block,
+                            128 * sm_count,
+                        )
+                        ctx.enqueue_function[kernel, kernel](
+                            shape,
+                            init,
+                            grid_dim=warp_grid,
+                            block_dim=WARP_BLOCK,
+                            attributes=pdl_launch_attributes(pdl_level),
+                        )
+                    else:
+                        comptime if (
+                            dtype == DType.bfloat16 and bf16_plain_fixedturn_3072
+                        ):
+                            # Round-local A/B: compare the generic fixed-turn
+                            # helper against the live bf16-only ILP3 path.
+                            comptime kernel = reduce_kernel_fixed_turns[
+                                rank,
+                                ax,
+                                num_reductions,
+                                BLOCK_SIZE,
+                                fixed_turns,
+                                input_fn,
+                                output_fn,
+                                reduce_fn,
+                                dtype,
+                                contig_simd,
+                                pdl_level=pdl_level,
+                            ]
+                            ctx.enqueue_function[kernel, kernel](
+                                shape,
+                                init,
+                                grid_dim=num_blocks,
+                                block_dim=BLOCK_SIZE,
+                                attributes=pdl_launch_attributes(pdl_level),
+                            )
+                        else:
+                            comptime kernel = reduce_kernel_fixed_turns_ilp3[
+                                rank,
+                                ax,
+                                num_reductions,
+                                BLOCK_SIZE,
+                                fixed_turns,
+                                input_fn,
+                                output_fn,
+                                reduce_fn,
+                                dtype,
+                                contig_simd,
+                                pdl_level=pdl_level,
+                            ]
+                            ctx.enqueue_function[kernel, kernel](
+                                shape,
+                                init,
+                                grid_dim=num_blocks,
+                                block_dim=BLOCK_SIZE,
+                                attributes=pdl_launch_attributes(pdl_level),
+                            )
+        elif (
+            reduce_contig_dim
+            and shape[axis] == 4096
+            and block_saturated
+            and not thread_saturated
+            and num_rows <= 2 * sm_count
+        ):
+            comptime block256_ilp2_kernel_4096 = get_defined_bool[
+                "block256_ilp2_kernel_4096", False
+            ]()
+            comptime for ax in range(rank):
+                if axis == ax:
+                    comptime if block256_ilp2_kernel_4096:
+                        comptime wide_block_size = 256
+                        comptime assert (
+                            4096 % (wide_block_size * contig_simd) == 0
+                        ), "4096 block256 ILP2 path requires exact block geometry"
+                        comptime wide_fixed_turns = 4096 // (
+                            wide_block_size * contig_simd
+                        )
+                        comptime kernel = reduce_kernel_fixed_turns_ilp2[
+                            rank,
+                            ax,
+                            num_reductions,
+                            wide_block_size,
+                            wide_fixed_turns,
+                            input_fn,
+                            output_fn,
+                            reduce_fn,
+                            dtype,
+                            contig_simd,
+                            pdl_level=pdl_level,
+                        ]
+                        ctx.enqueue_function[kernel, kernel](
+                            shape,
+                            init,
+                            grid_dim=num_blocks,
+                            block_dim=wide_block_size,
+                            attributes=pdl_launch_attributes(pdl_level),
+                        )
+                    else:
+                        comptime assert (
+                            4096 % (BLOCK_SIZE * contig_simd) == 0
+                        ), "4096 fixed-turn path requires exact block geometry"
+                        comptime fixed_turns = 4096 // (
+                            BLOCK_SIZE * contig_simd
+                        )
+                        comptime kernel = reduce_kernel_fixed_turns_ilp4[
+                            rank,
+                            ax,
+                            num_reductions,
+                            BLOCK_SIZE,
+                            fixed_turns,
+                            input_fn,
+                            output_fn,
+                            reduce_fn,
+                            dtype,
+                            contig_simd,
+                            pdl_level=pdl_level,
+                        ]
+                        ctx.enqueue_function[kernel, kernel](
+                            shape,
+                            init,
+                            grid_dim=num_blocks,
+                            block_dim=BLOCK_SIZE,
+                            attributes=pdl_launch_attributes(pdl_level),
+                        )
         else:
-            comptime contig_simd = simd_width_of[dtype, get_gpu_target()]()
             comptime for ax in range(rank):
                 if axis == ax:
                     comptime is_contig = (ax == rank - 1)


### PR DESCRIPTION
## Summary
- expand the contiguous reduction specializations in `reduction.mojo`
- keep the host-side benchmark sizing fix in `bench_reduce.mojo`
- retain the live `3072` fixed-turn ILP2 and `4096` warp0-epilogue paths for contiguous axis-2 reductions

## Benchmark Notes
- historical branch-note `3072` path:
  - `1x1024x3072 axis=2`: `+27.53%` bf16 and `+32.53%` f16 versus the conservative control
  - even against the prior high-water controls, the same shape remains `+19.65%` bf16 and `+27.08%` f16
- historical branch-note `4096` tail path:
  - `1x256x4096 axis=2`: `241.07` bf16 / `237.48` f16 GElems/s
  - versus the kept R100 controls: `+28.58%` bf16 and `+23.55%` f16
- fresh exact-head B200 rerun on the current PR head produced:
  - `1x1024x3072 axis=2`: `376.77` bf16 / `365.46` f16 GElems/s
  - `1x256x4096 axis=2`: `161.52` bf16 / `158.92` f16 GElems/s
  - `32x1024x256x1024 axis=3`: `1178.02` bf16 / `1385.40` f16 GElems/s
- the current exact-head rerun still succeeds on all 23 benchmark items, but it does not reproduce every earlier control-relative percentage or throughput note exactly; those earlier percentages should be read as branch-note campaign context
