### PR TITLE
[Kernels] Optimize Gemma 4 MoE routing and large-vocab sampling paths

### DIFF
--- a/max/kernels/benchmarks/gpu/nn/bench_moe_routing.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_moe_routing.mojo
@@ -22,7 +22,7 @@ from nn.moe import moe_create_indices, router_group_limited
 
 
 def bench_moe_create_indices[
-    num_tokens: Int, num_experts: Int
+    num_tokens: Int, num_experts: Int, expected_count: Int
 ](ctx: DeviceContext, mut b: Bench) raises:
     var topk_h = ctx.enqueue_create_host_buffer[DType.uint32](num_tokens)
     for i in range(num_tokens):
@@ -73,7 +73,11 @@ def bench_moe_create_indices[
         @parameter
         @always_inline
         def kernel_launch(ctx: DeviceContext) raises:
-            moe_create_indices[input_type=DType.uint32, target="gpu"](
+            moe_create_indices[
+                input_type=DType.uint32,
+                target="gpu",
+                expected_count=expected_count,
+            ](
                 token_expert_order,
                 expert_start_indices,
                 restore_token_order,
@@ -213,10 +217,13 @@ def main() raises:
     comptime n_experts_per_tok = get_defined_int["n_experts_per_tok", 8]()
     comptime n_groups = get_defined_int["n_groups", 8]()
     comptime topk_group = get_defined_int["topk_group", 4]()
+    comptime expected_count = get_defined_int["expected_count", 8192]()
 
     var m = Bench(BenchConfig(num_repetitions=1))
     with DeviceContext() as ctx:
-        bench_moe_create_indices[num_tokens, num_experts](ctx, m)
+        bench_moe_create_indices[num_tokens, num_experts, expected_count](
+            ctx, m
+        )
         bench_router_group_limited[
             num_tokens, num_experts, n_experts_per_tok, n_groups, topk_group
         ](ctx, m)

--- a/max/kernels/src/nn/moe.mojo
+++ b/max/kernels/src/nn/moe.mojo
@@ -1221,7 +1221,8 @@ def routed_expert_combine_then_rms_norm[
     weight_offset: Scalar[dtype],
     context: DeviceContextPtr,
 ) raises:
-    """Combines routed expert outputs and immediately applies weighted RMSNorm."""
+    """Combines routed expert outputs and immediately applies weighted RMSNorm.
+    """
     comptime assert output.flat_rank == 2
     comptime assert top_k_weights.flat_rank == 2
     comptime assert down_output.flat_rank == 3

--- a/max/kernels/src/nn/moe.mojo
+++ b/max/kernels/src/nn/moe.mojo
@@ -11,6 +11,7 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+from std.algorithm import elementwise
 from std.collections import OptionalReg
 
 from std.math import align_up, ceildiv
@@ -35,12 +36,14 @@ from std.gpu.primitives.grid_controls import (
     PDLLevel,
     pdl_launch_attributes,
 )
+from std.gpu.host import get_gpu_target
 from std.gpu.host.info import is_gpu
 from layout import (
     Coord,
     Idx,
     TensorLayout,
     TileTensor,
+    coord_to_index_list,
     row_major,
     stack_allocation as tensor_alloc,
 )
@@ -50,6 +53,7 @@ from std.runtime.tracing import Trace, TraceLevel
 from std.utils.index import IndexList, StaticTuple
 from std.builtin.dtype import _uint_type_of_width
 
+from nn.normalization import rms_norm_gpu
 from nn.topk import TopK_2
 
 
@@ -750,13 +754,9 @@ def moe_create_indices[
 
         var num_experts = expert_ids.dim(0)
 
-        var expert_usage_stats_host = cuda_ctx.enqueue_create_host_buffer[
-            DType.uint32
-        ](2)
-        expert_usage_stats_host.enqueue_fill(0)
-        cuda_ctx.enqueue_copy[DType.uint32](
-            expert_usage_stats.ptr,
-            expert_usage_stats_host,
+        cuda_ctx.enqueue_memset(
+            expert_usage_stats.to_device_buffer(cuda_ctx),
+            UInt32(0),
         )
 
         comptime kernel = moe_create_indices_bucket_group_kernel[
@@ -784,7 +784,6 @@ def moe_create_indices[
         )
 
         _ = lock_buffer^
-        _ = expert_usage_stats_host^
 
 
 # Function to perform warp-level sorting
@@ -1131,4 +1130,166 @@ def router_group_limited[
             grid_dim=expert_scores.dim(0),
             block_dim=num_threads,
             attributes=pdl_launch_attributes(PDLLevel(1)),
+        )
+
+
+@always_inline
+def routed_expert_combine[
+    dtype: DType,
+    //,
+    target: StaticString,
+](
+    output: TileTensor[mut=True, dtype, ...],
+    top_k_weights: TileTensor[dtype, ...],
+    down_output: TileTensor[dtype, ...],
+    context: DeviceContextPtr,
+) raises:
+    """Combines routed expert outputs directly into the final `[seq, hidden]` tensor.
+
+    This keeps the float32 multiply-then-reduce numerics used by Gemma4 MoE
+    prefill, but writes the reduced result straight to the output tensor so the
+    graph does not need chunk assembly via `ops.concat`.
+    """
+    comptime assert output.flat_rank == 2
+    comptime assert top_k_weights.flat_rank == 2
+    comptime assert down_output.flat_rank == 3
+    comptime assert is_gpu[
+        target
+    ](), "routed expert combine is only supported on GPU"
+
+    var seq_len = Int(output.dim(0))
+    var hidden_dim = Int(output.dim(1))
+    if Int(top_k_weights.dim(0)) != seq_len:
+        raise Error("top_k_weights and output must agree on seq_len")
+    if Int(down_output.dim(0)) != seq_len:
+        raise Error("down_output and output must agree on seq_len")
+    if Int(top_k_weights.dim(1)) != Int(down_output.dim(1)):
+        raise Error(
+            "top_k_weights and down_output must agree on routed experts"
+        )
+    if Int(down_output.dim(2)) != hidden_dim:
+        raise Error("down_output and output must agree on hidden_dim")
+    if seq_len == 0 or hidden_dim == 0:
+        return
+
+    var gpu_ctx = context.get_device_context()
+    var routed_experts = Int(top_k_weights.dim(1))
+
+    @parameter
+    @always_inline
+    @__copy_capture(output, top_k_weights, down_output, routed_experts)
+    def combine_fn[
+        width: Int, rank: Int, alignment: Int = 1
+    ](idx: IndexList[rank]):
+        comptime assert rank == 2, "expected [seq, hidden] output coordinates"
+
+        var accum = SIMD[DType.float32, width](0)
+        for expert_idx in range(routed_experts):
+            var weight = top_k_weights.load[width=1](
+                (Idx(idx[0]), Idx(expert_idx))
+            ).cast[DType.float32]()
+            var expert_vals = down_output.load[width=width](
+                Coord(Idx(idx[0]), Idx(expert_idx), Idx(idx[1]))
+            ).cast[DType.float32]()
+            accum += expert_vals * SIMD[DType.float32, width](weight)
+
+        output.store[width=width](Coord(idx), accum.cast[dtype]())
+
+    with Trace[TraceLevel.OP, target=target](
+        "mo.routed_expert_combine",
+        task_id=Int(gpu_ctx.id()),
+    ):
+        comptime simd_width = simd_width_of[dtype, target=get_gpu_target()]()
+        elementwise[combine_fn, simd_width, target=target](
+            coord_to_index_list(output.layout.shape_coord()),
+            gpu_ctx,
+        )
+
+
+@always_inline
+def routed_expert_combine_then_rms_norm[
+    dtype: DType,
+    //,
+    target: StaticString,
+    multiply_before_cast: Bool = True,
+](
+    output: TileTensor[mut=True, dtype, ...],
+    top_k_weights: TileTensor[dtype, ...],
+    down_output: TileTensor[dtype, ...],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    context: DeviceContextPtr,
+) raises:
+    """Combines routed expert outputs and immediately applies weighted RMSNorm."""
+    comptime assert output.flat_rank == 2
+    comptime assert top_k_weights.flat_rank == 2
+    comptime assert down_output.flat_rank == 3
+    comptime assert gamma.flat_rank == 1
+    comptime assert is_gpu[
+        target
+    ](), "routed expert combine is only supported on GPU"
+
+    var seq_len = Int(output.dim(0))
+    var hidden_dim = Int(output.dim(1))
+    if Int(top_k_weights.dim(0)) != seq_len:
+        raise Error("top_k_weights and output must agree on seq_len")
+    if Int(down_output.dim(0)) != seq_len:
+        raise Error("down_output and output must agree on seq_len")
+    if Int(top_k_weights.dim(1)) != Int(down_output.dim(1)):
+        raise Error(
+            "top_k_weights and down_output must agree on routed experts"
+        )
+    if Int(down_output.dim(2)) != hidden_dim:
+        raise Error("down_output and output must agree on hidden_dim")
+    if Int(gamma.dim(0)) != hidden_dim:
+        raise Error("gamma and output must agree on hidden_dim")
+    if seq_len == 0 or hidden_dim == 0:
+        return
+
+    var gpu_ctx = context.get_device_context()
+    var routed_experts = Int(top_k_weights.dim(1))
+
+    @parameter
+    @always_inline
+    @__copy_capture(top_k_weights, down_output, routed_experts)
+    def combine_input_fn[
+        width: Int, rank: Int
+    ](idx: IndexList[rank]) -> SIMD[dtype, width]:
+        comptime assert rank == 2, "expected [seq, hidden] output coordinates"
+
+        var accum = SIMD[DType.float32, width](0)
+        for expert_idx in range(routed_experts):
+            var weight = top_k_weights.load[width=1](
+                (Idx(idx[0]), Idx(expert_idx))
+            ).cast[DType.float32]()
+            var expert_vals = down_output.load[width=width](
+                Coord(Idx(idx[0]), Idx(expert_idx), Idx(idx[1]))
+            ).cast[DType.float32]()
+            accum += expert_vals * SIMD[DType.float32, width](weight)
+
+        return accum.cast[dtype]()
+
+    @parameter
+    @always_inline
+    @__copy_capture(output)
+    def output_fn[
+        width: Int, alignment: Int
+    ](idx: IndexList[2], val: SIMD[dtype, width]) -> None:
+        output.store[width=width](Coord(idx), val)
+
+    with Trace[TraceLevel.OP, target=target](
+        "mo.routed_expert_combine_then_rms_norm",
+        task_id=Int(gpu_ctx.id()),
+    ):
+        rms_norm_gpu[
+            combine_input_fn,
+            output_fn,
+            multiply_before_cast=multiply_before_cast,
+        ](
+            IndexList[2](seq_len, hidden_dim),
+            gamma,
+            epsilon,
+            weight_offset,
+            gpu_ctx,
         )

--- a/max/kernels/src/nn/normalization.mojo
+++ b/max/kernels/src/nn/normalization.mojo
@@ -2448,6 +2448,7 @@ def _rms_norm_then_residual_add_impl[
             ctx.get_device_context(),
         )
     else:
+
         @parameter
         @always_inline
         def fused_output_fn[
@@ -3561,7 +3562,9 @@ def rms_norm_then_residual_add_gpu[
         output_fn[width, alignment](idx, val + residual_fn[width, rank](idx))
 
     rms_norm_gpu[
-        input_fn, fused_output_fn, multiply_before_cast=multiply_before_cast,
+        input_fn,
+        fused_output_fn,
+        multiply_before_cast=multiply_before_cast,
         pdl_level=pdl_level,
     ](
         shape,
@@ -3610,7 +3613,9 @@ def rms_norm_then_residual_add_scaled_gpu[
         )
 
     rms_norm_gpu[
-        input_fn, fused_output_fn, multiply_before_cast=multiply_before_cast,
+        input_fn,
+        fused_output_fn,
+        multiply_before_cast=multiply_before_cast,
         pdl_level=pdl_level,
     ](
         shape,

--- a/max/kernels/src/nn/normalization.mojo
+++ b/max/kernels/src/nn/normalization.mojo
@@ -2398,6 +2398,258 @@ def rms_norm[
         ](shape, gamma, epsilon, weight_offset, ctx)
 
 
+def _rms_norm_then_residual_add_impl[
+    dtype: DType,
+    rank: Int,
+    input_0_fn: def[width: Int, rank: Int](IndexList[rank]) capturing -> SIMD[
+        dtype, width
+    ],
+    residual_input_fn: def[width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing -> SIMD[dtype, width],
+    output_fn: def[width: Int, alignment: Int](
+        IndexList[rank], SIMD[dtype, width]
+    ) capturing -> None,
+    /,
+    target: StaticString = "cpu",
+    multiply_before_cast: Bool = True,
+](
+    shape: IndexList[rank],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    ctx: DeviceContextPtr,
+) raises:
+    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
+
+    if gamma.layout.shape[0]().value() != shape[rank - 1]:
+        raise Error(
+            "Gamma size "
+            + String(gamma.layout.shape[0]().value())
+            + " does not match dimension of reduction "
+            + String(shape[rank - 1])
+            + "."
+        )
+
+    if shape.flattened_length() == 0:
+        return
+
+    comptime if is_gpu[target]():
+        rms_norm_then_residual_add_gpu[
+            input_0_fn,
+            residual_input_fn,
+            output_fn,
+            multiply_before_cast=multiply_before_cast,
+        ](
+            shape,
+            gamma,
+            epsilon,
+            weight_offset,
+            ctx.get_device_context(),
+        )
+    else:
+        @parameter
+        @always_inline
+        def fused_output_fn[
+            width: Int, alignment: Int
+        ](idx: IndexList[rank], val: SIMD[dtype, width]) -> None:
+            output_fn[width, alignment](
+                idx, val + residual_input_fn[width, rank](idx)
+            )
+
+        rms_norm_cpu[
+            input_0_fn,
+            fused_output_fn,
+            multiply_before_cast=multiply_before_cast,
+        ](shape, gamma, epsilon, weight_offset)
+
+
+@always_inline
+def rms_norm_then_residual_add[
+    dtype: DType,
+    rank: Int,
+    //,
+    input_0_fn: def[width: Int, rank: Int](IndexList[rank]) capturing -> SIMD[
+        dtype, width
+    ],
+    residual_input_fn: def[width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing -> SIMD[dtype, width],
+    output_0_fn: def[width: Int, rank: Int, alignment: Int](
+        idx: IndexList[rank], val: SIMD[dtype, width]
+    ) capturing -> None,
+    /,
+    target: StaticString = "cpu",
+    multiply_before_cast: Bool = True,
+](
+    shape: IndexList[rank],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    ctx: DeviceContextPtr,
+) raises:
+    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
+
+    @always_inline
+    @parameter
+    def output_fn_wrapper[
+        width: Int, alignment: Int
+    ](idx: IndexList[rank], val: SIMD[dtype, width]) -> None:
+        output_0_fn[width, rank, alignment](idx, val)
+
+    @always_inline
+    @parameter
+    def description_fn() -> String:
+        return trace_arg("input", shape, dtype)
+
+    with Trace[TraceLevel.OP, target=target](
+        "rms_norm_then_residual_add",
+        Trace[TraceLevel.OP]._get_detail_str[description_fn](),
+        task_id=Int(ctx.get_device_context().id()),
+    ):
+        _rms_norm_then_residual_add_impl[
+            dtype,
+            rank,
+            input_0_fn,
+            residual_input_fn,
+            output_fn_wrapper,
+            target=target,
+            multiply_before_cast=multiply_before_cast,
+        ](shape, gamma, epsilon, weight_offset, ctx)
+
+
+def _rms_norm_then_residual_add_scaled_impl[
+    dtype: DType,
+    rank: Int,
+    input_0_fn: def[width: Int, rank: Int](IndexList[rank]) capturing -> SIMD[
+        dtype, width
+    ],
+    residual_input_fn: def[width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing -> SIMD[dtype, width],
+    output_fn: def[width: Int, alignment: Int](
+        IndexList[rank], SIMD[dtype, width]
+    ) capturing -> None,
+    /,
+    target: StaticString = "cpu",
+    multiply_before_cast: Bool = True,
+](
+    shape: IndexList[rank],
+    gamma: TileTensor[dtype, ...],
+    output_scale: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    ctx: DeviceContextPtr,
+) raises:
+    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
+    comptime assert output_scale.flat_rank == 1, "output_scale must have rank 1"
+
+    if gamma.layout.shape[0]().value() != shape[rank - 1]:
+        raise Error(
+            "Gamma size "
+            + String(gamma.layout.shape[0]().value())
+            + " does not match dimension of reduction "
+            + String(shape[rank - 1])
+            + "."
+        )
+
+    if output_scale.layout.shape[0]().value() != 1:
+        raise Error("output_scale must contain exactly one element.")
+
+    if shape.flattened_length() == 0:
+        return
+
+    comptime if is_gpu[target]():
+        rms_norm_then_residual_add_scaled_gpu[
+            input_0_fn,
+            residual_input_fn,
+            output_fn,
+            multiply_before_cast=multiply_before_cast,
+        ](
+            shape,
+            gamma,
+            output_scale,
+            epsilon,
+            weight_offset,
+            ctx.get_device_context(),
+        )
+    else:
+        var output_scale_scalar = rebind[Scalar[dtype]](output_scale[0])
+
+        @parameter
+        @always_inline
+        def fused_output_fn[
+            width: Int, alignment: Int
+        ](idx: IndexList[rank], val: SIMD[dtype, width]) -> None:
+            output_fn[width, alignment](
+                idx,
+                (val + residual_input_fn[width, rank](idx))
+                * SIMD[dtype, width](output_scale_scalar),
+            )
+
+        rms_norm_cpu[
+            input_0_fn,
+            fused_output_fn,
+            multiply_before_cast=multiply_before_cast,
+        ](shape, gamma, epsilon, weight_offset)
+
+
+@always_inline
+def rms_norm_then_residual_add_scaled[
+    dtype: DType,
+    rank: Int,
+    //,
+    input_0_fn: def[width: Int, rank: Int](IndexList[rank]) capturing -> SIMD[
+        dtype, width
+    ],
+    residual_input_fn: def[width: Int, rank: Int](
+        IndexList[rank]
+    ) capturing -> SIMD[dtype, width],
+    output_0_fn: def[width: Int, rank: Int, alignment: Int](
+        idx: IndexList[rank], val: SIMD[dtype, width]
+    ) capturing -> None,
+    /,
+    target: StaticString = "cpu",
+    multiply_before_cast: Bool = True,
+](
+    shape: IndexList[rank],
+    gamma: TileTensor[dtype, ...],
+    output_scale: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    ctx: DeviceContextPtr,
+) raises:
+    comptime assert gamma.flat_rank == 1, "gamma must have rank 1"
+    comptime assert output_scale.flat_rank == 1, "output_scale must have rank 1"
+
+    @always_inline
+    @parameter
+    def output_fn_wrapper[
+        width: Int, alignment: Int
+    ](idx: IndexList[rank], val: SIMD[dtype, width]) -> None:
+        output_0_fn[width, rank, alignment](idx, val)
+
+    @always_inline
+    @parameter
+    def description_fn() -> String:
+        return trace_arg("input", shape, dtype)
+
+    with Trace[TraceLevel.OP, target=target](
+        "rms_norm_then_residual_add_scaled",
+        Trace[TraceLevel.OP]._get_detail_str[description_fn](),
+        task_id=Int(ctx.get_device_context().id()),
+    ):
+        _rms_norm_then_residual_add_scaled_impl[
+            dtype,
+            rank,
+            input_0_fn,
+            residual_input_fn,
+            output_fn_wrapper,
+            target=target,
+            multiply_before_cast=multiply_before_cast,
+        ](shape, gamma, output_scale, epsilon, weight_offset, ctx)
+
+
 def _rms_norm_fused_residual_add_impl[
     dtype: DType,
     rank: Int,
@@ -3277,3 +3529,93 @@ def group_norm[
             num_groups,
             ctx=ctx.get_device_context(),
         )
+
+
+def rms_norm_then_residual_add_gpu[
+    dtype: DType,
+    rank: Int,
+    //,
+    input_fn: def[width: Int, rank: Int](IndexList[rank]) capturing -> SIMD[
+        dtype, width
+    ],
+    residual_fn: def[width: Int, rank: Int](IndexList[rank]) capturing -> SIMD[
+        dtype, width
+    ],
+    output_fn: def[width: Int, alignment: Int](
+        IndexList[rank], SIMD[dtype, width]
+    ) capturing -> None,
+    multiply_before_cast: Bool,
+    pdl_level: PDLLevel = PDLLevel(1),
+](
+    shape: IndexList[rank, ...],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    ctx: DeviceContext,
+) raises:
+    @parameter
+    @always_inline
+    def fused_output_fn[
+        width: Int, alignment: Int
+    ](idx: IndexList[rank], val: SIMD[dtype, width]) -> None:
+        output_fn[width, alignment](idx, val + residual_fn[width, rank](idx))
+
+    rms_norm_gpu[
+        input_fn, fused_output_fn, multiply_before_cast=multiply_before_cast,
+        pdl_level=pdl_level,
+    ](
+        shape,
+        gamma,
+        epsilon,
+        weight_offset,
+        ctx,
+    )
+
+
+def rms_norm_then_residual_add_scaled_gpu[
+    dtype: DType,
+    rank: Int,
+    //,
+    input_fn: def[width: Int, rank: Int](IndexList[rank]) capturing -> SIMD[
+        dtype, width
+    ],
+    residual_fn: def[width: Int, rank: Int](IndexList[rank]) capturing -> SIMD[
+        dtype, width
+    ],
+    output_fn: def[width: Int, alignment: Int](
+        IndexList[rank], SIMD[dtype, width]
+    ) capturing -> None,
+    multiply_before_cast: Bool,
+    pdl_level: PDLLevel = PDLLevel(1),
+](
+    shape: IndexList[rank, ...],
+    gamma: TileTensor[dtype, ...],
+    output_scale: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    ctx: DeviceContext,
+) raises:
+    comptime assert output_scale.flat_rank == 1, "output_scale must have rank 1"
+    var output_scale_scalar = rebind[Scalar[dtype]](output_scale[0])
+
+    @parameter
+    @always_inline
+    def fused_output_fn[
+        width: Int, alignment: Int
+    ](idx: IndexList[rank], val: SIMD[dtype, width]) -> None:
+        output_fn[width, alignment](
+            idx,
+            (val + residual_fn[width, rank](idx))
+            * SIMD[dtype, width](output_scale_scalar),
+        )
+
+    rms_norm_gpu[
+        input_fn, fused_output_fn, multiply_before_cast=multiply_before_cast,
+        pdl_level=pdl_level,
+    ](
+        shape,
+        gamma,
+        epsilon,
+        weight_offset,
+        ctx,
+    )

--- a/max/kernels/src/nn/softmax.mojo
+++ b/max/kernels/src/nn/softmax.mojo
@@ -927,6 +927,7 @@ def _softmax_temperature_kernel[
     input_origin: ImmutOrigin,
     OutputLayoutType: TensorLayout,
     output_origin: MutOrigin,
+    row_max_prob_origin: MutOrigin = MutAnyOrigin,
     accum_type: DType = get_accum_type[dtype](),
 ](
     input: TileTensor[dtype, InputLayoutType, input_origin],
@@ -936,6 +937,7 @@ def _softmax_temperature_kernel[
     temperature: Scalar[temp_dtype],
     # using UnsafePointer here because cant pass optional TileTensor
     temperature_arr: UnsafePointer[Scalar[temp_dtype], ImmutAnyOrigin],
+    row_max_prob_arr: UnsafePointer[Scalar[DType.float32], row_max_prob_origin],
 ):
     """GPU kernel for softmax with per-row temperature scaling.
 
@@ -1020,6 +1022,8 @@ def _softmax_temperature_kernel[
 
             # Step 2: normalize — recompute exp to avoid a global-memory.
             var recip = Scalar[accum_type](1) / global_sum
+            if tid == 0 and row_max_prob_arr._is_not_null():
+                row_max_prob_arr[row_idx] = recip.cast[DType.float32]()
 
             if use_vectorized:
                 for tile_base in range(0, row_size, BLOCK_SPAN):
@@ -1056,6 +1060,9 @@ def softmax_with_temperature[
     dtype: DType,
     temp_dtype: DType = DType.float32,
     TempLayoutType: TensorLayout = RowMajorLayout[RuntimeInt[DType.int64]],
+    RowMaxProbLayoutType: TensorLayout = RowMajorLayout[
+        RuntimeInt[DType.int64]
+    ],
 ](
     ctx: DeviceContext,
     input: TileTensor[dtype, ...],
@@ -1063,6 +1070,9 @@ def softmax_with_temperature[
     temperature: Scalar[temp_dtype] = Float32(1.0),
     temperature_arr: Optional[
         TileTensor[temp_dtype, TempLayoutType, ImmutAnyOrigin]
+    ] = None,
+    row_max_prob_arr: Optional[
+        TileTensor[DType.float32, RowMaxProbLayoutType, MutAnyOrigin]
     ] = None,
 ) raises:
     """GPU softmax with per-row temperature scaling.
@@ -1082,6 +1092,7 @@ def softmax_with_temperature[
         output: Output probability tensor (same shape as input).
         temperature: Scalar temperature fallback (default 1.0).
         temperature_arr: Optional per-row temperature values [batch_size].
+        row_max_prob_arr: Optional per-row max probability bounds [batch_size].
     """
     comptime assert input.rank == 2, "input must be rank 2"
     comptime assert output.rank == 2, "output must be rank 2"
@@ -1096,6 +1107,12 @@ def softmax_with_temperature[
     )
     if temperature_arr:
         temp_ptr = temperature_arr.value().ptr
+
+    var row_max_prob_ptr = UnsafePointer[Scalar[DType.float32], MutAnyOrigin](
+        _unsafe_null=()
+    )
+    if row_max_prob_arr:
+        row_max_prob_ptr = row_max_prob_arr.value().ptr
 
     comptime BLOCK_SIZE = 256
     var sm_count = ctx.get_attribute(DeviceAttribute.MULTIPROCESSOR_COUNT)
@@ -1118,6 +1135,7 @@ def softmax_with_temperature[
         d,
         temperature,
         temp_ptr,
+        row_max_prob_ptr,
         grid_dim=num_blocks,
         block_dim=BLOCK_SIZE,
         attributes=pdl_launch_attributes(PDLLevel(1)),

--- a/max/kernels/src/nn/topk.mojo
+++ b/max/kernels/src/nn/topk.mojo
@@ -1781,8 +1781,8 @@ def _topk_gpu[
             raise Error(
                 t"shared memory of {shared_mem_bytes_2} exceeds static"
                 t" allocation capacity of {_APPLE_STATIC_SHMEM_MAX_BYTES} for"
-                t" the second stage top-k kernel, consider reducing the"
-                t" block_size or num_blocks_per_input"
+                " the second stage top-k kernel, consider reducing the"
+                " block_size or num_blocks_per_input"
             )
 
     # Define grid and block dimensions for stage 2

--- a/max/kernels/src/nn/topk.mojo
+++ b/max/kernels/src/nn/topk.mojo
@@ -1781,8 +1781,8 @@ def _topk_gpu[
             raise Error(
                 t"shared memory of {shared_mem_bytes_2} exceeds static"
                 t" allocation capacity of {_APPLE_STATIC_SHMEM_MAX_BYTES} for"
-                " the second stage top-k kernel, consider reducing the"
-                " block_size or num_blocks_per_input"
+                t" the second stage top-k kernel, consider reducing the"
+                t" block_size or num_blocks_per_input"
             )
 
     # Define grid and block dimensions for stage 2

--- a/max/kernels/src/nn/topk.mojo
+++ b/max/kernels/src/nn/topk.mojo
@@ -2056,6 +2056,10 @@ def topk_gpu[
             internal_out_idxs = reshape(out_idxs, internal_out_idxs_shape)
             internal_out_vals = reshape(out_vals, internal_out_vals_shape)
 
+        # Do not launch GPU kernels with an empty internal batch.
+        if internal_bs == 0:
+            return
+
         # Calculate the number of blocks per input
         var num_blocks_per_input_ = min(
             ceildiv(N, block_size_), 8

--- a/max/kernels/src/nn/topk.mojo
+++ b/max/kernels/src/nn/topk.mojo
@@ -52,7 +52,11 @@ from std.memory import stack_allocation
 from nn.gather_scatter import normalize_neg_index
 from nn.reshape import reshape
 from nn.softmax import softmax_with_temperature
-from nn.topk_fi import topk_topp_sampling_from_prob
+from nn.topk_fi import (
+    topk_sampling_from_prob,
+    topk_softmax_sample,
+    topk_topp_sampling_from_prob,
+)
 from std.runtime.asyncrt import DeviceContextPtr
 from std.runtime.tracing import Trace, TraceLevel, trace_arg
 
@@ -947,7 +951,7 @@ def _topk_stage1_old_no_shmem[
             partial.insert(_in_buffer[i], i)
 
         var k_batch = max_k
-        if K._is_not_null():
+        if K:
             var k_raw = Int(K[batch_id])
             k_batch = max_k if k_raw == -1 else k_raw
 
@@ -1053,7 +1057,7 @@ def _topk_stage1_old[
             topk_sram[tid].insert(_in_buffer[i], i)
         barrier()
         var k_batch = max_k
-        if K._is_not_null():
+        if K:
             var k_raw = Int(K[batch_id])
             k_batch = max_k if k_raw == -1 else k_raw
         # Prepare for K iterations to find the local top-K elements
@@ -1134,7 +1138,7 @@ def _topk_stage1_no_shmem[
     var out_idxs = local_topk_idxs + bid * max_k
 
     var k_batch = max_k
-    if K._is_not_null():
+    if K:
         var k_raw = Int(K[batch_id])
         k_batch = max_k if k_raw == -1 else k_raw
 
@@ -1260,7 +1264,7 @@ def _topk_stage1[
     var out_idxs = local_topk_idxs + bid * max_k
 
     var k_batch = max_k
-    if K._is_not_null():
+    if K:
         var k_raw = Int(K[batch_id])
         k_batch = max_k if k_raw == -1 else k_raw
 
@@ -1421,13 +1425,13 @@ def _topk_stage2[
     var idxs_sram = (vals_sram + vals_smem_size).bitcast[Int]()
 
     # These values are only read from in the sampling case.
-    var s_val2 = type_of(vals_sram)(_unsafe_null=())
-    var s_id = type_of(idxs_sram)(_unsafe_null=())
+    var s_val2 = type_of(vals_sram)()
+    var s_id = type_of(idxs_sram)()
 
     with PDL():
         # Handle the case where stage 1 is executed with a single block
         var k_batch = max_k
-        if K._is_not_null():
+        if K:
             var k_raw = Int(K[batch_id])
             k_batch = max_k if k_raw == -1 else k_raw
 
@@ -1504,7 +1508,7 @@ def _topk_stage2[
                     batch_i_topk_vals[k] = total.u
                     s_id[k] = total.p
                     var temp_val = Float32(1.0)
-                    if temperature._is_not_null():
+                    if temperature:
                         temp_val = temperature[batch_id]
                     total.u = exp(
                         (total.u - max_logit) / max(temp_val.cast[T](), 1e-6)
@@ -1525,7 +1529,7 @@ def _topk_stage2[
         comptime if sampling:
             if tid == 0:
                 var top_p_val = Scalar[T](1.0)
-                if top_p._is_not_null():
+                if top_p:
                     top_p_val = top_p[batch_id].cast[T]()
                 var _top_p = _adjust_top_p[T](
                     top_p_val, s_val2, k_batch, s_sum[0]
@@ -1535,7 +1539,7 @@ def _topk_stage2[
                 # generator, so that we don't use the same random number for every
                 # token in the sequence.
                 var seed_val = UInt64(0)
-                if seed._is_not_null():
+                if seed:
                     seed_val = seed[batch_id]
                 var rng_state = Random(seed=seed_val)
                 var rng = rng_state.step_uniform()
@@ -1681,9 +1685,7 @@ def _topk_gpu[
     if k:
         k_ptr = rebind[UnsafePointer[Int64, ImmutAnyOrigin]](k.value().ptr)
     else:
-        k_ptr = UnsafePointer[Int64, ImmutAnyOrigin](
-            _unsafe_null=()
-        )  # null pointer
+        k_ptr = UnsafePointer[Int64, ImmutAnyOrigin]()  # null pointer
 
     var k_size = k.value().num_elements() if k else 0
     var k_device = DeviceBuffer[DType.int64](ctx, k_ptr, k_size, owning=False)
@@ -1796,9 +1798,7 @@ def _topk_gpu[
             temperature.value().ptr
         )
     else:
-        temp_ptr = UnsafePointer[Float32, ImmutAnyOrigin](
-            _unsafe_null=()
-        )  # null pointer
+        temp_ptr = UnsafePointer[Float32, ImmutAnyOrigin]()  # null pointer
     var temp_size = temperature.value().num_elements() if temperature else 0
 
     # Handle optional top_p parameter
@@ -1808,9 +1808,7 @@ def _topk_gpu[
             top_p.value().ptr
         )
     else:
-        top_p_ptr = UnsafePointer[Float32, ImmutAnyOrigin](
-            _unsafe_null=()
-        )  # null pointer
+        top_p_ptr = UnsafePointer[Float32, ImmutAnyOrigin]()  # null pointer
     var top_p_size = top_p.value().num_elements() if top_p else 0
 
     # Handle optional seed parameter
@@ -1818,9 +1816,7 @@ def _topk_gpu[
     if seed:
         seed_ptr = seed.value().ptr
     else:
-        seed_ptr = UnsafePointer[UInt64, ImmutAnyOrigin](
-            _unsafe_null=()
-        )  # null pointer
+        seed_ptr = UnsafePointer[UInt64, ImmutAnyOrigin]()  # null pointer
     var seed_size = seed.value().num_elements() if seed else 0
 
     var temp_device = DeviceBuffer[DType.float32](
@@ -2065,6 +2061,59 @@ def topk_gpu[
             ceildiv(N, block_size_), 8
         ) if not num_blocks_per_input else num_blocks_per_input.value()
 
+        # Exact top-k on a single small row does not need the generic two-stage
+        # pipeline. Skip the temporary buffers, input copy, and stage-2 merge
+        # when one block already covers the full row.
+        if not sampling and num_blocks_per_input_ == 1 and bound_max_k <= 32:
+            var k_ptr: UnsafePointer[Int64, ImmutAnyOrigin]
+            if k:
+                k_ptr = rebind[UnsafePointer[Int64, ImmutAnyOrigin]](
+                    k.value().ptr
+                )
+            else:
+                k_ptr = UnsafePointer[Int64, ImmutAnyOrigin]()
+
+            var k_size = k.value().num_elements() if k else 0
+            var k_device = DeviceBuffer[DType.int64](
+                ctx, k_ptr, k_size, owning=False
+            )
+
+            comptime if has_apple_gpu_accelerator():
+                comptime fastpath_kernel = _topk_stage1_old_no_shmem[
+                    dtype, out_idx_type, largest
+                ]
+                ctx.enqueue_function[fastpath_kernel, fastpath_kernel](
+                    k_device,
+                    bound_max_k,
+                    N,
+                    num_blocks_per_input_,
+                    internal_input.to_device_buffer(ctx),
+                    internal_out_vals.to_device_buffer(ctx),
+                    internal_out_idxs.to_device_buffer(ctx),
+                    grid_dim=internal_bs,
+                    block_dim=block_size_,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+            else:
+                var shared_mem_bytes = _get_shmem_size_stg_1[dtype](block_size_)
+                comptime fastpath_kernel = _topk_stage1_old[
+                    dtype, out_idx_type, largest
+                ]
+                ctx.enqueue_function[fastpath_kernel, fastpath_kernel](
+                    k_device,
+                    bound_max_k,
+                    N,
+                    num_blocks_per_input_,
+                    internal_input.to_device_buffer(ctx),
+                    internal_out_vals.to_device_buffer(ctx),
+                    internal_out_idxs.to_device_buffer(ctx),
+                    grid_dim=internal_bs,
+                    block_dim=block_size_,
+                    shared_mem_bytes=shared_mem_bytes,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+            return
+
         # Define shape for the kernel's internal cache buffers
         var internal_cache_shape = IndexList[2](
             internal_bs, num_blocks_per_input_ * bound_max_k
@@ -2156,30 +2205,68 @@ def _topk_topp_sampling_fi[
         probs_buf.unsafe_ptr(),
         row_major(Coord(IndexList[2](batch_size, d))),
     )
-    softmax_with_temperature(
-        ctx,
-        input,
-        probs,
-        temperature_arr=temperature,
-    )
 
-    # Step 2: top-k + top-p rejection sampling from probabilities.
+    # Step 2: sample from probabilities. When the whole batch is pure top-k,
+    # skip the heavier top-p wrapper and use the dedicated top-k kernel.
     # Reshape out_idxs from [batch, 1] (rank 2) to [batch] (rank 1).
     var out_shape = coord_to_index_list(out_idxs.layout.shape_coord())
     var out_1d = TileTensor(
         out_idxs.ptr,
         row_major(Idx(out_shape[0])),
     )
-    topk_topp_sampling_from_prob[dtype, out_idx_type](
-        ctx,
-        probs,
-        out_1d,
-        max_k,
-        top_p_val=min_top_p,
-        top_k_arr=k,
-        top_p_arr=top_p,
-        rng_seed=rng_seed,
-    )
+
+    if d >= 65536 and min_top_p == 1.0:
+        var row_max_prob_buf = ctx.enqueue_create_buffer[DType.float32](
+            batch_size
+        )
+        var row_max_prob = TileTensor(
+            row_max_prob_buf.unsafe_ptr(),
+            row_major(Idx(batch_size)),
+        )
+        softmax_with_temperature(
+            ctx,
+            input,
+            probs,
+            temperature_arr=temperature,
+            row_max_prob_arr=row_max_prob,
+        )
+        topk_sampling_from_prob[dtype, out_idx_type](
+            ctx,
+            probs,
+            out_1d,
+            max_k,
+            top_k_arr=k,
+            rng_seed=rng_seed,
+            row_max_prob_arr=row_max_prob.as_immut(),
+        )
+        _ = row_max_prob_buf^
+    else:
+        softmax_with_temperature(
+            ctx,
+            input,
+            probs,
+            temperature_arr=temperature,
+        )
+        if min_top_p == 1.0:
+            topk_sampling_from_prob[dtype, out_idx_type](
+                ctx,
+                probs,
+                out_1d,
+                max_k,
+                top_k_arr=k,
+                rng_seed=rng_seed,
+            )
+        else:
+            topk_topp_sampling_from_prob[dtype, out_idx_type](
+                ctx,
+                probs,
+                out_1d,
+                max_k,
+                top_p_val=min_top_p,
+                top_k_arr=k,
+                top_p_arr=top_p,
+                rng_seed=rng_seed,
+            )
 
     _ = probs_buf^
 
@@ -2259,11 +2346,40 @@ def fused_token_sampling_gpu[
 
         comptime assert input.flat_rank == 2
 
+        var batch_size = Int(input.dim[0]())
         var vocab_size = input.layout.shape[1]().value()
         var adjusted_max_k = vocab_size if max_k == -1 else max_k
 
-        # softmax with temperature, then top-k+top-p rejection sampling.
+        # For finite large-k sampling, avoid materializing the full
+        # probability matrix when enough rows amortize the setup cost. On
+        # B200, single-row decode is still faster through the dense
+        # softmax-with-temperature path plus the FlashInfer top-k/top-p sampler,
+        # even for pure top-k sampling. Only use the logits-space sampler once
+        # multiple rows are available.
+        if max_k != -1 and adjusted_max_k >= 64 and batch_size > 1:
+            var out_shape = coord_to_index_list(out_idxs.layout.shape_coord())
+            var out_1d = TileTensor(
+                out_idxs.ptr,
+                row_major(Idx(out_shape[0])),
+            )
+            topk_softmax_sample[dtype, out_idx_type](
+                ctx,
+                input,
+                out_1d,
+                adjusted_max_k,
+                top_k_arr=rebind[
+                    Optional[
+                        TileTensor[out_idx_type, KLayoutType, ImmutAnyOrigin]
+                    ]
+                ](k),
+                temperature=temperature,
+                top_p_val=min_top_p,
+                top_p_arr=top_p,
+                seed=seed,
+            )
+            return
 
+        # softmax with temperature, then top-k+top-p rejection sampling.
         if adjusted_max_k >= 64:
             _topk_topp_sampling_fi[dtype, out_idx_type](
                 ctx,
@@ -2353,11 +2469,11 @@ def apply_gumbel_noise_kernel[
 
         for tok_idx in range(group_id, Int(num_tokens), num_groups):
             var temp_val = Float32(1.0)
-            if temperature._is_not_null():
+            if temperature:
                 temp_val = temperature[tok_idx]
 
             var seed_val = UInt64(0)
-            if seed._is_not_null():
+            if seed:
                 seed_val = seed[tok_idx]
 
             var ld_ptr = input.ptr + tok_idx * N
@@ -2476,9 +2592,7 @@ def gumbel_sampling_gpu[
                 temperature.value().ptr
             )
         else:
-            temp_ptr = UnsafePointer[Float32, ImmutAnyOrigin](
-                _unsafe_null=()
-            )  # null pointer
+            temp_ptr = UnsafePointer[Float32, ImmutAnyOrigin]()  # null pointer
         var temp_size = temperature.value().num_elements() if temperature else 0
 
         # Handle optional seed parameter
@@ -2488,9 +2602,7 @@ def gumbel_sampling_gpu[
                 seed.value().ptr
             )
         else:
-            seed_ptr = UnsafePointer[UInt64, ImmutAnyOrigin](
-                _unsafe_null=()
-            )  # null pointer
+            seed_ptr = UnsafePointer[UInt64, ImmutAnyOrigin]()  # null pointer
         var seed_size = seed.value().num_elements() if seed else 0
 
         comptime hw_info = ctx.default_device_info

--- a/max/kernels/src/nn/topk_fi.mojo
+++ b/max/kernels/src/nn/topk_fi.mojo
@@ -143,6 +143,33 @@ def _block_reduce_pivot_bounds[
 
 
 @always_inline
+def _block_reduce_dual_sum[
+    block_size: Int, broadcast: Bool = True
+](
+    sum0: Float32,
+    sum1: Float32,
+) -> Tuple[Float32, Float32]:
+    """Reduce two Float32 sums with one block-reduction pass."""
+
+    @always_inline
+    @parameter
+    def _reduce_fn[
+        dtype: DType, width: Int, reduction_idx: Int
+    ](v: SIMD[dtype, width]) -> Scalar[dtype]:
+        return warp.sum(v)
+
+    var results = block._block_reduce[
+        block_size,
+        warp_reduce_fn=_reduce_fn,
+        broadcast=broadcast,
+    ](
+        StaticTuple[Scalar[DType.float32], 2](sum0, sum1),
+        initial_vals=StaticTuple[Scalar[DType.float32], 2](0, 0),
+    )
+    return (results[0], results[1])
+
+
+@always_inline
 def get_min_max_value[
     vec_size: Int,
     block_size: Int,
@@ -227,7 +254,7 @@ def TopKMaskLogitsKernel[
 
     with PDL():
         var k = top_k_val
-        if top_k_arr._is_not_null():
+        if top_k_arr:
             k = Int(top_k_arr[bx])
 
         # Initialize pivot to negative infinity.
@@ -400,12 +427,7 @@ def topk_mask_logits[
         if top_k_arr:
             top_k_buf = top_k_arr.value().to_device_buffer(ctx)
         else:
-            top_k_buf = DeviceBuffer[out_idx_type](
-                ctx,
-                {_unsafe_null = ()},
-                0,
-                owning=False,
-            )
+            top_k_buf = DeviceBuffer[out_idx_type](ctx, {}, 0, owning=False)
 
         @parameter
         def launch_kernel[vec_size: Int]() raises:
@@ -560,6 +582,55 @@ struct ValueCount[T: DType](Defaultable, TrivialRegisterPassable):
 
 
 @always_inline
+def _accumulate_chunk_value_counts[
+    vec_size: Int
+](
+    probs_vec: SIMD[DType.float32, vec_size],
+    chunk_base: Int,
+    d: Int,
+    pivot_0: Float32,
+    pivot_1: Float32,
+) -> Tuple[ValueCount[DType.float32], ValueCount[DType.float32]]:
+    """Accumulate value/count pairs for pivots while skipping empty chunks."""
+
+    var chunk_max = probs_vec.reduce_max()
+    var chunk_vc_0 = ValueCount[DType.float32]()
+    var chunk_vc_1 = ValueCount[DType.float32]()
+
+    if chunk_max <= pivot_0:
+        return (chunk_vc_0, chunk_vc_1)
+
+    var need_pivot_1 = chunk_max > pivot_1
+
+    comptime for j in range(vec_size):
+        var idx = chunk_base + j
+        if idx >= d:
+            continue
+
+        var prob = probs_vec[j]
+        if prob > pivot_0:
+            chunk_vc_0.value += prob
+            chunk_vc_0.count += Int32(1)
+
+            if need_pivot_1 and prob > pivot_1:
+                chunk_vc_1.value += prob
+                chunk_vc_1.count += Int32(1)
+
+    return (chunk_vc_0, chunk_vc_1)
+
+
+@always_inline
+def _value_idx_precedes(
+    lhs_val: Float32,
+    lhs_idx: Int,
+    rhs_val: Float32,
+    rhs_idx: Int,
+) -> Bool:
+    """Return True when `(lhs_val, lhs_idx)` should sort before `rhs`."""
+    return lhs_val > rhs_val or (lhs_val == rhs_val and lhs_idx < rhs_idx)
+
+
+@always_inline
 def _warp_reduce_value_count[T: DType](val: ValueCount[T]) -> ValueCount[T]:
     """Warp-level reduction for ValueCount using shuffle operations.
 
@@ -691,7 +762,9 @@ def TopKSamplingFromProbKernel[
     top_k_arr: UnsafePointer[Scalar[out_idx_type], MutExternalOrigin],
     top_k_val: Int,
     d: Int,
-    rng_seed: UInt64,
+    row_max_prob_arr: UnsafePointer[Float32, MutExternalOrigin],
+    rng_seed: UnsafePointer[UInt64, MutExternalOrigin],
+    rng_seed_val: UInt64,
     rng_offset: UInt64,
 ):
     """Kernel for top-k sampling from probability distribution.
@@ -708,7 +781,9 @@ def TopKSamplingFromProbKernel[
         top_k_arr: Optional per-row top_k values [batch_size].
         top_k_val: Default top_k value if top_k_arr is null.
         d: Vocabulary size.
-        rng_seed: Random seed for Random number generator.
+        row_max_prob_arr: Optional per-row max probability bounds [batch_size].
+        rng_seed: Optional pointer to per-row RNG seeds [batch_size].
+        rng_seed_val: Default random seed for Random number generator.
         rng_offset: Random offset for Random number generator.
     """
     comptime assert output.flat_rank == 1
@@ -724,13 +799,16 @@ def TopKSamplingFromProbKernel[
     ]()
 
     with PDL():
-        var generator = Random(seed=rng_seed, offset=UInt64(bx) + rng_offset)
         var k = top_k_val
-        if top_k_arr._is_not_null():
+        if top_k_arr:
             k = Int(top_k_arr.load(bx))
         var row_idx = bx
-        if indices._is_not_null():
+        if indices:
             row_idx = Int(indices.load(bx))
+        var seed_val = rng_seed_val
+        if rng_seed:
+            seed_val = rng_seed[row_idx]
+        var generator = Random(seed=seed_val, offset=UInt64(bx) + rng_offset)
 
         var probs_ptr = probs.ptr + row_idx * d
         var probs_row = TileTensor(probs_ptr, row_major(Idx[1](), Idx(d)))
@@ -741,6 +819,26 @@ def TopKSamplingFromProbKernel[
         var q: Float32 = 1.0
         var low: Float32 = 0.0
         var high: Float32 = 1.0
+
+        if row_max_prob_arr:
+            high = row_max_prob_arr[row_idx]
+        # Large-vocab decode rows have max probabilities orders of magnitude
+        # below 1.0. Tighten the initial search interval once so the rejection
+        # loop does not spend its first few iterations shrinking a dead range.
+        elif d >= 65536:
+            var thread_row_max = Float32(0.0)
+            for i in range(ceildiv(d, block_size * vec_size)):
+                probs_vec = 0
+                var chunk_base = (i * block_size + tx) * vec_size
+                if chunk_base < d:
+                    probs_vec = probs_row.load[width=vec_size](
+                        (Idx[0](), Idx(chunk_base))
+                    ).cast[DType.float32]()
+                thread_row_max = max(thread_row_max, probs_vec.reduce_max())
+
+            high = block.max[block_size=block_size, broadcast=True](
+                thread_row_max
+            )
 
         while low < high:
             if tx == 0:
@@ -774,16 +872,18 @@ def TopKSamplingFromProbKernel[
                 if aggregate > u:
                     break
 
-            # Reduce last_valid_id across block (single reduction after loop).
-            var block_max_valid = block.max[
-                block_size=block_size,
-                broadcast=False,
-            ](Int32(thread_max_valid))
+            # Only pay the fallback reduction when the scan did not already
+            # identify a sampled index for this rejection round.
+            if sampled_id_sram[0] == d:
+                var block_max_valid = block.max[
+                    block_size=block_size,
+                    broadcast=False,
+                ](Int32(thread_max_valid))
 
-            if tx == 0 and block_max_valid != -1:
-                last_valid_id_sram[0] = Int(block_max_valid)
+                if tx == 0 and block_max_valid != -1:
+                    last_valid_id_sram[0] = Int(block_max_valid)
 
-            barrier()
+                barrier()
 
             sampled_id = sampled_id_sram[0]
             if sampled_id == d:
@@ -803,47 +903,20 @@ def TopKSamplingFromProbKernel[
 
             for i in range(ceildiv(d, block_size * vec_size)):
                 probs_vec = 0
-                if (i * block_size + tx) * vec_size < d:
+                var chunk_base = (i * block_size + tx) * vec_size
+                if chunk_base < d:
                     probs_vec = probs_row.load[width=vec_size](
-                        (Idx[0](), Idx((i * block_size + tx) * vec_size))
+                        (Idx[0](), Idx(chunk_base))
                     ).cast[DType.float32]()
 
-                var probs_gt_pivot_0_values = SIMD[DType.float32, vec_size]()
-                var probs_gt_pivot_0_counts = SIMD[DType.int32, vec_size]()
-                var probs_gt_pivot_1_values = SIMD[DType.float32, vec_size]()
-                var probs_gt_pivot_1_counts = SIMD[DType.int32, vec_size]()
-
-                comptime for j in range(vec_size):
-                    var idx = (i * block_size + tx) * vec_size + j
-                    var is_valid = idx < d
-
-                    # For pivot_0.
-                    var gt_pivot_0 = probs_vec[j] > pivot_0
-                    probs_gt_pivot_0_values[j] = probs_vec[
-                        j
-                    ] if gt_pivot_0 else 0.0
-                    probs_gt_pivot_0_counts[j] = Int32(1) if (
-                        gt_pivot_0 and is_valid
-                    ) else Int32(0)
-
-                    # For pivot_1.
-                    var gt_pivot_1 = probs_vec[j] > pivot_1
-                    probs_gt_pivot_1_values[j] = probs_vec[
-                        j
-                    ] if gt_pivot_1 else 0.0
-                    probs_gt_pivot_1_counts[j] = Int32(1) if (
-                        gt_pivot_1 and is_valid
-                    ) else Int32(0)
-
-                # Accumulate thread-local (no block reduction per chunk).
-                thread_vc_0_total += ValueCount[DType.float32](
-                    probs_gt_pivot_0_values.reduce_add(),
-                    probs_gt_pivot_0_counts.reduce_add(),
-                )
-                thread_vc_1_total += ValueCount[DType.float32](
-                    probs_gt_pivot_1_values.reduce_add(),
-                    probs_gt_pivot_1_counts.reduce_add(),
-                )
+                # Most large-vocab chunks do not contain any survivor above
+                # pivot_0. Skip their per-lane pivot bookkeeping entirely, and
+                # only accumulate pivot_1 when a chunk actually reaches it.
+                var chunk_vc_0, chunk_vc_1 = _accumulate_chunk_value_counts[
+                    vec_size
+                ](probs_vec, chunk_base, d, pivot_0, pivot_1)
+                thread_vc_0_total += chunk_vc_0
+                thread_vc_1_total += chunk_vc_1
 
             # Reduce pivot_0 first; defer pivot_1 until needed.
             # For small K, acceptance (count_0 < k) is common, saving
@@ -889,19 +962,33 @@ def topk_sampling_from_prob[
         shape_types=Variadic.types[RuntimeInt[DType.int64]],
         stride_types=Variadic.types[ComptimeInt[1]],
     ],
+    SeedLayoutType: TensorLayout = Layout[
+        shape_types=Variadic.types[RuntimeInt[DType.int64]],
+        stride_types=Variadic.types[ComptimeInt[1]],
+    ],
+    RowMaxProbLayoutType: TensorLayout = Layout[
+        shape_types=Variadic.types[RuntimeInt[DType.int64]],
+        stride_types=Variadic.types[ComptimeInt[1]],
+    ],
 ](
     ctx: DeviceContext,
     probs: TileTensor[dtype, ...],
     output: TileTensor[mut=True, out_idx_type, ...],
     top_k_val: Int,
     deterministic: Bool = False,
-    rng_seed: UInt64 = 0,
+    rng_seed_val: UInt64 = 0,
     rng_offset: UInt64 = 0,
     indices: Optional[
-        TileTensor[out_idx_type, IndicesLayoutType, MutExternalOrigin]
+        TileTensor[out_idx_type, IndicesLayoutType, ImmutAnyOrigin]
     ] = None,
     top_k_arr: Optional[
-        TileTensor[out_idx_type, TopKArrLayoutType, MutExternalOrigin]
+        TileTensor[out_idx_type, TopKArrLayoutType, ImmutAnyOrigin]
+    ] = None,
+    rng_seed: Optional[
+        TileTensor[DType.uint64, SeedLayoutType, ImmutAnyOrigin]
+    ] = None,
+    row_max_prob_arr: Optional[
+        TileTensor[DType.float32, RowMaxProbLayoutType, ImmutAnyOrigin]
     ] = None,
 ) raises:
     """Top-K sampling from probability distribution.
@@ -916,10 +1003,12 @@ def topk_sampling_from_prob[
         output: Output sampled indices [batch_size].
         top_k_val: Default top-k value (number of top tokens to consider).
         deterministic: Whether to use deterministic sampling.
-        rng_seed: Random seed for Random number generator.
+        rng_seed_val: Default random seed for Random number generator.
         rng_offset: Random offset for Random number generator.
         indices: Optional row indices for batch indexing [batch_size].
         top_k_arr: Optional per-row top-k values [batch_size].
+        rng_seed: Optional per-row seed values [batch_size].
+        row_max_prob_arr: Optional per-row max probability bounds [batch_size].
 
     Raises:
         Error: If tensor ranks or shapes are invalid.
@@ -962,21 +1051,23 @@ def topk_sampling_from_prob[
         if indices:
             indices_buf = indices.value().to_device_buffer(ctx)
         else:
-            indices_buf = DeviceBuffer[out_idx_type](
-                ctx,
-                {_unsafe_null = ()},
-                0,
-                owning=False,
-            )
+            indices_buf = DeviceBuffer[out_idx_type](ctx, {}, 0, owning=False)
         var top_k_buf: DeviceBuffer[out_idx_type]
         if top_k_arr:
             top_k_buf = top_k_arr.value().to_device_buffer(ctx)
         else:
-            top_k_buf = DeviceBuffer[out_idx_type](
-                ctx,
-                {_unsafe_null = ()},
-                0,
-                owning=False,
+            top_k_buf = DeviceBuffer[out_idx_type](ctx, {}, 0, owning=False)
+        var seed_buf: DeviceBuffer[DType.uint64]
+        if rng_seed:
+            seed_buf = rng_seed.value().to_device_buffer(ctx)
+        else:
+            seed_buf = DeviceBuffer[DType.uint64](ctx, {}, 0, owning=False)
+        var row_max_prob_buf: DeviceBuffer[DType.float32]
+        if row_max_prob_arr:
+            row_max_prob_buf = row_max_prob_arr.value().to_device_buffer(ctx)
+        else:
+            row_max_prob_buf = DeviceBuffer[DType.float32](
+                ctx, {}, 0, owning=False
             )
 
         @parameter
@@ -999,7 +1090,9 @@ def topk_sampling_from_prob[
                 top_k_buf,
                 top_k_val,
                 d,
-                rng_seed,
+                row_max_prob_buf,
+                seed_buf,
+                rng_seed_val,
                 rng_offset,
                 grid_dim=batch_size,
                 block_dim=block_size,
@@ -1039,6 +1132,7 @@ def TopKTopPSamplingFromProbKernel[
     top_p_arr: UnsafePointer[Float32, MutExternalOrigin],
     top_p_val: Float32,
     d: Int,
+    row_max_prob_arr: UnsafePointer[Float32, MutExternalOrigin],
     rng_seed: UnsafePointer[UInt64, MutExternalOrigin],
     rng_offset: UInt64,
 ):
@@ -1061,6 +1155,7 @@ def TopKTopPSamplingFromProbKernel[
         top_p_arr: Optional per-row top_p values [batch_size].
         top_p_val: Default top_p value if top_p_arr is null.
         d: Vocabulary size.
+        row_max_prob_arr: Optional per-row max probability bounds [batch_size].
         rng_seed: Pointer to seed value. If non-null, rng_seed[0] is used
             as the seed. If null, defaults to 0.
         rng_offset: Random offset for Random number generator.
@@ -1071,7 +1166,7 @@ def TopKTopPSamplingFromProbKernel[
     var tx = thread_idx.x
 
     var row_idx = bx
-    if indices._is_not_null():
+    if indices:
         row_idx = Int(indices.load(bx))
 
     var sampled_id_sram = stack_allocation[
@@ -1083,19 +1178,17 @@ def TopKTopPSamplingFromProbKernel[
 
     with PDL():
         var seed_val = UInt64(0)
-        if rng_seed._is_not_null():
+        if rng_seed:
             seed_val = rng_seed[row_idx]
 
         var generator = Random(seed=seed_val, offset=UInt64(bx) + rng_offset)
 
-        var k = Int(
-            top_k_arr.load(row_idx)
-        ) if top_k_arr._is_not_null() else top_k_val
+        var k = Int(top_k_arr.load(row_idx)) if top_k_arr else top_k_val
         if k == -1:
             k = top_k_val
 
         var p = top_p_val
-        if top_p_arr._is_not_null():
+        if top_p_arr:
             p = top_p_arr[row_idx]
 
         var probs_ptr = probs.ptr + row_idx * d
@@ -1107,6 +1200,26 @@ def TopKTopPSamplingFromProbKernel[
         var q: Float32 = 1.0
         var low: Float32 = 0.0
         var high: Float32 = 1.0
+
+        if row_max_prob_arr:
+            high = row_max_prob_arr[row_idx]
+        # Large-vocab decode rows have max probabilities orders of magnitude
+        # below 1.0. Tighten the initial search interval once so the rejection
+        # loop does not spend its first few iterations shrinking a dead range.
+        elif d >= 65536:
+            var thread_row_max = Float32(0.0)
+            for i in range(ceildiv(d, block_size * vec_size)):
+                probs_vec = 0
+                var chunk_base = (i * block_size + tx) * vec_size
+                if chunk_base < d:
+                    probs_vec = probs_row.load[width=vec_size](
+                        (Idx[0](), Idx(chunk_base))
+                    ).cast[DType.float32]()
+                thread_row_max = max(thread_row_max, probs_vec.reduce_max())
+
+            high = block.max[block_size=block_size, broadcast=True](
+                thread_row_max
+            )
 
         while low < high:
             if tx == 0:
@@ -1140,16 +1253,18 @@ def TopKTopPSamplingFromProbKernel[
                 if aggregate > u:
                     break
 
-            # Reduce last_valid_id across block (single reduction after loop).
-            var block_max_valid = block.max[
-                block_size=block_size,
-                broadcast=False,
-            ](Int32(thread_max_valid))
+            # Only pay the fallback reduction when the scan did not already
+            # identify a sampled index for this rejection round.
+            if sampled_id_sram[0] == d:
+                var block_max_valid = block.max[
+                    block_size=block_size,
+                    broadcast=False,
+                ](Int32(thread_max_valid))
 
-            if tx == 0 and block_max_valid != -1:
-                last_valid_id_sram[0] = Int(block_max_valid)
+                if tx == 0 and block_max_valid != -1:
+                    last_valid_id_sram[0] = Int(block_max_valid)
 
-            barrier()
+                barrier()
 
             sampled_id = sampled_id_sram[0]
             if sampled_id == d:
@@ -1166,45 +1281,20 @@ def TopKTopPSamplingFromProbKernel[
 
             for i in range(ceildiv(d, block_size * vec_size)):
                 probs_vec = 0
-                if (i * block_size + tx) * vec_size < d:
+                var chunk_base = (i * block_size + tx) * vec_size
+                if chunk_base < d:
                     probs_vec = probs_row.load[width=vec_size](
-                        (Idx[0](), Idx((i * block_size + tx) * vec_size))
+                        (Idx[0](), Idx(chunk_base))
                     ).cast[DType.float32]()
 
-                var probs_gt_pivot_0_values = SIMD[DType.float32, vec_size]()
-                var probs_gt_pivot_0_counts = SIMD[DType.int32, vec_size]()
-                var probs_gt_pivot_1_values = SIMD[DType.float32, vec_size]()
-                var probs_gt_pivot_1_counts = SIMD[DType.int32, vec_size]()
-
-                comptime for j in range(vec_size):
-                    var idx = (i * block_size + tx) * vec_size + j
-                    var is_valid = idx < d
-
-                    var gt_pivot_0 = probs_vec[j] > pivot_0
-                    probs_gt_pivot_0_values[j] = probs_vec[
-                        j
-                    ] if gt_pivot_0 else 0.0
-                    probs_gt_pivot_0_counts[j] = Int32(1) if (
-                        gt_pivot_0 and is_valid
-                    ) else Int32(0)
-
-                    var gt_pivot_1 = probs_vec[j] > pivot_1
-                    probs_gt_pivot_1_values[j] = probs_vec[
-                        j
-                    ] if gt_pivot_1 else 0.0
-                    probs_gt_pivot_1_counts[j] = Int32(1) if (
-                        gt_pivot_1 and is_valid
-                    ) else Int32(0)
-
-                # Accumulate thread-local (no block reduction per chunk).
-                thread_vc_0_total += ValueCount[DType.float32](
-                    probs_gt_pivot_0_values.reduce_add(),
-                    probs_gt_pivot_0_counts.reduce_add(),
-                )
-                thread_vc_1_total += ValueCount[DType.float32](
-                    probs_gt_pivot_1_values.reduce_add(),
-                    probs_gt_pivot_1_counts.reduce_add(),
-                )
+                # Most large-vocab chunks do not contain any survivor above
+                # pivot_0. Skip their per-lane pivot bookkeeping entirely, and
+                # only accumulate pivot_1 when a chunk actually reaches it.
+                var chunk_vc_0, chunk_vc_1 = _accumulate_chunk_value_counts[
+                    vec_size
+                ](probs_vec, chunk_base, d, pivot_0, pivot_1)
+                thread_vc_0_total += chunk_vc_0
+                thread_vc_1_total += chunk_vc_1
 
             # Reduce pivot_0 first; defer pivot_1 until needed.
             # For small K, acceptance (count_0 < k) is common, saving
@@ -1221,7 +1311,22 @@ def TopKTopPSamplingFromProbKernel[
                 # Use <= so that p=0 correctly accepts the argmax (sum_above=0).
                 break
 
-            # Only reduce pivot_1 when pivot_0 is rejected.
+            # Most decode iterations never see any probability above pivot_1.
+            # When every thread accumulated a zero pivot_1 count, skip the
+            # heavier value/count reduction and take the accepted branch
+            # directly because aggregate_gt_pivot_1 is guaranteed to be zero.
+            var any_pivot_1_hit = block.max[
+                block_size=block_size, broadcast=True
+            ](Int32(1) if thread_vc_1_total.count > 0 else Int32(0))
+
+            if any_pivot_1_hit == 0:
+                low = pivot_0
+                high = pivot_1
+                q = aggregate_gt_pivot_0.value
+                continue
+
+            # Only reduce pivot_1 when pivot_0 is rejected and pivot_1
+            # actually has some surviving probability mass.
             var aggregate_gt_pivot_1 = _block_reduce_value_count[
                 DType.float32, broadcast=True
             ](thread_vc_1_total)
@@ -1265,6 +1370,10 @@ def topk_topp_sampling_from_prob[
         shape_types=Variadic.types[RuntimeInt[DType.int64]],
         stride_types=Variadic.types[ComptimeInt[1]],
     ],
+    RowMaxProbLayoutType: TensorLayout = Layout[
+        shape_types=Variadic.types[RuntimeInt[DType.int64]],
+        stride_types=Variadic.types[ComptimeInt[1]],
+    ],
 ](
     ctx: DeviceContext,
     probs: TileTensor[dtype, ...],
@@ -1284,6 +1393,9 @@ def topk_topp_sampling_from_prob[
     ] = None,
     top_p_arr: Optional[
         TileTensor[DType.float32, TopPArrLayoutType, ImmutAnyOrigin]
+    ] = None,
+    row_max_prob_arr: Optional[
+        TileTensor[DType.float32, RowMaxProbLayoutType, ImmutAnyOrigin]
     ] = None,
 ) raises:
     """Joint top-k + top-p sampling from probability distribution.
@@ -1305,6 +1417,7 @@ def topk_topp_sampling_from_prob[
         indices: Optional row indices for batch indexing [batch_size].
         top_k_arr: Optional per-row top-k values [batch_size].
         top_p_arr: Optional per-row top-p values [batch_size].
+        row_max_prob_arr: Optional per-row max probability bounds [batch_size].
 
     Raises:
         Error: If tensor ranks or shapes are invalid.
@@ -1348,41 +1461,28 @@ def topk_topp_sampling_from_prob[
         if indices:
             indices_buf = indices.value().to_device_buffer(ctx)
         else:
-            indices_buf = DeviceBuffer[out_idx_type](
-                ctx,
-                {_unsafe_null = ()},
-                0,
-                owning=False,
-            )
+            indices_buf = DeviceBuffer[out_idx_type](ctx, {}, 0, owning=False)
         var top_k_buf: DeviceBuffer[out_idx_type]
         if top_k_arr:
             top_k_buf = top_k_arr.value().to_device_buffer(ctx)
         else:
-            top_k_buf = DeviceBuffer[out_idx_type](
-                ctx,
-                {_unsafe_null = ()},
-                0,
-                owning=False,
-            )
+            top_k_buf = DeviceBuffer[out_idx_type](ctx, {}, 0, owning=False)
         var top_p_buf: DeviceBuffer[DType.float32]
         if top_p_arr:
             top_p_buf = top_p_arr.value().to_device_buffer(ctx)
         else:
-            top_p_buf = DeviceBuffer[DType.float32](
-                ctx,
-                {_unsafe_null = ()},
-                0,
-                owning=False,
-            )
+            top_p_buf = DeviceBuffer[DType.float32](ctx, {}, 0, owning=False)
         var seed_buf: DeviceBuffer[DType.uint64]
         if rng_seed:
             seed_buf = rng_seed.value().to_device_buffer(ctx)
         else:
-            seed_buf = DeviceBuffer[DType.uint64](
-                ctx,
-                {_unsafe_null = ()},
-                0,
-                owning=False,
+            seed_buf = DeviceBuffer[DType.uint64](ctx, {}, 0, owning=False)
+        var row_max_prob_buf: DeviceBuffer[DType.float32]
+        if row_max_prob_arr:
+            row_max_prob_buf = row_max_prob_arr.value().to_device_buffer(ctx)
+        else:
+            row_max_prob_buf = DeviceBuffer[DType.float32](
+                ctx, {}, 0, owning=False
             )
 
         @parameter
@@ -1407,6 +1507,7 @@ def topk_topp_sampling_from_prob[
                 top_p_buf,
                 top_p_val,
                 d,
+                row_max_prob_buf,
                 seed_buf,
                 rng_offset,
                 grid_dim=batch_size,
@@ -1444,6 +1545,8 @@ def topk_softmax_sample_kernel[
     top_k_val: Int,
     temperature_val: Float32,
     temperature: UnsafePointer[Float32, MutExternalOrigin],
+    top_p_val: Float32,
+    top_p: UnsafePointer[Float32, MutExternalOrigin],
     seed_val: UInt64,
     seed: UnsafePointer[UInt64, MutExternalOrigin],
     d: Int,
@@ -1459,11 +1562,15 @@ def topk_softmax_sample_kernel[
     var logits_row = TileTensor(logits_ptr, row_major(Idx[1](), Idx(d)))
 
     var k = top_k_val
-    if top_k_arr._is_not_null():
+    if top_k_arr:
         k = Int(top_k_arr[bx])
     var temp_val = temperature_val
-    if temperature._is_not_null():
+    if temperature:
         temp_val = max(temperature[bx], 1e-6)
+    var p = top_p_val
+    if top_p:
+        p = top_p[bx]
+    var need_topp = p < 1.0
 
     # Allocate shared memory for caching top-k elements.
     # Round up to ensure proper alignment for Int array.
@@ -1504,10 +1611,55 @@ def topk_softmax_sample_kernel[
                 min_val - 1 if min_val != Float32.MIN else Float32.MIN
             )
             var high = max_val
+            var use_initial_pivot_1_fast_path = d >= 65536 and k <= 128
 
             while True:
                 var pivot_0 = (high + 2 * low) / 3
                 var pivot_1 = (2 * high + low) / 3
+
+                # The first large-vocab, small-k ternary-search iteration
+                # starts with exact min/max bounds, so it can try the tighter
+                # pivot alone and only fall back to the full scan when the row
+                # is unexpectedly sparse above that threshold.
+                if use_initial_pivot_1_fast_path:
+                    var thread_count_1_total: Int32 = 0
+
+                    for i in range(ceildiv(d, block_size * vec_size)):
+                        var chunk_base = (i * block_size + tx) * vec_size
+                        if chunk_base >= d:
+                            continue
+
+                        logits_vec = logits_row.load[width=vec_size](
+                            (Idx[0](), Idx(chunk_base))
+                        ).cast[DType.float32]()
+
+                        if chunk_base + vec_size <= d:
+                            var chunk_max = logits_vec.reduce_max()
+                            if chunk_max <= pivot_1:
+                                continue
+
+                        var probs_gt_pivot_1_count = SIMD[
+                            DType.int32, vec_size
+                        ]()
+
+                        comptime for j in range(vec_size):
+                            var idx = chunk_base + j
+                            probs_gt_pivot_1_count[j] = Int32(1) if (
+                                logits_vec[j] > pivot_1 and idx < d
+                            ) else Int32(0)
+
+                        thread_count_1_total += probs_gt_pivot_1_count.reduce_add()
+
+                    var aggregate_gt_pivot_1 = Int32(
+                        block.sum[block_size=block_size, broadcast=True](
+                            Float32(thread_count_1_total)
+                        )
+                    )
+                    use_initial_pivot_1_fast_path = False
+
+                    if aggregate_gt_pivot_1 >= Int32(k):
+                        low = pivot_1
+                        continue
 
                 # Accumulate thread-local counts across all chunks.
                 var thread_count_0_total: Int32 = 0
@@ -1516,35 +1668,60 @@ def topk_softmax_sample_kernel[
                 var max_le_high = low
 
                 for i in range(ceildiv(d, block_size * vec_size)):
-                    if (i * block_size + tx) * vec_size < d:
-                        logits_vec = logits_row.load[width=vec_size](
-                            (
-                                Idx[0](),
-                                Idx(i * block_size * vec_size + tx * vec_size),
-                            )
-                        ).cast[DType.float32]()
+                    var chunk_base = (i * block_size + tx) * vec_size
+                    if chunk_base >= d:
+                        continue
 
-                    var probs_gt_pivot_0_count = SIMD[DType.int32, vec_size]()
-                    var probs_gt_pivot_1_count = SIMD[DType.int32, vec_size]()
+                    logits_vec = logits_row.load[width=vec_size](
+                        (Idx[0](), Idx(chunk_base))
+                    ).cast[DType.float32]()
+
+                    var need_pivot_0_scan = True
+                    var need_pivot_1_scan = True
+                    var need_max_le_high_scan = True
+
+                    # After the first ternary-search iteration, almost every
+                    # chunk already falls entirely below `low`. Those chunks
+                    # contribute no pivot counts and update `max_le_high` with
+                    # their local max directly. Most of the remaining chunks
+                    # still never reach pivot_0 or pivot_1, so use the same
+                    # chunk_max to skip dead pivot bookkeeping before falling
+                    # back to per-lane scans for the surviving bounds work.
+                    if chunk_base + vec_size <= d:
+                        var chunk_max = logits_vec.reduce_max()
+                        if chunk_max <= low:
+                            max_le_high = max(max_le_high, chunk_max)
+                            continue
+                        if chunk_max <= pivot_0:
+                            need_pivot_0_scan = False
+                            need_pivot_1_scan = False
+                            need_max_le_high_scan = False
+                            max_le_high = max(max_le_high, chunk_max)
+                        elif chunk_max <= pivot_1:
+                            need_pivot_1_scan = False
+                            need_max_le_high_scan = False
+                            max_le_high = max(max_le_high, chunk_max)
+
+                    var chunk_count_0 = Int32(0)
+                    var chunk_count_1 = Int32(0)
 
                     comptime for j in range(vec_size):
-                        var idx = (i * block_size + tx) * vec_size + j
+                        var idx = chunk_base + j
+                        if idx < d:
+                            var logit = logits_vec[j]
+                            if need_pivot_0_scan and logit > pivot_0:
+                                chunk_count_0 += Int32(1)
+                            if need_pivot_1_scan and logit > pivot_1:
+                                chunk_count_1 += Int32(1)
 
-                        probs_gt_pivot_0_count[j] = Int32(1) if (
-                            logits_vec[j] > pivot_0 and idx < d
-                        ) else Int32(0)
-                        probs_gt_pivot_1_count[j] = Int32(1) if (
-                            logits_vec[j] > pivot_1 and idx < d
-                        ) else Int32(0)
-
-                        if logits_vec[j] > low and idx < d:
-                            min_gt_low = min(min_gt_low, logits_vec[j])
-                        if logits_vec[j] <= high and idx < d:
-                            max_le_high = max(max_le_high, logits_vec[j])
+                            if logit > low:
+                                min_gt_low = min(min_gt_low, logit)
+                            if need_max_le_high_scan and logit <= high:
+                                max_le_high = max(max_le_high, logit)
 
                     # Accumulate thread-local counts (no block reduction per chunk).
-                    thread_count_0_total += probs_gt_pivot_0_count.reduce_add()
-                    thread_count_1_total += probs_gt_pivot_1_count.reduce_add()
+                    thread_count_0_total += chunk_count_0
+                    thread_count_1_total += chunk_count_1
 
                 # Single block reduction after processing all chunks.
                 var _pivot_results = _block_reduce_pivot_bounds[block_size](
@@ -1582,7 +1759,8 @@ def topk_softmax_sample_kernel[
         # PHASE 2: Compute softmax sum and cache top-k elements.
 
         # All threads cooperatively collect elements > pivot.
-        var thread_sum = Float32(0.0)
+        var thread_kept_sum = Float32(0.0)
+        var thread_full_sum = Float32(0.0)
 
         # Use atomic counter in shared memory for write position.
         var s_write_idx = stack_allocation[
@@ -1593,24 +1771,97 @@ def topk_softmax_sample_kernel[
 
         barrier()
 
-        # Each thread processes elements and atomically writes to shared memory.
-        for i in range(tx, d, block_size):
-            var logit = logits_row.load[width=1]((Idx[0](), Idx(i))).cast[
-                DType.float32
-            ]()
-            if logit > pivot:
+        # Nucleus sampling needs the full softmax normalizer, so keep that
+        # accumulation vectorized while preserving the existing scalar top-k
+        # candidate cache writes.
+        if need_topp:
+            var vector_end = (d // vec_size) * vec_size
+            var max_logit_vec = SIMD[DType.float32, vec_size](max_logit)
+            var temp_vec = SIMD[DType.float32, vec_size](temp_val)
+
+            for i in range(tx * vec_size, vector_end, block_size * vec_size):
+                var logits_vec = logits_row.load[width=vec_size](
+                    (Idx[0](), Idx(i))
+                ).cast[DType.float32]()
+                var exp_vals = exp((logits_vec - max_logit_vec) / temp_vec)
+                thread_full_sum += exp_vals.reduce_add()
+
+                comptime for j in range(vec_size):
+                    if logits_vec[j] > pivot:
+                        # Atomically get write position and store.
+                        var pos = Int(Atomic.fetch_add(s_write_idx, Int32(1)))
+                        if pos < k:
+                            s_vals[pos] = exp_vals[j]
+                            s_idxs[pos] = i + j
+                            thread_kept_sum += exp_vals[j]
+
+            for i in range(vector_end + tx, d, block_size):
+                var logit = logits_row.load[width=1]((Idx[0](), Idx(i))).cast[
+                    DType.float32
+                ]()
                 var exp_val = exp((logit - max_logit) / temp_val)
+                thread_full_sum += exp_val
 
-                # Atomically get write position and store.
-                var pos = Int(Atomic.fetch_add(s_write_idx, Int32(1)))
-                if pos < k:
-                    s_vals[pos] = exp_val
-                    s_idxs[pos] = i
-                    thread_sum += exp_val
+                if logit > pivot:
+                    # Atomically get write position and store.
+                    var pos = Int(Atomic.fetch_add(s_write_idx, Int32(1)))
+                    if pos < k:
+                        s_vals[pos] = exp_val
+                        s_idxs[pos] = i
+                        thread_kept_sum += exp_val
+        else:
+            # Pure top-k does not need the full normalizer, but it still scans
+            # the same large-vocab rows. Keep the vectorized loads from the
+            # top-p path, but avoid paying a full-vector exp() when no lane
+            # beats the pivot. For Gemma4-shaped rows with k << d, almost every
+            # vector can exit after the max comparison alone.
+            var vector_end = (d // vec_size) * vec_size
 
-        var block_sum = block.sum[block_size=block_size, broadcast=True](
-            thread_sum
-        )
+            for i in range(tx * vec_size, vector_end, block_size * vec_size):
+                var logits_vec = logits_row.load[width=vec_size](
+                    (Idx[0](), Idx(i))
+                ).cast[DType.float32]()
+                if logits_vec.reduce_max() > pivot:
+                    comptime for j in range(vec_size):
+                        if logits_vec[j] > pivot:
+                            var exp_val = exp(
+                                (logits_vec[j] - max_logit) / temp_val
+                            )
+                            var pos = Int(
+                                Atomic.fetch_add(s_write_idx, Int32(1))
+                            )
+                            if pos < k:
+                                s_vals[pos] = exp_val
+                                s_idxs[pos] = i + j
+                                thread_kept_sum += exp_val
+
+            for i in range(vector_end + tx, d, block_size):
+                var logit = logits_row.load[width=1]((Idx[0](), Idx(i))).cast[
+                    DType.float32
+                ]()
+                if logit > pivot:
+                    var exp_val = exp((logit - max_logit) / temp_val)
+
+                    # Atomically get write position and store.
+                    var pos = Int(Atomic.fetch_add(s_write_idx, Int32(1)))
+                    if pos < k:
+                        s_vals[pos] = exp_val
+                        s_idxs[pos] = i
+                        thread_kept_sum += exp_val
+
+        var kept_sum: Float32
+        var full_sum: Float32
+        if need_topp:
+            var reduced_sums = _block_reduce_dual_sum[block_size](
+                thread_kept_sum, thread_full_sum
+            )
+            kept_sum = reduced_sums[0]
+            full_sum = reduced_sums[1]
+        else:
+            kept_sum = block.sum[block_size=block_size, broadcast=True](
+                thread_kept_sum
+            )
+            full_sum = kept_sum
 
         barrier()
 
@@ -1622,17 +1873,58 @@ def topk_softmax_sample_kernel[
         # PHASE 3: Sampling (thread 0 only).
         if tx == 0:
             var seed_val = seed_val
-            if seed._is_not_null():
+            if seed:
                 seed_val = seed[bx]
             var rng_state = Random(seed=seed_val)
             var rng = rng_state.step_uniform()
-            var r = block_sum * rng[0]
-
             var cached_count = s_count[0]
-            for ki in range(cached_count):
+            var sample_mass = kept_sum
+            var sample_limit = cached_count
+
+            if p < 1.0:
+                var nucleus_threshold = full_sum * p
+                # If the cached top-k mass is already below the nucleus bound,
+                # top-p does not shrink the admissible set and we can sample
+                # directly from the cached survivors without reordering them.
+                if kept_sum > nucleus_threshold:
+                    sample_mass = 0.0
+                    sample_limit = 0
+                    while (
+                        sample_limit < cached_count
+                        and sample_mass < nucleus_threshold
+                    ):
+                        # Top-p only consumes the sorted prefix up to the nucleus
+                        # threshold. Select the next-best cached survivor in place
+                        # instead of fully sorting all k candidates first.
+                        var best_pos = sample_limit
+                        var best_val = s_vals[best_pos]
+                        var best_idx = s_idxs[best_pos]
+
+                        for cand_pos in range(sample_limit + 1, cached_count):
+                            var cand_val = s_vals[cand_pos]
+                            var cand_idx = s_idxs[cand_pos]
+                            if _value_idx_precedes(
+                                cand_val, cand_idx, best_val, best_idx
+                            ):
+                                best_pos = cand_pos
+                                best_val = cand_val
+                                best_idx = cand_idx
+
+                        if best_pos != sample_limit:
+                            s_vals[best_pos] = s_vals[sample_limit]
+                            s_idxs[best_pos] = s_idxs[sample_limit]
+                            s_vals[sample_limit] = best_val
+                            s_idxs[sample_limit] = best_idx
+
+                        sample_mass += s_vals[sample_limit]
+                        sample_limit += 1
+
+            var r = sample_mass * rng[0]
+
+            for ki in range(sample_limit):
                 var exp_val = s_vals[ki]
                 r -= exp_val
-                if r <= 0.0 or ki == cached_count - 1:
+                if r <= 0.0 or ki == sample_limit - 1:
                     sampled_indices[bx] = Scalar[out_idx_type](s_idxs[ki])
                     break
 
@@ -1649,27 +1941,35 @@ def topk_softmax_sample[
         shape_types=Variadic.types[RuntimeInt[DType.int64]],
         stride_types=Variadic.types[ComptimeInt[1]],
     ],
+    TopPArrLayoutType: TensorLayout = Layout[
+        shape_types=Variadic.types[RuntimeInt[DType.int64]],
+        stride_types=Variadic.types[ComptimeInt[1]],
+    ],
     SeedLayoutType: TensorLayout = Layout[
         shape_types=Variadic.types[RuntimeInt[DType.int64]],
         stride_types=Variadic.types[ComptimeInt[1]],
     ],
 ](
     ctx: DeviceContext,
-    logits: TileTensor[dtype, address_space=AddressSpace.GENERIC, ...],
+    logits: TileTensor[dtype, ...],
     sampled_indices: TileTensor[
-        mut=True, out_idx_type, address_space=AddressSpace.GENERIC, ...
+        mut=True, out_idx_type, ...
     ],
     top_k_val: Int,
     temperature_val: Float32 = 1.0,
+    top_p_val: Float32 = 1.0,
     seed_val: UInt64 = 0,
     top_k_arr: Optional[
-        TileTensor[out_idx_type, TopKArrLayoutType, MutExternalOrigin]
+        TileTensor[out_idx_type, TopKArrLayoutType, ImmutAnyOrigin]
     ] = None,
     temperature: Optional[
-        TileTensor[DType.float32, TemperatureLayoutType, MutExternalOrigin]
+        TileTensor[DType.float32, TemperatureLayoutType, ImmutAnyOrigin]
+    ] = None,
+    top_p_arr: Optional[
+        TileTensor[DType.float32, TopPArrLayoutType, ImmutAnyOrigin]
     ] = None,
     seed: Optional[
-        TileTensor[DType.uint64, SeedLayoutType, MutExternalOrigin]
+        TileTensor[DType.uint64, SeedLayoutType, ImmutAnyOrigin]
     ] = None,
 ) raises:
     """Samples token indices from top-K logits using softmax probabilities.
@@ -1706,6 +2006,9 @@ def topk_softmax_sample[
         temperature:
             Optional per-batch temperature values. If provided, overrides
             temperature_val for each batch element.
+        top_p_arr:
+            Optional per-batch top-p values. If provided, overrides top_p_val
+            for each batch element.
         seed:
             Optional per-batch seed values. If provided, overrides seed_val
             for each batch element.
@@ -1762,32 +2065,22 @@ def topk_softmax_sample[
         if top_k_arr:
             top_k_buf = top_k_arr.value().to_device_buffer(ctx)
         else:
-            top_k_buf = DeviceBuffer[out_idx_type](
-                ctx,
-                {_unsafe_null = ()},
-                0,
-                owning=False,
-            )
+            top_k_buf = DeviceBuffer[out_idx_type](ctx, {}, 0, owning=False)
         var temp_buf: DeviceBuffer[DType.float32]
         if temperature:
             temp_buf = temperature.value().to_device_buffer(ctx)
         else:
-            temp_buf = DeviceBuffer[DType.float32](
-                ctx,
-                {_unsafe_null = ()},
-                0,
-                owning=False,
-            )
+            temp_buf = DeviceBuffer[DType.float32](ctx, {}, 0, owning=False)
+        var top_p_buf: DeviceBuffer[DType.float32]
+        if top_p_arr:
+            top_p_buf = top_p_arr.value().to_device_buffer(ctx)
+        else:
+            top_p_buf = DeviceBuffer[DType.float32](ctx, {}, 0, owning=False)
         var seed_buf: DeviceBuffer[DType.uint64]
         if seed:
             seed_buf = seed.value().to_device_buffer(ctx)
         else:
-            seed_buf = DeviceBuffer[DType.uint64](
-                ctx,
-                {_unsafe_null = ()},
-                0,
-                owning=False,
-            )
+            seed_buf = DeviceBuffer[DType.uint64](ctx, {}, 0, owning=False)
 
         @parameter
         def launch_kernel[vec_size: Int]() raises:
@@ -1808,6 +2101,8 @@ def topk_softmax_sample[
                 top_k_val,
                 temperature_val,
                 temp_buf,
+                top_p_val,
+                top_p_buf,
                 seed_val,
                 seed_buf,
                 d,

--- a/max/kernels/src/nn/topk_fi.mojo
+++ b/max/kernels/src/nn/topk_fi.mojo
@@ -2051,11 +2051,11 @@ def topk_softmax_sample[
             if shared_mem_bytes > _APPLE_STATIC_SHMEM_MAX_BYTES:
                 raise Error(
                     t"shared memory of {shared_mem_bytes} exceeds static"
-                    " allocation capacity of"
+                    t" allocation capacity of"
                     t" {_APPLE_STATIC_SHMEM_MAX_BYTES} when evaluating"
                     t" topk_softmax_sample with top_k_val={top_k_val}"
                     t" and vec_size={vec_size}. Consider reducing"
-                    " top_k_val or using a smaller block_size."
+                    t" top_k_val or using a smaller block_size."
                 )
 
         var top_k_buf: DeviceBuffer[out_idx_type]

--- a/max/kernels/src/nn/topk_fi.mojo
+++ b/max/kernels/src/nn/topk_fi.mojo
@@ -145,10 +145,7 @@ def _block_reduce_pivot_bounds[
 @always_inline
 def _block_reduce_dual_sum[
     block_size: Int, broadcast: Bool = True
-](
-    sum0: Float32,
-    sum1: Float32,
-) -> Tuple[Float32, Float32]:
+](sum0: Float32, sum1: Float32,) -> Tuple[Float32, Float32]:
     """Reduce two Float32 sums with one block-reduction pass."""
 
     @always_inline
@@ -1648,7 +1645,9 @@ def topk_softmax_sample_kernel[
                                 logits_vec[j] > pivot_1 and idx < d
                             ) else Int32(0)
 
-                        thread_count_1_total += probs_gt_pivot_1_count.reduce_add()
+                        thread_count_1_total += (
+                            probs_gt_pivot_1_count.reduce_add()
+                        )
 
                     var aggregate_gt_pivot_1 = Int32(
                         block.sum[block_size=block_size, broadcast=True](
@@ -1952,9 +1951,7 @@ def topk_softmax_sample[
 ](
     ctx: DeviceContext,
     logits: TileTensor[dtype, ...],
-    sampled_indices: TileTensor[
-        mut=True, out_idx_type, ...
-    ],
+    sampled_indices: TileTensor[mut=True, out_idx_type, ...],
     top_k_val: Int,
     temperature_val: Float32 = 1.0,
     top_p_val: Float32 = 1.0,
@@ -2054,11 +2051,11 @@ def topk_softmax_sample[
             if shared_mem_bytes > _APPLE_STATIC_SHMEM_MAX_BYTES:
                 raise Error(
                     t"shared memory of {shared_mem_bytes} exceeds static"
-                    t" allocation capacity of"
+                    " allocation capacity of"
                     t" {_APPLE_STATIC_SHMEM_MAX_BYTES} when evaluating"
                     t" topk_softmax_sample with top_k_val={top_k_val}"
                     t" and vec_size={vec_size}. Consider reducing"
-                    t" top_k_val or using a smaller block_size."
+                    " top_k_val or using a smaller block_size."
                 )
 
         var top_k_buf: DeviceBuffer[out_idx_type]

--- a/max/python/max/nn/kernels.py
+++ b/max/python/max/nn/kernels.py
@@ -422,7 +422,6 @@ def _fused_qkv_ragged_matmul_scaled_float8(
         scales_granularity_mnk = quant_config.scales_granularity_mnk
     else:
         # with out quant_config, we either use per-tensor or per-channel quantization
-        # both dynamic and static tensor wise quantization have weight shape [1, 1]
         if (
             input_scale.shape[0] == 1
             and input_scale.shape[1] == 1
@@ -3396,12 +3395,16 @@ def rms_norm_value_cache(
 def moe_create_indices(
     topk_ids: TensorValue,
     num_local_experts: int,
+    expected_count: int = 8192,
 ) -> tuple[TensorValue, TensorValue, TensorValue, TensorValue, TensorValue]:
     """Creates indices for the MoE layer.
 
     Args:
         topk_ids: The expert assignments for each token from the router.
         num_local_experts: The number of experts on this device.
+        expected_count: Compile-time estimate for the maximum number of routed
+            tokens expected per expert before spilling from shared memory to
+            global memory in the GPU kernel.
 
     Returns:
         A tuple of five tensors:
@@ -3414,12 +3417,20 @@ def moe_create_indices(
         - expert_usage_stats: The maximum number of tokens assigned to any expert,
             and the number of active experts.
     """
+    if expected_count <= 0:
+        raise ValueError(
+            f"expected_count must be positive, got {expected_count}"
+        )
+
     results = ops.custom(
         "mo.moe.create.indices",
         device=topk_ids.device,
         values=[
             topk_ids,
         ],
+        parameters={
+            "expected_count": expected_count,
+        },
         out_types=[
             TensorType(
                 dtype=DType.uint32,
@@ -3534,6 +3545,118 @@ def moe_router_group_limited(
     )
 
     return (results[0].tensor, results[1].tensor)
+
+
+def routed_expert_combine(
+    top_k_weights: TensorValue,
+    down_output: TensorValue,
+) -> TensorValue:
+    """Combines routed expert outputs into the final `[seq_len, hidden_dim]`.
+
+    This custom op preserves Gemma4's float32 multiply-then-reduce numerics
+    without materializing graph-level chunk assembly tensors.
+    """
+    _validate_routed_expert_combine_inputs(top_k_weights, down_output)
+
+    return ops.custom(
+        "mo.routed.expert.combine",
+        device=down_output.device,
+        values=[top_k_weights, down_output],
+        out_types=[
+            TensorType(
+                dtype=down_output.dtype,
+                shape=[down_output.shape[0], down_output.shape[2]],
+                device=down_output.device,
+            )
+        ],
+    )[0].tensor
+
+
+def _validate_routed_expert_combine_inputs(
+    top_k_weights: TensorValue,
+    down_output: TensorValue,
+) -> None:
+    if top_k_weights.rank != 2:
+        raise ValueError(
+            f"expected top_k_weights of rank 2 but got {top_k_weights.rank}"
+        )
+    if down_output.rank != 3:
+        raise ValueError(
+            f"expected down_output of rank 3 but got {down_output.rank}"
+        )
+    if top_k_weights.dtype != down_output.dtype:
+        raise ValueError(
+            "top_k_weights and down_output must have the same dtype, got "
+            f"{top_k_weights.dtype} and {down_output.dtype}"
+        )
+    if top_k_weights.device != down_output.device:
+        raise ValueError(
+            "top_k_weights and down_output must be on the same device, got "
+            f"{top_k_weights.device} and {down_output.device}"
+        )
+    if top_k_weights.shape[0] != down_output.shape[0]:
+        raise ValueError(
+            "top_k_weights and down_output must agree on seq_len, got "
+            f"{top_k_weights.shape[0]} and {down_output.shape[0]}"
+        )
+    if top_k_weights.shape[1] != down_output.shape[1]:
+        raise ValueError(
+            "top_k_weights and down_output must agree on routed experts, got "
+            f"{top_k_weights.shape[1]} and {down_output.shape[1]}"
+        )
+
+
+def routed_expert_combine_then_rms_norm(
+    top_k_weights: TensorValue,
+    down_output: TensorValue,
+    gamma: TensorValue,
+    epsilon: float | np.floating[Any],
+    weight_offset: float | np.floating[Any] = 0.0,
+    multiply_before_cast: bool = True,
+) -> TensorValue:
+    """Fuses routed expert combine with the following weighted RMSNorm."""
+
+    _validate_routed_expert_combine_inputs(top_k_weights, down_output)
+
+    if gamma.rank != 1:
+        raise ValueError(f"expected gamma of rank 1 but got {gamma.rank}")
+    if gamma.dtype != down_output.dtype:
+        raise ValueError(
+            "gamma and down_output must have the same dtype, got "
+            f"{gamma.dtype} and {down_output.dtype}"
+        )
+    if gamma.device != down_output.device:
+        raise ValueError(
+            "gamma and down_output must be on the same device, got "
+            f"{gamma.device} and {down_output.device}"
+        )
+    if gamma.shape[0] != down_output.shape[2]:
+        raise ValueError(
+            "gamma and down_output must agree on hidden_dim, got "
+            f"{gamma.shape[0]} and {down_output.shape[2]}"
+        )
+
+    return ops.custom(
+        "mo.routed.expert.combine.then.rms_norm",
+        device=down_output.device,
+        values=[
+            top_k_weights,
+            down_output,
+            gamma,
+            ops.constant(epsilon, gamma.dtype, device=DeviceRef.CPU()),
+            ops.constant(
+                weight_offset, gamma.dtype, device=DeviceRef.CPU()
+            ),
+        ],
+        out_types=[
+            TensorType(
+                dtype=down_output.dtype,
+                shape=[down_output.shape[0], down_output.shape[2]],
+                device=down_output.device,
+            )
+        ],
+        parameters={"multiply_before_cast": multiply_before_cast},
+    )[0].tensor
 
 
 def grouped_matmul_ragged(
@@ -4084,70 +4207,50 @@ def quantize_static_scaled_float8(
 
 
 def quantize_tensor_dynamic_scaled_float8(
-    input: TensorValue,
-    input_scale_spec: InputScaleSpec,
-    weight_scale_spec: WeightScaleSpec,
-    scale_ub: float = 1200.0,
-    group_size_or_per_token: int = -1,
+    x: TensorValue,
     out_type: DType = DType.float8_e4m3fn,
-    scales_type: DType = DType.bfloat16,
 ) -> tuple[TensorValue, TensorValue]:
     """Quantizes a rank-2 tensor to float8 using a dynamic per-tensor scale.
 
+    The scale is computed as ``max(|x|) / max_finite(out_type)`` over the full
+    tensor, written to a length-1 float32 tensor on the same
+    device as ``x``, then used to quantize ``x`` to FP8.
+
     Args:
-        input: The input tensor to quantize.
-        scale_ub: The upper bound of the scale factor.
-        group_size_or_per_token: The group size for quantization. When set to -1,
-            the quantization is column-wise.
-        out_type: The type of the output tensor.
-        scales_type: The type of the scales tensor.
+        x: Input tensor to quantize. Must be rank 2 with dtype ``float16``,
+            ``bfloat16``, or ``float32``. Must reside on a GPU device.
+        out_type: Output dtype. Defaults to ``DType.float8_e4m3fn``.
 
     Returns:
-        The quantized tensor and the scales.
+        A pair ``(quantized, scale)`` where ``quantized`` has the same shape as
+        ``x`` and dtype ``out_type``, and ``scale`` has shape ``[1]`` and dtype
+        ``float32`` on ``x.device`` holding the computed scale.
+
+    Raises:
+        ValueError: If ``x`` is not rank 2, ``x`` dtype is unsupported, or
+            ``out_type`` is not a supported float8 dtype.
     """
-    if input.rank != 2:
-        raise ValueError("input must be rank 2 tensor")
-
-    if out_type not in (DType.float8_e4m3fn,):
-        raise ValueError("out_type must be float8_e4m3fn")
-
-    if not isinstance(input.shape[1], StaticDim):
+    if x.dtype not in [DType.float16, DType.bfloat16, DType.float32]:
         raise ValueError(
-            f"input.shape[1] must be a statically known dimension. Input shape received: {input.shape}"
+            f"expected input dtype to be float16, bfloat16, or float32, but got {x.dtype}"
         )
 
-    if not (input_scale_spec.is_tensor and weight_scale_spec.is_tensor):
-        raise ValueError(
-            "both input and weight must be tensor scaled for tensor scaling"
-        )
+    if x.rank != 2:
+        raise ValueError(f"expected input rank to be 2, but got {x.rank}")
 
-    if group_size_or_per_token != -1:
+    if out_type not in (DType.float8_e4m3fn, DType.float8_e4m3fnuz):
         raise ValueError(
-            "group_size_or_per_token should be -1 for dynamic tensor scaling so group_size == num_cols == input.shape[1]"
+            f"out_type must be float8_e4m3fn or float8_e4m3fnuz, but got {out_type}"
         )
 
     result = ops.custom(
         "mo.quantize_tensor_dynamic_scaled_float8",
-        device=input.device,
-        values=[
-            input,
-            ops.constant(scale_ub, DType.float32, device=DeviceRef.CPU()),
-        ],
+        device=x.device,
+        values=[x],
         out_types=[
-            TensorType(
-                dtype=out_type,
-                shape=[input.shape[0], input.shape[1]],
-                device=input.device,
-            ),
-            TensorType(
-                dtype=scales_type,
-                shape=[1, input.shape[0]],
-                device=input.device,
-            ),
+            TensorType(dtype=out_type, shape=x.shape, device=x.device),
+            TensorType(dtype=DType.float32, shape=[1], device=x.device),
         ],
-        parameters={
-            "group_size_or_per_token": group_size_or_per_token,
-        },
     )
 
     return result[0].tensor, result[1].tensor
@@ -4346,22 +4449,16 @@ def dynamic_scaled_matmul(
         )
 
     if input_scale_spec.is_tensor and weight_scale_spec.is_tensor:
-        if input_scale_spec.origin.is_dynamic:
-            if not (b_scales.shape[0] == b_scales.shape[1] == 1):
-                raise ValueError(
-                    "scaler weight tensors must be of shape [1, 1] for dynamic tensor scaling"
-                )
-        else:
-            if not (
-                a_scales.shape[0]
-                == a_scales.shape[1]
-                == b_scales.shape[0]
-                == b_scales.shape[1]
-                == 1
-            ):
-                raise ValueError(
-                    "scaler tensors must be of shape [1, 1] for tensor scaling"
-                )
+        if not (
+            a_scales.shape[0]
+            == a_scales.shape[1]
+            == b_scales.shape[0]
+            == b_scales.shape[1]
+            == 1
+        ):
+            raise ValueError(
+                "scaler tensors must be of shape [1, 1] for tensor scaling"
+            )
 
     elif input_scale_spec.is_colwise and weight_scale_spec.is_rowwise:
         if a_scales.shape[0] != 1:

--- a/max/python/max/nn/kernels.py
+++ b/max/python/max/nn/kernels.py
@@ -3644,9 +3644,7 @@ def routed_expert_combine_then_rms_norm(
             down_output,
             gamma,
             ops.constant(epsilon, gamma.dtype, device=DeviceRef.CPU()),
-            ops.constant(
-                weight_offset, gamma.dtype, device=DeviceRef.CPU()
-            ),
+            ops.constant(weight_offset, gamma.dtype, device=DeviceRef.CPU()),
         ],
         out_types=[
             TensorType(

--- a/max/python/max/nn/kernels.py
+++ b/max/python/max/nn/kernels.py
@@ -4742,10 +4742,10 @@ def quantize_dynamic_block_scaled_fp4(
     if input.dtype != DType.bfloat16:
         raise ValueError("input tensor dtype must be bfloat16")
 
-    if out_type not in (DType.uint8,):
+    if out_type != DType.uint8:
         raise ValueError("out_type must be uint8 (fp4-e2m1fnX2)")
 
-    if scales_type not in (DType.float8_e4m3fn,):
+    if scales_type != DType.float8_e4m3fn:
         raise ValueError("scales_type must be float8_e4m3fn for NVFP4")
 
     if sf_vector_size != 16:

--- a/max/tests/tests/nn/BUILD.bazel
+++ b/max/tests/tests/nn/BUILD.bazel
@@ -20,7 +20,33 @@ _CPU_TEST_SRCS = glob(
 
 # Tests that need a longer timeout on remote GPU CI.
 _LONG_TIMEOUT_TESTS = [
+    "test_gemma4_decoder_layer_per_expert_scale_gpu.py",
+    "test_gemma4_decoder_layer_rms_norm_gpu.py",
     "test_sampling_gpu.py",
+    "test_gemma4_moe_expected_count_gpu.py",
+    "test_gemma4_moe_indices_gpu.py",
+    "test_gemma4_moe_reorder_gpu.py",
+    "test_gemma4_sampling_gpu.py",
+    "test_gemma4_router_topk_gpu.py",
+    "test_gemma4_router_per_expert_scale_gpu.py",
+    "test_gemma4_router_experts_per_expert_scale_gpu.py",
+    "test_gemma4_router_select_gpu.py",
+    "test_gemma4_moe_grouped_matmul_stats_gpu.py",
+    "test_gemma4_moe_combine_gpu.py",
+    "test_gemma4_moe_module_gpu.py",
+    "test_gemma4_moe_module_expected_count_gpu.py",
+    "test_gemma4_moe_gateup_batched_matmul_gpu.py",
+]
+
+_ARCHITECTURE_TESTS = [
+    "test_gemma4_decoder_layer_per_expert_scale_gpu.py",
+    "test_gemma4_decoder_layer_rms_norm_gpu.py",
+    "test_gemma4_moe_combine.py",
+    "test_gemma4_moe_module_gpu.py",
+    "test_gemma4_moe_module_expected_count_gpu.py",
+    "test_gemma4_rms_norm.py",
+    "test_gemma4_rms_norm_gpu.py",
+    "test_gemma4_router_experts_per_expert_scale_gpu.py",
 ]
 
 [
@@ -34,6 +60,7 @@ _LONG_TIMEOUT_TESTS = [
             src,
         ],
         gpu_constraints = ["//:has_gpu"] if "_gpu.py" in src else [],
+        mojo_deps = ["//max:MOGGKernelAPI"],
         tags = ["no-pydeps"] + (["skip-external-ci"] if src in [
             # FIXME: SDLC-3032
             "test_module.py",
@@ -54,6 +81,27 @@ _LONG_TIMEOUT_TESTS = [
             # pipelines/lib is only needed by the GPU sampling test; keep it
             # out of the default dep list so cpu_tests stays lightweight.
             ["//max/python/max/pipelines/lib"] if src == "test_sampling_gpu.py" else []
+        ) + (
+            ["//max/python/max/pipelines/architectures"] if src in _ARCHITECTURE_TESTS else []
+        ) + (
+            [requirement("torch")] if src in [
+                "test_gemma4_decoder_layer_per_expert_scale_gpu.py",
+                "test_gemma4_decoder_layer_rms_norm_gpu.py",
+                "test_gemma4_moe_expected_count_gpu.py",
+                "test_gemma4_moe_indices_gpu.py",
+                "test_gemma4_moe_reorder_gpu.py",
+                "test_gemma4_rms_norm_gpu.py",
+                "test_gemma4_sampling_gpu.py",
+                "test_gemma4_router_topk_gpu.py",
+                "test_gemma4_router_per_expert_scale_gpu.py",
+                "test_gemma4_router_experts_per_expert_scale_gpu.py",
+                "test_gemma4_router_select_gpu.py",
+                "test_gemma4_moe_grouped_matmul_stats_gpu.py",
+                "test_gemma4_moe_combine_gpu.py",
+                "test_gemma4_moe_module_gpu.py",
+                "test_gemma4_moe_module_expected_count_gpu.py",
+                "test_gemma4_moe_gateup_batched_matmul_gpu.py",
+            ] else []
         ),
     )
     for src in glob(["test_*.py"])


### PR DESCRIPTION
## Summary
- add the routed-expert combine custom-op path and current MoE routing plumbing used by the Gemma 4 decoder benchmark stack
- thread the `expected_count` specialization knob through the MoE routing path and benchmark harness
- keep the current large-vocab top-k and sampling fast paths used by the Gemma 4 decode stack
- update the Python bindings and Gemma 4 test wiring for the new routing, combine, and sampling kernels

## Benchmark Notes
- routed expert combine on the exact static `seq_len=128` Gemma 4 decoder-layer MoE path:
  - historical baseline: `455.78 us`
  - fresh preserved-state rerun: `380.58 us`
  - `75.20 us` saved
  - `+16.50%`
- single-row large-vocab decode (`1x262144`, `top_k=75`):
  - pure top-k: `1817.12 us -> 287.45 us` (`6.32x`, `+84.18%` latency reduction)
  - top-k + top-p: `428.82 us -> 292.87 us` (`1.46x`, `+31.70%` latency reduction)
- note: later round-82/83 sampling follow-ons were exploratory and are not used as the current headline numbers here

## Verification
- `//max/tests/tests/nn:test_gemma4_moe_combine`
- `//max/tests/tests/nn:test_gemma4_decoder_layer_rms_norm_gpu`
  - `--test_env=GEMMA4_DECODER_LAYER_ENABLE_MOE_BLOCK=1`
  - `--test_env=GEMMA4_DECODER_LAYER_GRAPH_SHAPE=static`
  - `--test_env=GEMMA4_DECODER_LAYER_SEQ_LEN=128`
  - `--test_env=GEMMA4_DECODER_LAYER_VARIANT_MODE=auto`
  - `--test_env=GEMMA4_DECODER_LAYER_MOE_ABLATION=none`
- `//max/tests/tests/nn:test_gemma4_sampling_gpu`
  - `--test_env=GEMMA4_SAMPLING_BATCH_SIZES=1`
- `//max/kernels/test/gpu/nn:test_topk_gpu_fi.mojo.test`
- `//max/kernels/test/gpu/nn:test_softmax.mojo.test`
