### PR TITLE
[stdlib] Add docstring examples to hashlib hash functions Body:

### DIFF
--- a/mojo/stdlib/std/hashlib/hash.mojo
+++ b/mojo/stdlib/std/hashlib/hash.mojo
@@ -112,6 +112,14 @@ def hash[
 
     Returns:
         A 64-bit integer hash based on the underlying implementation.
+
+    Example:
+    ```mojo
+    from hashlib import hash
+
+    var h = hash(42)
+    print(h)  # prints a UInt64 hash value
+    ```
     """
     var hasher = HasherType()
     hasher.update(hashable)
@@ -133,6 +141,15 @@ def hash[
 
     Returns:
         A 64-bit integer hash value.
+
+    Example:
+    ```mojo
+    from hashlib import hash
+
+    var msg = String("hello")
+    var h = hash(msg.unsafe_ptr(), len(msg))
+    print(h)  # prints a UInt64 hash value
+    ```
     """
     var hasher = HasherType()
     hasher._update_with_bytes(Span(ptr=bytes, length=n))


### PR DESCRIPTION
## Summary
2 hash function overloads in std.hashlib had no usage examples in their docstrings. No logic changes — docstrings only.
Partial fix for #3572.

## Testing

./bazelw test //mojo/stdlib/std:std.docs_test — passes, all docstring examples compile

## Checklist

- [x]  PR is small and focused
- [x]  I ran ./bazelw run format
- [x]  I added or updated tests to cover my changes
- [x]  If AI tools assisted with this contribution, I have included an Assisted-by: trailer in my commit message or this PR description