### PR TITLE
[stdlib] Unify init pointee methods

### DIFF
--- a/max/kernels/src/Mogg/MOGGPrimitives/MOGGPrimitives.mojo
+++ b/max/kernels/src/Mogg/MOGGPrimitives/MOGGPrimitives.mojo
@@ -981,7 +981,7 @@ struct MoggAsyncPackHelper:
             UnsafePointer[UInt8, MutExternalOrigin],
         ](size_of[Type](), align_of[Type]())
 
-        dst_ptr.bitcast[Type]().init_pointee_move(data^)
+        dst_ptr.bitcast[Type]().init_pointee(take=data^)
 
         external_call["MGP_RT_CreateOwnedAsyncMojoValue", NoneType](
             dst_ptr,

--- a/max/kernels/src/comm/vendor/ccl.mojo
+++ b/max/kernels/src/comm/vendor/ccl.mojo
@@ -275,7 +275,7 @@ def _get_global_comms(ngpus: Int) raises -> Communicators:
     var c = Communicators(ngpus=ngpus, comms=comms.copy())
 
     var ptr = alloc[Communicators](1)
-    ptr.init_pointee_move(c)
+    ptr.init_pointee(take=c)
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
         StringSlice(NAME), ptr.bitcast[NoneType]()
     )

--- a/max/kernels/src/layout/coord.mojo
+++ b/max/kernels/src/layout/coord.mojo
@@ -1994,7 +1994,7 @@ struct _RegTuple[*element_types: CoordLike](
         )
 
         comptime for i in range(type_of(self).__len__()):
