### PR TITLE
[Kernels] Optimize Gemma 3 rope and fused QK decode paths

### DIFF
--- a/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
@@ -1999,7 +1999,7 @@ comptime _TransposeStrideTypes[
     input_stride_types: Variadic.TypesOfTrait[CoordLike],
 ] = _ReduceVariadicAndIdxToVariadic[
     BaseVal=Variadic.empty_of_trait[CoordLike],
-    VariadicType=Variadic.types[
+    ParamListType=Variadic.types[
         T=CoordLike,
         *Variadic.splat_type[Trait=CoordLike, rank, RuntimeInt[]],
     ],
@@ -2140,7 +2140,7 @@ comptime _SliceStrideTypes[
     step_types: Variadic.TypesOfTrait[CoordLike],
 ] = _ReduceVariadicAndIdxToVariadic[
     BaseVal=Variadic.empty_of_trait[CoordLike],
-    VariadicType=Variadic.types[
+    ParamListType=Variadic.types[
         T=CoordLike,
         *Variadic.splat_type[Trait=CoordLike, rank, RuntimeInt[]],
     ],

--- a/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
+++ b/max/kernels/src/Mogg/MOGGKernelAPI/MOGGKernelAPI.mojo
@@ -89,12 +89,11 @@ from linalg.bmm import (
     elementwise_epilogue_type as batched_matmul_elementwise_epilogue_type,
 )
 from linalg.fp8_quantization import (
-    batched_quantize_dynamic_scaled_fp8,
     convert_e4m3fn_to_e4m3fnuz,
     matmul_dynamic_scaled_fp8,
     quantize_dynamic_scaled_fp8,
     quantize_static_scaled_fp8,
-    quantize_tensor_dynamic_scaled_fp8,
+    batched_quantize_dynamic_scaled_fp8,
 )
 from linalg.fp4_quantization import (
     block_scaled_matmul,
@@ -186,7 +185,6 @@ from nn.kv_cache import (
     print_kv_cache_paged_generic_cpu,
     print_kv_cache_paged_generic_gpu,
     rms_norm_kv_cache_ragged_paged,
-    rms_norm_value_cache_ragged_paged,
 )
 from nn.rope_split_store import rope_split_store_paged_ragged
 from nn.kv_cache_ragged import (
@@ -256,7 +254,13 @@ from nn.resize import (
     resize_nearest_neighbor,
 )
 from nn.roi_align import roi_align_nhwc
-from nn.rope import rope_ragged
+from nn.rope import (
+    _rope_k_cache_ragged,
+    k_rms_norm_rope_ragged,
+    q_rms_norm_rope_ragged,
+    q_rms_norm_fused_qk_rope_ragged,
+    rope_ragged,
+)
 from nn.sampling import apply_penalties_to_logits, update_frequency_data
 from nn.slice import (
     copy_to_slice,
@@ -293,11 +297,11 @@ from quantization.qmatmul_k import (
     matmul_Q6_K,
     matmul_Q6_K_pack_b,
 )
-from std.ffi import external_call
 from std.runtime.asyncrt import (
     DeviceContextPtr,
     DeviceContextPtrList,
     TaskGroup,
+    parallelism_level,
 )
 from std.runtime.tracing import Trace, TraceLevel, get_safe_task_id, trace_arg
 from tensor import (
@@ -1995,7 +1999,7 @@ comptime _TransposeStrideTypes[
     input_stride_types: Variadic.TypesOfTrait[CoordLike],
 ] = _ReduceVariadicAndIdxToVariadic[
     BaseVal=Variadic.empty_of_trait[CoordLike],
-    ParamListType=Variadic.types[
+    VariadicType=Variadic.types[
         T=CoordLike,
         *Variadic.splat_type[Trait=CoordLike, rank, RuntimeInt[]],
     ],
@@ -2136,7 +2140,7 @@ comptime _SliceStrideTypes[
     step_types: Variadic.TypesOfTrait[CoordLike],
 ] = _ReduceVariadicAndIdxToVariadic[
     BaseVal=Variadic.empty_of_trait[CoordLike],
-    ParamListType=Variadic.types[
+    VariadicType=Variadic.types[
         T=CoordLike,
         *Variadic.splat_type[Trait=CoordLike, rank, RuntimeInt[]],
     ],
@@ -6329,6 +6333,7 @@ struct Struct_fused_qkv_matmul_padded_paged:
         valid_lengths: InputTensor[dtype=DType.uint32, rank=1, ...],
         ctx: DeviceContextPtr,
     ) raises:
+        comptime assert not is_cpu[target](), "Only the GPU path is implemented"
         var kv_collection = generic_get_paged_cache(
             kv_blocks,
             cache_lengths,
@@ -6868,7 +6873,7 @@ struct Struct_fused_qk_rope_ragged_paged[interleaved: Bool]:
     ) raises:
         # Dummy position_ids - won't be used since has_position_ids=False
         var dummy_position_ids = DynamicTensor[dtype=DType.uint32, rank=2, ...](
-            {_unsafe_null = ()}, IndexList[2](0)
+            {}, IndexList[2](0)
         )
         var kv_collection = generic_get_paged_cache(
             kv_blocks,
@@ -6929,6 +6934,207 @@ struct Struct_fused_qk_rope_padded_paged[interleaved: Bool]:
             valid_lengths.to_tile_tensor[DType.int64](),
             output.to_tile_tensor[DType.int64](),
             context,
+        )
+
+
+# ===-----------------------------------------------------------------------===#
+# K-Only RoPE Ragged
+#
+# Expected kernel name format:
+# mo.rope_k_cache.ragged.paged
+# ===-----------------------------------------------------------------------===#
+
+
+@compiler.register("mo.rope_k_cache.ragged.paged")
+struct Struct_rope_k_cache_ragged_paged[interleaved: Bool]:
+    @always_inline
+    @staticmethod
+    def execute[
+        freq_dtype: DType,
+        cache_dtype: DType,
+        //,
+        target: StaticString,
+    ](
+        kv_blocks: MutableInputTensor[dtype=cache_dtype, rank=6, ...],
+        cache_lengths: InputTensor[dtype=DType.uint32, rank=1, ...],
+        kv_lookup_table: InputTensor[dtype=DType.uint32, rank=2, ...],
+        max_lengths: InputTensor[dtype=DType.uint32, rank=2, ...],
+        freqs_cis: InputTensor[dtype=freq_dtype, rank=2, ...],
+        layer_idx: UInt32,
+        total_seq_len: UInt32,
+        input_row_offsets: InputTensor[dtype=DType.uint32, rank=1, ...],
+        ctx: DeviceContextPtr,
+    ) raises:
+        var kv_collection = generic_get_paged_cache(
+            kv_blocks,
+            cache_lengths,
+            kv_lookup_table,
+            max_lengths,
+        )
+        _rope_k_cache_ragged[
+            target=target,
+            interleaved=Self.interleaved,
+        ](
+            Int(total_seq_len),
+            input_row_offsets.to_tile_tensor[DType.int64](),
+            kv_collection,
+            freqs_cis.to_tile_tensor[DType.int64](),
+            layer_idx,
+            ctx.get_device_context(),
+        )
+
+
+# ===-----------------------------------------------------------------------===#
+# K-Only Gemma RMSNorm + RoPE Ragged
+#
+# Expected kernel name format:
+# mo.k_rms_norm_rope.ragged.paged
+# ===-----------------------------------------------------------------------===#
+
+
+@compiler.register("mo.k_rms_norm_rope.ragged.paged")
+struct Struct_k_rms_norm_rope_ragged_paged[interleaved: Bool]:
+    @always_inline
+    @staticmethod
+    def execute[
+        dtype: DType,
+        freq_dtype: DType,
+        cache_dtype: DType,
+        //,
+        target: StaticString,
+    ](
+        kv_blocks: MutableInputTensor[dtype=cache_dtype, rank=6, ...],
+        cache_lengths: InputTensor[dtype=DType.uint32, rank=1, ...],
+        kv_lookup_table: InputTensor[dtype=DType.uint32, rank=2, ...],
+        max_lengths: InputTensor[dtype=DType.uint32, rank=2, ...],
+        freqs_cis: InputTensor[dtype=freq_dtype, rank=2, ...],
+        gamma: InputTensor[dtype=dtype, rank=1, ...],
+        epsilon: Scalar[dtype],
+        layer_idx: UInt32,
+        total_seq_len: UInt32,
+        input_row_offsets: InputTensor[dtype=DType.uint32, rank=1, ...],
+        weight_offset: Scalar[dtype],
+        ctx: DeviceContextPtr,
+    ) raises:
+        var kv_collection = generic_get_paged_cache(
+            kv_blocks,
+            cache_lengths,
+            kv_lookup_table,
+            max_lengths,
+        )
+        k_rms_norm_rope_ragged[
+            target=target,
+            interleaved=Self.interleaved,
+        ](
+            Int(total_seq_len),
+            input_row_offsets.to_tile_tensor[DType.int64](),
+            kv_collection,
+            freqs_cis.to_tile_tensor[DType.int64](),
+            gamma.to_tile_tensor[DType.int64](),
+            epsilon,
+            weight_offset,
+            layer_idx,
+            ctx.get_device_context(),
+        )
+
+
+# ===-----------------------------------------------------------------------===#
+# Q-Only Gemma RMSNorm + RoPE Ragged
+#
+# Expected kernel name format:
+# mo.q_rms_norm_rope.ragged
+# ===-----------------------------------------------------------------------===#
+
+
+@compiler.register("mo.q_rms_norm_rope.ragged")
+struct Struct_q_rms_norm_rope_ragged:
+    @always_inline
+    @staticmethod
+    def execute[
+        dtype: DType,
+        freq_dtype: DType,
+        //,
+        target: StaticString,
+    ](
+        output: FusedOutputTensor[dtype=dtype, rank=3, ...],
+        x: InputTensor[dtype=dtype, rank=3, ...],
+        input_row_offsets: InputTensor[dtype=DType.uint32, rank=1, ...],
+        start_pos: InputTensor[dtype=DType.uint32, rank=1, ...],
+        freqs_cis: InputTensor[dtype=freq_dtype, rank=2, ...],
+        gamma: InputTensor[dtype=dtype, rank=1, ...],
+        epsilon: Scalar[dtype],
+        weight_offset: Scalar[dtype],
+        ctx: DeviceContextPtr,
+    ) raises:
+        q_rms_norm_rope_ragged[target=target](
+            x.to_tile_tensor[DType.int64](),
+            input_row_offsets.to_tile_tensor[DType.int64](),
+            start_pos.to_tile_tensor[DType.int64](),
+            freqs_cis.to_tile_tensor[DType.int64](),
+            gamma.to_tile_tensor[DType.int64](),
+            epsilon,
+            weight_offset,
+            output.to_tile_tensor[DType.int64](),
+            ctx.get_device_context(),
+        )
+
+
+# ===-----------------------------------------------------------------------===#
+# Fused Gemma Query RMSNorm + QK RoPE Ragged
+#
+# Expected kernel name format:
+# mo.q_rms_norm_fused_qk_rope.ragged.paged
+# ===-----------------------------------------------------------------------===#
+
+
+@compiler.register("mo.q_rms_norm_fused_qk_rope.ragged.paged")
+struct Struct_q_rms_norm_fused_qk_rope_ragged_paged[interleaved: Bool]:
+    @always_inline
+    @staticmethod
+    def execute[
+        dtype: DType,
+        freq_dtype: DType,
+        cache_dtype: DType,
+        //,
+        target: StaticString,
+    ](
+        output: OutputTensor[dtype=dtype, rank=3, ...],
+        x: InputTensor[dtype=dtype, rank=3, ...],
+        input_row_offsets: InputTensor[dtype=DType.uint32, rank=1, ...],
+        kv_blocks: MutableInputTensor[dtype=cache_dtype, rank=6, ...],
+        cache_lengths: InputTensor[dtype=DType.uint32, rank=1, ...],
+        kv_lookup_table: InputTensor[dtype=DType.uint32, rank=2, ...],
+        max_lengths: InputTensor[dtype=DType.uint32, rank=2, ...],
+        freqs_cis: InputTensor[dtype=freq_dtype, rank=2, ...],
+        q_gamma: InputTensor[dtype=dtype, rank=1, ...],
+        k_gamma: InputTensor[dtype=dtype, rank=1, ...],
+        epsilon: Scalar[dtype],
+        layer_idx: UInt32,
+        weight_offset: Scalar[dtype],
+        ctx: DeviceContextPtr,
+    ) raises:
+        var kv_collection = generic_get_paged_cache(
+            kv_blocks,
+            cache_lengths,
+            kv_lookup_table,
+            max_lengths,
+        )
+        q_rms_norm_fused_qk_rope_ragged[
+            target=target,
+            interleaved=Self.interleaved,
+        ](
+            x.to_tile_tensor[DType.int64](),
+            input_row_offsets.to_tile_tensor[DType.int64](),
+            cache_lengths.to_tile_tensor[DType.int64](),
+            kv_collection,
+            freqs_cis.to_tile_tensor[DType.int64](),
+            q_gamma.to_tile_tensor[DType.int64](),
+            k_gamma.to_tile_tensor[DType.int64](),
+            epsilon,
+            weight_offset,
+            layer_idx,
+            output.to_tile_tensor[DType.int64](),
+            ctx.get_device_context(),
         )
 
 
@@ -9456,52 +9662,6 @@ struct Struct_rms_norm_kv_cache_ragged_paged:
         )
 
 
-@compiler.register("mo.rms_norm_value_cache.ragged.paged")
-struct Struct_rms_norm_value_cache_ragged_paged:
-    @always_inline
-    @staticmethod
-    def execute[
-        dtype: DType,
-        multiply_before_cast: Bool,
-        per_head_norm: Bool,
-        cache_dtype: DType,
-        //,
-        target: StaticString,
-    ](
-        kv_blocks: MutableInputTensor[dtype=cache_dtype, rank=6, ...],
-        cache_lengths: InputTensor[dtype=DType.uint32, rank=1, ...],
-        kv_lookup_table: InputTensor[dtype=DType.uint32, rank=2, ...],
-        max_lengths: InputTensor[dtype=DType.uint32, rank=2, ...],
-        gamma: InputTensor[dtype=dtype, rank=1, ...],
-        epsilon: Scalar[dtype],
-        layer_idx: UInt32,
-        total_seq_len: UInt32,
-        input_row_offsets: InputTensor[dtype=DType.uint32, rank=1, ...],
-        weight_offset: Scalar[dtype=dtype],
-        context: DeviceContextPtr,
-    ) raises:
-        var kv_collection = generic_get_paged_cache(
-            kv_blocks,
-            cache_lengths,
-            kv_lookup_table,
-            max_lengths,
-        )
-        rms_norm_value_cache_ragged_paged[
-            target=target,
-            multiply_before_cast=multiply_before_cast,
-            per_head_norm=per_head_norm,
-        ](
-            kv_collection,
-            gamma.to_tile_tensor[DType.int64](),
-            epsilon,
-            weight_offset,
-            layer_idx,
-            total_seq_len,
-            input_row_offsets.to_tile_tensor[DType.int64](),
-            context,
-        )
-
-
 # ===-----------------------------------------------------------------------===#
 # Print KV Cache
 #
@@ -9952,18 +10112,12 @@ def _check_signal_buffer_size(
 
 
 @always_inline("nodebug")
-def task_id_for_device(device_id: Int) -> Int:
-    """Map from device ID to task ID for CPU affinity.
-
-    Delegates to the shared C++ implementation in DeviceAffinity.cpp which
-    handles explicit MODULAR_RUNTIME_DEVICE_TASK_CPU_IDS config,
-    NUMA-inferred GPU-to-CPU core mapping, and round-robin fallback.
-    """
-    return Int(
-        external_call["KGEN_CompilerRT_TaskIdForDevice", Int32](
-            Int32(device_id),
-        )
-    )
+def task_id_for_device(device_id: Int, num_workers: Int) -> Int:
+    # Map from device ID to task ID for CPU affinity.
+    # Note: Keep in sync with taskIdForDevice() in MGPPrimitives.cpp
+    if num_workers <= 1:
+        return -1
+    return 1 + (device_id % (num_workers - 1))
 
 
 @always_inline
@@ -9994,9 +10148,10 @@ def _launch_device_collective[
 
     # Set up a task group to launch the tasks in parallel.
     var tg = TaskGroup()
+    var num_workers = parallelism_level()
     comptime for i in range(num_devices):
         # Dispatch to the worker thread that has affinity for this device.
-        var worker_id = task_id_for_device(Int(dev_ctxs[i].id()))
+        var worker_id = task_id_for_device(Int(dev_ctxs[i].id()), num_workers)
         tg._create_task(wrapper[i](), desired_worker_id=worker_id)
 
     # Wait for all tasks to complete.
@@ -10071,7 +10226,7 @@ struct DistributedAllReduceSum:
         # Marshal signal buffers into the expected format.
         var rank_sigs = InlineArray[
             UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-        ](fill={_unsafe_null = ()})
+        ](fill={})
         comptime for i in range(num_devices):
             rank_sigs[i] = signal_buffers[i]._ptr.bitcast[Signal]()
 
@@ -10203,7 +10358,7 @@ struct BundledAllReduceSum:
         var out_buf = output.to_tile_tensor[DType.int64]()
         var rank_sigs = InlineArray[
             UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-        ](fill={_unsafe_null = ()})
+        ](fill={})
 
         comptime for i in range(num_devices):
             in_tensors[i] = rebind[InputTensorType](
@@ -10290,7 +10445,7 @@ struct DistributedReduceScatterSum:
         # Marshal signal buffers.
         var rank_sigs = InlineArray[
             UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-        ](fill={_unsafe_null = ()})
+        ](fill={})
 
         comptime for i in range(num_devices):
             rank_sigs[i] = signal_buffers[i]._ptr.bitcast[Signal]()
@@ -10404,7 +10559,7 @@ struct DistributedAllGather:
         # Marshal signal buffers.
         var rank_sigs = InlineArray[
             UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-        ](fill={_unsafe_null = ()})
+        ](fill={})
 
         comptime for i in range(num_devices):
             in_tensors[i] = TileTensor(
@@ -10515,7 +10670,7 @@ struct DistributedBroadcast:
 
         var rank_sigs = InlineArray[
             UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-        ](fill={_unsafe_null = ()})
+        ](fill={})
 
         comptime for i in range(signal_buffers.size):
             rank_sigs[i] = signal_buffers[i]._ptr.bitcast[Signal]()
@@ -10599,7 +10754,7 @@ struct DistributedScatter:
         var in_tensors = InlineArray[InputTensorType, ngpus](uninitialized=True)
         var rank_sigs = InlineArray[
             UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-        ](fill={_unsafe_null = ()})
+        ](fill={})
 
         comptime for i in range(ngpus):
             in_tensors[i] = rebind[InputTensorType](
@@ -10690,7 +10845,7 @@ struct DistributedAllReduceAddRMSNormQuantFP8:
         # Marshal signal buffers.
         var rank_sigs = InlineArray[
             UnsafePointer[Signal, MutAnyOrigin], MAX_GPUS
-        ](fill={_unsafe_null = ()})
+        ](fill={})
 
         comptime for i in range(inputs.size):
             in_tensors[i] = rebind[InputTensorType](
@@ -11054,51 +11209,6 @@ struct QuantizeStaticScaledFloat8[*, scale_is_inverted: Bool]:
         )
 
 
-@compiler.register("mo.quantize_tensor_dynamic_scaled_float8")
-struct QuantizeTensorDynamicScaledFloat8:
-    @always_inline
-    @staticmethod
-    def execute[
-        input_type: DType,
-        scales_type: DType,
-        output_type: DType,
-        //,
-        group_size_or_per_token: Int,
-        target: StaticString,
-    ](
-        output: OutputTensor[dtype=output_type, rank=2, ...],
-        scales: OutputTensor[dtype=scales_type, rank=2, ...],
-        input: FusedInputTensor[dtype=input_type, rank=2, ...],
-        scale_ub: Float32,
-        ctx: DeviceContextPtr,
-    ) raises:
-        comptime assert is_gpu[target](), "only valid on GPUs"
-
-        @parameter
-        @always_inline
-        def input_fn[
-            width: Int, alignment: Int
-        ](row: Int, col: Int) capturing -> SIMD[input_type, width]:
-            return input._lambda_load[width=width, element_alignment=alignment](
-                Index(row, col)
-            )
-
-        quantize_tensor_dynamic_scaled_fp8[
-            out_dtype=output_type,
-            in_dtype=input_type,
-            scales_dtype=scales_type,
-            input_fn,
-            group_size_or_per_token,
-            num_cols=Int(input.static_spec.shape_tuple[1]),
-        ](
-            output.to_tile_tensor[DType.int64](),
-            scales.to_tile_tensor[DType.int64](),
-            scale_ub,
-            ctx.get_device_context(),
-            num_rows=input.dim_size(0),
-        )
-
-
 @compiler.register("mo.quantize_dynamic_scaled_float8")
 struct QuantizeDynamicScaledFloat8:
     @parameter
@@ -11273,7 +11383,7 @@ struct MatmulStaticScaledFloat8:
         comptime N = type_of(weight_tt).static_shape[0]
         var M = Int(input_tt.dim[0]())
         var output_dummy = TileTensor(
-            UnsafePointer[Scalar[DType.float32], MutAnyOrigin](_unsafe_null=()),
+            UnsafePointer[Scalar[DType.float32], MutAnyOrigin](),
             row_major(Coord(RuntimeInt[DType.int64](Int64(M)), Idx[N]())),
         )
 

--- a/max/kernels/src/nn/fused_qk_rope.mojo
+++ b/max/kernels/src/nn/fused_qk_rope.mojo
@@ -12,12 +12,18 @@
 # ===----------------------------------------------------------------------=== #
 
 from std.collections import OptionalReg
-from std.math import gcd
+from std.math import ceildiv, gcd
 from std.sys.info import _current_target, align_of, simd_width_of
 
 from std.algorithm.functional import elementwise
 from std.utils.numerics import get_accum_type
 from std.complex import ComplexSIMD
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    WARP_SIZE,
+    block_idx_uint as block_idx,
+    thread_idx_uint as thread_idx,
+)
 from std.gpu.host import DeviceContext, get_gpu_target
 from std.gpu.host.info import is_cpu
 from kv_cache.types import KVCacheT, KVCollectionT
@@ -33,6 +39,28 @@ from layout import (
 from nn._ragged_utils import get_batch_from_row_offsets
 
 from std.utils import IndexList
+from std.utils.static_tuple import StaticTuple
+
+
+
+@always_inline
+def _rope_complex_mul_half[
+    dtype: DType,
+    freq_dtype: DType,
+    width_2: Int,
+    freq_width: Int,
+](
+    x_re: SIMD[dtype, width_2],
+    x_im: SIMD[dtype, width_2],
+    freq: SIMD[freq_dtype, freq_width],
+) -> Tuple[SIMD[dtype, width_2], SIMD[dtype, width_2]]:
+    var f_re = rebind[SIMD[freq_dtype, width_2]](freq.deinterleave()[0])
+    var f_im = rebind[SIMD[freq_dtype, width_2]](freq.deinterleave()[1])
+    var xr = x_re.cast[freq_dtype]()
+    var xi = x_im.cast[freq_dtype]()
+    var res_re = (xr * f_re - xi * f_im).cast[dtype]()
+    var res_im = (xr * f_im + xi * f_re).cast[dtype]()
+    return (res_re, res_im)
 
 
 @always_inline
@@ -105,23 +133,14 @@ def rope_q_proj[
 
     comptime if interleaved:
         val = q_proj.load[width=width, alignment=alignment](coord)
-    else:
-        val = rebind[SIMD[dtype, width]](
-            q_proj.load[width=width_2, alignment=half_alignment](
-                coord_re
-            ).interleave(
-                q_proj.load[width=width_2, alignment=half_alignment](coord_im)
-            )
-        )
-
-    var res = rope_value(val, freq_val).cast[output_dtype]()
-
-    comptime if interleaved:
+        var res = rope_value(val, freq_val).cast[output_dtype]()
         output.store[alignment=alignment](coord, res)
     else:
-        output_re, output_im = res.deinterleave()
-        output.store[alignment=half_alignment](coord_re, output_re)
-        output.store[alignment=half_alignment](coord_im, output_im)
+        var q_re = q_proj.load[width=width_2, alignment=half_alignment](coord_re)
+        var q_im = q_proj.load[width=width_2, alignment=half_alignment](coord_im)
+        var q_result = _rope_complex_mul_half(q_re, q_im, freq_val)
+        output.store[alignment=half_alignment](coord_re, q_result[0].cast[output_dtype]())
+        output.store[alignment=half_alignment](coord_im, q_result[1].cast[output_dtype]())
 
 
 @always_inline
@@ -148,25 +167,14 @@ def rope_k_cache[
         val = k_cache.load[width=width](b_idx, h_idx, s_idx, d_idx).cast[
             accum_type
         ]()
-    else:
-        val = rebind[SIMD[accum_type, width]](
-            k_cache.load[width=width_2](b_idx, h_idx, s_idx, h_re)
-            .cast[accum_type]()
-            .interleave(
-                k_cache.load[width=width_2](b_idx, h_idx, s_idx, h_im).cast[
-                    accum_type
-                ]()
-            )
-        )
-
-    var res = rope_value(val, freq_val).cast[cache_type]()
-
-    comptime if interleaved:
+        var res = rope_value(val, freq_val).cast[cache_type]()
         k_cache.store(b_idx, h_idx, s_idx, d_idx, res)
     else:
-        output_re, output_im = res.deinterleave()
-        k_cache.store(b_idx, h_idx, s_idx, h_re, output_re)
-        k_cache.store(b_idx, h_idx, s_idx, h_im, output_im)
+        var k_re = k_cache.load[width=width_2](b_idx, h_idx, s_idx, h_re).cast[accum_type]()
+        var k_im = k_cache.load[width=width_2](b_idx, h_idx, s_idx, h_im).cast[accum_type]()
+        var k_result = _rope_complex_mul_half(k_re, k_im, freq_val)
+        k_cache.store(b_idx, h_idx, s_idx, h_re, k_result[0].cast[cache_type]())
+        k_cache.store(b_idx, h_idx, s_idx, h_im, k_result[1].cast[cache_type]())
 
 
 @always_inline
@@ -292,6 +300,115 @@ def fused_qk_rope[
         )
 
 
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _fused_qk_rope_decode_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    q_proj: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    total_rows: Int,
+):
+    comptime assert q_proj.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert freqs_cis.flat_rank == 2
+
+    comptime cache_dtype = KCacheType.dtype
+    comptime num_q_heads = Int(q_proj.static_shape[1])
+    comptime num_k_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(q_proj.static_shape[2])
+    comptime assert head_dim == 128, "Only 128-column BF16 rows are supported"
+    comptime assert head_dim == Int(KCacheType.kv_params.head_size)
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime vec_width = simd_width // 2
+    comptime half_align = align_of[SIMD[dtype, vec_width]]()
+    comptime accum_type = get_accum_type[cache_dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime total_heads = num_q_heads + num_k_heads
+    comptime assert head_dim == half_warp_size * simd_width
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // total_heads
+        var head_idx = flat_row % total_heads
+        var batch_idx = global_token_idx
+        var post_seq_idx = Int(k_cache.cache_length(batch_idx))
+        var re_offset = Int(local_tid) * vec_width
+        var im_offset = re_offset + head_dim // 2
+        var freq_offset = Int(local_tid) * simd_width
+        var freq = freqs_cis.load[width=simd_width, alignment=1](
+            Coord(Idx(post_seq_idx), Idx(freq_offset))
+        )
+
+        if head_idx < num_q_heads:
+            var q_re = q_proj.load[width=vec_width, alignment=half_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset))
+            )
+            var q_im = q_proj.load[width=vec_width, alignment=half_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset))
+            )
+            var q_rope = _rope_complex_mul_half[
+                dtype,
+                freq_dtype,
+                vec_width,
+                simd_width,
+            ](q_re, q_im, freq)
+            output.store[alignment=half_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset)),
+                q_rope[0],
+            )
+            output.store[alignment=half_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset)),
+                q_rope[1],
+            )
+        else:
+            var k_head_idx = head_idx - num_q_heads
+            var k_re = k_cache.load[width=vec_width](
+                batch_idx, k_head_idx, post_seq_idx, re_offset
+            ).cast[accum_type]()
+            var k_im = k_cache.load[width=vec_width](
+                batch_idx, k_head_idx, post_seq_idx, im_offset
+            ).cast[accum_type]()
+            var k_rope = _rope_complex_mul_half[
+                accum_type,
+                freq_dtype,
+                vec_width,
+                simd_width,
+            ](k_re, k_im, freq)
+            k_cache.store(
+                batch_idx,
+                k_head_idx,
+                post_seq_idx,
+                re_offset,
+                k_rope[0].cast[cache_dtype](),
+            )
+            k_cache.store(
+                batch_idx,
+                k_head_idx,
+                post_seq_idx,
+                im_offset,
+                k_rope[1].cast[cache_dtype](),
+            )
+
+
 @always_inline
 def fused_qk_rope_ragged[
     dtype: DType,
@@ -302,6 +419,7 @@ def fused_qk_rope_ragged[
     *,
     interleaved: Bool,
     target: StaticString,
+    allow_decode_fastpath: Bool = True,
     mrope_types: Variadic.TypesOfTrait[CoordLike] = Variadic.empty_of_trait[
         CoordLike
     ],
@@ -366,6 +484,42 @@ def fused_qk_rope_ragged[
     )
 
     var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+    var total_tokens = Int(q_proj.dim(0))
+    var total_rows = total_tokens * (num_q_heads + Int(num_k_heads))
+
+    comptime if (
+        allow_decode_fastpath
+        and not interleaved
+        and dtype == DType.bfloat16
+        and cache_t.dtype == DType.bfloat16
+        and q_head_size == 128
+        and Int(k_head_size) == 128
+        and rope_dim == 128
+    ):
+        var is_decode_uniform = total_tokens == Int(batch_size)
+        if is_decode_uniform and not position_ids:
+            comptime block_size = 64
+            comptime warps_per_block = 2
+            comptime kernel = _fused_qk_rope_decode_ragged_kernel[
+                dtype,
+                freq_dtype,
+                cache_t,
+                q_proj.LayoutType,
+                output.LayoutType,
+                freqs_cis.LayoutType,
+                block_size,
+                warps_per_block,
+            ]
+            context.value().enqueue_function[kernel, kernel](
+                q_proj,
+                output,
+                k_cache,
+                freqs_cis,
+                total_rows,
+                grid_dim=ceildiv(total_rows, warps_per_block * 2),
+                block_dim=block_size,
+            )
+            return
 
     @always_inline
     @parameter

--- a/max/kernels/src/nn/fused_qk_rope.mojo
+++ b/max/kernels/src/nn/fused_qk_rope.mojo
@@ -42,7 +42,6 @@ from std.utils import IndexList
 from std.utils.static_tuple import StaticTuple
 
 
-
 @always_inline
 def _rope_complex_mul_half[
     dtype: DType,
@@ -136,11 +135,19 @@ def rope_q_proj[
         var res = rope_value(val, freq_val).cast[output_dtype]()
         output.store[alignment=alignment](coord, res)
     else:
-        var q_re = q_proj.load[width=width_2, alignment=half_alignment](coord_re)
-        var q_im = q_proj.load[width=width_2, alignment=half_alignment](coord_im)
+        var q_re = q_proj.load[width=width_2, alignment=half_alignment](
+            coord_re
+        )
+        var q_im = q_proj.load[width=width_2, alignment=half_alignment](
+            coord_im
+        )
         var q_result = _rope_complex_mul_half(q_re, q_im, freq_val)
-        output.store[alignment=half_alignment](coord_re, q_result[0].cast[output_dtype]())
-        output.store[alignment=half_alignment](coord_im, q_result[1].cast[output_dtype]())
+        output.store[alignment=half_alignment](
+            coord_re, q_result[0].cast[output_dtype]()
+        )
+        output.store[alignment=half_alignment](
+            coord_im, q_result[1].cast[output_dtype]()
+        )
 
 
 @always_inline
@@ -170,8 +177,12 @@ def rope_k_cache[
         var res = rope_value(val, freq_val).cast[cache_type]()
         k_cache.store(b_idx, h_idx, s_idx, d_idx, res)
     else:
-        var k_re = k_cache.load[width=width_2](b_idx, h_idx, s_idx, h_re).cast[accum_type]()
-        var k_im = k_cache.load[width=width_2](b_idx, h_idx, s_idx, h_im).cast[accum_type]()
+        var k_re = k_cache.load[width=width_2](b_idx, h_idx, s_idx, h_re).cast[
+            accum_type
+        ]()
+        var k_im = k_cache.load[width=width_2](b_idx, h_idx, s_idx, h_im).cast[
+            accum_type
+        ]()
         var k_result = _rope_complex_mul_half(k_re, k_im, freq_val)
         k_cache.store(b_idx, h_idx, s_idx, h_re, k_result[0].cast[cache_type]())
         k_cache.store(b_idx, h_idx, s_idx, h_im, k_result[1].cast[cache_type]())
@@ -343,7 +354,9 @@ def _fused_qk_rope_decode_ragged_kernel[
     var warp_idx = tid // UInt(WARP_SIZE)
     var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
     var local_tid = tid % UInt(half_warp_size)
-    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var row = (
+        block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    )
 
     if row < UInt(total_rows):
         var flat_row = Int(row)

--- a/max/kernels/src/nn/kv_cache.mojo
+++ b/max/kernels/src/nn/kv_cache.mojo
@@ -950,9 +950,9 @@ def _rms_norm_kv_cache_ragged_paged_decode_uniform_direct[
     @always_inline
     @parameter
     @__copy_capture(k_cache)
-    def direct_input_fn_2d[width: Int](
-        row: Int, col: Int
-    ) -> SIMD[dtype, width]:
+    def direct_input_fn_2d[
+        width: Int
+    ](row: Int, col: Int) -> SIMD[dtype, width]:
         var batch_idx = row // Int(params.num_heads)
         var head_idx = row % Int(params.num_heads)
         var cache_token_idx = Int(k_cache.cache_length(batch_idx))
@@ -966,9 +966,9 @@ def _rms_norm_kv_cache_ragged_paged_decode_uniform_direct[
     @always_inline
     @parameter
     @__copy_capture(k_cache)
-    def direct_output_fn_2d[width: Int, alignment: Int](
-        row: Int, col: Int, val: SIMD[dtype, width]
-    ) -> None:
+    def direct_output_fn_2d[
+        width: Int, alignment: Int
+    ](row: Int, col: Int, val: SIMD[dtype, width]) -> None:
         var batch_idx = row // Int(params.num_heads)
         var head_idx = row % Int(params.num_heads)
         var cache_token_idx = Int(k_cache.cache_length(batch_idx))
@@ -1261,9 +1261,8 @@ def rms_norm_kv_cache_ragged_paged[
     )
 
     comptime if use_no_trace_decode_uniform_fastpath:
-        if (
-            kv_collection.max_seq_length == 1
-            and total_seq_len == UInt32(batch_size)
+        if kv_collection.max_seq_length == 1 and total_seq_len == UInt32(
+            batch_size
         ):
             _rms_norm_kv_cache_ragged_paged_no_trace[
                 dtype=dtype,

--- a/max/kernels/src/nn/kv_cache.mojo
+++ b/max/kernels/src/nn/kv_cache.mojo
@@ -12,8 +12,11 @@
 # ===----------------------------------------------------------------------=== #
 
 from std.algorithm.functional import unswitch
+from std.math import ceildiv
+from std.gpu import WARP_SIZE
 from std.gpu.host import DeviceContext, DeviceBuffer
 from std.gpu.host.info import is_cpu, is_gpu
+from std.gpu.primitives.grid_controls import PDLLevel, pdl_launch_attributes
 from std.collections import OptionalReg
 from kv_cache.types import (
     ContinuousBatchingKVCacheCollection,
@@ -43,7 +46,7 @@ from nn.attention.mha_utils import (
     dispatch_mask,
     dispatch_materialized_mask,
 )
-from nn.normalization import _rms_norm_impl
+from nn.normalization import _rms_norm_impl, rms_norm_gpu_warp_tiling_128
 from std.runtime.asyncrt import DeviceContextPtr
 from std.runtime.tracing import Trace, TraceLevel, get_safe_task_id, trace_arg
 
@@ -420,7 +423,7 @@ def _matmul_common[
         )
     else:
         c_nd = LayoutTensor[dtype, c_layout, MutAnyOrigin](
-            UnsafePointer[Scalar[dtype], MutExternalOrigin](_unsafe_null=()),
+            UnsafePointer[Scalar[dtype], MutExternalOrigin](),
             RuntimeLayout[c_layout].row_major(IndexList[2](BS * SEQ_LEN, N)),
         )
 
@@ -901,7 +904,128 @@ def _flash_attention_dispatch_materialized_mask[
 # ===-----------------------------------------------------------------------===#
 
 
-def rms_norm_kv_cache_ragged_paged[
+@always_inline
+def _rms_norm_kv_cache_ragged_paged_decode_uniform_direct[
+    dtype: DType,
+    params: KVCacheStaticParams,
+    page_size: Int,
+    cache_dtype: DType,
+    //,
+    target: StaticString,
+    multiply_before_cast: Bool,
+](
+    kv_collection: PagedKVCacheCollection[
+        cache_dtype,
+        params,
+        page_size,
+    ],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    total_seq_len: UInt32,
+    context: DeviceContextPtr,
+) raises:
+    comptime assert is_gpu[target](), "decode-uniform direct path is GPU-only"
+    comptime assert dtype == DType.bfloat16
+    comptime assert cache_dtype == DType.bfloat16
+    comptime assert gamma.static_shape[0] == 128
+    comptime assert Int(params.head_size) == 128
+    comptime assert page_size == 128
+
+    var ctx = context.get_device_context()
+    var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+    var num_rows = Int(total_seq_len) * Int(params.num_heads)
+    comptime simd_width = 8
+    comptime default_warps_per_block = 2
+    comptime large_row_warps_per_block = 8
+    comptime default_block_size = default_warps_per_block * WARP_SIZE
+    comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
+    comptime min_large_row_blocks_per_sm = 5
+    var min_large_row_blocks = (
+        ctx.default_device_info.sm_count * min_large_row_blocks_per_sm
+    )
+    var large_row_grid_dim = ceildiv(num_rows, large_row_warps_per_block * 2)
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache)
+    def direct_input_fn_2d[width: Int](
+        row: Int, col: Int
+    ) -> SIMD[dtype, width]:
+        var batch_idx = row // Int(params.num_heads)
+        var head_idx = row % Int(params.num_heads)
+        var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+        return k_cache.load[width=width](
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=head_idx,
+            head_dim_idx=col,
+        ).cast[dtype]()
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache)
+    def direct_output_fn_2d[width: Int, alignment: Int](
+        row: Int, col: Int, val: SIMD[dtype, width]
+    ) -> None:
+        var batch_idx = row // Int(params.num_heads)
+        var head_idx = row % Int(params.num_heads)
+        var cache_token_idx = Int(k_cache.cache_length(batch_idx))
+        k_cache.store(
+            bs=batch_idx,
+            tok_idx=cache_token_idx,
+            head_idx=head_idx,
+            head_dim_idx=col,
+            val=val.cast[cache_dtype](),
+        )
+
+    if large_row_grid_dim >= min_large_row_blocks:
+        comptime kernel = rms_norm_gpu_warp_tiling_128[
+            mut=gamma.mut,
+            LayoutType=gamma.LayoutType,
+            origin=gamma.origin,
+            simd_width,
+            large_row_warps_per_block,
+            direct_input_fn_2d,
+            direct_output_fn_2d,
+            multiply_before_cast=multiply_before_cast,
+        ]
+        ctx.enqueue_function[kernel, kernel](
+            gamma,
+            epsilon,
+            weight_offset,
+            num_rows,
+            gamma.static_shape[0],
+            grid_dim=large_row_grid_dim,
+            block_dim=large_row_block_size,
+            attributes=pdl_launch_attributes(PDLLevel(1)),
+        )
+    else:
+        comptime kernel = rms_norm_gpu_warp_tiling_128[
+            mut=gamma.mut,
+            LayoutType=gamma.LayoutType,
+            origin=gamma.origin,
+            simd_width,
+            default_warps_per_block,
+            direct_input_fn_2d,
+            direct_output_fn_2d,
+            multiply_before_cast=multiply_before_cast,
+        ]
+        ctx.enqueue_function[kernel, kernel](
+            gamma,
+            epsilon,
+            weight_offset,
+            num_rows,
+            gamma.static_shape[0],
+            grid_dim=ceildiv(num_rows, default_warps_per_block * 2),
+            block_dim=default_block_size,
+            attributes=pdl_launch_attributes(PDLLevel(1)),
+        )
+
+
+@always_inline
+def _rms_norm_kv_cache_ragged_paged_no_trace[
     dtype: DType,
     params: KVCacheStaticParams,
     page_size: Int,
@@ -924,7 +1048,7 @@ def rms_norm_kv_cache_ragged_paged[
     input_row_offsets: TileTensor[DType.uint32, ...],
     context: DeviceContextPtr,
 ) raises:
-    """Performs RMSNorm in place on new entries in the key cache.
+    """Implements RMSNorm in place on new entries in the key cache.
 
     This is done by first creating the ragged tensor weight_shape
     (total_seq_len, num_heads, head_dim) of the new token tensor.
@@ -963,6 +1087,22 @@ def rms_norm_kv_cache_ragged_paged[
         rms_norm_cols <= Int(kv_collection.kv_params.head_size)
         or not per_head_norm
     ), "Length of gamma must be smaller or equal to head size"
+    comptime has_uniform_decode_rank3_specialization = (
+        per_head_norm
+        and dtype == DType.bfloat16
+        and cache_dtype == DType.bfloat16
+        and rms_norm_cols == 128
+        and Int(params.head_size) == 128
+        and page_size == 128
+    )
+    var batch_size = Int(input_row_offsets.dim(0)) - 1
+    var use_uniform_decode_batch_mapping = False
+
+    comptime if has_uniform_decode_rank3_specialization:
+        use_uniform_decode_batch_mapping = (
+            kv_collection.max_seq_length == 1
+            and total_seq_len == UInt32(batch_size)
+        )
 
     var shape = IndexList[rank]()
     shape[0] = Int(total_seq_len)
@@ -1047,30 +1187,43 @@ def rms_norm_kv_cache_ragged_paged[
             val=val.cast[cache_dtype](),
         )
 
-    with Trace[TraceLevel.OP, target=target](
-        "rms_norm_kv_cache_ragged_paged_nhead_"
-        + String(kv_collection.kv_params.num_heads)
-        + ".hdim_"
-        + String(kv_collection.kv_params.head_size),
-        task_id=get_safe_task_id(context),
-    ):
-        _rms_norm_impl[
-            dtype,
-            rank,
-            key_cache_input_fn,
-            key_cache_output_fn,
-            target=target,
-            multiply_before_cast=multiply_before_cast,
-        ](
-            shape,
-            gamma,
-            epsilon,
-            weight_offset,
-            context,
-        )
+    comptime if has_uniform_decode_rank3_specialization:
+        if use_uniform_decode_batch_mapping:
+            _rms_norm_kv_cache_ragged_paged_decode_uniform_direct[
+                dtype=dtype,
+                params=params,
+                page_size=page_size,
+                cache_dtype=cache_dtype,
+                target=target,
+                multiply_before_cast=multiply_before_cast,
+            ](
+                kv_collection,
+                gamma,
+                epsilon,
+                weight_offset,
+                layer_idx,
+                total_seq_len,
+                context,
+            )
+            return
+
+    _rms_norm_impl[
+        dtype,
+        rank,
+        key_cache_input_fn,
+        key_cache_output_fn,
+        target=target,
+        multiply_before_cast=multiply_before_cast,
+    ](
+        shape,
+        gamma,
+        epsilon,
+        weight_offset,
+        context,
+    )
 
 
-def rms_norm_value_cache_ragged_paged[
+def rms_norm_kv_cache_ragged_paged[
     dtype: DType,
     params: KVCacheStaticParams,
     page_size: Int,
@@ -1093,128 +1246,68 @@ def rms_norm_value_cache_ragged_paged[
     input_row_offsets: TileTensor[DType.uint32, ...],
     context: DeviceContextPtr,
 ) raises:
-    """Performs RMSNorm in place on new entries in the value cache.
+    """Performs RMSNorm in place on new entries in the key cache."""
 
-    Same indexing and layout as ``rms_norm_kv_cache_ragged_paged`` on the key
-    cache, but reads/writes the value cache tensor for ``layer_idx``.
-    """
-    comptime assert gamma.flat_rank == 1, "gamma must be rank 1"
-    comptime assert (
-        input_row_offsets.flat_rank == 1
-    ), "input_row_offsets must be rank 1"
+    var batch_size = Int(input_row_offsets.dim(0)) - 1
 
-    comptime rank = 3 if per_head_norm else 2
-    var v_cache = kv_collection.get_value_cache(Int(layer_idx))
-    var kv_params = v_cache.kv_params
-    comptime rms_norm_cols = gamma.static_shape[0]
+    comptime use_no_trace_decode_uniform_fastpath = (
+        is_gpu[target]()
+        and per_head_norm
+        and dtype == DType.bfloat16
+        and cache_dtype == DType.bfloat16
+        and gamma.static_shape[0] == 128
+        and Int(params.head_size) == 128
+        and page_size == 128
+    )
 
-    comptime assert rms_norm_cols != -1, "Need static shape for gamma"
-    comptime assert (
-        rms_norm_cols <= Int(kv_collection.kv_params.head_size)
-        or not per_head_norm
-    ), "Length of gamma must be smaller or equal to head size"
-
-    var shape = IndexList[rank]()
-    shape[0] = Int(total_seq_len)
-
-    comptime if per_head_norm:
-        shape[1] = Int(kv_params.num_heads)
-        shape[2] = rms_norm_cols
-    else:
-        shape[1] = rms_norm_cols
-
-    @always_inline
-    @parameter
-    @__copy_capture(v_cache, input_row_offsets)
-    def value_cache_input_fn[
-        width: Int, rank_: Int
-    ](idx: IndexList[rank_]) -> SIMD[dtype, width]:
-        comptime assert rank_ == rank, (
-            "rms_norm_value_cache input lambda index should have rank "
-            + String(rank)
-        )
-
-        var global_token_idx = idx[0]
-        var batch_idx = get_batch_from_row_offsets(
-            input_row_offsets, global_token_idx
-        )
-        var token_idx = Int(
-            UInt32(global_token_idx) - input_row_offsets[batch_idx]
-        )
-
-        var cache_length = v_cache.cache_length(batch_idx)
-        var cache_token_idx = token_idx + cache_length
-
-        var head_idx: Int
-        var head_dim_idx: Int
-
-        comptime if per_head_norm:
-            head_idx = idx[1]
-            head_dim_idx = idx[2]
-        else:
-            head_idx = idx[1] // Int(params.head_size)
-            head_dim_idx = idx[1] % Int(params.head_size)
-
-        return v_cache.load[width=width](
-            bs=batch_idx,
-            tok_idx=cache_token_idx,
-            head_idx=head_idx,
-            head_dim_idx=head_dim_idx,
-        ).cast[dtype]()
-
-    @always_inline
-    @parameter
-    @__copy_capture(v_cache)
-    def value_cache_output_fn[
-        width: Int, alignment: Int
-    ](idx: IndexList[rank], val: SIMD[dtype, width]) -> None:
-        var global_token_idx = idx[0]
-        var batch_idx = get_batch_from_row_offsets(
-            input_row_offsets, global_token_idx
-        )
-        var token_idx = Int(
-            UInt32(global_token_idx) - input_row_offsets[batch_idx]
-        )
-
-        var cache_length = v_cache.cache_length(batch_idx)
-        var cache_token_idx = token_idx + cache_length
-
-        var head_idx: Int
-        var head_dim_idx: Int
-
-        comptime if per_head_norm:
-            head_idx = idx[1]
-            head_dim_idx = idx[2]
-        else:
-            head_idx = idx[1] // Int(params.head_size)
-            head_dim_idx = idx[1] % Int(params.head_size)
-        v_cache.store(
-            bs=batch_idx,
-            tok_idx=cache_token_idx,
-            head_idx=head_idx,
-            head_dim_idx=head_dim_idx,
-            val=val.cast[cache_dtype](),
-        )
+    comptime if use_no_trace_decode_uniform_fastpath:
+        if (
+            kv_collection.max_seq_length == 1
+            and total_seq_len == UInt32(batch_size)
+        ):
+            _rms_norm_kv_cache_ragged_paged_no_trace[
+                dtype=dtype,
+                params=params,
+                page_size=page_size,
+                cache_dtype=cache_dtype,
+                target=target,
+                multiply_before_cast=multiply_before_cast,
+                per_head_norm=per_head_norm,
+            ](
+                kv_collection,
+                gamma,
+                epsilon,
+                weight_offset,
+                layer_idx,
+                total_seq_len,
+                input_row_offsets,
+                context,
+            )
+            return
 
     with Trace[TraceLevel.OP, target=target](
-        "rms_norm_value_cache_ragged_paged_nhead_"
+        "rms_norm_kv_cache_ragged_paged_nhead_"
         + String(kv_collection.kv_params.num_heads)
         + ".hdim_"
         + String(kv_collection.kv_params.head_size),
         task_id=get_safe_task_id(context),
     ):
-        _rms_norm_impl[
-            dtype,
-            rank,
-            value_cache_input_fn,
-            value_cache_output_fn,
+        _rms_norm_kv_cache_ragged_paged_no_trace[
+            dtype=dtype,
+            params=params,
+            page_size=page_size,
+            cache_dtype=cache_dtype,
             target=target,
             multiply_before_cast=multiply_before_cast,
+            per_head_norm=per_head_norm,
         ](
-            shape,
+            kv_collection,
             gamma,
             epsilon,
             weight_offset,
+            layer_idx,
+            total_seq_len,
+            input_row_offsets,
             context,
         )
 

--- a/max/kernels/src/nn/rope.mojo
+++ b/max/kernels/src/nn/rope.mojo
@@ -485,7 +485,9 @@ def _rope_k_cache_ragged_kernel[
     comptime vec_width = simd_width // 2
     comptime accum_type = get_accum_type[cache_dtype]()
     comptime half_warp_size = WARP_SIZE // 2
-    comptime assert head_dim == 128, "Only 128-column BF16 key rows are supported"
+    comptime assert (
+        head_dim == 128
+    ), "Only 128-column BF16 key rows are supported"
     comptime assert head_dim == half_warp_size * simd_width
     comptime assert freqs_cis.static_shape[1] == head_dim
 
@@ -493,7 +495,9 @@ def _rope_k_cache_ragged_kernel[
     var warp_idx = tid // UInt(WARP_SIZE)
     var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
     var local_tid = tid % UInt(half_warp_size)
-    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var row = (
+        block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    )
     if row < UInt(total_rows):
         var flat_row = Int(row)
         var global_token_idx = flat_row // num_heads
@@ -562,7 +566,9 @@ def _rope_k_cache_decode_ragged_kernel[
     comptime vec_width = simd_width // 2
     comptime accum_type = get_accum_type[cache_dtype]()
     comptime half_warp_size = WARP_SIZE // 2
-    comptime assert head_dim == 128, "Only 128-column BF16 key rows are supported"
+    comptime assert (
+        head_dim == 128
+    ), "Only 128-column BF16 key rows are supported"
     comptime assert head_dim == half_warp_size * simd_width
     comptime assert freqs_cis.static_shape[1] == head_dim
 
@@ -570,7 +576,9 @@ def _rope_k_cache_decode_ragged_kernel[
     var warp_idx = tid // UInt(WARP_SIZE)
     var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
     var local_tid = tid % UInt(half_warp_size)
-    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var row = (
+        block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    )
     if row < UInt(total_rows):
         var flat_row = Int(row)
         var global_token_idx = flat_row // num_heads
@@ -644,7 +652,9 @@ def _k_rms_norm_rope_ragged_kernel[
     comptime wide_align = align_of[SIMD[dtype, simd_width]]()
     comptime accum_type = get_accum_type[dtype]()
     comptime half_warp_size = WARP_SIZE // 2
-    comptime assert head_dim == 128, "Only 128-column BF16 key rows are supported"
+    comptime assert (
+        head_dim == 128
+    ), "Only 128-column BF16 key rows are supported"
     comptime assert gamma.static_shape[0] == head_dim
     comptime assert freqs_cis.static_shape[1] == head_dim
     comptime assert head_dim == half_warp_size * simd_width
@@ -653,7 +663,9 @@ def _k_rms_norm_rope_ragged_kernel[
     var warp_idx = tid // UInt(WARP_SIZE)
     var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
     var local_tid = tid % UInt(half_warp_size)
-    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var row = (
+        block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    )
     var col = local_tid * UInt(simd_width)
 
     if row < UInt(total_rows):
@@ -691,9 +703,9 @@ def _k_rms_norm_rope_ragged_kernel[
             head_dim,
         )
 
-        var sub_warp_mask = (
-            (UInt(1) << UInt(half_warp_size)) - UInt(1)
-        ) << (sub_warp_idx * UInt(half_warp_size))
+        var sub_warp_mask = ((UInt(1) << UInt(half_warp_size)) - UInt(1)) << (
+            sub_warp_idx * UInt(half_warp_size)
+        )
         var partner_lane = (
             sub_warp_idx * UInt(half_warp_size)
             + (local_tid % UInt(half_warp_size // 2))
@@ -789,7 +801,9 @@ def _k_rms_norm_rope_decode_ragged_kernel[
     comptime wide_align = align_of[SIMD[dtype, simd_width]]()
     comptime accum_type = get_accum_type[dtype]()
     comptime half_warp_size = WARP_SIZE // 2
-    comptime assert head_dim == 128, "Only 128-column BF16 key rows are supported"
+    comptime assert (
+        head_dim == 128
+    ), "Only 128-column BF16 key rows are supported"
     comptime assert gamma.static_shape[0] == head_dim
     comptime assert freqs_cis.static_shape[1] == head_dim
     comptime assert head_dim == half_warp_size * simd_width
@@ -798,7 +812,9 @@ def _k_rms_norm_rope_decode_ragged_kernel[
     var warp_idx = tid // UInt(WARP_SIZE)
     var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
     var local_tid = tid % UInt(half_warp_size)
-    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var row = (
+        block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    )
     var col = local_tid * UInt(simd_width)
 
     if row < UInt(total_rows):
@@ -831,9 +847,9 @@ def _k_rms_norm_rope_decode_ragged_kernel[
             head_dim,
         )
 
-        var sub_warp_mask = (
-            (UInt(1) << UInt(half_warp_size)) - UInt(1)
-        ) << (sub_warp_idx * UInt(half_warp_size))
+        var sub_warp_mask = ((UInt(1) << UInt(half_warp_size)) - UInt(1)) << (
+            sub_warp_idx * UInt(half_warp_size)
+        )
         var partner_lane = (
             sub_warp_idx * UInt(half_warp_size)
             + (local_tid % UInt(half_warp_size // 2))
@@ -930,7 +946,9 @@ def _k_rms_norm_rope_ragged_wide_kernel[
     comptime simd_width = simd_width_of[dtype]()
     comptime wide_align = align_of[SIMD[dtype, simd_width]]()
     comptime accum_type = get_accum_type[dtype]()
-    comptime assert head_dim == 256, "Only 256-column BF16 key rows are supported"
+    comptime assert (
+        head_dim == 256
+    ), "Only 256-column BF16 key rows are supported"
     comptime assert gamma.static_shape[0] == head_dim
     comptime assert freqs_cis.static_shape[1] == head_dim
     comptime assert head_dim == WARP_SIZE * simd_width
@@ -991,8 +1009,10 @@ def _k_rms_norm_rope_ragged_wide_kernel[
         var norm_factor = rsqrt(
             (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
         )
-        var norm_val = vec_data * norm_factor * (
-            gamma_val.cast[accum_type]() + weight_offset_accum
+        var norm_val = (
+            vec_data
+            * norm_factor
+            * (gamma_val.cast[accum_type]() + weight_offset_accum)
         )
         var shared_base = Int(warp_idx) * head_dim
         shared_norm.store[width=simd_width, alignment=wide_align](
@@ -1063,22 +1083,24 @@ def k_rms_norm_rope_ragged[
     comptime assert freqs_cis.flat_rank == 2, "freqs_cis must be rank 2"
     comptime assert gamma.flat_rank == 1, "gamma must be rank 1"
     comptime head_dim = Int(collection_t.CacheType.kv_params.head_size)
-    comptime assert dtype == DType.bfloat16, (
-        "k_rms_norm_rope_ragged currently supports BF16 inputs only"
-    )
-    comptime assert collection_t.CacheType.dtype == DType.bfloat16, (
-        "k_rms_norm_rope_ragged currently supports BF16 key cache only"
-    )
-    comptime assert head_dim == 128 or head_dim == 256, (
-        "k_rms_norm_rope_ragged currently supports 128- and 256-column keys only"
-    )
+    comptime assert (
+        dtype == DType.bfloat16
+    ), "k_rms_norm_rope_ragged currently supports BF16 inputs only"
+    comptime assert (
+        collection_t.CacheType.dtype == DType.bfloat16
+    ), "k_rms_norm_rope_ragged currently supports BF16 key cache only"
+    comptime assert (
+        head_dim == 128 or head_dim == 256
+    ), "k_rms_norm_rope_ragged currently supports 128- and 256-column keys only"
     comptime assert gamma.static_shape[0] == head_dim
     comptime assert freqs_cis.static_shape[1] == head_dim
 
     if total_seq_len == 0:
         return
 
-    var total_rows = total_seq_len * Int(collection_t.CacheType.kv_params.num_heads)
+    var total_rows = total_seq_len * Int(
+        collection_t.CacheType.kv_params.num_heads
+    )
     var batch_size = Int(input_row_offsets.dim(0)) - 1
     var is_decode_uniform = total_seq_len == batch_size
     comptime default_warps_per_block = 2
@@ -1181,8 +1203,8 @@ def k_rms_norm_rope_ragged[
                     total_rows,
                     grid_dim=ceildiv(total_rows, default_warps_per_block * 2),
                     block_dim=default_block_size,
-                attributes=pdl_launch_attributes(PDLLevel(1)),
-            )
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
     else:
         large_row_grid_dim = ceildiv(total_rows, large_row_warps_per_block)
         if large_row_grid_dim >= min_large_row_blocks:
@@ -1275,7 +1297,9 @@ def _q_rms_norm_rope_ragged_kernel[
     comptime num_q_heads = x.static_shape[1]
     comptime head_dim = x.static_shape[2]
 
-    comptime assert head_dim == 128, "Only 128-column BF16 query rows are supported"
+    comptime assert (
+        head_dim == 128
+    ), "Only 128-column BF16 query rows are supported"
     comptime assert head_dim == half_warp_size * simd_width
     comptime assert freqs_cis.static_shape[1] == head_dim
 
@@ -1283,7 +1307,9 @@ def _q_rms_norm_rope_ragged_kernel[
     var warp_idx = tid // UInt(WARP_SIZE)
     var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
     var local_tid = tid % UInt(half_warp_size)
-    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var row = (
+        block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    )
     if row < UInt(num_rows):
         var row_int = Int(row)
         var global_token_idx = row_int // num_q_heads
@@ -1389,7 +1415,9 @@ def _q_rms_norm_rope_decode_ragged_kernel[
     comptime num_q_heads = x.static_shape[1]
     comptime head_dim = x.static_shape[2]
 
-    comptime assert head_dim == 128, "Only 128-column BF16 query rows are supported"
+    comptime assert (
+        head_dim == 128
+    ), "Only 128-column BF16 query rows are supported"
     comptime assert head_dim == half_warp_size * simd_width
     comptime assert freqs_cis.static_shape[1] == head_dim
 
@@ -1397,7 +1425,9 @@ def _q_rms_norm_rope_decode_ragged_kernel[
     var warp_idx = tid // UInt(WARP_SIZE)
     var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
     var local_tid = tid % UInt(half_warp_size)
-    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var row = (
+        block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    )
     if row < UInt(num_rows):
         var row_int = Int(row)
         var global_token_idx = row_int // num_q_heads
@@ -1501,7 +1531,9 @@ def _q_rms_norm_rope_ragged_wide_kernel[
     comptime num_q_heads = x.static_shape[1]
     comptime head_dim = x.static_shape[2]
 
-    comptime assert head_dim == 256, "Only 256-column BF16 query rows are supported"
+    comptime assert (
+        head_dim == 256
+    ), "Only 256-column BF16 query rows are supported"
     comptime assert freqs_cis.static_shape[1] == head_dim
     comptime assert gamma.static_shape[0] == head_dim
     comptime assert head_dim == WARP_SIZE * simd_width
@@ -1629,7 +1661,9 @@ def _q_rms_norm_rope_decode_ragged_wide_kernel[
     comptime num_q_heads = x.static_shape[1]
     comptime head_dim = x.static_shape[2]
 
-    comptime assert head_dim == 256, "Only 256-column BF16 query rows are supported"
+    comptime assert (
+        head_dim == 256
+    ), "Only 256-column BF16 query rows are supported"
     comptime assert freqs_cis.static_shape[1] == head_dim
     comptime assert gamma.static_shape[0] == head_dim
     comptime assert head_dim == WARP_SIZE * simd_width
@@ -1753,7 +1787,9 @@ def q_rms_norm_rope_ragged[
         comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
         comptime min_large_row_blocks_per_sm = 5
 
-        var large_row_grid_dim = ceildiv(num_rows, large_row_warps_per_block * 2)
+        var large_row_grid_dim = ceildiv(
+            num_rows, large_row_warps_per_block * 2
+        )
         if is_decode_uniform:
             if large_row_grid_dim >= sm_count * min_large_row_blocks_per_sm:
                 comptime kernel = _q_rms_norm_rope_decode_ragged_kernel[
@@ -1972,6 +2008,7 @@ def q_rms_norm_rope_ragged[
                     block_dim=default_block_size,
                 )
     else:
+
         @always_inline
         @__copy_capture(x)
         @parameter
@@ -2075,7 +2112,9 @@ def _q_rms_norm_fused_qk_rope_ragged_kernel[
     var warp_idx = tid // UInt(WARP_SIZE)
     var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
     var local_tid = tid % UInt(half_warp_size)
-    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var row = (
+        block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    )
     var col = local_tid * UInt(simd_width)
 
     var flat_row = Int(row)
@@ -2090,10 +2129,10 @@ def _q_rms_norm_fused_qk_rope_ragged_kernel[
     if is_active_row:
         global_token_idx = flat_row // total_heads
         head_slot = flat_row % total_heads
-        batch_idx = get_batch_from_row_offsets(input_row_offsets, global_token_idx)
-        token_idx = Int(
-            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
         )
+        token_idx = Int(UInt32(global_token_idx) - input_row_offsets[batch_idx])
         q_post_seq_idx = Int(start_pos[batch_idx] + UInt32(token_idx))
         k_post_seq_idx = k_cache.cache_length(batch_idx) + token_idx
 
@@ -2115,7 +2154,9 @@ def _q_rms_norm_fused_qk_rope_ragged_kernel[
             var thread_m2 = (q_re.cast[accum_type]() ** 2).reduce_add() + (
                 q_im.cast[accum_type]() ** 2
             ).reduce_add()
-            var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](thread_m2)
+            var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](
+                thread_m2
+            )
             var norm_factor = rsqrt(
                 (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
             )
@@ -2159,9 +2200,9 @@ def _q_rms_norm_fused_qk_rope_ragged_kernel[
             var vec_data = k_cache.load[width=simd_width](
                 batch_idx, k_head_idx, k_post_seq_idx, Int(col)
             ).cast[accum_type]()
-            var gamma_val = k_gamma.load[width=simd_width, alignment=wide_align](
-                Coord(Idx(Int(col)))
-            )
+            var gamma_val = k_gamma.load[
+                width=simd_width, alignment=wide_align
+            ](Coord(Idx(Int(col))))
             var norm_val = _rms_norm_warp_tiling_subkernel[
                 warps_per_block,
                 True,
@@ -2299,7 +2340,9 @@ def _q_rms_norm_fused_qk_rope_decode_ragged_kernel[
     var warp_idx = tid // UInt(WARP_SIZE)
     var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
     var local_tid = tid % UInt(half_warp_size)
-    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var row = (
+        block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    )
     var col = local_tid * UInt(simd_width)
 
     var flat_row = Int(row)
@@ -2333,7 +2376,9 @@ def _q_rms_norm_fused_qk_rope_decode_ragged_kernel[
             var thread_m2 = (q_re.cast[accum_type]() ** 2).reduce_add() + (
                 q_im.cast[accum_type]() ** 2
             ).reduce_add()
-            var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](thread_m2)
+            var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](
+                thread_m2
+            )
             var norm_factor = rsqrt(
                 (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
             )
@@ -2377,9 +2422,9 @@ def _q_rms_norm_fused_qk_rope_decode_ragged_kernel[
             var vec_data = k_cache.load[width=simd_width](
                 batch_idx, k_head_idx, post_seq_idx, Int(col)
             ).cast[accum_type]()
-            var gamma_val = k_gamma.load[width=simd_width, alignment=wide_align](
-                Coord(Idx(Int(col)))
-            )
+            var gamma_val = k_gamma.load[
+                width=simd_width, alignment=wide_align
+            ](Coord(Idx(Int(col))))
             var norm_val = _rms_norm_warp_tiling_subkernel[
                 warps_per_block,
                 True,
@@ -2590,11 +2635,15 @@ def _q_rms_norm_fused_qk_rope_decode_ragged_wide_kernel[
                     simd_width * 2,
                 ](rope_re, rope_im, q_freq)
                 output.store[alignment=align](
-                    Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset)),
+                    Coord(
+                        Idx(global_token_idx), Idx(head_slot), Idx(re_offset)
+                    ),
                     q_rope[0],
                 )
                 output.store[alignment=align](
-                    Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset)),
+                    Coord(
+                        Idx(global_token_idx), Idx(head_slot), Idx(im_offset)
+                    ),
                     q_rope[1],
                 )
         else:
@@ -2610,8 +2659,10 @@ def _q_rms_norm_fused_qk_rope_decode_ragged_wide_kernel[
             var gamma_val = k_gamma.load[width=simd_width, alignment=align](
                 Coord(Idx(Int(col)))
             )
-            var norm_val = k_vec * norm_factor * (
-                gamma_val.cast[accum_type]() + weight_offset_accum
+            var norm_val = (
+                k_vec
+                * norm_factor
+                * (gamma_val.cast[accum_type]() + weight_offset_accum)
             )
             shared_norm.store[width=simd_width, alignment=align](
                 shared_base + Int(col), norm_val.cast[dtype]()
@@ -2713,6 +2764,7 @@ def _q_rms_norm_fused_qk_rope_generic_fallback[
             context,
         )
     else:
+
         @always_inline
         @parameter
         @__copy_capture(x)
@@ -2756,7 +2808,9 @@ def _q_rms_norm_fused_qk_rope_generic_fallback[
                 input_row_offsets.load[width=1](Coord(Idx(batch_idx)))
             )
             var token_idx = Int(UInt32(global_token_idx) - batch_start)
-            var cache_token_idx = token_idx + Int(k_cache.cache_length(batch_idx))
+            var cache_token_idx = token_idx + Int(
+                k_cache.cache_length(batch_idx)
+            )
             return k_cache.load[width=width](
                 bs=batch_idx,
                 tok_idx=cache_token_idx,
@@ -2778,7 +2832,9 @@ def _q_rms_norm_fused_qk_rope_generic_fallback[
                 input_row_offsets.load[width=1](Coord(Idx(batch_idx)))
             )
             var token_idx = Int(UInt32(global_token_idx) - batch_start)
-            var cache_token_idx = token_idx + Int(k_cache.cache_length(batch_idx))
+            var cache_token_idx = token_idx + Int(
+                k_cache.cache_length(batch_idx)
+            )
             k_cache.store(
                 bs=batch_idx,
                 tok_idx=cache_token_idx,
@@ -2847,9 +2903,10 @@ def q_rms_norm_fused_qk_rope_ragged[
     output: TileTensor[mut=True, dtype, ...],
     context: DeviceContext,
 ) raises:
-    comptime assert (
-        not interleaved
-    ), "q_rms_norm_fused_qk_rope_ragged currently supports non-interleaved RoPE only"
+    comptime assert not interleaved, (
+        "q_rms_norm_fused_qk_rope_ragged currently supports non-interleaved"
+        " RoPE only"
+    )
 
     comptime head_dim = Int(x.static_shape[2])
     comptime num_q_heads = x.static_shape[1]

--- a/max/kernels/src/nn/rope.mojo
+++ b/max/kernels/src/nn/rope.mojo
@@ -12,16 +12,29 @@
 # ===----------------------------------------------------------------------=== #
 
 from std.collections import OptionalReg
-from std.math import gcd
-from std.sys.info import _current_target, simd_width_of
+from std.math import ceildiv, gcd, rsqrt
+from std.sys.info import _current_target, align_of, simd_width_of
 
 from std.algorithm.functional import elementwise
 from std.complex import ComplexSIMD
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    WARP_SIZE,
+    block_idx_uint as block_idx,
+    syncwarp,
+    thread_idx_uint as thread_idx,
+)
 from std.gpu.host import DeviceContext, get_gpu_target
 from std.gpu.host.info import is_cpu
+from std.gpu.memory import AddressSpace
+from std.gpu.primitives.grid_controls import PDLLevel, pdl_launch_attributes
+import std.gpu.primitives.warp as warp
+from std.memory import stack_allocation
+from kv_cache.types import KVCacheT, KVCollectionT
 from layout import (
     Coord,
     CoordLike,
+    Idx,
     RowMajorLayout,
     RuntimeInt,
     TensorLayout,
@@ -29,8 +42,16 @@ from layout import (
     coord,
 )
 from nn._ragged_utils import get_batch_from_row_offsets
+from nn.fused_qk_rope import (
+    _rope_complex_mul_half,
+    fused_qk_rope_ragged,
+    rope_k_cache,
+)
+from nn.normalization import _rms_norm_warp_tiling_subkernel, rms_norm_gpu
 
 from std.utils import IndexList
+from std.utils.numerics import get_accum_type
+from std.utils.static_tuple import StaticTuple
 
 
 @always_inline
@@ -263,4 +284,2715 @@ def rope_ragged[
     else:
         elementwise[func=rope_fn, simd_width=kernel_simd_width, target=target](
             launch_shape_index_list, context.value()
+        )
+
+
+def _rope_k_cache_ragged[
+    freq_dtype: DType,
+    collection_t: KVCollectionT,
+    *,
+    interleaved: Bool,
+    target: StaticString,
+](
+    total_seq_len: Int,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    kv_collection: collection_t,
+    freqs_cis: TileTensor[freq_dtype, ...],
+    layer_idx: UInt32,
+    context: DeviceContext,
+) raises:
+    comptime assert not is_cpu[target](), "Only the GPU path is implemented"
+    comptime assert (
+        input_row_offsets.flat_rank == 1
+    ), "input_row_offsets must be rank 1"
+    comptime assert freqs_cis.flat_rank == 2, "freqs_cis must be rank 2"
+    comptime kv_params = collection_t.CacheType.kv_params
+    comptime head_size = Int(kv_params.head_size)
+    comptime rope_dim = Int(freqs_cis.static_shape[1])
+    comptime assert rope_dim == head_size, (
+        "_rope_k_cache_ragged currently expects freqs_cis width to match the "
+        "key head size"
+    )
+
+    var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+
+    comptime if (
+        not interleaved
+        and collection_t.CacheType.dtype == DType.bfloat16
+        and head_size == 128
+    ):
+        var total_rows = total_seq_len * Int(kv_params.num_heads)
+        var batch_size = Int(input_row_offsets.dim(0)) - 1
+        var is_decode_uniform = total_seq_len == batch_size
+        comptime default_warps_per_block = 2
+        comptime default_block_size = default_warps_per_block * WARP_SIZE
+        comptime large_row_warps_per_block = 8
+        comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
+        comptime min_large_row_blocks_per_sm = 6
+        var large_row_grid_dim = ceildiv(
+            total_rows, large_row_warps_per_block * 2
+        )
+        var min_large_row_blocks = (
+            context.default_device_info.sm_count * min_large_row_blocks_per_sm
+        )
+
+        if is_decode_uniform:
+            if large_row_grid_dim >= min_large_row_blocks:
+                comptime kernel = _rope_k_cache_decode_ragged_kernel[
+                    freq_dtype,
+                    collection_t.CacheType,
+                    freqs_cis.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    k_cache,
+                    freqs_cis,
+                    total_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+            else:
+                comptime kernel = _rope_k_cache_decode_ragged_kernel[
+                    freq_dtype,
+                    collection_t.CacheType,
+                    freqs_cis.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    k_cache,
+                    freqs_cis,
+                    total_rows,
+                    grid_dim=ceildiv(total_rows, default_warps_per_block * 2),
+                    block_dim=default_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+        else:
+            if large_row_grid_dim >= min_large_row_blocks:
+                comptime kernel = _rope_k_cache_ragged_kernel[
+                    freq_dtype,
+                    collection_t.CacheType,
+                    input_row_offsets.LayoutType,
+                    freqs_cis.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    input_row_offsets,
+                    k_cache,
+                    freqs_cis,
+                    total_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+            else:
+                comptime kernel = _rope_k_cache_ragged_kernel[
+                    freq_dtype,
+                    collection_t.CacheType,
+                    input_row_offsets.LayoutType,
+                    freqs_cis.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    input_row_offsets,
+                    k_cache,
+                    freqs_cis,
+                    total_rows,
+                    grid_dim=ceildiv(total_rows, default_warps_per_block * 2),
+                    block_dim=default_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+        return
+
+    @always_inline
+    @parameter
+    @__copy_capture(k_cache, input_row_offsets)
+    def rope_fn[
+        width: Int, rank: Int, alignment: Int = 1
+    ](idx_arg: IndexList[rank]):
+        comptime assert rank == 3, "Invalid rank passed to key rope kernel"
+        comptime if width == 1:
+            return
+        else:
+            var idx = rebind[IndexList[3]](idx_arg)
+            var global_token_idx = idx[0]
+            var batch_idx = get_batch_from_row_offsets(
+                input_row_offsets, global_token_idx
+            )
+            var token_idx = Int(
+                UInt32(global_token_idx) - input_row_offsets[batch_idx]
+            )
+            var head_idx = idx[1]
+            var head_dim_idx = idx[2]
+            var post_seq_idx = k_cache.cache_length(batch_idx) + token_idx
+            var freq = freqs_cis.load[width=width, alignment=1](
+                Coord(Idx(post_seq_idx), Idx(head_dim_idx))
+            )
+
+            rope_k_cache[interleaved=interleaved](
+                k_cache,
+                batch_idx,
+                head_idx,
+                post_seq_idx,
+                head_dim_idx,
+                freq,
+                head_size,
+            )
+
+    var launch_shape = IndexList[3](
+        total_seq_len, Int(kv_params.num_heads), head_size
+    )
+    comptime kernel_simd_width = gcd(
+        simd_width_of[collection_t.CacheType.dtype, target=get_gpu_target()](),
+        head_size,
+    )
+    comptime assert kernel_simd_width >= 2, "invalid simd_width and head size"
+
+    elementwise[func=rope_fn, simd_width=kernel_simd_width, target=target](
+        launch_shape, context
+    )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _rope_k_cache_ragged_kernel[
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    OffsetsLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    total_rows: Int,
+):
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+
+    comptime cache_dtype = KCacheType.dtype
+    comptime num_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(KCacheType.kv_params.head_size)
+    comptime simd_width = simd_width_of[cache_dtype]()
+    comptime vec_width = simd_width // 2
+    comptime accum_type = get_accum_type[cache_dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime assert head_dim == 128, "Only 128-column BF16 key rows are supported"
+    comptime assert head_dim == half_warp_size * simd_width
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_heads
+        var head_idx = flat_row % num_heads
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+        var post_seq_idx = k_cache.cache_length(batch_idx) + token_idx
+        var re_offset = Int(local_tid) * vec_width
+        var im_offset = re_offset + head_dim // 2
+        var freq_offset = Int(local_tid) * simd_width
+        var k_re = k_cache.load[width=vec_width](
+            batch_idx, head_idx, post_seq_idx, re_offset
+        ).cast[accum_type]()
+        var k_im = k_cache.load[width=vec_width](
+            batch_idx, head_idx, post_seq_idx, im_offset
+        ).cast[accum_type]()
+        var freq = freqs_cis.load[width=simd_width, alignment=1](
+            Coord(Idx(post_seq_idx), Idx(freq_offset))
+        )
+        var k_rope = _rope_complex_mul_half[
+            accum_type,
+            freq_dtype,
+            vec_width,
+            simd_width,
+        ](k_re, k_im, freq)
+        k_cache.store(
+            batch_idx,
+            head_idx,
+            post_seq_idx,
+            re_offset,
+            k_rope[0].cast[cache_dtype](),
+        )
+        k_cache.store(
+            batch_idx,
+            head_idx,
+            post_seq_idx,
+            im_offset,
+            k_rope[1].cast[cache_dtype](),
+        )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _rope_k_cache_decode_ragged_kernel[
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    FreqLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    total_rows: Int,
+):
+    comptime assert freqs_cis.flat_rank == 2
+
+    comptime cache_dtype = KCacheType.dtype
+    comptime num_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(KCacheType.kv_params.head_size)
+    comptime simd_width = simd_width_of[cache_dtype]()
+    comptime vec_width = simd_width // 2
+    comptime accum_type = get_accum_type[cache_dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime assert head_dim == 128, "Only 128-column BF16 key rows are supported"
+    comptime assert head_dim == half_warp_size * simd_width
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_heads
+        var head_idx = flat_row % num_heads
+        var batch_idx = global_token_idx
+        var post_seq_idx = k_cache.cache_length(batch_idx)
+        var re_offset = Int(local_tid) * vec_width
+        var im_offset = re_offset + head_dim // 2
+        var freq_offset = Int(local_tid) * simd_width
+        var k_re = k_cache.load[width=vec_width](
+            batch_idx, head_idx, post_seq_idx, re_offset
+        ).cast[accum_type]()
+        var k_im = k_cache.load[width=vec_width](
+            batch_idx, head_idx, post_seq_idx, im_offset
+        ).cast[accum_type]()
+        var freq = freqs_cis.load[width=simd_width, alignment=1](
+            Coord(Idx(post_seq_idx), Idx(freq_offset))
+        )
+        var k_rope = _rope_complex_mul_half[
+            accum_type,
+            freq_dtype,
+            vec_width,
+            simd_width,
+        ](k_re, k_im, freq)
+        k_cache.store(
+            batch_idx,
+            head_idx,
+            post_seq_idx,
+            re_offset,
+            k_rope[0].cast[cache_dtype](),
+        )
+        k_cache.store(
+            batch_idx,
+            head_idx,
+            post_seq_idx,
+            im_offset,
+            k_rope[1].cast[cache_dtype](),
+        )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _k_rms_norm_rope_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    OffsetsLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime num_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(KCacheType.kv_params.head_size)
+    comptime simd_width = simd_width_of[dtype]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime assert head_dim == 128, "Only 128-column BF16 key rows are supported"
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert freqs_cis.static_shape[1] == head_dim
+    comptime assert head_dim == half_warp_size * simd_width
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_heads
+        var head_idx = flat_row % num_heads
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+        var cache_token_idx = token_idx + k_cache.cache_length(batch_idx)
+
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var vec_data = k_cache.load[width=simd_width](
+            batch_idx, head_idx, cache_token_idx, Int(col)
+        ).cast[accum_type]()
+        var gamma_val = gamma.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(Int(col)))
+        )
+
+        var norm_val = _rms_norm_warp_tiling_subkernel[
+            warps_per_block,
+            True,
+            rows_per_warp=2,
+        ](
+            flat_row,
+            Int(col),
+            vec_data,
+            gamma_val,
+            epsilon_accum,
+            weight_offset_accum,
+            head_dim,
+        )
+
+        var sub_warp_mask = (
+            (UInt(1) << UInt(half_warp_size)) - UInt(1)
+        ) << (sub_warp_idx * UInt(half_warp_size))
+        var partner_lane = (
+            sub_warp_idx * UInt(half_warp_size)
+            + (local_tid % UInt(half_warp_size // 2))
+            + UInt(half_warp_size // 2)
+        )
+        var norm_parts = norm_val.split()
+        var norm_lo_parts = norm_parts[0].split()
+        var norm_hi_parts = norm_parts[1].split()
+        var partner_norm_lo = warp.shuffle_idx(
+            sub_warp_mask,
+            norm_lo_parts[0],
+            UInt32(partner_lane),
+        ).join(
+            warp.shuffle_idx(
+                sub_warp_mask,
+                norm_lo_parts[1],
+                UInt32(partner_lane),
+            )
+        )
+        var partner_norm_hi = warp.shuffle_idx(
+            sub_warp_mask,
+            norm_hi_parts[0],
+            UInt32(partner_lane),
+        ).join(
+            warp.shuffle_idx(
+                sub_warp_mask,
+                norm_hi_parts[1],
+                UInt32(partner_lane),
+            )
+        )
+        var partner_norm = rebind[type_of(norm_val)](
+            partner_norm_lo.join(partner_norm_hi)
+        )
+
+        if local_tid < UInt(half_warp_size // 2):
+            var re_offset = Int(local_tid) * simd_width
+            var im_offset = re_offset + head_dim // 2
+            var freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                Coord(Idx(cache_token_idx), Idx(re_offset * 2))
+            )
+            comptime cache_dtype = KCacheType.dtype
+            var rope_val = _rope_complex_mul_half[
+                accum_type,
+                freq_dtype,
+                simd_width,
+                simd_width * 2,
+            ](
+                norm_val.cast[accum_type](),
+                partner_norm.cast[accum_type](),
+                freq,
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                re_offset,
+                rope_val[0].cast[cache_dtype](),
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                im_offset,
+                rope_val[1].cast[cache_dtype](),
+            )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _k_rms_norm_rope_decode_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime num_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(KCacheType.kv_params.head_size)
+    comptime simd_width = simd_width_of[dtype]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime assert head_dim == 128, "Only 128-column BF16 key rows are supported"
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert freqs_cis.static_shape[1] == head_dim
+    comptime assert head_dim == half_warp_size * simd_width
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_heads
+        var head_idx = flat_row % num_heads
+        var batch_idx = global_token_idx
+        var cache_token_idx = k_cache.cache_length(batch_idx)
+
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var vec_data = k_cache.load[width=simd_width](
+            batch_idx, head_idx, cache_token_idx, Int(col)
+        ).cast[accum_type]()
+        var gamma_val = gamma.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(Int(col)))
+        )
+
+        var norm_val = _rms_norm_warp_tiling_subkernel[
+            warps_per_block,
+            True,
+            rows_per_warp=2,
+        ](
+            flat_row,
+            Int(col),
+            vec_data,
+            gamma_val,
+            epsilon_accum,
+            weight_offset_accum,
+            head_dim,
+        )
+
+        var sub_warp_mask = (
+            (UInt(1) << UInt(half_warp_size)) - UInt(1)
+        ) << (sub_warp_idx * UInt(half_warp_size))
+        var partner_lane = (
+            sub_warp_idx * UInt(half_warp_size)
+            + (local_tid % UInt(half_warp_size // 2))
+            + UInt(half_warp_size // 2)
+        )
+        var norm_parts = norm_val.split()
+        var norm_lo_parts = norm_parts[0].split()
+        var norm_hi_parts = norm_parts[1].split()
+        var partner_norm_lo = warp.shuffle_idx(
+            sub_warp_mask,
+            norm_lo_parts[0],
+            UInt32(partner_lane),
+        ).join(
+            warp.shuffle_idx(
+                sub_warp_mask,
+                norm_lo_parts[1],
+                UInt32(partner_lane),
+            )
+        )
+        var partner_norm_hi = warp.shuffle_idx(
+            sub_warp_mask,
+            norm_hi_parts[0],
+            UInt32(partner_lane),
+        ).join(
+            warp.shuffle_idx(
+                sub_warp_mask,
+                norm_hi_parts[1],
+                UInt32(partner_lane),
+            )
+        )
+        var partner_norm = rebind[type_of(norm_val)](
+            partner_norm_lo.join(partner_norm_hi)
+        )
+
+        if local_tid < UInt(half_warp_size // 2):
+            var re_offset = Int(local_tid) * simd_width
+            var im_offset = re_offset + head_dim // 2
+            var freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                Coord(Idx(cache_token_idx), Idx(re_offset * 2))
+            )
+            comptime cache_dtype = KCacheType.dtype
+            var rope_val = _rope_complex_mul_half[
+                accum_type,
+                freq_dtype,
+                simd_width,
+                simd_width * 2,
+            ](
+                norm_val.cast[accum_type](),
+                partner_norm.cast[accum_type](),
+                freq,
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                re_offset,
+                rope_val[0].cast[cache_dtype](),
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                im_offset,
+                rope_val[1].cast[cache_dtype](),
+            )
+
+
+def _k_rms_norm_rope_ragged_wide_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    OffsetsLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime num_heads = Int(KCacheType.kv_params.num_heads)
+    comptime head_dim = Int(KCacheType.kv_params.head_size)
+    comptime simd_width = simd_width_of[dtype]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime assert head_dim == 256, "Only 256-column BF16 key rows are supported"
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert freqs_cis.static_shape[1] == head_dim
+    comptime assert head_dim == WARP_SIZE * simd_width
+
+    var shared_norm = stack_allocation[
+        warps_per_block * head_dim,
+        Scalar[dtype],
+        address_space=AddressSpace.SHARED,
+    ]()
+    var shared_batch_idx = stack_allocation[
+        warps_per_block,
+        Int32,
+        address_space=AddressSpace.SHARED,
+    ]()
+    var shared_post_seq = stack_allocation[
+        warps_per_block,
+        Int32,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var local_tid = tid % UInt(WARP_SIZE)
+    var row = block_idx.x * UInt(warps_per_block) + warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    if row < UInt(total_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_heads
+        var head_idx = flat_row % num_heads
+
+        if local_tid == 0:
+            var batch_idx = get_batch_from_row_offsets(
+                input_row_offsets, global_token_idx
+            )
+            var token_idx = Int(
+                UInt32(global_token_idx) - input_row_offsets[batch_idx]
+            )
+            shared_batch_idx[Int(warp_idx)] = Int32(batch_idx)
+            shared_post_seq[Int(warp_idx)] = Int32(
+                token_idx + Int(k_cache.cache_length(batch_idx))
+            )
+        syncwarp()
+
+        var batch_idx = Int(shared_batch_idx[Int(warp_idx)])
+        var cache_token_idx = Int(shared_post_seq[Int(warp_idx)])
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var vec_data = k_cache.load[width=simd_width](
+            batch_idx, head_idx, cache_token_idx, Int(col)
+        ).cast[accum_type]()
+        var gamma_val = gamma.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(Int(col)))
+        )
+
+        var thread_m2 = (vec_data**2).reduce_add()
+        var row_m2 = warp.sum(thread_m2)
+        var norm_factor = rsqrt(
+            (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+        )
+        var norm_val = vec_data * norm_factor * (
+            gamma_val.cast[accum_type]() + weight_offset_accum
+        )
+        var shared_base = Int(warp_idx) * head_dim
+        shared_norm.store[width=simd_width, alignment=wide_align](
+            shared_base + Int(col), norm_val.cast[dtype]()
+        )
+        syncwarp()
+
+        if local_tid < UInt(WARP_SIZE // 2):
+            var re_offset = Int(local_tid) * simd_width
+            var im_offset = re_offset + head_dim // 2
+            var rope_re = shared_norm.load[width=simd_width](
+                shared_base + re_offset
+            ).cast[accum_type]()
+            var rope_im = shared_norm.load[width=simd_width](
+                shared_base + im_offset
+            ).cast[accum_type]()
+            var freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                Coord(Idx(cache_token_idx), Idx(re_offset * 2))
+            )
+            comptime cache_dtype = KCacheType.dtype
+            var rope_val = _rope_complex_mul_half[
+                accum_type,
+                freq_dtype,
+                simd_width,
+                simd_width * 2,
+            ](rope_re, rope_im, freq)
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                re_offset,
+                rope_val[0].cast[cache_dtype](),
+            )
+            k_cache.store(
+                batch_idx,
+                head_idx,
+                cache_token_idx,
+                im_offset,
+                rope_val[1].cast[cache_dtype](),
+            )
+
+
+def k_rms_norm_rope_ragged[
+    dtype: DType,
+    freq_dtype: DType,
+    collection_t: KVCollectionT,
+    *,
+    interleaved: Bool,
+    target: StaticString,
+](
+    total_seq_len: Int,
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    kv_collection: collection_t,
+    freqs_cis: TileTensor[freq_dtype, ...],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    context: DeviceContext,
+) raises:
+    comptime assert not is_cpu[target](), "Only the GPU path is implemented"
+    comptime assert (
+        not interleaved
+    ), "k_rms_norm_rope_ragged currently supports non-interleaved RoPE only"
+    comptime assert (
+        input_row_offsets.flat_rank == 1
+    ), "input_row_offsets must be rank 1"
+    comptime assert freqs_cis.flat_rank == 2, "freqs_cis must be rank 2"
+    comptime assert gamma.flat_rank == 1, "gamma must be rank 1"
+    comptime head_dim = Int(collection_t.CacheType.kv_params.head_size)
+    comptime assert dtype == DType.bfloat16, (
+        "k_rms_norm_rope_ragged currently supports BF16 inputs only"
+    )
+    comptime assert collection_t.CacheType.dtype == DType.bfloat16, (
+        "k_rms_norm_rope_ragged currently supports BF16 key cache only"
+    )
+    comptime assert head_dim == 128 or head_dim == 256, (
+        "k_rms_norm_rope_ragged currently supports 128- and 256-column keys only"
+    )
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    if total_seq_len == 0:
+        return
+
+    var total_rows = total_seq_len * Int(collection_t.CacheType.kv_params.num_heads)
+    var batch_size = Int(input_row_offsets.dim(0)) - 1
+    var is_decode_uniform = total_seq_len == batch_size
+    comptime default_warps_per_block = 2
+    comptime default_block_size = default_warps_per_block * WARP_SIZE
+    comptime large_row_warps_per_block = 8
+    comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
+    comptime min_large_row_blocks_per_sm = 5
+    var large_row_grid_dim = ceildiv(total_rows, large_row_warps_per_block * 2)
+    var min_large_row_blocks = (
+        context.default_device_info.sm_count * min_large_row_blocks_per_sm
+    )
+    var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+
+    comptime if head_dim == 128:
+        if is_decode_uniform:
+            if large_row_grid_dim >= min_large_row_blocks:
+                comptime kernel = _k_rms_norm_rope_decode_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    collection_t.CacheType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    k_cache,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    total_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+            else:
+                comptime kernel = _k_rms_norm_rope_decode_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    collection_t.CacheType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    k_cache,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    total_rows,
+                    grid_dim=ceildiv(total_rows, default_warps_per_block * 2),
+                    block_dim=default_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+        else:
+            if large_row_grid_dim >= min_large_row_blocks:
+                comptime kernel = _k_rms_norm_rope_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    collection_t.CacheType,
+                    input_row_offsets.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    input_row_offsets,
+                    k_cache,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    total_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                    attributes=pdl_launch_attributes(PDLLevel(1)),
+                )
+            else:
+                comptime kernel = _k_rms_norm_rope_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    collection_t.CacheType,
+                    input_row_offsets.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    input_row_offsets,
+                    k_cache,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    total_rows,
+                    grid_dim=ceildiv(total_rows, default_warps_per_block * 2),
+                    block_dim=default_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+    else:
+        large_row_grid_dim = ceildiv(total_rows, large_row_warps_per_block)
+        if large_row_grid_dim >= min_large_row_blocks:
+            comptime kernel = _k_rms_norm_rope_ragged_wide_kernel[
+                dtype,
+                freq_dtype,
+                collection_t.CacheType,
+                input_row_offsets.LayoutType,
+                freqs_cis.LayoutType,
+                gamma.LayoutType,
+                large_row_block_size,
+                large_row_warps_per_block,
+            ]
+            context.enqueue_function[kernel, kernel](
+                input_row_offsets,
+                k_cache,
+                freqs_cis,
+                gamma,
+                epsilon,
+                weight_offset,
+                total_rows,
+                grid_dim=large_row_grid_dim,
+                block_dim=large_row_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+        else:
+            comptime kernel = _k_rms_norm_rope_ragged_wide_kernel[
+                dtype,
+                freq_dtype,
+                collection_t.CacheType,
+                input_row_offsets.LayoutType,
+                freqs_cis.LayoutType,
+                gamma.LayoutType,
+                default_block_size,
+                default_warps_per_block,
+            ]
+            context.enqueue_function[kernel, kernel](
+                input_row_offsets,
+                k_cache,
+                freqs_cis,
+                gamma,
+                epsilon,
+                weight_offset,
+                total_rows,
+                grid_dim=ceildiv(total_rows, default_warps_per_block),
+                block_dim=default_block_size,
+                attributes=pdl_launch_attributes(PDLLevel(1)),
+            )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _q_rms_norm_rope_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    OffsetsLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    num_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime vec_width = simd_width // 2
+    comptime align = align_of[SIMD[dtype, vec_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+
+    comptime assert head_dim == 128, "Only 128-column BF16 query rows are supported"
+    comptime assert head_dim == half_warp_size * simd_width
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    if row < UInt(num_rows):
+        var row_int = Int(row)
+        var global_token_idx = row_int // num_q_heads
+        var head_idx = row_int % num_q_heads
+        var batch_idx = get_batch_from_row_offsets(
+            input_row_offsets, global_token_idx
+        )
+        var token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+        var position = Int(start_pos[batch_idx] + UInt32(token_idx))
+
+        var re_offset = Int(local_tid) * vec_width
+        var im_offset = re_offset + head_dim // 2
+        var freq_offset = Int(local_tid) * simd_width
+
+        var q_re = x.load[width=vec_width, alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset))
+        )
+        var q_im = x.load[width=vec_width, alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset))
+        )
+        var thread_m2 = (q_re.cast[accum_type]() ** 2).reduce_add() + (
+            q_im.cast[accum_type]() ** 2
+        ).reduce_add()
+        var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](thread_m2)
+        var norm_factor = rsqrt(
+            (row_m2 / Scalar[accum_type](head_dim)) + epsilon.cast[accum_type]()
+        )
+
+        var gamma_re = gamma.load[width=vec_width, alignment=align](
+            Coord(Idx(re_offset))
+        )
+        var gamma_im = gamma.load[width=vec_width, alignment=align](
+            Coord(Idx(im_offset))
+        )
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var norm_re = (
+            q_re.cast[accum_type]()
+            * norm_factor
+            * (gamma_re.cast[accum_type]() + weight_offset_accum)
+        ).cast[dtype]()
+        var norm_im = (
+            q_im.cast[accum_type]()
+            * norm_factor
+            * (gamma_im.cast[accum_type]() + weight_offset_accum)
+        ).cast[dtype]()
+
+        var freq = freqs_cis.load[width=simd_width, alignment=1](
+            Coord(Idx(position), Idx(freq_offset))
+        )
+        var rope_val = _rope_complex_mul_half[
+            dtype,
+            freq_dtype,
+            vec_width,
+            simd_width,
+        ](norm_re, norm_im, freq)
+
+        output.store[alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset)),
+            rope_val[0],
+        )
+        output.store[alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset)),
+            rope_val[1],
+        )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _q_rms_norm_rope_decode_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    num_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime vec_width = simd_width // 2
+    comptime align = align_of[SIMD[dtype, vec_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+
+    comptime assert head_dim == 128, "Only 128-column BF16 query rows are supported"
+    comptime assert head_dim == half_warp_size * simd_width
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    if row < UInt(num_rows):
+        var row_int = Int(row)
+        var global_token_idx = row_int // num_q_heads
+        var head_idx = row_int % num_q_heads
+        var batch_idx = global_token_idx
+        var position = Int(start_pos[batch_idx])
+
+        var re_offset = Int(local_tid) * vec_width
+        var im_offset = re_offset + head_dim // 2
+        var freq_offset = Int(local_tid) * simd_width
+
+        var q_re = x.load[width=vec_width, alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset))
+        )
+        var q_im = x.load[width=vec_width, alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset))
+        )
+        var thread_m2 = (q_re.cast[accum_type]() ** 2).reduce_add() + (
+            q_im.cast[accum_type]() ** 2
+        ).reduce_add()
+        var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](thread_m2)
+        var norm_factor = rsqrt(
+            (row_m2 / Scalar[accum_type](head_dim)) + epsilon.cast[accum_type]()
+        )
+
+        var gamma_re = gamma.load[width=vec_width, alignment=align](
+            Coord(Idx(re_offset))
+        )
+        var gamma_im = gamma.load[width=vec_width, alignment=align](
+            Coord(Idx(im_offset))
+        )
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var norm_re = (
+            q_re.cast[accum_type]()
+            * norm_factor
+            * (gamma_re.cast[accum_type]() + weight_offset_accum)
+        ).cast[dtype]()
+        var norm_im = (
+            q_im.cast[accum_type]()
+            * norm_factor
+            * (gamma_im.cast[accum_type]() + weight_offset_accum)
+        ).cast[dtype]()
+
+        var freq = freqs_cis.load[width=simd_width, alignment=1](
+            Coord(Idx(position), Idx(freq_offset))
+        )
+        var rope_val = _rope_complex_mul_half[
+            dtype,
+            freq_dtype,
+            vec_width,
+            simd_width,
+        ](norm_re, norm_im, freq)
+
+        output.store[alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset)),
+            rope_val[0],
+        )
+        output.store[alignment=align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset)),
+            rope_val[1],
+        )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _q_rms_norm_rope_ragged_wide_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    OffsetsLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    num_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+
+    comptime assert head_dim == 256, "Only 256-column BF16 query rows are supported"
+    comptime assert freqs_cis.static_shape[1] == head_dim
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert head_dim == WARP_SIZE * simd_width
+
+    var shared_norm = stack_allocation[
+        warps_per_block * head_dim,
+        Scalar[dtype],
+        address_space=AddressSpace.SHARED,
+    ]()
+    var shared_position = stack_allocation[
+        warps_per_block,
+        Int32,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var local_tid = tid % UInt(WARP_SIZE)
+    var row = block_idx.x * UInt(warps_per_block) + warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    if row < UInt(num_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_q_heads
+        var head_idx = flat_row % num_q_heads
+
+        if local_tid == 0:
+            var batch_idx = get_batch_from_row_offsets(
+                input_row_offsets, global_token_idx
+            )
+            var token_idx = Int(
+                UInt32(global_token_idx) - input_row_offsets[batch_idx]
+            )
+            shared_position[Int(warp_idx)] = Int32(
+                Int(start_pos[batch_idx] + UInt32(token_idx))
+            )
+        syncwarp()
+
+        var position = Int(shared_position[Int(warp_idx)])
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var q_vec = x.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(Int(col)))
+        )
+        var thread_m2 = (q_vec.cast[accum_type]() ** 2).reduce_add()
+        var row_m2 = warp.sum(thread_m2)
+        var norm_factor = rsqrt(
+            (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+        )
+        var gamma_val = gamma.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(Int(col)))
+        )
+        var norm_val = (
+            q_vec.cast[accum_type]()
+            * norm_factor
+            * (gamma_val.cast[accum_type]() + weight_offset_accum)
+        ).cast[dtype]()
+        var shared_base = Int(warp_idx) * head_dim
+        shared_norm.store[width=simd_width, alignment=wide_align](
+            shared_base + Int(col), norm_val
+        )
+        syncwarp()
+
+        if local_tid < UInt(WARP_SIZE // 2):
+            var re_offset = Int(local_tid) * simd_width
+            var im_offset = re_offset + head_dim // 2
+            var rope_re = shared_norm.load[width=simd_width](
+                shared_base + re_offset
+            )
+            var rope_im = shared_norm.load[width=simd_width](
+                shared_base + im_offset
+            )
+            var freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                Coord(Idx(position), Idx(re_offset * 2))
+            )
+            var rope_val = _rope_complex_mul_half[
+                dtype,
+                freq_dtype,
+                simd_width,
+                simd_width * 2,
+            ](rope_re, rope_im, freq)
+
+            output.store[alignment=wide_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset)),
+                rope_val[0],
+            )
+            output.store[alignment=wide_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset)),
+                rope_val[1],
+            )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _q_rms_norm_rope_decode_ragged_wide_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    GammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    gamma: TileTensor[dtype, GammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    num_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+
+    comptime assert head_dim == 256, "Only 256-column BF16 query rows are supported"
+    comptime assert freqs_cis.static_shape[1] == head_dim
+    comptime assert gamma.static_shape[0] == head_dim
+    comptime assert head_dim == WARP_SIZE * simd_width
+
+    var shared_norm = stack_allocation[
+        warps_per_block * head_dim,
+        Scalar[dtype],
+        address_space=AddressSpace.SHARED,
+    ]()
+    var shared_position = stack_allocation[
+        warps_per_block,
+        Int32,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var local_tid = tid % UInt(WARP_SIZE)
+    var row = block_idx.x * UInt(warps_per_block) + warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    if row < UInt(num_rows):
+        var flat_row = Int(row)
+        var global_token_idx = flat_row // num_q_heads
+        var head_idx = flat_row % num_q_heads
+
+        if local_tid == 0:
+            shared_position[Int(warp_idx)] = Int32(
+                Int(start_pos[global_token_idx])
+            )
+        syncwarp()
+
+        var position = Int(shared_position[Int(warp_idx)])
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var q_vec = x.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(global_token_idx), Idx(head_idx), Idx(Int(col)))
+        )
+        var thread_m2 = (q_vec.cast[accum_type]() ** 2).reduce_add()
+        var row_m2 = warp.sum(thread_m2)
+        var norm_factor = rsqrt(
+            (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+        )
+        var gamma_val = gamma.load[width=simd_width, alignment=wide_align](
+            Coord(Idx(Int(col)))
+        )
+        var norm_val = (
+            q_vec.cast[accum_type]()
+            * norm_factor
+            * (gamma_val.cast[accum_type]() + weight_offset_accum)
+        ).cast[dtype]()
+        var shared_base = Int(warp_idx) * head_dim
+        shared_norm.store[width=simd_width, alignment=wide_align](
+            shared_base + Int(col), norm_val
+        )
+        syncwarp()
+
+        if local_tid < UInt(WARP_SIZE // 2):
+            var re_offset = Int(local_tid) * simd_width
+            var im_offset = re_offset + head_dim // 2
+            var rope_re = shared_norm.load[width=simd_width](
+                shared_base + re_offset
+            )
+            var rope_im = shared_norm.load[width=simd_width](
+                shared_base + im_offset
+            )
+            var freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                Coord(Idx(position), Idx(re_offset * 2))
+            )
+            var rope_val = _rope_complex_mul_half[
+                dtype,
+                freq_dtype,
+                simd_width,
+                simd_width * 2,
+            ](rope_re, rope_im, freq)
+
+            output.store[alignment=wide_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(re_offset)),
+                rope_val[0],
+            )
+            output.store[alignment=wide_align](
+                Coord(Idx(global_token_idx), Idx(head_idx), Idx(im_offset)),
+                rope_val[1],
+            )
+
+
+def q_rms_norm_rope_ragged[
+    dtype: DType,
+    freq_dtype: DType,
+    *,
+    target: StaticString,
+](
+    x: TileTensor[dtype, ...],
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    start_pos: TileTensor[DType.uint32, ...],
+    freqs_cis: TileTensor[freq_dtype, ...],
+    gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    output: TileTensor[mut=True, dtype, ...],
+    context: DeviceContext,
+) raises:
+    comptime assert not is_cpu[target](), "Only the GPU path is implemented"
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert gamma.flat_rank == 1
+    comptime head_dim = Int(x.static_shape[2])
+
+    comptime if head_dim == 128 and dtype == DType.bfloat16:
+        comptime num_q_heads = x.static_shape[1]
+        var total_tokens = Int(x.dim(0))
+        var is_decode_uniform = total_tokens == Int(start_pos.dim(0))
+        var num_rows = total_tokens * num_q_heads
+        comptime sm_count = context.default_device_info.sm_count
+        comptime default_warps_per_block = 2
+        comptime default_block_size = default_warps_per_block * WARP_SIZE
+        comptime large_row_warps_per_block = 8
+        comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
+        comptime min_large_row_blocks_per_sm = 5
+
+        var large_row_grid_dim = ceildiv(num_rows, large_row_warps_per_block * 2)
+        if is_decode_uniform:
+            if large_row_grid_dim >= sm_count * min_large_row_blocks_per_sm:
+                comptime kernel = _q_rms_norm_rope_decode_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                )
+            else:
+                comptime kernel = _q_rms_norm_rope_decode_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=ceildiv(num_rows, default_warps_per_block * 2),
+                    block_dim=default_block_size,
+                )
+        else:
+            if large_row_grid_dim >= sm_count * min_large_row_blocks_per_sm:
+                comptime kernel = _q_rms_norm_rope_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    input_row_offsets.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    input_row_offsets,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                )
+            else:
+                comptime kernel = _q_rms_norm_rope_ragged_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    input_row_offsets.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    input_row_offsets,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=ceildiv(num_rows, default_warps_per_block * 2),
+                    block_dim=default_block_size,
+                )
+    elif head_dim == 256 and dtype == DType.bfloat16:
+        comptime num_q_heads = x.static_shape[1]
+        var total_tokens = Int(x.dim(0))
+        var is_decode_uniform = total_tokens == Int(start_pos.dim(0))
+        var num_rows = total_tokens * num_q_heads
+        comptime sm_count = context.default_device_info.sm_count
+        comptime default_warps_per_block = 2
+        comptime default_block_size = default_warps_per_block * WARP_SIZE
+        comptime large_row_warps_per_block = 8
+        comptime large_row_block_size = large_row_warps_per_block * WARP_SIZE
+        comptime min_large_row_blocks_per_sm = 6
+        var large_row_grid_dim = ceildiv(num_rows, large_row_warps_per_block)
+
+        if is_decode_uniform:
+            if large_row_grid_dim >= sm_count * min_large_row_blocks_per_sm:
+                comptime kernel = _q_rms_norm_rope_decode_ragged_wide_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                )
+            else:
+                comptime kernel = _q_rms_norm_rope_decode_ragged_wide_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=ceildiv(num_rows, default_warps_per_block),
+                    block_dim=default_block_size,
+                )
+        else:
+            if large_row_grid_dim >= sm_count * min_large_row_blocks_per_sm:
+                comptime kernel = _q_rms_norm_rope_ragged_wide_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    input_row_offsets.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    large_row_block_size,
+                    large_row_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    input_row_offsets,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=large_row_grid_dim,
+                    block_dim=large_row_block_size,
+                )
+            else:
+                comptime kernel = _q_rms_norm_rope_ragged_wide_kernel[
+                    dtype,
+                    freq_dtype,
+                    x.LayoutType,
+                    output.LayoutType,
+                    input_row_offsets.LayoutType,
+                    start_pos.LayoutType,
+                    freqs_cis.LayoutType,
+                    gamma.LayoutType,
+                    default_block_size,
+                    default_warps_per_block,
+                ]
+                context.enqueue_function[kernel, kernel](
+                    x,
+                    output,
+                    input_row_offsets,
+                    start_pos,
+                    freqs_cis,
+                    gamma,
+                    epsilon,
+                    weight_offset,
+                    num_rows,
+                    grid_dim=ceildiv(num_rows, default_warps_per_block),
+                    block_dim=default_block_size,
+                )
+    else:
+        @always_inline
+        @__copy_capture(x)
+        @parameter
+        def input_fn[
+            width: Int, rank: Int
+        ](coords: IndexList[rank]) -> SIMD[dtype, width]:
+            return x.load[width=width](Coord(coords))
+
+        @always_inline
+        @__copy_capture(output)
+        @parameter
+        def norm_output_fn[
+            width: Int, alignment: Int
+        ](coords: IndexList[3], val: SIMD[dtype, width]) -> None:
+            output.store[alignment=alignment](Coord(coords), val)
+
+        @always_inline
+        @__copy_capture(output)
+        def rope_output_fn[
+            width: Int, alignment: Int
+        ](idx: IndexList[3], val: SIMD[dtype, width]) capturing -> None:
+            output.store[alignment=alignment](Coord(idx), val)
+
+        var shape = IndexList[3](Int(x.dim(0)), Int(x.dim(1)), Int(x.dim(2)))
+        rms_norm_gpu[
+            input_fn,
+            norm_output_fn,
+            multiply_before_cast=True,
+        ](shape, gamma, epsilon, weight_offset, context)
+        rope_ragged[
+            dtype,
+            freq_dtype,
+            interleaved=False,
+            target=target,
+            output_fn=rope_output_fn,
+        ](
+            output,
+            input_row_offsets,
+            start_pos,
+            freqs_cis,
+            Optional[DeviceContext](context),
+        )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _q_rms_norm_fused_qk_rope_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    OffsetsLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    QGammaLayoutType: TensorLayout,
+    KGammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    input_row_offsets: TileTensor[
+        DType.uint32, OffsetsLayoutType, MutAnyOrigin
+    ],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    q_gamma: TileTensor[dtype, QGammaLayoutType, MutAnyOrigin],
+    k_gamma: TileTensor[dtype, KGammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert q_gamma.flat_rank == 1
+    comptime assert k_gamma.flat_rank == 1
+
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+    comptime num_kv_heads = Int(KCacheType.kv_params.num_heads)
+    comptime assert head_dim == 128, "Only 128-column BF16 rows are supported"
+    comptime assert head_dim == Int(KCacheType.kv_params.head_size)
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime vec_width = simd_width // 2
+    comptime align = align_of[SIMD[dtype, vec_width]]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime total_heads = num_q_heads + num_kv_heads
+    comptime assert head_dim == half_warp_size * simd_width
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    var flat_row = Int(row)
+    var global_token_idx = 0
+    var head_slot = 0
+    var batch_idx = 0
+    var token_idx = 0
+    var q_post_seq_idx = 0
+    var k_post_seq_idx = 0
+
+    var is_active_row = row < UInt(total_rows)
+    if is_active_row:
+        global_token_idx = flat_row // total_heads
+        head_slot = flat_row % total_heads
+        batch_idx = get_batch_from_row_offsets(input_row_offsets, global_token_idx)
+        token_idx = Int(
+            UInt32(global_token_idx) - input_row_offsets[batch_idx]
+        )
+        q_post_seq_idx = Int(start_pos[batch_idx] + UInt32(token_idx))
+        k_post_seq_idx = k_cache.cache_length(batch_idx) + token_idx
+
+    var is_q_row = is_active_row and head_slot < num_q_heads
+    if is_active_row:
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+
+        if is_q_row:
+            var re_offset = Int(local_tid) * vec_width
+            var im_offset = re_offset + head_dim // 2
+            var freq_offset = Int(local_tid) * simd_width
+            var q_re = x.load[width=vec_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset))
+            )
+            var q_im = x.load[width=vec_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset))
+            )
+            var thread_m2 = (q_re.cast[accum_type]() ** 2).reduce_add() + (
+                q_im.cast[accum_type]() ** 2
+            ).reduce_add()
+            var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](thread_m2)
+            var norm_factor = rsqrt(
+                (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+            )
+
+            var q_gamma_re = q_gamma.load[width=vec_width, alignment=align](
+                Coord(Idx(re_offset))
+            )
+            var q_gamma_im = q_gamma.load[width=vec_width, alignment=align](
+                Coord(Idx(im_offset))
+            )
+            var q_norm_re = (
+                q_re.cast[accum_type]()
+                * norm_factor
+                * (q_gamma_re.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+            var q_norm_im = (
+                q_im.cast[accum_type]()
+                * norm_factor
+                * (q_gamma_im.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+
+            var q_freq = freqs_cis.load[width=simd_width, alignment=1](
+                Coord(Idx(q_post_seq_idx), Idx(freq_offset))
+            )
+            var q_rope = _rope_complex_mul_half[
+                dtype,
+                freq_dtype,
+                vec_width,
+                simd_width,
+            ](q_norm_re, q_norm_im, q_freq)
+            output.store[alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset)),
+                q_rope[0],
+            )
+            output.store[alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset)),
+                q_rope[1],
+            )
+        else:
+            var k_head_idx = head_slot - num_q_heads
+            var vec_data = k_cache.load[width=simd_width](
+                batch_idx, k_head_idx, k_post_seq_idx, Int(col)
+            ).cast[accum_type]()
+            var gamma_val = k_gamma.load[width=simd_width, alignment=wide_align](
+                Coord(Idx(Int(col)))
+            )
+            var norm_val = _rms_norm_warp_tiling_subkernel[
+                warps_per_block,
+                True,
+                rows_per_warp=2,
+            ](
+                flat_row,
+                Int(col),
+                vec_data,
+                gamma_val,
+                epsilon_accum,
+                weight_offset_accum,
+                head_dim,
+            )
+            var sub_warp_mask = (
+                (UInt(1) << UInt(half_warp_size)) - UInt(1)
+            ) << (sub_warp_idx * UInt(half_warp_size))
+            var partner_lane = (
+                sub_warp_idx * UInt(half_warp_size)
+                + (local_tid % UInt(half_warp_size // 2))
+                + UInt(half_warp_size // 2)
+            )
+            var norm_parts = norm_val.split()
+            var norm_lo_parts = norm_parts[0].split()
+            var norm_hi_parts = norm_parts[1].split()
+            var partner_norm_lo = warp.shuffle_idx(
+                sub_warp_mask,
+                norm_lo_parts[0],
+                UInt32(partner_lane),
+            ).join(
+                warp.shuffle_idx(
+                    sub_warp_mask,
+                    norm_lo_parts[1],
+                    UInt32(partner_lane),
+                )
+            )
+            var partner_norm_hi = warp.shuffle_idx(
+                sub_warp_mask,
+                norm_hi_parts[0],
+                UInt32(partner_lane),
+            ).join(
+                warp.shuffle_idx(
+                    sub_warp_mask,
+                    norm_hi_parts[1],
+                    UInt32(partner_lane),
+                )
+            )
+            var partner_norm = rebind[type_of(norm_val)](
+                partner_norm_lo.join(partner_norm_hi)
+            )
+
+            if local_tid < UInt(half_warp_size // 2):
+                var re_offset = Int(local_tid) * simd_width
+                var im_offset = re_offset + head_dim // 2
+                comptime cache_dtype = KCacheType.dtype
+                var k_freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                    Coord(Idx(k_post_seq_idx), Idx(re_offset * 2))
+                )
+                var k_rope = _rope_complex_mul_half[
+                    accum_type,
+                    freq_dtype,
+                    simd_width,
+                    simd_width * 2,
+                ](
+                    norm_val.cast[accum_type](),
+                    partner_norm.cast[accum_type](),
+                    k_freq,
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    k_post_seq_idx,
+                    re_offset,
+                    k_rope[0].cast[cache_dtype](),
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    k_post_seq_idx,
+                    im_offset,
+                    k_rope[1].cast[cache_dtype](),
+                )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _q_rms_norm_fused_qk_rope_decode_ragged_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    QGammaLayoutType: TensorLayout,
+    KGammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    q_gamma: TileTensor[dtype, QGammaLayoutType, MutAnyOrigin],
+    k_gamma: TileTensor[dtype, KGammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert q_gamma.flat_rank == 1
+    comptime assert k_gamma.flat_rank == 1
+
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+    comptime num_kv_heads = Int(KCacheType.kv_params.num_heads)
+    comptime assert head_dim == 128, "Only 128-column BF16 rows are supported"
+    comptime assert head_dim == Int(KCacheType.kv_params.head_size)
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime vec_width = simd_width // 2
+    comptime align = align_of[SIMD[dtype, vec_width]]()
+    comptime wide_align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime half_warp_size = WARP_SIZE // 2
+    comptime total_heads = num_q_heads + num_kv_heads
+    comptime assert head_dim == half_warp_size * simd_width
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var sub_warp_idx = (tid % UInt(WARP_SIZE)) // UInt(half_warp_size)
+    var local_tid = tid % UInt(half_warp_size)
+    var row = block_idx.x * UInt(warps_per_block * 2) + warp_idx * 2 + sub_warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    var flat_row = Int(row)
+    var global_token_idx = 0
+    var head_slot = 0
+    var batch_idx = 0
+    var post_seq_idx = 0
+
+    var is_active_row = row < UInt(total_rows)
+    if is_active_row:
+        global_token_idx = flat_row // total_heads
+        head_slot = flat_row % total_heads
+        batch_idx = global_token_idx
+        post_seq_idx = Int(start_pos[batch_idx])
+
+    var is_q_row = is_active_row and head_slot < num_q_heads
+    if is_active_row:
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+
+        if is_q_row:
+            var re_offset = Int(local_tid) * vec_width
+            var im_offset = re_offset + head_dim // 2
+            var freq_offset = Int(local_tid) * simd_width
+            var q_re = x.load[width=vec_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset))
+            )
+            var q_im = x.load[width=vec_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset))
+            )
+            var thread_m2 = (q_re.cast[accum_type]() ** 2).reduce_add() + (
+                q_im.cast[accum_type]() ** 2
+            ).reduce_add()
+            var row_m2 = warp.lane_group_sum[num_lanes=half_warp_size](thread_m2)
+            var norm_factor = rsqrt(
+                (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+            )
+
+            var q_gamma_re = q_gamma.load[width=vec_width, alignment=align](
+                Coord(Idx(re_offset))
+            )
+            var q_gamma_im = q_gamma.load[width=vec_width, alignment=align](
+                Coord(Idx(im_offset))
+            )
+            var q_norm_re = (
+                q_re.cast[accum_type]()
+                * norm_factor
+                * (q_gamma_re.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+            var q_norm_im = (
+                q_im.cast[accum_type]()
+                * norm_factor
+                * (q_gamma_im.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+
+            var q_freq = freqs_cis.load[width=simd_width, alignment=1](
+                Coord(Idx(post_seq_idx), Idx(freq_offset))
+            )
+            var q_rope = _rope_complex_mul_half[
+                dtype,
+                freq_dtype,
+                vec_width,
+                simd_width,
+            ](q_norm_re, q_norm_im, q_freq)
+            output.store[alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset)),
+                q_rope[0],
+            )
+            output.store[alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset)),
+                q_rope[1],
+            )
+        else:
+            var k_head_idx = head_slot - num_q_heads
+            var vec_data = k_cache.load[width=simd_width](
+                batch_idx, k_head_idx, post_seq_idx, Int(col)
+            ).cast[accum_type]()
+            var gamma_val = k_gamma.load[width=simd_width, alignment=wide_align](
+                Coord(Idx(Int(col)))
+            )
+            var norm_val = _rms_norm_warp_tiling_subkernel[
+                warps_per_block,
+                True,
+                rows_per_warp=2,
+            ](
+                flat_row,
+                Int(col),
+                vec_data,
+                gamma_val,
+                epsilon_accum,
+                weight_offset_accum,
+                head_dim,
+            )
+            var sub_warp_mask = (
+                (UInt(1) << UInt(half_warp_size)) - UInt(1)
+            ) << (sub_warp_idx * UInt(half_warp_size))
+            var partner_lane = (
+                sub_warp_idx * UInt(half_warp_size)
+                + (local_tid % UInt(half_warp_size // 2))
+                + UInt(half_warp_size // 2)
+            )
+            var norm_parts = norm_val.split()
+            var norm_lo_parts = norm_parts[0].split()
+            var norm_hi_parts = norm_parts[1].split()
+            var partner_norm_lo = warp.shuffle_idx(
+                sub_warp_mask,
+                norm_lo_parts[0],
+                UInt32(partner_lane),
+            ).join(
+                warp.shuffle_idx(
+                    sub_warp_mask,
+                    norm_lo_parts[1],
+                    UInt32(partner_lane),
+                )
+            )
+            var partner_norm_hi = warp.shuffle_idx(
+                sub_warp_mask,
+                norm_hi_parts[0],
+                UInt32(partner_lane),
+            ).join(
+                warp.shuffle_idx(
+                    sub_warp_mask,
+                    norm_hi_parts[1],
+                    UInt32(partner_lane),
+                )
+            )
+            var partner_norm = rebind[type_of(norm_val)](
+                partner_norm_lo.join(partner_norm_hi)
+            )
+
+            if local_tid < UInt(half_warp_size // 2):
+                var re_offset = Int(local_tid) * simd_width
+                var im_offset = re_offset + head_dim // 2
+                comptime cache_dtype = KCacheType.dtype
+                var k_freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                    Coord(Idx(post_seq_idx), Idx(re_offset * 2))
+                )
+                var k_rope = _rope_complex_mul_half[
+                    accum_type,
+                    freq_dtype,
+                    simd_width,
+                    simd_width * 2,
+                ](
+                    norm_val.cast[accum_type](),
+                    partner_norm.cast[accum_type](),
+                    k_freq,
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    re_offset,
+                    k_rope[0].cast[cache_dtype](),
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    im_offset,
+                    k_rope[1].cast[cache_dtype](),
+                )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(block_size))
+)
+def _q_rms_norm_fused_qk_rope_decode_ragged_wide_kernel[
+    dtype: DType,
+    freq_dtype: DType,
+    KCacheType: KVCacheT,
+    QLayoutType: TensorLayout,
+    OutputLayoutType: TensorLayout,
+    StartPosLayoutType: TensorLayout,
+    FreqLayoutType: TensorLayout,
+    QGammaLayoutType: TensorLayout,
+    KGammaLayoutType: TensorLayout,
+    block_size: Int,
+    warps_per_block: Int,
+](
+    x: TileTensor[dtype, QLayoutType, MutAnyOrigin],
+    output: TileTensor[mut=True, dtype, OutputLayoutType, MutAnyOrigin],
+    start_pos: TileTensor[DType.uint32, StartPosLayoutType, MutAnyOrigin],
+    k_cache: KCacheType,
+    freqs_cis: TileTensor[freq_dtype, FreqLayoutType, MutAnyOrigin],
+    q_gamma: TileTensor[dtype, QGammaLayoutType, MutAnyOrigin],
+    k_gamma: TileTensor[dtype, KGammaLayoutType, MutAnyOrigin],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    total_rows: Int,
+):
+    comptime assert x.flat_rank == 3
+    comptime assert output.flat_rank == 3
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime assert q_gamma.flat_rank == 1
+    comptime assert k_gamma.flat_rank == 1
+
+    comptime num_q_heads = x.static_shape[1]
+    comptime head_dim = x.static_shape[2]
+    comptime num_kv_heads = Int(KCacheType.kv_params.num_heads)
+    comptime assert head_dim == 256, "Only 256-column BF16 rows are supported"
+    comptime assert head_dim == Int(KCacheType.kv_params.head_size)
+    comptime assert freqs_cis.static_shape[1] == head_dim
+
+    comptime simd_width = simd_width_of[dtype]()
+    comptime align = align_of[SIMD[dtype, simd_width]]()
+    comptime accum_type = get_accum_type[dtype]()
+    comptime total_heads = num_q_heads + num_kv_heads
+    comptime assert head_dim == WARP_SIZE * simd_width
+
+    var shared_norm = stack_allocation[
+        warps_per_block * head_dim,
+        Scalar[dtype],
+        address_space=AddressSpace.SHARED,
+    ]()
+    var shared_post_seq = stack_allocation[
+        warps_per_block,
+        Int32,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var tid = thread_idx.x
+    var warp_idx = tid // UInt(WARP_SIZE)
+    var local_tid = tid % UInt(WARP_SIZE)
+    var row = block_idx.x * UInt(warps_per_block) + warp_idx
+    var col = local_tid * UInt(simd_width)
+
+    var flat_row = Int(row)
+    var global_token_idx = 0
+    var head_slot = 0
+    var batch_idx = 0
+    var post_seq_idx = 0
+
+    var is_active_row = row < UInt(total_rows)
+    if is_active_row:
+        global_token_idx = flat_row // total_heads
+        head_slot = flat_row % total_heads
+        batch_idx = global_token_idx
+        if local_tid == 0:
+            shared_post_seq[Int(warp_idx)] = Int32(Int(start_pos[batch_idx]))
+        syncwarp()
+        post_seq_idx = Int(shared_post_seq[Int(warp_idx)])
+
+    var is_q_row = is_active_row and head_slot < num_q_heads
+    if is_active_row:
+        var epsilon_accum = epsilon.cast[accum_type]()
+        var weight_offset_accum = weight_offset.cast[accum_type]()
+        var shared_base = Int(warp_idx) * head_dim
+
+        if is_q_row:
+            var q_vec = x.load[width=simd_width, alignment=align](
+                Coord(Idx(global_token_idx), Idx(head_slot), Idx(Int(col)))
+            )
+            var thread_m2 = (q_vec.cast[accum_type]() ** 2).reduce_add()
+            var row_m2 = warp.sum(thread_m2)
+            var norm_factor = rsqrt(
+                (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+            )
+            var gamma_val = q_gamma.load[width=simd_width, alignment=align](
+                Coord(Idx(Int(col)))
+            )
+            var norm_val = (
+                q_vec.cast[accum_type]()
+                * norm_factor
+                * (gamma_val.cast[accum_type]() + weight_offset_accum)
+            ).cast[dtype]()
+            shared_norm.store[width=simd_width, alignment=align](
+                shared_base + Int(col), norm_val
+            )
+            syncwarp()
+
+            if local_tid < UInt(WARP_SIZE // 2):
+                var re_offset = Int(local_tid) * simd_width
+                var im_offset = re_offset + head_dim // 2
+                var rope_re = shared_norm.load[width=simd_width](
+                    shared_base + re_offset
+                )
+                var rope_im = shared_norm.load[width=simd_width](
+                    shared_base + im_offset
+                )
+                var q_freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                    Coord(Idx(post_seq_idx), Idx(re_offset * 2))
+                )
+                var q_rope = _rope_complex_mul_half[
+                    dtype,
+                    freq_dtype,
+                    simd_width,
+                    simd_width * 2,
+                ](rope_re, rope_im, q_freq)
+                output.store[alignment=align](
+                    Coord(Idx(global_token_idx), Idx(head_slot), Idx(re_offset)),
+                    q_rope[0],
+                )
+                output.store[alignment=align](
+                    Coord(Idx(global_token_idx), Idx(head_slot), Idx(im_offset)),
+                    q_rope[1],
+                )
+        else:
+            var k_head_idx = head_slot - num_q_heads
+            var k_vec = k_cache.load[width=simd_width](
+                batch_idx, k_head_idx, post_seq_idx, Int(col)
+            ).cast[accum_type]()
+            var thread_m2 = (k_vec**2).reduce_add()
+            var row_m2 = warp.sum(thread_m2)
+            var norm_factor = rsqrt(
+                (row_m2 / Scalar[accum_type](head_dim)) + epsilon_accum
+            )
+            var gamma_val = k_gamma.load[width=simd_width, alignment=align](
+                Coord(Idx(Int(col)))
+            )
+            var norm_val = k_vec * norm_factor * (
+                gamma_val.cast[accum_type]() + weight_offset_accum
+            )
+            shared_norm.store[width=simd_width, alignment=align](
+                shared_base + Int(col), norm_val.cast[dtype]()
+            )
+            syncwarp()
+
+            if local_tid < UInt(WARP_SIZE // 2):
+                var re_offset = Int(local_tid) * simd_width
+                var im_offset = re_offset + head_dim // 2
+                var rope_re = shared_norm.load[width=simd_width](
+                    shared_base + re_offset
+                ).cast[accum_type]()
+                var rope_im = shared_norm.load[width=simd_width](
+                    shared_base + im_offset
+                ).cast[accum_type]()
+                var k_freq = freqs_cis.load[width=simd_width * 2, alignment=1](
+                    Coord(Idx(post_seq_idx), Idx(re_offset * 2))
+                )
+                comptime cache_dtype = KCacheType.dtype
+                var k_rope = _rope_complex_mul_half[
+                    accum_type,
+                    freq_dtype,
+                    simd_width,
+                    simd_width * 2,
+                ](rope_re, rope_im, k_freq)
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    re_offset,
+                    k_rope[0].cast[cache_dtype](),
+                )
+                k_cache.store(
+                    batch_idx,
+                    k_head_idx,
+                    post_seq_idx,
+                    im_offset,
+                    k_rope[1].cast[cache_dtype](),
+                )
+
+
+def _q_rms_norm_fused_qk_rope_generic_fallback[
+    dtype: DType,
+    freq_dtype: DType,
+    collection_t: KVCollectionT,
+    *,
+    interleaved: Bool,
+    target: StaticString,
+](
+    x: TileTensor[dtype, ...],
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    start_pos: TileTensor[DType.uint32, ...],
+    kv_collection: collection_t,
+    freqs_cis: TileTensor[freq_dtype, ...],
+    q_gamma: TileTensor[dtype, ...],
+    k_gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    output: TileTensor[mut=True, dtype, ...],
+    context: DeviceContext,
+) raises:
+    comptime assert input_row_offsets.flat_rank == 1
+    comptime assert start_pos.flat_rank == 1
+    comptime assert freqs_cis.flat_rank == 2
+    comptime head_dim = Int(x.static_shape[2])
+
+    comptime if dtype == DType.bfloat16 and head_dim == 256:
+        q_rms_norm_rope_ragged[
+            dtype,
+            freq_dtype,
+            target=target,
+        ](
+            x,
+            input_row_offsets,
+            start_pos,
+            freqs_cis,
+            q_gamma,
+            epsilon,
+            weight_offset,
+            output,
+            context,
+        )
+        k_rms_norm_rope_ragged[
+            dtype,
+            freq_dtype,
+            collection_t,
+            interleaved=interleaved,
+            target=target,
+        ](
+            Int(x.dim(0)),
+            input_row_offsets,
+            kv_collection,
+            freqs_cis,
+            k_gamma,
+            epsilon,
+            weight_offset,
+            layer_idx,
+            context,
+        )
+    else:
+        @always_inline
+        @parameter
+        @__copy_capture(x)
+        def q_input_fn[
+            width: Int, rank: Int
+        ](coords: IndexList[rank]) -> SIMD[dtype, width]:
+            return x.load[width=width](Coord(coords))
+
+        @always_inline
+        @parameter
+        @__copy_capture(output)
+        def q_output_fn[
+            width: Int, alignment: Int
+        ](coords: IndexList[3], val: SIMD[dtype, width]) -> None:
+            output.store[alignment=alignment](Coord(coords), val)
+
+        var q_shape = IndexList[3](
+            Int(x.dim(0)),
+            Int(x.dim(1)),
+            Int(x.dim(2)),
+        )
+        rms_norm_gpu[
+            q_input_fn,
+            q_output_fn,
+            multiply_before_cast=True,
+        ](q_shape, q_gamma, epsilon, weight_offset, context)
+
+        var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache, input_row_offsets)
+        def k_input_fn[
+            width: Int, rank: Int
+        ](coords: IndexList[rank]) -> SIMD[dtype, width]:
+            var global_token_idx = coords[0]
+            var batch_idx = get_batch_from_row_offsets(
+                input_row_offsets, global_token_idx
+            )
+            var batch_start = rebind[Scalar[DType.uint32]](
+                input_row_offsets.load[width=1](Coord(Idx(batch_idx)))
+            )
+            var token_idx = Int(UInt32(global_token_idx) - batch_start)
+            var cache_token_idx = token_idx + Int(k_cache.cache_length(batch_idx))
+            return k_cache.load[width=width](
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=coords[1],
+                head_dim_idx=coords[2],
+            ).cast[dtype]()
+
+        @always_inline
+        @parameter
+        @__copy_capture(k_cache, input_row_offsets)
+        def k_output_fn[
+            width: Int, alignment: Int
+        ](coords: IndexList[3], val: SIMD[dtype, width]) -> None:
+            var global_token_idx = coords[0]
+            var batch_idx = get_batch_from_row_offsets(
+                input_row_offsets, global_token_idx
+            )
+            var batch_start = rebind[Scalar[DType.uint32]](
+                input_row_offsets.load[width=1](Coord(Idx(batch_idx)))
+            )
+            var token_idx = Int(UInt32(global_token_idx) - batch_start)
+            var cache_token_idx = token_idx + Int(k_cache.cache_length(batch_idx))
+            k_cache.store(
+                bs=batch_idx,
+                tok_idx=cache_token_idx,
+                head_idx=coords[1],
+                head_dim_idx=coords[2],
+                val=val.cast[collection_t.CacheType.dtype](),
+            )
+
+        var k_shape = IndexList[3](
+            Int(x.dim(0)),
+            Int(collection_t.CacheType.kv_params.num_heads),
+            Int(k_gamma.dim(0)),
+        )
+        rms_norm_gpu[
+            k_input_fn,
+            k_output_fn,
+            multiply_before_cast=True,
+        ](k_shape, k_gamma, epsilon, weight_offset, context)
+
+        rope_ragged[
+            dtype,
+            freq_dtype,
+            interleaved=interleaved,
+            target=target,
+            output_fn=q_output_fn,
+        ](
+            output,
+            input_row_offsets,
+            start_pos,
+            freqs_cis,
+            Optional[DeviceContext](context),
+        )
+        _rope_k_cache_ragged[
+            freq_dtype,
+            collection_t,
+            interleaved=interleaved,
+            target=target,
+        ](
+            Int(x.dim(0)),
+            input_row_offsets,
+            kv_collection,
+            freqs_cis,
+            layer_idx,
+            context,
+        )
+
+
+def q_rms_norm_fused_qk_rope_ragged[
+    dtype: DType,
+    freq_dtype: DType,
+    collection_t: KVCollectionT,
+    *,
+    interleaved: Bool,
+    target: StaticString,
+](
+    x: TileTensor[dtype, ...],
+    input_row_offsets: TileTensor[DType.uint32, ...],
+    start_pos: TileTensor[DType.uint32, ...],
+    kv_collection: collection_t,
+    freqs_cis: TileTensor[freq_dtype, ...],
+    q_gamma: TileTensor[dtype, ...],
+    k_gamma: TileTensor[dtype, ...],
+    epsilon: Scalar[dtype],
+    weight_offset: Scalar[dtype],
+    layer_idx: UInt32,
+    output: TileTensor[mut=True, dtype, ...],
+    context: DeviceContext,
+) raises:
+    comptime assert (
+        not interleaved
+    ), "q_rms_norm_fused_qk_rope_ragged currently supports non-interleaved RoPE only"
+
+    comptime head_dim = Int(x.static_shape[2])
+    comptime num_q_heads = x.static_shape[1]
+    comptime num_kv_heads = Int(collection_t.CacheType.kv_params.num_heads)
+    var total_tokens = Int(x.dim(0))
+    var is_decode_uniform = total_tokens == Int(start_pos.dim(0))
+    var total_rows = total_tokens * (num_q_heads + num_kv_heads)
+
+    comptime if head_dim == 128 and dtype == DType.bfloat16:
+        comptime block_size = 64
+        comptime warps_per_block = 2
+        var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+        if is_decode_uniform:
+            # Decode submits one token per active request, so batch_idx matches
+            # global_token_idx and start_pos already carries the RoPE position.
+            comptime kernel = _q_rms_norm_fused_qk_rope_decode_ragged_kernel[
+                dtype,
+                freq_dtype,
+                collection_t.CacheType,
+                x.LayoutType,
+                output.LayoutType,
+                start_pos.LayoutType,
+                freqs_cis.LayoutType,
+                q_gamma.LayoutType,
+                k_gamma.LayoutType,
+                block_size,
+                warps_per_block,
+            ]
+            context.enqueue_function[kernel, kernel](
+                x,
+                output,
+                start_pos,
+                k_cache,
+                freqs_cis,
+                q_gamma,
+                k_gamma,
+                epsilon,
+                weight_offset,
+                total_rows,
+                grid_dim=ceildiv(total_rows, warps_per_block * 2),
+                block_dim=block_size,
+            )
+        else:
+            comptime kernel = _q_rms_norm_fused_qk_rope_ragged_kernel[
+                dtype,
+                freq_dtype,
+                collection_t.CacheType,
+                x.LayoutType,
+                output.LayoutType,
+                input_row_offsets.LayoutType,
+                start_pos.LayoutType,
+                freqs_cis.LayoutType,
+                q_gamma.LayoutType,
+                k_gamma.LayoutType,
+                block_size,
+                warps_per_block,
+            ]
+            context.enqueue_function[kernel, kernel](
+                x,
+                output,
+                input_row_offsets,
+                start_pos,
+                k_cache,
+                freqs_cis,
+                q_gamma,
+                k_gamma,
+                epsilon,
+                weight_offset,
+                total_rows,
+                grid_dim=ceildiv(total_rows, warps_per_block * 2),
+                block_dim=block_size,
+            )
+    elif dtype == DType.bfloat16 and head_dim == 256:
+        if is_decode_uniform:
+            comptime block_size = 64
+            comptime warps_per_block = 2
+            var k_cache = kv_collection.get_key_cache(Int(layer_idx))
+            comptime kernel = _q_rms_norm_fused_qk_rope_decode_ragged_wide_kernel[
+                dtype,
+                freq_dtype,
+                collection_t.CacheType,
+                x.LayoutType,
+                output.LayoutType,
+                start_pos.LayoutType,
+                freqs_cis.LayoutType,
+                q_gamma.LayoutType,
+                k_gamma.LayoutType,
+                block_size,
+                warps_per_block,
+            ]
+            context.enqueue_function[kernel, kernel](
+                x,
+                output,
+                start_pos,
+                k_cache,
+                freqs_cis,
+                q_gamma,
+                k_gamma,
+                epsilon,
+                weight_offset,
+                total_rows,
+                grid_dim=ceildiv(total_rows, warps_per_block),
+                block_dim=block_size,
+            )
+        else:
+            _q_rms_norm_fused_qk_rope_generic_fallback[
+                dtype,
+                freq_dtype,
+                collection_t,
+                interleaved=interleaved,
+                target=target,
+            ](
+                x,
+                input_row_offsets,
+                start_pos,
+                kv_collection,
+                freqs_cis,
+                q_gamma,
+                k_gamma,
+                epsilon,
+                weight_offset,
+                layer_idx,
+                output,
+                context,
+            )
+    else:
+        _q_rms_norm_fused_qk_rope_generic_fallback[
+            dtype,
+            freq_dtype,
+            collection_t,
+            interleaved=interleaved,
+            target=target,
+        ](
+            x,
+            input_row_offsets,
+            start_pos,
+            kv_collection,
+            freqs_cis,
+            q_gamma,
+            k_gamma,
+            epsilon,
+            weight_offset,
+            layer_idx,
+            output,
+            context,
         )

--- a/max/python/max/nn/kernels.py
+++ b/max/python/max/nn/kernels.py
@@ -1095,6 +1095,75 @@ def fused_qk_ragged_rope(
     )[0].tensor
 
 
+def q_rms_norm_fused_qk_ragged_rope(
+    kv_params: KVCacheParams,
+    input: TensorValue,
+    input_row_offsets: TensorValue,
+    kv_collection: PagedCacheValues,
+    freqs_cis: TensorValue,
+    q_gamma: TensorValue,
+    k_gamma: TensorValue,
+    epsilon: float | np.floating[Any],
+    layer_idx: TensorValue,
+    weight_offset: float | np.floating[Any],
+    *,
+    interleaved: bool = False,
+) -> TensorValue:
+    """Apply fused Q RMSNorm + QK RoPE on ragged inputs while updating K cache."""
+    if input.rank != 3:
+        raise ValueError(f"expected input rank 3, was {input.rank}")
+
+    if input_row_offsets.dtype != DType.uint32:
+        raise ValueError(
+            "expected input_row_offsets to have dtype uint32, was"
+            f" {input_row_offsets.dtype}"
+        )
+
+    if layer_idx.dtype != DType.uint32:
+        raise ValueError(
+            f"expected layer_idx to have dtype uint32, was {layer_idx.dtype}"
+        )
+
+    if q_gamma.rank != 1:
+        raise ValueError(f"expected q_gamma rank 1, was {q_gamma.rank}")
+
+    if k_gamma.rank != 1:
+        raise ValueError(f"expected k_gamma rank 1, was {k_gamma.rank}")
+
+    if q_gamma.dtype != kv_params.dtype or k_gamma.dtype != kv_params.dtype:
+        raise TypeError(
+            "expected q_gamma and k_gamma dtype to match KV cache dtype"
+            f" {kv_params.dtype}, but got {q_gamma.dtype} and {k_gamma.dtype}"
+        )
+
+    parameters: dict[str, bool | int | str | DType] = {
+        "interleaved": interleaved,
+        "cache_dtype": kv_params.dtype,
+    }
+
+    return ops.inplace_custom(
+        "mo.q_rms_norm_fused_qk_rope.ragged.paged",
+        device=input.device,
+        values=[
+            input,
+            input_row_offsets,
+            *kv_collection,
+            freqs_cis,
+            q_gamma,
+            k_gamma,
+            ops.constant(epsilon, q_gamma.dtype, device=DeviceRef.CPU()),
+            layer_idx,
+            ops.constant(weight_offset, q_gamma.dtype, device=DeviceRef.CPU()),
+        ],
+        out_types=[
+            TensorType(
+                dtype=input.dtype, shape=input.shape, device=input.device
+            )
+        ],
+        parameters=parameters,
+    )[0].tensor
+
+
 def fused_qk_padded_rope(
     kv_params: KVCacheParams,
     input: TensorValue,

--- a/max/python/max/pipelines/architectures/gemma3/gemma3.py
+++ b/max/python/max/pipelines/architectures/gemma3/gemma3.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Sequence
+from typing import cast
 
 from max.dtype import DType
 from max.graph import BufferValue, ShardingStrategy, TensorValue, ops
@@ -29,6 +30,7 @@ from max.nn.rotary_embedding import (
 )
 from max.nn.transformer.distributed_transformer import (
     DistributedLogitsPostprocessMixin,
+    distributed_logits_postprocess,
 )
 
 from .layers.attention import Gemma3Attention
@@ -36,6 +38,10 @@ from .layers.rms_norm import Gemma3RMSNorm
 from .layers.scaled_word_embedding import ScaledWordEmbedding
 from .layers.transformer_block import Gemma3TransformerBlock
 from .model_config import Gemma3Config
+
+
+def _identity_norm(x: TensorValue) -> TensorValue:
+    return x
 
 
 class Gemma3TextModel(DistributedLogitsPostprocessMixin, Module):
@@ -170,21 +176,49 @@ class Gemma3TextModel(DistributedLogitsPostprocessMixin, Module):
         # Create KV cache collections per device
 
         # Run through transformer layers
+        next_norm_xs: list[TensorValue] | None = None
         for idx, layer in enumerate(self.layers):
             layer_idx_tensor = ops.constant(
                 idx, DType.uint32, device=self.devices[0]
             )
-            h = layer(
+            next_input_layernorm_shards = cast(
+                Sequence[Gemma3RMSNorm], self.norm_shards
+            )
+            if idx + 1 < len(self.layers):
+                next_input_layernorm_shards = cast(
+                    Sequence[Gemma3RMSNorm],
+                    cast(
+                        Gemma3TransformerBlock, self.layers[idx + 1]
+                    ).input_layernorm_shards,
+                )
+            h, next_norm_xs = layer(
                 layer_idx_tensor,
                 h,
                 signal_buffers,
                 kv_collections,
                 input_row_offsets=input_row_offsets,
+                normalized_xs=next_norm_xs,
+                next_input_layernorm_shards=next_input_layernorm_shards,
                 **kwargs,
             )
 
-        return self._postprocess_logits(
-            h, input_row_offsets, return_n_logits, signal_buffers
+        postprocess_h = next_norm_xs if next_norm_xs is not None else h
+        postprocess_norms = (
+            [_identity_norm for _ in self.devices]
+            if next_norm_xs is not None
+            else self.norm_shards
+        )
+        return distributed_logits_postprocess(
+            postprocess_h,
+            input_row_offsets,
+            return_n_logits,
+            norm_shards=postprocess_norms,
+            lm_head=self.lm_head,
+            signal_buffers=signal_buffers,
+            return_logits=self.return_logits,
+            device=self.devices[0],
+            return_hidden_states=self.return_hidden_states,
+            logits_scaling=self.logits_scaling,
         )
 
 

--- a/max/python/max/pipelines/architectures/gemma3/layers/attention.py
+++ b/max/python/max/pipelines/architectures/gemma3/layers/attention.py
@@ -30,6 +30,7 @@ from max.nn.kernels import (
     flash_attention_ragged,
     fused_qk_ragged_rope,
     fused_qkv_ragged_matmul,
+    q_rms_norm_fused_qk_ragged_rope,
     quantize_static_scaled_float8,
     rms_norm_key_cache,
 )
@@ -271,35 +272,60 @@ class Gemma3Attention(Module, Shardable):
         # Apply rope.
         xq = xq.reshape((-1, self.n_heads, self.kv_params.head_dim))
 
-        # Apply QK norm to query and key states.
-        xq = self.q_norm(xq)
-        rms_norm_key_cache(
-            self.kv_params,
-            kv_collection=kv_collection,
-            gamma=self.k_norm.weight.cast(self.kv_params.dtype).to(
-                self.devices[0]
-            ),
-            epsilon=self.qk_norm_eps,
-            layer_idx=layer_idx,
-            total_seq_len=total_seq_len,
-            input_row_offsets=kwargs["input_row_offsets"],
-            weight_offset=1.0,
-        )
-
         # Apply rotary embedding.
         use_local = bool((self.layer_idx + 1) % self.sliding_window_pattern)
         rope = self.rope_local if use_local else self.rope_global
 
         freqs_cis = ops.cast(rope.freqs_cis, xq.dtype).to(xq.device)
-        xq = fused_qk_ragged_rope(
-            self.kv_params,
-            xq,
-            kwargs["input_row_offsets"],
-            kv_collection,
-            freqs_cis,
-            layer_idx,
-            interleaved=rope.interleaved,
+        can_fuse_qk_norm_rope = (
+            not rope.interleaved
+            and xq.dtype == DType.bfloat16
+            and self.kv_params.dtype == DType.bfloat16
+            and self.kv_params.head_dim in (128, 256)
         )
+        if can_fuse_qk_norm_rope:
+            xq = q_rms_norm_fused_qk_ragged_rope(
+                self.kv_params,
+                xq,
+                kwargs["input_row_offsets"],
+                kv_collection,
+                freqs_cis,
+                self.q_norm.weight.cast(self.kv_params.dtype).to(
+                    self.devices[0]
+                ),
+                self.k_norm.weight.cast(self.kv_params.dtype).to(
+                    self.devices[0]
+                ),
+                self.qk_norm_eps,
+                layer_idx,
+                weight_offset=1.0,
+                interleaved=False,
+            )
+        else:
+            # Other shapes stay on the original seam until they have their own
+            # measured win and correctness coverage.
+            rms_norm_key_cache(
+                self.kv_params,
+                kv_collection=kv_collection,
+                gamma=self.k_norm.weight.cast(self.kv_params.dtype).to(
+                    self.devices[0]
+                ),
+                epsilon=self.qk_norm_eps,
+                layer_idx=layer_idx,
+                total_seq_len=total_seq_len,
+                input_row_offsets=kwargs["input_row_offsets"],
+                weight_offset=1.0,
+            )
+            xq = self.q_norm(xq)
+            xq = fused_qk_ragged_rope(
+                self.kv_params,
+                xq,
+                kwargs["input_row_offsets"],
+                kv_collection,
+                freqs_cis,
+                layer_idx,
+                interleaved=rope.interleaved,
+            )
 
         # Calculate Flash Attention.
         mask_variant = (

--- a/max/python/max/pipelines/architectures/gemma3/layers/rms_norm.py
+++ b/max/python/max/pipelines/architectures/gemma3/layers/rms_norm.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 
 from max.dtype import DType
-from max.graph import DeviceRef
+from max.graph import DeviceRef, TensorType, TensorValue, ops
 from max.nn.norm.rms_norm import RMSNorm
 
 
@@ -54,3 +54,65 @@ class Gemma3RMSNorm(RMSNorm):
             shards.append(sharded)
 
         return shards
+
+
+def gemma3_rms_norm_fused_residual_add(
+    x: TensorValue,
+    residual: TensorValue,
+    norm1: Gemma3RMSNorm,
+    norm2: Gemma3RMSNorm,
+) -> tuple[TensorValue, TensorValue]:
+    """Compute norm2(norm1(x) + residual) and return both outputs."""
+    input_last_dim = x.shape[-1]
+
+    if input_last_dim != norm1.weight.shape[0]:
+        raise ValueError(
+            "First RMSNorm weight dimension "
+            f"({norm1.weight.shape[0]}) must match the input's last dimension "
+            f"({input_last_dim})"
+        )
+    if input_last_dim != norm2.weight.shape[0]:
+        raise ValueError(
+            "Second RMSNorm weight dimension "
+            f"({norm2.weight.shape[0]}) must match the input's last dimension "
+            f"({input_last_dim})"
+        )
+    if norm1.multiply_before_cast != norm2.multiply_before_cast:
+        raise ValueError(
+            "Fused Gemma3 RMSNorm requires both norms to share the same "
+            "multiply_before_cast setting"
+        )
+
+    gamma1: TensorValue = norm1.weight.cast(x.dtype)
+    gamma2: TensorValue = norm2.weight.cast(x.dtype)
+    if x.device:
+        gamma1 = gamma1.to(x.device)
+        gamma2 = gamma2.to(x.device)
+
+    results = ops.custom(
+        "rms_norm_fused_residual_add",
+        x.device,
+        [
+            x,
+            residual,
+            gamma1,
+            gamma2,
+            ops.constant(norm1.eps, dtype=x.dtype, device=DeviceRef.CPU()),
+            ops.constant(norm2.eps, dtype=x.dtype, device=DeviceRef.CPU()),
+            ops.constant(
+                norm1.weight_offset, dtype=x.dtype, device=DeviceRef.CPU()
+            ),
+            ops.constant(
+                norm2.weight_offset, dtype=x.dtype, device=DeviceRef.CPU()
+            ),
+        ],
+        [
+            TensorType(dtype=x.dtype, shape=x.shape, device=x.device),
+            TensorType(dtype=x.dtype, shape=x.shape, device=x.device),
+        ],
+        parameters={
+            "multiply_before_cast": norm1.multiply_before_cast,
+        },
+    )
+
+    return results[0].tensor, results[1].tensor

--- a/max/python/max/pipelines/architectures/gemma3/layers/transformer_block.py
+++ b/max/python/max/pipelines/architectures/gemma3/layers/transformer_block.py
@@ -15,6 +15,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import cast
+
 from max.graph import (
     BufferValue,
     DeviceRef,
@@ -29,6 +32,10 @@ from max.nn.transformer.distributed_transformer import (
     forward_sharded_layers,
 )
 from max.pipelines.architectures.gemma3.layers.attention import Gemma3Attention
+from max.pipelines.architectures.gemma3.layers.rms_norm import (
+    Gemma3RMSNorm,
+    gemma3_rms_norm_fused_residual_add,
+)
 
 
 class Gemma3TransformerBlock(Module):
@@ -105,10 +112,16 @@ class Gemma3TransformerBlock(Module):
         signal_buffers: list[BufferValue],
         kv_collections: list[PagedCacheValues],
         input_row_offsets: list[TensorValue],
+        normalized_xs: Sequence[TensorValue] | None = None,
+        next_input_layernorm_shards: Sequence[Gemma3RMSNorm] | None = None,
         **kwargs,
-    ) -> list[TensorValue]:
+    ) -> tuple[list[TensorValue], list[TensorValue] | None]:
         residual = xs
-        norm_xs = forward_sharded_layers(self.input_layernorm_shards, xs)
+        norm_xs = (
+            list(normalized_xs)
+            if normalized_xs is not None
+            else forward_sharded_layers(self.input_layernorm_shards, xs)
+        )
         attn_out = [
             shard(
                 norm_xs[i],
@@ -120,24 +133,49 @@ class Gemma3TransformerBlock(Module):
         ]
         attn_out = self.allreduce(attn_out, signal_buffers)
 
-        hidden_states = forward_sharded_layers(
-            self.post_attention_layernorm_shards, attn_out
-        )
-        hidden_states = [
-            residual[i] + hidden_states[i] for i in range(len(hidden_states))
+        fused_attn_norm = [
+            gemma3_rms_norm_fused_residual_add(
+                attn_out[i],
+                residual[i],
+                cast(
+                    Gemma3RMSNorm, self.post_attention_layernorm_shards[i]
+                ),
+                cast(
+                    Gemma3RMSNorm, self.pre_feedforward_layernorm_shards[i]
+                ),
+            )
+            for i in range(len(attn_out))
         ]
-
-        residual = hidden_states
-        norm_xs = forward_sharded_layers(
-            self.pre_feedforward_layernorm_shards, hidden_states
-        )
+        norm_xs = [fused_output for fused_output, _ in fused_attn_norm]
+        residual = [fused_residual for _, fused_residual in fused_attn_norm]
 
         hidden_states = forward_sharded_layers(self.mlp_shards, norm_xs)
         hidden_states = self.allreduce(hidden_states, signal_buffers)
 
-        hidden_states = forward_sharded_layers(
-            self.post_feedforward_layernorm_shards, hidden_states
-        )
-        return [
-            residual[i] + hidden_states[i] for i in range(len(hidden_states))
+        if next_input_layernorm_shards is None:
+            hidden_states = forward_sharded_layers(
+                self.post_feedforward_layernorm_shards, hidden_states
+            )
+            return (
+                [
+                    residual[i] + hidden_states[i]
+                    for i in range(len(hidden_states))
+                ],
+                None,
+            )
+
+        fused_mlp_norm = [
+            gemma3_rms_norm_fused_residual_add(
+                hidden_states[i],
+                residual[i],
+                cast(
+                    Gemma3RMSNorm, self.post_feedforward_layernorm_shards[i]
+                ),
+                next_input_layernorm_shards[i],
+            )
+            for i in range(len(hidden_states))
         ]
+        return (
+            [fused_residual for _, fused_residual in fused_mlp_norm],
+            [fused_output for fused_output, _ in fused_mlp_norm],
+        )

--- a/max/python/max/pipelines/architectures/gemma3/layers/transformer_block.py
+++ b/max/python/max/pipelines/architectures/gemma3/layers/transformer_block.py
@@ -137,12 +137,8 @@ class Gemma3TransformerBlock(Module):
             gemma3_rms_norm_fused_residual_add(
                 attn_out[i],
                 residual[i],
-                cast(
-                    Gemma3RMSNorm, self.post_attention_layernorm_shards[i]
-                ),
-                cast(
-                    Gemma3RMSNorm, self.pre_feedforward_layernorm_shards[i]
-                ),
+                cast(Gemma3RMSNorm, self.post_attention_layernorm_shards[i]),
+                cast(Gemma3RMSNorm, self.pre_feedforward_layernorm_shards[i]),
             )
             for i in range(len(attn_out))
         ]
@@ -168,9 +164,7 @@ class Gemma3TransformerBlock(Module):
             gemma3_rms_norm_fused_residual_add(
                 hidden_states[i],
                 residual[i],
-                cast(
-                    Gemma3RMSNorm, self.post_feedforward_layernorm_shards[i]
-                ),
+                cast(Gemma3RMSNorm, self.post_feedforward_layernorm_shards[i]),
                 next_input_layernorm_shards[i],
             )
             for i in range(len(hidden_states))

--- a/max/python/max/pipelines/architectures/gemma3multimodal/vision_model/gemma3multimodal.py
+++ b/max/python/max/pipelines/architectures/gemma3multimodal/vision_model/gemma3multimodal.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import functools
 import logging
 from collections.abc import Sequence
+from typing import cast
 
 from max.dtype import DType
 from max.graph import (
@@ -36,6 +37,7 @@ from max.nn.rotary_embedding import (
 )
 from max.nn.transformer.distributed_transformer import (
     DistributedLogitsPostprocessMixin,
+    distributed_logits_postprocess,
 )
 from max.pipelines.architectures.gemma3.layers.attention import Gemma3Attention
 from max.pipelines.architectures.gemma3.layers.rms_norm import Gemma3RMSNorm
@@ -53,6 +55,10 @@ from .encoding import Gemma3VisionEncoder
 from .projection import Gemma3MultiModalProjector
 
 logger = logging.getLogger("max.pipelines")
+
+
+def _identity_norm(x: TensorValue) -> TensorValue:
+    return x
 
 
 class Gemma3LanguageModel(DistributedLogitsPostprocessMixin, Module):
@@ -199,20 +205,48 @@ class Gemma3LanguageModel(DistributedLogitsPostprocessMixin, Module):
         ]
 
         # Run through transformer layers
+        next_norm_xs: list[TensorValue] | None = None
         for idx, layer in enumerate(self.layers):
             layer_idx_tensor = ops.constant(
                 idx, DType.uint32, device=self.devices[0]
             )
-            h = layer(
+            next_input_layernorm_shards = cast(
+                Sequence[Gemma3RMSNorm], self.norm_shards
+            )
+            if idx + 1 < len(self.layers):
+                next_input_layernorm_shards = cast(
+                    Sequence[Gemma3RMSNorm],
+                    cast(
+                        Gemma3TransformerBlock, self.layers[idx + 1]
+                    ).input_layernorm_shards,
+                )
+            h, next_norm_xs = layer(
                 layer_idx_tensor,
                 h,
                 signal_buffers,
                 kv_collections,
                 input_row_offsets=input_row_offsets,
+                normalized_xs=next_norm_xs,
+                next_input_layernorm_shards=next_input_layernorm_shards,
             )
 
-        return self._postprocess_logits(
-            h, input_row_offsets, return_n_logits, signal_buffers
+        postprocess_h = next_norm_xs if next_norm_xs is not None else h
+        postprocess_norms = (
+            [_identity_norm for _ in self.devices]
+            if next_norm_xs is not None
+            else self.norm_shards
+        )
+        return distributed_logits_postprocess(
+            postprocess_h,
+            input_row_offsets,
+            return_n_logits,
+            norm_shards=postprocess_norms,
+            lm_head=self.lm_head,
+            signal_buffers=signal_buffers,
+            return_logits=self.return_logits,
+            device=self.devices[0],
+            return_hidden_states=self.return_hidden_states,
+            logits_scaling=self.logits_scaling,
         )
 
 


### PR DESCRIPTION
## Summary
- keep the decode-focused Gemma 3 rope, fused QK, and KV-cache fast paths without the unrelated shared-kernel tuning work
- wire the Gemma 3 and Gemma 3 multimodal architecture layers to the current decode path
- keep this PR focused on the runtime path, not the profiling harness expansion

## Benchmark Notes
- fresh preserved-harness rerun for exact BF16/128 live QK decode with correctness restored:
  - baseline `86.5193 us`
  - fused `49.9235 us`
  - `1.7330x` speedup
  - `36.5958 us` saved
  - `+42.30%` latency reduction
- historical campaign peak on the same QK path:
  - baseline `62.2772 us`
  - fused `33.2468 us`
  - `1.8732x` speedup
  - `+46.61%` latency reduction
- note: the earlier q-only and K-only decode rows remain historical campaign measurements and were not rerun in the current validation pass

## Verification
- reran the preserved Gemma 3 decode harness on the 2x B200 workspace with the exact BF16/128 live QK decode configuration
- confirmed correctness passes on the fused QK decode path
