### PR TITLE
Optimize Gemma 3 decode rope and fused QK paths

### DIFF
--- a/max/kernels/benchmarks/gpu/nn/bench_gemma3_k_norm_rope_boundary.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_gemma3_k_norm_rope_boundary.mojo
@@ -1,0 +1,1054 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import ceildiv, rsqrt
+from std.random import seed
+from std.sys import get_defined_dtype, get_defined_int
+from std.sys.info import align_of, simd_width_of
+
+from std.benchmark import Bench, BenchConfig, Bencher, BenchId
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    WARP_SIZE,
+    block_idx_uint as block_idx,
+    syncwarp,
+    thread_idx_uint as thread_idx,
+)
+from std.gpu.host import DeviceContext
+from std.gpu.memory import AddressSpace
+from std.gpu.primitives import warp
+from std.gpu.primitives.grid_controls import PDLLevel, pdl_launch_attributes
+from std.memory import stack_allocation
+from std.testing import assert_almost_equal
+
+from internal_utils import arg_parse
+from kv_cache.types import KVCacheStaticParams, KVCacheT, PagedKVCacheCollection
+from layout import (
+    Coord,
+    Idx,
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TensorLayout,
+    TileTensor,
+    UNKNOWN_VALUE,
+    row_major,
+)
+from layout._fillers import random
+from nn._ragged_utils import get_batch_from_row_offsets
+from nn.fused_qk_rope import _rope_complex_mul_half
+from nn.kv_cache import rms_norm_kv_cache_ragged_paged
+from nn.normalization import _rms_norm_warp_tiling_subkernel
+from nn.rope import _rope_k_cache_ragged, k_rms_norm_rope_ragged
+from std.utils.numerics import get_accum_type
+from std.utils.static_tuple import StaticTuple
+
+from std.utils import IndexList
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _gemma3_k_norm_rope_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    OffsetsLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime num_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(KCacheType.kv_params.head_size)
+    comptime simd_width = simd_width_of[dtype]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime assert head_dim == 128, "Only 128-column BF16 key rows are supported"
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert freqs_cis.static_shape[1] == head_dim
+    comptime assert head_dim == half_warp_size * simd_width
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_heads
+        var head_idx = flat_row % num_heads
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+        var cache_token_idx = token_idx + k_cache.cache_length(batch_idx)
+
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var vec_data = k_cache.load[width=simd_width](
+            batch_idx, head_idx, cache_token_idx, Int(col)
+        ).cast[accum_type]()
+        var gamma_val = gamma.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(Int(col)))
+        )
+
+        var norm_val = _rms_norm_warp_tiling_subkernel[
+            warps_per_block,
+            True,
+            rows_per_warp=2,
+        ](
+            flat_row,
+            Int(col),
+            vec_data,
+            gamma_val,
+            epsilon_accum,
+            weight_offset_accum,
+            head_dim,
+        )
+
+        var sub_warp_mask = (
+            (UInt(1) << UInt(half_warp_size)) - UInt(1)
+        ) << (sub_warp_idx * UInt(half_warp_size))
+        var partner_lane = (
+            sub_warp_idx * UInt(half_warp_size)
+            + (local_tid % UInt(half_warp_size // 2))
+            + UInt(half_warp_size // 2)
+        )
+        var norm_parts = norm_val.split()
+        var norm_lo_parts = norm_parts[0].split()
+        var norm_hi_parts = norm_parts[1].split()
+        var partner_norm_lo = warp.shuffle_idx(
+            sub_warp_mask,
+            norm_lo_parts[0],
+            UInt32(partner_lane),
+        ).join(
+            warp.shuffle_idx(
+                sub_warp_mask,
+                norm_lo_parts[1],
+                UInt32(partner_lane),
+            )
+        )
+        var partner_norm_hi = warp.shuffle_idx(
+            sub_warp_mask,
+            norm_hi_parts[0],
+            UInt32(partner_lane),
+        ).join(
+            warp.shuffle_idx(
+                sub_warp_mask,
+                norm_hi_parts[1],
+                UInt32(partner_lane),
+            )
+        )
+        var partner_norm = rebind[type_of(norm_val)](
+            partner_norm_lo.join(partner_norm_hi)
+        )
+
+        if local_tid < UInt(half_warp_size // 2):
+            var re_offset = Int(local_tid) * simd_width
+            var im_offset = re_offset + head_dim // 2
+            var freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                Coord(Idx(cache_token_idx), Idx(re_offset * 2))
+            )
+            comptime cache_dtype = KCacheType.dtype
+            var rope_val = _rope_complex_mul_half[
+                accum_type,
+                freq_dtype,
+                simd_width,
+                simd_width * 2,
+            ](
+                norm_val.cast[accum_type](),
+                partner_norm.cast[accum_type](),
+                freq,
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                re_offset,
+                rope_val[0].cast[cache_dtype](),
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                im_offset,
+                rope_val[1].cast[cache_dtype](),
+            )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _gemma3_k_norm_rope_decode_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime num_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(KCacheType.kv_params.head_size)
+    comptime simd_width = simd_width_of[dtype]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime assert head_dim == 128, "Only 128-column BF16 key rows are supported"
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert freqs_cis.static_shape[1] == head_dim
+    comptime assert head_dim == half_warp_size * simd_width
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_heads
+        var head_idx = flat_row % num_heads
+        var batch_idx = global_token_idx
+        var cache_token_idx = k_cache.cache_length(batch_idx)
+
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var vec_data = k_cache.load[width=simd_width](
+            batch_idx, head_idx, cache_token_idx, Int(col)
+        ).cast[accum_type]()
+        var gamma_val = gamma.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(Int(col)))
+        )
+
+        var norm_val = _rms_norm_warp_tiling_subkernel[
+            warps_per_block,
+            True,
+            rows_per_warp=2,
+        ](
+            flat_row,
+            Int(col),
+            vec_data,
+            gamma_val,
+            epsilon_accum,
+            weight_offset_accum,
+            head_dim,
+        )
+
+        var sub_warp_mask = (
+            (UInt(1) << UInt(half_warp_size)) - UInt(1)
+        ) << (sub_warp_idx * UInt(half_warp_size))
+        var partner_lane = (
+            sub_warp_idx * UInt(half_warp_size)
+            + (local_tid % UInt(half_warp_size // 2))
+            + UInt(half_warp_size // 2)
+        )
+        var norm_parts = norm_val.split()
+        var norm_lo_parts = norm_parts[0].split()
+        var norm_hi_parts = norm_parts[1].split()
+        var partner_norm_lo = warp.shuffle_idx(
+            sub_warp_mask,
+            norm_lo_parts[0],
+            UInt32(partner_lane),
+        ).join(
+            warp.shuffle_idx(
+                sub_warp_mask,
+                norm_lo_parts[1],
+                UInt32(partner_lane),
+            )
+        )
+        var partner_norm_hi = warp.shuffle_idx(
+            sub_warp_mask,
+            norm_hi_parts[0],
+            UInt32(partner_lane),
+        ).join(
+            warp.shuffle_idx(
+                sub_warp_mask,
+                norm_hi_parts[1],
+                UInt32(partner_lane),
+            )
+        )
+        var partner_norm = rebind[type_of(norm_val)](
+            partner_norm_lo.join(partner_norm_hi)
+        )
+
+        if local_tid < UInt(half_warp_size // 2):
+            var re_offset = Int(local_tid) * simd_width
+            var im_offset = re_offset + head_dim // 2
+            var freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                Coord(Idx(cache_token_idx), Idx(re_offset * 2))
+            )
+            comptime cache_dtype = KCacheType.dtype
+            var rope_val = _rope_complex_mul_half[
+                accum_type,
+                freq_dtype,
+                simd_width,
+                simd_width * 2,
+            ](
+                norm_val.cast[accum_type](),
+                partner_norm.cast[accum_type](),
+                freq,
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                re_offset,
+                rope_val[0].cast[cache_dtype](),
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                im_offset,
+                rope_val[1].cast[cache_dtype](),
+            )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _gemma3_k_norm_rope_ragged_wide_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    OffsetsLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime num_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(KCacheType.kv_params.head_size)
+    comptime simd_width = simd_width_of[dtype]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime assert head_dim == 256, "Only 256-column BF16 key rows are supported"
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert freqs_cis.static_shape[1] == head_dim
+    comptime assert head_dim == WARP_SIZE * simd_width
+
+    var shared_norm = stack_allocation[
+        warps_per_block * head_dim,
+        Scalar[dtype],
+        address_space=AddressSpace.SHARED,
+    ]()
+    var shared_batch_idx = stack_allocation[
+        warps_per_block,
+        Int32,
+        address_space=AddressSpace.SHARED,
+    ]()
+    var shared_post_seq = stack_allocation[
+        warps_per_block,
+        Int32,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var local_tid = tid % UInt(WARP_SIZE)
+    var row = block_idx.x * UInt(warps_per_block) + warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_heads
+        var head_idx = flat_row % num_heads
+
+        if local_tid == 0:
+            var batch_idx = get_batch_from_row_offsets(
+                input_row_offsets, global_token_idx
+            )
+            var token_idx = Int(
+                UInt32(global_token_idx) - input_row_offsets[batch_idx]
+            )
+            shared_batch_idx[Int(warp_idx)] = Int32(batch_idx)
+            shared_post_seq[Int(warp_idx)] = Int32(
+                token_idx + Int(k_cache.cache_length(batch_idx))
+            )
+        syncwarp()
+
+        var batch_idx = Int(shared_batch_idx[Int(warp_idx)])
+        var cache_token_idx = Int(shared_post_seq[Int(warp_idx)])
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var vec_data = k_cache.load[width=simd_width](
+            batch_idx, head_idx, cache_token_idx, Int(col)
+        ).cast[accum_type]()
+        var gamma_val = gamma.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(Int(col)))
+        )
+
+        var thread_m2 = (vec_data**2).reduce_add()
+        var row_m2 = warp.sum(thread_m2)
+        var norm_factor = rsqrt(
+            (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+        )
+        var norm_val = vec_data * norm_factor * (
+            gamma_val.cast[accum_type]() + weight_offset_accum
+        )
+        var shared_base = Int(warp_idx) * head_dim
+        shared_norm.store[width=simd_width, alignment=wide_align](
+            shared_base + Int(col), norm_val.cast[dtype]()
+        )
+        syncwarp()
+
+        if local_tid < UInt(WARP_SIZE // 2):
+            var re_offset = Int(local_tid) * simd_width
+            var im_offset = re_offset + head_dim // 2
+            var rope_re = shared_norm.load[width=simd_width](
+                shared_base + re_offset
+            ).cast[accum_type]()
+            var rope_im = shared_norm.load[width=simd_width](
+                shared_base + im_offset
+            ).cast[accum_type]()
+            var freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                Coord(Idx(cache_token_idx), Idx(re_offset * 2))
+            )
+            comptime cache_dtype = KCacheType.dtype
+            var rope_val = _rope_complex_mul_half[
+                accum_type,
+                freq_dtype,
+                simd_width,
+                simd_width * 2,
+            ](rope_re, rope_im, freq)
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                re_offset,
+                rope_val[0].cast[cache_dtype](),
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                im_offset,
+                rope_val[1].cast[cache_dtype](),
+            )
+
+
+def _bench_trial_k_norm_rope_ragged_paged[
+    dtype: DType,
+    freq_dtype: DType,
+    params: KVCacheStaticParams,
+    page_size: Int,
+    cache_dtype: DType,
+](
+    kv_collection: PagedKVCacheCollection[cache_dtype, params, page_size],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    total_seq_len: UInt32,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    freqs_cis: TileTensor[freq_dtype, ...],
+    ctx: DeviceContext,
+) raises:
+    comptime head_dim = Int(params.head_size)
+    comptime assert dtype == DType.bfloat16
+    comptime assert cache_dtype == DType.bfloat16
+    comptime assert head_dim == 128 or head_dim == 256
+
+    var total_rows = Int(total_seq_len) * Int(params.num_heads)
+    comptime default_warps_per_block = 2
+    comptime default_block_size = default_warps_per_block * WARP_SIZE
+    comptime large_row_warps_per_block = 8
+    comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
+    comptime min_large_row_blocks_per_sm = 6
+    var large_row_grid_dim = ceildiv(total_rows, large_row_warps_per_block)
+    var min_large_row_blocks = (
+        ctx.default_device_info.sm_count * min_large_row_blocks_per_sm
+    )
+    var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+    comptime if head_dim == 128:
+        var batch_size = Int(input_row_offsets.dim(0)) - 1
+        var is_decode_uniform = Int(total_seq_len) == batch_size
+        var large_row_grid_dim_128 = ceildiv(
+            total_rows, large_row_warps_per_block * 2
+        )
+
+        if is_decode_uniform:
+            if large_row_grid_dim_128 >= min_large_row_blocks:
+                comptime kernel = _gemma3_k_norm_rope_decode_kernel[
+                    dtype,
+                    freq_dtype,
+                    PagedKVCacheCollection[
+                        cache_dtype, params, page_size
+                    ].CacheType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                ctx.enqueue_function[kernel, kernel](
+                    k_cache,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    total_rows,
+                    grid_dim=large_row_grid_dim_128,
+                    block_dim=large_row_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+            else:
+                comptime kernel = _gemma3_k_norm_rope_decode_kernel[
+                    dtype,
+                    freq_dtype,
+                    PagedKVCacheCollection[
+                        cache_dtype, params, page_size
+                    ].CacheType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                ctx.enqueue_function[kernel, kernel](
+                    k_cache,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    total_rows,
+                    grid_dim=ceildiv(total_rows, default_warps_per_block * 2),
+                    block_dim=default_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+        else:
+            if large_row_grid_dim_128 >= min_large_row_blocks:
+                comptime kernel = _gemma3_k_norm_rope_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    PagedKVCacheCollection[
+                        cache_dtype, params, page_size
+                    ].CacheType,
+                    input_row_offsets.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                ctx.enqueue_function[kernel, kernel](
+                    input_row_offsets,
+                    k_cache,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    total_rows,
+                    grid_dim=large_row_grid_dim_128,
+                    block_dim=large_row_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+            else:
+                comptime kernel = _gemma3_k_norm_rope_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    PagedKVCacheCollection[
+                        cache_dtype, params, page_size
+                    ].CacheType,
+                    input_row_offsets.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                ctx.enqueue_function[kernel, kernel](
+                    input_row_offsets,
+                    k_cache,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    total_rows,
+                    grid_dim=ceildiv(total_rows, default_warps_per_block * 2),
+                    block_dim=default_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+    else:
+        if large_row_grid_dim >= min_large_row_blocks:
+            comptime kernel = _gemma3_k_norm_rope_ragged_wide_kernel[
+                dtype,
+                freq_dtype,
+                PagedKVCacheCollection[
+                    cache_dtype, params, page_size
+                ].CacheType,
+                input_row_offsets.LayoutType,
+                freqs_cis.LayoutType,
+                gamma.LayoutType,
+                large_row_block_size,
+                large_row_warps_per_block,
+            ]
+            ctx.enqueue_function[kernel, kernel](
+                input_row_offsets,
+                k_cache,
+                freqs_cis,
+                gamma,
+                epsilon,
+                weight_offset,
+                total_rows,
+                grid_dim=large_row_grid_dim,
+                block_dim=large_row_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+        else:
+            comptime kernel = _gemma3_k_norm_rope_ragged_wide_kernel[
+                dtype,
+                freq_dtype,
+                PagedKVCacheCollection[
+                    cache_dtype, params, page_size
+                ].CacheType,
+                input_row_offsets.LayoutType,
+                freqs_cis.LayoutType,
+                gamma.LayoutType,
+                default_block_size,
+                default_warps_per_block,
+            ]
+            ctx.enqueue_function[kernel, kernel](
+                input_row_offsets,
+                k_cache,
+                freqs_cis,
+                gamma,
+                epsilon,
+                weight_offset,
+                total_rows,
+                grid_dim=ceildiv(total_rows, default_warps_per_block),
+                block_dim=default_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+
+
+def bench_gemma3_k_norm_rope_boundary[
+    dtype: DType,
+    head_dim: Int,
+    num_kv_heads: Int,
+    page_size: Int,
+](
+    ctx: DeviceContext,
+    mut bench: Bench,
+    batch_size: Int,
+    seq_len: Int,
+    cache_len: Int,
+    cache_len_step: Int,
+) raises:
+    comptime layer_idx = 0
+    comptime num_layers = 1
+    comptime kv_params = KVCacheStaticParams(
+        num_heads=UInt(num_kv_heads), head_size=UInt(head_dim)
+    )
+    comptime CollectionType = PagedKVCacheCollection[dtype, kv_params, page_size]
+    comptime kv_block_layout = Layout.row_major[6]()
+    comptime cache_lengths_layout = Layout(UNKNOWN_VALUE)
+
+    var total_seq_len = UInt32(batch_size * seq_len)
+    var max_cache_len = cache_len + (batch_size - 1) * cache_len_step
+    var max_context_length = seq_len + max_cache_len
+    var paged_lut_cols = ceildiv(max_context_length, page_size)
+    var num_pages = batch_size * paged_lut_cols
+
+    var input_row_offsets_h = alloc[Scalar[DType.uint32]](batch_size + 1)
+    var cache_lengths_h = alloc[Scalar[DType.uint32]](batch_size)
+    var gamma_h = alloc[Scalar[dtype]](head_dim)
+    var freqs_h = alloc[Scalar[dtype]](max_context_length * head_dim)
+    var paged_lut_h = alloc[Scalar[DType.uint32]](batch_size * paged_lut_cols)
+
+    for i in range(batch_size):
+        input_row_offsets_h[i] = UInt32(i * seq_len)
+        cache_lengths_h[i] = UInt32(cache_len + i * cache_len_step)
+    input_row_offsets_h[batch_size] = total_seq_len
+
+    for i in range(head_dim):
+        gamma_h[i] = (Float64(i + head_dim) / Float64(head_dim)).cast[dtype]()
+
+    random(
+        LayoutTensor[dtype, Layout.row_major[2](), MutAnyOrigin](
+            freqs_h,
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](max_context_length, head_dim)
+            ),
+        )
+    )
+
+    var paged_lut_host = LayoutTensor[
+        DType.uint32, Layout.row_major[2](), MutAnyOrigin
+    ](
+        paged_lut_h,
+        RuntimeLayout[Layout.row_major[2]()].row_major(
+            IndexList[2](batch_size, paged_lut_cols)
+        ),
+    )
+    for bs in range(batch_size):
+        for page_idx in range(paged_lut_cols):
+            paged_lut_host[bs, page_idx] = UInt32(bs * paged_lut_cols + page_idx)
+
+    var input_row_offsets_d = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size + 1
+    )
+    var cache_lengths_d = ctx.enqueue_create_buffer[DType.uint32](batch_size)
+    var gamma_d = ctx.enqueue_create_buffer[dtype](head_dim)
+    var freqs_d = ctx.enqueue_create_buffer[dtype](max_context_length * head_dim)
+    var paged_lut_d = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size * paged_lut_cols
+    )
+
+    ctx.enqueue_copy(input_row_offsets_d, input_row_offsets_h)
+    ctx.enqueue_copy(cache_lengths_d, cache_lengths_h)
+    ctx.enqueue_copy(gamma_d, gamma_h)
+    ctx.enqueue_copy(freqs_d, freqs_h)
+    ctx.enqueue_copy(paged_lut_d, paged_lut_h)
+
+    var kv_block_shape = IndexList[6](
+        num_pages,
+        2,
+        num_layers,
+        page_size,
+        num_kv_heads,
+        head_dim,
+    )
+    var kv_block_size = kv_block_shape.flattened_length()
+    var initial_kv_block_h = alloc[Scalar[dtype]](kv_block_size)
+    var baseline_kv_block_h = alloc[Scalar[dtype]](kv_block_size)
+    var trial_kv_block_h = alloc[Scalar[dtype]](kv_block_size)
+    random(
+        LayoutTensor[dtype, Layout.row_major[6](), MutAnyOrigin](
+            initial_kv_block_h,
+            RuntimeLayout[Layout.row_major[6]()].row_major(kv_block_shape),
+        )
+    )
+
+    var baseline_kv_block_d = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    var trial_kv_block_d = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    ctx.enqueue_copy(baseline_kv_block_d, initial_kv_block_h)
+    ctx.enqueue_copy(trial_kv_block_d, initial_kv_block_h)
+
+    var gamma_tensor = TileTensor(
+        gamma_d.unsafe_ptr(), row_major(Idx[head_dim]())
+    )
+    var input_row_offsets_tensor = TileTensor(
+        input_row_offsets_d.unsafe_ptr(), row_major(Idx(batch_size + 1))
+    )
+    var freqs_tensor = TileTensor(
+        freqs_d.unsafe_ptr(),
+        row_major(Idx(max_context_length), Idx[head_dim]()),
+    )
+
+    var baseline_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            baseline_kv_block_d.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_d.unsafe_ptr(),
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+            paged_lut_d.unsafe_ptr(),
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var trial_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            trial_kv_block_d.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_d.unsafe_ptr(),
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+            paged_lut_d.unsafe_ptr(),
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+
+    var epsilon = Scalar[dtype](1e-6)
+    var weight_offset = Scalar[dtype](1.0)
+
+    @always_inline
+    @__copy_capture(
+        baseline_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+        freqs_tensor,
+    )
+    @parameter
+    def run_baseline(ctx: DeviceContext) raises:
+        rms_norm_kv_cache_ragged_paged[
+            target="gpu",
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            baseline_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+        _rope_k_cache_ragged[target="gpu", interleaved=False](
+            Int(total_seq_len),
+            input_row_offsets_tensor,
+            baseline_kv_collection,
+            freqs_tensor,
+            UInt32(layer_idx),
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        trial_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        freqs_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_trial(ctx: DeviceContext) raises:
+        k_rms_norm_rope_ragged[
+            dtype,
+            dtype,
+            CollectionType,
+            interleaved=False,
+            target="gpu",
+        ](
+            Int(total_seq_len),
+            input_row_offsets_tensor,
+            trial_kv_collection,
+            freqs_tensor,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            ctx,
+        )
+
+    @always_inline
+    @parameter
+    def baseline_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_baseline](ctx)
+
+    @always_inline
+    @parameter
+    def trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_trial](ctx)
+
+    bench.bench_function[baseline_bench](
+        BenchId(
+            "gemma3_k_norm_rope_boundary_baseline",
+            input_id=String(
+                dtype,
+                "/bs=",
+                batch_size,
+                "/seq=",
+                seq_len,
+                "/cache=",
+                cache_len,
+                "/step=",
+                cache_len_step,
+            ),
+        ),
+    )
+    bench.bench_function[trial_bench](
+        BenchId(
+            "gemma3_k_norm_rope_boundary_trial",
+            input_id=String(
+                dtype,
+                "/bs=",
+                batch_size,
+                "/seq=",
+                seq_len,
+                "/cache=",
+                cache_len,
+                "/step=",
+                cache_len_step,
+            ),
+        ),
+    )
+
+    run_baseline(ctx)
+    run_trial(ctx)
+    ctx.enqueue_copy(baseline_kv_block_h, baseline_kv_block_d)
+    ctx.enqueue_copy(trial_kv_block_h, trial_kv_block_d)
+    ctx.synchronize()
+
+    var baseline_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            baseline_kv_block_h,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_h,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+            paged_lut_h,
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var trial_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            trial_kv_block_h,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_h,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+            paged_lut_h,
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var baseline_k_cache_host = baseline_kv_collection_host.get_key_cache(layer_idx)
+    var trial_k_cache_host = trial_kv_collection_host.get_key_cache(layer_idx)
+
+    for bs_idx in range(batch_size):
+        for tok_idx in range(seq_len):
+            var post_seq_idx = Int(cache_lengths_h[bs_idx]) + tok_idx
+            for head_idx in range(num_kv_heads):
+                for dim_idx in range(head_dim):
+                    assert_almost_equal(
+                        baseline_k_cache_host.load[width=1](
+                            bs_idx,
+                            head_idx,
+                            post_seq_idx,
+                            dim_idx,
+                        ),
+                        trial_k_cache_host.load[width=1](
+                            bs_idx,
+                            head_idx,
+                            post_seq_idx,
+                            dim_idx,
+                        ),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+
+    _ = input_row_offsets_d
+    _ = cache_lengths_d
+    _ = gamma_d
+    _ = freqs_d
+    _ = paged_lut_d
+    _ = baseline_kv_block_d
+    _ = trial_kv_block_d
+
+    input_row_offsets_h.free()
+    cache_lengths_h.free()
+    gamma_h.free()
+    freqs_h.free()
+    paged_lut_h.free()
+    initial_kv_block_h.free()
+    baseline_kv_block_h.free()
+    trial_kv_block_h.free()
+
+
+def main() raises:
+    comptime dtype = get_defined_dtype["dtype", DType.bfloat16]()
+    comptime head_dim = get_defined_int["head_dim", 128]()
+    comptime num_kv_heads = get_defined_int["num_kv_heads", 16]()
+    comptime page_size = 128
+
+    var batch_size = arg_parse("batch_size", 64)
+    var seq_len = arg_parse("seq_len", 1)
+    var cache_len = arg_parse("cache_len", 1024)
+    var cache_len_step = arg_parse("cache_len_step", 0)
+
+    seed(0)
+
+    var bench = Bench(BenchConfig(num_repetitions=1))
+    with DeviceContext() as ctx:
+        bench_gemma3_k_norm_rope_boundary[
+            dtype,
+            head_dim,
+            num_kv_heads,
+            page_size,
+        ](ctx, bench, batch_size, seq_len, cache_len, cache_len_step)
+
+    bench.dump_report()

--- a/max/kernels/benchmarks/gpu/nn/bench_gemma3_k_rope_boundary.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_gemma3_k_rope_boundary.mojo
@@ -1,0 +1,1014 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import ceildiv, gcd
+from std.random import seed
+from std.sys import get_defined_dtype, get_defined_int
+
+from std.benchmark import Bench, BenchConfig, Bencher, BenchId
+from std.gpu import WARP_SIZE
+from std.gpu.host import DeviceContext
+from std.gpu.primitives.grid_controls import PDLLevel, pdl_launch_attributes
+from std.testing import assert_almost_equal
+
+from internal_utils import arg_parse
+from kv_cache.types import KVCacheStaticParams, KVCollectionT, PagedKVCacheCollection
+from layout import (
+    Idx,
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    UNKNOWN_VALUE,
+    row_major,
+)
+from layout._fillers import random
+from nn.rope import (
+    _rope_k_cache_decode_ragged_kernel,
+    _rope_k_cache_ragged,
+    _rope_k_cache_ragged_kernel,
+)
+
+from std.utils import IndexList
+
+
+def _rope_k_cache_direct_row_trial[
+    freq_dtype: DType,
+    collection_t: KVCollectionT,
+](
+    total_seq_len: Int,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    kv_collection: collection_t,
+    freqs_cis: TileTensor[freq_dtype, ...],
+    layer_idx: UInt32,
+    ctx: DeviceContext,
+) raises:
+    comptime assert (
+        input_row_offsets.flat_rank == 1
+    ), "input_row_offsets must be rank 1"
+    comptime assert freqs_cis.flat_rank == 2, "freqs_cis must be rank 2"
+    comptime assert collection_t.CacheType.dtype == DType.bfloat16, (
+        "The direct-row K-rope trial only supports BF16 cache storage"
+    )
+    comptime head_size = Int(collection_t.CacheType.kv_params.head_size)
+    comptime assert head_size == 128, (
+        "The direct-row K-rope trial only supports 128-column keys"
+    )
+
+    var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+    var total_rows = total_seq_len * Int(collection_t.CacheType.kv_params.num_heads)
+    var batch_size = Int(input_row_offsets.dim(0)) - 1
+    var is_decode_uniform = total_seq_len == batch_size
+    comptime default_warps_per_block = 2
+    comptime default_block_size = default_warps_per_block * WARP_SIZE
+    comptime large_row_warps_per_block = 8
+    comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
+    comptime min_large_row_blocks_per_sm = 6
+    var large_row_grid_dim = ceildiv(total_rows, large_row_warps_per_block * 2)
+    var min_large_row_blocks = (
+        ctx.default_device_info.sm_count * min_large_row_blocks_per_sm
+    )
+
+    if is_decode_uniform:
+        if large_row_grid_dim >= min_large_row_blocks:
+            comptime kernel = _rope_k_cache_decode_ragged_kernel[
+                freq_dtype,
+                collection_t.CacheType,
+                freqs_cis.LayoutType,
+                large_row_block_size,
+                large_row_warps_per_block,
+            ]
+            ctx.enqueue_function[kernel, kernel](
+                k_cache,
+                freqs_cis,
+                total_rows,
+                grid_dim=large_row_grid_dim,
+                block_dim=large_row_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+        else:
+            comptime kernel = _rope_k_cache_decode_ragged_kernel[
+                freq_dtype,
+                collection_t.CacheType,
+                freqs_cis.LayoutType,
+                default_block_size,
+                default_warps_per_block,
+            ]
+            ctx.enqueue_function[kernel, kernel](
+                k_cache,
+                freqs_cis,
+                total_rows,
+                grid_dim=ceildiv(total_rows, default_warps_per_block * 2),
+                block_dim=default_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+    else:
+        if large_row_grid_dim >= min_large_row_blocks:
+            comptime kernel = _rope_k_cache_ragged_kernel[
+                freq_dtype,
+                collection_t.CacheType,
+                input_row_offsets.LayoutType,
+                freqs_cis.LayoutType,
+                large_row_block_size,
+                large_row_warps_per_block,
+            ]
+            ctx.enqueue_function[kernel, kernel](
+                input_row_offsets,
+                k_cache,
+                freqs_cis,
+                total_rows,
+                grid_dim=large_row_grid_dim,
+                block_dim=large_row_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+        else:
+            comptime kernel = _rope_k_cache_ragged_kernel[
+                freq_dtype,
+                collection_t.CacheType,
+                input_row_offsets.LayoutType,
+                freqs_cis.LayoutType,
+                default_block_size,
+                default_warps_per_block,
+            ]
+            ctx.enqueue_function[kernel, kernel](
+                input_row_offsets,
+                k_cache,
+                freqs_cis,
+                total_rows,
+                grid_dim=ceildiv(total_rows, default_warps_per_block * 2),
+                block_dim=default_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+
+
+def _fill_paged_lut[origin: MutOrigin, //](
+    paged_lut_h: UnsafePointer[Scalar[DType.uint32], origin],
+    row_page_counts_h: UnsafePointer[Scalar[DType.uint32], _],
+    batch_size: Int,
+    paged_lut_cols: Int,
+    num_pages: Int,
+    packed_pages: Bool,
+    fragment_pages: Bool,
+):
+    var paged_lut_host = LayoutTensor[
+        DType.uint32, Layout.row_major[2](), origin
+    ](
+        paged_lut_h,
+        RuntimeLayout[Layout.row_major[2]()].row_major(
+            IndexList[2](batch_size, paged_lut_cols)
+        ),
+    )
+    assert not (
+        packed_pages and fragment_pages
+    ), "pack_pages and fragment_pages are mutually exclusive"
+
+    var next_page_id = 0
+    var fragment_cursor = 0
+    var fragment_stride = 1
+    var fragment_offset = 0
+    if fragment_pages:
+        fragment_stride = num_pages // 2 + 1
+        while gcd(fragment_stride, num_pages) != 1:
+            fragment_stride += 1
+        fragment_offset = num_pages // 3
+
+    for bs in range(batch_size):
+        var row_page_count = Int(row_page_counts_h[bs])
+        for page_idx in range(paged_lut_cols):
+            if packed_pages:
+                if page_idx < row_page_count:
+                    paged_lut_host[bs, page_idx] = UInt32(next_page_id)
+                    next_page_id += 1
+                else:
+                    paged_lut_host[bs, page_idx] = UInt32(num_pages)
+            elif fragment_pages:
+                if page_idx < row_page_count:
+                    # A deterministic co-prime walk scatters used pages across
+                    # the dense pool while keeping the exact layout reproducible.
+                    var fragment_page_id = (
+                        fragment_offset + fragment_cursor * fragment_stride
+                    ) % num_pages
+                    fragment_cursor += 1
+                    paged_lut_host[bs, page_idx] = UInt32(fragment_page_id)
+                else:
+                    paged_lut_host[bs, page_idx] = UInt32(num_pages)
+            else:
+                paged_lut_host[bs, page_idx] = UInt32(
+                    bs * paged_lut_cols + page_idx
+                )
+
+
+def _assert_k_cache_match[collection_t: KVCollectionT](
+    baseline_kv_collection_host: collection_t,
+    trial_kv_collection_host: collection_t,
+    cache_lengths_h: UnsafePointer[Scalar[DType.uint32], _],
+    layer_idx: Int,
+    batch_size: Int,
+    seq_len: Int,
+    num_kv_heads: Int,
+    head_dim: Int,
+) raises:
+    var baseline_k_cache_host = baseline_kv_collection_host.get_key_cache(layer_idx)
+    var trial_k_cache_host = trial_kv_collection_host.get_key_cache(layer_idx)
+
+    for bs_idx in range(batch_size):
+        for tok_idx in range(seq_len):
+            var post_seq_idx = Int(cache_lengths_h[bs_idx]) + tok_idx
+            for head_idx in range(num_kv_heads):
+                for dim_idx in range(head_dim):
+                    assert_almost_equal(
+                        baseline_k_cache_host.load[width=1](
+                            bs_idx,
+                            head_idx,
+                            post_seq_idx,
+                            dim_idx,
+                        ),
+                        trial_k_cache_host.load[width=1](
+                            bs_idx,
+                            head_idx,
+                            post_seq_idx,
+                            dim_idx,
+                        ),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+
+
+def bench_gemma3_k_rope_boundary[
+    dtype: DType,
+    head_dim: Int,
+    num_kv_heads: Int,
+    page_size: Int,
+](
+    ctx: DeviceContext,
+    mut bench: Bench,
+    batch_size: Int,
+    seq_len: Int,
+    cache_len: Int,
+    cache_len_step: Int,
+    packed_pages: Bool,
+    fragment_pages: Bool,
+    paired_fragment_pages: Bool,
+) raises:
+    comptime layer_idx = 0
+    comptime num_layers = 1
+    comptime kv_params = KVCacheStaticParams(
+        num_heads=UInt(num_kv_heads), head_size=UInt(head_dim)
+    )
+    comptime CollectionType = PagedKVCacheCollection[dtype, kv_params, page_size]
+    comptime kv_block_layout = Layout.row_major[6]()
+    comptime cache_lengths_layout = Layout(UNKNOWN_VALUE)
+
+    var total_seq_len = UInt32(batch_size * seq_len)
+    var max_cache_len = cache_len + (batch_size - 1) * cache_len_step
+    var max_context_length = seq_len + max_cache_len
+
+    var input_row_offsets_h = alloc[Scalar[DType.uint32]](batch_size + 1)
+    var cache_lengths_h = alloc[Scalar[DType.uint32]](batch_size)
+    var row_page_counts_h = alloc[Scalar[DType.uint32]](batch_size)
+    var freqs_h = alloc[Scalar[dtype]](max_context_length * head_dim)
+    var paged_lut_cols = 0
+    var num_pages = 0
+
+    for i in range(batch_size):
+        input_row_offsets_h[i] = UInt32(i * seq_len)
+        var row_cache_len = cache_len + i * cache_len_step
+        cache_lengths_h[i] = UInt32(row_cache_len)
+        var row_page_count = ceildiv(row_cache_len + seq_len, page_size)
+        row_page_counts_h[i] = UInt32(row_page_count)
+        if row_page_count > paged_lut_cols:
+            paged_lut_cols = row_page_count
+        if packed_pages:
+            num_pages += row_page_count
+    input_row_offsets_h[batch_size] = total_seq_len
+    if not packed_pages:
+        num_pages = batch_size * paged_lut_cols
+
+    assert not (
+        paired_fragment_pages and (packed_pages or fragment_pages)
+    ), (
+        "paired_fragment_pages cannot be combined with pack_pages or "
+        "fragment_pages"
+    )
+
+    var paged_lut_h = alloc[Scalar[DType.uint32]](batch_size * paged_lut_cols)
+    _fill_paged_lut(
+        paged_lut_h,
+        row_page_counts_h,
+        batch_size,
+        paged_lut_cols,
+        num_pages,
+        packed_pages,
+        fragment_pages,
+    )
+
+    random(
+        LayoutTensor[dtype, Layout.row_major[2](), MutAnyOrigin](
+            freqs_h,
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](max_context_length, head_dim)
+            ),
+        )
+    )
+
+    var input_row_offsets_d = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size + 1
+    )
+    var cache_lengths_d = ctx.enqueue_create_buffer[DType.uint32](batch_size)
+    var freqs_d = ctx.enqueue_create_buffer[dtype](max_context_length * head_dim)
+    var paged_lut_d = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size * paged_lut_cols
+    )
+
+    ctx.enqueue_copy(input_row_offsets_d, input_row_offsets_h)
+    ctx.enqueue_copy(cache_lengths_d, cache_lengths_h)
+    ctx.enqueue_copy(freqs_d, freqs_h)
+    ctx.enqueue_copy(paged_lut_d, paged_lut_h)
+
+    var kv_block_shape = IndexList[6](
+        num_pages,
+        2,
+        num_layers,
+        page_size,
+        num_kv_heads,
+        head_dim,
+    )
+    var kv_block_size = kv_block_shape.flattened_length()
+    var initial_kv_block_h = alloc[Scalar[dtype]](kv_block_size)
+    var baseline_kv_block_h = alloc[Scalar[dtype]](kv_block_size)
+    var trial_kv_block_h = alloc[Scalar[dtype]](kv_block_size)
+    random(
+        LayoutTensor[dtype, Layout.row_major[6](), MutAnyOrigin](
+            initial_kv_block_h,
+            RuntimeLayout[Layout.row_major[6]()].row_major(kv_block_shape),
+        )
+    )
+
+    var baseline_kv_block_d = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    var trial_kv_block_d = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    ctx.enqueue_copy(baseline_kv_block_d, initial_kv_block_h)
+    ctx.enqueue_copy(trial_kv_block_d, initial_kv_block_h)
+
+    var input_row_offsets_tensor = TileTensor(
+        input_row_offsets_d.unsafe_ptr(), row_major(Idx(batch_size + 1))
+    )
+    var freqs_tensor = TileTensor(
+        freqs_d.unsafe_ptr(),
+        row_major(Idx(max_context_length), Idx[head_dim]()),
+    )
+
+    if paired_fragment_pages:
+        var fragmented_paged_lut_h = alloc[Scalar[DType.uint32]](
+            batch_size * paged_lut_cols
+        )
+        _fill_paged_lut(
+            fragmented_paged_lut_h,
+            row_page_counts_h,
+            batch_size,
+            paged_lut_cols,
+            num_pages,
+            False,
+            True,
+        )
+        var fragmented_paged_lut_d = ctx.enqueue_create_buffer[DType.uint32](
+            batch_size * paged_lut_cols
+        )
+        ctx.enqueue_copy(fragmented_paged_lut_d, fragmented_paged_lut_h)
+
+        var fragment_baseline_kv_block_h = alloc[Scalar[dtype]](kv_block_size)
+        var fragment_trial_kv_block_h = alloc[Scalar[dtype]](kv_block_size)
+        var fragment_baseline_kv_block_d = ctx.enqueue_create_buffer[dtype](
+            kv_block_size
+        )
+        var fragment_trial_kv_block_d = ctx.enqueue_create_buffer[dtype](
+            kv_block_size
+        )
+        ctx.enqueue_copy(fragment_baseline_kv_block_d, initial_kv_block_h)
+        ctx.enqueue_copy(fragment_trial_kv_block_d, initial_kv_block_h)
+
+        var dense_baseline_kv_collection = CollectionType(
+            LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+                baseline_kv_block_d.unsafe_ptr(),
+                RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+            ),
+            LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+                cache_lengths_d.unsafe_ptr(),
+                RuntimeLayout[cache_lengths_layout].row_major(
+                    IndexList[1](batch_size)
+                ),
+            ),
+            LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+                paged_lut_d.unsafe_ptr(),
+                RuntimeLayout[Layout.row_major[2]()].row_major(
+                    IndexList[2](batch_size, paged_lut_cols)
+                ),
+            ),
+            UInt32(seq_len),
+            UInt32(max_context_length),
+        )
+        var dense_trial_kv_collection = CollectionType(
+            LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+                trial_kv_block_d.unsafe_ptr(),
+                RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+            ),
+            LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+                cache_lengths_d.unsafe_ptr(),
+                RuntimeLayout[cache_lengths_layout].row_major(
+                    IndexList[1](batch_size)
+                ),
+            ),
+            LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+                paged_lut_d.unsafe_ptr(),
+                RuntimeLayout[Layout.row_major[2]()].row_major(
+                    IndexList[2](batch_size, paged_lut_cols)
+                ),
+            ),
+            UInt32(seq_len),
+            UInt32(max_context_length),
+        )
+        var fragment_baseline_kv_collection = CollectionType(
+            LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+                fragment_baseline_kv_block_d.unsafe_ptr(),
+                RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+            ),
+            LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+                cache_lengths_d.unsafe_ptr(),
+                RuntimeLayout[cache_lengths_layout].row_major(
+                    IndexList[1](batch_size)
+                ),
+            ),
+            LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+                fragmented_paged_lut_d.unsafe_ptr(),
+                RuntimeLayout[Layout.row_major[2]()].row_major(
+                    IndexList[2](batch_size, paged_lut_cols)
+                ),
+            ),
+            UInt32(seq_len),
+            UInt32(max_context_length),
+        )
+        var fragment_trial_kv_collection = CollectionType(
+            LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+                fragment_trial_kv_block_d.unsafe_ptr(),
+                RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+            ),
+            LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+                cache_lengths_d.unsafe_ptr(),
+                RuntimeLayout[cache_lengths_layout].row_major(
+                    IndexList[1](batch_size)
+                ),
+            ),
+            LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+                fragmented_paged_lut_d.unsafe_ptr(),
+                RuntimeLayout[Layout.row_major[2]()].row_major(
+                    IndexList[2](batch_size, paged_lut_cols)
+                ),
+            ),
+            UInt32(seq_len),
+            UInt32(max_context_length),
+        )
+
+        @always_inline
+        @__copy_capture(
+            dense_baseline_kv_collection,
+            input_row_offsets_tensor,
+            total_seq_len,
+            freqs_tensor,
+        )
+        @parameter
+        def run_dense_baseline(ctx: DeviceContext) raises:
+            _rope_k_cache_ragged[target="gpu", interleaved=False](
+                Int(total_seq_len),
+                input_row_offsets_tensor,
+                dense_baseline_kv_collection,
+                freqs_tensor,
+                UInt32(layer_idx),
+                ctx,
+            )
+
+        @always_inline
+        @__copy_capture(
+            fragment_baseline_kv_collection,
+            input_row_offsets_tensor,
+            total_seq_len,
+            freqs_tensor,
+        )
+        @parameter
+        def run_fragment_baseline(ctx: DeviceContext) raises:
+            _rope_k_cache_ragged[target="gpu", interleaved=False](
+                Int(total_seq_len),
+                input_row_offsets_tensor,
+                fragment_baseline_kv_collection,
+                freqs_tensor,
+                UInt32(layer_idx),
+                ctx,
+            )
+
+        @always_inline
+        @__copy_capture(
+            dense_trial_kv_collection,
+            input_row_offsets_tensor,
+            total_seq_len,
+            freqs_tensor,
+        )
+        @parameter
+        def run_dense_trial(ctx: DeviceContext) raises:
+            _rope_k_cache_direct_row_trial[dtype, CollectionType](
+                Int(total_seq_len),
+                input_row_offsets_tensor,
+                dense_trial_kv_collection,
+                freqs_tensor,
+                UInt32(layer_idx),
+                ctx,
+            )
+
+        @always_inline
+        @__copy_capture(
+            fragment_trial_kv_collection,
+            input_row_offsets_tensor,
+            total_seq_len,
+            freqs_tensor,
+        )
+        @parameter
+        def run_fragment_trial(ctx: DeviceContext) raises:
+            _rope_k_cache_direct_row_trial[dtype, CollectionType](
+                Int(total_seq_len),
+                input_row_offsets_tensor,
+                fragment_trial_kv_collection,
+                freqs_tensor,
+                UInt32(layer_idx),
+                ctx,
+            )
+
+        # Warm all four variants in one process, then reset them back to the
+        # same initial KV state before collecting timings.
+        run_dense_baseline(ctx)
+        run_fragment_baseline(ctx)
+        run_dense_trial(ctx)
+        run_fragment_trial(ctx)
+        ctx.synchronize()
+        ctx.enqueue_copy(baseline_kv_block_d, initial_kv_block_h)
+        ctx.enqueue_copy(trial_kv_block_d, initial_kv_block_h)
+        ctx.enqueue_copy(fragment_baseline_kv_block_d, initial_kv_block_h)
+        ctx.enqueue_copy(fragment_trial_kv_block_d, initial_kv_block_h)
+        ctx.synchronize()
+
+        @always_inline
+        @parameter
+        def dense_baseline_bench(mut bencher: Bencher) raises:
+            bencher.iter_custom[run_dense_baseline](ctx)
+
+        @always_inline
+        @parameter
+        def fragment_baseline_bench(mut bencher: Bencher) raises:
+            bencher.iter_custom[run_fragment_baseline](ctx)
+
+        @always_inline
+        @parameter
+        def dense_trial_bench(mut bencher: Bencher) raises:
+            bencher.iter_custom[run_dense_trial](ctx)
+
+        @always_inline
+        @parameter
+        def fragment_trial_bench(mut bencher: Bencher) raises:
+            bencher.iter_custom[run_fragment_trial](ctx)
+
+        bench.bench_function[dense_baseline_bench](
+            BenchId(
+                "gemma3_k_rope_boundary_dense_baseline",
+                input_id=String(
+                    dtype,
+                    "/bs=",
+                    batch_size,
+                    "/seq=",
+                    seq_len,
+                    "/cache=",
+                    cache_len,
+                    "/step=",
+                    cache_len_step,
+                ),
+            ),
+        )
+        bench.bench_function[fragment_baseline_bench](
+            BenchId(
+                "gemma3_k_rope_boundary_fragmented_baseline",
+                input_id=String(
+                    dtype,
+                    "/bs=",
+                    batch_size,
+                    "/seq=",
+                    seq_len,
+                    "/cache=",
+                    cache_len,
+                    "/step=",
+                    cache_len_step,
+                ),
+            ),
+        )
+        bench.bench_function[dense_trial_bench](
+            BenchId(
+                "gemma3_k_rope_boundary_dense_trial",
+                input_id=String(
+                    dtype,
+                    "/bs=",
+                    batch_size,
+                    "/seq=",
+                    seq_len,
+                    "/cache=",
+                    cache_len,
+                    "/step=",
+                    cache_len_step,
+                ),
+            ),
+        )
+        bench.bench_function[fragment_trial_bench](
+            BenchId(
+                "gemma3_k_rope_boundary_fragmented_trial",
+                input_id=String(
+                    dtype,
+                    "/bs=",
+                    batch_size,
+                    "/seq=",
+                    seq_len,
+                    "/cache=",
+                    cache_len,
+                    "/step=",
+                    cache_len_step,
+                ),
+            ),
+        )
+
+        run_dense_baseline(ctx)
+        run_fragment_baseline(ctx)
+        run_dense_trial(ctx)
+        run_fragment_trial(ctx)
+        ctx.enqueue_copy(baseline_kv_block_h, baseline_kv_block_d)
+        ctx.enqueue_copy(trial_kv_block_h, trial_kv_block_d)
+        ctx.enqueue_copy(fragment_baseline_kv_block_h, fragment_baseline_kv_block_d)
+        ctx.enqueue_copy(fragment_trial_kv_block_h, fragment_trial_kv_block_d)
+        ctx.synchronize()
+
+        var dense_baseline_kv_collection_host = CollectionType(
+            LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+                baseline_kv_block_h,
+                RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+            ),
+            LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+                cache_lengths_h,
+                RuntimeLayout[cache_lengths_layout].row_major(
+                    IndexList[1](batch_size)
+                ),
+            ),
+            LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+                paged_lut_h,
+                RuntimeLayout[Layout.row_major[2]()].row_major(
+                    IndexList[2](batch_size, paged_lut_cols)
+                ),
+            ),
+            UInt32(seq_len),
+            UInt32(max_context_length),
+        )
+        var dense_trial_kv_collection_host = CollectionType(
+            LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+                trial_kv_block_h,
+                RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+            ),
+            LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+                cache_lengths_h,
+                RuntimeLayout[cache_lengths_layout].row_major(
+                    IndexList[1](batch_size)
+                ),
+            ),
+            LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+                paged_lut_h,
+                RuntimeLayout[Layout.row_major[2]()].row_major(
+                    IndexList[2](batch_size, paged_lut_cols)
+                ),
+            ),
+            UInt32(seq_len),
+            UInt32(max_context_length),
+        )
+        var fragment_baseline_kv_collection_host = CollectionType(
+            LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+                fragment_baseline_kv_block_h,
+                RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+            ),
+            LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+                cache_lengths_h,
+                RuntimeLayout[cache_lengths_layout].row_major(
+                    IndexList[1](batch_size)
+                ),
+            ),
+            LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+                fragmented_paged_lut_h,
+                RuntimeLayout[Layout.row_major[2]()].row_major(
+                    IndexList[2](batch_size, paged_lut_cols)
+                ),
+            ),
+            UInt32(seq_len),
+            UInt32(max_context_length),
+        )
+        var fragment_trial_kv_collection_host = CollectionType(
+            LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+                fragment_trial_kv_block_h,
+                RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+            ),
+            LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+                cache_lengths_h,
+                RuntimeLayout[cache_lengths_layout].row_major(
+                    IndexList[1](batch_size)
+                ),
+            ),
+            LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+                fragmented_paged_lut_h,
+                RuntimeLayout[Layout.row_major[2]()].row_major(
+                    IndexList[2](batch_size, paged_lut_cols)
+                ),
+            ),
+            UInt32(seq_len),
+            UInt32(max_context_length),
+        )
+
+        _assert_k_cache_match(
+            dense_baseline_kv_collection_host,
+            dense_trial_kv_collection_host,
+            cache_lengths_h,
+            layer_idx,
+            batch_size,
+            seq_len,
+            num_kv_heads,
+            head_dim,
+        )
+        _assert_k_cache_match(
+            fragment_baseline_kv_collection_host,
+            fragment_trial_kv_collection_host,
+            cache_lengths_h,
+            layer_idx,
+            batch_size,
+            seq_len,
+            num_kv_heads,
+            head_dim,
+        )
+
+        _ = input_row_offsets_d
+        _ = cache_lengths_d
+        _ = freqs_d
+        _ = paged_lut_d
+        _ = fragmented_paged_lut_d
+        _ = baseline_kv_block_d
+        _ = trial_kv_block_d
+        _ = fragment_baseline_kv_block_d
+        _ = fragment_trial_kv_block_d
+
+        input_row_offsets_h.free()
+        cache_lengths_h.free()
+        row_page_counts_h.free()
+        freqs_h.free()
+        paged_lut_h.free()
+        fragmented_paged_lut_h.free()
+        initial_kv_block_h.free()
+        baseline_kv_block_h.free()
+        trial_kv_block_h.free()
+        fragment_baseline_kv_block_h.free()
+        fragment_trial_kv_block_h.free()
+        return
+
+    var baseline_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            baseline_kv_block_d.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_d.unsafe_ptr(),
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+            paged_lut_d.unsafe_ptr(),
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var trial_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            trial_kv_block_d.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_d.unsafe_ptr(),
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+            paged_lut_d.unsafe_ptr(),
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+
+    @always_inline
+    @__copy_capture(
+        baseline_kv_collection,
+        input_row_offsets_tensor,
+        total_seq_len,
+        freqs_tensor,
+    )
+    @parameter
+    def run_baseline(ctx: DeviceContext) raises:
+        _rope_k_cache_ragged[target="gpu", interleaved=False](
+            Int(total_seq_len),
+            input_row_offsets_tensor,
+            baseline_kv_collection,
+            freqs_tensor,
+            UInt32(layer_idx),
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        trial_kv_collection,
+        input_row_offsets_tensor,
+        total_seq_len,
+        freqs_tensor,
+    )
+    @parameter
+    def run_trial(ctx: DeviceContext) raises:
+        _rope_k_cache_direct_row_trial[dtype, CollectionType](
+            Int(total_seq_len),
+            input_row_offsets_tensor,
+            trial_kv_collection,
+            freqs_tensor,
+            UInt32(layer_idx),
+            ctx,
+        )
+
+    @always_inline
+    @parameter
+    def baseline_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_baseline](ctx)
+
+    @always_inline
+    @parameter
+    def trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_trial](ctx)
+
+    bench.bench_function[baseline_bench](
+        BenchId(
+            "gemma3_k_rope_boundary_baseline",
+            input_id=String(
+                dtype,
+                "/bs=",
+                batch_size,
+                "/seq=",
+                seq_len,
+                "/cache=",
+                cache_len,
+                "/step=",
+                cache_len_step,
+            ),
+        ),
+    )
+    bench.bench_function[trial_bench](
+        BenchId(
+            "gemma3_k_rope_boundary_trial",
+            input_id=String(
+                dtype,
+                "/bs=",
+                batch_size,
+                "/seq=",
+                seq_len,
+                "/cache=",
+                cache_len,
+                "/step=",
+                cache_len_step,
+            ),
+        ),
+    )
+
+    run_baseline(ctx)
+    run_trial(ctx)
+    ctx.enqueue_copy(baseline_kv_block_h, baseline_kv_block_d)
+    ctx.enqueue_copy(trial_kv_block_h, trial_kv_block_d)
+    ctx.synchronize()
+
+    var baseline_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            baseline_kv_block_h,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_h,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+            paged_lut_h,
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var trial_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            trial_kv_block_h,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_h,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+            paged_lut_h,
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    _assert_k_cache_match(
+        baseline_kv_collection_host,
+        trial_kv_collection_host,
+        cache_lengths_h,
+        layer_idx,
+        batch_size,
+        seq_len,
+        num_kv_heads,
+        head_dim,
+    )
+
+    _ = input_row_offsets_d
+    _ = cache_lengths_d
+    _ = freqs_d
+    _ = paged_lut_d
+    _ = baseline_kv_block_d
+    _ = trial_kv_block_d
+
+    input_row_offsets_h.free()
+    cache_lengths_h.free()
+    row_page_counts_h.free()
+    freqs_h.free()
+    paged_lut_h.free()
+    initial_kv_block_h.free()
+    baseline_kv_block_h.free()
+    trial_kv_block_h.free()
+
+
+def main() raises:
+    comptime dtype = get_defined_dtype["dtype", DType.bfloat16]()
+    comptime head_dim = get_defined_int["head_dim", 128]()
+    comptime num_kv_heads = get_defined_int["num_kv_heads", 16]()
+    comptime page_size = 128
+
+    var batch_size = arg_parse("batch_size", 64)
+    var seq_len = arg_parse("seq_len", 1)
+    var cache_len = arg_parse("cache_len", 1024)
+    var cache_len_step = arg_parse("cache_len_step", 0)
+    var packed_pages = arg_parse("pack_pages", 0) != 0
+    var fragment_pages = arg_parse("fragment_pages", 0) != 0
+    var paired_fragment_pages = arg_parse("paired_fragment_pages", 0) != 0
+
+    seed(0)
+
+    var bench = Bench(BenchConfig(num_repetitions=1))
+    with DeviceContext() as ctx:
+        bench_gemma3_k_rope_boundary[
+            dtype,
+            head_dim,
+            num_kv_heads,
+            page_size,
+        ](
+            ctx,
+            bench,
+            batch_size,
+            seq_len,
+            cache_len,
+            cache_len_step,
+            packed_pages,
+            fragment_pages,
+            paired_fragment_pages,
+        )
+
+    bench.dump_report()

--- a/max/kernels/benchmarks/gpu/nn/bench_gemma3_q_norm_rope_boundary.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_gemma3_q_norm_rope_boundary.mojo
@@ -1,0 +1,270 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.random import random_float64
+from std.sys import get_defined_dtype, get_defined_int
+
+from std.benchmark import Bench, BenchConfig, Bencher, BenchId
+from std.gpu.host import DeviceContext
+from std.testing import assert_almost_equal
+
+from internal_utils import arg_parse
+from layout import Coord, Idx, TileTensor, row_major
+from nn.normalization import rms_norm_gpu
+from nn.rope import q_rms_norm_rope_ragged, rope_ragged
+
+from std.utils.index import Index, IndexList
+
+
+def bench_gemma3_q_norm_rope_boundary[
+    dtype: DType, head_dim: Int, num_q_heads: Int
+](
+    ctx: DeviceContext,
+    mut bench: Bench,
+    batch_size: Int,
+    seq_len: Int,
+    cache_len: Int,
+) raises:
+    comptime max_seq_len = 2048
+
+    var total_seq_len = batch_size * seq_len
+    var num_elems = total_seq_len * num_q_heads * head_dim
+    var q_shape = IndexList[3](total_seq_len, num_q_heads, head_dim)
+    var q_layout = row_major(
+        (Idx(total_seq_len), Idx[num_q_heads](), Idx[head_dim]())
+    )
+
+    var q_h = alloc[Scalar[dtype]](num_elems)
+    var gamma_h = alloc[Scalar[dtype]](head_dim)
+    var input_row_offsets_h = alloc[Scalar[DType.uint32]](batch_size + 1)
+    var start_pos_h = alloc[Scalar[DType.uint32]](batch_size)
+    var freqs_h = alloc[Scalar[dtype]](max_seq_len * head_dim)
+    var baseline_h = alloc[Scalar[dtype]](num_elems)
+    var fused_h = alloc[Scalar[dtype]](num_elems)
+
+    for i in range(num_elems):
+        q_h[i] = Scalar[dtype](random_float64(0, 100).cast[dtype]())
+
+    for i in range(head_dim):
+        gamma_h[i] = (Float64(i + head_dim) / Float64(head_dim)).cast[dtype]()
+
+    var running_offset: UInt32 = 0
+    for i in range(batch_size):
+        input_row_offsets_h[i] = running_offset
+        start_pos_h[i] = UInt32(cache_len)
+        running_offset += UInt32(seq_len)
+    input_row_offsets_h[batch_size] = running_offset
+
+    for i in range(max_seq_len * head_dim):
+        freqs_h[i] = Scalar[dtype](random_float64(-1, 1).cast[dtype]())
+
+    var q_d = ctx.enqueue_create_buffer[dtype](num_elems)
+    var gamma_d = ctx.enqueue_create_buffer[dtype](head_dim)
+    var input_row_offsets_d = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size + 1
+    )
+    var start_pos_d = ctx.enqueue_create_buffer[DType.uint32](batch_size)
+    var freqs_d = ctx.enqueue_create_buffer[dtype](max_seq_len * head_dim)
+    var baseline_norm_d = ctx.enqueue_create_buffer[dtype](num_elems)
+    var baseline_output_d = ctx.enqueue_create_buffer[dtype](num_elems)
+    var fused_output_d = ctx.enqueue_create_buffer[dtype](num_elems)
+
+    ctx.enqueue_copy(q_d, q_h)
+    ctx.enqueue_copy(gamma_d, gamma_h)
+    ctx.enqueue_copy(input_row_offsets_d, input_row_offsets_h)
+    ctx.enqueue_copy(start_pos_d, start_pos_h)
+    ctx.enqueue_copy(freqs_d, freqs_h)
+
+    var q_tensor = TileTensor(q_d, q_layout)
+    var gamma_tensor = TileTensor(gamma_d, row_major(Idx[head_dim]()))
+    var input_row_offsets_tensor = TileTensor(
+        input_row_offsets_d, row_major(Idx(batch_size + 1))
+    )
+    var start_pos_tensor = TileTensor(start_pos_d, row_major(Idx(batch_size)))
+    comptime freqs_layout = row_major[max_seq_len, head_dim]()
+    var freqs_tensor = TileTensor(freqs_d, freqs_layout)
+    var baseline_norm_tensor = TileTensor(baseline_norm_d, q_layout)
+    var baseline_output_tensor = TileTensor(baseline_output_d, q_layout)
+    var fused_output_tensor = TileTensor(fused_output_d, q_layout)
+
+    var epsilon = Scalar[dtype](1e-6)
+    var weight_offset = Scalar[dtype](1.0)
+
+    @always_inline
+    @__copy_capture(q_tensor)
+    @parameter
+    def input_fn[
+        width: Int, rank: Int
+    ](coords: IndexList[rank]) -> SIMD[dtype, width]:
+        return q_tensor.load[width=width](Coord(coords))
+
+    @always_inline
+    @__copy_capture(baseline_norm_tensor)
+    @parameter
+    def baseline_norm_output_fn[
+        width: Int, alignment: Int
+    ](coords: IndexList[3], val: SIMD[dtype, width]) -> None:
+        baseline_norm_tensor.store[alignment=alignment](Coord(coords), val)
+
+    @always_inline
+    @__copy_capture(baseline_output_tensor)
+    def rope_output_fn[
+        width: Int, alignment: Int
+    ](idx: IndexList[3], val: SIMD[dtype, width]) capturing -> None:
+        baseline_output_tensor.store[alignment=alignment](Coord(idx), val)
+
+    @always_inline
+    @__copy_capture(
+        q_layout,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        baseline_norm_tensor,
+        input_row_offsets_tensor,
+        start_pos_tensor,
+        freqs_tensor,
+    )
+    @parameter
+    def run_baseline(ctx: DeviceContext) raises:
+        rms_norm_gpu[
+            input_fn,
+            baseline_norm_output_fn,
+            multiply_before_cast=True,
+        ](q_shape, gamma_tensor, epsilon, weight_offset, ctx)
+        rope_ragged[
+            dtype,
+            dtype,
+            interleaved=False,
+            target="gpu",
+            output_fn=rope_output_fn,
+        ](
+            x=baseline_norm_tensor,
+            input_row_offsets=input_row_offsets_tensor,
+            start_pos=start_pos_tensor,
+            freqs_cis=freqs_tensor,
+            context=Optional[DeviceContext](ctx),
+        )
+
+    @always_inline
+    @__copy_capture(
+        q_tensor,
+        fused_output_tensor,
+        input_row_offsets_tensor,
+        start_pos_tensor,
+        freqs_tensor,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+    )
+    @parameter
+    def run_fused(ctx: DeviceContext) raises:
+        q_rms_norm_rope_ragged[
+            dtype,
+            dtype,
+            target="gpu",
+        ](
+            x=q_tensor,
+            input_row_offsets=input_row_offsets_tensor,
+            start_pos=start_pos_tensor,
+            freqs_cis=freqs_tensor,
+            gamma=gamma_tensor,
+            epsilon=epsilon,
+            weight_offset=weight_offset,
+            output=fused_output_tensor,
+            context=ctx,
+        )
+
+    @always_inline
+    @parameter
+    def baseline_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_baseline](ctx)
+
+    @always_inline
+    @parameter
+    def fused_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_fused](ctx)
+
+    bench.bench_function[baseline_bench](
+        BenchId(
+            "gemma3_q_norm_rope_boundary_baseline",
+            input_id=String(
+                dtype,
+                "/bs=",
+                batch_size,
+                "/seq=",
+                seq_len,
+                "/cache=",
+                cache_len,
+            ),
+        ),
+    )
+    bench.bench_function[fused_bench](
+        BenchId(
+            "gemma3_q_norm_rope_boundary_fused",
+            input_id=String(
+                dtype,
+                "/bs=",
+                batch_size,
+                "/seq=",
+                seq_len,
+                "/cache=",
+                cache_len,
+            ),
+        ),
+    )
+
+    run_baseline(ctx)
+    run_fused(ctx)
+    ctx.enqueue_copy(baseline_h, baseline_output_d)
+    ctx.enqueue_copy(fused_h, fused_output_d)
+    ctx.synchronize()
+
+    for i in range(num_elems):
+        assert_almost_equal(baseline_h[i], fused_h[i], rtol=2e-2, atol=2e-2)
+
+    _ = q_d
+    _ = gamma_d
+    _ = input_row_offsets_d
+    _ = start_pos_d
+    _ = freqs_d
+    _ = baseline_norm_d
+    _ = baseline_output_d
+    _ = fused_output_d
+
+    q_h.free()
+    gamma_h.free()
+    input_row_offsets_h.free()
+    start_pos_h.free()
+    freqs_h.free()
+    baseline_h.free()
+    fused_h.free()
+
+
+def main() raises:
+    comptime dtype = get_defined_dtype["dtype", DType.bfloat16]()
+    comptime head_dim = get_defined_int["head_dim", 128]()
+    comptime num_q_heads = get_defined_int["num_q_heads", 32]()
+
+    var batch_size = arg_parse("batch_size", 64)
+    var seq_len = arg_parse("seq_len", 1)
+    var cache_len = arg_parse("cache_len", 1024)
+
+    var bench = Bench(BenchConfig(num_repetitions=1))
+    with DeviceContext() as ctx:
+        bench_gemma3_q_norm_rope_boundary[
+            dtype,
+            head_dim,
+            num_q_heads,
+        ](ctx, bench, batch_size, seq_len, cache_len)
+
+    bench.dump_report()

--- a/max/kernels/benchmarks/gpu/nn/bench_gemma3_qk_norm_rope_boundary.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_gemma3_qk_norm_rope_boundary.mojo
@@ -1,0 +1,2868 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import ceildiv, rsqrt
+from std.random import random_float64, seed
+from std.sys import get_defined_dtype, get_defined_int
+from std.sys.info import align_of, simd_width_of
+
+from std.benchmark import Bench, BenchConfig, Bencher, BenchId
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    WARP_SIZE,
+    block_idx_uint as block_idx,
+    syncwarp,
+    thread_idx_uint as thread_idx,
+)
+from std.gpu.host import DeviceContext
+from std.gpu.memory import AddressSpace
+from std.gpu.primitives import warp
+from std.memory import stack_allocation
+from std.testing import assert_almost_equal
+from internal_utils import arg_parse, update_bench_config_args
+from kv_cache.types import KVCacheStaticParams, KVCacheT, PagedKVCacheCollection
+from layout import (
+    Coord,
+    Idx,
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TensorLayout,
+    TileTensor,
+    UNKNOWN_VALUE,
+    row_major,
+)
+from layout._fillers import random
+from nn._ragged_utils import get_batch_from_row_offsets
+from nn.fused_qk_rope import _rope_complex_mul_half, fused_qk_rope_ragged
+from nn.kv_cache import rms_norm_kv_cache_ragged_paged
+from nn.normalization import _rms_norm_warp_tiling_subkernel, rms_norm_gpu
+from nn.rope import q_rms_norm_fused_qk_rope_ragged
+from std.utils.numerics import get_accum_type
+from std.utils.static_tuple import StaticTuple
+
+from std.utils import IndexList
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _gemma3_qk_norm_rope_single_launch_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    OffsetsLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+    num_q_heads: Int,
+    num_kv_heads: Int,
+    head_dim: Int,
+](
+    q: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert head_dim == 128, "Prototype currently targets 128-wide heads"
+    comptime assert q.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime total_heads = num_q_heads + num_kv_heads
+
+    var shared_norm = stack_allocation[
+        warps_per_block * 2 * head_dim,
+        Scalar[dtype],
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    var is_active_row = row < UInt(total_rows)
+    var flat_row = Int(row)
+    var global_token_idx = 0
+    var head_slot = 0
+    var batch_idx = 0
+    var token_idx = 0
+    var post_seq_idx = 0
+
+    if is_active_row:
+        global_token_idx = flat_row // total_heads
+        head_slot = flat_row % total_heads
+        batch_idx = get_batch_from_row_offsets(input_row_offsets, global_token_idx)
+        token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+        post_seq_idx = k_cache.cache_length(batch_idx) + token_idx
+
+    var is_q_row = is_active_row and head_slot < num_q_heads
+    var k_head_idx = 0
+    if is_active_row and not is_q_row:
+        k_head_idx = head_slot - num_q_heads
+    var vec_data = SIMD[accum_type, simd_width](0)
+    var gamma_val = SIMD[dtype, simd_width](0)
+
+    if is_active_row and col < UInt(head_dim):
+        if is_q_row:
+            vec_data = q.load[width=simd_width](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(Int(col)))
+            ).cast[accum_type]()
+        else:
+            vec_data = k_cache.load[width=simd_width](
+                batch_idx, k_head_idx, post_seq_idx, Int(col)
+            ).cast[accum_type]()
+        gamma_val = gamma.load[width=simd_width, alignment=align](
+            Coord(Idx(Int(col)))
+        )
+
+    var norm_val = _rms_norm_warp_tiling_subkernel[
+        warps_per_block,
+        True,
+        rows_per_warp=2,
+    ](
+        flat_row,
+        Int(col),
+        vec_data,
+        gamma_val,
+        epsilon.cast[accum_type](),
+        weight_offset.cast[accum_type](),
+        head_dim,
+    )
+
+    if is_active_row and col < UInt(head_dim):
+        var shared_offset = (
+            (Int(warp_idx) * 2 + Int(sub_warp_idx)) * head_dim + Int(col)
+        )
+        shared_norm.store[width=simd_width, alignment=align](
+            shared_offset, norm_val
+        )
+
+    syncwarp()
+
+    if not is_active_row or local_tid >= UInt(half_warp_size // 2):
+        return
+
+    var re_offset = Int(local_tid) * simd_width
+    var im_offset = re_offset + head_dim // 2
+    var freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+        Coord(Idx(post_seq_idx), Idx(re_offset * 2))
+    )
+
+    var shared_base = (Int(warp_idx) * 2 + Int(sub_warp_idx)) * head_dim
+    var rope_re = shared_norm.load[width=simd_width](shared_base + re_offset)
+    var rope_im = shared_norm.load[width=simd_width](shared_base + im_offset)
+
+    if is_q_row:
+        var q_rope = _rope_complex_mul_half[
+            dtype,
+            freq_dtype,
+            simd_width,
+            simd_width * 2,
+        ](rope_re, rope_im, freq)
+        output.store[alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset)),
+            q_rope[0],
+        )
+        output.store[alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset)),
+            q_rope[1],
+        )
+    else:
+        comptime cache_dtype = KCacheType.dtype
+        var k_rope = _rope_complex_mul_half[
+            accum_type,
+            freq_dtype,
+            simd_width,
+            simd_width * 2,
+        ](
+            rope_re.cast[accum_type](),
+            rope_im.cast[accum_type](),
+            freq,
+        )
+        k_cache.store(
+            batch_idx,
+            k_head_idx,
+            post_seq_idx,
+            re_offset,
+            k_rope[0].cast[cache_dtype](),
+        )
+        k_cache.store(
+            batch_idx,
+            k_head_idx,
+            post_seq_idx,
+            im_offset,
+            k_rope[1].cast[cache_dtype](),
+        )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _gemma3_qk_norm_rope_decode_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    QGammaLayoutType: TensorLayout,
+    KGammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    q: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    q_gamma: TileTensor[dtype, QGammaLayoutType, MutAnyOrigin],
+    k_gamma: TileTensor[dtype, KGammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert q.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert q_gamma.flat_rank == 1
+    comptime assert k_gamma.flat_rank == 1
+
+    comptime num_q_heads = q.static_shape[1]
+    comptime head_dim = q.static_shape[2]
+    comptime num_kv_heads = Int(KCacheType.kv_params.num_heads)
+    comptime assert head_dim == 128, "Only 128-column BF16 rows are supported"
+    comptime assert head_dim == Int(KCacheType.kv_params.head_size)
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime vec_width = simd_width // 2
+    comptime align = align_of[SIMD[dtype, vec_width]]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime total_heads = num_q_heads + num_kv_heads
+    comptime assert head_dim == half_warp_size * simd_width
+
+    var shared_post_seq = stack_allocation[
+        warps_per_block * 2,
+        Int32,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    var flat_row = Int(row)
+    var global_token_idx = 0
+    var head_slot = 0
+    var batch_idx = 0
+    var post_seq_idx = 0
+    var shared_post_idx = 0
+
+    var is_active_row = row < UInt(total_rows)
+    if is_active_row:
+        global_token_idx = flat_row // total_heads
+        head_slot = flat_row % total_heads
+        batch_idx = global_token_idx
+        shared_post_idx = Int(warp_idx) * 2 + Int(sub_warp_idx)
+        if local_tid == 0:
+            shared_post_seq[shared_post_idx] = Int32(Int(start_pos[batch_idx]))
+        syncwarp()
+        post_seq_idx = Int(shared_post_seq[shared_post_idx])
+
+    var is_q_row = is_active_row and head_slot < num_q_heads
+    if is_active_row:
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+
+        if is_q_row:
+            var re_offset = Int(local_tid) * vec_width
+            var im_offset = re_offset + head_dim // 2
+            var freq_offset = Int(local_tid) * simd_width
+            var q_re = q.load[width=vec_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset))
+            )
+            var q_im = q.load[width=vec_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset))
+            )
+            var thread_m2 = (q_re.cast[accum_type]() ** 2).reduce_add() + (
+                q_im.cast[accum_type]() ** 2
+            ).reduce_add()
+            var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](thread_m2)
+            var norm_factor = rsqrt(
+                (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+            )
+
+            var q_gamma_re = q_gamma.load[width=vec_width, alignment=align](
+                Coord(Idx(re_offset))
+            )
+            var q_gamma_im = q_gamma.load[width=vec_width, alignment=align](
+                Coord(Idx(im_offset))
+            )
+            var q_norm_re = (
+                q_re.cast[accum_type]()
+                * norm_factor
+                * (q_gamma_re.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+            var q_norm_im = (
+                q_im.cast[accum_type]()
+                * norm_factor
+                * (q_gamma_im.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+
+            var q_freq = freqs_cis.load[width=simd_width, alignment=1](
+                Coord(Idx(post_seq_idx), Idx(freq_offset))
+            )
+            var q_rope = _rope_complex_mul_half[
+                dtype,
+                freq_dtype,
+                vec_width,
+                simd_width,
+            ](q_norm_re, q_norm_im, q_freq)
+            output.store[alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset)),
+                q_rope[0],
+            )
+            output.store[alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset)),
+                q_rope[1],
+            )
+        else:
+            var k_head_idx = head_slot - num_q_heads
+            var vec_data = k_cache.load[width=simd_width](
+                batch_idx, k_head_idx, post_seq_idx, Int(col)
+            ).cast[accum_type]()
+            var gamma_val = k_gamma.load[width=simd_width, alignment=wide_align](
+                Coord(Idx(Int(col)))
+            )
+            var norm_val = _rms_norm_warp_tiling_subkernel[
+                warps_per_block,
+                True,
+                rows_per_warp=2,
+            ](
+                flat_row,
+                Int(col),
+                vec_data,
+                gamma_val,
+                epsilon_accum,
+                weight_offset_accum,
+                head_dim,
+            )
+            var sub_warp_mask = (
+                (UInt(1) << UInt(half_warp_size)) - UInt(1)
+            ) << (sub_warp_idx * UInt(half_warp_size))
+            var partner_lane = (
+                sub_warp_idx * UInt(half_warp_size)
+                + (local_tid % UInt(half_warp_size // 2))
+                + UInt(half_warp_size // 2)
+            )
+            var norm_parts = norm_val.split()
+            var norm_lo_parts = norm_parts[0].split()
+            var norm_hi_parts = norm_parts[1].split()
+            var partner_norm_lo = warp.shuffle_idx(
+                sub_warp_mask,
+                norm_lo_parts[0],
+                UInt32(partner_lane),
+            ).join(
+                warp.shuffle_idx(
+                    sub_warp_mask,
+                    norm_lo_parts[1],
+                    UInt32(partner_lane),
+                )
+            )
+            var partner_norm_hi = warp.shuffle_idx(
+                sub_warp_mask,
+                norm_hi_parts[0],
+                UInt32(partner_lane),
+            ).join(
+                warp.shuffle_idx(
+                    sub_warp_mask,
+                    norm_hi_parts[1],
+                    UInt32(partner_lane),
+                )
+            )
+            var partner_norm = rebind[type_of(norm_val)](
+                partner_norm_lo.join(partner_norm_hi)
+            )
+
+            if local_tid < UInt(half_warp_size // 2):
+                var re_offset = Int(local_tid) * simd_width
+                var im_offset = re_offset + head_dim // 2
+                comptime cache_dtype = KCacheType.dtype
+                var k_freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                    Coord(Idx(post_seq_idx), Idx(re_offset * 2))
+                )
+                var k_rope = _rope_complex_mul_half[
+                    accum_type,
+                    freq_dtype,
+                    simd_width,
+                    simd_width * 2,
+                ](
+                    norm_val.cast[accum_type](),
+                    partner_norm.cast[accum_type](),
+                    k_freq,
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    re_offset,
+                    k_rope[0].cast[cache_dtype](),
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    im_offset,
+                    k_rope[1].cast[cache_dtype](),
+                )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _gemma3_qk_norm_rope_decode_uniform_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    QGammaLayoutType: TensorLayout,
+    KGammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    q: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    q_gamma: TileTensor[dtype, QGammaLayoutType, MutAnyOrigin],
+    k_gamma: TileTensor[dtype, KGammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+    post_seq_idx: Int,
+):
+    comptime assert q.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert q_gamma.flat_rank == 1
+    comptime assert k_gamma.flat_rank == 1
+
+    comptime num_q_heads = q.static_shape[1]
+    comptime head_dim = q.static_shape[2]
+    comptime num_kv_heads = Int(KCacheType.kv_params.num_heads)
+    comptime assert head_dim == 128, "Only 128-column BF16 rows are supported"
+    comptime assert head_dim == Int(KCacheType.kv_params.head_size)
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime vec_width = simd_width // 2
+    comptime align = align_of[SIMD[dtype, vec_width]]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime total_heads = num_q_heads + num_kv_heads
+    comptime assert head_dim == half_warp_size * simd_width
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    var flat_row = Int(row)
+    var global_token_idx = 0
+    var head_slot = 0
+    var batch_idx = 0
+
+    var is_active_row = row < UInt(total_rows)
+    if is_active_row:
+        global_token_idx = flat_row // total_heads
+        head_slot = flat_row % total_heads
+        batch_idx = global_token_idx
+
+    var is_q_row = is_active_row and head_slot < num_q_heads
+    if is_active_row:
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+
+        if is_q_row:
+            var re_offset = Int(local_tid) * vec_width
+            var im_offset = re_offset + head_dim // 2
+            var freq_offset = Int(local_tid) * simd_width
+            var q_re = q.load[width=vec_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset))
+            )
+            var q_im = q.load[width=vec_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset))
+            )
+            var thread_m2 = (q_re.cast[accum_type]() ** 2).reduce_add() + (
+                q_im.cast[accum_type]() ** 2
+            ).reduce_add()
+            var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](thread_m2)
+            var norm_factor = rsqrt(
+                (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+            )
+
+            var q_gamma_re = q_gamma.load[width=vec_width, alignment=align](
+                Coord(Idx(re_offset))
+            )
+            var q_gamma_im = q_gamma.load[width=vec_width, alignment=align](
+                Coord(Idx(im_offset))
+            )
+            var q_norm_re = (
+                q_re.cast[accum_type]()
+                * norm_factor
+                * (q_gamma_re.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+            var q_norm_im = (
+                q_im.cast[accum_type]()
+                * norm_factor
+                * (q_gamma_im.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+
+            var q_freq = freqs_cis.load[width=simd_width, alignment=1](
+                Coord(Idx(post_seq_idx), Idx(freq_offset))
+            )
+            var q_rope = _rope_complex_mul_half[
+                dtype,
+                freq_dtype,
+                vec_width,
+                simd_width,
+            ](q_norm_re, q_norm_im, q_freq)
+            output.store[alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset)),
+                q_rope[0],
+            )
+            output.store[alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset)),
+                q_rope[1],
+            )
+        else:
+            var k_head_idx = head_slot - num_q_heads
+            var vec_data = k_cache.load[width=simd_width](
+                batch_idx, k_head_idx, post_seq_idx, Int(col)
+            ).cast[accum_type]()
+            var gamma_val = k_gamma.load[width=simd_width, alignment=wide_align](
+                Coord(Idx(Int(col)))
+            )
+            var norm_val = _rms_norm_warp_tiling_subkernel[
+                warps_per_block,
+                True,
+                rows_per_warp=2,
+            ](
+                flat_row,
+                Int(col),
+                vec_data,
+                gamma_val,
+                epsilon_accum,
+                weight_offset_accum,
+                head_dim,
+            )
+            var sub_warp_mask = (
+                (UInt(1) << UInt(half_warp_size)) - UInt(1)
+            ) << (sub_warp_idx * UInt(half_warp_size))
+            var partner_lane = (
+                sub_warp_idx * UInt(half_warp_size)
+                + (local_tid % UInt(half_warp_size // 2))
+                + UInt(half_warp_size // 2)
+            )
+            var norm_parts = norm_val.split()
+            var norm_lo_parts = norm_parts[0].split()
+            var norm_hi_parts = norm_parts[1].split()
+            var partner_norm_lo = warp.shuffle_idx(
+                sub_warp_mask,
+                norm_lo_parts[0],
+                UInt32(partner_lane),
+            ).join(
+                warp.shuffle_idx(
+                    sub_warp_mask,
+                    norm_lo_parts[1],
+                    UInt32(partner_lane),
+                )
+            )
+            var partner_norm_hi = warp.shuffle_idx(
+                sub_warp_mask,
+                norm_hi_parts[0],
+                UInt32(partner_lane),
+            ).join(
+                warp.shuffle_idx(
+                    sub_warp_mask,
+                    norm_hi_parts[1],
+                    UInt32(partner_lane),
+                )
+            )
+            var partner_norm = rebind[type_of(norm_val)](
+                partner_norm_lo.join(partner_norm_hi)
+            )
+
+            if local_tid < UInt(half_warp_size // 2):
+                var re_offset = Int(local_tid) * simd_width
+                var im_offset = re_offset + head_dim // 2
+                comptime cache_dtype = KCacheType.dtype
+                var k_freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                    Coord(Idx(post_seq_idx), Idx(re_offset * 2))
+                )
+                var k_rope = _rope_complex_mul_half[
+                    accum_type,
+                    freq_dtype,
+                    simd_width,
+                    simd_width * 2,
+                ](
+                    norm_val.cast[accum_type](),
+                    partner_norm.cast[accum_type](),
+                    k_freq,
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    re_offset,
+                    k_rope[0].cast[cache_dtype](),
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    im_offset,
+                    k_rope[1].cast[cache_dtype](),
+                )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _gemma3_qk_norm_rope_decode_uniform_wide_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    QGammaLayoutType: TensorLayout,
+    KGammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    q: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    q_gamma: TileTensor[dtype, QGammaLayoutType, MutAnyOrigin],
+    k_gamma: TileTensor[dtype, KGammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+    post_seq_idx: Int,
+):
+    comptime assert q.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert q_gamma.flat_rank == 1
+    comptime assert k_gamma.flat_rank == 1
+
+    comptime num_q_heads = q.static_shape[1]
+    comptime head_dim = q.static_shape[2]
+    comptime num_kv_heads = Int(KCacheType.kv_params.num_heads)
+    comptime assert head_dim == 256, "Only 256-column BF16 rows are supported"
+    comptime assert head_dim == Int(KCacheType.kv_params.head_size)
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime total_heads = num_q_heads + num_kv_heads
+    comptime assert head_dim == WARP_SIZE * simd_width
+
+    var shared_norm = stack_allocation[
+        warps_per_block * head_dim,
+        Scalar[dtype],
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var local_tid = tid % UInt(WARP_SIZE)
+    var row = block_idx.x * UInt(warps_per_block) + warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    var flat_row = Int(row)
+    var global_token_idx = 0
+    var head_slot = 0
+    var batch_idx = 0
+
+    var is_active_row = row < UInt(total_rows)
+    if is_active_row:
+        global_token_idx = flat_row // total_heads
+        head_slot = flat_row % total_heads
+        batch_idx = global_token_idx
+
+    var is_q_row = is_active_row and head_slot < num_q_heads
+    if is_active_row:
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+
+        if is_q_row:
+            var q_vec = q.load[width=simd_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(Int(col)))
+            )
+            var thread_m2 = (q_vec.cast[accum_type]() ** 2).reduce_add()
+            var row_m2 = warp.sum(thread_m2)
+            var norm_factor = rsqrt(
+                (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+            )
+            var gamma_val = q_gamma.load[width=simd_width, alignment=align](
+                Coord(Idx(Int(col)))
+            )
+            var norm_val = (
+                q_vec.cast[accum_type]()
+                * norm_factor
+                * (gamma_val.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+            var shared_base = Int(warp_idx) * head_dim
+            shared_norm.store[width=simd_width, alignment=align](
+                shared_base + Int(col), norm_val
+            )
+            syncwarp()
+
+            if local_tid < UInt(WARP_SIZE // 2):
+                var re_offset = Int(local_tid) * simd_width
+                var im_offset = re_offset + head_dim // 2
+                var rope_re = shared_norm.load[width=simd_width](
+                    shared_base + re_offset
+                )
+                var rope_im = shared_norm.load[width=simd_width](
+                    shared_base + im_offset
+                )
+                var q_freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                    Coord(Idx(post_seq_idx), Idx(re_offset * 2))
+                )
+                var q_rope = _rope_complex_mul_half[
+                    dtype,
+                    freq_dtype,
+                    simd_width,
+                    simd_width * 2,
+                ](rope_re, rope_im, q_freq)
+                output.store[alignment=align](
+                    Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset)),
+                    q_rope[0],
+                )
+                output.store[alignment=align](
+                    Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset)),
+                    q_rope[1],
+                )
+        else:
+            var k_head_idx = head_slot - num_q_heads
+            var k_vec = k_cache.load[width=simd_width](
+                batch_idx, k_head_idx, post_seq_idx, Int(col)
+            ).cast[accum_type]()
+            var thread_m2 = (k_vec**2).reduce_add()
+            var row_m2 = warp.sum(thread_m2)
+            var norm_factor = rsqrt(
+                (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+            )
+            var gamma_val = k_gamma.load[width=simd_width, alignment=align](
+                Coord(Idx(Int(col)))
+            )
+            var norm_val = k_vec * norm_factor * (
+                gamma_val.cast[accum_type]() + weight_offset_accum
+            )
+            var shared_base = Int(warp_idx) * head_dim
+            shared_norm.store[width=simd_width, alignment=align](
+                shared_base + Int(col), norm_val.cast[dtype]()
+            )
+            syncwarp()
+
+            if local_tid < UInt(WARP_SIZE // 2):
+                var re_offset = Int(local_tid) * simd_width
+                var im_offset = re_offset + head_dim // 2
+                var rope_re = shared_norm.load[width=simd_width](
+                    shared_base + re_offset
+                ).cast[accum_type]()
+                var rope_im = shared_norm.load[width=simd_width](
+                    shared_base + im_offset
+                ).cast[accum_type]()
+                var k_freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                    Coord(Idx(post_seq_idx), Idx(re_offset * 2))
+                )
+                comptime cache_dtype = KCacheType.dtype
+                var k_rope = _rope_complex_mul_half[
+                    accum_type,
+                    freq_dtype,
+                    simd_width,
+                    simd_width * 2,
+                ](rope_re, rope_im, k_freq)
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    re_offset,
+                    k_rope[0].cast[cache_dtype](),
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    im_offset,
+                    k_rope[1].cast[cache_dtype](),
+                )
+
+
+def _gemma3_qk_norm_rope_decode_ragged_wide_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    QGammaLayoutType: TensorLayout,
+    KGammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    q: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    q_gamma: TileTensor[dtype, QGammaLayoutType, MutAnyOrigin],
+    k_gamma: TileTensor[dtype, KGammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert q.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert q_gamma.flat_rank == 1
+    comptime assert k_gamma.flat_rank == 1
+
+    comptime num_q_heads = q.static_shape[1]
+    comptime head_dim = q.static_shape[2]
+    comptime num_kv_heads = Int(KCacheType.kv_params.num_heads)
+    comptime assert head_dim == 256, "Only 256-column BF16 rows are supported"
+    comptime assert head_dim == Int(KCacheType.kv_params.head_size)
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime total_heads = num_q_heads + num_kv_heads
+    comptime assert head_dim == WARP_SIZE * simd_width
+
+    var shared_norm = stack_allocation[
+        warps_per_block * head_dim,
+        Scalar[dtype],
+        address_space=AddressSpace.SHARED,
+    ]()
+    var shared_post_seq = stack_allocation[
+        warps_per_block,
+        Int32,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var local_tid = tid % UInt(WARP_SIZE)
+    var row = block_idx.x * UInt(warps_per_block) + warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    var flat_row = Int(row)
+    var global_token_idx = 0
+    var head_slot = 0
+    var batch_idx = 0
+    var post_seq_idx = 0
+
+    var is_active_row = row < UInt(total_rows)
+    if is_active_row:
+        global_token_idx = flat_row // total_heads
+        head_slot = flat_row % total_heads
+        batch_idx = global_token_idx
+        if local_tid == 0:
+            shared_post_seq[Int(warp_idx)] = Int32(Int(start_pos[batch_idx]))
+        syncwarp()
+        post_seq_idx = Int(shared_post_seq[Int(warp_idx)])
+
+    var is_q_row = is_active_row and head_slot < num_q_heads
+    if is_active_row:
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var shared_base = Int(warp_idx) * head_dim
+
+        if is_q_row:
+            var q_vec = q.load[width=simd_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(Int(col)))
+            )
+            var thread_m2 = (q_vec.cast[accum_type]() ** 2).reduce_add()
+            var row_m2 = warp.sum(thread_m2)
+            var norm_factor = rsqrt(
+                (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+            )
+            var gamma_val = q_gamma.load[width=simd_width, alignment=align](
+                Coord(Idx(Int(col)))
+            )
+            var norm_val = (
+                q_vec.cast[accum_type]()
+                * norm_factor
+                * (gamma_val.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+            shared_norm.store[width=simd_width, alignment=align](
+                shared_base + Int(col), norm_val
+            )
+            syncwarp()
+
+            if local_tid < UInt(WARP_SIZE // 2):
+                var re_offset = Int(local_tid) * simd_width
+                var im_offset = re_offset + head_dim // 2
+                var rope_re = shared_norm.load[width=simd_width](
+                    shared_base + re_offset
+                )
+                var rope_im = shared_norm.load[width=simd_width](
+                    shared_base + im_offset
+                )
+                var q_freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                    Coord(Idx(post_seq_idx), Idx(re_offset * 2))
+                )
+                var q_rope = _rope_complex_mul_half[
+                    dtype,
+                    freq_dtype,
+                    simd_width,
+                    simd_width * 2,
+                ](rope_re, rope_im, q_freq)
+                output.store[alignment=align](
+                    Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset)),
+                    q_rope[0],
+                )
+                output.store[alignment=align](
+                    Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset)),
+                    q_rope[1],
+                )
+        else:
+            var k_head_idx = head_slot - num_q_heads
+            var k_vec = k_cache.load[width=simd_width](
+                batch_idx, k_head_idx, post_seq_idx, Int(col)
+            ).cast[accum_type]()
+            var thread_m2 = (k_vec**2).reduce_add()
+            var row_m2 = warp.sum(thread_m2)
+            var norm_factor = rsqrt(
+                (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+            )
+            var gamma_val = k_gamma.load[width=simd_width, alignment=align](
+                Coord(Idx(Int(col)))
+            )
+            var norm_val = k_vec * norm_factor * (
+                gamma_val.cast[accum_type]() + weight_offset_accum
+            )
+            shared_norm.store[width=simd_width, alignment=align](
+                shared_base + Int(col), norm_val.cast[dtype]()
+            )
+            syncwarp()
+
+            if local_tid < UInt(WARP_SIZE // 2):
+                var re_offset = Int(local_tid) * simd_width
+                var im_offset = re_offset + head_dim // 2
+                var rope_re = shared_norm.load[width=simd_width](
+                    shared_base + re_offset
+                ).cast[accum_type]()
+                var rope_im = shared_norm.load[width=simd_width](
+                    shared_base + im_offset
+                ).cast[accum_type]()
+                var k_freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                    Coord(Idx(post_seq_idx), Idx(re_offset * 2))
+                )
+                comptime cache_dtype = KCacheType.dtype
+                var k_rope = _rope_complex_mul_half[
+                    accum_type,
+                    freq_dtype,
+                    simd_width,
+                    simd_width * 2,
+                ](rope_re, rope_im, k_freq)
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    re_offset,
+                    k_rope[0].cast[cache_dtype](),
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    im_offset,
+                    k_rope[1].cast[cache_dtype](),
+                )
+
+
+def bench_gemma3_qk_norm_rope_boundary[
+    dtype: DType,
+    head_dim: Int,
+    num_q_heads: Int,
+    num_kv_heads: Int,
+    page_size: Int,
+](
+    ctx: DeviceContext,
+    mut bench: Bench,
+    batch_size: Int,
+    seq_len: Int,
+    cache_len: Int,
+    cache_len_step: Int,
+    trial_baseline_disable_decode_fastpath: Bool,
+    verify_results: Bool,
+) raises:
+    comptime max_seq_len = 2048
+    comptime num_layers = 1
+    comptime layer_idx = 0
+    comptime kv_params = KVCacheStaticParams(
+        num_heads=UInt(num_kv_heads), head_size=UInt(head_dim)
+    )
+    comptime CollectionType = PagedKVCacheCollection[dtype, kv_params, page_size]
+
+    var total_seq_len = UInt32(batch_size * seq_len)
+    var max_cache_len = cache_len + (batch_size - 1) * cache_len_step
+    var max_context_length = seq_len + max_cache_len
+    var paged_lut_cols = ceildiv(max_context_length, page_size)
+    var num_pages = batch_size * paged_lut_cols
+    var q_elems = Int(total_seq_len) * num_q_heads * head_dim
+
+    var input_row_offsets_h = alloc[Scalar[DType.uint32]](batch_size + 1)
+    var cache_lengths_h = alloc[Scalar[DType.uint32]](batch_size)
+    var q_gamma_h = alloc[Scalar[dtype]](head_dim)
+    var k_gamma_h = alloc[Scalar[dtype]](head_dim)
+    var freqs_h = alloc[Scalar[dtype]](max_seq_len * head_dim)
+    var q_h = alloc[Scalar[dtype]](q_elems)
+    var paged_lut_h = alloc[Scalar[DType.uint32]](batch_size * paged_lut_cols)
+    var baseline_output_h = alloc[Scalar[dtype]](q_elems)
+    var fused_output_h = alloc[Scalar[dtype]](q_elems)
+    var trial_output_h = alloc[Scalar[dtype]](q_elems)
+
+    var running_offset: UInt32 = 0
+    for i in range(batch_size):
+        input_row_offsets_h[i] = running_offset
+        cache_lengths_h[i] = UInt32(cache_len + i * cache_len_step)
+        running_offset += UInt32(seq_len)
+    input_row_offsets_h[batch_size] = running_offset
+
+    # Gemma keeps distinct learned Q/K RMSNorm weights, so benchmark the exact
+    # live seam with separate deterministic gamma vectors.
+    for i in range(head_dim):
+        q_gamma_h[i] = (Float64(i + head_dim) / Float64(head_dim)).cast[dtype]()
+        k_gamma_h[i] = (
+            Float64(i + (head_dim // 2)) / Float64(head_dim)
+        ).cast[dtype]()
+
+    for i in range(max_seq_len * head_dim):
+        freqs_h[i] = Scalar[dtype](random_float64(-1, 1).cast[dtype]())
+
+    for i in range(q_elems):
+        q_h[i] = Scalar[dtype](random_float64(0, 100).cast[dtype]())
+
+    var paged_lut_host = LayoutTensor[
+        DType.uint32, Layout.row_major[2](), MutAnyOrigin
+    ](
+        paged_lut_h,
+        RuntimeLayout[Layout.row_major[2]()].row_major(
+            IndexList[2](batch_size, paged_lut_cols)
+        ),
+    )
+    for bs in range(batch_size):
+        for page_idx in range(paged_lut_cols):
+            paged_lut_host[bs, page_idx] = UInt32(bs * paged_lut_cols + page_idx)
+
+    var input_row_offsets_d = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size + 1
+    )
+    var cache_lengths_d = ctx.enqueue_create_buffer[DType.uint32](batch_size)
+    var q_gamma_d = ctx.enqueue_create_buffer[dtype](head_dim)
+    var k_gamma_d = ctx.enqueue_create_buffer[dtype](head_dim)
+    var freqs_d = ctx.enqueue_create_buffer[dtype](max_seq_len * head_dim)
+    var q_d = ctx.enqueue_create_buffer[dtype](q_elems)
+    var baseline_q_norm_d = ctx.enqueue_create_buffer[dtype](q_elems)
+    var baseline_output_d = ctx.enqueue_create_buffer[dtype](q_elems)
+    var fused_output_d = ctx.enqueue_create_buffer[dtype](q_elems)
+    var trial_output_d = ctx.enqueue_create_buffer[dtype](q_elems)
+    var paged_lut_d = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size * paged_lut_cols
+    )
+
+    ctx.enqueue_copy(input_row_offsets_d, input_row_offsets_h)
+    ctx.enqueue_copy(cache_lengths_d, cache_lengths_h)
+    ctx.enqueue_copy(q_gamma_d, q_gamma_h)
+    ctx.enqueue_copy(k_gamma_d, k_gamma_h)
+    ctx.enqueue_copy(freqs_d, freqs_h)
+    ctx.enqueue_copy(q_d, q_h)
+    ctx.enqueue_copy(paged_lut_d, paged_lut_h)
+
+    var kv_block_shape = IndexList[6](
+        num_pages,
+        2,
+        num_layers,
+        page_size,
+        num_kv_heads,
+        head_dim,
+    )
+    var kv_block_size = kv_block_shape.flattened_length()
+    var baseline_kv_block_h = alloc[Scalar[dtype]](kv_block_size)
+    var fused_kv_block_h = alloc[Scalar[dtype]](kv_block_size)
+    var trial_kv_block_h = alloc[Scalar[dtype]](kv_block_size)
+    random(
+        LayoutTensor[dtype, Layout.row_major[6](), MutAnyOrigin](
+            baseline_kv_block_h,
+            RuntimeLayout[Layout.row_major[6]()].row_major(kv_block_shape),
+        )
+    )
+
+    var baseline_kv_block_d = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    var fused_kv_block_d = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    var trial_kv_block_d = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    ctx.enqueue_copy(baseline_kv_block_d, baseline_kv_block_h)
+    ctx.enqueue_copy(fused_kv_block_d, baseline_kv_block_h)
+    ctx.enqueue_copy(trial_kv_block_d, baseline_kv_block_h)
+
+    var q_shape = IndexList[3](Int(total_seq_len), num_q_heads, head_dim)
+    var q_layout = row_major(
+        (Idx(total_seq_len), Idx[num_q_heads](), Idx[head_dim]())
+    )
+    var q_tensor = TileTensor(q_d.unsafe_ptr(), q_layout)
+    var baseline_q_norm_tensor = TileTensor(baseline_q_norm_d.unsafe_ptr(), q_layout)
+    var baseline_output_tensor = TileTensor(baseline_output_d.unsafe_ptr(), q_layout)
+    var fused_output_tensor = TileTensor(fused_output_d.unsafe_ptr(), q_layout)
+    var trial_output_tensor = TileTensor(trial_output_d.unsafe_ptr(), q_layout)
+    var q_gamma_tensor = TileTensor(
+        q_gamma_d.unsafe_ptr(), row_major(Idx[head_dim]())
+    )
+    var k_gamma_tensor = TileTensor(
+        k_gamma_d.unsafe_ptr(), row_major(Idx[head_dim]())
+    )
+    var input_row_offsets_tensor = TileTensor(
+        input_row_offsets_d.unsafe_ptr(), row_major(Idx(batch_size + 1))
+    )
+    var start_pos_tensor = TileTensor(
+        cache_lengths_d.unsafe_ptr(), row_major(Idx(batch_size))
+    )
+    comptime freqs_layout = row_major[max_seq_len, head_dim]()
+    var freqs_tensor = TileTensor(freqs_d.unsafe_ptr(), freqs_layout)
+
+    comptime kv_block_layout = Layout.row_major[6]()
+    comptime cache_lengths_layout = Layout(UNKNOWN_VALUE)
+    var baseline_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            baseline_kv_block_d.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_d.unsafe_ptr(),
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+            paged_lut_d.unsafe_ptr(),
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var fused_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            fused_kv_block_d.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_d.unsafe_ptr(),
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+            paged_lut_d.unsafe_ptr(),
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var trial_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            trial_kv_block_d.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_d.unsafe_ptr(),
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+            paged_lut_d.unsafe_ptr(),
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+
+    var epsilon = Scalar[dtype](1e-6)
+    var weight_offset = Scalar[dtype](1.0)
+
+    @always_inline
+    @__copy_capture(q_tensor)
+    @parameter
+    def input_fn[
+        width: Int, rank: Int
+    ](coords: IndexList[rank]) -> SIMD[dtype, width]:
+        return q_tensor.load[width=width](Coord(coords))
+
+    @always_inline
+    @__copy_capture(baseline_q_norm_tensor)
+    @parameter
+    def baseline_q_norm_output_fn[
+        width: Int, alignment: Int
+    ](coords: IndexList[3], val: SIMD[dtype, width]) -> None:
+        baseline_q_norm_tensor.store[alignment=alignment](Coord(coords), val)
+
+    @always_inline
+    @__copy_capture(
+        q_shape,
+        q_gamma_tensor,
+        k_gamma_tensor,
+        epsilon,
+        weight_offset,
+        baseline_kv_collection,
+        input_row_offsets_tensor,
+        total_seq_len,
+        freqs_tensor,
+        baseline_q_norm_tensor,
+        baseline_output_tensor,
+    )
+    @parameter
+    def run_baseline(ctx: DeviceContext) raises:
+        rms_norm_gpu[
+            input_fn,
+            baseline_q_norm_output_fn,
+            multiply_before_cast=True,
+        ](q_shape, q_gamma_tensor, epsilon, weight_offset, ctx)
+        rms_norm_kv_cache_ragged_paged[
+            target="gpu",
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            baseline_kv_collection,
+            k_gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+        fused_qk_rope_ragged[CollectionType.CacheType, interleaved=False, target="gpu"](
+            baseline_q_norm_tensor,
+            input_row_offsets_tensor,
+            baseline_kv_collection,
+            freqs_tensor,
+            None,
+            UInt32(layer_idx),
+            baseline_output_tensor,
+            Optional[DeviceContext](ctx),
+        )
+
+    @always_inline
+    @__copy_capture(
+        q_tensor,
+        input_row_offsets_tensor,
+        start_pos_tensor,
+        fused_kv_collection,
+        freqs_tensor,
+        q_gamma_tensor,
+        k_gamma_tensor,
+        epsilon,
+        weight_offset,
+        fused_output_tensor,
+    )
+    @parameter
+    def run_fused(ctx: DeviceContext) raises:
+        q_rms_norm_fused_qk_rope_ragged[
+            dtype,
+            dtype,
+            CollectionType,
+            interleaved=False,
+            target="gpu",
+        ](
+            q_tensor,
+            input_row_offsets_tensor,
+            start_pos_tensor,
+            fused_kv_collection,
+            freqs_tensor,
+            q_gamma_tensor,
+            k_gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            fused_output_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        q_tensor,
+        input_row_offsets_tensor,
+        start_pos_tensor,
+        trial_kv_collection,
+        baseline_q_norm_tensor,
+        freqs_tensor,
+        q_gamma_tensor,
+        k_gamma_tensor,
+        epsilon,
+        weight_offset,
+        trial_output_tensor,
+    )
+    @parameter
+    def run_trial_fused(ctx: DeviceContext) raises:
+        q_rms_norm_fused_qk_rope_ragged[
+            dtype,
+            dtype,
+            CollectionType,
+            interleaved=False,
+            target="gpu",
+        ](
+            q_tensor,
+            input_row_offsets_tensor,
+            start_pos_tensor,
+            trial_kv_collection,
+            freqs_tensor,
+            q_gamma_tensor,
+            k_gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            trial_output_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        q_tensor,
+        input_row_offsets_tensor,
+        start_pos_tensor,
+        trial_kv_collection,
+        freqs_tensor,
+        q_gamma_tensor,
+        k_gamma_tensor,
+        epsilon,
+        weight_offset,
+        trial_output_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_trial(ctx: DeviceContext) raises:
+        if trial_baseline_disable_decode_fastpath:
+            rms_norm_gpu[
+                input_fn,
+                baseline_q_norm_output_fn,
+                multiply_before_cast=True,
+            ](q_shape, q_gamma_tensor, epsilon, weight_offset, ctx)
+            rms_norm_kv_cache_ragged_paged[
+                target="gpu",
+                multiply_before_cast=True,
+                per_head_norm=True,
+            ](
+                trial_kv_collection,
+                k_gamma_tensor,
+                epsilon,
+                weight_offset,
+                UInt32(layer_idx),
+                total_seq_len,
+                input_row_offsets_tensor,
+                ctx,
+            )
+            fused_qk_rope_ragged[
+                CollectionType.CacheType,
+                interleaved=False,
+                target="gpu",
+                allow_decode_fastpath=False,
+            ](
+                baseline_q_norm_tensor,
+                input_row_offsets_tensor,
+                trial_kv_collection,
+                freqs_tensor,
+                None,
+                UInt32(layer_idx),
+                trial_output_tensor,
+                Optional[DeviceContext](ctx),
+            )
+            return
+
+        comptime if dtype == DType.bfloat16:
+            comptime if head_dim == 128:
+                if seq_len == 1:
+                    comptime block_size = 64
+                    comptime warps_per_block = 2
+                    comptime total_heads = num_q_heads + num_kv_heads
+
+                    var total_rows = Int(total_seq_len) * total_heads
+                    var k_cache = trial_kv_collection.get_key_cache(layer_idx)
+
+                    if cache_len_step == 0:
+                        comptime kernel = _gemma3_qk_norm_rope_decode_uniform_kernel[
+                            dtype,
+                            dtype,
+                            CollectionType.CacheType,
+                            type_of(q_tensor).LayoutType,
+                            type_of(trial_output_tensor).LayoutType,
+                            type_of(freqs_tensor).LayoutType,
+                            type_of(q_gamma_tensor).LayoutType,
+                            type_of(k_gamma_tensor).LayoutType,
+                            block_size,
+                            warps_per_block,
+                        ]
+                        ctx.enqueue_function[kernel, kernel](
+                            q_tensor,
+                            trial_output_tensor,
+                            k_cache,
+                            freqs_tensor,
+                            q_gamma_tensor,
+                            k_gamma_tensor,
+                            epsilon,
+                            weight_offset,
+                            total_rows,
+                            cache_len,
+                            grid_dim=ceildiv(total_rows, warps_per_block * 2),
+                            block_dim=block_size,
+                        )
+                    else:
+                        comptime kernel = _gemma3_qk_norm_rope_decode_ragged_kernel[
+                            dtype,
+                            dtype,
+                            CollectionType.CacheType,
+                            type_of(q_tensor).LayoutType,
+                            type_of(trial_output_tensor).LayoutType,
+                            type_of(start_pos_tensor).LayoutType,
+                            type_of(freqs_tensor).LayoutType,
+                            type_of(q_gamma_tensor).LayoutType,
+                            type_of(k_gamma_tensor).LayoutType,
+                            block_size,
+                            warps_per_block,
+                        ]
+                        ctx.enqueue_function[kernel, kernel](
+                            q_tensor,
+                            trial_output_tensor,
+                            start_pos_tensor,
+                            k_cache,
+                            freqs_tensor,
+                            q_gamma_tensor,
+                            k_gamma_tensor,
+                            epsilon,
+                            weight_offset,
+                            total_rows,
+                            grid_dim=ceildiv(total_rows, warps_per_block * 2),
+                            block_dim=block_size,
+                        )
+                else:
+                    run_trial_fused(ctx)
+            else:
+                comptime if head_dim == 256:
+                    if seq_len == 1:
+                        comptime block_size = 64
+                        comptime warps_per_block = 2
+                        comptime total_heads = num_q_heads + num_kv_heads
+
+                        var total_rows = Int(total_seq_len) * total_heads
+                        var k_cache = trial_kv_collection.get_key_cache(layer_idx)
+
+                        if cache_len_step == 0:
+                            comptime kernel = _gemma3_qk_norm_rope_decode_uniform_wide_kernel[
+                                dtype,
+                                dtype,
+                                CollectionType.CacheType,
+                                type_of(q_tensor).LayoutType,
+                                type_of(trial_output_tensor).LayoutType,
+                                type_of(freqs_tensor).LayoutType,
+                                type_of(q_gamma_tensor).LayoutType,
+                                type_of(k_gamma_tensor).LayoutType,
+                                block_size,
+                                warps_per_block,
+                            ]
+                            ctx.enqueue_function[kernel, kernel](
+                                q_tensor,
+                                trial_output_tensor,
+                                k_cache,
+                                freqs_tensor,
+                                q_gamma_tensor,
+                                k_gamma_tensor,
+                                epsilon,
+                                weight_offset,
+                                total_rows,
+                                cache_len,
+                                grid_dim=ceildiv(total_rows, warps_per_block),
+                                block_dim=block_size,
+                            )
+                        else:
+                            comptime kernel = _gemma3_qk_norm_rope_decode_ragged_wide_kernel[
+                                dtype,
+                                dtype,
+                                CollectionType.CacheType,
+                                type_of(q_tensor).LayoutType,
+                                type_of(trial_output_tensor).LayoutType,
+                                type_of(start_pos_tensor).LayoutType,
+                                type_of(freqs_tensor).LayoutType,
+                                type_of(q_gamma_tensor).LayoutType,
+                                type_of(k_gamma_tensor).LayoutType,
+                                block_size,
+                                warps_per_block,
+                            ]
+                            ctx.enqueue_function[kernel, kernel](
+                                q_tensor,
+                                trial_output_tensor,
+                                start_pos_tensor,
+                                k_cache,
+                                freqs_tensor,
+                                q_gamma_tensor,
+                                k_gamma_tensor,
+                                epsilon,
+                                weight_offset,
+                                total_rows,
+                                grid_dim=ceildiv(total_rows, warps_per_block),
+                                block_dim=block_size,
+                            )
+                    else:
+                        run_trial_fused(ctx)
+                else:
+                    run_trial_fused(ctx)
+        else:
+            run_trial_fused(ctx)
+
+    @always_inline
+    @parameter
+    def baseline_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_baseline](ctx)
+
+    @always_inline
+    @parameter
+    def fused_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_fused](ctx)
+
+    @always_inline
+    @parameter
+    def trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_trial](ctx)
+
+    bench.bench_function[baseline_bench](
+        BenchId(
+            "gemma3_qk_norm_rope_boundary_baseline",
+            input_id=String(
+                dtype,
+                "/bs=",
+                batch_size,
+                "/seq=",
+                seq_len,
+                "/cache=",
+                cache_len,
+                "/cache_step=",
+                cache_len_step,
+            ),
+        ),
+    )
+    bench.bench_function[fused_bench](
+        BenchId(
+            "gemma3_qk_norm_rope_boundary_fused",
+            input_id=String(
+                dtype,
+                "/bs=",
+                batch_size,
+                "/seq=",
+                seq_len,
+                "/cache=",
+                cache_len,
+                "/cache_step=",
+                cache_len_step,
+            ),
+        ),
+    )
+    comptime if dtype == DType.bfloat16 and (head_dim == 128 or head_dim == 256):
+        bench.bench_function[trial_bench](
+            BenchId(
+                "gemma3_qk_norm_rope_boundary_trial",
+                input_id=String(
+                    dtype,
+                    "/bs=",
+                    batch_size,
+                    "/seq=",
+                    seq_len,
+                    "/cache=",
+                    cache_len,
+                    "/cache_step=",
+                    cache_len_step,
+                ),
+            ),
+        )
+
+    if verify_results:
+        ctx.enqueue_copy(baseline_kv_block_d, baseline_kv_block_h)
+        ctx.enqueue_copy(fused_kv_block_d, baseline_kv_block_h)
+        comptime if dtype == DType.bfloat16 and (head_dim == 128 or head_dim == 256):
+            ctx.enqueue_copy(trial_kv_block_d, baseline_kv_block_h)
+        run_baseline(ctx)
+        run_fused(ctx)
+        comptime if dtype == DType.bfloat16 and (head_dim == 128 or head_dim == 256):
+            run_trial(ctx)
+        ctx.enqueue_copy(baseline_output_h, baseline_output_d)
+        ctx.enqueue_copy(fused_output_h, fused_output_d)
+        comptime if dtype == DType.bfloat16 and (head_dim == 128 or head_dim == 256):
+            ctx.enqueue_copy(trial_output_h, trial_output_d)
+        ctx.enqueue_copy(baseline_kv_block_h, baseline_kv_block_d)
+        ctx.enqueue_copy(fused_kv_block_h, fused_kv_block_d)
+        comptime if dtype == DType.bfloat16 and (head_dim == 128 or head_dim == 256):
+            ctx.enqueue_copy(trial_kv_block_h, trial_kv_block_d)
+        ctx.synchronize()
+
+        for i in range(q_elems):
+            assert_almost_equal(
+                baseline_output_h[i], fused_output_h[i], rtol=2e-2, atol=2e-2
+            )
+            comptime if dtype == DType.bfloat16 and (head_dim == 128 or head_dim == 256):
+                assert_almost_equal(
+                    baseline_output_h[i], trial_output_h[i], rtol=2e-2, atol=2e-2
+                )
+
+        var baseline_kv_collection_host = CollectionType(
+            LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+                baseline_kv_block_h,
+                RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+            ),
+            LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+                cache_lengths_h,
+                RuntimeLayout[cache_lengths_layout].row_major(
+                    IndexList[1](batch_size)
+                ),
+            ),
+            LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+                paged_lut_h,
+                RuntimeLayout[Layout.row_major[2]()].row_major(
+                    IndexList[2](batch_size, paged_lut_cols)
+                ),
+            ),
+            UInt32(seq_len),
+            UInt32(max_context_length),
+        )
+        var fused_kv_collection_host = CollectionType(
+            LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+                fused_kv_block_h,
+                RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+            ),
+            LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+                cache_lengths_h,
+                RuntimeLayout[cache_lengths_layout].row_major(
+                    IndexList[1](batch_size)
+                ),
+            ),
+            LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+                paged_lut_h,
+                RuntimeLayout[Layout.row_major[2]()].row_major(
+                    IndexList[2](batch_size, paged_lut_cols)
+                ),
+            ),
+            UInt32(seq_len),
+            UInt32(max_context_length),
+        )
+        var baseline_k_cache_host = baseline_kv_collection_host.get_key_cache(
+            layer_idx
+        )
+        var fused_k_cache_host = fused_kv_collection_host.get_key_cache(layer_idx)
+
+        for bs_idx in range(batch_size):
+            for tok_idx in range(seq_len):
+                var post_seq_idx = Int(cache_lengths_h[bs_idx]) + tok_idx
+                for head_idx in range(num_kv_heads):
+                    for dim_idx in range(head_dim):
+                        assert_almost_equal(
+                            baseline_k_cache_host.load[width=1](
+                                bs_idx,
+                                head_idx,
+                                post_seq_idx,
+                                dim_idx,
+                            ),
+                            fused_k_cache_host.load[width=1](
+                                bs_idx,
+                                head_idx,
+                                post_seq_idx,
+                                dim_idx,
+                            ),
+                            rtol=2e-2,
+                            atol=2e-2,
+                        )
+        comptime if dtype == DType.bfloat16 and (head_dim == 128 or head_dim == 256):
+            var trial_kv_collection_host = CollectionType(
+                LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+                    trial_kv_block_h,
+                    RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+                ),
+                LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+                    cache_lengths_h,
+                    RuntimeLayout[cache_lengths_layout].row_major(
+                        IndexList[1](batch_size)
+                    ),
+                ),
+                LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+                    paged_lut_h,
+                    RuntimeLayout[Layout.row_major[2]()].row_major(
+                        IndexList[2](batch_size, paged_lut_cols)
+                    ),
+                ),
+                UInt32(seq_len),
+                UInt32(max_context_length),
+            )
+            var trial_k_cache_host = trial_kv_collection_host.get_key_cache(
+                layer_idx
+            )
+            for bs_idx in range(batch_size):
+                for tok_idx in range(seq_len):
+                    var post_seq_idx = Int(cache_lengths_h[bs_idx]) + tok_idx
+                    for head_idx in range(num_kv_heads):
+                        for dim_idx in range(head_dim):
+                            assert_almost_equal(
+                                baseline_k_cache_host.load[width=1](
+                                    bs_idx,
+                                    head_idx,
+                                    post_seq_idx,
+                                    dim_idx,
+                                ),
+                                trial_k_cache_host.load[width=1](
+                                    bs_idx,
+                                    head_idx,
+                                    post_seq_idx,
+                                    dim_idx,
+                                ),
+                                rtol=2e-2,
+                                atol=2e-2,
+                            )
+
+    _ = input_row_offsets_d
+    _ = cache_lengths_d
+    _ = q_gamma_d
+    _ = k_gamma_d
+    _ = freqs_d
+    _ = q_d
+    _ = baseline_q_norm_d
+    _ = baseline_output_d
+    _ = fused_output_d
+    _ = trial_output_d
+    _ = paged_lut_d
+    _ = baseline_kv_block_d
+    _ = fused_kv_block_d
+    _ = trial_kv_block_d
+
+    input_row_offsets_h.free()
+    cache_lengths_h.free()
+    q_gamma_h.free()
+    k_gamma_h.free()
+    freqs_h.free()
+    q_h.free()
+    paged_lut_h.free()
+    baseline_output_h.free()
+    fused_output_h.free()
+    trial_output_h.free()
+    baseline_kv_block_h.free()
+    fused_kv_block_h.free()
+    trial_kv_block_h.free()
+
+
+def bench_gemma3_qk_norm_rope_boundary_pair[
+    dtype: DType,
+    head_dim: Int,
+    num_q_heads: Int,
+    num_kv_heads: Int,
+    page_size: Int,
+](
+    ctx: DeviceContext,
+    mut bench: Bench,
+    batch_size: Int,
+    seq_len: Int,
+    cache_len: Int,
+    cache_len_step: Int,
+    trial_baseline_disable_decode_fastpath: Bool,
+    verify_results: Bool,
+) raises:
+    comptime assert dtype == DType.bfloat16, (
+        "pair_only only supports the BF16 boundary trial"
+    )
+    comptime assert head_dim == 128 or head_dim == 256, (
+        "pair_only only supports head_dim 128 or 256"
+    )
+    if verify_results:
+        raise Error("pair_only requires --verify=False")
+    if trial_baseline_disable_decode_fastpath:
+        raise Error(
+            "pair_only requires trial_baseline_disable_decode_fastpath=False"
+        )
+
+    comptime max_seq_len = 2048
+    comptime num_layers = 1
+    comptime layer_idx = 0
+    comptime kv_params = KVCacheStaticParams(
+        num_heads=UInt(num_kv_heads), head_size=UInt(head_dim)
+    )
+    comptime CollectionType = PagedKVCacheCollection[dtype, kv_params, page_size]
+
+    var total_seq_len = UInt32(batch_size * seq_len)
+    var max_cache_len = cache_len + (batch_size - 1) * cache_len_step
+    var max_context_length = seq_len + max_cache_len
+    var paged_lut_cols = ceildiv(max_context_length, page_size)
+    var num_pages = batch_size * paged_lut_cols
+    var q_elems = Int(total_seq_len) * num_q_heads * head_dim
+
+    var input_row_offsets_h = alloc[Scalar[DType.uint32]](batch_size + 1)
+    var cache_lengths_h = alloc[Scalar[DType.uint32]](batch_size)
+    var q_gamma_h = alloc[Scalar[dtype]](head_dim)
+    var k_gamma_h = alloc[Scalar[dtype]](head_dim)
+    var freqs_h = alloc[Scalar[dtype]](max_seq_len * head_dim)
+    var q_h = alloc[Scalar[dtype]](q_elems)
+    var paged_lut_h = alloc[Scalar[DType.uint32]](batch_size * paged_lut_cols)
+
+    var running_offset: UInt32 = 0
+    for i in range(batch_size):
+        input_row_offsets_h[i] = running_offset
+        cache_lengths_h[i] = UInt32(cache_len + i * cache_len_step)
+        running_offset += UInt32(seq_len)
+    input_row_offsets_h[batch_size] = running_offset
+
+    for i in range(head_dim):
+        q_gamma_h[i] = (Float64(i + head_dim) / Float64(head_dim)).cast[dtype]()
+        k_gamma_h[i] = (
+            Float64(i + (head_dim // 2)) / Float64(head_dim)
+        ).cast[dtype]()
+
+    for i in range(max_seq_len * head_dim):
+        freqs_h[i] = Scalar[dtype](random_float64(-1, 1).cast[dtype]())
+
+    for i in range(q_elems):
+        q_h[i] = Scalar[dtype](random_float64(0, 100).cast[dtype]())
+
+    var paged_lut_host = LayoutTensor[
+        DType.uint32, Layout.row_major[2](), MutAnyOrigin
+    ](
+        paged_lut_h,
+        RuntimeLayout[Layout.row_major[2]()].row_major(
+            IndexList[2](batch_size, paged_lut_cols)
+        ),
+    )
+    for bs in range(batch_size):
+        for page_idx in range(paged_lut_cols):
+            paged_lut_host[bs, page_idx] = UInt32(bs * paged_lut_cols + page_idx)
+
+    var input_row_offsets_d = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size + 1
+    )
+    var cache_lengths_d = ctx.enqueue_create_buffer[DType.uint32](batch_size)
+    var q_gamma_d = ctx.enqueue_create_buffer[dtype](head_dim)
+    var k_gamma_d = ctx.enqueue_create_buffer[dtype](head_dim)
+    var freqs_d = ctx.enqueue_create_buffer[dtype](max_seq_len * head_dim)
+    var q_d = ctx.enqueue_create_buffer[dtype](q_elems)
+    var fused_output_d = ctx.enqueue_create_buffer[dtype](q_elems)
+    var trial_output_d = ctx.enqueue_create_buffer[dtype](q_elems)
+    var paged_lut_d = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size * paged_lut_cols
+    )
+
+    ctx.enqueue_copy(input_row_offsets_d, input_row_offsets_h)
+    ctx.enqueue_copy(cache_lengths_d, cache_lengths_h)
+    ctx.enqueue_copy(q_gamma_d, q_gamma_h)
+    ctx.enqueue_copy(k_gamma_d, k_gamma_h)
+    ctx.enqueue_copy(freqs_d, freqs_h)
+    ctx.enqueue_copy(q_d, q_h)
+    ctx.enqueue_copy(paged_lut_d, paged_lut_h)
+
+    var kv_block_shape = IndexList[6](
+        num_pages,
+        2,
+        num_layers,
+        page_size,
+        num_kv_heads,
+        head_dim,
+    )
+    var kv_block_size = kv_block_shape.flattened_length()
+    var kv_block_seed_h = alloc[Scalar[dtype]](kv_block_size)
+    random(
+        LayoutTensor[dtype, Layout.row_major[6](), MutAnyOrigin](
+            kv_block_seed_h,
+            RuntimeLayout[Layout.row_major[6]()].row_major(kv_block_shape),
+        )
+    )
+
+    var fused_kv_block_d = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    var trial_kv_block_d = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    ctx.enqueue_copy(fused_kv_block_d, kv_block_seed_h)
+    ctx.enqueue_copy(trial_kv_block_d, kv_block_seed_h)
+
+    var q_layout = row_major(
+        (Idx(total_seq_len), Idx[num_q_heads](), Idx[head_dim]())
+    )
+    var q_tensor = TileTensor(q_d.unsafe_ptr(), q_layout)
+    var fused_output_tensor = TileTensor(fused_output_d.unsafe_ptr(), q_layout)
+    var trial_output_tensor = TileTensor(trial_output_d.unsafe_ptr(), q_layout)
+    var q_gamma_tensor = TileTensor(
+        q_gamma_d.unsafe_ptr(), row_major(Idx[head_dim]())
+    )
+    var k_gamma_tensor = TileTensor(
+        k_gamma_d.unsafe_ptr(), row_major(Idx[head_dim]())
+    )
+    var input_row_offsets_tensor = TileTensor(
+        input_row_offsets_d.unsafe_ptr(), row_major(Idx(batch_size + 1))
+    )
+    var start_pos_tensor = TileTensor(
+        cache_lengths_d.unsafe_ptr(), row_major(Idx(batch_size))
+    )
+    comptime freqs_layout = row_major[max_seq_len, head_dim]()
+    var freqs_tensor = TileTensor(freqs_d.unsafe_ptr(), freqs_layout)
+
+    comptime kv_block_layout = Layout.row_major[6]()
+    comptime cache_lengths_layout = Layout(UNKNOWN_VALUE)
+    var fused_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            fused_kv_block_d.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_d.unsafe_ptr(),
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+            paged_lut_d.unsafe_ptr(),
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var trial_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            trial_kv_block_d.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_d.unsafe_ptr(),
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+            paged_lut_d.unsafe_ptr(),
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+
+    var epsilon = Scalar[dtype](1e-6)
+    var weight_offset = Scalar[dtype](1.0)
+
+    @always_inline
+    @__copy_capture(
+        q_tensor,
+        input_row_offsets_tensor,
+        start_pos_tensor,
+        fused_kv_collection,
+        freqs_tensor,
+        q_gamma_tensor,
+        k_gamma_tensor,
+        epsilon,
+        weight_offset,
+        fused_output_tensor,
+    )
+    @parameter
+    def run_fused(ctx: DeviceContext) raises:
+        q_rms_norm_fused_qk_rope_ragged[
+            dtype,
+            dtype,
+            CollectionType,
+            interleaved=False,
+            target="gpu",
+        ](
+            q_tensor,
+            input_row_offsets_tensor,
+            start_pos_tensor,
+            fused_kv_collection,
+            freqs_tensor,
+            q_gamma_tensor,
+            k_gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            fused_output_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        q_tensor,
+        input_row_offsets_tensor,
+        start_pos_tensor,
+        trial_kv_collection,
+        freqs_tensor,
+        q_gamma_tensor,
+        k_gamma_tensor,
+        epsilon,
+        weight_offset,
+        trial_output_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_trial_fused(ctx: DeviceContext) raises:
+        q_rms_norm_fused_qk_rope_ragged[
+            dtype,
+            dtype,
+            CollectionType,
+            interleaved=False,
+            target="gpu",
+        ](
+            q_tensor,
+            input_row_offsets_tensor,
+            start_pos_tensor,
+            trial_kv_collection,
+            freqs_tensor,
+            q_gamma_tensor,
+            k_gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            trial_output_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        q_tensor,
+        start_pos_tensor,
+        trial_kv_collection,
+        freqs_tensor,
+        q_gamma_tensor,
+        k_gamma_tensor,
+        epsilon,
+        weight_offset,
+        trial_output_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_trial(ctx: DeviceContext) raises:
+        comptime if dtype == DType.bfloat16:
+            comptime if head_dim == 128:
+                if seq_len == 1:
+                    comptime block_size = 64
+                    comptime warps_per_block = 2
+                    comptime total_heads = num_q_heads + num_kv_heads
+
+                    var total_rows = Int(total_seq_len) * total_heads
+                    var k_cache = trial_kv_collection.get_key_cache(layer_idx)
+
+                    if cache_len_step == 0:
+                        comptime kernel = _gemma3_qk_norm_rope_decode_uniform_kernel[
+                            dtype,
+                            dtype,
+                            CollectionType.CacheType,
+                            type_of(q_tensor).LayoutType,
+                            type_of(trial_output_tensor).LayoutType,
+                            type_of(freqs_tensor).LayoutType,
+                            type_of(q_gamma_tensor).LayoutType,
+                            type_of(k_gamma_tensor).LayoutType,
+                            block_size,
+                            warps_per_block,
+                        ]
+                        ctx.enqueue_function[kernel, kernel](
+                            q_tensor,
+                            trial_output_tensor,
+                            k_cache,
+                            freqs_tensor,
+                            q_gamma_tensor,
+                            k_gamma_tensor,
+                            epsilon,
+                            weight_offset,
+                            total_rows,
+                            cache_len,
+                            grid_dim=ceildiv(total_rows, warps_per_block * 2),
+                            block_dim=block_size,
+                        )
+                    else:
+                        comptime kernel = _gemma3_qk_norm_rope_decode_ragged_kernel[
+                            dtype,
+                            dtype,
+                            CollectionType.CacheType,
+                            type_of(q_tensor).LayoutType,
+                            type_of(trial_output_tensor).LayoutType,
+                            type_of(start_pos_tensor).LayoutType,
+                            type_of(freqs_tensor).LayoutType,
+                            type_of(q_gamma_tensor).LayoutType,
+                            type_of(k_gamma_tensor).LayoutType,
+                            block_size,
+                            warps_per_block,
+                        ]
+                        ctx.enqueue_function[kernel, kernel](
+                            q_tensor,
+                            trial_output_tensor,
+                            start_pos_tensor,
+                            k_cache,
+                            freqs_tensor,
+                            q_gamma_tensor,
+                            k_gamma_tensor,
+                            epsilon,
+                            weight_offset,
+                            total_rows,
+                            grid_dim=ceildiv(total_rows, warps_per_block * 2),
+                            block_dim=block_size,
+                        )
+                else:
+                    run_trial_fused(ctx)
+            else:
+                comptime if head_dim == 256:
+                    if seq_len == 1:
+                        comptime block_size = 64
+                        comptime warps_per_block = 2
+                        comptime total_heads = num_q_heads + num_kv_heads
+
+                        var total_rows = Int(total_seq_len) * total_heads
+                        var k_cache = trial_kv_collection.get_key_cache(layer_idx)
+
+                        if cache_len_step == 0:
+                            comptime kernel = _gemma3_qk_norm_rope_decode_uniform_wide_kernel[
+                                dtype,
+                                dtype,
+                                CollectionType.CacheType,
+                                type_of(q_tensor).LayoutType,
+                                type_of(trial_output_tensor).LayoutType,
+                                type_of(freqs_tensor).LayoutType,
+                                type_of(q_gamma_tensor).LayoutType,
+                                type_of(k_gamma_tensor).LayoutType,
+                                block_size,
+                                warps_per_block,
+                            ]
+                            ctx.enqueue_function[kernel, kernel](
+                                q_tensor,
+                                trial_output_tensor,
+                                k_cache,
+                                freqs_tensor,
+                                q_gamma_tensor,
+                                k_gamma_tensor,
+                                epsilon,
+                                weight_offset,
+                                total_rows,
+                                cache_len,
+                                grid_dim=ceildiv(total_rows, warps_per_block),
+                                block_dim=block_size,
+                            )
+                        else:
+                            comptime kernel = _gemma3_qk_norm_rope_decode_ragged_wide_kernel[
+                                dtype,
+                                dtype,
+                                CollectionType.CacheType,
+                                type_of(q_tensor).LayoutType,
+                                type_of(trial_output_tensor).LayoutType,
+                                type_of(start_pos_tensor).LayoutType,
+                                type_of(freqs_tensor).LayoutType,
+                                type_of(q_gamma_tensor).LayoutType,
+                                type_of(k_gamma_tensor).LayoutType,
+                                block_size,
+                                warps_per_block,
+                            ]
+                            ctx.enqueue_function[kernel, kernel](
+                                q_tensor,
+                                trial_output_tensor,
+                                start_pos_tensor,
+                                k_cache,
+                                freqs_tensor,
+                                q_gamma_tensor,
+                                k_gamma_tensor,
+                                epsilon,
+                                weight_offset,
+                                total_rows,
+                                grid_dim=ceildiv(total_rows, warps_per_block),
+                                block_dim=block_size,
+                            )
+                    else:
+                        run_trial_fused(ctx)
+                else:
+                    run_trial_fused(ctx)
+        else:
+            run_trial_fused(ctx)
+
+    @always_inline
+    @parameter
+    def fused_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_fused](ctx)
+
+    @always_inline
+    @parameter
+    def trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_trial](ctx)
+
+    bench.bench_function[fused_bench](
+        BenchId(
+            "gemma3_qk_norm_rope_boundary_pair_fused",
+            input_id=String(
+                dtype,
+                "/bs=",
+                batch_size,
+                "/seq=",
+                seq_len,
+                "/cache=",
+                cache_len,
+                "/cache_step=",
+                cache_len_step,
+                "/pair_only",
+            ),
+        ),
+    )
+    bench.bench_function[trial_bench](
+        BenchId(
+            "gemma3_qk_norm_rope_boundary_pair_trial",
+            input_id=String(
+                dtype,
+                "/bs=",
+                batch_size,
+                "/seq=",
+                seq_len,
+                "/cache=",
+                cache_len,
+                "/cache_step=",
+                cache_len_step,
+                "/pair_only",
+            ),
+        ),
+    )
+
+    _ = input_row_offsets_d
+    _ = cache_lengths_d
+    _ = q_gamma_d
+    _ = k_gamma_d
+    _ = freqs_d
+    _ = q_d
+    _ = fused_output_d
+    _ = trial_output_d
+    _ = paged_lut_d
+    _ = fused_kv_block_d
+    _ = trial_kv_block_d
+
+    input_row_offsets_h.free()
+    cache_lengths_h.free()
+    q_gamma_h.free()
+    k_gamma_h.free()
+    freqs_h.free()
+    q_h.free()
+    paged_lut_h.free()
+    kv_block_seed_h.free()
+
+
+def bench_gemma3_qk_norm_rope_boundary_pair_single_variant[
+    dtype: DType,
+    head_dim: Int,
+    num_q_heads: Int,
+    num_kv_heads: Int,
+    page_size: Int,
+    run_trial_variant: Bool,
+](
+    ctx: DeviceContext,
+    mut bench: Bench,
+    batch_size: Int,
+    seq_len: Int,
+    cache_len: Int,
+    cache_len_step: Int,
+    trial_baseline_disable_decode_fastpath: Bool,
+    verify_results: Bool,
+) raises:
+    comptime assert dtype == DType.bfloat16, (
+        "single pair variant only supports the BF16 boundary trial"
+    )
+    comptime assert head_dim == 128 or head_dim == 256, (
+        "single pair variant only supports head_dim 128 or 256"
+    )
+    if verify_results:
+        raise Error("single pair variant requires --verify=False")
+    if trial_baseline_disable_decode_fastpath:
+        raise Error(
+            "single pair variant requires trial_baseline_disable_decode_fastpath=False"
+        )
+
+    comptime max_seq_len = 2048
+    comptime num_layers = 1
+    comptime layer_idx = 0
+    comptime kv_params = KVCacheStaticParams(
+        num_heads=UInt(num_kv_heads), head_size=UInt(head_dim)
+    )
+    comptime CollectionType = PagedKVCacheCollection[dtype, kv_params, page_size]
+
+    var total_seq_len = UInt32(batch_size * seq_len)
+    var max_cache_len = cache_len + (batch_size - 1) * cache_len_step
+    var max_context_length = seq_len + max_cache_len
+    var paged_lut_cols = ceildiv(max_context_length, page_size)
+    var num_pages = batch_size * paged_lut_cols
+    var q_elems = Int(total_seq_len) * num_q_heads * head_dim
+
+    var input_row_offsets_h = alloc[Scalar[DType.uint32]](batch_size + 1)
+    var cache_lengths_h = alloc[Scalar[DType.uint32]](batch_size)
+    var q_gamma_h = alloc[Scalar[dtype]](head_dim)
+    var k_gamma_h = alloc[Scalar[dtype]](head_dim)
+    var freqs_h = alloc[Scalar[dtype]](max_seq_len * head_dim)
+    var q_h = alloc[Scalar[dtype]](q_elems)
+    var paged_lut_h = alloc[Scalar[DType.uint32]](batch_size * paged_lut_cols)
+
+    var running_offset: UInt32 = 0
+    for i in range(batch_size):
+        input_row_offsets_h[i] = running_offset
+        cache_lengths_h[i] = UInt32(cache_len + i * cache_len_step)
+        running_offset += UInt32(seq_len)
+    input_row_offsets_h[batch_size] = running_offset
+
+    for i in range(head_dim):
+        q_gamma_h[i] = (Float64(i + head_dim) / Float64(head_dim)).cast[dtype]()
+        k_gamma_h[i] = (
+            Float64(i + (head_dim // 2)) / Float64(head_dim)
+        ).cast[dtype]()
+
+    for i in range(max_seq_len * head_dim):
+        freqs_h[i] = Scalar[dtype](random_float64(-1, 1).cast[dtype]())
+
+    for i in range(q_elems):
+        q_h[i] = Scalar[dtype](random_float64(0, 100).cast[dtype]())
+
+    var paged_lut_host = LayoutTensor[
+        DType.uint32, Layout.row_major[2](), MutAnyOrigin
+    ](
+        paged_lut_h,
+        RuntimeLayout[Layout.row_major[2]()].row_major(
+            IndexList[2](batch_size, paged_lut_cols)
+        ),
+    )
+    for bs in range(batch_size):
+        for page_idx in range(paged_lut_cols):
+            paged_lut_host[bs, page_idx] = UInt32(bs * paged_lut_cols + page_idx)
+
+    var input_row_offsets_d = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size + 1
+    )
+    var cache_lengths_d = ctx.enqueue_create_buffer[DType.uint32](batch_size)
+    var q_gamma_d = ctx.enqueue_create_buffer[dtype](head_dim)
+    var k_gamma_d = ctx.enqueue_create_buffer[dtype](head_dim)
+    var freqs_d = ctx.enqueue_create_buffer[dtype](max_seq_len * head_dim)
+    var q_d = ctx.enqueue_create_buffer[dtype](q_elems)
+    var output_d = ctx.enqueue_create_buffer[dtype](q_elems)
+    var paged_lut_d = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size * paged_lut_cols
+    )
+
+    ctx.enqueue_copy(input_row_offsets_d, input_row_offsets_h)
+    ctx.enqueue_copy(cache_lengths_d, cache_lengths_h)
+    ctx.enqueue_copy(q_gamma_d, q_gamma_h)
+    ctx.enqueue_copy(k_gamma_d, k_gamma_h)
+    ctx.enqueue_copy(freqs_d, freqs_h)
+    ctx.enqueue_copy(q_d, q_h)
+    ctx.enqueue_copy(paged_lut_d, paged_lut_h)
+
+    var kv_block_shape = IndexList[6](
+        num_pages,
+        2,
+        num_layers,
+        page_size,
+        num_kv_heads,
+        head_dim,
+    )
+    var kv_block_size = kv_block_shape.flattened_length()
+    var kv_block_seed_h = alloc[Scalar[dtype]](kv_block_size)
+    random(
+        LayoutTensor[dtype, Layout.row_major[6](), MutAnyOrigin](
+            kv_block_seed_h,
+            RuntimeLayout[Layout.row_major[6]()].row_major(kv_block_shape),
+        )
+    )
+
+    var kv_block_d = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    ctx.enqueue_copy(kv_block_d, kv_block_seed_h)
+
+    var q_layout = row_major(
+        (Idx(total_seq_len), Idx[num_q_heads](), Idx[head_dim]())
+    )
+    var q_tensor = TileTensor(q_d.unsafe_ptr(), q_layout)
+    var output_tensor = TileTensor(output_d.unsafe_ptr(), q_layout)
+    var q_gamma_tensor = TileTensor(
+        q_gamma_d.unsafe_ptr(), row_major(Idx[head_dim]())
+    )
+    var k_gamma_tensor = TileTensor(
+        k_gamma_d.unsafe_ptr(), row_major(Idx[head_dim]())
+    )
+    var input_row_offsets_tensor = TileTensor(
+        input_row_offsets_d.unsafe_ptr(), row_major(Idx(batch_size + 1))
+    )
+    var start_pos_tensor = TileTensor(
+        cache_lengths_d.unsafe_ptr(), row_major(Idx(batch_size))
+    )
+    comptime freqs_layout = row_major[max_seq_len, head_dim]()
+    var freqs_tensor = TileTensor(freqs_d.unsafe_ptr(), freqs_layout)
+
+    comptime kv_block_layout = Layout.row_major[6]()
+    comptime cache_lengths_layout = Layout(UNKNOWN_VALUE)
+    var kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            kv_block_d.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_d.unsafe_ptr(),
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, Layout.row_major[2](), ImmutAnyOrigin](
+            paged_lut_d.unsafe_ptr(),
+            RuntimeLayout[Layout.row_major[2]()].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+
+    var epsilon = Scalar[dtype](1e-6)
+    var weight_offset = Scalar[dtype](1.0)
+
+    comptime if run_trial_variant:
+        @always_inline
+        @__copy_capture(
+            q_tensor,
+            input_row_offsets_tensor,
+            start_pos_tensor,
+            kv_collection,
+            freqs_tensor,
+            q_gamma_tensor,
+            k_gamma_tensor,
+            epsilon,
+            weight_offset,
+            output_tensor,
+            total_seq_len,
+        )
+        @parameter
+        def run_trial_fused(ctx: DeviceContext) raises:
+            q_rms_norm_fused_qk_rope_ragged[
+                dtype,
+                dtype,
+                CollectionType,
+                interleaved=False,
+                target="gpu",
+            ](
+                q_tensor,
+                input_row_offsets_tensor,
+                start_pos_tensor,
+                kv_collection,
+                freqs_tensor,
+                q_gamma_tensor,
+                k_gamma_tensor,
+                epsilon,
+                weight_offset,
+                UInt32(layer_idx),
+                output_tensor,
+                ctx,
+            )
+
+        @always_inline
+        @__copy_capture(
+            q_tensor,
+            start_pos_tensor,
+            kv_collection,
+            freqs_tensor,
+            q_gamma_tensor,
+            k_gamma_tensor,
+            epsilon,
+            weight_offset,
+            output_tensor,
+            total_seq_len,
+        )
+        @parameter
+        def run_trial(ctx: DeviceContext) raises:
+            comptime if dtype == DType.bfloat16:
+                comptime if head_dim == 128:
+                    if seq_len == 1:
+                        comptime block_size = 64
+                        comptime warps_per_block = 2
+                        comptime total_heads = num_q_heads + num_kv_heads
+
+                        var total_rows = Int(total_seq_len) * total_heads
+                        var k_cache = kv_collection.get_key_cache(layer_idx)
+
+                        if cache_len_step == 0:
+                            comptime kernel = _gemma3_qk_norm_rope_decode_uniform_kernel[
+                                dtype,
+                                dtype,
+                                CollectionType.CacheType,
+                                type_of(q_tensor).LayoutType,
+                                type_of(output_tensor).LayoutType,
+                                type_of(freqs_tensor).LayoutType,
+                                type_of(q_gamma_tensor).LayoutType,
+                                type_of(k_gamma_tensor).LayoutType,
+                                block_size,
+                                warps_per_block,
+                            ]
+                            ctx.enqueue_function[kernel, kernel](
+                                q_tensor,
+                                output_tensor,
+                                k_cache,
+                                freqs_tensor,
+                                q_gamma_tensor,
+                                k_gamma_tensor,
+                                epsilon,
+                                weight_offset,
+                                total_rows,
+                                cache_len,
+                                grid_dim=ceildiv(total_rows, warps_per_block * 2),
+                                block_dim=block_size,
+                            )
+                        else:
+                            comptime kernel = _gemma3_qk_norm_rope_decode_ragged_kernel[
+                                dtype,
+                                dtype,
+                                CollectionType.CacheType,
+                                type_of(q_tensor).LayoutType,
+                                type_of(output_tensor).LayoutType,
+                                type_of(start_pos_tensor).LayoutType,
+                                type_of(freqs_tensor).LayoutType,
+                                type_of(q_gamma_tensor).LayoutType,
+                                type_of(k_gamma_tensor).LayoutType,
+                                block_size,
+                                warps_per_block,
+                            ]
+                            ctx.enqueue_function[kernel, kernel](
+                                q_tensor,
+                                output_tensor,
+                                start_pos_tensor,
+                                k_cache,
+                                freqs_tensor,
+                                q_gamma_tensor,
+                                k_gamma_tensor,
+                                epsilon,
+                                weight_offset,
+                                total_rows,
+                                grid_dim=ceildiv(total_rows, warps_per_block * 2),
+                                block_dim=block_size,
+                            )
+                    else:
+                        run_trial_fused(ctx)
+                else:
+                    comptime if head_dim == 256:
+                        if seq_len == 1:
+                            comptime block_size = 64
+                            comptime warps_per_block = 2
+                            comptime total_heads = num_q_heads + num_kv_heads
+
+                            var total_rows = Int(total_seq_len) * total_heads
+                            var k_cache = kv_collection.get_key_cache(layer_idx)
+
+                            if cache_len_step == 0:
+                                comptime kernel = _gemma3_qk_norm_rope_decode_uniform_wide_kernel[
+                                    dtype,
+                                    dtype,
+                                    CollectionType.CacheType,
+                                    type_of(q_tensor).LayoutType,
+                                    type_of(output_tensor).LayoutType,
+                                    type_of(freqs_tensor).LayoutType,
+                                    type_of(q_gamma_tensor).LayoutType,
+                                    type_of(k_gamma_tensor).LayoutType,
+                                    block_size,
+                                    warps_per_block,
+                                ]
+                                ctx.enqueue_function[kernel, kernel](
+                                    q_tensor,
+                                    output_tensor,
+                                    k_cache,
+                                    freqs_tensor,
+                                    q_gamma_tensor,
+                                    k_gamma_tensor,
+                                    epsilon,
+                                    weight_offset,
+                                    total_rows,
+                                    cache_len,
+                                    grid_dim=ceildiv(total_rows, warps_per_block),
+                                    block_dim=block_size,
+                                )
+                            else:
+                                comptime kernel = _gemma3_qk_norm_rope_decode_ragged_wide_kernel[
+                                    dtype,
+                                    dtype,
+                                    CollectionType.CacheType,
+                                    type_of(q_tensor).LayoutType,
+                                    type_of(output_tensor).LayoutType,
+                                    type_of(start_pos_tensor).LayoutType,
+                                    type_of(freqs_tensor).LayoutType,
+                                    type_of(q_gamma_tensor).LayoutType,
+                                    type_of(k_gamma_tensor).LayoutType,
+                                    block_size,
+                                    warps_per_block,
+                                ]
+                                ctx.enqueue_function[kernel, kernel](
+                                    q_tensor,
+                                    output_tensor,
+                                    start_pos_tensor,
+                                    k_cache,
+                                    freqs_tensor,
+                                    q_gamma_tensor,
+                                    k_gamma_tensor,
+                                    epsilon,
+                                    weight_offset,
+                                    total_rows,
+                                    grid_dim=ceildiv(total_rows, warps_per_block),
+                                    block_dim=block_size,
+                                )
+                        else:
+                            run_trial_fused(ctx)
+                    else:
+                        run_trial_fused(ctx)
+            else:
+                run_trial_fused(ctx)
+
+        @always_inline
+        @parameter
+        def trial_variant_bench(mut bencher: Bencher) raises:
+            bencher.iter_custom[run_trial](ctx)
+
+        bench.bench_function[trial_variant_bench](
+            BenchId(
+                "gemma3_qk_norm_rope_boundary_pair_trial",
+                input_id=String(
+                    dtype,
+                    "/bs=",
+                    batch_size,
+                    "/seq=",
+                    seq_len,
+                    "/cache=",
+                    cache_len,
+                    "/cache_step=",
+                    cache_len_step,
+                    "/pair_only/trial_only",
+                ),
+            ),
+        )
+    else:
+        @always_inline
+        @__copy_capture(
+            q_tensor,
+            input_row_offsets_tensor,
+            start_pos_tensor,
+            kv_collection,
+            freqs_tensor,
+            q_gamma_tensor,
+            k_gamma_tensor,
+            epsilon,
+            weight_offset,
+            output_tensor,
+        )
+        @parameter
+        def run_fused(ctx: DeviceContext) raises:
+            q_rms_norm_fused_qk_rope_ragged[
+                dtype,
+                dtype,
+                CollectionType,
+                interleaved=False,
+                target="gpu",
+            ](
+                q_tensor,
+                input_row_offsets_tensor,
+                start_pos_tensor,
+                kv_collection,
+                freqs_tensor,
+                q_gamma_tensor,
+                k_gamma_tensor,
+                epsilon,
+                weight_offset,
+                UInt32(layer_idx),
+                output_tensor,
+                ctx,
+            )
+
+        @always_inline
+        @parameter
+        def fused_variant_bench(mut bencher: Bencher) raises:
+            bencher.iter_custom[run_fused](ctx)
+
+        bench.bench_function[fused_variant_bench](
+            BenchId(
+                "gemma3_qk_norm_rope_boundary_pair_fused",
+                input_id=String(
+                    dtype,
+                    "/bs=",
+                    batch_size,
+                    "/seq=",
+                    seq_len,
+                    "/cache=",
+                    cache_len,
+                    "/cache_step=",
+                    cache_len_step,
+                    "/pair_only/fused_only",
+                ),
+            ),
+        )
+
+    _ = input_row_offsets_d
+    _ = cache_lengths_d
+    _ = q_gamma_d
+    _ = k_gamma_d
+    _ = freqs_d
+    _ = q_d
+    _ = output_d
+    _ = paged_lut_d
+    _ = kv_block_d
+
+    input_row_offsets_h.free()
+    cache_lengths_h.free()
+    q_gamma_h.free()
+    k_gamma_h.free()
+    freqs_h.free()
+    q_h.free()
+    paged_lut_h.free()
+    kv_block_seed_h.free()
+
+
+def main() raises:
+    comptime dtype = get_defined_dtype["dtype", DType.bfloat16]()
+    comptime head_dim = get_defined_int["head_dim", 128]()
+    comptime num_q_heads = get_defined_int["num_q_heads", 32]()
+    comptime num_kv_heads = get_defined_int["num_kv_heads", 16]()
+    comptime page_size = 128
+
+    var batch_size = arg_parse("batch_size", 64)
+    var seq_len = arg_parse("seq_len", 1)
+    var cache_len = arg_parse("cache_len", 1024)
+    var cache_len_step = arg_parse("cache_len_step", 0)
+    var trial_baseline_disable_decode_fastpath = arg_parse(
+        "trial_baseline_disable_decode_fastpath", False
+    )
+    var pair_only = arg_parse("pair_only", False)
+    var pair_variant = String(arg_parse("pair_variant", "both"))
+    var verify_results = arg_parse("verify", True)
+
+    seed(0)
+
+    var bench = Bench(BenchConfig(num_repetitions=1))
+    update_bench_config_args(bench)
+    with DeviceContext() as ctx:
+        if pair_only:
+            if pair_variant == "both":
+                bench_gemma3_qk_norm_rope_boundary_pair[
+                    dtype,
+                    head_dim,
+                    num_q_heads,
+                    num_kv_heads,
+                    page_size,
+                ](
+                    ctx,
+                    bench,
+                    batch_size,
+                    seq_len,
+                    cache_len,
+                    cache_len_step,
+                    trial_baseline_disable_decode_fastpath,
+                    verify_results,
+                )
+            elif pair_variant == "fused":
+                bench_gemma3_qk_norm_rope_boundary_pair_single_variant[
+                    dtype,
+                    head_dim,
+                    num_q_heads,
+                    num_kv_heads,
+                    page_size,
+                    run_trial_variant=False,
+                ](
+                    ctx,
+                    bench,
+                    batch_size,
+                    seq_len,
+                    cache_len,
+                    cache_len_step,
+                    trial_baseline_disable_decode_fastpath,
+                    verify_results,
+                )
+            elif pair_variant == "trial":
+                bench_gemma3_qk_norm_rope_boundary_pair_single_variant[
+                    dtype,
+                    head_dim,
+                    num_q_heads,
+                    num_kv_heads,
+                    page_size,
+                    run_trial_variant=True,
+                ](
+                    ctx,
+                    bench,
+                    batch_size,
+                    seq_len,
+                    cache_len,
+                    cache_len_step,
+                    trial_baseline_disable_decode_fastpath,
+                    verify_results,
+                )
+            else:
+                raise Error("pair_variant must be one of: both, fused, trial")
+        else:
+            if pair_variant != "both":
+                raise Error("pair_variant requires --pair_only=True")
+            bench_gemma3_qk_norm_rope_boundary[
+                dtype,
+                head_dim,
+                num_q_heads,
+                num_kv_heads,
+                page_size,
+            ](
+                ctx,
+                bench,
+                batch_size,
+                seq_len,
+                cache_len,
+                cache_len_step,
+                trial_baseline_disable_decode_fastpath,
+                verify_results,
+            )
+
+    bench.dump_report()

--- a/max/kernels/benchmarks/gpu/nn/bench_gemma3_rms_norm_boundary.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_gemma3_rms_norm_boundary.mojo
@@ -1,0 +1,271 @@
+from std.random import random_float64
+from std.sys import get_defined_dtype, simd_width_of
+
+from std.algorithm.functional import elementwise
+from std.benchmark import Bench, BenchConfig, Bencher, BenchId
+from std.gpu.host import DeviceContext
+from std.testing import assert_almost_equal
+from internal_utils import get_defined_shape, int_list_to_tuple
+from layout import Coord, Idx, TileTensor, row_major
+from nn.normalization import rms_norm_fused_residual_add_gpu, rms_norm_gpu
+
+from std.utils.index import Index, IndexList
+
+
+def bench_gemma3_rms_norm_boundary[
+    rank: Int, //, dtype: DType, shape: IndexList[rank]
+](ctx: DeviceContext, mut b: Bench) raises:
+    comptime cols = shape[rank - 1]
+    comptime rows = shape.flattened_length() // cols
+    comptime add_simd_width = simd_width_of[dtype]()
+
+    var data_h = alloc[Scalar[dtype]](rows * cols)
+    var residual_h = alloc[Scalar[dtype]](rows * cols)
+    var gamma1_h = alloc[Scalar[dtype]](cols)
+    var gamma2_h = alloc[Scalar[dtype]](cols)
+    var baseline_sum_h = alloc[Scalar[dtype]](rows * cols)
+    var baseline_output_h = alloc[Scalar[dtype]](rows * cols)
+    var fused_sum_h = alloc[Scalar[dtype]](rows * cols)
+    var fused_output_h = alloc[Scalar[dtype]](rows * cols)
+
+    for i in range(rows * cols):
+        data_h[i] = Scalar[dtype](random_float64(0, 100).cast[dtype]())
+        residual_h[i] = Scalar[dtype](random_float64(0, 100).cast[dtype]())
+
+    for i in range(cols):
+        gamma1_h[i] = (Float64(i + cols) / Float64(cols)).cast[dtype]()
+        gamma2_h[i] = (Float64(i + cols + 1) / Float64(cols)).cast[dtype]()
+
+    var data_d = ctx.enqueue_create_buffer[dtype](rows * cols)
+    var residual_d = ctx.enqueue_create_buffer[dtype](rows * cols)
+    var baseline_norm_d = ctx.enqueue_create_buffer[dtype](rows * cols)
+    var baseline_sum_d = ctx.enqueue_create_buffer[dtype](rows * cols)
+    var baseline_output_d = ctx.enqueue_create_buffer[dtype](rows * cols)
+    var fused_sum_d = ctx.enqueue_create_buffer[dtype](rows * cols)
+    var fused_output_d = ctx.enqueue_create_buffer[dtype](rows * cols)
+    var gamma1_d = ctx.enqueue_create_buffer[dtype](cols)
+    var gamma2_d = ctx.enqueue_create_buffer[dtype](cols)
+
+    var param_shape = Index(cols)
+
+    var data_buf = TileTensor(data_d, row_major(Coord(shape)))
+    var residual_buf = TileTensor(residual_d, row_major(Coord(shape)))
+    var baseline_norm_buf = TileTensor(
+        baseline_norm_d, row_major(Coord(shape))
+    )
+    var baseline_sum_buf = TileTensor(baseline_sum_d, row_major(Coord(shape)))
+    var baseline_output_buf = TileTensor(
+        baseline_output_d, row_major(Coord(shape))
+    )
+    var fused_sum_buf = TileTensor(fused_sum_d, row_major(Coord(shape)))
+    var fused_output_buf = TileTensor(fused_output_d, row_major(Coord(shape)))
+    var gamma1 = TileTensor(gamma1_d, row_major(Coord(param_shape)))
+    var gamma2 = TileTensor(gamma2_d, row_major(Coord(param_shape)))
+    var epsilon1 = Scalar[dtype](0.001)
+    var epsilon2 = Scalar[dtype](0.001)
+    # Gemma-family RMSNorm uses (1 + gamma).
+    var weight_offset1 = Scalar[dtype](1.0)
+    var weight_offset2 = Scalar[dtype](1.0)
+
+    ctx.enqueue_copy(data_d, data_h)
+    ctx.enqueue_copy(residual_d, residual_h)
+    ctx.enqueue_copy(gamma1_d, gamma1_h)
+    ctx.enqueue_copy(gamma2_d, gamma2_h)
+
+    @always_inline
+    @__copy_capture(data_buf)
+    @parameter
+    def input_fn[
+        width: Int, _rank: Int
+    ](coords: IndexList[_rank]) -> SIMD[dtype, width]:
+        return data_buf.load[width=width](Coord(coords))
+
+    @always_inline
+    @__copy_capture(residual_buf)
+    @parameter
+    def residual_input_fn[
+        width: Int, _rank: Int
+    ](coords: IndexList[_rank]) -> SIMD[dtype, width]:
+        return residual_buf.load[width=width](Coord(coords))
+
+    @always_inline
+    @__copy_capture(baseline_norm_buf)
+    @parameter
+    def baseline_norm_output_fn[
+        width: Int, alignment: Int
+    ](coords: IndexList[rank], val: SIMD[dtype, width]) -> None:
+        baseline_norm_buf.store[alignment=alignment](Coord(coords), val)
+
+    @always_inline
+    @__copy_capture(baseline_sum_buf)
+    @parameter
+    def baseline_sum_output_fn[
+        width: Int, alignment: Int
+    ](coords: IndexList[rank], val: SIMD[dtype, width]) -> None:
+        baseline_sum_buf.store[alignment=alignment](Coord(coords), val)
+
+    @always_inline
+    @__copy_capture(baseline_sum_buf)
+    @parameter
+    def baseline_sum_input_fn[
+        width: Int, _rank: Int
+    ](coords: IndexList[_rank]) -> SIMD[dtype, width]:
+        return baseline_sum_buf.load[width=width](Coord(coords))
+
+    @always_inline
+    @__copy_capture(baseline_output_buf)
+    @parameter
+    def baseline_output_fn[
+        width: Int, alignment: Int
+    ](coords: IndexList[rank], val: SIMD[dtype, width]) -> None:
+        baseline_output_buf.store[alignment=alignment](Coord(coords), val)
+
+    @always_inline
+    @__copy_capture(fused_sum_buf)
+    @parameter
+    def fused_sum_output_fn[
+        width: Int, alignment: Int
+    ](coords: IndexList[rank], val: SIMD[dtype, width]) -> None:
+        fused_sum_buf.store[alignment=alignment](Coord(coords), val)
+
+    @always_inline
+    @__copy_capture(fused_output_buf)
+    @parameter
+    def fused_output_fn[
+        width: Int, alignment: Int
+    ](coords: IndexList[rank], val: SIMD[dtype, width]) -> None:
+        fused_output_buf.store[alignment=alignment](Coord(coords), val)
+
+    @always_inline
+    @__copy_capture(baseline_norm_buf, residual_buf, baseline_sum_buf)
+    @parameter
+    def add_kernel[
+        width: Int, _rank: Int, alignment: Int = 1
+    ](coords: IndexList[_rank]) -> None:
+        var coord = Coord(coords)
+        var val = baseline_norm_buf.load[width=width](coord) + residual_buf.load[
+            width=width
+        ](coord)
+        baseline_sum_buf.store[width=width](coord, val)
+
+    @always_inline
+    @__copy_capture(
+        shape,
+        gamma1,
+        epsilon1,
+        weight_offset1,
+        gamma2,
+        epsilon2,
+        weight_offset2,
+    )
+    @parameter
+    def run_baseline(ctx: DeviceContext) raises:
+        rms_norm_gpu[
+            input_fn, baseline_norm_output_fn, multiply_before_cast=True
+        ](shape, gamma1, epsilon1, weight_offset1, ctx)
+        elementwise[add_kernel, simd_width=add_simd_width, target="gpu"](
+            shape, ctx
+        )
+        rms_norm_gpu[
+            baseline_sum_input_fn,
+            baseline_output_fn,
+            multiply_before_cast=True,
+        ](shape, gamma2, epsilon2, weight_offset2, ctx)
+
+    @always_inline
+    @__copy_capture(
+        shape,
+        gamma1,
+        epsilon1,
+        weight_offset1,
+        gamma2,
+        epsilon2,
+        weight_offset2,
+    )
+    @parameter
+    def run_fused(ctx: DeviceContext) raises:
+        rms_norm_fused_residual_add_gpu[
+            input_fn,
+            residual_input_fn,
+            fused_sum_output_fn,
+            fused_output_fn,
+            multiply_before_cast=True,
+        ](
+            shape,
+            gamma1,
+            epsilon1,
+            weight_offset1,
+            gamma2,
+            epsilon2,
+            weight_offset2,
+            ctx,
+        )
+
+    @always_inline
+    @parameter
+    def baseline_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_baseline](ctx)
+
+    @always_inline
+    @parameter
+    def fused_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_fused](ctx)
+
+    b.bench_function[baseline_bench](
+        BenchId(
+            "gemma3_rms_norm_boundary_baseline",
+            input_id=String(dtype, "/", shape),
+        ),
+    )
+    b.bench_function[fused_bench](
+        BenchId(
+            "gemma3_rms_norm_boundary_fused",
+            input_id=String(dtype, "/", shape),
+        ),
+    )
+
+    run_baseline(ctx)
+    run_fused(ctx)
+    ctx.enqueue_copy(baseline_sum_h, baseline_sum_d)
+    ctx.enqueue_copy(baseline_output_h, baseline_output_d)
+    ctx.enqueue_copy(fused_sum_h, fused_sum_d)
+    ctx.enqueue_copy(fused_output_h, fused_output_d)
+    ctx.synchronize()
+
+    for i in range(rows * cols):
+        assert_almost_equal(
+            baseline_sum_h[i], fused_sum_h[i], rtol=2e-2, atol=2e-2
+        )
+        assert_almost_equal(
+            baseline_output_h[i], fused_output_h[i], rtol=2e-2, atol=2e-2
+        )
+
+    _ = data_d
+    _ = residual_d
+    _ = baseline_norm_d
+    _ = baseline_sum_d
+    _ = baseline_output_d
+    _ = fused_sum_d
+    _ = fused_output_d
+    _ = gamma1_d
+    _ = gamma2_d
+
+    data_h.free()
+    residual_h.free()
+    gamma1_h.free()
+    gamma2_h.free()
+    baseline_sum_h.free()
+    baseline_output_h.free()
+    fused_sum_h.free()
+    fused_output_h.free()
+
+
+def main() raises:
+    comptime dtype = get_defined_dtype["dtype", DType.bfloat16]()
+    comptime shape = int_list_to_tuple[get_defined_shape["shape", "1x64x4608"]()]()
+
+    var b = Bench(BenchConfig(num_repetitions=1))
+    with DeviceContext() as ctx:
+        bench_gemma3_rms_norm_boundary[dtype, shape](ctx, b)
+
+    b.dump_report()

--- a/max/kernels/benchmarks/gpu/nn/bench_kv_cache_ragged_k_rope.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_kv_cache_ragged_k_rope.mojo
@@ -1,0 +1,256 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import ceildiv
+from std.random import seed
+from std.sys import get_defined_dtype, get_defined_int
+from std.sys.info import size_of
+
+from std.benchmark import (
+    Bench,
+    Bencher,
+    BenchId,
+    BenchMetric,
+    ThroughputMeasure,
+)
+from std.gpu.host import DeviceContext, get_gpu_target
+from internal_utils import arg_parse
+from kv_cache.types import KVCacheStaticParams, PagedKVCacheCollection
+from layout import (
+    Idx,
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    UNKNOWN_VALUE,
+    row_major,
+)
+from layout._fillers import random
+from nn.rope import _rope_k_cache_ragged
+
+from std.utils import IndexList
+
+
+def _get_run_name[
+    dtype: DType, num_kv_heads: Int, head_dim: Int, page_size: Int
+](batch_size: Int, seq_len: Int, cache_len: Int) -> String:
+    return String(
+        "k_cache_rope(",
+        dtype,
+        ") : num_kv_heads=",
+        num_kv_heads,
+        ", head_dim=",
+        head_dim,
+        ", page_size=",
+        page_size,
+        " : batch_size=",
+        batch_size,
+        ", seq_len=",
+        seq_len,
+        ", cache_len=",
+        cache_len,
+    )
+
+
+def execute_kv_cache_ragged_k_rope[
+    dtype: DType, head_dim: Int, num_kv_heads: Int, page_size: Int
+](
+    ctx: DeviceContext,
+    mut m: Bench,
+    batch_size: Int,
+    seq_len: Int,
+    cache_len: Int,
+) raises:
+    comptime num_layers = 1
+    comptime layer_idx = 0
+    comptime kv_params = KVCacheStaticParams(
+        num_heads=UInt(num_kv_heads), head_size=UInt(head_dim)
+    )
+    comptime CollectionType = PagedKVCacheCollection[dtype, kv_params, page_size]
+
+    var total_seq_len = UInt32(batch_size * seq_len)
+    var max_context_length = seq_len + cache_len
+    var paged_lut_cols = ceildiv(max_context_length, page_size)
+    var num_pages = batch_size * paged_lut_cols
+
+    var input_row_offsets_host_ptr = alloc[Scalar[DType.uint32]](batch_size + 1)
+    var cache_lengths_host_ptr = alloc[Scalar[DType.uint32]](batch_size)
+
+    for i in range(batch_size):
+        input_row_offsets_host_ptr[i] = UInt32(i * seq_len)
+        cache_lengths_host_ptr[i] = UInt32(cache_len)
+    input_row_offsets_host_ptr[batch_size] = total_seq_len
+
+    var input_row_offsets_dev_buffer = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size + 1
+    )
+    ctx.enqueue_copy(input_row_offsets_dev_buffer, input_row_offsets_host_ptr)
+
+    var cache_lengths_dev_buffer = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size
+    )
+    ctx.enqueue_copy(cache_lengths_dev_buffer, cache_lengths_host_ptr)
+
+    var paged_lut_size = batch_size * paged_lut_cols
+    var paged_lut_host_ptr = alloc[Scalar[DType.uint32]](paged_lut_size)
+    comptime paged_lut_layout = Layout.row_major[2]()
+    var paged_lut_host = LayoutTensor[
+        DType.uint32, paged_lut_layout, MutAnyOrigin
+    ](
+        paged_lut_host_ptr,
+        RuntimeLayout[paged_lut_layout].row_major(
+            IndexList[2](batch_size, paged_lut_cols)
+        ),
+    )
+
+    # Assign each request a deterministic, non-overlapping page range.
+    for bs in range(batch_size):
+        for page_idx in range(paged_lut_cols):
+            paged_lut_host[bs, page_idx] = UInt32(bs * paged_lut_cols + page_idx)
+
+    var paged_lut_dev_buffer = ctx.enqueue_create_buffer[DType.uint32](
+        paged_lut_size
+    )
+    ctx.enqueue_copy(paged_lut_dev_buffer, paged_lut_host_ptr)
+
+    var kv_block_shape = IndexList[6](
+        num_pages,
+        2,
+        num_layers,
+        page_size,
+        num_kv_heads,
+        head_dim,
+    )
+    var kv_block_size = kv_block_shape.flattened_length()
+    var kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    random(
+        LayoutTensor[dtype, Layout.row_major[6](), MutAnyOrigin](
+            kv_block_host_ptr,
+            RuntimeLayout[Layout.row_major[6]()].row_major(kv_block_shape),
+        )
+    )
+    var kv_block_dev_buffer = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    ctx.enqueue_copy(kv_block_dev_buffer, kv_block_host_ptr)
+
+    comptime kv_block_layout = Layout.row_major[6]()
+    var kv_block_layout_tensor = LayoutTensor[
+        dtype, kv_block_layout, MutAnyOrigin
+    ](
+        kv_block_dev_buffer.unsafe_ptr(),
+        RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+    )
+
+    comptime cache_lengths_layout = Layout(UNKNOWN_VALUE)
+    var cache_lengths_layout_tensor = LayoutTensor[
+        DType.uint32, cache_lengths_layout, ImmutAnyOrigin
+    ](
+        cache_lengths_dev_buffer.unsafe_ptr(),
+        RuntimeLayout[cache_lengths_layout].row_major(IndexList[1](batch_size)),
+    )
+
+    var paged_lut_layout_tensor = LayoutTensor[
+        DType.uint32, paged_lut_layout, ImmutAnyOrigin
+    ](
+        paged_lut_dev_buffer.unsafe_ptr(),
+        RuntimeLayout[paged_lut_layout].row_major(
+            IndexList[2](batch_size, paged_lut_cols)
+        ),
+    )
+
+    var kv_collection = CollectionType(
+        kv_block_layout_tensor,
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+
+    var input_row_offsets_tensor = TileTensor(
+        input_row_offsets_dev_buffer.unsafe_ptr(),
+        row_major(Idx(batch_size + 1)),
+    )
+    var freqs_cis_layout = row_major(Idx(max_context_length), Idx[head_dim]())
+    var freqs_cis_device = ctx.enqueue_create_buffer[dtype](
+        max_context_length * head_dim
+    )
+    with freqs_cis_device.map_to_host() as freqs_host:
+        random(TileTensor(freqs_host, freqs_cis_layout))
+    var freqs_cis_tensor = TileTensor(
+        freqs_cis_device.unsafe_ptr(), freqs_cis_layout
+    )
+
+    var num_bytes = (
+        3 * Int(total_seq_len) * num_kv_heads * head_dim * size_of[dtype]()
+    )
+
+    @parameter
+    @__copy_capture(kv_collection, input_row_offsets_tensor, freqs_cis_tensor)
+    @always_inline
+    def bench_func(mut b: Bencher):
+        @parameter
+        @always_inline
+        def kernel_launch(ctx: DeviceContext) raises:
+            _rope_k_cache_ragged[target="gpu", interleaved=False](
+                Int(total_seq_len),
+                input_row_offsets_tensor,
+                kv_collection,
+                freqs_cis_tensor,
+                UInt32(layer_idx),
+                ctx,
+            )
+
+        b.iter_custom[kernel_launch](ctx)
+
+    m.bench_function[bench_func](
+        BenchId(
+            _get_run_name[dtype, num_kv_heads, head_dim, page_size](
+                batch_size, seq_len, cache_len
+            )
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+    ctx.synchronize()
+
+    input_row_offsets_host_ptr.free()
+    cache_lengths_host_ptr.free()
+    paged_lut_host_ptr.free()
+    kv_block_host_ptr.free()
+
+    _ = input_row_offsets_dev_buffer^
+    _ = cache_lengths_dev_buffer^
+    _ = paged_lut_dev_buffer^
+    _ = kv_block_dev_buffer^
+    _ = freqs_cis_device^
+
+
+def main() raises:
+    comptime dtype = get_defined_dtype["dtype", DType.bfloat16]()
+    comptime head_dim = get_defined_int["head_dim", 128]()
+    comptime num_kv_heads = get_defined_int["num_kv_heads", 16]()
+
+    var batch_size = arg_parse("batch_size", 1)
+    var seq_len = arg_parse("seq_len", 1)
+    var cache_len = arg_parse("cache_len", 0)
+
+    seed(0)
+
+    var m = Bench()
+    with DeviceContext() as ctx:
+        execute_kv_cache_ragged_k_rope[
+            dtype,
+            head_dim,
+            num_kv_heads,
+            512,
+        ](ctx, m, batch_size, seq_len, cache_len)
+
+    m.dump_report()

--- a/max/kernels/benchmarks/gpu/nn/bench_kv_cache_ragged_rms_norm.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_kv_cache_ragged_rms_norm.mojo
@@ -1,0 +1,2280 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import ceildiv
+from std.random import seed
+from std.sys import get_defined_dtype, get_defined_int
+from std.sys.info import size_of
+
+from std.benchmark import (
+    Bench,
+    Bencher,
+    BenchId,
+    BenchMetric,
+    ThroughputMeasure,
+)
+from std.gpu import WARP_SIZE
+from std.gpu.host import DeviceContext
+from std.gpu.primitives.grid_controls import PDLLevel, pdl_launch_attributes
+from std.runtime.asyncrt import DeviceContextPtr
+from std.runtime.tracing import Trace, TraceLevel, get_safe_task_id
+from std.testing import assert_almost_equal
+from internal_utils import arg_parse
+from kv_cache.types import KVCacheStaticParams, PagedKVCacheCollection
+from layout import (
+    Idx,
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    UNKNOWN_VALUE,
+    row_major,
+)
+from layout._fillers import random
+from nn._ragged_utils import get_batch_from_row_offsets
+from nn.kv_cache import rms_norm_kv_cache_ragged_paged
+from nn.normalization import _rms_norm_impl, rms_norm_gpu, rms_norm_gpu_warp_tiling_128
+
+from std.utils import IndexList
+
+
+def _get_run_name[
+    dtype: DType, num_kv_heads: Int, head_dim: Int, page_size: Int
+](batch_size: Int, seq_len: Int, cache_len: Int) -> String:
+    return String(
+        "rms_norm_key_cache(",
+        dtype,
+        ") : num_kv_heads=",
+        num_kv_heads,
+        ", head_dim=",
+        head_dim,
+        ", page_size=",
+        page_size,
+        " : batch_size=",
+        batch_size,
+        ", seq_len=",
+        seq_len,
+        ", cache_len=",
+        cache_len,
+    )
+
+
+def _rms_norm_kv_cache_decode_direct_trial[
+    dtype: DType,
+    params: KVCacheStaticParams,
+    page_size: Int,
+    cache_dtype: DType,
+    //,
+    multiply_before_cast: Bool,
+    per_head_norm: Bool,
+](
+    kv_collection: PagedKVCacheCollection[cache_dtype, params, page_size],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    total_seq_len: UInt32,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    ctx: DeviceContext,
+) raises:
+    comptime assert per_head_norm, (
+        "The benchmark-local direct KV RMSNorm trial expects per-head norm"
+    )
+    comptime rms_norm_cols = gamma.static_shape[0]
+    comptime head_size = Int(params.head_size)
+    comptime assert rms_norm_cols != -1, "Need static gamma shape"
+
+    comptime if dtype != DType.bfloat16 or rms_norm_cols != 128 or head_size != 128:
+        rms_norm_kv_cache_ragged_paged[
+            dtype=dtype,
+            params=params,
+            page_size=page_size,
+            cache_dtype=cache_dtype,
+            target="gpu",
+            multiply_before_cast=multiply_before_cast,
+            per_head_norm=per_head_norm,
+        ](
+            kv_collection,
+            gamma,
+            epsilon,
+            weight_offset,
+            layer_idx,
+            total_seq_len,
+            input_row_offsets,
+            ctx,
+        )
+    else:
+        var batch_size = Int(input_row_offsets.dim(0)) - 1
+        var is_decode_uniform = Int(total_seq_len) == batch_size
+
+        if not is_decode_uniform:
+            rms_norm_kv_cache_ragged_paged[
+                dtype=dtype,
+                params=params,
+                page_size=page_size,
+                cache_dtype=cache_dtype,
+                target="gpu",
+                multiply_before_cast=multiply_before_cast,
+                per_head_norm=per_head_norm,
+            ](
+                kv_collection,
+                gamma,
+                epsilon,
+                weight_offset,
+                layer_idx,
+                total_seq_len,
+                input_row_offsets,
+                ctx,
+            )
+            return
+
+        var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+        var num_rows = Int(total_seq_len) * Int(params.num_heads)
+        comptime simd_width = 8
+        comptime default_warps_per_block = 2
+        comptime large_row_warps_per_block = 8
+        comptime default_block_size = default_warps_per_block * WARP_SIZE
+        comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
+        comptime min_large_row_blocks_per_sm = 5
+        var min_large_row_blocks = (
+            ctx.default_device_info.sm_count * min_large_row_blocks_per_sm
+        )
+        var large_row_grid_dim = ceildiv(
+            num_rows, large_row_warps_per_block * 2
+        )
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache)
+        def direct_input_fn_2d[width: Int](
+            row: Int, col: Int
+        ) -> SIMD[dtype, width]:
+            var batch_idx = row // Int(params.num_heads)
+            var head_idx = row % Int(params.num_heads)
+            var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+            return k_cache.load[width=width](
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=head_idx,
+                head_dim_idx=col,
+            ).cast[dtype]()
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache)
+        def direct_output_fn_2d[width: Int, alignment: Int](
+            row: Int, col: Int, val: SIMD[dtype, width]
+        ) -> None:
+            var batch_idx = row // Int(params.num_heads)
+            var head_idx = row % Int(params.num_heads)
+            var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+            k_cache.store(
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=head_idx,
+                head_dim_idx=col,
+                val=val.cast[cache_dtype](),
+            )
+
+        if large_row_grid_dim >= min_large_row_blocks:
+            comptime kernel = rms_norm_gpu_warp_tiling_128[
+                mut=gamma.mut,
+                LayoutType=gamma.LayoutType,
+                origin=gamma.origin,
+                simd_width,
+                large_row_warps_per_block,
+                direct_input_fn_2d,
+                direct_output_fn_2d,
+                multiply_before_cast=multiply_before_cast,
+            ]
+            ctx.enqueue_function[kernel, kernel](
+                gamma,
+                epsilon,
+                weight_offset,
+                num_rows,
+                rms_norm_cols,
+                grid_dim=large_row_grid_dim,
+                block_dim=large_row_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+        else:
+            comptime kernel = rms_norm_gpu_warp_tiling_128[
+                mut=gamma.mut,
+                LayoutType=gamma.LayoutType,
+                origin=gamma.origin,
+                simd_width,
+                default_warps_per_block,
+                direct_input_fn_2d,
+                direct_output_fn_2d,
+                multiply_before_cast=multiply_before_cast,
+            ]
+            ctx.enqueue_function[kernel, kernel](
+                gamma,
+                epsilon,
+                weight_offset,
+                num_rows,
+                rms_norm_cols,
+                grid_dim=ceildiv(num_rows, default_warps_per_block * 2),
+                block_dim=default_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+
+
+def _rms_norm_kv_cache_decode_uniform_rank3_trial[
+    dtype: DType,
+    params: KVCacheStaticParams,
+    page_size: Int,
+    cache_dtype: DType,
+    //,
+    multiply_before_cast: Bool,
+    per_head_norm: Bool,
+](
+    kv_collection: PagedKVCacheCollection[cache_dtype, params, page_size],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    total_seq_len: UInt32,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    ctx: DeviceContext,
+) raises:
+    comptime assert per_head_norm, (
+        "The benchmark-local rank-3 KV RMSNorm trial expects per-head norm"
+    )
+    comptime rms_norm_cols = gamma.static_shape[0]
+    comptime head_size = Int(params.head_size)
+    comptime assert rms_norm_cols != -1, "Need static gamma shape"
+
+    comptime if dtype != DType.bfloat16 or rms_norm_cols != 128 or head_size != 128:
+        rms_norm_kv_cache_ragged_paged[
+            dtype=dtype,
+            params=params,
+            page_size=page_size,
+            cache_dtype=cache_dtype,
+            target="gpu",
+            multiply_before_cast=multiply_before_cast,
+            per_head_norm=per_head_norm,
+        ](
+            kv_collection,
+            gamma,
+            epsilon,
+            weight_offset,
+            layer_idx,
+            total_seq_len,
+            input_row_offsets,
+            ctx,
+        )
+    else:
+        var batch_size = Int(input_row_offsets.dim(0)) - 1
+        var is_decode_uniform = Int(total_seq_len) == batch_size
+
+        if not is_decode_uniform:
+            rms_norm_kv_cache_ragged_paged[
+                dtype=dtype,
+                params=params,
+                page_size=page_size,
+                cache_dtype=cache_dtype,
+                target="gpu",
+                multiply_before_cast=multiply_before_cast,
+                per_head_norm=per_head_norm,
+            ](
+                kv_collection,
+                gamma,
+                epsilon,
+                weight_offset,
+                layer_idx,
+                total_seq_len,
+                input_row_offsets,
+                ctx,
+            )
+            return
+
+        var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+        var shape = IndexList[3](
+            Int(total_seq_len), Int(params.num_heads), rms_norm_cols
+        )
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache)
+        def uniform_rank3_input_fn[width: Int, rank: Int](
+            idx: IndexList[rank]
+        ) -> SIMD[dtype, width]:
+            comptime assert rank == 3
+
+            var batch_idx = idx[0]
+            var head_idx = idx[1]
+            var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+            return k_cache.load[width=width](
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=head_idx,
+                head_dim_idx=idx[2],
+            ).cast[dtype]()
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache)
+        def uniform_rank3_output_fn[width: Int, alignment: Int](
+            idx: IndexList[3], val: SIMD[dtype, width]
+        ) -> None:
+            var batch_idx = idx[0]
+            var head_idx = idx[1]
+            var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+            k_cache.store(
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=head_idx,
+                head_dim_idx=idx[2],
+                val=val.cast[cache_dtype](),
+            )
+
+        rms_norm_gpu[
+            uniform_rank3_input_fn,
+            uniform_rank3_output_fn,
+            multiply_before_cast=multiply_before_cast,
+        ](shape, gamma, epsilon, weight_offset, ctx)
+
+
+def _rms_norm_kv_cache_decode_uniform_impl_trial[
+    dtype: DType,
+    params: KVCacheStaticParams,
+    page_size: Int,
+    cache_dtype: DType,
+    //,
+    multiply_before_cast: Bool,
+    per_head_norm: Bool,
+](
+    kv_collection: PagedKVCacheCollection[cache_dtype, params, page_size],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    total_seq_len: UInt32,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    ctx: DeviceContext,
+) raises:
+    comptime assert per_head_norm, (
+        "The benchmark-local impl KV RMSNorm trial expects per-head norm"
+    )
+    comptime rms_norm_cols = gamma.static_shape[0]
+    comptime head_size = Int(params.head_size)
+    comptime assert rms_norm_cols != -1, "Need static gamma shape"
+
+    comptime if dtype != DType.bfloat16 or rms_norm_cols != 128 or head_size != 128:
+        rms_norm_kv_cache_ragged_paged[
+            dtype=dtype,
+            params=params,
+            page_size=page_size,
+            cache_dtype=cache_dtype,
+            target="gpu",
+            multiply_before_cast=multiply_before_cast,
+            per_head_norm=per_head_norm,
+        ](
+            kv_collection,
+            gamma,
+            epsilon,
+            weight_offset,
+            layer_idx,
+            total_seq_len,
+            input_row_offsets,
+            ctx,
+        )
+    else:
+        var batch_size = Int(input_row_offsets.dim(0)) - 1
+        var is_decode_uniform = Int(total_seq_len) == batch_size
+
+        if not is_decode_uniform:
+            rms_norm_kv_cache_ragged_paged[
+                dtype=dtype,
+                params=params,
+                page_size=page_size,
+                cache_dtype=cache_dtype,
+                target="gpu",
+                multiply_before_cast=multiply_before_cast,
+                per_head_norm=per_head_norm,
+            ](
+                kv_collection,
+                gamma,
+                epsilon,
+                weight_offset,
+                layer_idx,
+                total_seq_len,
+                input_row_offsets,
+                ctx,
+            )
+            return
+
+        var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+        var shape = IndexList[3](
+            Int(total_seq_len), Int(params.num_heads), rms_norm_cols
+        )
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache)
+        def uniform_decode_input_fn[width: Int, rank: Int](
+            idx: IndexList[rank]
+        ) -> SIMD[dtype, width]:
+            comptime assert rank == 3
+
+            var batch_idx = idx[0]
+            var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+            return k_cache.load[width=width](
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=idx[1],
+                head_dim_idx=idx[2],
+            ).cast[dtype]()
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache)
+        def uniform_decode_output_fn[width: Int, alignment: Int](
+            idx: IndexList[3], val: SIMD[dtype, width]
+        ) -> None:
+            var batch_idx = idx[0]
+            var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+            k_cache.store(
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=idx[1],
+                head_dim_idx=idx[2],
+                val=val.cast[cache_dtype](),
+            )
+
+        _rms_norm_impl[
+            dtype,
+            3,
+            uniform_decode_input_fn,
+            uniform_decode_output_fn,
+            target="gpu",
+            multiply_before_cast=multiply_before_cast,
+        ](shape, gamma, epsilon, weight_offset, ctx)
+
+
+def _rms_norm_kv_cache_decode_uniform_trace_trial[
+    dtype: DType,
+    params: KVCacheStaticParams,
+    page_size: Int,
+    cache_dtype: DType,
+    //,
+    multiply_before_cast: Bool,
+    per_head_norm: Bool,
+](
+    kv_collection: PagedKVCacheCollection[cache_dtype, params, page_size],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    total_seq_len: UInt32,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    ctx: DeviceContextPtr,
+) raises:
+    comptime assert per_head_norm, (
+        "The benchmark-local traced impl KV RMSNorm trial expects per-head norm"
+    )
+    comptime rms_norm_cols = gamma.static_shape[0]
+    comptime head_size = Int(params.head_size)
+    comptime assert rms_norm_cols != -1, "Need static gamma shape"
+
+    comptime if dtype != DType.bfloat16 or rms_norm_cols != 128 or head_size != 128:
+        rms_norm_kv_cache_ragged_paged[
+            dtype=dtype,
+            params=params,
+            page_size=page_size,
+            cache_dtype=cache_dtype,
+            target="gpu",
+            multiply_before_cast=multiply_before_cast,
+            per_head_norm=per_head_norm,
+        ](
+            kv_collection,
+            gamma,
+            epsilon,
+            weight_offset,
+            layer_idx,
+            total_seq_len,
+            input_row_offsets,
+            ctx,
+        )
+    else:
+        var batch_size = Int(input_row_offsets.dim(0)) - 1
+        var is_decode_uniform = Int(total_seq_len) == batch_size
+
+        if not is_decode_uniform:
+            rms_norm_kv_cache_ragged_paged[
+                dtype=dtype,
+                params=params,
+                page_size=page_size,
+                cache_dtype=cache_dtype,
+                target="gpu",
+                multiply_before_cast=multiply_before_cast,
+                per_head_norm=per_head_norm,
+            ](
+                kv_collection,
+                gamma,
+                epsilon,
+                weight_offset,
+                layer_idx,
+                total_seq_len,
+                input_row_offsets,
+                ctx,
+            )
+            return
+
+        var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+        var shape = IndexList[3](
+            Int(total_seq_len), Int(params.num_heads), rms_norm_cols
+        )
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache)
+        def uniform_decode_input_fn[width: Int, rank: Int](
+            idx: IndexList[rank]
+        ) -> SIMD[dtype, width]:
+            comptime assert rank == 3
+
+            var batch_idx = idx[0]
+            var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+            return k_cache.load[width=width](
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=idx[1],
+                head_dim_idx=idx[2],
+            ).cast[dtype]()
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache)
+        def uniform_decode_output_fn[width: Int, alignment: Int](
+            idx: IndexList[3], val: SIMD[dtype, width]
+        ) -> None:
+            var batch_idx = idx[0]
+            var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+            k_cache.store(
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=idx[1],
+                head_dim_idx=idx[2],
+                val=val.cast[cache_dtype](),
+            )
+
+        with Trace[TraceLevel.OP, target=StaticString("gpu")](
+            "rms_norm_kv_cache_ragged_paged_nhead_"
+            + String(kv_collection.kv_params.num_heads)
+            + ".hdim_"
+            + String(kv_collection.kv_params.head_size),
+            task_id=get_safe_task_id(ctx),
+        ):
+            _rms_norm_impl[
+                dtype,
+                3,
+                uniform_decode_input_fn,
+                uniform_decode_output_fn,
+                target="gpu",
+                multiply_before_cast=multiply_before_cast,
+            ](shape, gamma, epsilon, weight_offset, ctx)
+
+
+def _rms_norm_kv_cache_decode_uniform_trace_no_task_trial[
+    dtype: DType,
+    params: KVCacheStaticParams,
+    page_size: Int,
+    cache_dtype: DType,
+    //,
+    multiply_before_cast: Bool,
+    per_head_norm: Bool,
+](
+    kv_collection: PagedKVCacheCollection[cache_dtype, params, page_size],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    total_seq_len: UInt32,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    ctx: DeviceContextPtr,
+) raises:
+    comptime assert per_head_norm, (
+        "The benchmark-local traced no-task impl KV RMSNorm trial expects per-head norm"
+    )
+    comptime rms_norm_cols = gamma.static_shape[0]
+    comptime head_size = Int(params.head_size)
+    comptime assert rms_norm_cols != -1, "Need static gamma shape"
+
+    comptime if dtype != DType.bfloat16 or rms_norm_cols != 128 or head_size != 128:
+        rms_norm_kv_cache_ragged_paged[
+            dtype=dtype,
+            params=params,
+            page_size=page_size,
+            cache_dtype=cache_dtype,
+            target="gpu",
+            multiply_before_cast=multiply_before_cast,
+            per_head_norm=per_head_norm,
+        ](
+            kv_collection,
+            gamma,
+            epsilon,
+            weight_offset,
+            layer_idx,
+            total_seq_len,
+            input_row_offsets,
+            ctx,
+        )
+    else:
+        var batch_size = Int(input_row_offsets.dim(0)) - 1
+        var is_decode_uniform = Int(total_seq_len) == batch_size
+
+        if not is_decode_uniform:
+            rms_norm_kv_cache_ragged_paged[
+                dtype=dtype,
+                params=params,
+                page_size=page_size,
+                cache_dtype=cache_dtype,
+                target="gpu",
+                multiply_before_cast=multiply_before_cast,
+                per_head_norm=per_head_norm,
+            ](
+                kv_collection,
+                gamma,
+                epsilon,
+                weight_offset,
+                layer_idx,
+                total_seq_len,
+                input_row_offsets,
+                ctx,
+            )
+            return
+
+        var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+        var shape = IndexList[3](
+            Int(total_seq_len), Int(params.num_heads), rms_norm_cols
+        )
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache)
+        def uniform_decode_input_fn[width: Int, rank: Int](
+            idx: IndexList[rank]
+        ) -> SIMD[dtype, width]:
+            comptime assert rank == 3
+
+            var batch_idx = idx[0]
+            var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+            return k_cache.load[width=width](
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=idx[1],
+                head_dim_idx=idx[2],
+            ).cast[dtype]()
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache)
+        def uniform_decode_output_fn[width: Int, alignment: Int](
+            idx: IndexList[3], val: SIMD[dtype, width]
+        ) -> None:
+            var batch_idx = idx[0]
+            var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+            k_cache.store(
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=idx[1],
+                head_dim_idx=idx[2],
+                val=val.cast[cache_dtype](),
+            )
+
+        with Trace[TraceLevel.OP, target=StaticString("gpu")](
+            "rms_norm_kv_cache_ragged_paged_nhead_"
+            + String(kv_collection.kv_params.num_heads)
+            + ".hdim_"
+            + String(kv_collection.kv_params.head_size)
+        ):
+            _rms_norm_impl[
+                dtype,
+                3,
+                uniform_decode_input_fn,
+                uniform_decode_output_fn,
+                target="gpu",
+                multiply_before_cast=multiply_before_cast,
+            ](shape, gamma, epsilon, weight_offset, ctx)
+
+
+def _rms_norm_kv_cache_production_clone_trial[
+    dtype: DType,
+    params: KVCacheStaticParams,
+    page_size: Int,
+    cache_dtype: DType,
+    //,
+    multiply_before_cast: Bool,
+    per_head_norm: Bool,
+](
+    kv_collection: PagedKVCacheCollection[cache_dtype, params, page_size],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    total_seq_len: UInt32,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    context: DeviceContextPtr,
+) raises:
+    """Benchmark-local copy of the production helper, including the generic
+    ragged lambdas plus the uniform-decode specialization."""
+    comptime assert gamma.flat_rank == 1, "gamma must be rank 1"
+    comptime assert (
+        input_row_offsets.flat_rank == 1
+    ), "input_row_offsets must be rank 1"
+
+    comptime rank = 3 if per_head_norm else 2
+    var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+    var kv_params = k_cache.kv_params
+    comptime rms_norm_cols = gamma.static_shape[0]
+
+    comptime assert rms_norm_cols != -1, "Need static shape for gamma"
+    comptime assert (
+        rms_norm_cols <= Int(kv_collection.kv_params.head_size)
+        or not per_head_norm
+    ), "Length of gamma must be smaller or equal to head size"
+    comptime has_uniform_decode_rank3_specialization = (
+        per_head_norm
+        and dtype == DType.bfloat16
+        and cache_dtype == DType.bfloat16
+        and rms_norm_cols == 128
+        and Int(params.head_size) == 128
+        and page_size == 128
+    )
+    var batch_size = Int(input_row_offsets.dim(0)) - 1
+    var use_uniform_decode_batch_mapping = False
+
+    comptime if has_uniform_decode_rank3_specialization:
+        use_uniform_decode_batch_mapping = (
+            kv_collection.max_seq_length == 1
+            and total_seq_len == UInt32(batch_size)
+        )
+
+    var shape = IndexList[rank]()
+    shape[0] = Int(total_seq_len)
+
+    comptime if per_head_norm:
+        shape[1] = Int(kv_params.num_heads)
+        shape[2] = rms_norm_cols
+    else:
+        shape[1] = rms_norm_cols
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache, input_row_offsets)
+    def key_cache_input_fn[
+        width: Int, rank_: Int
+    ](idx: IndexList[rank_]) -> SIMD[dtype, width]:
+        comptime assert (
+            rank_ == rank
+        ), "rms_norm_key_cache input lambda index should have rank " + String(
+            rank
+        )
+
+        var global_token_idx = idx[0]
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+
+        var cache_length = k_cache.cache_length(batch_idx)
+        var cache_token_idx = token_idx + cache_length
+
+        var head_idx: Int
+        var head_dim_idx: Int
+
+        comptime if per_head_norm:
+            head_idx = idx[1]
+            head_dim_idx = idx[2]
+        else:
+            head_idx = idx[1] // Int(params.head_size)
+            head_dim_idx = idx[1] % Int(params.head_size)
+
+        return k_cache.load[width=width](
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=head_idx,
+            head_dim_idx=head_dim_idx,
+        ).cast[dtype]()
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache, input_row_offsets)
+    def key_cache_output_fn[
+        width: Int, alignment: Int
+    ](idx: IndexList[rank], val: SIMD[dtype, width]) -> None:
+        var global_token_idx = idx[0]
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+
+        var cache_length = k_cache.cache_length(batch_idx)
+        var cache_token_idx = token_idx + cache_length
+
+        var head_idx: Int
+        var head_dim_idx: Int
+
+        comptime if per_head_norm:
+            head_idx = idx[1]
+            head_dim_idx = idx[2]
+        else:
+            head_idx = idx[1] // Int(params.head_size)
+            head_dim_idx = idx[1] % Int(params.head_size)
+        k_cache.store(
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=head_idx,
+            head_dim_idx=head_dim_idx,
+            val=val.cast[cache_dtype](),
+        )
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache)
+    def key_cache_uniform_decode_input_fn[
+        width: Int, rank_: Int
+    ](idx: IndexList[rank_]) -> SIMD[dtype, width]:
+        comptime assert rank_ == 3, (
+            "decode-uniform KV RMSNorm specialization expects rank 3"
+        )
+
+        var batch_idx = idx[0]
+        var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+        return k_cache.load[width=width](
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=idx[1],
+            head_dim_idx=idx[2],
+        ).cast[dtype]()
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache)
+    def key_cache_uniform_decode_output_fn[
+        width: Int, alignment: Int
+    ](idx: IndexList[3], val: SIMD[dtype, width]) -> None:
+        var batch_idx = idx[0]
+        var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+        k_cache.store(
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=idx[1],
+            head_dim_idx=idx[2],
+            val=val.cast[cache_dtype](),
+        )
+
+    with Trace[TraceLevel.OP, target=StaticString("gpu")](
+        "rms_norm_kv_cache_ragged_paged_nhead_"
+        + String(kv_collection.kv_params.num_heads)
+        + ".hdim_"
+        + String(kv_collection.kv_params.head_size),
+        task_id=get_safe_task_id(context),
+    ):
+        comptime if has_uniform_decode_rank3_specialization:
+            if use_uniform_decode_batch_mapping:
+                var uniform_decode_shape = IndexList[3](
+                    shape[0], shape[1], shape[2]
+                )
+                _rms_norm_impl[
+                    dtype,
+                    3,
+                    key_cache_uniform_decode_input_fn,
+                    key_cache_uniform_decode_output_fn,
+                    target="gpu",
+                    multiply_before_cast=multiply_before_cast,
+                ](
+                    uniform_decode_shape,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    context,
+                )
+                return
+
+        _rms_norm_impl[
+            dtype,
+            rank,
+            key_cache_input_fn,
+            key_cache_output_fn,
+            target="gpu",
+            multiply_before_cast=multiply_before_cast,
+        ](
+            shape,
+            gamma,
+            epsilon,
+            weight_offset,
+            context,
+        )
+
+
+def _rms_norm_kv_cache_production_clone_no_trace_trial[
+    dtype: DType,
+    params: KVCacheStaticParams,
+    page_size: Int,
+    cache_dtype: DType,
+    //,
+    multiply_before_cast: Bool,
+    per_head_norm: Bool,
+](
+    kv_collection: PagedKVCacheCollection[cache_dtype, params, page_size],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    total_seq_len: UInt32,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    ctx: DeviceContextPtr,
+) raises:
+    """Benchmark-local production-shape clone without the outer Trace wrapper."""
+    comptime assert gamma.flat_rank == 1, "gamma must be rank 1"
+    comptime assert (
+        input_row_offsets.flat_rank == 1
+    ), "input_row_offsets must be rank 1"
+
+    comptime rank = 3 if per_head_norm else 2
+    var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+    var kv_params = k_cache.kv_params
+    comptime rms_norm_cols = gamma.static_shape[0]
+
+    comptime assert rms_norm_cols != -1, "Need static shape for gamma"
+    comptime assert (
+        rms_norm_cols <= Int(kv_collection.kv_params.head_size)
+        or not per_head_norm
+    ), "Length of gamma must be smaller or equal to head size"
+    comptime has_uniform_decode_rank3_specialization = (
+        per_head_norm
+        and dtype == DType.bfloat16
+        and cache_dtype == DType.bfloat16
+        and rms_norm_cols == 128
+        and Int(params.head_size) == 128
+        and page_size == 128
+    )
+    var batch_size = Int(input_row_offsets.dim(0)) - 1
+    var use_uniform_decode_batch_mapping = False
+
+    comptime if has_uniform_decode_rank3_specialization:
+        use_uniform_decode_batch_mapping = (
+            kv_collection.max_seq_length == 1
+            and total_seq_len == UInt32(batch_size)
+        )
+
+    var shape = IndexList[rank]()
+    shape[0] = Int(total_seq_len)
+
+    comptime if per_head_norm:
+        shape[1] = Int(kv_params.num_heads)
+        shape[2] = rms_norm_cols
+    else:
+        shape[1] = rms_norm_cols
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache, input_row_offsets)
+    def key_cache_input_fn[
+        width: Int, rank_: Int
+    ](idx: IndexList[rank_]) -> SIMD[dtype, width]:
+        comptime assert (
+            rank_ == rank
+        ), "rms_norm_key_cache input lambda index should have rank " + String(
+            rank
+        )
+
+        var global_token_idx = idx[0]
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+
+        var cache_length = k_cache.cache_length(batch_idx)
+        var cache_token_idx = token_idx + cache_length
+
+        var head_idx: Int
+        var head_dim_idx: Int
+
+        comptime if per_head_norm:
+            head_idx = idx[1]
+            head_dim_idx = idx[2]
+        else:
+            head_idx = idx[1] // Int(params.head_size)
+            head_dim_idx = idx[1] % Int(params.head_size)
+
+        return k_cache.load[width=width](
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=head_idx,
+            head_dim_idx=head_dim_idx,
+        ).cast[dtype]()
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache, input_row_offsets)
+    def key_cache_output_fn[
+        width: Int, alignment: Int
+    ](idx: IndexList[rank], val: SIMD[dtype, width]) -> None:
+        var global_token_idx = idx[0]
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+
+        var cache_length = k_cache.cache_length(batch_idx)
+        var cache_token_idx = token_idx + cache_length
+
+        var head_idx: Int
+        var head_dim_idx: Int
+
+        comptime if per_head_norm:
+            head_idx = idx[1]
+            head_dim_idx = idx[2]
+        else:
+            head_idx = idx[1] // Int(params.head_size)
+            head_dim_idx = idx[1] % Int(params.head_size)
+        k_cache.store(
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=head_idx,
+            head_dim_idx=head_dim_idx,
+            val=val.cast[cache_dtype](),
+        )
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache)
+    def key_cache_uniform_decode_input_fn[
+        width: Int, rank_: Int
+    ](idx: IndexList[rank_]) -> SIMD[dtype, width]:
+        comptime assert rank_ == 3, (
+            "decode-uniform KV RMSNorm specialization expects rank 3"
+        )
+
+        var batch_idx = idx[0]
+        var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+        return k_cache.load[width=width](
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=idx[1],
+            head_dim_idx=idx[2],
+        ).cast[dtype]()
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache)
+    def key_cache_uniform_decode_output_fn[
+        width: Int, alignment: Int
+    ](idx: IndexList[3], val: SIMD[dtype, width]) -> None:
+        var batch_idx = idx[0]
+        var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+        k_cache.store(
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=idx[1],
+            head_dim_idx=idx[2],
+            val=val.cast[cache_dtype](),
+        )
+
+    comptime if has_uniform_decode_rank3_specialization:
+        if use_uniform_decode_batch_mapping:
+            var uniform_decode_shape = IndexList[3](
+                shape[0], shape[1], shape[2]
+            )
+            _rms_norm_impl[
+                dtype,
+                3,
+                key_cache_uniform_decode_input_fn,
+                key_cache_uniform_decode_output_fn,
+                target="gpu",
+                multiply_before_cast=multiply_before_cast,
+            ](
+                uniform_decode_shape,
+                gamma,
+                epsilon,
+                weight_offset,
+                ctx,
+            )
+            return
+
+    _rms_norm_impl[
+        dtype,
+        rank,
+        key_cache_input_fn,
+        key_cache_output_fn,
+        target="gpu",
+        multiply_before_cast=multiply_before_cast,
+    ](
+        shape,
+        gamma,
+        epsilon,
+        weight_offset,
+        ctx,
+    )
+
+
+def execute_kv_cache_ragged_rms_norm[
+    dtype: DType, head_dim: Int, num_kv_heads: Int, page_size: Int
+](
+    ctx: DeviceContext,
+    mut m: Bench,
+    batch_size: Int,
+    seq_len: Int,
+    cache_len: Int,
+    cache_len_step: Int,
+) raises:
+    comptime num_layers = 1
+    comptime layer_idx = 0
+    comptime kv_params = KVCacheStaticParams(
+        num_heads=UInt(num_kv_heads), head_size=UInt(head_dim)
+    )
+    comptime CollectionType = PagedKVCacheCollection[dtype, kv_params, page_size]
+
+    var total_seq_len = UInt32(batch_size * seq_len)
+    var max_cache_len = cache_len + (batch_size - 1) * cache_len_step
+    var max_context_length = seq_len + max_cache_len
+    var paged_lut_cols = ceildiv(max_context_length, page_size)
+    var num_pages = batch_size * paged_lut_cols
+
+    var input_row_offsets_host_ptr = alloc[Scalar[DType.uint32]](batch_size + 1)
+    var cache_lengths_host_ptr = alloc[Scalar[DType.uint32]](batch_size)
+    var gamma_host_ptr = alloc[Scalar[dtype]](head_dim)
+
+    for i in range(batch_size):
+        input_row_offsets_host_ptr[i] = UInt32(i * seq_len)
+        cache_lengths_host_ptr[i] = UInt32(cache_len + i * cache_len_step)
+    input_row_offsets_host_ptr[batch_size] = total_seq_len
+
+    for i in range(head_dim):
+        gamma_host_ptr[i] = (
+            Float64(i + head_dim) / Float64(head_dim)
+        ).cast[dtype]()
+
+    var input_row_offsets_dev_buffer = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size + 1
+    )
+    ctx.enqueue_copy(input_row_offsets_dev_buffer, input_row_offsets_host_ptr)
+
+    var cache_lengths_dev_buffer = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size
+    )
+    ctx.enqueue_copy(cache_lengths_dev_buffer, cache_lengths_host_ptr)
+
+    var gamma_dev_buffer = ctx.enqueue_create_buffer[dtype](head_dim)
+    ctx.enqueue_copy(gamma_dev_buffer, gamma_host_ptr)
+
+    var paged_lut_size = batch_size * paged_lut_cols
+    var paged_lut_host_ptr = alloc[Scalar[DType.uint32]](paged_lut_size)
+    comptime paged_lut_layout = Layout.row_major[2]()
+    var paged_lut_host = LayoutTensor[
+        DType.uint32, paged_lut_layout, MutAnyOrigin
+    ](
+        paged_lut_host_ptr,
+        RuntimeLayout[paged_lut_layout].row_major(
+            IndexList[2](batch_size, paged_lut_cols)
+        ),
+    )
+
+    # Assign each request a deterministic, non-overlapping page range.
+    for bs in range(batch_size):
+        for page_idx in range(paged_lut_cols):
+            paged_lut_host[bs, page_idx] = UInt32(bs * paged_lut_cols + page_idx)
+
+    var paged_lut_dev_buffer = ctx.enqueue_create_buffer[DType.uint32](
+        paged_lut_size
+    )
+    ctx.enqueue_copy(paged_lut_dev_buffer, paged_lut_host_ptr)
+
+    var kv_block_shape = IndexList[6](
+        num_pages,
+        2,
+        num_layers,
+        page_size,
+        num_kv_heads,
+        head_dim,
+    )
+    var kv_block_size = kv_block_shape.flattened_length()
+    var initial_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    var baseline_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    var direct_early_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    var impl_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    var trace_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    var trace_no_task_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    var production_clone_no_trace_kv_block_host_ptr = alloc[Scalar[dtype]](
+        kv_block_size
+    )
+    var production_clone_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    var rank3_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    var rank3_late_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    var trial_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    random(
+        LayoutTensor[dtype, Layout.row_major[6](), MutAnyOrigin](
+            initial_kv_block_host_ptr,
+            RuntimeLayout[Layout.row_major[6]()].row_major(kv_block_shape),
+        )
+    )
+    var baseline_kv_block_dev_buffer = ctx.enqueue_create_buffer[dtype](
+        kv_block_size
+    )
+    var direct_early_kv_block_dev_buffer = ctx.enqueue_create_buffer[dtype](
+        kv_block_size
+    )
+    var impl_kv_block_dev_buffer = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    var trace_kv_block_dev_buffer = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    var trace_no_task_kv_block_dev_buffer = ctx.enqueue_create_buffer[dtype](
+        kv_block_size
+    )
+    var production_clone_no_trace_kv_block_dev_buffer = (
+        ctx.enqueue_create_buffer[dtype](kv_block_size)
+    )
+    var production_clone_kv_block_dev_buffer = ctx.enqueue_create_buffer[dtype](
+        kv_block_size
+    )
+    var rank3_kv_block_dev_buffer = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    var rank3_late_kv_block_dev_buffer = ctx.enqueue_create_buffer[dtype](
+        kv_block_size
+    )
+    var trial_kv_block_dev_buffer = ctx.enqueue_create_buffer[dtype](kv_block_size)
+    ctx.enqueue_copy(baseline_kv_block_dev_buffer, initial_kv_block_host_ptr)
+    ctx.enqueue_copy(direct_early_kv_block_dev_buffer, initial_kv_block_host_ptr)
+    ctx.enqueue_copy(impl_kv_block_dev_buffer, initial_kv_block_host_ptr)
+    ctx.enqueue_copy(trace_kv_block_dev_buffer, initial_kv_block_host_ptr)
+    ctx.enqueue_copy(trace_no_task_kv_block_dev_buffer, initial_kv_block_host_ptr)
+    ctx.enqueue_copy(
+        production_clone_no_trace_kv_block_dev_buffer,
+        initial_kv_block_host_ptr,
+    )
+    ctx.enqueue_copy(
+        production_clone_kv_block_dev_buffer, initial_kv_block_host_ptr
+    )
+    ctx.enqueue_copy(rank3_kv_block_dev_buffer, initial_kv_block_host_ptr)
+    ctx.enqueue_copy(rank3_late_kv_block_dev_buffer, initial_kv_block_host_ptr)
+    ctx.enqueue_copy(trial_kv_block_dev_buffer, initial_kv_block_host_ptr)
+
+    comptime kv_block_layout = Layout.row_major[6]()
+    comptime cache_lengths_layout = Layout(UNKNOWN_VALUE)
+    var cache_lengths_layout_tensor = LayoutTensor[
+        DType.uint32, cache_lengths_layout, ImmutAnyOrigin
+    ](
+        cache_lengths_dev_buffer.unsafe_ptr(),
+        RuntimeLayout[cache_lengths_layout].row_major(IndexList[1](batch_size)),
+    )
+
+    var paged_lut_layout_tensor = LayoutTensor[
+        DType.uint32, paged_lut_layout, ImmutAnyOrigin
+    ](
+        paged_lut_dev_buffer.unsafe_ptr(),
+        RuntimeLayout[paged_lut_layout].row_major(
+            IndexList[2](batch_size, paged_lut_cols)
+        ),
+    )
+
+    var baseline_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            baseline_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var direct_early_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            direct_early_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var impl_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            impl_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var trace_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            trace_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var trace_no_task_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            trace_no_task_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var production_clone_no_trace_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            production_clone_no_trace_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var production_clone_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            production_clone_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var trial_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            trial_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var rank3_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            rank3_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var rank3_late_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            rank3_late_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+
+    var gamma_tensor = TileTensor(
+        gamma_dev_buffer.unsafe_ptr(), row_major(Idx[head_dim]())
+    )
+    var input_row_offsets_tensor = TileTensor(
+        input_row_offsets_dev_buffer.unsafe_ptr(),
+        row_major(Idx(batch_size + 1)),
+    )
+    var epsilon = Scalar[dtype](1e-6)
+    var weight_offset = Scalar[dtype](1.0)
+    var num_bytes = (
+        3 * Int(total_seq_len) * num_kv_heads * head_dim * size_of[dtype]()
+    )
+
+    @always_inline
+    @__copy_capture(
+        baseline_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_baseline(ctx: DeviceContext) raises:
+        rms_norm_kv_cache_ragged_paged[
+            target="gpu",
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            baseline_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        direct_early_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_direct_early_trial(ctx: DeviceContext) raises:
+        _rms_norm_kv_cache_decode_direct_trial[
+            dtype=dtype,
+            params=kv_params,
+            page_size=page_size,
+            cache_dtype=dtype,
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            direct_early_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        impl_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_impl_trial(ctx: DeviceContext) raises:
+        _rms_norm_kv_cache_decode_uniform_impl_trial[
+            dtype=dtype,
+            params=kv_params,
+            page_size=page_size,
+            cache_dtype=dtype,
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            impl_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        trace_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_trace_trial(ctx: DeviceContext) raises:
+        _rms_norm_kv_cache_decode_uniform_trace_trial[
+            dtype=dtype,
+            params=kv_params,
+            page_size=page_size,
+            cache_dtype=dtype,
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            trace_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        trace_no_task_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_trace_no_task_trial(ctx: DeviceContext) raises:
+        _rms_norm_kv_cache_decode_uniform_trace_no_task_trial[
+            dtype=dtype,
+            params=kv_params,
+            page_size=page_size,
+            cache_dtype=dtype,
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            trace_no_task_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        production_clone_no_trace_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_production_clone_no_trace_trial(ctx: DeviceContext) raises:
+        _rms_norm_kv_cache_production_clone_no_trace_trial[
+            dtype=dtype,
+            params=kv_params,
+            page_size=page_size,
+            cache_dtype=dtype,
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            production_clone_no_trace_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        production_clone_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_production_clone_trial(ctx: DeviceContext) raises:
+        _rms_norm_kv_cache_production_clone_trial[
+            dtype=dtype,
+            params=kv_params,
+            page_size=page_size,
+            cache_dtype=dtype,
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            production_clone_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        rank3_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_rank3_trial(ctx: DeviceContext) raises:
+        _rms_norm_kv_cache_decode_uniform_rank3_trial[
+            dtype=dtype,
+            params=kv_params,
+            page_size=page_size,
+            cache_dtype=dtype,
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            rank3_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        rank3_late_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_rank3_late_trial(ctx: DeviceContext) raises:
+        _rms_norm_kv_cache_decode_uniform_rank3_trial[
+            dtype=dtype,
+            params=kv_params,
+            page_size=page_size,
+            cache_dtype=dtype,
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            rank3_late_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        trial_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_direct_trial(ctx: DeviceContext) raises:
+        _rms_norm_kv_cache_decode_direct_trial[
+            dtype=dtype,
+            params=kv_params,
+            page_size=page_size,
+            cache_dtype=dtype,
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            trial_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @parameter
+    def baseline_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_baseline](ctx)
+
+    @always_inline
+    @parameter
+    def direct_early_trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_direct_early_trial](ctx)
+
+    @always_inline
+    @parameter
+    def impl_trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_impl_trial](ctx)
+
+    @always_inline
+    @parameter
+    def trace_trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_trace_trial](ctx)
+
+    @always_inline
+    @parameter
+    def trace_no_task_trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_trace_no_task_trial](ctx)
+
+    @always_inline
+    @parameter
+    def production_clone_no_trace_trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_production_clone_no_trace_trial](ctx)
+
+    @always_inline
+    @parameter
+    def production_clone_trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_production_clone_trial](ctx)
+
+    @always_inline
+    @parameter
+    def rank3_trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_rank3_trial](ctx)
+
+    @always_inline
+    @parameter
+    def direct_trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_direct_trial](ctx)
+
+    @always_inline
+    @parameter
+    def rank3_late_trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_rank3_late_trial](ctx)
+
+    var input_id = String(
+        dtype,
+        "/bs=",
+        batch_size,
+        "/seq=",
+        seq_len,
+        "/cache=",
+        cache_len,
+        "/step=",
+        cache_len_step,
+    )
+
+    m.bench_function[baseline_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_baseline",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+    m.bench_function[direct_early_trial_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_direct_early_trial",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+    m.bench_function[impl_trial_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_impl_trial",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+    m.bench_function[trace_trial_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_trace_trial",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+    m.bench_function[trace_no_task_trial_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_trace_no_task_trial",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+    m.bench_function[production_clone_no_trace_trial_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_production_clone_no_trace_trial",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+    m.bench_function[production_clone_trial_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_production_clone_trial",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+    m.bench_function[rank3_trial_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_rank3_trial",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+    m.bench_function[direct_trial_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_direct_trial",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+    m.bench_function[rank3_late_trial_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_rank3_late_trial",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+
+    run_baseline(ctx)
+    run_direct_early_trial(ctx)
+    run_impl_trial(ctx)
+    run_trace_trial(ctx)
+    run_trace_no_task_trial(ctx)
+    run_production_clone_no_trace_trial(ctx)
+    run_production_clone_trial(ctx)
+    run_rank3_trial(ctx)
+    run_direct_trial(ctx)
+    run_rank3_late_trial(ctx)
+    ctx.enqueue_copy(baseline_kv_block_host_ptr, baseline_kv_block_dev_buffer)
+    ctx.enqueue_copy(
+        direct_early_kv_block_host_ptr, direct_early_kv_block_dev_buffer
+    )
+    ctx.enqueue_copy(impl_kv_block_host_ptr, impl_kv_block_dev_buffer)
+    ctx.enqueue_copy(trace_kv_block_host_ptr, trace_kv_block_dev_buffer)
+    ctx.enqueue_copy(
+        trace_no_task_kv_block_host_ptr, trace_no_task_kv_block_dev_buffer
+    )
+    ctx.enqueue_copy(
+        production_clone_no_trace_kv_block_host_ptr,
+        production_clone_no_trace_kv_block_dev_buffer,
+    )
+    ctx.enqueue_copy(
+        production_clone_kv_block_host_ptr, production_clone_kv_block_dev_buffer
+    )
+    ctx.enqueue_copy(rank3_kv_block_host_ptr, rank3_kv_block_dev_buffer)
+    ctx.enqueue_copy(rank3_late_kv_block_host_ptr, rank3_late_kv_block_dev_buffer)
+    ctx.enqueue_copy(trial_kv_block_host_ptr, trial_kv_block_dev_buffer)
+    ctx.synchronize()
+
+    var baseline_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            baseline_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var direct_early_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            direct_early_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var impl_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            impl_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var trace_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            trace_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var trace_no_task_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            trace_no_task_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var production_clone_no_trace_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            production_clone_no_trace_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var production_clone_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            production_clone_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var trial_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            trial_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var rank3_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            rank3_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var rank3_late_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            rank3_late_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+
+    var baseline_k_cache_host = baseline_kv_collection_host.get_key_cache(layer_idx)
+    var direct_early_k_cache_host = (
+        direct_early_kv_collection_host.get_key_cache(layer_idx)
+    )
+    var impl_k_cache_host = impl_kv_collection_host.get_key_cache(layer_idx)
+    var trace_k_cache_host = trace_kv_collection_host.get_key_cache(layer_idx)
+    var trace_no_task_k_cache_host = (
+        trace_no_task_kv_collection_host.get_key_cache(layer_idx)
+    )
+    var production_clone_no_trace_k_cache_host = (
+        production_clone_no_trace_kv_collection_host.get_key_cache(layer_idx)
+    )
+    var production_clone_k_cache_host = (
+        production_clone_kv_collection_host.get_key_cache(layer_idx)
+    )
+    var rank3_k_cache_host = rank3_kv_collection_host.get_key_cache(layer_idx)
+    var rank3_late_k_cache_host = (
+        rank3_late_kv_collection_host.get_key_cache(layer_idx)
+    )
+    var trial_k_cache_host = trial_kv_collection_host.get_key_cache(layer_idx)
+
+    for bs_idx in range(batch_size):
+        for tok_idx in range(seq_len):
+            var cache_tok_idx = Int(cache_lengths_host_ptr[bs_idx]) + tok_idx
+            for head_idx in range(num_kv_heads):
+                for dim_idx in range(head_dim):
+                    assert_almost_equal(
+                        baseline_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        direct_early_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+                    assert_almost_equal(
+                        baseline_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        impl_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+                    assert_almost_equal(
+                        baseline_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        trace_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+                    assert_almost_equal(
+                        baseline_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        trace_no_task_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+                    assert_almost_equal(
+                        baseline_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        production_clone_no_trace_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+                    assert_almost_equal(
+                        baseline_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        production_clone_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+                    assert_almost_equal(
+                        baseline_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        rank3_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+                    assert_almost_equal(
+                        baseline_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        rank3_late_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+                    assert_almost_equal(
+                        baseline_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        trial_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+
+    input_row_offsets_host_ptr.free()
+    cache_lengths_host_ptr.free()
+    gamma_host_ptr.free()
+    paged_lut_host_ptr.free()
+    initial_kv_block_host_ptr.free()
+    baseline_kv_block_host_ptr.free()
+    direct_early_kv_block_host_ptr.free()
+    impl_kv_block_host_ptr.free()
+    trace_kv_block_host_ptr.free()
+    trace_no_task_kv_block_host_ptr.free()
+    production_clone_no_trace_kv_block_host_ptr.free()
+    production_clone_kv_block_host_ptr.free()
+    rank3_kv_block_host_ptr.free()
+    rank3_late_kv_block_host_ptr.free()
+    trial_kv_block_host_ptr.free()
+
+    _ = input_row_offsets_dev_buffer^
+    _ = cache_lengths_dev_buffer^
+    _ = gamma_dev_buffer^
+    _ = paged_lut_dev_buffer^
+    _ = baseline_kv_block_dev_buffer^
+    _ = direct_early_kv_block_dev_buffer^
+    _ = impl_kv_block_dev_buffer^
+    _ = trace_kv_block_dev_buffer^
+    _ = trace_no_task_kv_block_dev_buffer^
+    _ = production_clone_no_trace_kv_block_dev_buffer^
+    _ = production_clone_kv_block_dev_buffer^
+    _ = rank3_kv_block_dev_buffer^
+    _ = rank3_late_kv_block_dev_buffer^
+    _ = trial_kv_block_dev_buffer^
+
+
+def main() raises:
+    comptime dtype = get_defined_dtype["dtype", DType.bfloat16]()
+    comptime head_dim = get_defined_int["head_dim", 128]()
+    comptime num_kv_heads = get_defined_int["num_kv_heads", 16]()
+    comptime page_size = get_defined_int["page_size", 512]()
+
+    var batch_size = arg_parse("batch_size", 1)
+    var seq_len = arg_parse("seq_len", 1)
+    var cache_len = arg_parse("cache_len", 0)
+    var cache_len_step = arg_parse("cache_len_step", 0)
+
+    seed(0)
+
+    var m = Bench()
+    with DeviceContext() as ctx:
+        execute_kv_cache_ragged_rms_norm[
+            dtype,
+            head_dim,
+            num_kv_heads,
+            page_size,
+        ](ctx, m, batch_size, seq_len, cache_len, cache_len_step)
+
+    m.dump_report()

--- a/max/kernels/benchmarks/gpu/nn/bench_kv_cache_ragged_rms_norm_direct_pair.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_kv_cache_ragged_rms_norm_direct_pair.mojo
@@ -1,0 +1,561 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import ceildiv
+from std.random import seed
+from std.sys import get_defined_dtype, get_defined_int
+from std.sys.info import size_of
+
+from std.benchmark import (
+    Bench,
+    Bencher,
+    BenchId,
+    BenchMetric,
+    ThroughputMeasure,
+)
+from std.gpu import WARP_SIZE
+from std.gpu.host import DeviceContext
+from std.gpu.primitives.grid_controls import PDLLevel, pdl_launch_attributes
+from std.testing import assert_almost_equal
+from internal_utils import arg_parse
+from kv_cache.types import KVCacheStaticParams, PagedKVCacheCollection
+from layout import (
+    Idx,
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    UNKNOWN_VALUE,
+    row_major,
+)
+from layout._fillers import random
+from nn.kv_cache import rms_norm_kv_cache_ragged_paged
+from nn.normalization import rms_norm_gpu_warp_tiling_128
+
+from std.utils import IndexList
+
+
+def _rms_norm_kv_cache_decode_direct_trial[
+    dtype: DType,
+    params: KVCacheStaticParams,
+    page_size: Int,
+    cache_dtype: DType,
+    //,
+    multiply_before_cast: Bool,
+    per_head_norm: Bool,
+](
+    kv_collection: PagedKVCacheCollection[cache_dtype, params, page_size],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    total_seq_len: UInt32,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    ctx: DeviceContext,
+) raises:
+    comptime assert per_head_norm, (
+        "The direct KV RMSNorm trial expects per-head norm"
+    )
+    comptime rms_norm_cols = gamma.static_shape[0]
+    comptime head_size = Int(params.head_size)
+    comptime assert rms_norm_cols != -1, "Need static gamma shape"
+
+    comptime if dtype != DType.bfloat16 or rms_norm_cols != 128 or head_size != 128:
+        rms_norm_kv_cache_ragged_paged[
+            dtype=dtype,
+            params=params,
+            page_size=page_size,
+            cache_dtype=cache_dtype,
+            target="gpu",
+            multiply_before_cast=multiply_before_cast,
+            per_head_norm=per_head_norm,
+        ](
+            kv_collection,
+            gamma,
+            epsilon,
+            weight_offset,
+            layer_idx,
+            total_seq_len,
+            input_row_offsets,
+            ctx,
+        )
+    else:
+        var batch_size = Int(input_row_offsets.dim(0)) - 1
+        var is_decode_uniform = Int(total_seq_len) == batch_size
+
+        if not is_decode_uniform:
+            rms_norm_kv_cache_ragged_paged[
+                dtype=dtype,
+                params=params,
+                page_size=page_size,
+                cache_dtype=cache_dtype,
+                target="gpu",
+                multiply_before_cast=multiply_before_cast,
+                per_head_norm=per_head_norm,
+            ](
+                kv_collection,
+                gamma,
+                epsilon,
+                weight_offset,
+                layer_idx,
+                total_seq_len,
+                input_row_offsets,
+                ctx,
+            )
+            return
+
+        var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+        var num_rows = Int(total_seq_len) * Int(params.num_heads)
+        comptime simd_width = 8
+        comptime default_warps_per_block = 2
+        comptime large_row_warps_per_block = 8
+        comptime default_block_size = default_warps_per_block * WARP_SIZE
+        comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
+        comptime min_large_row_blocks_per_sm = 5
+        var min_large_row_blocks = (
+            ctx.default_device_info.sm_count * min_large_row_blocks_per_sm
+        )
+        var large_row_grid_dim = ceildiv(
+            num_rows, large_row_warps_per_block * 2
+        )
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache)
+        def direct_input_fn_2d[width: Int](
+            row: Int, col: Int
+        ) -> SIMD[dtype, width]:
+            var batch_idx = row // Int(params.num_heads)
+            var head_idx = row % Int(params.num_heads)
+            var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+            return k_cache.load[width=width](
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=head_idx,
+                head_dim_idx=col,
+            ).cast[dtype]()
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache)
+        def direct_output_fn_2d[width: Int, alignment: Int](
+            row: Int, col: Int, val: SIMD[dtype, width]
+        ) -> None:
+            var batch_idx = row // Int(params.num_heads)
+            var head_idx = row % Int(params.num_heads)
+            var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+            k_cache.store(
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=head_idx,
+                head_dim_idx=col,
+                val=val.cast[cache_dtype](),
+            )
+
+        if large_row_grid_dim >= min_large_row_blocks:
+            comptime kernel = rms_norm_gpu_warp_tiling_128[
+                mut=gamma.mut,
+                LayoutType=gamma.LayoutType,
+                origin=gamma.origin,
+                simd_width,
+                large_row_warps_per_block,
+                direct_input_fn_2d,
+                direct_output_fn_2d,
+                multiply_before_cast=multiply_before_cast,
+            ]
+            ctx.enqueue_function[kernel, kernel](
+                gamma,
+                epsilon,
+                weight_offset,
+                num_rows,
+                rms_norm_cols,
+                grid_dim=large_row_grid_dim,
+                block_dim=large_row_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+        else:
+            comptime kernel = rms_norm_gpu_warp_tiling_128[
+                mut=gamma.mut,
+                LayoutType=gamma.LayoutType,
+                origin=gamma.origin,
+                simd_width,
+                default_warps_per_block,
+                direct_input_fn_2d,
+                direct_output_fn_2d,
+                multiply_before_cast=multiply_before_cast,
+            ]
+            ctx.enqueue_function[kernel, kernel](
+                gamma,
+                epsilon,
+                weight_offset,
+                num_rows,
+                rms_norm_cols,
+                grid_dim=ceildiv(num_rows, default_warps_per_block * 2),
+                block_dim=default_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+
+
+def execute_kv_cache_ragged_rms_norm_direct_pair[
+    dtype: DType, head_dim: Int, num_kv_heads: Int, page_size: Int
+](
+    ctx: DeviceContext,
+    mut m: Bench,
+    batch_size: Int,
+    seq_len: Int,
+    cache_len: Int,
+    cache_len_step: Int,
+) raises:
+    comptime num_layers = 1
+    comptime layer_idx = 0
+    comptime kv_params = KVCacheStaticParams(
+        num_heads=UInt(num_kv_heads), head_size=UInt(head_dim)
+    )
+    comptime CollectionType = PagedKVCacheCollection[dtype, kv_params, page_size]
+
+    var total_seq_len = UInt32(batch_size * seq_len)
+    var max_cache_len = cache_len + (batch_size - 1) * cache_len_step
+    var max_context_length = seq_len + max_cache_len
+    var paged_lut_cols = ceildiv(max_context_length, page_size)
+    var num_pages = batch_size * paged_lut_cols
+
+    var input_row_offsets_host_ptr = alloc[Scalar[DType.uint32]](batch_size + 1)
+    var cache_lengths_host_ptr = alloc[Scalar[DType.uint32]](batch_size)
+    var gamma_host_ptr = alloc[Scalar[dtype]](head_dim)
+
+    for i in range(batch_size):
+        input_row_offsets_host_ptr[i] = UInt32(i * seq_len)
+        cache_lengths_host_ptr[i] = UInt32(cache_len + i * cache_len_step)
+    input_row_offsets_host_ptr[batch_size] = total_seq_len
+
+    for i in range(head_dim):
+        gamma_host_ptr[i] = (
+            Float64(i + head_dim) / Float64(head_dim)
+        ).cast[dtype]()
+
+    var input_row_offsets_dev_buffer = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size + 1
+    )
+    ctx.enqueue_copy(input_row_offsets_dev_buffer, input_row_offsets_host_ptr)
+
+    var cache_lengths_dev_buffer = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size
+    )
+    ctx.enqueue_copy(cache_lengths_dev_buffer, cache_lengths_host_ptr)
+
+    var gamma_dev_buffer = ctx.enqueue_create_buffer[dtype](head_dim)
+    ctx.enqueue_copy(gamma_dev_buffer, gamma_host_ptr)
+
+    var paged_lut_size = batch_size * paged_lut_cols
+    var paged_lut_host_ptr = alloc[Scalar[DType.uint32]](paged_lut_size)
+    comptime paged_lut_layout = Layout.row_major[2]()
+    var paged_lut_host = LayoutTensor[
+        DType.uint32, paged_lut_layout, MutAnyOrigin
+    ](
+        paged_lut_host_ptr,
+        RuntimeLayout[paged_lut_layout].row_major(
+            IndexList[2](batch_size, paged_lut_cols)
+        ),
+    )
+
+    for bs in range(batch_size):
+        for page_idx in range(paged_lut_cols):
+            paged_lut_host[bs, page_idx] = UInt32(bs * paged_lut_cols + page_idx)
+
+    var paged_lut_dev_buffer = ctx.enqueue_create_buffer[DType.uint32](
+        paged_lut_size
+    )
+    ctx.enqueue_copy(paged_lut_dev_buffer, paged_lut_host_ptr)
+
+    var kv_block_shape = IndexList[6](
+        num_pages,
+        2,
+        num_layers,
+        page_size,
+        num_kv_heads,
+        head_dim,
+    )
+    var kv_block_size = kv_block_shape.flattened_length()
+    var initial_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    var baseline_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    var direct_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    random(
+        LayoutTensor[dtype, Layout.row_major[6](), MutAnyOrigin](
+            initial_kv_block_host_ptr,
+            RuntimeLayout[Layout.row_major[6]()].row_major(kv_block_shape),
+        )
+    )
+    var baseline_kv_block_dev_buffer = ctx.enqueue_create_buffer[dtype](
+        kv_block_size
+    )
+    var direct_kv_block_dev_buffer = ctx.enqueue_create_buffer[dtype](
+        kv_block_size
+    )
+    ctx.enqueue_copy(baseline_kv_block_dev_buffer, initial_kv_block_host_ptr)
+    ctx.enqueue_copy(direct_kv_block_dev_buffer, initial_kv_block_host_ptr)
+
+    comptime kv_block_layout = Layout.row_major[6]()
+    comptime cache_lengths_layout = Layout(UNKNOWN_VALUE)
+    var cache_lengths_layout_tensor = LayoutTensor[
+        DType.uint32, cache_lengths_layout, ImmutAnyOrigin
+    ](
+        cache_lengths_dev_buffer.unsafe_ptr(),
+        RuntimeLayout[cache_lengths_layout].row_major(IndexList[1](batch_size)),
+    )
+
+    var paged_lut_layout_tensor = LayoutTensor[
+        DType.uint32, paged_lut_layout, ImmutAnyOrigin
+    ](
+        paged_lut_dev_buffer.unsafe_ptr(),
+        RuntimeLayout[paged_lut_layout].row_major(
+            IndexList[2](batch_size, paged_lut_cols)
+        ),
+    )
+
+    var baseline_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            baseline_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var direct_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            direct_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+
+    var gamma_tensor = TileTensor(
+        gamma_dev_buffer.unsafe_ptr(), row_major(Idx[head_dim]())
+    )
+    var input_row_offsets_tensor = TileTensor(
+        input_row_offsets_dev_buffer.unsafe_ptr(),
+        row_major(Idx(batch_size + 1)),
+    )
+    var epsilon = Scalar[dtype](1e-6)
+    var weight_offset = Scalar[dtype](1.0)
+    var num_bytes = (
+        3 * Int(total_seq_len) * num_kv_heads * head_dim * size_of[dtype]()
+    )
+
+    @always_inline
+    @__copy_capture(
+        baseline_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_baseline(ctx: DeviceContext) raises:
+        rms_norm_kv_cache_ragged_paged[
+            target="gpu",
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            baseline_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        direct_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_direct_trial(ctx: DeviceContext) raises:
+        _rms_norm_kv_cache_decode_direct_trial[
+            dtype=dtype,
+            params=kv_params,
+            page_size=page_size,
+            cache_dtype=dtype,
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            direct_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @parameter
+    def baseline_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_baseline](ctx)
+
+    @always_inline
+    @parameter
+    def direct_trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_direct_trial](ctx)
+
+    var input_id = String(
+        dtype,
+        "/bs=",
+        batch_size,
+        "/seq=",
+        seq_len,
+        "/cache=",
+        cache_len,
+        "/step=",
+        cache_len_step,
+    )
+
+    m.bench_function[baseline_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_baseline",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+    m.bench_function[direct_trial_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_direct_trial",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+
+    run_baseline(ctx)
+    run_direct_trial(ctx)
+    ctx.enqueue_copy(baseline_kv_block_host_ptr, baseline_kv_block_dev_buffer)
+    ctx.enqueue_copy(direct_kv_block_host_ptr, direct_kv_block_dev_buffer)
+    ctx.synchronize()
+
+    var baseline_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            baseline_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var direct_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            direct_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+
+    var baseline_k_cache_host = baseline_kv_collection_host.get_key_cache(layer_idx)
+    var direct_k_cache_host = direct_kv_collection_host.get_key_cache(layer_idx)
+
+    for bs_idx in range(batch_size):
+        for tok_idx in range(seq_len):
+            var cache_tok_idx = Int(cache_lengths_host_ptr[bs_idx]) + tok_idx
+            for head_idx in range(num_kv_heads):
+                for dim_idx in range(head_dim):
+                    assert_almost_equal(
+                        baseline_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        direct_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+
+    input_row_offsets_host_ptr.free()
+    cache_lengths_host_ptr.free()
+    gamma_host_ptr.free()
+    paged_lut_host_ptr.free()
+    initial_kv_block_host_ptr.free()
+    baseline_kv_block_host_ptr.free()
+    direct_kv_block_host_ptr.free()
+
+    _ = input_row_offsets_dev_buffer^
+    _ = cache_lengths_dev_buffer^
+    _ = gamma_dev_buffer^
+    _ = paged_lut_dev_buffer^
+    _ = baseline_kv_block_dev_buffer^
+    _ = direct_kv_block_dev_buffer^
+
+
+def main() raises:
+    comptime dtype = get_defined_dtype["dtype", DType.bfloat16]()
+    comptime head_dim = get_defined_int["head_dim", 128]()
+    comptime num_kv_heads = get_defined_int["num_kv_heads", 16]()
+    comptime page_size = get_defined_int["page_size", 512]()
+
+    var batch_size = arg_parse("batch_size", 1)
+    var seq_len = arg_parse("seq_len", 1)
+    var cache_len = arg_parse("cache_len", 0)
+    var cache_len_step = arg_parse("cache_len_step", 0)
+
+    seed(0)
+
+    var m = Bench()
+    with DeviceContext() as ctx:
+        execute_kv_cache_ragged_rms_norm_direct_pair[
+            dtype,
+            head_dim,
+            num_kv_heads,
+            page_size,
+        ](ctx, m, batch_size, seq_len, cache_len, cache_len_step)
+
+    m.dump_report()

--- a/max/kernels/benchmarks/gpu/nn/bench_kv_cache_ragged_rms_norm_pair.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_kv_cache_ragged_rms_norm_pair.mojo
@@ -1,0 +1,937 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import ceildiv
+from std.random import seed
+from std.sys import get_defined_dtype, get_defined_int
+from std.sys.info import size_of
+
+from std.benchmark import (
+    Bench,
+    Bencher,
+    BenchId,
+    BenchMetric,
+    ThroughputMeasure,
+)
+from std.gpu.host import DeviceContext
+from std.runtime.asyncrt import DeviceContextPtr
+from std.runtime.tracing import Trace, TraceLevel, get_safe_task_id
+from std.testing import assert_almost_equal
+from internal_utils import arg_parse
+from kv_cache.types import KVCacheStaticParams, PagedKVCacheCollection
+from layout import (
+    Idx,
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    UNKNOWN_VALUE,
+    row_major,
+)
+from layout._fillers import random
+from nn._ragged_utils import get_batch_from_row_offsets
+from nn.kv_cache import (
+    _rms_norm_kv_cache_ragged_paged_no_trace,
+    rms_norm_kv_cache_ragged_paged,
+)
+from nn.normalization import _rms_norm_impl
+
+from std.utils import IndexList
+
+
+def _rms_norm_kv_cache_production_clone_trial[
+    dtype: DType,
+    params: KVCacheStaticParams,
+    page_size: Int,
+    cache_dtype: DType,
+    //,
+    multiply_before_cast: Bool,
+    per_head_norm: Bool,
+](
+    kv_collection: PagedKVCacheCollection[cache_dtype, params, page_size],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    total_seq_len: UInt32,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    context: DeviceContextPtr,
+) raises:
+    """Benchmark-local copy of the production helper, including the generic
+    ragged lambdas plus the uniform-decode specialization."""
+    comptime assert gamma.flat_rank == 1, "gamma must be rank 1"
+    comptime assert (
+        input_row_offsets.flat_rank == 1
+    ), "input_row_offsets must be rank 1"
+
+    comptime rank = 3 if per_head_norm else 2
+    var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+    var kv_params = k_cache.kv_params
+    comptime rms_norm_cols = gamma.static_shape[0]
+
+    comptime assert rms_norm_cols != -1, "Need static shape for gamma"
+    comptime assert (
+        rms_norm_cols <= Int(kv_collection.kv_params.head_size)
+        or not per_head_norm
+    ), "Length of gamma must be smaller or equal to head size"
+    comptime has_uniform_decode_rank3_specialization = (
+        per_head_norm
+        and dtype == DType.bfloat16
+        and cache_dtype == DType.bfloat16
+        and rms_norm_cols == 128
+        and Int(params.head_size) == 128
+        and page_size == 128
+    )
+    var batch_size = Int(input_row_offsets.dim(0)) - 1
+    var use_uniform_decode_batch_mapping = False
+
+    comptime if has_uniform_decode_rank3_specialization:
+        use_uniform_decode_batch_mapping = (
+            kv_collection.max_seq_length == 1
+            and total_seq_len == UInt32(batch_size)
+        )
+
+    var shape = IndexList[rank]()
+    shape[0] = Int(total_seq_len)
+
+    comptime if per_head_norm:
+        shape[1] = Int(kv_params.num_heads)
+        shape[2] = rms_norm_cols
+    else:
+        shape[1] = rms_norm_cols
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache, input_row_offsets)
+    def key_cache_input_fn[
+        width: Int, rank_: Int
+    ](idx: IndexList[rank_]) -> SIMD[dtype, width]:
+        comptime assert (
+            rank_ == rank
+        ), "rms_norm_key_cache input lambda index should have rank " + String(
+            rank
+        )
+
+        var global_token_idx = idx[0]
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+
+        var cache_length = k_cache.cache_length(batch_idx)
+        var cache_token_idx = token_idx + cache_length
+
+        var head_idx: Int
+        var head_dim_idx: Int
+
+        comptime if per_head_norm:
+            head_idx = idx[1]
+            head_dim_idx = idx[2]
+        else:
+            head_idx = idx[1] // Int(params.head_size)
+            head_dim_idx = idx[1] % Int(params.head_size)
+
+        return k_cache.load[width=width](
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=head_idx,
+            head_dim_idx=head_dim_idx,
+        ).cast[dtype]()
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache, input_row_offsets)
+    def key_cache_output_fn[
+        width: Int, alignment: Int
+    ](idx: IndexList[rank], val: SIMD[dtype, width]) -> None:
+        var global_token_idx = idx[0]
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+
+        var cache_length = k_cache.cache_length(batch_idx)
+        var cache_token_idx = token_idx + cache_length
+
+        var head_idx: Int
+        var head_dim_idx: Int
+
+        comptime if per_head_norm:
+            head_idx = idx[1]
+            head_dim_idx = idx[2]
+        else:
+            head_idx = idx[1] // Int(params.head_size)
+            head_dim_idx = idx[1] % Int(params.head_size)
+        k_cache.store(
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=head_idx,
+            head_dim_idx=head_dim_idx,
+            val=val.cast[cache_dtype](),
+        )
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache)
+    def key_cache_uniform_decode_input_fn[
+        width: Int, rank_: Int
+    ](idx: IndexList[rank_]) -> SIMD[dtype, width]:
+        comptime assert rank_ == 3, (
+            "decode-uniform KV RMSNorm specialization expects rank 3"
+        )
+
+        var batch_idx = idx[0]
+        var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+        return k_cache.load[width=width](
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=idx[1],
+            head_dim_idx=idx[2],
+        ).cast[dtype]()
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache)
+    def key_cache_uniform_decode_output_fn[
+        width: Int, alignment: Int
+    ](idx: IndexList[3], val: SIMD[dtype, width]) -> None:
+        var batch_idx = idx[0]
+        var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+        k_cache.store(
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=idx[1],
+            head_dim_idx=idx[2],
+            val=val.cast[cache_dtype](),
+        )
+
+    with Trace[TraceLevel.OP, target=StaticString("gpu")](
+        "rms_norm_kv_cache_ragged_paged_nhead_"
+        + String(kv_collection.kv_params.num_heads)
+        + ".hdim_"
+        + String(kv_collection.kv_params.head_size),
+        task_id=get_safe_task_id(context),
+    ):
+        comptime if has_uniform_decode_rank3_specialization:
+            if use_uniform_decode_batch_mapping:
+                var uniform_decode_shape = IndexList[3](
+                    shape[0], shape[1], shape[2]
+                )
+                _rms_norm_impl[
+                    dtype,
+                    3,
+                    key_cache_uniform_decode_input_fn,
+                    key_cache_uniform_decode_output_fn,
+                    target="gpu",
+                    multiply_before_cast=multiply_before_cast,
+                ](
+                    uniform_decode_shape,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    context,
+                )
+                return
+
+        _rms_norm_impl[
+            dtype,
+            rank,
+            key_cache_input_fn,
+            key_cache_output_fn,
+            target="gpu",
+            multiply_before_cast=multiply_before_cast,
+        ](
+            shape,
+            gamma,
+            epsilon,
+            weight_offset,
+            context,
+        )
+
+
+def _rms_norm_kv_cache_production_clone_no_trace_trial[
+    dtype: DType,
+    params: KVCacheStaticParams,
+    page_size: Int,
+    cache_dtype: DType,
+    //,
+    multiply_before_cast: Bool,
+    per_head_norm: Bool,
+](
+    kv_collection: PagedKVCacheCollection[cache_dtype, params, page_size],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    total_seq_len: UInt32,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    ctx: DeviceContextPtr,
+) raises:
+    """Benchmark-local production-shape clone without the outer Trace wrapper."""
+    comptime assert gamma.flat_rank == 1, "gamma must be rank 1"
+    comptime assert (
+        input_row_offsets.flat_rank == 1
+    ), "input_row_offsets must be rank 1"
+
+    comptime rank = 3 if per_head_norm else 2
+    var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+    var kv_params = k_cache.kv_params
+    comptime rms_norm_cols = gamma.static_shape[0]
+
+    comptime assert rms_norm_cols != -1, "Need static shape for gamma"
+    comptime assert (
+        rms_norm_cols <= Int(kv_collection.kv_params.head_size)
+        or not per_head_norm
+    ), "Length of gamma must be smaller or equal to head size"
+    comptime has_uniform_decode_rank3_specialization = (
+        per_head_norm
+        and dtype == DType.bfloat16
+        and cache_dtype == DType.bfloat16
+        and rms_norm_cols == 128
+        and Int(params.head_size) == 128
+        and page_size == 128
+    )
+    var batch_size = Int(input_row_offsets.dim(0)) - 1
+    var use_uniform_decode_batch_mapping = False
+
+    comptime if has_uniform_decode_rank3_specialization:
+        use_uniform_decode_batch_mapping = (
+            kv_collection.max_seq_length == 1
+            and total_seq_len == UInt32(batch_size)
+        )
+
+    var shape = IndexList[rank]()
+    shape[0] = Int(total_seq_len)
+
+    comptime if per_head_norm:
+        shape[1] = Int(kv_params.num_heads)
+        shape[2] = rms_norm_cols
+    else:
+        shape[1] = rms_norm_cols
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache, input_row_offsets)
+    def key_cache_input_fn[
+        width: Int, rank_: Int
+    ](idx: IndexList[rank_]) -> SIMD[dtype, width]:
+        comptime assert (
+            rank_ == rank
+        ), "rms_norm_key_cache input lambda index should have rank " + String(
+            rank
+        )
+
+        var global_token_idx = idx[0]
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+
+        var cache_length = k_cache.cache_length(batch_idx)
+        var cache_token_idx = token_idx + cache_length
+
+        var head_idx: Int
+        var head_dim_idx: Int
+
+        comptime if per_head_norm:
+            head_idx = idx[1]
+            head_dim_idx = idx[2]
+        else:
+            head_idx = idx[1] // Int(params.head_size)
+            head_dim_idx = idx[1] % Int(params.head_size)
+
+        return k_cache.load[width=width](
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=head_idx,
+            head_dim_idx=head_dim_idx,
+        ).cast[dtype]()
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache, input_row_offsets)
+    def key_cache_output_fn[
+        width: Int, alignment: Int
+    ](idx: IndexList[rank], val: SIMD[dtype, width]) -> None:
+        var global_token_idx = idx[0]
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+
+        var cache_length = k_cache.cache_length(batch_idx)
+        var cache_token_idx = token_idx + cache_length
+
+        var head_idx: Int
+        var head_dim_idx: Int
+
+        comptime if per_head_norm:
+            head_idx = idx[1]
+            head_dim_idx = idx[2]
+        else:
+            head_idx = idx[1] // Int(params.head_size)
+            head_dim_idx = idx[1] % Int(params.head_size)
+        k_cache.store(
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=head_idx,
+            head_dim_idx=head_dim_idx,
+            val=val.cast[cache_dtype](),
+        )
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache)
+    def key_cache_uniform_decode_input_fn[
+        width: Int, rank_: Int
+    ](idx: IndexList[rank_]) -> SIMD[dtype, width]:
+        comptime assert rank_ == 3, (
+            "decode-uniform KV RMSNorm specialization expects rank 3"
+        )
+
+        var batch_idx = idx[0]
+        var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+        return k_cache.load[width=width](
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=idx[1],
+            head_dim_idx=idx[2],
+        ).cast[dtype]()
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache)
+    def key_cache_uniform_decode_output_fn[
+        width: Int, alignment: Int
+    ](idx: IndexList[3], val: SIMD[dtype, width]) -> None:
+        var batch_idx = idx[0]
+        var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+        k_cache.store(
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=idx[1],
+            head_dim_idx=idx[2],
+            val=val.cast[cache_dtype](),
+        )
+
+    comptime if has_uniform_decode_rank3_specialization:
+        if use_uniform_decode_batch_mapping:
+            var uniform_decode_shape = IndexList[3](
+                shape[0], shape[1], shape[2]
+            )
+            _rms_norm_impl[
+                dtype,
+                3,
+                key_cache_uniform_decode_input_fn,
+                key_cache_uniform_decode_output_fn,
+                target="gpu",
+                multiply_before_cast=multiply_before_cast,
+            ](
+                uniform_decode_shape,
+                gamma,
+                epsilon,
+                weight_offset,
+                ctx,
+            )
+            return
+
+    _rms_norm_impl[
+        dtype,
+        rank,
+        key_cache_input_fn,
+        key_cache_output_fn,
+        target="gpu",
+        multiply_before_cast=multiply_before_cast,
+    ](
+        shape,
+        gamma,
+        epsilon,
+        weight_offset,
+        ctx,
+    )
+
+
+def execute_kv_cache_ragged_rms_norm_pair[
+    dtype: DType, head_dim: Int, num_kv_heads: Int, page_size: Int
+](
+    ctx: DeviceContext,
+    mut m: Bench,
+    batch_size: Int,
+    seq_len: Int,
+    cache_len: Int,
+    cache_len_step: Int,
+) raises:
+    comptime num_layers = 1
+    comptime layer_idx = 0
+    comptime kv_params = KVCacheStaticParams(
+        num_heads=UInt(num_kv_heads), head_size=UInt(head_dim)
+    )
+    comptime CollectionType = PagedKVCacheCollection[dtype, kv_params, page_size]
+
+    var total_seq_len = UInt32(batch_size * seq_len)
+    var max_cache_len = cache_len + (batch_size - 1) * cache_len_step
+    var max_context_length = seq_len + max_cache_len
+    var paged_lut_cols = ceildiv(max_context_length, page_size)
+    var num_pages = batch_size * paged_lut_cols
+
+    var input_row_offsets_host_ptr = alloc[Scalar[DType.uint32]](batch_size + 1)
+    var cache_lengths_host_ptr = alloc[Scalar[DType.uint32]](batch_size)
+    var gamma_host_ptr = alloc[Scalar[dtype]](head_dim)
+
+    for i in range(batch_size):
+        input_row_offsets_host_ptr[i] = UInt32(i * seq_len)
+        cache_lengths_host_ptr[i] = UInt32(cache_len + i * cache_len_step)
+    input_row_offsets_host_ptr[batch_size] = total_seq_len
+
+    for i in range(head_dim):
+        gamma_host_ptr[i] = (
+            Float64(i + head_dim) / Float64(head_dim)
+        ).cast[dtype]()
+
+    var input_row_offsets_dev_buffer = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size + 1
+    )
+    ctx.enqueue_copy(input_row_offsets_dev_buffer, input_row_offsets_host_ptr)
+
+    var cache_lengths_dev_buffer = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size
+    )
+    ctx.enqueue_copy(cache_lengths_dev_buffer, cache_lengths_host_ptr)
+
+    var gamma_dev_buffer = ctx.enqueue_create_buffer[dtype](head_dim)
+    ctx.enqueue_copy(gamma_dev_buffer, gamma_host_ptr)
+
+    var paged_lut_size = batch_size * paged_lut_cols
+    var paged_lut_host_ptr = alloc[Scalar[DType.uint32]](paged_lut_size)
+    comptime paged_lut_layout = Layout.row_major[2]()
+    var paged_lut_host = LayoutTensor[
+        DType.uint32, paged_lut_layout, MutAnyOrigin
+    ](
+        paged_lut_host_ptr,
+        RuntimeLayout[paged_lut_layout].row_major(
+            IndexList[2](batch_size, paged_lut_cols)
+        ),
+    )
+
+    for bs in range(batch_size):
+        for page_idx in range(paged_lut_cols):
+            paged_lut_host[bs, page_idx] = UInt32(bs * paged_lut_cols + page_idx)
+
+    var paged_lut_dev_buffer = ctx.enqueue_create_buffer[DType.uint32](
+        paged_lut_size
+    )
+    ctx.enqueue_copy(paged_lut_dev_buffer, paged_lut_host_ptr)
+
+    var kv_block_shape = IndexList[6](
+        num_pages,
+        2,
+        num_layers,
+        page_size,
+        num_kv_heads,
+        head_dim,
+    )
+    var kv_block_size = kv_block_shape.flattened_length()
+    var initial_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    var baseline_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    var production_clone_kv_block_host_ptr = alloc[Scalar[dtype]](kv_block_size)
+    var production_clone_no_trace_kv_block_host_ptr = alloc[Scalar[dtype]](
+        kv_block_size
+    )
+    random(
+        LayoutTensor[dtype, Layout.row_major[6](), MutAnyOrigin](
+            initial_kv_block_host_ptr,
+            RuntimeLayout[Layout.row_major[6]()].row_major(kv_block_shape),
+        )
+    )
+    var baseline_kv_block_dev_buffer = ctx.enqueue_create_buffer[dtype](
+        kv_block_size
+    )
+    var production_clone_kv_block_dev_buffer = ctx.enqueue_create_buffer[dtype](
+        kv_block_size
+    )
+    var production_clone_no_trace_kv_block_dev_buffer = (
+        ctx.enqueue_create_buffer[dtype](kv_block_size)
+    )
+    ctx.enqueue_copy(baseline_kv_block_dev_buffer, initial_kv_block_host_ptr)
+    ctx.enqueue_copy(
+        production_clone_kv_block_dev_buffer, initial_kv_block_host_ptr
+    )
+    ctx.enqueue_copy(
+        production_clone_no_trace_kv_block_dev_buffer,
+        initial_kv_block_host_ptr,
+    )
+
+    comptime kv_block_layout = Layout.row_major[6]()
+    comptime cache_lengths_layout = Layout(UNKNOWN_VALUE)
+    var cache_lengths_layout_tensor = LayoutTensor[
+        DType.uint32, cache_lengths_layout, ImmutAnyOrigin
+    ](
+        cache_lengths_dev_buffer.unsafe_ptr(),
+        RuntimeLayout[cache_lengths_layout].row_major(IndexList[1](batch_size)),
+    )
+
+    var paged_lut_layout_tensor = LayoutTensor[
+        DType.uint32, paged_lut_layout, ImmutAnyOrigin
+    ](
+        paged_lut_dev_buffer.unsafe_ptr(),
+        RuntimeLayout[paged_lut_layout].row_major(
+            IndexList[2](batch_size, paged_lut_cols)
+        ),
+    )
+
+    var baseline_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            baseline_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var production_clone_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            production_clone_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var production_clone_no_trace_kv_collection = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            production_clone_no_trace_kv_block_dev_buffer.unsafe_ptr(),
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        cache_lengths_layout_tensor,
+        paged_lut_layout_tensor,
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+
+    var gamma_tensor = TileTensor(
+        gamma_dev_buffer.unsafe_ptr(), row_major(Idx[head_dim]())
+    )
+    var input_row_offsets_tensor = TileTensor(
+        input_row_offsets_dev_buffer.unsafe_ptr(),
+        row_major(Idx(batch_size + 1)),
+    )
+    var epsilon = Scalar[dtype](1e-6)
+    var weight_offset = Scalar[dtype](1.0)
+    var num_bytes = (
+        3 * Int(total_seq_len) * num_kv_heads * head_dim * size_of[dtype]()
+    )
+
+    @always_inline
+    @__copy_capture(
+        baseline_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_baseline(ctx: DeviceContext) raises:
+        rms_norm_kv_cache_ragged_paged[
+            target="gpu",
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            baseline_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        production_clone_no_trace_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_production_clone_no_trace_trial(ctx: DeviceContext) raises:
+        _rms_norm_kv_cache_production_clone_no_trace_trial[
+            dtype=dtype,
+            params=kv_params,
+            page_size=page_size,
+            cache_dtype=dtype,
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            production_clone_no_trace_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @__copy_capture(
+        production_clone_kv_collection,
+        gamma_tensor,
+        epsilon,
+        weight_offset,
+        input_row_offsets_tensor,
+        total_seq_len,
+    )
+    @parameter
+    def run_production_clone_trial(ctx: DeviceContext) raises:
+        _rms_norm_kv_cache_production_clone_trial[
+            dtype=dtype,
+            params=kv_params,
+            page_size=page_size,
+            cache_dtype=dtype,
+            multiply_before_cast=True,
+            per_head_norm=True,
+        ](
+            production_clone_kv_collection,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            UInt32(layer_idx),
+            total_seq_len,
+            input_row_offsets_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @parameter
+    def baseline_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_baseline](ctx)
+
+    @always_inline
+    @parameter
+    def production_clone_trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_production_clone_trial](ctx)
+
+    @always_inline
+    @parameter
+    def production_clone_no_trace_trial_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_production_clone_no_trace_trial](ctx)
+
+    var input_id = String(
+        dtype,
+        "/bs=",
+        batch_size,
+        "/seq=",
+        seq_len,
+        "/cache=",
+        cache_len,
+        "/step=",
+        cache_len_step,
+    )
+
+    m.bench_function[baseline_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_baseline",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+    m.bench_function[production_clone_trial_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_production_clone_trial",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+    m.bench_function[production_clone_no_trace_trial_bench](
+        BenchId(
+            "kv_cache_ragged_rms_norm_production_clone_no_trace_trial",
+            input_id=input_id,
+        ),
+        [ThroughputMeasure(BenchMetric.bytes, num_bytes)],
+    )
+
+    run_baseline(ctx)
+    run_production_clone_trial(ctx)
+    run_production_clone_no_trace_trial(ctx)
+    ctx.enqueue_copy(baseline_kv_block_host_ptr, baseline_kv_block_dev_buffer)
+    ctx.enqueue_copy(
+        production_clone_kv_block_host_ptr, production_clone_kv_block_dev_buffer
+    )
+    ctx.enqueue_copy(
+        production_clone_no_trace_kv_block_host_ptr,
+        production_clone_no_trace_kv_block_dev_buffer,
+    )
+    ctx.synchronize()
+
+    var baseline_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            baseline_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var production_clone_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            production_clone_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+    var production_clone_no_trace_kv_collection_host = CollectionType(
+        LayoutTensor[dtype, kv_block_layout, MutAnyOrigin](
+            production_clone_no_trace_kv_block_host_ptr,
+            RuntimeLayout[kv_block_layout].row_major(kv_block_shape),
+        ),
+        LayoutTensor[DType.uint32, cache_lengths_layout, ImmutAnyOrigin](
+            cache_lengths_host_ptr,
+            RuntimeLayout[cache_lengths_layout].row_major(
+                IndexList[1](batch_size)
+            ),
+        ),
+        LayoutTensor[DType.uint32, paged_lut_layout, ImmutAnyOrigin](
+            paged_lut_host_ptr,
+            RuntimeLayout[paged_lut_layout].row_major(
+                IndexList[2](batch_size, paged_lut_cols)
+            ),
+        ),
+        UInt32(seq_len),
+        UInt32(max_context_length),
+    )
+
+    var baseline_k_cache_host = baseline_kv_collection_host.get_key_cache(layer_idx)
+    var production_clone_k_cache_host = (
+        production_clone_kv_collection_host.get_key_cache(layer_idx)
+    )
+    var production_clone_no_trace_k_cache_host = (
+        production_clone_no_trace_kv_collection_host.get_key_cache(layer_idx)
+    )
+
+    for bs_idx in range(batch_size):
+        for tok_idx in range(seq_len):
+            var cache_tok_idx = Int(cache_lengths_host_ptr[bs_idx]) + tok_idx
+            for head_idx in range(num_kv_heads):
+                for dim_idx in range(head_dim):
+                    assert_almost_equal(
+                        baseline_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        production_clone_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+                    assert_almost_equal(
+                        baseline_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        production_clone_no_trace_k_cache_host.load[width=1](
+                            bs=bs_idx,
+                            tok_idx=cache_tok_idx,
+                            head_idx=head_idx,
+                            head_dim_idx=dim_idx,
+                        ),
+                        rtol=2e-2,
+                        atol=2e-2,
+                    )
+
+    input_row_offsets_host_ptr.free()
+    cache_lengths_host_ptr.free()
+    gamma_host_ptr.free()
+    paged_lut_host_ptr.free()
+    initial_kv_block_host_ptr.free()
+    baseline_kv_block_host_ptr.free()
+    production_clone_kv_block_host_ptr.free()
+    production_clone_no_trace_kv_block_host_ptr.free()
+
+    _ = input_row_offsets_dev_buffer^
+    _ = cache_lengths_dev_buffer^
+    _ = gamma_dev_buffer^
+    _ = paged_lut_dev_buffer^
+    _ = baseline_kv_block_dev_buffer^
+    _ = production_clone_kv_block_dev_buffer^
+    _ = production_clone_no_trace_kv_block_dev_buffer^
+
+
+def main() raises:
+    comptime dtype = get_defined_dtype["dtype", DType.bfloat16]()
+    comptime head_dim = get_defined_int["head_dim", 128]()
+    comptime num_kv_heads = get_defined_int["num_kv_heads", 16]()
+    comptime page_size = get_defined_int["page_size", 512]()
+
+    var batch_size = arg_parse("batch_size", 1)
+    var seq_len = arg_parse("seq_len", 1)
+    var cache_len = arg_parse("cache_len", 0)
+    var cache_len_step = arg_parse("cache_len_step", 0)
+
+    seed(0)
+
+    var m = Bench()
+    with DeviceContext() as ctx:
+        execute_kv_cache_ragged_rms_norm_pair[
+            dtype,
+            head_dim,
+            num_kv_heads,
+            page_size,
+        ](ctx, m, batch_size, seq_len, cache_len, cache_len_step)
+
+    m.dump_report()

--- a/max/kernels/benchmarks/gpu/nn/bench_kv_cache_ragged_rope_interleaved.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_kv_cache_ragged_rope_interleaved.mojo
@@ -48,7 +48,7 @@ def _get_run_name[
     num_q_heads: Int,
     num_kv_heads: Int,
     head_dim: Int,
-](batch_size: Int, seq_len: Int, cache_len: Int, use_random_seq_lengths: Bool, use_decode_fastpath: Bool,) -> String:
+](batch_size: Int, seq_len: Int, use_random_seq_lengths: Bool,) -> String:
     # fmt: off
     return String(
         "fused_qkv_ragged_rope(", dtype, ") : ",
@@ -60,9 +60,7 @@ def _get_run_name[
 
         "batch_size=", batch_size, ", ",
         "seq_len=", seq_len, ", ",
-        "cache_len=", cache_len, ", ",
         "use_random_seq_lengths=", use_random_seq_lengths, ", ",
-        "use_decode_fastpath=", use_decode_fastpath, ", ",
     )
     # fmt: on
 
@@ -74,9 +72,7 @@ def execute_kv_cache_ragged_rope[
     mut m: Bench,
     batch_size: Int,
     seq_len: Int,
-    cache_len: Int,
     use_random_seq_lengths: Bool,
-    use_decode_fastpath: Bool,
 ) raises:
     comptime max_seq_len = 2048
     var num_blocks = batch_size * 2
@@ -96,7 +92,7 @@ def execute_kv_cache_ragged_rope[
     )
     var max_prompt_length = 0
     var total_seq_len: UInt32 = 0
-    var cache_len_u32 = UInt32(cache_len)
+    var cache_len: UInt32 = 10
 
     var flop_count = 0
     with cache_lengths_device.map_to_host() as cache_lengths_host:
@@ -115,11 +111,11 @@ def execute_kv_cache_ragged_rope[
                 if curr_seq_length > UInt32(max_prompt_length):
                     max_prompt_length = Int(curr_seq_length)
 
-                cache_lengths_host[i] = cache_len_u32
+                cache_lengths_host[i] = cache_len
                 running_offset += curr_seq_length
 
             total_seq_len = running_offset
-            max_context_length = UInt32(max_prompt_length) + cache_len_u32
+            max_context_length = UInt32(max_prompt_length) + cache_len
 
             input_row_offsets_host[batch_size] = total_seq_len
 
@@ -135,7 +131,7 @@ def execute_kv_cache_ragged_rope[
         random(q_tensor)
     ctx.enqueue_copy(output_device, q_device)
     var output_device_tensor = TileTensor(
-        output_device.unsafe_ptr(),
+        output_device,
         row_major(Idx(total_seq_len), Idx[num_q_heads](), Idx[head_dim]()),
     )
 
@@ -143,7 +139,7 @@ def execute_kv_cache_ragged_rope[
         num_blocks,
         2,
         num_layers,
-        Int(UInt32(max_prompt_length) + cache_len_u32),
+        Int(UInt32(max_prompt_length) + cache_len),
         num_kv_heads,
         head_dim,
     )
@@ -172,13 +168,13 @@ def execute_kv_cache_ragged_rope[
         LayoutTensor[
             kv_block_device.dtype, Layout.row_major[6](), MutAnyOrigin
         ](
-            kv_block_device.unsafe_ptr(),
+            kv_block_device,
             RuntimeLayout[Layout.row_major[6]()].row_major(kv_block_shape),
         ),
         LayoutTensor[
             cache_lengths_device.dtype, Layout(UNKNOWN_VALUE), ImmutAnyOrigin
         ](
-            cache_lengths_device.unsafe_ptr(),
+            cache_lengths_device,
             RuntimeLayout[Layout(UNKNOWN_VALUE)].row_major(
                 IndexList[1](batch_size)
             ),
@@ -186,7 +182,7 @@ def execute_kv_cache_ragged_rope[
         LayoutTensor[
             lookup_table_device.dtype, Layout(UNKNOWN_VALUE), ImmutAnyOrigin
         ](
-            lookup_table_device.unsafe_ptr(),
+            lookup_table_device,
             RuntimeLayout[Layout(UNKNOWN_VALUE)].row_major(
                 IndexList[1](batch_size)
             ),
@@ -217,50 +213,22 @@ def execute_kv_cache_ragged_rope[
         @parameter
         @always_inline
         def kernel_launch(ctx: DeviceContext) raises:
-            if use_decode_fastpath:
-                fused_qk_rope_ragged[
-                    CollectionType.CacheType,
-                    interleaved=False,
-                    target="gpu",
-                    allow_decode_fastpath=True,
-                ](
-                    TileTensor(q_device.unsafe_ptr(), q_layout),
-                    TileTensor(
-                        input_row_offsets_device.unsafe_ptr(),
-                        row_major(Idx(batch_size + 1)),
-                    ),
-                    kv_collection_device,
-                    TileTensor(
-                        freqs_cis_table_device.unsafe_ptr(),
-                        freqs_cis_table_layout,
-                    ),
-                    None,
-                    0,
-                    output_device_tensor,
-                    ctx,
-                )
-            else:
-                fused_qk_rope_ragged[
-                    CollectionType.CacheType,
-                    interleaved=False,
-                    target="gpu",
-                    allow_decode_fastpath=False,
-                ](
-                    TileTensor(q_device.unsafe_ptr(), q_layout),
-                    TileTensor(
-                        input_row_offsets_device.unsafe_ptr(),
-                        row_major(Idx(batch_size + 1)),
-                    ),
-                    kv_collection_device,
-                    TileTensor(
-                        freqs_cis_table_device.unsafe_ptr(),
-                        freqs_cis_table_layout,
-                    ),
-                    None,
-                    0,
-                    output_device_tensor,
-                    ctx,
-                )
+            fused_qk_rope_ragged[
+                CollectionType.CacheType,
+                interleaved=True,
+                target="gpu",
+            ](
+                TileTensor(q_device, q_layout),
+                TileTensor(
+                    input_row_offsets_device, row_major(Idx(batch_size + 1))
+                ),
+                kv_collection_device,
+                TileTensor(freqs_cis_table_device, freqs_cis_table_layout),
+                None,
+                0,
+                output_device_tensor,
+                ctx,
+            )
 
         b.iter_custom[kernel_launch](ctx)
 
@@ -269,9 +237,7 @@ def execute_kv_cache_ragged_rope[
             _get_run_name[dtype, num_q_heads, num_kv_heads, head_dim](
                 batch_size,
                 seq_len,
-                cache_len,
                 use_random_seq_lengths,
-                use_decode_fastpath,
             )
         ),
         [ThroughputMeasure(BenchMetric.flops, flop_count)],
@@ -286,9 +252,7 @@ def main() raises:
     comptime num_kv_heads = get_defined_int["num_kv_heads", 8]()
 
     var batch_size = arg_parse("batch_size", 1)
-    var cache_len = arg_parse("cache_len", 10)
     var use_random_seq_lengths = arg_parse("use_random_lengths", False)
-    var use_decode_fastpath = arg_parse("use_decode_fastpath", True)
     var seq_len = arg_parse("seq_len", 1)
 
     seed(0)
@@ -306,9 +270,7 @@ def main() raises:
             m,
             batch_size,
             seq_len,
-            cache_len,
             use_random_seq_lengths,
-            use_decode_fastpath,
         )
 
     m.dump_report()

--- a/max/kernels/benchmarks/gpu/nn/bench_kv_cache_ragged_rope_qonly.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_kv_cache_ragged_rope_qonly.mojo
@@ -1,0 +1,342 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import ceildiv
+from std.random import random_ui64, seed
+from std.sys import get_defined_dtype, get_defined_int
+from std.sys.info import align_of, simd_width_of
+
+from std.benchmark import (
+    Bench,
+    Bencher,
+    BenchId,
+    BenchMetric,
+    ThroughputMeasure,
+)
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    WARP_SIZE,
+    block_idx_uint as block_idx,
+    thread_idx_uint as thread_idx,
+)
+from std.gpu.host import DeviceContext
+from internal_utils import arg_parse
+from layout import Coord, Idx, TensorLayout, TileTensor, row_major
+from layout._fillers import random
+from nn.fused_qk_rope import _rope_complex_mul_half
+from nn.rope import rope_ragged
+
+from std.utils.index import IndexList
+from std.utils.static_tuple import StaticTuple
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _rope_qonly_decode_ragged_trial_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    num_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime vec_width = simd_width // 2
+    comptime align = align_of[SIMD[dtype, vec_width]]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+
+    comptime assert head_dim == 128, "Only 128-column BF16 query rows are supported"
+    comptime assert head_dim == half_warp_size * simd_width
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    if row < UInt(num_rows):
+        var row_int = Int(row)
+        var global_token_idx = row_int // num_q_heads
+        var head_idx = row_int % num_q_heads
+        var position = Int(start_pos[global_token_idx])
+
+        var re_offset = Int(local_tid) * vec_width
+        var im_offset = re_offset + head_dim // 2
+        var freq_offset = Int(local_tid) * simd_width
+
+        var q_re = x.load[width=vec_width, alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset))
+        )
+        var q_im = x.load[width=vec_width, alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset))
+        )
+        var freq = freqs_cis.load[width=simd_width, alignment=1](
+            Coord(Idx(position), Idx(freq_offset))
+        )
+        var rope_val = _rope_complex_mul_half[
+            dtype,
+            freq_dtype,
+            vec_width,
+            simd_width,
+        ](q_re, q_im, freq)
+
+        output.store[alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset)),
+            rope_val[0],
+        )
+        output.store[alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset)),
+            rope_val[1],
+        )
+
+
+def _get_run_name[
+    dtype: DType,
+    num_q_heads: Int,
+    num_kv_heads: Int,
+    head_dim: Int,
+](batch_size: Int, seq_len: Int, cache_len: Int, use_random_seq_lengths: Bool, use_decode_fastpath: Bool,) -> String:
+    # fmt: off
+    return String(
+        "q_ragged_rope(", dtype, ") : ",
+
+        # head_info
+        "num_q_heads=", num_q_heads, ", ",
+        "ref_num_kv_heads=", num_kv_heads, ", ",
+        "head_dim=", head_dim, " : ",
+
+        "batch_size=", batch_size, ", ",
+        "seq_len=", seq_len, ", ",
+        "cache_len=", cache_len, ", ",
+        "use_random_seq_lengths=", use_random_seq_lengths, ", ",
+        "use_decode_fastpath=", use_decode_fastpath, ", ",
+    )
+    # fmt: on
+
+
+def execute_kv_cache_ragged_rope[
+    dtype: DType, head_dim: Int, num_q_heads: Int, num_kv_heads: Int
+](
+    ctx: DeviceContext,
+    mut m: Bench,
+    batch_size: Int,
+    seq_len: Int,
+    cache_len: Int,
+    use_random_seq_lengths: Bool,
+    use_decode_fastpath: Bool,
+) raises:
+    comptime max_seq_len = 2048
+
+    var input_row_offsets_device = ctx.enqueue_create_buffer[dtype.uint32](
+        batch_size + 1
+    )
+    var start_pos_device = ctx.enqueue_create_buffer[DType.uint32](batch_size)
+    var total_seq_len: UInt32 = 0
+
+    var flop_count = 0
+    with start_pos_device.map_to_host() as start_pos_host:
+        with input_row_offsets_device.map_to_host() as input_row_offsets_host:
+            var running_offset: UInt32 = 0
+            for i in range(batch_size):
+                var curr_seq_length: UInt32
+                if use_random_seq_lengths:
+                    curr_seq_length = random_ui64(1, UInt64(seq_len)).cast[
+                        DType.uint32
+                    ]()
+                else:
+                    curr_seq_length = UInt32(seq_len)
+
+                input_row_offsets_host[i] = running_offset
+                start_pos_host[i] = UInt32(cache_len)
+                running_offset += curr_seq_length
+
+            total_seq_len = running_offset
+            input_row_offsets_host[batch_size] = total_seq_len
+
+    var q_device = ctx.enqueue_create_buffer[dtype](
+        Int(total_seq_len) * num_q_heads * head_dim
+    )
+    var output_device = ctx.enqueue_create_buffer[dtype](len(q_device))
+    var q_layout = row_major(
+        (Idx(total_seq_len), Idx[num_q_heads](), Idx[head_dim]())
+    )
+    with q_device.map_to_host() as q_host:
+        var q_tensor = TileTensor(q_host, q_layout)
+        random(q_tensor)
+
+    var q_device_tensor = TileTensor(q_device, q_layout)
+    var output_device_tensor = TileTensor(
+        output_device,
+        row_major(Idx(total_seq_len), Idx[num_q_heads](), Idx[head_dim]()),
+    )
+    var input_row_offsets_tensor = TileTensor(
+        input_row_offsets_device, row_major(Idx(batch_size + 1))
+    )
+    var start_pos_tensor = TileTensor(
+        start_pos_device, row_major(Idx(batch_size))
+    )
+
+    comptime freqs_cis_table_layout = row_major[max_seq_len, head_dim]()
+    var freqs_cis_table_device = ctx.enqueue_create_buffer[dtype](
+        freqs_cis_table_layout.static_product
+    )
+    var freqs_cis_table_tensor = TileTensor(
+        freqs_cis_table_device, freqs_cis_table_layout
+    )
+
+    num_flops_per_elem = 6
+    num_elems = Int(total_seq_len) * num_q_heads * head_dim // 2
+    flop_count = num_flops_per_elem * num_elems
+    var is_decode_uniform = (
+        not use_random_seq_lengths and seq_len == 1 and Int(total_seq_len) == batch_size
+    )
+
+    @always_inline
+    @__copy_capture(output_device_tensor)
+    def output_fn[
+        width: Int, alignment: Int
+    ](idx: IndexList[3], val: SIMD[dtype, width]) capturing -> None:
+        output_device_tensor.store[width=width, alignment=alignment](
+            Coord(idx), val
+        )
+
+    @parameter
+    @__copy_capture(
+        q_device_tensor,
+        input_row_offsets_tensor,
+        start_pos_tensor,
+        freqs_cis_table_tensor,
+    )
+    @always_inline
+    def bench_func(mut b: Bencher):
+        @parameter
+        @always_inline
+        def kernel_launch(ctx: DeviceContext) raises:
+            comptime if dtype == DType.bfloat16 and head_dim == 128:
+                if use_decode_fastpath and is_decode_uniform:
+                    comptime warps_per_block = 2
+                    comptime block_size = warps_per_block * WARP_SIZE
+                    comptime kernel = _rope_qonly_decode_ragged_trial_kernel[
+                        dtype,
+                        dtype,
+                        q_device_tensor.LayoutType,
+                        output_device_tensor.LayoutType,
+                        start_pos_tensor.LayoutType,
+                        freqs_cis_table_tensor.LayoutType,
+                        block_size,
+                        warps_per_block,
+                    ]
+                    var num_rows = Int(total_seq_len) * num_q_heads
+                    ctx.enqueue_function[kernel, kernel](
+                        q_device_tensor,
+                        output_device_tensor,
+                        start_pos_tensor,
+                        freqs_cis_table_tensor,
+                        num_rows,
+                        grid_dim=ceildiv(num_rows, warps_per_block * 2),
+                        block_dim=block_size,
+                    )
+                else:
+                    rope_ragged[
+                        dtype,
+                        dtype,
+                        interleaved=False,
+                        target="gpu",
+                        output_fn=output_fn,
+                    ](
+                        x=q_device_tensor,
+                        input_row_offsets=input_row_offsets_tensor,
+                        start_pos=start_pos_tensor,
+                        freqs_cis=freqs_cis_table_tensor,
+                        context=Optional[DeviceContext](ctx),
+                    )
+            else:
+                rope_ragged[
+                    dtype,
+                    dtype,
+                    interleaved=False,
+                    target="gpu",
+                    output_fn=output_fn,
+                ](
+                    x=q_device_tensor,
+                    input_row_offsets=input_row_offsets_tensor,
+                    start_pos=start_pos_tensor,
+                    freqs_cis=freqs_cis_table_tensor,
+                    context=Optional[DeviceContext](ctx),
+                )
+
+        b.iter_custom[kernel_launch](ctx)
+
+    m.bench_function[bench_func](
+        BenchId(
+            _get_run_name[dtype, num_q_heads, num_kv_heads, head_dim](
+                batch_size,
+                seq_len,
+                cache_len,
+                use_random_seq_lengths,
+                use_decode_fastpath,
+            )
+        ),
+        [ThroughputMeasure(BenchMetric.flops, flop_count)],
+    )
+
+
+def main() raises:
+    comptime dtype = get_defined_dtype["dtype", DType.bfloat16]()
+
+    comptime head_dim = get_defined_int["head_dim", 128]()
+    comptime num_q_heads = get_defined_int["num_q_heads", 32]()
+    comptime num_kv_heads = get_defined_int["num_kv_heads", 8]()
+
+    var batch_size = arg_parse("batch_size", 1)
+    var cache_len = arg_parse("cache_len", 10)
+    var use_random_seq_lengths = arg_parse("use_random_lengths", False)
+    var use_decode_fastpath = arg_parse("use_decode_fastpath", False)
+    var seq_len = arg_parse("seq_len", 1)
+
+    seed(0)
+
+    var m = Bench()
+    with DeviceContext() as ctx:
+        execute_kv_cache_ragged_rope[
+            dtype,
+            head_dim,
+            num_q_heads,
+            num_kv_heads,
+        ](
+            ctx,
+            m,
+            batch_size,
+            seq_len,
+            cache_len,
+            use_random_seq_lengths,
+            use_decode_fastpath,
+        )
+
+    m.dump_report()

--- a/max/kernels/benchmarks/gpu/nn/bench_qnorm_rope_boundary.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_qnorm_rope_boundary.mojo
@@ -1,0 +1,429 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.random import random_float64, seed
+from std.sys import get_defined_dtype, get_defined_int
+from std.sys.info import align_of, simd_width_of
+
+from std.benchmark import Bench, BenchConfig, Bencher, BenchId
+from std.gpu import WARP_SIZE, block_idx, thread_idx
+from std.gpu.host import DeviceContext
+from std.gpu.primitives import warp
+from std.testing import assert_almost_equal
+from std.utils.numerics import get_accum_type
+
+from internal_utils import arg_parse
+from layout import Coord, Idx, TileTensor, row_major
+from nn._ragged_utils import get_batch_from_row_offsets
+from nn.normalization import rms_norm_gpu
+from nn.rope import q_rms_norm_rope_ragged, rope_ragged
+
+from std.utils import IndexList
+
+
+@always_inline
+def _rope_complex_mul_half_local[
+    dtype: DType,
+    freq_dtype: DType,
+    width_2: Int,
+    freq_width: Int,
+](
+    x_re: SIMD[dtype, width_2],
+    x_im: SIMD[dtype, width_2],
+    freq: SIMD[freq_dtype, freq_width],
+) -> Tuple[SIMD[dtype, width_2], SIMD[dtype, width_2]]:
+    var f_re = rebind[SIMD[freq_dtype, width_2]](freq.deinterleave()[0])
+    var f_im = rebind[SIMD[freq_dtype, width_2]](freq.deinterleave()[1])
+    var xr = x_re.cast[freq_dtype]()
+    var xi = x_im.cast[freq_dtype]()
+    var res_re = (xr * f_re - xi * f_im).cast[dtype]()
+    var res_im = (xr * f_im + xi * f_re).cast[dtype]()
+    return (res_re, res_im)
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](
+        Int32(warps_per_block * WARP_SIZE)
+    )
+)
+def qnorm_rope_ragged_non_interleaved_128_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    //,
+    warps_per_block: Int,
+](
+    q_proj: TileTensor[dtype, ...],
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    start_pos: TileTensor[DType.uint32, ...],
+    freqs_cis: TileTensor[freq_dtype, ...],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    num_rows: Int,
+    output: TileTensor[mut=True, dtype, ...],
+):
+    comptime assert q_proj.flat_rank == 3
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+    comptime num_q_heads = Int(q_proj.static_shape[1])
+    comptime head_dim = Int(q_proj.static_shape[2])
+    comptime assert head_dim == 128
+    comptime simd_width = simd_width_of[dtype]()
+    comptime assert simd_width == 8
+    comptime vec_width = simd_width // 2
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime align = align_of[SIMD[dtype, vec_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+
+    var eps_accum = epsilon.cast[accum_type]()
+    var weight_offset_accum = weight_offset.cast[accum_type]()
+
+    var tid = thread_idx.x
+    var block_row = Int(block_idx.x) * (warps_per_block * 2)
+    var warp_id = Int(tid // UInt(WARP_SIZE))
+    var sub_warp_id = Int((tid % UInt(WARP_SIZE)) // UInt(half_warp_size))
+    var row = block_row + (warp_id * 2) + sub_warp_id
+    var local_tid = Int(tid % UInt(half_warp_size))
+
+    if row < num_rows:
+        var global_token_idx = row // num_q_heads
+        var head_idx = row % num_q_heads
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+        var position_idx = Int(start_pos[batch_idx] + UInt32(token_idx))
+
+        var re_col = local_tid * vec_width
+        var im_col = re_col + (head_dim // 2)
+        var freq_col = local_tid * simd_width
+
+        var coord_re = IndexList[3](global_token_idx, head_idx, re_col)
+        var coord_im = IndexList[3](global_token_idx, head_idx, im_col)
+        var q_re = q_proj.load[width=vec_width, alignment=align](Coord(coord_re))
+        var q_im = q_proj.load[width=vec_width, alignment=align](Coord(coord_im))
+
+        var thread_m2 = (q_re.cast[accum_type]() ** 2).reduce_add() + (
+            q_im.cast[accum_type]() ** 2
+        ).reduce_add()
+        var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](thread_m2)
+        var norm_factor = rsqrt(
+            (row_m2 / Scalar[accum_type](head_dim)) + eps_accum
+        )
+
+        var gamma_re = gamma.load[width=vec_width, alignment=align](
+            Coord(Idx(re_col))
+        )
+        var gamma_im = gamma.load[width=vec_width, alignment=align](
+            Coord(Idx(im_col))
+        )
+        var norm_re = (
+            q_re.cast[accum_type]()
+            * norm_factor
+            * (gamma_re.cast[accum_type]() + weight_offset_accum)
+        ).cast[dtype]()
+        var norm_im = (
+            q_im.cast[accum_type]()
+            * norm_factor
+            * (gamma_im.cast[accum_type]() + weight_offset_accum)
+        ).cast[dtype]()
+
+        var freq = freqs_cis.load[width=simd_width](
+            Coord(Idx(position_idx), Idx(freq_col))
+        )
+        var rope_out = _rope_complex_mul_half_local(norm_re, norm_im, freq)
+
+        output.store[alignment=align](Coord(coord_re), rope_out[0])
+        output.store[alignment=align](Coord(coord_im), rope_out[1])
+
+
+def qnorm_rope_ragged_non_interleaved_128[
+    dtype: DType,
+    freq_dtype: DType,
+](
+    q_proj: TileTensor[dtype, ...],
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    start_pos: TileTensor[DType.uint32, ...],
+    freqs_cis: TileTensor[freq_dtype, ...],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    output: TileTensor[mut=True, dtype, ...],
+    ctx: DeviceContext,
+) raises:
+    comptime num_q_heads = Int(q_proj.static_shape[1])
+    var num_rows = q_proj.dim(0) * num_q_heads
+    comptime sm_count = ctx.default_device_info.sm_count
+    comptime default_warps_per_block = 2
+    comptime large_row_warps_per_block = 8
+    comptime min_large_row_blocks_per_sm = 6
+
+    var large_row_grid_dim = ceildiv(num_rows, large_row_warps_per_block * 2)
+    if large_row_grid_dim >= sm_count * min_large_row_blocks_per_sm:
+        comptime kernel = qnorm_rope_ragged_non_interleaved_128_kernel[
+            dtype, freq_dtype, large_row_warps_per_block
+        ]
+        ctx.enqueue_function[kernel, kernel](
+            q_proj,
+            input_row_offsets,
+            start_pos,
+            freqs_cis,
+            gamma,
+            epsilon,
+            weight_offset,
+            num_rows,
+            output,
+            grid_dim=large_row_grid_dim,
+            block_dim=large_row_warps_per_block * WARP_SIZE,
+        )
+    else:
+        comptime kernel = qnorm_rope_ragged_non_interleaved_128_kernel[
+            dtype, freq_dtype, default_warps_per_block
+        ]
+        ctx.enqueue_function[kernel, kernel](
+            q_proj,
+            input_row_offsets,
+            start_pos,
+            freqs_cis,
+            gamma,
+            epsilon,
+            weight_offset,
+            num_rows,
+            output,
+            grid_dim=ceildiv(num_rows, default_warps_per_block * 2),
+            block_dim=default_warps_per_block * WARP_SIZE,
+        )
+
+
+def _get_run_name[
+    dtype: DType,
+    num_q_heads: Int,
+    head_dim: Int,
+](batch_size: Int, seq_len: Int, cache_len: Int,) -> String:
+    return String(
+        "qnorm_rope_boundary(",
+        dtype,
+        ") : num_q_heads=",
+        num_q_heads,
+        ", head_dim=",
+        head_dim,
+        " : batch_size=",
+        batch_size,
+        ", seq_len=",
+        seq_len,
+        ", cache_len=",
+        cache_len,
+    )
+
+
+def bench_qnorm_rope_boundary[
+    dtype: DType,
+    head_dim: Int,
+    num_q_heads: Int,
+](
+    ctx: DeviceContext,
+    mut b: Bench,
+    batch_size: Int,
+    seq_len: Int,
+    cache_len: Int,
+) raises:
+    comptime max_seq_len = 2048
+    var input_row_offsets_device = ctx.enqueue_create_buffer[DType.uint32](
+        batch_size + 1
+    )
+    var start_pos_device = ctx.enqueue_create_buffer[DType.uint32](batch_size)
+    var total_seq_len: UInt32 = 0
+
+    with start_pos_device.map_to_host() as start_pos_host:
+        with input_row_offsets_device.map_to_host() as input_row_offsets_host:
+            var running_offset: UInt32 = 0
+            for i in range(batch_size):
+                input_row_offsets_host[i] = running_offset
+                start_pos_host[i] = UInt32(cache_len)
+                running_offset += UInt32(seq_len)
+
+            total_seq_len = running_offset
+            input_row_offsets_host[batch_size] = total_seq_len
+
+    var q_layout = row_major(
+        (Idx(total_seq_len), Idx[num_q_heads](), Idx[head_dim]())
+    )
+    var q_device = ctx.enqueue_create_buffer[dtype](
+        Int(total_seq_len) * num_q_heads * head_dim
+    )
+    var baseline_norm_device = ctx.enqueue_create_buffer[dtype](len(q_device))
+    var baseline_output_device = ctx.enqueue_create_buffer[dtype](len(q_device))
+    var fused_output_device = ctx.enqueue_create_buffer[dtype](len(q_device))
+    var gamma_device = ctx.enqueue_create_buffer[dtype](head_dim)
+    comptime freqs_cis_layout = row_major[max_seq_len, head_dim]()
+    var freqs_cis_device = ctx.enqueue_create_buffer[dtype](
+        freqs_cis_layout.static_product
+    )
+
+    with q_device.map_to_host() as q_host:
+        var q_tensor = TileTensor(q_host, q_layout)
+        for i in range(Int(total_seq_len) * num_q_heads * head_dim):
+            q_host[i] = Scalar[dtype](random_float64(-1, 1).cast[dtype]())
+
+    with freqs_cis_device.map_to_host() as freqs_h:
+        for i in range(freqs_cis_layout.static_product):
+            freqs_h[i] = Scalar[dtype](random_float64(-1, 1).cast[dtype]())
+
+    with gamma_device.map_to_host() as gamma_h:
+        for i in range(head_dim):
+            gamma_h[i] = Scalar[dtype]((Float64(i + head_dim) / Float64(head_dim)).cast[dtype]())
+
+    var q_tensor = TileTensor(q_device, q_layout)
+    var baseline_norm_tensor = TileTensor(baseline_norm_device, q_layout)
+    var baseline_output_tensor = TileTensor(baseline_output_device, q_layout)
+    var fused_output_tensor = TileTensor(fused_output_device, q_layout)
+    var input_row_offsets_tensor = TileTensor(
+        input_row_offsets_device, row_major(Idx(batch_size + 1))
+    )
+    var start_pos_tensor = TileTensor(start_pos_device, row_major(Idx(batch_size)))
+    var freqs_cis_tensor = TileTensor(freqs_cis_device, freqs_cis_layout)
+    var gamma_tensor = TileTensor(gamma_device, row_major(Idx[head_dim]()))
+    var epsilon = Scalar[dtype](0.001)
+    var weight_offset = Scalar[dtype](1.0)
+
+    @always_inline
+    @__copy_capture(q_tensor)
+    @parameter
+    def rms_input_fn[
+        width: Int, rank: Int
+    ](coords: IndexList[rank]) -> SIMD[dtype, width]:
+        return q_tensor.load[width=width](Coord(coords))
+
+    @always_inline
+    @__copy_capture(baseline_norm_tensor)
+    @parameter
+    def rms_output_fn[
+        width: Int, alignment: Int
+    ](coords: IndexList[3], val: SIMD[dtype, width]) -> None:
+        baseline_norm_tensor.store[alignment=alignment](Coord(coords), val)
+
+    @always_inline
+    @__copy_capture(baseline_output_tensor)
+    @parameter
+    def rope_output_fn[
+        width: Int, alignment: Int
+    ](idx: IndexList[3], val: SIMD[dtype, width]) -> None:
+        baseline_output_tensor.store[alignment=alignment](Coord(idx), val)
+
+    @always_inline
+    @__copy_capture(q_layout, gamma_tensor, epsilon, weight_offset)
+    @parameter
+    def run_baseline(ctx: DeviceContext) raises:
+        rms_norm_gpu[rms_input_fn, rms_output_fn, multiply_before_cast=True](
+            IndexList[3](Int(total_seq_len), num_q_heads, head_dim),
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            ctx,
+        )
+        rope_ragged[
+            dtype,
+            dtype,
+            interleaved=False,
+            target="gpu",
+            output_fn=rope_output_fn,
+        ](
+            x=baseline_norm_tensor,
+            input_row_offsets=input_row_offsets_tensor,
+            start_pos=start_pos_tensor,
+            freqs_cis=freqs_cis_tensor,
+            context=Optional[DeviceContext](ctx),
+        )
+
+    @always_inline
+    @__copy_capture(q_tensor, gamma_tensor, epsilon, weight_offset)
+    @parameter
+    def run_fused(ctx: DeviceContext) raises:
+        q_rms_norm_rope_ragged[dtype, dtype, target="gpu"](
+            q_tensor,
+            input_row_offsets_tensor,
+            start_pos_tensor,
+            freqs_cis_tensor,
+            gamma_tensor,
+            epsilon,
+            weight_offset,
+            fused_output_tensor,
+            ctx,
+        )
+
+    @always_inline
+    @parameter
+    def baseline_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_baseline](ctx)
+
+    @always_inline
+    @parameter
+    def fused_bench(mut bencher: Bencher) raises:
+        bencher.iter_custom[run_fused](ctx)
+
+    b.bench_function[baseline_bench](
+        BenchId(
+            "qnorm_rope_boundary_baseline",
+            input_id=_get_run_name[dtype, num_q_heads, head_dim](
+                batch_size, seq_len, cache_len
+            ),
+        ),
+    )
+    b.bench_function[fused_bench](
+        BenchId(
+            "qnorm_rope_boundary_fused",
+            input_id=_get_run_name[dtype, num_q_heads, head_dim](
+                batch_size, seq_len, cache_len
+            ),
+        ),
+    )
+
+    run_baseline(ctx)
+    run_fused(ctx)
+    var baseline_host = alloc[Scalar[dtype]](len(q_device))
+    var fused_host = alloc[Scalar[dtype]](len(q_device))
+    ctx.enqueue_copy(baseline_host, baseline_output_device)
+    ctx.enqueue_copy(fused_host, fused_output_device)
+    ctx.synchronize()
+
+    for i in range(len(q_device)):
+        assert_almost_equal(
+            baseline_host[i], fused_host[i], rtol=2e-2, atol=2e-2
+        )
+
+    baseline_host.free()
+    fused_host.free()
+
+
+def main() raises:
+    comptime dtype = get_defined_dtype["dtype", DType.bfloat16]()
+    comptime head_dim = get_defined_int["head_dim", 128]()
+    comptime num_q_heads = get_defined_int["num_q_heads", 32]()
+
+    var batch_size = arg_parse("batch_size", 1)
+    var seq_len = arg_parse("seq_len", 1)
+    var cache_len = arg_parse("cache_len", 0)
+
+    seed(0)
+
+    var b = Bench(BenchConfig(num_repetitions=1))
+    with DeviceContext() as ctx:
+        bench_qnorm_rope_boundary[dtype, head_dim, num_q_heads](
+            ctx, b, batch_size, seq_len, cache_len
+        )
+
+    b.dump_report()

--- a/max/kernels/benchmarks/gpu/nn/bench_topk.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_topk.mojo
@@ -27,7 +27,14 @@ from internal_utils import arg_parse
 
 from layout import Coord, Idx, TileTensor, coord_to_index_list, row_major
 
-from nn.topk import _top_k_cpu, _topk_gpu, _topk_topp_sampling_fi, topk_gpu
+from nn.topk import (
+    _default_num_blocks_per_input,
+    _default_topk_block_size,
+    _top_k_cpu,
+    _topk_gpu,
+    _topk_topp_sampling_fi,
+    topk_gpu,
+)
 from std.testing import assert_almost_equal, assert_equal
 
 from std.utils import IndexList
@@ -103,8 +110,18 @@ def bench_topk_batched[
         device_out_idxs_buffer, row_major(Idx(batch_size), Idx(out_idx_len))
     )
 
+    var effective_block_size = (
+        block_size if block_size > 0 else
+        _default_topk_block_size(in_size, batch_size, sampling)
+    )
+
     if not num_blocks_per_input:
-        num_blocks_per_input = min(ceildiv(N, block_size), 8)
+        num_blocks_per_input = (
+            min(ceildiv(N, effective_block_size), 32) if sampling else
+            _default_num_blocks_per_input(
+                batch_size, N, effective_block_size, K
+            )
+        )
 
     var local_topk_size = batch_size * num_blocks_per_input * K
     var device_local_topk_vals_buffer = ctx.enqueue_create_buffer[dtype](
@@ -170,7 +187,7 @@ def bench_topk_batched[
                 k=TileTensor(k.ptr, row_major(Idx(Int64(batch_size))))
                 .as_any_origin()
                 .as_immut(),
-                block_size=block_size,
+                block_size=effective_block_size,
                 num_blocks_per_input=num_blocks_per_input,
                 top_p=top_p_tt.as_any_origin().as_immut(),
             )
@@ -261,9 +278,7 @@ def bench_topk_multi_rank[
     # var input_shape = test_case.input_shape
     var K = test_case.K
     var block_size = test_case.block_size
-    var num_blocks_per_input: Int = min(
-        ceildiv(input_shape.flattened_length(), block_size), 8
-    ) if not test_case.num_blocks_per_input else test_case.num_blocks_per_input
+    var num_blocks_per_input = test_case.num_blocks_per_input
 
     comptime largest = test_case.largest
     comptime sampling = test_case.sampling
@@ -317,6 +332,19 @@ def bench_topk_multi_rank[
         var last_dim = input_shape[rank - 1]
         batch_size = input_shape.flattened_length() // last_dim
 
+    var row_size = input_shape[rank - 1]
+    var effective_block_size = (
+        block_size if block_size > 0 else
+        _default_topk_block_size(in_size, batch_size, sampling)
+    )
+    if not num_blocks_per_input:
+        num_blocks_per_input = (
+            min(ceildiv(row_size, effective_block_size), 32) if sampling else
+            _default_num_blocks_per_input(
+                batch_size, row_size, effective_block_size, K
+            )
+        )
+
     var K_host_ptr = alloc[Int64](batch_size)
     var K_host_buffer = TileTensor(K_host_ptr, row_major(Idx(batch_size)))
     for i in range(batch_size):
@@ -348,7 +376,7 @@ def bench_topk_multi_rank[
                 k=TileTensor(k.ptr, row_major(Idx(Int64(batch_size))))
                 .as_any_origin()
                 .as_immut(),
-                block_size=block_size,
+                block_size=effective_block_size,
                 num_blocks_per_input=num_blocks_per_input,
             )
 
@@ -425,10 +453,22 @@ def bench_topk_fi[
     fill_fn_name: String,
     top_p: Float32 = 1.0,
     temperature: Float32 = 1.0,
+    use_k_arr: Bool = True,
+    use_temperature_arr: Bool = True,
+    use_top_p_arr: Bool = True,
+    softmax_block_size: Int = 0,
 ) raises:
     var batch_size = test_case.batch_size
     var N = test_case.N
     var K = test_case.K
+    var fi_block_size = (
+        Optional[Int](test_case.block_size) if test_case.block_size > 0 else
+        Optional[Int]()
+    )
+    var fi_softmax_block_size = (
+        Optional[Int](softmax_block_size) if softmax_block_size > 0 else
+        Optional[Int]()
+    )
 
     var in_size = batch_size * N
 
@@ -444,7 +484,11 @@ def bench_topk_fi[
     var device_out_idxs_buffer = ctx.enqueue_create_buffer[out_idx_type](
         batch_size
     )
+    var device_k_buffer = ctx.enqueue_create_buffer[out_idx_type](batch_size)
     var device_temp_buffer = ctx.enqueue_create_buffer[DType.float32](
+        batch_size
+    )
+    var device_top_p_buffer = ctx.enqueue_create_buffer[DType.float32](
         batch_size
     )
 
@@ -455,8 +499,14 @@ def bench_topk_fi[
         device_out_idxs_buffer.unsafe_ptr(),
         row_major(Idx(batch_size), Idx(1)),
     )
+    var k_tt = TileTensor(
+        device_k_buffer.unsafe_ptr(), row_major(Idx(batch_size))
+    )
     var temp_tt = TileTensor(
         device_temp_buffer.unsafe_ptr(), row_major(Idx(batch_size))
+    )
+    var top_p_tt = TileTensor(
+        device_top_p_buffer.unsafe_ptr(), row_major(Idx(batch_size))
     )
 
     ctx.enqueue_copy(device_in_buffer, in_buffer_ptr)
@@ -466,6 +516,16 @@ def bench_topk_fi[
     for i in range(batch_size):
         temp_host_ptr[i] = temperature
     ctx.enqueue_copy(device_temp_buffer, temp_host_ptr)
+
+    var top_p_host_ptr = alloc[Float32](batch_size)
+    for i in range(batch_size):
+        top_p_host_ptr[i] = top_p
+    ctx.enqueue_copy(device_top_p_buffer, top_p_host_ptr)
+
+    var k_host_ptr = alloc[Scalar[out_idx_type]](batch_size)
+    for i in range(batch_size):
+        k_host_ptr[i] = Scalar[out_idx_type](K)
+    ctx.enqueue_copy(device_k_buffer, k_host_ptr)
 
     # Create per-row seed buffer on device.
     var seed_device_buffer = ctx.enqueue_create_buffer[DType.uint64](batch_size)
@@ -484,15 +544,108 @@ def bench_topk_fi[
         @parameter
         @always_inline
         def kernel_launch(ctx: DeviceContext) raises:
-            _topk_topp_sampling_fi[dtype, out_idx_type](
-                ctx,
-                K,
-                top_p,
-                device_in,
-                device_out_idxs,
-                temperature=temp_tt.as_any_origin().as_immut(),
-                rng_seed=seed_tt.as_any_origin().as_immut(),
-            )
+            if use_k_arr:
+                if use_temperature_arr and use_top_p_arr:
+                    _topk_topp_sampling_fi[dtype, out_idx_type](
+                        ctx,
+                        K,
+                        top_p,
+                        device_in,
+                        device_out_idxs,
+                        block_size=fi_block_size,
+                        softmax_block_size=fi_softmax_block_size,
+                        k=k_tt.as_any_origin().as_immut(),
+                        temperature=temp_tt.as_any_origin().as_immut(),
+                        top_p=top_p_tt.as_any_origin().as_immut(),
+                        rng_seed=seed_tt.as_any_origin().as_immut(),
+                    )
+                elif use_temperature_arr:
+                    _topk_topp_sampling_fi[dtype, out_idx_type](
+                        ctx,
+                        K,
+                        top_p,
+                        device_in,
+                        device_out_idxs,
+                        block_size=fi_block_size,
+                        softmax_block_size=fi_softmax_block_size,
+                        k=k_tt.as_any_origin().as_immut(),
+                        temperature=temp_tt.as_any_origin().as_immut(),
+                        rng_seed=seed_tt.as_any_origin().as_immut(),
+                    )
+                elif use_top_p_arr:
+                    _topk_topp_sampling_fi[dtype, out_idx_type](
+                        ctx,
+                        K,
+                        top_p,
+                        device_in,
+                        device_out_idxs,
+                        block_size=fi_block_size,
+                        softmax_block_size=fi_softmax_block_size,
+                        k=k_tt.as_any_origin().as_immut(),
+                        top_p=top_p_tt.as_any_origin().as_immut(),
+                        rng_seed=seed_tt.as_any_origin().as_immut(),
+                    )
+                else:
+                    _topk_topp_sampling_fi[dtype, out_idx_type](
+                        ctx,
+                        K,
+                        top_p,
+                        device_in,
+                        device_out_idxs,
+                        block_size=fi_block_size,
+                        softmax_block_size=fi_softmax_block_size,
+                        k=k_tt.as_any_origin().as_immut(),
+                        rng_seed=seed_tt.as_any_origin().as_immut(),
+                    )
+            else:
+                if use_temperature_arr and use_top_p_arr:
+                    _topk_topp_sampling_fi[dtype, out_idx_type](
+                        ctx,
+                        K,
+                        top_p,
+                        device_in,
+                        device_out_idxs,
+                        block_size=fi_block_size,
+                        softmax_block_size=fi_softmax_block_size,
+                        temperature=temp_tt.as_any_origin().as_immut(),
+                        top_p=top_p_tt.as_any_origin().as_immut(),
+                        rng_seed=seed_tt.as_any_origin().as_immut(),
+                    )
+                elif use_temperature_arr:
+                    _topk_topp_sampling_fi[dtype, out_idx_type](
+                        ctx,
+                        K,
+                        top_p,
+                        device_in,
+                        device_out_idxs,
+                        block_size=fi_block_size,
+                        softmax_block_size=fi_softmax_block_size,
+                        temperature=temp_tt.as_any_origin().as_immut(),
+                        rng_seed=seed_tt.as_any_origin().as_immut(),
+                    )
+                elif use_top_p_arr:
+                    _topk_topp_sampling_fi[dtype, out_idx_type](
+                        ctx,
+                        K,
+                        top_p,
+                        device_in,
+                        device_out_idxs,
+                        block_size=fi_block_size,
+                        softmax_block_size=fi_softmax_block_size,
+                        top_p=top_p_tt.as_any_origin().as_immut(),
+                        rng_seed=seed_tt.as_any_origin().as_immut(),
+                    )
+                else:
+                    _topk_topp_sampling_fi[dtype, out_idx_type](
+                        ctx,
+                        K,
+                        top_p,
+                        device_in,
+                        device_out_idxs,
+                        block_size=fi_block_size,
+                        softmax_block_size=fi_softmax_block_size,
+                        rng_seed=seed_tt.as_any_origin().as_immut(),
+                    )
 
         b.iter_custom[kernel_launch](ctx)
 
@@ -504,8 +657,18 @@ def bench_topk_fi[
         K,
         "/batch_size=",
         batch_size,
+        "/block_size=",
+        test_case.block_size,
         "/top_p=",
         top_p,
+        "/softmax_block_size=",
+        softmax_block_size,
+        "/use_k_arr=",
+        use_k_arr,
+        "/use_temperature_arr=",
+        use_temperature_arr,
+        "/use_top_p_arr=",
+        use_top_p_arr,
     )
 
     var num_bytes = device_in.num_elements() * size_of[dtype]()
@@ -516,11 +679,15 @@ def bench_topk_fi[
 
     # Cleanup.
     in_buffer_ptr.free()
+    k_host_ptr.free()
     temp_host_ptr.free()
+    top_p_host_ptr.free()
     seed_host_ptr.free()
     _ = device_in_buffer^
     _ = device_out_idxs_buffer^
+    _ = device_k_buffer^
     _ = device_temp_buffer^
+    _ = device_top_p_buffer^
     _ = seed_device_buffer^
 
 
@@ -582,17 +749,23 @@ struct TestCase[_sampling: Bool, _largest: Bool = True](ImplicitlyCopyable):
 def main() raises:
     var N = arg_parse("N", -1)
     var K = arg_parse("K", -1)
-    var block_size = arg_parse("block_size", 256)
+    var block_size = arg_parse("block_size", 0)
     var batch_size = arg_parse("batch_size", -1)
     var num_blocks_per_input = arg_parse("num_blocks_per_input", 0)
     var fill_fn_name = arg_parse("fill_fn_name", "fill_random")
+    var top_p = Float32(arg_parse("top_p", 1.0))
+    var temperature = Float32(arg_parse("temperature", 1.0))
+    var use_fi = arg_parse("use_fi", False)
+    var use_k_arr = arg_parse("use_k_arr", True)
+    var use_temperature_arr = arg_parse("use_temperature_arr", True)
+    var use_top_p_arr = arg_parse("use_top_p_arr", True)
+    var softmax_block_size = arg_parse("softmax_block_size", 0)
 
     comptime dtype = get_defined_dtype["dtype", DType.float32]()
     comptime rank = get_defined_int["rank", 2]()
     comptime out_idx_type = get_defined_dtype["out_idx_type", DType.int]()
     comptime sampling = get_defined_bool["sampling", False]()
     comptime largest = get_defined_bool["largest", True]()
-    comptime use_fi = get_defined_bool["USE_FI_TOPK_KERNEL", False]()
 
     var m = Bench()
     with DeviceContext() as ctx:
@@ -604,8 +777,19 @@ def main() raises:
             num_blocks_per_input=num_blocks_per_input,
         )
 
-        comptime if use_fi:
-            bench_topk_fi[dtype, out_idx_type](ctx, m, test_case, fill_fn_name)
+        if use_fi:
+            bench_topk_fi[dtype, out_idx_type](
+                ctx,
+                m,
+                test_case,
+                fill_fn_name,
+                top_p=top_p,
+                temperature=temperature,
+                use_k_arr=use_k_arr,
+                use_temperature_arr=use_temperature_arr,
+                use_top_p_arr=use_top_p_arr,
+                softmax_block_size=softmax_block_size,
+            )
         else:
             bench_topk_batched[dtype, out_idx_type, rank](
                 ctx, m, test_case, fill_fn_name

--- a/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
@@ -89,12 +89,11 @@ from linalg.bmm import (
     elementwise_epilogue_type as batched_matmul_elementwise_epilogue_type,
 )
 from linalg.fp8_quantization import (
-    batched_quantize_dynamic_scaled_fp8,
     convert_e4m3fn_to_e4m3fnuz,
     matmul_dynamic_scaled_fp8,
     quantize_dynamic_scaled_fp8,
     quantize_static_scaled_fp8,
-    quantize_tensor_dynamic_scaled_fp8,
+    batched_quantize_dynamic_scaled_fp8,
 )
 from linalg.fp4_quantization import (
     block_scaled_matmul,
@@ -186,7 +185,6 @@ from nn.kv_cache import (
     print_kv_cache_paged_generic_cpu,
     print_kv_cache_paged_generic_gpu,
     rms_norm_kv_cache_ragged_paged,
-    rms_norm_value_cache_ragged_paged,
 )
 from nn.rope_split_store import rope_split_store_paged_ragged
 from nn.kv_cache_ragged import (
@@ -256,7 +254,13 @@ from nn.resize import (
     resize_nearest_neighbor,
 )
 from nn.roi_align import roi_align_nhwc
-from nn.rope import rope_ragged
+from nn.rope import (
+    _rope_k_cache_ragged,
+    k_rms_norm_rope_ragged,
+    q_rms_norm_rope_ragged,
+    q_rms_norm_fused_qk_rope_ragged,
+    rope_ragged,
+)
 from nn.sampling import apply_penalties_to_logits, update_frequency_data
 from nn.slice import (
     copy_to_slice,
@@ -293,11 +297,11 @@ from quantization.qmatmul_k import (
     matmul_Q6_K,
     matmul_Q6_K_pack_b,
 )
-from std.ffi import external_call
 from std.runtime.asyncrt import (
     DeviceContextPtr,
     DeviceContextPtrList,
     TaskGroup,
+    parallelism_level,
 )
 from std.runtime.tracing import Trace, TraceLevel, get_safe_task_id, trace_arg
 from tensor import (
@@ -1995,7 +1999,7 @@ comptime _TransposeStrideTypes[
     input_stride_types: Variadic.TypesOfTrait[CoordLike],
 ] = _ReduceVariadicAndIdxToVariadic[
     BaseVal=Variadic.empty_of_trait[CoordLike],
-    ParamListType=Variadic.types[
+    VariadicType=Variadic.types[
         T=CoordLike,
         *Variadic.splat_type[Trait=CoordLike, rank, RuntimeInt[]],
     ],
@@ -2136,7 +2140,7 @@ comptime _SliceStrideTypes[
     step_types: Variadic.TypesOfTrait[CoordLike],
 ] = _ReduceVariadicAndIdxToVariadic[
     BaseVal=Variadic.empty_of_trait[CoordLike],
-    ParamListType=Variadic.types[
+    VariadicType=Variadic.types[
         T=CoordLike,
         *Variadic.splat_type[Trait=CoordLike, rank, RuntimeInt[]],
     ],
@@ -6329,6 +6333,7 @@ struct Struct_fused_qkv_matmul_padded_paged:
         valid_lengths: InputTensor[dtype=DType.uint32, rank=1, ...],
         ctx: DeviceContextPtr,
     ) raises:
+        comptime assert not is_cpu[target](), "Only the GPU path is implemented"
         var kv_collection = generic_get_paged_cache(
             kv_blocks,
             cache_lengths,
@@ -6868,7 +6873,7 @@ struct Struct_fused_qk_rope_ragged_paged[interleaved: Bool]:
     ) raises:
         # Dummy position_ids - won't be used since has_position_ids=False
         var dummy_position_ids = DynamicTensor[dtype=DType.uint32, rank=2, ...](
-            {_unsafe_null = ()}, IndexList[2](0)
+            {}, IndexList[2](0)
         )
         var kv_collection = generic_get_paged_cache(
             kv_blocks,
@@ -6929,6 +6934,207 @@ struct Struct_fused_qk_rope_padded_paged[interleaved: Bool]:
             valid_lengths.to_tile_tensor[DType.int64](),
             output.to_tile_tensor[DType.int64](),
             context,
+        )
+
+
+# ===-----------------------------------------------------------------------===#
+# K-Only RoPE Ragged
+#
+# Expected kernel name format:
+# mo.rope_k_cache.ragged.paged
+# ===-----------------------------------------------------------------------===#
+
+
+@compiler.register("mo.rope_k_cache.ragged.paged")
+struct Struct_rope_k_cache_ragged_paged[interleaved: Bool]:
+    @always_inline
+    @staticmethod
+    def execute[
+        freq_dtype: DType,
+        cache_dtype: DType,
+        //,
+        target: StaticString,
+    ](
+        kv_blocks: MutableInputTensor[dtype=cache_dtype, rank=6, ...],
+        cache_lengths: InputTensor[dtype=DType.uint32, rank=1, ...],
+        kv_lookup_table: InputTensor[dtype=DType.uint32, rank=2, ...],
+        max_lengths: InputTensor[dtype=DType.uint32, rank=2, ...],
+        freqs_cis: InputTensor[dtype=freq_dtype, rank=2, ...],
+        layer_idx: UInt32,
+        total_seq_len: UInt32,
+        input_row_offsets: InputTensor[dtype=DType.uint32, rank=1, ...],
+        ctx: DeviceContextPtr,
+    ) raises:
+        var kv_collection = generic_get_paged_cache(
+            kv_blocks,
+            cache_lengths,
+            kv_lookup_table,
+            max_lengths,
+        )
+        _rope_k_cache_ragged[
+            target=target,
+            interleaved=Self.interleaved,
+        ](
+            Int(total_seq_len),
+            input_row_offsets.to_tile_tensor[DType.int64](),
+            kv_collection,
+            freqs_cis.to_tile_tensor[DType.int64](),
+            layer_idx,
+            ctx.get_device_context(),
+        )
+
+
+# ===-----------------------------------------------------------------------===#
+# K-Only Gemma RMSNorm + RoPE Ragged
+#
+# Expected kernel name format:
+# mo.k_rms_norm_rope.ragged.paged
+# ===-----------------------------------------------------------------------===#
+
+
+@compiler.register("mo.k_rms_norm_rope.ragged.paged")
+struct Struct_k_rms_norm_rope_ragged_paged[interleaved: Bool]:
+    @always_inline
+    @staticmethod
+    def execute[
+        dtype: DType,
+        freq_dtype: DType,
+        cache_dtype: DType,
+        //,
+        target: StaticString,
+    ](
+        kv_blocks: MutableInputTensor[dtype=cache_dtype, rank=6, ...],
+        cache_lengths: InputTensor[dtype=DType.uint32, rank=1, ...],
+        kv_lookup_table: InputTensor[dtype=DType.uint32, rank=2, ...],
+        max_lengths: InputTensor[dtype=DType.uint32, rank=2, ...],
+        freqs_cis: InputTensor[dtype=freq_dtype, rank=2, ...],
+        gamma: InputTensor[dtype=dtype, rank=1, ...],
+        epsilon: Scalar[dtype],
+        layer_idx: UInt32,
+        total_seq_len: UInt32,
+        input_row_offsets: InputTensor[dtype=DType.uint32, rank=1, ...],
+        weight_offset: Scalar[dtype],
+        ctx: DeviceContextPtr,
+    ) raises:
+        var kv_collection = generic_get_paged_cache(
+            kv_blocks,
+            cache_lengths,
+            kv_lookup_table,
+            max_lengths,
+        )
+        k_rms_norm_rope_ragged[
+            target=target,
+            interleaved=Self.interleaved,
+        ](
+            Int(total_seq_len),
+            input_row_offsets.to_tile_tensor[DType.int64](),
+            kv_collection,
+            freqs_cis.to_tile_tensor[DType.int64](),
+            gamma.to_tile_tensor[DType.int64](),
+            epsilon,
+            weight_offset,
+            layer_idx,
+            ctx.get_device_context(),
+        )
+
+
+# ===-----------------------------------------------------------------------===#
+# Q-Only Gemma RMSNorm + RoPE Ragged
+#
+# Expected kernel name format:
+# mo.q_rms_norm_rope.ragged
+# ===-----------------------------------------------------------------------===#
+
+
+@compiler.register("mo.q_rms_norm_rope.ragged")
+struct Struct_q_rms_norm_rope_ragged:
+    @always_inline
+    @staticmethod
+    def execute[
+        dtype: DType,
+        freq_dtype: DType,
+        //,
+        target: StaticString,
+    ](
+        output: FusedOutputTensor[dtype=dtype, rank=3, ...],
+        x: InputTensor[dtype=dtype, rank=3, ...],
+        input_row_offsets: InputTensor[dtype=DType.uint32, rank=1, ...],
+        start_pos: InputTensor[dtype=DType.uint32, rank=1, ...],
+        freqs_cis: InputTensor[dtype=freq_dtype, rank=2, ...],
+        gamma: InputTensor[dtype=dtype, rank=1, ...],
+        epsilon: Scalar[dtype],
+        weight_offset: Scalar[dtype],
+        ctx: DeviceContextPtr,
+    ) raises:
+        q_rms_norm_rope_ragged[target=target](
+            x.to_tile_tensor[DType.int64](),
+            input_row_offsets.to_tile_tensor[DType.int64](),
+            start_pos.to_tile_tensor[DType.int64](),
+            freqs_cis.to_tile_tensor[DType.int64](),
+            gamma.to_tile_tensor[DType.int64](),
+            epsilon,
+            weight_offset,
+            output.to_tile_tensor[DType.int64](),
+            ctx.get_device_context(),
+        )
+
+
+# ===-----------------------------------------------------------------------===#
+# Fused Gemma Query RMSNorm + QK RoPE Ragged
+#
+# Expected kernel name format:
+# mo.q_rms_norm_fused_qk_rope.ragged.paged
+# ===-----------------------------------------------------------------------===#
+
+
+@compiler.register("mo.q_rms_norm_fused_qk_rope.ragged.paged")
+struct Struct_q_rms_norm_fused_qk_rope_ragged_paged[interleaved: Bool]:
+    @always_inline
+    @staticmethod
+    def execute[
+        dtype: DType,
+        freq_dtype: DType,
+        cache_dtype: DType,
+        //,
+        target: StaticString,
+    ](
+        output: OutputTensor[dtype=dtype, rank=3, ...],
+        x: InputTensor[dtype=dtype, rank=3, ...],
+        input_row_offsets: InputTensor[dtype=DType.uint32, rank=1, ...],
+        kv_blocks: MutableInputTensor[dtype=cache_dtype, rank=6, ...],
+        cache_lengths: InputTensor[dtype=DType.uint32, rank=1, ...],
+        kv_lookup_table: InputTensor[dtype=DType.uint32, rank=2, ...],
+        max_lengths: InputTensor[dtype=DType.uint32, rank=2, ...],
+        freqs_cis: InputTensor[dtype=freq_dtype, rank=2, ...],
+        q_gamma: InputTensor[dtype=dtype, rank=1, ...],
+        k_gamma: InputTensor[dtype=dtype, rank=1, ...],
+        epsilon: Scalar[dtype],
+        layer_idx: UInt32,
+        weight_offset: Scalar[dtype],
+        ctx: DeviceContextPtr,
+    ) raises:
+        var kv_collection = generic_get_paged_cache(
+            kv_blocks,
+            cache_lengths,
+            kv_lookup_table,
+            max_lengths,
+        )
+        q_rms_norm_fused_qk_rope_ragged[
+            target=target,
+            interleaved=Self.interleaved,
+        ](
+            x.to_tile_tensor[DType.int64](),
+            input_row_offsets.to_tile_tensor[DType.int64](),
+            cache_lengths.to_tile_tensor[DType.int64](),
+            kv_collection,
+            freqs_cis.to_tile_tensor[DType.int64](),
+            q_gamma.to_tile_tensor[DType.int64](),
+            k_gamma.to_tile_tensor[DType.int64](),
+            epsilon,
+            weight_offset,
+            layer_idx,
+            output.to_tile_tensor[DType.int64](),
+            ctx.get_device_context(),
         )
 
 
@@ -9456,52 +9662,6 @@ struct Struct_rms_norm_kv_cache_ragged_paged:
         )
 
 
-@compiler.register("mo.rms_norm_value_cache.ragged.paged")
-struct Struct_rms_norm_value_cache_ragged_paged:
-    @always_inline
-    @staticmethod
-    def execute[
-        dtype: DType,
-        multiply_before_cast: Bool,
-        per_head_norm: Bool,
-        cache_dtype: DType,
-        //,
-        target: StaticString,
-    ](
-        kv_blocks: MutableInputTensor[dtype=cache_dtype, rank=6, ...],
-        cache_lengths: InputTensor[dtype=DType.uint32, rank=1, ...],
-        kv_lookup_table: InputTensor[dtype=DType.uint32, rank=2, ...],
-        max_lengths: InputTensor[dtype=DType.uint32, rank=2, ...],
-        gamma: InputTensor[dtype=dtype, rank=1, ...],
-        epsilon: Scalar[dtype],
-        layer_idx: UInt32,
-        total_seq_len: UInt32,
-        input_row_offsets: InputTensor[dtype=DType.uint32, rank=1, ...],
-        weight_offset: Scalar[dtype=dtype],
-        context: DeviceContextPtr,
-    ) raises:
-        var kv_collection = generic_get_paged_cache(
-            kv_blocks,
-            cache_lengths,
-            kv_lookup_table,
-            max_lengths,
-        )
-        rms_norm_value_cache_ragged_paged[
-            target=target,
-            multiply_before_cast=multiply_before_cast,
-            per_head_norm=per_head_norm,
-        ](
-            kv_collection,
-            gamma.to_tile_tensor[DType.int64](),
-            epsilon,
-            weight_offset,
-            layer_idx,
-            total_seq_len,
-            input_row_offsets.to_tile_tensor[DType.int64](),
-            context,
-        )
-
-
 # ===-----------------------------------------------------------------------===#
 # Print KV Cache
 #
@@ -9952,18 +10112,12 @@ def _check_signal_buffer_size(
 
 
 @always_inline("nodebug")
-def task_id_for_device(device_id: Int) -> Int:
-    """Map from device ID to task ID for CPU affinity.
-
-    Delegates to the shared C++ implementation in DeviceAffinity.cpp which
-    handles explicit MODULAR_RUNTIME_DEVICE_TASK_CPU_IDS config,
-    NUMA-inferred GPU-to-CPU core mapping, and round-robin fallback.
-    """
-    return Int(
-        external_call["KGEN_CompilerRT_TaskIdForDevice", Int32](
-            Int32(device_id),
-        )
-    )
+def task_id_for_device(device_id: Int, num_workers: Int) -> Int:
+    # Map from device ID to task ID for CPU affinity.
+    # Note: Keep in sync with taskIdForDevice() in MGPPrimitives.cpp
+    if num_workers <= 1:
+        return -1
+    return 1 + (device_id % (num_workers - 1))
 
 
 @always_inline
@@ -9994,9 +10148,10 @@ def _launch_device_collective[
 
     # Set up a task group to launch the tasks in parallel.
     var tg = TaskGroup()
+    var num_workers = parallelism_level()
     comptime for i in range(num_devices):
         # Dispatch to the worker thread that has affinity for this device.
-        var worker_id = task_id_for_device(Int(dev_ctxs[i].id()))
+        var worker_id = task_id_for_device(Int(dev_ctxs[i].id()), num_workers)
         tg._create_task(wrapper[i](), desired_worker_id=worker_id)
 
     # Wait for all tasks to complete.
@@ -10071,7 +10226,7 @@ struct DistributedAllReduceSum:
         # Marshal signal buffers into the expected format.
         var rank_sigs = InlineArray[
             UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-        ](fill={_unsafe_null = ()})
+        ](fill={})
         comptime for i in range(num_devices):
             rank_sigs[i] = signal_buffers[i]._ptr.bitcast[Signal]()
 
@@ -10203,7 +10358,7 @@ struct BundledAllReduceSum:
         var out_buf = output.to_tile_tensor[DType.int64]()
         var rank_sigs = InlineArray[
             UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-        ](fill={_unsafe_null = ()})
+        ](fill={})
 
         comptime for i in range(num_devices):
             in_tensors[i] = rebind[InputTensorType](
@@ -10290,7 +10445,7 @@ struct DistributedReduceScatterSum:
         # Marshal signal buffers.
         var rank_sigs = InlineArray[
             UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-        ](fill={_unsafe_null = ()})
+        ](fill={})
 
         comptime for i in range(num_devices):
             rank_sigs[i] = signal_buffers[i]._ptr.bitcast[Signal]()
@@ -10404,7 +10559,7 @@ struct DistributedAllGather:
         # Marshal signal buffers.
         var rank_sigs = InlineArray[
             UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-        ](fill={_unsafe_null = ()})
+        ](fill={})
 
         comptime for i in range(num_devices):
             in_tensors[i] = TileTensor(
@@ -10515,7 +10670,7 @@ struct DistributedBroadcast:
 
         var rank_sigs = InlineArray[
             UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-        ](fill={_unsafe_null = ()})
+        ](fill={})
 
         comptime for i in range(signal_buffers.size):
             rank_sigs[i] = signal_buffers[i]._ptr.bitcast[Signal]()
@@ -10599,7 +10754,7 @@ struct DistributedScatter:
         var in_tensors = InlineArray[InputTensorType, ngpus](uninitialized=True)
         var rank_sigs = InlineArray[
             UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-        ](fill={_unsafe_null = ()})
+        ](fill={})
 
         comptime for i in range(ngpus):
             in_tensors[i] = rebind[InputTensorType](
@@ -10690,7 +10845,7 @@ struct DistributedAllReduceAddRMSNormQuantFP8:
         # Marshal signal buffers.
         var rank_sigs = InlineArray[
             UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-        ](fill={_unsafe_null = ()})
+        ](fill={})
 
         comptime for i in range(inputs.size):
             in_tensors[i] = rebind[InputTensorType](
@@ -11054,51 +11209,6 @@ struct QuantizeStaticScaledFloat8[*, scale_is_inverted: Bool]:
         )
 
 
-@compiler.register("mo.quantize_tensor_dynamic_scaled_float8")
-struct QuantizeTensorDynamicScaledFloat8:
-    @always_inline
-    @staticmethod
-    def execute[
-        input_type: DType,
-        scales_type: DType,
-        output_type: DType,
-        //,
-        group_size_or_per_token: Int,
-        target: StaticString,
-    ](
-        output: OutputTensor[dtype=output_type, rank=2, ...],
-        scales: OutputTensor[dtype=scales_type, rank=2, ...],
-        input: FusedInputTensor[dtype=input_type, rank=2, ...],
-        scale_ub: Float32,
-        ctx: DeviceContextPtr,
-    ) raises:
-        comptime assert is_gpu[target](), "only valid on GPUs"
-
-        @parameter
-        @always_inline
-        def input_fn[
-            width: Int, alignment: Int
-        ](row: Int, col: Int) capturing -> SIMD[input_type, width]:
-            return input._lambda_load[width=width, element_alignment=alignment](
-                Index(row, col)
-            )
-
-        quantize_tensor_dynamic_scaled_fp8[
-            out_dtype=output_type,
-            in_dtype=input_type,
-            scales_dtype=scales_type,
-            input_fn,
-            group_size_or_per_token,
-            num_cols=Int(input.static_spec.shape_tuple[1]),
-        ](
-            output.to_tile_tensor[DType.int64](),
-            scales.to_tile_tensor[DType.int64](),
-            scale_ub,
-            ctx.get_device_context(),
-            num_rows=input.dim_size(0),
-        )
-
-
 @compiler.register("mo.quantize_dynamic_scaled_float8")
 struct QuantizeDynamicScaledFloat8:
     @parameter
@@ -11273,7 +11383,7 @@ struct MatmulStaticScaledFloat8:
         comptime N = type_of(weight_tt).static_shape[0]
         var M = Int(input_tt.dim[0]())
         var output_dummy = TileTensor(
-            UnsafePointer[Scalar[DType.float32], MutAnyOrigin](_unsafe_null=()),
+            UnsafePointer[Scalar[DType.float32], MutAnyOrigin](),
             row_major(Coord(RuntimeInt[DType.int64](Int64(M)), Idx[N]())),
         )
 

--- a/max/kernels/src/nn/fused_qk_rope.mojo
+++ b/max/kernels/src/nn/fused_qk_rope.mojo
@@ -12,12 +12,18 @@
 # ===----------------------------------------------------------------------=== #
 
 from std.collections import OptionalReg
-from std.math import gcd
+from std.math import ceildiv, gcd
 from std.sys.info import _current_target, align_of, simd_width_of
 
 from std.algorithm.functional import elementwise
 from std.utils.numerics import get_accum_type
 from std.complex import ComplexSIMD
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    WARP_SIZE,
+    block_idx_uint as block_idx,
+    thread_idx_uint as thread_idx,
+)
 from std.gpu.host import DeviceContext, get_gpu_target
 from std.gpu.host.info import is_cpu
 from kv_cache.types import KVCacheT, KVCollectionT
@@ -33,6 +39,28 @@ from layout import (
 from nn._ragged_utils import get_batch_from_row_offsets
 
 from std.utils import IndexList
+from std.utils.static_tuple import StaticTuple
+
+
+
+@always_inline
+def _rope_complex_mul_half[
+    dtype: DType,
+    freq_dtype: DType,
+    width_2: Int,
+    freq_width: Int,
+](
+    x_re: SIMD[dtype, width_2],
+    x_im: SIMD[dtype, width_2],
+    freq: SIMD[freq_dtype, freq_width],
+) -> Tuple[SIMD[dtype, width_2], SIMD[dtype, width_2]]:
+    var f_re = rebind[SIMD[freq_dtype, width_2]](freq.deinterleave()[0])
+    var f_im = rebind[SIMD[freq_dtype, width_2]](freq.deinterleave()[1])
+    var xr = x_re.cast[freq_dtype]()
+    var xi = x_im.cast[freq_dtype]()
+    var res_re = (xr * f_re - xi * f_im).cast[dtype]()
+    var res_im = (xr * f_im + xi * f_re).cast[dtype]()
+    return (res_re, res_im)
 
 
 @always_inline
@@ -105,23 +133,14 @@ def rope_q_proj[
 
     comptime if interleaved:
         val = q_proj.load[width=width, alignment=alignment](coord)
-    else:
-        val = rebind[SIMD[dtype, width]](
-            q_proj.load[width=width_2, alignment=half_alignment](
-                coord_re
-            ).interleave(
-                q_proj.load[width=width_2, alignment=half_alignment](coord_im)
-            )
-        )
-
-    var res = rope_value(val, freq_val).cast[output_dtype]()
-
-    comptime if interleaved:
+        var res = rope_value(val, freq_val).cast[output_dtype]()
         output.store[alignment=alignment](coord, res)
     else:
-        output_re, output_im = res.deinterleave()
-        output.store[alignment=half_alignment](coord_re, output_re)
-        output.store[alignment=half_alignment](coord_im, output_im)
+        var q_re = q_proj.load[width=width_2, alignment=half_alignment](coord_re)
+        var q_im = q_proj.load[width=width_2, alignment=half_alignment](coord_im)
+        var q_result = _rope_complex_mul_half(q_re, q_im, freq_val)
+        output.store[alignment=half_alignment](coord_re, q_result[0].cast[output_dtype]())
+        output.store[alignment=half_alignment](coord_im, q_result[1].cast[output_dtype]())
 
 
 @always_inline
@@ -148,25 +167,14 @@ def rope_k_cache[
         val = k_cache.load[width=width](b_idx, h_idx, s_idx, d_idx).cast[
             accum_type
         ]()
-    else:
-        val = rebind[SIMD[accum_type, width]](
-            k_cache.load[width=width_2](b_idx, h_idx, s_idx, h_re)
-            .cast[accum_type]()
-            .interleave(
-                k_cache.load[width=width_2](b_idx, h_idx, s_idx, h_im).cast[
-                    accum_type
-                ]()
-            )
-        )
-
-    var res = rope_value(val, freq_val).cast[cache_type]()
-
-    comptime if interleaved:
+        var res = rope_value(val, freq_val).cast[cache_type]()
         k_cache.store(b_idx, h_idx, s_idx, d_idx, res)
     else:
-        output_re, output_im = res.deinterleave()
-        k_cache.store(b_idx, h_idx, s_idx, h_re, output_re)
-        k_cache.store(b_idx, h_idx, s_idx, h_im, output_im)
+        var k_re = k_cache.load[width=width_2](b_idx, h_idx, s_idx, h_re).cast[accum_type]()
+        var k_im = k_cache.load[width=width_2](b_idx, h_idx, s_idx, h_im).cast[accum_type]()
+        var k_result = _rope_complex_mul_half(k_re, k_im, freq_val)
+        k_cache.store(b_idx, h_idx, s_idx, h_re, k_result[0].cast[cache_type]())
+        k_cache.store(b_idx, h_idx, s_idx, h_im, k_result[1].cast[cache_type]())
 
 
 @always_inline
@@ -292,6 +300,115 @@ def fused_qk_rope[
         )
 
 
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _fused_qk_rope_decode_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    q_proj: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    total_rows: Int,
+):
+    comptime assert q_proj.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert freqs_cis.flat_rank == 2
+
+    comptime cache_dtype = KCacheType.dtype
+    comptime num_q_heads = Int(q_proj.static_shape[1])
+    comptime num_k_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(q_proj.static_shape[2])
+    comptime assert head_dim == 128, "Only 128-column BF16 rows are supported"
+    comptime assert head_dim == Int(KCacheType.kv_params.head_size)
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime vec_width = simd_width // 2
+    comptime half_align = align_of[SIMD[dtype, vec_width]]()
+    comptime accum_type = get_accum_type[cache_dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime total_heads = num_q_heads + num_k_heads
+    comptime assert head_dim == half_warp_size * simd_width
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // total_heads
+        var head_idx = flat_row % total_heads
+        var batch_idx = global_token_idx
+        var post_seq_idx = Int(k_cache.cache_length(batch_idx))
+        var re_offset = Int(local_tid) * vec_width
+        var im_offset = re_offset + head_dim // 2
+        var freq_offset = Int(local_tid) * simd_width
+        var freq = freqs_cis.load[width=simd_width, alignment=1](
+            Coord(Idx(post_seq_idx), Idx(freq_offset))
+        )
+
+        if head_idx < num_q_heads:
+            var q_re = q_proj.load[width=vec_width, alignment=half_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset))
+            )
+            var q_im = q_proj.load[width=vec_width, alignment=half_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset))
+            )
+            var q_rope = _rope_complex_mul_half[
+                dtype,
+                freq_dtype,
+                vec_width,
+                simd_width,
+            ](q_re, q_im, freq)
+            output.store[alignment=half_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset)),
+                q_rope[0],
+            )
+            output.store[alignment=half_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset)),
+                q_rope[1],
+            )
+        else:
+            var k_head_idx = head_idx - num_q_heads
+            var k_re = k_cache.load[width=vec_width](
+                batch_idx, k_head_idx, post_seq_idx, re_offset
+            ).cast[accum_type]()
+            var k_im = k_cache.load[width=vec_width](
+                batch_idx, k_head_idx, post_seq_idx, im_offset
+            ).cast[accum_type]()
+            var k_rope = _rope_complex_mul_half[
+                accum_type,
+                freq_dtype,
+                vec_width,
+                simd_width,
+            ](k_re, k_im, freq)
+            k_cache.store(
+                batch_idx,
+                k_head_idx,
+                post_seq_idx,
+                re_offset,
+                k_rope[0].cast[cache_dtype](),
+            )
+            k_cache.store(
+                batch_idx,
+                k_head_idx,
+                post_seq_idx,
+                im_offset,
+                k_rope[1].cast[cache_dtype](),
+            )
+
+
 @always_inline
 def fused_qk_rope_ragged[
     dtype: DType,
@@ -302,6 +419,7 @@ def fused_qk_rope_ragged[
     *,
     interleaved: Bool,
     target: StaticString,
+    allow_decode_fastpath: Bool = True,
     mrope_types: Variadic.TypesOfTrait[CoordLike] = Variadic.empty_of_trait[
         CoordLike
     ],
@@ -366,6 +484,42 @@ def fused_qk_rope_ragged[
     )
 
     var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+    var total_tokens = Int(q_proj.dim(0))
+    var total_rows = total_tokens * (num_q_heads + Int(num_k_heads))
+
+    comptime if (
+        allow_decode_fastpath
+        and not interleaved
+        and dtype == DType.bfloat16
+        and cache_t.dtype == DType.bfloat16
+        and q_head_size == 128
+        and Int(k_head_size) == 128
+        and rope_dim == 128
+    ):
+        var is_decode_uniform = total_tokens == Int(batch_size)
+        if is_decode_uniform and not position_ids:
+            comptime block_size = 64
+            comptime warps_per_block = 2
+            comptime kernel = _fused_qk_rope_decode_ragged_kernel[
+                dtype,
+                freq_dtype,
+                cache_t,
+                q_proj.LayoutType,
+                output.LayoutType,
+                freqs_cis.LayoutType,
+                block_size,
+                warps_per_block,
+            ]
+            context.value().enqueue_function[kernel, kernel](
+                q_proj,
+                output,
+                k_cache,
+                freqs_cis,
+                total_rows,
+                grid_dim=ceildiv(total_rows, warps_per_block * 2),
+                block_dim=block_size,
+            )
+            return
 
     @always_inline
     @parameter

--- a/max/kernels/src/nn/kv_cache.mojo
+++ b/max/kernels/src/nn/kv_cache.mojo
@@ -12,8 +12,11 @@
 # ===----------------------------------------------------------------------=== #
 
 from std.algorithm.functional import unswitch
+from std.math import ceildiv
+from std.gpu import WARP_SIZE
 from std.gpu.host import DeviceContext, DeviceBuffer
 from std.gpu.host.info import is_cpu, is_gpu
+from std.gpu.primitives.grid_controls import PDLLevel, pdl_launch_attributes
 from std.collections import OptionalReg
 from kv_cache.types import (
     ContinuousBatchingKVCacheCollection,
@@ -43,7 +46,7 @@ from nn.attention.mha_utils import (
     dispatch_mask,
     dispatch_materialized_mask,
 )
-from nn.normalization import _rms_norm_impl
+from nn.normalization import _rms_norm_impl, rms_norm_gpu_warp_tiling_128
 from std.runtime.asyncrt import DeviceContextPtr
 from std.runtime.tracing import Trace, TraceLevel, get_safe_task_id, trace_arg
 
@@ -420,7 +423,7 @@ def _matmul_common[
         )
     else:
         c_nd = LayoutTensor[dtype, c_layout, MutAnyOrigin](
-            UnsafePointer[Scalar[dtype], MutExternalOrigin](_unsafe_null=()),
+            UnsafePointer[Scalar[dtype], MutExternalOrigin](),
             RuntimeLayout[c_layout].row_major(IndexList[2](BS * SEQ_LEN, N)),
         )
 
@@ -901,7 +904,128 @@ def _flash_attention_dispatch_materialized_mask[
 # ===-----------------------------------------------------------------------===#
 
 
-def rms_norm_kv_cache_ragged_paged[
+@always_inline
+def _rms_norm_kv_cache_ragged_paged_decode_uniform_direct[
+    dtype: DType,
+    params: KVCacheStaticParams,
+    page_size: Int,
+    cache_dtype: DType,
+    //,
+    target: StaticString,
+    multiply_before_cast: Bool,
+](
+    kv_collection: PagedKVCacheCollection[
+        cache_dtype,
+        params,
+        page_size,
+    ],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    total_seq_len: UInt32,
+    context: DeviceContextPtr,
+) raises:
+    comptime assert is_gpu[target](), "decode-uniform direct path is GPU-only"
+    comptime assert dtype == DType.bfloat16
+    comptime assert cache_dtype == DType.bfloat16
+    comptime assert gamma.static_shape[0] == 128
+    comptime assert Int(params.head_size) == 128
+    comptime assert page_size == 128
+
+    var ctx = context.get_device_context()
+    var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+    var num_rows = Int(total_seq_len) * Int(params.num_heads)
+    comptime simd_width = 8
+    comptime default_warps_per_block = 2
+    comptime large_row_warps_per_block = 8
+    comptime default_block_size = default_warps_per_block * WARP_SIZE
+    comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
+    comptime min_large_row_blocks_per_sm = 5
+    var min_large_row_blocks = (
+        ctx.default_device_info.sm_count * min_large_row_blocks_per_sm
+    )
+    var large_row_grid_dim = ceildiv(num_rows, large_row_warps_per_block * 2)
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache)
+    def direct_input_fn_2d[width: Int](
+        row: Int, col: Int
+    ) -> SIMD[dtype, width]:
+        var batch_idx = row // Int(params.num_heads)
+        var head_idx = row % Int(params.num_heads)
+        var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+        return k_cache.load[width=width](
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=head_idx,
+            head_dim_idx=col,
+        ).cast[dtype]()
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache)
+    def direct_output_fn_2d[width: Int, alignment: Int](
+        row: Int, col: Int, val: SIMD[dtype, width]
+    ) -> None:
+        var batch_idx = row // Int(params.num_heads)
+        var head_idx = row % Int(params.num_heads)
+        var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+        k_cache.store(
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=head_idx,
+            head_dim_idx=col,
+            val=val.cast[cache_dtype](),
+        )
+
+    if large_row_grid_dim >= min_large_row_blocks:
+        comptime kernel = rms_norm_gpu_warp_tiling_128[
+            mut=gamma.mut,
+            LayoutType=gamma.LayoutType,
+            origin=gamma.origin,
+            simd_width,
+            large_row_warps_per_block,
+            direct_input_fn_2d,
+            direct_output_fn_2d,
+            multiply_before_cast=multiply_before_cast,
+        ]
+        ctx.enqueue_function[kernel, kernel](
+            gamma,
+            epsilon,
+            weight_offset,
+            num_rows,
+            gamma.static_shape[0],
+            grid_dim=large_row_grid_dim,
+            block_dim=large_row_block_size,
+            attributes=pdl_launch_attributes(PDLLevel(1)),
+        )
+    else:
+        comptime kernel = rms_norm_gpu_warp_tiling_128[
+            mut=gamma.mut,
+            LayoutType=gamma.LayoutType,
+            origin=gamma.origin,
+            simd_width,
+            default_warps_per_block,
+            direct_input_fn_2d,
+            direct_output_fn_2d,
+            multiply_before_cast=multiply_before_cast,
+        ]
+        ctx.enqueue_function[kernel, kernel](
+            gamma,
+            epsilon,
+            weight_offset,
+            num_rows,
+            gamma.static_shape[0],
+            grid_dim=ceildiv(num_rows, default_warps_per_block * 2),
+            block_dim=default_block_size,
+            attributes=pdl_launch_attributes(PDLLevel(1)),
+        )
+
+
+@always_inline
+def _rms_norm_kv_cache_ragged_paged_no_trace[
     dtype: DType,
     params: KVCacheStaticParams,
     page_size: Int,
@@ -924,7 +1048,7 @@ def rms_norm_kv_cache_ragged_paged[
     input_row_offsets: TileTensor[DType.uint32, ...],
     context: DeviceContextPtr,
 ) raises:
-    """Performs RMSNorm in place on new entries in the key cache.
+    """Implements RMSNorm in place on new entries in the key cache.
 
     This is done by first creating the ragged tensor weight_shape
     (total_seq_len, num_heads, head_dim) of the new token tensor.
@@ -963,6 +1087,22 @@ def rms_norm_kv_cache_ragged_paged[
         rms_norm_cols <= Int(kv_collection.kv_params.head_size)
         or not per_head_norm
     ), "Length of gamma must be smaller or equal to head size"
+    comptime has_uniform_decode_rank3_specialization = (
+        per_head_norm
+        and dtype == DType.bfloat16
+        and cache_dtype == DType.bfloat16
+        and rms_norm_cols == 128
+        and Int(params.head_size) == 128
+        and page_size == 128
+    )
+    var batch_size = Int(input_row_offsets.dim(0)) - 1
+    var use_uniform_decode_batch_mapping = False
+
+    comptime if has_uniform_decode_rank3_specialization:
+        use_uniform_decode_batch_mapping = (
+            kv_collection.max_seq_length == 1
+            and total_seq_len == UInt32(batch_size)
+        )
 
     var shape = IndexList[rank]()
     shape[0] = Int(total_seq_len)
@@ -1047,30 +1187,43 @@ def rms_norm_kv_cache_ragged_paged[
             val=val.cast[cache_dtype](),
         )
 
-    with Trace[TraceLevel.OP, target=target](
-        "rms_norm_kv_cache_ragged_paged_nhead_"
-        + String(kv_collection.kv_params.num_heads)
-        + ".hdim_"
-        + String(kv_collection.kv_params.head_size),
-        task_id=get_safe_task_id(context),
-    ):
-        _rms_norm_impl[
-            dtype,
-            rank,
-            key_cache_input_fn,
-            key_cache_output_fn,
-            target=target,
-            multiply_before_cast=multiply_before_cast,
-        ](
-            shape,
-            gamma,
-            epsilon,
-            weight_offset,
-            context,
-        )
+    comptime if has_uniform_decode_rank3_specialization:
+        if use_uniform_decode_batch_mapping:
+            _rms_norm_kv_cache_ragged_paged_decode_uniform_direct[
+                dtype=dtype,
+                params=params,
+                page_size=page_size,
+                cache_dtype=cache_dtype,
+                target=target,
+                multiply_before_cast=multiply_before_cast,
+            ](
+                kv_collection,
+                gamma,
+                epsilon,
+                weight_offset,
+                layer_idx,
+                total_seq_len,
+                context,
+            )
+            return
+
+    _rms_norm_impl[
+        dtype,
+        rank,
+        key_cache_input_fn,
+        key_cache_output_fn,
+        target=target,
+        multiply_before_cast=multiply_before_cast,
+    ](
+        shape,
+        gamma,
+        epsilon,
+        weight_offset,
+        context,
+    )
 
 
-def rms_norm_value_cache_ragged_paged[
+def rms_norm_kv_cache_ragged_paged[
     dtype: DType,
     params: KVCacheStaticParams,
     page_size: Int,
@@ -1093,128 +1246,68 @@ def rms_norm_value_cache_ragged_paged[
     input_row_offsets: TileTensor[DType.uint32, ...],
     context: DeviceContextPtr,
 ) raises:
-    """Performs RMSNorm in place on new entries in the value cache.
+    """Performs RMSNorm in place on new entries in the key cache."""
 
-    Same indexing and layout as ``rms_norm_kv_cache_ragged_paged`` on the key
-    cache, but reads/writes the value cache tensor for ``layer_idx``.
-    """
-    comptime assert gamma.flat_rank == 1, "gamma must be rank 1"
-    comptime assert (
-        input_row_offsets.flat_rank == 1
-    ), "input_row_offsets must be rank 1"
+    var batch_size = Int(input_row_offsets.dim(0)) - 1
 
-    comptime rank = 3 if per_head_norm else 2
-    var v_cache = kv_collection.get_value_cache(Int(layer_idx))
-    var kv_params = v_cache.kv_params
-    comptime rms_norm_cols = gamma.static_shape[0]
+    comptime use_no_trace_decode_uniform_fastpath = (
+        is_gpu[target]()
+        and per_head_norm
+        and dtype == DType.bfloat16
+        and cache_dtype == DType.bfloat16
+        and gamma.static_shape[0] == 128
+        and Int(params.head_size) == 128
+        and page_size == 128
+    )
 
-    comptime assert rms_norm_cols != -1, "Need static shape for gamma"
-    comptime assert (
-        rms_norm_cols <= Int(kv_collection.kv_params.head_size)
-        or not per_head_norm
-    ), "Length of gamma must be smaller or equal to head size"
-
-    var shape = IndexList[rank]()
-    shape[0] = Int(total_seq_len)
-
-    comptime if per_head_norm:
-        shape[1] = Int(kv_params.num_heads)
-        shape[2] = rms_norm_cols
-    else:
-        shape[1] = rms_norm_cols
-
-    @always_inline
-    @parameter
-    @__copy_capture(v_cache, input_row_offsets)
-    def value_cache_input_fn[
-        width: Int, rank_: Int
-    ](idx: IndexList[rank_]) -> SIMD[dtype, width]:
-        comptime assert rank_ == rank, (
-            "rms_norm_value_cache input lambda index should have rank "
-            + String(rank)
-        )
-
-        var global_token_idx = idx[0]
-        var batch_idx = get_batch_from_row_offsets(
-            input_row_offsets, global_token_idx
-        )
-        var token_idx = Int(
-            UInt32(global_token_idx) - input_row_offsets[batch_idx]
-        )
-
-        var cache_length = v_cache.cache_length(batch_idx)
-        var cache_token_idx = token_idx + cache_length
-
-        var head_idx: Int
-        var head_dim_idx: Int
-
-        comptime if per_head_norm:
-            head_idx = idx[1]
-            head_dim_idx = idx[2]
-        else:
-            head_idx = idx[1] // Int(params.head_size)
-            head_dim_idx = idx[1] % Int(params.head_size)
-
-        return v_cache.load[width=width](
-            bs=batch_idx,
-            tok_idx=cache_token_idx,
-            head_idx=head_idx,
-            head_dim_idx=head_dim_idx,
-        ).cast[dtype]()
-
-    @always_inline
-    @parameter
-    @__copy_capture(v_cache)
-    def value_cache_output_fn[
-        width: Int, alignment: Int
-    ](idx: IndexList[rank], val: SIMD[dtype, width]) -> None:
-        var global_token_idx = idx[0]
-        var batch_idx = get_batch_from_row_offsets(
-            input_row_offsets, global_token_idx
-        )
-        var token_idx = Int(
-            UInt32(global_token_idx) - input_row_offsets[batch_idx]
-        )
-
-        var cache_length = v_cache.cache_length(batch_idx)
-        var cache_token_idx = token_idx + cache_length
-
-        var head_idx: Int
-        var head_dim_idx: Int
-
-        comptime if per_head_norm:
-            head_idx = idx[1]
-            head_dim_idx = idx[2]
-        else:
-            head_idx = idx[1] // Int(params.head_size)
-            head_dim_idx = idx[1] % Int(params.head_size)
-        v_cache.store(
-            bs=batch_idx,
-            tok_idx=cache_token_idx,
-            head_idx=head_idx,
-            head_dim_idx=head_dim_idx,
-            val=val.cast[cache_dtype](),
-        )
+    comptime if use_no_trace_decode_uniform_fastpath:
+        if (
+            kv_collection.max_seq_length == 1
+            and total_seq_len == UInt32(batch_size)
+        ):
+            _rms_norm_kv_cache_ragged_paged_no_trace[
+                dtype=dtype,
+                params=params,
+                page_size=page_size,
+                cache_dtype=cache_dtype,
+                target=target,
+                multiply_before_cast=multiply_before_cast,
+                per_head_norm=per_head_norm,
+            ](
+                kv_collection,
+                gamma,
+                epsilon,
+                weight_offset,
+                layer_idx,
+                total_seq_len,
+                input_row_offsets,
+                context,
+            )
+            return
 
     with Trace[TraceLevel.OP, target=target](
-        "rms_norm_value_cache_ragged_paged_nhead_"
+        "rms_norm_kv_cache_ragged_paged_nhead_"
         + String(kv_collection.kv_params.num_heads)
         + ".hdim_"
         + String(kv_collection.kv_params.head_size),
         task_id=get_safe_task_id(context),
     ):
-        _rms_norm_impl[
-            dtype,
-            rank,
-            value_cache_input_fn,
-            value_cache_output_fn,
+        _rms_norm_kv_cache_ragged_paged_no_trace[
+            dtype=dtype,
+            params=params,
+            page_size=page_size,
+            cache_dtype=cache_dtype,
             target=target,
             multiply_before_cast=multiply_before_cast,
+            per_head_norm=per_head_norm,
         ](
-            shape,
+            kv_collection,
             gamma,
             epsilon,
             weight_offset,
+            layer_idx,
+            total_seq_len,
+            input_row_offsets,
             context,
         )
 

--- a/max/kernels/src/nn/normalization.mojo
+++ b/max/kernels/src/nn/normalization.mojo
@@ -1231,6 +1231,7 @@ def rms_norm_gpu[
         return input_fn[simd_width](indices.canonicalize())
 
     comptime simd_width = simd_width_of[dtype, target=get_gpu_target()]()
+    comptime sm_count = ctx.default_device_info.sm_count
     comptime max_warps_per_block = ctx.default_device_info.max_thread_block_size // WARP_SIZE
 
     var grid_dim = rows
@@ -1244,32 +1245,63 @@ def rms_norm_gpu[
         # registers we do warp tiling which is a single pass to do mean/var
         # computation and normalization.
         if cols <= 128 and dtype == DType.bfloat16:
-            # Experimentally determined to be the best - tapers off at 2.
-            comptime warps_per_block = 2
-            # Each warp handles 2 rows, so total rows per block is warps_per_block * 2.
-            block_dim = warps_per_block * WARP_SIZE
-            grid_dim = ceildiv(rows, warps_per_block * 2)
+            comptime default_warps_per_block = 2
+            comptime large_row_warps_per_block = 8
+            comptime min_large_row_blocks_per_sm = 6
 
-            comptime kernel = rms_norm_gpu_warp_tiling_128[
-                mut=gamma.mut,
-                LayoutType=gamma.LayoutType,
-                origin=gamma.origin,
-                simd_width,
-                warps_per_block,
-                input_fn_2d,
-                output_fn_2d,
-                multiply_before_cast=multiply_before_cast,
-            ]
-            ctx.enqueue_function[kernel, kernel](
-                gamma,
-                epsilon,
-                weight_offset,
-                rows,
-                cols,
-                grid_dim=grid_dim,
-                block_dim=block_dim,
-                attributes=pdl_launch_attributes(pdl_level),
-            )
+            var min_large_row_blocks = sm_count * min_large_row_blocks_per_sm
+            var large_row_grid_dim = ceildiv(rows, large_row_warps_per_block * 2)
+
+            # The wider 256-thread launch only pays off once there are enough
+            # 16-row blocks to keep the GPU saturated.
+            if large_row_grid_dim >= min_large_row_blocks:
+                block_dim = large_row_warps_per_block * WARP_SIZE
+                grid_dim = large_row_grid_dim
+
+                comptime kernel = rms_norm_gpu_warp_tiling_128[
+                    mut=gamma.mut,
+                    LayoutType=gamma.LayoutType,
+                    origin=gamma.origin,
+                    simd_width,
+                    large_row_warps_per_block,
+                    input_fn_2d,
+                    output_fn_2d,
+                    multiply_before_cast=multiply_before_cast,
+                ]
+                ctx.enqueue_function[kernel, kernel](
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    rows,
+                    cols,
+                    grid_dim=grid_dim,
+                    block_dim=block_dim,
+                    attributes=pdl_launch_attributes(pdl_level),
+                )
+            else:
+                block_dim = default_warps_per_block * WARP_SIZE
+                grid_dim = ceildiv(rows, default_warps_per_block * 2)
+
+                comptime kernel = rms_norm_gpu_warp_tiling_128[
+                    mut=gamma.mut,
+                    LayoutType=gamma.LayoutType,
+                    origin=gamma.origin,
+                    simd_width,
+                    default_warps_per_block,
+                    input_fn_2d,
+                    output_fn_2d,
+                    multiply_before_cast=multiply_before_cast,
+                ]
+                ctx.enqueue_function[kernel, kernel](
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    rows,
+                    cols,
+                    grid_dim=grid_dim,
+                    block_dim=block_dim,
+                    attributes=pdl_launch_attributes(pdl_level),
+                )
         elif cols <= (WARP_SIZE * simd_width * max_warps_per_block):
             comptime kernel = rms_norm_gpu_warp_tiling[
                 mut=gamma.mut,
@@ -1291,8 +1323,8 @@ def rms_norm_gpu[
                 attributes=pdl_launch_attributes(pdl_level),
             )
         elif (
-            cols <= (WARP_SIZE * (simd_width * 2) * max_warps_per_block)
-            and cols % (simd_width * 2) == 0
+            cols % (simd_width * 2) == 0
+            and cols <= (WARP_SIZE * (simd_width * 2) * max_warps_per_block)
         ):
             comptime kernel = rms_norm_gpu_warp_tiling[
                 mut=gamma.mut,
@@ -2113,6 +2145,37 @@ def rms_norm_fused_residual_add_gpu[
                 LayoutType2=gamma2.LayoutType,
                 origin2=gamma2.origin,
                 simd_width,
+                max_warps_per_block,
+                input_fn_2d,
+                residual_input_fn_2d,
+                output_fn_2d,
+                output_residual_fn_2d,
+                multiply_before_cast=multiply_before_cast,
+            ]
+            ctx.enqueue_function[kernel, kernel](
+                gamma1,
+                epsilon1,
+                weight_offset1,
+                gamma2,
+                epsilon2,
+                weight_offset2,
+                cols,
+                grid_dim=grid_dim,
+                block_dim=block_dim,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+        elif (
+            cols % (simd_width * 2) == 0
+            and cols <= (WARP_SIZE * (simd_width * 2) * max_warps_per_block)
+        ):
+            comptime kernel = rms_norm_fused_residual_add_gpu_warp_tiling[
+                mut1=gamma1.mut,
+                LayoutType1=gamma1.LayoutType,
+                origin1=gamma1.origin,
+                mut2=gamma2.mut,
+                LayoutType2=gamma2.LayoutType,
+                origin2=gamma2.origin,
+                simd_width * 2,
                 max_warps_per_block,
                 input_fn_2d,
                 residual_input_fn_2d,

--- a/max/kernels/src/nn/rope.mojo
+++ b/max/kernels/src/nn/rope.mojo
@@ -12,16 +12,29 @@
 # ===----------------------------------------------------------------------=== #
 
 from std.collections import OptionalReg
-from std.math import gcd
-from std.sys.info import _current_target, simd_width_of
+from std.math import ceildiv, gcd, rsqrt
+from std.sys.info import _current_target, align_of, simd_width_of
 
 from std.algorithm.functional import elementwise
 from std.complex import ComplexSIMD
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    WARP_SIZE,
+    block_idx_uint as block_idx,
+    syncwarp,
+    thread_idx_uint as thread_idx,
+)
 from std.gpu.host import DeviceContext, get_gpu_target
 from std.gpu.host.info import is_cpu
+from std.gpu.memory import AddressSpace
+from std.gpu.primitives.grid_controls import PDLLevel, pdl_launch_attributes
+import std.gpu.primitives.warp as warp
+from std.memory import stack_allocation
+from kv_cache.types import KVCacheT, KVCollectionT
 from layout import (
     Coord,
     CoordLike,
+    Idx,
     RowMajorLayout,
     RuntimeInt,
     TensorLayout,
@@ -29,8 +42,16 @@ from layout import (
     coord,
 )
 from nn._ragged_utils import get_batch_from_row_offsets
+from nn.fused_qk_rope import (
+    _rope_complex_mul_half,
+    fused_qk_rope_ragged,
+    rope_k_cache,
+)
+from nn.normalization import _rms_norm_warp_tiling_subkernel, rms_norm_gpu
 
 from std.utils import IndexList
+from std.utils.numerics import get_accum_type
+from std.utils.static_tuple import StaticTuple
 
 
 @always_inline
@@ -263,4 +284,2715 @@ def rope_ragged[
     else:
         elementwise[func=rope_fn, simd_width=kernel_simd_width, target=target](
             launch_shape_index_list, context.value()
+        )
+
+
+def _rope_k_cache_ragged[
+    freq_dtype: DType,
+    collection_t: KVCollectionT,
+    *,
+    interleaved: Bool,
+    target: StaticString,
+](
+    total_seq_len: Int,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    kv_collection: collection_t,
+    freqs_cis: TileTensor[freq_dtype, ...],
+    layer_idx: UInt32,
+    context: DeviceContext,
+) raises:
+    comptime assert not is_cpu[target](), "Only the GPU path is implemented"
+    comptime assert (
+        input_row_offsets.flat_rank == 1
+    ), "input_row_offsets must be rank 1"
+    comptime assert freqs_cis.flat_rank == 2, "freqs_cis must be rank 2"
+    comptime kv_params = collection_t.CacheType.kv_params
+    comptime head_size = Int(kv_params.head_size)
+    comptime rope_dim = Int(freqs_cis.static_shape[1])
+    comptime assert rope_dim == head_size, (
+        "_rope_k_cache_ragged currently expects freqs_cis width to match the "
+        "key head size"
+    )
+
+    var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+
+    comptime if (
+        not interleaved
+        and collection_t.CacheType.dtype == DType.bfloat16
+        and head_size == 128
+    ):
+        var total_rows = total_seq_len * Int(kv_params.num_heads)
+        var batch_size = Int(input_row_offsets.dim(0)) - 1
+        var is_decode_uniform = total_seq_len == batch_size
+        comptime default_warps_per_block = 2
+        comptime default_block_size = default_warps_per_block * WARP_SIZE
+        comptime large_row_warps_per_block = 8
+        comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
+        comptime min_large_row_blocks_per_sm = 6
+        var large_row_grid_dim = ceildiv(
+            total_rows, large_row_warps_per_block * 2
+        )
+        var min_large_row_blocks = (
+            context.default_device_info.sm_count * min_large_row_blocks_per_sm
+        )
+
+        if is_decode_uniform:
+            if large_row_grid_dim >= min_large_row_blocks:
+                comptime kernel = _rope_k_cache_decode_ragged_kernel[
+                    freq_dtype,
+                    collection_t.CacheType,
+                    freqs_cis.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    k_cache,
+                    freqs_cis,
+                    total_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+            else:
+                comptime kernel = _rope_k_cache_decode_ragged_kernel[
+                    freq_dtype,
+                    collection_t.CacheType,
+                    freqs_cis.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    k_cache,
+                    freqs_cis,
+                    total_rows,
+                    grid_dim=ceildiv(total_rows, default_warps_per_block * 2),
+                    block_dim=default_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+        else:
+            if large_row_grid_dim >= min_large_row_blocks:
+                comptime kernel = _rope_k_cache_ragged_kernel[
+                    freq_dtype,
+                    collection_t.CacheType,
+                    input_row_offsets.LayoutType,
+                    freqs_cis.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    input_row_offsets,
+                    k_cache,
+                    freqs_cis,
+                    total_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+            else:
+                comptime kernel = _rope_k_cache_ragged_kernel[
+                    freq_dtype,
+                    collection_t.CacheType,
+                    input_row_offsets.LayoutType,
+                    freqs_cis.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    input_row_offsets,
+                    k_cache,
+                    freqs_cis,
+                    total_rows,
+                    grid_dim=ceildiv(total_rows, default_warps_per_block * 2),
+                    block_dim=default_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+        return
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache, input_row_offsets)
+    def rope_fn[
+        width: Int, rank: Int, alignment: Int = 1
+    ](idx_arg: IndexList[rank]):
+        comptime assert rank == 3, "Invalid rank passed to key rope kernel"
+        comptime if width == 1:
+            return
+        else:
+            var idx = rebind[IndexList[3]](idx_arg)
+            var global_token_idx = idx[0]
+            var batch_idx = get_batch_from_row_offsets(
+                input_row_offsets, global_token_idx
+            )
+            var token_idx = Int(
+                UInt32(global_token_idx) - input_row_offsets[batch_idx]
+            )
+            var head_idx = idx[1]
+            var head_dim_idx = idx[2]
+            var post_seq_idx = k_cache.cache_length(batch_idx) + token_idx
+            var freq = freqs_cis.load[width=width, alignment=1](
+                Coord(Idx(post_seq_idx), Idx(head_dim_idx))
+            )
+
+            rope_k_cache[interleaved=interleaved](
+                k_cache,
+                batch_idx,
+                head_idx,
+                post_seq_idx,
+                head_dim_idx,
+                freq,
+                head_size,
+            )
+
+    var launch_shape = IndexList[3](
+        total_seq_len, Int(kv_params.num_heads), head_size
+    )
+    comptime kernel_simd_width = gcd(
+        simd_width_of[collection_t.CacheType.dtype, target=get_gpu_target()](),
+        head_size,
+    )
+    comptime assert kernel_simd_width >= 2, "invalid simd_width and head size"
+
+    elementwise[func=rope_fn, simd_width=kernel_simd_width, target=target](
+        launch_shape, context
+    )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _rope_k_cache_ragged_kernel[
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    OffsetsLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    total_rows: Int,
+):
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+
+    comptime cache_dtype = KCacheType.dtype
+    comptime num_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(KCacheType.kv_params.head_size)
+    comptime simd_width = simd_width_of[cache_dtype]()
+    comptime vec_width = simd_width // 2
+    comptime accum_type = get_accum_type[cache_dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime assert head_dim == 128, "Only 128-column BF16 key rows are supported"
+    comptime assert head_dim == half_warp_size * simd_width
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_heads
+        var head_idx = flat_row % num_heads
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+        var post_seq_idx = k_cache.cache_length(batch_idx) + token_idx
+        var re_offset = Int(local_tid) * vec_width
+        var im_offset = re_offset + head_dim // 2
+        var freq_offset = Int(local_tid) * simd_width
+        var k_re = k_cache.load[width=vec_width](
+            batch_idx, head_idx, post_seq_idx, re_offset
+        ).cast[accum_type]()
+        var k_im = k_cache.load[width=vec_width](
+            batch_idx, head_idx, post_seq_idx, im_offset
+        ).cast[accum_type]()
+        var freq = freqs_cis.load[width=simd_width, alignment=1](
+            Coord(Idx(post_seq_idx), Idx(freq_offset))
+        )
+        var k_rope = _rope_complex_mul_half[
+            accum_type,
+            freq_dtype,
+            vec_width,
+            simd_width,
+        ](k_re, k_im, freq)
+        k_cache.store(
+            batch_idx,
+            head_idx,
+            post_seq_idx,
+            re_offset,
+            k_rope[0].cast[cache_dtype](),
+        )
+        k_cache.store(
+            batch_idx,
+            head_idx,
+            post_seq_idx,
+            im_offset,
+            k_rope[1].cast[cache_dtype](),
+        )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _rope_k_cache_decode_ragged_kernel[
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    FreqLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    total_rows: Int,
+):
+    comptime assert freqs_cis.flat_rank == 2
+
+    comptime cache_dtype = KCacheType.dtype
+    comptime num_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(KCacheType.kv_params.head_size)
+    comptime simd_width = simd_width_of[cache_dtype]()
+    comptime vec_width = simd_width // 2
+    comptime accum_type = get_accum_type[cache_dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime assert head_dim == 128, "Only 128-column BF16 key rows are supported"
+    comptime assert head_dim == half_warp_size * simd_width
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_heads
+        var head_idx = flat_row % num_heads
+        var batch_idx = global_token_idx
+        var post_seq_idx = k_cache.cache_length(batch_idx)
+        var re_offset = Int(local_tid) * vec_width
+        var im_offset = re_offset + head_dim // 2
+        var freq_offset = Int(local_tid) * simd_width
+        var k_re = k_cache.load[width=vec_width](
+            batch_idx, head_idx, post_seq_idx, re_offset
+        ).cast[accum_type]()
+        var k_im = k_cache.load[width=vec_width](
+            batch_idx, head_idx, post_seq_idx, im_offset
+        ).cast[accum_type]()
+        var freq = freqs_cis.load[width=simd_width, alignment=1](
+            Coord(Idx(post_seq_idx), Idx(freq_offset))
+        )
+        var k_rope = _rope_complex_mul_half[
+            accum_type,
+            freq_dtype,
+            vec_width,
+            simd_width,
+        ](k_re, k_im, freq)
+        k_cache.store(
+            batch_idx,
+            head_idx,
+            post_seq_idx,
+            re_offset,
+            k_rope[0].cast[cache_dtype](),
+        )
+        k_cache.store(
+            batch_idx,
+            head_idx,
+            post_seq_idx,
+            im_offset,
+            k_rope[1].cast[cache_dtype](),
+        )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _k_rms_norm_rope_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    OffsetsLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime num_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(KCacheType.kv_params.head_size)
+    comptime simd_width = simd_width_of[dtype]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime assert head_dim == 128, "Only 128-column BF16 key rows are supported"
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert freqs_cis.static_shape[1] == head_dim
+    comptime assert head_dim == half_warp_size * simd_width
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_heads
+        var head_idx = flat_row % num_heads
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+        var cache_token_idx = token_idx + k_cache.cache_length(batch_idx)
+
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var vec_data = k_cache.load[width=simd_width](
+            batch_idx, head_idx, cache_token_idx, Int(col)
+        ).cast[accum_type]()
+        var gamma_val = gamma.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(Int(col)))
+        )
+
+        var norm_val = _rms_norm_warp_tiling_subkernel[
+            warps_per_block,
+            True,
+            rows_per_warp=2,
+        ](
+            flat_row,
+            Int(col),
+            vec_data,
+            gamma_val,
+            epsilon_accum,
+            weight_offset_accum,
+            head_dim,
+        )
+
+        var sub_warp_mask = (
+            (UInt(1) << UInt(half_warp_size)) - UInt(1)
+        ) << (sub_warp_idx * UInt(half_warp_size))
+        var partner_lane = (
+            sub_warp_idx * UInt(half_warp_size)
+            + (local_tid % UInt(half_warp_size // 2))
+            + UInt(half_warp_size // 2)
+        )
+        var norm_parts = norm_val.split()
+        var norm_lo_parts = norm_parts[0].split()
+        var norm_hi_parts = norm_parts[1].split()
+        var partner_norm_lo = warp.shuffle_idx(
+            sub_warp_mask,
+            norm_lo_parts[0],
+            UInt32(partner_lane),
+        ).join(
+            warp.shuffle_idx(
+                sub_warp_mask,
+                norm_lo_parts[1],
+                UInt32(partner_lane),
+            )
+        )
+        var partner_norm_hi = warp.shuffle_idx(
+            sub_warp_mask,
+            norm_hi_parts[0],
+            UInt32(partner_lane),
+        ).join(
+            warp.shuffle_idx(
+                sub_warp_mask,
+                norm_hi_parts[1],
+                UInt32(partner_lane),
+            )
+        )
+        var partner_norm = rebind[type_of(norm_val)](
+            partner_norm_lo.join(partner_norm_hi)
+        )
+
+        if local_tid < UInt(half_warp_size // 2):
+            var re_offset = Int(local_tid) * simd_width
+            var im_offset = re_offset + head_dim // 2
+            var freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                Coord(Idx(cache_token_idx), Idx(re_offset * 2))
+            )
+            comptime cache_dtype = KCacheType.dtype
+            var rope_val = _rope_complex_mul_half[
+                accum_type,
+                freq_dtype,
+                simd_width,
+                simd_width * 2,
+            ](
+                norm_val.cast[accum_type](),
+                partner_norm.cast[accum_type](),
+                freq,
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                re_offset,
+                rope_val[0].cast[cache_dtype](),
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                im_offset,
+                rope_val[1].cast[cache_dtype](),
+            )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _k_rms_norm_rope_decode_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime num_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(KCacheType.kv_params.head_size)
+    comptime simd_width = simd_width_of[dtype]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime assert head_dim == 128, "Only 128-column BF16 key rows are supported"
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert freqs_cis.static_shape[1] == head_dim
+    comptime assert head_dim == half_warp_size * simd_width
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_heads
+        var head_idx = flat_row % num_heads
+        var batch_idx = global_token_idx
+        var cache_token_idx = k_cache.cache_length(batch_idx)
+
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var vec_data = k_cache.load[width=simd_width](
+            batch_idx, head_idx, cache_token_idx, Int(col)
+        ).cast[accum_type]()
+        var gamma_val = gamma.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(Int(col)))
+        )
+
+        var norm_val = _rms_norm_warp_tiling_subkernel[
+            warps_per_block,
+            True,
+            rows_per_warp=2,
+        ](
+            flat_row,
+            Int(col),
+            vec_data,
+            gamma_val,
+            epsilon_accum,
+            weight_offset_accum,
+            head_dim,
+        )
+
+        var sub_warp_mask = (
+            (UInt(1) << UInt(half_warp_size)) - UInt(1)
+        ) << (sub_warp_idx * UInt(half_warp_size))
+        var partner_lane = (
+            sub_warp_idx * UInt(half_warp_size)
+            + (local_tid % UInt(half_warp_size // 2))
+            + UInt(half_warp_size // 2)
+        )
+        var norm_parts = norm_val.split()
+        var norm_lo_parts = norm_parts[0].split()
+        var norm_hi_parts = norm_parts[1].split()
+        var partner_norm_lo = warp.shuffle_idx(
+            sub_warp_mask,
+            norm_lo_parts[0],
+            UInt32(partner_lane),
+        ).join(
+            warp.shuffle_idx(
+                sub_warp_mask,
+                norm_lo_parts[1],
+                UInt32(partner_lane),
+            )
+        )
+        var partner_norm_hi = warp.shuffle_idx(
+            sub_warp_mask,
+            norm_hi_parts[0],
+            UInt32(partner_lane),
+        ).join(
+            warp.shuffle_idx(
+                sub_warp_mask,
+                norm_hi_parts[1],
+                UInt32(partner_lane),
+            )
+        )
+        var partner_norm = rebind[type_of(norm_val)](
+            partner_norm_lo.join(partner_norm_hi)
+        )
+
+        if local_tid < UInt(half_warp_size // 2):
+            var re_offset = Int(local_tid) * simd_width
+            var im_offset = re_offset + head_dim // 2
+            var freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                Coord(Idx(cache_token_idx), Idx(re_offset * 2))
+            )
+            comptime cache_dtype = KCacheType.dtype
+            var rope_val = _rope_complex_mul_half[
+                accum_type,
+                freq_dtype,
+                simd_width,
+                simd_width * 2,
+            ](
+                norm_val.cast[accum_type](),
+                partner_norm.cast[accum_type](),
+                freq,
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                re_offset,
+                rope_val[0].cast[cache_dtype](),
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                im_offset,
+                rope_val[1].cast[cache_dtype](),
+            )
+
+
+def _k_rms_norm_rope_ragged_wide_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    OffsetsLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime num_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(KCacheType.kv_params.head_size)
+    comptime simd_width = simd_width_of[dtype]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime assert head_dim == 256, "Only 256-column BF16 key rows are supported"
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert freqs_cis.static_shape[1] == head_dim
+    comptime assert head_dim == WARP_SIZE * simd_width
+
+    var shared_norm = stack_allocation[
+        warps_per_block * head_dim,
+        Scalar[dtype],
+        address_space=AddressSpace.SHARED,
+    ]()
+    var shared_batch_idx = stack_allocation[
+        warps_per_block,
+        Int32,
+        address_space=AddressSpace.SHARED,
+    ]()
+    var shared_post_seq = stack_allocation[
+        warps_per_block,
+        Int32,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var local_tid = tid % UInt(WARP_SIZE)
+    var row = block_idx.x * UInt(warps_per_block) + warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_heads
+        var head_idx = flat_row % num_heads
+
+        if local_tid == 0:
+            var batch_idx = get_batch_from_row_offsets(
+                input_row_offsets, global_token_idx
+            )
+            var token_idx = Int(
+                UInt32(global_token_idx) - input_row_offsets[batch_idx]
+            )
+            shared_batch_idx[Int(warp_idx)] = Int32(batch_idx)
+            shared_post_seq[Int(warp_idx)] = Int32(
+                token_idx + Int(k_cache.cache_length(batch_idx))
+            )
+        syncwarp()
+
+        var batch_idx = Int(shared_batch_idx[Int(warp_idx)])
+        var cache_token_idx = Int(shared_post_seq[Int(warp_idx)])
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var vec_data = k_cache.load[width=simd_width](
+            batch_idx, head_idx, cache_token_idx, Int(col)
+        ).cast[accum_type]()
+        var gamma_val = gamma.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(Int(col)))
+        )
+
+        var thread_m2 = (vec_data**2).reduce_add()
+        var row_m2 = warp.sum(thread_m2)
+        var norm_factor = rsqrt(
+            (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+        )
+        var norm_val = vec_data * norm_factor * (
+            gamma_val.cast[accum_type]() + weight_offset_accum
+        )
+        var shared_base = Int(warp_idx) * head_dim
+        shared_norm.store[width=simd_width, alignment=wide_align](
+            shared_base + Int(col), norm_val.cast[dtype]()
+        )
+        syncwarp()
+
+        if local_tid < UInt(WARP_SIZE // 2):
+            var re_offset = Int(local_tid) * simd_width
+            var im_offset = re_offset + head_dim // 2
+            var rope_re = shared_norm.load[width=simd_width](
+                shared_base + re_offset
+            ).cast[accum_type]()
+            var rope_im = shared_norm.load[width=simd_width](
+                shared_base + im_offset
+            ).cast[accum_type]()
+            var freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                Coord(Idx(cache_token_idx), Idx(re_offset * 2))
+            )
+            comptime cache_dtype = KCacheType.dtype
+            var rope_val = _rope_complex_mul_half[
+                accum_type,
+                freq_dtype,
+                simd_width,
+                simd_width * 2,
+            ](rope_re, rope_im, freq)
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                re_offset,
+                rope_val[0].cast[cache_dtype](),
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                im_offset,
+                rope_val[1].cast[cache_dtype](),
+            )
+
+
+def k_rms_norm_rope_ragged[
+    dtype: DType,
+    freq_dtype: DType,
+    collection_t: KVCollectionT,
+    *,
+    interleaved: Bool,
+    target: StaticString,
+](
+    total_seq_len: Int,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    kv_collection: collection_t,
+    freqs_cis: TileTensor[freq_dtype, ...],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    context: DeviceContext,
+) raises:
+    comptime assert not is_cpu[target](), "Only the GPU path is implemented"
+    comptime assert (
+        not interleaved
+    ), "k_rms_norm_rope_ragged currently supports non-interleaved RoPE only"
+    comptime assert (
+        input_row_offsets.flat_rank == 1
+    ), "input_row_offsets must be rank 1"
+    comptime assert freqs_cis.flat_rank == 2, "freqs_cis must be rank 2"
+    comptime assert gamma.flat_rank == 1, "gamma must be rank 1"
+    comptime head_dim = Int(collection_t.CacheType.kv_params.head_size)
+    comptime assert dtype == DType.bfloat16, (
+        "k_rms_norm_rope_ragged currently supports BF16 inputs only"
+    )
+    comptime assert collection_t.CacheType.dtype == DType.bfloat16, (
+        "k_rms_norm_rope_ragged currently supports BF16 key cache only"
+    )
+    comptime assert head_dim == 128 or head_dim == 256, (
+        "k_rms_norm_rope_ragged currently supports 128- and 256-column keys only"
+    )
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    if total_seq_len == 0:
+        return
+
+    var total_rows = total_seq_len * Int(collection_t.CacheType.kv_params.num_heads)
+    var batch_size = Int(input_row_offsets.dim(0)) - 1
+    var is_decode_uniform = total_seq_len == batch_size
+    comptime default_warps_per_block = 2
+    comptime default_block_size = default_warps_per_block * WARP_SIZE
+    comptime large_row_warps_per_block = 8
+    comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
+    comptime min_large_row_blocks_per_sm = 5
+    var large_row_grid_dim = ceildiv(total_rows, large_row_warps_per_block * 2)
+    var min_large_row_blocks = (
+        context.default_device_info.sm_count * min_large_row_blocks_per_sm
+    )
+    var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+
+    comptime if head_dim == 128:
+        if is_decode_uniform:
+            if large_row_grid_dim >= min_large_row_blocks:
+                comptime kernel = _k_rms_norm_rope_decode_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    collection_t.CacheType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    k_cache,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    total_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+            else:
+                comptime kernel = _k_rms_norm_rope_decode_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    collection_t.CacheType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    k_cache,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    total_rows,
+                    grid_dim=ceildiv(total_rows, default_warps_per_block * 2),
+                    block_dim=default_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+        else:
+            if large_row_grid_dim >= min_large_row_blocks:
+                comptime kernel = _k_rms_norm_rope_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    collection_t.CacheType,
+                    input_row_offsets.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    input_row_offsets,
+                    k_cache,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    total_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+            else:
+                comptime kernel = _k_rms_norm_rope_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    collection_t.CacheType,
+                    input_row_offsets.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    input_row_offsets,
+                    k_cache,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    total_rows,
+                    grid_dim=ceildiv(total_rows, default_warps_per_block * 2),
+                    block_dim=default_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+    else:
+        large_row_grid_dim = ceildiv(total_rows, large_row_warps_per_block)
+        if large_row_grid_dim >= min_large_row_blocks:
+            comptime kernel = _k_rms_norm_rope_ragged_wide_kernel[
+                dtype,
+                freq_dtype,
+                collection_t.CacheType,
+                input_row_offsets.LayoutType,
+                freqs_cis.LayoutType,
+                gamma.LayoutType,
+                large_row_block_size,
+                large_row_warps_per_block,
+            ]
+            context.enqueue_function[kernel, kernel](
+                input_row_offsets,
+                k_cache,
+                freqs_cis,
+                gamma,
+                epsilon,
+                weight_offset,
+                total_rows,
+                grid_dim=large_row_grid_dim,
+                block_dim=large_row_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+        else:
+            comptime kernel = _k_rms_norm_rope_ragged_wide_kernel[
+                dtype,
+                freq_dtype,
+                collection_t.CacheType,
+                input_row_offsets.LayoutType,
+                freqs_cis.LayoutType,
+                gamma.LayoutType,
+                default_block_size,
+                default_warps_per_block,
+            ]
+            context.enqueue_function[kernel, kernel](
+                input_row_offsets,
+                k_cache,
+                freqs_cis,
+                gamma,
+                epsilon,
+                weight_offset,
+                total_rows,
+                grid_dim=ceildiv(total_rows, default_warps_per_block),
+                block_dim=default_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _q_rms_norm_rope_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    OffsetsLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    num_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime vec_width = simd_width // 2
+    comptime align = align_of[SIMD[dtype, vec_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+
+    comptime assert head_dim == 128, "Only 128-column BF16 query rows are supported"
+    comptime assert head_dim == half_warp_size * simd_width
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    if row < UInt(num_rows):
+        var row_int = Int(row)
+        var global_token_idx = row_int // num_q_heads
+        var head_idx = row_int % num_q_heads
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+        var position = Int(start_pos[batch_idx] + UInt32(token_idx))
+
+        var re_offset = Int(local_tid) * vec_width
+        var im_offset = re_offset + head_dim // 2
+        var freq_offset = Int(local_tid) * simd_width
+
+        var q_re = x.load[width=vec_width, alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset))
+        )
+        var q_im = x.load[width=vec_width, alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset))
+        )
+        var thread_m2 = (q_re.cast[accum_type]() ** 2).reduce_add() + (
+            q_im.cast[accum_type]() ** 2
+        ).reduce_add()
+        var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](thread_m2)
+        var norm_factor = rsqrt(
+            (row_m2 / Scalar[accum_type](head_dim)) + epsilon.cast[accum_type]()
+        )
+
+        var gamma_re = gamma.load[width=vec_width, alignment=align](
+            Coord(Idx(re_offset))
+        )
+        var gamma_im = gamma.load[width=vec_width, alignment=align](
+            Coord(Idx(im_offset))
+        )
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var norm_re = (
+            q_re.cast[accum_type]()
+            * norm_factor
+            * (gamma_re.cast[accum_type]() + weight_offset_accum)
+        ).cast[dtype]()
+        var norm_im = (
+            q_im.cast[accum_type]()
+            * norm_factor
+            * (gamma_im.cast[accum_type]() + weight_offset_accum)
+        ).cast[dtype]()
+
+        var freq = freqs_cis.load[width=simd_width, alignment=1](
+            Coord(Idx(position), Idx(freq_offset))
+        )
+        var rope_val = _rope_complex_mul_half[
+            dtype,
+            freq_dtype,
+            vec_width,
+            simd_width,
+        ](norm_re, norm_im, freq)
+
+        output.store[alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset)),
+            rope_val[0],
+        )
+        output.store[alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset)),
+            rope_val[1],
+        )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _q_rms_norm_rope_decode_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    num_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime vec_width = simd_width // 2
+    comptime align = align_of[SIMD[dtype, vec_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+
+    comptime assert head_dim == 128, "Only 128-column BF16 query rows are supported"
+    comptime assert head_dim == half_warp_size * simd_width
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    if row < UInt(num_rows):
+        var row_int = Int(row)
+        var global_token_idx = row_int // num_q_heads
+        var head_idx = row_int % num_q_heads
+        var batch_idx = global_token_idx
+        var position = Int(start_pos[batch_idx])
+
+        var re_offset = Int(local_tid) * vec_width
+        var im_offset = re_offset + head_dim // 2
+        var freq_offset = Int(local_tid) * simd_width
+
+        var q_re = x.load[width=vec_width, alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset))
+        )
+        var q_im = x.load[width=vec_width, alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset))
+        )
+        var thread_m2 = (q_re.cast[accum_type]() ** 2).reduce_add() + (
+            q_im.cast[accum_type]() ** 2
+        ).reduce_add()
+        var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](thread_m2)
+        var norm_factor = rsqrt(
+            (row_m2 / Scalar[accum_type](head_dim)) + epsilon.cast[accum_type]()
+        )
+
+        var gamma_re = gamma.load[width=vec_width, alignment=align](
+            Coord(Idx(re_offset))
+        )
+        var gamma_im = gamma.load[width=vec_width, alignment=align](
+            Coord(Idx(im_offset))
+        )
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var norm_re = (
+            q_re.cast[accum_type]()
+            * norm_factor
+            * (gamma_re.cast[accum_type]() + weight_offset_accum)
+        ).cast[dtype]()
+        var norm_im = (
+            q_im.cast[accum_type]()
+            * norm_factor
+            * (gamma_im.cast[accum_type]() + weight_offset_accum)
+        ).cast[dtype]()
+
+        var freq = freqs_cis.load[width=simd_width, alignment=1](
+            Coord(Idx(position), Idx(freq_offset))
+        )
+        var rope_val = _rope_complex_mul_half[
+            dtype,
+            freq_dtype,
+            vec_width,
+            simd_width,
+        ](norm_re, norm_im, freq)
+
+        output.store[alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset)),
+            rope_val[0],
+        )
+        output.store[alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset)),
+            rope_val[1],
+        )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _q_rms_norm_rope_ragged_wide_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    OffsetsLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    num_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+
+    comptime assert head_dim == 256, "Only 256-column BF16 query rows are supported"
+    comptime assert freqs_cis.static_shape[1] == head_dim
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert head_dim == WARP_SIZE * simd_width
+
+    var shared_norm = stack_allocation[
+        warps_per_block * head_dim,
+        Scalar[dtype],
+        address_space=AddressSpace.SHARED,
+    ]()
+    var shared_position = stack_allocation[
+        warps_per_block,
+        Int32,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var local_tid = tid % UInt(WARP_SIZE)
+    var row = block_idx.x * UInt(warps_per_block) + warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    if row < UInt(num_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_q_heads
+        var head_idx = flat_row % num_q_heads
+
+        if local_tid == 0:
+            var batch_idx = get_batch_from_row_offsets(
+                input_row_offsets, global_token_idx
+            )
+            var token_idx = Int(
+                UInt32(global_token_idx) - input_row_offsets[batch_idx]
+            )
+            shared_position[Int(warp_idx)] = Int32(
+                Int(start_pos[batch_idx] + UInt32(token_idx))
+            )
+        syncwarp()
+
+        var position = Int(shared_position[Int(warp_idx)])
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var q_vec = x.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(Int(col)))
+        )
+        var thread_m2 = (q_vec.cast[accum_type]() ** 2).reduce_add()
+        var row_m2 = warp.sum(thread_m2)
+        var norm_factor = rsqrt(
+            (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+        )
+        var gamma_val = gamma.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(Int(col)))
+        )
+        var norm_val = (
+            q_vec.cast[accum_type]()
+            * norm_factor
+            * (gamma_val.cast[accum_type]() + weight_offset_accum)
+        ).cast[dtype]()
+        var shared_base = Int(warp_idx) * head_dim
+        shared_norm.store[width=simd_width, alignment=wide_align](
+            shared_base + Int(col), norm_val
+        )
+        syncwarp()
+
+        if local_tid < UInt(WARP_SIZE // 2):
+            var re_offset = Int(local_tid) * simd_width
+            var im_offset = re_offset + head_dim // 2
+            var rope_re = shared_norm.load[width=simd_width](
+                shared_base + re_offset
+            )
+            var rope_im = shared_norm.load[width=simd_width](
+                shared_base + im_offset
+            )
+            var freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                Coord(Idx(position), Idx(re_offset * 2))
+            )
+            var rope_val = _rope_complex_mul_half[
+                dtype,
+                freq_dtype,
+                simd_width,
+                simd_width * 2,
+            ](rope_re, rope_im, freq)
+
+            output.store[alignment=wide_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset)),
+                rope_val[0],
+            )
+            output.store[alignment=wide_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset)),
+                rope_val[1],
+            )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _q_rms_norm_rope_decode_ragged_wide_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    num_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+
+    comptime assert head_dim == 256, "Only 256-column BF16 query rows are supported"
+    comptime assert freqs_cis.static_shape[1] == head_dim
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert head_dim == WARP_SIZE * simd_width
+
+    var shared_norm = stack_allocation[
+        warps_per_block * head_dim,
+        Scalar[dtype],
+        address_space=AddressSpace.SHARED,
+    ]()
+    var shared_position = stack_allocation[
+        warps_per_block,
+        Int32,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var local_tid = tid % UInt(WARP_SIZE)
+    var row = block_idx.x * UInt(warps_per_block) + warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    if row < UInt(num_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_q_heads
+        var head_idx = flat_row % num_q_heads
+
+        if local_tid == 0:
+            shared_position[Int(warp_idx)] = Int32(
+                Int(start_pos[global_token_idx])
+            )
+        syncwarp()
+
+        var position = Int(shared_position[Int(warp_idx)])
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var q_vec = x.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(Int(col)))
+        )
+        var thread_m2 = (q_vec.cast[accum_type]() ** 2).reduce_add()
+        var row_m2 = warp.sum(thread_m2)
+        var norm_factor = rsqrt(
+            (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+        )
+        var gamma_val = gamma.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(Int(col)))
+        )
+        var norm_val = (
+            q_vec.cast[accum_type]()
+            * norm_factor
+            * (gamma_val.cast[accum_type]() + weight_offset_accum)
+        ).cast[dtype]()
+        var shared_base = Int(warp_idx) * head_dim
+        shared_norm.store[width=simd_width, alignment=wide_align](
+            shared_base + Int(col), norm_val
+        )
+        syncwarp()
+
+        if local_tid < UInt(WARP_SIZE // 2):
+            var re_offset = Int(local_tid) * simd_width
+            var im_offset = re_offset + head_dim // 2
+            var rope_re = shared_norm.load[width=simd_width](
+                shared_base + re_offset
+            )
+            var rope_im = shared_norm.load[width=simd_width](
+                shared_base + im_offset
+            )
+            var freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                Coord(Idx(position), Idx(re_offset * 2))
+            )
+            var rope_val = _rope_complex_mul_half[
+                dtype,
+                freq_dtype,
+                simd_width,
+                simd_width * 2,
+            ](rope_re, rope_im, freq)
+
+            output.store[alignment=wide_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset)),
+                rope_val[0],
+            )
+            output.store[alignment=wide_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset)),
+                rope_val[1],
+            )
+
+
+def q_rms_norm_rope_ragged[
+    dtype: DType,
+    freq_dtype: DType,
+    *,
+    target: StaticString,
+](
+    x: TileTensor[dtype, ...],
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    start_pos: TileTensor[DType.uint32, ...],
+    freqs_cis: TileTensor[freq_dtype, ...],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    output: TileTensor[mut=True, dtype, ...],
+    context: DeviceContext,
+) raises:
+    comptime assert not is_cpu[target](), "Only the GPU path is implemented"
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+    comptime head_dim = Int(x.static_shape[2])
+
+    comptime if head_dim == 128 and dtype == DType.bfloat16:
+        comptime num_q_heads = x.static_shape[1]
+        var total_tokens = Int(x.dim(0))
+        var is_decode_uniform = total_tokens == Int(start_pos.dim(0))
+        var num_rows = total_tokens * num_q_heads
+        comptime sm_count = context.default_device_info.sm_count
+        comptime default_warps_per_block = 2
+        comptime default_block_size = default_warps_per_block * WARP_SIZE
+        comptime large_row_warps_per_block = 8
+        comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
+        comptime min_large_row_blocks_per_sm = 5
+
+        var large_row_grid_dim = ceildiv(num_rows, large_row_warps_per_block * 2)
+        if is_decode_uniform:
+            if large_row_grid_dim >= sm_count * min_large_row_blocks_per_sm:
+                comptime kernel = _q_rms_norm_rope_decode_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                )
+            else:
+                comptime kernel = _q_rms_norm_rope_decode_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=ceildiv(num_rows, default_warps_per_block * 2),
+                    block_dim=default_block_size,
+                )
+        else:
+            if large_row_grid_dim >= sm_count * min_large_row_blocks_per_sm:
+                comptime kernel = _q_rms_norm_rope_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    input_row_offsets.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    input_row_offsets,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                )
+            else:
+                comptime kernel = _q_rms_norm_rope_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    input_row_offsets.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    input_row_offsets,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=ceildiv(num_rows, default_warps_per_block * 2),
+                    block_dim=default_block_size,
+                )
+    elif head_dim == 256 and dtype == DType.bfloat16:
+        comptime num_q_heads = x.static_shape[1]
+        var total_tokens = Int(x.dim(0))
+        var is_decode_uniform = total_tokens == Int(start_pos.dim(0))
+        var num_rows = total_tokens * num_q_heads
+        comptime sm_count = context.default_device_info.sm_count
+        comptime default_warps_per_block = 2
+        comptime default_block_size = default_warps_per_block * WARP_SIZE
+        comptime large_row_warps_per_block = 8
+        comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
+        comptime min_large_row_blocks_per_sm = 6
+        var large_row_grid_dim = ceildiv(num_rows, large_row_warps_per_block)
+
+        if is_decode_uniform:
+            if large_row_grid_dim >= sm_count * min_large_row_blocks_per_sm:
+                comptime kernel = _q_rms_norm_rope_decode_ragged_wide_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                )
+            else:
+                comptime kernel = _q_rms_norm_rope_decode_ragged_wide_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=ceildiv(num_rows, default_warps_per_block),
+                    block_dim=default_block_size,
+                )
+        else:
+            if large_row_grid_dim >= sm_count * min_large_row_blocks_per_sm:
+                comptime kernel = _q_rms_norm_rope_ragged_wide_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    input_row_offsets.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    input_row_offsets,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                )
+            else:
+                comptime kernel = _q_rms_norm_rope_ragged_wide_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    input_row_offsets.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    input_row_offsets,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=ceildiv(num_rows, default_warps_per_block),
+                    block_dim=default_block_size,
+                )
+    else:
+        @always_inline
+        @__copy_capture(x)
+        @parameter
+        def input_fn[
+            width: Int, rank: Int
+        ](coords: IndexList[rank]) -> SIMD[dtype, width]:
+            return x.load[width=width](Coord(coords))
+
+        @always_inline
+        @__copy_capture(output)
+        @parameter
+        def norm_output_fn[
+            width: Int, alignment: Int
+        ](coords: IndexList[3], val: SIMD[dtype, width]) -> None:
+            output.store[alignment=alignment](Coord(coords), val)
+
+        @always_inline
+        @__copy_capture(output)
+        def rope_output_fn[
+            width: Int, alignment: Int
+        ](idx: IndexList[3], val: SIMD[dtype, width]) capturing -> None:
+            output.store[alignment=alignment](Coord(idx), val)
+
+        var shape = IndexList[3](Int(x.dim(0)), Int(x.dim(1)), Int(x.dim(2)))
+        rms_norm_gpu[
+            input_fn,
+            norm_output_fn,
+            multiply_before_cast=True,
+        ](shape, gamma, epsilon, weight_offset, context)
+        rope_ragged[
+            dtype,
+            freq_dtype,
+            interleaved=False,
+            target=target,
+            output_fn=rope_output_fn,
+        ](
+            output,
+            input_row_offsets,
+            start_pos,
+            freqs_cis,
+            Optional[DeviceContext](context),
+        )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _q_rms_norm_fused_qk_rope_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    OffsetsLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    QGammaLayoutType: TensorLayout,
+    KGammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    q_gamma: TileTensor[dtype, QGammaLayoutType, MutAnyOrigin],
+    k_gamma: TileTensor[dtype, KGammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert q_gamma.flat_rank == 1
+    comptime assert k_gamma.flat_rank == 1
+
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+    comptime num_kv_heads = Int(KCacheType.kv_params.num_heads)
+    comptime assert head_dim == 128, "Only 128-column BF16 rows are supported"
+    comptime assert head_dim == Int(KCacheType.kv_params.head_size)
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime vec_width = simd_width // 2
+    comptime align = align_of[SIMD[dtype, vec_width]]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime total_heads = num_q_heads + num_kv_heads
+    comptime assert head_dim == half_warp_size * simd_width
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    var flat_row = Int(row)
+    var global_token_idx = 0
+    var head_slot = 0
+    var batch_idx = 0
+    var token_idx = 0
+    var q_post_seq_idx = 0
+    var k_post_seq_idx = 0
+
+    var is_active_row = row < UInt(total_rows)
+    if is_active_row:
+        global_token_idx = flat_row // total_heads
+        head_slot = flat_row % total_heads
+        batch_idx = get_batch_from_row_offsets(input_row_offsets, global_token_idx)
+        token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+        q_post_seq_idx = Int(start_pos[batch_idx] + UInt32(token_idx))
+        k_post_seq_idx = k_cache.cache_length(batch_idx) + token_idx
+
+    var is_q_row = is_active_row and head_slot < num_q_heads
+    if is_active_row:
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+
+        if is_q_row:
+            var re_offset = Int(local_tid) * vec_width
+            var im_offset = re_offset + head_dim // 2
+            var freq_offset = Int(local_tid) * simd_width
+            var q_re = x.load[width=vec_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset))
+            )
+            var q_im = x.load[width=vec_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset))
+            )
+            var thread_m2 = (q_re.cast[accum_type]() ** 2).reduce_add() + (
+                q_im.cast[accum_type]() ** 2
+            ).reduce_add()
+            var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](thread_m2)
+            var norm_factor = rsqrt(
+                (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+            )
+
+            var q_gamma_re = q_gamma.load[width=vec_width, alignment=align](
+                Coord(Idx(re_offset))
+            )
+            var q_gamma_im = q_gamma.load[width=vec_width, alignment=align](
+                Coord(Idx(im_offset))
+            )
+            var q_norm_re = (
+                q_re.cast[accum_type]()
+                * norm_factor
+                * (q_gamma_re.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+            var q_norm_im = (
+                q_im.cast[accum_type]()
+                * norm_factor
+                * (q_gamma_im.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+
+            var q_freq = freqs_cis.load[width=simd_width, alignment=1](
+                Coord(Idx(q_post_seq_idx), Idx(freq_offset))
+            )
+            var q_rope = _rope_complex_mul_half[
+                dtype,
+                freq_dtype,
+                vec_width,
+                simd_width,
+            ](q_norm_re, q_norm_im, q_freq)
+            output.store[alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset)),
+                q_rope[0],
+            )
+            output.store[alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset)),
+                q_rope[1],
+            )
+        else:
+            var k_head_idx = head_slot - num_q_heads
+            var vec_data = k_cache.load[width=simd_width](
+                batch_idx, k_head_idx, k_post_seq_idx, Int(col)
+            ).cast[accum_type]()
+            var gamma_val = k_gamma.load[width=simd_width, alignment=wide_align](
+                Coord(Idx(Int(col)))
+            )
+            var norm_val = _rms_norm_warp_tiling_subkernel[
+                warps_per_block,
+                True,
+                rows_per_warp=2,
+            ](
+                flat_row,
+                Int(col),
+                vec_data,
+                gamma_val,
+                epsilon_accum,
+                weight_offset_accum,
+                head_dim,
+            )
+            var sub_warp_mask = (
+                (UInt(1) << UInt(half_warp_size)) - UInt(1)
+            ) << (sub_warp_idx * UInt(half_warp_size))
+            var partner_lane = (
+                sub_warp_idx * UInt(half_warp_size)
+                + (local_tid % UInt(half_warp_size // 2))
+                + UInt(half_warp_size // 2)
+            )
+            var norm_parts = norm_val.split()
+            var norm_lo_parts = norm_parts[0].split()
+            var norm_hi_parts = norm_parts[1].split()
+            var partner_norm_lo = warp.shuffle_idx(
+                sub_warp_mask,
+                norm_lo_parts[0],
+                UInt32(partner_lane),
+            ).join(
+                warp.shuffle_idx(
+                    sub_warp_mask,
+                    norm_lo_parts[1],
+                    UInt32(partner_lane),
+                )
+            )
+            var partner_norm_hi = warp.shuffle_idx(
+                sub_warp_mask,
+                norm_hi_parts[0],
+                UInt32(partner_lane),
+            ).join(
+                warp.shuffle_idx(
+                    sub_warp_mask,
+                    norm_hi_parts[1],
+                    UInt32(partner_lane),
+                )
+            )
+            var partner_norm = rebind[type_of(norm_val)](
+                partner_norm_lo.join(partner_norm_hi)
+            )
+
+            if local_tid < UInt(half_warp_size // 2):
+                var re_offset = Int(local_tid) * simd_width
+                var im_offset = re_offset + head_dim // 2
+                comptime cache_dtype = KCacheType.dtype
+                var k_freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                    Coord(Idx(k_post_seq_idx), Idx(re_offset * 2))
+                )
+                var k_rope = _rope_complex_mul_half[
+                    accum_type,
+                    freq_dtype,
+                    simd_width,
+                    simd_width * 2,
+                ](
+                    norm_val.cast[accum_type](),
+                    partner_norm.cast[accum_type](),
+                    k_freq,
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    k_post_seq_idx,
+                    re_offset,
+                    k_rope[0].cast[cache_dtype](),
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    k_post_seq_idx,
+                    im_offset,
+                    k_rope[1].cast[cache_dtype](),
+                )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _q_rms_norm_fused_qk_rope_decode_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    QGammaLayoutType: TensorLayout,
+    KGammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    q_gamma: TileTensor[dtype, QGammaLayoutType, MutAnyOrigin],
+    k_gamma: TileTensor[dtype, KGammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert q_gamma.flat_rank == 1
+    comptime assert k_gamma.flat_rank == 1
+
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+    comptime num_kv_heads = Int(KCacheType.kv_params.num_heads)
+    comptime assert head_dim == 128, "Only 128-column BF16 rows are supported"
+    comptime assert head_dim == Int(KCacheType.kv_params.head_size)
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime vec_width = simd_width // 2
+    comptime align = align_of[SIMD[dtype, vec_width]]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime total_heads = num_q_heads + num_kv_heads
+    comptime assert head_dim == half_warp_size * simd_width
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    var flat_row = Int(row)
+    var global_token_idx = 0
+    var head_slot = 0
+    var batch_idx = 0
+    var post_seq_idx = 0
+
+    var is_active_row = row < UInt(total_rows)
+    if is_active_row:
+        global_token_idx = flat_row // total_heads
+        head_slot = flat_row % total_heads
+        batch_idx = global_token_idx
+        post_seq_idx = Int(start_pos[batch_idx])
+
+    var is_q_row = is_active_row and head_slot < num_q_heads
+    if is_active_row:
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+
+        if is_q_row:
+            var re_offset = Int(local_tid) * vec_width
+            var im_offset = re_offset + head_dim // 2
+            var freq_offset = Int(local_tid) * simd_width
+            var q_re = x.load[width=vec_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset))
+            )
+            var q_im = x.load[width=vec_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset))
+            )
+            var thread_m2 = (q_re.cast[accum_type]() ** 2).reduce_add() + (
+                q_im.cast[accum_type]() ** 2
+            ).reduce_add()
+            var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](thread_m2)
+            var norm_factor = rsqrt(
+                (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+            )
+
+            var q_gamma_re = q_gamma.load[width=vec_width, alignment=align](
+                Coord(Idx(re_offset))
+            )
+            var q_gamma_im = q_gamma.load[width=vec_width, alignment=align](
+                Coord(Idx(im_offset))
+            )
+            var q_norm_re = (
+                q_re.cast[accum_type]()
+                * norm_factor
+                * (q_gamma_re.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+            var q_norm_im = (
+                q_im.cast[accum_type]()
+                * norm_factor
+                * (q_gamma_im.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+
+            var q_freq = freqs_cis.load[width=simd_width, alignment=1](
+                Coord(Idx(post_seq_idx), Idx(freq_offset))
+            )
+            var q_rope = _rope_complex_mul_half[
+                dtype,
+                freq_dtype,
+                vec_width,
+                simd_width,
+            ](q_norm_re, q_norm_im, q_freq)
+            output.store[alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset)),
+                q_rope[0],
+            )
+            output.store[alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset)),
+                q_rope[1],
+            )
+        else:
+            var k_head_idx = head_slot - num_q_heads
+            var vec_data = k_cache.load[width=simd_width](
+                batch_idx, k_head_idx, post_seq_idx, Int(col)
+            ).cast[accum_type]()
+            var gamma_val = k_gamma.load[width=simd_width, alignment=wide_align](
+                Coord(Idx(Int(col)))
+            )
+            var norm_val = _rms_norm_warp_tiling_subkernel[
+                warps_per_block,
+                True,
+                rows_per_warp=2,
+            ](
+                flat_row,
+                Int(col),
+                vec_data,
+                gamma_val,
+                epsilon_accum,
+                weight_offset_accum,
+                head_dim,
+            )
+            var sub_warp_mask = (
+                (UInt(1) << UInt(half_warp_size)) - UInt(1)
+            ) << (sub_warp_idx * UInt(half_warp_size))
+            var partner_lane = (
+                sub_warp_idx * UInt(half_warp_size)
+                + (local_tid % UInt(half_warp_size // 2))
+                + UInt(half_warp_size // 2)
+            )
+            var norm_parts = norm_val.split()
+            var norm_lo_parts = norm_parts[0].split()
+            var norm_hi_parts = norm_parts[1].split()
+            var partner_norm_lo = warp.shuffle_idx(
+                sub_warp_mask,
+                norm_lo_parts[0],
+                UInt32(partner_lane),
+            ).join(
+                warp.shuffle_idx(
+                    sub_warp_mask,
+                    norm_lo_parts[1],
+                    UInt32(partner_lane),
+                )
+            )
+            var partner_norm_hi = warp.shuffle_idx(
+                sub_warp_mask,
+                norm_hi_parts[0],
+                UInt32(partner_lane),
+            ).join(
+                warp.shuffle_idx(
+                    sub_warp_mask,
+                    norm_hi_parts[1],
+                    UInt32(partner_lane),
+                )
+            )
+            var partner_norm = rebind[type_of(norm_val)](
+                partner_norm_lo.join(partner_norm_hi)
+            )
+
+            if local_tid < UInt(half_warp_size // 2):
+                var re_offset = Int(local_tid) * simd_width
+                var im_offset = re_offset + head_dim // 2
+                comptime cache_dtype = KCacheType.dtype
+                var k_freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                    Coord(Idx(post_seq_idx), Idx(re_offset * 2))
+                )
+                var k_rope = _rope_complex_mul_half[
+                    accum_type,
+                    freq_dtype,
+                    simd_width,
+                    simd_width * 2,
+                ](
+                    norm_val.cast[accum_type](),
+                    partner_norm.cast[accum_type](),
+                    k_freq,
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    re_offset,
+                    k_rope[0].cast[cache_dtype](),
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    im_offset,
+                    k_rope[1].cast[cache_dtype](),
+                )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _q_rms_norm_fused_qk_rope_decode_ragged_wide_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    QGammaLayoutType: TensorLayout,
+    KGammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    q_gamma: TileTensor[dtype, QGammaLayoutType, MutAnyOrigin],
+    k_gamma: TileTensor[dtype, KGammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert q_gamma.flat_rank == 1
+    comptime assert k_gamma.flat_rank == 1
+
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+    comptime num_kv_heads = Int(KCacheType.kv_params.num_heads)
+    comptime assert head_dim == 256, "Only 256-column BF16 rows are supported"
+    comptime assert head_dim == Int(KCacheType.kv_params.head_size)
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime total_heads = num_q_heads + num_kv_heads
+    comptime assert head_dim == WARP_SIZE * simd_width
+
+    var shared_norm = stack_allocation[
+        warps_per_block * head_dim,
+        Scalar[dtype],
+        address_space=AddressSpace.SHARED,
+    ]()
+    var shared_post_seq = stack_allocation[
+        warps_per_block,
+        Int32,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var local_tid = tid % UInt(WARP_SIZE)
+    var row = block_idx.x * UInt(warps_per_block) + warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    var flat_row = Int(row)
+    var global_token_idx = 0
+    var head_slot = 0
+    var batch_idx = 0
+    var post_seq_idx = 0
+
+    var is_active_row = row < UInt(total_rows)
+    if is_active_row:
+        global_token_idx = flat_row // total_heads
+        head_slot = flat_row % total_heads
+        batch_idx = global_token_idx
+        if local_tid == 0:
+            shared_post_seq[Int(warp_idx)] = Int32(Int(start_pos[batch_idx]))
+        syncwarp()
+        post_seq_idx = Int(shared_post_seq[Int(warp_idx)])
+
+    var is_q_row = is_active_row and head_slot < num_q_heads
+    if is_active_row:
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var shared_base = Int(warp_idx) * head_dim
+
+        if is_q_row:
+            var q_vec = x.load[width=simd_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(Int(col)))
+            )
+            var thread_m2 = (q_vec.cast[accum_type]() ** 2).reduce_add()
+            var row_m2 = warp.sum(thread_m2)
+            var norm_factor = rsqrt(
+                (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+            )
+            var gamma_val = q_gamma.load[width=simd_width, alignment=align](
+                Coord(Idx(Int(col)))
+            )
+            var norm_val = (
+                q_vec.cast[accum_type]()
+                * norm_factor
+                * (gamma_val.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+            shared_norm.store[width=simd_width, alignment=align](
+                shared_base + Int(col), norm_val
+            )
+            syncwarp()
+
+            if local_tid < UInt(WARP_SIZE // 2):
+                var re_offset = Int(local_tid) * simd_width
+                var im_offset = re_offset + head_dim // 2
+                var rope_re = shared_norm.load[width=simd_width](
+                    shared_base + re_offset
+                )
+                var rope_im = shared_norm.load[width=simd_width](
+                    shared_base + im_offset
+                )
+                var q_freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                    Coord(Idx(post_seq_idx), Idx(re_offset * 2))
+                )
+                var q_rope = _rope_complex_mul_half[
+                    dtype,
+                    freq_dtype,
+                    simd_width,
+                    simd_width * 2,
+                ](rope_re, rope_im, q_freq)
+                output.store[alignment=align](
+                    Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset)),
+                    q_rope[0],
+                )
+                output.store[alignment=align](
+                    Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset)),
+                    q_rope[1],
+                )
+        else:
+            var k_head_idx = head_slot - num_q_heads
+            var k_vec = k_cache.load[width=simd_width](
+                batch_idx, k_head_idx, post_seq_idx, Int(col)
+            ).cast[accum_type]()
+            var thread_m2 = (k_vec**2).reduce_add()
+            var row_m2 = warp.sum(thread_m2)
+            var norm_factor = rsqrt(
+                (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+            )
+            var gamma_val = k_gamma.load[width=simd_width, alignment=align](
+                Coord(Idx(Int(col)))
+            )
+            var norm_val = k_vec * norm_factor * (
+                gamma_val.cast[accum_type]() + weight_offset_accum
+            )
+            shared_norm.store[width=simd_width, alignment=align](
+                shared_base + Int(col), norm_val.cast[dtype]()
+            )
+            syncwarp()
+
+            if local_tid < UInt(WARP_SIZE // 2):
+                var re_offset = Int(local_tid) * simd_width
+                var im_offset = re_offset + head_dim // 2
+                var rope_re = shared_norm.load[width=simd_width](
+                    shared_base + re_offset
+                ).cast[accum_type]()
+                var rope_im = shared_norm.load[width=simd_width](
+                    shared_base + im_offset
+                ).cast[accum_type]()
+                var k_freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                    Coord(Idx(post_seq_idx), Idx(re_offset * 2))
+                )
+                comptime cache_dtype = KCacheType.dtype
+                var k_rope = _rope_complex_mul_half[
+                    accum_type,
+                    freq_dtype,
+                    simd_width,
+                    simd_width * 2,
+                ](rope_re, rope_im, k_freq)
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    re_offset,
+                    k_rope[0].cast[cache_dtype](),
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    im_offset,
+                    k_rope[1].cast[cache_dtype](),
+                )
+
+
+def _q_rms_norm_fused_qk_rope_generic_fallback[
+    dtype: DType,
+    freq_dtype: DType,
+    collection_t: KVCollectionT,
+    *,
+    interleaved: Bool,
+    target: StaticString,
+](
+    x: TileTensor[dtype, ...],
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    start_pos: TileTensor[DType.uint32, ...],
+    kv_collection: collection_t,
+    freqs_cis: TileTensor[freq_dtype, ...],
+    q_gamma: TileTensor[dtype, ...],
+    k_gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    output: TileTensor[mut=True, dtype, ...],
+    context: DeviceContext,
+) raises:
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime head_dim = Int(x.static_shape[2])
+
+    comptime if dtype == DType.bfloat16 and head_dim == 256:
+        q_rms_norm_rope_ragged[
+            dtype,
+            freq_dtype,
+            target=target,
+        ](
+            x,
+            input_row_offsets,
+            start_pos,
+            freqs_cis,
+            q_gamma,
+            epsilon,
+            weight_offset,
+            output,
+            context,
+        )
+        k_rms_norm_rope_ragged[
+            dtype,
+            freq_dtype,
+            collection_t,
+            interleaved=interleaved,
+            target=target,
+        ](
+            Int(x.dim(0)),
+            input_row_offsets,
+            kv_collection,
+            freqs_cis,
+            k_gamma,
+            epsilon,
+            weight_offset,
+            layer_idx,
+            context,
+        )
+    else:
+        @always_inline
+        @parameter
+        @__copy_capture(x)
+        def q_input_fn[
+            width: Int, rank: Int
+        ](coords: IndexList[rank]) -> SIMD[dtype, width]:
+            return x.load[width=width](Coord(coords))
+
+        @always_inline
+        @parameter
+        @__copy_capture(output)
+        def q_output_fn[
+            width: Int, alignment: Int
+        ](coords: IndexList[3], val: SIMD[dtype, width]) -> None:
+            output.store[alignment=alignment](Coord(coords), val)
+
+        var q_shape = IndexList[3](
+            Int(x.dim(0)),
+            Int(x.dim(1)),
+            Int(x.dim(2)),
+        )
+        rms_norm_gpu[
+            q_input_fn,
+            q_output_fn,
+            multiply_before_cast=True,
+        ](q_shape, q_gamma, epsilon, weight_offset, context)
+
+        var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache, input_row_offsets)
+        def k_input_fn[
+            width: Int, rank: Int
+        ](coords: IndexList[rank]) -> SIMD[dtype, width]:
+            var global_token_idx = coords[0]
+            var batch_idx = get_batch_from_row_offsets(
+                input_row_offsets, global_token_idx
+            )
+            var batch_start = rebind[Scalar[DType.uint32]](
+                input_row_offsets.load[width=1](Coord(Idx(batch_idx)))
+            )
+            var token_idx = Int(UInt32(global_token_idx) - batch_start)
+            var cache_token_idx = token_idx + Int(k_cache.cache_length(batch_idx))
+            return k_cache.load[width=width](
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=coords[1],
+                head_dim_idx=coords[2],
+            ).cast[dtype]()
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache, input_row_offsets)
+        def k_output_fn[
+            width: Int, alignment: Int
+        ](coords: IndexList[3], val: SIMD[dtype, width]) -> None:
+            var global_token_idx = coords[0]
+            var batch_idx = get_batch_from_row_offsets(
+                input_row_offsets, global_token_idx
+            )
+            var batch_start = rebind[Scalar[DType.uint32]](
+                input_row_offsets.load[width=1](Coord(Idx(batch_idx)))
+            )
+            var token_idx = Int(UInt32(global_token_idx) - batch_start)
+            var cache_token_idx = token_idx + Int(k_cache.cache_length(batch_idx))
+            k_cache.store(
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=coords[1],
+                head_dim_idx=coords[2],
+                val=val.cast[collection_t.CacheType.dtype](),
+            )
+
+        var k_shape = IndexList[3](
+            Int(x.dim(0)),
+            Int(collection_t.CacheType.kv_params.num_heads),
+            Int(k_gamma.dim(0)),
+        )
+        rms_norm_gpu[
+            k_input_fn,
+            k_output_fn,
+            multiply_before_cast=True,
+        ](k_shape, k_gamma, epsilon, weight_offset, context)
+
+        rope_ragged[
+            dtype,
+            freq_dtype,
+            interleaved=interleaved,
+            target=target,
+            output_fn=q_output_fn,
+        ](
+            output,
+            input_row_offsets,
+            start_pos,
+            freqs_cis,
+            Optional[DeviceContext](context),
+        )
+        _rope_k_cache_ragged[
+            freq_dtype,
+            collection_t,
+            interleaved=interleaved,
+            target=target,
+        ](
+            Int(x.dim(0)),
+            input_row_offsets,
+            kv_collection,
+            freqs_cis,
+            layer_idx,
+            context,
+        )
+
+
+def q_rms_norm_fused_qk_rope_ragged[
+    dtype: DType,
+    freq_dtype: DType,
+    collection_t: KVCollectionT,
+    *,
+    interleaved: Bool,
+    target: StaticString,
+](
+    x: TileTensor[dtype, ...],
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    start_pos: TileTensor[DType.uint32, ...],
+    kv_collection: collection_t,
+    freqs_cis: TileTensor[freq_dtype, ...],
+    q_gamma: TileTensor[dtype, ...],
+    k_gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    output: TileTensor[mut=True, dtype, ...],
+    context: DeviceContext,
+) raises:
+    comptime assert (
+        not interleaved
+    ), "q_rms_norm_fused_qk_rope_ragged currently supports non-interleaved RoPE only"
+
+    comptime head_dim = Int(x.static_shape[2])
+    comptime num_q_heads = x.static_shape[1]
+    comptime num_kv_heads = Int(collection_t.CacheType.kv_params.num_heads)
+    var total_tokens = Int(x.dim(0))
+    var is_decode_uniform = total_tokens == Int(start_pos.dim(0))
+    var total_rows = total_tokens * (num_q_heads + num_kv_heads)
+
+    comptime if head_dim == 128 and dtype == DType.bfloat16:
+        comptime block_size = 64
+        comptime warps_per_block = 2
+        var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+        if is_decode_uniform:
+            # Decode submits one token per active request, so batch_idx matches
+            # global_token_idx and start_pos already carries the RoPE position.
+            comptime kernel = _q_rms_norm_fused_qk_rope_decode_ragged_kernel[
+                dtype,
+                freq_dtype,
+                collection_t.CacheType,
+                x.LayoutType,
+                output.LayoutType,
+                start_pos.LayoutType,
+                freqs_cis.LayoutType,
+                q_gamma.LayoutType,
+                k_gamma.LayoutType,
+                block_size,
+                warps_per_block,
+            ]
+            context.enqueue_function[kernel, kernel](
+                x,
+                output,
+                start_pos,
+                k_cache,
+                freqs_cis,
+                q_gamma,
+                k_gamma,
+                epsilon,
+                weight_offset,
+                total_rows,
+                grid_dim=ceildiv(total_rows, warps_per_block * 2),
+                block_dim=block_size,
+            )
+        else:
+            comptime kernel = _q_rms_norm_fused_qk_rope_ragged_kernel[
+                dtype,
+                freq_dtype,
+                collection_t.CacheType,
+                x.LayoutType,
+                output.LayoutType,
+                input_row_offsets.LayoutType,
+                start_pos.LayoutType,
+                freqs_cis.LayoutType,
+                q_gamma.LayoutType,
+                k_gamma.LayoutType,
+                block_size,
+                warps_per_block,
+            ]
+            context.enqueue_function[kernel, kernel](
+                x,
+                output,
+                input_row_offsets,
+                start_pos,
+                k_cache,
+                freqs_cis,
+                q_gamma,
+                k_gamma,
+                epsilon,
+                weight_offset,
+                total_rows,
+                grid_dim=ceildiv(total_rows, warps_per_block * 2),
+                block_dim=block_size,
+            )
+    elif dtype == DType.bfloat16 and head_dim == 256:
+        if is_decode_uniform:
+            comptime block_size = 64
+            comptime warps_per_block = 2
+            var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+            comptime kernel = _q_rms_norm_fused_qk_rope_decode_ragged_wide_kernel[
+                dtype,
+                freq_dtype,
+                collection_t.CacheType,
+                x.LayoutType,
+                output.LayoutType,
+                start_pos.LayoutType,
+                freqs_cis.LayoutType,
+                q_gamma.LayoutType,
+                k_gamma.LayoutType,
+                block_size,
+                warps_per_block,
+            ]
+            context.enqueue_function[kernel, kernel](
+                x,
+                output,
+                start_pos,
+                k_cache,
+                freqs_cis,
+                q_gamma,
+                k_gamma,
+                epsilon,
+                weight_offset,
+                total_rows,
+                grid_dim=ceildiv(total_rows, warps_per_block),
+                block_dim=block_size,
+            )
+        else:
+            _q_rms_norm_fused_qk_rope_generic_fallback[
+                dtype,
+                freq_dtype,
+                collection_t,
+                interleaved=interleaved,
+                target=target,
+            ](
+                x,
+                input_row_offsets,
+                start_pos,
+                kv_collection,
+                freqs_cis,
+                q_gamma,
+                k_gamma,
+                epsilon,
+                weight_offset,
+                layer_idx,
+                output,
+                context,
+            )
+    else:
+        _q_rms_norm_fused_qk_rope_generic_fallback[
+            dtype,
+            freq_dtype,
+            collection_t,
+            interleaved=interleaved,
+            target=target,
+        ](
+            x,
+            input_row_offsets,
+            start_pos,
+            kv_collection,
+            freqs_cis,
+            q_gamma,
+            k_gamma,
+            epsilon,
+            weight_offset,
+            layer_idx,
+            output,
+            context,
         )

--- a/max/kernels/src/nn/softmax.mojo
+++ b/max/kernels/src/nn/softmax.mojo
@@ -12,7 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 
 from std.math import align_down, ceildiv, exp, exp2, log
-from std.math.uutils import umod, ufloordiv, udivmod
 from std.collections import Optional, OptionalReg
 
 from std.sys import align_of, is_amd_gpu, is_nvidia_gpu, simd_width_of
@@ -33,11 +32,11 @@ from std.bit import log2_floor
 from std.gpu import (
     WARP_SIZE,
     barrier,
-    block_idx,
-    grid_dim,
-    lane_id,
-    thread_idx,
-    warp_id,
+    block_idx_uint as block_idx,
+    grid_dim_uint as grid_dim,
+    lane_id_int as lane_id,
+    thread_idx_uint as thread_idx,
+    warp_id_uint as warp_id,
 )
 from std.gpu.host import DeviceAttribute, DeviceContext
 from std.gpu.host.info import is_cpu, is_gpu
@@ -704,8 +703,8 @@ def softmax_kernel[
     ), "accum_type must be floating point"
     comptime axis = rank - 1
 
-    var row_size: Int = shape[axis]
-    var num_rows = ufloordiv(shape.flattened_length(), row_size)
+    var row_size = UInt(shape[axis])
+    var num_rows = UInt(shape.flattened_length()) // row_size
 
     var max_buf = tt_stack_allocation[
         dtype=accum_type, address_space=AddressSpace.SHARED
@@ -730,80 +729,79 @@ def softmax_kernel[
 
     var tid = thread_idx.x
 
-    with PDL():
-        # grid stride loop over rows
-        # each block reduces a row, which is convenient because it requires no partial
-        # reductions across blocks
-        for row_idx in range(block_idx.x, num_rows, grid_dim.x):
-            var sink_val = Scalar[accum_type].MIN
+    # grid stride loop over rows
+    # each block reduces a row, which is convenient because it requires no partial
+    # reductions across blocks
+    for row_idx in range(block_idx.x, num_rows, grid_dim.x):
+        var sink_val = Scalar[accum_type].MIN
 
-            comptime if sink:
-                sink_val = sink_weights[umod(row_idx, sink_weights.dim[0]())][
-                    0
-                ].cast[accum_type]()
+        comptime if sink:
+            sink_val = sink_weights[row_idx % UInt(sink_weights.dim[0]())][
+                0
+            ].cast[accum_type]()
 
-            # Step 1: compute max in row
-            var row_coords = _get_nd_indices_from_flat_index(
-                row_idx, shape, axis
+        # Step 1: compute max in row
+        var row_coords = _get_nd_indices_from_flat_index(
+            Int(row_idx), shape, axis
+        )
+        var row_max = row_reduce[
+            BLOCK_SIZE,
+            input_fn,
+            _max,
+            dtype,
+            1,
+            rank,
+            accum_type=accum_type,
+        ](row_coords, axis, Scalar[dtype].MIN, Int(row_size))
+
+        comptime if sink:
+            row_max = max(row_max, sink_val)
+
+        if tid == 0:
+            max_buf[0] = row_max
+        barrier()
+
+        row_max = max_buf[0][0]
+
+        # Step 2: out[i] = exp(in[i] - max) and compute sum of out[i]
+        var exp_sum = Scalar[accum_type](0)
+
+        for row_offset in range(tid, row_size, UInt(BLOCK_SIZE)):
+            row_coords[axis] = Int(row_offset)
+
+            # loads from input_fn twice
+            var val = exp(
+                input_fn[dtype, 1, rank](row_coords).cast[accum_type]()
+                - row_max
             )
-            var row_max = row_reduce[
-                BLOCK_SIZE,
-                input_fn,
-                _max,
-                dtype,
-                1,
-                rank,
-                accum_type=accum_type,
-            ](row_coords, axis, Scalar[dtype].MIN, row_size)
 
-            comptime if sink:
-                row_max = max(row_max, sink_val)
+            # TODO we're writing to and reading from global memory twice
+            # we can reduce the amount of reads by keeping values local here.
+            output.store_linear(row_coords, val.cast[dtype]())
+            exp_sum += val
 
-            if tid == 0:
-                max_buf[0] = row_max
-            barrier()
+        var block_exp_sum = block_reduce[BLOCK_SIZE, _sum](exp_sum, 0)
 
-            row_max = max_buf[0][0]
+        if tid == 0:
+            exp_sum_buf[0] = block_exp_sum
+        barrier()
 
-            # Step 2: out[i] = exp(in[i] - max) and compute sum of out[i]
-            var exp_sum = Scalar[accum_type](0)
+        comptime if sink:
+            block_exp_sum += exp(sink_val - row_max)
 
-            for row_offset in range(tid, row_size, BLOCK_SIZE):
-                row_coords[axis] = row_offset
+        # Step 3: Normalize output (and apply log for logsoftmax)
+        var block_exp_sum_recip = 1 / exp_sum_buf[0]
+        for row_offset in range(tid, row_size, UInt(BLOCK_SIZE)):
+            row_coords[axis] = Int(row_offset)
+            var normalized = (
+                output.load_linear[width=1](row_coords)
+                * block_exp_sum_recip.cast[dtype]()
+            )
 
-                # loads from input_fn twice
-                var val = exp(
-                    input_fn[dtype, 1, rank](row_coords).cast[accum_type]()
-                    - row_max
-                )
+            comptime if logsoftmax:
+                normalized = log(normalized)
 
-                # TODO we're writing to and reading from global memory twice
-                # we can reduce the amount of reads by keeping values local here.
-                output.store_linear(row_coords, val.cast[dtype]())
-                exp_sum += val
-
-            var block_exp_sum = block_reduce[BLOCK_SIZE, _sum](exp_sum, 0)
-
-            if tid == 0:
-                exp_sum_buf[0] = block_exp_sum
-            barrier()
-
-            comptime if sink:
-                block_exp_sum += exp(sink_val - row_max)
-
-            # Step 3: Normalize output (and apply log for logsoftmax)
-            var block_exp_sum_recip = 1 / exp_sum_buf[0]
-            for row_offset in range(tid, row_size, BLOCK_SIZE):
-                row_coords[axis] = row_offset
-                var normalized = (
-                    output.load_linear[width=1](row_coords)
-                    * block_exp_sum_recip.cast[dtype]()
-                )
-
-                comptime if logsoftmax:
-                    normalized = log(normalized)
-
-                output.store_linear(row_coords, normalized)
+            output.store_linear(row_coords, normalized)
 
 
 def _softmax_gpu[
@@ -858,7 +856,6 @@ def _softmax_gpu[
         sink_weights.value(),
         grid_dim=num_blocks,
         block_dim=BLOCK_SIZE,
-        attributes=pdl_launch_attributes(PDLLevel(1)),
     )
 
 
@@ -919,8 +916,10 @@ def softmax[
 # ===----------------------------------------------------------------------=== #
 
 
-def _softmax_temperature_kernel[
+@always_inline
+def _softmax_temperature_rows[
     BLOCK_SIZE: Int,
+    VEC_WIDTH: Int,
     dtype: DType,
     temp_dtype: DType,
     InputLayoutType: TensorLayout,
@@ -931,43 +930,28 @@ def _softmax_temperature_kernel[
 ](
     input: TileTensor[dtype, InputLayoutType, input_origin],
     output: TileTensor[dtype, OutputLayoutType, output_origin],
-    batch_size: Int,
-    d: Int,
+    num_rows: Int,
+    row_size: Int,
     temperature: Scalar[temp_dtype],
-    # using UnsafePointer here because cant pass optional TileTensor
     temperature_arr: UnsafePointer[Scalar[temp_dtype], ImmutAnyOrigin],
 ):
-    """GPU kernel for softmax with per-row temperature scaling.
-
-    Computes softmax(logits / T) where T is resolved per row from
-    `temperature_arr` (if non-null) or the scalar `temperature` fallback.
-    """
-
-    comptime assert input.flat_rank == 2, "input must be rank 2"
-    comptime assert output.flat_rank == 2, "output must be rank 2"
-
-    var row_size = d
-    var num_rows = batch_size
-
     comptime assert dtype.is_floating_point(), "dtype must be floating point"
     comptime assert (
         accum_type.is_floating_point()
     ), "accum_type must be floating point"
 
-    comptime VEC_WIDTH = simd_width_of[dtype]()
-
-    var tid = thread_idx.x
-    var bid = block_idx.x
-    var gid = grid_dim.x
+    var tid = Int(thread_idx.x)
+    var bid = Int(block_idx.x)
+    var gid = Int(grid_dim.x)
 
     comptime BLOCK_SPAN = BLOCK_SIZE * VEC_WIDTH
-    var use_vectorized = row_size >= 4 * BLOCK_SIZE * VEC_WIDTH
+    var use_vectorized = row_size >= 4 * BLOCK_SPAN
 
     with PDL():
         for row_idx in range(bid, num_rows, gid):
             # Resolve per-row temperature, clamping to prevent division by zero.
             var temp = temperature.cast[accum_type]()
-            if temperature_arr._is_not_null():
+            if temperature_arr:
                 temp = temperature_arr[row_idx].cast[accum_type]()
             temp = max(temp, Scalar[accum_type](1e-6))
             var inv_temp = Scalar[accum_type](1) / temp
@@ -1052,10 +1036,113 @@ def _softmax_temperature_kernel[
                     output.store_linear(coords, val.cast[dtype]())
 
 
+def _softmax_temperature_kernel[
+    BLOCK_SIZE: Int,
+    dtype: DType,
+    temp_dtype: DType,
+    InputLayoutType: TensorLayout,
+    input_origin: ImmutOrigin,
+    OutputLayoutType: TensorLayout,
+    output_origin: MutOrigin,
+    accum_type: DType = get_accum_type[dtype](),
+](
+    input: TileTensor[dtype, InputLayoutType, input_origin],
+    output: TileTensor[dtype, OutputLayoutType, output_origin],
+    batch_size: Int,
+    d: Int,
+    temperature: Scalar[temp_dtype],
+    # using UnsafePointer here because cant pass optional TileTensor
+    temperature_arr: UnsafePointer[Scalar[temp_dtype], ImmutAnyOrigin],
+):
+    """GPU kernel for softmax with per-row temperature scaling.
+
+    Computes softmax(logits / T) where T is resolved per row from
+    `temperature_arr` (if non-null) or the scalar `temperature` fallback.
+    """
+
+    comptime assert input.flat_rank == 2, "input must be rank 2"
+    comptime assert output.flat_rank == 2, "output must be rank 2"
+
+    var row_size = d
+    var num_rows = batch_size
+
+    comptime assert dtype.is_floating_point(), "dtype must be floating point"
+    comptime assert (
+        accum_type.is_floating_point()
+    ), "accum_type must be floating point"
+
+    comptime NATIVE_VEC_WIDTH = simd_width_of[dtype]()
+    comptime WIDE_FLOAT32_VEC_WIDTH = 8
+
+    # Keep the wider float32 vector path on aligned rows only; the exact
+    # Gemma vocab sizes are 8-aligned, while nearby misaligned controls are not.
+    comptime if dtype == DType.float32 and (
+        WIDE_FLOAT32_VEC_WIDTH > NATIVE_VEC_WIDTH
+    ):
+        if row_size % WIDE_FLOAT32_VEC_WIDTH == 0:
+            _softmax_temperature_rows[
+                BLOCK_SIZE,
+                WIDE_FLOAT32_VEC_WIDTH,
+                dtype,
+                temp_dtype,
+                InputLayoutType,
+                input_origin,
+                OutputLayoutType,
+                output_origin,
+                accum_type,
+            ](
+                input,
+                output,
+                num_rows,
+                row_size,
+                temperature,
+                temperature_arr,
+            )
+        else:
+            _softmax_temperature_rows[
+                BLOCK_SIZE,
+                NATIVE_VEC_WIDTH,
+                dtype,
+                temp_dtype,
+                InputLayoutType,
+                input_origin,
+                OutputLayoutType,
+                output_origin,
+                accum_type,
+            ](
+                input,
+                output,
+                num_rows,
+                row_size,
+                temperature,
+                temperature_arr,
+            )
+    else:
+        _softmax_temperature_rows[
+            BLOCK_SIZE,
+            NATIVE_VEC_WIDTH,
+            dtype,
+            temp_dtype,
+            InputLayoutType,
+            input_origin,
+            OutputLayoutType,
+            output_origin,
+            accum_type,
+        ](
+            input,
+            output,
+            num_rows,
+            row_size,
+            temperature,
+            temperature_arr,
+        )
+
+
 def softmax_with_temperature[
     dtype: DType,
     temp_dtype: DType = DType.float32,
     TempLayoutType: TensorLayout = RowMajorLayout[RuntimeInt[DType.int64]],
+    pdl_level: PDLLevel = PDLLevel(1),
 ](
     ctx: DeviceContext,
     input: TileTensor[dtype, ...],
@@ -1064,6 +1151,7 @@ def softmax_with_temperature[
     temperature_arr: Optional[
         TileTensor[temp_dtype, TempLayoutType, ImmutAnyOrigin]
     ] = None,
+    block_size_override: Optional[Int] = None,
 ) raises:
     """GPU softmax with per-row temperature scaling.
 
@@ -1075,6 +1163,7 @@ def softmax_with_temperature[
         dtype: The data type of the input and output tensors.
         temp_dtype: The data type for temperature values (default float32).
         TempLayoutType: The layout type for the optional temperature array.
+        pdl_level: The PDL level for kernel launch attributes.
 
     Args:
         ctx: Device context for kernel execution.
@@ -1082,6 +1171,8 @@ def softmax_with_temperature[
         output: Output probability tensor (same shape as input).
         temperature: Scalar temperature fallback (default 1.0).
         temperature_arr: Optional per-row temperature values [batch_size].
+        block_size_override: Optional launch block size override for
+            benchmarking. Supported values are 256, 512, and 1024.
     """
     comptime assert input.rank == 2, "input must be rank 2"
     comptime assert output.rank == 2, "output must be rank 2"
@@ -1091,37 +1182,52 @@ def softmax_with_temperature[
     var d = shape[1]
 
     # Extract raw pointer for the kernel (null if not provided).
-    var temp_ptr = UnsafePointer[Scalar[temp_dtype], ImmutAnyOrigin](
-        _unsafe_null=()
-    )
+    var temp_ptr = UnsafePointer[Scalar[temp_dtype], ImmutAnyOrigin]()
     if temperature_arr:
         temp_ptr = temperature_arr.value().ptr
 
-    comptime BLOCK_SIZE = 256
     var sm_count = ctx.get_attribute(DeviceAttribute.MULTIPROCESSOR_COUNT)
     comptime sm_overprovision_factor = 32
     var num_blocks = min(batch_size, sm_overprovision_factor * sm_count)
 
-    comptime kernel = _softmax_temperature_kernel[
-        BLOCK_SIZE,
-        dtype,
-        temp_dtype,
-        input.LayoutType,
-        ImmutOrigin(input.origin),
-        output.LayoutType,
-        output.origin,
-    ]
-    ctx.enqueue_function[kernel, kernel](
-        input.as_immut(),
-        output,
-        batch_size,
-        d,
-        temperature,
-        temp_ptr,
-        grid_dim=num_blocks,
-        block_dim=BLOCK_SIZE,
-        attributes=pdl_launch_attributes(PDLLevel(1)),
-    )
+    @parameter
+    @always_inline
+    def launch_kernel[block_size: Int]() raises:
+        comptime kernel = _softmax_temperature_kernel[
+            block_size,
+            dtype,
+            temp_dtype,
+            input.LayoutType,
+            ImmutOrigin(input.origin),
+            output.LayoutType,
+            output.origin,
+        ]
+        ctx.enqueue_function[kernel, kernel](
+            input.as_immut(),
+            output,
+            batch_size,
+            d,
+            temperature,
+            temp_ptr,
+            grid_dim=num_blocks,
+            block_dim=block_size,
+            attributes=pdl_launch_attributes(pdl_level),
+        )
+
+    var launch_block_size = block_size_override.value() if (
+        block_size_override
+    ) else 1024
+    if launch_block_size == 256:
+        launch_kernel[256]()
+    elif launch_block_size == 512:
+        launch_kernel[512]()
+    elif launch_block_size == 1024:
+        launch_kernel[1024]()
+    else:
+        raise Error(
+            "softmax_with_temperature only supports block_size_override "
+            "values 256, 512, or 1024"
+        )
 
 
 # ===----------------------------------------------------------------------=== #
@@ -1185,11 +1291,15 @@ def _online_softmax_kernel[
 
     # If we do more than 2 iterations, the first N - 2 iterations won't be
     # corrected with the right rowmax.
-    var input_warp_tile0 = input.tile[WM, WN](0, warp_id)
-    var input_warp_tile1 = input.tile[WM, WN](0, warp_id + num_rowwise_warps)
+    var input_warp_tile0 = input.tile[WM, WN](0, Int(warp_id))
+    var input_warp_tile1 = input.tile[WM, WN](
+        0, Int(warp_id) + num_rowwise_warps
+    )
 
-    var output_warp_tile0 = output.tile[WM, WN](0, warp_id)
-    var output_warp_tile1 = output.tile[WM, WN](0, warp_id + num_rowwise_warps)
+    var output_warp_tile0 = output.tile[WM, WN](0, Int(warp_id))
+    var output_warp_tile1 = output.tile[WM, WN](
+        0, Int(warp_id) + num_rowwise_warps
+    )
 
     var p = LayoutTensor[
         dtype,
@@ -1348,8 +1458,9 @@ def _online_softmax_iter_for_mma_output[
     comptime num_colwise_warps = block_layout_by_warp.shape[0].value()
     comptime num_rowwise_warps = block_layout_by_warp.shape[1].value()
 
+    var tid = thread_idx.x
     var lane_id = lane_id()
-    var warp_x = umod(warp_id[broadcast=True](), num_rowwise_warps)
+    var warp_x = warp_id[broadcast=True]() % UInt(num_rowwise_warps)
 
     # Assume p_reg_tile has been properly vectorized. The element layout
     # represents number elements per thread in a row or column
@@ -1463,7 +1574,7 @@ def _online_softmax_iter_for_mma_output[
                     # warp scratch has layout row_major(num_warps, num_rows). The
                     # "score_row_idx" is the idx-th row in the score matrix.
                     warp_scratch[
-                        warp_x, Int(score_row_idx)
+                        Int(warp_x), Int(score_row_idx)
                     ] = score_frag_rowmax[col_tile, row][0]
 
         barrier()
@@ -1559,7 +1670,7 @@ def _online_softmax_iter_for_mma_output[
                     )
 
                     warp_scratch[
-                        warp_x + num_rowwise_warps, Int(score_row_idx)
+                        warp_x + UInt(num_rowwise_warps), Int(score_row_idx)
                     ] = score_frag_rowsum[col_tile, row][0]
 
         # Guard writing warp_scratch
@@ -1720,7 +1831,7 @@ def _online_softmax_iter_for_mma_output_split_warp_reduce[
 
     var tid = thread_idx.x
     var lane = UInt32(lane_id())
-    var warp_y, warp_x = udivmod(ufloordiv(tid, WARP_SIZE), num_warps_n)
+    var warp_y, warp_x = divmod(tid // UInt(WARP_SIZE), UInt(num_warps_n))
 
     comptime fragment_layout = Layout.row_major(
         1, 2
@@ -1755,12 +1866,14 @@ def _online_softmax_iter_for_mma_output_split_warp_reduce[
     #    constant when writing, and iterate across it when reducing.
     # 3-4. ((WM*WN)//frag_size) x frag_size: the two trailing dimensions of
     #    output_reg_tile
-    comptime warp_tile_size = Int(WM * WN)  # ((WM*WN)//frag_size) x frag_size
-    comptime row_warp_tile_size = (num_warps_n - 1) * warp_tile_size
+    comptime warp_tile_size = WM * WN  # ((WM*WN)//frag_size) x frag_size
+    comptime row_warp_tile_size = (num_warps_n - 1) * Int(warp_tile_size)
     # Makes sure arithmetic is optimized away when `num_warps_m == 1`.
     var o_smem_ptr = (
         o_smem_ptr_base
-        + warp_y * (num_warps_n - 1) * row_warp_tile_size if num_warps_m
+        + warp_y
+        * UInt(num_warps_n - 1)
+        * UInt(row_warp_tile_size) if num_warps_m
         > 1 else o_smem_ptr_base
     )
 
@@ -1795,7 +1908,7 @@ def _online_softmax_iter_for_mma_output_split_warp_reduce[
                 # warp scratch has layout row_major(num_warps, num_rows). The
                 # "score_row_idx" is the idx-th row in the score matrix.
                 warp_scratch[
-                    warp_x + num_warps_n, Int(score_row_idx)
+                    Int(warp_x) + num_warps_n, Int(score_row_idx)
                 ] = rowmax_tensor[col_tile, row][0]
 
     barrier()
@@ -1850,7 +1963,7 @@ def _online_softmax_iter_for_mma_output_split_warp_reduce[
                     + UInt32(row)
                 )
                 var c = rebind[Scalar[dtype]](correction[col_tile, row])
-                warp_scratch[warp_x, Int(score_row_idx)] = (
+                warp_scratch[Int(warp_x), Int(score_row_idx)] = (
                     0.0 if c == 0.0 else rowsum_tensor[col_tile, row][0] * c
                 )
 
@@ -1912,7 +2025,7 @@ def _online_softmax_iter_for_mma_output_split_warp_reduce[
         var reg_tile = output_reg_tile.tile[num_m_mmas * num_n_mmas, 1](
             warp_n, 0
         )
-        if warp_n == warp_x:
+        if warp_n == Int(warp_x):
             comptime if warp_n > 0:
                 # we want `output_reg_tile[0,:,:]` to be the real output reg tile.
                 out_reg_tile.copy_from(
@@ -1930,10 +2043,10 @@ def _online_softmax_iter_for_mma_output_split_warp_reduce[
             # -----------------------------------
             # `N\X` refer to `warp_n`, `warp_x`
             comptime row = warp_n
-            var col = warp_x - (1 if warp_x > warp_n else 0)
-            var o_smem_ptr_write = (
-                o_smem_ptr + (row * (num_warps_n - 1) + col) * warp_tile_size
-            )
+            var col = warp_x - UInt(1 if warp_x > UInt(warp_n) else 0)
+            var o_smem_ptr_write = o_smem_ptr + (
+                row * (num_warps_n - 1) + Int(col)
+            ) * Int(warp_tile_size)
             var o_smem_write = (
                 LayoutTensor[
                     dtype,
@@ -1962,7 +2075,8 @@ def _online_softmax_iter_for_mma_output_split_warp_reduce[
         var row = warp_x
         comptime col = warp_n
         var o_smem_ptr_reduce = (
-            o_smem_ptr + (row * (num_warps_n - 1) + col) * warp_tile_size
+            o_smem_ptr
+            + (row * UInt(num_warps_n - 1) + UInt(col)) * warp_tile_size
         )
         var o_smem_reduce = (
             LayoutTensor[

--- a/max/kernels/src/nn/topk.mojo
+++ b/max/kernels/src/nn/topk.mojo
@@ -12,7 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 
 from std.math import ceildiv, exp, iota
-from std.math.uutils import ufloordiv, udivmod
 from std.memory import alloc
 from std.sys import align_of, simd_width_of, size_of, get_defined_bool
 
@@ -23,11 +22,11 @@ from std.bit import log2_floor
 from std.gpu import (
     WARP_SIZE,
     barrier,
-    thread_idx,
-    block_dim,
-    block_idx,
-    lane_id,
-    warp_id,
+    block_dim_uint as block_dim,
+    block_idx_uint as block_idx,
+    lane_id_uint as lane_id,
+    thread_idx_uint as thread_idx,
+    warp_id_uint as warp_id,
 )
 from std.gpu.primitives.grid_controls import PDL, pdl_launch_attributes
 from std.gpu.host import DeviceContext, DeviceBuffer
@@ -54,11 +53,9 @@ from nn.reshape import reshape
 from nn.softmax import softmax_with_temperature
 from nn.topk_fi import topk_topp_sampling_from_prob
 from std.runtime.asyncrt import DeviceContextPtr
-from std.runtime.tracing import Trace, TraceLevel, trace_arg
 
 from std.utils.index import IndexList, product
 from std.utils.numerics import max_or_inf, min_or_neg_inf
-from std.gpu.primitives.grid_controls import PDLLevel
 
 from .normalization import (
     _APPLE_STATIC_SHMEM_MAX_COUNT,
@@ -175,66 +172,44 @@ def top_k[
         input.rank == out_idxs.rank
     ), "input.rank must match out_idx.rank"
 
-    var input_shape = rebind[IndexList[input.rank]](
-        coord_to_index_list(input.layout.shape_coord())
-    )
+    var normalized_axis = normalize_neg_index(Int64(axis), input.rank)
 
-    @parameter
-    def trace_information() -> String:
-        return String(";").join(
-            Span(
-                [
-                    trace_arg("input", input_shape, dtype),
-                    "max_k=" + String(max_k),
-                    "axis=" + String(axis),
-                    "largest=" + String(largest),
-                ]
-            )
+    # Clamp max_k
+    var bound_max_k = 255 if max_k == -1 else max_k
+
+    comptime if is_cpu[target]():
+        comptime assert (
+            out_idx_type == DType.int64
+        ), "out_idx_type must be int64 for cpu"
+
+        comptime grain_size = 1000
+        _top_k_cpu[largest=largest](
+            input,
+            bound_max_k,
+            Int(normalized_axis),
+            out_vals,
+            out_idxs,
+            grain_size,
+            sorted,
+            k=k,
         )
-
-    with Trace[TraceLevel.OP, target=target](
-        "top_k",
-        Trace[TraceLevel.OP]._get_detail_str[trace_information](),
-        task_id=Int(ctx.get_device_context().id()),
-    ):
-        var normalized_axis = normalize_neg_index(Int64(axis), input.rank)
-
-        # Clamp max_k
-        var bound_max_k = 255 if max_k == -1 else max_k
-
-        comptime if is_cpu[target]():
-            comptime assert (
-                out_idx_type == DType.int64
-            ), "out_idx_type must be int64 for cpu"
-
-            comptime grain_size = 1000
-            _top_k_cpu[largest=largest](
-                input,
-                bound_max_k,
-                Int(normalized_axis),
-                out_vals,
-                out_idxs,
-                grain_size,
-                sorted,
-                k=k,
+    else:
+        if normalized_axis != Scalar[DType.int](input.rank - 1):
+            raise Error("axis other than -1 not supported on GPU")
+        if not sorted:
+            print(
+                "Warning: Unsorted top-k is not supported on GPU. Falling"
+                " back to sorted top-k."
             )
-        else:
-            if normalized_axis != Scalar[DType.int](input.rank - 1):
-                raise Error("axis other than -1 not supported on GPU")
-            if not sorted:
-                print(
-                    "Warning: Unsorted top-k is not supported on GPU. Falling"
-                    " back to sorted top-k."
-                )
-            var cuda_ctx = ctx.get_device_context()
-            topk_gpu[sampling=False, largest=largest](
-                cuda_ctx,
-                bound_max_k,
-                input,
-                out_vals,
-                out_idxs,
-                k=k,
-            )
+        var cuda_ctx = ctx.get_device_context()
+        topk_gpu[sampling=False, largest=largest](
+            cuda_ctx,
+            bound_max_k,
+            input,
+            out_vals,
+            out_idxs,
+            k=k,
+        )
 
 
 def _top_k_cpu[
@@ -406,47 +381,28 @@ def fused_token_sampling_cpu[
     ), "input.rank must match out_idx.rank"
     comptime assert out_idx_type == DType.int64, "out_idx_type must be int64"
 
-    var input_shape = rebind[IndexList[input.rank]](
-        coord_to_index_list(input.layout.shape_coord())
+    bound_max_k = 255 if max_k == -1 else max_k
+
+    # materialize the out_vals which is of shape [input[:-1]] + [k]
+    var out_vals_shape = coord_to_index_list(input.layout.shape_coord())
+    out_vals_shape[input.rank - 1] = bound_max_k
+    var out_vals = TileTensor(
+        alloc[Scalar[dtype]](out_vals_shape.flattened_length()),
+        row_major(Coord(out_vals_shape)),
     )
 
-    @parameter
-    def trace_information() -> String:
-        return String(";").join(
-            Span(
-                [
-                    trace_arg("input", input_shape, dtype),
-                    "max_k=" + String(max_k),
-                ]
-            )
-        )
+    _top_k_sampling(
+        bound_max_k,
+        input,
+        out_vals,
+        TileTensor(out_idxs.ptr.bitcast[Int64](), out_idxs.layout),
+        k,
+        temperature,
+        top_p,
+        seed,
+    )
 
-    with Trace[TraceLevel.OP, target=StaticString("cpu")](
-        "fused_token_sampling",
-        Trace[TraceLevel.OP]._get_detail_str[trace_information](),
-    ):
-        bound_max_k = 255 if max_k == -1 else max_k
-
-        # materialize the out_vals which is of shape [input[:-1]] + [k]
-        var out_vals_shape = coord_to_index_list(input.layout.shape_coord())
-        out_vals_shape[input.rank - 1] = bound_max_k
-        var out_vals = TileTensor(
-            alloc[Scalar[dtype]](out_vals_shape.flattened_length()),
-            row_major(Coord(out_vals_shape)),
-        )
-
-        _top_k_sampling(
-            bound_max_k,
-            input,
-            out_vals,
-            TileTensor(out_idxs.ptr.bitcast[Int64](), out_idxs.layout),
-            k,
-            temperature,
-            top_p,
-            seed,
-        )
-
-        out_vals.ptr.free()
+    out_vals.ptr.free()
 
 
 def _top_k_sampling[
@@ -646,105 +602,6 @@ struct TopK_2[T: DType, largest: Bool = True](
                 self.p = elem_id
 
 
-struct TopKHeap[T: DType, largest: Bool, M: Int]:
-    """Fixed-capacity register heap for per-thread top-M tracking.
-
-    Stores up to M (value, index) pairs in registers. During the scan
-    phase, a cached threshold provides O(1) rejection of non-competitive
-    elements. All internal loops are compile-time unrolled to keep data
-    in registers on GPU. Indices are stored as Int32 to reduce register
-    pressure for large block sizes.
-    """
-
-    var vals: InlineArray[Scalar[Self.T], Self.M]
-    var idxs: InlineArray[Int32, Self.M]
-    var threshold: Scalar[Self.T]
-
-    @always_inline
-    def __init__(out self):
-        self.vals = InlineArray[Scalar[Self.T], Self.M](
-            fill=_topk_dead_val[Self.T, Self.largest]()
-        )
-        self.idxs = InlineArray[Int32, Self.M](fill=Int32(-1))
-        self.threshold = _topk_dead_val[Self.T, Self.largest]()
-
-    @always_inline
-    def insert(mut self, val: Scalar[Self.T], idx: Int):
-        """Insert an element, evicting the worst if full."""
-        # Fast reject against threshold. When the heap has empty slots
-        # the threshold equals dead_val, so the check naturally fails
-        # for all real values and we fall through to the empty-slot path.
-        comptime if Self.largest:
-            if val <= self.threshold:
-                return
-        else:
-            if val >= self.threshold:
-                return
-
-        var idx32 = Int32(idx)
-
-        # Try to place in an empty slot.
-        var inserted = False
-        comptime for i in range(Self.M):
-            if not inserted and self.idxs[i] == -1:
-                self.vals[i] = val
-                self.idxs[i] = idx32
-                inserted = True
-
-        if not inserted:
-            # All slots full — replace the first element at threshold.
-            comptime for i in range(Self.M):
-                if not inserted and self.vals[i] == self.threshold:
-                    self.vals[i] = val
-                    self.idxs[i] = idx32
-                    inserted = True
-        self._update_threshold()
-
-    @always_inline
-    def _update_threshold(mut self):
-        """Recompute eviction threshold (worst value in the heap)."""
-        self.threshold = self.vals[0]
-        comptime for i in range(1, Self.M):
-            comptime if Self.largest:
-                if self.vals[i] < self.threshold:
-                    self.threshold = self.vals[i]
-            else:
-                if self.vals[i] > self.threshold:
-                    self.threshold = self.vals[i]
-
-    @always_inline
-    def best(self) -> TopK_2[Self.T, Self.largest]:
-        """Return the best element, ties broken by smallest index.
-
-        Returns a dead TopK_2 (p=-1) when all entries are exhausted.
-        """
-        var best_u = self.vals[0]
-        var best_p = self.idxs[0]
-        comptime for i in range(1, Self.M):
-            comptime if Self.largest:
-                if self.vals[i] > best_u or (
-                    self.vals[i] == best_u and self.idxs[i] < best_p
-                ):
-                    best_u = self.vals[i]
-                    best_p = self.idxs[i]
-            else:
-                if self.vals[i] < best_u or (
-                    self.vals[i] == best_u and self.idxs[i] < best_p
-                ):
-                    best_u = self.vals[i]
-                    best_p = self.idxs[i]
-        return TopK_2[Self.T, Self.largest](p=Int(best_p), u=best_u)
-
-    @always_inline
-    def remove(mut self, idx: Int):
-        """Remove element by global index, replacing with dead value."""
-        var idx32 = Int32(idx)
-        comptime for i in range(Self.M):
-            if self.idxs[i] == idx32:
-                self.vals[i] = _topk_dead_val[Self.T, Self.largest]()
-                self.idxs[i] = Int32(-1)
-
-
 # Function to perform warp-level reduction to find the maximum TopK_2
 @always_inline
 @parameter
@@ -879,20 +736,22 @@ def _block_reduce_topk[
     var warp_accum: TopK_2[T, ascending] = _warp_reduce_topk[T, ascending](val)
 
     # Store warp-level results in shared memory
-    if lane_id() == 0 and warp < num_warps_needed:
+    if lane_id() == 0 and warp < UInt(num_warps_needed):
         # Note: Potential bank conflict for sub 4 byte data elements
-        p_sram[warp * p_width] = Scalar[DType.int](warp_accum.p)
-        u_sram[warp * u_width] = warp_accum.u
+        p_sram[Int(warp) * p_width] = Scalar[DType.int](warp_accum.p)
+        u_sram[Int(warp) * u_width] = warp_accum.u
     barrier()
 
     # Load warp results into final warp for block-level reduction
     var block_accum = TopK_2[T, ascending]()
-    var thread_in_final_warp = thread_idx.x < ufloordiv(block_dim.x, WARP_SIZE)
+    var thread_in_final_warp = thread_idx.x < block_dim.x // UInt(WARP_SIZE)
     if thread_in_final_warp:
-        var p_idx = p_sram[lane_id() * p_width]  # loaded value is a scalar
+        var p_idx = p_sram[
+            lane_id() * UInt(p_width)
+        ]  # loaded value is a scalar
         block_accum = TopK_2[T, ascending](
-            p=Int(p_idx),  # Convert back to int
-            u=u_sram[lane_id() * u_width],
+            p=Int(p_idx),
+            u=u_sram[lane_id() * UInt(u_width)],  # Convert back to int
         )
     else:
         # Initialize unused threads with dummy values
@@ -934,20 +793,20 @@ def _topk_stage1_old_no_shmem[
     bid = block_idx.x
     block_size = block_dim.x
 
-    batch_id, block_lane = udivmod(bid, num_blocks_per_input)
+    batch_id, block_lane = divmod(bid, UInt(num_blocks_per_input))
 
-    _in_buffer = in_buffer + batch_id * num_elements
+    _in_buffer = in_buffer + batch_id * UInt(num_elements)
 
     with PDL():
         # Each thread finds its local best element in registers.
         var block_offset = block_lane * block_size
-        var stride = block_size * num_blocks_per_input
+        var stride = block_size * UInt(num_blocks_per_input)
         var partial = TopK_2[T, largest]()
-        for i in range(tid + block_offset, num_elements, stride):
+        for i in range(Int(tid + block_offset), num_elements, Int(stride)):
             partial.insert(_in_buffer[i], i)
 
         var k_batch = max_k
-        if K._is_not_null():
+        if K:
             var k_raw = Int(K[batch_id])
             k_batch = max_k if k_raw == -1 else k_raw
 
@@ -962,10 +821,10 @@ def _topk_stage1_old_no_shmem[
             var winner_p = warp.broadcast(total.p)
 
             if tid == 0:
-                local_topk_vals[bid * max_k + k] = total.u
-                local_topk_idxs[bid * max_k + k] = Scalar[DType.int](
-                    total.p
-                ).cast[out_idx_type]()
+                local_topk_vals[bid * UInt(max_k) + UInt(k)] = total.u
+                local_topk_idxs[bid * UInt(max_k) + UInt(k)] = Scalar[
+                    DType.int
+                ](total.p).cast[out_idx_type]()
 
             # The thread that owned the winning element invalidates it.
             if partial.p == winner_p:
@@ -975,10 +834,10 @@ def _topk_stage1_old_no_shmem[
         # Fill remaining positions with sentinel values.
         if tid == 0:
             for remaining_k in range(k_batch, max_k):
-                local_topk_vals[bid * max_k + remaining_k] = _topk_dead_val[
-                    T, largest
-                ]()
-                local_topk_idxs[bid * max_k + remaining_k] = Scalar[
+                local_topk_vals[
+                    bid * UInt(max_k) + UInt(remaining_k)
+                ] = _topk_dead_val[T, largest]()
+                local_topk_idxs[bid * UInt(max_k) + UInt(remaining_k)] = Scalar[
                     out_idx_type
                 ](-1)
 
@@ -1029,9 +888,9 @@ def _topk_stage1_old[
     bid = block_idx.x
     block_size = block_dim.x
 
-    batch_id, block_lane = udivmod(bid, num_blocks_per_input)
+    batch_id, block_lane = divmod(bid, UInt(num_blocks_per_input))
 
-    _in_buffer = in_buffer + batch_id * num_elements
+    _in_buffer = in_buffer + batch_id * UInt(num_elements)
 
     # Allocate shared memory for the values and indices
     var topk_sram = stack_allocation[
@@ -1047,13 +906,13 @@ def _topk_stage1_old[
     with PDL():
         # Pack the topk_vals and topk_idxs into shared memory
         var block_offset = block_lane * block_size
-        var stride = block_size * num_blocks_per_input
+        var stride = block_size * UInt(num_blocks_per_input)
         topk_sram[tid] = TopK_2[T, largest]()
-        for i in range(tid + block_offset, num_elements, stride):
+        for i in range(Int(tid + block_offset), num_elements, Int(stride)):
             topk_sram[tid].insert(_in_buffer[i], i)
         barrier()
         var k_batch = max_k
-        if K._is_not_null():
+        if K:
             var k_raw = Int(K[batch_id])
             k_batch = max_k if k_raw == -1 else k_raw
         # Prepare for K iterations to find the local top-K elements
@@ -1067,14 +926,16 @@ def _topk_stage1_old[
             if tid == 0:
                 # Store the local top-K values and indices in global memory
                 var vector_idx = total.p
-                local_topk_vals[bid * max_k + k] = total.u
-                local_topk_idxs[bid * max_k + k] = Scalar[DType.int](
-                    vector_idx
-                ).cast[out_idx_type]()
+                local_topk_vals[bid * UInt(max_k) + UInt(k)] = total.u
+                local_topk_idxs[bid * UInt(max_k) + UInt(k)] = Scalar[
+                    DType.int
+                ](vector_idx).cast[out_idx_type]()
 
                 # Remove the found maximum from consideration in the next iteration
                 if total.p >= 0:
-                    var orig_tid = (vector_idx - block_offset) % stride
+                    var orig_tid = (vector_idx - Int(block_offset)) % Int(
+                        stride
+                    )
                     topk_sram[orig_tid].u = _topk_dead_val[T, largest]()
 
             barrier()
@@ -1082,10 +943,10 @@ def _topk_stage1_old[
         # Fill remaining positions with sentinel values for unused elements
         if tid == 0:
             for remaining_k in range(k_batch, max_k):
-                local_topk_vals[bid * max_k + remaining_k] = _topk_dead_val[
-                    T, largest
-                ]()
-                local_topk_idxs[bid * max_k + remaining_k] = Scalar[
+                local_topk_vals[
+                    bid * UInt(max_k) + UInt(remaining_k)
+                ] = _topk_dead_val[T, largest]()
+                local_topk_idxs[bid * UInt(max_k) + UInt(remaining_k)] = Scalar[
                     out_idx_type
                 ](-1)
 
@@ -1122,19 +983,15 @@ def _topk_stage1_no_shmem[
     bid = block_idx.x
     block_size = block_dim.x
 
-    batch_id, block_lane = udivmod(bid, num_blocks_per_input)
+    batch_id, block_lane = divmod(bid, UInt(num_blocks_per_input))
 
     var block_offset = block_lane * block_size
-    var stride = block_size * num_blocks_per_input
+    var stride = block_size * UInt(num_blocks_per_input)
 
-    _in_buffer_tmp = in_buffer_tmp + batch_id * num_elements
-
-    # Hoist per-block output base pointers out of the k loop.
-    var out_vals = local_topk_vals + bid * max_k
-    var out_idxs = local_topk_idxs + bid * max_k
+    _in_buffer_tmp = in_buffer_tmp + batch_id * UInt(num_elements)
 
     var k_batch = max_k
-    if K._is_not_null():
+    if K:
         var k_raw = Int(K[batch_id])
         k_batch = max_k if k_raw == -1 else k_raw
 
@@ -1142,61 +999,40 @@ def _topk_stage1_no_shmem[
     if k_batch > num_elements:
         k_batch = num_elements
 
-    comptime HEAP_SIZE = 8
-
     with PDL():
-        # Phase 1: Single scan to build per-thread register heap.
-        var heap = TopKHeap[T, largest, HEAP_SIZE]()
-        for i in range(tid + block_offset, num_elements, stride):
-            heap.insert(_in_buffer_tmp[i], i)
-
-        # Phase 2: Extract winners from heaps without re-scanning.
-        # Threads whose heap is exhausted fall back to a global-memory
-        # re-scan so that non-top-M elements are still discoverable.
-        var heap_iters = min(k_batch, HEAP_SIZE)
-        for k in range(heap_iters):
-            # Use heap if it has valid entries, else fall back to re-scan.
-            var partial = heap.best()
-            if partial.p < 0:
-                partial = TopK_2[T, largest]()
-                for i in range(tid + block_offset, num_elements, stride):
-                    partial.insert(_in_buffer_tmp[i], i)
-
-            var total = _warp_reduce_topk[T, largest](partial)
-
-            var winner_p = warp.broadcast(total.p)
-
-            if tid == 0:
-                out_vals[k] = total.u
-                out_idxs[k] = Scalar[DType.int](total.p).cast[out_idx_type]()
-
-            if partial.p == winner_p and winner_p >= 0:
-                heap.remove(winner_p)
-                _in_buffer_tmp[winner_p] = _topk_dead_val[T, largest]()
-
-        # Phase 3: Fallback to global-memory re-scan for remaining k.
-        for k in range(heap_iters, k_batch):
+        for k in range(k_batch):
             var partial = TopK_2[T, largest]()
 
-            for i in range(tid + block_offset, num_elements, stride):
-                partial.insert(_in_buffer_tmp[i], i)
+            for i in range(Int(tid + block_offset), num_elements, Int(stride)):
+                var val = _in_buffer_tmp[i]
+                partial.insert(val, i)
 
             var total = _warp_reduce_topk[T, largest](partial)
 
+            # Broadcast winner index so the owning thread can write
+            # the dead value to its own global memory element.
             var winner_p = warp.broadcast(total.p)
 
             if tid == 0:
-                out_vals[k] = total.u
-                out_idxs[k] = Scalar[DType.int](total.p).cast[out_idx_type]()
+                local_topk_vals[bid * UInt(max_k) + UInt(k)] = total.u
+                local_topk_idxs[bid * UInt(max_k) + UInt(k)] = Scalar[
+                    DType.int
+                ](total.p).cast[out_idx_type]()
 
+            # Each thread that owned the winner writes the dead value
+            # to global memory for its own element.
             if partial.p == winner_p and winner_p >= 0:
                 _in_buffer_tmp[winner_p] = _topk_dead_val[T, largest]()
 
         # Fill remaining positions with sentinel values.
         if tid == 0:
             for remaining_k in range(k_batch, max_k):
-                out_vals[remaining_k] = _topk_dead_val[T, largest]()
-                out_idxs[remaining_k] = Scalar[out_idx_type](-1)
+                local_topk_vals[
+                    bid * UInt(max_k) + UInt(remaining_k)
+                ] = _topk_dead_val[T, largest]()
+                local_topk_idxs[bid * UInt(max_k) + UInt(remaining_k)] = Scalar[
+                    out_idx_type
+                ](-1)
 
 
 def _topk_stage1[
@@ -1248,19 +1084,19 @@ def _topk_stage1[
     bid = block_idx.x
     block_size = block_dim.x
 
-    batch_id, block_lane = udivmod(bid, num_blocks_per_input)
+    batch_id, block_lane = divmod(bid, UInt(num_blocks_per_input))
 
     var block_offset = block_lane * block_size
-    var stride = block_size * num_blocks_per_input
+    var stride = block_size * UInt(num_blocks_per_input)
 
-    _in_buffer_tmp = in_buffer_tmp + batch_id * num_elements
+    _in_buffer_tmp = in_buffer_tmp + batch_id * UInt(num_elements)
 
     # Hoist per-block output base pointers out of the k loop.
-    var out_vals = local_topk_vals + bid * max_k
-    var out_idxs = local_topk_idxs + bid * max_k
+    var out_vals = local_topk_vals + bid * UInt(max_k)
+    var out_idxs = local_topk_idxs + bid * UInt(max_k)
 
     var k_batch = max_k
-    if K._is_not_null():
+    if K:
         var k_raw = Int(K[batch_id])
         k_batch = max_k if k_raw == -1 else k_raw
 
@@ -1274,44 +1110,11 @@ def _topk_stage1[
         1, Int, address_space=AddressSpace.SHARED
     ]()
 
-    comptime HEAP_SIZE = 8
-
     with PDL():
-        # Phase 1: Single scan to build per-thread register heap.
-        var heap = TopKHeap[T, largest, HEAP_SIZE]()
-        for i in range(tid + block_offset, num_elements, stride):
-            heap.insert(_in_buffer_tmp[i], i)
-
-        # Phase 2: Extract winners from heaps without re-scanning.
-        # Threads whose heap is exhausted fall back to a global-memory
-        # re-scan so that non-top-M elements are still discoverable.
-        var heap_iters = min(k_batch, HEAP_SIZE)
-        for k in range(heap_iters):
-            # Use heap if it has valid entries, else fall back to re-scan.
-            var partial = heap.best()
-            if partial.p < 0:
-                partial = TopK_2[T, largest]()
-                for i in range(tid + block_offset, num_elements, stride):
-                    partial.insert(_in_buffer_tmp[i], i)
-
-            var total = _block_reduce_topk[ascending=largest](partial)
-
-            if tid == 0:
-                out_vals[k] = total.u
-                out_idxs[k] = Scalar[DType.int](total.p).cast[out_idx_type]()
-                winner_sram[0] = total.p
-            barrier()
-
-            var winner_p = winner_sram[0]
-            if partial.p == winner_p and winner_p >= 0:
-                heap.remove(winner_p)
-                _in_buffer_tmp[winner_p] = _topk_dead_val[T, largest]()
-
-        # Phase 3: Fallback to global-memory re-scan for remaining k.
-        for k in range(heap_iters, k_batch):
+        for k in range(k_batch):
             var partial = TopK_2[T, largest]()
 
-            for i in range(tid + block_offset, num_elements, stride):
+            for i in range(Int(tid + block_offset), num_elements, Int(stride)):
                 var val = _in_buffer_tmp[i]
                 partial.insert(val, i)
 
@@ -1323,12 +1126,17 @@ def _topk_stage1[
                 winner_sram[0] = total.p
             barrier()
 
+            # Distributed dead-value write: the owning thread writes
+            # the dead value to its own global memory element.  Each
+            # thread's stride is disjoint, so no further barrier is
+            # required — the owning thread sees its own write on the
+            # next iteration.
             var winner_p = winner_sram[0]
             if partial.p == winner_p and winner_p >= 0:
                 _in_buffer_tmp[winner_p] = _topk_dead_val[T, largest]()
 
         # Parallel sentinel fill using all threads.
-        for remaining_k in range(k_batch + tid, max_k, block_size):
+        for remaining_k in range(k_batch + Int(tid), max_k, Int(block_size)):
             out_vals[remaining_k] = _topk_dead_val[T, largest]()
             out_idxs[remaining_k] = Scalar[out_idx_type](-1)
 
@@ -1398,12 +1206,12 @@ def _topk_stage2[
     var batch_id = block_idx.x
     # assert (block_idx.x == 0)
     # assert (grid_dim.x == 1)
-    var batch_i_topk_vals = global_topk_vals + batch_id * max_k
-    var batch_i_topk_idxs = global_topk_idxs + batch_id * (
+    var batch_i_topk_vals = global_topk_vals + batch_id * UInt(max_k)
+    var batch_i_topk_idxs = global_topk_idxs + batch_id * UInt(
         1 if sampling else max_k
     )
-    var _local_topk_vals = local_topk_vals + batch_id * num_elem_reduced
-    var _local_topk_idxs = local_topk_idxs + batch_id * num_elem_reduced
+    var _local_topk_vals = local_topk_vals + batch_id * UInt(num_elem_reduced)
+    var _local_topk_idxs = local_topk_idxs + batch_id * UInt(num_elem_reduced)
 
     # Allocate shared memory for values and indices
     var num_e_rounded = ceildiv(num_elem_reduced, WARP_SIZE) * WARP_SIZE
@@ -1421,13 +1229,13 @@ def _topk_stage2[
     var idxs_sram = (vals_sram + vals_smem_size).bitcast[Int]()
 
     # These values are only read from in the sampling case.
-    var s_val2 = type_of(vals_sram)(_unsafe_null=())
-    var s_id = type_of(idxs_sram)(_unsafe_null=())
+    var s_val2 = type_of(vals_sram)()
+    var s_id = type_of(idxs_sram)()
 
     with PDL():
         # Handle the case where stage 1 is executed with a single block
         var k_batch = max_k
-        if K._is_not_null():
+        if K:
             var k_raw = Int(K[batch_id])
             k_batch = max_k if k_raw == -1 else k_raw
 
@@ -1436,11 +1244,11 @@ def _topk_stage2[
             k_batch = num_elem_reduced
 
         if num_blocks_per_input == 1 and not sampling:
-            if tid < k_batch:
+            if tid < UInt(k_batch):
                 batch_i_topk_vals[tid] = _local_topk_vals[tid]
                 # cast to out_idx_type
                 batch_i_topk_idxs[tid] = _local_topk_idxs[tid]
-            elif tid >= k_batch and tid < max_k:
+            elif tid >= UInt(k_batch) and tid < UInt(max_k):
                 # Fill unused positions with sentinel values
                 batch_i_topk_vals[tid] = _topk_dead_val[T, largest]()
                 batch_i_topk_idxs[tid] = Scalar[out_idx_type](-1)
@@ -1459,7 +1267,7 @@ def _topk_stage2[
         var max_logit = Scalar[T](0)
 
         # Cache local top-K results from stage 1 into shared memory
-        for i in range(tid, num_elem_reduced, block_dim.x):
+        for i in range(Int(tid), num_elem_reduced, Int(block_dim.x)):
             vals_sram[i] = _local_topk_vals[i]
             idxs_sram[i] = i
         barrier()
@@ -1481,7 +1289,7 @@ def _topk_stage2[
             # Re-initialize partial for each thread
             var partial = TopK_2[T, largest]()
             # TODO: unroll this
-            for i in range(tid, num_elem_reduced, block_dim.x):
+            for i in range(Int(tid), num_elem_reduced, Int(block_dim.x)):
                 partial.insert(vals_sram[i], i)
 
             barrier()
@@ -1504,7 +1312,7 @@ def _topk_stage2[
                     batch_i_topk_vals[k] = total.u
                     s_id[k] = total.p
                     var temp_val = Float32(1.0)
-                    if temperature._is_not_null():
+                    if temperature:
                         temp_val = temperature[batch_id]
                     total.u = exp(
                         (total.u - max_logit) / max(temp_val.cast[T](), 1e-6)
@@ -1525,7 +1333,7 @@ def _topk_stage2[
         comptime if sampling:
             if tid == 0:
                 var top_p_val = Scalar[T](1.0)
-                if top_p._is_not_null():
+                if top_p:
                     top_p_val = top_p[batch_id].cast[T]()
                 var _top_p = _adjust_top_p[T](
                     top_p_val, s_val2, k_batch, s_sum[0]
@@ -1535,7 +1343,7 @@ def _topk_stage2[
                 # generator, so that we don't use the same random number for every
                 # token in the sequence.
                 var seed_val = UInt64(0)
-                if seed._is_not_null():
+                if seed:
                     seed_val = seed[batch_id]
                 var rng_state = Random(seed=seed_val)
                 var rng = rng_state.step_uniform()
@@ -1681,9 +1489,7 @@ def _topk_gpu[
     if k:
         k_ptr = rebind[UnsafePointer[Int64, ImmutAnyOrigin]](k.value().ptr)
     else:
-        k_ptr = UnsafePointer[Int64, ImmutAnyOrigin](
-            _unsafe_null=()
-        )  # null pointer
+        k_ptr = UnsafePointer[Int64, ImmutAnyOrigin]()  # null pointer
 
     var k_size = k.value().num_elements() if k else 0
     var k_device = DeviceBuffer[DType.int64](ctx, k_ptr, k_size, owning=False)
@@ -1698,7 +1504,7 @@ def _topk_gpu[
             comptime kernel_1 = _topk_stage1_old_no_shmem[
                 dtype, out_idx_type, largest
             ]
-            ctx.enqueue_function[kernel_1, kernel_1](
+            ctx.enqueue_function_experimental[kernel_1](
                 k_device,
                 max_k,
                 N,
@@ -1708,12 +1514,12 @@ def _topk_gpu[
                 device_local_topk_idxs.to_device_buffer(ctx),
                 grid_dim=grid_dim_stage1,
                 block_dim=block_dim_stage1,
-                attributes=pdl_launch_attributes(PDLLevel(1)),
+                attributes=pdl_launch_attributes(),
             )
         else:
             var shared_mem_bytes_1 = _get_shmem_size_stg_1[dtype](block_size)
             comptime kernel_1 = _topk_stage1_old[dtype, out_idx_type, largest]
-            ctx.enqueue_function[kernel_1, kernel_1](
+            ctx.enqueue_function_experimental[kernel_1](
                 k_device,
                 max_k,
                 N,
@@ -1724,7 +1530,7 @@ def _topk_gpu[
                 grid_dim=grid_dim_stage1,
                 block_dim=block_dim_stage1,
                 shared_mem_bytes=shared_mem_bytes_1,
-                attributes=pdl_launch_attributes(PDLLevel(1)),
+                attributes=pdl_launch_attributes(),
             )
     else:
         var input_buf_tmp = ctx.enqueue_create_buffer[dtype](batch_size * N)
@@ -1734,7 +1540,7 @@ def _topk_gpu[
             comptime kernel_1 = _topk_stage1_no_shmem[
                 dtype, out_idx_type, largest
             ]
-            ctx.enqueue_function[kernel_1, kernel_1](
+            ctx.enqueue_function_experimental[kernel_1](
                 k_device,
                 max_k,
                 N,
@@ -1744,11 +1550,11 @@ def _topk_gpu[
                 device_local_topk_idxs.to_device_buffer(ctx),
                 grid_dim=grid_dim_stage1,
                 block_dim=block_dim_stage1,
-                attributes=pdl_launch_attributes(PDLLevel(1)),
+                attributes=pdl_launch_attributes(),
             )
         else:
             comptime kernel_1 = _topk_stage1[dtype, out_idx_type, largest]
-            ctx.enqueue_function[kernel_1, kernel_1](
+            ctx.enqueue_function_experimental[kernel_1](
                 k_device,
                 max_k,
                 N,
@@ -1758,7 +1564,7 @@ def _topk_gpu[
                 device_local_topk_idxs.to_device_buffer(ctx),
                 grid_dim=grid_dim_stage1,
                 block_dim=block_dim_stage1,
-                attributes=pdl_launch_attributes(PDLLevel(1)),
+                attributes=pdl_launch_attributes(),
             )
         _ = input_buf_tmp^
 
@@ -1796,9 +1602,7 @@ def _topk_gpu[
             temperature.value().ptr
         )
     else:
-        temp_ptr = UnsafePointer[Float32, ImmutAnyOrigin](
-            _unsafe_null=()
-        )  # null pointer
+        temp_ptr = UnsafePointer[Float32, ImmutAnyOrigin]()  # null pointer
     var temp_size = temperature.value().num_elements() if temperature else 0
 
     # Handle optional top_p parameter
@@ -1808,9 +1612,7 @@ def _topk_gpu[
             top_p.value().ptr
         )
     else:
-        top_p_ptr = UnsafePointer[Float32, ImmutAnyOrigin](
-            _unsafe_null=()
-        )  # null pointer
+        top_p_ptr = UnsafePointer[Float32, ImmutAnyOrigin]()  # null pointer
     var top_p_size = top_p.value().num_elements() if top_p else 0
 
     # Handle optional seed parameter
@@ -1818,9 +1620,7 @@ def _topk_gpu[
     if seed:
         seed_ptr = seed.value().ptr
     else:
-        seed_ptr = UnsafePointer[UInt64, ImmutAnyOrigin](
-            _unsafe_null=()
-        )  # null pointer
+        seed_ptr = UnsafePointer[UInt64, ImmutAnyOrigin]()  # null pointer
     var seed_size = seed.value().num_elements() if seed else 0
 
     var temp_device = DeviceBuffer[DType.float32](
@@ -1844,7 +1644,7 @@ def _topk_gpu[
 
     # Enqueue the second kernel (stage 2)
     comptime kernel_2 = _topk_stage2[dtype, out_idx_type, sampling, largest]
-    ctx.enqueue_function[kernel_2, kernel_2](
+    ctx.enqueue_function_experimental[kernel_2](
         k_device,
         max_k,
         num_blocks_per_input_,
@@ -1858,8 +1658,52 @@ def _topk_gpu[
         grid_dim=grid_dim_stage2,
         block_dim=block_dim_stage2,
         shared_mem_bytes=shared_mem_bytes_2,
-        attributes=pdl_launch_attributes(PDLLevel(1)),
+        attributes=pdl_launch_attributes(),
     )
+
+
+@always_inline
+def _default_topk_block_size(
+    num_elements: Int, internal_bs: Int, sampling: Bool
+) -> Int:
+    if sampling:
+        if num_elements <= 1024 * 64 * 3:
+            return 256
+        elif num_elements <= 32000 * 256:
+            return 512
+        else:
+            return 1024
+
+    # On B200, once row count reaches 128+, the large non-sampling surfaces
+    # consistently prefer 256-thread blocks over the old 512-thread default.
+    if num_elements <= 1024 * 64 * 3:
+        return 256
+    comptime if not has_apple_gpu_accelerator():
+        if internal_bs >= 128:
+            return 256
+    return 512
+
+
+@always_inline
+def _default_num_blocks_per_input(
+    internal_bs: Int, N: Int, block_size: Int, bound_max_k: Int
+) -> Int:
+    var per_row_cap = 32
+    # B200 still wants deeper stage-1 partitioning for one or two large rows,
+    # but mid-high batches saturate before the old 32-block fallback.
+    comptime if not has_apple_gpu_accelerator():
+        if internal_bs == 1:
+            per_row_cap = 128
+        elif internal_bs == 2:
+            per_row_cap = 64
+        elif internal_bs >= 64 and internal_bs < 128:
+            per_row_cap = 16
+        elif (
+            (internal_bs >= 160 and bound_max_k >= 16)
+            or (internal_bs >= 192 and bound_max_k >= 8)
+        ):
+            per_row_cap = 16
+    return min(ceildiv(N, block_size), per_row_cap)
 
 
 @always_inline
@@ -1939,180 +1783,157 @@ def topk_gpu[
     var orig_in_shape = rebind[IndexList[input.rank]](
         coord_to_index_list(input.layout.shape_coord())
     )
+    var N = orig_in_shape[input.rank - 1]
+    var last_idx_dim = 1 if sampling else max_k
 
-    @parameter
-    def trace_information() -> String:
-        return String(";").join(
-            Span(
-                [
-                    trace_arg("input", orig_in_shape, dtype),
-                    "max_k=" + String(max_k),
-                    "sampling=" + String(sampling),
-                    "largest=" + String(largest),
-                ]
-            )
+    # Clamp max_k
+    bound_max_k = 255 if max_k == -1 else max_k
+
+    # This section handles different input ranks by reshaping to a 2D tensor
+    var internal_bs: Int  # Internal batch size
+    comptime internal_rank = 2  # We always reshape to 2D for internal processing
+    var internal_input: TileTensor[
+        dtype,
+        Layout[
+            shape_types=DynamicCoord[DType.int64, 2].element_types,
+            stride_types=DynamicCoord[DType.int64, 2].element_types,
+        ],
+        input.origin,
+        address_space=input.address_space,
+    ]
+    var internal_out_idxs: TileTensor[
+        out_idx_type,
+        Layout[
+            shape_types=DynamicCoord[DType.int64, 2].element_types,
+            stride_types=DynamicCoord[DType.int64, 2].element_types,
+        ],
+        out_idxs.origin,
+        address_space=out_idxs.address_space,
+    ]
+    var internal_out_vals: TileTensor[
+        dtype,
+        Layout[
+            shape_types=DynamicCoord[DType.int64, 2].element_types,
+            stride_types=DynamicCoord[DType.int64, 2].element_types,
+        ],
+        out_vals.origin,
+        address_space=out_vals.address_space,
+    ]
+
+    comptime if input.rank == 1:
+        # Handle 1D input: treat it as a single batch with one element
+        internal_bs = 1
+        var internal_in_shape = IndexList[internal_rank](
+            1, input.num_elements()
+        )
+        var internal_out_vals_shape = IndexList[internal_rank](1, bound_max_k)
+        var internal_out_idxs_shape = IndexList[internal_rank](1, last_idx_dim)
+        # Reshape 1D inputs to 2D
+        internal_input = reshape(input, internal_in_shape)
+        internal_out_idxs = reshape(out_idxs, internal_out_idxs_shape)
+        internal_out_vals = reshape(out_vals, internal_out_vals_shape)
+    elif input.rank == internal_rank:
+        # Input is already 2D, no reshaping needed
+        internal_bs = orig_in_shape[0]
+        internal_input = rebind[type_of(internal_input)](
+            input.make_dynamic[DType.int64]()
+        )
+        internal_out_idxs = rebind[type_of(internal_out_idxs)](
+            out_idxs.make_dynamic[DType.int64]()
+        )
+        internal_out_vals = rebind[type_of(internal_out_vals)](
+            out_vals.make_dynamic[DType.int64]()
+        )
+    else:  # rank > 2
+        # Handle higher dimensional inputs by flattening all but the last dimension
+        var _last_dim = orig_in_shape[input.rank - 1]
+        internal_bs = Int(
+            Float64(orig_in_shape.flattened_length()) / Float64(_last_dim)
         )
 
-    with Trace[TraceLevel.OP, target=StaticString("gpu")](
-        "topk_gpu",
-        Trace[TraceLevel.OP]._get_detail_str[trace_information](),
-        task_id=Int(ctx.id()),
-    ):
-        var N = orig_in_shape[input.rank - 1]
-        var last_idx_dim = 1 if sampling else max_k
-
-        # Clamp max_k
-        bound_max_k = 255 if max_k == -1 else max_k
-
-        # heuristic to set block size
-        var block_size_: Int
-        if input.num_elements() <= 1024 * 64 * 3:
-            block_size_ = 256
-        elif input.num_elements() <= 32000 * 256:
-            block_size_ = 512
-        else:
-            block_size_ = 1024
-        block_size_ = block_size.value() if block_size else block_size_
-
-        # On Apple GPUs, the no-shmem kernel variants require single-warp
-        # blocks. Clamp block_size to WARP_SIZE.
-        comptime if has_apple_gpu_accelerator():
-            block_size_ = min(block_size_, WARP_SIZE)
-
-        # This section handles different input ranks by reshaping to a 2D tensor
-        var internal_bs: Int  # Internal batch size
-        comptime internal_rank = 2  # We always reshape to 2D for internal processing
-        var internal_input: TileTensor[
-            dtype,
-            Layout[
-                shape_types=DynamicCoord[DType.int64, 2].element_types,
-                stride_types=DynamicCoord[DType.int64, 2].element_types,
-            ],
-            input.origin,
-            address_space=input.address_space,
-        ]
-        var internal_out_idxs: TileTensor[
-            out_idx_type,
-            Layout[
-                shape_types=DynamicCoord[DType.int64, 2].element_types,
-                stride_types=DynamicCoord[DType.int64, 2].element_types,
-            ],
-            out_idxs.origin,
-            address_space=out_idxs.address_space,
-        ]
-        var internal_out_vals: TileTensor[
-            dtype,
-            Layout[
-                shape_types=DynamicCoord[DType.int64, 2].element_types,
-                stride_types=DynamicCoord[DType.int64, 2].element_types,
-            ],
-            out_vals.origin,
-            address_space=out_vals.address_space,
-        ]
-
-        comptime if input.rank == 1:
-            # Handle 1D input: treat it as a single batch with one element
-            internal_bs = 1
-            var internal_in_shape = IndexList[internal_rank](
-                1, input.num_elements()
-            )
-            var internal_out_vals_shape = IndexList[internal_rank](
-                1, bound_max_k
-            )
-            var internal_out_idxs_shape = IndexList[internal_rank](
-                1, last_idx_dim
-            )
-            # Reshape 1D inputs to 2D
-            internal_input = reshape(input, internal_in_shape)
-            internal_out_idxs = reshape(out_idxs, internal_out_idxs_shape)
-            internal_out_vals = reshape(out_vals, internal_out_vals_shape)
-        elif input.rank == internal_rank:
-            # Input is already 2D, no reshaping needed
-            internal_bs = orig_in_shape[0]
-            internal_input = rebind[type_of(internal_input)](
-                input.make_dynamic[DType.int64]()
-            )
-            internal_out_idxs = rebind[type_of(internal_out_idxs)](
-                out_idxs.make_dynamic[DType.int64]()
-            )
-            internal_out_vals = rebind[type_of(internal_out_vals)](
-                out_vals.make_dynamic[DType.int64]()
-            )
-        else:  # rank > 2
-            # Handle higher dimensional inputs by flattening all but the last dimension
-            var _last_dim = orig_in_shape[input.rank - 1]
-            internal_bs = Int(
-                Float64(orig_in_shape.flattened_length()) / Float64(_last_dim)
-            )
-
-            var internal_in_shape = IndexList[internal_rank](
-                internal_bs, _last_dim
-            )
-            var internal_out_idxs_shape = IndexList[internal_rank](
-                internal_bs, last_idx_dim
-            )
-            var internal_out_vals_shape = IndexList[internal_rank](
-                internal_bs, bound_max_k
-            )
-
-            # Reshape higher dimensional inputs to 2D
-            internal_input = reshape(input, internal_in_shape)
-            internal_out_idxs = reshape(out_idxs, internal_out_idxs_shape)
-            internal_out_vals = reshape(out_vals, internal_out_vals_shape)
-
-        # Calculate the number of blocks per input
-        var num_blocks_per_input_ = min(
-            ceildiv(N, block_size_), 8
-        ) if not num_blocks_per_input else num_blocks_per_input.value()
-
-        # Define shape for the kernel's internal cache buffers
-        var internal_cache_shape = IndexList[2](
-            internal_bs, num_blocks_per_input_ * bound_max_k
+        var internal_in_shape = IndexList[internal_rank](internal_bs, _last_dim)
+        var internal_out_idxs_shape = IndexList[internal_rank](
+            internal_bs, last_idx_dim
+        )
+        var internal_out_vals_shape = IndexList[internal_rank](
+            internal_bs, bound_max_k
         )
 
-        # Create temporary buffer for local top-K values
-        var internal_vals_buf = ctx.enqueue_create_buffer[dtype](
-            product(internal_cache_shape)
-        )
-        var device_local_topk_vals = TileTensor(
-            internal_vals_buf.unsafe_ptr(),
-            row_major(Coord(internal_cache_shape)),
-        )
+        # Reshape higher dimensional inputs to 2D
+        internal_input = reshape(input, internal_in_shape)
+        internal_out_idxs = reshape(out_idxs, internal_out_idxs_shape)
+        internal_out_vals = reshape(out_vals, internal_out_vals_shape)
 
-        # Create temporary buffer for local top-K indices
-        var internal_idxs_buf = ctx.enqueue_create_buffer[out_idx_type](
-            product(internal_cache_shape)
-        )
-        var device_local_topk_idxs = TileTensor(
-            internal_idxs_buf.unsafe_ptr(),
-            row_major(Coord(internal_cache_shape)),
-        )
+    # heuristic to set block size
+    var block_size_ = _default_topk_block_size(
+        input.num_elements(), internal_bs, sampling
+    )
+    block_size_ = block_size.value() if block_size else block_size_
 
-        _topk_gpu[
-            dtype=dtype,
-            out_idx_type=out_idx_type,
-            sampling=sampling,
-            largest=largest,
-            _force_old_impl=_force_old_impl,
-        ](
-            ctx,
-            bound_max_k,
-            internal_input,
-            device_local_topk_vals,
-            device_local_topk_idxs,
-            internal_out_vals,
-            internal_out_idxs,
-            k=k,
-            temperature=temperature,
-            block_size=block_size_,
-            num_blocks_per_input=num_blocks_per_input_,
-            top_p=top_p,
-            seed=seed,
-        )
+    # On Apple GPUs, the no-shmem kernel variants require single-warp
+    # blocks. Clamp block_size to WARP_SIZE.
+    comptime if has_apple_gpu_accelerator():
+        block_size_ = min(block_size_, WARP_SIZE)
 
-        # Clean up buffers
-        _ = internal_vals_buf^
-        _ = internal_idxs_buf^
+    # Keep the broader B200 stage-1 partitioning only on the non-sampling path;
+    # the sampling path still uses the uniform 32-block fallback.
+    var num_blocks_per_input_ = num_blocks_per_input.value() if (
+        num_blocks_per_input
+    ) else (
+        min(ceildiv(N, block_size_), 32) if sampling else
+        _default_num_blocks_per_input(
+            internal_bs, N, block_size_, bound_max_k
+        )
+    )
+
+    # Define shape for the kernel's internal cache buffers
+    var internal_cache_shape = IndexList[2](
+        internal_bs, num_blocks_per_input_ * bound_max_k
+    )
+
+    # Create temporary buffer for local top-K values
+    var internal_vals_buf = ctx.enqueue_create_buffer[dtype](
+        product(internal_cache_shape)
+    )
+    var device_local_topk_vals = TileTensor(
+        internal_vals_buf.unsafe_ptr(),
+        row_major(Coord(internal_cache_shape)),
+    )
+
+    # Create temporary buffer for local top-K indices
+    var internal_idxs_buf = ctx.enqueue_create_buffer[out_idx_type](
+        product(internal_cache_shape)
+    )
+    var device_local_topk_idxs = TileTensor(
+        internal_idxs_buf.unsafe_ptr(),
+        row_major(Coord(internal_cache_shape)),
+    )
+
+    _topk_gpu[
+        dtype=dtype,
+        out_idx_type=out_idx_type,
+        sampling=sampling,
+        largest=largest,
+        _force_old_impl=_force_old_impl,
+    ](
+        ctx,
+        bound_max_k,
+        internal_input,
+        device_local_topk_vals,
+        device_local_topk_idxs,
+        internal_out_vals,
+        internal_out_idxs,
+        k=k,
+        temperature=temperature,
+        block_size=block_size_,
+        num_blocks_per_input=num_blocks_per_input_,
+        top_p=top_p,
+        seed=seed,
+    )
+
+    # Clean up buffers
+    _ = internal_vals_buf^
+    _ = internal_idxs_buf^
 
 
 def _topk_topp_sampling_fi[
@@ -2130,6 +1951,8 @@ def _topk_topp_sampling_fi[
     min_top_p: Float32,
     input: TileTensor[dtype, ...],
     out_idxs: TileTensor[mut=True, out_idx_type, ...],
+    block_size: Optional[Int] = None,
+    softmax_block_size: Optional[Int] = None,
     k: Optional[TileTensor[out_idx_type, KLayoutType, ImmutAnyOrigin]] = None,
     temperature: Optional[
         TileTensor[DType.float32, TemperatureLayoutType, ImmutAnyOrigin]
@@ -2161,6 +1984,7 @@ def _topk_topp_sampling_fi[
         input,
         probs,
         temperature_arr=temperature,
+        block_size_override=softmax_block_size,
     )
 
     # Step 2: top-k + top-p rejection sampling from probabilities.
@@ -2170,16 +1994,30 @@ def _topk_topp_sampling_fi[
         out_idxs.ptr,
         row_major(Idx(out_shape[0])),
     )
-    topk_topp_sampling_from_prob[dtype, out_idx_type](
-        ctx,
-        probs,
-        out_1d,
-        max_k,
-        top_p_val=min_top_p,
-        top_k_arr=k,
-        top_p_arr=top_p,
-        rng_seed=rng_seed,
-    )
+    @parameter
+    def launch_sampling[sampling_block_size: Int]() raises:
+        topk_topp_sampling_from_prob[
+            dtype, out_idx_type, block_size=sampling_block_size
+        ](
+            ctx,
+            probs,
+            out_1d,
+            max_k,
+            top_p_val=min_top_p,
+            top_k_arr=k,
+            top_p_arr=top_p,
+            rng_seed=rng_seed,
+        )
+
+    var fi_block_size = block_size.value() if block_size else 1024
+    if fi_block_size == 256:
+        launch_sampling[256]()
+    elif fi_block_size == 512:
+        launch_sampling[512]()
+    elif fi_block_size == 1024:
+        launch_sampling[1024]()
+    else:
+        raise Error("FI sampling only supports block_size 256, 512, or 1024")
 
     _ = probs_buf^
 
@@ -2220,93 +2058,71 @@ def fused_token_sampling_gpu[
     dimension of the input tensor for each row/subvolume.
     """
 
-    var input_shape = rebind[IndexList[input.rank]](
-        coord_to_index_list(input.layout.shape_coord())
-    )
-
-    @parameter
-    def trace_information() -> String:
-        return String(";").join(
-            Span(
-                [
-                    trace_arg("input", input_shape, dtype),
-                    "max_k=" + String(max_k),
-                    "min_top_p=" + String(min_top_p),
-                ]
-            )
+    # If all items in the batch, want to sample all tokens (top_k==-1, top_p=1)
+    # We can use gumbel sampling.
+    if max_k == -1 and min_top_p == 1.0:
+        gumbel_sampling_gpu(
+            ctx,
+            input,
+            out_idxs,
+            temperature,
+            seed,
         )
+        return
 
-    with Trace[TraceLevel.OP, target=StaticString("gpu")](
-        "fused_token_sampling_gpu",
-        Trace[TraceLevel.OP]._get_detail_str[trace_information](),
-        task_id=Int(ctx.id()),
-    ):
-        # If all items in the batch, want to sample all tokens (top_k==-1, top_p=1)
-        # We can use gumbel sampling.
-        if max_k == -1 and min_top_p == 1.0:
-            gumbel_sampling_gpu(
-                ctx,
-                input,
-                out_idxs,
-                temperature,
-                seed,
-            )
-            return
+    comptime assert (
+        input.rank == out_idxs.rank
+    ), "input.rank must match out_idx.rank"
 
-        comptime assert (
-            input.rank == out_idxs.rank
-        ), "input.rank must match out_idx.rank"
+    comptime assert input.flat_rank == 2
 
-        comptime assert input.flat_rank == 2
+    var vocab_size = input.layout.shape[1]().value()
+    var adjusted_max_k = vocab_size if max_k == -1 else max_k
 
-        var vocab_size = input.layout.shape[1]().value()
-        var adjusted_max_k = vocab_size if max_k == -1 else max_k
+    # softmax with temperature, then top-k+top-p
+    # rejection sampling. Enabled via compile-time env var.
 
-        # softmax with temperature, then top-k+top-p rejection sampling.
-
-        if adjusted_max_k >= 64:
-            _topk_topp_sampling_fi[dtype, out_idx_type](
-                ctx,
-                adjusted_max_k,
-                min_top_p,
-                input,
-                out_idxs,
-                k=rebind[
-                    Optional[
-                        TileTensor[out_idx_type, KLayoutType, ImmutAnyOrigin]
-                    ]
-                ](k),
-                temperature=temperature,
-                top_p=top_p,
-                rng_seed=seed,
-            )
-            return
-
-        var out_vals_shape = coord_to_index_list(input.layout.shape_coord())
-        out_vals_shape[input.rank - 1] = adjusted_max_k
-        var out_vals_buf = ctx.enqueue_create_buffer[dtype](
-            out_vals_shape.flattened_length()
-        )
-        var out_vals = TileTensor(
-            out_vals_buf.unsafe_ptr(),
-            row_major(Coord(out_vals_shape)),
-        )
-
-        topk_gpu[sampling=True, largest=True](
+    if adjusted_max_k >= 1:
+        _topk_topp_sampling_fi[dtype, out_idx_type](
             ctx,
             adjusted_max_k,
+            min_top_p,
             input,
-            out_vals,
             out_idxs,
-            k=k,
+            k=rebind[
+                Optional[TileTensor[out_idx_type, KLayoutType, ImmutAnyOrigin]]
+            ](k),
             temperature=temperature,
             top_p=top_p,
-            block_size=block_size,
-            num_blocks_per_input=num_blocks_per_input,
-            seed=seed,
+            rng_seed=seed,
         )
+        return
 
-        _ = out_vals_buf^
+    var out_vals_shape = coord_to_index_list(input.layout.shape_coord())
+    out_vals_shape[input.rank - 1] = adjusted_max_k
+    var out_vals_buf = ctx.enqueue_create_buffer[dtype](
+        out_vals_shape.flattened_length()
+    )
+    var out_vals = TileTensor(
+        out_vals_buf.unsafe_ptr(),
+        row_major(Coord(out_vals_shape)),
+    )
+
+    topk_gpu[sampling=True, largest=True](
+        ctx,
+        adjusted_max_k,
+        input,
+        out_vals,
+        out_idxs,
+        k=k,
+        temperature=temperature,
+        top_p=top_p,
+        block_size=block_size,
+        num_blocks_per_input=num_blocks_per_input,
+        seed=seed,
+    )
+
+    _ = out_vals_buf^
 
 
 # ===-----------------------------------------------------------------------===#
@@ -2335,8 +2151,8 @@ def apply_gumbel_noise_kernel[
     comptime group_size = num_blocks_per_token * num_threads
     comptime num_groups = num_sms // num_blocks_per_token
 
-    var tid = thread_idx.x
-    var sm_id = block_idx.x
+    var tid = Int(thread_idx.x)
+    var sm_id = Int(block_idx.x)
     var group_id, sm_id_rem = divmod(sm_id, num_blocks_per_token)
     var tid_in_group = tid + sm_id_rem * num_threads
 
@@ -2353,11 +2169,11 @@ def apply_gumbel_noise_kernel[
 
         for tok_idx in range(group_id, Int(num_tokens), num_groups):
             var temp_val = Float32(1.0)
-            if temperature._is_not_null():
+            if temperature:
                 temp_val = temperature[tok_idx]
 
             var seed_val = UInt64(0)
-            if seed._is_not_null():
+            if seed:
                 seed_val = seed[tok_idx]
 
             var ld_ptr = input.ptr + tok_idx * N
@@ -2450,87 +2266,70 @@ def gumbel_sampling_gpu[
         seed: Optional per-token random seeds [batch] for reproducibility.
     """
 
-    var input_shape = rebind[IndexList[input.rank]](
-        coord_to_index_list(input.layout.shape_coord())
+    # create a buffer to hold the Gumbel noise applied input
+    var noised_input_buf = ctx.enqueue_create_buffer[dtype](
+        input.num_elements()
+    )
+    var noised_input = TileTensor(noised_input_buf, input.layout)
+
+    # Handle optional temperature parameter
+    var temp_ptr: UnsafePointer[Float32, ImmutAnyOrigin]
+    if temperature:
+        temp_ptr = rebind[UnsafePointer[Float32, ImmutAnyOrigin]](
+            temperature.value().ptr
+        )
+    else:
+        temp_ptr = UnsafePointer[Float32, ImmutAnyOrigin]()  # null pointer
+    var temp_size = temperature.value().num_elements() if temperature else 0
+
+    # Handle optional seed parameter
+    var seed_ptr: UnsafePointer[UInt64, ImmutAnyOrigin]
+    if seed:
+        seed_ptr = rebind[UnsafePointer[UInt64, ImmutAnyOrigin]](
+            seed.value().ptr
+        )
+    else:
+        seed_ptr = UnsafePointer[UInt64, ImmutAnyOrigin]()  # null pointer
+    var seed_size = seed.value().num_elements() if seed else 0
+
+    comptime hw_info = ctx.default_device_info
+    comptime gumbel_kernel = apply_gumbel_noise_kernel[
+        dtype,
+        noised_input.LayoutType,
+        input.LayoutType,
+        hw_info.sm_count,
+        hw_info.max_thread_block_size,
+    ]
+
+    ctx.enqueue_function_experimental[gumbel_kernel](
+        noised_input,
+        input.as_immut(),
+        temperature.value().to_device_buffer(ctx),
+        seed.value().to_device_buffer(ctx),
+        grid_dim=hw_info.sm_count,
+        block_dim=hw_info.max_thread_block_size,
+        attributes=pdl_launch_attributes(),
     )
 
-    @parameter
-    def trace_information() -> String:
-        return trace_arg("input", input_shape, dtype)
+    # Extract argmax after Gumbel noise application.
+    var out_vals_shape = coord_to_index_list(input.layout.shape_coord())
+    out_vals_shape[input.rank - 1] = 1
+    var out_vals_buf = ctx.enqueue_create_buffer[dtype](
+        out_vals_shape.flattened_length()
+    )
+    var out_vals = TileTensor(
+        out_vals_buf.unsafe_ptr(),
+        row_major(Coord(out_vals_shape)),
+    )
 
-    with Trace[TraceLevel.OP, target=StaticString("gpu")](
-        "gumbel_sampling_gpu",
-        Trace[TraceLevel.OP]._get_detail_str[trace_information](),
-        task_id=Int(ctx.id()),
-    ):
-        # create a buffer to hold the Gumbel noise applied input
-        var noised_input_buf = ctx.enqueue_create_buffer[dtype](
-            input.num_elements()
-        )
-        var noised_input = TileTensor(noised_input_buf, input.layout)
+    # The old implementation of topk_gpu is correct when top_k = 1.
+    topk_gpu[sampling=False, _force_old_impl=True](
+        ctx,
+        1,
+        noised_input,
+        out_vals,
+        out_idxs,
+    )
 
-        # Handle optional temperature parameter
-        var temp_ptr: UnsafePointer[Float32, ImmutAnyOrigin]
-        if temperature:
-            temp_ptr = rebind[UnsafePointer[Float32, ImmutAnyOrigin]](
-                temperature.value().ptr
-            )
-        else:
-            temp_ptr = UnsafePointer[Float32, ImmutAnyOrigin](
-                _unsafe_null=()
-            )  # null pointer
-        var temp_size = temperature.value().num_elements() if temperature else 0
-
-        # Handle optional seed parameter
-        var seed_ptr: UnsafePointer[UInt64, ImmutAnyOrigin]
-        if seed:
-            seed_ptr = rebind[UnsafePointer[UInt64, ImmutAnyOrigin]](
-                seed.value().ptr
-            )
-        else:
-            seed_ptr = UnsafePointer[UInt64, ImmutAnyOrigin](
-                _unsafe_null=()
-            )  # null pointer
-        var seed_size = seed.value().num_elements() if seed else 0
-
-        comptime hw_info = ctx.default_device_info
-        comptime gumbel_kernel = apply_gumbel_noise_kernel[
-            dtype,
-            noised_input.LayoutType,
-            input.LayoutType,
-            hw_info.sm_count,
-            hw_info.max_thread_block_size,
-        ]
-
-        ctx.enqueue_function[gumbel_kernel, gumbel_kernel](
-            noised_input,
-            input.as_immut(),
-            temperature.value().to_device_buffer(ctx),
-            seed.value().to_device_buffer(ctx),
-            grid_dim=hw_info.sm_count,
-            block_dim=hw_info.max_thread_block_size,
-            attributes=pdl_launch_attributes(PDLLevel(1)),
-        )
-
-        # Extract argmax after Gumbel noise application.
-        var out_vals_shape = coord_to_index_list(input.layout.shape_coord())
-        out_vals_shape[input.rank - 1] = 1
-        var out_vals_buf = ctx.enqueue_create_buffer[dtype](
-            out_vals_shape.flattened_length()
-        )
-        var out_vals = TileTensor(
-            out_vals_buf.unsafe_ptr(),
-            row_major(Coord(out_vals_shape)),
-        )
-
-        # The old implementation of topk_gpu is correct when top_k = 1.
-        topk_gpu[sampling=False, _force_old_impl=True](
-            ctx,
-            1,
-            noised_input,
-            out_vals,
-            out_idxs,
-        )
-
-        _ = noised_input_buf^
-        _ = out_vals_buf^
+    _ = noised_input_buf^
+    _ = out_vals_buf^

--- a/max/python/max/nn/kernels.py
+++ b/max/python/max/nn/kernels.py
@@ -422,7 +422,6 @@ def _fused_qkv_ragged_matmul_scaled_float8(
         scales_granularity_mnk = quant_config.scales_granularity_mnk
     else:
         # with out quant_config, we either use per-tensor or per-channel quantization
-        # both dynamic and static tensor wise quantization have weight shape [1, 1]
         if (
             input_scale.shape[0] == 1
             and input_scale.shape[1] == 1
@@ -1086,6 +1085,276 @@ def fused_qk_ragged_rope(
         op_name,
         device=input.device,
         values=values,
+        out_types=[
+            TensorType(
+                dtype=input.dtype, shape=input.shape, device=input.device
+            )
+        ],
+        parameters=parameters,
+    )[0].tensor
+
+
+def rope_k_cache_ragged(
+    kv_params: KVCacheParams,
+    total_seq_len: Dim,
+    input_row_offsets: TensorValue,
+    kv_collection: PagedCacheValues,
+    freqs_cis: TensorValue,
+    layer_idx: TensorValue,
+    interleaved: bool = False,
+) -> None:
+    """Applies RoPE only to the new paged key-cache rows for ragged input."""
+    if interleaved:
+        raise NotImplementedError(
+            "rope_k_cache_ragged currently supports non-interleaved RoPE only"
+        )
+    if kv_params.dtype != DType.bfloat16:
+        raise NotImplementedError(
+            "rope_k_cache_ragged currently supports BF16 KV cache only"
+        )
+    if input_row_offsets.dtype != DType.uint32:
+        raise ValueError(
+            "expected input_row_offsets to have dtype uint32, was"
+            f" {input_row_offsets.dtype}"
+        )
+    if input_row_offsets.rank != 1:
+        raise ValueError(
+            f"expected input_row_offsets to have rank 1, was {input_row_offsets.rank}"
+        )
+    if freqs_cis.rank != 2:
+        raise ValueError(
+            f"expected freqs_cis to have rank 2, was {freqs_cis.rank}"
+        )
+    if layer_idx.dtype != DType.uint32:
+        raise ValueError(
+            f"expected layer_idx to have dtype uint32, was {layer_idx.dtype}"
+        )
+
+    parameters: dict[str, bool | int | str | DType] = {
+        "interleaved": interleaved,
+        "cache_dtype": kv_params.dtype,
+    }
+
+    ops.inplace_custom(
+        "mo.rope_k_cache.ragged.paged",
+        device=input_row_offsets.device,
+        values=[
+            *kv_collection,
+            freqs_cis,
+            layer_idx,
+            ops.cast(TensorValue(total_seq_len), DType.uint32),
+            input_row_offsets,
+        ],
+        parameters=parameters,
+    )
+
+
+def k_rms_norm_rope_ragged(
+    kv_params: KVCacheParams,
+    total_seq_len: Dim,
+    input_row_offsets: TensorValue,
+    kv_collection: PagedCacheValues,
+    freqs_cis: TensorValue,
+    gamma: TensorValue,
+    epsilon: float | np.floating[Any],
+    layer_idx: TensorValue,
+    weight_offset: float | np.floating[Any],
+    interleaved: bool = False,
+) -> None:
+    """Applies Gemma-style key RMSNorm and RoPE in one op."""
+    if interleaved:
+        raise NotImplementedError(
+            "k_rms_norm_rope_ragged currently supports non-interleaved RoPE only"
+        )
+    if kv_params.dtype != DType.bfloat16 or gamma.dtype != DType.bfloat16:
+        raise NotImplementedError(
+            "k_rms_norm_rope_ragged currently supports BF16 gamma and KV cache only"
+        )
+    if input_row_offsets.dtype != DType.uint32:
+        raise ValueError(
+            "expected input_row_offsets to have dtype uint32, was"
+            f" {input_row_offsets.dtype}"
+        )
+    if input_row_offsets.rank != 1:
+        raise ValueError(
+            f"expected input_row_offsets to have rank 1, was {input_row_offsets.rank}"
+        )
+    if freqs_cis.rank != 2:
+        raise ValueError(
+            f"expected freqs_cis to have rank 2, was {freqs_cis.rank}"
+        )
+    if gamma.rank != 1:
+        raise ValueError(f"expected gamma to have rank 1, was {gamma.rank}")
+    if layer_idx.dtype != DType.uint32:
+        raise ValueError(
+            f"expected layer_idx to have dtype uint32, was {layer_idx.dtype}"
+        )
+
+    parameters: dict[str, bool | int | str | DType] = {
+        "interleaved": interleaved,
+        "cache_dtype": kv_params.dtype,
+    }
+
+    ops.inplace_custom(
+        "mo.k_rms_norm_rope.ragged.paged",
+        device=input_row_offsets.device,
+        values=[
+            *kv_collection,
+            freqs_cis,
+            gamma,
+            ops.constant(epsilon, gamma.dtype, device=DeviceRef.CPU()),
+            layer_idx,
+            ops.cast(TensorValue(total_seq_len), DType.uint32),
+            input_row_offsets,
+            ops.constant(weight_offset, gamma.dtype, device=DeviceRef.CPU()),
+        ],
+        parameters=parameters,
+    )
+
+
+def q_rms_norm_rope_ragged(
+    input: TensorValue,
+    input_row_offsets: TensorValue,
+    start_pos: TensorValue,
+    freqs_cis: TensorValue,
+    gamma: TensorValue,
+    epsilon: float | np.floating[Any],
+    weight_offset: float | np.floating[Any],
+    interleaved: bool = False,
+) -> TensorValue:
+    """Applies Gemma-style query RMSNorm and RoPE in one op."""
+    if interleaved:
+        raise NotImplementedError(
+            "q_rms_norm_rope_ragged currently supports non-interleaved RoPE only"
+        )
+    if input.dtype != DType.bfloat16 or gamma.dtype != DType.bfloat16:
+        raise NotImplementedError(
+            "q_rms_norm_rope_ragged currently supports BF16 inputs and gamma only"
+        )
+    if input.rank != 3:
+        raise ValueError(f"expected input to have rank 3, was {input.rank}")
+    if input_row_offsets.dtype != DType.uint32:
+        raise ValueError(
+            "expected input_row_offsets to have dtype uint32, was"
+            f" {input_row_offsets.dtype}"
+        )
+    if input_row_offsets.rank != 1:
+        raise ValueError(
+            f"expected input_row_offsets to have rank 1, was {input_row_offsets.rank}"
+        )
+    if start_pos.dtype != DType.uint32:
+        raise ValueError(
+            f"expected start_pos to have dtype uint32, was {start_pos.dtype}"
+        )
+    if start_pos.rank != 1:
+        raise ValueError(
+            f"expected start_pos to have rank 1, was {start_pos.rank}"
+        )
+    if freqs_cis.rank != 2:
+        raise ValueError(
+            f"expected freqs_cis to have rank 2, was {freqs_cis.rank}"
+        )
+    if gamma.rank != 1:
+        raise ValueError(f"expected gamma to have rank 1, was {gamma.rank}")
+
+    return ops.custom(
+        "mo.q_rms_norm_rope.ragged",
+        device=input.device,
+        values=[
+            input,
+            input_row_offsets,
+            start_pos,
+            freqs_cis,
+            gamma,
+            ops.constant(epsilon, input.dtype, device=DeviceRef.CPU()),
+            ops.constant(weight_offset, input.dtype, device=DeviceRef.CPU()),
+        ],
+        out_types=[
+            TensorType(
+                dtype=input.dtype, shape=input.shape, device=input.device
+            )
+        ],
+    )[0].tensor
+
+
+def q_rms_norm_fused_qk_ragged_rope(
+    kv_params: KVCacheParams,
+    input: TensorValue,
+    input_row_offsets: TensorValue,
+    kv_collection: PagedCacheValues,
+    freqs_cis: TensorValue,
+    q_gamma: TensorValue,
+    k_gamma: TensorValue,
+    epsilon: float | np.floating[Any],
+    layer_idx: TensorValue,
+    weight_offset: float | np.floating[Any],
+    interleaved: bool = False,
+) -> TensorValue:
+    """Applies Gemma-style Q/K RMSNorm and RoPE in one op.
+
+    The BF16/128 path normalizes both query and key rows before applying
+    non-interleaved RoPE in a single launch. BF16/256 decode rows use a wide
+    single-launch kernel, while non-decode wide rows pair the dedicated
+    `q_rms_norm_rope_ragged` and `k_rms_norm_rope_ragged` helpers so the live
+    fallback no longer pays separate Q RMSNorm and Q RoPE launches.
+    """
+    if interleaved:
+        raise NotImplementedError(
+            "q_rms_norm_fused_qk_ragged_rope currently supports "
+            "non-interleaved RoPE only"
+        )
+    if kv_params.dtype != DType.bfloat16 or input.dtype != DType.bfloat16:
+        raise NotImplementedError(
+            "q_rms_norm_fused_qk_ragged_rope currently supports BF16 "
+            "inputs and KV cache only"
+        )
+    if input.rank != 3:
+        raise ValueError(f"expected input to have rank 3, was {input.rank}")
+    if input_row_offsets.dtype != DType.uint32:
+        raise ValueError(
+            "expected input_row_offsets to have dtype uint32, was"
+            f" {input_row_offsets.dtype}"
+        )
+    if input_row_offsets.rank != 1:
+        raise ValueError(
+            f"expected input_row_offsets to have rank 1, was {input_row_offsets.rank}"
+        )
+    if freqs_cis.rank != 2:
+        raise ValueError(
+            f"expected freqs_cis to have rank 2, was {freqs_cis.rank}"
+        )
+    if q_gamma.rank != 1:
+        raise ValueError(
+            f"expected q_gamma to have rank 1, was {q_gamma.rank}"
+        )
+    if k_gamma.rank != 1:
+        raise ValueError(
+            f"expected k_gamma to have rank 1, was {k_gamma.rank}"
+        )
+    if layer_idx.dtype != DType.uint32:
+        raise ValueError(
+            f"expected layer_idx to have dtype uint32, was {layer_idx.dtype}"
+        )
+
+    parameters: dict[str, bool | int | str | DType] = {
+        "interleaved": interleaved,
+        "cache_dtype": kv_params.dtype,
+    }
+
+    return ops.inplace_custom(
+        "mo.q_rms_norm_fused_qk_rope.ragged.paged",
+        device=input.device,
+        values=[
+            input,
+            input_row_offsets,
+            *kv_collection,
+            freqs_cis,
+            q_gamma,
+            k_gamma,
+            ops.constant(epsilon, input.dtype, device=DeviceRef.CPU()),
+            layer_idx,
+            ops.constant(weight_offset, input.dtype, device=DeviceRef.CPU()),
+        ],
         out_types=[
             TensorType(
                 dtype=input.dtype, shape=input.shape, device=input.device
@@ -3331,68 +3600,6 @@ def rms_norm_key_cache(
     )
 
 
-def rms_norm_value_cache(
-    kv_params: KVCacheParams,
-    kv_collection: PagedCacheValues,
-    gamma: TensorValue,
-    epsilon: float | np.floating[Any],
-    layer_idx: TensorValue,
-    total_seq_len: Dim,
-    input_row_offsets: TensorValue,
-    weight_offset: float | np.floating[Any],
-    rms_norm_cols: int | None = None,
-    multiply_before_cast: bool = True,
-    per_head_norm: bool = True,
-) -> None:
-    """Applies RMSNorm in place to the _new_ entries in the value cache.
-    Semantics match :func:`rms_norm_key_cache`, but updates the value tensor
-    for the layer instead of the key tensor.
-    """
-    gamma_rank_expected = 1
-    if gamma.rank != gamma_rank_expected:
-        raise ValueError(
-            f"expected gamma of rank {gamma_rank_expected} but got {gamma.rank}"
-        )
-    if input_row_offsets.dtype != DType.uint32:
-        raise ValueError(
-            f"expected uint32 input_row_offsets but got {input_row_offsets.dtype}"
-        )
-    if gamma.shape[0] != kv_params.head_dim and per_head_norm:
-        if rms_norm_cols is None:
-            raise ValueError(
-                "Size of gamma doesn't match head_dim. Please pass rms_norm_cols "
-                "explicitly if you intend to apply RMSNorm to only a subset of "
-                "head dimensions"
-            )
-        elif rms_norm_cols != gamma.shape[0]:
-            raise ValueError(
-                f"expected gamma of size {rms_norm_cols} but got {gamma.shape[0]}"
-            )
-    if gamma.dtype != kv_params.dtype:
-        raise TypeError(
-            f"expected gamma dtype {gamma.dtype} to match KV dtype {kv_params.dtype}"
-        )
-    parameters: dict[str, int | str | DType | bool] = {
-        "multiply_before_cast": multiply_before_cast,
-        "per_head_norm": per_head_norm,
-    }
-    assert kv_params.page_size is not None
-    ops.inplace_custom(
-        "mo.rms_norm_value_cache.ragged.paged",
-        device=input_row_offsets.device,
-        values=[
-            *kv_collection,
-            gamma,
-            ops.constant(epsilon, gamma.dtype, device=DeviceRef.CPU()),
-            layer_idx,
-            ops.cast(TensorValue(total_seq_len), DType.uint32),
-            input_row_offsets,
-            ops.constant(weight_offset, gamma.dtype, device=DeviceRef.CPU()),
-        ],
-        parameters=parameters,
-    )
-
-
 def moe_create_indices(
     topk_ids: TensorValue,
     num_local_experts: int,
@@ -4083,76 +4290,6 @@ def quantize_static_scaled_float8(
     )[0].tensor
 
 
-def quantize_tensor_dynamic_scaled_float8(
-    input: TensorValue,
-    input_scale_spec: InputScaleSpec,
-    weight_scale_spec: WeightScaleSpec,
-    scale_ub: float = 1200.0,
-    group_size_or_per_token: int = -1,
-    out_type: DType = DType.float8_e4m3fn,
-    scales_type: DType = DType.bfloat16,
-) -> tuple[TensorValue, TensorValue]:
-    """Quantizes a rank-2 tensor to float8 using a dynamic per-tensor scale.
-
-    Args:
-        input: The input tensor to quantize.
-        scale_ub: The upper bound of the scale factor.
-        group_size_or_per_token: The group size for quantization. When set to -1,
-            the quantization is column-wise.
-        out_type: The type of the output tensor.
-        scales_type: The type of the scales tensor.
-
-    Returns:
-        The quantized tensor and the scales.
-    """
-    if input.rank != 2:
-        raise ValueError("input must be rank 2 tensor")
-
-    if out_type not in (DType.float8_e4m3fn,):
-        raise ValueError("out_type must be float8_e4m3fn")
-
-    if not isinstance(input.shape[1], StaticDim):
-        raise ValueError(
-            f"input.shape[1] must be a statically known dimension. Input shape received: {input.shape}"
-        )
-
-    if not (input_scale_spec.is_tensor and weight_scale_spec.is_tensor):
-        raise ValueError(
-            "both input and weight must be tensor scaled for tensor scaling"
-        )
-
-    if group_size_or_per_token != -1:
-        raise ValueError(
-            "group_size_or_per_token should be -1 for dynamic tensor scaling so group_size == num_cols == input.shape[1]"
-        )
-
-    result = ops.custom(
-        "mo.quantize_tensor_dynamic_scaled_float8",
-        device=input.device,
-        values=[
-            input,
-            ops.constant(scale_ub, DType.float32, device=DeviceRef.CPU()),
-        ],
-        out_types=[
-            TensorType(
-                dtype=out_type,
-                shape=[input.shape[0], input.shape[1]],
-                device=input.device,
-            ),
-            TensorType(
-                dtype=scales_type,
-                shape=[1, input.shape[0]],
-                device=input.device,
-            ),
-        ],
-        parameters={
-            "group_size_or_per_token": group_size_or_per_token,
-        },
-    )
-
-    return result[0].tensor, result[1].tensor
-
-
 def quantize_dynamic_scaled_float8(
     input: TensorValue,
     input_scale_spec: InputScaleSpec,
@@ -4346,22 +4483,16 @@ def dynamic_scaled_matmul(
         )
 
     if input_scale_spec.is_tensor and weight_scale_spec.is_tensor:
-        if input_scale_spec.origin.is_dynamic:
-            if not (b_scales.shape[0] == b_scales.shape[1] == 1):
-                raise ValueError(
-                    "scaler weight tensors must be of shape [1, 1] for dynamic tensor scaling"
-                )
-        else:
-            if not (
-                a_scales.shape[0]
-                == a_scales.shape[1]
-                == b_scales.shape[0]
-                == b_scales.shape[1]
-                == 1
-            ):
-                raise ValueError(
-                    "scaler tensors must be of shape [1, 1] for tensor scaling"
-                )
+        if not (
+            a_scales.shape[0]
+            == a_scales.shape[1]
+            == b_scales.shape[0]
+            == b_scales.shape[1]
+            == 1
+        ):
+            raise ValueError(
+                "scaler tensors must be of shape [1, 1] for tensor scaling"
+            )
 
     elif input_scale_spec.is_colwise and weight_scale_spec.is_rowwise:
         if a_scales.shape[0] != 1:

--- a/max/python/max/pipelines/architectures/gemma3/gemma3.py
+++ b/max/python/max/pipelines/architectures/gemma3/gemma3.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Sequence
+from typing import cast
 
 from max.dtype import DType
 from max.graph import BufferValue, ShardingStrategy, TensorValue, ops
@@ -29,6 +30,7 @@ from max.nn.rotary_embedding import (
 )
 from max.nn.transformer.distributed_transformer import (
     DistributedLogitsPostprocessMixin,
+    distributed_logits_postprocess,
 )
 
 from .layers.attention import Gemma3Attention
@@ -36,6 +38,10 @@ from .layers.rms_norm import Gemma3RMSNorm
 from .layers.scaled_word_embedding import ScaledWordEmbedding
 from .layers.transformer_block import Gemma3TransformerBlock
 from .model_config import Gemma3Config
+
+
+def _identity_norm(x: TensorValue) -> TensorValue:
+    return x
 
 
 class Gemma3TextModel(DistributedLogitsPostprocessMixin, Module):
@@ -170,21 +176,49 @@ class Gemma3TextModel(DistributedLogitsPostprocessMixin, Module):
         # Create KV cache collections per device
 
         # Run through transformer layers
+        next_norm_xs: list[TensorValue] | None = None
         for idx, layer in enumerate(self.layers):
             layer_idx_tensor = ops.constant(
                 idx, DType.uint32, device=self.devices[0]
             )
-            h = layer(
+            next_input_layernorm_shards = cast(
+                Sequence[Gemma3RMSNorm], self.norm_shards
+            )
+            if idx + 1 < len(self.layers):
+                next_input_layernorm_shards = cast(
+                    Sequence[Gemma3RMSNorm],
+                    cast(
+                        Gemma3TransformerBlock, self.layers[idx + 1]
+                    ).input_layernorm_shards,
+                )
+            h, next_norm_xs = layer(
                 layer_idx_tensor,
                 h,
                 signal_buffers,
                 kv_collections,
                 input_row_offsets=input_row_offsets,
+                normalized_xs=next_norm_xs,
+                next_input_layernorm_shards=next_input_layernorm_shards,
                 **kwargs,
             )
 
-        return self._postprocess_logits(
-            h, input_row_offsets, return_n_logits, signal_buffers
+        postprocess_h = next_norm_xs if next_norm_xs is not None else h
+        postprocess_norms = (
+            [_identity_norm for _ in self.devices]
+            if next_norm_xs is not None
+            else self.norm_shards
+        )
+        return distributed_logits_postprocess(
+            postprocess_h,
+            input_row_offsets,
+            return_n_logits,
+            norm_shards=postprocess_norms,
+            lm_head=self.lm_head,
+            signal_buffers=signal_buffers,
+            return_logits=self.return_logits,
+            device=self.devices[0],
+            return_hidden_states=self.return_hidden_states,
+            logits_scaling=self.logits_scaling,
         )
 
 

--- a/max/python/max/pipelines/architectures/gemma3/layers/attention.py
+++ b/max/python/max/pipelines/architectures/gemma3/layers/attention.py
@@ -30,6 +30,7 @@ from max.nn.kernels import (
     flash_attention_ragged,
     fused_qk_ragged_rope,
     fused_qkv_ragged_matmul,
+    q_rms_norm_fused_qk_ragged_rope,
     quantize_static_scaled_float8,
     rms_norm_key_cache,
 )
@@ -271,35 +272,60 @@ class Gemma3Attention(Module, Shardable):
         # Apply rope.
         xq = xq.reshape((-1, self.n_heads, self.kv_params.head_dim))
 
-        # Apply QK norm to query and key states.
-        xq = self.q_norm(xq)
-        rms_norm_key_cache(
-            self.kv_params,
-            kv_collection=kv_collection,
-            gamma=self.k_norm.weight.cast(self.kv_params.dtype).to(
-                self.devices[0]
-            ),
-            epsilon=self.qk_norm_eps,
-            layer_idx=layer_idx,
-            total_seq_len=total_seq_len,
-            input_row_offsets=kwargs["input_row_offsets"],
-            weight_offset=1.0,
-        )
-
         # Apply rotary embedding.
         use_local = bool((self.layer_idx + 1) % self.sliding_window_pattern)
         rope = self.rope_local if use_local else self.rope_global
 
         freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
-        xq = fused_qk_ragged_rope(
-            self.kv_params,
-            xq,
-            kwargs["input_row_offsets"],
-            kv_collection,
-            freqs_cis,
-            layer_idx,
-            interleaved=rope.interleaved,
+        can_fuse_qk_norm_rope = (
+            not rope.interleaved
+            and xq.dtype == DType.bfloat16
+            and self.kv_params.dtype == DType.bfloat16
+            and self.kv_params.head_dim in (128, 256)
         )
+        if can_fuse_qk_norm_rope:
+            xq = q_rms_norm_fused_qk_ragged_rope(
+                self.kv_params,
+                xq,
+                kwargs["input_row_offsets"],
+                kv_collection,
+                freqs_cis,
+                self.q_norm.weight.cast(self.kv_params.dtype).to(
+                    self.devices[0]
+                ),
+                self.k_norm.weight.cast(self.kv_params.dtype).to(
+                    self.devices[0]
+                ),
+                self.qk_norm_eps,
+                layer_idx,
+                weight_offset=1.0,
+                interleaved=False,
+            )
+        else:
+            # Other shapes stay on the original seam until they have their own
+            # measured win and correctness coverage.
+            rms_norm_key_cache(
+                self.kv_params,
+                kv_collection=kv_collection,
+                gamma=self.k_norm.weight.cast(self.kv_params.dtype).to(
+                    self.devices[0]
+                ),
+                epsilon=self.qk_norm_eps,
+                layer_idx=layer_idx,
+                total_seq_len=total_seq_len,
+                input_row_offsets=kwargs["input_row_offsets"],
+                weight_offset=1.0,
+            )
+            xq = self.q_norm(xq)
+            xq = fused_qk_ragged_rope(
+                self.kv_params,
+                xq,
+                kwargs["input_row_offsets"],
+                kv_collection,
+                freqs_cis,
+                layer_idx,
+                interleaved=rope.interleaved,
+            )
 
         # Calculate Flash Attention.
         mask_variant = (

--- a/max/python/max/pipelines/architectures/gemma3/layers/rms_norm.py
+++ b/max/python/max/pipelines/architectures/gemma3/layers/rms_norm.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 
 from max.dtype import DType
-from max.graph import DeviceRef
+from max.graph import DeviceRef, TensorType, TensorValue, ops
 from max.nn.norm.rms_norm import RMSNorm
 
 
@@ -54,3 +54,65 @@ class Gemma3RMSNorm(RMSNorm):
             shards.append(sharded)
 
         return shards
+
+
+def gemma3_rms_norm_fused_residual_add(
+    x: TensorValue,
+    residual: TensorValue,
+    norm1: Gemma3RMSNorm,
+    norm2: Gemma3RMSNorm,
+) -> tuple[TensorValue, TensorValue]:
+    """Compute norm2(norm1(x) + residual) and return both outputs."""
+    input_last_dim = x.shape[-1]
+
+    if input_last_dim != norm1.weight.shape[0]:
+        raise ValueError(
+            "First RMSNorm weight dimension "
+            f"({norm1.weight.shape[0]}) must match the input's last dimension "
+            f"({input_last_dim})"
+        )
+    if input_last_dim != norm2.weight.shape[0]:
+        raise ValueError(
+            "Second RMSNorm weight dimension "
+            f"({norm2.weight.shape[0]}) must match the input's last dimension "
+            f"({input_last_dim})"
+        )
+    if norm1.multiply_before_cast != norm2.multiply_before_cast:
+        raise ValueError(
+            "Fused Gemma3 RMSNorm requires both norms to share the same "
+            "multiply_before_cast setting"
+        )
+
+    gamma1: TensorValue = norm1.weight.cast(x.dtype)
+    gamma2: TensorValue = norm2.weight.cast(x.dtype)
+    if x.device:
+        gamma1 = gamma1.to(x.device)
+        gamma2 = gamma2.to(x.device)
+
+    results = ops.custom(
+        "rms_norm_fused_residual_add",
+        x.device,
+        [
+            x,
+            residual,
+            gamma1,
+            gamma2,
+            ops.constant(norm1.eps, dtype=x.dtype, device=DeviceRef.CPU()),
+            ops.constant(norm2.eps, dtype=x.dtype, device=DeviceRef.CPU()),
+            ops.constant(
+                norm1.weight_offset, dtype=x.dtype, device=DeviceRef.CPU()
+            ),
+            ops.constant(
+                norm2.weight_offset, dtype=x.dtype, device=DeviceRef.CPU()
+            ),
+        ],
+        [
+            TensorType(dtype=x.dtype, shape=x.shape, device=x.device),
+            TensorType(dtype=x.dtype, shape=x.shape, device=x.device),
+        ],
+        parameters={
+            "multiply_before_cast": norm1.multiply_before_cast,
+        },
+    )
+
+    return results[0].tensor, results[1].tensor

--- a/max/python/max/pipelines/architectures/gemma3/layers/transformer_block.py
+++ b/max/python/max/pipelines/architectures/gemma3/layers/transformer_block.py
@@ -15,6 +15,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import cast
+
 from max.graph import (
     BufferValue,
     DeviceRef,
@@ -29,6 +32,10 @@ from max.nn.transformer.distributed_transformer import (
     forward_sharded_layers,
 )
 from max.pipelines.architectures.gemma3.layers.attention import Gemma3Attention
+from max.pipelines.architectures.gemma3.layers.rms_norm import (
+    Gemma3RMSNorm,
+    gemma3_rms_norm_fused_residual_add,
+)
 
 
 class Gemma3TransformerBlock(Module):
@@ -105,10 +112,16 @@ class Gemma3TransformerBlock(Module):
         signal_buffers: list[BufferValue],
         kv_collections: list[PagedCacheValues],
         input_row_offsets: list[TensorValue],
+        normalized_xs: Sequence[TensorValue] | None = None,
+        next_input_layernorm_shards: Sequence[Gemma3RMSNorm] | None = None,
         **kwargs,
-    ) -> list[TensorValue]:
+    ) -> tuple[list[TensorValue], list[TensorValue] | None]:
         residual = xs
-        norm_xs = forward_sharded_layers(self.input_layernorm_shards, xs)
+        norm_xs = (
+            list(normalized_xs)
+            if normalized_xs is not None
+            else forward_sharded_layers(self.input_layernorm_shards, xs)
+        )
         attn_out = [
             shard(
                 norm_xs[i],
@@ -120,24 +133,49 @@ class Gemma3TransformerBlock(Module):
         ]
         attn_out = self.allreduce(attn_out, signal_buffers)
 
-        hidden_states = forward_sharded_layers(
-            self.post_attention_layernorm_shards, attn_out
-        )
-        hidden_states = [
-            residual[i] + hidden_states[i] for i in range(len(hidden_states))
+        fused_attn_norm = [
+            gemma3_rms_norm_fused_residual_add(
+                attn_out[i],
+                residual[i],
+                cast(
+                    Gemma3RMSNorm, self.post_attention_layernorm_shards[i]
+                ),
+                cast(
+                    Gemma3RMSNorm, self.pre_feedforward_layernorm_shards[i]
+                ),
+            )
+            for i in range(len(attn_out))
         ]
-
-        residual = hidden_states
-        norm_xs = forward_sharded_layers(
-            self.pre_feedforward_layernorm_shards, hidden_states
-        )
+        norm_xs = [fused_output for fused_output, _ in fused_attn_norm]
+        residual = [fused_residual for _, fused_residual in fused_attn_norm]
 
         hidden_states = forward_sharded_layers(self.mlp_shards, norm_xs)
         hidden_states = self.allreduce(hidden_states, signal_buffers)
 
-        hidden_states = forward_sharded_layers(
-            self.post_feedforward_layernorm_shards, hidden_states
-        )
-        return [
-            residual[i] + hidden_states[i] for i in range(len(hidden_states))
+        if next_input_layernorm_shards is None:
+            hidden_states = forward_sharded_layers(
+                self.post_feedforward_layernorm_shards, hidden_states
+            )
+            return (
+                [
+                    residual[i] + hidden_states[i]
+                    for i in range(len(hidden_states))
+                ],
+                None,
+            )
+
+        fused_mlp_norm = [
+            gemma3_rms_norm_fused_residual_add(
+                hidden_states[i],
+                residual[i],
+                cast(
+                    Gemma3RMSNorm, self.post_feedforward_layernorm_shards[i]
+                ),
+                next_input_layernorm_shards[i],
+            )
+            for i in range(len(hidden_states))
         ]
+        return (
+            [fused_residual for _, fused_residual in fused_mlp_norm],
+            [fused_output for fused_output, _ in fused_mlp_norm],
+        )

--- a/max/python/max/pipelines/architectures/gemma3multimodal/vision_model/gemma3multimodal.py
+++ b/max/python/max/pipelines/architectures/gemma3multimodal/vision_model/gemma3multimodal.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import functools
 import logging
 from collections.abc import Sequence
+from typing import cast
 
 from max.dtype import DType
 from max.graph import (
@@ -36,6 +37,7 @@ from max.nn.rotary_embedding import (
 )
 from max.nn.transformer.distributed_transformer import (
     DistributedLogitsPostprocessMixin,
+    distributed_logits_postprocess,
 )
 from max.pipelines.architectures.gemma3.layers.attention import Gemma3Attention
 from max.pipelines.architectures.gemma3.layers.rms_norm import Gemma3RMSNorm
@@ -53,6 +55,10 @@ from .encoding import Gemma3VisionEncoder
 from .projection import Gemma3MultiModalProjector
 
 logger = logging.getLogger("max.pipelines")
+
+
+def _identity_norm(x: TensorValue) -> TensorValue:
+    return x
 
 
 class Gemma3LanguageModel(DistributedLogitsPostprocessMixin, Module):
@@ -199,20 +205,48 @@ class Gemma3LanguageModel(DistributedLogitsPostprocessMixin, Module):
         ]
 
         # Run through transformer layers
+        next_norm_xs: list[TensorValue] | None = None
         for idx, layer in enumerate(self.layers):
             layer_idx_tensor = ops.constant(
                 idx, DType.uint32, device=self.devices[0]
             )
-            h = layer(
+            next_input_layernorm_shards = cast(
+                Sequence[Gemma3RMSNorm], self.norm_shards
+            )
+            if idx + 1 < len(self.layers):
+                next_input_layernorm_shards = cast(
+                    Sequence[Gemma3RMSNorm],
+                    cast(
+                        Gemma3TransformerBlock, self.layers[idx + 1]
+                    ).input_layernorm_shards,
+                )
+            h, next_norm_xs = layer(
                 layer_idx_tensor,
                 h,
                 signal_buffers,
                 kv_collections,
                 input_row_offsets=input_row_offsets,
+                normalized_xs=next_norm_xs,
+                next_input_layernorm_shards=next_input_layernorm_shards,
             )
 
-        return self._postprocess_logits(
-            h, input_row_offsets, return_n_logits, signal_buffers
+        postprocess_h = next_norm_xs if next_norm_xs is not None else h
+        postprocess_norms = (
+            [_identity_norm for _ in self.devices]
+            if next_norm_xs is not None
+            else self.norm_shards
+        )
+        return distributed_logits_postprocess(
+            postprocess_h,
+            input_row_offsets,
+            return_n_logits,
+            norm_shards=postprocess_norms,
+            lm_head=self.lm_head,
+            signal_buffers=signal_buffers,
+            return_logits=self.return_logits,
+            device=self.devices[0],
+            return_hidden_states=self.return_hidden_states,
+            logits_scaling=self.logits_scaling,
         )
 
 

--- a/max/tests/integration/architectures/gemma3/BUILD.bazel
+++ b/max/tests/integration/architectures/gemma3/BUILD.bazel
@@ -13,6 +13,42 @@ package(default_visibility = [
     "//oss/modular/max/tests:__subpackages__",
 ])
 
+_PROFILE_DATA = [
+    "//max/tests/integration/architectures/gemma3/testdata",
+]
+
+_PROFILE_DEPS = [
+    "//max/python/max:_core",
+    "//max/python/max/driver",
+    "//max/python/max/dtype",
+    "//max/python/max/engine",
+    "//max/python/max/graph",
+    "//max/python/max/interfaces",
+    "//max/python/max/kv_cache",
+    "//max/python/max/nn",
+    "//max/python/max/pipelines/architectures",
+    "//max/python/max/pipelines/core",
+    requirement("numpy"),
+    requirement("torch"),
+    requirement("transformers"),
+]
+
+_PROFILE_GPU_CONSTRAINTS = ["//:has_gpu"] + select({
+    "//:apple_gpu": ["@platforms//:incompatible"],
+    "//conditions:default": [],
+})
+
+_PROFILE_TAGS = [
+    "gpu",
+    "no-sandbox",
+]
+
+_PROFILE_ENV = {
+    "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+    "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+}
+
+
 modular_py_test(
     name = "gemma3",
     size = "large",
@@ -50,4 +86,777 @@ modular_py_test(
         requirement("torch"),
         requirement("transformers"),
     ],
+)
+
+modular_py_test(
+    name = "profile_k_norm_rope_prefill",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_k_norm_rope_prefill.py",
+    ],
+    data = _PROFILE_DATA,
+    env = _PROFILE_ENV,
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_k_norm_rope_decode",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_k_norm_rope_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = _PROFILE_ENV,
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_q_norm_rope_prefill",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_q_norm_rope_prefill.py",
+    ],
+    data = _PROFILE_DATA,
+    env = _PROFILE_ENV,
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_q_norm_rope_decode",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_q_norm_rope_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = _PROFILE_ENV,
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_qk_norm_rope_decode",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_qk_norm_rope_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = _PROFILE_ENV,
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_qk_norm_rope_prefill",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_qk_norm_rope_prefill.py",
+    ],
+    data = _PROFILE_DATA,
+    env = _PROFILE_ENV,
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_qkv_qk_prefill_bridge",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_qkv_qk_prefill_bridge.py",
+    ],
+    data = _PROFILE_DATA,
+    env = _PROFILE_ENV,
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_flash_attention_prefill_bridge",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_flash_attention_prefill_bridge.py",
+    ],
+    data = _PROFILE_DATA,
+    env = _PROFILE_ENV,
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_flash_attention_prefill_bridge_global",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_flash_attention_prefill_bridge.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_ATTENTION_LAYER_IDX": "5",
+        "PROFILE_ATTENTION_LAYER_TYPE": "global",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_attention_tail_prefill_bridge_global",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_attention_tail_prefill_bridge.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_ATTENTION_LAYER_IDX": "5",
+        "PROFILE_ATTENTION_LAYER_TYPE": "global",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_attention_composed_prefill_bridge",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_attention_composed_prefill_bridge.py",
+    ],
+    data = _PROFILE_DATA,
+    env = _PROFILE_ENV,
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_attention_composed_prefill_bridge_global",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_attention_composed_prefill_bridge.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_ATTENTION_LAYER_IDX": "5",
+        "PROFILE_ATTENTION_LAYER_TYPE": "global",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_attention_composed_prefill_bridge_global_output_only",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_attention_composed_prefill_bridge.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_ATTENTION_LAYER_IDX": "5",
+        "PROFILE_ATTENTION_LAYER_TYPE": "global",
+        "PROFILE_ATTENTION_COMPOSED_OUTPUT_MODE": "attention_output_only",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_attention_prefill",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_attention_prefill.py",
+    ],
+    data = _PROFILE_DATA,
+    env = _PROFILE_ENV,
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_attention_prefill_global",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_attention_prefill.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_ATTENTION_LAYER_IDX": "5",
+        "PROFILE_ATTENTION_LAYER_TYPE": "global",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_attention_prefill_fused_parity_global",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_attention_prefill.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_ATTENTION_LAYER_IDX": "5",
+        "PROFILE_ATTENTION_LAYER_TYPE": "global",
+        "PROFILE_ATTENTION_PREFILL_COMPARE_MODE": "manual_fused_graph_vs_attention_fused",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_attention_prefill_baseline_parity_global",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_attention_prefill.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_ATTENTION_LAYER_IDX": "5",
+        "PROFILE_ATTENTION_LAYER_TYPE": "global",
+        "PROFILE_ATTENTION_PREFILL_COMPARE_MODE": "manual_baseline_graph_vs_attention_baseline",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_attention_prefill_pair_matrix_global",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_attention_prefill.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_ATTENTION_LAYER_IDX": "5",
+        "PROFILE_ATTENTION_LAYER_TYPE": "global",
+        "PROFILE_ATTENTION_PREFILL_COMPARE_MODE": "manual_and_attention_pair_matrix",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_attention_decode",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_attention_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = _PROFILE_ENV,
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_attention_decode_k_only",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_attention_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_ATTENTION_DECODE_FUSED_VARIANT": "k_only",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_attention_decode_q_only",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_attention_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_ATTENTION_DECODE_FUSED_VARIANT": "q_only",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_attention_decode_qk_incremental",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_attention_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_ATTENTION_DECODE_BASELINE_GRAPH_VARIANT": "q_only",
+        "PROFILE_ATTENTION_DECODE_FUSED_GRAPH_VARIANT": "full",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_transformer_block_decode",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_transformer_block_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = _PROFILE_ENV,
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_transformer_block_decode_local_compile_smoke",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_transformer_block_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_TRANSFORMER_BLOCK_COMPILE_ONLY": "residual_ladder_pre_ffn_norm",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_transformer_block_decode_local_residual_only_pre_ffn_norm",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_transformer_block_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_IDX": "0",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_TYPE": "local",
+        "PROFILE_TRANSFORMER_BLOCK_BASELINE_VARIANT": "residual_only",
+        "PROFILE_TRANSFORMER_BLOCK_PRODUCER_VARIANT": "pre_ffn_norm",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_transformer_block_decode_local_post_attention_residual_only_pre_ffn_norm",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_transformer_block_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_IDX": "0",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_TYPE": "local",
+        "PROFILE_TRANSFORMER_BLOCK_BASELINE_VARIANT": "post_attention_residual_only",
+        "PROFILE_TRANSFORMER_BLOCK_PRODUCER_VARIANT": "pre_ffn_norm",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_transformer_block_decode_local_post_mlp_residual_only_pre_ffn_norm",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_transformer_block_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_IDX": "0",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_TYPE": "local",
+        "PROFILE_TRANSFORMER_BLOCK_BASELINE_VARIANT": "post_mlp_residual_only",
+        "PROFILE_TRANSFORMER_BLOCK_PRODUCER_VARIANT": "pre_ffn_norm",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_transformer_block_decode_global_post_mlp_residual_only",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_transformer_block_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_IDX": "5",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_TYPE": "global",
+        "PROFILE_TRANSFORMER_BLOCK_BASELINE_VARIANT": "post_mlp_residual_only",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_transformer_block_decode_global_post_mlp_residual_only_pre_ffn_producer",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_transformer_block_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_IDX": "5",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_TYPE": "global",
+        "PROFILE_TRANSFORMER_BLOCK_BASELINE_VARIANT": "post_mlp_residual_only",
+        "PROFILE_TRANSFORMER_BLOCK_PRODUCER_VARIANT": "pre_ffn",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_transformer_block_decode_global_post_mlp_residual_only_down_proj_producer",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_transformer_block_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_IDX": "5",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_TYPE": "global",
+        "PROFILE_TRANSFORMER_BLOCK_BASELINE_VARIANT": "post_mlp_residual_only",
+        "PROFILE_TRANSFORMER_BLOCK_PRODUCER_VARIANT": "down_proj",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_transformer_block_decode_global_post_mlp_residual_only_gate_up_activation_producer",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_transformer_block_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_IDX": "5",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_TYPE": "global",
+        "PROFILE_TRANSFORMER_BLOCK_BASELINE_VARIANT": "post_mlp_residual_only",
+        "PROFILE_TRANSFORMER_BLOCK_PRODUCER_VARIANT": "gate_up_activation",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_transformer_block_decode_global_post_mlp_residual_only_materialized_mlp_producer",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_transformer_block_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_IDX": "5",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_TYPE": "global",
+        "PROFILE_TRANSFORMER_BLOCK_BASELINE_VARIANT": "post_mlp_residual_only",
+        "PROFILE_TRANSFORMER_BLOCK_PRODUCER_VARIANT": "materialized_mlp",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_transformer_block_decode_global_post_mlp_residual_only_permuted_mlp_producer",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_transformer_block_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_IDX": "5",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_TYPE": "global",
+        "PROFILE_TRANSFORMER_BLOCK_BASELINE_VARIANT": "post_mlp_residual_only",
+        "PROFILE_TRANSFORMER_BLOCK_PRODUCER_VARIANT": "permuted_mlp",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_transformer_block_decode_global_post_mlp_residual_only_hidden_permuted_mlp_producer",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_transformer_block_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_IDX": "5",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_TYPE": "global",
+        "PROFILE_TRANSFORMER_BLOCK_BASELINE_VARIANT": "post_mlp_residual_only",
+        "PROFILE_TRANSFORMER_BLOCK_PRODUCER_VARIANT": "hidden_permuted_mlp",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_transformer_block_decode_global_post_mlp_residual_only_upstream_permuted_mlp_producer",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_transformer_block_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_IDX": "5",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_TYPE": "global",
+        "PROFILE_TRANSFORMER_BLOCK_BASELINE_VARIANT": "post_mlp_residual_only",
+        "PROFILE_TRANSFORMER_BLOCK_PRODUCER_VARIANT": "upstream_permuted_mlp",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_transformer_block_decode_global_post_mlp_residual_only_native_upstream_permuted_mlp_producer",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_transformer_block_decode.py",
+    ],
+    data = _PROFILE_DATA,
+    env = {
+        "PIPELINES_TESTDATA": "max/tests/integration/architectures/gemma3/testdata",
+        "MODULAR_TORCH_MEMORY_PERCENT": "0.6",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_IDX": "5",
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_TYPE": "global",
+        "PROFILE_TRANSFORMER_BLOCK_BASELINE_VARIANT": "post_mlp_residual_only",
+        "PROFILE_TRANSFORMER_BLOCK_PRODUCER_VARIANT": "native_upstream_permuted_mlp",
+    },
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
+)
+
+modular_py_test(
+    name = "profile_post_mlp_boundary",
+    size = "large",
+    srcs = [
+        "conftest.py",
+        "test_profile_post_mlp_boundary.py",
+    ],
+    data = _PROFILE_DATA,
+    env = _PROFILE_ENV,
+    exec_properties = {
+        "test.resources:gpu-memory": "16",
+    },
+    gpu_constraints = _PROFILE_GPU_CONSTRAINTS,
+    tags = _PROFILE_TAGS,
+    deps = _PROFILE_DEPS,
 )

--- a/max/tests/integration/architectures/gemma3/test_profile_attention_composed_prefill_bridge.py
+++ b/max/tests/integration/architectures/gemma3/test_profile_attention_composed_prefill_bridge.py
@@ -1,0 +1,880 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from max.driver import Accelerator, Buffer
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Graph, TensorType, ops
+from max.interfaces import RequestID, TokenBuffer
+from max.kv_cache import PagedKVCacheManager
+from max.nn.attention import MHAMaskVariant
+from max.nn.kernels import (
+    KVCacheParams,
+    flash_attention_ragged,
+    fused_qk_ragged_rope,
+    fused_qkv_ragged_matmul,
+    q_rms_norm_fused_qk_ragged_rope,
+    rms_norm_key_cache,
+)
+from max.nn.kv_cache import (
+    AttentionDispatchResolver,
+    KVCacheInputsPerDevice,
+    build_max_lengths_tensor,
+    unflatten_ragged_attention_inputs,
+)
+from max.nn.rotary_embedding import Llama3RotaryEmbedding
+from max.pipelines.architectures.gemma3.layers.attention import (
+    Gemma3Attention as MaxGemma3Attention,
+)
+from max.pipelines.core import TextContext
+from torch.utils.dlpack import from_dlpack
+
+
+PAGE_SIZE = 128
+EPS = 1e-6
+DEFAULT_LAYER_IDX = 0
+DEFAULT_LAYER_TYPE = "local"
+Q_NORM_STD = 0.68
+K_NORM_STD = 0.793
+Q_PROJ_STD = 0.0284
+K_PROJ_STD = 0.0309
+V_PROJ_STD = 0.0309
+O_PROJ_STD = 0.0237
+WARMUP_ITERS = 20
+TIMED_ITERS = 50
+PREFILL_SHAPES = (
+    (1, 11),
+    (1, 512),
+    (1, 1024),
+    (1, 2048),
+    (2, 2048),
+)
+PLACEHOLDER_CACHE_LEN = 1
+
+
+class CorrectnessMismatch(AssertionError):
+    def __init__(self, stage: str, details: str):
+        super().__init__(f"{stage} mismatch: {details}")
+        self.stage = stage
+        self.details = details
+
+
+def _resolve_layer_metadata(config: dict[str, Any]) -> tuple[int, str]:
+    layer_idx = int(
+        os.environ.get("PROFILE_ATTENTION_LAYER_IDX", str(DEFAULT_LAYER_IDX))
+    )
+    num_hidden_layers = int(config["num_hidden_layers"])
+    assert 0 <= layer_idx < num_hidden_layers, (
+        f"layer_idx={layer_idx} must be in [0, {num_hidden_layers})"
+    )
+    layer_type = (
+        "local"
+        if bool((layer_idx + 1) % config["sliding_window_pattern"])
+        else "global"
+    )
+    expected_layer_type = os.environ.get(
+        "PROFILE_ATTENTION_LAYER_TYPE", DEFAULT_LAYER_TYPE
+    )
+    assert (
+        layer_type == expected_layer_type
+    ), f"expected {expected_layer_type} layer, got {layer_type} for layer_idx={layer_idx}"
+    return layer_idx, layer_type
+
+
+def _resolve_kv_num_layers(config: dict[str, Any], layer_idx: int) -> int:
+    min_num_layers = layer_idx + 1
+    kv_num_layers = int(
+        os.environ.get("PROFILE_ATTENTION_KV_NUM_LAYERS", str(min_num_layers))
+    )
+    assert kv_num_layers >= min_num_layers, (
+        f"kv_num_layers={kv_num_layers} must cover layer_idx={layer_idx}"
+    )
+    assert kv_num_layers <= int(config["num_hidden_layers"]), (
+        "kv_num_layers cannot exceed the model layer count "
+        f"({config['num_hidden_layers']})"
+    )
+    return kv_num_layers
+
+
+def _resolve_flash_mask_config(
+    *,
+    use_local: bool,
+    default_local_window_size: int,
+) -> tuple[MHAMaskVariant, int, str]:
+    mask_override = os.environ.get(
+        "PROFILE_FLASH_ATTENTION_MASK_VARIANT", "layer_default"
+    ).strip()
+    local_window_override = os.environ.get(
+        "PROFILE_FLASH_ATTENTION_LOCAL_WINDOW_SIZE"
+    )
+
+    if local_window_override is None:
+        local_window_size = default_local_window_size if use_local else -1
+    else:
+        local_window_size = int(local_window_override)
+
+    if mask_override in ("", "layer_default"):
+        return (
+            (
+                MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK
+                if use_local
+                else MHAMaskVariant.CAUSAL_MASK
+            ),
+            local_window_size,
+            "layer_default",
+        )
+
+    if mask_override == "causal":
+        return MHAMaskVariant.CAUSAL_MASK, -1, mask_override
+
+    if mask_override == "sliding_window_causal":
+        return (
+            MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK,
+            local_window_size,
+            mask_override,
+        )
+
+    raise ValueError(
+        "PROFILE_FLASH_ATTENTION_MASK_VARIANT must be one of "
+        "{'layer_default', 'causal', 'sliding_window_causal'}, got "
+        f"{mask_override!r}"
+    )
+
+
+def _resolve_output_mode() -> tuple[str, bool]:
+    output_mode = os.environ.get(
+        "PROFILE_ATTENTION_COMPOSED_OUTPUT_MODE", "attn_and_output"
+    ).strip()
+    if output_mode == "attn_and_output":
+        return output_mode, True
+    if output_mode == "attention_output_only":
+        return output_mode, False
+    raise ValueError(
+        "PROFILE_ATTENTION_COMPOSED_OUTPUT_MODE must be one of "
+        "{'attn_and_output', 'attention_output_only'}, got "
+        f"{output_mode!r}"
+    )
+
+
+def _load_text_config() -> dict[str, Any]:
+    config_path = Path(os.environ["PIPELINES_TESTDATA"]) / "config.json"
+    with open(config_path) as file:
+        data = json.load(file)
+    return data.get("text_config", data)
+
+
+def _make_weight_registry(config: dict[str, Any]) -> dict[str, torch.Tensor]:
+    torch.manual_seed(42)
+    q_dim = config["head_dim"] * config["num_attention_heads"]
+    kv_dim = config["head_dim"] * config["num_key_value_heads"]
+    hidden_size = config["hidden_size"]
+    return {
+        "k_norm.weight": torch.randn(
+            config["head_dim"], dtype=torch.bfloat16
+        )
+        * K_NORM_STD,
+        "k_proj.weight": torch.randn(
+            kv_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * K_PROJ_STD,
+        "o_proj.weight": torch.randn(
+            hidden_size, q_dim, dtype=torch.bfloat16
+        )
+        * O_PROJ_STD,
+        "q_norm.weight": torch.randn(
+            config["head_dim"], dtype=torch.bfloat16
+        )
+        * Q_NORM_STD,
+        "q_proj.weight": torch.randn(
+            q_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * Q_PROJ_STD,
+        "v_proj.weight": torch.randn(
+            kv_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * V_PROJ_STD,
+    }
+
+
+def _make_placeholder_text_context(max_length: int) -> TextContext:
+    return TextContext(
+        request_id=RequestID(),
+        max_length=max_length,
+        tokens=TokenBuffer(np.zeros(PLACEHOLDER_CACHE_LEN, dtype=np.int64)),
+    )
+
+
+def _device_uint32_buffer(array: np.ndarray, device: Accelerator) -> Buffer:
+    return Buffer.from_numpy(array).to(device)
+
+
+def _row_offsets_array(batch_size: int, seq_len: int) -> np.ndarray:
+    return np.arange(
+        0,
+        (batch_size + 1) * seq_len,
+        seq_len,
+        dtype=np.uint32,
+    )
+
+
+def _prefill_run_name(
+    layer_type: str,
+    layer_idx: int,
+    batch_size: int,
+    seq_len: int,
+    output_mode: str,
+) -> str:
+    suffix = (
+        "_cache0_step0_attention_composed_bridge"
+        if output_mode == "attn_and_output"
+        else "_cache0_step0_attention_composed_bridge_output_only"
+    )
+    return (
+        f"prefill_{layer_type}_layer{layer_idx}_bs{batch_size}_seq{seq_len}"
+        f"{suffix}"
+    )
+
+
+def _build_graph(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    config: dict[str, Any],
+    weight_registry: dict[str, torch.Tensor],
+    batch_size: int,
+    seq_len: int,
+    use_fused: bool,
+    layer_idx: int,
+    layer_type: str,
+    observe_attn_out: bool,
+) -> Any:
+    device_ref = DeviceRef.GPU()
+    max_seq_len = seq_len + PLACEHOLDER_CACHE_LEN + 256
+    attention = MaxGemma3Attention(
+        rope_global=Llama3RotaryEmbedding(
+            config["hidden_size"],
+            config["num_attention_heads"],
+            config["rope_theta"],
+            max_seq_len,
+            interleaved=False,
+            head_dim=config["head_dim"],
+        ),
+        rope_local=Llama3RotaryEmbedding(
+            config["hidden_size"],
+            config["num_attention_heads"],
+            config["rope_local_base_freq"],
+            max_seq_len,
+            interleaved=False,
+            head_dim=config["head_dim"],
+        ),
+        num_attention_heads=config["num_attention_heads"],
+        num_key_value_heads=config["num_key_value_heads"],
+        hidden_size=config["hidden_size"],
+        kv_params=kv_params,
+        layer_idx=layer_idx,
+        dtype=DType.bfloat16,
+        devices=[device_ref],
+        qk_norm_eps=EPS,
+        sliding_window_pattern=config["sliding_window_pattern"],
+        local_window_size=config["sliding_window"],
+        has_bias=bool(config["attention_bias"]),
+    )
+    attention.load_state_dict(weight_registry)
+
+    input_type = TensorType(
+        DType.bfloat16,
+        ["total_seq_len", config["hidden_size"]],
+        device=device_ref,
+    )
+    input_row_offsets_type = TensorType(
+        DType.uint32,
+        [batch_size + 1],
+        device=device_ref,
+    )
+    flattened_kv_types = kv_params.get_symbolic_inputs().flatten()
+
+    graph_name = (
+        "Gemma3AttentionComposedPrefillBridge"
+        f"{layer_type.title()}FusedBS{batch_size}Seq{seq_len}"
+        if use_fused
+        else "Gemma3AttentionComposedPrefillBridge"
+        f"{layer_type.title()}BaselineBS{batch_size}Seq{seq_len}"
+    )
+    graph_name += "Observed" if observe_attn_out else "OutputOnly"
+
+    with Graph(
+        graph_name,
+        input_types=(input_type, input_row_offsets_type, *flattened_kv_types),
+    ) as graph:
+        x, input_row_offsets, *kv_cache = graph.inputs
+        kv_collection = unflatten_ragged_attention_inputs(
+            kv_cache, n_devices=1
+        )[0]
+        graph_layer_idx = ops.constant(
+            layer_idx, DType.uint32, device=DeviceRef.CPU()
+        )
+        total_seq_len = x.tensor.shape[0]
+
+        xq = fused_qkv_ragged_matmul(
+            kv_params,
+            input=x.tensor,
+            wqkv=attention.wqkv,
+            bias=attention.wqkv_bias,
+            input_row_offsets=input_row_offsets.tensor,
+            kv_collection=kv_collection,
+            layer_idx=graph_layer_idx,
+            n_heads=attention.n_heads,
+        )
+        xq = xq.reshape((-1, attention.n_heads, kv_params.head_dim))
+
+        use_local = bool((layer_idx + 1) % attention.sliding_window_pattern)
+        assert use_local == (layer_type == "local")
+        rope = attention.rope_local if use_local else attention.rope_global
+        freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
+
+        if use_fused:
+            xq = q_rms_norm_fused_qk_ragged_rope(
+                kv_params,
+                xq,
+                input_row_offsets.tensor,
+                kv_collection,
+                freqs_cis,
+                attention.q_norm.weight.cast(kv_params.dtype).to(device_ref),
+                attention.k_norm.weight.cast(kv_params.dtype).to(device_ref),
+                EPS,
+                graph_layer_idx,
+                weight_offset=1.0,
+                interleaved=False,
+            )
+        else:
+            rms_norm_key_cache(
+                kv_params,
+                kv_collection=kv_collection,
+                gamma=attention.k_norm.weight.cast(kv_params.dtype).to(
+                    device_ref
+                ),
+                epsilon=EPS,
+                layer_idx=graph_layer_idx,
+                total_seq_len=total_seq_len,
+                input_row_offsets=input_row_offsets.tensor,
+                weight_offset=1.0,
+            )
+            xq = attention.q_norm(xq)
+            xq = fused_qk_ragged_rope(
+                kv_params,
+                xq,
+                input_row_offsets.tensor,
+                kv_collection,
+                freqs_cis,
+                graph_layer_idx,
+                interleaved=False,
+            )
+
+        mask_variant, local_window_size, _ = _resolve_flash_mask_config(
+            use_local=use_local,
+            default_local_window_size=attention.local_window_size,
+        )
+        attn_out = flash_attention_ragged(
+            kv_params,
+            input=xq,
+            kv_collection=kv_collection,
+            layer_idx=graph_layer_idx,
+            input_row_offsets=input_row_offsets.tensor,
+            mask_variant=mask_variant,
+            scale=attention.scale,
+            local_window_size=local_window_size,
+        )
+        flattened_attn_out = ops.reshape(attn_out, shape=[total_seq_len, -1])
+        attention_output = attention.o_proj(flattened_attn_out)
+        if observe_attn_out:
+            graph.output(attn_out, attention_output)
+        else:
+            graph.output(attention_output)
+
+    return session.load(graph, weights_registry=attention.state_dict())
+
+
+def _make_runtime_inputs(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    seq_len: int,
+    device: Accelerator,
+) -> KVCacheInputsPerDevice:
+    max_cache_length = PLACEHOLDER_CACHE_LEN + seq_len
+    total_num_pages = batch_size * math.ceil(max_cache_length / PAGE_SIZE)
+    kv_manager = PagedKVCacheManager(
+        params=kv_params,
+        total_num_pages=total_num_pages,
+        session=session,
+        max_batch_size=batch_size,
+    )
+
+    contexts: list[TextContext] = []
+    for _ in range(batch_size):
+        context = _make_placeholder_text_context(max_cache_length)
+        kv_manager.claim(context.request_id, replica_idx=0)
+        kv_manager.alloc(
+            context,
+            replica_idx=0,
+            num_steps=seq_len,
+        )
+        contexts.append(context)
+
+    runtime_inputs = kv_manager.runtime_inputs(
+        [contexts],
+        num_steps=seq_len,
+    ).inputs[0]
+
+    dispatch_metadata = AttentionDispatchResolver(
+        devices=kv_params.devices,
+        is_mla=kv_params.is_mla,
+        n_kv_heads_per_device=kv_params.n_kv_heads_per_device,
+        num_q_heads_per_device=kv_params.num_q_heads_per_device,
+        is_fp8_kv=kv_params.is_fp8_kv_dtype,
+    ).resolve_for_replica(
+        batch_size,
+        seq_len,
+        seq_len,
+    )[0]
+
+    return KVCacheInputsPerDevice(
+        blocks=runtime_inputs.blocks,
+        cache_lengths=_device_uint32_buffer(
+            np.zeros(batch_size, dtype=np.uint32), device
+        ),
+        lookup_table=runtime_inputs.lookup_table,
+        max_lengths=build_max_lengths_tensor(1, seq_len, seq_len),
+        kv_scales=runtime_inputs.kv_scales,
+        attention_dispatch_metadata=dispatch_metadata,
+    )
+
+
+def _clone_kv_blocks(blocks: Buffer, seed: int) -> Buffer:
+    torch.manual_seed(seed)
+    shape = tuple(int(dim) for dim in blocks.shape)
+    tensor = torch.randn(shape, dtype=torch.bfloat16, device="cuda").contiguous()
+    return Buffer.from_dlpack(tensor)
+
+
+def _make_execution_args(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    device: Accelerator,
+    x_seed: int,
+    blocks_seed: int,
+) -> tuple[Any, ...]:
+    runtime_inputs = _make_runtime_inputs(
+        session=session,
+        kv_params=kv_params,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        device=device,
+    )
+
+    torch.manual_seed(x_seed)
+    x = torch.randn(
+        (batch_size * seq_len, hidden_size),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+
+    return (
+        Buffer.from_dlpack(x),
+        _device_uint32_buffer(_row_offsets_array(batch_size, seq_len), device),
+        _clone_kv_blocks(runtime_inputs.blocks, seed=blocks_seed),
+        runtime_inputs.cache_lengths,
+        runtime_inputs.lookup_table,
+        runtime_inputs.max_lengths,
+        runtime_inputs.attention_dispatch_metadata,
+    )
+
+
+def _to_bfloat16_tensor(value: Any) -> torch.Tensor:
+    return from_dlpack(value).to(torch.bfloat16).contiguous()
+
+
+def _assert_close(
+    stage: str,
+    baseline: torch.Tensor,
+    fused: torch.Tensor,
+) -> None:
+    try:
+        torch.testing.assert_close(
+            baseline,
+            fused,
+            rtol=2 * torch.finfo(torch.bfloat16).eps,
+            atol=8 * torch.finfo(torch.bfloat16).eps,
+        )
+    except AssertionError as exc:
+        raise CorrectnessMismatch(stage, str(exc)) from exc
+
+
+def _run_correctness_check(
+    *,
+    baseline: Any,
+    fused: Any,
+    baseline_args: tuple[Any, ...],
+    fused_args: tuple[Any, ...],
+    layer_idx: int,
+    observe_attn_out: bool,
+) -> None:
+    baseline_outputs = baseline.execute(*baseline_args)
+    fused_outputs = fused.execute(*fused_args)
+    torch.cuda.synchronize()
+
+    if observe_attn_out:
+        baseline_attn_out, baseline_output = baseline_outputs
+        fused_attn_out, fused_output = fused_outputs
+        _assert_close(
+            "attn_out",
+            _to_bfloat16_tensor(baseline_attn_out),
+            _to_bfloat16_tensor(fused_attn_out),
+        )
+    else:
+        (baseline_output,) = baseline_outputs
+        (fused_output,) = fused_outputs
+    _assert_close(
+        "attention_output",
+        _to_bfloat16_tensor(baseline_output),
+        _to_bfloat16_tensor(fused_output),
+    )
+
+    baseline_blocks = _to_bfloat16_tensor(baseline_args[2])[
+        :, :, layer_idx : layer_idx + 1, :, :, :
+    ]
+    fused_blocks = _to_bfloat16_tensor(fused_args[2])[
+        :, :, layer_idx : layer_idx + 1, :, :, :
+    ]
+    _assert_close("kv_cache_layer_slice", baseline_blocks, fused_blocks)
+
+
+def _benchmark_us(compiled: Any, args: list[tuple[Any, ...]]) -> float:
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def _geomean(values: list[float]) -> float:
+    return math.exp(sum(math.log(value) for value in values) / len(values))
+
+
+def _localization_for_stage(stage: str) -> str:
+    if stage == "attn_out":
+        return "composed_bridge_attn_out_fails_when_tail_stays_in_graph"
+    if stage == "attention_output":
+        return (
+            "composed_bridge_attn_out_passes_but_attention_output_fails_"
+            "inside_reshape_or_o_proj"
+        )
+    if stage == "kv_cache_layer_slice":
+        return "composed_bridge_outputs_pass_but_kv_cache_layer_slice_diverges"
+    return f"composed_bridge_failed_at_{stage}"
+
+
+def _output_only_localization_for_stage(stage: str) -> str:
+    if stage == "attention_output":
+        return "composed_bridge_output_only_fails_without_attn_out_observation"
+    if stage == "kv_cache_layer_slice":
+        return "composed_bridge_output_only_matches_output_but_kv_cache_diverges"
+    return f"composed_bridge_output_only_failed_at_{stage}"
+
+
+def _print_results(results: dict[str, Any]) -> None:
+    print("GEMMA3_ATTENTION_COMPOSED_PREFILL_BRIDGE_PROFILE_START")
+    print(json.dumps(results, indent=2, sort_keys=True))
+    print("GEMMA3_ATTENTION_COMPOSED_PREFILL_BRIDGE_PROFILE_END")
+
+
+def test_profile_attention_composed_prefill_bridge() -> None:
+    config = _load_text_config()
+    layer_idx, layer_type = _resolve_layer_metadata(config)
+    kv_num_layers = _resolve_kv_num_layers(config, layer_idx)
+    mask_variant, local_window_size, mask_mode = _resolve_flash_mask_config(
+        use_local=(layer_type == "local"),
+        default_local_window_size=int(config["sliding_window"]),
+    )
+    output_mode, observe_attn_out = _resolve_output_mode()
+    session = InferenceSession(devices=[Accelerator(0)])
+    device = Accelerator(0)
+    kv_params = KVCacheParams(
+        dtype=DType.bfloat16,
+        devices=[DeviceRef.GPU()],
+        n_kv_heads=config["num_key_value_heads"],
+        head_dim=config["head_dim"],
+        num_layers=kv_num_layers,
+        page_size=PAGE_SIZE,
+    )
+    weight_registry = _make_weight_registry(config)
+
+    results: dict[str, Any] = {
+        "benchmark_config": {
+            "dtype": "bfloat16",
+            "hidden_size": config["hidden_size"],
+            "head_dim": config["head_dim"],
+            "num_q_heads": config["num_attention_heads"],
+            "num_kv_heads": config["num_key_value_heads"],
+            "page_size": PAGE_SIZE,
+            "layer_idx": layer_idx,
+            "layer_type": layer_type,
+            "kv_num_layers": kv_num_layers,
+            "mask_variant": mask_variant.name,
+            "mask_mode": mask_mode,
+            "local_window_size": local_window_size,
+            "rope": "non-interleaved",
+            "mode": (
+                "prefill-ragged-attention-composed-bridge"
+                if observe_attn_out
+                else "prefill-ragged-attention-composed-bridge-output-only"
+            ),
+            "output_mode": output_mode,
+            "outputs": (
+                ["attn_out", "attention_output"]
+                if observe_attn_out
+                else ["attention_output"]
+            ),
+            "shapes": [
+                _prefill_run_name(
+                    layer_type,
+                    layer_idx,
+                    batch_size,
+                    seq_len,
+                    output_mode,
+                )
+                for batch_size, seq_len in PREFILL_SHAPES
+            ],
+            "warmup_iters": WARMUP_ITERS,
+            "timed_iters": TIMED_ITERS,
+            "placeholder_cache_len": PLACEHOLDER_CACHE_LEN,
+        },
+        "correctness": "pass",
+        "first_sweep_us": {},
+        "confirm_sweep_us": {},
+        "average_us": {},
+        "average_speedup_ratio_vs_composed_bridge_baseline": {},
+    }
+
+    large_shape_names: list[str] = []
+
+    for batch_size, seq_len in PREFILL_SHAPES:
+        run_name = _prefill_run_name(
+            layer_type, layer_idx, batch_size, seq_len, output_mode
+        )
+        if seq_len >= 512:
+            large_shape_names.append(run_name)
+
+        baseline = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=False,
+            layer_idx=layer_idx,
+            layer_type=layer_type,
+            observe_attn_out=observe_attn_out,
+        )
+        fused = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=True,
+            layer_idx=layer_idx,
+            layer_type=layer_type,
+            observe_attn_out=observe_attn_out,
+        )
+
+        baseline_correctness_args = _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=config["hidden_size"],
+            device=device,
+            x_seed=1000 + batch_size + seq_len,
+            blocks_seed=2000 + batch_size + seq_len,
+        )
+        fused_correctness_args = _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=config["hidden_size"],
+            device=device,
+            x_seed=1000 + batch_size + seq_len,
+            blocks_seed=2000 + batch_size + seq_len,
+        )
+        try:
+            _run_correctness_check(
+                baseline=baseline,
+                fused=fused,
+                baseline_args=baseline_correctness_args,
+                fused_args=fused_correctness_args,
+                layer_idx=layer_idx,
+                observe_attn_out=observe_attn_out,
+            )
+        except CorrectnessMismatch as exc:
+            results["correctness"] = "failed"
+            results["failure_stage"] = exc.stage
+            results["failure_shape"] = run_name
+            results["failure_message"] = exc.details
+            results["localization"] = (
+                _localization_for_stage(exc.stage)
+                if observe_attn_out
+                else _output_only_localization_for_stage(exc.stage)
+            )
+            _print_results(results)
+            raise
+        del baseline_correctness_args
+        del fused_correctness_args
+        torch.cuda.empty_cache()
+
+        baseline_first_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=3000 + idx,
+                blocks_seed=4000 + idx,
+            )
+            for idx in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        fused_first_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=3000 + idx,
+                blocks_seed=4000 + idx,
+            )
+            for idx in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        baseline_first = _benchmark_us(baseline, baseline_first_args)
+        fused_first = _benchmark_us(fused, fused_first_args)
+        del baseline_first_args
+        del fused_first_args
+        torch.cuda.empty_cache()
+
+        baseline_confirm_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=5000 + idx,
+                blocks_seed=6000 + idx,
+            )
+            for idx in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        fused_confirm_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=5000 + idx,
+                blocks_seed=6000 + idx,
+            )
+            for idx in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        baseline_confirm = _benchmark_us(baseline, baseline_confirm_args)
+        fused_confirm = _benchmark_us(fused, fused_confirm_args)
+        del baseline_confirm_args
+        del fused_confirm_args
+        torch.cuda.empty_cache()
+
+        average_baseline = (baseline_first + baseline_confirm) / 2.0
+        average_fused = (fused_first + fused_confirm) / 2.0
+        results["first_sweep_us"][run_name] = {
+            "baseline": baseline_first,
+            "fused": fused_first,
+        }
+        results["confirm_sweep_us"][run_name] = {
+            "baseline": baseline_confirm,
+            "fused": fused_confirm,
+        }
+        results["average_us"][run_name] = {
+            "baseline": average_baseline,
+            "fused": average_fused,
+        }
+        results["average_speedup_ratio_vs_composed_bridge_baseline"][
+            run_name
+        ] = (average_baseline / average_fused)
+        del baseline
+        del fused
+        torch.cuda.empty_cache()
+
+    ratios = list(
+        results["average_speedup_ratio_vs_composed_bridge_baseline"].values()
+    )
+    large_ratios = [
+        results["average_speedup_ratio_vs_composed_bridge_baseline"][name]
+        for name in large_shape_names
+    ]
+    confirm_ratios = [
+        results["confirm_sweep_us"][name]["baseline"]
+        / results["confirm_sweep_us"][name]["fused"]
+        for name in results["confirm_sweep_us"]
+    ]
+    confirm_large_ratios = [
+        results["confirm_sweep_us"][name]["baseline"]
+        / results["confirm_sweep_us"][name]["fused"]
+        for name in large_shape_names
+    ]
+
+    results["average_geomean_speedup_vs_composed_bridge_baseline"] = (
+        _geomean(ratios)
+    )
+    results[
+        "average_large_shape_geomean_speedup_vs_composed_bridge_baseline"
+    ] = _geomean(large_ratios)
+    results["confirm_geomean_speedup_vs_composed_bridge_baseline"] = _geomean(
+        confirm_ratios
+    )
+    results[
+        "confirm_large_shape_geomean_speedup_vs_composed_bridge_baseline"
+    ] = _geomean(confirm_large_ratios)
+    results["localization"] = (
+        "composed_bridge_passes_when_attn_out_is_observed_"
+        "suggesting_an_unobserved_graph_seam_issue"
+        if observe_attn_out
+        else "composed_bridge_output_only_passes_without_attn_out_observation"
+    )
+    _print_results(results)

--- a/max/tests/integration/architectures/gemma3/test_profile_attention_decode.py
+++ b/max/tests/integration/architectures/gemma3/test_profile_attention_decode.py
@@ -1,0 +1,1375 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from max.driver import Accelerator, Buffer
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Graph, TensorType, TensorValue, ops
+from max.interfaces import RequestID, TokenBuffer
+from max.kv_cache import PagedKVCacheManager
+from max.nn.attention import MHAMaskVariant
+from max.nn.kernels import (
+    KVCacheParams,
+    flash_attention_ragged,
+    fused_qk_ragged_rope,
+    fused_qkv_ragged_matmul,
+    k_rms_norm_rope_ragged,
+    q_rms_norm_rope_ragged,
+    rms_norm_key_cache,
+    rope_ragged,
+    rope_k_cache_ragged,
+)
+from max.nn.kv_cache import PagedCacheValues, unflatten_ragged_attention_inputs
+from max.nn.rotary_embedding import Llama3RotaryEmbedding
+from max.pipelines.architectures.gemma3.layers.attention import (
+    Gemma3Attention as MaxGemma3Attention,
+)
+from max.pipelines.core import TextContext
+from torch.utils.dlpack import from_dlpack
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return int(value) if value is not None else default
+
+
+def _env_int_tuple(name: str, default: tuple[int, ...]) -> tuple[int, ...]:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return tuple(
+        int(part.strip()) for part in value.split(",") if part.strip()
+    )
+
+
+PAGE_SIZE = 128
+EPS = 1e-6
+DEFAULT_LAYER_IDX = 0
+DEFAULT_LAYER_TYPE = "local"
+DEFAULT_FUSED_VARIANT = "full"
+DEFAULT_TIMING_ORDER_MODE = "baseline_then_fused"
+FUSED_VARIANTS = ("full", "k_only", "q_only")
+GRAPH_VARIANTS = (
+    "baseline",
+    "full",
+    "k_only",
+    "q_only_baseline",
+    "q_only",
+)
+TIMING_ORDER_MODES = (
+    DEFAULT_TIMING_ORDER_MODE,
+    "both_orders",
+)
+Q_NORM_STD = 0.68
+K_NORM_STD = 0.793
+Q_PROJ_STD = 0.0284
+K_PROJ_STD = 0.0309
+V_PROJ_STD = 0.0309
+O_PROJ_STD = 0.0237
+DEFAULT_WARMUP_ITERS = 20
+DEFAULT_TIMED_ITERS = 50
+DEFAULT_CACHE_LEN_BASE = 1024
+DEFAULT_CACHE_LEN_STEP = 7
+DEFAULT_BATCH_SIZES = (64, 128)
+WARMUP_ITERS = _env_int(
+    "PROFILE_ATTENTION_DECODE_WARMUP_ITERS", DEFAULT_WARMUP_ITERS
+)
+TIMED_ITERS = _env_int(
+    "PROFILE_ATTENTION_DECODE_TIMED_ITERS", DEFAULT_TIMED_ITERS
+)
+CACHE_LEN_BASE = _env_int(
+    "PROFILE_ATTENTION_DECODE_CACHE_LEN_BASE", DEFAULT_CACHE_LEN_BASE
+)
+CACHE_LEN_STEP = _env_int(
+    "PROFILE_ATTENTION_DECODE_CACHE_LEN_STEP", DEFAULT_CACHE_LEN_STEP
+)
+BATCH_SIZES = _env_int_tuple(
+    "PROFILE_ATTENTION_DECODE_BATCH_SIZES", DEFAULT_BATCH_SIZES
+)
+if not BATCH_SIZES:
+    raise ValueError(
+        "PROFILE_ATTENTION_DECODE_BATCH_SIZES must define at least one batch size"
+    )
+if WARMUP_ITERS < 0:
+    raise ValueError("PROFILE_ATTENTION_DECODE_WARMUP_ITERS must be >= 0")
+if TIMED_ITERS <= 0:
+    raise ValueError("PROFILE_ATTENTION_DECODE_TIMED_ITERS must be >= 1")
+MAX_EXTRA_STEPS = WARMUP_ITERS + TIMED_ITERS
+
+
+def _resolve_layer_metadata(config: dict[str, Any]) -> tuple[int, str]:
+    layer_idx = int(
+        os.environ.get("PROFILE_ATTENTION_LAYER_IDX", str(DEFAULT_LAYER_IDX))
+    )
+    num_hidden_layers = int(config["num_hidden_layers"])
+    assert 0 <= layer_idx < num_hidden_layers, (
+        f"layer_idx={layer_idx} must be in [0, {num_hidden_layers})"
+    )
+    layer_type = (
+        "local"
+        if bool((layer_idx + 1) % config["sliding_window_pattern"])
+        else "global"
+    )
+    expected_layer_type = os.environ.get(
+        "PROFILE_ATTENTION_LAYER_TYPE", DEFAULT_LAYER_TYPE
+    )
+    assert (
+        layer_type == expected_layer_type
+    ), f"expected {expected_layer_type} layer, got {layer_type} for layer_idx={layer_idx}"
+    return layer_idx, layer_type
+
+
+def _resolve_kv_num_layers(config: dict[str, Any], layer_idx: int) -> int:
+    min_num_layers = layer_idx + 1
+    kv_num_layers = int(
+        os.environ.get("PROFILE_ATTENTION_KV_NUM_LAYERS", str(min_num_layers))
+    )
+    assert kv_num_layers >= min_num_layers, (
+        f"kv_num_layers={kv_num_layers} must cover layer_idx={layer_idx}"
+    )
+    assert kv_num_layers <= int(config["num_hidden_layers"]), (
+        "kv_num_layers cannot exceed the model layer count "
+        f"({config['num_hidden_layers']})"
+    )
+    return kv_num_layers
+
+
+def _resolve_fused_variant() -> str:
+    fused_variant = os.environ.get(
+        "PROFILE_ATTENTION_DECODE_FUSED_VARIANT",
+        DEFAULT_FUSED_VARIANT,
+    )
+    assert fused_variant in FUSED_VARIANTS, (
+        f"fused variant must be one of {FUSED_VARIANTS}, got {fused_variant!r}"
+    )
+    return fused_variant
+
+
+def _resolve_graph_variants() -> tuple[str, str]:
+    baseline_graph_variant = os.environ.get(
+        "PROFILE_ATTENTION_DECODE_BASELINE_GRAPH_VARIANT"
+    )
+    fused_graph_variant = os.environ.get(
+        "PROFILE_ATTENTION_DECODE_FUSED_GRAPH_VARIANT"
+    )
+
+    if baseline_graph_variant is None and fused_graph_variant is None:
+        fused_variant = _resolve_fused_variant()
+        baseline_graph_variant = (
+            "q_only_baseline" if fused_variant == "q_only" else "baseline"
+        )
+        fused_graph_variant = {
+            "full": "full",
+            "k_only": "k_only",
+            "q_only": "q_only",
+        }[fused_variant]
+    else:
+        assert baseline_graph_variant is not None, (
+            "PROFILE_ATTENTION_DECODE_BASELINE_GRAPH_VARIANT must be set "
+            "whenever PROFILE_ATTENTION_DECODE_FUSED_GRAPH_VARIANT is set"
+        )
+        assert fused_graph_variant is not None, (
+            "PROFILE_ATTENTION_DECODE_FUSED_GRAPH_VARIANT must be set "
+            "whenever PROFILE_ATTENTION_DECODE_BASELINE_GRAPH_VARIANT is set"
+        )
+
+    assert baseline_graph_variant in GRAPH_VARIANTS, (
+        "baseline graph variant must be one of "
+        f"{GRAPH_VARIANTS}, got {baseline_graph_variant!r}"
+    )
+    assert fused_graph_variant in GRAPH_VARIANTS, (
+        "fused graph variant must be one of "
+        f"{GRAPH_VARIANTS}, got {fused_graph_variant!r}"
+    )
+    return baseline_graph_variant, fused_graph_variant
+
+
+def _resolve_timing_order_mode() -> str:
+    timing_order_mode = os.environ.get(
+        "PROFILE_ATTENTION_DECODE_TIMING_ORDER",
+        DEFAULT_TIMING_ORDER_MODE,
+    ).strip()
+    if timing_order_mode in ("", DEFAULT_TIMING_ORDER_MODE):
+        return DEFAULT_TIMING_ORDER_MODE
+    assert timing_order_mode in TIMING_ORDER_MODES, (
+        "PROFILE_ATTENTION_DECODE_TIMING_ORDER must be one of "
+        f"{TIMING_ORDER_MODES}, got {timing_order_mode!r}"
+    )
+    return timing_order_mode
+
+
+def _comparison_metadata(
+    baseline_graph_variant: str, fused_graph_variant: str
+) -> tuple[str, str]:
+    comparison = (baseline_graph_variant, fused_graph_variant)
+    if comparison == ("baseline", "full"):
+        return "decode-ragged-full-attention", ""
+    if comparison == ("baseline", "k_only"):
+        return "decode-ragged-full-attention-k-only", "_k_only"
+    if comparison == ("q_only_baseline", "q_only"):
+        return "decode-ragged-full-attention-q-only", "_q_only"
+    if comparison == ("q_only", "full"):
+        return "decode-ragged-full-attention-qk-incremental", "_qk_incremental"
+
+    comparison_tag = (
+        f"{baseline_graph_variant.replace('_', '-')}-vs-"
+        f"{fused_graph_variant.replace('_', '-')}"
+    )
+    return (
+        f"decode-ragged-full-attention-{comparison_tag}",
+        f"_{comparison_tag.replace('-', '_')}",
+    )
+
+
+def _timing_order_metadata(
+    comparison_mode: str,
+    run_name_suffix: str,
+    timing_order_mode: str,
+) -> tuple[str, str]:
+    if timing_order_mode == DEFAULT_TIMING_ORDER_MODE:
+        return comparison_mode, run_name_suffix
+    return f"{comparison_mode}-order-probe", f"{run_name_suffix}_order_probe"
+
+
+def _load_text_config() -> dict[str, Any]:
+    config_path = Path(os.environ["PIPELINES_TESTDATA"]) / "config.json"
+    with open(config_path) as file:
+        data = json.load(file)
+    return data.get("text_config", data)
+
+
+def _make_weight_registry(config: dict[str, Any]) -> dict[str, torch.Tensor]:
+    torch.manual_seed(42)
+    q_dim = config["head_dim"] * config["num_attention_heads"]
+    kv_dim = config["head_dim"] * config["num_key_value_heads"]
+    hidden_size = config["hidden_size"]
+    return {
+        "k_norm.weight": torch.randn(
+            config["head_dim"], dtype=torch.bfloat16
+        )
+        * K_NORM_STD,
+        "k_proj.weight": torch.randn(
+            kv_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * K_PROJ_STD,
+        "o_proj.weight": torch.randn(
+            hidden_size, q_dim, dtype=torch.bfloat16
+        )
+        * O_PROJ_STD,
+        "q_norm.weight": torch.randn(
+            config["head_dim"], dtype=torch.bfloat16
+        )
+        * Q_NORM_STD,
+        "q_proj.weight": torch.randn(
+            q_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * Q_PROJ_STD,
+        "v_proj.weight": torch.randn(
+            kv_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * V_PROJ_STD,
+    }
+
+
+class _Gemma3AttentionBaseline(MaxGemma3Attention):
+    def __call__(
+        self,
+        x: TensorValue,
+        kv_collection: PagedCacheValues,
+        **kwargs,
+    ) -> TensorValue:
+        total_seq_len = x.shape[0]
+        layer_idx = ops.constant(
+            self.layer_idx, DType.uint32, device=DeviceRef.CPU()
+        )
+
+        xq = fused_qkv_ragged_matmul(
+            self.kv_params,
+            input=x,
+            wqkv=self.wqkv,
+            bias=self.wqkv_bias,
+            input_row_offsets=kwargs["input_row_offsets"],
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            n_heads=self.n_heads,
+        )
+        xq = xq.reshape((-1, self.n_heads, self.kv_params.head_dim))
+
+        use_local = bool((self.layer_idx + 1) % self.sliding_window_pattern)
+        rope = self.rope_local if use_local else self.rope_global
+        freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
+
+        rms_norm_key_cache(
+            self.kv_params,
+            kv_collection=kv_collection,
+            gamma=self.k_norm.weight.cast(self.kv_params.dtype).to(
+                self.devices[0]
+            ),
+            epsilon=self.qk_norm_eps,
+            layer_idx=layer_idx,
+            total_seq_len=total_seq_len,
+            input_row_offsets=kwargs["input_row_offsets"],
+            weight_offset=1.0,
+        )
+        xq = self.q_norm(xq)
+        xq = fused_qk_ragged_rope(
+            self.kv_params,
+            xq,
+            kwargs["input_row_offsets"],
+            kv_collection,
+            freqs_cis,
+            layer_idx,
+            interleaved=rope.interleaved,
+        )
+
+        mask_variant = (
+            MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK
+            if use_local
+            else MHAMaskVariant.CAUSAL_MASK
+        )
+        attn_out = flash_attention_ragged(
+            self.kv_params,
+            input=xq,
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            input_row_offsets=kwargs["input_row_offsets"],
+            mask_variant=mask_variant,
+            scale=self.scale,
+            local_window_size=self.local_window_size,
+        )
+        attn_out = ops.reshape(attn_out, shape=[total_seq_len, -1])
+        return self.o_proj(attn_out)
+
+
+class _Gemma3AttentionKOnlyFused(MaxGemma3Attention):
+    def __call__(
+        self,
+        x: TensorValue,
+        kv_collection: PagedCacheValues,
+        **kwargs,
+    ) -> TensorValue:
+        total_seq_len = x.shape[0]
+        layer_idx = ops.constant(
+            self.layer_idx, DType.uint32, device=DeviceRef.CPU()
+        )
+
+        xq = fused_qkv_ragged_matmul(
+            self.kv_params,
+            input=x,
+            wqkv=self.wqkv,
+            bias=self.wqkv_bias,
+            input_row_offsets=kwargs["input_row_offsets"],
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            n_heads=self.n_heads,
+        )
+        xq = xq.reshape((-1, self.n_heads, self.kv_params.head_dim))
+
+        use_local = bool((self.layer_idx + 1) % self.sliding_window_pattern)
+        rope = self.rope_local if use_local else self.rope_global
+        freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
+
+        k_rms_norm_rope_ragged(
+            self.kv_params,
+            total_seq_len=total_seq_len,
+            input_row_offsets=kwargs["input_row_offsets"],
+            kv_collection=kv_collection,
+            freqs_cis=freqs_cis,
+            gamma=self.k_norm.weight.cast(self.kv_params.dtype).to(
+                self.devices[0]
+            ),
+            epsilon=self.qk_norm_eps,
+            layer_idx=layer_idx,
+            weight_offset=1.0,
+            interleaved=rope.interleaved,
+        )
+        xq = self.q_norm(xq)
+        xq = rope_ragged(
+            xq,
+            kwargs["input_row_offsets"],
+            kv_collection.cache_lengths,
+            freqs_cis,
+            interleaved=rope.interleaved,
+        )
+
+        mask_variant = (
+            MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK
+            if use_local
+            else MHAMaskVariant.CAUSAL_MASK
+        )
+        attn_out = flash_attention_ragged(
+            self.kv_params,
+            input=xq,
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            input_row_offsets=kwargs["input_row_offsets"],
+            mask_variant=mask_variant,
+            scale=self.scale,
+            local_window_size=self.local_window_size,
+        )
+        attn_out = ops.reshape(attn_out, shape=[total_seq_len, -1])
+        return self.o_proj(attn_out)
+
+
+class _Gemma3AttentionQOnlyBaseline(MaxGemma3Attention):
+    def __call__(
+        self,
+        x: TensorValue,
+        kv_collection: PagedCacheValues,
+        **kwargs,
+    ) -> TensorValue:
+        total_seq_len = x.shape[0]
+        layer_idx = ops.constant(
+            self.layer_idx, DType.uint32, device=DeviceRef.CPU()
+        )
+
+        xq = fused_qkv_ragged_matmul(
+            self.kv_params,
+            input=x,
+            wqkv=self.wqkv,
+            bias=self.wqkv_bias,
+            input_row_offsets=kwargs["input_row_offsets"],
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            n_heads=self.n_heads,
+        )
+        xq = xq.reshape((-1, self.n_heads, self.kv_params.head_dim))
+
+        use_local = bool((self.layer_idx + 1) % self.sliding_window_pattern)
+        rope = self.rope_local if use_local else self.rope_global
+        freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
+
+        rms_norm_key_cache(
+            self.kv_params,
+            kv_collection=kv_collection,
+            gamma=self.k_norm.weight.cast(self.kv_params.dtype).to(
+                self.devices[0]
+            ),
+            epsilon=self.qk_norm_eps,
+            layer_idx=layer_idx,
+            total_seq_len=total_seq_len,
+            input_row_offsets=kwargs["input_row_offsets"],
+            weight_offset=1.0,
+        )
+        rope_k_cache_ragged(
+            self.kv_params,
+            total_seq_len=total_seq_len,
+            input_row_offsets=kwargs["input_row_offsets"],
+            kv_collection=kv_collection,
+            freqs_cis=freqs_cis,
+            layer_idx=layer_idx,
+            interleaved=rope.interleaved,
+        )
+        xq = self.q_norm(xq)
+        xq = rope_ragged(
+            xq,
+            kwargs["input_row_offsets"],
+            kv_collection.cache_lengths,
+            freqs_cis,
+            interleaved=rope.interleaved,
+        )
+
+        mask_variant = (
+            MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK
+            if use_local
+            else MHAMaskVariant.CAUSAL_MASK
+        )
+        attn_out = flash_attention_ragged(
+            self.kv_params,
+            input=xq,
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            input_row_offsets=kwargs["input_row_offsets"],
+            mask_variant=mask_variant,
+            scale=self.scale,
+            local_window_size=self.local_window_size,
+        )
+        attn_out = ops.reshape(attn_out, shape=[total_seq_len, -1])
+        return self.o_proj(attn_out)
+
+
+class _Gemma3AttentionQOnlyFused(MaxGemma3Attention):
+    def __call__(
+        self,
+        x: TensorValue,
+        kv_collection: PagedCacheValues,
+        **kwargs,
+    ) -> TensorValue:
+        total_seq_len = x.shape[0]
+        layer_idx = ops.constant(
+            self.layer_idx, DType.uint32, device=DeviceRef.CPU()
+        )
+
+        xq = fused_qkv_ragged_matmul(
+            self.kv_params,
+            input=x,
+            wqkv=self.wqkv,
+            bias=self.wqkv_bias,
+            input_row_offsets=kwargs["input_row_offsets"],
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            n_heads=self.n_heads,
+        )
+        xq = xq.reshape((-1, self.n_heads, self.kv_params.head_dim))
+
+        use_local = bool((self.layer_idx + 1) % self.sliding_window_pattern)
+        rope = self.rope_local if use_local else self.rope_global
+        freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
+
+        rms_norm_key_cache(
+            self.kv_params,
+            kv_collection=kv_collection,
+            gamma=self.k_norm.weight.cast(self.kv_params.dtype).to(
+                self.devices[0]
+            ),
+            epsilon=self.qk_norm_eps,
+            layer_idx=layer_idx,
+            total_seq_len=total_seq_len,
+            input_row_offsets=kwargs["input_row_offsets"],
+            weight_offset=1.0,
+        )
+        rope_k_cache_ragged(
+            self.kv_params,
+            total_seq_len=total_seq_len,
+            input_row_offsets=kwargs["input_row_offsets"],
+            kv_collection=kv_collection,
+            freqs_cis=freqs_cis,
+            layer_idx=layer_idx,
+            interleaved=rope.interleaved,
+        )
+        xq = q_rms_norm_rope_ragged(
+            xq,
+            kwargs["input_row_offsets"],
+            kv_collection.cache_lengths,
+            freqs_cis,
+            self.q_norm.weight.cast(self.kv_params.dtype).to(self.devices[0]),
+            self.qk_norm_eps,
+            weight_offset=1.0,
+            interleaved=rope.interleaved,
+        )
+
+        mask_variant = (
+            MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK
+            if use_local
+            else MHAMaskVariant.CAUSAL_MASK
+        )
+        attn_out = flash_attention_ragged(
+            self.kv_params,
+            input=xq,
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            input_row_offsets=kwargs["input_row_offsets"],
+            mask_variant=mask_variant,
+            scale=self.scale,
+            local_window_size=self.local_window_size,
+        )
+        attn_out = ops.reshape(attn_out, shape=[total_seq_len, -1])
+        return self.o_proj(attn_out)
+
+
+def _build_graph(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    config: dict[str, Any],
+    weight_registry: dict[str, torch.Tensor],
+    graph_variant: str,
+    layer_idx: int,
+    layer_type: str,
+) -> Any:
+    device_ref = DeviceRef.GPU()
+    max_seq_len = (
+        CACHE_LEN_BASE
+        + CACHE_LEN_STEP * (max(BATCH_SIZES) - 1)
+        + MAX_EXTRA_STEPS
+        + 256
+    )
+    attention_cls = {
+        "baseline": _Gemma3AttentionBaseline,
+        "full": MaxGemma3Attention,
+        "k_only": _Gemma3AttentionKOnlyFused,
+        "q_only_baseline": _Gemma3AttentionQOnlyBaseline,
+        "q_only": _Gemma3AttentionQOnlyFused,
+    }.get(graph_variant)
+    if attention_cls is None:
+        raise ValueError(
+            f"unsupported attention decode graph variant {graph_variant!r}"
+        )
+    attention = attention_cls(
+        rope_global=Llama3RotaryEmbedding(
+            config["hidden_size"],
+            config["num_attention_heads"],
+            config["rope_theta"],
+            max_seq_len,
+            interleaved=False,
+            head_dim=config["head_dim"],
+        ),
+        rope_local=Llama3RotaryEmbedding(
+            config["hidden_size"],
+            config["num_attention_heads"],
+            config["rope_local_base_freq"],
+            max_seq_len,
+            interleaved=False,
+            head_dim=config["head_dim"],
+        ),
+        num_attention_heads=config["num_attention_heads"],
+        num_key_value_heads=config["num_key_value_heads"],
+        hidden_size=config["hidden_size"],
+        kv_params=kv_params,
+        layer_idx=layer_idx,
+        dtype=DType.bfloat16,
+        devices=[device_ref],
+        qk_norm_eps=EPS,
+        sliding_window_pattern=config["sliding_window_pattern"],
+        local_window_size=config["sliding_window"],
+        has_bias=bool(config["attention_bias"]),
+    )
+    attention.load_state_dict(weight_registry)
+
+    input_type = TensorType(
+        DType.bfloat16,
+        ["total_seq_len", config["hidden_size"]],
+        device=device_ref,
+    )
+    input_row_offsets_type = TensorType(
+        DType.uint32,
+        ["input_row_offsets_len"],
+        device=device_ref,
+    )
+    flattened_kv_types = kv_params.get_symbolic_inputs().flatten()
+
+    graph_variant_name = {
+        "baseline": "Baseline",
+        "full": "Fused",
+        "k_only": "KOnlyFused",
+        "q_only_baseline": "QOnlyBaseline",
+        "q_only": "QOnlyFused",
+    }[graph_variant]
+    graph_name = (
+        f"Gemma3AttentionDecode{layer_type.title()}{graph_variant_name}"
+    )
+
+    with Graph(
+        graph_name,
+        input_types=(input_type, input_row_offsets_type, *flattened_kv_types),
+    ) as graph:
+        x, input_row_offsets, *kv_cache = graph.inputs
+        kv_collection = unflatten_ragged_attention_inputs(
+            kv_cache, n_devices=1
+        )[0]
+        graph.output(
+            attention(
+                x.tensor,
+                kv_collection,
+                input_row_offsets=input_row_offsets.tensor,
+            )
+        )
+
+    return session.load(graph, weights_registry=attention.state_dict())
+
+
+def _make_text_context(length: int, max_length: int) -> TextContext:
+    return TextContext(
+        request_id=RequestID(),
+        max_length=max_length,
+        tokens=TokenBuffer(np.zeros(length, dtype=np.int64)),
+    )
+
+
+def _make_runtime_inputs(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+) -> tuple[np.ndarray, Any]:
+    cache_lengths = np.asarray(
+        [
+            CACHE_LEN_BASE + CACHE_LEN_STEP * request_idx
+            for request_idx in range(batch_size)
+        ],
+        dtype=np.uint32,
+    )
+    max_cache_length = int(cache_lengths[-1]) + MAX_EXTRA_STEPS + 1
+    total_num_pages = sum(
+        math.ceil((int(cache_length) + MAX_EXTRA_STEPS + 1) / PAGE_SIZE)
+        for cache_length in cache_lengths
+    )
+
+    kv_manager = PagedKVCacheManager(
+        params=kv_params,
+        total_num_pages=total_num_pages,
+        session=session,
+        max_batch_size=batch_size,
+    )
+
+    contexts: list[TextContext] = []
+    for cache_length in cache_lengths:
+        context = _make_text_context(int(cache_length), max_cache_length)
+        kv_manager.claim(context.request_id, replica_idx=0)
+        kv_manager.alloc(
+            context,
+            replica_idx=0,
+            num_steps=MAX_EXTRA_STEPS + 1,
+        )
+        contexts.append(context)
+
+    runtime_inputs = kv_manager.runtime_inputs([contexts], num_steps=1).inputs[0]
+    return cache_lengths, runtime_inputs
+
+
+def _clone_kv_blocks(blocks: Buffer, seed: int) -> Buffer:
+    torch.manual_seed(seed)
+    shape = tuple(int(dim) for dim in blocks.shape)
+    tensor = torch.randn(shape, dtype=torch.bfloat16, device="cuda").contiguous()
+    return Buffer.from_dlpack(tensor)
+
+
+def _device_uint32_buffer(array: np.ndarray, device: Accelerator) -> Buffer:
+    return Buffer.from_numpy(array).to(device)
+
+
+def _run_nvidia_smi_query(query_fields: str) -> list[list[str]]:
+    result = subprocess.run(
+        [
+            "nvidia-smi",
+            f"--query-{query_fields}",
+            "--format=csv,noheader,nounits",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        [field.strip() for field in row]
+        for row in csv.reader(result.stdout.splitlines())
+        if row
+    ]
+
+
+def _build_gpu_isolation_guard() -> dict[str, Any] | None:
+    raw_guard = os.environ.get(
+        "PROFILE_ATTENTION_DECODE_ENFORCE_GPU_ISOLATION", ""
+    ).strip()
+    if raw_guard.lower() not in ("1", "true", "yes"):
+        return None
+
+    cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", "").strip()
+    target_gpu_index = (
+        0 if cuda_visible_devices == "" else int(cuda_visible_devices.split(",")[0])
+    )
+
+    for index_text, gpu_uuid in _run_nvidia_smi_query("gpu=index,uuid"):
+        if int(index_text) == target_gpu_index:
+            return {
+                "allowed_pid": os.getpid(),
+                "target_gpu_index": target_gpu_index,
+                "target_gpu_uuid": gpu_uuid,
+            }
+
+    raise AssertionError(
+        "Could not resolve the target GPU UUID for "
+        f"CUDA_VISIBLE_DEVICES={cuda_visible_devices!r}"
+    )
+
+
+def _write_results_json_if_requested(results: dict[str, Any]) -> None:
+    path = os.environ.get("PROFILE_ATTENTION_DECODE_RESULTS_JSON")
+    if not path:
+        return
+    Path(path).write_text(json.dumps(results, indent=2, sort_keys=True) + "\n")
+
+
+def _mark_results_progress(results: dict[str, Any], stage: str) -> None:
+    results["progress"] = {
+        "last_completed_stage": stage,
+        "updated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+    _write_results_json_if_requested(results)
+
+
+def _assert_gpu_isolation(
+    gpu_isolation_guard: dict[str, Any] | None,
+    *,
+    label: str,
+) -> None:
+    if gpu_isolation_guard is None:
+        return
+
+    resident_compute_apps = []
+    unexpected_apps = []
+    for gpu_uuid, pid_text, process_name, used_gpu_memory_mib in (
+        _run_nvidia_smi_query(
+            "compute-apps=gpu_uuid,pid,process_name,used_gpu_memory"
+        )
+    ):
+        if gpu_uuid != gpu_isolation_guard["target_gpu_uuid"]:
+            continue
+        resident_app = {
+            "gpu_uuid": gpu_uuid,
+            "pid": int(pid_text),
+            "process_name": process_name,
+            "used_gpu_memory_mib": float(used_gpu_memory_mib),
+        }
+        resident_compute_apps.append(resident_app)
+        if resident_app["pid"] != gpu_isolation_guard["allowed_pid"]:
+            unexpected_apps.append(resident_app)
+
+    if unexpected_apps:
+        raise AssertionError(
+            f"{label} at {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}: "
+            "unexpected compute apps on physical GPU "
+            f"{gpu_isolation_guard['target_gpu_index']} "
+            f"({gpu_isolation_guard['target_gpu_uuid']}): "
+            f"{unexpected_apps}; all resident apps: {resident_compute_apps}"
+        )
+
+
+def _make_benchmark_args(
+    *,
+    batch_size: int,
+    hidden_size: int,
+    cache_lengths: np.ndarray,
+    runtime_inputs: Any,
+    device: Accelerator,
+    x_seed: int,
+    blocks_seed: int,
+) -> tuple[list[tuple[Any, ...]], Buffer]:
+    torch.manual_seed(x_seed)
+    x = torch.randn(
+        (batch_size, hidden_size),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+    x_buffer = Buffer.from_dlpack(x)
+    row_offsets = _device_uint32_buffer(
+        np.arange(batch_size + 1, dtype=np.uint32),
+        device,
+    )
+    kv_blocks = _clone_kv_blocks(runtime_inputs.blocks, seed=blocks_seed)
+    lookup_table = runtime_inputs.lookup_table.to(device)
+    dispatch_metadata = runtime_inputs.attention_dispatch_metadata
+    assert dispatch_metadata is not None
+
+    args: list[tuple[Any, ...]] = []
+    for step in range(MAX_EXTRA_STEPS + 1):
+        step_cache_lengths = _device_uint32_buffer(
+            cache_lengths + np.uint32(step), device
+        )
+        args.append(
+            (
+                x_buffer,
+                row_offsets,
+                kv_blocks,
+                step_cache_lengths,
+                lookup_table,
+                runtime_inputs.max_lengths,
+                dispatch_metadata,
+            )
+        )
+    return args, kv_blocks
+
+
+def _run_correctness_check(
+    *,
+    baseline: Any,
+    fused: Any,
+    baseline_args: tuple[Any, ...],
+    fused_args: tuple[Any, ...],
+    layer_idx: int,
+) -> None:
+    baseline_output = baseline.execute(*baseline_args)[0]
+    fused_output = fused.execute(*fused_args)[0]
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        from_dlpack(baseline_output).to(torch.bfloat16),
+        from_dlpack(fused_output).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+    # Only the addressed layer should mutate during decode; comparing that
+    # layer keeps the global-layer harness under the PyTorch memory cap.
+    baseline_blocks = from_dlpack(baseline_args[2]).to(torch.bfloat16)[
+        :, :, layer_idx : layer_idx + 1, :, :, :
+    ]
+    fused_blocks = from_dlpack(fused_args[2]).to(torch.bfloat16)[
+        :, :, layer_idx : layer_idx + 1, :, :, :
+    ]
+    torch.testing.assert_close(
+        baseline_blocks,
+        fused_blocks,
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+
+def _benchmark_us(compiled: Any, args: list[tuple[Any, ...]]) -> float:
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def _benchmark_us_guarded(
+    compiled: Any,
+    args: list[tuple[Any, ...]],
+    *,
+    gpu_isolation_guard: dict[str, Any] | None,
+    label: str,
+) -> float:
+    _assert_gpu_isolation(
+        gpu_isolation_guard,
+        label=f"{label}:before_warmup",
+    )
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    _assert_gpu_isolation(
+        gpu_isolation_guard,
+        label=f"{label}:after_timed",
+    )
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def _benchmark_pair_order(
+    *,
+    compiled_graphs: dict[str, Any],
+    benchmark_args: dict[str, list[tuple[Any, ...]]],
+    order: tuple[str, str],
+    gpu_isolation_guard: dict[str, Any] | None,
+    run_name: str,
+) -> dict[str, float]:
+    results: dict[str, float] = {}
+    for graph_name in order:
+        results[graph_name] = _benchmark_us_guarded(
+            compiled_graphs[graph_name],
+            benchmark_args[graph_name],
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:{graph_name}",
+        )
+    return results
+
+
+def test_profile_attention_decode() -> None:
+    config = _load_text_config()
+    layer_idx, layer_type = _resolve_layer_metadata(config)
+    kv_num_layers = _resolve_kv_num_layers(config, layer_idx)
+    baseline_graph_variant, fused_graph_variant = _resolve_graph_variants()
+    timing_order_mode = _resolve_timing_order_mode()
+    comparison_mode, run_name_suffix = _comparison_metadata(
+        baseline_graph_variant, fused_graph_variant
+    )
+    comparison_mode, run_name_suffix = _timing_order_metadata(
+        comparison_mode,
+        run_name_suffix,
+        timing_order_mode,
+    )
+    session = InferenceSession(devices=[Accelerator(0)])
+    device = Accelerator(0)
+    gpu_isolation_guard = _build_gpu_isolation_guard()
+    kv_params = KVCacheParams(
+        dtype=DType.bfloat16,
+        devices=[DeviceRef.GPU()],
+        n_kv_heads=config["num_key_value_heads"],
+        head_dim=config["head_dim"],
+        num_layers=kv_num_layers,
+        page_size=PAGE_SIZE,
+    )
+    weight_registry = _make_weight_registry(config)
+    baseline = _build_graph(
+        session=session,
+        kv_params=kv_params,
+        config=config,
+        weight_registry=weight_registry,
+        graph_variant=baseline_graph_variant,
+        layer_idx=layer_idx,
+        layer_type=layer_type,
+    )
+    fused = _build_graph(
+        session=session,
+        kv_params=kv_params,
+        config=config,
+        weight_registry=weight_registry,
+        graph_variant=fused_graph_variant,
+        layer_idx=layer_idx,
+        layer_type=layer_type,
+    )
+
+    benchmark_config: dict[str, Any] = {
+        "dtype": "bfloat16",
+        "hidden_size": config["hidden_size"],
+        "head_dim": config["head_dim"],
+        "num_q_heads": config["num_attention_heads"],
+        "num_kv_heads": config["num_key_value_heads"],
+        "page_size": PAGE_SIZE,
+        "layer_idx": layer_idx,
+        "layer_type": layer_type,
+        "kv_num_layers": kv_num_layers,
+        "mode": comparison_mode,
+        "baseline_graph_variant": baseline_graph_variant,
+        "fused_graph_variant": fused_graph_variant,
+        "cache_len_base": CACHE_LEN_BASE,
+        "cache_len_step": CACHE_LEN_STEP,
+        "warmup_iters": WARMUP_ITERS,
+        "timed_iters": TIMED_ITERS,
+        "timing_order_mode": timing_order_mode,
+        "selected_shapes": [
+            f"decode_{layer_type}_layer{layer_idx}_bs{batch_size}_seq1_cache"
+            f"{CACHE_LEN_BASE}_step{CACHE_LEN_STEP}{run_name_suffix}"
+            for batch_size in BATCH_SIZES
+        ],
+    }
+    if gpu_isolation_guard is not None:
+        benchmark_config["gpu_isolation_guard"] = {
+            "allowed_pid": gpu_isolation_guard["allowed_pid"],
+            "target_gpu_index": gpu_isolation_guard["target_gpu_index"],
+            "target_gpu_uuid": gpu_isolation_guard["target_gpu_uuid"],
+        }
+    results_json_path = os.environ.get("PROFILE_ATTENTION_DECODE_RESULTS_JSON")
+    if results_json_path:
+        benchmark_config["results_json_env"] = (
+            "PROFILE_ATTENTION_DECODE_RESULTS_JSON"
+        )
+        benchmark_config["results_json_path"] = results_json_path
+
+    if timing_order_mode == "both_orders":
+        results: dict[str, Any] = {
+            "benchmark_config": benchmark_config,
+            "correctness": "pass",
+            "progress": {
+                "last_completed_stage": "initialized",
+                "updated_at_utc": time.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+                ),
+            },
+            "ordered_sweep_us": {},
+            "order_position_us": {},
+            "order_slowdown_ratio_when_second": {},
+            "pair_speedup_ratio_by_order": {},
+        }
+    else:
+        results = {
+            "benchmark_config": benchmark_config,
+            "correctness": "pass",
+            "progress": {
+                "last_completed_stage": "initialized",
+                "updated_at_utc": time.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+                ),
+            },
+            "first_sweep_us": {},
+            "confirm_sweep_us": {},
+            "average_us": {},
+            "average_speedup_ratio_vs_baseline_graph": {},
+        }
+    _write_results_json_if_requested(results)
+
+    for batch_size in BATCH_SIZES:
+        cache_lengths, runtime_inputs = _make_runtime_inputs(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+        )
+        run_name = (
+            f"decode_{layer_type}_layer{layer_idx}_bs{batch_size}_seq1_cache"
+            f"{CACHE_LEN_BASE}_step{CACHE_LEN_STEP}{run_name_suffix}"
+        )
+
+        correctness_baseline_args, correctness_baseline_blocks = _make_benchmark_args(
+            batch_size=batch_size,
+            hidden_size=config["hidden_size"],
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            x_seed=100 + batch_size,
+            blocks_seed=200 + batch_size,
+        )
+        correctness_fused_args, correctness_fused_blocks = _make_benchmark_args(
+            batch_size=batch_size,
+            hidden_size=config["hidden_size"],
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            x_seed=100 + batch_size,
+            blocks_seed=200 + batch_size,
+        )
+        _run_correctness_check(
+            baseline=baseline,
+            fused=fused,
+            baseline_args=correctness_baseline_args[0],
+            fused_args=correctness_fused_args[0],
+            layer_idx=layer_idx,
+        )
+        del correctness_baseline_blocks
+        del correctness_fused_blocks
+        del correctness_baseline_args
+        del correctness_fused_args
+        torch.cuda.empty_cache()
+
+        if timing_order_mode == "both_orders":
+            forward_baseline_args, _ = _make_benchmark_args(
+                batch_size=batch_size,
+                hidden_size=config["hidden_size"],
+                cache_lengths=cache_lengths,
+                runtime_inputs=runtime_inputs,
+                device=device,
+                x_seed=300 + batch_size,
+                blocks_seed=400 + batch_size,
+            )
+            forward_fused_args, _ = _make_benchmark_args(
+                batch_size=batch_size,
+                hidden_size=config["hidden_size"],
+                cache_lengths=cache_lengths,
+                runtime_inputs=runtime_inputs,
+                device=device,
+                x_seed=300 + batch_size,
+                blocks_seed=400 + batch_size,
+            )
+            forward_order = _benchmark_pair_order(
+                compiled_graphs={
+                    "baseline": baseline,
+                    "fused": fused,
+                },
+                benchmark_args={
+                    "baseline": forward_baseline_args,
+                    "fused": forward_fused_args,
+                },
+                order=("baseline", "fused"),
+                gpu_isolation_guard=gpu_isolation_guard,
+                run_name=f"{run_name}:baseline_then_fused",
+            )
+            del forward_baseline_args
+            del forward_fused_args
+            torch.cuda.empty_cache()
+
+            reverse_baseline_args, _ = _make_benchmark_args(
+                batch_size=batch_size,
+                hidden_size=config["hidden_size"],
+                cache_lengths=cache_lengths,
+                runtime_inputs=runtime_inputs,
+                device=device,
+                x_seed=500 + batch_size,
+                blocks_seed=600 + batch_size,
+            )
+            reverse_fused_args, _ = _make_benchmark_args(
+                batch_size=batch_size,
+                hidden_size=config["hidden_size"],
+                cache_lengths=cache_lengths,
+                runtime_inputs=runtime_inputs,
+                device=device,
+                x_seed=500 + batch_size,
+                blocks_seed=600 + batch_size,
+            )
+            reverse_order = _benchmark_pair_order(
+                compiled_graphs={
+                    "baseline": baseline,
+                    "fused": fused,
+                },
+                benchmark_args={
+                    "baseline": reverse_baseline_args,
+                    "fused": reverse_fused_args,
+                },
+                order=("fused", "baseline"),
+                gpu_isolation_guard=gpu_isolation_guard,
+                run_name=f"{run_name}:fused_then_baseline",
+            )
+            del reverse_baseline_args
+            del reverse_fused_args
+            torch.cuda.empty_cache()
+
+            results["ordered_sweep_us"][run_name] = {
+                "baseline_then_fused": forward_order,
+                "fused_then_baseline": reverse_order,
+            }
+            results["order_position_us"][run_name] = {
+                "baseline_first": forward_order["baseline"],
+                "baseline_second": reverse_order["baseline"],
+                "fused_first": reverse_order["fused"],
+                "fused_second": forward_order["fused"],
+            }
+            results["order_slowdown_ratio_when_second"][run_name] = {
+                "baseline": reverse_order["baseline"] / forward_order["baseline"],
+                "fused": forward_order["fused"] / reverse_order["fused"],
+            }
+            results["pair_speedup_ratio_by_order"][run_name] = {
+                "baseline_then_fused": (
+                    forward_order["baseline"] / forward_order["fused"]
+                ),
+                "fused_then_baseline": (
+                    reverse_order["baseline"] / reverse_order["fused"]
+                ),
+            }
+            _mark_results_progress(results, f"{run_name}:order_probe_complete")
+            continue
+
+        first_baseline_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            hidden_size=config["hidden_size"],
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            x_seed=300 + batch_size,
+            blocks_seed=400 + batch_size,
+        )
+        first_fused_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            hidden_size=config["hidden_size"],
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            x_seed=300 + batch_size,
+            blocks_seed=400 + batch_size,
+        )
+        first_baseline_us = _benchmark_us_guarded(
+            baseline,
+            first_baseline_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:first:baseline",
+        )
+        first_fused_us = _benchmark_us_guarded(
+            fused,
+            first_fused_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:first:fused",
+        )
+        results["first_sweep_us"][run_name] = {
+            "baseline": first_baseline_us,
+            "fused": first_fused_us,
+        }
+        _mark_results_progress(results, f"{run_name}:first_sweep")
+        del first_baseline_args
+        del first_fused_args
+        torch.cuda.empty_cache()
+
+        confirm_baseline_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            hidden_size=config["hidden_size"],
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            x_seed=500 + batch_size,
+            blocks_seed=600 + batch_size,
+        )
+        confirm_fused_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            hidden_size=config["hidden_size"],
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            x_seed=500 + batch_size,
+            blocks_seed=600 + batch_size,
+        )
+        confirm_baseline_us = _benchmark_us_guarded(
+            baseline,
+            confirm_baseline_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:confirm:baseline",
+        )
+        confirm_fused_us = _benchmark_us_guarded(
+            fused,
+            confirm_fused_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:confirm:fused",
+        )
+        results["confirm_sweep_us"][run_name] = {
+            "baseline": confirm_baseline_us,
+            "fused": confirm_fused_us,
+        }
+        _mark_results_progress(results, f"{run_name}:confirm_sweep")
+        del confirm_baseline_args
+        del confirm_fused_args
+        torch.cuda.empty_cache()
+
+        average_baseline_us = (first_baseline_us + confirm_baseline_us) / 2.0
+        average_fused_us = (first_fused_us + confirm_fused_us) / 2.0
+        results["average_us"][run_name] = {
+            "baseline": average_baseline_us,
+            "fused": average_fused_us,
+        }
+        results["average_speedup_ratio_vs_baseline_graph"][run_name] = (
+            average_baseline_us / average_fused_us
+        )
+
+    if timing_order_mode == "both_orders":
+        baseline_slowdowns = [
+            run_results["baseline"]
+            for run_results in results["order_slowdown_ratio_when_second"].values()
+        ]
+        fused_slowdowns = [
+            run_results["fused"]
+            for run_results in results["order_slowdown_ratio_when_second"].values()
+        ]
+        results["order_slowdown_geomean_when_second"] = {
+            "baseline": float(np.exp(np.mean(np.log(baseline_slowdowns)))),
+            "fused": float(np.exp(np.mean(np.log(fused_slowdowns)))),
+        }
+        baseline_then_fused_speedups = [
+            run_results["baseline_then_fused"]
+            for run_results in results["pair_speedup_ratio_by_order"].values()
+        ]
+        fused_then_baseline_speedups = [
+            run_results["fused_then_baseline"]
+            for run_results in results["pair_speedup_ratio_by_order"].values()
+        ]
+        results["pair_speedup_geomean_by_order"] = {
+            "baseline_then_fused": float(
+                np.exp(np.mean(np.log(baseline_then_fused_speedups)))
+            ),
+            "fused_then_baseline": float(
+                np.exp(np.mean(np.log(fused_then_baseline_speedups)))
+            ),
+        }
+    else:
+        speedups = list(
+            results["average_speedup_ratio_vs_baseline_graph"].values()
+        )
+        results["average_geomean_speedup_vs_baseline_graph"] = float(
+            np.exp(np.mean(np.log(speedups)))
+        )
+    _mark_results_progress(results, "complete")
+
+    print("GEMMA3_ATTENTION_DECODE_PROFILE_START")
+    print(json.dumps(results, sort_keys=True))
+    print("GEMMA3_ATTENTION_DECODE_PROFILE_END")

--- a/max/tests/integration/architectures/gemma3/test_profile_attention_prefill.py
+++ b/max/tests/integration/architectures/gemma3/test_profile_attention_prefill.py
@@ -1,0 +1,1583 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from max.driver import Accelerator, Buffer
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Graph, TensorType, TensorValue, ops
+from max.interfaces import RequestID, TokenBuffer
+from max.kv_cache import PagedKVCacheManager
+from max.nn.attention import MHAMaskVariant
+from max.nn.kernels import (
+    KVCacheParams,
+    flash_attention_ragged,
+    fused_qk_ragged_rope,
+    fused_qkv_ragged_matmul,
+    k_rms_norm_rope_ragged,
+    q_rms_norm_fused_qk_ragged_rope,
+    rms_norm_key_cache,
+    rope_ragged,
+)
+from max.nn.kv_cache import (
+    AttentionDispatchResolver,
+    KVCacheInputsPerDevice,
+    PagedCacheValues,
+    build_max_lengths_tensor,
+    unflatten_ragged_attention_inputs,
+)
+from max.nn.rotary_embedding import Llama3RotaryEmbedding
+from max.pipelines.architectures.gemma3.layers.attention import (
+    Gemma3Attention as MaxGemma3Attention,
+)
+from max.pipelines.core import TextContext
+from torch.utils.dlpack import from_dlpack
+
+
+PAGE_SIZE = 128
+EPS = 1e-6
+DEFAULT_LAYER_IDX = 0
+DEFAULT_LAYER_TYPE = "local"
+DEFAULT_COMPARE_MODE = "baseline_vs_fused"
+DEFAULT_FUSED_VARIANT = "full"
+FUSED_VARIANTS = ("full", "k_only")
+Q_NORM_STD = 0.68
+K_NORM_STD = 0.793
+Q_PROJ_STD = 0.0284
+K_PROJ_STD = 0.0309
+V_PROJ_STD = 0.0309
+O_PROJ_STD = 0.0237
+WARMUP_ITERS = 20
+TIMED_ITERS = 50
+PREFILL_SHAPES = (
+    (1, 11),
+    (1, 512),
+    (1, 1024),
+    (1, 2048),
+    (2, 2048),
+)
+PLACEHOLDER_CACHE_LEN = 1
+PAIR_MATRIX_COMPARE_MODE = "manual_and_attention_pair_matrix"
+PAIR_MATRIX_GRAPH_SPECS = (
+    (
+        "manual_baseline_graph",
+        "manual_baseline_graph_vs_attention_baseline",
+        False,
+    ),
+    (
+        "attention_baseline",
+        "manual_baseline_graph_vs_attention_baseline",
+        True,
+    ),
+    (
+        "manual_fused_graph",
+        "manual_fused_graph_vs_attention_fused",
+        False,
+    ),
+    (
+        "attention_fused",
+        "manual_fused_graph_vs_attention_fused",
+        True,
+    ),
+)
+PAIR_MATRIX_PAIRS = (
+    ("manual_baseline_graph", "attention_baseline"),
+    ("manual_fused_graph", "attention_fused"),
+    ("manual_baseline_graph", "manual_fused_graph"),
+    ("attention_baseline", "attention_fused"),
+    ("manual_baseline_graph", "attention_fused"),
+    ("attention_baseline", "manual_fused_graph"),
+)
+
+
+def _resolve_layer_metadata(config: dict[str, Any]) -> tuple[int, str]:
+    layer_idx = int(
+        os.environ.get("PROFILE_ATTENTION_LAYER_IDX", str(DEFAULT_LAYER_IDX))
+    )
+    num_hidden_layers = int(config["num_hidden_layers"])
+    assert 0 <= layer_idx < num_hidden_layers, (
+        f"layer_idx={layer_idx} must be in [0, {num_hidden_layers})"
+    )
+    layer_type = (
+        "local"
+        if bool((layer_idx + 1) % config["sliding_window_pattern"])
+        else "global"
+    )
+    expected_layer_type = os.environ.get(
+        "PROFILE_ATTENTION_LAYER_TYPE", DEFAULT_LAYER_TYPE
+    )
+    assert (
+        layer_type == expected_layer_type
+    ), f"expected {expected_layer_type} layer, got {layer_type} for layer_idx={layer_idx}"
+    return layer_idx, layer_type
+
+
+def _resolve_kv_num_layers(config: dict[str, Any], layer_idx: int) -> int:
+    min_num_layers = layer_idx + 1
+    kv_num_layers = int(
+        os.environ.get("PROFILE_ATTENTION_KV_NUM_LAYERS", str(min_num_layers))
+    )
+    assert kv_num_layers >= min_num_layers, (
+        f"kv_num_layers={kv_num_layers} must cover layer_idx={layer_idx}"
+    )
+    assert kv_num_layers <= int(config["num_hidden_layers"]), (
+        "kv_num_layers cannot exceed the model layer count "
+        f"({config['num_hidden_layers']})"
+    )
+    return kv_num_layers
+
+
+def _resolve_compare_mode() -> str:
+    compare_mode = os.environ.get(
+        "PROFILE_ATTENTION_PREFILL_COMPARE_MODE", DEFAULT_COMPARE_MODE
+    ).strip()
+    if compare_mode in ("", DEFAULT_COMPARE_MODE):
+        return DEFAULT_COMPARE_MODE
+    if compare_mode == PAIR_MATRIX_COMPARE_MODE:
+        return compare_mode
+    if compare_mode == "manual_baseline_graph_vs_attention_baseline":
+        return compare_mode
+    if compare_mode == "manual_fused_graph_vs_attention_fused":
+        return compare_mode
+    raise ValueError(
+        "PROFILE_ATTENTION_PREFILL_COMPARE_MODE must be one of "
+        "{'baseline_vs_fused', 'manual_and_attention_pair_matrix', "
+        "'manual_baseline_graph_vs_attention_baseline', "
+        "'manual_fused_graph_vs_attention_fused'}, got "
+        f"{compare_mode!r}"
+    )
+
+
+def _resolve_fused_variant() -> str:
+    fused_variant = os.environ.get(
+        "PROFILE_ATTENTION_PREFILL_FUSED_VARIANT",
+        DEFAULT_FUSED_VARIANT,
+    ).strip()
+    if fused_variant in ("", DEFAULT_FUSED_VARIANT):
+        return DEFAULT_FUSED_VARIANT
+    if fused_variant in FUSED_VARIANTS:
+        return fused_variant
+    raise ValueError(
+        "PROFILE_ATTENTION_PREFILL_FUSED_VARIANT must be one of "
+        f"{FUSED_VARIANTS}, got {fused_variant!r}"
+    )
+
+
+def _resolve_prefill_shapes() -> tuple[tuple[int, int], ...]:
+    raw_shapes = os.environ.get("PROFILE_ATTENTION_PREFILL_SHAPES", "").strip()
+    if raw_shapes == "":
+        return PREFILL_SHAPES
+
+    resolved: list[tuple[int, int]] = []
+    for raw_shape in raw_shapes.split(","):
+        shape_text = raw_shape.strip().lower()
+        if shape_text == "":
+            continue
+        if "x" not in shape_text:
+            raise ValueError(
+                "PROFILE_ATTENTION_PREFILL_SHAPES entries must look like "
+                f"'batchxseq', got {raw_shape!r}"
+            )
+        batch_text, seq_text = shape_text.split("x", maxsplit=1)
+        shape = (int(batch_text), int(seq_text))
+        if shape not in PREFILL_SHAPES:
+            raise ValueError(
+                "PROFILE_ATTENTION_PREFILL_SHAPES only supports the existing "
+                f"prefill grid {PREFILL_SHAPES}, got {shape}"
+            )
+        if shape not in resolved:
+            resolved.append(shape)
+
+    if not resolved:
+        raise ValueError(
+            "PROFILE_ATTENTION_PREFILL_SHAPES must select at least one shape"
+        )
+    return tuple(resolved)
+
+
+def _load_text_config() -> dict[str, Any]:
+    config_path = Path(os.environ["PIPELINES_TESTDATA"]) / "config.json"
+    with open(config_path) as file:
+        data = json.load(file)
+    return data.get("text_config", data)
+
+
+def _make_weight_registry(config: dict[str, Any]) -> dict[str, torch.Tensor]:
+    torch.manual_seed(42)
+    q_dim = config["head_dim"] * config["num_attention_heads"]
+    kv_dim = config["head_dim"] * config["num_key_value_heads"]
+    hidden_size = config["hidden_size"]
+    return {
+        "k_norm.weight": torch.randn(
+            config["head_dim"], dtype=torch.bfloat16
+        )
+        * K_NORM_STD,
+        "k_proj.weight": torch.randn(
+            kv_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * K_PROJ_STD,
+        "o_proj.weight": torch.randn(
+            hidden_size, q_dim, dtype=torch.bfloat16
+        )
+        * O_PROJ_STD,
+        "q_norm.weight": torch.randn(
+            config["head_dim"], dtype=torch.bfloat16
+        )
+        * Q_NORM_STD,
+        "q_proj.weight": torch.randn(
+            q_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * Q_PROJ_STD,
+        "v_proj.weight": torch.randn(
+            kv_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * V_PROJ_STD,
+    }
+
+
+class _Gemma3AttentionBaseline(MaxGemma3Attention):
+    def __call__(
+        self,
+        x: TensorValue,
+        kv_collection: PagedCacheValues,
+        **kwargs,
+    ) -> TensorValue:
+        total_seq_len = x.shape[0]
+        layer_idx = ops.constant(
+            self.layer_idx, DType.uint32, device=DeviceRef.CPU()
+        )
+
+        xq = fused_qkv_ragged_matmul(
+            self.kv_params,
+            input=x,
+            wqkv=self.wqkv,
+            bias=self.wqkv_bias,
+            input_row_offsets=kwargs["input_row_offsets"],
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            n_heads=self.n_heads,
+        )
+        xq = xq.reshape((-1, self.n_heads, self.kv_params.head_dim))
+
+        use_local = bool((self.layer_idx + 1) % self.sliding_window_pattern)
+        rope = self.rope_local if use_local else self.rope_global
+        freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
+
+        rms_norm_key_cache(
+            self.kv_params,
+            kv_collection=kv_collection,
+            gamma=self.k_norm.weight.cast(self.kv_params.dtype).to(
+                self.devices[0]
+            ),
+            epsilon=self.qk_norm_eps,
+            layer_idx=layer_idx,
+            total_seq_len=total_seq_len,
+            input_row_offsets=kwargs["input_row_offsets"],
+            weight_offset=1.0,
+        )
+        xq = self.q_norm(xq)
+        xq = fused_qk_ragged_rope(
+            self.kv_params,
+            xq,
+            kwargs["input_row_offsets"],
+            kv_collection,
+            freqs_cis,
+            layer_idx,
+            interleaved=rope.interleaved,
+        )
+
+        mask_variant = (
+            MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK
+            if use_local
+            else MHAMaskVariant.CAUSAL_MASK
+        )
+        attn_out = flash_attention_ragged(
+            self.kv_params,
+            input=xq,
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            input_row_offsets=kwargs["input_row_offsets"],
+            mask_variant=mask_variant,
+            scale=self.scale,
+            local_window_size=self.local_window_size,
+        )
+        attn_out = ops.reshape(attn_out, shape=[total_seq_len, -1])
+        return self.o_proj(attn_out)
+
+
+class _Gemma3AttentionKOnlyFused(MaxGemma3Attention):
+    def __call__(
+        self,
+        x: TensorValue,
+        kv_collection: PagedCacheValues,
+        **kwargs,
+    ) -> TensorValue:
+        total_seq_len = x.shape[0]
+        layer_idx = ops.constant(
+            self.layer_idx, DType.uint32, device=DeviceRef.CPU()
+        )
+
+        xq = fused_qkv_ragged_matmul(
+            self.kv_params,
+            input=x,
+            wqkv=self.wqkv,
+            bias=self.wqkv_bias,
+            input_row_offsets=kwargs["input_row_offsets"],
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            n_heads=self.n_heads,
+        )
+        xq = xq.reshape((-1, self.n_heads, self.kv_params.head_dim))
+
+        use_local = bool((self.layer_idx + 1) % self.sliding_window_pattern)
+        rope = self.rope_local if use_local else self.rope_global
+        freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
+
+        k_rms_norm_rope_ragged(
+            self.kv_params,
+            total_seq_len=total_seq_len,
+            input_row_offsets=kwargs["input_row_offsets"],
+            kv_collection=kv_collection,
+            freqs_cis=freqs_cis,
+            gamma=self.k_norm.weight.cast(self.kv_params.dtype).to(
+                self.devices[0]
+            ),
+            epsilon=self.qk_norm_eps,
+            layer_idx=layer_idx,
+            weight_offset=1.0,
+            interleaved=rope.interleaved,
+        )
+        xq = self.q_norm(xq)
+        xq = rope_ragged(
+            xq,
+            kwargs["input_row_offsets"],
+            kv_collection.cache_lengths,
+            freqs_cis,
+            interleaved=rope.interleaved,
+        )
+
+        mask_variant = (
+            MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK
+            if use_local
+            else MHAMaskVariant.CAUSAL_MASK
+        )
+        attn_out = flash_attention_ragged(
+            self.kv_params,
+            input=xq,
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            input_row_offsets=kwargs["input_row_offsets"],
+            mask_variant=mask_variant,
+            scale=self.scale,
+            local_window_size=self.local_window_size,
+        )
+        attn_out = ops.reshape(attn_out, shape=[total_seq_len, -1])
+        return self.o_proj(attn_out)
+
+
+def _manual_attention_output(
+    *,
+    attention: MaxGemma3Attention,
+    kv_params: KVCacheParams,
+    x: TensorValue,
+    kv_collection: PagedCacheValues,
+    input_row_offsets: TensorValue,
+    use_fused_qk_rope: bool,
+) -> TensorValue:
+    total_seq_len = x.shape[0]
+    layer_idx = ops.constant(
+        attention.layer_idx, DType.uint32, device=DeviceRef.CPU()
+    )
+
+    xq = fused_qkv_ragged_matmul(
+        kv_params,
+        input=x,
+        wqkv=attention.wqkv,
+        bias=attention.wqkv_bias,
+        input_row_offsets=input_row_offsets,
+        kv_collection=kv_collection,
+        layer_idx=layer_idx,
+        n_heads=attention.n_heads,
+    )
+    xq = xq.reshape((-1, attention.n_heads, kv_params.head_dim))
+
+    use_local = bool((attention.layer_idx + 1) % attention.sliding_window_pattern)
+    rope = attention.rope_local if use_local else attention.rope_global
+    freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
+
+    if use_fused_qk_rope:
+        xq = q_rms_norm_fused_qk_ragged_rope(
+            kv_params,
+            xq,
+            input_row_offsets,
+            kv_collection,
+            freqs_cis,
+            attention.q_norm.weight.cast(kv_params.dtype).to(
+                attention.devices[0]
+            ),
+            attention.k_norm.weight.cast(kv_params.dtype).to(
+                attention.devices[0]
+            ),
+            attention.qk_norm_eps,
+            layer_idx,
+            weight_offset=1.0,
+            interleaved=rope.interleaved,
+        )
+    else:
+        rms_norm_key_cache(
+            kv_params,
+            kv_collection=kv_collection,
+            gamma=attention.k_norm.weight.cast(kv_params.dtype).to(
+                attention.devices[0]
+            ),
+            epsilon=attention.qk_norm_eps,
+            layer_idx=layer_idx,
+            total_seq_len=total_seq_len,
+            input_row_offsets=input_row_offsets,
+            weight_offset=1.0,
+        )
+        xq = attention.q_norm(xq)
+        xq = fused_qk_ragged_rope(
+            kv_params,
+            xq,
+            input_row_offsets,
+            kv_collection,
+            freqs_cis,
+            layer_idx,
+            interleaved=rope.interleaved,
+        )
+
+    mask_variant = (
+        MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK
+        if use_local
+        else MHAMaskVariant.CAUSAL_MASK
+    )
+    attn_out = flash_attention_ragged(
+        kv_params,
+        input=xq,
+        kv_collection=kv_collection,
+        layer_idx=layer_idx,
+        input_row_offsets=input_row_offsets,
+        mask_variant=mask_variant,
+        scale=attention.scale,
+        local_window_size=attention.local_window_size,
+    )
+    attn_out = ops.reshape(attn_out, shape=[total_seq_len, -1])
+    return attention.o_proj(attn_out)
+
+
+def _manual_baseline_attention_output(
+    *,
+    attention: MaxGemma3Attention,
+    kv_params: KVCacheParams,
+    x: TensorValue,
+    kv_collection: PagedCacheValues,
+    input_row_offsets: TensorValue,
+) -> TensorValue:
+    return _manual_attention_output(
+        attention=attention,
+        kv_params=kv_params,
+        x=x,
+        kv_collection=kv_collection,
+        input_row_offsets=input_row_offsets,
+        use_fused_qk_rope=False,
+    )
+
+
+def _manual_fused_attention_output(
+    *,
+    attention: MaxGemma3Attention,
+    kv_params: KVCacheParams,
+    x: TensorValue,
+    kv_collection: PagedCacheValues,
+    input_row_offsets: TensorValue,
+) -> TensorValue:
+    return _manual_attention_output(
+        attention=attention,
+        kv_params=kv_params,
+        x=x,
+        kv_collection=kv_collection,
+        input_row_offsets=input_row_offsets,
+        use_fused_qk_rope=True,
+    )
+
+
+def _make_placeholder_text_context(max_length: int) -> TextContext:
+    return TextContext(
+        request_id=RequestID(),
+        max_length=max_length,
+        tokens=TokenBuffer(np.zeros(PLACEHOLDER_CACHE_LEN, dtype=np.int64)),
+    )
+
+
+def _device_uint32_buffer(array: np.ndarray, device: Accelerator) -> Buffer:
+    return Buffer.from_numpy(array).to(device)
+
+
+def _run_nvidia_smi_query(query_fields: str) -> list[list[str]]:
+    result = subprocess.run(
+        [
+            "nvidia-smi",
+            f"--query-{query_fields}",
+            "--format=csv,noheader,nounits",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        [field.strip() for field in row]
+        for row in csv.reader(result.stdout.splitlines())
+        if row
+    ]
+
+
+def _build_gpu_isolation_guard() -> dict[str, Any] | None:
+    raw_guard = os.environ.get(
+        "PROFILE_ATTENTION_PREFILL_ENFORCE_GPU_ISOLATION", ""
+    ).strip()
+    if raw_guard.lower() not in ("1", "true", "yes"):
+        return None
+
+    cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", "").strip()
+    target_gpu_index = (
+        0 if cuda_visible_devices == "" else int(cuda_visible_devices.split(",")[0])
+    )
+
+    for index_text, gpu_uuid in _run_nvidia_smi_query("gpu=index,uuid"):
+        if int(index_text) == target_gpu_index:
+            return {
+                "allowed_pid": os.getpid(),
+                "target_gpu_index": target_gpu_index,
+                "target_gpu_uuid": gpu_uuid,
+            }
+
+    raise AssertionError(
+        "Could not resolve the target GPU UUID for "
+        f"CUDA_VISIBLE_DEVICES={cuda_visible_devices!r}"
+    )
+
+
+def _assert_gpu_isolation(
+    gpu_isolation_guard: dict[str, Any] | None,
+    *,
+    label: str,
+) -> None:
+    if gpu_isolation_guard is None:
+        return
+
+    resident_compute_apps = []
+    unexpected_apps = []
+    for gpu_uuid, pid_text, process_name, used_gpu_memory_mib in (
+        _run_nvidia_smi_query(
+            "compute-apps=gpu_uuid,pid,process_name,used_gpu_memory"
+        )
+    ):
+        if gpu_uuid != gpu_isolation_guard["target_gpu_uuid"]:
+            continue
+        resident_app = {
+            "gpu_uuid": gpu_uuid,
+            "pid": int(pid_text),
+            "process_name": process_name,
+            "used_gpu_memory_mib": float(used_gpu_memory_mib),
+        }
+        resident_compute_apps.append(resident_app)
+        if resident_app["pid"] != gpu_isolation_guard["allowed_pid"]:
+            unexpected_apps.append(resident_app)
+
+    if unexpected_apps:
+        raise AssertionError(
+            f"{label} at {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}: "
+            "unexpected compute apps on physical GPU "
+            f"{gpu_isolation_guard['target_gpu_index']} "
+            f"({gpu_isolation_guard['target_gpu_uuid']}): "
+            f"{unexpected_apps}; all resident apps: {resident_compute_apps}"
+        )
+
+
+def _row_offsets_array(batch_size: int, seq_len: int) -> np.ndarray:
+    return np.arange(
+        0,
+        (batch_size + 1) * seq_len,
+        seq_len,
+        dtype=np.uint32,
+    )
+
+
+def _prefill_run_name(
+    layer_type: str,
+    layer_idx: int,
+    batch_size: int,
+    seq_len: int,
+    compare_mode: str,
+    run_name_suffix: str = "",
+) -> str:
+    if compare_mode == PAIR_MATRIX_COMPARE_MODE:
+        suffix = "_cache0_step0_attention_pair_matrix"
+    elif compare_mode == "manual_baseline_graph_vs_attention_baseline":
+        suffix = "_cache0_step0_attention_baseline_graph_parity"
+    elif compare_mode == "manual_fused_graph_vs_attention_fused":
+        suffix = "_cache0_step0_attention_fused_graph_parity"
+    else:
+        suffix = f"_cache0_step0_attention{run_name_suffix}"
+    return (
+        f"prefill_{layer_type}_layer{layer_idx}_bs{batch_size}_seq{seq_len}"
+        f"{suffix}"
+    )
+
+
+def _build_graph(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    config: dict[str, Any],
+    weight_registry: dict[str, torch.Tensor],
+    batch_size: int,
+    seq_len: int,
+    use_fused: bool,
+    fused_variant: str,
+    layer_idx: int,
+    layer_type: str,
+    compare_mode: str,
+) -> Any:
+    device_ref = DeviceRef.GPU()
+    max_seq_len = seq_len + PLACEHOLDER_CACHE_LEN + 256
+    attention_cls: type[MaxGemma3Attention]
+    if compare_mode == "manual_baseline_graph_vs_attention_baseline":
+        attention_cls = _Gemma3AttentionBaseline
+        graph_variant = (
+            "AttentionBaseline" if use_fused else "ManualBaselineGraph"
+        )
+    elif compare_mode == "manual_fused_graph_vs_attention_fused":
+        attention_cls = MaxGemma3Attention
+        graph_variant = "AttentionFused" if use_fused else "ManualFusedGraph"
+    else:
+        if use_fused and fused_variant == "k_only":
+            attention_cls = _Gemma3AttentionKOnlyFused
+            graph_variant = "KOnlyFused"
+        else:
+            attention_cls = (
+                MaxGemma3Attention
+                if use_fused
+                else _Gemma3AttentionBaseline
+            )
+            graph_variant = "Fused" if use_fused else "Baseline"
+    attention = attention_cls(
+        rope_global=Llama3RotaryEmbedding(
+            config["hidden_size"],
+            config["num_attention_heads"],
+            config["rope_theta"],
+            max_seq_len,
+            interleaved=False,
+            head_dim=config["head_dim"],
+        ),
+        rope_local=Llama3RotaryEmbedding(
+            config["hidden_size"],
+            config["num_attention_heads"],
+            config["rope_local_base_freq"],
+            max_seq_len,
+            interleaved=False,
+            head_dim=config["head_dim"],
+        ),
+        num_attention_heads=config["num_attention_heads"],
+        num_key_value_heads=config["num_key_value_heads"],
+        hidden_size=config["hidden_size"],
+        kv_params=kv_params,
+        layer_idx=layer_idx,
+        dtype=DType.bfloat16,
+        devices=[device_ref],
+        qk_norm_eps=EPS,
+        sliding_window_pattern=config["sliding_window_pattern"],
+        local_window_size=config["sliding_window"],
+        has_bias=bool(config["attention_bias"]),
+    )
+    attention.load_state_dict(weight_registry)
+
+    input_type = TensorType(
+        DType.bfloat16,
+        ["total_seq_len", config["hidden_size"]],
+        device=device_ref,
+    )
+    input_row_offsets_type = TensorType(
+        DType.uint32,
+        [batch_size + 1],
+        device=device_ref,
+    )
+    flattened_kv_types = kv_params.get_symbolic_inputs().flatten()
+
+    graph_name = (
+        f"Gemma3AttentionPrefill{layer_type.title()}"
+        f"{graph_variant}BS{batch_size}Seq{seq_len}"
+    )
+
+    with Graph(
+        graph_name,
+        input_types=(input_type, input_row_offsets_type, *flattened_kv_types),
+    ) as graph:
+        x, input_row_offsets, *kv_cache = graph.inputs
+        kv_collection = unflatten_ragged_attention_inputs(
+            kv_cache, n_devices=1
+        )[0]
+        if (
+            compare_mode == "manual_baseline_graph_vs_attention_baseline"
+            and not use_fused
+        ):
+            graph.output(
+                _manual_baseline_attention_output(
+                    attention=attention,
+                    kv_params=kv_params,
+                    x=x.tensor,
+                    kv_collection=kv_collection,
+                    input_row_offsets=input_row_offsets.tensor,
+                )
+            )
+        elif (
+            compare_mode == "manual_fused_graph_vs_attention_fused"
+            and not use_fused
+        ):
+            graph.output(
+                _manual_fused_attention_output(
+                    attention=attention,
+                    kv_params=kv_params,
+                    x=x.tensor,
+                    kv_collection=kv_collection,
+                    input_row_offsets=input_row_offsets.tensor,
+                )
+            )
+        else:
+            graph.output(
+                attention(
+                    x.tensor,
+                    kv_collection,
+                    input_row_offsets=input_row_offsets.tensor,
+                )
+            )
+
+    return session.load(graph, weights_registry=attention.state_dict())
+
+
+def _make_runtime_inputs(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    seq_len: int,
+    device: Accelerator,
+) -> KVCacheInputsPerDevice:
+    max_cache_length = PLACEHOLDER_CACHE_LEN + seq_len
+    total_num_pages = batch_size * math.ceil(max_cache_length / PAGE_SIZE)
+    kv_manager = PagedKVCacheManager(
+        params=kv_params,
+        total_num_pages=total_num_pages,
+        session=session,
+        max_batch_size=batch_size,
+    )
+
+    contexts: list[TextContext] = []
+    for _ in range(batch_size):
+        context = _make_placeholder_text_context(max_cache_length)
+        kv_manager.claim(context.request_id, replica_idx=0)
+        kv_manager.alloc(
+            context,
+            replica_idx=0,
+            num_steps=seq_len,
+        )
+        contexts.append(context)
+
+    runtime_inputs = kv_manager.runtime_inputs(
+        [contexts],
+        num_steps=seq_len,
+    ).inputs[0]
+
+    # The placeholder TextContext leaves KV metadata in decode shape
+    # (`q_max_seq_len == 1`), but this harness is validating multi-token
+    # prefill. Rebuild the packed metadata to match cache0 step0 prefill.
+    dispatch_metadata = AttentionDispatchResolver(
+        devices=kv_params.devices,
+        is_mla=kv_params.is_mla,
+        n_kv_heads_per_device=kv_params.n_kv_heads_per_device,
+        num_q_heads_per_device=kv_params.num_q_heads_per_device,
+        is_fp8_kv=kv_params.is_fp8_kv_dtype,
+    ).resolve_for_replica(
+        batch_size,
+        seq_len,
+        seq_len,
+    )[0]
+
+    return KVCacheInputsPerDevice(
+        blocks=runtime_inputs.blocks,
+        cache_lengths=_device_uint32_buffer(
+            np.zeros(batch_size, dtype=np.uint32), device
+        ),
+        lookup_table=runtime_inputs.lookup_table,
+        max_lengths=build_max_lengths_tensor(1, seq_len, seq_len),
+        kv_scales=runtime_inputs.kv_scales,
+        attention_dispatch_metadata=dispatch_metadata,
+    )
+
+
+def _clone_kv_blocks(blocks: Buffer, seed: int) -> Buffer:
+    torch.manual_seed(seed)
+    shape = tuple(int(dim) for dim in blocks.shape)
+    tensor = torch.randn(shape, dtype=torch.bfloat16, device="cuda").contiguous()
+    return Buffer.from_dlpack(tensor)
+
+
+def _make_execution_args(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    device: Accelerator,
+    x_seed: int,
+    blocks_seed: int,
+) -> tuple[Any, ...]:
+    runtime_inputs = _make_runtime_inputs(
+        session=session,
+        kv_params=kv_params,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        device=device,
+    )
+
+    torch.manual_seed(x_seed)
+    x = torch.randn(
+        (batch_size * seq_len, hidden_size),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+
+    return (
+        Buffer.from_dlpack(x),
+        _device_uint32_buffer(_row_offsets_array(batch_size, seq_len), device),
+        _clone_kv_blocks(runtime_inputs.blocks, seed=blocks_seed),
+        runtime_inputs.cache_lengths,
+        runtime_inputs.lookup_table,
+        runtime_inputs.max_lengths,
+        runtime_inputs.attention_dispatch_metadata,
+    )
+
+
+def _run_correctness_check(
+    *,
+    baseline: Any,
+    fused: Any,
+    baseline_args: tuple[Any, ...],
+    fused_args: tuple[Any, ...],
+    layer_idx: int,
+) -> None:
+    baseline_output = baseline.execute(*baseline_args)[0]
+    fused_output = fused.execute(*fused_args)[0]
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        from_dlpack(baseline_output).to(torch.bfloat16),
+        from_dlpack(fused_output).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+    baseline_blocks = from_dlpack(baseline_args[2]).to(torch.bfloat16)[
+        :, :, layer_idx : layer_idx + 1, :, :, :
+    ]
+    fused_blocks = from_dlpack(fused_args[2]).to(torch.bfloat16)[
+        :, :, layer_idx : layer_idx + 1, :, :, :
+    ]
+    torch.testing.assert_close(
+        baseline_blocks,
+        fused_blocks,
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+
+def _to_bfloat16_tensor(value: Any) -> torch.Tensor:
+    return from_dlpack(value).to(torch.bfloat16).contiguous()
+
+
+def _pair_matrix_name(lhs_name: str, rhs_name: str) -> str:
+    return f"{lhs_name}_vs_{rhs_name}"
+
+
+def _pair_matrix_localization(
+    failures: list[dict[str, str]],
+) -> str:
+    failed_pairs = {failure["pair"] for failure in failures}
+    if failed_pairs == {"attention_baseline_vs_attention_fused"}:
+        return "production_pair_only_fails_with_manual_pairings_passing"
+    if "manual_baseline_graph_vs_attention_baseline" in failed_pairs:
+        return "baseline_wrapper_diverges_from_manual_baseline_graph"
+    if "manual_fused_graph_vs_attention_fused" in failed_pairs:
+        return "fused_wrapper_diverges_from_manual_fused_graph"
+    if "manual_baseline_graph_vs_manual_fused_graph" in failed_pairs:
+        return "manual_baseline_and_manual_fused_graphs_diverge"
+    if "attention_baseline_vs_attention_fused" in failed_pairs:
+        return "production_baseline_and_fused_wrappers_diverge_in_pair_matrix"
+    return "pair_matrix_found_mixed_divergence"
+
+
+def _build_pair_matrix_graphs(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    config: dict[str, Any],
+    weight_registry: dict[str, torch.Tensor],
+    batch_size: int,
+    seq_len: int,
+    layer_idx: int,
+    layer_type: str,
+) -> dict[str, Any]:
+    graphs: dict[str, Any] = {}
+    for graph_name, compare_mode, use_fused in PAIR_MATRIX_GRAPH_SPECS:
+        graphs[graph_name] = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=use_fused,
+            fused_variant=DEFAULT_FUSED_VARIANT,
+            layer_idx=layer_idx,
+            layer_type=layer_type,
+            compare_mode=compare_mode,
+        )
+    return graphs
+
+
+def _make_pair_matrix_execution_args(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    device: Accelerator,
+    x_seed: int,
+    blocks_seed: int,
+) -> dict[str, tuple[Any, ...]]:
+    return {
+        graph_name: _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=hidden_size,
+            device=device,
+            x_seed=x_seed,
+            blocks_seed=blocks_seed,
+        )
+        for graph_name, _, _ in PAIR_MATRIX_GRAPH_SPECS
+    }
+
+
+def _compare_pair_matrix_tensors(
+    lhs_name: str,
+    rhs_name: str,
+    stage: str,
+    lhs_tensor: torch.Tensor,
+    rhs_tensor: torch.Tensor,
+) -> dict[str, str]:
+    result = {"status": "pass"}
+    try:
+        torch.testing.assert_close(
+            lhs_tensor,
+            rhs_tensor,
+            rtol=2 * torch.finfo(torch.bfloat16).eps,
+            atol=8 * torch.finfo(torch.bfloat16).eps,
+        )
+    except AssertionError as exc:
+        result = {
+            "status": "failed",
+            "details": str(exc),
+            "stage": stage,
+            "pair": _pair_matrix_name(lhs_name, rhs_name),
+        }
+    return result
+
+
+def _run_pair_matrix_correctness_check(
+    *,
+    compiled: dict[str, Any],
+    execution_args: dict[str, tuple[Any, ...]],
+    layer_idx: int,
+) -> tuple[dict[str, Any], list[dict[str, str]]]:
+    outputs = {
+        graph_name: _to_bfloat16_tensor(compiled_graph.execute(*execution_args[graph_name])[0])
+        for graph_name, compiled_graph in compiled.items()
+    }
+    torch.cuda.synchronize()
+
+    kv_blocks = {
+        graph_name: _to_bfloat16_tensor(graph_args[2])[
+            :, :, layer_idx : layer_idx + 1, :, :, :
+        ]
+        for graph_name, graph_args in execution_args.items()
+    }
+
+    pair_results: dict[str, Any] = {}
+    failures: list[dict[str, str]] = []
+    for lhs_name, rhs_name in PAIR_MATRIX_PAIRS:
+        pair_name = _pair_matrix_name(lhs_name, rhs_name)
+        attention_output_result = _compare_pair_matrix_tensors(
+            lhs_name,
+            rhs_name,
+            "attention_output",
+            outputs[lhs_name],
+            outputs[rhs_name],
+        )
+        kv_result = _compare_pair_matrix_tensors(
+            lhs_name,
+            rhs_name,
+            "kv_cache_layer_slice",
+            kv_blocks[lhs_name],
+            kv_blocks[rhs_name],
+        )
+        pair_results[pair_name] = {
+            "attention_output": attention_output_result,
+            "kv_cache_layer_slice": kv_result,
+        }
+        for result in (attention_output_result, kv_result):
+            if result["status"] == "failed":
+                failures.append(
+                    {
+                        "pair": result["pair"],
+                        "stage": result["stage"],
+                        "details": result["details"],
+                    }
+                )
+
+    return pair_results, failures
+
+
+def _benchmark_us(compiled: Any, args: list[tuple[Any, ...]]) -> float:
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def _benchmark_us_guarded(
+    compiled: Any,
+    args: list[tuple[Any, ...]],
+    *,
+    gpu_isolation_guard: dict[str, Any] | None,
+    label: str,
+) -> float:
+    _assert_gpu_isolation(
+        gpu_isolation_guard,
+        label=f"{label}:before_warmup",
+    )
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    _assert_gpu_isolation(
+        gpu_isolation_guard,
+        label=f"{label}:after_timed",
+    )
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def _geomean(values: list[float]) -> float:
+    return math.exp(sum(math.log(value) for value in values) / len(values))
+
+
+def test_profile_attention_prefill() -> None:
+    config = _load_text_config()
+    layer_idx, layer_type = _resolve_layer_metadata(config)
+    kv_num_layers = _resolve_kv_num_layers(config, layer_idx)
+    compare_mode = _resolve_compare_mode()
+    fused_variant = _resolve_fused_variant()
+    prefill_shapes = _resolve_prefill_shapes()
+    session = InferenceSession(devices=[Accelerator(0)])
+    device = Accelerator(0)
+    gpu_isolation_guard = _build_gpu_isolation_guard()
+    kv_params = KVCacheParams(
+        dtype=DType.bfloat16,
+        devices=[DeviceRef.GPU()],
+        n_kv_heads=config["num_key_value_heads"],
+        head_dim=config["head_dim"],
+        num_layers=kv_num_layers,
+        page_size=PAGE_SIZE,
+    )
+    weight_registry = _make_weight_registry(config)
+    run_name_suffix = (
+        "_k_only"
+        if compare_mode == DEFAULT_COMPARE_MODE and fused_variant == "k_only"
+        else ""
+    )
+
+    if (
+        compare_mode != DEFAULT_COMPARE_MODE
+        and fused_variant != DEFAULT_FUSED_VARIANT
+    ):
+        raise ValueError(
+            "PROFILE_ATTENTION_PREFILL_FUSED_VARIANT only supports the "
+            "baseline_vs_fused compare mode"
+        )
+
+    if compare_mode == "manual_baseline_graph_vs_attention_baseline":
+        benchmark_mode = "prefill-ragged-full-attention-baseline-graph-parity"
+        baseline_impl = "manual_baseline_graph"
+        fused_impl = "attention_baseline"
+        ratio_metric_key = (
+            "average_runtime_ratio_manual_baseline_graph_over_"
+            "attention_baseline"
+        )
+        average_geomean_key = (
+            "average_geomean_runtime_ratio_manual_baseline_graph_over_"
+            "attention_baseline"
+        )
+        average_large_geomean_key = (
+            "average_large_shape_geomean_runtime_ratio_manual_baseline_graph_"
+            "over_attention_baseline"
+        )
+        confirm_geomean_key = (
+            "confirm_geomean_runtime_ratio_manual_baseline_graph_over_"
+            "attention_baseline"
+        )
+        confirm_large_geomean_key = (
+            "confirm_large_shape_geomean_runtime_ratio_manual_baseline_graph_"
+            "over_attention_baseline"
+        )
+    elif compare_mode == "manual_fused_graph_vs_attention_fused":
+        benchmark_mode = "prefill-ragged-full-attention-fused-graph-parity"
+        baseline_impl = "manual_fused_graph"
+        fused_impl = "attention_fused"
+        ratio_metric_key = (
+            "average_runtime_ratio_manual_fused_graph_over_attention_fused"
+        )
+        average_geomean_key = (
+            "average_geomean_runtime_ratio_manual_fused_graph_over_"
+            "attention_fused"
+        )
+        average_large_geomean_key = (
+            "average_large_shape_geomean_runtime_ratio_manual_fused_graph_"
+            "over_attention_fused"
+        )
+        confirm_geomean_key = (
+            "confirm_geomean_runtime_ratio_manual_fused_graph_over_"
+            "attention_fused"
+        )
+        confirm_large_geomean_key = (
+            "confirm_large_shape_geomean_runtime_ratio_manual_fused_graph_"
+            "over_attention_fused"
+        )
+    else:
+        benchmark_mode = (
+            "prefill-ragged-full-attention-k-only"
+            if fused_variant == "k_only"
+            else "prefill-ragged-full-attention"
+        )
+        baseline_impl = "attention_baseline"
+        fused_impl = (
+            "attention_k_only"
+            if fused_variant == "k_only"
+            else "attention_fused"
+        )
+        ratio_metric_key = "average_speedup_ratio_vs_attention_baseline"
+        average_geomean_key = "average_geomean_speedup_vs_attention_baseline"
+        average_large_geomean_key = (
+            "average_large_shape_geomean_speedup_vs_attention_baseline"
+        )
+        confirm_geomean_key = "confirm_geomean_speedup_vs_attention_baseline"
+        confirm_large_geomean_key = (
+            "confirm_large_shape_geomean_speedup_vs_attention_baseline"
+        )
+
+    results: dict[str, Any] = {
+        "benchmark_config": {
+            "dtype": "bfloat16",
+            "hidden_size": config["hidden_size"],
+            "head_dim": config["head_dim"],
+            "num_q_heads": config["num_attention_heads"],
+            "num_kv_heads": config["num_key_value_heads"],
+            "page_size": PAGE_SIZE,
+            "layer_idx": layer_idx,
+            "layer_type": layer_type,
+            "kv_num_layers": kv_num_layers,
+            "rope": "non-interleaved",
+            "mode": benchmark_mode,
+            "compare_mode": compare_mode,
+            "fused_variant": fused_variant,
+            "baseline_impl": baseline_impl,
+            "fused_impl": fused_impl,
+            "shapes": [
+                _prefill_run_name(
+                    layer_type,
+                    layer_idx,
+                    batch_size,
+                    seq_len,
+                    compare_mode,
+                    run_name_suffix,
+                )
+                for batch_size, seq_len in prefill_shapes
+            ],
+            "warmup_iters": WARMUP_ITERS,
+            "timed_iters": TIMED_ITERS,
+            "placeholder_cache_len": PLACEHOLDER_CACHE_LEN,
+        },
+        "correctness": "pass",
+        "first_sweep_us": {},
+        "confirm_sweep_us": {},
+        "average_us": {},
+        ratio_metric_key: {},
+    }
+
+    if gpu_isolation_guard is not None:
+        results["benchmark_config"]["gpu_isolation_guard"] = {
+            "allowed_pid": gpu_isolation_guard["allowed_pid"],
+            "target_gpu_index": gpu_isolation_guard["target_gpu_index"],
+            "target_gpu_uuid": gpu_isolation_guard["target_gpu_uuid"],
+        }
+
+    if compare_mode == PAIR_MATRIX_COMPARE_MODE:
+        results = {
+            "benchmark_config": {
+                "dtype": "bfloat16",
+                "hidden_size": config["hidden_size"],
+                "head_dim": config["head_dim"],
+                "num_q_heads": config["num_attention_heads"],
+                "num_kv_heads": config["num_key_value_heads"],
+                "page_size": PAGE_SIZE,
+                "layer_idx": layer_idx,
+                "layer_type": layer_type,
+                "kv_num_layers": kv_num_layers,
+                "rope": "non-interleaved",
+                "mode": "prefill-ragged-full-attention-pair-matrix",
+                "compare_mode": compare_mode,
+                "fused_variant": fused_variant,
+                "graph_names": [graph_name for graph_name, _, _ in PAIR_MATRIX_GRAPH_SPECS],
+                "pairs": [
+                    _pair_matrix_name(lhs_name, rhs_name)
+                    for lhs_name, rhs_name in PAIR_MATRIX_PAIRS
+                ],
+                "shapes": [
+                    _prefill_run_name(
+                        layer_type,
+                        layer_idx,
+                        batch_size,
+                        seq_len,
+                        compare_mode,
+                        run_name_suffix,
+                    )
+                    for batch_size, seq_len in prefill_shapes
+                ],
+                "placeholder_cache_len": PLACEHOLDER_CACHE_LEN,
+            },
+            "correctness": "pass",
+            "pair_results": {},
+        }
+
+        if gpu_isolation_guard is not None:
+            results["benchmark_config"]["gpu_isolation_guard"] = {
+                "allowed_pid": gpu_isolation_guard["allowed_pid"],
+                "target_gpu_index": gpu_isolation_guard["target_gpu_index"],
+                "target_gpu_uuid": gpu_isolation_guard["target_gpu_uuid"],
+            }
+
+        for batch_size, seq_len in prefill_shapes:
+            run_name = _prefill_run_name(
+                layer_type,
+                layer_idx,
+                batch_size,
+                seq_len,
+                compare_mode,
+                run_name_suffix,
+            )
+            compiled = _build_pair_matrix_graphs(
+                session=session,
+                kv_params=kv_params,
+                config=config,
+                weight_registry=weight_registry,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                layer_idx=layer_idx,
+                layer_type=layer_type,
+            )
+            correctness_args = _make_pair_matrix_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=1000 + batch_size + seq_len,
+                blocks_seed=2000 + batch_size + seq_len,
+            )
+            pair_results, failures = _run_pair_matrix_correctness_check(
+                compiled=compiled,
+                execution_args=correctness_args,
+                layer_idx=layer_idx,
+            )
+            results["pair_results"][run_name] = pair_results
+            if failures:
+                results["correctness"] = "failed"
+                results["failure_shape"] = run_name
+                results["failures"] = failures
+                results["localization"] = _pair_matrix_localization(
+                    failures
+                )
+                print("GEMMA3_ATTENTION_PREFILL_PROFILE_START")
+                print(json.dumps(results, indent=2, sort_keys=True))
+                print("GEMMA3_ATTENTION_PREFILL_PROFILE_END")
+                raise AssertionError(
+                    f"{run_name} pair-matrix failures: {failures}"
+                )
+
+            del correctness_args
+            del compiled
+            torch.cuda.empty_cache()
+
+        results["localization"] = "pair_matrix_passed_all_pairs"
+        print("GEMMA3_ATTENTION_PREFILL_PROFILE_START")
+        print(json.dumps(results, indent=2, sort_keys=True))
+        print("GEMMA3_ATTENTION_PREFILL_PROFILE_END")
+        return
+
+    large_shape_names: list[str] = []
+
+    for batch_size, seq_len in prefill_shapes:
+        run_name = _prefill_run_name(
+            layer_type,
+            layer_idx,
+            batch_size,
+            seq_len,
+            compare_mode,
+            run_name_suffix,
+        )
+        if seq_len >= 512:
+            large_shape_names.append(run_name)
+
+        baseline = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=False,
+            fused_variant=fused_variant,
+            layer_idx=layer_idx,
+            layer_type=layer_type,
+            compare_mode=compare_mode,
+        )
+        fused = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=True,
+            fused_variant=fused_variant,
+            layer_idx=layer_idx,
+            layer_type=layer_type,
+            compare_mode=compare_mode,
+        )
+
+        baseline_correctness_args = _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=config["hidden_size"],
+            device=device,
+            x_seed=1000 + batch_size + seq_len,
+            blocks_seed=2000 + batch_size + seq_len,
+        )
+        fused_correctness_args = _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=config["hidden_size"],
+            device=device,
+            x_seed=1000 + batch_size + seq_len,
+            blocks_seed=2000 + batch_size + seq_len,
+        )
+        _run_correctness_check(
+            baseline=baseline,
+            fused=fused,
+            baseline_args=baseline_correctness_args,
+            fused_args=fused_correctness_args,
+            layer_idx=layer_idx,
+        )
+        del baseline_correctness_args
+        del fused_correctness_args
+        torch.cuda.empty_cache()
+
+        first_baseline_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=3000 + batch_size + seq_len + iteration,
+                blocks_seed=4000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        first_fused_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=3000 + batch_size + seq_len + iteration,
+                blocks_seed=4000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        first_baseline_us = _benchmark_us_guarded(
+            baseline,
+            first_baseline_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:baseline:first_sweep",
+        )
+        first_fused_us = _benchmark_us_guarded(
+            fused,
+            first_fused_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:fused:first_sweep",
+        )
+        results["first_sweep_us"][run_name] = {
+            "baseline": first_baseline_us,
+            "fused": first_fused_us,
+        }
+        del first_baseline_args
+        del first_fused_args
+        torch.cuda.empty_cache()
+
+        confirm_baseline_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=5000 + batch_size + seq_len + iteration,
+                blocks_seed=6000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        confirm_fused_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=5000 + batch_size + seq_len + iteration,
+                blocks_seed=6000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        confirm_baseline_us = _benchmark_us_guarded(
+            baseline,
+            confirm_baseline_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:baseline:confirm_sweep",
+        )
+        confirm_fused_us = _benchmark_us_guarded(
+            fused,
+            confirm_fused_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:fused:confirm_sweep",
+        )
+        results["confirm_sweep_us"][run_name] = {
+            "baseline": confirm_baseline_us,
+            "fused": confirm_fused_us,
+        }
+        del confirm_baseline_args
+        del confirm_fused_args
+        torch.cuda.empty_cache()
+
+        average_baseline_us = (first_baseline_us + confirm_baseline_us) / 2.0
+        average_fused_us = (first_fused_us + confirm_fused_us) / 2.0
+        results["average_us"][run_name] = {
+            "baseline": average_baseline_us,
+            "fused": average_fused_us,
+        }
+        results[ratio_metric_key][run_name] = average_baseline_us / average_fused_us
+
+        del baseline
+        del fused
+        torch.cuda.empty_cache()
+
+    ratios = list(results[ratio_metric_key].values())
+    results[average_geomean_key] = _geomean(ratios)
+    results[average_large_geomean_key] = _geomean(
+        [
+            results[ratio_metric_key][run_name]
+            for run_name in large_shape_names
+        ]
+    )
+
+    confirm_ratios = [
+        results["confirm_sweep_us"][run_name]["baseline"]
+        / results["confirm_sweep_us"][run_name]["fused"]
+        for run_name in results["confirm_sweep_us"]
+    ]
+    results[confirm_geomean_key] = _geomean(confirm_ratios)
+    results[confirm_large_geomean_key] = _geomean(
+        [
+            results["confirm_sweep_us"][run_name]["baseline"]
+            / results["confirm_sweep_us"][run_name]["fused"]
+            for run_name in large_shape_names
+        ]
+    )
+    if gpu_isolation_guard is not None:
+        results["gpu_isolation_guard"] = "pass"
+
+    print("GEMMA3_ATTENTION_PREFILL_PROFILE_START")
+    print(json.dumps(results, indent=2, sort_keys=True))
+    print("GEMMA3_ATTENTION_PREFILL_PROFILE_END")

--- a/max/tests/integration/architectures/gemma3/test_profile_attention_tail_prefill_bridge.py
+++ b/max/tests/integration/architectures/gemma3/test_profile_attention_tail_prefill_bridge.py
@@ -1,0 +1,788 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from max.driver import Accelerator, Buffer
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Graph, TensorType, ops
+from max.interfaces import RequestID, TokenBuffer
+from max.kv_cache import PagedKVCacheManager
+from max.nn.attention import MHAMaskVariant
+from max.nn.kernels import (
+    KVCacheParams,
+    flash_attention_ragged,
+    fused_qk_ragged_rope,
+    fused_qkv_ragged_matmul,
+    q_rms_norm_fused_qk_ragged_rope,
+    rms_norm_key_cache,
+)
+from max.nn.kv_cache import (
+    AttentionDispatchResolver,
+    KVCacheInputsPerDevice,
+    build_max_lengths_tensor,
+    unflatten_ragged_attention_inputs,
+)
+from max.nn.linear import Linear
+from max.nn.rotary_embedding import Llama3RotaryEmbedding
+from max.pipelines.architectures.gemma3.layers.attention import (
+    Gemma3Attention as MaxGemma3Attention,
+)
+from max.pipelines.core import TextContext
+from torch.utils.dlpack import from_dlpack
+
+
+PAGE_SIZE = 128
+EPS = 1e-6
+DEFAULT_LAYER_IDX = 0
+DEFAULT_LAYER_TYPE = "local"
+Q_NORM_STD = 0.68
+K_NORM_STD = 0.793
+Q_PROJ_STD = 0.0284
+K_PROJ_STD = 0.0309
+V_PROJ_STD = 0.0309
+O_PROJ_STD = 0.0237
+WARMUP_ITERS = 20
+TIMED_ITERS = 50
+PREFILL_SHAPES = (
+    (1, 11),
+    (1, 512),
+    (1, 1024),
+    (1, 2048),
+    (2, 2048),
+)
+PLACEHOLDER_CACHE_LEN = 1
+
+
+def _resolve_layer_metadata(config: dict[str, Any]) -> tuple[int, str]:
+    layer_idx = int(
+        os.environ.get("PROFILE_ATTENTION_LAYER_IDX", str(DEFAULT_LAYER_IDX))
+    )
+    num_hidden_layers = int(config["num_hidden_layers"])
+    assert 0 <= layer_idx < num_hidden_layers, (
+        f"layer_idx={layer_idx} must be in [0, {num_hidden_layers})"
+    )
+    layer_type = (
+        "local"
+        if bool((layer_idx + 1) % config["sliding_window_pattern"])
+        else "global"
+    )
+    expected_layer_type = os.environ.get(
+        "PROFILE_ATTENTION_LAYER_TYPE", DEFAULT_LAYER_TYPE
+    )
+    assert (
+        layer_type == expected_layer_type
+    ), f"expected {expected_layer_type} layer, got {layer_type} for layer_idx={layer_idx}"
+    return layer_idx, layer_type
+
+
+def _resolve_kv_num_layers(config: dict[str, Any], layer_idx: int) -> int:
+    min_num_layers = layer_idx + 1
+    kv_num_layers = int(
+        os.environ.get("PROFILE_ATTENTION_KV_NUM_LAYERS", str(min_num_layers))
+    )
+    assert kv_num_layers >= min_num_layers, (
+        f"kv_num_layers={kv_num_layers} must cover layer_idx={layer_idx}"
+    )
+    assert kv_num_layers <= int(config["num_hidden_layers"]), (
+        "kv_num_layers cannot exceed the model layer count "
+        f"({config['num_hidden_layers']})"
+    )
+    return kv_num_layers
+
+
+def _resolve_flash_mask_config(
+    *,
+    use_local: bool,
+    default_local_window_size: int,
+) -> tuple[MHAMaskVariant, int, str]:
+    mask_override = os.environ.get(
+        "PROFILE_FLASH_ATTENTION_MASK_VARIANT", "layer_default"
+    ).strip()
+    local_window_override = os.environ.get(
+        "PROFILE_FLASH_ATTENTION_LOCAL_WINDOW_SIZE"
+    )
+
+    if local_window_override is None:
+        local_window_size = default_local_window_size if use_local else -1
+    else:
+        local_window_size = int(local_window_override)
+
+    if mask_override in ("", "layer_default"):
+        return (
+            (
+                MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK
+                if use_local
+                else MHAMaskVariant.CAUSAL_MASK
+            ),
+            local_window_size,
+            "layer_default",
+        )
+
+    if mask_override == "causal":
+        return MHAMaskVariant.CAUSAL_MASK, -1, mask_override
+
+    if mask_override == "sliding_window_causal":
+        return (
+            MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK,
+            local_window_size,
+            mask_override,
+        )
+
+    raise ValueError(
+        "PROFILE_FLASH_ATTENTION_MASK_VARIANT must be one of "
+        "{'layer_default', 'causal', 'sliding_window_causal'}, got "
+        f"{mask_override!r}"
+    )
+
+
+def _load_text_config() -> dict[str, Any]:
+    config_path = Path(os.environ["PIPELINES_TESTDATA"]) / "config.json"
+    with open(config_path) as file:
+        data = json.load(file)
+    return data.get("text_config", data)
+
+
+def _make_weight_registry(config: dict[str, Any]) -> dict[str, torch.Tensor]:
+    torch.manual_seed(42)
+    q_dim = config["head_dim"] * config["num_attention_heads"]
+    kv_dim = config["head_dim"] * config["num_key_value_heads"]
+    hidden_size = config["hidden_size"]
+    return {
+        "k_norm.weight": torch.randn(
+            config["head_dim"], dtype=torch.bfloat16
+        )
+        * K_NORM_STD,
+        "k_proj.weight": torch.randn(
+            kv_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * K_PROJ_STD,
+        "o_proj.weight": torch.randn(
+            hidden_size, q_dim, dtype=torch.bfloat16
+        )
+        * O_PROJ_STD,
+        "q_norm.weight": torch.randn(
+            config["head_dim"], dtype=torch.bfloat16
+        )
+        * Q_NORM_STD,
+        "q_proj.weight": torch.randn(
+            q_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * Q_PROJ_STD,
+        "v_proj.weight": torch.randn(
+            kv_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * V_PROJ_STD,
+    }
+
+
+def _make_placeholder_text_context(max_length: int) -> TextContext:
+    return TextContext(
+        request_id=RequestID(),
+        max_length=max_length,
+        tokens=TokenBuffer(np.zeros(PLACEHOLDER_CACHE_LEN, dtype=np.int64)),
+    )
+
+
+def _device_uint32_buffer(array: np.ndarray, device: Accelerator) -> Buffer:
+    return Buffer.from_numpy(array).to(device)
+
+
+def _row_offsets_array(batch_size: int, seq_len: int) -> np.ndarray:
+    return np.arange(
+        0,
+        (batch_size + 1) * seq_len,
+        seq_len,
+        dtype=np.uint32,
+    )
+
+
+def _prefill_run_name(
+    layer_type: str,
+    layer_idx: int,
+    batch_size: int,
+    seq_len: int,
+) -> str:
+    return (
+        f"prefill_{layer_type}_layer{layer_idx}_bs{batch_size}_seq{seq_len}"
+        "_cache0_step0_attention_tail_bridge"
+    )
+
+
+def _build_flash_producer_graph(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    config: dict[str, Any],
+    weight_registry: dict[str, torch.Tensor],
+    batch_size: int,
+    seq_len: int,
+    use_fused: bool,
+    layer_idx: int,
+    layer_type: str,
+) -> Any:
+    device_ref = DeviceRef.GPU()
+    max_seq_len = seq_len + PLACEHOLDER_CACHE_LEN + 256
+    attention = MaxGemma3Attention(
+        rope_global=Llama3RotaryEmbedding(
+            config["hidden_size"],
+            config["num_attention_heads"],
+            config["rope_theta"],
+            max_seq_len,
+            interleaved=False,
+            head_dim=config["head_dim"],
+        ),
+        rope_local=Llama3RotaryEmbedding(
+            config["hidden_size"],
+            config["num_attention_heads"],
+            config["rope_local_base_freq"],
+            max_seq_len,
+            interleaved=False,
+            head_dim=config["head_dim"],
+        ),
+        num_attention_heads=config["num_attention_heads"],
+        num_key_value_heads=config["num_key_value_heads"],
+        hidden_size=config["hidden_size"],
+        kv_params=kv_params,
+        layer_idx=layer_idx,
+        dtype=DType.bfloat16,
+        devices=[device_ref],
+        qk_norm_eps=EPS,
+        sliding_window_pattern=config["sliding_window_pattern"],
+        local_window_size=config["sliding_window"],
+        has_bias=bool(config["attention_bias"]),
+    )
+    attention.load_state_dict(weight_registry)
+
+    input_type = TensorType(
+        DType.bfloat16,
+        ["total_seq_len", config["hidden_size"]],
+        device=device_ref,
+    )
+    input_row_offsets_type = TensorType(
+        DType.uint32,
+        [batch_size + 1],
+        device=device_ref,
+    )
+    flattened_kv_types = kv_params.get_symbolic_inputs().flatten()
+
+    graph_name = (
+        "Gemma3AttentionTailPrefillFlashProducer"
+        f"{layer_type.title()}FusedBS{batch_size}Seq{seq_len}"
+        if use_fused
+        else "Gemma3AttentionTailPrefillFlashProducer"
+        f"{layer_type.title()}BaselineBS{batch_size}Seq{seq_len}"
+    )
+
+    with Graph(
+        graph_name,
+        input_types=(input_type, input_row_offsets_type, *flattened_kv_types),
+    ) as graph:
+        x, input_row_offsets, *kv_cache = graph.inputs
+        kv_collection = unflatten_ragged_attention_inputs(
+            kv_cache, n_devices=1
+        )[0]
+        graph_layer_idx = ops.constant(
+            layer_idx, DType.uint32, device=DeviceRef.CPU()
+        )
+        total_seq_len = x.tensor.shape[0]
+
+        xq = fused_qkv_ragged_matmul(
+            kv_params,
+            input=x.tensor,
+            wqkv=attention.wqkv,
+            bias=attention.wqkv_bias,
+            input_row_offsets=input_row_offsets.tensor,
+            kv_collection=kv_collection,
+            layer_idx=graph_layer_idx,
+            n_heads=attention.n_heads,
+        )
+        xq = xq.reshape((-1, attention.n_heads, kv_params.head_dim))
+
+        use_local = bool((layer_idx + 1) % attention.sliding_window_pattern)
+        assert use_local == (layer_type == "local")
+        rope = attention.rope_local if use_local else attention.rope_global
+        freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
+
+        if use_fused:
+            xq = q_rms_norm_fused_qk_ragged_rope(
+                kv_params,
+                xq,
+                input_row_offsets.tensor,
+                kv_collection,
+                freqs_cis,
+                attention.q_norm.weight.cast(kv_params.dtype).to(device_ref),
+                attention.k_norm.weight.cast(kv_params.dtype).to(device_ref),
+                EPS,
+                graph_layer_idx,
+                weight_offset=1.0,
+                interleaved=False,
+            )
+        else:
+            rms_norm_key_cache(
+                kv_params,
+                kv_collection=kv_collection,
+                gamma=attention.k_norm.weight.cast(kv_params.dtype).to(
+                    device_ref
+                ),
+                epsilon=EPS,
+                layer_idx=graph_layer_idx,
+                total_seq_len=total_seq_len,
+                input_row_offsets=input_row_offsets.tensor,
+                weight_offset=1.0,
+            )
+            xq = attention.q_norm(xq)
+            xq = fused_qk_ragged_rope(
+                kv_params,
+                xq,
+                input_row_offsets.tensor,
+                kv_collection,
+                freqs_cis,
+                graph_layer_idx,
+                interleaved=False,
+            )
+
+        mask_variant, local_window_size, _ = _resolve_flash_mask_config(
+            use_local=use_local,
+            default_local_window_size=attention.local_window_size,
+        )
+        attn_out = flash_attention_ragged(
+            kv_params,
+            input=xq,
+            kv_collection=kv_collection,
+            layer_idx=graph_layer_idx,
+            input_row_offsets=input_row_offsets.tensor,
+            mask_variant=mask_variant,
+            scale=attention.scale,
+            local_window_size=local_window_size,
+        )
+        graph.output(attn_out)
+
+    return session.load(graph, weights_registry=attention.state_dict())
+
+
+def _build_tail_consumer_graph(
+    *,
+    session: InferenceSession,
+    config: dict[str, Any],
+    weight_registry: dict[str, torch.Tensor],
+) -> Any:
+    o_proj = Linear(
+        in_dim=config["head_dim"] * config["num_attention_heads"],
+        out_dim=config["hidden_size"],
+        dtype=DType.bfloat16,
+        device=DeviceRef.GPU(),
+        name="o_proj",
+    )
+
+    attn_out_type = TensorType(
+        DType.bfloat16,
+        [
+            "total_seq_len",
+            config["num_attention_heads"],
+            config["head_dim"],
+        ],
+        device=DeviceRef.GPU(),
+    )
+    with Graph(
+        "Gemma3AttentionTailPrefillConsumer",
+        input_types=(attn_out_type,),
+    ) as graph:
+        (attn_out,) = graph.inputs
+        total_seq_len = attn_out.tensor.shape[0]
+        flattened = ops.reshape(attn_out.tensor, shape=[total_seq_len, -1])
+        graph.output(o_proj(flattened))
+
+    return session.load(
+        graph,
+        weights_registry={"o_proj.weight": weight_registry["o_proj.weight"]},
+    )
+
+
+def _make_runtime_inputs(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    seq_len: int,
+    device: Accelerator,
+) -> KVCacheInputsPerDevice:
+    max_cache_length = PLACEHOLDER_CACHE_LEN + seq_len
+    total_num_pages = batch_size * math.ceil(max_cache_length / PAGE_SIZE)
+    kv_manager = PagedKVCacheManager(
+        params=kv_params,
+        total_num_pages=total_num_pages,
+        session=session,
+        max_batch_size=batch_size,
+    )
+
+    contexts: list[TextContext] = []
+    for _ in range(batch_size):
+        context = _make_placeholder_text_context(max_cache_length)
+        kv_manager.claim(context.request_id, replica_idx=0)
+        kv_manager.alloc(
+            context,
+            replica_idx=0,
+            num_steps=seq_len,
+        )
+        contexts.append(context)
+
+    runtime_inputs = kv_manager.runtime_inputs(
+        [contexts],
+        num_steps=seq_len,
+    ).inputs[0]
+
+    dispatch_metadata = AttentionDispatchResolver(
+        devices=kv_params.devices,
+        is_mla=kv_params.is_mla,
+        n_kv_heads_per_device=kv_params.n_kv_heads_per_device,
+        num_q_heads_per_device=kv_params.num_q_heads_per_device,
+        is_fp8_kv=kv_params.is_fp8_kv_dtype,
+    ).resolve_for_replica(
+        batch_size,
+        seq_len,
+        seq_len,
+    )[0]
+
+    return KVCacheInputsPerDevice(
+        blocks=runtime_inputs.blocks,
+        cache_lengths=_device_uint32_buffer(
+            np.zeros(batch_size, dtype=np.uint32), device
+        ),
+        lookup_table=runtime_inputs.lookup_table,
+        max_lengths=build_max_lengths_tensor(1, seq_len, seq_len),
+        kv_scales=runtime_inputs.kv_scales,
+        attention_dispatch_metadata=dispatch_metadata,
+    )
+
+
+def _clone_kv_blocks(blocks: Buffer, seed: int) -> Buffer:
+    torch.manual_seed(seed)
+    shape = tuple(int(dim) for dim in blocks.shape)
+    tensor = torch.randn(shape, dtype=torch.bfloat16, device="cuda").contiguous()
+    return Buffer.from_dlpack(tensor)
+
+
+def _make_execution_args(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    device: Accelerator,
+    x_seed: int,
+    blocks_seed: int,
+) -> tuple[Any, ...]:
+    runtime_inputs = _make_runtime_inputs(
+        session=session,
+        kv_params=kv_params,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        device=device,
+    )
+
+    torch.manual_seed(x_seed)
+    x = torch.randn(
+        (batch_size * seq_len, hidden_size),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+
+    return (
+        Buffer.from_dlpack(x),
+        _device_uint32_buffer(_row_offsets_array(batch_size, seq_len), device),
+        _clone_kv_blocks(runtime_inputs.blocks, seed=blocks_seed),
+        runtime_inputs.cache_lengths,
+        runtime_inputs.lookup_table,
+        runtime_inputs.max_lengths,
+        runtime_inputs.attention_dispatch_metadata,
+    )
+
+
+def _materialize_attn_out(
+    producer: Any,
+    producer_args: tuple[Any, ...],
+) -> torch.Tensor:
+    attn_out = producer.execute(*producer_args)[0]
+    torch.cuda.synchronize()
+    return from_dlpack(attn_out).to(torch.bfloat16).contiguous()
+
+
+def _run_correctness_check(
+    *,
+    baseline_producer: Any,
+    fused_producer: Any,
+    tail_consumer: Any,
+    baseline_args: tuple[Any, ...],
+    fused_args: tuple[Any, ...],
+    layer_idx: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    baseline_attn_out = _materialize_attn_out(baseline_producer, baseline_args)
+    fused_attn_out = _materialize_attn_out(fused_producer, fused_args)
+
+    torch.testing.assert_close(
+        baseline_attn_out,
+        fused_attn_out,
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+    baseline_output = tail_consumer.execute(baseline_attn_out)[0]
+    fused_output = tail_consumer.execute(fused_attn_out)[0]
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        from_dlpack(baseline_output).to(torch.bfloat16),
+        from_dlpack(fused_output).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+    baseline_blocks = from_dlpack(baseline_args[2]).to(torch.bfloat16)[
+        :, :, layer_idx : layer_idx + 1, :, :, :
+    ]
+    fused_blocks = from_dlpack(fused_args[2]).to(torch.bfloat16)[
+        :, :, layer_idx : layer_idx + 1, :, :, :
+    ]
+    torch.testing.assert_close(
+        baseline_blocks,
+        fused_blocks,
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+    return baseline_attn_out, fused_attn_out
+
+
+def _benchmark_us(compiled: Any, arg: torch.Tensor) -> float:
+    for _ in range(WARMUP_ITERS):
+        compiled.execute(arg)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for _ in range(TIMED_ITERS):
+        compiled.execute(arg)
+    torch.cuda.synchronize()
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / TIMED_ITERS
+
+
+def _geomean(values: list[float]) -> float:
+    return math.exp(sum(math.log(value) for value in values) / len(values))
+
+
+def test_profile_attention_tail_prefill_bridge() -> None:
+    config = _load_text_config()
+    layer_idx, layer_type = _resolve_layer_metadata(config)
+    kv_num_layers = _resolve_kv_num_layers(config, layer_idx)
+    session = InferenceSession(devices=[Accelerator(0)])
+    device = Accelerator(0)
+    kv_params = KVCacheParams(
+        dtype=DType.bfloat16,
+        devices=[DeviceRef.GPU()],
+        n_kv_heads=config["num_key_value_heads"],
+        head_dim=config["head_dim"],
+        num_layers=kv_num_layers,
+        page_size=PAGE_SIZE,
+    )
+    weight_registry = _make_weight_registry(config)
+    use_local = layer_type == "local"
+    mask_variant, local_window_size, mask_mode = _resolve_flash_mask_config(
+        use_local=use_local,
+        default_local_window_size=(
+            config["sliding_window"] if use_local else -1
+        ),
+    )
+
+    tail_consumer = _build_tail_consumer_graph(
+        session=session,
+        config=config,
+        weight_registry=weight_registry,
+    )
+
+    results: dict[str, Any] = {
+        "benchmark_config": {
+            "dtype": "bfloat16",
+            "hidden_size": config["hidden_size"],
+            "head_dim": config["head_dim"],
+            "num_q_heads": config["num_attention_heads"],
+            "num_kv_heads": config["num_key_value_heads"],
+            "page_size": PAGE_SIZE,
+            "layer_idx": layer_idx,
+            "layer_type": layer_type,
+            "kv_num_layers": kv_num_layers,
+            "mask_variant": mask_variant.name,
+            "mask_mode": mask_mode,
+            "local_window_size": local_window_size,
+            "rope": "non-interleaved",
+            "mode": "prefill-ragged-attention-tail-bridge",
+            "shapes": [
+                _prefill_run_name(layer_type, layer_idx, bs, seq_len)
+                for bs, seq_len in PREFILL_SHAPES
+            ],
+            "warmup_iters": WARMUP_ITERS,
+            "timed_iters": TIMED_ITERS,
+            "placeholder_cache_len": PLACEHOLDER_CACHE_LEN,
+        },
+        "correctness": "pass",
+        "first_sweep_us": {},
+        "confirm_sweep_us": {},
+        "average_us": {},
+        "average_tail_ratio_baseline_input_over_fused_input": {},
+    }
+
+    first_ratios: list[float] = []
+    confirm_ratios: list[float] = []
+    average_ratios: list[float] = []
+    first_large_ratios: list[float] = []
+    confirm_large_ratios: list[float] = []
+    average_large_ratios: list[float] = []
+
+    for batch_size, seq_len in PREFILL_SHAPES:
+        run_name = _prefill_run_name(layer_type, layer_idx, batch_size, seq_len)
+
+        baseline_producer = _build_flash_producer_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=False,
+            layer_idx=layer_idx,
+            layer_type=layer_type,
+        )
+        fused_producer = _build_flash_producer_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=True,
+            layer_idx=layer_idx,
+            layer_type=layer_type,
+        )
+
+        first_baseline_args = _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=config["hidden_size"],
+            device=device,
+            x_seed=1000 + batch_size + seq_len,
+            blocks_seed=2000 + batch_size + seq_len,
+        )
+        first_fused_args = _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=config["hidden_size"],
+            device=device,
+            x_seed=1000 + batch_size + seq_len,
+            blocks_seed=2000 + batch_size + seq_len,
+        )
+        first_baseline_attn, first_fused_attn = _run_correctness_check(
+            baseline_producer=baseline_producer,
+            fused_producer=fused_producer,
+            tail_consumer=tail_consumer,
+            baseline_args=first_baseline_args,
+            fused_args=first_fused_args,
+            layer_idx=layer_idx,
+        )
+        first_baseline_us = _benchmark_us(tail_consumer, first_baseline_attn)
+        first_fused_us = _benchmark_us(tail_consumer, first_fused_attn)
+        results["first_sweep_us"][run_name] = {
+            "baseline": first_baseline_us,
+            "fused": first_fused_us,
+        }
+
+        confirm_baseline_args = _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=config["hidden_size"],
+            device=device,
+            x_seed=3000 + batch_size + seq_len,
+            blocks_seed=4000 + batch_size + seq_len,
+        )
+        confirm_fused_args = _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=config["hidden_size"],
+            device=device,
+            x_seed=3000 + batch_size + seq_len,
+            blocks_seed=4000 + batch_size + seq_len,
+        )
+        confirm_baseline_attn, confirm_fused_attn = _run_correctness_check(
+            baseline_producer=baseline_producer,
+            fused_producer=fused_producer,
+            tail_consumer=tail_consumer,
+            baseline_args=confirm_baseline_args,
+            fused_args=confirm_fused_args,
+            layer_idx=layer_idx,
+        )
+        confirm_baseline_us = _benchmark_us(
+            tail_consumer, confirm_baseline_attn
+        )
+        confirm_fused_us = _benchmark_us(tail_consumer, confirm_fused_attn)
+        results["confirm_sweep_us"][run_name] = {
+            "baseline": confirm_baseline_us,
+            "fused": confirm_fused_us,
+        }
+
+        average_baseline_us = (first_baseline_us + confirm_baseline_us) / 2.0
+        average_fused_us = (first_fused_us + confirm_fused_us) / 2.0
+        first_ratio = first_baseline_us / first_fused_us
+        confirm_ratio = confirm_baseline_us / confirm_fused_us
+        average_ratio = average_baseline_us / average_fused_us
+        results["average_us"][run_name] = {
+            "baseline": average_baseline_us,
+            "fused": average_fused_us,
+        }
+        results["average_tail_ratio_baseline_input_over_fused_input"][
+            run_name
+        ] = average_ratio
+
+        first_ratios.append(first_ratio)
+        confirm_ratios.append(confirm_ratio)
+        average_ratios.append(average_ratio)
+        if seq_len >= 512:
+            first_large_ratios.append(first_ratio)
+            confirm_large_ratios.append(confirm_ratio)
+            average_large_ratios.append(average_ratio)
+
+    results["average_geomean_tail_ratio_baseline_input_over_fused_input"] = (
+        _geomean(average_ratios)
+    )
+    results[
+        "average_large_shape_geomean_tail_ratio_baseline_input_over_fused_input"
+    ] = _geomean(average_large_ratios)
+    results["first_geomean_tail_ratio_baseline_input_over_fused_input"] = (
+        _geomean(first_ratios)
+    )
+    results[
+        "first_large_shape_geomean_tail_ratio_baseline_input_over_fused_input"
+    ] = _geomean(first_large_ratios)
+    results["confirm_geomean_tail_ratio_baseline_input_over_fused_input"] = (
+        _geomean(confirm_ratios)
+    )
+    results[
+        "confirm_large_shape_geomean_tail_ratio_baseline_input_over_fused_input"
+    ] = _geomean(confirm_large_ratios)
+
+    print(json.dumps(results, indent=2, sort_keys=True))
+

--- a/max/tests/integration/architectures/gemma3/test_profile_flash_attention_prefill_bridge.py
+++ b/max/tests/integration/architectures/gemma3/test_profile_flash_attention_prefill_bridge.py
@@ -1,0 +1,770 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from max.driver import Accelerator, Buffer
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Graph, TensorType, ops
+from max.interfaces import RequestID, TokenBuffer
+from max.kv_cache import PagedKVCacheManager
+from max.nn.attention import MHAMaskVariant
+from max.nn.kernels import (
+    KVCacheParams,
+    flash_attention_ragged,
+    fused_qk_ragged_rope,
+    fused_qkv_ragged_matmul,
+    q_rms_norm_fused_qk_ragged_rope,
+    rms_norm_key_cache,
+)
+from max.nn.kv_cache import (
+    AttentionDispatchResolver,
+    KVCacheInputsPerDevice,
+    build_max_lengths_tensor,
+    unflatten_ragged_attention_inputs,
+)
+from max.nn.rotary_embedding import Llama3RotaryEmbedding
+from max.pipelines.architectures.gemma3.layers.attention import (
+    Gemma3Attention as MaxGemma3Attention,
+)
+from max.pipelines.core import TextContext
+from torch.utils.dlpack import from_dlpack
+
+
+PAGE_SIZE = 128
+EPS = 1e-6
+DEFAULT_LAYER_IDX = 0
+DEFAULT_LAYER_TYPE = "local"
+Q_NORM_STD = 0.68
+K_NORM_STD = 0.793
+Q_PROJ_STD = 0.0284
+K_PROJ_STD = 0.0309
+V_PROJ_STD = 0.0309
+O_PROJ_STD = 0.0237
+WARMUP_ITERS = 20
+TIMED_ITERS = 50
+PREFILL_SHAPES = (
+    (1, 11),
+    (1, 512),
+    (1, 1024),
+    (1, 2048),
+    (2, 2048),
+)
+PLACEHOLDER_CACHE_LEN = 1
+
+
+def _resolve_layer_metadata(config: dict[str, Any]) -> tuple[int, str]:
+    layer_idx = int(
+        os.environ.get("PROFILE_ATTENTION_LAYER_IDX", str(DEFAULT_LAYER_IDX))
+    )
+    num_hidden_layers = int(config["num_hidden_layers"])
+    assert 0 <= layer_idx < num_hidden_layers, (
+        f"layer_idx={layer_idx} must be in [0, {num_hidden_layers})"
+    )
+    layer_type = (
+        "local"
+        if bool((layer_idx + 1) % config["sliding_window_pattern"])
+        else "global"
+    )
+    expected_layer_type = os.environ.get(
+        "PROFILE_ATTENTION_LAYER_TYPE", DEFAULT_LAYER_TYPE
+    )
+    assert (
+        layer_type == expected_layer_type
+    ), f"expected {expected_layer_type} layer, got {layer_type} for layer_idx={layer_idx}"
+    return layer_idx, layer_type
+
+
+def _resolve_kv_num_layers(config: dict[str, Any], layer_idx: int) -> int:
+    min_num_layers = layer_idx + 1
+    kv_num_layers = int(
+        os.environ.get("PROFILE_ATTENTION_KV_NUM_LAYERS", str(min_num_layers))
+    )
+    assert kv_num_layers >= min_num_layers, (
+        f"kv_num_layers={kv_num_layers} must cover layer_idx={layer_idx}"
+    )
+    assert kv_num_layers <= int(config["num_hidden_layers"]), (
+        "kv_num_layers cannot exceed the model layer count "
+        f"({config['num_hidden_layers']})"
+    )
+    return kv_num_layers
+
+
+def _resolve_flash_mask_config(
+    *,
+    use_local: bool,
+    default_local_window_size: int,
+) -> tuple[MHAMaskVariant, int, str]:
+    mask_override = os.environ.get(
+        "PROFILE_FLASH_ATTENTION_MASK_VARIANT", "layer_default"
+    ).strip()
+    local_window_override = os.environ.get(
+        "PROFILE_FLASH_ATTENTION_LOCAL_WINDOW_SIZE"
+    )
+
+    if local_window_override is None:
+        local_window_size = default_local_window_size if use_local else -1
+    else:
+        local_window_size = int(local_window_override)
+
+    if mask_override in ("", "layer_default"):
+        return (
+            (
+                MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK
+                if use_local
+                else MHAMaskVariant.CAUSAL_MASK
+            ),
+            local_window_size,
+            "layer_default",
+        )
+
+    if mask_override == "causal":
+        return MHAMaskVariant.CAUSAL_MASK, -1, mask_override
+
+    if mask_override == "sliding_window_causal":
+        return (
+            MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK,
+            local_window_size,
+            mask_override,
+        )
+
+    raise ValueError(
+        "PROFILE_FLASH_ATTENTION_MASK_VARIANT must be one of "
+        "{'layer_default', 'causal', 'sliding_window_causal'}, got "
+        f"{mask_override!r}"
+    )
+
+
+def _load_text_config() -> dict[str, Any]:
+    config_path = Path(os.environ["PIPELINES_TESTDATA"]) / "config.json"
+    with open(config_path) as file:
+        data = json.load(file)
+    return data.get("text_config", data)
+
+
+def _make_weight_registry(config: dict[str, Any]) -> dict[str, torch.Tensor]:
+    torch.manual_seed(42)
+    q_dim = config["head_dim"] * config["num_attention_heads"]
+    kv_dim = config["head_dim"] * config["num_key_value_heads"]
+    hidden_size = config["hidden_size"]
+    return {
+        "k_norm.weight": torch.randn(
+            config["head_dim"], dtype=torch.bfloat16
+        )
+        * K_NORM_STD,
+        "k_proj.weight": torch.randn(
+            kv_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * K_PROJ_STD,
+        "o_proj.weight": torch.randn(
+            hidden_size, q_dim, dtype=torch.bfloat16
+        )
+        * O_PROJ_STD,
+        "q_norm.weight": torch.randn(
+            config["head_dim"], dtype=torch.bfloat16
+        )
+        * Q_NORM_STD,
+        "q_proj.weight": torch.randn(
+            q_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * Q_PROJ_STD,
+        "v_proj.weight": torch.randn(
+            kv_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * V_PROJ_STD,
+    }
+
+
+def _make_placeholder_text_context(max_length: int) -> TextContext:
+    return TextContext(
+        request_id=RequestID(),
+        max_length=max_length,
+        tokens=TokenBuffer(np.zeros(PLACEHOLDER_CACHE_LEN, dtype=np.int64)),
+    )
+
+
+def _device_uint32_buffer(array: np.ndarray, device: Accelerator) -> Buffer:
+    return Buffer.from_numpy(array).to(device)
+
+
+def _row_offsets_array(batch_size: int, seq_len: int) -> np.ndarray:
+    return np.arange(
+        0,
+        (batch_size + 1) * seq_len,
+        seq_len,
+        dtype=np.uint32,
+    )
+
+
+def _prefill_run_name(
+    layer_type: str,
+    layer_idx: int,
+    batch_size: int,
+    seq_len: int,
+) -> str:
+    return (
+        f"prefill_{layer_type}_layer{layer_idx}_bs{batch_size}_seq{seq_len}"
+        "_cache0_step0_flash_attention_bridge"
+    )
+
+
+def _build_graph(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    config: dict[str, Any],
+    weight_registry: dict[str, torch.Tensor],
+    batch_size: int,
+    seq_len: int,
+    use_fused: bool,
+    layer_idx: int,
+    layer_type: str,
+) -> Any:
+    device_ref = DeviceRef.GPU()
+    max_seq_len = seq_len + PLACEHOLDER_CACHE_LEN + 256
+    attention = MaxGemma3Attention(
+        rope_global=Llama3RotaryEmbedding(
+            config["hidden_size"],
+            config["num_attention_heads"],
+            config["rope_theta"],
+            max_seq_len,
+            interleaved=False,
+            head_dim=config["head_dim"],
+        ),
+        rope_local=Llama3RotaryEmbedding(
+            config["hidden_size"],
+            config["num_attention_heads"],
+            config["rope_local_base_freq"],
+            max_seq_len,
+            interleaved=False,
+            head_dim=config["head_dim"],
+        ),
+        num_attention_heads=config["num_attention_heads"],
+        num_key_value_heads=config["num_key_value_heads"],
+        hidden_size=config["hidden_size"],
+        kv_params=kv_params,
+        layer_idx=layer_idx,
+        dtype=DType.bfloat16,
+        devices=[device_ref],
+        qk_norm_eps=EPS,
+        sliding_window_pattern=config["sliding_window_pattern"],
+        local_window_size=config["sliding_window"],
+        has_bias=bool(config["attention_bias"]),
+    )
+    attention.load_state_dict(weight_registry)
+
+    input_type = TensorType(
+        DType.bfloat16,
+        ["total_seq_len", config["hidden_size"]],
+        device=device_ref,
+    )
+    input_row_offsets_type = TensorType(
+        DType.uint32,
+        [batch_size + 1],
+        device=device_ref,
+    )
+    flattened_kv_types = kv_params.get_symbolic_inputs().flatten()
+
+    graph_name = (
+        "Gemma3FlashAttentionPrefillBridge"
+        f"{layer_type.title()}FusedBS{batch_size}Seq{seq_len}"
+        if use_fused
+        else "Gemma3FlashAttentionPrefillBridge"
+        f"{layer_type.title()}BaselineBS{batch_size}Seq{seq_len}"
+    )
+
+    with Graph(
+        graph_name,
+        input_types=(input_type, input_row_offsets_type, *flattened_kv_types),
+    ) as graph:
+        x, input_row_offsets, *kv_cache = graph.inputs
+        kv_collection = unflatten_ragged_attention_inputs(
+            kv_cache, n_devices=1
+        )[0]
+        graph_layer_idx = ops.constant(
+            layer_idx, DType.uint32, device=DeviceRef.CPU()
+        )
+        total_seq_len = x.tensor.shape[0]
+
+        xq = fused_qkv_ragged_matmul(
+            kv_params,
+            input=x.tensor,
+            wqkv=attention.wqkv,
+            bias=attention.wqkv_bias,
+            input_row_offsets=input_row_offsets.tensor,
+            kv_collection=kv_collection,
+            layer_idx=graph_layer_idx,
+            n_heads=attention.n_heads,
+        )
+        xq = xq.reshape((-1, attention.n_heads, kv_params.head_dim))
+
+        use_local = bool((layer_idx + 1) % attention.sliding_window_pattern)
+        assert use_local == (layer_type == "local")
+        rope = attention.rope_local if use_local else attention.rope_global
+        freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
+
+        if use_fused:
+            xq = q_rms_norm_fused_qk_ragged_rope(
+                kv_params,
+                xq,
+                input_row_offsets.tensor,
+                kv_collection,
+                freqs_cis,
+                attention.q_norm.weight.cast(kv_params.dtype).to(device_ref),
+                attention.k_norm.weight.cast(kv_params.dtype).to(device_ref),
+                EPS,
+                graph_layer_idx,
+                weight_offset=1.0,
+                interleaved=False,
+            )
+        else:
+            rms_norm_key_cache(
+                kv_params,
+                kv_collection=kv_collection,
+                gamma=attention.k_norm.weight.cast(kv_params.dtype).to(
+                    device_ref
+                ),
+                epsilon=EPS,
+                layer_idx=graph_layer_idx,
+                total_seq_len=total_seq_len,
+                input_row_offsets=input_row_offsets.tensor,
+                weight_offset=1.0,
+            )
+            xq = attention.q_norm(xq)
+            xq = fused_qk_ragged_rope(
+                kv_params,
+                xq,
+                input_row_offsets.tensor,
+                kv_collection,
+                freqs_cis,
+                graph_layer_idx,
+                interleaved=False,
+            )
+
+        mask_variant, local_window_size, _ = _resolve_flash_mask_config(
+            use_local=use_local,
+            default_local_window_size=attention.local_window_size,
+        )
+        attn_out = flash_attention_ragged(
+            kv_params,
+            input=xq,
+            kv_collection=kv_collection,
+            layer_idx=graph_layer_idx,
+            input_row_offsets=input_row_offsets.tensor,
+            mask_variant=mask_variant,
+            scale=attention.scale,
+            local_window_size=local_window_size,
+        )
+        graph.output(ops.reshape(attn_out, shape=[total_seq_len, -1]))
+
+    return session.load(graph, weights_registry=attention.state_dict())
+
+
+def _make_runtime_inputs(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    seq_len: int,
+    device: Accelerator,
+) -> KVCacheInputsPerDevice:
+    max_cache_length = PLACEHOLDER_CACHE_LEN + seq_len
+    total_num_pages = batch_size * math.ceil(max_cache_length / PAGE_SIZE)
+    kv_manager = PagedKVCacheManager(
+        params=kv_params,
+        total_num_pages=total_num_pages,
+        session=session,
+        max_batch_size=batch_size,
+    )
+
+    contexts: list[TextContext] = []
+    for _ in range(batch_size):
+        context = _make_placeholder_text_context(max_cache_length)
+        kv_manager.claim(context.request_id, replica_idx=0)
+        kv_manager.alloc(
+            context,
+            replica_idx=0,
+            num_steps=seq_len,
+        )
+        contexts.append(context)
+
+    runtime_inputs = kv_manager.runtime_inputs(
+        [contexts],
+        num_steps=seq_len,
+    ).inputs[0]
+
+    # The placeholder TextContext keeps KV runtime metadata in decode shape
+    # (`q_max_seq_len == 1`), but this harness is exercising multi-token prefill.
+    # Flash attention consumes both `max_lengths` and packed dispatch metadata,
+    # so overwrite them with the real prefill window while leaving cache_lengths
+    # at zero to model cache0 step0.
+    dispatch_metadata = AttentionDispatchResolver(
+        devices=kv_params.devices,
+        is_mla=kv_params.is_mla,
+        n_kv_heads_per_device=kv_params.n_kv_heads_per_device,
+        num_q_heads_per_device=kv_params.num_q_heads_per_device,
+        is_fp8_kv=kv_params.is_fp8_kv_dtype,
+    ).resolve_for_replica(
+        batch_size,
+        seq_len,
+        seq_len,
+    )[0]
+
+    return KVCacheInputsPerDevice(
+        blocks=runtime_inputs.blocks,
+        cache_lengths=_device_uint32_buffer(
+            np.zeros(batch_size, dtype=np.uint32), device
+        ),
+        lookup_table=runtime_inputs.lookup_table,
+        max_lengths=build_max_lengths_tensor(1, seq_len, seq_len),
+        kv_scales=runtime_inputs.kv_scales,
+        attention_dispatch_metadata=dispatch_metadata,
+    )
+
+
+def _clone_kv_blocks(blocks: Buffer, seed: int) -> Buffer:
+    torch.manual_seed(seed)
+    shape = tuple(int(dim) for dim in blocks.shape)
+    tensor = torch.randn(shape, dtype=torch.bfloat16, device="cuda").contiguous()
+    return Buffer.from_dlpack(tensor)
+
+
+def _make_execution_args(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    device: Accelerator,
+    x_seed: int,
+    blocks_seed: int,
+) -> tuple[Any, ...]:
+    runtime_inputs = _make_runtime_inputs(
+        session=session,
+        kv_params=kv_params,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        device=device,
+    )
+
+    torch.manual_seed(x_seed)
+    x = torch.randn(
+        (batch_size * seq_len, hidden_size),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+
+    return (
+        Buffer.from_dlpack(x),
+        _device_uint32_buffer(_row_offsets_array(batch_size, seq_len), device),
+        _clone_kv_blocks(runtime_inputs.blocks, seed=blocks_seed),
+        runtime_inputs.cache_lengths,
+        runtime_inputs.lookup_table,
+        runtime_inputs.max_lengths,
+        runtime_inputs.attention_dispatch_metadata,
+    )
+
+
+def _run_correctness_check(
+    *,
+    baseline: Any,
+    fused: Any,
+    baseline_args: tuple[Any, ...],
+    fused_args: tuple[Any, ...],
+    layer_idx: int,
+) -> None:
+    baseline_output = baseline.execute(*baseline_args)[0]
+    fused_output = fused.execute(*fused_args)[0]
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        from_dlpack(baseline_output).to(torch.bfloat16),
+        from_dlpack(fused_output).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+    baseline_blocks = from_dlpack(baseline_args[2]).to(torch.bfloat16)[
+        :, :, layer_idx : layer_idx + 1, :, :, :
+    ]
+    fused_blocks = from_dlpack(fused_args[2]).to(torch.bfloat16)[
+        :, :, layer_idx : layer_idx + 1, :, :, :
+    ]
+    torch.testing.assert_close(
+        baseline_blocks,
+        fused_blocks,
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+
+def _benchmark_us(compiled: Any, args: list[tuple[Any, ...]]) -> float:
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def _geomean(values: list[float]) -> float:
+    return math.exp(sum(math.log(value) for value in values) / len(values))
+
+
+def test_profile_flash_attention_prefill_bridge() -> None:
+    config = _load_text_config()
+    layer_idx, layer_type = _resolve_layer_metadata(config)
+    kv_num_layers = _resolve_kv_num_layers(config, layer_idx)
+    mask_variant, local_window_size, mask_mode = _resolve_flash_mask_config(
+        use_local=(layer_type == "local"),
+        default_local_window_size=int(config["sliding_window"]),
+    )
+    session = InferenceSession(devices=[Accelerator(0)])
+    device = Accelerator(0)
+    kv_params = KVCacheParams(
+        dtype=DType.bfloat16,
+        devices=[DeviceRef.GPU()],
+        n_kv_heads=config["num_key_value_heads"],
+        head_dim=config["head_dim"],
+        num_layers=kv_num_layers,
+        page_size=PAGE_SIZE,
+    )
+    weight_registry = _make_weight_registry(config)
+
+    results: dict[str, Any] = {
+        "benchmark_config": {
+            "dtype": "bfloat16",
+            "hidden_size": config["hidden_size"],
+            "head_dim": config["head_dim"],
+            "num_q_heads": config["num_attention_heads"],
+            "num_kv_heads": config["num_key_value_heads"],
+            "page_size": PAGE_SIZE,
+            "layer_idx": layer_idx,
+            "layer_type": layer_type,
+            "kv_num_layers": kv_num_layers,
+            "mask_variant": mask_variant.name,
+            "mask_mode": mask_mode,
+            "local_window_size": local_window_size,
+            "rope": "non-interleaved",
+            "mode": "prefill-ragged-flash-attention-bridge",
+            "shapes": [
+                _prefill_run_name(layer_type, layer_idx, batch_size, seq_len)
+                for batch_size, seq_len in PREFILL_SHAPES
+            ],
+            "warmup_iters": WARMUP_ITERS,
+            "timed_iters": TIMED_ITERS,
+            "placeholder_cache_len": PLACEHOLDER_CACHE_LEN,
+        },
+        "correctness": "pass",
+        "first_sweep_us": {},
+        "confirm_sweep_us": {},
+        "average_us": {},
+        "average_speedup_ratio_vs_flash_bridge_baseline": {},
+    }
+
+    large_shape_names: list[str] = []
+
+    for batch_size, seq_len in PREFILL_SHAPES:
+        run_name = _prefill_run_name(layer_type, layer_idx, batch_size, seq_len)
+        if seq_len >= 512:
+            large_shape_names.append(run_name)
+
+        baseline = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=False,
+            layer_idx=layer_idx,
+            layer_type=layer_type,
+        )
+        fused = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=True,
+            layer_idx=layer_idx,
+            layer_type=layer_type,
+        )
+
+        baseline_correctness_args = _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=config["hidden_size"],
+            device=device,
+            x_seed=1000 + batch_size + seq_len,
+            blocks_seed=2000 + batch_size + seq_len,
+        )
+        fused_correctness_args = _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=config["hidden_size"],
+            device=device,
+            x_seed=1000 + batch_size + seq_len,
+            blocks_seed=2000 + batch_size + seq_len,
+        )
+        _run_correctness_check(
+            baseline=baseline,
+            fused=fused,
+            baseline_args=baseline_correctness_args,
+            fused_args=fused_correctness_args,
+            layer_idx=layer_idx,
+        )
+        del baseline_correctness_args
+        del fused_correctness_args
+        torch.cuda.empty_cache()
+
+        baseline_first_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=3000 + idx,
+                blocks_seed=4000 + idx,
+            )
+            for idx in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        fused_first_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=3000 + idx,
+                blocks_seed=4000 + idx,
+            )
+            for idx in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        baseline_first = _benchmark_us(baseline, baseline_first_args)
+        fused_first = _benchmark_us(fused, fused_first_args)
+        del baseline_first_args
+        del fused_first_args
+        torch.cuda.empty_cache()
+
+        baseline_confirm_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=5000 + idx,
+                blocks_seed=6000 + idx,
+            )
+            for idx in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        fused_confirm_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=5000 + idx,
+                blocks_seed=6000 + idx,
+            )
+            for idx in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        baseline_confirm = _benchmark_us(baseline, baseline_confirm_args)
+        fused_confirm = _benchmark_us(fused, fused_confirm_args)
+        del baseline_confirm_args
+        del fused_confirm_args
+        torch.cuda.empty_cache()
+
+        average_baseline = (baseline_first + baseline_confirm) / 2.0
+        average_fused = (fused_first + fused_confirm) / 2.0
+        results["first_sweep_us"][run_name] = {
+            "baseline": baseline_first,
+            "fused": fused_first,
+        }
+        results["confirm_sweep_us"][run_name] = {
+            "baseline": baseline_confirm,
+            "fused": fused_confirm,
+        }
+        results["average_us"][run_name] = {
+            "baseline": average_baseline,
+            "fused": average_fused,
+        }
+        results["average_speedup_ratio_vs_flash_bridge_baseline"][run_name] = (
+            average_baseline / average_fused
+        )
+        del baseline
+        del fused
+        torch.cuda.empty_cache()
+
+    ratios = list(
+        results["average_speedup_ratio_vs_flash_bridge_baseline"].values()
+    )
+    large_ratios = [
+        results["average_speedup_ratio_vs_flash_bridge_baseline"][name]
+        for name in large_shape_names
+    ]
+    confirm_ratios = [
+        results["confirm_sweep_us"][name]["baseline"]
+        / results["confirm_sweep_us"][name]["fused"]
+        for name in results["confirm_sweep_us"]
+    ]
+    confirm_large_ratios = [
+        results["confirm_sweep_us"][name]["baseline"]
+        / results["confirm_sweep_us"][name]["fused"]
+        for name in large_shape_names
+    ]
+
+    results["average_geomean_speedup_vs_flash_bridge_baseline"] = _geomean(
+        ratios
+    )
+    results["average_large_shape_geomean_speedup_vs_flash_bridge_baseline"] = (
+        _geomean(large_ratios)
+    )
+    results["confirm_geomean_speedup_vs_flash_bridge_baseline"] = _geomean(
+        confirm_ratios
+    )
+    results["confirm_large_shape_geomean_speedup_vs_flash_bridge_baseline"] = (
+        _geomean(confirm_large_ratios)
+    )
+    results["localization"] = "flash_bridge_passes_mismatch_is_downstream_of_flash"
+    print(json.dumps(results, indent=2, sort_keys=True))

--- a/max/tests/integration/architectures/gemma3/test_profile_k_norm_rope_decode.py
+++ b/max/tests/integration/architectures/gemma3/test_profile_k_norm_rope_decode.py
@@ -1,0 +1,576 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from max.driver import Accelerator, Buffer
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Dim, Graph, TensorType, ops
+from max.interfaces import RequestID, TokenBuffer
+from max.kv_cache import PagedKVCacheManager
+from max.nn.kernels import (
+    KVCacheParams,
+    k_rms_norm_rope_ragged,
+    rms_norm_key_cache,
+    rope_k_cache_ragged,
+)
+from max.nn.kv_cache import unflatten_ragged_attention_inputs
+from max.nn.rotary_embedding import Llama3RotaryEmbedding
+from max.pipelines.architectures.gemma3.layers.rms_norm import Gemma3RMSNorm
+from max.pipelines.core import TextContext
+from torch.utils.dlpack import from_dlpack
+
+
+PAGE_SIZE = 128
+EPS = 1e-6
+K_NORM_STD = 0.793
+DEFAULT_WARMUP_ITERS = 20
+DEFAULT_TIMED_ITERS = 50
+CACHE_LEN_BASE = 1024
+CACHE_LEN_STEP = 7
+BATCH_SIZES = (64, 128)
+KV_BLOCK_COMPARE_CHUNK_ELEMENTS = 8_388_608
+
+
+def _load_text_config() -> dict[str, Any]:
+    config_path = Path(os.environ["PIPELINES_TESTDATA"]) / "config.json"
+    with open(config_path) as file:
+        data = json.load(file)
+    return data.get("text_config", data)
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return int(value) if value is not None else default
+
+
+def _env_int_tuple(name: str, default: tuple[int, ...]) -> tuple[int, ...]:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return tuple(
+        int(part.strip()) for part in value.split(",") if part.strip()
+    )
+
+
+def _profile_config(config: dict[str, Any]) -> dict[str, Any]:
+    batch_sizes = _env_int_tuple(
+        "PROFILE_K_NORM_ROPE_BATCH_SIZES", BATCH_SIZES
+    )
+    if not batch_sizes:
+        raise ValueError(
+            "PROFILE_K_NORM_ROPE_BATCH_SIZES must define at least one batch size"
+        )
+
+    warmup_iters = _env_int(
+        "PROFILE_K_NORM_ROPE_WARMUP_ITERS", DEFAULT_WARMUP_ITERS
+    )
+    timed_iters = _env_int(
+        "PROFILE_K_NORM_ROPE_TIMED_ITERS", DEFAULT_TIMED_ITERS
+    )
+    if warmup_iters < 0:
+        raise ValueError("PROFILE_K_NORM_ROPE_WARMUP_ITERS must be >= 0")
+    if timed_iters <= 0:
+        raise ValueError("PROFILE_K_NORM_ROPE_TIMED_ITERS must be >= 1")
+
+    return {
+        "hidden_size": _env_int(
+            "PROFILE_K_NORM_ROPE_HIDDEN_SIZE", config["hidden_size"]
+        ),
+        "num_attention_heads": _env_int(
+            "PROFILE_K_NORM_ROPE_NUM_Q_HEADS", config["num_attention_heads"]
+        ),
+        "num_key_value_heads": _env_int(
+            "PROFILE_K_NORM_ROPE_NUM_KV_HEADS",
+            config["num_key_value_heads"],
+        ),
+        "head_dim": _env_int(
+            "PROFILE_K_NORM_ROPE_HEAD_DIM", config["head_dim"]
+        ),
+        "rope_theta": _env_int(
+            "PROFILE_K_NORM_ROPE_THETA", config["rope_local_base_freq"]
+        ),
+        "cache_len_base": _env_int(
+            "PROFILE_K_NORM_ROPE_CACHE_LEN_BASE", CACHE_LEN_BASE
+        ),
+        "cache_len_step": _env_int(
+            "PROFILE_K_NORM_ROPE_CACHE_LEN_STEP", CACHE_LEN_STEP
+        ),
+        "batch_sizes": batch_sizes,
+        "warmup_iters": warmup_iters,
+        "timed_iters": timed_iters,
+        "max_extra_steps": warmup_iters + timed_iters,
+    }
+
+
+def _make_weight_registry(head_dim: int) -> dict[str, torch.Tensor]:
+    torch.manual_seed(42)
+    return {
+        "k_gamma": torch.randn(head_dim, dtype=torch.bfloat16) * K_NORM_STD,
+    }
+
+
+def _make_text_context(length: int, max_length: int) -> TextContext:
+    return TextContext(
+        request_id=RequestID(),
+        max_length=max_length,
+        tokens=TokenBuffer(np.zeros(length, dtype=np.int64)),
+    )
+
+
+def _build_graph(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    hidden_size: int,
+    num_attention_heads: int,
+    head_dim: int,
+    rope_theta: int,
+    batch_size: int,
+    max_batch_size: int,
+    cache_len_base: int,
+    cache_len_step: int,
+    max_extra_steps: int,
+    use_fused: bool,
+) -> Any:
+    device_ref = DeviceRef.GPU()
+    rope = Llama3RotaryEmbedding(
+        hidden_size,
+        num_attention_heads,
+        rope_theta,
+        cache_len_base + cache_len_step * (max_batch_size - 1) + max_extra_steps + 256,
+        interleaved=False,
+        head_dim=head_dim,
+    )
+    k_norm = Gemma3RMSNorm(head_dim, DType.bfloat16, EPS)
+    k_norm.weight.name = "k_gamma"
+
+    input_row_offsets_type = TensorType(
+        DType.uint32,
+        [batch_size + 1],
+        device=device_ref,
+    )
+    flattened_kv_types = kv_params.get_symbolic_inputs().flatten()
+
+    graph_name = (
+        f"Gemma3WideKNormRopeDecodeFusedBS{batch_size}"
+        if use_fused
+        else f"Gemma3WideKNormRopeDecodeBaselineBS{batch_size}"
+    )
+
+    with Graph(
+        graph_name,
+        input_types=(input_row_offsets_type, *flattened_kv_types),
+    ) as graph:
+        input_row_offsets, *kv_cache = graph.inputs
+        kv_collection = unflatten_ragged_attention_inputs(
+            kv_cache, n_devices=1
+        )[0]
+        layer_idx = ops.constant(0, DType.uint32, device=DeviceRef.CPU())
+        freqs_cis = ops.cast(rope.freqs_cis, DType.bfloat16).to(device_ref)
+        gamma = k_norm.weight.cast(kv_params.dtype).to(device_ref)
+        total_seq_len = Dim(batch_size)
+
+        if use_fused:
+            k_rms_norm_rope_ragged(
+                kv_params,
+                total_seq_len=total_seq_len,
+                input_row_offsets=input_row_offsets.tensor,
+                kv_collection=kv_collection,
+                freqs_cis=freqs_cis,
+                gamma=gamma,
+                epsilon=EPS,
+                layer_idx=layer_idx,
+                weight_offset=1.0,
+                interleaved=False,
+            )
+        else:
+            rms_norm_key_cache(
+                kv_params,
+                kv_collection=kv_collection,
+                gamma=gamma,
+                epsilon=EPS,
+                layer_idx=layer_idx,
+                total_seq_len=total_seq_len,
+                input_row_offsets=input_row_offsets.tensor,
+                weight_offset=1.0,
+            )
+            rope_k_cache_ragged(
+                kv_params,
+                total_seq_len=total_seq_len,
+                input_row_offsets=input_row_offsets.tensor,
+                kv_collection=kv_collection,
+                freqs_cis=freqs_cis,
+                layer_idx=layer_idx,
+                interleaved=False,
+            )
+
+        graph.output(input_row_offsets.tensor)
+
+    return session.load(graph, weights_registry=_make_weight_registry(head_dim))
+
+
+def _make_runtime_inputs(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    cache_len_base: int,
+    cache_len_step: int,
+    max_extra_steps: int,
+) -> tuple[np.ndarray, Any]:
+    cache_lengths = np.asarray(
+        [
+            cache_len_base + cache_len_step * request_idx
+            for request_idx in range(batch_size)
+        ],
+        dtype=np.uint32,
+    )
+    max_cache_length = int(cache_lengths[-1]) + max_extra_steps + 1
+    total_num_pages = sum(
+        math.ceil((int(cache_length) + max_extra_steps + 1) / PAGE_SIZE)
+        for cache_length in cache_lengths
+    )
+
+    kv_manager = PagedKVCacheManager(
+        params=kv_params,
+        total_num_pages=total_num_pages,
+        session=session,
+        max_batch_size=batch_size,
+    )
+
+    contexts: list[TextContext] = []
+    for cache_length in cache_lengths:
+        context = _make_text_context(int(cache_length), max_cache_length)
+        kv_manager.claim(context.request_id, replica_idx=0)
+        kv_manager.alloc(
+            context,
+            replica_idx=0,
+            num_steps=max_extra_steps + 1,
+        )
+        contexts.append(context)
+
+    runtime_inputs = kv_manager.runtime_inputs([contexts], num_steps=1).inputs[0]
+    return cache_lengths, runtime_inputs
+
+
+def _clone_kv_blocks(blocks: Buffer, seed: int) -> Buffer:
+    torch.manual_seed(seed)
+    shape = tuple(int(dim) for dim in blocks.shape)
+    tensor = torch.randn(shape, dtype=torch.bfloat16, device="cuda").contiguous()
+    return Buffer.from_dlpack(tensor)
+
+
+def _device_uint32_buffer(array: np.ndarray, device: Accelerator) -> Buffer:
+    return Buffer.from_numpy(array).to(device)
+
+
+def _make_benchmark_args(
+    *,
+    batch_size: int,
+    cache_lengths: np.ndarray,
+    runtime_inputs: Any,
+    device: Accelerator,
+    blocks_seed: int,
+    max_extra_steps: int,
+) -> tuple[list[tuple[Any, ...]], Buffer]:
+    row_offsets = _device_uint32_buffer(
+        np.arange(batch_size + 1, dtype=np.uint32),
+        device,
+    )
+    kv_blocks = _clone_kv_blocks(runtime_inputs.blocks, seed=blocks_seed)
+    lookup_table = runtime_inputs.lookup_table.to(device)
+    dispatch_metadata = runtime_inputs.attention_dispatch_metadata
+
+    args: list[tuple[Any, ...]] = []
+    for step in range(max_extra_steps + 1):
+        step_cache_lengths = _device_uint32_buffer(
+            cache_lengths + np.uint32(step), device
+        )
+        args.append(
+            (
+                row_offsets,
+                kv_blocks,
+                step_cache_lengths,
+                lookup_table,
+                runtime_inputs.max_lengths,
+                dispatch_metadata,
+            )
+        )
+    return args, kv_blocks
+
+
+def _run_correctness_check(
+    *,
+    baseline: Any,
+    fused: Any,
+    baseline_args: tuple[Any, ...],
+    fused_args: tuple[Any, ...],
+) -> None:
+    baseline_output = baseline.execute(*baseline_args)[0]
+    fused_output = fused.execute(*fused_args)[0]
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        from_dlpack(baseline_output).to(torch.uint32),
+        from_dlpack(fused_output).to(torch.uint32),
+        rtol=0,
+        atol=0,
+    )
+
+    baseline_blocks = from_dlpack(baseline_args[1]).to(torch.bfloat16)
+    fused_blocks = from_dlpack(fused_args[1]).to(torch.bfloat16)
+    flat_baseline_blocks = baseline_blocks.reshape(-1)
+    flat_fused_blocks = fused_blocks.reshape(-1)
+    for start in range(
+        0, flat_baseline_blocks.numel(), KV_BLOCK_COMPARE_CHUNK_ELEMENTS
+    ):
+        end = start + KV_BLOCK_COMPARE_CHUNK_ELEMENTS
+        torch.testing.assert_close(
+            flat_baseline_blocks[start:end],
+            flat_fused_blocks[start:end],
+            rtol=2 * torch.finfo(torch.bfloat16).eps,
+            atol=8 * torch.finfo(torch.bfloat16).eps,
+        )
+
+
+def _benchmark_us(
+    compiled: Any,
+    args: list[tuple[Any, ...]],
+    *,
+    warmup_iters: int,
+    timed_iters: int,
+) -> float:
+    warmup_args = args[:warmup_iters]
+    timed_args = args[warmup_iters : warmup_iters + timed_iters]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / timed_iters
+
+
+def test_profile_k_norm_rope_decode() -> None:
+    config = _load_text_config()
+    profile = _profile_config(config)
+    session = InferenceSession(devices=[Accelerator(0)])
+    device = Accelerator(0)
+    kv_params = KVCacheParams(
+        dtype=DType.bfloat16,
+        devices=[DeviceRef.GPU()],
+        n_kv_heads=profile["num_key_value_heads"],
+        head_dim=profile["head_dim"],
+        num_layers=1,
+        page_size=PAGE_SIZE,
+    )
+
+    results: dict[str, Any] = {
+        "benchmark_config": {
+            "dtype": "bfloat16",
+            "hidden_size": profile["hidden_size"],
+            "head_dim": profile["head_dim"],
+            "num_q_heads": profile["num_attention_heads"],
+            "num_kv_heads": profile["num_key_value_heads"],
+            "page_size": PAGE_SIZE,
+            "rope": "non-interleaved",
+            "mode": "decode-ragged-live-graph-k-only",
+            "cache_len_base": profile["cache_len_base"],
+            "cache_len_step": profile["cache_len_step"],
+            "batch_sizes": list(profile["batch_sizes"]),
+            "warmup_iters": profile["warmup_iters"],
+            "timed_iters": profile["timed_iters"],
+        },
+        "correctness": "pass",
+        "first_sweep_us": {},
+        "confirm_sweep_us": {},
+        "average_us": {},
+        "average_speedup_ratio_vs_graph_baseline": {},
+    }
+
+    max_batch_size = max(profile["batch_sizes"])
+    for batch_size in profile["batch_sizes"]:
+        cache_lengths, runtime_inputs = _make_runtime_inputs(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            cache_len_base=profile["cache_len_base"],
+            cache_len_step=profile["cache_len_step"],
+            max_extra_steps=profile["max_extra_steps"],
+        )
+        baseline = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            hidden_size=profile["hidden_size"],
+            num_attention_heads=profile["num_attention_heads"],
+            head_dim=profile["head_dim"],
+            rope_theta=profile["rope_theta"],
+            batch_size=batch_size,
+            max_batch_size=max_batch_size,
+            cache_len_base=profile["cache_len_base"],
+            cache_len_step=profile["cache_len_step"],
+            max_extra_steps=profile["max_extra_steps"],
+            use_fused=False,
+        )
+        fused = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            hidden_size=profile["hidden_size"],
+            num_attention_heads=profile["num_attention_heads"],
+            head_dim=profile["head_dim"],
+            rope_theta=profile["rope_theta"],
+            batch_size=batch_size,
+            max_batch_size=max_batch_size,
+            cache_len_base=profile["cache_len_base"],
+            cache_len_step=profile["cache_len_step"],
+            max_extra_steps=profile["max_extra_steps"],
+            use_fused=True,
+        )
+        run_name = (
+            "decode_bs"
+            f"{batch_size}_seq1_cache{profile['cache_len_base']}"
+            f"_step{profile['cache_len_step']}_k_only"
+        )
+
+        correctness_baseline_args, correctness_baseline_blocks = (
+            _make_benchmark_args(
+                batch_size=batch_size,
+                cache_lengths=cache_lengths,
+                runtime_inputs=runtime_inputs,
+                device=device,
+                blocks_seed=100 + batch_size,
+                max_extra_steps=profile["max_extra_steps"],
+            )
+        )
+        correctness_fused_args, correctness_fused_blocks = _make_benchmark_args(
+            batch_size=batch_size,
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            blocks_seed=100 + batch_size,
+            max_extra_steps=profile["max_extra_steps"],
+        )
+        _run_correctness_check(
+            baseline=baseline,
+            fused=fused,
+            baseline_args=correctness_baseline_args[0],
+            fused_args=correctness_fused_args[0],
+        )
+        del correctness_baseline_args
+        del correctness_fused_args
+        del correctness_baseline_blocks
+        del correctness_fused_blocks
+
+        first_baseline_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            blocks_seed=200 + batch_size,
+            max_extra_steps=profile["max_extra_steps"],
+        )
+        first_fused_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            blocks_seed=300 + batch_size,
+            max_extra_steps=profile["max_extra_steps"],
+        )
+        first_baseline_us = _benchmark_us(
+            baseline,
+            first_baseline_args,
+            warmup_iters=profile["warmup_iters"],
+            timed_iters=profile["timed_iters"],
+        )
+        first_fused_us = _benchmark_us(
+            fused,
+            first_fused_args,
+            warmup_iters=profile["warmup_iters"],
+            timed_iters=profile["timed_iters"],
+        )
+        results["first_sweep_us"][run_name] = {
+            "baseline": first_baseline_us,
+            "fused": first_fused_us,
+        }
+        del first_baseline_args
+        del first_fused_args
+
+        confirm_baseline_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            blocks_seed=400 + batch_size,
+            max_extra_steps=profile["max_extra_steps"],
+        )
+        confirm_fused_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            blocks_seed=500 + batch_size,
+            max_extra_steps=profile["max_extra_steps"],
+        )
+        confirm_baseline_us = _benchmark_us(
+            baseline,
+            confirm_baseline_args,
+            warmup_iters=profile["warmup_iters"],
+            timed_iters=profile["timed_iters"],
+        )
+        confirm_fused_us = _benchmark_us(
+            fused,
+            confirm_fused_args,
+            warmup_iters=profile["warmup_iters"],
+            timed_iters=profile["timed_iters"],
+        )
+        results["confirm_sweep_us"][run_name] = {
+            "baseline": confirm_baseline_us,
+            "fused": confirm_fused_us,
+        }
+        del confirm_baseline_args
+        del confirm_fused_args
+
+        average_baseline_us = (first_baseline_us + confirm_baseline_us) / 2.0
+        average_fused_us = (first_fused_us + confirm_fused_us) / 2.0
+        results["average_us"][run_name] = {
+            "baseline": average_baseline_us,
+            "fused": average_fused_us,
+        }
+        results["average_speedup_ratio_vs_graph_baseline"][run_name] = (
+            average_baseline_us / average_fused_us
+        )
+
+    speedups = list(results["average_speedup_ratio_vs_graph_baseline"].values())
+    results["average_geomean_speedup_vs_graph_baseline"] = float(
+        np.exp(np.mean(np.log(speedups)))
+    )
+
+    print("GEMMA3_WIDE_K_NORM_ROPE_DECODE_PROFILE_START")
+    print(json.dumps(results, sort_keys=True))
+    print("GEMMA3_WIDE_K_NORM_ROPE_DECODE_PROFILE_END")

--- a/max/tests/integration/architectures/gemma3/test_profile_k_norm_rope_prefill.py
+++ b/max/tests/integration/architectures/gemma3/test_profile_k_norm_rope_prefill.py
@@ -1,0 +1,486 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from max.driver import Accelerator, Buffer
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Dim, Graph, TensorType, ops
+from max.interfaces import RequestID, TokenBuffer
+from max.kv_cache import PagedKVCacheManager
+from max.nn.kernels import (
+    KVCacheParams,
+    k_rms_norm_rope_ragged,
+    rms_norm_key_cache,
+    rope_k_cache_ragged,
+)
+from max.nn.kv_cache import KVCacheInputsPerDevice, unflatten_ragged_attention_inputs
+from max.nn.rotary_embedding import Llama3RotaryEmbedding
+from max.pipelines.architectures.gemma3.layers.rms_norm import Gemma3RMSNorm
+from max.pipelines.core import TextContext
+from torch.utils.dlpack import from_dlpack
+
+
+PAGE_SIZE = 128
+EPS = 1e-6
+K_NORM_STD = 0.793
+WARMUP_ITERS = 20
+TIMED_ITERS = 50
+PREFILL_SHAPES = (
+    (1, 11),
+    (1, 512),
+    (1, 1024),
+    (1, 2048),
+    (2, 2048),
+)
+PLACEHOLDER_CACHE_LEN = 1
+
+
+def _resolve_prefill_shapes() -> tuple[tuple[int, int], ...]:
+    raw_shapes = os.environ.get("PROFILE_K_NORM_ROPE_PREFILL_SHAPES", "").strip()
+    if raw_shapes == "":
+        return PREFILL_SHAPES
+
+    resolved: list[tuple[int, int]] = []
+    for raw_shape in raw_shapes.split(","):
+        shape_text = raw_shape.strip().lower()
+        if shape_text == "":
+            continue
+        if "x" not in shape_text:
+            raise ValueError(
+                "PROFILE_K_NORM_ROPE_PREFILL_SHAPES entries must look like "
+                f"'batchxseq', got {raw_shape!r}"
+            )
+        batch_text, seq_text = shape_text.split("x", maxsplit=1)
+        shape = (int(batch_text), int(seq_text))
+        if shape not in PREFILL_SHAPES:
+            raise ValueError(
+                "PROFILE_K_NORM_ROPE_PREFILL_SHAPES only supports the "
+                f"existing prefill grid {PREFILL_SHAPES}, got {shape}"
+            )
+        if shape not in resolved:
+            resolved.append(shape)
+
+    if not resolved:
+        raise ValueError(
+            "PROFILE_K_NORM_ROPE_PREFILL_SHAPES must select at least one shape"
+        )
+    return tuple(resolved)
+
+
+def _load_text_config() -> dict[str, Any]:
+    config_path = Path(os.environ["PIPELINES_TESTDATA"]) / "config.json"
+    with open(config_path) as file:
+        data = json.load(file)
+    return data.get("text_config", data)
+
+
+def _make_weight_registry(head_dim: int) -> dict[str, torch.Tensor]:
+    torch.manual_seed(42)
+    return {
+        "k_gamma": torch.randn(head_dim, dtype=torch.bfloat16) * K_NORM_STD,
+    }
+
+
+def _make_placeholder_text_context(max_length: int) -> TextContext:
+    return TextContext(
+        request_id=RequestID(),
+        max_length=max_length,
+        tokens=TokenBuffer(
+            np.zeros(PLACEHOLDER_CACHE_LEN, dtype=np.int64)
+        ),
+    )
+
+
+def _device_uint32_buffer(array: np.ndarray, device: Accelerator) -> Buffer:
+    return Buffer.from_numpy(array).to(device)
+
+
+def _row_offsets_array(batch_size: int, seq_len: int) -> np.ndarray:
+    return np.arange(
+        0,
+        (batch_size + 1) * seq_len,
+        seq_len,
+        dtype=np.uint32,
+    )
+
+
+def _prefill_run_name(batch_size: int, seq_len: int) -> str:
+    return f"prefill_bs{batch_size}_seq{seq_len}_cache0_step0_k_only"
+
+
+def _build_graph(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    config: dict[str, Any],
+    weight_registry: dict[str, torch.Tensor],
+    batch_size: int,
+    seq_len: int,
+    use_fused: bool,
+) -> Any:
+    device_ref = DeviceRef.GPU()
+    total_seq_len = Dim(batch_size * seq_len)
+    rope = Llama3RotaryEmbedding(
+        config["hidden_size"],
+        config["num_attention_heads"],
+        config["rope_local_base_freq"],
+        seq_len + 256,
+        interleaved=False,
+        head_dim=config["head_dim"],
+    )
+    k_norm = Gemma3RMSNorm(config["head_dim"], DType.bfloat16, EPS)
+    k_norm.weight.name = "k_gamma"
+
+    input_row_offsets_type = TensorType(
+        DType.uint32,
+        [batch_size + 1],
+        device=device_ref,
+    )
+    flattened_kv_types = kv_params.get_symbolic_inputs().flatten()
+
+    graph_name = (
+        f"Gemma3KOnlyNormRopePrefillFusedBS{batch_size}Seq{seq_len}"
+        if use_fused
+        else f"Gemma3KOnlyNormRopePrefillBaselineBS{batch_size}Seq{seq_len}"
+    )
+
+    with Graph(
+        graph_name,
+        input_types=(input_row_offsets_type, *flattened_kv_types),
+    ) as graph:
+        input_row_offsets, *kv_cache = graph.inputs
+        kv_collection = unflatten_ragged_attention_inputs(
+            kv_cache, n_devices=1
+        )[0]
+        layer_idx = ops.constant(0, DType.uint32, device=DeviceRef.CPU())
+        freqs_cis = ops.cast(rope.freqs_cis, DType.bfloat16).to(device_ref)
+        gamma = k_norm.weight.cast(kv_params.dtype).to(device_ref)
+
+        if use_fused:
+            k_rms_norm_rope_ragged(
+                kv_params,
+                total_seq_len=total_seq_len,
+                input_row_offsets=input_row_offsets.tensor,
+                kv_collection=kv_collection,
+                freqs_cis=freqs_cis,
+                gamma=gamma,
+                epsilon=EPS,
+                layer_idx=layer_idx,
+                weight_offset=1.0,
+                interleaved=False,
+            )
+        else:
+            rms_norm_key_cache(
+                kv_params,
+                kv_collection=kv_collection,
+                gamma=gamma,
+                epsilon=EPS,
+                layer_idx=layer_idx,
+                total_seq_len=total_seq_len,
+                input_row_offsets=input_row_offsets.tensor,
+                weight_offset=1.0,
+            )
+            rope_k_cache_ragged(
+                kv_params,
+                total_seq_len=total_seq_len,
+                input_row_offsets=input_row_offsets.tensor,
+                kv_collection=kv_collection,
+                freqs_cis=freqs_cis,
+                layer_idx=layer_idx,
+                interleaved=False,
+            )
+
+        graph.output(input_row_offsets.tensor)
+
+    return session.load(graph, weights_registry=weight_registry)
+
+
+def _make_runtime_inputs(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    seq_len: int,
+    device: Accelerator,
+) -> KVCacheInputsPerDevice:
+    max_cache_length = PLACEHOLDER_CACHE_LEN + seq_len
+    total_num_pages = batch_size * math.ceil(max_cache_length / PAGE_SIZE)
+    kv_manager = PagedKVCacheManager(
+        params=kv_params,
+        total_num_pages=total_num_pages,
+        session=session,
+        max_batch_size=batch_size,
+    )
+
+    contexts: list[TextContext] = []
+    for _ in range(batch_size):
+        context = _make_placeholder_text_context(max_cache_length)
+        kv_manager.claim(context.request_id, replica_idx=0)
+        kv_manager.alloc(
+            context,
+            replica_idx=0,
+            num_steps=seq_len,
+        )
+        contexts.append(context)
+
+    runtime_inputs = kv_manager.runtime_inputs(
+        [contexts],
+        num_steps=seq_len,
+    ).inputs[0]
+
+    return KVCacheInputsPerDevice(
+        blocks=runtime_inputs.blocks,
+        cache_lengths=_device_uint32_buffer(
+            np.zeros(batch_size, dtype=np.uint32), device
+        ),
+        lookup_table=runtime_inputs.lookup_table,
+        max_lengths=runtime_inputs.max_lengths,
+        kv_scales=runtime_inputs.kv_scales,
+        attention_dispatch_metadata=runtime_inputs.attention_dispatch_metadata,
+    )
+
+
+def _clone_kv_blocks(blocks: Buffer, seed: int) -> Buffer:
+    torch.manual_seed(seed)
+    shape = tuple(int(dim) for dim in blocks.shape)
+    tensor = torch.randn(shape, dtype=torch.bfloat16, device="cuda").contiguous()
+    return Buffer.from_dlpack(tensor)
+
+
+def _make_benchmark_args(
+    *,
+    batch_size: int,
+    seq_len: int,
+    runtime_inputs: KVCacheInputsPerDevice,
+    device: Accelerator,
+    blocks_seed: int,
+) -> tuple[Any, ...]:
+    row_offsets = _device_uint32_buffer(
+        _row_offsets_array(batch_size, seq_len),
+        device,
+    )
+    return (
+        row_offsets,
+        _clone_kv_blocks(runtime_inputs.blocks, seed=blocks_seed),
+        runtime_inputs.cache_lengths,
+        runtime_inputs.lookup_table,
+        runtime_inputs.max_lengths,
+        runtime_inputs.attention_dispatch_metadata,
+    )
+
+
+def _run_correctness_check(
+    *,
+    baseline: Any,
+    fused: Any,
+    baseline_args: tuple[Any, ...],
+    fused_args: tuple[Any, ...],
+) -> None:
+    baseline.execute(*baseline_args)
+    fused.execute(*fused_args)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        from_dlpack(baseline_args[1]).to(torch.bfloat16),
+        from_dlpack(fused_args[1]).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+
+def _benchmark_us(compiled: Any, args: list[tuple[Any, ...]]) -> float:
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def _geomean(values: list[float]) -> float:
+    return math.exp(sum(math.log(value) for value in values) / len(values))
+
+
+def test_profile_k_norm_rope_prefill() -> None:
+    config = _load_text_config()
+    prefill_shapes = _resolve_prefill_shapes()
+    session = InferenceSession(devices=[Accelerator(0)])
+    device = Accelerator(0)
+    kv_params = KVCacheParams(
+        dtype=DType.bfloat16,
+        devices=[DeviceRef.GPU()],
+        n_kv_heads=config["num_key_value_heads"],
+        head_dim=config["head_dim"],
+        num_layers=1,
+        page_size=PAGE_SIZE,
+    )
+    weight_registry = _make_weight_registry(config["head_dim"])
+
+    results: dict[str, Any] = {
+        "benchmark_config": {
+            "dtype": "bfloat16",
+            "head_dim": config["head_dim"],
+            "num_kv_heads": config["num_key_value_heads"],
+            "page_size": PAGE_SIZE,
+            "rope": "non-interleaved",
+            "mode": "prefill-ragged-live-graph-k-only",
+            "shapes": [
+                _prefill_run_name(batch_size, seq_len)
+                for batch_size, seq_len in prefill_shapes
+            ],
+            "warmup_iters": WARMUP_ITERS,
+            "timed_iters": TIMED_ITERS,
+            "placeholder_cache_len": PLACEHOLDER_CACHE_LEN,
+        },
+        "correctness": "pass",
+        "first_sweep_us": {},
+        "confirm_sweep_us": {},
+        "average_us": {},
+        "average_speedup_ratio_vs_graph_baseline": {},
+    }
+
+    for batch_size, seq_len in prefill_shapes:
+        run_name = _prefill_run_name(batch_size, seq_len)
+        runtime_inputs = _make_runtime_inputs(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            device=device,
+        )
+        baseline = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=False,
+        )
+        fused = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=True,
+        )
+
+        baseline_correctness_args = _make_benchmark_args(
+            batch_size=batch_size,
+            seq_len=seq_len,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            blocks_seed=1000 + batch_size + seq_len,
+        )
+        fused_correctness_args = _make_benchmark_args(
+            batch_size=batch_size,
+            seq_len=seq_len,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            blocks_seed=1000 + batch_size + seq_len,
+        )
+        _run_correctness_check(
+            baseline=baseline,
+            fused=fused,
+            baseline_args=baseline_correctness_args,
+            fused_args=fused_correctness_args,
+        )
+
+        first_baseline_args = [
+            _make_benchmark_args(
+                batch_size=batch_size,
+                seq_len=seq_len,
+                runtime_inputs=runtime_inputs,
+                device=device,
+                blocks_seed=2000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        first_fused_args = [
+            _make_benchmark_args(
+                batch_size=batch_size,
+                seq_len=seq_len,
+                runtime_inputs=runtime_inputs,
+                device=device,
+                blocks_seed=2000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        first_baseline_us = _benchmark_us(baseline, first_baseline_args)
+        first_fused_us = _benchmark_us(fused, first_fused_args)
+        results["first_sweep_us"][run_name] = {
+            "baseline": first_baseline_us,
+            "fused": first_fused_us,
+        }
+
+        confirm_baseline_args = [
+            _make_benchmark_args(
+                batch_size=batch_size,
+                seq_len=seq_len,
+                runtime_inputs=runtime_inputs,
+                device=device,
+                blocks_seed=3000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        confirm_fused_args = [
+            _make_benchmark_args(
+                batch_size=batch_size,
+                seq_len=seq_len,
+                runtime_inputs=runtime_inputs,
+                device=device,
+                blocks_seed=3000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        confirm_baseline_us = _benchmark_us(baseline, confirm_baseline_args)
+        confirm_fused_us = _benchmark_us(fused, confirm_fused_args)
+        results["confirm_sweep_us"][run_name] = {
+            "baseline": confirm_baseline_us,
+            "fused": confirm_fused_us,
+        }
+
+        average_baseline_us = (first_baseline_us + confirm_baseline_us) / 2.0
+        average_fused_us = (first_fused_us + confirm_fused_us) / 2.0
+        results["average_us"][run_name] = {
+            "baseline": average_baseline_us,
+            "fused": average_fused_us,
+        }
+        results["average_speedup_ratio_vs_graph_baseline"][run_name] = (
+            average_baseline_us / average_fused_us
+        )
+
+    ratios = list(results["average_speedup_ratio_vs_graph_baseline"].values())
+    results["average_geomean_speedup_vs_graph_baseline"] = _geomean(ratios)
+
+    print(json.dumps(results, indent=2, sort_keys=True))

--- a/max/tests/integration/architectures/gemma3/test_profile_post_mlp_boundary.py
+++ b/max/tests/integration/architectures/gemma3/test_profile_post_mlp_boundary.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+from max.driver import Accelerator
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Graph, TensorType
+from max.pipelines.architectures.gemma3.layers.rms_norm import (
+    Gemma3RMSNorm,
+    gemma3_rms_norm_fused_residual_add,
+)
+from torch.utils.dlpack import from_dlpack
+
+
+EPS = 1e-6
+RMS_NORM_STD = 0.05
+WARMUP_ITERS = 20
+TIMED_ITERS = 50
+BATCH_SIZES = (64, 128)
+
+
+def _load_text_config() -> dict[str, Any]:
+    config_path = Path(os.environ["PIPELINES_TESTDATA"]) / "config.json"
+    with open(config_path) as file:
+        data = json.load(file)
+    return data.get("text_config", data)
+
+
+def _make_weight_registry(hidden_size: int) -> dict[str, torch.Tensor]:
+    torch.manual_seed(42)
+    return {
+        "post_feedforward_layernorm.weight": torch.randn(
+            hidden_size,
+            dtype=torch.bfloat16,
+        )
+        * RMS_NORM_STD,
+        "next_input_layernorm.weight": torch.randn(
+            hidden_size,
+            dtype=torch.bfloat16,
+        )
+        * RMS_NORM_STD,
+    }
+
+
+def _build_graph(
+    *,
+    session: InferenceSession,
+    hidden_size: int,
+    weight_registry: dict[str, torch.Tensor],
+    use_fused_boundary: bool,
+) -> Any:
+    post_feedforward_layernorm = Gemma3RMSNorm(
+        hidden_size,
+        DType.bfloat16,
+        EPS,
+    )
+    post_feedforward_layernorm.weight.name = "post_feedforward_layernorm.weight"
+    next_input_layernorm = Gemma3RMSNorm(
+        hidden_size,
+        DType.bfloat16,
+        EPS,
+    )
+    next_input_layernorm.weight.name = "next_input_layernorm.weight"
+
+    input_type = TensorType(
+        DType.bfloat16,
+        ["rows", hidden_size],
+        device=DeviceRef.GPU(),
+    )
+
+    graph_name = (
+        "Gemma3PostMlpBoundaryFused"
+        if use_fused_boundary
+        else "Gemma3PostMlpBoundaryBaseline"
+    )
+    with Graph(graph_name, input_types=(input_type, input_type)) as graph:
+        hidden_states, residual = graph.inputs
+        if use_fused_boundary:
+            next_norm, residual_out = gemma3_rms_norm_fused_residual_add(
+                hidden_states.tensor,
+                residual.tensor,
+                post_feedforward_layernorm,
+                next_input_layernorm,
+            )
+        else:
+            post_mlp = post_feedforward_layernorm(hidden_states.tensor)
+            residual_out = residual.tensor + post_mlp
+            next_norm = next_input_layernorm(residual_out)
+        graph.output(residual_out, next_norm)
+
+    return session.load(graph, weights_registry=weight_registry)
+
+
+def _make_inputs(
+    *,
+    batch_size: int,
+    hidden_size: int,
+    hidden_seed: int,
+    residual_seed: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    torch.manual_seed(hidden_seed)
+    hidden_states = torch.randn(
+        batch_size,
+        hidden_size,
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+    torch.manual_seed(residual_seed)
+    residual = torch.randn(
+        batch_size,
+        hidden_size,
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+    return hidden_states, residual
+
+
+def _run_correctness_check(
+    *,
+    baseline: Any,
+    fused: Any,
+    hidden_states: torch.Tensor,
+    residual: torch.Tensor,
+) -> None:
+    baseline_residual, baseline_next_norm = baseline.execute(
+        hidden_states,
+        residual,
+    )
+    fused_residual, fused_next_norm = fused.execute(hidden_states, residual)
+
+    torch.testing.assert_close(
+        from_dlpack(baseline_residual).to(torch.bfloat16),
+        from_dlpack(fused_residual).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+    torch.testing.assert_close(
+        from_dlpack(baseline_next_norm).to(torch.bfloat16),
+        from_dlpack(fused_next_norm).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+
+def _benchmark_us(
+    compiled: Any,
+    args: list[tuple[torch.Tensor, torch.Tensor]],
+) -> float:
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def test_profile_post_mlp_boundary() -> None:
+    config = _load_text_config()
+    hidden_size = int(config["hidden_size"])
+    session = InferenceSession(devices=[Accelerator(0)])
+    weight_registry = _make_weight_registry(hidden_size)
+
+    baseline = _build_graph(
+        session=session,
+        hidden_size=hidden_size,
+        weight_registry=weight_registry,
+        use_fused_boundary=False,
+    )
+    fused = _build_graph(
+        session=session,
+        hidden_size=hidden_size,
+        weight_registry=weight_registry,
+        use_fused_boundary=True,
+    )
+
+    results: dict[str, Any] = {
+        "benchmark_config": {
+            "dtype": "bfloat16",
+            "hidden_size": hidden_size,
+            "mode": "graph-post-mlp-boundary",
+            "warmup_iters": WARMUP_ITERS,
+            "timed_iters": TIMED_ITERS,
+        },
+        "correctness": "pass",
+        "first_sweep_us": {},
+        "confirm_sweep_us": {},
+        "average_us": {},
+        "average_speedup_ratio_vs_baseline": {},
+    }
+
+    for batch_size in BATCH_SIZES:
+        run_name = f"post_mlp_boundary_bs{batch_size}_hidden{hidden_size}"
+
+        baseline_args = [
+            _make_inputs(
+                batch_size=batch_size,
+                hidden_size=hidden_size,
+                hidden_seed=1000 + batch_size + iteration,
+                residual_seed=2000 + batch_size + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        fused_args = [
+            _make_inputs(
+                batch_size=batch_size,
+                hidden_size=hidden_size,
+                hidden_seed=1000 + batch_size + iteration,
+                residual_seed=2000 + batch_size + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+
+        _run_correctness_check(
+            baseline=baseline,
+            fused=fused,
+            hidden_states=baseline_args[0][0],
+            residual=baseline_args[0][1],
+        )
+
+        first_baseline_us = _benchmark_us(baseline, baseline_args)
+        first_fused_us = _benchmark_us(fused, fused_args)
+        results["first_sweep_us"][run_name] = {
+            "baseline": first_baseline_us,
+            "fused": first_fused_us,
+        }
+
+        del baseline_args
+        del fused_args
+
+        baseline_args = [
+            _make_inputs(
+                batch_size=batch_size,
+                hidden_size=hidden_size,
+                hidden_seed=3000 + batch_size + iteration,
+                residual_seed=4000 + batch_size + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        fused_args = [
+            _make_inputs(
+                batch_size=batch_size,
+                hidden_size=hidden_size,
+                hidden_seed=3000 + batch_size + iteration,
+                residual_seed=4000 + batch_size + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+
+        confirm_baseline_us = _benchmark_us(baseline, baseline_args)
+        confirm_fused_us = _benchmark_us(fused, fused_args)
+        results["confirm_sweep_us"][run_name] = {
+            "baseline": confirm_baseline_us,
+            "fused": confirm_fused_us,
+        }
+
+        average_baseline_us = 0.5 * (first_baseline_us + confirm_baseline_us)
+        average_fused_us = 0.5 * (first_fused_us + confirm_fused_us)
+        results["average_us"][run_name] = {
+            "baseline": average_baseline_us,
+            "fused": average_fused_us,
+        }
+        results["average_speedup_ratio_vs_baseline"][run_name] = (
+            average_baseline_us / average_fused_us
+        )
+
+        del baseline_args
+        del fused_args
+        torch.cuda.empty_cache()
+
+    speedups = list(results["average_speedup_ratio_vs_baseline"].values())
+    results["average_geomean_speedup_vs_baseline"] = math.prod(speedups) ** (
+        1.0 / len(speedups)
+    )
+    print(json.dumps(results, indent=2, sort_keys=True))

--- a/max/tests/integration/architectures/gemma3/test_profile_q_norm_rope_decode.py
+++ b/max/tests/integration/architectures/gemma3/test_profile_q_norm_rope_decode.py
@@ -1,0 +1,459 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from max.driver import Accelerator, Buffer
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Graph, TensorType, ops
+from max.nn.kernels import q_rms_norm_rope_ragged, rope_ragged
+from max.nn.rotary_embedding import Llama3RotaryEmbedding
+from max.pipelines.architectures.gemma3.layers.rms_norm import Gemma3RMSNorm
+from torch.utils.dlpack import from_dlpack
+
+
+EPS = 1e-6
+Q_NORM_STD = 0.68
+WARMUP_ITERS = 20
+TIMED_ITERS = 50
+CACHE_LEN_BASE = 1024
+CACHE_LEN_STEP = 7
+ITERATION_STEP = 1
+BATCH_SIZES = (64, 128)
+MAX_EXTRA_STEPS = WARMUP_ITERS + TIMED_ITERS
+
+
+def _load_text_config() -> dict[str, Any]:
+    config_path = Path(os.environ["PIPELINES_TESTDATA"]) / "config.json"
+    with open(config_path) as file:
+        data = json.load(file)
+    return data.get("text_config", data)
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return int(value) if value is not None else default
+
+
+def _env_int_tuple(name: str, default: tuple[int, ...]) -> tuple[int, ...]:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return tuple(
+        int(part.strip()) for part in value.split(",") if part.strip()
+    )
+
+
+def _profile_config(config: dict[str, Any]) -> dict[str, Any]:
+    batch_sizes = _env_int_tuple(
+        "PROFILE_Q_NORM_ROPE_DECODE_BATCH_SIZES", BATCH_SIZES
+    )
+    if not batch_sizes:
+        raise ValueError(
+            "PROFILE_Q_NORM_ROPE_DECODE_BATCH_SIZES must define at least one batch size"
+        )
+
+    num_attention_heads = _env_int(
+        "PROFILE_Q_NORM_ROPE_NUM_Q_HEADS", config["num_attention_heads"]
+    )
+    head_dim = _env_int("PROFILE_Q_NORM_ROPE_HEAD_DIM", config["head_dim"])
+    hidden_size = os.environ.get("PROFILE_Q_NORM_ROPE_HIDDEN_SIZE")
+    if hidden_size is None and (
+        num_attention_heads != config["num_attention_heads"]
+        or head_dim != config["head_dim"]
+    ):
+        resolved_hidden_size = num_attention_heads * head_dim
+    else:
+        resolved_hidden_size = (
+            int(hidden_size)
+            if hidden_size is not None
+            else config["hidden_size"]
+        )
+
+    return {
+        "hidden_size": resolved_hidden_size,
+        "num_attention_heads": num_attention_heads,
+        "head_dim": head_dim,
+        "rope_theta": _env_int(
+            "PROFILE_Q_NORM_ROPE_THETA", config["rope_local_base_freq"]
+        ),
+        "cache_len_base": _env_int(
+            "PROFILE_Q_NORM_ROPE_CACHE_LEN_BASE", CACHE_LEN_BASE
+        ),
+        "cache_len_step": _env_int(
+            "PROFILE_Q_NORM_ROPE_CACHE_LEN_STEP", CACHE_LEN_STEP
+        ),
+        "iteration_step": _env_int(
+            "PROFILE_Q_NORM_ROPE_DECODE_ITERATION_STEP", ITERATION_STEP
+        ),
+        "batch_sizes": batch_sizes,
+    }
+
+
+def _make_weight_registry(head_dim: int) -> dict[str, torch.Tensor]:
+    torch.manual_seed(42)
+    return {
+        "q_gamma": torch.randn(head_dim, dtype=torch.bfloat16) * Q_NORM_STD,
+    }
+
+
+def _device_uint32_buffer(array: np.ndarray, device: Accelerator) -> Buffer:
+    return Buffer.from_numpy(array).to(device)
+
+
+def _decode_run_name(
+    batch_size: int,
+    cache_len_base: int,
+    cache_len_step: int,
+    iteration_step: int,
+) -> str:
+    run_name = (
+        f"decode_bs{batch_size}_seq1_cache{cache_len_base}"
+        f"_step{cache_len_step}_q_only"
+    )
+    if iteration_step != ITERATION_STEP:
+        return f"{run_name}_iterstep{iteration_step}"
+    return run_name
+
+
+def _build_graph(
+    *,
+    session: InferenceSession,
+    config: dict[str, Any],
+    batch_size: int,
+    max_batch_size: int,
+    use_fused: bool,
+) -> Any:
+    device_ref = DeviceRef.GPU()
+    rope = Llama3RotaryEmbedding(
+        config["hidden_size"],
+        config["num_attention_heads"],
+        config["rope_theta"],
+        config["cache_len_base"]
+        + config["cache_len_step"] * (max_batch_size - 1)
+        + config["iteration_step"] * MAX_EXTRA_STEPS
+        + 256,
+        interleaved=False,
+        head_dim=config["head_dim"],
+    )
+    q_norm = Gemma3RMSNorm(config["head_dim"], DType.bfloat16, EPS)
+    q_norm.weight.name = "q_gamma"
+
+    input_type = TensorType(
+        DType.bfloat16,
+        [batch_size, config["num_attention_heads"], config["head_dim"]],
+        device=device_ref,
+    )
+    input_row_offsets_type = TensorType(
+        DType.uint32,
+        [batch_size + 1],
+        device=device_ref,
+    )
+    start_pos_type = TensorType(
+        DType.uint32,
+        [batch_size],
+        device=device_ref,
+    )
+
+    graph_name = (
+        f"Gemma3WideQOnlyNormRopeDecodeFusedBS{batch_size}"
+        if use_fused
+        else f"Gemma3WideQOnlyNormRopeDecodeBaselineBS{batch_size}"
+    )
+
+    with Graph(
+        graph_name,
+        input_types=(input_type, input_row_offsets_type, start_pos_type),
+    ) as graph:
+        xq, input_row_offsets, start_pos = graph.inputs
+        freqs_cis = ops.cast(rope.freqs_cis, DType.bfloat16).to(device_ref)
+        gamma = q_norm.weight.cast(DType.bfloat16).to(device_ref)
+
+        if use_fused:
+            output = q_rms_norm_rope_ragged(
+                xq.tensor,
+                input_row_offsets.tensor,
+                start_pos.tensor,
+                freqs_cis,
+                gamma,
+                EPS,
+                weight_offset=1.0,
+                interleaved=False,
+            )
+        else:
+            output = q_norm(xq.tensor)
+            output = rope_ragged(
+                output,
+                input_row_offsets.tensor,
+                start_pos.tensor,
+                freqs_cis,
+                interleaved=False,
+            )
+
+        graph.output(output)
+
+    return session.load(
+        graph,
+        weights_registry=_make_weight_registry(config["head_dim"]),
+    )
+
+
+def _make_benchmark_args(
+    *,
+    batch_size: int,
+    num_attention_heads: int,
+    head_dim: int,
+    cache_len_base: int,
+    cache_len_step: int,
+    iteration_step: int,
+    device: Accelerator,
+    xq_seed: int,
+) -> tuple[list[tuple[Any, ...]], Buffer]:
+    torch.manual_seed(xq_seed)
+    xq = torch.randn(
+        (batch_size, num_attention_heads, head_dim),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+    xq_buffer = Buffer.from_dlpack(xq)
+    row_offsets = _device_uint32_buffer(
+        np.arange(batch_size + 1, dtype=np.uint32),
+        device,
+    )
+    base_start_pos = np.asarray(
+        [
+            cache_len_base + cache_len_step * request_idx
+            for request_idx in range(batch_size)
+        ],
+        dtype=np.uint32,
+    )
+
+    args: list[tuple[Any, ...]] = []
+    for step in range(MAX_EXTRA_STEPS + 1):
+        step_offset = np.uint32(step * iteration_step)
+        start_pos = _device_uint32_buffer(
+            base_start_pos + step_offset, device
+        )
+        args.append((xq_buffer, row_offsets, start_pos))
+
+    return args, xq_buffer
+
+
+def _run_correctness_check(
+    *,
+    baseline: Any,
+    fused: Any,
+    baseline_args: tuple[Any, ...],
+    fused_args: tuple[Any, ...],
+) -> None:
+    baseline_output = baseline.execute(*baseline_args)[0]
+    fused_output = fused.execute(*fused_args)[0]
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        from_dlpack(baseline_output).to(torch.bfloat16),
+        from_dlpack(fused_output).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+
+def _benchmark_us(compiled: Any, args: list[tuple[Any, ...]]) -> float:
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def _geomean(values: list[float]) -> float:
+    return math.exp(sum(math.log(value) for value in values) / len(values))
+
+
+def test_profile_q_norm_rope_decode() -> None:
+    config = _profile_config(_load_text_config())
+    session = InferenceSession(devices=[Accelerator(0)])
+    device = Accelerator(0)
+
+    results: dict[str, Any] = {
+        "benchmark_config": {
+            "dtype": "bfloat16",
+            "hidden_size": config["hidden_size"],
+            "head_dim": config["head_dim"],
+            "num_q_heads": config["num_attention_heads"],
+            "rope": "non-interleaved",
+            "mode": "decode-ragged-live-graph-q-only",
+            "selected_shapes": [
+                _decode_run_name(
+                    batch_size,
+                    config["cache_len_base"],
+                    config["cache_len_step"],
+                    config["iteration_step"],
+                )
+                for batch_size in config["batch_sizes"]
+            ],
+            "cache_len_base": config["cache_len_base"],
+            "cache_len_step": config["cache_len_step"],
+            "iteration_step": config["iteration_step"],
+            "warmup_iters": WARMUP_ITERS,
+            "timed_iters": TIMED_ITERS,
+        },
+        "correctness": "pass",
+        "first_sweep_us": {},
+        "confirm_sweep_us": {},
+        "average_us": {},
+        "average_speedup_ratio_vs_graph_baseline": {},
+    }
+
+    speedups: list[float] = []
+
+    for batch_size in config["batch_sizes"]:
+        run_name = _decode_run_name(
+            batch_size,
+            config["cache_len_base"],
+            config["cache_len_step"],
+            config["iteration_step"],
+        )
+        baseline = _build_graph(
+            session=session,
+            config=config,
+            batch_size=batch_size,
+            max_batch_size=max(config["batch_sizes"]),
+            use_fused=False,
+        )
+        fused = _build_graph(
+            session=session,
+            config=config,
+            batch_size=batch_size,
+            max_batch_size=max(config["batch_sizes"]),
+            use_fused=True,
+        )
+
+        correctness_baseline_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            num_attention_heads=config["num_attention_heads"],
+            head_dim=config["head_dim"],
+            cache_len_base=config["cache_len_base"],
+            cache_len_step=config["cache_len_step"],
+            iteration_step=config["iteration_step"],
+            device=device,
+            xq_seed=1000 + batch_size,
+        )
+        correctness_fused_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            num_attention_heads=config["num_attention_heads"],
+            head_dim=config["head_dim"],
+            cache_len_base=config["cache_len_base"],
+            cache_len_step=config["cache_len_step"],
+            iteration_step=config["iteration_step"],
+            device=device,
+            xq_seed=1000 + batch_size,
+        )
+        _run_correctness_check(
+            baseline=baseline,
+            fused=fused,
+            baseline_args=correctness_baseline_args[0],
+            fused_args=correctness_fused_args[0],
+        )
+        del correctness_baseline_args
+        del correctness_fused_args
+
+        first_baseline_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            num_attention_heads=config["num_attention_heads"],
+            head_dim=config["head_dim"],
+            cache_len_base=config["cache_len_base"],
+            cache_len_step=config["cache_len_step"],
+            iteration_step=config["iteration_step"],
+            device=device,
+            xq_seed=2000 + batch_size,
+        )
+        first_fused_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            num_attention_heads=config["num_attention_heads"],
+            head_dim=config["head_dim"],
+            cache_len_base=config["cache_len_base"],
+            cache_len_step=config["cache_len_step"],
+            iteration_step=config["iteration_step"],
+            device=device,
+            xq_seed=2000 + batch_size,
+        )
+        first_baseline_us = _benchmark_us(baseline, first_baseline_args)
+        first_fused_us = _benchmark_us(fused, first_fused_args)
+        results["first_sweep_us"][run_name] = {
+            "baseline": first_baseline_us,
+            "fused": first_fused_us,
+        }
+        del first_baseline_args
+        del first_fused_args
+
+        confirm_baseline_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            num_attention_heads=config["num_attention_heads"],
+            head_dim=config["head_dim"],
+            cache_len_base=config["cache_len_base"],
+            cache_len_step=config["cache_len_step"],
+            iteration_step=config["iteration_step"],
+            device=device,
+            xq_seed=3000 + batch_size,
+        )
+        confirm_fused_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            num_attention_heads=config["num_attention_heads"],
+            head_dim=config["head_dim"],
+            cache_len_base=config["cache_len_base"],
+            cache_len_step=config["cache_len_step"],
+            iteration_step=config["iteration_step"],
+            device=device,
+            xq_seed=3000 + batch_size,
+        )
+        confirm_baseline_us = _benchmark_us(baseline, confirm_baseline_args)
+        confirm_fused_us = _benchmark_us(fused, confirm_fused_args)
+        results["confirm_sweep_us"][run_name] = {
+            "baseline": confirm_baseline_us,
+            "fused": confirm_fused_us,
+        }
+        del confirm_baseline_args
+        del confirm_fused_args
+
+        average_baseline_us = (first_baseline_us + confirm_baseline_us) / 2.0
+        average_fused_us = (first_fused_us + confirm_fused_us) / 2.0
+        speedup = average_baseline_us / average_fused_us
+
+        results["average_us"][run_name] = {
+            "baseline": average_baseline_us,
+            "fused": average_fused_us,
+        }
+        results["average_speedup_ratio_vs_graph_baseline"][run_name] = speedup
+        speedups.append(speedup)
+
+    results["average_geomean_speedup_vs_graph_baseline"] = _geomean(speedups)
+    print(json.dumps(results, indent=2))

--- a/max/tests/integration/architectures/gemma3/test_profile_q_norm_rope_prefill.py
+++ b/max/tests/integration/architectures/gemma3/test_profile_q_norm_rope_prefill.py
@@ -1,0 +1,473 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from max.driver import Accelerator, Buffer
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Graph, TensorType, ops
+from max.nn.kernels import q_rms_norm_rope_ragged, rope_ragged
+from max.nn.rotary_embedding import Llama3RotaryEmbedding
+from max.pipelines.architectures.gemma3.layers.rms_norm import Gemma3RMSNorm
+from torch.utils.dlpack import from_dlpack
+
+
+EPS = 1e-6
+Q_NORM_STD = 0.68
+WARMUP_ITERS = 20
+TIMED_ITERS = 50
+PREFILL_SHAPES = (
+    (1, 11),
+    (1, 512),
+    (1, 1024),
+    (1, 2048),
+    (2, 2048),
+)
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return int(value) if value is not None else default
+
+
+def _resolve_prefill_shapes() -> tuple[tuple[int, int], ...]:
+    raw_shapes = os.environ.get("PROFILE_Q_NORM_ROPE_PREFILL_SHAPES", "").strip()
+    if raw_shapes == "":
+        return PREFILL_SHAPES
+
+    resolved: list[tuple[int, int]] = []
+    for raw_shape in raw_shapes.split(","):
+        shape_text = raw_shape.strip().lower()
+        if shape_text == "":
+            continue
+        if "x" not in shape_text:
+            raise ValueError(
+                "PROFILE_Q_NORM_ROPE_PREFILL_SHAPES entries must look like "
+                f"'batchxseq', got {raw_shape!r}"
+            )
+        batch_text, seq_text = shape_text.split("x", maxsplit=1)
+        shape = (int(batch_text), int(seq_text))
+        if shape[0] <= 0 or shape[1] <= 0:
+            raise ValueError(
+                "PROFILE_Q_NORM_ROPE_PREFILL_SHAPES entries must be positive, "
+                f"got {shape}"
+            )
+        if shape not in resolved:
+            resolved.append(shape)
+
+    if not resolved:
+        raise ValueError(
+            "PROFILE_Q_NORM_ROPE_PREFILL_SHAPES must select at least one shape"
+        )
+    return tuple(resolved)
+
+
+def _load_text_config() -> dict[str, Any]:
+    config_path = Path(os.environ["PIPELINES_TESTDATA"]) / "config.json"
+    with open(config_path) as file:
+        data = json.load(file)
+    return data.get("text_config", data)
+
+
+def _profile_config(config: dict[str, Any]) -> dict[str, Any]:
+    num_attention_heads = _env_int(
+        "PROFILE_Q_NORM_ROPE_NUM_Q_HEADS", config["num_attention_heads"]
+    )
+    head_dim = _env_int("PROFILE_Q_NORM_ROPE_HEAD_DIM", config["head_dim"])
+    hidden_size = os.environ.get("PROFILE_Q_NORM_ROPE_HIDDEN_SIZE")
+    if hidden_size is None and (
+        num_attention_heads != config["num_attention_heads"]
+        or head_dim != config["head_dim"]
+    ):
+        resolved_hidden_size = num_attention_heads * head_dim
+    else:
+        resolved_hidden_size = (
+            int(hidden_size) if hidden_size is not None else config["hidden_size"]
+        )
+
+    return {
+        "hidden_size": resolved_hidden_size,
+        "num_attention_heads": num_attention_heads,
+        "head_dim": head_dim,
+        "rope_local_base_freq": _env_int(
+            "PROFILE_Q_NORM_ROPE_THETA", config["rope_local_base_freq"]
+        ),
+        "prefill_shapes": _resolve_prefill_shapes(),
+    }
+
+
+def _make_weight_registry(head_dim: int) -> dict[str, torch.Tensor]:
+    torch.manual_seed(42)
+    return {
+        "q_gamma": torch.randn(head_dim, dtype=torch.bfloat16) * Q_NORM_STD,
+    }
+
+
+def _device_uint32_buffer(array: np.ndarray, device: Accelerator) -> Buffer:
+    return Buffer.from_numpy(array).to(device)
+
+
+def _row_offsets_array(batch_size: int, seq_len: int) -> np.ndarray:
+    return np.arange(
+        0,
+        (batch_size + 1) * seq_len,
+        seq_len,
+        dtype=np.uint32,
+    )
+
+
+def _cache_lengths_array(batch_size: int) -> np.ndarray:
+    return np.zeros(batch_size, dtype=np.uint32)
+
+
+def _prefill_run_name(batch_size: int, seq_len: int) -> str:
+    return f"prefill_bs{batch_size}_seq{seq_len}_cache0_step0_q_only"
+
+
+def _build_graph(
+    *,
+    session: InferenceSession,
+    config: dict[str, Any],
+    weight_registry: dict[str, torch.Tensor],
+    batch_size: int,
+    seq_len: int,
+    use_fused: bool,
+) -> Any:
+    device_ref = DeviceRef.GPU()
+    rope = Llama3RotaryEmbedding(
+        config["hidden_size"],
+        config["num_attention_heads"],
+        config["rope_local_base_freq"],
+        seq_len + 256,
+        interleaved=False,
+        head_dim=config["head_dim"],
+    )
+    q_norm = Gemma3RMSNorm(config["head_dim"], DType.bfloat16, EPS)
+    q_norm.weight.name = "q_gamma"
+
+    input_type = TensorType(
+        DType.bfloat16,
+        [batch_size * seq_len, config["num_attention_heads"], config["head_dim"]],
+        device=device_ref,
+    )
+    input_row_offsets_type = TensorType(
+        DType.uint32,
+        [batch_size + 1],
+        device=device_ref,
+    )
+    start_pos_type = TensorType(
+        DType.uint32,
+        [batch_size],
+        device=device_ref,
+    )
+
+    graph_name = (
+        f"Gemma3WideQOnlyNormRopePrefillFusedBS{batch_size}Seq{seq_len}"
+        if use_fused
+        else f"Gemma3WideQOnlyNormRopePrefillBaselineBS{batch_size}Seq{seq_len}"
+    )
+
+    with Graph(
+        graph_name,
+        input_types=(input_type, input_row_offsets_type, start_pos_type),
+    ) as graph:
+        xq, input_row_offsets, start_pos = graph.inputs
+        freqs_cis = ops.cast(rope.freqs_cis, DType.bfloat16).to(device_ref)
+        gamma = q_norm.weight.cast(DType.bfloat16).to(device_ref)
+
+        if use_fused:
+            output = q_rms_norm_rope_ragged(
+                xq.tensor,
+                input_row_offsets.tensor,
+                start_pos.tensor,
+                freqs_cis,
+                gamma,
+                EPS,
+                weight_offset=1.0,
+            )
+        else:
+            output = q_norm(xq.tensor)
+            output = rope_ragged(
+                output,
+                input_row_offsets.tensor,
+                start_pos.tensor,
+                freqs_cis,
+                interleaved=False,
+            )
+
+        graph.output(output)
+
+    return session.load(graph, weights_registry=weight_registry)
+
+
+def _make_execution_args(
+    *,
+    batch_size: int,
+    seq_len: int,
+    num_attention_heads: int,
+    head_dim: int,
+    device: Accelerator,
+    xq_seed: int,
+) -> tuple[Any, ...]:
+    torch.manual_seed(xq_seed)
+    xq = torch.randn(
+        (batch_size * seq_len, num_attention_heads, head_dim),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+    return (
+        Buffer.from_dlpack(xq),
+        _device_uint32_buffer(_row_offsets_array(batch_size, seq_len), device),
+        _device_uint32_buffer(_cache_lengths_array(batch_size), device),
+    )
+
+
+def _run_correctness_check(
+    *,
+    baseline: Any,
+    fused: Any,
+    baseline_args: tuple[Any, ...],
+    fused_args: tuple[Any, ...],
+) -> None:
+    baseline_output = baseline.execute(*baseline_args)[0]
+    fused_output = fused.execute(*fused_args)[0]
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        from_dlpack(baseline_output).to(torch.bfloat16),
+        from_dlpack(fused_output).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+
+def _benchmark_us(compiled: Any, args: list[tuple[Any, ...]]) -> float:
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def _geomean(values: list[float]) -> float:
+    return math.exp(sum(math.log(value) for value in values) / len(values))
+
+
+def test_profile_q_norm_rope_prefill() -> None:
+    config = _profile_config(_load_text_config())
+    session = InferenceSession(devices=[Accelerator(0)])
+    device = Accelerator(0)
+    weight_registry = _make_weight_registry(config["head_dim"])
+    prefill_shapes = config["prefill_shapes"]
+
+    results: dict[str, Any] = {
+        "benchmark_config": {
+            "dtype": "bfloat16",
+            "head_dim": config["head_dim"],
+            "num_q_heads": config["num_attention_heads"],
+            "rope": "non-interleaved",
+            "mode": "prefill-ragged-live-graph-q-only",
+            "shapes": [
+                _prefill_run_name(batch_size, seq_len)
+                for batch_size, seq_len in prefill_shapes
+            ],
+            "warmup_iters": WARMUP_ITERS,
+            "timed_iters": TIMED_ITERS,
+        },
+        "correctness": "pass",
+        "first_sweep_us": {},
+        "confirm_sweep_us": {},
+        "average_us": {},
+        "average_speedup_ratio_vs_graph_baseline": {},
+    }
+
+    large_shape_names: list[str] = []
+
+    for batch_size, seq_len in prefill_shapes:
+        run_name = _prefill_run_name(batch_size, seq_len)
+        if seq_len >= 512:
+            large_shape_names.append(run_name)
+
+        baseline = _build_graph(
+            session=session,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=False,
+        )
+        fused = _build_graph(
+            session=session,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=True,
+        )
+
+        baseline_correctness_args = _make_execution_args(
+            batch_size=batch_size,
+            seq_len=seq_len,
+            num_attention_heads=config["num_attention_heads"],
+            head_dim=config["head_dim"],
+            device=device,
+            xq_seed=1000 + batch_size + seq_len,
+        )
+        fused_correctness_args = _make_execution_args(
+            batch_size=batch_size,
+            seq_len=seq_len,
+            num_attention_heads=config["num_attention_heads"],
+            head_dim=config["head_dim"],
+            device=device,
+            xq_seed=1000 + batch_size + seq_len,
+        )
+        _run_correctness_check(
+            baseline=baseline,
+            fused=fused,
+            baseline_args=baseline_correctness_args,
+            fused_args=fused_correctness_args,
+        )
+
+        first_baseline_args = [
+            _make_execution_args(
+                batch_size=batch_size,
+                seq_len=seq_len,
+                num_attention_heads=config["num_attention_heads"],
+                head_dim=config["head_dim"],
+                device=device,
+                xq_seed=3000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        first_fused_args = [
+            _make_execution_args(
+                batch_size=batch_size,
+                seq_len=seq_len,
+                num_attention_heads=config["num_attention_heads"],
+                head_dim=config["head_dim"],
+                device=device,
+                xq_seed=3000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        first_baseline_us = _benchmark_us(baseline, first_baseline_args)
+        first_fused_us = _benchmark_us(fused, first_fused_args)
+        results["first_sweep_us"][run_name] = {
+            "baseline": first_baseline_us,
+            "fused": first_fused_us,
+        }
+        del first_baseline_args
+        del first_fused_args
+
+        confirm_baseline_args = [
+            _make_execution_args(
+                batch_size=batch_size,
+                seq_len=seq_len,
+                num_attention_heads=config["num_attention_heads"],
+                head_dim=config["head_dim"],
+                device=device,
+                xq_seed=5000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        confirm_fused_args = [
+            _make_execution_args(
+                batch_size=batch_size,
+                seq_len=seq_len,
+                num_attention_heads=config["num_attention_heads"],
+                head_dim=config["head_dim"],
+                device=device,
+                xq_seed=5000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        confirm_baseline_us = _benchmark_us(baseline, confirm_baseline_args)
+        confirm_fused_us = _benchmark_us(fused, confirm_fused_args)
+        results["confirm_sweep_us"][run_name] = {
+            "baseline": confirm_baseline_us,
+            "fused": confirm_fused_us,
+        }
+        del confirm_baseline_args
+        del confirm_fused_args
+        del baseline_correctness_args
+        del fused_correctness_args
+
+        average_baseline_us = (first_baseline_us + confirm_baseline_us) / 2.0
+        average_fused_us = (first_fused_us + confirm_fused_us) / 2.0
+        results["average_us"][run_name] = {
+            "baseline": average_baseline_us,
+            "fused": average_fused_us,
+        }
+        results["average_speedup_ratio_vs_graph_baseline"][run_name] = (
+            average_baseline_us / average_fused_us
+        )
+
+        del baseline
+        del fused
+
+    ratios = list(results["average_speedup_ratio_vs_graph_baseline"].values())
+    results["average_geomean_speedup_vs_graph_baseline"] = _geomean(ratios)
+    large_shape_ratio_names = (
+        large_shape_names
+        if large_shape_names
+        else list(results["average_speedup_ratio_vs_graph_baseline"].keys())
+    )
+    results["average_large_shape_geomean_speedup_vs_graph_baseline"] = _geomean(
+        [
+            results["average_speedup_ratio_vs_graph_baseline"][run_name]
+            for run_name in large_shape_ratio_names
+        ]
+    )
+
+    confirm_ratios = [
+        results["confirm_sweep_us"][run_name]["baseline"]
+        / results["confirm_sweep_us"][run_name]["fused"]
+        for run_name in results["confirm_sweep_us"]
+    ]
+    results["confirm_geomean_speedup_vs_graph_baseline"] = _geomean(
+        confirm_ratios
+    )
+    confirm_large_shape_names = (
+        large_shape_names
+        if large_shape_names
+        else list(results["confirm_sweep_us"].keys())
+    )
+    results["confirm_large_shape_geomean_speedup_vs_graph_baseline"] = _geomean(
+        [
+            results["confirm_sweep_us"][run_name]["baseline"]
+            / results["confirm_sweep_us"][run_name]["fused"]
+            for run_name in confirm_large_shape_names
+        ]
+    )
+
+    print("GEMMA3_WIDE_Q_NORM_ROPE_PREFILL_PROFILE_START")
+    print(json.dumps(results, indent=2, sort_keys=True))
+    print("GEMMA3_WIDE_Q_NORM_ROPE_PREFILL_PROFILE_END")

--- a/max/tests/integration/architectures/gemma3/test_profile_qk_norm_rope_decode.py
+++ b/max/tests/integration/architectures/gemma3/test_profile_qk_norm_rope_decode.py
@@ -1,0 +1,747 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from max.driver import Accelerator, Buffer
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Graph, TensorType, ops
+from max.interfaces import RequestID, TokenBuffer
+from max.kv_cache import PagedKVCacheManager
+from max.nn.kernels import (
+    KVCacheParams,
+    fused_qk_ragged_rope,
+    q_rms_norm_fused_qk_ragged_rope,
+    rms_norm_key_cache,
+)
+from max.nn.kv_cache import unflatten_ragged_attention_inputs
+from max.nn.rotary_embedding import Llama3RotaryEmbedding
+from max.pipelines.architectures.gemma3.layers.rms_norm import Gemma3RMSNorm
+from max.pipelines.core import TextContext
+from torch.utils.dlpack import from_dlpack
+
+
+PAGE_SIZE = 128
+EPS = 1e-6
+Q_NORM_STD = 0.68
+K_NORM_STD = 0.793
+DEFAULT_WARMUP_ITERS = 20
+DEFAULT_TIMED_ITERS = 50
+CACHE_LEN_BASE = 1024
+CACHE_LEN_STEP = 7
+BATCH_SIZES = (64, 128)
+KV_BLOCK_COMPARE_CHUNK_ELEMENTS = 8_388_608
+
+
+def _load_text_config() -> dict[str, Any]:
+    config_path = Path(os.environ["PIPELINES_TESTDATA"]) / "config.json"
+    with open(config_path) as file:
+        data = json.load(file)
+    return data.get("text_config", data)
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    return int(value) if value is not None else default
+
+
+def _env_int_tuple(name: str, default: tuple[int, ...]) -> tuple[int, ...]:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return tuple(
+        int(part.strip()) for part in value.split(",") if part.strip()
+    )
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _max_extra_steps(warmup_iters: int, timed_iters: int) -> int:
+    return warmup_iters + timed_iters
+
+
+def _profile_config(config: dict[str, Any]) -> dict[str, Any]:
+    batch_sizes = _env_int_tuple(
+        "PROFILE_QK_NORM_ROPE_BATCH_SIZES", BATCH_SIZES
+    )
+    if not batch_sizes:
+        raise ValueError(
+            "PROFILE_QK_NORM_ROPE_BATCH_SIZES must define at least one batch size"
+        )
+
+    warmup_iters = _env_int(
+        "PROFILE_QK_NORM_ROPE_WARMUP_ITERS", DEFAULT_WARMUP_ITERS
+    )
+    timed_iters = _env_int(
+        "PROFILE_QK_NORM_ROPE_TIMED_ITERS", DEFAULT_TIMED_ITERS
+    )
+    if warmup_iters < 0:
+        raise ValueError("PROFILE_QK_NORM_ROPE_WARMUP_ITERS must be >= 0")
+    if timed_iters <= 0:
+        raise ValueError("PROFILE_QK_NORM_ROPE_TIMED_ITERS must be > 0")
+
+    return {
+        "hidden_size": _env_int(
+            "PROFILE_QK_NORM_ROPE_HIDDEN_SIZE", config["hidden_size"]
+        ),
+        "num_attention_heads": _env_int(
+            "PROFILE_QK_NORM_ROPE_NUM_Q_HEADS", config["num_attention_heads"]
+        ),
+        "num_key_value_heads": _env_int(
+            "PROFILE_QK_NORM_ROPE_NUM_KV_HEADS",
+            config["num_key_value_heads"],
+        ),
+        "head_dim": _env_int(
+            "PROFILE_QK_NORM_ROPE_HEAD_DIM", config["head_dim"]
+        ),
+        "rope_theta": _env_int(
+            "PROFILE_QK_NORM_ROPE_THETA", config["rope_local_base_freq"]
+        ),
+        "cache_len_base": _env_int(
+            "PROFILE_QK_NORM_ROPE_CACHE_LEN_BASE", CACHE_LEN_BASE
+        ),
+        "cache_len_step": _env_int(
+            "PROFILE_QK_NORM_ROPE_CACHE_LEN_STEP", CACHE_LEN_STEP
+        ),
+        "batch_sizes": batch_sizes,
+        "warmup_iters": warmup_iters,
+        "timed_iters": timed_iters,
+        "max_extra_steps": _max_extra_steps(warmup_iters, timed_iters),
+        "run_correctness": _env_bool(
+            "PROFILE_QK_NORM_ROPE_RUN_CORRECTNESS", True
+        ),
+        "run_confirm_sweep": _env_bool(
+            "PROFILE_QK_NORM_ROPE_RUN_CONFIRM_SWEEP", True
+        ),
+        "baseline_use_position_ids": _env_bool(
+            "PROFILE_QK_NORM_ROPE_BASELINE_USE_POSITION_IDS", False
+        ),
+    }
+
+
+def _make_weight_registry(head_dim: int) -> dict[str, torch.Tensor]:
+    torch.manual_seed(42)
+    return {
+        "q_gamma": torch.randn(head_dim, dtype=torch.bfloat16) * Q_NORM_STD,
+        "k_gamma": torch.randn(head_dim, dtype=torch.bfloat16) * K_NORM_STD,
+    }
+
+
+def _make_text_context(length: int, max_length: int) -> TextContext:
+    return TextContext(
+        request_id=RequestID(),
+        max_length=max_length,
+        tokens=TokenBuffer(np.zeros(length, dtype=np.int64)),
+    )
+
+
+def _build_graph(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    hidden_size: int,
+    num_attention_heads: int,
+    head_dim: int,
+    rope_theta: int,
+    max_batch_size: int,
+    cache_len_base: int,
+    cache_len_step: int,
+    max_extra_steps: int,
+    use_fused: bool,
+    baseline_use_position_ids: bool,
+) -> Any:
+    device_ref = DeviceRef.GPU()
+    rope = Llama3RotaryEmbedding(
+        hidden_size,
+        num_attention_heads,
+        rope_theta,
+        cache_len_base
+        + cache_len_step * (max_batch_size - 1)
+        + max_extra_steps
+        + 256,
+        interleaved=False,
+        head_dim=head_dim,
+    )
+    q_norm = Gemma3RMSNorm(head_dim, DType.bfloat16, EPS)
+    k_norm = Gemma3RMSNorm(head_dim, DType.bfloat16, EPS)
+    q_norm.weight.name = "q_gamma"
+    k_norm.weight.name = "k_gamma"
+
+    input_type = TensorType(
+        DType.bfloat16,
+        ["total_seq_len", num_attention_heads, head_dim],
+        device=device_ref,
+    )
+    input_row_offsets_type = TensorType(
+        DType.uint32,
+        ["input_row_offsets_len"],
+        device=device_ref,
+    )
+    position_ids_type = TensorType(
+        DType.uint32,
+        [1, "total_seq_len"],
+        device=device_ref,
+    )
+    flattened_kv_types = kv_params.get_symbolic_inputs().flatten()
+
+    graph_name = (
+        "Gemma3WideQKNormRopeFused"
+        if use_fused
+        else "Gemma3WideQKNormRopeBaseline"
+    )
+    graph_input_types = [input_type, input_row_offsets_type, *flattened_kv_types]
+    use_baseline_position_ids = baseline_use_position_ids and not use_fused
+    if use_baseline_position_ids:
+        graph_input_types.append(position_ids_type)
+
+    with Graph(
+        graph_name,
+        input_types=tuple(graph_input_types),
+    ) as graph:
+        xq, input_row_offsets, *graph_inputs = graph.inputs
+        position_ids = None
+        if use_baseline_position_ids:
+            *kv_cache, position_ids = graph_inputs
+        else:
+            kv_cache = graph_inputs
+        kv_collection = unflatten_ragged_attention_inputs(
+            kv_cache, n_devices=1
+        )[0]
+        layer_idx = ops.constant(0, DType.uint32, device=DeviceRef.CPU())
+        freqs_cis = ops.cast(rope.freqs_cis, xq.tensor.dtype).to(device_ref)
+
+        if use_fused:
+            output = q_rms_norm_fused_qk_ragged_rope(
+                kv_params,
+                xq.tensor,
+                input_row_offsets.tensor,
+                kv_collection,
+                freqs_cis,
+                q_norm.weight.cast(kv_params.dtype).to(device_ref),
+                k_norm.weight.cast(kv_params.dtype).to(device_ref),
+                EPS,
+                layer_idx,
+                weight_offset=1.0,
+                interleaved=False,
+            )
+        else:
+            rms_norm_key_cache(
+                kv_params,
+                kv_collection=kv_collection,
+                gamma=k_norm.weight.cast(kv_params.dtype).to(device_ref),
+                epsilon=EPS,
+                layer_idx=layer_idx,
+                total_seq_len=xq.tensor.shape[0],
+                input_row_offsets=input_row_offsets.tensor,
+                weight_offset=1.0,
+            )
+            output = q_norm(xq.tensor)
+            output = fused_qk_ragged_rope(
+                kv_params,
+                output,
+                input_row_offsets.tensor,
+                kv_collection,
+                freqs_cis,
+                layer_idx,
+                interleaved=False,
+                position_ids=(
+                    position_ids.tensor if position_ids is not None else None
+                ),
+            )
+
+        graph.output(output)
+
+    return session.load(graph, weights_registry=_make_weight_registry(head_dim))
+
+
+def _make_runtime_inputs(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    cache_len_base: int,
+    cache_len_step: int,
+    max_extra_steps: int,
+) -> tuple[np.ndarray, Any]:
+    cache_lengths = np.asarray(
+        [
+            cache_len_base + cache_len_step * request_idx
+            for request_idx in range(batch_size)
+        ],
+        dtype=np.uint32,
+    )
+    max_cache_length = int(cache_lengths[-1]) + max_extra_steps + 1
+    total_num_pages = sum(
+        math.ceil((int(cache_length) + max_extra_steps + 1) / PAGE_SIZE)
+        for cache_length in cache_lengths
+    )
+
+    kv_manager = PagedKVCacheManager(
+        params=kv_params,
+        total_num_pages=total_num_pages,
+        session=session,
+        max_batch_size=batch_size,
+    )
+
+    contexts: list[TextContext] = []
+    for cache_length in cache_lengths:
+        context = _make_text_context(int(cache_length), max_cache_length)
+        kv_manager.claim(context.request_id, replica_idx=0)
+        kv_manager.alloc(
+            context,
+            replica_idx=0,
+            num_steps=max_extra_steps + 1,
+        )
+        contexts.append(context)
+
+    runtime_inputs = kv_manager.runtime_inputs([contexts], num_steps=1).inputs[0]
+    return cache_lengths, runtime_inputs
+
+
+def _clone_kv_blocks(blocks: Buffer, seed: int) -> Buffer:
+    torch.manual_seed(seed)
+    shape = tuple(int(dim) for dim in blocks.shape)
+    tensor = torch.randn(shape, dtype=torch.bfloat16, device="cuda").contiguous()
+    return Buffer.from_dlpack(tensor)
+
+
+def _device_uint32_buffer(array: np.ndarray, device: Accelerator) -> Buffer:
+    return Buffer.from_numpy(array).to(device)
+
+
+def _make_benchmark_args(
+    *,
+    batch_size: int,
+    num_attention_heads: int,
+    head_dim: int,
+    cache_lengths: np.ndarray,
+    runtime_inputs: Any,
+    device: Accelerator,
+    xq_seed: int,
+    blocks_seed: int,
+    max_extra_steps: int,
+    use_position_ids: bool = False,
+) -> tuple[list[tuple[Any, ...]], Buffer, Buffer]:
+    torch.manual_seed(xq_seed)
+    xq = torch.randn(
+        (batch_size, num_attention_heads, head_dim),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+    xq_buffer = Buffer.from_dlpack(xq)
+    row_offsets = _device_uint32_buffer(
+        np.arange(batch_size + 1, dtype=np.uint32),
+        device,
+    )
+    kv_blocks = _clone_kv_blocks(runtime_inputs.blocks, seed=blocks_seed)
+    lookup_table = runtime_inputs.lookup_table.to(device)
+    dispatch_metadata = runtime_inputs.attention_dispatch_metadata
+
+    args: list[tuple[Any, ...]] = []
+    for step in range(max_extra_steps + 1):
+        step_cache_lengths = _device_uint32_buffer(
+            cache_lengths + np.uint32(step), device
+        )
+        run_args: tuple[Any, ...] = (
+            xq_buffer,
+            row_offsets,
+            kv_blocks,
+            step_cache_lengths,
+            lookup_table,
+            runtime_inputs.max_lengths,
+            dispatch_metadata,
+        )
+        if use_position_ids:
+            step_position_ids = _device_uint32_buffer(
+                np.expand_dims(cache_lengths + np.uint32(step), axis=0),
+                device,
+            )
+            run_args = (*run_args, step_position_ids)
+        args.append(run_args)
+    return args, kv_blocks, lookup_table
+
+
+def _run_correctness_check(
+    *,
+    baseline: Any,
+    fused: Any,
+    baseline_args: tuple[Any, ...],
+    fused_args: tuple[Any, ...],
+) -> None:
+    baseline_output = baseline.execute(*baseline_args)[0]
+    fused_output = fused.execute(*fused_args)[0]
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        from_dlpack(baseline_output).to(torch.bfloat16),
+        from_dlpack(fused_output).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+    baseline_blocks = from_dlpack(baseline_args[2]).to(torch.bfloat16)
+    fused_blocks = from_dlpack(fused_args[2]).to(torch.bfloat16)
+    flat_baseline_blocks = baseline_blocks.reshape(-1)
+    flat_fused_blocks = fused_blocks.reshape(-1)
+    for start in range(
+        0, flat_baseline_blocks.numel(), KV_BLOCK_COMPARE_CHUNK_ELEMENTS
+    ):
+        end = start + KV_BLOCK_COMPARE_CHUNK_ELEMENTS
+        torch.testing.assert_close(
+            flat_baseline_blocks[start:end],
+            flat_fused_blocks[start:end],
+            rtol=2 * torch.finfo(torch.bfloat16).eps,
+            atol=8 * torch.finfo(torch.bfloat16).eps,
+        )
+
+
+def _benchmark_us(
+    compiled: Any,
+    args: list[tuple[Any, ...]],
+    *,
+    warmup_iters: int,
+    timed_iters: int,
+) -> float:
+    warmup_args = args[:warmup_iters]
+    timed_args = args[warmup_iters : warmup_iters + timed_iters]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def _write_results_if_requested(results: dict[str, Any]) -> None:
+    path = os.environ.get("PROFILE_QK_NORM_ROPE_RESULTS_JSON")
+    if path is None:
+        return
+    results_path = Path(path)
+    results_path.parent.mkdir(parents=True, exist_ok=True)
+    results_path.write_text(
+        json.dumps(results, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _mark_results_progress(results: dict[str, Any], stage: str) -> None:
+    results["progress"] = {
+        "last_completed_stage": stage,
+        "updated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
+def _set_average_results(
+    results: dict[str, Any],
+    *,
+    run_name: str,
+    first_baseline_us: float,
+    first_fused_us: float,
+    confirm_baseline_us: float | None = None,
+    confirm_fused_us: float | None = None,
+    confirm_state: dict[str, Any] | None = None,
+) -> None:
+    average_baseline_us = first_baseline_us
+    average_fused_us = first_fused_us
+    if confirm_baseline_us is not None and confirm_fused_us is not None:
+        average_baseline_us = (first_baseline_us + confirm_baseline_us) / 2.0
+        average_fused_us = (first_fused_us + confirm_fused_us) / 2.0
+
+    results["confirm_sweep_us"][run_name] = (
+        confirm_state if confirm_state is not None else {"pending": True}
+    )
+    results["average_us"][run_name] = {
+        "baseline": average_baseline_us,
+        "fused": average_fused_us,
+    }
+    results["average_speedup_ratio_vs_graph_baseline"][run_name] = (
+        average_baseline_us / average_fused_us
+    )
+
+    speedups = list(results["average_speedup_ratio_vs_graph_baseline"].values())
+    results["average_geomean_speedup_vs_graph_baseline"] = float(
+        np.exp(np.mean(np.log(speedups)))
+    )
+
+
+def test_profile_qk_norm_rope_decode() -> None:
+    config = _load_text_config()
+    profile = _profile_config(config)
+    session = InferenceSession(devices=[Accelerator(0)])
+    device = Accelerator(0)
+    kv_params = KVCacheParams(
+        dtype=DType.bfloat16,
+        devices=[DeviceRef.GPU()],
+        n_kv_heads=profile["num_key_value_heads"],
+        head_dim=profile["head_dim"],
+        num_layers=1,
+        page_size=PAGE_SIZE,
+    )
+    baseline = _build_graph(
+        session=session,
+        kv_params=kv_params,
+        hidden_size=profile["hidden_size"],
+        num_attention_heads=profile["num_attention_heads"],
+        head_dim=profile["head_dim"],
+        rope_theta=profile["rope_theta"],
+        max_batch_size=max(profile["batch_sizes"]),
+        cache_len_base=profile["cache_len_base"],
+        cache_len_step=profile["cache_len_step"],
+        max_extra_steps=profile["max_extra_steps"],
+        use_fused=False,
+        baseline_use_position_ids=profile["baseline_use_position_ids"],
+    )
+    fused = _build_graph(
+        session=session,
+        kv_params=kv_params,
+        hidden_size=profile["hidden_size"],
+        num_attention_heads=profile["num_attention_heads"],
+        head_dim=profile["head_dim"],
+        rope_theta=profile["rope_theta"],
+        max_batch_size=max(profile["batch_sizes"]),
+        cache_len_base=profile["cache_len_base"],
+        cache_len_step=profile["cache_len_step"],
+        max_extra_steps=profile["max_extra_steps"],
+        use_fused=True,
+        baseline_use_position_ids=profile["baseline_use_position_ids"],
+    )
+
+    results: dict[str, Any] = {
+        "benchmark_config": {
+            "dtype": "bfloat16",
+            "hidden_size": profile["hidden_size"],
+            "head_dim": profile["head_dim"],
+            "num_q_heads": profile["num_attention_heads"],
+            "num_kv_heads": profile["num_key_value_heads"],
+            "page_size": PAGE_SIZE,
+            "rope": "non-interleaved",
+            "mode": "decode-ragged-live-graph",
+            "cache_len_base": profile["cache_len_base"],
+            "cache_len_step": profile["cache_len_step"],
+            "batch_sizes": list(profile["batch_sizes"]),
+            "warmup_iters": profile["warmup_iters"],
+            "timed_iters": profile["timed_iters"],
+            "run_correctness": profile["run_correctness"],
+            "run_confirm_sweep": profile["run_confirm_sweep"],
+            "baseline_use_position_ids": profile["baseline_use_position_ids"],
+        },
+        "correctness": (
+            "pass" if profile["run_correctness"] else "skipped_by_env"
+        ),
+        "progress": {
+            "last_completed_stage": "initialized",
+            "updated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        },
+        "first_sweep_us": {},
+        "confirm_sweep_us": {},
+        "average_us": {},
+        "average_speedup_ratio_vs_graph_baseline": {},
+    }
+
+    for batch_size in profile["batch_sizes"]:
+        cache_lengths, runtime_inputs = _make_runtime_inputs(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            cache_len_base=profile["cache_len_base"],
+            cache_len_step=profile["cache_len_step"],
+            max_extra_steps=profile["max_extra_steps"],
+        )
+        run_name = (
+            "decode_bs"
+            f"{batch_size}_seq1_cache{profile['cache_len_base']}"
+            f"_step{profile['cache_len_step']}"
+        )
+
+        if profile["run_correctness"]:
+            correctness_baseline_args, correctness_baseline_blocks, _ = (
+                _make_benchmark_args(
+                    batch_size=batch_size,
+                    num_attention_heads=profile["num_attention_heads"],
+                    head_dim=profile["head_dim"],
+                    cache_lengths=cache_lengths,
+                    runtime_inputs=runtime_inputs,
+                    device=device,
+                    xq_seed=100 + batch_size,
+                    blocks_seed=200 + batch_size,
+                    max_extra_steps=profile["max_extra_steps"],
+                    use_position_ids=profile["baseline_use_position_ids"],
+                )
+            )
+            correctness_fused_args, correctness_fused_blocks, _ = (
+                _make_benchmark_args(
+                    batch_size=batch_size,
+                    num_attention_heads=profile["num_attention_heads"],
+                    head_dim=profile["head_dim"],
+                    cache_lengths=cache_lengths,
+                    runtime_inputs=runtime_inputs,
+                    device=device,
+                    xq_seed=100 + batch_size,
+                    blocks_seed=200 + batch_size,
+                    max_extra_steps=profile["max_extra_steps"],
+                )
+            )
+            _run_correctness_check(
+                baseline=baseline,
+                fused=fused,
+                baseline_args=correctness_baseline_args[0],
+                fused_args=correctness_fused_args[0],
+            )
+            del correctness_baseline_blocks
+            del correctness_fused_blocks
+            del correctness_baseline_args
+            del correctness_fused_args
+
+        first_baseline_args, _, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            num_attention_heads=profile["num_attention_heads"],
+            head_dim=profile["head_dim"],
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            xq_seed=300 + batch_size,
+            blocks_seed=400 + batch_size,
+            max_extra_steps=profile["max_extra_steps"],
+            use_position_ids=profile["baseline_use_position_ids"],
+        )
+        first_fused_args, _, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            num_attention_heads=profile["num_attention_heads"],
+            head_dim=profile["head_dim"],
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            xq_seed=300 + batch_size,
+            blocks_seed=500 + batch_size,
+            max_extra_steps=profile["max_extra_steps"],
+        )
+        first_baseline_us = _benchmark_us(
+            baseline,
+            first_baseline_args,
+            warmup_iters=profile["warmup_iters"],
+            timed_iters=profile["timed_iters"],
+        )
+        first_fused_us = _benchmark_us(
+            fused,
+            first_fused_args,
+            warmup_iters=profile["warmup_iters"],
+            timed_iters=profile["timed_iters"],
+        )
+        results["first_sweep_us"][run_name] = {
+            "baseline": first_baseline_us,
+            "fused": first_fused_us,
+        }
+        _set_average_results(
+            results,
+            run_name=run_name,
+            first_baseline_us=first_baseline_us,
+            first_fused_us=first_fused_us,
+        )
+        _mark_results_progress(results, f"{run_name}:first_sweep")
+        if profile["run_confirm_sweep"]:
+            _write_results_if_requested(results)
+        del first_baseline_args
+        del first_fused_args
+
+        if profile["run_confirm_sweep"]:
+            confirm_baseline_args, _, _ = _make_benchmark_args(
+                batch_size=batch_size,
+                num_attention_heads=profile["num_attention_heads"],
+                head_dim=profile["head_dim"],
+                cache_lengths=cache_lengths,
+                runtime_inputs=runtime_inputs,
+                device=device,
+                xq_seed=600 + batch_size,
+                blocks_seed=700 + batch_size,
+                max_extra_steps=profile["max_extra_steps"],
+                use_position_ids=profile["baseline_use_position_ids"],
+            )
+            confirm_fused_args, _, _ = _make_benchmark_args(
+                batch_size=batch_size,
+                num_attention_heads=profile["num_attention_heads"],
+                head_dim=profile["head_dim"],
+                cache_lengths=cache_lengths,
+                runtime_inputs=runtime_inputs,
+                device=device,
+                xq_seed=600 + batch_size,
+                blocks_seed=800 + batch_size,
+                max_extra_steps=profile["max_extra_steps"],
+            )
+            confirm_baseline_us = _benchmark_us(
+                baseline,
+                confirm_baseline_args,
+                warmup_iters=profile["warmup_iters"],
+                timed_iters=profile["timed_iters"],
+            )
+            confirm_fused_us = _benchmark_us(
+                fused,
+                confirm_fused_args,
+                warmup_iters=profile["warmup_iters"],
+                timed_iters=profile["timed_iters"],
+            )
+            results["confirm_sweep_us"][run_name] = {
+                "baseline": confirm_baseline_us,
+                "fused": confirm_fused_us,
+            }
+            del confirm_baseline_args
+            del confirm_fused_args
+
+            _set_average_results(
+                results,
+                run_name=run_name,
+                first_baseline_us=first_baseline_us,
+                first_fused_us=first_fused_us,
+                confirm_baseline_us=confirm_baseline_us,
+                confirm_fused_us=confirm_fused_us,
+                confirm_state={
+                    "baseline": confirm_baseline_us,
+                    "fused": confirm_fused_us,
+                },
+            )
+            _mark_results_progress(results, f"{run_name}:confirm_sweep")
+        else:
+            _set_average_results(
+                results,
+                run_name=run_name,
+                first_baseline_us=first_baseline_us,
+                first_fused_us=first_fused_us,
+                confirm_state={"skipped": True},
+            )
+            _mark_results_progress(results, f"{run_name}:confirm_skipped")
+
+    _mark_results_progress(results, "complete")
+
+    _write_results_if_requested(results)
+    print("GEMMA3_WIDE_QK_NORM_ROPE_PROFILE_START")
+    print(json.dumps(results, sort_keys=True))
+    print("GEMMA3_WIDE_QK_NORM_ROPE_PROFILE_END")

--- a/max/tests/integration/architectures/gemma3/test_profile_qk_norm_rope_prefill.py
+++ b/max/tests/integration/architectures/gemma3/test_profile_qk_norm_rope_prefill.py
@@ -1,0 +1,709 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from max.driver import Accelerator, Buffer
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Dim, Graph, TensorType, ops
+from max.interfaces import RequestID, TokenBuffer
+from max.kv_cache import PagedKVCacheManager
+from max.nn.kernels import (
+    KVCacheParams,
+    fused_qk_ragged_rope,
+    q_rms_norm_fused_qk_ragged_rope,
+    rms_norm_key_cache,
+)
+from max.nn.kv_cache import KVCacheInputsPerDevice, unflatten_ragged_attention_inputs
+from max.nn.rotary_embedding import Llama3RotaryEmbedding
+from max.pipelines.architectures.gemma3.layers.rms_norm import Gemma3RMSNorm
+from max.pipelines.core import TextContext
+from torch.utils.dlpack import from_dlpack
+
+
+PAGE_SIZE = 128
+EPS = 1e-6
+Q_NORM_STD = 0.68
+K_NORM_STD = 0.793
+WARMUP_ITERS = 20
+TIMED_ITERS = 50
+PREFILL_SHAPES = (
+    (1, 11),
+    (1, 512),
+    (1, 1024),
+    (1, 2048),
+    (2, 2048),
+)
+PLACEHOLDER_CACHE_LEN = 1
+
+
+def _resolve_prefill_shapes() -> tuple[tuple[int, int], ...]:
+    raw_shapes = os.environ.get("PROFILE_QK_NORM_ROPE_PREFILL_SHAPES", "").strip()
+    if raw_shapes == "":
+        return PREFILL_SHAPES
+
+    resolved: list[tuple[int, int]] = []
+    for raw_shape in raw_shapes.split(","):
+        shape_text = raw_shape.strip().lower()
+        if shape_text == "":
+            continue
+        if "x" not in shape_text:
+            raise ValueError(
+                "PROFILE_QK_NORM_ROPE_PREFILL_SHAPES entries must look like "
+                f"'batchxseq', got {raw_shape!r}"
+            )
+        batch_text, seq_text = shape_text.split("x", maxsplit=1)
+        shape = (int(batch_text), int(seq_text))
+        if shape not in PREFILL_SHAPES:
+            raise ValueError(
+                "PROFILE_QK_NORM_ROPE_PREFILL_SHAPES only supports the existing "
+                f"prefill grid {PREFILL_SHAPES}, got {shape}"
+            )
+        if shape not in resolved:
+            resolved.append(shape)
+
+    if not resolved:
+        raise ValueError(
+            "PROFILE_QK_NORM_ROPE_PREFILL_SHAPES must select at least one shape"
+        )
+    return tuple(resolved)
+
+
+def _load_text_config() -> dict[str, Any]:
+    config_path = Path(os.environ["PIPELINES_TESTDATA"]) / "config.json"
+    with open(config_path) as file:
+        data = json.load(file)
+    return data.get("text_config", data)
+
+
+def _make_weight_registry(head_dim: int) -> dict[str, torch.Tensor]:
+    torch.manual_seed(42)
+    return {
+        "q_gamma": torch.randn(head_dim, dtype=torch.bfloat16) * Q_NORM_STD,
+        "k_gamma": torch.randn(head_dim, dtype=torch.bfloat16) * K_NORM_STD,
+    }
+
+
+def _make_placeholder_text_context(max_length: int) -> TextContext:
+    return TextContext(
+        request_id=RequestID(),
+        max_length=max_length,
+        tokens=TokenBuffer(
+            np.zeros(PLACEHOLDER_CACHE_LEN, dtype=np.int64)
+        ),
+    )
+
+
+def _device_uint32_buffer(array: np.ndarray, device: Accelerator) -> Buffer:
+    return Buffer.from_numpy(array).to(device)
+
+
+def _row_offsets_array(batch_size: int, seq_len: int) -> np.ndarray:
+    return np.arange(
+        0,
+        (batch_size + 1) * seq_len,
+        seq_len,
+        dtype=np.uint32,
+    )
+
+
+def _prefill_run_name(batch_size: int, seq_len: int) -> str:
+    return f"prefill_bs{batch_size}_seq{seq_len}_cache0_step0_qk"
+
+
+def _build_graph(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    config: dict[str, Any],
+    weight_registry: dict[str, torch.Tensor],
+    batch_size: int,
+    seq_len: int,
+    use_fused: bool,
+) -> Any:
+    device_ref = DeviceRef.GPU()
+    total_seq_len = Dim(batch_size * seq_len)
+    rope = Llama3RotaryEmbedding(
+        config["hidden_size"],
+        config["num_attention_heads"],
+        config["rope_local_base_freq"],
+        seq_len + PLACEHOLDER_CACHE_LEN + 256,
+        interleaved=False,
+        head_dim=config["head_dim"],
+    )
+    q_norm = Gemma3RMSNorm(config["head_dim"], DType.bfloat16, EPS)
+    k_norm = Gemma3RMSNorm(config["head_dim"], DType.bfloat16, EPS)
+    q_norm.weight.name = "q_gamma"
+    k_norm.weight.name = "k_gamma"
+
+    input_type = TensorType(
+        DType.bfloat16,
+        [batch_size * seq_len, config["num_attention_heads"], config["head_dim"]],
+        device=device_ref,
+    )
+    input_row_offsets_type = TensorType(
+        DType.uint32,
+        [batch_size + 1],
+        device=device_ref,
+    )
+    flattened_kv_types = kv_params.get_symbolic_inputs().flatten()
+
+    graph_name = (
+        f"Gemma3WideQKNormRopePrefillFusedBS{batch_size}Seq{seq_len}"
+        if use_fused
+        else f"Gemma3WideQKNormRopePrefillBaselineBS{batch_size}Seq{seq_len}"
+    )
+
+    with Graph(
+        graph_name,
+        input_types=(input_type, input_row_offsets_type, *flattened_kv_types),
+    ) as graph:
+        xq, input_row_offsets, *kv_cache = graph.inputs
+        kv_collection = unflatten_ragged_attention_inputs(
+            kv_cache, n_devices=1
+        )[0]
+        layer_idx = ops.constant(0, DType.uint32, device=DeviceRef.CPU())
+        freqs_cis = ops.cast(rope.freqs_cis, DType.bfloat16).to(device_ref)
+
+        if use_fused:
+            output = q_rms_norm_fused_qk_ragged_rope(
+                kv_params,
+                xq.tensor,
+                input_row_offsets.tensor,
+                kv_collection,
+                freqs_cis,
+                q_norm.weight.cast(kv_params.dtype).to(device_ref),
+                k_norm.weight.cast(kv_params.dtype).to(device_ref),
+                EPS,
+                layer_idx,
+                weight_offset=1.0,
+                interleaved=False,
+            )
+        else:
+            rms_norm_key_cache(
+                kv_params,
+                kv_collection=kv_collection,
+                gamma=k_norm.weight.cast(kv_params.dtype).to(device_ref),
+                epsilon=EPS,
+                layer_idx=layer_idx,
+                total_seq_len=total_seq_len,
+                input_row_offsets=input_row_offsets.tensor,
+                weight_offset=1.0,
+            )
+            output = q_norm(xq.tensor)
+            output = fused_qk_ragged_rope(
+                kv_params,
+                output,
+                input_row_offsets.tensor,
+                kv_collection,
+                freqs_cis,
+                layer_idx,
+                interleaved=False,
+            )
+
+        graph.output(output)
+
+    return session.load(graph, weights_registry=weight_registry)
+
+
+def _make_runtime_inputs(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    seq_len: int,
+    device: Accelerator,
+) -> KVCacheInputsPerDevice:
+    max_cache_length = PLACEHOLDER_CACHE_LEN + seq_len
+    total_num_pages = batch_size * math.ceil(max_cache_length / PAGE_SIZE)
+    kv_manager = PagedKVCacheManager(
+        params=kv_params,
+        total_num_pages=total_num_pages,
+        session=session,
+        max_batch_size=batch_size,
+    )
+
+    contexts: list[TextContext] = []
+    for _ in range(batch_size):
+        context = _make_placeholder_text_context(max_cache_length)
+        kv_manager.claim(context.request_id, replica_idx=0)
+        kv_manager.alloc(
+            context,
+            replica_idx=0,
+            num_steps=seq_len,
+        )
+        contexts.append(context)
+
+    runtime_inputs = kv_manager.runtime_inputs(
+        [contexts],
+        num_steps=seq_len,
+    ).inputs[0]
+
+    return KVCacheInputsPerDevice(
+        blocks=runtime_inputs.blocks,
+        cache_lengths=_device_uint32_buffer(
+            np.zeros(batch_size, dtype=np.uint32), device
+        ),
+        lookup_table=runtime_inputs.lookup_table,
+        max_lengths=runtime_inputs.max_lengths,
+        kv_scales=runtime_inputs.kv_scales,
+        attention_dispatch_metadata=runtime_inputs.attention_dispatch_metadata,
+    )
+
+
+def _clone_kv_blocks(blocks: Buffer, seed: int) -> Buffer:
+    torch.manual_seed(seed)
+    shape = tuple(int(dim) for dim in blocks.shape)
+    tensor = torch.randn(shape, dtype=torch.bfloat16, device="cuda").contiguous()
+    return Buffer.from_dlpack(tensor)
+
+
+def _make_execution_args(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    seq_len: int,
+    num_attention_heads: int,
+    head_dim: int,
+    device: Accelerator,
+    xq_seed: int,
+    blocks_seed: int,
+) -> tuple[Any, ...]:
+    runtime_inputs = _make_runtime_inputs(
+        session=session,
+        kv_params=kv_params,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        device=device,
+    )
+
+    torch.manual_seed(xq_seed)
+    xq = torch.randn(
+        (batch_size * seq_len, num_attention_heads, head_dim),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+
+    return (
+        Buffer.from_dlpack(xq),
+        _device_uint32_buffer(_row_offsets_array(batch_size, seq_len), device),
+        _clone_kv_blocks(runtime_inputs.blocks, seed=blocks_seed),
+        runtime_inputs.cache_lengths,
+        runtime_inputs.lookup_table,
+        runtime_inputs.max_lengths,
+        runtime_inputs.attention_dispatch_metadata,
+    )
+
+
+def _run_correctness_check(
+    *,
+    baseline: Any,
+    fused: Any,
+    baseline_args: tuple[Any, ...],
+    fused_args: tuple[Any, ...],
+) -> None:
+    baseline_output = baseline.execute(*baseline_args)[0]
+    fused_output = fused.execute(*fused_args)[0]
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        from_dlpack(baseline_output).to(torch.bfloat16),
+        from_dlpack(fused_output).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+    torch.testing.assert_close(
+        from_dlpack(baseline_args[2]).to(torch.bfloat16),
+        from_dlpack(fused_args[2]).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+
+def _benchmark_us(compiled: Any, args: list[tuple[Any, ...]]) -> float:
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def _run_nvidia_smi_query(query_fields: str) -> list[list[str]]:
+    result = subprocess.run(
+        [
+            "nvidia-smi",
+            f"--query-{query_fields}",
+            "--format=csv,noheader,nounits",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        [field.strip() for field in row]
+        for row in csv.reader(result.stdout.splitlines())
+        if row
+    ]
+
+
+def _build_gpu_isolation_guard() -> dict[str, Any] | None:
+    raw_guard = os.environ.get(
+        "PROFILE_QK_NORM_ROPE_PREFILL_ENFORCE_GPU_ISOLATION", ""
+    ).strip()
+    if raw_guard.lower() not in ("1", "true", "yes"):
+        return None
+
+    cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", "").strip()
+    target_gpu_index = (
+        0 if cuda_visible_devices == "" else int(cuda_visible_devices.split(",")[0])
+    )
+
+    for index_text, gpu_uuid in _run_nvidia_smi_query("gpu=index,uuid"):
+        if int(index_text) == target_gpu_index:
+            return {
+                "allowed_pid": os.getpid(),
+                "target_gpu_index": target_gpu_index,
+                "target_gpu_uuid": gpu_uuid,
+            }
+
+    raise AssertionError(
+        "Could not resolve the target GPU UUID for "
+        f"CUDA_VISIBLE_DEVICES={cuda_visible_devices!r}"
+    )
+
+
+def _assert_gpu_isolation(
+    gpu_isolation_guard: dict[str, Any] | None,
+    *,
+    label: str,
+) -> None:
+    if gpu_isolation_guard is None:
+        return
+
+    resident_compute_apps = []
+    unexpected_apps = []
+    for gpu_uuid, pid_text, process_name, used_gpu_memory_mib in (
+        _run_nvidia_smi_query(
+            "compute-apps=gpu_uuid,pid,process_name,used_gpu_memory"
+        )
+    ):
+        if gpu_uuid != gpu_isolation_guard["target_gpu_uuid"]:
+            continue
+        resident_app = {
+            "gpu_uuid": gpu_uuid,
+            "pid": int(pid_text),
+            "process_name": process_name,
+            "used_gpu_memory_mib": float(used_gpu_memory_mib),
+        }
+        resident_compute_apps.append(resident_app)
+        if resident_app["pid"] != gpu_isolation_guard["allowed_pid"]:
+            unexpected_apps.append(resident_app)
+
+    if unexpected_apps:
+        raise AssertionError(
+            f"{label} at {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}: "
+            "unexpected compute apps on physical GPU "
+            f"{gpu_isolation_guard['target_gpu_index']} "
+            f"({gpu_isolation_guard['target_gpu_uuid']}): "
+            f"{unexpected_apps}; all resident apps: {resident_compute_apps}"
+        )
+
+
+def _benchmark_us_guarded(
+    compiled: Any,
+    args: list[tuple[Any, ...]],
+    *,
+    gpu_isolation_guard: dict[str, Any] | None,
+    label: str,
+) -> float:
+    _assert_gpu_isolation(
+        gpu_isolation_guard,
+        label=f"{label}:before_warmup",
+    )
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    _assert_gpu_isolation(
+        gpu_isolation_guard,
+        label=f"{label}:after_timed",
+    )
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def _geomean(values: list[float]) -> float:
+    return math.exp(sum(math.log(value) for value in values) / len(values))
+
+
+def test_profile_qk_norm_rope_prefill() -> None:
+    config = _load_text_config()
+    prefill_shapes = _resolve_prefill_shapes()
+    session = InferenceSession(devices=[Accelerator(0)])
+    device = Accelerator(0)
+    gpu_isolation_guard = _build_gpu_isolation_guard()
+    kv_params = KVCacheParams(
+        dtype=DType.bfloat16,
+        devices=[DeviceRef.GPU()],
+        n_kv_heads=config["num_key_value_heads"],
+        head_dim=config["head_dim"],
+        num_layers=1,
+        page_size=PAGE_SIZE,
+    )
+    weight_registry = _make_weight_registry(config["head_dim"])
+
+    results: dict[str, Any] = {
+        "benchmark_config": {
+            "dtype": "bfloat16",
+            "head_dim": config["head_dim"],
+            "num_q_heads": config["num_attention_heads"],
+            "num_kv_heads": config["num_key_value_heads"],
+            "page_size": PAGE_SIZE,
+            "rope": "non-interleaved",
+            "mode": "prefill-ragged-live-graph-qk-one-shot",
+            "shapes": [
+                _prefill_run_name(batch_size, seq_len)
+                for batch_size, seq_len in prefill_shapes
+            ],
+            "warmup_iters": WARMUP_ITERS,
+            "timed_iters": TIMED_ITERS,
+            "placeholder_cache_len": PLACEHOLDER_CACHE_LEN,
+        },
+        "correctness": "pass",
+        "first_sweep_us": {},
+        "confirm_sweep_us": {},
+        "average_us": {},
+        "average_speedup_ratio_vs_graph_baseline": {},
+    }
+
+    large_shape_names: list[str] = []
+
+    for batch_size, seq_len in prefill_shapes:
+        run_name = _prefill_run_name(batch_size, seq_len)
+        if seq_len >= 512:
+            large_shape_names.append(run_name)
+
+        baseline = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=False,
+        )
+        fused = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=True,
+        )
+
+        baseline_correctness_args = _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            num_attention_heads=config["num_attention_heads"],
+            head_dim=config["head_dim"],
+            device=device,
+            xq_seed=1000 + batch_size + seq_len,
+            blocks_seed=2000 + batch_size + seq_len,
+        )
+        fused_correctness_args = _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            num_attention_heads=config["num_attention_heads"],
+            head_dim=config["head_dim"],
+            device=device,
+            xq_seed=1000 + batch_size + seq_len,
+            blocks_seed=2000 + batch_size + seq_len,
+        )
+        _run_correctness_check(
+            baseline=baseline,
+            fused=fused,
+            baseline_args=baseline_correctness_args,
+            fused_args=fused_correctness_args,
+        )
+
+        first_baseline_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                num_attention_heads=config["num_attention_heads"],
+                head_dim=config["head_dim"],
+                device=device,
+                xq_seed=3000 + batch_size + seq_len + iteration,
+                blocks_seed=4000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        first_fused_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                num_attention_heads=config["num_attention_heads"],
+                head_dim=config["head_dim"],
+                device=device,
+                xq_seed=3000 + batch_size + seq_len + iteration,
+                blocks_seed=4000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        first_baseline_us = _benchmark_us_guarded(
+            baseline,
+            first_baseline_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:baseline:first",
+        )
+        first_fused_us = _benchmark_us_guarded(
+            fused,
+            first_fused_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:fused:first",
+        )
+        results["first_sweep_us"][run_name] = {
+            "baseline": first_baseline_us,
+            "fused": first_fused_us,
+        }
+        del first_baseline_args
+        del first_fused_args
+
+        confirm_baseline_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                num_attention_heads=config["num_attention_heads"],
+                head_dim=config["head_dim"],
+                device=device,
+                xq_seed=5000 + batch_size + seq_len + iteration,
+                blocks_seed=6000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        confirm_fused_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                num_attention_heads=config["num_attention_heads"],
+                head_dim=config["head_dim"],
+                device=device,
+                xq_seed=5000 + batch_size + seq_len + iteration,
+                blocks_seed=6000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        confirm_baseline_us = _benchmark_us_guarded(
+            baseline,
+            confirm_baseline_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:baseline:confirm",
+        )
+        confirm_fused_us = _benchmark_us_guarded(
+            fused,
+            confirm_fused_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:fused:confirm",
+        )
+        results["confirm_sweep_us"][run_name] = {
+            "baseline": confirm_baseline_us,
+            "fused": confirm_fused_us,
+        }
+        del confirm_baseline_args
+        del confirm_fused_args
+        del baseline_correctness_args
+        del fused_correctness_args
+
+        average_baseline_us = (first_baseline_us + confirm_baseline_us) / 2.0
+        average_fused_us = (first_fused_us + confirm_fused_us) / 2.0
+        results["average_us"][run_name] = {
+            "baseline": average_baseline_us,
+            "fused": average_fused_us,
+        }
+        results["average_speedup_ratio_vs_graph_baseline"][run_name] = (
+            average_baseline_us / average_fused_us
+        )
+
+        del baseline
+        del fused
+
+    ratios = list(results["average_speedup_ratio_vs_graph_baseline"].values())
+    results["average_geomean_speedup_vs_graph_baseline"] = _geomean(ratios)
+    results["average_large_shape_geomean_speedup_vs_graph_baseline"] = _geomean(
+        [
+            results["average_speedup_ratio_vs_graph_baseline"][run_name]
+            for run_name in large_shape_names
+        ]
+    )
+
+    confirm_ratios = [
+        results["confirm_sweep_us"][run_name]["baseline"]
+        / results["confirm_sweep_us"][run_name]["fused"]
+        for run_name in results["confirm_sweep_us"]
+    ]
+    results["confirm_geomean_speedup_vs_graph_baseline"] = _geomean(
+        confirm_ratios
+    )
+    results["confirm_large_shape_geomean_speedup_vs_graph_baseline"] = _geomean(
+        [
+            results["confirm_sweep_us"][run_name]["baseline"]
+            / results["confirm_sweep_us"][run_name]["fused"]
+            for run_name in large_shape_names
+        ]
+    )
+
+    print("GEMMA3_WIDE_QK_NORM_ROPE_PREFILL_PROFILE_START")
+    print(json.dumps(results, indent=2, sort_keys=True))
+    print("GEMMA3_WIDE_QK_NORM_ROPE_PREFILL_PROFILE_END")

--- a/max/tests/integration/architectures/gemma3/test_profile_qkv_qk_prefill_bridge.py
+++ b/max/tests/integration/architectures/gemma3/test_profile_qkv_qk_prefill_bridge.py
@@ -1,0 +1,676 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from max.driver import Accelerator, Buffer
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Graph, TensorType, ops
+from max.interfaces import RequestID, TokenBuffer
+from max.kv_cache import PagedKVCacheManager
+from max.nn.kernels import (
+    KVCacheParams,
+    fused_qk_ragged_rope,
+    fused_qkv_ragged_matmul,
+    q_rms_norm_fused_qk_ragged_rope,
+    rms_norm_key_cache,
+)
+from max.nn.kv_cache import KVCacheInputsPerDevice, unflatten_ragged_attention_inputs
+from max.nn.rotary_embedding import Llama3RotaryEmbedding
+from max.pipelines.architectures.gemma3.layers.attention import (
+    Gemma3Attention as MaxGemma3Attention,
+)
+from max.pipelines.core import TextContext
+from torch.utils.dlpack import from_dlpack
+
+
+PAGE_SIZE = 128
+EPS = 1e-6
+DEFAULT_LAYER_IDX = 0
+DEFAULT_LAYER_TYPE = "local"
+Q_NORM_STD = 0.68
+K_NORM_STD = 0.793
+Q_PROJ_STD = 0.0284
+K_PROJ_STD = 0.0309
+V_PROJ_STD = 0.0309
+O_PROJ_STD = 0.0237
+WARMUP_ITERS = 20
+TIMED_ITERS = 50
+PREFILL_SHAPES = (
+    (1, 11),
+    (1, 512),
+    (1, 1024),
+    (1, 2048),
+    (2, 2048),
+)
+PLACEHOLDER_CACHE_LEN = 1
+
+
+def _resolve_layer_metadata(config: dict[str, Any]) -> tuple[int, str]:
+    layer_idx = int(
+        os.environ.get("PROFILE_ATTENTION_LAYER_IDX", str(DEFAULT_LAYER_IDX))
+    )
+    num_hidden_layers = int(config["num_hidden_layers"])
+    assert 0 <= layer_idx < num_hidden_layers, (
+        f"layer_idx={layer_idx} must be in [0, {num_hidden_layers})"
+    )
+    layer_type = (
+        "local"
+        if bool((layer_idx + 1) % config["sliding_window_pattern"])
+        else "global"
+    )
+    expected_layer_type = os.environ.get(
+        "PROFILE_ATTENTION_LAYER_TYPE", DEFAULT_LAYER_TYPE
+    )
+    assert (
+        layer_type == expected_layer_type
+    ), f"expected {expected_layer_type} layer, got {layer_type} for layer_idx={layer_idx}"
+    return layer_idx, layer_type
+
+
+def _resolve_kv_num_layers(config: dict[str, Any], layer_idx: int) -> int:
+    min_num_layers = layer_idx + 1
+    kv_num_layers = int(
+        os.environ.get("PROFILE_ATTENTION_KV_NUM_LAYERS", str(min_num_layers))
+    )
+    assert kv_num_layers >= min_num_layers, (
+        f"kv_num_layers={kv_num_layers} must cover layer_idx={layer_idx}"
+    )
+    assert kv_num_layers <= int(config["num_hidden_layers"]), (
+        "kv_num_layers cannot exceed the model layer count "
+        f"({config['num_hidden_layers']})"
+    )
+    return kv_num_layers
+
+
+def _load_text_config() -> dict[str, Any]:
+    config_path = Path(os.environ["PIPELINES_TESTDATA"]) / "config.json"
+    with open(config_path) as file:
+        data = json.load(file)
+    return data.get("text_config", data)
+
+
+def _make_weight_registry(config: dict[str, Any]) -> dict[str, torch.Tensor]:
+    torch.manual_seed(42)
+    q_dim = config["head_dim"] * config["num_attention_heads"]
+    kv_dim = config["head_dim"] * config["num_key_value_heads"]
+    hidden_size = config["hidden_size"]
+    return {
+        "k_norm.weight": torch.randn(
+            config["head_dim"], dtype=torch.bfloat16
+        )
+        * K_NORM_STD,
+        "k_proj.weight": torch.randn(
+            kv_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * K_PROJ_STD,
+        "o_proj.weight": torch.randn(
+            hidden_size, q_dim, dtype=torch.bfloat16
+        )
+        * O_PROJ_STD,
+        "q_norm.weight": torch.randn(
+            config["head_dim"], dtype=torch.bfloat16
+        )
+        * Q_NORM_STD,
+        "q_proj.weight": torch.randn(
+            q_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * Q_PROJ_STD,
+        "v_proj.weight": torch.randn(
+            kv_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * V_PROJ_STD,
+    }
+
+
+def _make_placeholder_text_context(max_length: int) -> TextContext:
+    return TextContext(
+        request_id=RequestID(),
+        max_length=max_length,
+        tokens=TokenBuffer(np.zeros(PLACEHOLDER_CACHE_LEN, dtype=np.int64)),
+    )
+
+
+def _device_uint32_buffer(array: np.ndarray, device: Accelerator) -> Buffer:
+    return Buffer.from_numpy(array).to(device)
+
+
+def _row_offsets_array(batch_size: int, seq_len: int) -> np.ndarray:
+    return np.arange(
+        0,
+        (batch_size + 1) * seq_len,
+        seq_len,
+        dtype=np.uint32,
+    )
+
+
+def _prefill_run_name(
+    layer_type: str,
+    layer_idx: int,
+    batch_size: int,
+    seq_len: int,
+) -> str:
+    return (
+        f"prefill_{layer_type}_layer{layer_idx}_bs{batch_size}_seq{seq_len}"
+        "_cache0_step0_qkv_qk_bridge"
+    )
+
+
+def _build_graph(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    config: dict[str, Any],
+    weight_registry: dict[str, torch.Tensor],
+    batch_size: int,
+    seq_len: int,
+    use_fused: bool,
+    layer_idx: int,
+    layer_type: str,
+) -> Any:
+    device_ref = DeviceRef.GPU()
+    max_seq_len = seq_len + PLACEHOLDER_CACHE_LEN + 256
+    attention = MaxGemma3Attention(
+        rope_global=Llama3RotaryEmbedding(
+            config["hidden_size"],
+            config["num_attention_heads"],
+            config["rope_theta"],
+            max_seq_len,
+            interleaved=False,
+            head_dim=config["head_dim"],
+        ),
+        rope_local=Llama3RotaryEmbedding(
+            config["hidden_size"],
+            config["num_attention_heads"],
+            config["rope_local_base_freq"],
+            max_seq_len,
+            interleaved=False,
+            head_dim=config["head_dim"],
+        ),
+        num_attention_heads=config["num_attention_heads"],
+        num_key_value_heads=config["num_key_value_heads"],
+        hidden_size=config["hidden_size"],
+        kv_params=kv_params,
+        layer_idx=layer_idx,
+        dtype=DType.bfloat16,
+        devices=[device_ref],
+        qk_norm_eps=EPS,
+        sliding_window_pattern=config["sliding_window_pattern"],
+        local_window_size=config["sliding_window"],
+        has_bias=bool(config["attention_bias"]),
+    )
+    attention.load_state_dict(weight_registry)
+
+    input_type = TensorType(
+        DType.bfloat16,
+        ["total_seq_len", config["hidden_size"]],
+        device=device_ref,
+    )
+    input_row_offsets_type = TensorType(
+        DType.uint32,
+        [batch_size + 1],
+        device=device_ref,
+    )
+    flattened_kv_types = kv_params.get_symbolic_inputs().flatten()
+
+    graph_name = (
+        f"Gemma3QKVQKBridgePrefill{layer_type.title()}FusedBS{batch_size}Seq{seq_len}"
+        if use_fused
+        else "Gemma3QKVQKBridgePrefill"
+        f"{layer_type.title()}BaselineBS{batch_size}Seq{seq_len}"
+    )
+
+    with Graph(
+        graph_name,
+        input_types=(input_type, input_row_offsets_type, *flattened_kv_types),
+    ) as graph:
+        x, input_row_offsets, *kv_cache = graph.inputs
+        kv_collection = unflatten_ragged_attention_inputs(
+            kv_cache, n_devices=1
+        )[0]
+        graph_layer_idx = ops.constant(
+            layer_idx, DType.uint32, device=DeviceRef.CPU()
+        )
+        total_seq_len = x.tensor.shape[0]
+
+        xq = fused_qkv_ragged_matmul(
+            kv_params,
+            input=x.tensor,
+            wqkv=attention.wqkv,
+            bias=attention.wqkv_bias,
+            input_row_offsets=input_row_offsets.tensor,
+            kv_collection=kv_collection,
+            layer_idx=graph_layer_idx,
+            n_heads=attention.n_heads,
+        )
+        xq = xq.reshape((-1, attention.n_heads, kv_params.head_dim))
+
+        use_local = bool((layer_idx + 1) % attention.sliding_window_pattern)
+        assert use_local == (layer_type == "local")
+        rope = attention.rope_local if use_local else attention.rope_global
+        freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
+
+        if use_fused:
+            output = q_rms_norm_fused_qk_ragged_rope(
+                kv_params,
+                xq,
+                input_row_offsets.tensor,
+                kv_collection,
+                freqs_cis,
+                attention.q_norm.weight.cast(kv_params.dtype).to(device_ref),
+                attention.k_norm.weight.cast(kv_params.dtype).to(device_ref),
+                EPS,
+                graph_layer_idx,
+                weight_offset=1.0,
+                interleaved=False,
+            )
+        else:
+            rms_norm_key_cache(
+                kv_params,
+                kv_collection=kv_collection,
+                gamma=attention.k_norm.weight.cast(kv_params.dtype).to(
+                    device_ref
+                ),
+                epsilon=EPS,
+                layer_idx=graph_layer_idx,
+                total_seq_len=total_seq_len,
+                input_row_offsets=input_row_offsets.tensor,
+                weight_offset=1.0,
+            )
+            output = attention.q_norm(xq)
+            output = fused_qk_ragged_rope(
+                kv_params,
+                output,
+                input_row_offsets.tensor,
+                kv_collection,
+                freqs_cis,
+                graph_layer_idx,
+                interleaved=False,
+            )
+
+        graph.output(output)
+
+    return session.load(graph, weights_registry=attention.state_dict())
+
+
+def _make_runtime_inputs(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    seq_len: int,
+    device: Accelerator,
+) -> KVCacheInputsPerDevice:
+    max_cache_length = PLACEHOLDER_CACHE_LEN + seq_len
+    total_num_pages = batch_size * math.ceil(max_cache_length / PAGE_SIZE)
+    kv_manager = PagedKVCacheManager(
+        params=kv_params,
+        total_num_pages=total_num_pages,
+        session=session,
+        max_batch_size=batch_size,
+    )
+
+    contexts: list[TextContext] = []
+    for _ in range(batch_size):
+        context = _make_placeholder_text_context(max_cache_length)
+        kv_manager.claim(context.request_id, replica_idx=0)
+        kv_manager.alloc(
+            context,
+            replica_idx=0,
+            num_steps=seq_len,
+        )
+        contexts.append(context)
+
+    runtime_inputs = kv_manager.runtime_inputs(
+        [contexts],
+        num_steps=seq_len,
+    ).inputs[0]
+
+    return KVCacheInputsPerDevice(
+        blocks=runtime_inputs.blocks,
+        cache_lengths=_device_uint32_buffer(
+            np.zeros(batch_size, dtype=np.uint32), device
+        ),
+        lookup_table=runtime_inputs.lookup_table,
+        max_lengths=runtime_inputs.max_lengths,
+        kv_scales=runtime_inputs.kv_scales,
+        attention_dispatch_metadata=runtime_inputs.attention_dispatch_metadata,
+    )
+
+
+def _clone_kv_blocks(blocks: Buffer, seed: int) -> Buffer:
+    torch.manual_seed(seed)
+    shape = tuple(int(dim) for dim in blocks.shape)
+    tensor = torch.randn(shape, dtype=torch.bfloat16, device="cuda").contiguous()
+    return Buffer.from_dlpack(tensor)
+
+
+def _make_execution_args(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+    seq_len: int,
+    hidden_size: int,
+    device: Accelerator,
+    x_seed: int,
+    blocks_seed: int,
+) -> tuple[Any, ...]:
+    runtime_inputs = _make_runtime_inputs(
+        session=session,
+        kv_params=kv_params,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        device=device,
+    )
+
+    torch.manual_seed(x_seed)
+    x = torch.randn(
+        (batch_size * seq_len, hidden_size),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+
+    return (
+        Buffer.from_dlpack(x),
+        _device_uint32_buffer(_row_offsets_array(batch_size, seq_len), device),
+        _clone_kv_blocks(runtime_inputs.blocks, seed=blocks_seed),
+        runtime_inputs.cache_lengths,
+        runtime_inputs.lookup_table,
+        runtime_inputs.max_lengths,
+        runtime_inputs.attention_dispatch_metadata,
+    )
+
+
+def _run_correctness_check(
+    *,
+    baseline: Any,
+    fused: Any,
+    baseline_args: tuple[Any, ...],
+    fused_args: tuple[Any, ...],
+    layer_idx: int,
+) -> None:
+    baseline_output = baseline.execute(*baseline_args)[0]
+    fused_output = fused.execute(*fused_args)[0]
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        from_dlpack(baseline_output).to(torch.bfloat16),
+        from_dlpack(fused_output).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+    baseline_blocks = from_dlpack(baseline_args[2]).to(torch.bfloat16)[
+        :, :, layer_idx : layer_idx + 1, :, :, :
+    ]
+    fused_blocks = from_dlpack(fused_args[2]).to(torch.bfloat16)[
+        :, :, layer_idx : layer_idx + 1, :, :, :
+    ]
+    torch.testing.assert_close(
+        baseline_blocks,
+        fused_blocks,
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+
+def _benchmark_us(compiled: Any, args: list[tuple[Any, ...]]) -> float:
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def _geomean(values: list[float]) -> float:
+    return math.exp(sum(math.log(value) for value in values) / len(values))
+
+
+def test_profile_qkv_qk_prefill_bridge() -> None:
+    config = _load_text_config()
+    layer_idx, layer_type = _resolve_layer_metadata(config)
+    kv_num_layers = _resolve_kv_num_layers(config, layer_idx)
+    session = InferenceSession(devices=[Accelerator(0)])
+    device = Accelerator(0)
+    kv_params = KVCacheParams(
+        dtype=DType.bfloat16,
+        devices=[DeviceRef.GPU()],
+        n_kv_heads=config["num_key_value_heads"],
+        head_dim=config["head_dim"],
+        num_layers=kv_num_layers,
+        page_size=PAGE_SIZE,
+    )
+    weight_registry = _make_weight_registry(config)
+
+    results: dict[str, Any] = {
+        "benchmark_config": {
+            "dtype": "bfloat16",
+            "hidden_size": config["hidden_size"],
+            "head_dim": config["head_dim"],
+            "num_q_heads": config["num_attention_heads"],
+            "num_kv_heads": config["num_key_value_heads"],
+            "page_size": PAGE_SIZE,
+            "layer_idx": layer_idx,
+            "layer_type": layer_type,
+            "kv_num_layers": kv_num_layers,
+            "rope": "non-interleaved",
+            "mode": "prefill-ragged-qkv-qk-bridge",
+            "shapes": [
+                _prefill_run_name(layer_type, layer_idx, batch_size, seq_len)
+                for batch_size, seq_len in PREFILL_SHAPES
+            ],
+            "warmup_iters": WARMUP_ITERS,
+            "timed_iters": TIMED_ITERS,
+            "placeholder_cache_len": PLACEHOLDER_CACHE_LEN,
+        },
+        "correctness": "pass",
+        "first_sweep_us": {},
+        "confirm_sweep_us": {},
+        "average_us": {},
+        "average_speedup_ratio_vs_bridge_baseline": {},
+    }
+
+    large_shape_names: list[str] = []
+
+    for batch_size, seq_len in PREFILL_SHAPES:
+        run_name = _prefill_run_name(layer_type, layer_idx, batch_size, seq_len)
+        if seq_len >= 512:
+            large_shape_names.append(run_name)
+
+        baseline = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=False,
+            layer_idx=layer_idx,
+            layer_type=layer_type,
+        )
+        fused = _build_graph(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            use_fused=True,
+            layer_idx=layer_idx,
+            layer_type=layer_type,
+        )
+
+        baseline_correctness_args = _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=config["hidden_size"],
+            device=device,
+            x_seed=1000 + batch_size + seq_len,
+            blocks_seed=2000 + batch_size + seq_len,
+        )
+        fused_correctness_args = _make_execution_args(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            hidden_size=config["hidden_size"],
+            device=device,
+            x_seed=1000 + batch_size + seq_len,
+            blocks_seed=2000 + batch_size + seq_len,
+        )
+        _run_correctness_check(
+            baseline=baseline,
+            fused=fused,
+            baseline_args=baseline_correctness_args,
+            fused_args=fused_correctness_args,
+            layer_idx=layer_idx,
+        )
+        del baseline_correctness_args
+        del fused_correctness_args
+        torch.cuda.empty_cache()
+
+        first_baseline_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=3000 + batch_size + seq_len + iteration,
+                blocks_seed=4000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        first_fused_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=3000 + batch_size + seq_len + iteration,
+                blocks_seed=4000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        first_baseline_us = _benchmark_us(baseline, first_baseline_args)
+        first_fused_us = _benchmark_us(fused, first_fused_args)
+        results["first_sweep_us"][run_name] = {
+            "baseline": first_baseline_us,
+            "fused": first_fused_us,
+        }
+        del first_baseline_args
+        del first_fused_args
+        torch.cuda.empty_cache()
+
+        confirm_baseline_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=5000 + batch_size + seq_len + iteration,
+                blocks_seed=6000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        confirm_fused_args = [
+            _make_execution_args(
+                session=session,
+                kv_params=kv_params,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                hidden_size=config["hidden_size"],
+                device=device,
+                x_seed=5000 + batch_size + seq_len + iteration,
+                blocks_seed=6000 + batch_size + seq_len + iteration,
+            )
+            for iteration in range(WARMUP_ITERS + TIMED_ITERS)
+        ]
+        confirm_baseline_us = _benchmark_us(baseline, confirm_baseline_args)
+        confirm_fused_us = _benchmark_us(fused, confirm_fused_args)
+        results["confirm_sweep_us"][run_name] = {
+            "baseline": confirm_baseline_us,
+            "fused": confirm_fused_us,
+        }
+        del confirm_baseline_args
+        del confirm_fused_args
+        torch.cuda.empty_cache()
+
+        average_baseline_us = (first_baseline_us + confirm_baseline_us) / 2.0
+        average_fused_us = (first_fused_us + confirm_fused_us) / 2.0
+        results["average_us"][run_name] = {
+            "baseline": average_baseline_us,
+            "fused": average_fused_us,
+        }
+        results["average_speedup_ratio_vs_bridge_baseline"][run_name] = (
+            average_baseline_us / average_fused_us
+        )
+
+        del baseline
+        del fused
+        torch.cuda.empty_cache()
+
+    ratios = list(results["average_speedup_ratio_vs_bridge_baseline"].values())
+    results["average_geomean_speedup_vs_bridge_baseline"] = _geomean(ratios)
+    results["average_large_shape_geomean_speedup_vs_bridge_baseline"] = _geomean(
+        [
+            results["average_speedup_ratio_vs_bridge_baseline"][run_name]
+            for run_name in large_shape_names
+        ]
+    )
+
+    confirm_ratios = [
+        results["confirm_sweep_us"][run_name]["baseline"]
+        / results["confirm_sweep_us"][run_name]["fused"]
+        for run_name in results["confirm_sweep_us"]
+    ]
+    results["confirm_geomean_speedup_vs_bridge_baseline"] = _geomean(
+        confirm_ratios
+    )
+    results["confirm_large_shape_geomean_speedup_vs_bridge_baseline"] = _geomean(
+        [
+            results["confirm_sweep_us"][run_name]["baseline"]
+            / results["confirm_sweep_us"][run_name]["fused"]
+            for run_name in large_shape_names
+        ]
+    )
+
+    print("GEMMA3_QKV_QK_PREFILL_BRIDGE_PROFILE_START")
+    print(json.dumps(results, indent=2, sort_keys=True))
+    print("GEMMA3_QKV_QK_PREFILL_BRIDGE_PROFILE_END")

--- a/max/tests/integration/architectures/gemma3/test_profile_transformer_block_decode.py
+++ b/max/tests/integration/architectures/gemma3/test_profile_transformer_block_decode.py
@@ -1,0 +1,1821 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+import subprocess
+import time
+from pathlib import Path
+from collections.abc import Sequence
+from typing import Any, cast
+
+import numpy as np
+import torch
+from max.driver import Accelerator, Buffer
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import BufferValue, DeviceRef, Graph, TensorType, TensorValue, ops
+from max.interfaces import RequestID, TokenBuffer
+from max.kv_cache import PagedKVCacheManager
+from max.nn.attention import MHAMaskVariant
+from max.nn.comm.allreduce import Signals
+from max.nn.kernels import (
+    KVCacheParams,
+    flash_attention_ragged,
+    fused_qk_ragged_rope,
+    fused_qkv_ragged_matmul,
+    rms_norm_key_cache,
+)
+from max.nn.kv_cache import PagedCacheValues, unflatten_ragged_attention_inputs
+from max.nn.linear import MLP, linear
+from max.nn.rotary_embedding import Llama3RotaryEmbedding
+from max.nn.transformer.distributed_transformer import forward_sharded_layers
+from max.pipelines.architectures.gemma3.layers.attention import (
+    Gemma3Attention as MaxGemma3Attention,
+)
+from max.pipelines.architectures.gemma3.layers.rms_norm import Gemma3RMSNorm
+from max.pipelines.architectures.gemma3.layers.rms_norm import (
+    gemma3_rms_norm_fused_residual_add,
+)
+from max.pipelines.architectures.gemma3.layers.transformer_block import (
+    Gemma3TransformerBlock as MaxGemma3TransformerBlock,
+)
+from max.pipelines.core import TextContext
+from torch.utils.dlpack import from_dlpack
+
+
+PAGE_SIZE = 128
+EPS = 1e-6
+DEFAULT_LAYER_IDX = 0
+DEFAULT_LAYER_TYPE = "local"
+DEFAULT_BASELINE_VARIANT = "full"
+DEFAULT_PRODUCER_VARIANT = "mlp"
+COMPILE_ONLY_RESIDUAL_LADDER_MODE = "residual_ladder_pre_ffn_norm"
+BASELINE_VARIANTS = (
+    "full",
+    "attention_only",
+    "residual_only",
+    "post_attention_residual_only",
+    "post_mlp_residual_only",
+)
+PRODUCER_VARIANTS = (
+    "mlp",
+    "pre_ffn_norm",
+    "down_proj_only",
+    "gate_up_activation_only",
+    "materialized_mlp",
+    "permuted_mlp",
+    "hidden_permuted_mlp",
+    "upstream_permuted_mlp",
+    "native_upstream_permuted_mlp",
+)
+Q_NORM_STD = 0.68
+K_NORM_STD = 0.793
+Q_PROJ_STD = 0.0284
+K_PROJ_STD = 0.0309
+V_PROJ_STD = 0.0309
+O_PROJ_STD = 0.0237
+RMS_NORM_STD = 0.05
+MLP_GATE_STD = 0.018
+MLP_UP_STD = 0.018
+MLP_DOWN_STD = 0.015
+WARMUP_ITERS = 20
+TIMED_ITERS = 50
+CACHE_LEN_BASE = 1024
+CACHE_LEN_STEP = 7
+BATCH_SIZES = (64, 128)
+MAX_EXTRA_STEPS = WARMUP_ITERS + TIMED_ITERS
+
+
+def _resolve_layer_metadata(config: dict[str, Any]) -> tuple[int, str]:
+    layer_idx = int(
+        os.environ.get(
+            "PROFILE_TRANSFORMER_BLOCK_LAYER_IDX", str(DEFAULT_LAYER_IDX)
+        )
+    )
+    num_hidden_layers = int(config["num_hidden_layers"])
+    assert 0 <= layer_idx < num_hidden_layers, (
+        f"layer_idx={layer_idx} must be in [0, {num_hidden_layers})"
+    )
+    layer_type = (
+        "local"
+        if bool((layer_idx + 1) % config["sliding_window_pattern"])
+        else "global"
+    )
+    expected_layer_type = os.environ.get(
+        "PROFILE_TRANSFORMER_BLOCK_LAYER_TYPE", DEFAULT_LAYER_TYPE
+    )
+    assert (
+        layer_type == expected_layer_type
+    ), f"expected {expected_layer_type} layer, got {layer_type} for layer_idx={layer_idx}"
+    return layer_idx, layer_type
+
+
+def _resolve_kv_num_layers(config: dict[str, Any], layer_idx: int) -> int:
+    min_num_layers = layer_idx + 1
+    kv_num_layers = int(
+        os.environ.get(
+            "PROFILE_TRANSFORMER_BLOCK_KV_NUM_LAYERS", str(min_num_layers)
+        )
+    )
+    assert kv_num_layers >= min_num_layers, (
+        f"kv_num_layers={kv_num_layers} must cover layer_idx={layer_idx}"
+    )
+    assert kv_num_layers <= int(config["num_hidden_layers"]), (
+        "kv_num_layers cannot exceed the model layer count "
+        f"({config['num_hidden_layers']})"
+    )
+    return kv_num_layers
+
+
+def _resolve_hidden_activation(config: dict[str, Any]) -> str:
+    hidden_activation = str(config["hidden_activation"])
+    return {
+        "gelu_pytorch_tanh": "gelu_tanh",
+        "swish": "silu",
+    }.get(hidden_activation, hidden_activation)
+
+
+def _resolve_baseline_variant() -> str:
+    baseline_variant = os.environ.get(
+        "PROFILE_TRANSFORMER_BLOCK_BASELINE_VARIANT",
+        DEFAULT_BASELINE_VARIANT,
+    )
+    assert baseline_variant in BASELINE_VARIANTS, (
+        "baseline variant must be one of "
+        f"{BASELINE_VARIANTS}, got {baseline_variant!r}"
+    )
+    return baseline_variant
+
+
+def _resolve_producer_variant() -> str:
+    producer_variant = os.environ.get(
+        "PROFILE_TRANSFORMER_BLOCK_PRODUCER_VARIANT",
+        DEFAULT_PRODUCER_VARIANT,
+    )
+    assert producer_variant in PRODUCER_VARIANTS, (
+        "producer variant must be one of "
+        f"{PRODUCER_VARIANTS}, got {producer_variant!r}"
+    )
+    return producer_variant
+
+
+def _resolve_compile_only_mode() -> str | None:
+    compile_only_mode = os.environ.get(
+        "PROFILE_TRANSFORMER_BLOCK_COMPILE_ONLY", ""
+    ).strip()
+    if not compile_only_mode:
+        return None
+    assert compile_only_mode == COMPILE_ONLY_RESIDUAL_LADDER_MODE, (
+        "compile-only mode must be "
+        f"{COMPILE_ONLY_RESIDUAL_LADDER_MODE!r}, got "
+        f"{compile_only_mode!r}"
+    )
+    return compile_only_mode
+
+
+def _baseline_variant_flags(
+    baseline_variant: str,
+) -> tuple[bool, bool, bool]:
+    match baseline_variant:
+        case "full":
+            return False, False, False
+        case "attention_only":
+            return False, True, True
+        case "residual_only":
+            return True, False, False
+        case "post_attention_residual_only":
+            return True, False, True
+        case "post_mlp_residual_only":
+            return True, True, False
+        case _:
+            raise ValueError(
+                f"unsupported baseline variant: {baseline_variant}"
+            )
+
+
+def _residual_variant_name(
+    *,
+    use_fused_post_attention_residual_add: bool,
+    use_fused_post_mlp_residual_add: bool,
+) -> str:
+    match (
+        use_fused_post_attention_residual_add,
+        use_fused_post_mlp_residual_add,
+    ):
+        case (True, True):
+            return "FusedResidual"
+        case (False, False):
+            return "BaselineResidual"
+        case (False, True):
+            return "BaselinePostAttentionFusedPostMlpResidual"
+        case (True, False):
+            return "FusedPostAttentionBaselinePostMlpResidual"
+        case _:
+            raise ValueError("unsupported residual variant")
+
+
+def _graph_variant_name(
+    *,
+    layer_type: str,
+    use_fused_attention: bool,
+    use_fused_post_attention_residual_add: bool,
+    use_fused_post_mlp_residual_add: bool,
+    producer_variant: str,
+) -> str:
+    attention_variant = (
+        "FusedAttention" if use_fused_attention else "BaselineAttention"
+    )
+    residual_variant = _residual_variant_name(
+        use_fused_post_attention_residual_add=(
+            use_fused_post_attention_residual_add
+        ),
+        use_fused_post_mlp_residual_add=use_fused_post_mlp_residual_add,
+    )
+    match producer_variant:
+        case "mlp":
+            producer_variant_name = "MlpProducer"
+        case "pre_ffn_norm":
+            producer_variant_name = "PreFfnNormProducer"
+        case "down_proj_only":
+            producer_variant_name = "DownProjOnlyProducer"
+        case "gate_up_activation_only":
+            producer_variant_name = "GateUpActivationOnlyProducer"
+        case "materialized_mlp":
+            producer_variant_name = "MaterializedMlpProducer"
+        case "permuted_mlp":
+            producer_variant_name = "PermutedMlpProducer"
+        case "hidden_permuted_mlp":
+            producer_variant_name = "HiddenPermutedMlpProducer"
+        case "upstream_permuted_mlp":
+            producer_variant_name = "UpstreamPermutedMlpProducer"
+        case "native_upstream_permuted_mlp":
+            producer_variant_name = "NativeUpstreamPermutedMlpProducer"
+        case _:
+            raise ValueError(
+                f"unsupported producer variant: {producer_variant}"
+            )
+    return (
+        f"Gemma3TransformerBlockDecode{layer_type.title()}"
+        f"{attention_variant}{residual_variant}{producer_variant_name}"
+    )
+
+
+def _load_text_config() -> dict[str, Any]:
+    config_path = Path(os.environ["PIPELINES_TESTDATA"]) / "config.json"
+    with open(config_path) as file:
+        data = json.load(file)
+    return data.get("text_config", data)
+
+
+def _make_weight_registry(config: dict[str, Any]) -> dict[str, torch.Tensor]:
+    torch.manual_seed(42)
+    q_dim = config["head_dim"] * config["num_attention_heads"]
+    kv_dim = config["head_dim"] * config["num_key_value_heads"]
+    hidden_size = config["hidden_size"]
+    intermediate_size = config["intermediate_size"]
+    return {
+        "block.self_attn.k_norm.weight": torch.randn(
+            config["head_dim"], dtype=torch.bfloat16
+        )
+        * K_NORM_STD,
+        "block.self_attn.k_proj.weight": torch.randn(
+            kv_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * K_PROJ_STD,
+        "block.self_attn.o_proj.weight": torch.randn(
+            hidden_size, q_dim, dtype=torch.bfloat16
+        )
+        * O_PROJ_STD,
+        "block.self_attn.q_norm.weight": torch.randn(
+            config["head_dim"], dtype=torch.bfloat16
+        )
+        * Q_NORM_STD,
+        "block.self_attn.q_proj.weight": torch.randn(
+            q_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * Q_PROJ_STD,
+        "block.self_attn.v_proj.weight": torch.randn(
+            kv_dim, hidden_size, dtype=torch.bfloat16
+        )
+        * V_PROJ_STD,
+        "block.mlp.gate_proj.weight": torch.randn(
+            intermediate_size, hidden_size, dtype=torch.bfloat16
+        )
+        * MLP_GATE_STD,
+        "block.mlp.down_proj.weight": torch.randn(
+            hidden_size, intermediate_size, dtype=torch.bfloat16
+        )
+        * MLP_DOWN_STD,
+        "block.mlp.up_proj.weight": torch.randn(
+            intermediate_size, hidden_size, dtype=torch.bfloat16
+        )
+        * MLP_UP_STD,
+        "block.input_layernorm.weight": torch.randn(
+            hidden_size, dtype=torch.bfloat16
+        )
+        * RMS_NORM_STD,
+        "block.post_attention_layernorm.weight": torch.randn(
+            hidden_size, dtype=torch.bfloat16
+        )
+        * RMS_NORM_STD,
+        "block.pre_feedforward_layernorm.weight": torch.randn(
+            hidden_size, dtype=torch.bfloat16
+        )
+        * RMS_NORM_STD,
+        "block.post_feedforward_layernorm.weight": torch.randn(
+            hidden_size, dtype=torch.bfloat16
+        )
+        * RMS_NORM_STD,
+        "next_input_layernorm.weight": torch.randn(
+            hidden_size, dtype=torch.bfloat16
+        )
+        * RMS_NORM_STD,
+    }
+
+
+def _feed_forward_chunk_permutation_from_dims(
+    hidden_size: int,
+    intermediate_size: int,
+) -> tuple[int, ...]:
+    repeat_factor, remainder = divmod(intermediate_size, hidden_size)
+    assert remainder == 0, (
+        "feed-forward chunk permutation requires the intermediate size to "
+        f"be an integer multiple of hidden size, got {intermediate_size} "
+        f"and {hidden_size}"
+    )
+    if repeat_factor == 1:
+        return (0,)
+    permutation = tuple(range(1, repeat_factor, 2)) + tuple(
+        range(0, repeat_factor, 2)
+    )
+    assert permutation != tuple(range(repeat_factor))
+    return permutation
+
+
+def _permute_feed_forward_torch_tensor(
+    tensor: torch.Tensor,
+    *,
+    hidden_size: int,
+    intermediate_size: int,
+    axis: int,
+) -> torch.Tensor:
+    permutation = _feed_forward_chunk_permutation_from_dims(
+        hidden_size, intermediate_size
+    )
+    if len(permutation) == 1:
+        return tensor
+    tensor_chunks = torch.split(tensor, hidden_size, dim=axis)
+    assert len(tensor_chunks) == len(permutation)
+    return torch.cat(
+        [tensor_chunks[idx] for idx in permutation],
+        dim=axis,
+    ).contiguous()
+
+
+def _materialize_weight_registry_for_producer_variant(
+    weight_registry: dict[str, torch.Tensor],
+    *,
+    config: dict[str, Any],
+    producer_variant: str,
+) -> tuple[dict[str, torch.Tensor], str]:
+    if producer_variant != "native_upstream_permuted_mlp":
+        return weight_registry, producer_variant
+
+    hidden_size = int(config["hidden_size"])
+    intermediate_size = int(config["intermediate_size"])
+    materialized_registry = dict(weight_registry)
+    materialized_registry["block.mlp.gate_proj.weight"] = (
+        _permute_feed_forward_torch_tensor(
+            weight_registry["block.mlp.gate_proj.weight"],
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            axis=0,
+        )
+    )
+    materialized_registry["block.mlp.up_proj.weight"] = (
+        _permute_feed_forward_torch_tensor(
+            weight_registry["block.mlp.up_proj.weight"],
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            axis=0,
+        )
+    )
+    materialized_registry["block.mlp.down_proj.weight"] = (
+        _permute_feed_forward_torch_tensor(
+            weight_registry["block.mlp.down_proj.weight"],
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            axis=1,
+        )
+    )
+    return materialized_registry, "mlp"
+
+
+class _Gemma3AttentionBaseline(MaxGemma3Attention):
+    def __call__(
+        self,
+        x: TensorValue,
+        kv_collection: PagedCacheValues,
+        **kwargs,
+    ) -> TensorValue:
+        total_seq_len = x.shape[0]
+        layer_idx = ops.constant(
+            self.layer_idx, DType.uint32, device=DeviceRef.CPU()
+        )
+
+        xq = fused_qkv_ragged_matmul(
+            self.kv_params,
+            input=x,
+            wqkv=self.wqkv,
+            bias=self.wqkv_bias,
+            input_row_offsets=kwargs["input_row_offsets"],
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            n_heads=self.n_heads,
+        )
+        xq = xq.reshape((-1, self.n_heads, self.kv_params.head_dim))
+
+        use_local = bool((self.layer_idx + 1) % self.sliding_window_pattern)
+        rope = self.rope_local if use_local else self.rope_global
+        freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
+
+        rms_norm_key_cache(
+            self.kv_params,
+            kv_collection=kv_collection,
+            gamma=self.k_norm.weight.cast(self.kv_params.dtype).to(
+                self.devices[0]
+            ),
+            epsilon=self.qk_norm_eps,
+            layer_idx=layer_idx,
+            total_seq_len=total_seq_len,
+            input_row_offsets=kwargs["input_row_offsets"],
+            weight_offset=1.0,
+        )
+        xq = self.q_norm(xq)
+        xq = fused_qk_ragged_rope(
+            self.kv_params,
+            xq,
+            kwargs["input_row_offsets"],
+            kv_collection,
+            freqs_cis,
+            layer_idx,
+            interleaved=rope.interleaved,
+        )
+
+        mask_variant = (
+            MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK
+            if use_local
+            else MHAMaskVariant.CAUSAL_MASK
+        )
+        attn_out = flash_attention_ragged(
+            self.kv_params,
+            input=xq,
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            input_row_offsets=kwargs["input_row_offsets"],
+            mask_variant=mask_variant,
+            scale=self.scale,
+            local_window_size=self.local_window_size,
+        )
+        attn_out = ops.reshape(attn_out, shape=[total_seq_len, -1])
+        return self.o_proj(attn_out)
+
+
+class _Gemma3TransformerBlockVariant(MaxGemma3TransformerBlock):
+    def __init__(
+        self,
+        *,
+        use_fused_post_attention_residual_add: bool,
+        use_fused_post_mlp_residual_add: bool,
+        producer_variant: str,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.use_fused_post_attention_residual_add = (
+            use_fused_post_attention_residual_add
+        )
+        self.use_fused_post_mlp_residual_add = (
+            use_fused_post_mlp_residual_add
+        )
+        self.producer_variant = producer_variant
+
+    def _make_down_proj_only_input(
+        self,
+        x: TensorValue,
+        mlp_shard: MLP,
+    ) -> TensorValue:
+        repeat_factor, remainder = divmod(
+            mlp_shard.feed_forward_length, mlp_shard.hidden_dim
+        )
+        assert remainder == 0, (
+            "down_proj_only producer requires the feed-forward width to be "
+            f"an integer multiple of hidden_dim, got "
+            f"{mlp_shard.feed_forward_length} and {mlp_shard.hidden_dim}"
+        )
+        if repeat_factor == 1:
+            return x
+        return ops.concat([x] * repeat_factor, axis=1)
+
+    def _project_feed_forward_hidden_to_model_dim(
+        self,
+        hidden: TensorValue,
+        mlp_shard: MLP,
+    ) -> TensorValue:
+        repeat_factor, remainder = divmod(
+            mlp_shard.feed_forward_length, mlp_shard.hidden_dim
+        )
+        assert remainder == 0, (
+            "gate_up_activation_only producer requires the feed-forward "
+            "width to be an integer multiple of hidden_dim, got "
+            f"{mlp_shard.feed_forward_length} and {mlp_shard.hidden_dim}"
+        )
+        if repeat_factor == 1:
+            return hidden
+        hidden = ops.reshape(
+            hidden,
+            [hidden.shape[0], repeat_factor, mlp_shard.hidden_dim],
+        )
+        hidden = ops.sum(hidden, axis=1)
+        return ops.reshape(hidden, [hidden.shape[0], mlp_shard.hidden_dim])
+
+    def _make_gate_up_activation_hidden(
+        self,
+        x: TensorValue,
+        mlp_shard: MLP,
+    ) -> TensorValue:
+        if not mlp_shard._can_used_fused_mlp():
+            return (
+                mlp_shard.activation_function(mlp_shard.gate_proj(x))
+                * mlp_shard.up_proj(x)
+            )
+
+        output = linear(
+            x,
+            mlp_shard._concat_or_max_gate_up_weights(),
+            mlp_shard.quantization_encoding,
+            mlp_shard.quant_config,
+            input_scale=mlp_shard._concat_or_max_gate_up_input_scale(),
+            weight_scale=mlp_shard._concat_or_max_gate_up_scales(),
+            weight_scale_2=mlp_shard._concat_or_max_gate_up_weight_scale_2(),
+        )
+        bias = mlp_shard._concat_or_max_gate_up_bias()
+        if bias is not None:
+            output += bias
+
+        feed_forward_length = mlp_shard.gate_proj.weight.shape[0]
+        gate_out, up_out = ops.split(
+            output, [feed_forward_length, feed_forward_length], axis=1
+        )
+        return mlp_shard.activation_function(gate_out) * up_out
+
+    def _feed_forward_chunk_permutation(
+        self,
+        mlp_shard: MLP,
+    ) -> tuple[int, ...]:
+        repeat_factor, remainder = divmod(
+            mlp_shard.feed_forward_length, mlp_shard.hidden_dim
+        )
+        assert remainder == 0, (
+            "permuted_mlp producer requires the feed-forward width to be "
+            f"an integer multiple of hidden_dim, got "
+            f"{mlp_shard.feed_forward_length} and {mlp_shard.hidden_dim}"
+        )
+        if repeat_factor == 1:
+            return (0,)
+        permutation = tuple(range(1, repeat_factor, 2)) + tuple(
+            range(0, repeat_factor, 2)
+        )
+        assert permutation != tuple(range(repeat_factor))
+        return permutation
+
+    def _permute_feed_forward_tensor(
+        self,
+        tensor: TensorValue,
+        mlp_shard: MLP,
+        *,
+        axis: int,
+    ) -> TensorValue:
+        permutation = self._feed_forward_chunk_permutation(mlp_shard)
+        if len(permutation) == 1:
+            return tensor
+        tensor_chunks = ops.split(
+            tensor,
+            [mlp_shard.hidden_dim] * len(permutation),
+            axis=axis,
+        )
+        return ops.concat(
+            [tensor_chunks[idx] for idx in permutation],
+            axis=axis,
+        )
+
+    def _permute_feed_forward_hidden(
+        self,
+        hidden: TensorValue,
+        mlp_shard: MLP,
+    ) -> TensorValue:
+        return self._permute_feed_forward_tensor(
+            hidden, mlp_shard, axis=1
+        )
+
+    def _make_permuted_down_proj_weight(
+        self,
+        mlp_shard: MLP,
+        device: DeviceRef,
+    ) -> TensorValue:
+        weight = mlp_shard.down_proj.weight.to(device)
+        return self._permute_feed_forward_tensor(
+            weight, mlp_shard, axis=1
+        )
+
+    def _make_permuted_gate_up_tensor(
+        self,
+        gate_tensor: TensorValue | None,
+        up_tensor: TensorValue | None,
+        mlp_shard: MLP,
+        device: DeviceRef,
+    ) -> TensorValue | None:
+        if gate_tensor is None or up_tensor is None:
+            return None
+        if len(gate_tensor.shape) != 0:
+            gate_tensor = self._permute_feed_forward_tensor(
+                gate_tensor.to(device), mlp_shard, axis=0
+            )
+            up_tensor = self._permute_feed_forward_tensor(
+                up_tensor.to(device), mlp_shard, axis=0
+            )
+        return mlp_shard._concat_or_max_gate_up_tensors(
+            gate_tensor, up_tensor
+        )
+
+    def _materialize_feed_forward_hidden(
+        self,
+        hidden: TensorValue,
+        mlp_shard: MLP,
+    ) -> TensorValue:
+        repeat_factor, remainder = divmod(
+            mlp_shard.feed_forward_length, mlp_shard.hidden_dim
+        )
+        assert remainder == 0, (
+            "materialized_mlp producer requires the feed-forward width to be "
+            f"an integer multiple of hidden_dim, got "
+            f"{mlp_shard.feed_forward_length} and {mlp_shard.hidden_dim}"
+        )
+        if repeat_factor == 1:
+            return hidden
+        hidden_chunks = ops.split(
+            hidden,
+            [mlp_shard.hidden_dim] * repeat_factor,
+            axis=1,
+        )
+        return ops.concat(hidden_chunks, axis=1)
+
+    def _make_gate_up_activation_only_output(
+        self,
+        x: TensorValue,
+        mlp_shard: MLP,
+    ) -> TensorValue:
+        hidden = self._make_gate_up_activation_hidden(x, mlp_shard)
+        return self._project_feed_forward_hidden_to_model_dim(
+            hidden, mlp_shard
+        )
+
+    def _make_materialized_mlp_output(
+        self,
+        x: TensorValue,
+        mlp_shard: MLP,
+    ) -> TensorValue:
+        hidden = self._make_gate_up_activation_hidden(x, mlp_shard)
+        hidden = self._materialize_feed_forward_hidden(hidden, mlp_shard)
+        return mlp_shard.down_proj(hidden)
+
+    def _make_permuted_mlp_output(
+        self,
+        x: TensorValue,
+        mlp_shard: MLP,
+    ) -> TensorValue:
+        hidden = self._make_gate_up_activation_hidden(x, mlp_shard)
+        hidden = self._permute_feed_forward_hidden(hidden, mlp_shard)
+        weight = self._make_permuted_down_proj_weight(mlp_shard, hidden.device)
+        output = linear(
+            hidden,
+            weight,
+            mlp_shard.down_proj.weight.quantization_encoding,
+            mlp_shard.down_proj.quant_config,
+            mlp_shard.down_proj.input_scale,
+            mlp_shard.down_proj.weight_scale,
+            mlp_shard.down_proj.weight_scale_2,
+        )
+        if mlp_shard.down_proj.bias is not None:
+            output += mlp_shard.down_proj.bias.to(output.device)
+        return output
+
+    def _make_hidden_permuted_mlp_output(
+        self,
+        x: TensorValue,
+        mlp_shard: MLP,
+    ) -> TensorValue:
+        hidden = self._make_gate_up_activation_hidden(x, mlp_shard)
+        hidden = self._permute_feed_forward_hidden(hidden, mlp_shard)
+        return mlp_shard.down_proj(hidden)
+
+    def _make_upstream_permuted_mlp_output(
+        self,
+        x: TensorValue,
+        mlp_shard: MLP,
+    ) -> TensorValue:
+        if not mlp_shard._can_used_fused_mlp():
+            hidden = self._make_gate_up_activation_hidden(x, mlp_shard)
+            hidden = self._permute_feed_forward_hidden(hidden, mlp_shard)
+        else:
+            # Emit the odd-even hidden order directly from gate/up so
+            # `down_proj` sees round 89's layout without a runtime permute.
+            weight = self._make_permuted_gate_up_tensor(
+                mlp_shard.gate_proj.weight,
+                mlp_shard.up_proj.weight,
+                mlp_shard,
+                x.device,
+            )
+            assert weight is not None
+            output = linear(
+                x,
+                weight,
+                mlp_shard.quantization_encoding,
+                mlp_shard.quant_config,
+                input_scale=self._make_permuted_gate_up_tensor(
+                    mlp_shard.gate_proj.input_scale,
+                    mlp_shard.up_proj.input_scale,
+                    mlp_shard,
+                    x.device,
+                ),
+                weight_scale=self._make_permuted_gate_up_tensor(
+                    mlp_shard.gate_proj.weight_scale,
+                    mlp_shard.up_proj.weight_scale,
+                    mlp_shard,
+                    x.device,
+                ),
+                weight_scale_2=self._make_permuted_gate_up_tensor(
+                    mlp_shard.gate_proj.weight_scale_2,
+                    mlp_shard.up_proj.weight_scale_2,
+                    mlp_shard,
+                    x.device,
+                ),
+            )
+            bias = self._make_permuted_gate_up_tensor(
+                mlp_shard.gate_proj.bias,
+                mlp_shard.up_proj.bias,
+                mlp_shard,
+                x.device,
+            )
+            if bias is not None:
+                output += bias
+
+            feed_forward_length = mlp_shard.gate_proj.weight.shape[0]
+            gate_out, up_out = ops.split(
+                output,
+                [feed_forward_length, feed_forward_length],
+                axis=1,
+            )
+            hidden = mlp_shard.activation_function(gate_out) * up_out
+
+        weight = self._make_permuted_down_proj_weight(mlp_shard, hidden.device)
+        output = linear(
+            hidden,
+            weight,
+            mlp_shard.down_proj.weight.quantization_encoding,
+            mlp_shard.down_proj.quant_config,
+            mlp_shard.down_proj.input_scale,
+            mlp_shard.down_proj.weight_scale,
+            mlp_shard.down_proj.weight_scale_2,
+        )
+        if mlp_shard.down_proj.bias is not None:
+            output += mlp_shard.down_proj.bias.to(output.device)
+        return output
+
+    def __call__(
+        self,
+        layer_idx: TensorValue,
+        xs: list[TensorValue],
+        signal_buffers: list[BufferValue],
+        kv_collections: list[PagedCacheValues],
+        input_row_offsets: list[TensorValue],
+        normalized_xs: Sequence[TensorValue] | None = None,
+        next_input_layernorm_shards: Sequence[Gemma3RMSNorm] | None = None,
+        **kwargs,
+    ) -> tuple[list[TensorValue], list[TensorValue] | None]:
+        del layer_idx
+        residual = xs
+        norm_xs = (
+            list(normalized_xs)
+            if normalized_xs is not None
+            else forward_sharded_layers(self.input_layernorm_shards, xs)
+        )
+        attn_out = [
+            shard(
+                norm_xs[i],
+                kv_collections[i],
+                input_row_offsets=input_row_offsets[i],
+                **kwargs,
+            )
+            for i, shard in enumerate(self.self_attn_shards)
+        ]
+        attn_out = self.allreduce(attn_out, signal_buffers)
+
+        if self.use_fused_post_attention_residual_add:
+            fused_attn_norm = [
+                gemma3_rms_norm_fused_residual_add(
+                    attn_out[i],
+                    residual[i],
+                    cast(
+                        Gemma3RMSNorm, self.post_attention_layernorm_shards[i]
+                    ),
+                    cast(
+                        Gemma3RMSNorm,
+                        self.pre_feedforward_layernorm_shards[i],
+                    ),
+                )
+                for i in range(len(attn_out))
+            ]
+            norm_xs = [fused_output for fused_output, _ in fused_attn_norm]
+            residual = [
+                fused_residual for _, fused_residual in fused_attn_norm
+            ]
+        else:
+            norm_xs = forward_sharded_layers(
+                self.post_attention_layernorm_shards, attn_out
+            )
+            residual = [residual[i] + norm_xs[i] for i in range(len(norm_xs))]
+            norm_xs = forward_sharded_layers(
+                self.pre_feedforward_layernorm_shards, residual
+            )
+
+        if self.producer_variant == "mlp":
+            hidden_states = forward_sharded_layers(self.mlp_shards, norm_xs)
+            hidden_states = self.allreduce(hidden_states, signal_buffers)
+        elif self.producer_variant == "pre_ffn_norm":
+            hidden_states = list(norm_xs)
+        elif self.producer_variant == "down_proj_only":
+            hidden_states = []
+            for i, norm_x in enumerate(norm_xs):
+                mlp_shard = cast(MLP, self.mlp_shards[i])
+                synthetic_hidden = self._make_down_proj_only_input(
+                    norm_x, mlp_shard
+                )
+                hidden_states.append(mlp_shard.down_proj(synthetic_hidden))
+            hidden_states = self.allreduce(hidden_states, signal_buffers)
+        elif self.producer_variant == "gate_up_activation_only":
+            hidden_states = []
+            for i, norm_x in enumerate(norm_xs):
+                mlp_shard = cast(MLP, self.mlp_shards[i])
+                hidden_states.append(
+                    self._make_gate_up_activation_only_output(
+                        norm_x, mlp_shard
+                    )
+                )
+            hidden_states = self.allreduce(hidden_states, signal_buffers)
+        elif self.producer_variant == "materialized_mlp":
+            hidden_states = []
+            for i, norm_x in enumerate(norm_xs):
+                mlp_shard = cast(MLP, self.mlp_shards[i])
+                hidden_states.append(
+                    self._make_materialized_mlp_output(norm_x, mlp_shard)
+                )
+            hidden_states = self.allreduce(hidden_states, signal_buffers)
+        elif self.producer_variant == "permuted_mlp":
+            hidden_states = []
+            for i, norm_x in enumerate(norm_xs):
+                mlp_shard = cast(MLP, self.mlp_shards[i])
+                hidden_states.append(
+                    self._make_permuted_mlp_output(norm_x, mlp_shard)
+                )
+            hidden_states = self.allreduce(hidden_states, signal_buffers)
+        elif self.producer_variant == "hidden_permuted_mlp":
+            hidden_states = []
+            for i, norm_x in enumerate(norm_xs):
+                mlp_shard = cast(MLP, self.mlp_shards[i])
+                hidden_states.append(
+                    self._make_hidden_permuted_mlp_output(
+                        norm_x, mlp_shard
+                    )
+                )
+            hidden_states = self.allreduce(hidden_states, signal_buffers)
+        elif self.producer_variant == "upstream_permuted_mlp":
+            hidden_states = []
+            for i, norm_x in enumerate(norm_xs):
+                mlp_shard = cast(MLP, self.mlp_shards[i])
+                hidden_states.append(
+                    self._make_upstream_permuted_mlp_output(
+                        norm_x, mlp_shard
+                    )
+                )
+            hidden_states = self.allreduce(hidden_states, signal_buffers)
+        else:
+            raise ValueError(
+                f"unsupported producer variant: {self.producer_variant}"
+            )
+
+        if next_input_layernorm_shards is None:
+            hidden_states = forward_sharded_layers(
+                self.post_feedforward_layernorm_shards, hidden_states
+            )
+            return (
+                [
+                    residual[i] + hidden_states[i]
+                    for i in range(len(hidden_states))
+                ],
+                None,
+            )
+
+        if self.use_fused_post_mlp_residual_add:
+            fused_mlp_norm = [
+                gemma3_rms_norm_fused_residual_add(
+                    hidden_states[i],
+                    residual[i],
+                    cast(
+                        Gemma3RMSNorm,
+                        self.post_feedforward_layernorm_shards[i],
+                    ),
+                    cast(Gemma3RMSNorm, next_input_layernorm_shards[i]),
+                )
+                for i in range(len(hidden_states))
+            ]
+            return (
+                [
+                    fused_residual
+                    for _, fused_residual in fused_mlp_norm
+                ],
+                [fused_output for fused_output, _ in fused_mlp_norm],
+            )
+
+        hidden_states = forward_sharded_layers(
+            self.post_feedforward_layernorm_shards, hidden_states
+        )
+        residual = [
+            residual[i] + hidden_states[i] for i in range(len(hidden_states))
+        ]
+        next_norm_xs = forward_sharded_layers(
+            next_input_layernorm_shards, residual
+        )
+        return residual, next_norm_xs
+
+
+class _Gemma3TransformerBlockDecodeHarness:
+    def __init__(
+        self,
+        *,
+        kv_params: KVCacheParams,
+        config: dict[str, Any],
+        use_fused_attention: bool,
+        use_fused_post_attention_residual_add: bool,
+        use_fused_post_mlp_residual_add: bool,
+        producer_variant: str,
+        layer_idx: int,
+    ) -> None:
+        device_ref = DeviceRef.GPU()
+        max_seq_len = (
+            CACHE_LEN_BASE
+            + CACHE_LEN_STEP * (max(BATCH_SIZES) - 1)
+            + MAX_EXTRA_STEPS
+            + 256
+        )
+        attention_cls = (
+            MaxGemma3Attention
+            if use_fused_attention
+            else _Gemma3AttentionBaseline
+        )
+        attention = attention_cls(
+            rope_global=Llama3RotaryEmbedding(
+                config["hidden_size"],
+                config["num_attention_heads"],
+                config["rope_theta"],
+                max_seq_len,
+                interleaved=False,
+                head_dim=config["head_dim"],
+            ),
+            rope_local=Llama3RotaryEmbedding(
+                config["hidden_size"],
+                config["num_attention_heads"],
+                config["rope_local_base_freq"],
+                max_seq_len,
+                interleaved=False,
+                head_dim=config["head_dim"],
+            ),
+            num_attention_heads=config["num_attention_heads"],
+            num_key_value_heads=config["num_key_value_heads"],
+            hidden_size=config["hidden_size"],
+            kv_params=kv_params,
+            layer_idx=layer_idx,
+            dtype=DType.bfloat16,
+            devices=[device_ref],
+            qk_norm_eps=EPS,
+            sliding_window_pattern=config["sliding_window_pattern"],
+            local_window_size=config["sliding_window"],
+            has_bias=bool(config["attention_bias"]),
+        )
+        self.block = _Gemma3TransformerBlockVariant(
+            attention=attention,
+            mlp=MLP(
+                dtype=DType.bfloat16,
+                quantization_encoding=None,
+                hidden_dim=config["hidden_size"],
+                feed_forward_length=config["intermediate_size"],
+                devices=[device_ref],
+                activation_function=_resolve_hidden_activation(config),
+                has_bias=False,
+            ),
+            input_layernorm=Gemma3RMSNorm(
+                config["hidden_size"], DType.bfloat16, EPS
+            ),
+            post_attention_layernorm=Gemma3RMSNorm(
+                config["hidden_size"], DType.bfloat16, EPS
+            ),
+            pre_feedforward_layernorm=Gemma3RMSNorm(
+                config["hidden_size"], DType.bfloat16, EPS
+            ),
+            post_feedforward_layernorm=Gemma3RMSNorm(
+                config["hidden_size"], DType.bfloat16, EPS
+            ),
+            devices=[device_ref],
+            use_fused_post_attention_residual_add=(
+                use_fused_post_attention_residual_add
+            ),
+            use_fused_post_mlp_residual_add=(
+                use_fused_post_mlp_residual_add
+            ),
+            producer_variant=producer_variant,
+        )
+        self.layer_idx = layer_idx
+        self.next_input_layernorm = Gemma3RMSNorm(
+            config["hidden_size"], DType.bfloat16, EPS
+        )
+        sharding_strategy = self.block.input_layernorm.sharding_strategy
+        assert sharding_strategy is not None
+        self.next_input_layernorm.sharding_strategy = sharding_strategy
+        self.next_input_layernorm_shards = self.next_input_layernorm.shard(
+            [device_ref]
+        )
+
+    def load_state_dict(self, state_dict: dict[str, torch.Tensor]) -> None:
+        self.block.load_state_dict(
+            {
+                key.removeprefix("block."): value
+                for key, value in state_dict.items()
+                if key.startswith("block.")
+            }
+        )
+        self.next_input_layernorm.load_state_dict(
+            {"weight": state_dict["next_input_layernorm.weight"]}
+        )
+
+    def state_dict(self) -> dict[str, Any]:
+        weights = {
+            f"block.{key}": value
+            for key, value in self.block.state_dict().items()
+        }
+        weights["next_input_layernorm.weight"] = (
+            self.next_input_layernorm.state_dict()["weight"]
+        )
+        return weights
+
+    def graph_weights(self) -> dict[str, Any]:
+        weights = dict(self.block.state_dict())
+        weights["weight"] = self.next_input_layernorm.state_dict()["weight"]
+        return weights
+
+    def __call__(
+        self,
+        x: TensorValue,
+        normalized_x: TensorValue,
+        signal_buffers: list[BufferValue],
+        kv_collection: PagedCacheValues,
+        input_row_offsets: TensorValue,
+    ) -> tuple[TensorValue, TensorValue]:
+        hidden_states, next_norm_xs = self.block(
+            ops.constant(self.layer_idx, DType.uint32, device=DeviceRef.CPU()),
+            [x],
+            signal_buffers,
+            [kv_collection],
+            input_row_offsets=[input_row_offsets],
+            normalized_xs=[normalized_x],
+            next_input_layernorm_shards=self.next_input_layernorm_shards,
+        )
+        assert next_norm_xs is not None
+        return hidden_states[0], next_norm_xs[0]
+
+
+def _build_graph(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    config: dict[str, Any],
+    weight_registry: dict[str, torch.Tensor],
+    use_fused_attention: bool,
+    use_fused_post_attention_residual_add: bool,
+    use_fused_post_mlp_residual_add: bool,
+    producer_variant: str,
+    layer_idx: int,
+    layer_type: str,
+) -> Any:
+    device_ref = DeviceRef.GPU()
+    materialized_weight_registry, block_producer_variant = (
+        _materialize_weight_registry_for_producer_variant(
+            weight_registry,
+            config=config,
+            producer_variant=producer_variant,
+        )
+    )
+    harness = _Gemma3TransformerBlockDecodeHarness(
+        kv_params=kv_params,
+        config=config,
+        use_fused_attention=use_fused_attention,
+        use_fused_post_attention_residual_add=(
+            use_fused_post_attention_residual_add
+        ),
+        use_fused_post_mlp_residual_add=(
+            use_fused_post_mlp_residual_add
+        ),
+        producer_variant=block_producer_variant,
+        layer_idx=layer_idx,
+    )
+    harness.load_state_dict(materialized_weight_registry)
+    signals = Signals(devices=[device_ref])
+
+    input_type = TensorType(
+        DType.bfloat16,
+        ["total_seq_len", config["hidden_size"]],
+        device=device_ref,
+    )
+    normalized_input_type = TensorType(
+        DType.bfloat16,
+        ["total_seq_len", config["hidden_size"]],
+        device=device_ref,
+    )
+    input_row_offsets_type = TensorType(
+        DType.uint32,
+        ["input_row_offsets_len"],
+        device=device_ref,
+    )
+    flattened_kv_types = kv_params.get_symbolic_inputs().flatten()
+
+    graph_name = _graph_variant_name(
+        layer_type=layer_type,
+        use_fused_attention=use_fused_attention,
+        use_fused_post_attention_residual_add=(
+            use_fused_post_attention_residual_add
+        ),
+        use_fused_post_mlp_residual_add=use_fused_post_mlp_residual_add,
+        producer_variant=producer_variant,
+    )
+
+    with Graph(
+        graph_name,
+        input_types=(
+            input_type,
+            normalized_input_type,
+            input_row_offsets_type,
+            *signals.input_types(),
+            *flattened_kv_types,
+        ),
+    ) as graph:
+        x, normalized_x, input_row_offsets, signal, *kv_cache = graph.inputs
+        kv_collection = unflatten_ragged_attention_inputs(
+            kv_cache, n_devices=1
+        )[0]
+        hidden_states, next_norm = harness(
+            x.tensor,
+            normalized_x.tensor,
+            [signal.buffer],
+            kv_collection,
+            input_row_offsets.tensor,
+        )
+        graph.output(hidden_states, next_norm)
+
+    return session.load(graph, weights_registry=harness.graph_weights())
+
+
+def _run_compile_only_smoke(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    config: dict[str, Any],
+    weight_registry: dict[str, torch.Tensor],
+    layer_idx: int,
+    layer_type: str,
+    compile_only_mode: str,
+) -> None:
+    assert compile_only_mode == COMPILE_ONLY_RESIDUAL_LADDER_MODE
+    smoke_cases = (
+        {
+            "name": "FusedAttentionBaselineResidualPreFfnNorm",
+            "use_fused_attention": True,
+            "use_fused_post_attention_residual_add": False,
+            "use_fused_post_mlp_residual_add": False,
+            "producer_variant": "pre_ffn_norm",
+        },
+        {
+            "name": "FusedAttentionFusedPostAttentionBaselinePostMlpResidualPreFfnNorm",
+            "use_fused_attention": True,
+            "use_fused_post_attention_residual_add": True,
+            "use_fused_post_mlp_residual_add": False,
+            "producer_variant": "pre_ffn_norm",
+        },
+        {
+            "name": "FusedAttentionFusedResidualPreFfnNorm",
+            "use_fused_attention": True,
+            "use_fused_post_attention_residual_add": True,
+            "use_fused_post_mlp_residual_add": True,
+            "producer_variant": "pre_ffn_norm",
+        },
+    )
+
+    results: dict[str, Any] = {
+        "benchmark_config": {
+            "dtype": "bfloat16",
+            "hidden_size": config["hidden_size"],
+            "intermediate_size": config["intermediate_size"],
+            "head_dim": config["head_dim"],
+            "num_q_heads": config["num_attention_heads"],
+            "num_kv_heads": config["num_key_value_heads"],
+            "page_size": PAGE_SIZE,
+            "layer_idx": layer_idx,
+            "layer_type": layer_type,
+            "kv_num_layers": kv_params.num_layers,
+            "mode": compile_only_mode,
+        },
+        "cases": [],
+        "status": "pass",
+    }
+
+    for case in smoke_cases:
+        case_result = {
+            "name": case["name"],
+            "graph_name": _graph_variant_name(
+                layer_type=layer_type,
+                use_fused_attention=bool(case["use_fused_attention"]),
+                use_fused_post_attention_residual_add=bool(
+                    case["use_fused_post_attention_residual_add"]
+                ),
+                use_fused_post_mlp_residual_add=bool(
+                    case["use_fused_post_mlp_residual_add"]
+                ),
+                producer_variant=str(case["producer_variant"]),
+            ),
+            "producer_variant": case["producer_variant"],
+            "use_fused_attention": case["use_fused_attention"],
+            "use_fused_post_attention_residual_add": (
+                case["use_fused_post_attention_residual_add"]
+            ),
+            "use_fused_post_mlp_residual_add": (
+                case["use_fused_post_mlp_residual_add"]
+            ),
+        }
+        try:
+            compiled = _build_graph(
+                session=session,
+                kv_params=kv_params,
+                config=config,
+                weight_registry=weight_registry,
+                use_fused_attention=bool(case["use_fused_attention"]),
+                use_fused_post_attention_residual_add=bool(
+                    case["use_fused_post_attention_residual_add"]
+                ),
+                use_fused_post_mlp_residual_add=bool(
+                    case["use_fused_post_mlp_residual_add"]
+                ),
+                producer_variant=str(case["producer_variant"]),
+                layer_idx=layer_idx,
+                layer_type=layer_type,
+            )
+        except Exception as exc:
+            case_result["status"] = "failed"
+            case_result["error"] = str(exc)
+            results["cases"].append(case_result)
+            results["status"] = "blocker"
+            results["first_failure"] = case["name"]
+            print(json.dumps(results, indent=2, sort_keys=True))
+            raise
+
+        case_result["status"] = "pass"
+        results["cases"].append(case_result)
+        del compiled
+        torch.cuda.empty_cache()
+
+    print(json.dumps(results, indent=2, sort_keys=True))
+
+
+def _make_text_context(length: int, max_length: int) -> TextContext:
+    return TextContext(
+        request_id=RequestID(),
+        max_length=max_length,
+        tokens=TokenBuffer(np.zeros(length, dtype=np.int64)),
+    )
+
+
+def _make_runtime_inputs(
+    *,
+    session: InferenceSession,
+    kv_params: KVCacheParams,
+    batch_size: int,
+) -> tuple[np.ndarray, Any]:
+    cache_lengths = np.asarray(
+        [
+            CACHE_LEN_BASE + CACHE_LEN_STEP * request_idx
+            for request_idx in range(batch_size)
+        ],
+        dtype=np.uint32,
+    )
+    max_cache_length = int(cache_lengths[-1]) + MAX_EXTRA_STEPS + 1
+    total_num_pages = sum(
+        math.ceil((int(cache_length) + MAX_EXTRA_STEPS + 1) / PAGE_SIZE)
+        for cache_length in cache_lengths
+    )
+
+    kv_manager = PagedKVCacheManager(
+        params=kv_params,
+        total_num_pages=total_num_pages,
+        session=session,
+        max_batch_size=batch_size,
+    )
+
+    contexts: list[TextContext] = []
+    for cache_length in cache_lengths:
+        context = _make_text_context(int(cache_length), max_cache_length)
+        kv_manager.claim(context.request_id, replica_idx=0)
+        kv_manager.alloc(
+            context,
+            replica_idx=0,
+            num_steps=MAX_EXTRA_STEPS + 1,
+        )
+        contexts.append(context)
+
+    runtime_inputs = kv_manager.runtime_inputs([contexts], num_steps=1).inputs[0]
+    return cache_lengths, runtime_inputs
+
+
+def _clone_kv_blocks(blocks: Buffer, seed: int) -> Buffer:
+    torch.manual_seed(seed)
+    shape = tuple(int(dim) for dim in blocks.shape)
+    tensor = torch.randn(
+        shape, dtype=torch.bfloat16, device="cuda"
+    ).contiguous()
+    return Buffer.from_dlpack(tensor)
+
+
+def _device_uint32_buffer(array: np.ndarray, device: Accelerator) -> Buffer:
+    return Buffer.from_numpy(array).to(device)
+
+
+def _make_benchmark_args(
+    *,
+    batch_size: int,
+    hidden_size: int,
+    cache_lengths: np.ndarray,
+    runtime_inputs: Any,
+    device: Accelerator,
+    x_seed: int,
+    blocks_seed: int,
+) -> tuple[list[tuple[Any, ...]], Buffer]:
+    torch.manual_seed(x_seed)
+    x = torch.randn(
+        (batch_size, hidden_size),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+    x_buffer = Buffer.from_dlpack(x)
+    torch.manual_seed(x_seed + 97)
+    normalized_x = torch.randn(
+        (batch_size, hidden_size),
+        dtype=torch.bfloat16,
+        device="cuda",
+    ).contiguous()
+    normalized_x_buffer = Buffer.from_dlpack(normalized_x)
+    row_offsets = _device_uint32_buffer(
+        np.arange(batch_size + 1, dtype=np.uint32),
+        device,
+    )
+    signal_buffer = Signals(devices=[DeviceRef.GPU()]).buffers()[0]
+    kv_blocks = _clone_kv_blocks(runtime_inputs.blocks, seed=blocks_seed)
+    lookup_table = runtime_inputs.lookup_table.to(device)
+    dispatch_metadata = runtime_inputs.attention_dispatch_metadata
+    assert dispatch_metadata is not None
+
+    args: list[tuple[Any, ...]] = []
+    for step in range(MAX_EXTRA_STEPS + 1):
+        step_cache_lengths = _device_uint32_buffer(
+            cache_lengths + np.uint32(step), device
+        )
+        args.append(
+            (
+                x_buffer,
+                normalized_x_buffer,
+                row_offsets,
+                signal_buffer,
+                kv_blocks,
+                step_cache_lengths,
+                lookup_table,
+                runtime_inputs.max_lengths,
+                dispatch_metadata,
+            )
+        )
+    return args, kv_blocks
+
+
+def _run_correctness_check(
+    *,
+    baseline: Any,
+    fused: Any,
+    baseline_args: tuple[Any, ...],
+    fused_args: tuple[Any, ...],
+    layer_idx: int,
+) -> None:
+    baseline_hidden, baseline_next_norm = baseline.execute(*baseline_args)
+    fused_hidden, fused_next_norm = fused.execute(*fused_args)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        from_dlpack(baseline_hidden).to(torch.bfloat16),
+        from_dlpack(fused_hidden).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+    torch.testing.assert_close(
+        from_dlpack(baseline_next_norm).to(torch.bfloat16),
+        from_dlpack(fused_next_norm).to(torch.bfloat16),
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+    baseline_blocks = from_dlpack(baseline_args[4]).to(torch.bfloat16)[
+        :, :, layer_idx : layer_idx + 1, :, :, :
+    ]
+    fused_blocks = from_dlpack(fused_args[4]).to(torch.bfloat16)[
+        :, :, layer_idx : layer_idx + 1, :, :, :
+    ]
+    torch.testing.assert_close(
+        baseline_blocks,
+        fused_blocks,
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+
+def _benchmark_us(compiled: Any, args: list[tuple[Any, ...]]) -> float:
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def _run_nvidia_smi_query(query_fields: str) -> list[list[str]]:
+    result = subprocess.run(
+        [
+            "nvidia-smi",
+            f"--query-{query_fields}",
+            "--format=csv,noheader,nounits",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        [field.strip() for field in row]
+        for row in csv.reader(result.stdout.splitlines())
+        if row
+    ]
+
+
+def _build_gpu_isolation_guard() -> dict[str, Any] | None:
+    raw_guard = os.environ.get(
+        "PROFILE_TRANSFORMER_BLOCK_ENFORCE_GPU_ISOLATION", ""
+    ).strip()
+    if raw_guard.lower() not in ("1", "true", "yes"):
+        return None
+
+    cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", "").strip()
+    target_gpu_index = (
+        0 if cuda_visible_devices == "" else int(cuda_visible_devices.split(",")[0])
+    )
+
+    for index_text, gpu_uuid in _run_nvidia_smi_query("gpu=index,uuid"):
+        if int(index_text) == target_gpu_index:
+            return {
+                "allowed_pid": os.getpid(),
+                "target_gpu_index": target_gpu_index,
+                "target_gpu_uuid": gpu_uuid,
+            }
+
+    raise AssertionError(
+        "Could not resolve the target GPU UUID for "
+        f"CUDA_VISIBLE_DEVICES={cuda_visible_devices!r}"
+    )
+
+
+def _assert_gpu_isolation(
+    gpu_isolation_guard: dict[str, Any] | None,
+    *,
+    label: str,
+) -> None:
+    if gpu_isolation_guard is None:
+        return
+
+    resident_compute_apps = []
+    unexpected_apps = []
+    for gpu_uuid, pid_text, process_name, used_gpu_memory_mib in (
+        _run_nvidia_smi_query(
+            "compute-apps=gpu_uuid,pid,process_name,used_gpu_memory"
+        )
+    ):
+        if gpu_uuid != gpu_isolation_guard["target_gpu_uuid"]:
+            continue
+        resident_app = {
+            "gpu_uuid": gpu_uuid,
+            "pid": int(pid_text),
+            "process_name": process_name,
+            "used_gpu_memory_mib": float(used_gpu_memory_mib),
+        }
+        resident_compute_apps.append(resident_app)
+        if resident_app["pid"] != gpu_isolation_guard["allowed_pid"]:
+            unexpected_apps.append(resident_app)
+
+    if unexpected_apps:
+        raise AssertionError(
+            f"{label} at {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}: "
+            "unexpected compute apps on physical GPU "
+            f"{gpu_isolation_guard['target_gpu_index']} "
+            f"({gpu_isolation_guard['target_gpu_uuid']}): "
+            f"{unexpected_apps}; all resident apps: {resident_compute_apps}"
+        )
+
+
+def _benchmark_us_guarded(
+    compiled: Any,
+    args: list[tuple[Any, ...]],
+    *,
+    gpu_isolation_guard: dict[str, Any] | None,
+    label: str,
+) -> float:
+    _assert_gpu_isolation(
+        gpu_isolation_guard,
+        label=f"{label}:before_warmup",
+    )
+    warmup_args = args[:WARMUP_ITERS]
+    timed_args = args[WARMUP_ITERS : WARMUP_ITERS + TIMED_ITERS]
+
+    for run_args in warmup_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+
+    start_s = time.perf_counter()
+    for run_args in timed_args:
+        compiled.execute(*run_args)
+    torch.cuda.synchronize()
+    _assert_gpu_isolation(
+        gpu_isolation_guard,
+        label=f"{label}:after_timed",
+    )
+    elapsed_s = time.perf_counter() - start_s
+    return elapsed_s * 1e6 / len(timed_args)
+
+
+def test_profile_transformer_block_decode() -> None:
+    config = _load_text_config()
+    layer_idx, layer_type = _resolve_layer_metadata(config)
+    kv_num_layers = _resolve_kv_num_layers(config, layer_idx)
+    baseline_variant = _resolve_baseline_variant()
+    producer_variant = _resolve_producer_variant()
+    compile_only_mode = _resolve_compile_only_mode()
+    gpu_isolation_guard = _build_gpu_isolation_guard()
+    (
+        baseline_use_fused_attention,
+        baseline_use_fused_post_attention_residual_add,
+        baseline_use_fused_post_mlp_residual_add,
+    ) = _baseline_variant_flags(baseline_variant)
+    session = InferenceSession(devices=[Accelerator(0)])
+    device = Accelerator(0)
+    kv_params = KVCacheParams(
+        dtype=DType.bfloat16,
+        devices=[DeviceRef.GPU()],
+        n_kv_heads=config["num_key_value_heads"],
+        head_dim=config["head_dim"],
+        num_layers=kv_num_layers,
+        page_size=PAGE_SIZE,
+    )
+    weight_registry = _make_weight_registry(config)
+    if compile_only_mode is not None:
+        _run_compile_only_smoke(
+            session=session,
+            kv_params=kv_params,
+            config=config,
+            weight_registry=weight_registry,
+            layer_idx=layer_idx,
+            layer_type=layer_type,
+            compile_only_mode=compile_only_mode,
+        )
+        return
+
+    baseline = _build_graph(
+        session=session,
+        kv_params=kv_params,
+        config=config,
+        weight_registry=weight_registry,
+        use_fused_attention=baseline_use_fused_attention,
+        use_fused_post_attention_residual_add=(
+            baseline_use_fused_post_attention_residual_add
+        ),
+        use_fused_post_mlp_residual_add=(
+            baseline_use_fused_post_mlp_residual_add
+        ),
+        producer_variant=producer_variant,
+        layer_idx=layer_idx,
+        layer_type=layer_type,
+    )
+    fused = _build_graph(
+        session=session,
+        kv_params=kv_params,
+        config=config,
+        weight_registry=weight_registry,
+        use_fused_attention=True,
+        use_fused_post_attention_residual_add=True,
+        use_fused_post_mlp_residual_add=True,
+        producer_variant=producer_variant,
+        layer_idx=layer_idx,
+        layer_type=layer_type,
+    )
+
+    benchmark_config: dict[str, Any] = {
+        "dtype": "bfloat16",
+        "hidden_size": config["hidden_size"],
+        "intermediate_size": config["intermediate_size"],
+        "head_dim": config["head_dim"],
+        "num_q_heads": config["num_attention_heads"],
+        "num_kv_heads": config["num_key_value_heads"],
+        "page_size": PAGE_SIZE,
+        "layer_idx": layer_idx,
+        "layer_type": layer_type,
+        "kv_num_layers": kv_num_layers,
+        "baseline_variant": baseline_variant,
+        "producer_variant": producer_variant,
+        "mode": "decode-ragged-transformer-block",
+        "cache_len_base": CACHE_LEN_BASE,
+        "cache_len_step": CACHE_LEN_STEP,
+        "warmup_iters": WARMUP_ITERS,
+        "timed_iters": TIMED_ITERS,
+    }
+    if gpu_isolation_guard is not None:
+        benchmark_config["gpu_isolation_guard"] = {
+            "allowed_pid": gpu_isolation_guard["allowed_pid"],
+            "target_gpu_index": gpu_isolation_guard["target_gpu_index"],
+            "target_gpu_uuid": gpu_isolation_guard["target_gpu_uuid"],
+        }
+
+    results: dict[str, Any] = {
+        "benchmark_config": benchmark_config,
+        "correctness": "pass",
+        "first_sweep_us": {},
+        "confirm_sweep_us": {},
+        "average_us": {},
+        "average_speedup_ratio_vs_baseline": {},
+    }
+
+    for batch_size in BATCH_SIZES:
+        cache_lengths, runtime_inputs = _make_runtime_inputs(
+            session=session,
+            kv_params=kv_params,
+            batch_size=batch_size,
+        )
+        run_name = (
+            f"decode_{layer_type}_block_layer{layer_idx}_bs{batch_size}_seq1"
+            f"_cache{CACHE_LEN_BASE}_step{CACHE_LEN_STEP}"
+            + (
+                ""
+                if producer_variant == DEFAULT_PRODUCER_VARIANT
+                else f"_{producer_variant}"
+            )
+        )
+
+        baseline_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            hidden_size=config["hidden_size"],
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            x_seed=1000 + batch_size,
+            blocks_seed=2000 + batch_size,
+        )
+        fused_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            hidden_size=config["hidden_size"],
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            x_seed=1000 + batch_size,
+            blocks_seed=2000 + batch_size,
+        )
+
+        _run_correctness_check(
+            baseline=baseline,
+            fused=fused,
+            baseline_args=baseline_args[0],
+            fused_args=fused_args[0],
+            layer_idx=layer_idx,
+        )
+
+        first_baseline_us = _benchmark_us_guarded(
+            baseline,
+            baseline_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:baseline:first",
+        )
+        first_fused_us = _benchmark_us_guarded(
+            fused,
+            fused_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:fused:first",
+        )
+        results["first_sweep_us"][run_name] = {
+            "baseline": first_baseline_us,
+            "fused": first_fused_us,
+        }
+
+        del baseline_args
+        del fused_args
+
+        baseline_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            hidden_size=config["hidden_size"],
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            x_seed=3000 + batch_size,
+            blocks_seed=4000 + batch_size,
+        )
+        fused_args, _ = _make_benchmark_args(
+            batch_size=batch_size,
+            hidden_size=config["hidden_size"],
+            cache_lengths=cache_lengths,
+            runtime_inputs=runtime_inputs,
+            device=device,
+            x_seed=3000 + batch_size,
+            blocks_seed=4000 + batch_size,
+        )
+
+        confirm_baseline_us = _benchmark_us_guarded(
+            baseline,
+            baseline_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:baseline:confirm",
+        )
+        confirm_fused_us = _benchmark_us_guarded(
+            fused,
+            fused_args,
+            gpu_isolation_guard=gpu_isolation_guard,
+            label=f"{run_name}:fused:confirm",
+        )
+        results["confirm_sweep_us"][run_name] = {
+            "baseline": confirm_baseline_us,
+            "fused": confirm_fused_us,
+        }
+
+        average_baseline_us = 0.5 * (first_baseline_us + confirm_baseline_us)
+        average_fused_us = 0.5 * (first_fused_us + confirm_fused_us)
+        results["average_us"][run_name] = {
+            "baseline": average_baseline_us,
+            "fused": average_fused_us,
+        }
+        results["average_speedup_ratio_vs_baseline"][run_name] = (
+            average_baseline_us / average_fused_us
+        )
+
+        del baseline_args
+        del fused_args
+        del runtime_inputs
+        torch.cuda.empty_cache()
+
+    speedups = list(results["average_speedup_ratio_vs_baseline"].values())
+    results["average_geomean_speedup_vs_baseline"] = math.prod(speedups) ** (
+        1.0 / len(speedups)
+    )
+    print(json.dumps(results, indent=2, sort_keys=True))

--- a/max/tests/integration/architectures/gemma3/test_rms_norm.py
+++ b/max/tests/integration/architectures/gemma3/test_rms_norm.py
@@ -19,6 +19,7 @@ from max.engine import InferenceSession
 from max.graph import DeviceRef, Graph, Shape, TensorType
 from max.pipelines.architectures.gemma3.layers.rms_norm import (
     Gemma3RMSNorm as MaxRMSNorm,
+    gemma3_rms_norm_fused_residual_add,
 )
 from torch.utils.dlpack import from_dlpack
 from transformers.models.gemma3.configuration_gemma3 import Gemma3TextConfig
@@ -72,6 +73,99 @@ def generate_max_outputs(
     )
 
 
+def generate_torch_fused_residual_add_outputs(
+    text_config: Gemma3TextConfig,
+    input_tensor: torch.Tensor,
+    residual_tensor: torch.Tensor,
+    first_rms_weight: torch.Tensor,
+    second_rms_weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    first_norm = TorchRMSNorm(
+        dim=text_config.hidden_size,
+        eps=1e-6,
+    ).to(dtype=torch.bfloat16, device="cuda")
+    second_norm = TorchRMSNorm(
+        dim=text_config.hidden_size,
+        eps=1e-6,
+    ).to(dtype=torch.bfloat16, device="cuda")
+    first_norm.weight.data = first_rms_weight.to(
+        dtype=torch.float32, device="cuda"
+    )
+    second_norm.weight.data = second_rms_weight.to(
+        dtype=torch.float32, device="cuda"
+    )
+
+    residual_output = residual_tensor.to("cuda") + first_norm(
+        input_tensor.to("cuda")
+    )
+    fused_output = second_norm(residual_output)
+    return fused_output, residual_output
+
+
+def generate_max_fused_residual_add_outputs(
+    text_config: Gemma3TextConfig,
+    input_tensor: torch.Tensor,
+    residual_tensor: torch.Tensor,
+    first_rms_weight: torch.Tensor,
+    second_rms_weight: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    first_norm = MaxRMSNorm(
+        dim=text_config.hidden_size,
+        dtype=DType.float32,
+        eps=1e-6,
+    )
+    second_norm = MaxRMSNorm(
+        dim=text_config.hidden_size,
+        dtype=DType.float32,
+        eps=1e-6,
+    )
+    first_norm.weight.name = "first_rms_weight"
+    second_norm.weight.name = "second_rms_weight"
+
+    session = InferenceSession(devices=[Accelerator()])
+    input_type = TensorType(
+        dtype=DType.bfloat16,
+        shape=Shape(input_tensor.shape),
+        device=DeviceRef.GPU(),
+    )
+    residual_type = TensorType(
+        dtype=DType.bfloat16,
+        shape=Shape(residual_tensor.shape),
+        device=DeviceRef.GPU(),
+    )
+
+    with Graph(
+        "Gemma3RMSNormFusedResidualAdd",
+        input_types=(input_type, residual_type),
+    ) as graph:
+        x, residual = graph.inputs
+        graph_fused_output, graph_residual_output = (
+            gemma3_rms_norm_fused_residual_add(
+                x.tensor,
+                residual.tensor,
+                first_norm,
+                second_norm,
+            )
+        )
+        graph.output(graph_fused_output, graph_residual_output)
+
+    compiled = session.load(
+        graph,
+        weights_registry={
+            "first_rms_weight": first_rms_weight.cpu(),
+            "second_rms_weight": second_rms_weight.cpu(),
+        },
+    )
+    compiled_outputs = compiled.execute(
+        input_tensor.to("cuda"),
+        residual_tensor.to("cuda"),
+    )
+    return (
+        from_dlpack(compiled_outputs[0]).to(torch.bfloat16),
+        from_dlpack(compiled_outputs[1]).to(torch.bfloat16),
+    )
+
+
 def test_gemma3_rms_norm(
     text_config: Gemma3TextConfig,
     input_tensor: torch.Tensor,
@@ -87,6 +181,44 @@ def test_gemma3_rms_norm(
     torch.testing.assert_close(
         torch_output,
         max_output,
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+
+
+def test_gemma3_rms_norm_fused_residual_add(
+    text_config: Gemma3TextConfig,
+    input_tensor: torch.Tensor,
+    rms_weight: torch.Tensor,
+) -> None:
+    torch.manual_seed(7)
+    residual_tensor = torch.randn_like(input_tensor)
+    second_rms_weight = torch.roll(rms_weight, shifts=17).contiguous()
+
+    torch_output, torch_residual = generate_torch_fused_residual_add_outputs(
+        text_config,
+        input_tensor,
+        residual_tensor,
+        rms_weight,
+        second_rms_weight,
+    )
+    max_output, max_residual = generate_max_fused_residual_add_outputs(
+        text_config,
+        input_tensor,
+        residual_tensor,
+        rms_weight,
+        second_rms_weight,
+    )
+
+    torch.testing.assert_close(
+        torch_output,
+        max_output,
+        rtol=2 * torch.finfo(torch.bfloat16).eps,
+        atol=8 * torch.finfo(torch.bfloat16).eps,
+    )
+    torch.testing.assert_close(
+        torch_residual,
+        max_residual,
         rtol=2 * torch.finfo(torch.bfloat16).eps,
         atol=8 * torch.finfo(torch.bfloat16).eps,
     )


### PR DESCRIPTION
## Summary
- add the current decode-focused rope, QK, and KV-cache fast paths used by the Gemma decode stack
- wire in the supporting Gemma integration profiling tests and benchmark harnesses
- keep the validated exact BF16/128 decode wins for the live q-only, qk, and k-only paths

## Benchmark Notes
- exact BF16/128 live q-only decode:
  - `1.16138153x` speedup
  - `6.92620000 us` saved
- exact BF16/128 live QK decode with correctness restored:
  - baseline `62.27719714 us`
  - fused `33.24680147 us`
  - `1.87317860x` speedup
  - `29.03039567 us` saved
- exact BF16/128 live K-only decode:
  - `1.23905479x` speedup
  - `9.10064846 us` saved
- the stronger composed QK result remains larger than the separable q-only and k-only wins, which matches the intended end-to-end decode path this branch is targeting