-            UnsafePointer(to=self[i]).init_pointee_move(elt_types[i]())
+            UnsafePointer(to=self[i]).init_pointee(take=elt_types[i]())
 
     @always_inline("nodebug")
     def reverse(

--- a/max/kernels/src/layout/coord.mojo
+++ b/max/kernels/src/layout/coord.mojo
@@ -478,8 +478,8 @@ struct Coord[*element_types: CoordLike](CoordLike, Sized, Writable):
         self = type_of(self)()
 
         comptime for i in range(rank):
-            UnsafePointer(to=self[i]).init_pointee_copy(
-                rebind[type_of(self[i])](
+            UnsafePointer(to=self[i]).init_pointee(
+                copy=rebind[type_of(self[i])](
                     RuntimeInt[dtype](Scalar[dtype](index_list[i]))
                 )
             )
@@ -837,14 +837,14 @@ struct Coord[*element_types: CoordLike](CoordLike, Sized, Writable):
 
             comptime if FlatType.is_static_value:
                 # Compile-time known value
-                UnsafePointer(to=flat_tuple[i]).init_pointee_copy(
-                    rebind[FlatType](ComptimeInt[FlatType.static_value]())
+                UnsafePointer(to=flat_tuple[i]).init_pointee(
+                    copy=rebind[FlatType](ComptimeInt[FlatType.static_value]())
                 )
             else:
                 # Runtime value - use _get_flattened to get the value
                 var val = _get_flattened[i](self)
-                UnsafePointer(to=flat_tuple[i]).init_pointee_copy(
-                    rebind[FlatType](
+                UnsafePointer(to=flat_tuple[i]).init_pointee(
+                    copy=rebind[FlatType](
                         RuntimeInt[FlatType.DTYPE](Scalar[FlatType.DTYPE](val))
                     )
                 )
@@ -879,8 +879,8 @@ struct Coord[*element_types: CoordLike](CoordLike, Sized, Writable):
 
         comptime for i in range(Self.__len__()):
             # Convert all elements to RuntimeInt[dtype]
-            UnsafePointer(to=result[i]).init_pointee_copy(
-                rebind[ResultTypes[i]](
+            UnsafePointer(to=result[i]).init_pointee(
+                copy=rebind[ResultTypes[i]](
                     RuntimeInt[dtype](Scalar[dtype](self[i].value()))
                 )
             )
@@ -1091,30 +1091,30 @@ def idx2crd[
                 var nested = idx2crd[out_dtype=out_dtype](
                     idx, shape_t[i], stride_t[i]
                 )
-                UnsafePointer(to=result[i]).init_pointee_copy(
-                    rebind[ResultTypes[i]](nested)
+                UnsafePointer(to=result[i]).init_pointee(
+                    copy=rebind[ResultTypes[i]](nested)
                 )
             elif (
                 Shape.ParamListType[i].is_static_value
                 and Shape.ParamListType[i].static_value == 1
             ):
-                UnsafePointer(to=result[i]).init_pointee_copy(
-                    rebind[ResultTypes[i]](ComptimeInt[0]())
+                UnsafePointer(to=result[i]).init_pointee(
+                    copy=rebind[ResultTypes[i]](ComptimeInt[0]())
                 )
             else:
                 var stride_val = stride_t[i].value()
                 var shape_val = shape_t[i].value()
                 var coord_val = _linear_idx_to_coord(idx, stride_val, shape_val)
 
-                UnsafePointer(to=result[i]).init_pointee_copy(
-                    rebind[ResultTypes[i]](
+                UnsafePointer(to=result[i]).init_pointee(
+                    copy=rebind[ResultTypes[i]](
                         RuntimeInt[out_dtype](Scalar[out_dtype](coord_val))
                     )
                 )
     else:
         comptime if Shape.is_static_value and Shape.static_value == 1:
-            UnsafePointer(to=result[0]).init_pointee_copy(
-                rebind[ResultTypes[0]](ComptimeInt[0]())
+            UnsafePointer(to=result[0]).init_pointee(
+                copy=rebind[ResultTypes[0]](ComptimeInt[0]())
             )
         else:
             var coord_val = _linear_idx_to_coord(
@@ -1122,8 +1122,8 @@ def idx2crd[
             )
 
             comptime for i in range(shape_len):
-                UnsafePointer(to=result[i]).init_pointee_copy(
-                    rebind[ResultTypes[i]](
+                UnsafePointer(to=result[i]).init_pointee(
+                    copy=rebind[ResultTypes[i]](
                         RuntimeInt[out_dtype](Scalar[out_dtype](coord_val))
                     )
                 )
@@ -1193,15 +1193,15 @@ def idx2crd[
                 var nested = idx2crd[out_dtype=out_dtype](
                     idx.value(), shape_t[i], stride_t[i]
                 )
-                UnsafePointer(to=result[i]).init_pointee_copy(
-                    rebind[ResultTypes[i]](nested)
+                UnsafePointer(to=result[i]).init_pointee(
+                    copy=rebind[ResultTypes[i]](nested)
                 )
             elif (
                 Shape.ParamListType[i].is_static_value
                 and Shape.ParamListType[i].static_value == 1
             ):
-                UnsafePointer(to=result[i]).init_pointee_copy(
-                    rebind[ResultTypes[i]](ComptimeInt[0]())
+                UnsafePointer(to=result[i]).init_pointee(
+                    copy=rebind[ResultTypes[i]](ComptimeInt[0]())
                 )
             elif (
                 Index.is_static_value
@@ -1216,15 +1216,15 @@ def idx2crd[
                 var coord_val = _linear_idx_to_coord(
                     idx.value(), stride_val, shape_val
                 )
-                UnsafePointer(to=result[i]).init_pointee_copy(
-                    rebind[ResultTypes[i]](
+                UnsafePointer(to=result[i]).init_pointee(
+                    copy=rebind[ResultTypes[i]](
                         RuntimeInt[out_dtype](Scalar[out_dtype](coord_val))
                     )
                 )
     else:
         comptime if Shape.is_static_value and Shape.static_value == 1:
-            UnsafePointer(to=result[0]).init_pointee_copy(
-                rebind[ResultTypes[0]](ComptimeInt[0]())
+            UnsafePointer(to=result[0]).init_pointee(
+                copy=rebind[ResultTypes[0]](ComptimeInt[0]())
             )
         elif (
             Index.is_static_value
@@ -1239,8 +1239,8 @@ def idx2crd[
             )
 
             comptime for i in range(shape_len):
-                UnsafePointer(to=result[i]).init_pointee_copy(
-                    rebind[ResultTypes[i]](
+                UnsafePointer(to=result[i]).init_pointee(
+                    copy=rebind[ResultTypes[i]](
                         RuntimeInt[out_dtype](Scalar[out_dtype](coord_val))
                     )
                 )
@@ -1360,8 +1360,8 @@ def coord[
     result = {}
 
     comptime for i in range(type_of(values).__len__()):
-        UnsafePointer(to=result[i]).init_pointee_copy(
-            rebind[type_of(result[i])](
+        UnsafePointer(to=result[i]).init_pointee(
+            copy=rebind[type_of(result[i])](
                 RuntimeInt[dtype](Scalar[dtype](rebind[Int](values[i])))
             )
         )
@@ -1933,7 +1933,7 @@ struct _RegTuple[*element_types: CoordLike](
         # Move each element into the tuple storage.
         @parameter
         def init_elt[idx: Int](var elt: Self.element_types[idx]):
-            UnsafePointer(to=self[idx]).init_pointee_move(elt)
+            UnsafePointer(to=self[idx]).init_pointee(take=elt)
 
         args^.consume_elements[init_elt]()
 
@@ -2020,8 +2020,8 @@ struct _RegTuple[*element_types: CoordLike](
         )
 
         comptime for i in range(type_of(result).__len__()):
-            UnsafePointer(to=result[i]).init_pointee_copy(
-                rebind[type_of(result[i])](
+            UnsafePointer(to=result[i]).init_pointee(
+                copy=rebind[type_of(result[i])](
                     self[Self.element_types.size - 1 - i]
                 )
             )
@@ -2067,13 +2067,13 @@ struct _RegTuple[*element_types: CoordLike](
         comptime self_len = Self.__len__()
 
         comptime for i in range(self_len):
-            UnsafePointer(to=result[i]).init_pointee_copy(
-                rebind[type_of(result[i])](self[i])
+            UnsafePointer(to=result[i]).init_pointee(
+                copy=rebind[type_of(result[i])](self[i])
             )
 
         comptime for i in range(type_of(other).__len__()):
-            UnsafePointer(to=result[self_len + i]).init_pointee_copy(
-                rebind[type_of(result[self_len + i])](other[i])
+            UnsafePointer(to=result[self_len + i]).init_pointee(
+                copy=rebind[type_of(result[self_len + i])](other[i])
             )
 
     @always_inline("nodebug")

--- a/max/kernels/src/layout/tile_layout.mojo
+++ b/max/kernels/src/layout/tile_layout.mojo
@@ -500,13 +500,13 @@ struct Layout[
                     var coord_val = _mod_by_shape[
                         Self.shape_types[i].ParamListType[j]
                     ](divided, sub_shape[j].value())
-                    UnsafePointer(to=sub_result[j]).init_pointee_copy(
-                        rebind[SubResultType.element_types[j]](
+                    UnsafePointer(to=sub_result[j]).init_pointee(
+                        copy=rebind[SubResultType.element_types[j]](
                             RuntimeInt[out_dtype](Scalar[out_dtype](coord_val))
                         )
                     )
-                UnsafePointer(to=result[i]).init_pointee_copy(
-                    rebind[ResultType.element_types[i]](sub_result)
+                UnsafePointer(to=result[i]).init_pointee(
+                    copy=rebind[ResultType.element_types[i]](sub_result)
                 )
             else:
                 var divided = _divide_by_stride[Self.stride_types[i]](
@@ -515,8 +515,8 @@ struct Layout[
                 var coord_val = _mod_by_shape[Self.shape_types[i]](
                     divided, shape_t[i].value()
                 )
-                UnsafePointer(to=result[i]).init_pointee_copy(
-                    rebind[ResultType.element_types[i]](
+                UnsafePointer(to=result[i]).init_pointee(
+                    copy=rebind[ResultType.element_types[i]](
                         RuntimeInt[out_dtype](Scalar[out_dtype](coord_val))
                     )
                 )
@@ -838,22 +838,22 @@ def row_major(var shape: Coord) -> RowMajorLayout[*shape.element_types]:
         comptime if i == 0:
             # Rightmost dimension always has stride 1
             comptime StrideType = RowMajorTypes[idx]
-            stride_ptr.init_pointee_copy(rebind[StrideType](Idx[1]()))
+            stride_ptr.init_pointee(copy=rebind[StrideType](Idx[1]()))
         else:
             # Calculate stride as product of shape[idx+1] * stride[idx+1]
             comptime StrideType = RowMajorTypes[idx]
 
             comptime if StrideType.is_static_value:
                 comptime stride_val = StrideType.static_value
-                stride_ptr.init_pointee_copy(
-                    rebind[StrideType](Idx[stride_val]())
+                stride_ptr.init_pointee(
+                    copy=rebind[StrideType](Idx[stride_val]())
                 )
             else:
                 var stride_val = (
                     shape[idx + 1].value() * strides[idx + 1].value()
                 )
-                stride_ptr.init_pointee_copy(
-                    rebind[StrideType](
+                stride_ptr.init_pointee(
+                    copy=rebind[StrideType](
                         RuntimeInt[StrideType.DTYPE](
                             Scalar[StrideType.DTYPE](stride_val)
                         )
@@ -897,7 +897,7 @@ def row_major[
         comptime if i == 0:
             # Rightmost dimension always has stride 1
             comptime StrideType = RowMajorTypes[idx]
-            stride_ptr.init_pointee_copy(rebind[StrideType](Idx[1]()))
+            stride_ptr.init_pointee(copy=rebind[StrideType](Idx[1]()))
         else:
             # Calculate stride as product of shape[idx+1] * stride[idx+1]
             comptime StrideType = RowMajorTypes[idx]
@@ -905,16 +905,16 @@ def row_major[
             comptime if StrideType.is_static_value:
                 # Stride is compile-time known (both shape and prev stride are compile-time)
                 comptime stride_val = StrideType.static_value
-                stride_ptr.init_pointee_copy(
-                    rebind[StrideType](Idx[stride_val]())
+                stride_ptr.init_pointee(
+                    copy=rebind[StrideType](Idx[stride_val]())
                 )
             else:
                 # At least one is runtime, compute at runtime
                 var stride_val = (
                     elements[idx + 1].value() * strides[idx + 1].value()
                 )
-                stride_ptr.init_pointee_copy(
-                    rebind[StrideType](
+                stride_ptr.init_pointee(
+                    copy=rebind[StrideType](
                         RuntimeInt[StrideType.DTYPE](
                             Scalar[StrideType.DTYPE](stride_val)
                         )
@@ -1045,7 +1045,7 @@ def col_major(var shape: Coord) -> ColMajorLayout[shape.element_types]:
         comptime if i == 0:
             # Leftmost dimension always has stride 1
             comptime StrideType = ColMajorTypes[i]
-            stride_ptr.init_pointee_copy(rebind[StrideType](Idx[1]()))
+            stride_ptr.init_pointee(copy=rebind[StrideType](Idx[1]()))
         else:
             # Calculate stride as product of shape[i-1] * stride[i-1]
             comptime StrideType = ColMajorTypes[i]
@@ -1053,14 +1053,14 @@ def col_major(var shape: Coord) -> ColMajorLayout[shape.element_types]:
             comptime if StrideType.is_static_value:
                 # Stride is compile-time known
                 comptime stride_val = StrideType.static_value
-                stride_ptr.init_pointee_copy(
-                    rebind[StrideType](Idx[stride_val]())
+                stride_ptr.init_pointee(
+                    copy=rebind[StrideType](Idx[stride_val]())
                 )
             else:
                 # At least one is runtime, compute at runtime
                 var stride_val = shape[i - 1].value() * strides[i - 1].value()
-                stride_ptr.init_pointee_copy(
-                    rebind[StrideType](
+                stride_ptr.init_pointee(
+                    copy=rebind[StrideType](
                         RuntimeInt[StrideType.DTYPE](
                             Scalar[StrideType.DTYPE](stride_val)
                         )
@@ -1517,15 +1517,15 @@ def blocked_product[
 
     comptime for i in range(outer_shape.rank):
         comptime if OuterStrideTypes[i].is_static_value:
-            UnsafePointer(to=outer_stride[i]).init_pointee_copy(
-                rebind[OuterStrideTypes[i]](
+            UnsafePointer(to=outer_stride[i]).init_pointee(
+                copy=rebind[OuterStrideTypes[i]](
                     ComptimeInt[OuterStrideTypes[i].static_value]()
                 )
             )
         else:
             var block_cosize = block.shape_coord().product()
-            UnsafePointer(to=outer_stride[i]).init_pointee_copy(
-                rebind[OuterStrideTypes[i]](
+            UnsafePointer(to=outer_stride[i]).init_pointee(
+                copy=rebind[OuterStrideTypes[i]](
                     RuntimeInt[OuterStrideTypes[i].DTYPE](
                         Scalar[OuterStrideTypes[i].DTYPE](
                             tiler.stride_coord()[i].value() * block_cosize
@@ -1540,13 +1540,13 @@ def blocked_product[
     var result_stride = Coord[*ResultType._stride_types]()
 
     comptime for i in range(inner_shape.rank):
-        UnsafePointer(to=result_shape[i]).init_pointee_copy(
-            rebind[ResultType._shape_types[i]](
+        UnsafePointer(to=result_shape[i]).init_pointee(
+            copy=rebind[ResultType._shape_types[i]](
                 Coord(inner_shape[i], outer_shape[i])
             )
         )
-        UnsafePointer(to=result_stride[i]).init_pointee_copy(
-            rebind[ResultType._stride_types[i]](
+        UnsafePointer(to=result_stride[i]).init_pointee(
+            copy=rebind[ResultType._stride_types[i]](
                 Coord(inner_stride[i], outer_stride[i])
             )
         )
@@ -1803,12 +1803,12 @@ def upcast[
 
         # Compute new_stride[i] = shape_div(stride[i], factor).
         comptime if ResultStrideTypes[i].is_static_value:
-            UnsafePointer(to=new_stride[i]).init_pointee_copy(
-                ResultStrideTypes[i]()
+            UnsafePointer(to=new_stride[i]).init_pointee(
+                copy=ResultStrideTypes[i]()
             )
         else:
-            UnsafePointer(to=new_stride[i]).init_pointee_copy(
-                rebind[ResultStrideTypes[i]](
+            UnsafePointer(to=new_stride[i]).init_pointee(
+                copy=rebind[ResultStrideTypes[i]](
                     RuntimeInt(
                         Scalar[ResultStrideTypes[i].DTYPE](
                             _runtime_shape_div(
@@ -1821,12 +1821,12 @@ def upcast[
 
         # Compute new_shape[i] = shape_div(shape[i], shape_div(factor, stride[i])).
         comptime if ResultShapeTypes[i].is_static_value:
-            UnsafePointer(to=new_shape[i]).init_pointee_copy(
-                ResultShapeTypes[i]()
+            UnsafePointer(to=new_shape[i]).init_pointee(
+                copy=ResultShapeTypes[i]()
             )
         else:
-            UnsafePointer(to=new_shape[i]).init_pointee_copy(
-                rebind[ResultShapeTypes[i]](
+            UnsafePointer(to=new_shape[i]).init_pointee(
+                copy=rebind[ResultShapeTypes[i]](
                     RuntimeInt(
                         Scalar[ResultShapeTypes[i].DTYPE](
                             _runtime_shape_div(

--- a/max/kernels/src/layout/tile_tensor.mojo
+++ b/max/kernels/src/layout/tile_tensor.mojo
@@ -451,8 +451,8 @@ struct TileTensor[
         var linear_tuple = DynamicCoord[Self.linear_idx_type, arg_count]()
 
         comptime for i in range(arg_count):
-            UnsafePointer(to=linear_tuple[i]).init_pointee_copy(
-                rebind[type_of(linear_tuple).element_types[i]](
+            UnsafePointer(to=linear_tuple[i]).init_pointee(
+                copy=rebind[type_of(linear_tuple).element_types[i]](
                     RuntimeInt[Self.linear_idx_type](
                         Scalar[Self.linear_idx_type](index(items[i]))
                     )
@@ -549,11 +549,15 @@ struct TileTensor[
         comptime for i in range(Self.rank):
             comptime if _type_is_eq_parse_time[IndexTypes[i], _All]():
                 comptime kept_idx = _count_all_before[i, *IndexTypes]()
-                UnsafePointer(to=new_shape[kept_idx]).init_pointee_copy(
-                    rebind[KeptShapeTypes[kept_idx]](self.layout.shape[i]())
+                UnsafePointer(to=new_shape[kept_idx]).init_pointee(
+                    copy=rebind[KeptShapeTypes[kept_idx]](
+                        self.layout.shape[i]()
+                    )
                 )
-                UnsafePointer(to=new_stride[kept_idx]).init_pointee_copy(
-                    rebind[KeptStrideTypes[kept_idx]](self.layout.stride[i]())
+                UnsafePointer(to=new_stride[kept_idx]).init_pointee(
+                    copy=rebind[KeptStrideTypes[kept_idx]](
+                        self.layout.stride[i]()
+                    )
                 )
 
         var new_layout = Layout(new_shape, new_stride)
@@ -605,8 +609,8 @@ struct TileTensor[
         var linear_tuple = DynamicCoord[Self.linear_idx_type, arg_count]()
 
         comptime for i in range(arg_count):
-            UnsafePointer(to=linear_tuple[i]).init_pointee_copy(
-                rebind[type_of(linear_tuple).element_types[i]](
+            UnsafePointer(to=linear_tuple[i]).init_pointee(
+                copy=rebind[type_of(linear_tuple).element_types[i]](
                     RuntimeInt[Self.linear_idx_type](
                         Scalar[Self.linear_idx_type](index(items[i]))
                     )
@@ -1159,8 +1163,8 @@ struct TileTensor[
         var coordinates = DynamicCoord[Self.linear_idx_type, Self.rank]()
 
         comptime for i in range(Self.rank):
-            UnsafePointer(to=coordinates[i]).init_pointee_copy(
-                rebind[coordinates.element_types[i]](
+            UnsafePointer(to=coordinates[i]).init_pointee(
+                copy=rebind[coordinates.element_types[i]](
                     RuntimeInt[Self.linear_idx_type](
                         Scalar[Self.linear_idx_type](tile_coords[i])
                     )
@@ -1481,8 +1485,10 @@ struct TileTensor[
             var shape_ptr = UnsafePointer(to=new_shape[i])
             comptime NewShapeType = NewShapeTypes[i]
 
-            shape_ptr.init_pointee_copy(
-                rebind[NewShapeType](ComptimeInt[NewShapeType.static_value]())
+            shape_ptr.init_pointee(
+                copy=rebind[NewShapeType](
+                    ComptimeInt[NewShapeType.static_value]()
+                )
             )
 
         # Strides remain unchanged
@@ -2520,8 +2526,8 @@ def _distribute[
     # Populate runtime values for dimensions that aren't statically known.
     comptime for i in range(NewShapeTypes.size):
         comptime if not NewShapeTypes[i].is_static_value:
-            UnsafePointer(to=shape[i]).init_pointee_copy(
-                rebind[NewShapeTypes[i]](
+            UnsafePointer(to=shape[i]).init_pointee(
+                copy=rebind[NewShapeTypes[i]](
                     Idx(
                         data_layout_tensor.layout.shape_coord()[i].value()
                         // thread_layout.shape_types[i].static_value
@@ -2529,8 +2535,8 @@ def _distribute[
                 )
             )
         comptime if not NewStrideTypes[i].is_static_value:
-            UnsafePointer(to=stride[i]).init_pointee_copy(
-                rebind[NewStrideTypes[i]](
+            UnsafePointer(to=stride[i]).init_pointee(
+                copy=rebind[NewStrideTypes[i]](
                     Idx(
                         data_layout_tensor.layout.stride_coord()[i].value()
                         * thread_layout.shape_types[i].static_value
@@ -2624,8 +2630,8 @@ def _distribute_with_offset[
     # Populate runtime values for dimensions that aren't statically known.
     comptime for i in range(NewShapeTypes.size):
         comptime if not NewShapeTypes[i].is_static_value:
-            UnsafePointer(to=shape[i]).init_pointee_copy(
-                rebind[NewShapeTypes[i]](
+            UnsafePointer(to=shape[i]).init_pointee(
+                copy=rebind[NewShapeTypes[i]](
                     Idx(
                         data_layout_tensor.layout.shape_coord()[i].value()
                         // thread_layout.shape_types[i].static_value
@@ -2633,8 +2639,8 @@ def _distribute_with_offset[
                 )
             )
         comptime if not NewStrideTypes[i].is_static_value:
-            UnsafePointer(to=stride[i]).init_pointee_copy(
-                rebind[NewStrideTypes[i]](
+            UnsafePointer(to=stride[i]).init_pointee(
+                copy=rebind[NewStrideTypes[i]](
                     Idx(
                         data_layout_tensor.layout.stride_coord()[i].value()
                         * thread_layout.shape_types[i].static_value
@@ -3004,8 +3010,8 @@ def _vectorize[
     # Populate runtime values for dimensions that aren't statically known.
     comptime for i in range(NewShapeTypes.size):
         comptime if not NewShapeTypes[i].is_static_value:
-            UnsafePointer(to=new_shape[i]).init_pointee_copy(
-                rebind[NewShapeTypes[i]](
+            UnsafePointer(to=new_shape[i]).init_pointee(
+                copy=rebind[NewShapeTypes[i]](
                     Scalar[NewShapeTypes[i].DTYPE](
                         ceildiv(
                             data_layout_tensor.layout.shape_coord()[i].value(),
@@ -3015,8 +3021,8 @@ def _vectorize[
                 )
             )
         comptime if not NewStrideTypes[i].is_static_value:
-            UnsafePointer(to=new_stride[i]).init_pointee_copy(
-                rebind[NewStrideTypes[i]](
+            UnsafePointer(to=new_stride[i]).init_pointee(
+                copy=rebind[NewStrideTypes[i]](
                     Scalar[NewStrideTypes[i].DTYPE](
                         data_layout_tensor.layout.stride_coord()[i].value()
                         * vector_shape[i].value()

--- a/max/kernels/src/linalg/bmm.mojo
+++ b/max/kernels/src/linalg/bmm.mojo
@@ -191,13 +191,13 @@ def _reshape_tile_tensor_with_batch_to_3d(
         comptime StrideType = out_stride_types[i]
 
         comptime if StrideType.is_static_value:
-            stride_ptr.init_pointee_copy(
-                rebind[StrideType](Idx[StrideType.static_value]())
+            stride_ptr.init_pointee(
+                copy=rebind[StrideType](Idx[StrideType.static_value]())
             )
         else:
             var stride_val = tensor.layout.stride[idx]().value()
-            stride_ptr.init_pointee_copy(
-                rebind[StrideType](
+            stride_ptr.init_pointee(
+                copy=rebind[StrideType](
                     RuntimeInt[StrideType.DTYPE](
                         Scalar[StrideType.DTYPE](stride_val)
                     )
@@ -209,8 +209,8 @@ def _reshape_tile_tensor_with_batch_to_3d(
         comptime ShapeType = out_shape_types[i]
 
         comptime if ShapeType.is_static_value:
-            shape_ptr.init_pointee_copy(
-                rebind[ShapeType](Idx[ShapeType.static_value]())
+            shape_ptr.init_pointee(
+                copy=rebind[ShapeType](Idx[ShapeType.static_value]())
             )
         else:
             var shape_val = tensor.layout.shape[idx]().value()
@@ -219,8 +219,8 @@ def _reshape_tile_tensor_with_batch_to_3d(
                 comptime for batch_idx in range(rank - 3):
                     shape_val *= tensor.layout.shape[batch_idx]().value()
 
-            shape_ptr.init_pointee_copy(
-                rebind[ShapeType](
+            shape_ptr.init_pointee(
+                copy=rebind[ShapeType](
                     RuntimeInt[ShapeType.DTYPE](
                         Scalar[ShapeType.DTYPE](shape_val)
                     )

--- a/max/kernels/src/linalg/matmul/vendor/blas.mojo
+++ b/max/kernels/src/linalg/matmul/vendor/blas.mojo
@@ -342,7 +342,7 @@ def _get_global_handle[
 
     # Otherwise, we have not initialized the handle yet.
     var handle_ptr = alloc[Handle[backend]](1)
-    handle_ptr.init_pointee_move(Handle[backend]())
+    handle_ptr.init_pointee(take=Handle[backend]())
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
         StringSlice(HANDLE_NAME),
         handle_ptr.bitcast[NoneType](),

--- a/max/kernels/src/nn/conv/conv.mojo
+++ b/max/kernels/src/nn/conv/conv.mojo
@@ -3424,7 +3424,7 @@ def _get_cudnn_meta(
         return ptr
 
     var new_ptr_meta = alloc[CuDNNConvMeta](1)
-    new_ptr_meta.init_pointee_move(CuDNNConvMeta())
+    new_ptr_meta.init_pointee(take=CuDNNConvMeta())
 
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
         StringSlice(cache_key),
@@ -3535,7 +3535,7 @@ def _get_cached_cudnn_meta_nhwc_full(
         return ptr
 
     var new_ptr_meta = alloc[CachedCuDNNMetaNHWCFull](1)
-    new_ptr_meta.init_pointee_move(CachedCuDNNMetaNHWCFull())
+    new_ptr_meta.init_pointee(take=CachedCuDNNMetaNHWCFull())
 
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
         StringSlice(cache_key),
@@ -3877,7 +3877,7 @@ def _get_cached_miopen_meta(
         return ptr
 
     var new_ptr_meta = alloc[CachedMIOpenMeta](1)
-    new_ptr_meta.init_pointee_move(CachedMIOpenMeta())
+    new_ptr_meta.init_pointee(take=CachedMIOpenMeta())
 
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
         StringSlice(cache_key),
@@ -5465,8 +5465,8 @@ def _conv3d_cudnn[
 
         # Store result in global cache.
         var ptr_entry = alloc[_Conv3dAlgoCacheEntry](1)
-        ptr_entry.init_pointee_move(
-            _Conv3dAlgoCacheEntry(
+        ptr_entry.init_pointee(
+            take=_Conv3dAlgoCacheEntry(
                 algo_value=rebind[Int8](algo),
                 workspace_size=workspace_size_var,
             )

--- a/mojo/docs/code/manual/lifecycle/death/heap_array_destructor.mojo
+++ b/mojo/docs/code/manual/lifecycle/death/heap_array_destructor.mojo
@@ -20,7 +20,7 @@ struct HeapArray(Writable):
         self.size = len(values)
         self.data = alloc[Int](self.size)
         for i in range(self.size):
-            (self.data + i).init_pointee_copy(values[i])
+            (self.data + i).init_pointee(copy=values[i])
 
     def write_to(self, mut writer: Some[Writer]):
         writer.write("[")

--- a/mojo/docs/code/manual/parameters/index/parameterized_structs.mojo
+++ b/mojo/docs/code/manual/parameters/index/parameterized_structs.mojo
@@ -20,7 +20,7 @@ struct GenericArray[ElementType: Copyable & ImplicitlyDestructible]:
         self.size = len(elements)
         self.data = alloc[Self.ElementType](self.size)
         for i in range(self.size):
-            (self.data + i).init_pointee_move(elements[i].copy())
+            (self.data + i).init_pointee(take=elements[i].copy())
 
     def __del__(deinit self):
         for i in range(self.size):

--- a/mojo/docs/code/manual/parameters/index/parameterized_structs_staticmethod.mojo
+++ b/mojo/docs/code/manual/parameters/index/parameterized_structs_staticmethod.mojo
@@ -20,13 +20,13 @@ struct GenericArray[ElementType: Copyable & ImplicitlyDestructible]:
         self.size = len(elements)
         self.data = alloc[Self.ElementType](self.size)
         for i in range(self.size):
-            (self.data + i).init_pointee_move(elements[i].copy())
+            (self.data + i).init_pointee(take=elements[i].copy())
 
     def __init__(out self, *, count: Int, value: Self.ElementType):
         self.size = count
         self.data = alloc[Self.ElementType](self.size)
         for i in range(self.size):
-            (self.data + i).init_pointee_copy(value)
+            (self.data + i).init_pointee(copy=value)
 
     def __del__(deinit self):
         for i in range(self.size):

--- a/mojo/docs/code/manual/structs/reference/self_referential.mojo
+++ b/mojo/docs/code/manual/structs/reference/self_referential.mojo
@@ -35,7 +35,7 @@ struct Node[ElementType: ImplicitlyCopyable & Writable](Movable):
     @staticmethod
     def make_node(value: Self.ElementType) -> Self.NodePointer:
         node_ptr = alloc[Self](1)
-        node_ptr.init_pointee_move(Self(value))
+        node_ptr.init_pointee(take=Self(value))
         return node_ptr
 
     # Constructs a `Node` with allocated memory, assigns a value, appends

--- a/mojo/docs/manual/lifecycle/death.mdx
+++ b/mojo/docs/manual/lifecycle/death.mdx
@@ -164,7 +164,7 @@ struct HeapArray(Writable):
         self.size = len(values)
         self.data = alloc[Int](self.size)
         for i in range(self.size):
-            (self.data + i).init_pointee_copy(values[i])
+            (self.data + i).init_pointee(copy=values[i])
 
     def write_to(self, mut writer: Some[Writer]):
         writer.write("[")

--- a/mojo/docs/manual/lifecycle/life.mdx
+++ b/mojo/docs/manual/lifecycle/life.mdx
@@ -372,7 +372,7 @@ struct HeapArray(Copyable):
         self.cap = size * 2
         self.data = alloc[Int](self.cap)
         for i in range(self.size):
-            (self.data + i).init_pointee_copy(val)
+            (self.data + i).init_pointee(copy=val)
 
     def __init__(out self, *, copy: Self):
         # Deep-copy the existing value
@@ -380,7 +380,7 @@ struct HeapArray(Copyable):
         self.cap = copy.cap
         self.data = alloc[Int](self.cap)
         for i in range(self.size):
-            (self.data + i).init_pointee_copy(copy.data[i])
+            (self.data + i).init_pointee(copy=copy.data[i])
         # The lifetime of `copy` continues unchanged
 
     def __del__(deinit self):
@@ -393,7 +393,7 @@ struct HeapArray(Copyable):
     def append(mut self, val: Int):
         # Update the array for demo purposes
         if self.size < self.cap:
-            (self.data + self.size).init_pointee_copy(val)
+            (self.data + self.size).init_pointee(copy=val)
             self.size += 1
         else:
             print("Out of bounds")

--- a/mojo/docs/manual/parameters/index.mdx
+++ b/mojo/docs/manual/parameters/index.mdx
@@ -207,7 +207,7 @@ struct GenericArray[ElementType: Copyable & ImplicitlyDestructible]:
         self.size = len(elements)
         self.data = alloc[Self.ElementType](self.size)
         for i in range(self.size):
-            (self.data + i).init_pointee_move(elements[i].copy())
+            (self.data + i).init_pointee(take=elements[i].copy())
 
     def __del__(deinit self):
         for i in range(self.size):

--- a/mojo/docs/manual/pointers/unsafe-pointers.mdx
+++ b/mojo/docs/manual/pointers/unsafe-pointers.mdx
@@ -31,7 +31,7 @@ value pointed to by a pointer is sometimes called a *pointee*.
 # Allocate memory to hold a value
 var ptr = alloc[Int](1)
 # Initialize the allocated memory
-ptr.init_pointee_copy(100)
+ptr.init_pointee(copy=100)
 ```
 
 <figure>
@@ -95,9 +95,9 @@ At any given time, a pointer can be in one of several states:
   keyword argument.
 
   ```mojo
-  ptr.init_pointee_copy(value)
+  ptr.init_pointee(copy=value)
   # or
-  ptr.init_pointee_move(value^)
+  ptr.init_pointee(take=value^)
   # or
   ptr = UnsafePointer(to=value)
   ```
@@ -146,20 +146,20 @@ not initialized.
 ### Initializing the pointee
 
 To initialize allocated memory, `UnsafePointer` provides the
-[`init_pointee_copy()`](/mojo/std/memory/unsafe_pointer/UnsafePointer#init_pointee_copy)
+[`init_pointee(copy=...)`](/mojo/std/memory/unsafe_pointer/UnsafePointer#init_pointee)
 and
-[`init_pointee_move()`](/mojo/std/memory/unsafe_pointer/UnsafePointer#init_pointee_move)
+[`init_pointee(take=...)`](/mojo/std/memory/unsafe_pointer/UnsafePointer#init_pointee)
 methods. For example:
 
 ```mojo
-ptr.init_pointee_copy(my_value)
+ptr.init_pointee(copy=my_value)
 ```
 
 To move a value into the pointer's memory location, use
-`init_pointee_move()`:
+`init_pointee(take=...)`:
 
 ```mojo
-str_ptr.init_pointee_move(my_string^)
+str_ptr.init_pointee(take=my_string^)
 ```
 
 Note that to move the value, you usually need to add the transfer sigil
@@ -168,7 +168,7 @@ type](/mojo/manual/traits#register-passable) (like `Int`) or a
 newly-constructed, "owned" value:
 
 ```mojo
-str_ptr.init_pointee_move("Owned string")
+str_ptr.init_pointee(take="Owned string")
 ```
 
 Alternately, you can get a pointer to an existing value by calling the
@@ -218,7 +218,7 @@ constructor or copy constructor).
 ```mojo
 var str_ptr = alloc[String](1)
 # str_ptr[] = "Testing" # Undefined behavior!
-str_ptr.init_pointee_move("Testing")
+str_ptr.init_pointee(take="Testing")
 str_ptr[] += " pointers" # Works now
 ```
 
@@ -307,7 +307,7 @@ values, and initializes them all to zero.
 ```mojo
 var float_ptr = alloc[Float64](6)
 for offset in range(6):
-    (float_ptr+offset).init_pointee_copy(0.0)
+    (float_ptr+offset).init_pointee(copy=0.0)
 ```
 
 Once the values are initialized, you can access them using subscript syntax:

--- a/mojo/docs/manual/structs/reference.mdx
+++ b/mojo/docs/manual/structs/reference.mdx
@@ -80,7 +80,7 @@ And here's an example of that pattern:
 @staticmethod
 def make_node(value: Self.ElementType) -> Self.NodePointer:
     node_ptr = alloc[Self](1)
-    node_ptr.init_pointee_move(Self(value))
+    node_ptr.init_pointee(take=Self(value))
     return node_ptr
 ```
 
@@ -222,7 +222,7 @@ struct Node[ElementType: ImplicitlyCopyable & Writable](Movable):
     @staticmethod
     def make_node(value: Self.ElementType) -> Self.NodePointer:
         node_ptr = alloc[Self](1)
-        node_ptr.init_pointee_move(Self(value))
+        node_ptr.init_pointee(take=Self(value))
         return node_ptr
 
     # Constructs a `Node` with allocated memory, assigns a value, appends

--- a/mojo/stdlib/std/builtin/format_int.mojo
+++ b/mojo/stdlib/std/builtin/format_int.mojo
@@ -294,8 +294,8 @@ def _write_int[
     # earlier in the buffer as we write the more-significant digits.
     var offset = CAPACITY - 1
 
-    (buf.unsafe_ptr() + offset).init_pointee_copy(
-        0
+    (buf.unsafe_ptr() + offset).init_pointee(
+        copy=0
     )  # Write NUL terminator at the end
 
     # Position the offset to write the least-significant digit just before the
@@ -315,8 +315,8 @@ def _write_int[
 
             # Write the char representing the value of the least significant
             # digit.
-            (buf.unsafe_ptr() + offset).init_pointee_copy(
-                digit_chars_array.unsafe_ptr()[Int(digit_value)]
+            (buf.unsafe_ptr() + offset).init_pointee(
+                copy=digit_chars_array.unsafe_ptr()[Int(digit_value)]
             )
 
             # Position the offset to write the next digit.

--- a/mojo/stdlib/std/builtin/sort.mojo
+++ b/mojo/stdlib/std/builtin/sort.mojo
@@ -51,7 +51,7 @@ def _insertion_sort[
             (array + j).init_pointee_move_from(array + j - 1)
             j -= 1
 
-        (array + j).init_pointee_move(value^)
+        (array + j).init_pointee(take=value^)
 
 
 # put everything thats "<" to the left of pivot

--- a/mojo/stdlib/std/builtin/tuple.mojo
+++ b/mojo/stdlib/std/builtin/tuple.mojo
@@ -129,7 +129,7 @@ struct Tuple[*element_types: Movable](
         # Move each element into the tuple storage.
         @parameter
         def init_elt[idx: Int](var elt: Self.element_types[idx]):
-            UnsafePointer(to=self[idx]).init_pointee_move(elt^)
+            UnsafePointer(to=self[idx]).init_pointee(take=elt^)
 
         args^.consume_elements[init_elt]()
 
@@ -165,9 +165,9 @@ struct Tuple[*element_types: Movable](
         comptime for i in range(Self.__len__()):
             # TODO: We should not use self[i] as this returns a reference to
             # uninitialized memory.
-            UnsafePointer(
-                to=trait_downcast[Copyable](self[i])
-            ).init_pointee_copy(trait_downcast[Copyable](copy[i]))
+            UnsafePointer(to=trait_downcast[Copyable](self[i])).init_pointee(
+                copy=trait_downcast[Copyable](copy[i])
+            )
 
     @always_inline("nodebug")
     def __init__(out self, *, deinit take: Self):

--- a/mojo/stdlib/std/builtin/tuple.mojo
+++ b/mojo/stdlib/std/builtin/tuple.mojo
@@ -112,7 +112,7 @@ struct Tuple[*element_types: Movable](
             )
             UnsafePointer(
                 to=trait_downcast[Defaultable & Movable](self[i])
-            ).init_pointee_move({})
+            ).init_pointee(take={})
 
     @always_inline("nodebug")
     def __init__(out self, var *args: *Self.element_types):

--- a/mojo/stdlib/std/collections/deque.mojo
+++ b/mojo/stdlib/std/collections/deque.mojo
@@ -174,7 +174,7 @@ struct Deque[ElementType: Copyable & ImplicitlyDestructible](
         # Transfer all of the values into the deque.
         @parameter
         def init_elt(idx: Int, var elt: Self.ElementType):
-            (self._data + idx).init_pointee_move(elt^)
+            (self._data + idx).init_pointee(take=elt^)
 
         values^.consume_elements[init_elt]()
 
@@ -195,7 +195,7 @@ struct Deque[ElementType: Copyable & ImplicitlyDestructible](
         )
         for i in range(len(copy)):
             offset = copy._physical_index(copy._head + i)
-            (self._data + i).init_pointee_copy((copy._data + offset)[])
+            (self._data + i).init_pointee(copy=(copy._data + offset)[])
 
         self._tail = len(copy)
 
@@ -469,7 +469,7 @@ struct Deque[ElementType: Copyable & ImplicitlyDestructible](
             (self._data + self._head).destroy_pointee()
             self._head = self._physical_index(self._head + 1)
 
-        (self._data + self._tail).init_pointee_move(value^)
+        (self._data + self._tail).init_pointee(take=value^)
         self._tail = self._physical_index(self._tail + 1)
 
         if self._head == self._tail:
@@ -487,7 +487,7 @@ struct Deque[ElementType: Copyable & ImplicitlyDestructible](
             (self._data + self._tail).destroy_pointee()
 
         self._head = self._physical_index(self._head - 1)
-        (self._data + self._head).init_pointee_move(value^)
+        (self._data + self._head).init_pointee(take=value^)
 
         if self._head == self._tail:
             self._realloc(self._capacity << 1)
@@ -674,7 +674,7 @@ struct Deque[ElementType: Copyable & ImplicitlyDestructible](
             self._tail = self._physical_index(self._tail + 1)
 
         offset = self._physical_index(self._head + idx)
-        (self._data + offset).init_pointee_move(value^)
+        (self._data + offset).init_pointee(take=value^)
 
         if self._head == self._tail:
             self._realloc(self._capacity << 1)
@@ -810,7 +810,7 @@ struct Deque[ElementType: Copyable & ImplicitlyDestructible](
             dst = self._physical_index(last - i)
             tmp = (self._data + dst).take_pointee()
             (self._data + dst).init_pointee_move_from(self._data + src)
-            (self._data + src).init_pointee_move(tmp^)
+            (self._data + src).init_pointee(take=tmp^)
 
     def rotate(mut self, n: Int = 1):
         """Rotates the deque by `n` steps.

--- a/mojo/stdlib/std/collections/dict.mojo
+++ b/mojo/stdlib/std/collections/dict.mojo
@@ -1036,7 +1036,7 @@ struct Dict[
         self._slots = alloc[DictEntry[Self.K, Self.V, Self.H]](self._capacity)
         for i in range(self._capacity):
             if _is_occupied(self._ctrl[i]):
-                (self._slots + i).init_pointee_copy((copy._slots + i)[])
+                (self._slots + i).init_pointee(copy=(copy._slots + i)[])
 
         # Copy the order array
         self._order = copy._order.copy()
@@ -1683,7 +1683,7 @@ struct Dict[
         if not found:
             var entry = DictEntry[H=Self.H](key.copy(), default^)
             self._set_ctrl(slot_idx, _h2(h))
-            (self._slots + slot_idx).init_pointee_move(entry^)
+            (self._slots + slot_idx).init_pointee(take=entry^)
             self._order.append(Int32(slot_idx))
             self._len += 1
             self._growth_left -= 1
@@ -1710,11 +1710,11 @@ struct Dict[
         if found:
             # Update existing entry: destroy old, move new in
             (self._slots + slot_idx).destroy_pointee()
-            (self._slots + slot_idx).init_pointee_move(entry^)
+            (self._slots + slot_idx).init_pointee(take=entry^)
         else:
             # New entry
             self._set_ctrl(slot_idx, _h2(entry.hash))
-            (self._slots + slot_idx).init_pointee_move(entry^)
+            (self._slots + slot_idx).init_pointee(take=entry^)
             self._order.append(Int32(slot_idx))
             self._len += 1
             self._growth_left -= 1
@@ -1842,7 +1842,7 @@ struct Dict[
                 var h2_val = _h2(entry.hash)
                 var new_slot = self._find_empty_slot(entry.hash)
                 self._set_ctrl(new_slot, h2_val)
-                (self._slots + new_slot).init_pointee_move(entry^)
+                (self._slots + new_slot).init_pointee(take=entry^)
                 self._order.append(Int32(new_slot))
 
         assert (
@@ -1910,7 +1910,7 @@ struct Dict[
                 # Target has another entry awaiting relocation; swap.
                 self._set_ctrl(target, _h2(entry.hash))
                 var displaced = (self._slots + target).take_pointee()
-                (self._slots + target).init_pointee_move(entry^)
+                (self._slots + target).init_pointee(take=entry^)
                 slot_map[source] = Int32(target)
 
                 entry = displaced^
@@ -1919,7 +1919,7 @@ struct Dict[
 
             # Target is EMPTY: final placement.
             self._set_ctrl(target, _h2(entry.hash))
-            (self._slots + target).init_pointee_move(entry^)
+            (self._slots + target).init_pointee(take=entry^)
             slot_map[source] = Int32(target)
 
         # Step 4: Update _order with new slot indices.

--- a/mojo/stdlib/std/collections/inline_array.mojo
+++ b/mojo/stdlib/std/collections/inline_array.mojo
@@ -419,12 +419,12 @@ struct InlineArray[ElementType: Copyable, size: Int](
 
         for _ in range(0, unroll_end, batch_size):
             comptime for _ in range(batch_size):
-                ptr.init_pointee_copy(fill)
+                ptr.init_pointee(copy=fill)
                 ptr += 1
 
         # Fill the remainder
         comptime for _ in range(unroll_end, Self.size):
-            ptr.init_pointee_copy(fill)
+            ptr.init_pointee(copy=fill)
             ptr += 1
         debug_assert(
             ptr == self.unsafe_ptr() + Self.size,
@@ -492,7 +492,7 @@ struct InlineArray[ElementType: Copyable, size: Int](
             self = Self(uninitialized=True)
             for idx in range(Self.size):
                 var ptr = self.unsafe_ptr() + idx
-                ptr.init_pointee_copy(copy.unsafe_get(idx))
+                ptr.init_pointee(copy=copy.unsafe_get(idx))
 
     def __init__(out self, *, deinit take: Self):
         """Move constructs the array from another array.

--- a/mojo/stdlib/std/collections/interval.mojo
+++ b/mojo/stdlib/std/collections/interval.mojo
@@ -650,7 +650,7 @@ struct IntervalTree[
         # Allocate memory for a new node and initialize it with the interval
         # and data
         var new_node = alloc[_IntervalNode[Self.T, Self.U]](1)
-        new_node.init_pointee_move(_IntervalNode(interval, data))
+        new_node.init_pointee(take=_IntervalNode(interval, data))
         self._len += 1
 
         # If the tree is empty, set the root to the new node and color it black.

--- a/mojo/stdlib/std/collections/linked_list.mojo
+++ b/mojo/stdlib/std/collections/linked_list.mojo
@@ -331,7 +331,7 @@ struct LinkedList[ElementType: Copyable & ImplicitlyDestructible](
         """
         var addr = alloc[Node[Self.ElementType]](1)
         var value_ptr = UnsafePointer(to=addr[].value)
-        value_ptr.init_pointee_move(value^)
+        value_ptr.init_pointee(take=value^)
         addr[].prev() = self._tail
         addr[].next() = Self._NodePointer()
         if self._tail:
@@ -352,7 +352,7 @@ struct LinkedList[ElementType: Copyable & ImplicitlyDestructible](
         """
         var node = _make_node[Self.ElementType](value^, None, self._head)
         var addr = alloc[Node[Self.ElementType]](1)
-        addr.init_pointee_move(node^)
+        addr.init_pointee(take=node^)
         if self:
             self._head.value()[].prev() = addr
         else:
@@ -549,8 +549,8 @@ struct LinkedList[ElementType: Copyable & ImplicitlyDestructible](
 
         if i == 0:
             var node = alloc[Node[Self.ElementType]](1)
-            node.init_pointee_move(
-                _make_node[Self.ElementType](
+            node.init_pointee(
+                take=_make_node[Self.ElementType](
                     elem^, Self._NodePointer(), Self._NodePointer()
                 )
             )

--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -429,7 +429,7 @@ struct List[T: Copyable](
         # Transfer all of the elements into the List.
         @parameter
         def init_elt(idx: Int, var elt: Self.T):
-            (self._data + idx).init_pointee_move(elt^)
+            (self._data + idx).init_pointee(take=elt^)
 
         values^.consume_elements[init_elt]()
 
@@ -777,7 +777,7 @@ struct List[T: Copyable](
         if self._len >= self.capacity:
             self._realloc(self.capacity * 2 | Int(self.capacity == 0))
         self._annotate_increase()
-        self._unsafe_next_uninit_ptr().init_pointee_move(value^)
+        self._unsafe_next_uninit_ptr().init_pointee(take=value^)
         self._len += 1
 
     def insert(mut self, i: Int, var value: Self.T):
@@ -812,7 +812,7 @@ struct List[T: Copyable](
 
             var tmp = earlier_ptr.take_pointee()
             earlier_ptr.init_pointee_move_from(later_ptr)
-            later_ptr.init_pointee_move(tmp^)
+            later_ptr.init_pointee(take=tmp^)
 
             earlier_idx -= 1
             later_idx -= 1
@@ -1051,7 +1051,7 @@ struct List[T: Copyable](
         self.reserve(new_size)
         self._annotate_increase(new_size - self._len)
         for i in range(self._len, new_size):
-            (self._data + i).init_pointee_copy(value)
+            (self._data + i).init_pointee(copy=value)
         self._len = new_size
 
     def resize(
@@ -1148,7 +1148,7 @@ struct List[T: Copyable](
 
             var tmp = earlier_ptr.take_pointee()
             earlier_ptr.init_pointee_move_from(later_ptr)
-            later_ptr.init_pointee_move(tmp^)
+            later_ptr.init_pointee(take=tmp^)
 
             earlier_idx += 1
             later_idx -= 1
@@ -1374,7 +1374,7 @@ struct List[T: Copyable](
         (self._data + idx).bitcast[
             downcast[Self.T, ImplicitlyDestructible]
         ]().destroy_pointee()
-        (self._data + idx).init_pointee_move(value^)
+        (self._data + idx).init_pointee(take=value^)
 
     def count(self, value: Self.T) -> Int where conforms_to(Self.T, Equatable):
         """Counts the number of occurrences of a value in the list.

--- a/mojo/stdlib/std/collections/optional.mojo
+++ b/mojo/stdlib/std/collections/optional.mojo
@@ -581,7 +581,7 @@ struct Optional[T: Movable](
         Args:
             target: The target pointer to store the device type.
         """
-        target.bitcast[Self]().init_pointee_copy(self)
+        target.bitcast[Self]().init_pointee(copy=self)
 
     @staticmethod
     def get_type_name() -> (
@@ -998,7 +998,7 @@ struct _NicheableOptionalRegStorage[
         comptime assert _type_is_eq[U, Self.T]()
         __mlir_op.`lit.ownership.mark_initialized`(__get_mvalue_as_litref(self))
         var ptr = UnsafePointer(to=self.storage).bitcast[Self.T]()
-        ptr.init_pointee_move(rebind[Self.T](value))
+        ptr.init_pointee(take=rebind[Self.T](value))
 
     @always_inline
     def value[U: TrivialRegisterPassable](self) -> U:

--- a/mojo/stdlib/std/collections/string/format.mojo
+++ b/mojo/stdlib/std/collections/string/format.mojo
@@ -140,7 +140,7 @@ def _comptime_list_to_span[
         var array = InlineArray[T, len(list)](uninitialized=True)
 
         comptime for i in range(len(list)):
-            UnsafePointer(to=array[i]).init_pointee_copy(materialize[list]()[i])
+            UnsafePointer(to=array[i]).init_pointee(copy=materialize[list]()[i])
         return array^
 
     comptime array = list_to_array[list]()

--- a/mojo/stdlib/std/collections/string/string.mojo
+++ b/mojo/stdlib/std/collections/string/string.mojo
@@ -904,7 +904,7 @@ struct String(
             self.capacity() > self.byte_length()
         ), "String: capacity is not sufficient"
         var length = self.byte_length()
-        (self.unsafe_ptr_mut() + length).init_pointee_move(byte)
+        (self.unsafe_ptr_mut() + length).init_pointee(take=byte)
         self.set_byte_length(length + 1)
 
     def append(mut self, codepoint: Codepoint):

--- a/mojo/stdlib/std/ffi/unsafe_union.mojo
+++ b/mojo/stdlib/std/ffi/unsafe_union.mojo
@@ -228,7 +228,7 @@ struct UnsafeUnion[*Ts: AnyType](ImplicitlyCopyable, Movable, Writable):
         comptime assert Self._is_element[
             T
         ](), "type is not a union element type"
-        self._get_ptr[T]().init_pointee_move(value^)
+        self._get_ptr[T]().init_pointee(take=value^)
 
     def __init__(out self, *, copy: Self):
         """Creates a bitwise copy of the union.
@@ -398,7 +398,7 @@ struct UnsafeUnion[*Ts: AnyType](ImplicitlyCopyable, Movable, Writable):
         comptime assert Self._is_element[
             T
         ](), "type is not a union element type"
-        self._get_ptr[T]().init_pointee_move(value^)
+        self._get_ptr[T]().init_pointee(take=value^)
 
     @always_inline("nodebug")
     def unsafe_ptr[

--- a/mojo/stdlib/std/memory/arc_pointer.mojo
+++ b/mojo/stdlib/std/memory/arc_pointer.mojo
@@ -127,7 +127,7 @@ struct ArcPointer[T: Movable & ImplicitlyDestructible](
             value: The value to manage.
         """
         self._inner = alloc[Self._inner_type](1)
-        # Cannot use init_pointee_move as _ArcPointerInner isn't movable.
+        # Cannot use init_pointee(take=...) as _ArcPointerInner isn't movable.
         __get_address_as_uninit_lvalue(self._inner.address) = Self._inner_type(
             value^
         )

--- a/mojo/stdlib/std/memory/memory.mojo
+++ b/mojo/stdlib/std/memory/memory.mojo
@@ -542,7 +542,7 @@ def uninit_copy_n[
 
     For types with trivial copy constructors, this is optimized to a single
     `memcpy` (or `memmove` when `overlapping=True`) operation. Otherwise, it
-    calls `init_pointee_copy()` on each element.
+    calls `init_pointee(copy=...)` on each element.
 
     The destination memory is treated as a raw span of bits to write to. Any
     existing values at `dest` are silently overwritten without being destroyed.
@@ -581,7 +581,7 @@ def uninit_copy_n[
             memcpy(dest=dest, src=src, count=count)
     else:
         for i in range(count):
-            (dest + i).init_pointee_copy((src + i)[])
+            (dest + i).init_pointee(copy=(src + i)[])
 
 
 @always_inline

--- a/mojo/stdlib/std/memory/owned_pointer.mojo
+++ b/mojo/stdlib/std/memory/owned_pointer.mojo
@@ -62,7 +62,7 @@ struct OwnedPointer[T: AnyType](
             value: The value to move into the `OwnedPointer`.
         """
         self._inner = alloc[_T](1)
-        self._inner.init_pointee_move(value^)
+        self._inner.init_pointee(take=value^)
 
     def __init__[_T: Copyable](out self: OwnedPointer[_T], *, copy_value: _T):
         """Construct a new `OwnedPointer` by explicitly copying the passed value into a new backing allocation.
@@ -75,7 +75,7 @@ struct OwnedPointer[T: AnyType](
             copy_value: The value to explicitly copy into the `OwnedPointer`.
         """
         self._inner = alloc[_T](1)
-        self._inner.init_pointee_copy(copy_value)
+        self._inner.init_pointee(copy=copy_value)
 
     def __init__[
         _T: Copyable, U: NoneType = None
@@ -90,7 +90,7 @@ struct OwnedPointer[T: AnyType](
             value: The value to copy into the `OwnedPointer`.
         """
         self._inner = alloc[_T](1)
-        self._inner.init_pointee_copy(value)
+        self._inner.init_pointee(copy=value)
 
     def __init__[
         _T: Copyable

--- a/mojo/stdlib/std/memory/span.mojo
+++ b/mojo/stdlib/std/memory/span.mojo
@@ -777,7 +777,7 @@ struct Span[
                 MutAnyOrigin
             ]()
             (ptr + middle + 1).init_pointee_move_from(middle_prev)
-            middle_prev.init_pointee_move(value)
+            middle_prev.init_pointee(take=value)
 
     def apply[
         dtype: DType,
@@ -806,7 +806,7 @@ struct Span[
                     processed += w
 
         for i in range(length - processed):
-            (ptr + processed + i).init_pointee_move(func(ptr[processed + i]))
+            (ptr + processed + i).init_pointee(take=func(ptr[processed + i]))
 
     def apply[
         dtype: DType,
@@ -842,7 +842,7 @@ struct Span[
         for i in range(length - processed):
             var vec = ptr[processed + i]
             if cond(vec):
-                (ptr + processed + i).init_pointee_move(func(vec))
+                (ptr + processed + i).init_pointee(take=func(vec))
 
     def count[
         dtype: DType,

--- a/mojo/stdlib/std/memory/unsafe_maybe_uninit.mojo
+++ b/mojo/stdlib/std/memory/unsafe_maybe_uninit.mojo
@@ -154,7 +154,7 @@ struct UnsafeMaybeUninit[T: AnyType](
         Args:
             value: The value to store in memory.
         """
-        self.unsafe_ptr().init_pointee_move(value^)
+        self.unsafe_ptr().init_pointee(take=value^)
 
     @always_inline
     def unsafe_assume_init_ref(ref self) -> ref[self._array] Self.T:

--- a/mojo/stdlib/std/memory/unsafe_pointer.mojo
+++ b/mojo/stdlib/std/memory/unsafe_pointer.mojo
@@ -642,9 +642,9 @@ struct UnsafePointer[
     def write_niche(
         memory: UnsafePointer[mut=True, UnsafeMaybeUninit[Self], _]
     ):
-        memory.bitcast[
-            _Null[Self.type, Self.address_space]
-        ]().init_pointee_move({})
+        memory.bitcast[_Null[Self.type, Self.address_space]]().init_pointee(
+            take={}
+        )
 
     @staticmethod
     @always_inline

--- a/mojo/stdlib/std/memory/unsafe_pointer.mojo
+++ b/mojo/stdlib/std/memory/unsafe_pointer.mojo
@@ -390,7 +390,7 @@ struct UnsafePointer[
     - `destroy_pointee()` / `take_pointee()`:
       Explicitly end the lifetime of the current pointee, or move it out, taking
       ownership.
-    - `init_pointee_move()` / `init_pointee_move_from()` / `init_pointee_copy()`
+    - `init_pointee(take=...)` / `init_pointee(copy=...)` / `init_pointee_move_from()`:
       Initialize a pointee that is currently uninitialized, by moving an existing
       value, moving from another pointee, or by copying an existing value.
       Use these to manage lifecycles when working with uninitialized memory.
@@ -1152,7 +1152,7 @@ struct UnsafePointer[
                 return
             var tmp = self.take_pointee()
             self.init_pointee_move_from(other)
-            other.init_pointee_move(tmp^)
+            other.init_pointee(take=tmp^)
 
     @always_inline("nodebug")
     def as_noalias_ptr(self) -> Self._UnsafePointerType:
@@ -1909,8 +1909,9 @@ struct UnsafePointer[
 
         This performs a _consuming_ move, ending the origin of the value stored
         in this pointer memory location. Subsequent reads of this pointer are
-        not valid. If a new valid value is stored using `init_pointee_move()`, then
-        reading from this pointer becomes valid again.
+        not valid. If a new valid value is stored using
+        `init_pointee(take=...)`, then reading from this pointer becomes valid
+        again.
 
         Parameters:
             T: The type the pointer points to, which must be `Movable`.
@@ -1920,6 +1921,7 @@ struct UnsafePointer[
         """
         return __get_address_as_owned_value(self.address)
 
+    @deprecated("use `init_pointee(take=...)`")
     @always_inline
     def init_pointee_move[
         T: Movable,
@@ -1941,8 +1943,9 @@ struct UnsafePointer[
         Args:
             value: The value to emplace.
         """
-        __get_address_as_uninit_lvalue(self.address) = value^
+        self.init_pointee(take=value^)
 
+    @deprecated("use `init_pointee(copy=...)`")
     @always_inline
     def init_pointee_copy[
         T: Copyable,
@@ -1964,7 +1967,53 @@ struct UnsafePointer[
         Args:
             value: The value to emplace.
         """
-        __get_address_as_uninit_lvalue(self.address) = value.copy()
+        self.init_pointee(copy=value)
+
+    @always_inline
+    def init_pointee[
+        T: Movable,
+        //,
+    ](self: UnsafePointer[T, _], *, var take: T) where type_of(self).mut:
+        """Emplace a new value into the pointer location, moving from `take`.
+
+        The pointer memory location is assumed to contain uninitialized data,
+        and consequently the current contents of this pointer are not destructed
+        before writing `take`. Similarly, ownership of `take` is logically
+        transferred into the pointer location.
+
+        When compared to `init_pointee(copy=...)`, this avoids an extra copy on
+        the caller side when the value is an rvalue.
+
+        Parameters:
+            T: The type the pointer points to, which must be `Movable`.
+
+        Args:
+            take: The value to emplace by moving from it.
+        """
+        __get_address_as_uninit_lvalue(self.address) = take^
+
+    @always_inline
+    def init_pointee[
+        T: Copyable,
+        //,
+    ](self: UnsafePointer[T, _], *, copy: T) where type_of(self).mut:
+        """Emplace a copy of `copy` into the pointer location.
+
+        The pointer memory location is assumed to contain uninitialized data,
+        and consequently the current contents of this pointer are not destructed
+        before writing `copy`. Similarly, ownership of `copy` is logically
+        transferred into the pointer location.
+
+        When compared to `init_pointee(take=...)`, this avoids an extra move on
+        the callee side when the value must be copied.
+
+        Parameters:
+            T: The type the pointer points to, which must be `Copyable`.
+
+        Args:
+            copy: The value to emplace by copying from it.
+        """
+        __get_address_as_uninit_lvalue(self.address) = copy.copy()
 
     @always_inline
     def init_pointee_move_from[
@@ -1988,7 +2037,7 @@ struct UnsafePointer[
         uninitialized data. Subsequent reads of or destructor calls on the `src`
         pointee value are invalid, unless and until a new valid value has been
         moved into the `src` pointer's memory location using an
-        `init_pointee_*()` operation.
+        `init_pointee(...)` operation.
 
         This transfers the value out of `src` and into `self` using at most one
         move constructor call.
@@ -2000,7 +2049,7 @@ struct UnsafePointer[
         var b_ptr = alloc[String](2)
 
         # Initialize A pointee
-        a_ptr.init_pointee_move("foo")
+        a_ptr.init_pointee(take="foo")
 
         # Perform the move
         b_ptr.init_pointee_move_from(a_ptr)

--- a/mojo/stdlib/std/python/_cpython.mojo
+++ b/mojo/stdlib/std/python/_cpython.mojo
@@ -2817,7 +2817,7 @@ struct CPython(Defaultable, Movable):
         # NOTE: See https://github.com/pybind/pybind11/blob/a1d00916b26b187e583f3bce39cd59c3b0652c32/include/pybind11/pybind11.h#L1326
         # for what we want to do here.
         var module_def_ptr = alloc[PyModuleDef](1)
-        module_def_ptr.init_pointee_move(PyModuleDef(name))
+        module_def_ptr.init_pointee(take=PyModuleDef(name))
 
         # TODO: set gil stuff
         # Note: Python automatically calls https://docs.python.org/3/c-api/module.html#c.PyState_AddModule

--- a/mojo/stdlib/std/python/bindings.mojo
+++ b/mojo/stdlib/std/python/bindings.mojo
@@ -1314,8 +1314,8 @@ def check_and_get_or_convert_arg[
     try:
         return check_and_get_arg[T](func_name, py_args, index)
     except e:
-        converted_arg_ptr.init_pointee_move(
-            _try_convert_arg[T](
+        converted_arg_ptr.init_pointee(
+            take=_try_convert_arg[T](
                 func_name,
                 py_args,
                 index,

--- a/mojo/stdlib/std/python/python_object.mojo
+++ b/mojo/stdlib/std/python/python_object.mojo
@@ -1848,7 +1848,7 @@ def _unsafe_init[
      type object. Use of any other pointer is invalid.
     """
     ref mojo_obj = obj_ptr.bitcast[PyMojoObject[T]]().value()[]
-    UnsafePointer(to=mojo_obj.mojo_value).init_pointee_move(mojo_value^)
+    UnsafePointer(to=mojo_obj.mojo_value).init_pointee(take=mojo_value^)
     mojo_obj.is_initialized = True
 
 

--- a/mojo/stdlib/std/reflection/location.mojo
+++ b/mojo/stdlib/std/reflection/location.mojo
@@ -172,7 +172,7 @@ struct SourceLocation(TrivialRegisterPassable, UnsafeSingleNicheable, Writable):
     ):
         (memory.bitcast[Byte]() + Self._LineByteOffset).bitcast[
             Int
-        ]().init_pointee_move(Self._LineNiche)
+        ]().init_pointee(take=Self._LineNiche)
 
     @staticmethod
     @always_inline

--- a/mojo/stdlib/std/utils/variant.mojo
+++ b/mojo/stdlib/std/utils/variant.mojo
@@ -285,7 +285,7 @@ struct _DefaultVariantStorage[*Ts: AnyType](
     def __init__[T: Movable](out self, var value: T):
         self = Self(unsafe_uninitialized=())
         self.get_discriminant() = UInt8(_get_type_index[T, *Self.Ts]())
-        self.unsafe_ptr[T]().init_pointee_move(value^)
+        self.unsafe_ptr[T]().init_pointee(take=value^)
 
     @always_inline
     def __init__(out self, *, copy: Self):
@@ -298,7 +298,7 @@ struct _DefaultVariantStorage[*Ts: AnyType](
             comptime T = downcast[TUnknown, Copyable]
 
             if self.get_discriminant() == UInt8(i):
-                self.unsafe_ptr[T]().init_pointee_copy(copy.unsafe_ptr[T]()[])
+                self.unsafe_ptr[T]().init_pointee(copy=copy.unsafe_ptr[T]()[])
                 return
 
     @always_inline

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -1095,16 +1095,16 @@ def test_list_fill_constructor() raises:
 def test_uninit_ctor() raises:
     var list = List[String](unsafe_uninit_length=2)
 
-    UnsafePointer(to=list[0]).init_pointee_move("hello ")
-    UnsafePointer(to=list[1]).init_pointee_move("world")
+    UnsafePointer(to=list[0]).init_pointee(take="hello ")
+    UnsafePointer(to=list[1]).init_pointee(take="world")
     assert_equal(list[0], "hello ")
     assert_equal(list[1], "world")
 
     # Resize with uninitialized memory.
     var list2 = List[String]()
     list2.resize(unsafe_uninit_length=2)
-    (list2.unsafe_ptr() + 0).init_pointee_move("hello ")
-    (list2.unsafe_ptr() + 1).init_pointee_move("world")
+    (list2.unsafe_ptr() + 0).init_pointee(take="hello ")
+    (list2.unsafe_ptr() + 1).init_pointee(take="world")
     assert_equal(list2[0], "hello ")
     assert_equal(list2[1], "world")
 

--- a/mojo/stdlib/test/iter/test_ref_iteration.mojo
+++ b/mojo/stdlib/test/iter/test_ref_iteration.mojo
@@ -103,14 +103,14 @@ struct MoveOnlyList[T: Movable & ImplicitlyDestructible]:
             var new_cap = self._capacity * 2 if self._capacity > 0 else 4
             var new_data = alloc[Self.T](new_cap)
             for i in range(self._len):
-                (new_data + i).init_pointee_move(
-                    (self._data + i).take_pointee()
+                (new_data + i).init_pointee(
+                    take=(self._data + i).take_pointee()
                 )
             if self._capacity > 0:
                 self._data.free()
             self._data = new_data
             self._capacity = new_cap
-        (self._data + self._len).init_pointee_move(value^)
+        (self._data + self._len).init_pointee(take=value^)
         self._len += 1
 
     def __getitem__(ref self, idx: Int) -> ref[self] Self.T:

--- a/mojo/stdlib/test/memory/test_memory.mojo
+++ b/mojo/stdlib/test/memory/test_memory.mojo
@@ -817,9 +817,9 @@ def test_uninit_move_n_trivial() raises:
     # Test with trivial move type - should use memcpy, not call move constructor
     comptime Counter = MoveCounter[Int, trivial_move=True]
     var src = alloc[Counter](3)
-    (src + 0).init_pointee_move(Counter(10))
-    (src + 1).init_pointee_move(Counter(20))
-    (src + 2).init_pointee_move(Counter(30))
+    (src + 0).init_pointee(take=Counter(10))
+    (src + 1).init_pointee(take=Counter(20))
+    (src + 2).init_pointee(take=Counter(30))
 
     var dest = alloc[Counter](3)
 
@@ -844,9 +844,9 @@ def test_uninit_move_n_trivial() raises:
 def test_uninit_move_n_nontrivial() raises:
     # Test with non-trivial type that tracks moves
     var src = alloc[MoveCounter[String]](3)
-    (src + 0).init_pointee_move(MoveCounter("foo"))
-    (src + 1).init_pointee_move(MoveCounter("bar"))
-    (src + 2).init_pointee_move(MoveCounter("baz"))
+    (src + 0).init_pointee(take=MoveCounter("foo"))
+    (src + 1).init_pointee(take=MoveCounter("bar"))
+    (src + 2).init_pointee(take=MoveCounter("baz"))
 
     var dest = alloc[MoveCounter[String]](3)
 
@@ -874,9 +874,9 @@ def test_uninit_copy_n_trivial() raises:
     # Test with trivial copy type - should use memcpy, not call copy ctor
     comptime Counter = CopyCounter[Int, trivial_copy=True]
     var src = alloc[Counter](3)
-    src.init_pointee_move(Counter(0))
-    (src + 1).init_pointee_move(Counter(1))
-    (src + 2).init_pointee_move(Counter(2))
+    src.init_pointee(take=Counter(0))
+    (src + 1).init_pointee(take=Counter(1))
+    (src + 2).init_pointee(take=Counter(2))
 
     var dest = alloc[Counter](3)
 
@@ -902,9 +902,9 @@ def test_uninit_copy_n_trivial() raises:
 def test_uninit_copy_n_nontrivial() raises:
     # Test with non-trivial type that tracks copies
     var src = alloc[CopyCounter[String]](3)
-    src.init_pointee_move(CopyCounter("alpha"))
-    (src + 1).init_pointee_move(CopyCounter("beta"))
-    (src + 2).init_pointee_move(CopyCounter("gamma"))
+    src.init_pointee(take=CopyCounter("alpha"))
+    (src + 1).init_pointee(take=CopyCounter("beta"))
+    (src + 2).init_pointee(take=CopyCounter("gamma"))
 
     var dest = alloc[CopyCounter[String]](3)
 
@@ -941,9 +941,9 @@ def test_destroy_n_trivial() raises:
     comptime Counter = DelCounter[origin_of(del_count), trivial_del=True]
 
     var ptr = alloc[Counter](3)
-    (ptr + 0).init_pointee_move(Counter(counter_ptr))
-    (ptr + 1).init_pointee_move(Counter(counter_ptr))
-    (ptr + 2).init_pointee_move(Counter(counter_ptr))
+    (ptr + 0).init_pointee(take=Counter(counter_ptr))
+    (ptr + 1).init_pointee(take=Counter(counter_ptr))
+    (ptr + 2).init_pointee(take=Counter(counter_ptr))
 
     # This should compile to nothing for trivial destructors
     destroy_n(ptr, count=3)
@@ -960,9 +960,9 @@ def test_destroy_n_nontrivial() raises:
     comptime Counter = DelCounter[origin_of(del_count)]
 
     var ptr = alloc[Counter](3)
-    (ptr + 0).init_pointee_move(Counter(counter_ptr))
-    (ptr + 1).init_pointee_move(Counter(counter_ptr))
-    (ptr + 2).init_pointee_move(Counter(counter_ptr))
+    (ptr + 0).init_pointee(take=Counter(counter_ptr))
+    (ptr + 1).init_pointee(take=Counter(counter_ptr))
+    (ptr + 2).init_pointee(take=Counter(counter_ptr))
 
     destroy_n(ptr, count=3)
     # Verify destructor was called for all 3 elements
@@ -994,7 +994,7 @@ def test_uninit_move_n_zero_count() raises:
 def test_uninit_copy_n_zero_count() raises:
     # Test with zero count - should be no-op
     var src = alloc[CopyCounter[String]](1)
-    src.init_pointee_move(CopyCounter("test"))
+    src.init_pointee(take=CopyCounter("test"))
 
     var dest = alloc[CopyCounter[String]](1)
 
@@ -1016,7 +1016,7 @@ def test_destroy_n_zero_count() raises:
     comptime Counter = DelCounter[origin_of(del_count), trivial_del=True]
 
     var ptr = alloc[Counter](1)
-    ptr.init_pointee_move(Counter(counter_ptr))
+    ptr.init_pointee(take=Counter(counter_ptr))
 
     destroy_n(ptr, count=0)
     # Destructor should NOT have been called - del_count should still be 0

--- a/mojo/stdlib/test/memory/test_owned_pointer.mojo
+++ b/mojo/stdlib/test/memory/test_owned_pointer.mojo
@@ -36,8 +36,8 @@ def test_basic_ref() raises:
 def test_from_unsafe_pointer_constructor() raises:
     var deleted = False
     var unsafe_ptr = alloc[ObservableDel[]](1)
-    unsafe_ptr.init_pointee_move(
-        ObservableDel(UnsafePointer(to=deleted).as_any_origin())
+    unsafe_ptr.init_pointee(
+        take=ObservableDel(UnsafePointer(to=deleted).as_any_origin())
     )
 
     var ptr = OwnedPointer(unsafe_from_raw_pointer=unsafe_ptr)

--- a/mojo/stdlib/test/memory/test_span.mojo
+++ b/mojo/stdlib/test/memory/test_span.mojo
@@ -590,8 +590,8 @@ struct HashableOnly(Hashable, ImplicitlyDestructible, Movable):
 
 def test_span_hashable_non_copyable() raises:
     var ptr = alloc[HashableOnly](2)
-    ptr.init_pointee_move(HashableOnly(1))
-    (ptr + 1).init_pointee_move(HashableOnly(2))
+    ptr.init_pointee(take=HashableOnly(1))
+    (ptr + 1).init_pointee(take=HashableOnly(2))
     var span = Span(ptr=ptr, length=2)
     _ = hash(span)
     (ptr + 1).destroy_pointee()
@@ -601,7 +601,7 @@ def test_span_hashable_non_copyable() raises:
 
 def test_span_with_move_only_type() raises:
     var ptr = alloc[MoveOnly[Int]](1)
-    ptr.init_pointee_move(MoveOnly(42))
+    ptr.init_pointee(take=MoveOnly(42))
     var span = Span(ptr=ptr, length=1)
     assert_equal(span[0].data, 42)
     ptr.destroy_pointee()

--- a/mojo/stdlib/test/memory/unsafe_pointer/test_unsafe_pointer_v2.mojo
+++ b/mojo/stdlib/test/memory/unsafe_pointer/test_unsafe_pointer_v2.mojo
@@ -118,7 +118,7 @@ def test_unsafepointer_of_move_only_type() raises:
     comptime ObserveType = ObservableMoveOnly[actions_ptr.origin]
 
     var ptr = alloc[ObserveType](1)
-    ptr.init_pointee_move(ObserveType(42, actions_ptr))
+    ptr.init_pointee(take=ObserveType(42, actions_ptr))
     assert_equal(len(actions_ptr[0]), 2)
     assert_equal(actions_ptr[0][0], "__init__")
     assert_equal(actions_ptr[0][1], "move ctor", msg="emplace_value")
@@ -143,7 +143,7 @@ def test_unsafepointer_move_pointee_move_count() raises:
 
     var value = MoveCounter(5)
     assert_equal(0, value.move_count)
-    ptr.init_pointee_move(value^)
+    ptr.init_pointee(take=value^)
 
     # -----
     # Test that `UnsafePointer.move_pointee` performs exactly one move.
@@ -157,14 +157,14 @@ def test_unsafepointer_move_pointee_move_count() raises:
     assert_equal(2, ptr_2[].move_count)
 
 
-def test_unsafepointer_init_pointee_copy() raises:
+def test_unsafepointer_init_pointee_copy_keyword() raises:
     var ptr = alloc[ExplicitCopyOnly](1)
 
     var orig = ExplicitCopyOnly(5)
     assert_equal(orig.copy_count, 0)
 
     # Test initialize pointee from `Copyable` type
-    ptr.init_pointee_copy(orig)
+    ptr.init_pointee(copy=orig)
 
     assert_equal(ptr[].value, 5)
     assert_equal(ptr[].copy_count, 1)

--- a/mojo/stdlib/test/test_utils/types.mojo
+++ b/mojo/stdlib/test/test_utils/types.mojo
@@ -386,7 +386,7 @@ struct ObservableDel[origin: MutOrigin = MutAnyOrigin](ImplicitlyCopyable):
 
     def __del__(deinit self):
         """Sets the target flag to True when destroyed."""
-        self.target.init_pointee_move(True)
+        self.target.init_pointee(take=True)
 
 
 # ===----------------------------------------------------------------------=== #

--- a/mojo/stdlib/test/utils/test_variant.mojo
+++ b/mojo/stdlib/test/utils/test_variant.mojo
@@ -57,13 +57,13 @@ struct Poison(ImplicitlyCopyable):
         pass
 
     def __init__(out self, *, copy: Self):
-        _poison_ptr().init_pointee_move(True)
+        _poison_ptr().init_pointee(take=True)
 
     def __init__(out self, *, deinit take: Self):
-        _poison_ptr().init_pointee_move(True)
+        _poison_ptr().init_pointee(take=True)
 
     def __del__(deinit self):
-        _poison_ptr().init_pointee_move(True)
+        _poison_ptr().init_pointee(take=True)
 
 
 comptime TestVariant = Variant[MoveCopyCounter, Poison]


### PR DESCRIPTION


## Summary

Unify `init_pointee` methods from:
- `init_pointee_copy`
- `init_pointee_move`

to only:
- `init_pointee`

with arguments `copy` and `take` to align with the "init-unification".


Actual method changes in:
- `mojo/stdlib/std/memory/unsafe_pointer.mojo`
- `mojo/stdlib/std/memory/_nonnull.mojo`


Rest is adjusting to the new name in stdlib, docs, mdx and changelog.


Assisted-by: AI

## Testing

As I am fairly new to the repo I am not sure which tests ideally to run. The following were run and passed.
```
./bazelw test //mojo/stdlib/test/memory/unsafe_pointer:test_unsafe_pointer_v2.mojo.test //mojo/stdlib/test/memory:test_span.mojo.test //mojo/stdlib/test/memory:test_memory.mojo.test //mojo/stdlib/test/memory:test_owned_pointer.mojo.test //mojo/stdlib/test/memory/unsafe_pointer/compile_fail:lit_tests
```

```
./bazelw test //mojo/stdlib/test/collections:test_list.mojo.test //mojo/stdlib/test/utils:test_variant.mojo.test //mojo/stdlib/test/iter:test_ref_iteration.mojo.test
```

<!--
Describe how you validated your changes. For code changes, this should include
what tests you ran and any relevant results. For documentation changes, describe
how you verified accuracy.
-->
