### PR TITLE
[stdlib] Fix FileHandle.seek offset type from UInt64 to Int64

### DIFF
--- a/mojo/stdlib/std/io/file.mojo
+++ b/mojo/stdlib/std/io/file.mojo
@@ -422,13 +422,12 @@ struct FileHandle(Defaultable, Movable, Writer):
 
         return result^
 
-    def seek(
-        self, offset: UInt64, whence: UInt8 = os.SEEK_SET
-    ) raises -> UInt64:
+    def seek(self, offset: Int64, whence: UInt8 = os.SEEK_SET) raises -> UInt64:
         """Seeks to the given offset in the file.
 
         Args:
-            offset: The byte offset to seek to.
+            offset: The byte offset to seek to. Can be negative when
+                seeking relative to the current position or end of file.
             whence: The reference point for the offset:
                 os.SEEK_SET = 0: start of file (Default).
                 os.SEEK_CUR = 1: current position.

--- a/mojo/stdlib/std/tempfile/tempfile.mojo
+++ b/mojo/stdlib/std/tempfile/tempfile.mojo
@@ -517,12 +517,13 @@ struct NamedTemporaryFile(Movable):
         return self._file_handle.read_bytes(size)
 
     def seek(
-        self, offset: UInt64, whence: UInt8 = std.os.SEEK_SET
+        self, offset: Int64, whence: UInt8 = std.os.SEEK_SET
     ) raises -> UInt64:
         """Seeks to the given offset in the file.
 
         Args:
-            offset: The byte offset to seek to from the start of the file.
+            offset: The byte offset to seek to. Can be negative when
+                seeking relative to the current position or end of file.
             whence: The reference point for the offset:
                 os.SEEK_SET = 0: start of file (Default).
                 os.SEEK_CUR = 1: current position.

--- a/mojo/stdlib/test/builtin/test_file.mojo
+++ b/mojo/stdlib/test/builtin/test_file.mojo
@@ -310,6 +310,36 @@ def test_file_seek() raises:
             )
 
 
+def test_file_seek_int64_offset() raises:
+    """Test that seek accepts Int64 offsets, including negative values."""
+    import std.os
+
+    var tmp = Path(gettempdir().value()) / "test_seek_int64"
+    with open(tmp, "w") as f:
+        f.write("abcdefghijklmnopqrstuvwxyz")
+
+    with open(tmp, "r") as f:
+        # Positive Int64 offset
+        var offset = Int64(10)
+        var pos = f.seek(offset)
+        assert_equal(pos, 10)
+        assert_equal(f.read(3), "klm")
+
+        # Negative Int64 offset from end
+        var neg_offset = Int64(-5)
+        pos = f.seek(neg_offset, std.os.SEEK_END)
+        assert_equal(pos, 21)
+        assert_equal(f.read(5), "vwxyz")
+
+        # Negative Int64 offset from current position
+        _ = f.seek(Int64(15))
+        pos = f.seek(Int64(-5), std.os.SEEK_CUR)
+        assert_equal(pos, 10)
+        assert_equal(f.read(3), "klm")
+
+    std.os.remove(tmp)
+
+
 def test_file_open_nodir() raises:
     var f = open(Path("test_file_open_nodir"), "w")
     f.close()

--- a/mojo/stdlib/test/builtin/test_print.mojo
+++ b/mojo/stdlib/test/builtin/test_print.mojo
@@ -40,7 +40,7 @@ def _assert_equal_error(
 
 struct PrintChecker(Movable):
     var tmp: NamedTemporaryFile
-    var cursor: UInt64
+    var cursor: Int64
     var call_location: SourceLocation
 
     @always_inline
@@ -63,7 +63,7 @@ struct PrintChecker(Movable):
             raise _assert_equal_error(
                 String(result), expected, msg, self.call_location
             )
-        self.cursor += UInt64(result.byte_length() + 1)
+        self.cursor += Int64(len(result) + 1)
 
     def check_line_starts_with(
         mut self, prefix: String, msg: String = ""
@@ -81,7 +81,7 @@ struct PrintChecker(Movable):
                 msg,
                 self.call_location,
             )
-        self.cursor += UInt64(result.byte_length() + 1)
+        self.cursor += Int64(len(result) + 1)
 
 
 def test_print() raises:


### PR DESCRIPTION
Fixes #4473

## Summary
- Changes `FileHandle.seek` offset parameter from `UInt64` to `Int64` to match `lseek` semantics — negative offsets are valid with `SEEK_CUR` and `SEEK_END`
- Applies the same fix to `NamedTemporaryFile.seek` which wraps `FileHandle.seek`
- Updates `test_print.mojo` to use `Int64` for the seek cursor (downstream consumer of the API change)
- Adds `test_file_seek_int64_offset` unit test covering positive, negative, and relative negative offsets

## Testing
- `//mojo/stdlib/test/builtin:test_file.mojo.test` — passes (includes new Int64 offset test)
- `//mojo/stdlib/test/tempfile:test_tempfile.mojo.test` — passes
- `//mojo/stdlib/test/builtin:test_print.mojo.test` — passes (updated cursor type)

## Checklist
- [x] PR is small and focused — consider splitting larger changes into a sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an `Assisted-by:` trailer in my commit message or this PR description (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))