### PR TITLE
[stdlib] Add `String.join(*Writable)`, `String.join(Iterable[Writable])`, `String.join(IterableOwned[Writable])`

### DIFF
--- a/mojo/stdlib/std/builtin/string_literal.mojo
+++ b/mojo/stdlib/std/builtin/string_literal.mojo
@@ -771,26 +771,62 @@ struct StringLiteral[value: __mlir_type.`!kgen.string`](
         _FormatUtils.format_to_comptime[StaticString(Self())](buffer, *args)
         return buffer^
 
-    def join[T: Copyable & Writable, //](self, elems: Span[T, ...]) -> String:
+    @always_inline
+    def join[*Ts: Writable](self, *values: *Ts) -> String:
         """Joins string elements using the current string as a delimiter.
-        Defaults to writing to the stack if total bytes of `elems` is less than
-        `buffer_size`, otherwise will allocate once to the heap and write
-        directly into that. The `buffer_size` defaults to 4096 bytes to match
-        the default page size on arm64 and x86-64.
 
         Parameters:
-            T: The type of the elements. Must implement the `Copyable`,
-                and `Writable` traits.
+            Ts: The type of the elements. Must implement the
+                `Writable` trait.
 
         Args:
-            elems: The input values.
+            values: The input values.
 
         Returns:
             The joined string.
         """
-        # Materialize self
-        var result = self
-        return result.join(elems)
+        return StringSlice(self).join(*values)
+
+    @always_inline
+    def join[
+        IterableType: Iterable,
+    ](self, ref iterable: IterableType) -> String where conforms_to(
+        IterableType.IteratorType[origin_of(iterable)].Element,
+        Writable & Movable,
+    ):
+        """Joins string elements using the current string as a delimiter.
+
+        Parameters:
+            IterableType: The type of the elements. Must implement the
+                `Writable & Movable` traits.
+
+        Args:
+            iterable: The input values.
+
+        Returns:
+            The joined string.
+        """
+        return StringSlice(self).join(iterable)
+
+    @always_inline
+    def join[
+        IterableType: Iterator & IterableOwned
+    ](self, var iterable: IterableType) -> String where conforms_to(
+        IterableType.Element, Writable & Movable
+    ):
+        """Joins string elements using the current string as a delimiter.
+
+        Parameters:
+            IterableType: The type of the elements. Must implement the
+                `Writable & Movable` traits.
+
+        Args:
+            iterable: The input values.
+
+        Returns:
+            The joined string.
+        """
+        return StringSlice(self).join(iterable^)
 
     @always_inline
     def split(self, sep: StringSlice) -> List[StaticString]:

--- a/mojo/stdlib/std/collections/string/string.mojo
+++ b/mojo/stdlib/std/collections/string/string.mojo
@@ -400,7 +400,7 @@ struct String(
         Examples:
 
         ```mojo
-        from testing import assert_equal
+        from std.testing import assert_equal
 
         # Valid UTF-8 sequence
         var fire_emoji_bytes = [Byte(0xF0), 0x9F, 0x94, 0xA5]
@@ -1017,32 +1017,62 @@ struct String(
         """
         StringSlice(self).write_repr_to(writer)
 
-    def join[T: Copyable & Writable](self, elems: Span[T, ...]) -> String:
+    @always_inline
+    def join[*Ts: Writable](self, *values: *Ts) -> String:
         """Joins string elements using the current string as a delimiter.
-        Defaults to writing to the stack if total bytes of `elems` is less than
-        `buffer_size`, otherwise will allocate once to the heap and write
-        directly into that. The `buffer_size` defaults to 4096 bytes to match
-        the default page size on arm64 and x86-64.
 
         Parameters:
-            T: The type of the elements. Must implement the `Copyable`,
-                and `Writable` traits.
+            Ts: The type of the elements. Must implement the
+                `Writable` trait.
 
         Args:
-            elems: The input values.
+            values: The input values.
 
         Returns:
             The joined string.
-
-        Notes:
-            - Defaults to writing directly to the string if the bytes
-            fit in an inline `String`, otherwise will process it by chunks.
-            - The `buffer_size` defaults to 4096 bytes to match the default
-            page size on arm64 and x86-64, but you can increase this if you're
-            joining a very large `List` of elements to write into the stack
-            instead of the heap.
         """
-        return StringSlice(self).join(elems)
+        return StringSlice(self).join(*values)
+
+    @always_inline
+    def join[
+        IterableType: Iterable,
+    ](self, ref iterable: IterableType) -> String where conforms_to(
+        IterableType.IteratorType[origin_of(iterable)].Element,
+        Writable & Movable,
+    ):
+        """Joins string elements using the current string as a delimiter.
+
+        Parameters:
+            IterableType: The type of the elements. Must implement the
+                `Writable & Movable` traits.
+
+        Args:
+            iterable: The input values.
+
+        Returns:
+            The joined string.
+        """
+        return StringSlice(self).join(iterable)
+
+    @always_inline
+    def join[
+        IterableType: Iterator & IterableOwned
+    ](self, var iterable: IterableType) -> String where conforms_to(
+        IterableType.Element, Writable & Movable
+    ):
+        """Joins string elements using the current string as a delimiter.
+
+        Parameters:
+            IterableType: The type of the elements. Must implement the
+                `Writable & Movable` traits.
+
+        Args:
+            iterable: The input values.
+
+        Returns:
+            The joined string.
+        """
+        return StringSlice(self).join(iterable^)
 
     def codepoints(self) -> CodepointsIter[origin_of(self)]:
         """Returns an iterator over the `Codepoint`s encoded in this string slice.
@@ -1254,7 +1284,7 @@ struct String(
             Query the length of a string, in bytes and Unicode codepoints:
 
             ```mojo
-            %# from testing import assert_equal
+            %# from std.testing import assert_equal
 
             var s = StringSlice("ನಮಸ್ಕಾರ")
             assert_equal(s.count_codepoints(), 7)
@@ -1265,7 +1295,7 @@ struct String(
             Unicode codepoint length:
 
             ```mojo
-            %# from testing import assert_equal
+            %# from std.testing import assert_equal
 
             var s = StringSlice("abc")
             assert_equal(s.count_codepoints(), 3)
@@ -1276,7 +1306,7 @@ struct String(
             the length in Unicode codepoints, not grapheme clusters:
 
             ```mojo
-            %# from testing import assert_equal
+            %# from std.testing import assert_equal
 
             var s = StringSlice("á")
             assert_equal(s.count_codepoints(), 2)

--- a/mojo/stdlib/std/collections/string/string_slice.mojo
+++ b/mojo/stdlib/std/collections/string/string_slice.mojo
@@ -2037,45 +2037,106 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
             result += fillchar
         return result
 
-    def join[
-        T: Copyable & Writable,
-        //,
-    ](self, elems: Span[T, ...]) -> String:
+    def join[*Ts: Writable](self, *values: *Ts) -> String:
         """Joins string elements using the current string as a delimiter.
 
         Parameters:
-            T: The type of the elements, must implement the `Copyable`,
-                and `Writable` traits.
+            Ts: The type of the elements. Must implement the
+                `Writable` trait.
 
         Args:
-            elems: The input values.
+            values: The input values.
 
         Returns:
             The joined string.
-
-        Notes:
-            - Defaults to writing directly to the string if the bytes
-            fit in an inline `String`, otherwise will process it by chunks.
         """
-        if len(elems) == 0:
-            return String()
+        var total_bytes = _TotalWritableBytes()
+        values._write_to(total_bytes, start="", end="", sep=self)
+        var result = String(capacity=total_bytes.size)
 
-        var sep = StringSlice(ptr=self.unsafe_ptr(), length=self.byte_length())
-        var total_bytes = _TotalWritableBytes(elems, sep=sep).size
-        var result = String(capacity=total_bytes)
-
-        if result._is_inline():
-            # Write directly to the stack address
-            result.write(elems[0])
-            for i in range(1, len(elems)):
-                result.write(self, elems[i])
+        if result._is_inline():  # Write directly to the stack address
+            result.write(values[0])
+            comptime for i in range(1, values.__len__()):
+                result.write(self, values[i])
             return result^
 
         var buffer = _WriteBufferStack(result)
+        buffer.write(values[0])
+        comptime for i in range(1, values.__len__()):
+            buffer.write(self, values[i])
+        buffer.flush()
+        return result^
 
-        buffer.write(elems[0])
-        for i in range(1, len(elems)):
-            buffer.write(self, elems[i])
+    def join[
+        IterableType: Iterable,
+    ](self, ref iterable: IterableType) -> String where conforms_to(
+        IterableType.IteratorType[origin_of(iterable)].Element,
+        Writable & Movable,
+    ):
+        """Joins string elements using the current string as a delimiter.
+
+        Parameters:
+            IterableType: The type of the elements, must implement the
+                `Writable & Movable` traits.
+
+        Args:
+            iterable: The input values.
+
+        Returns:
+            The joined string.
+        """
+
+        var total_bytes = _TotalWritableBytes(iterable, sep=self).size
+        if total_bytes == 0:
+            return String()
+        var result = String(capacity=total_bytes)
+
+        if result._is_inline():  # Write directly to the stack address
+            var is_first = True
+            for var value in iterable:
+                if not is_first:
+                    result.write(self)
+                result.write(trait_downcast_var[Writable & Movable](value^))
+                is_first = False
+            return result^
+
+        var buffer = _WriteBufferStack(result)
+        var is_first = True
+        for var value in iterable:
+            if not is_first:
+                buffer.write(self)
+            buffer.write(trait_downcast_var[Writable & Movable](value^))
+            is_first = False
+        buffer.flush()
+        return result^
+
+    def join[
+        IterableType: Iterator & IterableOwned
+    ](self, var iterable: IterableType) -> String where conforms_to(
+        IterableType.Element, Writable & Movable
+    ):
+        """Joins string elements using the current string as a delimiter.
+
+        Parameters:
+            IterableType: The type of the elements, must implement the
+                `Writable & Movable` traits.
+
+        Args:
+            iterable: The input values.
+
+        Returns:
+            The joined string.
+        """
+
+        var lb, _ = iterable.bounds()
+        var result = String(capacity=self.byte_length() * max(lb - 1, 0) + lb)
+        var buffer = _WriteBufferStack(result)
+        var is_first = True
+        for var value in iterable^:
+            if not is_first:
+                buffer.write(self)
+            buffer.write(trait_downcast_var[Writable & Movable](value^))
+            is_first = False
         buffer.flush()
         return result^
 

--- a/mojo/stdlib/std/format/_utils.mojo
+++ b/mojo/stdlib/std/format/_utils.mojo
@@ -528,22 +528,22 @@ struct _TotalWritableBytes(Writer):
         self.size = 0
 
     def __init__[
-        T: Copyable & Writable,
-        //,
-        origin: ImmutOrigin,
+        IterableType: Iterable, origin: ImmutOrigin = StaticConstantOrigin
     ](
         out self,
-        values: Span[T, ...],
+        ref iterable: IterableType,
         sep: StringSlice[origin] = StringSlice[origin](),
+    ) where conforms_to(
+        IterableType.IteratorType[origin_of(iterable)].Element,
+        Writable & Movable,
     ):
         self.size = 0
-        var length = len(values)
-        if length == 0:
-            return
-        self.write(values[0])
-        if length > 1:
-            for i in range(1, length):
-                self.write(sep, values[i])
+        var is_first = True
+        for var value in iterable:
+            if not is_first:
+                self.write(sep)
+            self.write(trait_downcast_var[Writable & Movable](value^))
+            is_first = False
 
     def write_string(mut self, string: StringSlice):
         self.size += string.byte_length()

--- a/mojo/stdlib/test/collections/string/test_iterators.mojo
+++ b/mojo/stdlib/test/collections/string/test_iterators.mojo
@@ -156,5 +156,20 @@ def test_string_slice_codepoint_slices_reversed() raises:
     assert_equal(concat, "")
 
 
+def test_string_join_iterable() raises:
+    var elems = [1, 2, 3]
+    assert_equal("".join(iter(elems)), "123")
+    assert_equal(",".join(iter(elems)), "1,2,3")
+    assert_equal("".join("123".codepoints()), "123")
+    assert_equal(",".join("123".codepoints()), "1,2,3")
+    assert_equal("".join("123".codepoint_slices()), "123")
+    assert_equal(",".join("123".codepoint_slices()), "1,2,3")
+
+
+def test_string_join_iterable_owned() raises:
+    assert_equal("".join(iter([1, 2, 3])), "123")
+    assert_equal(",".join(iter([1, 2, 3])), "1,2,3")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/mojo/stdlib/test/collections/string/test_string.mojo
+++ b/mojo/stdlib/test/collections/string/test_string.mojo
@@ -150,10 +150,10 @@ def test_add() raises:
     assert_equal("123abc", s3)
 
     var s4 = "x"
-    var s5 = s4.join(Span([1, 2, 3]))
+    var s5 = s4.join(iter([1, 2, 3]))
     assert_equal("1x2x3", s5)
 
-    var s6 = s4.join(Span([s1, s2]))
+    var s6 = s4.join(iter([s1, s2]))
     assert_equal("123xabc", s6)
 
     var s7 = String()
@@ -174,34 +174,6 @@ def test_add_string_slice() raises:
     s1 += s2
     s1 += s3
     assert_equal("123abcabc", s1)
-
-
-def test_string_join() raises:
-    var sep = ","
-    var s0 = "abc"
-    var s1 = sep.join(Span([s0, s0, s0, s0]))
-    assert_equal("abc,abc,abc,abc", s1)
-
-    assert_equal(sep.join(Span([1, 2, 3])), "1,2,3")
-
-    # TODO(MSTDL-2078): Continue supporting heterogenous String.join
-    #   arguments, somehow?
-    # assert_equal(sep.join(1, "abc", 3), "1,abc,3")
-
-    var s2 = ",".join(Span([UInt8(1), 2, 3]))
-    assert_equal(s2, "1,2,3")
-
-    var s3 = ",".join(Span([UInt8(1), 2, 3, 4, 5, 6, 7, 8, 9]))
-    assert_equal(s3, "1,2,3,4,5,6,7,8,9")
-
-    var s4 = ",".join(List[UInt8]())
-    assert_equal(s4, "")
-
-    var s5 = ",".join(Span([UInt8(1)]))
-    assert_equal(s5, "1")
-
-    var s6 = ",".join(Span[String](["1", "2", "3"]))
-    assert_equal(s6, "1,2,3")
 
 
 def test_ord() raises:

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -1021,30 +1021,28 @@ def test_replace() raises:
 def test_join() raises:
     # TODO(MOCO-2908): This explicit origin should not be necessary; the
     #   compiler ought to infer some default "bottom" origin.
-    assert_equal(StaticString("").join(Span[String, ImmutAnyOrigin]()), "")
-    assert_equal(StaticString("").join(Span(["a", "b", "c"])), "abc")
-    assert_equal(StaticString(" ").join(Span(["a", "b", "c"])), "a b c")
-    assert_equal(StaticString(" ").join(Span(["a", "b", "c", ""])), "a b c ")
-    assert_equal(StaticString(" ").join(Span(["a", "b", "c", " "])), "a b c  ")
+    assert_equal(StaticString("").join(iter(List[String]())), "")
+    assert_equal(StaticString("").join(iter(["a", "b", "c"])), "abc")
+    assert_equal(StaticString(" ").join(iter(["a", "b", "c"])), "a b c")
+    assert_equal(StaticString(" ").join(iter(["a", "b", "c", ""])), "a b c ")
+    assert_equal(StaticString(" ").join(iter(["a", "b", "c", " "])), "a b c  ")
 
     var sep = StaticString(",")
     var s = "abc"
-    assert_equal(sep.join(Span([s, s, s, s])), "abc,abc,abc,abc")
-    assert_equal(sep.join(Span([1, 2, 3])), "1,2,3")
-    # TODO(MSTDL-2078): Continue supporting heterogenous StringSlice.join
-    #   arguments, somehow?
-    # assert_equal(sep.join(Span([1, "abc", 3])), "1,abc,3")
+    assert_equal(sep.join(iter([s, s, s, s])), "abc,abc,abc,abc")
+    assert_equal(sep.join(iter([1, 2, 3])), "1,2,3")
+    assert_equal(sep.join(1, "abc", 3), "1,abc,3")
 
-    var s2 = StaticString(",").join(Span([Byte(1), 2, 3]))
+    var s2 = StaticString(",").join(iter([1, 2, 3]))
     assert_equal(s2, "1,2,3")
 
-    var s3 = StaticString(",").join(Span([Byte(1), 2, 3, 4, 5, 6, 7, 8, 9]))
+    var s3 = StaticString(",").join(iter([1, 2, 3, 4, 5, 6, 7, 8, 9]))
     assert_equal(s3, "1,2,3,4,5,6,7,8,9")
 
-    var s4 = StaticString(",").join(List[Byte]())
+    var s4 = StaticString(",").join(iter(List[Byte]()))
     assert_equal(s4, "")
 
-    var s5 = StaticString(",").join(Span([Byte(1)]))
+    var s5 = StaticString(",").join(iter([1]))
     assert_equal(s5, "1")
 
 


### PR DESCRIPTION
Add `String.join(*Writable)`, `String.join(Iterable[Writable])`, `String.join(IterableOwned[Writable])`.

Phase 0 of https://github.com/modular/modular/issues/6359

Closes MSTDL-2078