### PR TITLE
[Stdlib] Fix llvm.masked.scatter CUDA_ERROR_ILLEGAL_ADDRESS in shared memory

### DIFF
--- a/mojo/stdlib/std/memory/unsafe_pointer.mojo
+++ b/mojo/stdlib/std/memory/unsafe_pointer.mojo
@@ -1573,7 +1573,7 @@ struct UnsafePointer[
         # On GPU, llvm.masked.scatter causes CUDA_ERROR_ILLEGAL_ADDRESS for
         # non-global address spaces (e.g. shared memory). Use scalar stores
         # as a fallback for these cases.
-        comptime if is_gpu() and address_space != AddressSpace.GENERIC and address_space != AddressSpace.GLOBAL:
+        comptime if is_gpu() and Self.address_space != AddressSpace.GENERIC and Self.address_space != AddressSpace.GLOBAL:
             comptime for i in range(width):
                 if mask[i]:
                     (self + Int(offset[i])).store(val[i])

--- a/mojo/stdlib/std/memory/unsafe_pointer.mojo
+++ b/mojo/stdlib/std/memory/unsafe_pointer.mojo
@@ -1570,6 +1570,15 @@ struct UnsafePointer[
             alignment.is_power_of_two()
         ), "alignment must be a power of two integer value"
 
+        # On GPU, llvm.masked.scatter causes CUDA_ERROR_ILLEGAL_ADDRESS for
+        # non-global address spaces (e.g. shared memory). Use scalar stores
+        # as a fallback for these cases.
+        comptime if is_gpu() and address_space != AddressSpace.GENERIC and address_space != AddressSpace.GLOBAL:
+            comptime for i in range(width):
+                if mask[i]:
+                    (self + Int(offset[i])).store(val[i])
+            return
+
         var base = offset.cast[DType.int]().fma(
             SIMD[DType.int, width](size_of[dtype]()),
             SIMD[DType.int, width](Int(self)),

--- a/mojo/stdlib/std/sys/intrinsics.mojo
+++ b/mojo/stdlib/std/sys/intrinsics.mojo
@@ -237,7 +237,6 @@ def scatter[
         return
 
     comptime if is_gpu():
-
         comptime for i in range(size):
             if mask[i]:
                 UnsafePointer[Scalar[dtype], MutExternalOrigin](

--- a/mojo/stdlib/std/sys/intrinsics.mojo
+++ b/mojo/stdlib/std/sys/intrinsics.mojo
@@ -236,14 +236,6 @@ def scatter[
             ptr.store(value[0])
         return
 
-    comptime if is_gpu():
-        comptime for i in range(size):
-            if mask[i]:
-                UnsafePointer[Scalar[dtype], MutExternalOrigin](
-                    unsafe_from_address=Int(base[i])
-                ).store(value[i])
-        return
-
     llvm_intrinsic["llvm.masked.scatter", NoneType](
         value,
         UnsafePointer(to=base).bitcast[

--- a/mojo/stdlib/std/sys/intrinsics.mojo
+++ b/mojo/stdlib/std/sys/intrinsics.mojo
@@ -235,6 +235,16 @@ def scatter[
             )
             ptr.store(value[0])
         return
+
+    comptime if is_gpu():
+
+        comptime for i in range(size):
+            if mask[i]:
+                UnsafePointer[Scalar[dtype], MutExternalOrigin](
+                    unsafe_from_address=Int(base[i])
+                ).store(value[i])
+        return
+
     llvm_intrinsic["llvm.masked.scatter", NoneType](
         value,
         UnsafePointer(to=base).bitcast[

--- a/mojo/stdlib/test/gpu/memory/BUILD.bazel
+++ b/mojo/stdlib/test/gpu/memory/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//bazel:api.bzl", "mojo_test")
+
+package(default_visibility = ["//visibility:private"])
+
+[
+    mojo_test(
+        name = src + ".test",
+        size = "large",
+        srcs = [src],
+        tags = ["gpu"],
+        target_compatible_with = ["//:has_gpu"],
+        deps = [
+            "@mojo//:std",
+            "@mojo//:test_utils",
+        ],
+    )
+    for src in glob(["*.mojo"])
+]

--- a/mojo/stdlib/test/gpu/memory/test_scatter.mojo
+++ b/mojo/stdlib/test/gpu/memory/test_scatter.mojo
@@ -1,0 +1,172 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Tests for scatter operations on GPU with different address spaces.
+
+Verifies that scatter works correctly for both global memory (using the
+llvm.masked.scatter intrinsic) and shared memory (using the scalar fallback
+that avoids CUDA_ERROR_ILLEGAL_ADDRESS).
+"""
+
+from std.gpu import sync, thread_idx
+from std.gpu.host import DeviceContext
+from std.memory import stack_allocation
+from std.testing import assert_equal, TestSuite
+
+
+# ===-----------------------------------------------------------------------===#
+# Global memory scatter
+# ===-----------------------------------------------------------------------===#
+
+
+def scatter_global_kernel(
+    output: UnsafePointer[Float32, MutAnyOrigin],
+):
+    """Scatters values into global memory using reversed offsets."""
+    var tid = Int(thread_idx.x)
+    comptime N = 4
+
+    # Each thread scatters its thread ID to the reversed position.
+    var offset = SIMD[DType.int32, 1](N - 1 - tid)
+    output.scatter(offset, SIMD[DType.float32, 1](Float32(tid + 1)))
+
+
+def test_scatter_global() raises:
+    comptime N = 4
+
+    with DeviceContext() as ctx:
+        var buf = ctx.enqueue_create_buffer[DType.float32](N)
+        ctx.enqueue_function_experimental[scatter_global_kernel](
+            buf, grid_dim=1, block_dim=N
+        )
+        var result = ctx.enqueue_create_host_buffer[DType.float32](N)
+        ctx.enqueue_copy(result, buf)
+        ctx.synchronize()
+
+        # Thread 0 writes 1.0 to index 3, thread 1 writes 2.0 to index 2, etc.
+        assert_equal(result[0], Float32(4.0))
+        assert_equal(result[1], Float32(3.0))
+        assert_equal(result[2], Float32(2.0))
+        assert_equal(result[3], Float32(1.0))
+
+
+# ===-----------------------------------------------------------------------===#
+# Shared memory scatter
+# ===-----------------------------------------------------------------------===#
+
+
+def scatter_shared_kernel(
+    output: UnsafePointer[Float32, MutAnyOrigin],
+):
+    """Scatters values into shared memory, then copies to global output."""
+    var tid = Int(thread_idx.x)
+    comptime N = 4
+
+    var sram = stack_allocation[
+        N, Float32, address_space=AddressSpace.SHARED
+    ]()
+
+    # Initialize shared memory to zero.
+    sram[tid] = 0.0
+    sync.barrier()
+
+    # Scatter: each thread writes its value to the reversed position
+    # in shared memory.
+    var offset = SIMD[DType.int32, 1](N - 1 - tid)
+    sram.scatter(offset, SIMD[DType.float32, 1](Float32(tid + 1)))
+    sync.barrier()
+
+    # Copy shared memory result to global output.
+    output[tid] = sram[tid]
+
+
+def test_scatter_shared() raises:
+    comptime N = 4
+
+    with DeviceContext() as ctx:
+        var buf = ctx.enqueue_create_buffer[DType.float32](N)
+        ctx.enqueue_function_experimental[scatter_shared_kernel](
+            buf, grid_dim=1, block_dim=N
+        )
+        var result = ctx.enqueue_create_host_buffer[DType.float32](N)
+        ctx.enqueue_copy(result, buf)
+        ctx.synchronize()
+
+        # Same result: reversed mapping.
+        assert_equal(result[0], Float32(4.0))
+        assert_equal(result[1], Float32(3.0))
+        assert_equal(result[2], Float32(2.0))
+        assert_equal(result[3], Float32(1.0))
+
+
+# ===-----------------------------------------------------------------------===#
+# Masked scatter in shared memory
+# ===-----------------------------------------------------------------------===#
+
+
+def scatter_shared_masked_kernel(
+    output: UnsafePointer[Float32, MutAnyOrigin],
+):
+    """Scatters values into shared memory with a mask applied."""
+    var tid = Int(thread_idx.x)
+    comptime N = 4
+
+    var sram = stack_allocation[
+        N, Float32, address_space=AddressSpace.SHARED
+    ]()
+
+    # Initialize shared memory to -1 so we can verify masked-off lanes.
+    sram[tid] = -1.0
+    sync.barrier()
+
+    # Only even-indexed threads scatter their values.
+    var masked = (tid % 2) == 0
+    var offset = SIMD[DType.int32, 1](tid)
+    sram.scatter(
+        offset,
+        SIMD[DType.float32, 1](Float32(tid + 1)),
+        SIMD[DType.bool, 1](masked),
+    )
+    sync.barrier()
+
+    output[tid] = sram[tid]
+
+
+def test_scatter_shared_masked() raises:
+    comptime N = 4
+
+    with DeviceContext() as ctx:
+        var buf = ctx.enqueue_create_buffer[DType.float32](N)
+        ctx.enqueue_function_experimental[scatter_shared_masked_kernel](
+            buf, grid_dim=1, block_dim=N
+        )
+        var result = ctx.enqueue_create_host_buffer[DType.float32](N)
+        ctx.enqueue_copy(result, buf)
+        ctx.synchronize()
+
+        # Thread 0 (even) writes 1.0 to index 0.
+        assert_equal(result[0], Float32(1.0))
+        # Thread 1 (odd) is masked off, so index 1 stays -1.0.
+        assert_equal(result[1], Float32(-1.0))
+        # Thread 2 (even) writes 3.0 to index 2.
+        assert_equal(result[2], Float32(3.0))
+        # Thread 3 (odd) is masked off, so index 3 stays -1.0.
+        assert_equal(result[3], Float32(-1.0))
+
+
+# ===-----------------------------------------------------------------------===#
+# Main
+# ===-----------------------------------------------------------------------===#
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Fixes #5366 

## Summary

Add a GPU fallback for the scatter function in std/sys/intrinsics.mojo that performs element-wise stores

## Testing

- Validated that the fallback logic mirrors the existing gather GPU fallback pattern
