### PR TITLE
[stdlib][simd] Add test for simd construction checks

### DIFF
--- a/mojo/stdlib/test/builtin/BUILD.bazel
+++ b/mojo/stdlib/test/builtin/BUILD.bazel
@@ -37,6 +37,7 @@ _LIT_TESTS = [
     "test_format_compile_fail.mojo",
     "test_format_float_lut_optimization.mojo",
     "test_global_constant_compile_fail.mojo",
+    "test_simd_compile_fail.mojo",
     "test_issue_3908.mojo",
     "test_print_long_string.mojo",
     "test_print_stderr.mojo",

--- a/mojo/stdlib/test/builtin/test_simd_compile_fail.mojo
+++ b/mojo/stdlib/test/builtin/test_simd_compile_fail.mojo
@@ -1,0 +1,18 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+
+def main() raises:
+    # Addresses github issue: https://github.com/modular/modular/issues/6349
+    var simd = SIMD[DType.float32, 3](1.0, 2.0, 3.0)
+    _ = simd


### PR DESCRIPTION
Note, currently @always_inline("builtin") basically strips the asserts out of the code.

## Summary

SIMD `_simd_construction_checks` is noop due to `@always_inline("builtin")`

When you run the test, you will notice that `_simd_construction_checks` isn't the thing that fails.
```
def main() raises:
    ^
/home/mojo_user/momanim/third_party/modular/mojo/stdlib/test/builtin/test_simd_compile_fail.mojo:18:49: note: call expansion failed with parameter value(s): (..., "size": 3)
    _simd_construction_checks2[DType.float32, 3]()
                                                ^
mojo/stdlib/std/builtin/simd.mojo:255:5: note: function instantiation failed
mojo/stdlib/std/builtin/simd.mojo:265:5: note: constraint failed: simd width must be power of 2
/home/mojo_user/momanim/.pixi/envs/stdlib-dev/bin/mojo: error: failed to run the pass manager
```

## Testing

I have a compile fail test that demos this. 

## Checklist

- [X] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [ ] I ran `./bazelw run format` to format my changes
- [X] I added or updated tests to cover my changes
