### PR TITLE
[Stdlib] Use t-strings in HAL driver and plugin error messages

### DIFF
--- a/mojo/stdlib/std/sys/_hal/driver.mojo
+++ b/mojo/stdlib/std/sys/_hal/driver.mojo
@@ -73,7 +73,10 @@ struct Driver(Movable):
             var err = plugin.get_status_message(status)
             raise HALError(
                 err.status,
-                message=String(t"Failed to initialise driver plugin from {plugin.so_path}: {err.message}"),
+                message=String(
+                    t"Failed to initialise driver plugin from {plugin.so_path}:"
+                    t" {err.message}"
+                ),
             )
 
         var driver_handle = handle.unsafe_assume_init_ref()

--- a/mojo/stdlib/std/sys/_hal/driver.mojo
+++ b/mojo/stdlib/std/sys/_hal/driver.mojo
@@ -73,10 +73,7 @@ struct Driver(Movable):
             var err = plugin.get_status_message(status)
             raise HALError(
                 err.status,
-                message="Failed to initialise driver plugin from "
-                + plugin.so_path
-                + ": "
-                + err.message,
+                message=String(t"Failed to initialise driver plugin from {plugin.so_path}: {err.message}"),
             )
 
         var driver_handle = handle.unsafe_assume_init_ref()
@@ -90,7 +87,7 @@ struct Driver(Movable):
             var err = plugin.get_status_message(status)
             raise HALError(
                 err.status,
-                message="Failed to get device count: " + err.message,
+                message=String(t"Failed to get device count: {err.message}"),
             )
 
         return Driver(

--- a/mojo/stdlib/std/sys/_hal/plugin.mojo
+++ b/mojo/stdlib/std/sys/_hal/plugin.mojo
@@ -382,10 +382,7 @@ struct Plugin(Movable):
         except e:
             raise HALError(
                 STATUS_UNKNOWN_ERROR,
-                message="Failed to load plugin '"
-                + so_path
-                + "': "
-                + String.write(e),
+                message=String(t"Failed to load plugin '{so_path}': {e}"),
             )
 
     def get_status_message(self, status: Int64) raises HALError -> HALError:


### PR DESCRIPTION
Replace string concatenation with t-string interpolation in HAL error messages to avoid intermediate heap allocations.

Assisted-by: AI