### PR TITLE
[stdlib] Add default indexing for all iterators

### DIFF
--- a/mojo/stdlib/std/builtin/range.mojo
+++ b/mojo/stdlib/std/builtin/range.mojo
@@ -74,10 +74,9 @@ struct _ZeroStartingRange(
         return self.curr
 
     @always_inline
-    def __getitem__[I: Indexer](self, idx: I) -> Int:
-        var i = index(idx)
-        assert i < self.__len__(), "index out of range"
-        return i
+    def __getitem__(var self, idx: Some[Indexer]) -> Int:
+        assert index(idx) < self.__len__(), "index out of bounds."
+        return index(idx)
 
     @always_inline
     def __reversed__(self) -> _StridedRange:
@@ -121,8 +120,8 @@ struct _SequentialRange(
         return self.end - self.start
 
     @always_inline
-    def __getitem__[I: Indexer](self, idx: I) -> Int:
-        assert self.__len__() > index(idx), "index out of range"
+    def __getitem__(var self, idx: Some[Indexer]) -> Int:
+        assert index(idx) < self.__len__(), "index out of bounds."
         return self.start + index(idx)
 
     @always_inline
@@ -233,8 +232,8 @@ struct _StridedRange(
         return ceildiv(select(cnd, 0, numerator), select(cnd, 1, denominator))
 
     @always_inline
-    def __getitem__[I: Indexer](self, idx: I) -> Int:
-        assert self.__len__() > index(idx), "index out of range"
+    def __getitem__(var self, idx: Some[Indexer]) -> Int:
+        assert index(idx) < self.__len__(), "index out of bounds."
         return self.start + index(idx) * self.step
 
     @always_inline
@@ -361,8 +360,8 @@ struct _ZeroStartingScalarRange[dtype: DType](
         return self.curr
 
     @always_inline
-    def __getitem__(self, idx: Scalar[Self.dtype]) -> Scalar[Self.dtype]:
-        assert idx < self.__len__(), "index out of range"
+    def __getitem__(var self, idx: Scalar[Self.dtype]) -> Scalar[Self.dtype]:
+        assert idx < self.__len__(), "index out of bounds."
         return idx
 
     @always_inline
@@ -411,8 +410,8 @@ struct _SequentialScalarRange[dtype: DType](
         return self.end - self.start
 
     @always_inline
-    def __getitem__(self, idx: Scalar[Self.dtype]) -> Scalar[Self.dtype]:
-        assert idx < self.__len__(), "index out of range"
+    def __getitem__(var self, idx: Scalar[Self.dtype]) -> Scalar[Self.dtype]:
+        assert idx < self.__len__(), "index out of bounds."
         return self.start + idx
 
     @always_inline
@@ -482,8 +481,8 @@ struct _StridedScalarRange[dtype: DType](
         return _scalar_range_bounds(self.__len__())
 
     @always_inline
-    def __getitem__(self, idx: Scalar[Self.dtype]) -> Scalar[Self.dtype]:
-        assert idx < self.__len__(), "index out of range"
+    def __getitem__(var self, idx: Scalar[Self.dtype]) -> Scalar[Self.dtype]:
+        assert idx < self.__len__(), "index out of bounds."
         return self.start + idx * self.step
 
 

--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -456,10 +456,42 @@ struct List[T: Copyable](
         Args:
             iterable: The iterable of values to populate the list with.
         """
-        var lower, _ = iter(iterable).bounds()
+        return {iter(iterable)}
+
+    def __init__[
+        IterableType: IterableOwned,
+    ](
+        var iterable: IterableType,
+        out self: List[
+            downcast[IterableType.IteratorOwnedType.Element, Copyable]
+        ],
+    ) where conforms_to(IterableType.IteratorOwnedType.Element, Copyable):
+        """Constructs a list from an iterable of values.
+
+        Parameters:
+            IterableType: The type of the `iterable` argument.
+
+        Args:
+            iterable: The iterable of values to populate the list with.
+        """
+        return {iter(iterable^)}
+
+    def __init__(
+        var iterator: Some[Iterator],
+        out self: List[downcast[type_of(iterator).Element, Copyable]],
+    ) where conforms_to(type_of(iterator).Element, Copyable):
+        """Constructs a list from an iterator of values.
+
+        Args:
+            iterator: The iterator of values to populate the list with.
+        """
+        var lower, _ = iterator.bounds()
         self = type_of(self)(capacity=lower)
-        for var value in iterable:
-            self.append(rebind_var[type_of(self).T](value^))
+        while True:
+            try:
+                self.append(rebind_var[type_of(self).T](next(iterator)))
+            except StopIteration:
+                break
 
     @always_inline
     def __init__(out self, *, unsafe_uninit_length: Int):

--- a/mojo/stdlib/std/iter/__init__.mojo
+++ b/mojo/stdlib/std/iter/__init__.mojo
@@ -54,6 +54,8 @@ for squared in map[square](values):
 """
 
 from std.builtin.constrained import _constrained_conforms_to
+from std.builtin.builtin_slice import ContiguousSlice, StridedSlice
+from std.os import abort
 
 # ===-----------------------------------------------------------------------===#
 # Iterable
@@ -128,6 +130,83 @@ struct StopIteration(TrivialRegisterPassable, Writable):
         writer.write("StopIteration")
 
 
+@fieldwise_init
+struct _ContiguousIterator[IndexIter: Iterator](Iterator):
+    comptime Element = Self.IndexIter.Element
+
+    var _idx: Int
+    var _how: ContiguousSlice
+    var _inner_iter: Self.IndexIter
+
+    def __next__(mut self) raises StopIteration -> Self.Element:
+        for _ in range(self._how.start.or_else(0)):
+            self._idx += 1
+            _ = trait_downcast_var[ImplicitlyDestructible & Movable](
+                next(self._inner_iter)
+            )
+        self._how.start = None
+        if self._idx >= self._how.end.or_else(self._idx + 1):
+            raise StopIteration()
+        self._idx += 1
+        return next(self._inner_iter)
+
+    def bounds(self) -> Tuple[Int, Optional[Int]]:
+        ref lb, ub = self._inner_iter.bounds()
+        var new_lb = min(
+            lb, self._how.end.or_else(lb)
+        ) - self._how.start.or_else(0)
+        var new_ub = min(ub.or_else(0), self._how.end.or_else(ub.or_else(0)))
+        return {
+            max(new_lb, 0),
+            Optional(
+                max(new_ub - self._how.start.or_else(0), 0)
+            ) if ub else None,
+        }
+
+
+@fieldwise_init
+struct _StridedIterator[IndexIter: Iterator](Iterator):
+    comptime Element = Self.IndexIter.Element
+
+    var _idx: Int
+    var _how: Slice
+    var _inner_iter: Self.IndexIter
+
+    def __next__(mut self) raises StopIteration -> Self.Element:
+        for _ in range(self._how.start.or_else(0)):
+            self._idx += 1
+            _ = trait_downcast_var[ImplicitlyDestructible & Movable](
+                next(self._inner_iter)
+            )
+        self._how.start = None
+        if self._idx >= self._how.end.or_else(self._idx + 1):
+            raise StopIteration()
+        self._idx += 1
+        var value = next(self._inner_iter)
+        for _ in range(self._how.step.or_else(1) - 1):
+            self._idx += 1
+            try:
+                _ = trait_downcast_var[ImplicitlyDestructible & Movable](
+                    next(self._inner_iter)
+                )
+            except:
+                break
+        return value^
+
+    def bounds(self) -> Tuple[Int, Optional[Int]]:
+        ref lb, ub = self._inner_iter.bounds()
+        var new_lb = min(
+            lb, self._how.end.or_else(lb)
+        ) - self._how.start.or_else(0)
+        var new_ub = min(ub.or_else(0), self._how.end.or_else(ub.or_else(0)))
+        return {
+            max(new_lb // self._how.step.or_else(1), 0),
+            Optional(
+                max(new_ub // self._how.step.or_else(1), 0)
+            ) if ub else None,
+        }
+
+
 trait Iterator(ImplicitlyDestructible, Movable):
     """The `Iterator` trait describes a type that can be used as an
     iterator, e.g. in a `for` loop.
@@ -165,7 +244,7 @@ trait Iterator(ImplicitlyDestructible, Movable):
         Examples:
 
         ```mojo
-        def to_int_list[I: Iterable](iter: I) -> List[Int]:
+        def to_int_list(iter: Some[Iterable & Iterator]) -> List[Int]:
             var lower, _upper = iter.bounds()
             var list = List[Int](capacity=lower)
             for element in iter:
@@ -174,6 +253,82 @@ trait Iterator(ImplicitlyDestructible, Movable):
         ```
         """
         return (0, None)
+
+    def __getitem__(var self, idx: Some[Indexer]) -> Self.Element:
+        """Get the value from the iterator at a given index.
+
+        Args:
+            idx: The index.
+
+        Returns:
+            The element.
+
+        Notes:
+            Aborts on OOB.
+        """
+        comptime assert conforms_to(Self.Element, ImplicitlyDestructible), (
+            "The default indexing implementations require the Iterator.Element"
+            " to be ImplicitlyDestructible"
+        )
+
+        var i = index(idx)
+        comptime if conforms_to(Self, Sized):
+            assert UInt(i) < UInt(
+                len(trait_downcast[Sized](self))
+            ), "index out of bounds."
+        else:
+            assert i >= 0, "no negative indexing."
+
+        var j = 0
+        while True:
+            try:
+                var val = trait_downcast_var[ImplicitlyDestructible & Movable](
+                    next(self)
+                )
+                if i == j:
+                    return val^
+                j += 1
+            except StopIteration:
+                abort("index out of bounds.")
+
+    def __getitem__(
+        var self, span: ContiguousSlice
+    ) -> _ContiguousIterator[Self]:
+        """Get the values from the iterator from a given slice.
+
+        Args:
+            span: The slice.
+
+        Returns:
+            The elements.
+        """
+
+        comptime assert conforms_to(Self.Element, ImplicitlyDestructible), (
+            "The default indexing implementations require the Iterator.Element"
+            " to be ImplicitlyDestructible"
+        )
+        assert span.start.or_else(0) >= 0, "no negative indexing."
+        assert span.end.or_else(0) >= 0, "no negative indexing."
+        return {0, span, self^}
+
+    def __getitem__(var self, span: StridedSlice) -> _StridedIterator[Self]:
+        """Get the values from the iterator from a given slice.
+
+        Args:
+            span: The slice.
+
+        Returns:
+            The elements.
+        """
+
+        comptime assert conforms_to(Self.Element, ImplicitlyDestructible), (
+            "The default indexing implementations require the Iterator.Element"
+            " to be ImplicitlyDestructible"
+        )
+        assert span._inner.start.or_else(0) >= 0, "no negative indexing."
+        assert span._inner.end.or_else(0) >= 0, "no negative indexing."
+        assert span._inner.step.or_else(1) >= 1, "no negative indexing."
+        return {0, span._inner, self^}
 
 
 @always_inline

--- a/mojo/stdlib/test/iter/test_indexing.mojo
+++ b/mojo/stdlib/test/iter/test_indexing.mojo
@@ -1,0 +1,58 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.testing import TestSuite, assert_equal, assert_true, assert_raises
+
+
+def test_idx() raises:
+    var l = [1, 2, 3]
+    var it = iter(l)
+    assert_equal(it[0], 1)
+    assert_equal(it[1], 2)
+    assert_equal(it[2], 3)
+    # _ = it[3] # TODO: test oob abort like the `range` iterators
+
+    var l2 = ["hi", "hey", "hello"]
+    var it2 = iter(l2)
+    assert_equal(it2[0], "hi")
+    assert_equal(it2[1], "hey")
+    assert_equal(it2[2], "hello")
+    # _ = it2[3] # TODO: test oob abort like the `range` iterators
+
+
+def test_contiguous_slice() raises:
+    var data = [0, 1, 2, 3, 4, 5]
+    var it = iter(data)
+    assert_equal(List(it[0:6]), [0, 1, 2, 3, 4, 5])
+    assert_equal(List(it[:]), [0, 1, 2, 3, 4, 5])
+    assert_equal(List(it[0:2]), [0, 1])
+    assert_equal(List(it[1:3]), [1, 2])
+    assert_equal(List(it[1:6]), [1, 2, 3, 4, 5])
+
+
+def test_strided_slice() raises:
+    var data = [0, 1, 2, 3, 4, 5]
+    var it = iter(data)
+    assert_equal(List(it[0:6:1]), [0, 1, 2, 3, 4, 5])
+    assert_equal(List(it[::]), [0, 1, 2, 3, 4, 5])
+    assert_equal(List(it[0:2:1]), [0, 1])
+    assert_equal(List(it[1:3:1]), [1, 2])
+    assert_equal(List(it[1:6:1]), [1, 2, 3, 4, 5])
+    assert_equal(List(it[1:6:2]), [1, 3, 5])
+    assert_equal(List(it[0:6:2]), [0, 2, 4])
+    assert_equal(List(it[0:6:3]), [0, 3])
+    assert_equal(List(it[1:6:3]), [1, 4])
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Add default indexing for all iterators. Phase 0 of https://github.com/modular/modular/issues/6359