### PR TITLE
[kernels] Stabilize matmul benchmark cache-busting controls

### DIFF
--- a/max/kernels/benchmarks/gpu/linalg/bench_matmul.mojo
+++ b/max/kernels/benchmarks/gpu/linalg/bench_matmul.mojo
@@ -33,6 +33,7 @@ from internal_utils import (
     CacheBustingBuffer,
     arg_parse,
     pytorch_like_tolerances_for,
+    update_bench_config_args,
 )
 from std.random import rand
 from internal_utils._utils import InitializationType, init_vector_launch
@@ -346,9 +347,15 @@ def bench_matmul[
         return shape[0].value() * shape[1].value()
 
     comptime simd_size = 4
-    var cb_a = CacheBustingBuffer[a_type](get_size(shape_a), simd_size, ctx)
-    var cb_b = CacheBustingBuffer[a_type](get_size(shape_b), simd_size, ctx)
-    var cb_c = CacheBustingBuffer[c_type](get_size(shape_c), simd_size, ctx)
+    var cb_a = CacheBustingBuffer[a_type](
+        get_size(shape_a), simd_size, ctx, enabled=cache_busting
+    )
+    var cb_b = CacheBustingBuffer[a_type](
+        get_size(shape_b), simd_size, ctx, enabled=cache_busting
+    )
+    var cb_c = CacheBustingBuffer[c_type](
+        get_size(shape_c), simd_size, ctx, enabled=cache_busting
+    )
     # TODO: remove init_on_gpu flag and the loading on CPU
     comptime init_on_gpu = True
 
@@ -576,7 +583,7 @@ def main() raises:
         arg_parse("init_type", "uniform_distribution")
     )
     var verify = arg_parse("verify", True) if not c_type.is_float8() else False
-    comptime cache_busting = True
+    comptime cache_busting = get_defined_bool["cache_busting", True]()
     comptime transpose_b = True
     comptime use_vendor_blas = get_defined_bool["use_vendor_blas", False]()
     comptime enable_compute_epilogue = get_defined_bool[
@@ -588,6 +595,7 @@ def main() raises:
     var run_benchmark = arg_parse("run_benchmark", True)
 
     var m = Bench()
+    update_bench_config_args(m)
     with DeviceContext() as ctx:
         create_matmul_bench[
             c_type,


### PR DESCRIPTION
## Summary
- make matmul benchmark cache busting configurable instead of always forcing it on
- thread shared benchmark config arguments into the matmul benchmark harness
- allow matched reruns with and without cache-busting for exact-shape investigations

## Benchmark Notes
- this change does not claim a matmul kernel speedup on its own
- it narrows the benchmark harness so exact-shape reruns can be compared under the same cache-busting configuration
- the intent is measurement stability and reproducibility, not a production kernel behavior change

## Verification
- reviewed against the current exact-shape matmul benchmark workflow on B200
