### PR TITLE
[stdlib] Use `VariadicPack` instead of `VariadicList` where possible

### DIFF
--- a/max/kernels/src/extensibility/tensor/managed_tensor_slice.mojo
+++ b/max/kernels/src/extensibility/tensor/managed_tensor_slice.mojo
@@ -595,39 +595,54 @@ struct ManagedTensorSlice[
         return self._ptr[offset]
 
     @always_inline
-    def __getitem__(self, *indices: Int) -> Scalar[Self.dtype]:
+    def __getitem__[
+        *Ts: type_of(Int)
+    ](self, *indices: *Ts) -> Scalar[Self.dtype]:
         """Gets the value at the specified indices.
 
+        Parameters:
+            Ts: The types.
+
         Args:
-          indices: The indices of the value to retrieve.
+            indices: The indices of the value to retrieve.
 
         Returns:
-          The value at the specified indices.
+            The value at the specified indices.
         """
         comptime assert (
             not Self._has_input_fusion
         ), "Direct load on fused tensor is forbidden"
-        assert (
-            len(indices) == Self.rank
+        comptime assert (
+            indices.__len__() == Self.rank
         ), "mismatch between requested index and rank"
-        return self[IndexList[Self.rank](*indices)]
+        var idxes = IndexList[Self.rank]()
+        comptime for i in range(Self.rank):
+            idxes[i] = indices[i]
+        return self[idxes]
 
     @always_inline
-    def __setitem__(self, *indices: Int, val: Scalar[Self.dtype]):
+    def __setitem__[
+        *Ts: type_of(Int)
+    ](self, *indices: *Ts, val: Scalar[Self.dtype]):
         """Stores the value at the specified indices.
 
-        Args:
-          indices: The indices of the value to store.
-          val: The value to store.
+        Parameters:
+            Ts: The types.
 
+        Args:
+            indices: The indices of the value to store.
+            val: The value to store.
         """
         comptime assert (
             not Self._has_output_store_fusion
         ), "Direct store on fused tensor is forbidden"
-        assert (
-            len(indices) == Self.rank
+        comptime assert (
+            indices.__len__() == Self.rank
         ), "mismatch between requested index and rank"
-        self[IndexList[Self.rank](*indices)] = val
+        var idxes = IndexList[Self.rank]()
+        comptime for i in range(Self.rank):
+            idxes[i] = indices[i]
+        self[idxes] = val
 
     @always_inline
     def __setitem__(

--- a/max/kernels/src/layout/runtime_tuple.mojo
+++ b/max/kernels/src/layout/runtime_tuple.mojo
@@ -108,13 +108,22 @@ struct RuntimeTuple[
                 self.value[i] = UNKNOWN_VALUE
 
     @always_inline
-    def __init__(out self, *values: Int):
+    def __init__[*Ts: type_of(Int)](out self, *values: *Ts):
         """Initialize a `RuntimeTuple` with the provided values.
 
+        Parameters:
+            Ts: The integers.
+
         Args:
-            values: Variadic number of integer values to initialize the tuple with.
+            values: Variadic number of integer values to initialize the tuple
+                with.
         """
-        self.value = type_of(self.value)(*values)
+        comptime assert (
+            values.__len__() == Self.scalar_length
+        ), "mismatch in the number of elements"
+        self.value = {}
+        comptime for i in range(values.__len__()):
+            self.value[i] = values[i]
 
     @always_inline
     @implicit
@@ -621,31 +630,30 @@ def shape_div[
             comptime assert len(a_t) == len(
                 b_t
             ), "shape and stride length musth match"
-            var res = RuntimeTuple[shape_div_int_tuple(a_t, b_t)]()
+            result = {}
 
             comptime for i in range(len(a_t)):
                 var res_i = shape_div(a[i], b[i])
 
                 comptime for j in range(res_i.scalar_length):
-                    res.value[i + j] = res_i.value[j]
-            return res
+                    result.value[i + j] = res_i.value[j]
         else:
-            var res = RuntimeTuple[shape_div_int_tuple(a_t, b_t)]()
+            result = {}
             # FIXME: this used to be simpler
             # var vb = Int(to_int(b))
-            var vb = RuntimeTuple[IntTuple(UNKNOWN_VALUE)](Int(b))
+            comptime R = RuntimeTuple[IntTuple(UNKNOWN_VALUE)]
+            var vb = R(Int(b))
 
             comptime for i in range(len(a_t)):
                 var res_i = shape_div(a[i], vb)
 
                 comptime for j in range(res_i.scalar_length):
-                    res.value[i + j] = res_i.value[j]
+                    result.value[i + j] = res_i.value[j]
 
                 # FIXME: this used to be simpler
                 # vb = Int(to_int(shape_div(vb, product(a[i]))))
-                var t = RuntimeTuple[IntTuple(UNKNOWN_VALUE)](product(a[i]))
+                var t = R(product(a[i]))
                 vb = {Int(shape_div(vb, t))}
-            return res
     else:
         comptime if b_t.is_tuple():
             return shape_div(a, b)

--- a/mojo/stdlib/std/collections/inline_array.mojo
+++ b/mojo/stdlib/std/collections/inline_array.mojo
@@ -42,6 +42,7 @@ from std.compile import get_type_name
 import std.format._utils as fmt
 from std.hashlib.hasher import Hasher
 from std.memory import UnsafeMaybeUninit, uninit_move_n
+from std.sys.intrinsics import _type_is_eq_parse_time
 
 # ===-----------------------------------------------------------------------===#
 # Array
@@ -432,8 +433,19 @@ struct InlineArray[ElementType: Copyable, size: Int](
         )
 
     @always_inline
-    def __init__(out self, var *elems: Self.ElementType, __list_literal__: ()):
+    def __init__[
+        *Ts: type_of(Self.ElementType)
+    ](out self, var *elems: *Ts, __list_literal__: ()) where (
+        elems.__len__() == Self.size
+        # FIXME(#6357): somehow I'm getting: error: rebind input type
+        # '!kgen.pointer<index>' does not match result type '!kgen.pointer<scalar<ui8>>'
+        # even though this constructor should only accept the same type
+        and _type_is_eq_parse_time[Ts[0], Self.ElementType]()
+    ):
         """Constructs an array from a variadic list of elements.
+
+        Parameters:
+            Ts: The types.
 
         Args:
             elems: The elements to initialize the array with. Must match the
@@ -447,29 +459,101 @@ struct InlineArray[ElementType: Copyable, size: Int](
         var arr: InlineArray[Int, 3] = [1, 2, 3]
         ```
         """
-        debug_assert[assert_mode="safe"](
-            len(elems) == Self.size,
-            "InlineArray: expected ",
-            Self.size,
-            " elements, received ",
-            len(elems),
-        )
         _inline_array_construction_checks[Self.size]()
         __mlir_op.`lit.ownership.mark_initialized`(__get_mvalue_as_litref(self))
 
-        var ptr = self.unsafe_ptr()
+        comptime assert (
+            elems.__len__() == Self.size
+        ), "mismatch in the number of elements"
 
-        # Move each element into the array storage.
-        comptime for i in range(Self.size):
-            # Safety: We own the elements in the variadic list.
-            ptr.init_pointee_move_from(
-                UnsafePointer(to=elems[i]).unsafe_mut_cast[True]()
+        @parameter
+        def init_elt[idx: Int](var elt: elems.element_types[idx]):
+            (self.unsafe_ptr() + idx).init_pointee_move(
+                rebind_var[self.ElementType](elt^)
             )
-            ptr += 1
 
-        # Do not destroy the elements when their backing storage goes away.
-        # FIXME: Why doesn't consume_elements work here?
-        elems^._annihilate()
+        elems^.consume_elements[init_elt]()
+
+    # TODO(#6357): remove once implicit conversion in VariadicPack is solved
+    @always_inline
+    def __init__[
+        dtype: DType, *Ts: type_of(Int)
+    ](
+        out self: InlineArray[Scalar[dtype], Self.size],
+        var *elems: *Ts,
+        __list_literal__: (),
+    ):
+        """Constructs an array from a variadic list of elements.
+
+        Parameters:
+            dtype: The dtype.
+            Ts: The types.
+
+        Args:
+            elems: The elements to initialize the array with. Must match the
+                array size.
+            __list_literal__: Specifies that this constructor can be used for
+                list literals.
+
+        Examples:
+
+        ```mojo
+        var arr: InlineArray[Int32, 3] = [1, 2, 3]
+        ```
+        """
+        _inline_array_construction_checks[Self.size]()
+        __mlir_op.`lit.ownership.mark_initialized`(__get_mvalue_as_litref(self))
+
+        comptime assert (
+            elems.__len__() == Self.size
+        ), "mismatch in the number of elements"
+
+        @parameter
+        def init_elt[idx: Int](var elt: elems.element_types[idx]):
+            (self.unsafe_ptr() + idx).init_pointee_move(self.ElementType(elt))
+
+        elems^.consume_elements[init_elt]()
+
+    # TODO(#6357): remove once implicit conversion in VariadicPack is solved
+    @always_inline
+    def __init__[
+        *Ts: type_of(String)
+    ](
+        out self: InlineArray[StaticString, Self.size],
+        var *elems: *Ts,
+        __list_literal__: (),
+    ) where (elems.__len__() == Self.size):
+        """Constructs an array from a variadic list of elements.
+
+        Parameters:
+            Ts: The types.
+
+        Args:
+            elems: The elements to initialize the array with. Must match the
+                array size.
+            __list_literal__: Specifies that this constructor can be used for
+                list literals.
+
+        Examples:
+
+        ```mojo
+        var arr: InlineArray[StaticString, 3] = ["1", "2", "3"]
+        ```
+        """
+        _inline_array_construction_checks[Self.size]()
+        __mlir_op.`lit.ownership.mark_initialized`(__get_mvalue_as_litref(self))
+
+        comptime assert (
+            elems.__len__() == Self.size
+        ), "mismatch in the number of elements"
+
+        @parameter
+        def init_elt[idx: Int](var elt: elems.element_types[idx]):
+            (self.unsafe_ptr() + idx).init_pointee_move(
+                rebind[self.ElementType](StringSlice(elt))
+            )
+
+        elems^.consume_elements[init_elt]()
 
     def __init__(out self, *, copy: Self):
         """Copy constructs the array from another array.

--- a/mojo/stdlib/std/math/math.mojo
+++ b/mojo/stdlib/std/math/math.mojo
@@ -851,7 +851,7 @@ def frexp[
         zero,
     )
     var frac = selector.select(T(from_bits=x_int & ~mask1 | mask2), zero)
-    return StaticTuple[size=2](frac, exp)
+    return {frac, exp}
 
 
 # ===----------------------------------------------------------------------=== #

--- a/mojo/stdlib/std/utils/index.mojo
+++ b/mojo/stdlib/std/utils/index.mojo
@@ -230,8 +230,13 @@ struct IndexList[size: Int, *, element_type: DType = DType.int64](
         self = tup
 
     @always_inline
-    def __init__(out self, *elems: Int, __list_literal__: () = ()):
+    def __init__[
+        *Ts: type_of(Int)
+    ](out self, *elems: *Ts, __list_literal__: () = ()):
         """Constructs a static int tuple given a set of arguments.
+
+        Parameters:
+            Ts: The types.
 
         Args:
             elems: The elements to construct the tuple.
@@ -241,14 +246,11 @@ struct IndexList[size: Int, *, element_type: DType = DType.int64](
         comptime assert (
             Self.element_type.is_integral()
         ), "Element type must be of integral type."
-
         comptime assert (
             Self.element_type.is_integral()
         ), "Element type must be of integral type."
-        var num_elements = len(elems)
-
-        assert (
-            Self.size == num_elements
+        comptime assert (
+            elems.__len__() == Self.size
         ), "[IndexList] mismatch in the number of elements"
 
         self = Self()

--- a/mojo/stdlib/std/utils/static_tuple.mojo
+++ b/mojo/stdlib/std/utils/static_tuple.mojo
@@ -127,20 +127,58 @@ struct StaticTuple[element_type: _StaticTupleTraits, size: Int](
         ](fill)
 
     @always_inline
-    def __init__(out self, *elems: Self.element_type):
+    def __init__[*Ts: type_of(Self.element_type)](out self, *elems: *Ts):
         """Constructs a static tuple given a set of arguments.
+
+        Parameters:
+            Ts: The types.
 
         Args:
             elems: The element types.
         """
         _static_tuple_construction_checks[Self.element_type, Self.size]()
-        if len(elems) == 1:
-            return Self(fill=elems[0])
+        comptime if elems.__len__() == 1:
+            return Self(fill=rebind[Self.element_type](elems[0]))
 
-        assert Self.size == len(elems), "mismatch in the number of elements"
+        # FIXME(#6376): remove elems.__len__() == 1
+        comptime assert (
+            elems.__len__() == Self.size or elems.__len__() == 1
+        ), String(
+            "mismatch in the number of elements, Self.size: ",
+            Self.size,
+            " len(elems): ",
+            elems.__len__(),
+        )
+
         self = Self()
         comptime for idx in range(Self.size):
-            self[idx] = elems[idx]
+            self[idx] = rebind[Self.element_type](elems[idx])
+
+    # TODO(#6357): remove once implicit conversion in VariadicPack is solved
+    @always_inline
+    def __init__[
+        dtype: DType, *Ts: type_of(Int)
+    ](out self: StaticTuple[Scalar[dtype], Self.size], *elems: *Ts):
+        """Constructs a static tuple given a set of arguments.
+
+        Parameters:
+            dtype: The dtype.
+            Ts: The types.
+
+        Args:
+            elems: The element types.
+        """
+        _static_tuple_construction_checks[Self.element_type, Self.size]()
+        comptime if elems.__len__() == 1:
+            return {fill = self.element_type(elems[0])}
+
+        comptime assert (
+            elems.__len__() == Self.size
+        ), "mismatch in the number of elements"
+
+        self = type_of(self)()
+        comptime for idx in range(Self.size):
+            self[idx] = self.element_type(elems[idx])
 
     @always_inline
     def __init__[*values: Self.element_type](out self):


### PR DESCRIPTION
Use `VariadicPack` instead of `VariadicList` where possible. #6356 remains blocked in another PR, these here should work with no issues