### PR TITLE
[stdlib] Simplify and modernize `_PyIter`, and fix small mem-leaks

### DIFF
--- a/mojo/stdlib/std/python/_cpython.mojo
+++ b/mojo/stdlib/std/python/_cpython.mojo
@@ -240,7 +240,7 @@ struct PyObjectPtr(
 
 
 @fieldwise_init
-struct PythonVersion(ImplicitlyCopyable, RegisterPassable):
+struct PythonVersion(Comparable, ImplicitlyCopyable, RegisterPassable):
     """Represents a Python version with major, minor, and patch numbers."""
 
     var major: Int
@@ -249,6 +249,28 @@ struct PythonVersion(ImplicitlyCopyable, RegisterPassable):
     """The minor version number."""
     var patch: Int
     """The patch version number."""
+
+    @implicit
+    def __init__(out self, version: Tuple[Int, Int, Int]):
+        """Construct a version with a Tuple.
+
+        Args:
+            version: The version values.
+        """
+        self.major = version[0]
+        self.minor = version[1]
+        self.patch = version[2]
+
+    @implicit
+    def __init__(out self, version: Tuple[Int, Int]):
+        """Construct a version with a Tuple.
+
+        Args:
+            version: The version values.
+        """
+        self.major = version[0]
+        self.minor = version[1]
+        self.patch = 0
 
     def __init__(out self, version: StringSlice):
         """Initialize a PythonVersion object from a version string.
@@ -276,6 +298,22 @@ struct PythonVersion(ImplicitlyCopyable, RegisterPassable):
                 start = next_idx + 1
             next_idx += 1
         self = PythonVersion(components[0], components[1], components[2])
+
+    @always_inline
+    def __lt__(self, other: Self) -> Bool:
+        """Compare self to a full version.
+
+        Args:
+            other: The other version.
+
+        Returns:
+            The result.
+        """
+        return (self.major, self.minor, self.patch) < (
+            other.major,
+            other.minor,
+            other.patch,
+        )
 
 
 def _py_get_version(lib: _DLHandle) -> StaticString:
@@ -961,6 +999,11 @@ comptime PyIter_Check = ExternalFunction[
     # int PyIter_Check(PyObject *o)
     def(PyObjectPtr) thin -> c_int,
 ]
+comptime PyIter_NextItem = ExternalFunction[
+    "PyIter_NextItem",
+    # int PyIter_NextItem(PyObject *iter, PyObject **item)
+    def(PyObjectPtr, _CPointer[PyObjectPtr, MutAnyOrigin]) thin -> c_int,
+]
 comptime PyIter_Next = ExternalFunction[
     "PyIter_Next",
     # PyObject *PyIter_Next(PyObject *o)
@@ -1202,6 +1245,12 @@ def _PyType_GetName_dummy(type: PyTypeObjectPtr) -> PyObjectPtr:
     abort("PyType_GetName is not available in this Python version")
 
 
+def _PyIter_NextItem_dummy(
+    iter: PyObjectPtr, obj: _CPointer[PyObjectPtr, MutAnyOrigin]
+) -> c_int:
+    abort("PyIter_NextItem is not available in this Python version")
+
+
 # ===-------------------------------------------------------------------===#
 # Context Managers for Python GIL and Threading
 # ===-------------------------------------------------------------------===#
@@ -1365,6 +1414,7 @@ struct CPython(Defaultable, Movable):
     var _PyNumber_Float: PyNumber_Float.type
     # Iterator Protocol
     var _PyIter_Check: PyIter_Check.type
+    var _PyIter_NextItem: PyIter_NextItem.type
     var _PyIter_Next: PyIter_Next.type
     # Concrete Objects Layer
     # Type Objects
@@ -1492,7 +1542,7 @@ struct CPython(Defaultable, Movable):
         self._PyErr_SetString = PyErr_SetString.load(self.lib.borrow())
         self._PyErr_SetNone = PyErr_SetNone.load(self.lib.borrow())
         self._PyErr_Occurred = PyErr_Occurred.load(self.lib.borrow())
-        if self.version.minor >= 12:
+        if self.version >= (3, 12):
             self._PyErr_GetRaisedException = PyErr_GetRaisedException.load(
                 self.lib.borrow()
             )
@@ -1538,19 +1588,23 @@ struct CPython(Defaultable, Movable):
         self._PyNumber_Float = PyNumber_Float.load(self.lib.borrow())
         # Iterator Protocol
         self._PyIter_Check = PyIter_Check.load(self.lib.borrow())
+        if self.version >= (3, 14):
+            self._PyIter_NextItem = PyIter_NextItem.load(self.lib.borrow())
+        else:
+            self._PyIter_NextItem = _PyIter_NextItem_dummy
         self._PyIter_Next = PyIter_Next.load(self.lib.borrow())
         # Concrete Objects Layer
         # Type Objects
         self._PyType_GetFlags = PyType_GetFlags.load(self.lib.borrow())
         self._PyType_IsSubtype = PyType_IsSubtype.load(self.lib.borrow())
         self._PyType_GenericAlloc = PyType_GenericAlloc.load(self.lib.borrow())
-        if self.version.minor >= 11:
+        if self.version >= (3, 11):
             self._PyType_GetName = PyType_GetName.load(self.lib.borrow())
         else:
             self._PyType_GetName = _PyType_GetName_dummy
         self._PyType_FromSpec = PyType_FromSpec.load(self.lib.borrow())
         # The None Object
-        if self.version.minor >= 13:
+        if self.version >= (3, 13):
             # Py_GetConstantBorrowed is part of the Stable ABI since version 3.13
             # References:
             # - https://docs.python.org/3/c-api/object.html#c.Py_GetConstantBorrowed
@@ -1692,7 +1746,7 @@ struct CPython(Defaultable, Movable):
 
         var err_ptr: PyObjectPtr
         # NOTE: PyErr_Fetch is deprecated since Python 3.12.
-        var old_python = self.version.minor < 12
+        var old_python = self.version < (3, 12)
         if old_python:
             err_ptr = self.PyErr_Fetch()
         else:
@@ -2276,6 +2330,19 @@ struct CPython(Defaultable, Movable):
         """
         return self._PyIter_Check(obj)
 
+    def PyIter_NextItem(
+        self, iter: PyObjectPtr, item: _CPointer[PyObjectPtr, MutAnyOrigin]
+    ) -> c_int:
+        """Return 1 and set item to a strong reference of the next value of the
+        iterator iter on success. Return 0 and set item to NULL if there are no
+        remaining values. Return -1, set item to NULL and set an exception on
+        error.
+
+        References:
+        - https://docs.python.org/3/c-api/iter.html#c.PyIter_NextItem
+        """
+        return self._PyIter_NextItem(iter, item)
+
     def PyIter_Next(self, obj: PyObjectPtr) -> PyObjectPtr:
         """Return the next value from the iterator `obj`. The object must be an
         iterator according to `PyIter_Check()`. If there are no remaining values,
@@ -2359,7 +2426,7 @@ struct CPython(Defaultable, Movable):
         References:
         - https://docs.python.org/3/c-api/type.html#c.PyType_GetName
         """
-        if self.version.minor < 11:
+        if self.version < (3, 11):
             return self.PyObject_GetAttrString(
                 PyObjectPtr(upcast_from=type), "__name__"
             )

--- a/mojo/stdlib/std/python/_cpython.mojo
+++ b/mojo/stdlib/std/python/_cpython.mojo
@@ -254,8 +254,7 @@ struct PyObjectPtr(
         )
 
 
-@fieldwise_init
-struct PythonVersion(ImplicitlyCopyable, RegisterPassable):
+struct PythonVersion(Comparable, ImplicitlyCopyable, RegisterPassable):
     """Represents a Python version with major, minor, and patch numbers."""
 
     var major: Int
@@ -264,6 +263,18 @@ struct PythonVersion(ImplicitlyCopyable, RegisterPassable):
     """The minor version number."""
     var patch: Int
     """The patch version number."""
+
+    def __init__(out self, major: Int, minor: Int, patch: Int = 0):
+        """Construct a version with a Tuple.
+
+        Args:
+            major: The major version number.
+            minor: The minor version number.
+            patch: The patch version number.
+        """
+        self.major = major
+        self.minor = minor
+        self.patch = patch
 
     def __init__(out self, version: StringSlice):
         """Initialize a PythonVersion object from a version string.
@@ -291,6 +302,22 @@ struct PythonVersion(ImplicitlyCopyable, RegisterPassable):
                 start = next_idx + 1
             next_idx += 1
         self = PythonVersion(components[0], components[1], components[2])
+
+    @always_inline
+    def __lt__(self, other: Self) -> Bool:
+        """Compare self to a full version.
+
+        Args:
+            other: The other version.
+
+        Returns:
+            The result.
+        """
+        return (self.major, self.minor, self.patch) < (
+            other.major,
+            other.minor,
+            other.patch,
+        )
 
 
 def _py_get_version(lib: _DLHandle) -> StaticString:
@@ -1011,6 +1038,11 @@ comptime PyIter_Check = ExternalFunction[
     # int PyIter_Check(PyObject *o)
     def(PyObjectPtr) thin -> c_int,
 ]
+comptime PyIter_NextItem = ExternalFunction[
+    "PyIter_NextItem",
+    # int PyIter_NextItem(PyObject *iter, PyObject **item)
+    def(PyObjectPtr, _CPointer[PyObjectPtr, MutAnyOrigin]) thin -> c_int,
+]
 comptime PyIter_Next = ExternalFunction[
     "PyIter_Next",
     # PyObject *PyIter_Next(PyObject *o)
@@ -1252,6 +1284,12 @@ def _PyType_GetName_dummy(type: PyTypeObjectPtr) -> PyObjectPtr:
     abort("PyType_GetName is not available in this Python version")
 
 
+def _PyIter_NextItem_dummy(
+    iter: PyObjectPtr, obj: _CPointer[PyObjectPtr, MutAnyOrigin]
+) -> c_int:
+    abort("PyIter_NextItem is not available in this Python version")
+
+
 # ===-------------------------------------------------------------------===#
 # Context Managers for Python GIL and Threading
 # ===-------------------------------------------------------------------===#
@@ -1416,6 +1454,7 @@ struct CPython(Defaultable, Movable):
     var _PyNumber_Float: PyNumber_Float.type
     # Iterator Protocol
     var _PyIter_Check: PyIter_Check.type
+    var _PyIter_NextItem: PyIter_NextItem.type
     var _PyIter_Next: PyIter_Next.type
     # Concrete Objects Layer
     # Type Objects
@@ -1545,7 +1584,7 @@ struct CPython(Defaultable, Movable):
         self._PyErr_SetString = PyErr_SetString.load(self.lib.borrow())
         self._PyErr_SetNone = PyErr_SetNone.load(self.lib.borrow())
         self._PyErr_Occurred = PyErr_Occurred.load(self.lib.borrow())
-        if self.version.minor >= 12:
+        if self.version >= {3, 12}:
             self._PyErr_GetRaisedException = PyErr_GetRaisedException.load(
                 self.lib.borrow()
             )
@@ -1592,19 +1631,23 @@ struct CPython(Defaultable, Movable):
         self._PyNumber_Float = PyNumber_Float.load(self.lib.borrow())
         # Iterator Protocol
         self._PyIter_Check = PyIter_Check.load(self.lib.borrow())
+        if self.version >= {3, 14}:
+            self._PyIter_NextItem = PyIter_NextItem.load(self.lib.borrow())
+        else:
+            self._PyIter_NextItem = _PyIter_NextItem_dummy
         self._PyIter_Next = PyIter_Next.load(self.lib.borrow())
         # Concrete Objects Layer
         # Type Objects
         self._PyType_GetFlags = PyType_GetFlags.load(self.lib.borrow())
         self._PyType_IsSubtype = PyType_IsSubtype.load(self.lib.borrow())
         self._PyType_GenericAlloc = PyType_GenericAlloc.load(self.lib.borrow())
-        if self.version.minor >= 11:
+        if self.version >= {3, 11}:
             self._PyType_GetName = PyType_GetName.load(self.lib.borrow())
         else:
             self._PyType_GetName = _PyType_GetName_dummy
         self._PyType_FromSpec = PyType_FromSpec.load(self.lib.borrow())
         # The None Object
-        if self.version.minor >= 13:
+        if self.version >= {3, 13}:
             # Py_GetConstantBorrowed is part of the Stable ABI since version 3.13
             # References:
             # - https://docs.python.org/3/c-api/object.html#c.Py_GetConstantBorrowed
@@ -1746,7 +1789,7 @@ struct CPython(Defaultable, Movable):
 
         var err_ptr: PyObjectPtr
         # NOTE: PyErr_Fetch is deprecated since Python 3.12.
-        var old_python = self.version.minor < 12
+        var old_python = self.version < {3, 12}
         if old_python:
             err_ptr = self.PyErr_Fetch()
         else:
@@ -2341,6 +2384,19 @@ struct CPython(Defaultable, Movable):
         """
         return self._PyIter_Check(obj)
 
+    def PyIter_NextItem(
+        self, iter: PyObjectPtr, item: _CPointer[PyObjectPtr, MutAnyOrigin]
+    ) -> c_int:
+        """Return 1 and set item to a strong reference of the next value of the
+        iterator iter on success. Return 0 and set item to NULL if there are no
+        remaining values. Return -1, set item to NULL and set an exception on
+        error.
+
+        References:
+        - https://docs.python.org/3/c-api/iter.html#c.PyIter_NextItem
+        """
+        return self._PyIter_NextItem(iter, item)
+
     def PyIter_Next(self, obj: PyObjectPtr) -> PyObjectPtr:
         """Return the next value from the iterator `obj`. The object must be an
         iterator according to `PyIter_Check()`. If there are no remaining values,
@@ -2424,7 +2480,7 @@ struct CPython(Defaultable, Movable):
         References:
         - https://docs.python.org/3/c-api/type.html#c.PyType_GetName
         """
-        if self.version.minor < 11:
+        if self.version < {3, 11}:
             return self.PyObject_GetAttrString(
                 PyObjectPtr(upcast_from=type), "__name__"
             )

--- a/mojo/stdlib/std/python/python.mojo
+++ b/mojo/stdlib/std/python/python.mojo
@@ -380,7 +380,7 @@ struct Python(Defaultable, ImplicitlyCopyable):
     def dict[
         V: ConvertibleToPython & Copyable = PythonObject
     ](**kwargs: V) raises -> PythonObject:
-        """Construct an Python dictionary from keyword arguments.
+        """Construct a Python dictionary from keyword arguments.
 
         Parameters:
             V: The type of the values in the dictionary. Must implement the

--- a/mojo/stdlib/std/python/python.mojo
+++ b/mojo/stdlib/std/python/python.mojo
@@ -377,7 +377,7 @@ struct Python(Defaultable, ImplicitlyCopyable):
 
     @staticmethod
     def dict(**kwargs: PythonObject) raises -> PythonObject:
-        """Construct an Python dictionary from keyword arguments.
+        """Construct a Python dictionary from keyword arguments.
 
         Args:
             kwargs: The keyword arguments to construct the dictionary with.
@@ -395,7 +395,7 @@ struct Python(Defaultable, ImplicitlyCopyable):
     def dict(
         tuples: Span[Tuple[PythonObject, PythonObject], _]
     ) raises -> PythonObject:
-        """Construct an Python dictionary from a list of key-value tuples.
+        """Construct a Python dictionary from a list of key-value tuples.
 
         Args:
             tuples: The list of key-value tuples to construct the dictionary
@@ -441,7 +441,7 @@ struct Python(Defaultable, ImplicitlyCopyable):
 
     @staticmethod
     def list(var *values: PythonObject) raises -> PythonObject:
-        """Construct an Python list of objects.
+        """Construct a Python list of objects.
 
         Args:
             values: The values to initialize the list with.
@@ -461,7 +461,7 @@ struct Python(Defaultable, ImplicitlyCopyable):
 
     @staticmethod
     def tuple(var *values: PythonObject) raises -> PythonObject:
-        """Construct an Python tuple of objects.
+        """Construct a Python tuple of objects.
 
         Args:
             values: The values to initialize the tuple with.

--- a/mojo/stdlib/std/python/python_object.mojo
+++ b/mojo/stdlib/std/python/python_object.mojo
@@ -46,8 +46,6 @@ struct _PyIter(ImplicitlyCopyable, Iterable, Iterator):
 
     var iterator: PythonObject
     """The iterator object that stores location."""
-    var next_item: PyObjectPtr
-    """The next item to vend or zero if there are no items."""
 
     # ===-------------------------------------------------------------------===#
     # Life cycle methods
@@ -60,8 +58,10 @@ struct _PyIter(ImplicitlyCopyable, Iterable, Iterator):
             iter: A Python iterator instance.
         """
         ref cpy = Python().cpython()
+        assert (
+            cpy.PyIter_Check(iter._obj_ptr) != 0
+        ), "object is not a valid sync iterator"
         self.iterator = iter
-        self.next_item = cpy.PyIter_Next(iter._obj_ptr)
 
     # ===-------------------------------------------------------------------===#
     # Trait implementations
@@ -75,15 +75,26 @@ struct _PyIter(ImplicitlyCopyable, Iterable, Iterator):
             The next item in the traversable object that this iterator
             points to.
         """
-        if not self.next_item:
-            raise StopIteration()
         ref cpy = Python().cpython()
-        var curr_item = self.next_item
-        self.next_item = cpy.PyIter_Next(self.iterator._obj_ptr)
-        return PythonObject(from_owned=curr_item)
+        if cpy.version >= (3, 14):
+            var elem = PythonObject()
+            var err = cpy.PyIter_NextItem(
+                self.iterator._obj_ptr, UnsafePointer(to=elem._obj_ptr)
+            )
+            # FIXME: a return of -1 is an error, we should deal with it
+            # but we currently don't have a way to propagate it from here and
+            # still conform to the Iterator trait.
+            if err < 1:
+                raise StopIteration()
+            return elem^
+        else:
+            var curr_ptr = cpy.PyIter_Next(self.iterator._obj_ptr)
+            if not curr_ptr:
+                raise StopIteration()
+            return PythonObject(from_owned=curr_ptr)
 
     def __iter__(ref self) -> Self.IteratorType[origin_of(self)]:
-        return self
+        return self.copy()
 
 
 struct PythonObject(
@@ -347,13 +358,15 @@ struct PythonObject(
         """
         ref cpy = Python().cpython()
         var set_ptr = cpy.PySet_New({})
-
+        if not set_ptr:
+            raise cpy.unsafe_get_error()
+        var set_obj = PythonObject(from_owned=set_ptr)
         comptime for i in range(Ts.size):
             var obj = values[i].copy().to_python_object()
-            var errno = cpy.PySet_Add(set_ptr, obj.steal_data())
+            var errno = cpy.PySet_Add(set_obj._obj_ptr, obj.steal_data())
             if errno == -1:
                 raise cpy.unsafe_get_error()
-        return PythonObject(from_owned=set_ptr)
+        return set_obj^
 
     def __init__(
         out self,
@@ -373,11 +386,16 @@ struct PythonObject(
         """
         ref cpy = Python().cpython()
         var dict_ptr = cpy.PyDict_New()
-        for key, val in zip(keys, values):
-            var errno = cpy.PyDict_SetItem(dict_ptr, key._obj_ptr, val._obj_ptr)
+        if not dict_ptr:
+            raise cpy.unsafe_get_error()
+        var dict_obj = PythonObject(from_owned=dict_ptr)
+        for var key, val in zip(keys^, values^):
+            var errno = cpy.PyDict_SetItem(
+                dict_obj._obj_ptr, key._obj_ptr, val._obj_ptr
+            )
             if errno == -1:
                 raise cpy.unsafe_get_error()
-        return PythonObject(from_owned=dict_ptr)
+        return dict_obj^
 
     def __init__(out self, *, copy: Self):
         """Copy the object.

--- a/mojo/stdlib/std/python/python_object.mojo
+++ b/mojo/stdlib/std/python/python_object.mojo
@@ -45,8 +45,6 @@ struct _PyIter(ImplicitlyCopyable, Iterable, Iterator):
 
     var iterator: PythonObject
     """The iterator object that stores location."""
-    var next_item: PyObjectPtr
-    """The next item to vend or zero if there are no items."""
 
     # ===-------------------------------------------------------------------===#
     # Life cycle methods
@@ -59,8 +57,10 @@ struct _PyIter(ImplicitlyCopyable, Iterable, Iterator):
             iter: A Python iterator instance.
         """
         ref cpy = Python().cpython()
+        assert (
+            cpy.PyIter_Check(iter._obj_ptr) != 0
+        ), "object is not a valid sync iterator"
         self.iterator = iter
-        self.next_item = cpy.PyIter_Next(iter._obj_ptr)
 
     # ===-------------------------------------------------------------------===#
     # Trait implementations
@@ -74,15 +74,37 @@ struct _PyIter(ImplicitlyCopyable, Iterable, Iterator):
             The next item in the traversable object that this iterator
             points to.
         """
-        if not self.next_item:
-            raise StopIteration()
+        # FIXME(#6579): we are ignoring errors, we should deal with them
+        # but we currently don't have a way to propagate them from here and
+        # still conform to the Iterator trait.
+
         ref cpy = Python().cpython()
-        var curr_item = self.next_item
-        self.next_item = cpy.PyIter_Next(self.iterator._obj_ptr)
-        return PythonObject(from_owned=curr_item)
+        if cpy.version >= {3, 14}:
+            var ob_ptr = PyObjectPtr()
+            var err = cpy.PyIter_NextItem(
+                self.iterator._obj_ptr, UnsafePointer(to=ob_ptr)
+            )
+            var elem = PythonObject(from_owned=ob_ptr)
+            if err == -1:
+                # don't leak the indicator into the next FFI call
+                cpy.PyErr_Clear()
+                raise StopIteration()
+            if err == 0:
+                raise StopIteration()
+
+            return elem^
+        else:
+            var curr_ptr = cpy.PyIter_Next(self.iterator._obj_ptr)
+            if cpy.PyErr_Occurred():
+                # don't leak the indicator into the next FFI call
+                cpy.PyErr_Clear()
+                raise StopIteration()
+            if not curr_ptr:
+                raise StopIteration()
+            return PythonObject(from_owned=curr_ptr)
 
     def __iter__(ref self) -> Self.IteratorType[origin_of(self)]:
-        return self
+        return self.copy()
 
 
 struct PythonObject(
@@ -352,12 +374,15 @@ struct PythonObject(
         """
         ref cpy = Python().cpython()
         var set_ptr = cpy.PySet_New({})
+        if not set_ptr:
+            raise cpy.unsafe_get_error()
+        var set_obj = PythonObject(from_owned=set_ptr)
 
         for i in range(len(values)):
-            var errno = cpy.PySet_Add(set_ptr, values[i].steal_data())
+            var errno = cpy.PySet_Add(set_obj._obj_ptr, values[i].steal_data())
             if errno == -1:
                 raise cpy.unsafe_get_error()
-        return PythonObject(from_owned=set_ptr)
+        return set_obj^
 
     def __init__(
         out self,
@@ -377,11 +402,16 @@ struct PythonObject(
         """
         ref cpy = Python().cpython()
         var dict_ptr = cpy.PyDict_New()
-        for key, val in zip(keys, values):
-            var errno = cpy.PyDict_SetItem(dict_ptr, key._obj_ptr, val._obj_ptr)
+        if not dict_ptr:
+            raise cpy.unsafe_get_error()
+        var dict_obj = PythonObject(from_owned=dict_ptr)
+        for var key, val in zip(keys^, values^):
+            var errno = cpy.PyDict_SetItem(
+                dict_obj._obj_ptr, key._obj_ptr, val._obj_ptr
+            )
             if errno == -1:
                 raise cpy.unsafe_get_error()
-        return PythonObject(from_owned=dict_ptr)
+        return dict_obj^
 
     def __init__(out self, *, copy: Self):
         """Copy the object.

--- a/mojo/stdlib/test/python/test_python_cpython.mojo
+++ b/mojo/stdlib/test/python/test_python_cpython.mojo
@@ -74,7 +74,7 @@ def _test_exception_handling_api(cpy: CPython) raises:
     cpy.PyErr_SetString(ValueError, msg.as_c_string_slice().unsafe_ptr())
     assert_true(cpy.PyErr_Occurred())
 
-    if cpy.version.minor < 12:
+    if cpy.version < (3, 12):
         # PyErr_Fetch is deprecated since Python 3.12.
         assert_true(cpy.PyErr_Fetch())
         # Manually clear the error indicator.
@@ -154,8 +154,28 @@ def _test_iterator_protocol_api(cpy: CPython) raises:
     var it = cpy.PyObject_GetIter(l)
 
     assert_false(cpy.PyIter_Check(n))
+    assert_true(cpy.PyIter_Check(it))
     assert_true(it)
-    assert_true(cpy.PyIter_Next(it))
+    var obj = cpy.PyIter_Next(it)
+    assert_true(obj)
+    cpy.Py_DecRef(obj)
+    obj = cpy.PyIter_Next(it)
+    assert_false(obj)
+    cpy.Py_DecRef(it)
+
+    if cpy.version >= (3, 14):
+        it = cpy.PyObject_GetIter(l)
+        assert_true(cpy.PyIter_Check(it))
+        assert_true(it)
+        assert_equal(cpy.PyIter_NextItem(it, UnsafePointer(to=obj)), 1)
+        assert_true(obj, String("value: ", obj))
+        cpy.Py_DecRef(obj)
+        assert_equal(cpy.PyIter_NextItem(it, UnsafePointer(to=obj)), 0)
+        assert_false(obj)
+        cpy.Py_DecRef(it)
+
+    cpy.Py_DecRef(l)
+    cpy.Py_DecRef(n)
 
 
 def _test_type_object_api(cpy: CPython) raises:

--- a/mojo/stdlib/test/python/test_python_cpython.mojo
+++ b/mojo/stdlib/test/python/test_python_cpython.mojo
@@ -75,7 +75,7 @@ def _test_exception_handling_api(cpy: CPython) raises:
     cpy.PyErr_SetString(ValueError, msg.as_c_string_slice().unsafe_ptr())
     assert_true(cpy.PyErr_Occurred())
 
-    if cpy.version.minor < 12:
+    if cpy.version < {3, 12}:
         # PyErr_Fetch is deprecated since Python 3.12.
         assert_true(cpy.PyErr_Fetch())
         # Manually clear the error indicator.
@@ -155,8 +155,28 @@ def _test_iterator_protocol_api(cpy: CPython) raises:
     var it = cpy.PyObject_GetIter(l)
 
     assert_false(cpy.PyIter_Check(n))
+    assert_true(cpy.PyIter_Check(it))
     assert_true(it)
-    assert_true(cpy.PyIter_Next(it))
+    var obj = cpy.PyIter_Next(it)
+    assert_true(obj)
+    cpy.Py_DecRef(obj)
+    obj = cpy.PyIter_Next(it)
+    assert_false(obj)
+    cpy.Py_DecRef(it)
+
+    if cpy.version >= {3, 14}:
+        it = cpy.PyObject_GetIter(l)
+        assert_true(cpy.PyIter_Check(it))
+        assert_true(it)
+        assert_equal(cpy.PyIter_NextItem(it, UnsafePointer(to=obj)), 1)
+        assert_true(obj, String("value: ", obj))
+        cpy.Py_DecRef(obj)
+        assert_equal(cpy.PyIter_NextItem(it, UnsafePointer(to=obj)), 0)
+        assert_false(obj)
+        cpy.Py_DecRef(it)
+
+    cpy.Py_DecRef(l)
+    cpy.Py_DecRef(n)
 
 
 def _test_type_object_api(cpy: CPython) raises:


### PR DESCRIPTION
Simplify and modernize `_PyIter`, and fix small mem-leaks.

This also makes the use of `PythonVersion` nicer by adding default implicit constructors from tuples and comparison operations. It also fixes many call-sites that would fail if Python ever realeased a 4.0 version to use the 3 major version for the comparisons.