### PR TITLE
[Stdlib] Add CPython protocol builders for Mojo-defined Python types

### DIFF
--- a/mojo/examples/python-interop/BUILD.bazel
+++ b/mojo/examples/python-interop/BUILD.bazel
@@ -46,6 +46,21 @@ modular_py_binary(
     ],
 )
 
+modular_py_binary(
+    name = "columnar",
+    srcs = ["columnar.py"],
+    data = ["columnar_mojo.mojo"],
+    imports = ["."],
+    target_compatible_with = select({
+        "//:asan": ["@platforms//:incompatible"],
+        "//:ubsan": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "@mojo//:python",
+    ],
+)
+
 modular_run_binary_test(
     name = "hello_test",
     binary = "hello",
@@ -60,4 +75,9 @@ modular_run_binary_test(
     name = "mandelbrot_test",
     binary = "mandelbrot",
     tags = ["gpu"],
+)
+
+modular_run_binary_test(
+    name = "columnar_test",
+    binary = "columnar",
 )

--- a/mojo/examples/python-interop/BUILD.bazel
+++ b/mojo/examples/python-interop/BUILD.bazel
@@ -46,6 +46,22 @@ modular_py_binary(
     ],
 )
 
+modular_py_binary(
+    name = "columnar",
+    srcs = ["columnar.py"],
+    data = ["columnar_mojo.mojo"],
+    imports = ["."],
+    target_compatible_with = select({
+        "//:asan": ["@platforms//:incompatible"],
+        "//:tsan": ["@platforms//:incompatible"],
+        "//:ubsan": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "@mojo//:python",
+    ],
+)
+
 modular_run_binary_test(
     name = "hello_test",
     binary = "hello",
@@ -60,4 +76,9 @@ modular_run_binary_test(
     name = "mandelbrot_test",
     binary = "mandelbrot",
     tags = ["gpu"],
+)
+
+modular_run_binary_test(
+    name = "columnar_test",
+    binary = "columnar",
 )

--- a/mojo/examples/python-interop/columnar.py
+++ b/mojo/examples/python-interop/columnar.py
@@ -1,0 +1,137 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Integration test for the columnar DataFrame example.
+
+Run via:
+    pixi run test-example
+"""
+
+import mojo.importer  # noqa: F401, I001
+
+import columnar_mojo  # type: ignore
+
+
+def test_mojo_columnar() -> None:
+    print("Hello from Basic Columnar Example!")
+
+    # Mismatched column lengths should raise.
+    try:
+        _ = columnar_mojo.DataFrame.with_columns([1.0, 2.0, 3.0], [0.1, 0.2])
+        raise Exception("ValueError expected due to unbalanced columns.")
+    except Exception as ex:
+        assert "not match" in str(ex)
+
+    df = columnar_mojo.DataFrame.with_columns([1.0, 2.0, 3.0], [0.1, 0.2, 0.3])
+    assert "DataFrame" in str(df)
+
+    # __len__ (mp_length)
+    assert len(df) == 3
+
+    # __getitem__ (mp_subscript)
+    assert df[0] == (1.0, 0.1)
+    assert df[1] == (2.0, 0.2)
+
+    # __setitem__ (mp_ass_subscript — assignment)
+    df[1] = (5.0, 6.0)
+    assert df[1] == (5.0, 6.0)
+    assert df[0] == (1.0, 0.1)  # neighbours unchanged
+    assert df[2] == (3.0, 0.3)
+
+    # __delitem__ (mp_ass_subscript — deletion)
+    for_delete = columnar_mojo.DataFrame.with_columns(
+        [1.0, 2.0, 3.0], [0.1, 0.2, 0.3]
+    )
+    del for_delete[0]
+    assert for_delete[0] == (2.0, 0.2)
+
+    big_df = columnar_mojo.DataFrame.with_columns(
+        [1.0, 2.0, 30000.0], [0.1, 0.2, 1.0]
+    )
+
+    def rich_compare_counts(
+        d: columnar_mojo.DataFrame,
+    ) -> tuple[int, int, int]:
+        return tuple(
+            d.get_call_count(f"rich_compare[{op}]") for op in (0, 2, 4)
+        )
+
+    # LT and EQ are implemented directly.
+    assert df < big_df
+    assert rich_compare_counts(df) == (1, 0, 0)
+    assert rich_compare_counts(big_df) == (0, 0, 0)
+
+    # GT is not implemented, so Python retries as LT on the other operand.
+    assert big_df > df
+    assert rich_compare_counts(df) == (2, 0, 0)
+    assert rich_compare_counts(big_df) == (0, 0, 1)
+
+    # ------------------------------------------------------------------
+    # Number protocol
+    # ------------------------------------------------------------------
+
+    num_df = columnar_mojo.DataFrame.with_columns(
+        [1.0, 2.0, 3.0], [4.0, 5.0, 6.0]
+    )
+
+    # __neg__ (nb_negative)
+    neg_df = -num_df
+    assert neg_df[0] == (-1.0, -4.0)
+    assert neg_df[2] == (-3.0, -6.0)
+
+    # __abs__ (nb_absolute)
+    abs_df = abs(neg_df)
+    assert abs_df[0] == (1.0, 4.0)
+    assert abs_df[2] == (3.0, 6.0)
+
+    # __bool__ (nb_bool)
+    assert bool(num_df)
+    assert not bool(columnar_mojo.DataFrame())
+
+    # __add__ (nb_add) — concatenate two DataFrames
+    df_a = columnar_mojo.DataFrame.with_columns([1.0, 2.0], [3.0, 4.0])
+    df_b = columnar_mojo.DataFrame.with_columns([5.0, 6.0], [7.0, 8.0])
+    combined = df_a + df_b
+    assert len(combined) == 4
+    assert combined[0] == (1.0, 3.0)
+    assert combined[2] == (5.0, 7.0)
+
+    # __add__ with a non-DataFrame returns NotImplemented, so Python raises TypeError
+    try:
+        _ = df_a + 42
+        raise Exception("TypeError expected")
+    except TypeError:
+        pass
+
+    # __mul__ (nb_multiply) — scale coordinates by a scalar
+    scaled = df_a * 2.0
+    assert scaled[0] == (2.0, 6.0)
+    assert scaled[1] == (4.0, 8.0)
+
+    # __mul__ with a non-numeric returns NotImplemented → TypeError
+    try:
+        _ = df_a * "oops"
+        raise Exception("TypeError expected")
+    except TypeError:
+        pass
+
+    # __pow__ (nb_power) — raise coordinates to a power
+    squared = df_a**2
+    assert squared[0] == (1.0, 9.0)
+    assert squared[1] == (4.0, 16.0)
+
+    print("🎉🎉🎉 Mission Success! 🎉🎉🎉")
+
+
+if __name__ == "__main__":
+    test_mojo_columnar()

--- a/mojo/examples/python-interop/columnar_mojo.mojo
+++ b/mojo/examples/python-interop/columnar_mojo.mojo
@@ -1,0 +1,343 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Example from https://github.com/modular/modular/pull/5562, adapted to use
+# the pontoneer library instead of the stdlib additions directly.
+#
+# Exposes a simple columnar DataFrame to Python that supports:
+#   - len(df)          via mp_length
+#   - df[i]            via mp_subscript
+#   - df[i] = (x, y)  via mp_ass_subscript
+#   - del df[i]        via mp_ass_subscript (null value)
+#   - df < other       via tp_richcompare
+#   - -df              via nb_negative
+#   - abs(df)          via nb_absolute
+#   - bool(df)         via nb_bool
+#   - df + other       via nb_add
+#   - df * scalar      via nb_multiply
+#   - df ** exp        via nb_power
+# ===----------------------------------------------------------------------=== #
+
+from std.os import abort
+from std.memory import UnsafePointer
+from std.utils import Variant
+from std.python import Python, PythonObject
+from std.python.bindings import PythonModuleBuilder
+from std.ffi import _Global
+
+from std.python.utils import NotImplementedError, RichCompareOps
+from std.python.builders import (
+    TypeProtocolBuilder,
+    MappingProtocolBuilder,
+    NumberProtocolBuilder,
+)
+
+comptime Coord1DColumn = List[Float64]
+
+
+def _extent(pos: Coord1DColumn) -> Tuple[Float64, Float64]:
+    """Return the (min, max) of a column."""
+    v_min = Float64.MAX
+    v_max = Float64.MIN
+    for v in pos:
+        v_min = min(v_min, v)
+        v_max = max(v_max, v)
+    return (v_min, v_max)
+
+
+def _compute_bounding_box_area(
+    pos_x: Coord1DColumn,
+    pos_y: Coord1DColumn,
+) -> Float64:
+    if len(pos_x) == 0:
+        return 0.0
+    ext_x = _extent(pos_x)
+    ext_y = _extent(pos_y)
+    return (ext_x[1] - ext_x[0]) * (ext_y[1] - ext_y[0])
+
+
+def _init_call_count() -> Dict[String, Int]:
+    return {}
+
+
+# Track call counts for testing reasons.
+comptime _global_call_count = _Global["call_count", _init_call_count]
+
+
+def _get_global_call_count(
+    out result: UnsafePointer[Dict[String, Int], MutExternalOrigin]
+):
+    """Gets the global calls count.
+
+    Returns:
+        A pointer to the global calls count dictionary.
+    """
+    try:
+        result = _global_call_count.get_or_create_ptr()
+    except:
+        abort("Failed to initialize global calls count")
+
+
+struct DataFrame(Defaultable, Movable, Writable):
+    """A simple columnar data structure storing 2-D points.
+
+    x and y coordinates are stored in separate columns for cache-friendly
+    access patterns.  Used here to demonstrate the mapping protocol and
+    rich comparison protocol via pontoneer.
+    """
+
+    var pos_x: Coord1DColumn
+    var pos_y: Coord1DColumn
+    var _bounding_box_area: Float64
+
+    def __init__(out self):
+        self.pos_x = []
+        self.pos_y = []
+        self._bounding_box_area = 0
+
+    def __init__(
+        out self,
+        var x: Coord1DColumn,
+        var y: Coord1DColumn,
+    ):
+        self._bounding_box_area = _compute_bounding_box_area(x, y)
+        self.pos_x = x^
+        self.pos_y = y^
+
+    # ------------------------------------------------------------------
+    # Regular methods
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_call_count(
+        py_self: PythonObject, name: PythonObject
+    ) raises -> PythonObject:
+        """Return the number of times a named method was called (for testing).
+        """
+        var self_ptr = py_self.downcast_value_ptr[Self]()
+        var key = "{}{}".format(Int(self_ptr), String(py=name))
+        return _get_global_call_count()[].get(key, 0)
+
+    @staticmethod
+    def with_columns(
+        pos_x: PythonObject, pos_y: PythonObject
+    ) raises -> PythonObject:
+        var len_x = Int(pos_x.__len__())
+        var len_y = Int(pos_y.__len__())
+        if len_x != len_y:
+            raise Error("The length of the two columns does not match.")
+        var ptr_x = Coord1DColumn(capacity=len_x)
+        var ptr_y = Coord1DColumn(capacity=len_y)
+        for value in pos_x:
+            ptr_x.append(Float64(py=value))
+        for value in pos_y:
+            ptr_y.append(Float64(py=value))
+        return PythonObject(alloc=DataFrame(ptr_x^, ptr_y^))
+
+    # ------------------------------------------------------------------
+    # Mapping protocol
+    # ------------------------------------------------------------------
+
+    def py__len__(self) raises -> Int:
+        return len(self.pos_x)
+
+    def py__getitem__(self, index: PythonObject) raises -> PythonObject:
+        var i = Int(py=index)
+        var length = len(self.pos_x)
+        if i < 0 or i >= length:
+            raise Error("index out of range")
+        return Python().tuple(self.pos_x[i], self.pos_y[i])
+
+    def py__setitem__(
+        mut self,
+        index: PythonObject,
+        value: Variant[PythonObject, Int],
+    ) raises -> None:
+        var i = Int(py=index)
+        var length = len(self.pos_x)
+        if i < 0 or i >= length:
+            raise Error("index out of range")
+        if value.isa[PythonObject]():
+            # Assignment: value is a (x, y) tuple.
+            self.pos_x[i] = Float64(py=value[PythonObject][0])
+            self.pos_y[i] = Float64(py=value[PythonObject][1])
+        else:
+            # Deletion (value is null / Int(0)).
+            _ = self.pos_x.pop(i)
+            _ = self.pos_y.pop(i)
+
+    # ------------------------------------------------------------------
+    # Rich comparison protocol
+    # ------------------------------------------------------------------
+
+    def rich_compare(
+        self,
+        other: PythonObject,
+        op: Int,
+    ) raises -> Bool:
+        """Compare DataFrames by bounding-box area.
+
+        Only LT and EQ are implemented; all other operations raise
+        NotImplementedError so Python falls back to the reflected call.
+        """
+        var invocation = "{}rich_compare[{}]".format(
+            Int(UnsafePointer(to=self)), op
+        )
+        var call_count = _get_global_call_count()
+        call_count[][invocation] = call_count[].get(invocation, 0) + 1
+        var other_df = other.downcast_value_ptr[Self]()
+        if op == RichCompareOps.Py_LT:
+            return self._bounding_box_area < other_df[]._bounding_box_area
+        if op == RichCompareOps.Py_EQ:
+            return self._bounding_box_area == other_df[]._bounding_box_area
+        raise NotImplementedError()
+
+    # ------------------------------------------------------------------
+    # Number protocol — unary
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__neg__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises -> PythonObject:
+        var result_x = Coord1DColumn(capacity=len(self_ptr[].pos_x))
+        var result_y = Coord1DColumn(capacity=len(self_ptr[].pos_y))
+        for v in self_ptr[].pos_x:
+            result_x.append(-v)
+        for v in self_ptr[].pos_y:
+            result_y.append(-v)
+        return PythonObject(alloc=DataFrame(result_x^, result_y^))
+
+    @staticmethod
+    def py__abs__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises -> PythonObject:
+        var result_x = Coord1DColumn(capacity=len(self_ptr[].pos_x))
+        var result_y = Coord1DColumn(capacity=len(self_ptr[].pos_y))
+        for v in self_ptr[].pos_x:
+            result_x.append(abs(v))
+        for v in self_ptr[].pos_y:
+            result_y.append(abs(v))
+        return PythonObject(alloc=DataFrame(result_x^, result_y^))
+
+    # ------------------------------------------------------------------
+    # Number protocol — bool
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__bool__(self_ptr: UnsafePointer[Self, MutAnyOrigin]) raises -> Bool:
+        return len(self_ptr[].pos_x) > 0
+
+    # ------------------------------------------------------------------
+    # Number protocol — binary
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__add__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises -> PythonObject:
+        """Concatenate two DataFrames row-wise. Returns NotImplemented for non-DataFrames.
+        """
+        try:
+            var other_ptr = other.downcast_value_ptr[Self]()
+            var n = len(self_ptr[].pos_x) + len(other_ptr[].pos_x)
+            var result_x = Coord1DColumn(capacity=n)
+            var result_y = Coord1DColumn(capacity=n)
+            for v in self_ptr[].pos_x:
+                result_x.append(v)
+            for v in self_ptr[].pos_y:
+                result_y.append(v)
+            for v in other_ptr[].pos_x:
+                result_x.append(v)
+            for v in other_ptr[].pos_y:
+                result_y.append(v)
+            return PythonObject(alloc=DataFrame(result_x^, result_y^))
+        except:
+            raise NotImplementedError()
+
+    @staticmethod
+    def py__mul__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises -> PythonObject:
+        """Scale all coordinates by a numeric scalar. Returns NotImplemented otherwise.
+        """
+        try:
+            var scale = Float64(py=other)
+            var result_x = Coord1DColumn(capacity=len(self_ptr[].pos_x))
+            var result_y = Coord1DColumn(capacity=len(self_ptr[].pos_y))
+            for v in self_ptr[].pos_x:
+                result_x.append(v * scale)
+            for v in self_ptr[].pos_y:
+                result_y.append(v * scale)
+            return PythonObject(alloc=DataFrame(result_x^, result_y^))
+        except:
+            raise NotImplementedError()
+
+    # ------------------------------------------------------------------
+    # Number protocol — ternary
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__pow__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin],
+        exp: PythonObject,
+        mod: PythonObject,
+    ) raises -> PythonObject:
+        """Raise all coordinates to a power. The `mod` argument is ignored."""
+        var e = Float64(py=exp)
+        var result_x = Coord1DColumn(capacity=len(self_ptr[].pos_x))
+        var result_y = Coord1DColumn(capacity=len(self_ptr[].pos_y))
+        for v in self_ptr[].pos_x:
+            result_x.append(v**e)
+        for v in self_ptr[].pos_y:
+            result_y.append(v**e)
+        return PythonObject(alloc=DataFrame(result_x^, result_y^))
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("DataFrame( length=", len(self.pos_x), ")")
+
+
+@export
+def PyInit_columnar_mojo() -> PythonObject:
+    """Entry point: create the Python extension module."""
+    try:
+        var b = PythonModuleBuilder("columnar_mojo")
+
+        ref tb = (
+            b.add_type[DataFrame]("DataFrame")
+            .def_init_defaultable[DataFrame]()
+            .def_staticmethod[DataFrame.with_columns]("with_columns")
+            .def_method[DataFrame.get_call_count]("get_call_count")
+        )
+        var tpb = TypeProtocolBuilder[DataFrame](tb)
+        _ = tpb.def_richcompare[DataFrame.rich_compare]()
+        var mpb = MappingProtocolBuilder[DataFrame](tb)
+        _ = (
+            mpb.def_len[DataFrame.py__len__]()
+            .def_getitem[DataFrame.py__getitem__]()
+            .def_setitem[DataFrame.py__setitem__]()
+        )
+        var npb = NumberProtocolBuilder[DataFrame](tb)
+        _ = (
+            npb.def_neg[DataFrame.py__neg__]()
+            .def_abs[DataFrame.py__abs__]()
+            .def_bool[DataFrame.py__bool__]()
+            .def_add[DataFrame.py__add__]()
+            .def_mul[DataFrame.py__mul__]()
+            .def_pow[DataFrame.py__pow__]()
+        )
+
+        return b.finalize()
+    except e:
+        abort(String("failed to create Python module: ", e))

--- a/mojo/examples/python-interop/columnar_mojo.mojo
+++ b/mojo/examples/python-interop/columnar_mojo.mojo
@@ -1,0 +1,382 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Example from https://github.com/modular/modular/pull/5562, adapted to use
+# the pontoneer library instead of the stdlib additions directly.
+#
+# Exposes a simple columnar DataFrame to Python that supports:
+#   - len(df)          via mp_length
+#   - df[i]            via mp_subscript
+#   - df[i] = (x, y)  via mp_ass_subscript
+#   - del df[i]        via mp_ass_subscript (null value)
+#   - df < other       via tp_richcompare
+#   - -df              via nb_negative
+#   - abs(df)          via nb_absolute
+#   - bool(df)         via nb_bool
+#   - df + other       via nb_add
+#   - df * scalar      via nb_multiply
+#   - df ** exp        via nb_power
+# ===----------------------------------------------------------------------=== #
+
+from std.os import abort
+from std.memory import UnsafePointer
+from std.utils import Variant
+from std.python import Python, PythonObject
+from std.python.bindings import PythonModuleBuilder
+from std.ffi import _Global
+
+from std.python.utils import PySlotError, RichCompareOps
+from std.python.builders import (
+    TypeProtocolBuilder,
+    MappingProtocolBuilder,
+    NumberProtocolBuilder,
+)
+
+
+def _alloc[
+    T: Movable & ImplicitlyDestructible
+](var value: T) raises PySlotError -> PythonObject:
+    """Translate `PythonObject(alloc=...)`'s plain `Error` into `PySlotError`.
+    """
+    try:
+        return PythonObject(alloc=value^)
+    except e:
+        raise PySlotError.runtime_error(String(e))
+
+
+comptime Coord1DColumn = List[Float64]
+
+
+def _extent(pos: Coord1DColumn) -> Tuple[Float64, Float64]:
+    """Return the (min, max) of a column."""
+    v_min = Float64.MAX
+    v_max = Float64.MIN
+    for v in pos:
+        v_min = min(v_min, v)
+        v_max = max(v_max, v)
+    return (v_min, v_max)
+
+
+def _compute_bounding_box_area(
+    pos_x: Coord1DColumn,
+    pos_y: Coord1DColumn,
+) -> Float64:
+    if len(pos_x) == 0:
+        return 0.0
+    ext_x = _extent(pos_x)
+    ext_y = _extent(pos_y)
+    return (ext_x[1] - ext_x[0]) * (ext_y[1] - ext_y[0])
+
+
+def _init_call_count() -> Dict[String, Int]:
+    return {}
+
+
+# Track call counts for testing reasons.
+comptime _global_call_count = _Global["call_count", _init_call_count]
+
+
+def _get_global_call_count(
+    out result: UnsafePointer[Dict[String, Int], MutExternalOrigin]
+):
+    """Gets the global calls count.
+
+    Returns:
+        A pointer to the global calls count dictionary.
+    """
+    try:
+        result = _global_call_count.get_or_create_ptr()
+    except:
+        abort("Failed to initialize global calls count")
+
+
+struct DataFrame(Defaultable, Movable, Writable):
+    """A simple columnar data structure storing 2-D points.
+
+    x and y coordinates are stored in separate columns for cache-friendly
+    access patterns.  Used here to demonstrate the mapping protocol and
+    rich comparison protocol via pontoneer.
+    """
+
+    var pos_x: Coord1DColumn
+    var pos_y: Coord1DColumn
+    var _bounding_box_area: Float64
+
+    def __init__(out self):
+        self.pos_x = []
+        self.pos_y = []
+        self._bounding_box_area = 0
+
+    def __init__(
+        out self,
+        var x: Coord1DColumn,
+        var y: Coord1DColumn,
+    ):
+        self._bounding_box_area = _compute_bounding_box_area(x, y)
+        self.pos_x = x^
+        self.pos_y = y^
+
+    # ------------------------------------------------------------------
+    # Regular methods
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_call_count(
+        py_self: PythonObject, name: PythonObject
+    ) raises -> PythonObject:
+        """Return the number of times a named method was called (for testing).
+        """
+        var self_ptr = py_self.downcast_value_ptr[Self]()
+        var key = "{}{}".format(Int(self_ptr), String(py=name))
+        return _get_global_call_count()[].get(key, 0)
+
+    @staticmethod
+    def with_columns(
+        pos_x: PythonObject, pos_y: PythonObject
+    ) raises -> PythonObject:
+        var len_x = Int(pos_x.__len__())
+        var len_y = Int(pos_y.__len__())
+        if len_x != len_y:
+            raise Error("The length of the two columns does not match.")
+        var ptr_x = Coord1DColumn(capacity=len_x)
+        var ptr_y = Coord1DColumn(capacity=len_y)
+        for value in pos_x:
+            ptr_x.append(Float64(py=value))
+        for value in pos_y:
+            ptr_y.append(Float64(py=value))
+        return PythonObject(alloc=DataFrame(ptr_x^, ptr_y^))
+
+    # ------------------------------------------------------------------
+    # Mapping protocol
+    # ------------------------------------------------------------------
+
+    def py__len__(self) raises PySlotError -> Int:
+        return len(self.pos_x)
+
+    def py__getitem__(
+        self, index: PythonObject
+    ) raises PySlotError -> PythonObject:
+        var i: Int
+        try:
+            i = Int(py=index)
+        except e:
+            raise PySlotError.type_error(String(e))
+        var length = len(self.pos_x)
+        if i < 0 or i >= length:
+            raise PySlotError.index_error("index out of range")
+        try:
+            return Python().tuple(self.pos_x[i], self.pos_y[i])
+        except e:
+            raise PySlotError.runtime_error(String(e))
+
+    def py__setitem__(
+        mut self,
+        index: PythonObject,
+        value: Variant[PythonObject, Int],
+    ) raises PySlotError -> None:
+        var i: Int
+        try:
+            i = Int(py=index)
+        except e:
+            raise PySlotError.type_error(String(e))
+        var length = len(self.pos_x)
+        if i < 0 or i >= length:
+            raise PySlotError.index_error("index out of range")
+        if value.isa[PythonObject]():
+            # Assignment: value is a (x, y) tuple.
+            try:
+                self.pos_x[i] = Float64(py=value[PythonObject][0])
+                self.pos_y[i] = Float64(py=value[PythonObject][1])
+            except e:
+                raise PySlotError.type_error(String(e))
+        else:
+            # Deletion (value is null / Int(0)).
+            _ = self.pos_x.pop(i)
+            _ = self.pos_y.pop(i)
+
+    # ------------------------------------------------------------------
+    # Rich comparison protocol
+    # ------------------------------------------------------------------
+
+    def rich_compare(
+        self,
+        other: PythonObject,
+        op: Int,
+    ) raises PySlotError -> Bool:
+        """Compare DataFrames by bounding-box area.
+
+        Only LT and EQ are implemented; all other operations raise
+        `PySlotError.not_implemented()` so Python falls back to the reflected
+        call.
+        """
+        var invocation = "{}rich_compare[{}]".format(
+            Int(UnsafePointer(to=self)), op
+        )
+        var call_count = _get_global_call_count()
+        call_count[][invocation] = call_count[].get(invocation, 0) + 1
+        var other_df: UnsafePointer[Self, MutAnyOrigin]
+        try:
+            other_df = other.downcast_value_ptr[Self]()
+        except e:
+            raise PySlotError.type_error(String(e))
+        if op == RichCompareOps.Py_LT:
+            return self._bounding_box_area < other_df[]._bounding_box_area
+        if op == RichCompareOps.Py_EQ:
+            return self._bounding_box_area == other_df[]._bounding_box_area
+        raise PySlotError.not_implemented()
+
+    # ------------------------------------------------------------------
+    # Number protocol — unary
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__neg__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises PySlotError -> PythonObject:
+        var result_x = Coord1DColumn(capacity=len(self_ptr[].pos_x))
+        var result_y = Coord1DColumn(capacity=len(self_ptr[].pos_y))
+        for v in self_ptr[].pos_x:
+            result_x.append(-v)
+        for v in self_ptr[].pos_y:
+            result_y.append(-v)
+        return _alloc(DataFrame(result_x^, result_y^))
+
+    @staticmethod
+    def py__abs__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises PySlotError -> PythonObject:
+        var result_x = Coord1DColumn(capacity=len(self_ptr[].pos_x))
+        var result_y = Coord1DColumn(capacity=len(self_ptr[].pos_y))
+        for v in self_ptr[].pos_x:
+            result_x.append(abs(v))
+        for v in self_ptr[].pos_y:
+            result_y.append(abs(v))
+        return _alloc(DataFrame(result_x^, result_y^))
+
+    # ------------------------------------------------------------------
+    # Number protocol — bool
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__bool__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises PySlotError -> Bool:
+        return len(self_ptr[].pos_x) > 0
+
+    # ------------------------------------------------------------------
+    # Number protocol — binary
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__add__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        """Concatenate two DataFrames row-wise. Returns NotImplemented for non-DataFrames.
+        """
+        try:
+            var other_ptr = other.downcast_value_ptr[Self]()
+            var n = len(self_ptr[].pos_x) + len(other_ptr[].pos_x)
+            var result_x = Coord1DColumn(capacity=n)
+            var result_y = Coord1DColumn(capacity=n)
+            for v in self_ptr[].pos_x:
+                result_x.append(v)
+            for v in self_ptr[].pos_y:
+                result_y.append(v)
+            for v in other_ptr[].pos_x:
+                result_x.append(v)
+            for v in other_ptr[].pos_y:
+                result_y.append(v)
+            return PythonObject(alloc=DataFrame(result_x^, result_y^))
+        except:
+            raise PySlotError.not_implemented()
+
+    @staticmethod
+    def py__mul__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        """Scale all coordinates by a numeric scalar. Returns NotImplemented otherwise.
+        """
+        try:
+            var scale = Float64(py=other)
+            var result_x = Coord1DColumn(capacity=len(self_ptr[].pos_x))
+            var result_y = Coord1DColumn(capacity=len(self_ptr[].pos_y))
+            for v in self_ptr[].pos_x:
+                result_x.append(v * scale)
+            for v in self_ptr[].pos_y:
+                result_y.append(v * scale)
+            return PythonObject(alloc=DataFrame(result_x^, result_y^))
+        except:
+            raise PySlotError.not_implemented()
+
+    # ------------------------------------------------------------------
+    # Number protocol — ternary
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__pow__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin],
+        exp: PythonObject,
+        mod: PythonObject,
+    ) raises PySlotError -> PythonObject:
+        """Raise all coordinates to a power. The `mod` argument is ignored."""
+        var e: Float64
+        try:
+            e = Float64(py=exp)
+        except err:
+            raise PySlotError.type_error(String(err))
+        var result_x = Coord1DColumn(capacity=len(self_ptr[].pos_x))
+        var result_y = Coord1DColumn(capacity=len(self_ptr[].pos_y))
+        for v in self_ptr[].pos_x:
+            result_x.append(v**e)
+        for v in self_ptr[].pos_y:
+            result_y.append(v**e)
+        return _alloc(DataFrame(result_x^, result_y^))
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("DataFrame( length=", len(self.pos_x), ")")
+
+
+@export
+def PyInit_columnar_mojo() -> PythonObject:
+    """Entry point: create the Python extension module."""
+    try:
+        var b = PythonModuleBuilder("columnar_mojo")
+
+        ref tb = (
+            b.add_type[DataFrame]("DataFrame")
+            .def_init_defaultable[DataFrame]()
+            .def_staticmethod[DataFrame.with_columns]("with_columns")
+            .def_method[DataFrame.get_call_count]("get_call_count")
+        )
+        var tpb = TypeProtocolBuilder[DataFrame](tb)
+        _ = tpb.def_richcompare[DataFrame.rich_compare]()
+        var mpb = MappingProtocolBuilder[DataFrame](tb)
+        _ = (
+            mpb.def_len[DataFrame.py__len__]()
+            .def_getitem[DataFrame.py__getitem__]()
+            .def_setitem[DataFrame.py__setitem__]()
+        )
+        var npb = NumberProtocolBuilder[DataFrame](tb)
+        _ = (
+            npb.def_neg[DataFrame.py__neg__]()
+            .def_abs[DataFrame.py__abs__]()
+            .def_bool[DataFrame.py__bool__]()
+            .def_add[DataFrame.py__add__]()
+            .def_mul[DataFrame.py__mul__]()
+            .def_pow[DataFrame.py__pow__]()
+        )
+
+        return b.finalize()
+    except e:
+        abort(String("failed to create Python module: ", e))

--- a/mojo/proposals/python-type-builders.md
+++ b/mojo/proposals/python-type-builders.md
@@ -1,0 +1,315 @@
+# Python type builders
+
+## Goal
+
+This document proposes an approach for enabling Mojo developers to define
+[type objects](https://docs.python.org/3/c-api/typeobj.html).
+
+Type objects are the CPython mechanism that allows binary extensions to fully
+implement types that behave like native Python types. Libraries like `numpy`
+rely on them to deliver powerful APIs — for example
+[indexing](https://numpy.org/doc/stable/user/basics.indexing.html).
+
+To participate in CPython's protocols (operators, `len()`, iteration,
+subscripting, …), Mojo slot implementations must match the C function
+signatures that the interpreter expects to call. Some slots also have a
+sentinel contract — for example, a `tp_richcompare` slot can implement only
+`<` and `==` and return `NotImplemented` for the others; CPython then derives
+`>`, `>=`, `<=` and `!=` from the reflected operands. The exact set of slots
+addressed by this proposal is enumerated in [Type Objects
+protocols](#type-objects-protocols) below.
+
+## Current state
+
+The Mojo standard library already allows developers to expose Mojo modules as
+native Python extensions — see ["Calling Mojo from
+Python"](https://docs.modular.com/mojo/manual/python/mojo-from-python/). The
+library provides ways to convert native scalar types between the two systems
+and also provides ways to define Python modules and classes with user-defined
+methods.
+
+Today, however, those user-defined methods are bound by name as regular
+attributes — not as `PyTypeObject` slots. A Mojo type can declare
+`__getitem__` and it will be callable as `obj.__getitem__(i)`, but `obj[i]`,
+`for x in obj`, `len(obj)`, `a + b`, and the rich comparison operators bypass
+the user-supplied method entirely because CPython dispatches them through
+type-slot function pointers rather than attribute lookup. This proposal
+closes that gap by extending the existing Python integration to populate
+those slots.
+
+## Example
+
+Columnar data — values laid out one column at a time rather than row-by-row —
+is a foundational representation in data analytics and machine learning. It
+underpins formats like Arrow and Parquet, DataFrame libraries such as pandas,
+Polars, and cuDF, and the dense numeric tensors that most ML pipelines consume.
+
+Under this proposal a `DataFrame` library would use the following Type Objects
+protocols.
+
+- **Mapping protocol** — `len(df)`, `df[i]`, `df[i] = (x, y)`, `del df[i]`
+  via `mp_length` / `mp_subscript` / `mp_ass_subscript`.
+- **Rich comparison** — `df < other`, `df == other` via `tp_richcompare`,
+  with the remaining operators raising `PySlotError.not_implemented()` so
+  CPython falls back to the reflected call on the other operand.
+- **Number protocol** — `-df`, `abs(df)`, `bool(df)`, `df + other`,
+  `df * scalar`, `df ** exp` via `nb_negative` / `nb_absolute` / `nb_bool` /
+  `nb_add` / `nb_multiply` / `nb_power`. Operations against incompatible
+  types return `NotImplemented`, letting Python raise `TypeError` naturally.
+
+The code below is just for illustration purposes.
+
+```mojo
+struct DataFrame(Defaultable, Movable, Writable):
+    """A simple columnar data structure storing 2-D points.
+
+    x and y coordinates are stored in separate columns for cache-friendly
+    access patterns. Used here to demonstrate the mapping, rich comparison,
+    and number protocols.
+    """
+
+    var pos_x: Coord1DColumn
+    var pos_y: Coord1DColumn
+    var _bounding_box_area: Float64
+
+    def __init__(out self):
+        self.pos_x = []
+        self.pos_y = []
+        self._bounding_box_area = 0
+
+    def py__getitem__(
+        self, index: PythonObject
+    ) raises PySlotError -> PythonObject:
+        var i: Int
+        try:
+            i = Int(py=index)
+        except e:
+            raise PySlotError.type_error(String(e))
+        var length = len(self.pos_x)
+        if i < 0 or i >= length:
+            raise PySlotError.index_error("index out of range")
+        try:
+            return Python().tuple(self.pos_x[i], self.pos_y[i])
+        except e:
+            raise PySlotError.runtime_error(String(e))
+
+@export
+def PyInit_columnar_mojo() -> PythonObject:
+    """Entry point: create the Python extension module."""
+    try:
+        var b = PythonModuleBuilder("columnar_mojo")
+
+        ref tb = (
+            b.add_type[DataFrame]("DataFrame")
+            .def_init_defaultable[DataFrame]()
+        )
+        var tpb = TypeProtocolBuilder[DataFrame](tb)
+        _ = tpb.def_richcompare[DataFrame.rich_compare]()
+        var mpb = MappingProtocolBuilder[DataFrame](tb)
+        _ = (
+            mpb.def_len[DataFrame.py__len__]()
+            .def_getitem[DataFrame.py__getitem__]()
+            .def_setitem[DataFrame.py__setitem__]()
+        )
+        var npb = NumberProtocolBuilder[DataFrame](tb)
+        _ = (
+            npb.def_neg[DataFrame.py__neg__]()
+            .def_abs[DataFrame.py__abs__]()
+            .def_bool[DataFrame.py__bool__]()
+            .def_add[DataFrame.py__add__]()
+            .def_mul[DataFrame.py__mul__]()
+            .def_pow[DataFrame.py__pow__]()
+        )
+
+        return b.finalize()
+    except e:
+        abort(String("failed to create Python module: ", e))
+
+```
+
+## Type Objects protocols
+
+The following protocols and their methods are addressed in this proposal.
+
+### Type protocol
+
+Top-level `PyTypeObject` slots that apply to every type. In this branch the
+builder exposes rich comparison; other `tp_*` slots (init, dealloc, repr, hash,
+…) are already populated in the Mojo stdlib.
+
+See
+[`PyTypeObject`](https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject).
+
+| Builder method    | CPython slot                                                                                   | Python operator                  |
+|-------------------|------------------------------------------------------------------------------------------------|----------------------------------|
+| `def_richcompare` | [`tp_richcompare`](https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_richcompare) | `<`, `<=`, `==`, `!=`, `>`, `>=` |
+
+### Mapping protocol
+
+Slots that make a type behave like a dict-like mapping keyed by arbitrary
+Python objects.
+
+See
+[`PyMappingMethods`](https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods).
+
+| Builder method | CPython slot                                                                                           | Python operator                |
+|----------------|--------------------------------------------------------------------------------------------------------|--------------------------------|
+| `def_len`      | [`mp_length`](https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_length)               | `len(obj)`                     |
+| `def_getitem`  | [`mp_subscript`](https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript)         | `obj[key]`                     |
+| `def_setitem`  | [`mp_ass_subscript`](https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_ass_subscript) | `obj[key] = v`, `del obj[key]` |
+
+### Sequence protocol
+
+Slots for list/tuple-like types indexed by `Py_ssize_t`. Assignment with a
+`null` value indicates deletion, so `def_setitem` covers both `__setitem__`
+and `__delitem__`.
+
+See
+[`PySequenceMethods`](https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods).
+
+| Builder method | CPython slot                                                                                              | Python operator            |
+|----------------|-----------------------------------------------------------------------------------------------------------|----------------------------|
+| `def_len`      | [`sq_length`](https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_length)                 | `len(obj)`                 |
+| `def_getitem`  | [`sq_item`](https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_item)                     | `obj[i]`                   |
+| `def_setitem`  | [`sq_ass_item`](https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_ass_item)             | `obj[i] = v`, `del obj[i]` |
+| `def_contains` | [`sq_contains`](https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_contains)             | `x in obj`                 |
+| `def_concat`   | [`sq_concat`](https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_concat)                 | `obj + other`              |
+| `def_repeat`   | [`sq_repeat`](https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_repeat)                 | `obj * n`                  |
+| `def_iconcat`  | [`sq_inplace_concat`](https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_concat) | `obj += other`             |
+| `def_irepeat`  | [`sq_inplace_repeat`](https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_repeat) | `obj *= n`                 |
+
+### Number protocol
+
+Arithmetic, bitwise, and numeric-conversion slots. Each binary operator has an
+in-place counterpart (`def_iadd`, …) that backs the augmented assignment
+operators. Binary slots may raise `PySlotError.not_implemented()` to return
+`NotImplemented` so CPython tries the reflected operation on the other operand.
+
+See
+[`PyNumberMethods`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods).
+
+Unary, conversion, and predicate slots:
+
+| Builder method | CPython slot                                                                                | Python operator       |
+|----------------|---------------------------------------------------------------------------------------------|-----------------------|
+| `def_neg`      | [`nb_negative`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_negative) | `-obj`                |
+| `def_pos`      | [`nb_positive`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_positive) | `+obj`                |
+| `def_abs`      | [`nb_absolute`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_absolute) | `abs(obj)`            |
+| `def_invert`   | [`nb_invert`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_invert)     | `~obj`                |
+| `def_bool`     | [`nb_bool`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_bool)         | `bool(obj)`           |
+| `def_int`      | [`nb_int`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_int)           | `int(obj)`            |
+| `def_float`    | [`nb_float`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_float)       | `float(obj)`          |
+| `def_index`    | [`nb_index`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_index)       | `operator.index(obj)` |
+
+Binary slots (each has an `def_i<name>` in-place counterpart):
+
+| Builder method                   | CPython slot                                                                                                                                                                                                                          | Python operator                                    |
+|----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
+| `def_add` / `def_iadd`           | [`nb_add`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_add) / [`nb_inplace_add`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_add)                                                 | `a + b` / `a += b`                                 |
+| `def_sub` / `def_isub`           | [`nb_subtract`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_subtract) / [`nb_inplace_subtract`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_subtract)                             | `a - b` / `a -= b`                                 |
+| `def_mul` / `def_imul`           | [`nb_multiply`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_multiply) / [`nb_inplace_multiply`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_multiply)                             | `a * b` / `a *= b`                                 |
+| `def_truediv` / `def_itruediv`   | [`nb_true_divide`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_true_divide) / [`nb_inplace_true_divide`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_true_divide)                 | `a / b` / `a /= b`                                 |
+| `def_floordiv` / `def_ifloordiv` | [`nb_floor_divide`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_floor_divide) / [`nb_inplace_floor_divide`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_floor_divide)             | `a // b` / `a //= b`                               |
+| `def_mod` / `def_imod`           | [`nb_remainder`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_remainder) / [`nb_inplace_remainder`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_remainder)                         | `a % b` / `a %= b`                                 |
+| `def_divmod`                     | [`nb_divmod`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_divmod)                                                                                                                                               | `divmod(a, b)`                                     |
+| `def_pow` / `def_ipow`           | [`nb_power`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_power) / [`nb_inplace_power`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_power)                                         | `a ** b` / `a **= b`                               |
+| `def_matmul` / `def_imatmul`     | [`nb_matrix_multiply`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_matrix_multiply) / [`nb_inplace_matrix_multiply`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_matrix_multiply) | `a @ b` / `a @= b`                                 |
+| `def_lshift` / `def_ilshift`     | [`nb_lshift`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_lshift) / [`nb_inplace_lshift`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_lshift)                                     | `a << b` / `a <<= b`                               |
+| `def_rshift` / `def_irshift`     | [`nb_rshift`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_rshift) / [`nb_inplace_rshift`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_rshift)                                     | `a >> b` / `a >>= b`                               |
+| `def_and` / `def_iand`           | [`nb_and`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_and) / [`nb_inplace_and`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_and)                                                 | `a & b` / `a &= b`                                 |
+| `def_or` / `def_ior`             | [`nb_or`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_or) / [`nb_inplace_or`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_or)                                                     | <code>a &#124; b</code> / <code>a &#124;= b</code> |
+| `def_xor` / `def_ixor`           | [`nb_xor`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_xor) / [`nb_inplace_xor`](https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_xor)                                                 | `a ^ b` / `a ^= b`                                 |
+
+## Implementation support code
+
+The number protocol alone has ~30 slots, and every builder method admits
+multiple user-signature flavors (pointer-receiver vs. value-receiver vs.
+mut-receiver, raising vs. non-raising, returning `PythonObject` vs. any
+`ConvertibleToPython` type). To keep that combinatorial explosion off the
+public API, an internal `_SlotInstaller` struct in `adapters.mojo` hosts
+all installation helpers as static methods (`_SlotInstaller.binary`,
+`_SlotInstaller.unary_val`, `_SlotInstaller.ternary_conv_nr`, …), and a
+sibling `_BfSlotInstaller` in `buffer.mojo` does the same for the buffer
+protocol. The handful of builder `def_*` methods then each reduce to one
+line that picks the right installer variant and forwards the user's
+function as a template parameter.
+
+### Adapter wrappers
+
+Each CPython type slot has a fixed C function signature that the
+interpreter calls directly (e.g. `tp_richcompare` is
+`PyObject *(*)(PyObject *, PyObject *, int)`). Mojo cannot register a
+user method against those signatures directly — methods take typed
+receivers, raise `PySlotError`, and return `PythonObject` rather than a
+raw `PyObjectPtr`. The adapter wrappers (`_unaryfunc_wrapper`,
+`_binaryfunc_wrapper`, `_ternaryfunc_wrapper`, `_richcompare_wrapper`,
+`_inquiry_wrapper`, `_mp_length_wrapper`, `_mp_subscript_wrapper`,
+`_mp_ass_subscript_wrapper`, `_ssizeargfunc_wrapper`,
+`_ssizeobjargproc_wrapper`, `_objobjproc_wrapper`, and
+`_bf_getbuffer_wrapper`) sit between the two worlds: each is a small
+`abi("C")` function that takes the raw `PyObjectPtr` arguments CPython
+hands it, calls `_unwrap_self` to downcast `self`, invokes the
+user-supplied `method` template parameter, and translates the result
+back to whatever C type the slot's signature requires.
+
+The wrappers also encode the per-slot error contract. For all slots, a
+typed `except e: PySlotError` block branches on `e._variant` and either
+calls `PyErr_SetString` with the matching `PyExc_*` global or — for
+binary, ternary, and rich-compare slots, where the `not_implemented`
+variant has Python-visible meaning — returns
+`Py_NewRef(Py_NotImplemented())` so CPython falls back to the reflected
+operation. Binary/ternary/richcompare wrappers also map any *prep-block*
+failure (e.g. `_unwrap_self` failing because the LHS isn't our type
+during a reflected call) to `Py_NotImplemented` rather than
+`RuntimeError`, matching CPython's expectation for reflected dispatch.
+
+### `_lift_*` and `_conv_*` helpers
+
+User slot methods come in several shapes. A handler can take a
+`UnsafePointer[T, MutAnyOrigin]` (the canonical form), a value receiver
+`T`, or a `mut T`; it can be raising or non-raising; and number-protocol
+return values can be either `PythonObject` or any type conforming to
+`ConvertibleToPython`. Multiplying these axes out would force every
+adapter wrapper to ship in a dozen variants. Instead, a single canonical
+wrapper consumes a `def(UnsafePointer[T, MutAnyOrigin], …) raises
+PySlotError -> PythonObject` shape, and a family of tiny `_lift_*` /
+`_conv_*` template functions adapts each user signature to that shape
+before the wrapper sees it.
+
+The `_lift_*` helpers handle receiver and raising-ness — for example
+`_lift_val_int_to_obj` takes a value-receiver, integer-arg, raising
+method and produces a pointer-receiver version that calls
+`method(ptr[], index)`. The `_conv_*` helpers handle the return type —
+`_conv_ptr_r_binary` takes a method returning `R: ConvertibleToPython`
+and produces one returning `PythonObject` by routing through `_to_py[R]`
+(which itself translates `to_python_object`'s plain `Error` into
+`PySlotError.value_error`). The builder `def_*` overloads then become
+one-liners: `_SlotInstaller.binary_val[…]` already knows it needs
+`_lift_val_obj_to_obj`, `binary_conv_r[…]` knows it needs
+`_conv_ptr_r_binary`, and so on.
+
+### `PySlotError` — the Mojo-native slot error type
+
+CPython slots have a richer error contract than a single `Error` type can
+express: a `tp_richcompare` slot may want to *raise* `TypeError`, *raise*
+`ValueError`, or *return* `Py_NotImplemented`; a `sq_ass_item` slot picks
+between `IndexError` and `TypeError`; and so on. Mojo today allows only one
+error type per `raises` clause and only one `except` clause per `try` block (see
+[Representing multiple error conditions](https://docs.modular.com/mojo/manual/errors#representing-multiple-error-conditions)),
+so we collapse the contract into a single enumerated type. User slot methods
+declare `raises PySlotError` and construct values via static factories:
+
+```mojo
+raise PySlotError.index_error("index out of range")
+raise PySlotError.type_error("expected int")
+raise PySlotError.not_implemented()
+```
+
+The wrapper's `except e:` block infers `e: PySlotError`, branches on
+`e._variant`, and either calls
+`cpython.PyErr_SetString(e.pyexc_global_name(), e.msg)` for the real-exception
+variants or returns `Py_NewRef(cpython.Py_NotImplemented())` for the
+`not_implemented` variant. The variants currently supported are `index_error`,
+`type_error`, `value_error`, `key_error`, `attribute_error`, `overflow_error`,
+`runtime_error`, and `not_implemented`; extending the set is a localized change
+in `utils.mojo` plus one branch in `pyexc_global_name()`.

--- a/mojo/stdlib/std/python/_cpython.mojo
+++ b/mojo/stdlib/std/python/_cpython.mojo
@@ -460,13 +460,6 @@ struct PyType_Spec(ImplicitlyCopyable, RegisterPassable):
     var slots: _CPointer[PyType_Slot, MutAnyOrigin]
 
 
-# https://github.com/python/cpython/blob/main/Include/typeslots.h
-comptime Py_tp_dealloc = 52
-comptime Py_tp_init = 60
-comptime Py_tp_methods = 64
-comptime Py_tp_new = 65
-comptime Py_tp_repr = 66
-
 # https://docs.python.org/3/c-api/typeobj.html#slot-type-typedefs
 
 comptime destructor = def(PyObjectPtr) thin abi("C") -> None
@@ -487,6 +480,110 @@ comptime Typed_newfunc = def(
 """`typedef PyObject *(*newfunc)(PyTypeObject*, PyObject*, PyObject*)`."""
 
 
+struct PySlotIndex:
+    """CPython type-slot index constants.
+
+    Each constant is the integer ID assigned to a slot in CPython's
+    `Include/typeslots.h`, which is part of the stable ABI — do not
+    renumber them. Use these values as the `slot` field of a
+    `PyType_Slot`.
+
+    References:
+    - https://github.com/python/cpython/blob/main/Include/typeslots.h
+    - https://docs.python.org/3/c-api/typeobj.html
+    """
+
+    # Buffer protocol
+    comptime bf_getbuffer = Int32(1)
+    comptime bf_releasebuffer = Int32(2)
+    # Mapping protocol
+    comptime mp_setitem = Int32(3)  # mp_ass_subscript
+    comptime mp_length = Int32(4)
+    comptime mp_getitem = Int32(5)  # mp_subscript
+    # Number protocol
+    comptime nb_absolute = Int32(6)
+    comptime nb_add = Int32(7)
+    comptime nb_and = Int32(8)
+    comptime nb_bool = Int32(9)
+    comptime nb_divmod = Int32(10)
+    comptime nb_float = Int32(11)
+    comptime nb_floor_divide = Int32(12)
+    comptime nb_index = Int32(13)
+    comptime nb_inplace_add = Int32(14)
+    comptime nb_inplace_and = Int32(15)
+    comptime nb_inplace_floor_divide = Int32(16)
+    comptime nb_inplace_lshift = Int32(17)
+    comptime nb_inplace_multiply = Int32(18)
+    comptime nb_inplace_or = Int32(19)
+    comptime nb_inplace_power = Int32(20)
+    comptime nb_inplace_remainder = Int32(21)
+    comptime nb_inplace_rshift = Int32(22)
+    comptime nb_inplace_subtract = Int32(23)
+    comptime nb_inplace_true_divide = Int32(24)
+    comptime nb_inplace_xor = Int32(25)
+    comptime nb_int = Int32(26)
+    comptime nb_invert = Int32(27)
+    comptime nb_lshift = Int32(28)
+    comptime nb_multiply = Int32(29)
+    comptime nb_negative = Int32(30)
+    comptime nb_or = Int32(31)
+    comptime nb_positive = Int32(32)
+    comptime nb_power = Int32(33)
+    comptime nb_remainder = Int32(34)
+    comptime nb_rshift = Int32(35)
+    comptime nb_subtract = Int32(36)
+    comptime nb_true_divide = Int32(37)
+    comptime nb_xor = Int32(38)
+    # Sequence protocol
+    comptime sq_ass_item = Int32(39)
+    comptime sq_concat = Int32(40)
+    comptime sq_contains = Int32(41)
+    comptime sq_inplace_concat = Int32(42)
+    comptime sq_inplace_repeat = Int32(43)
+    comptime sq_item = Int32(44)
+    comptime sq_length = Int32(45)
+    comptime sq_repeat = Int32(46)
+    # Type protocol
+    comptime tp_alloc = Int32(47)
+    comptime tp_base = Int32(48)
+    comptime tp_bases = Int32(49)
+    comptime tp_call = Int32(50)
+    comptime tp_clear = Int32(51)
+    comptime tp_dealloc = Int32(52)
+    comptime tp_del = Int32(53)
+    comptime tp_descr_get = Int32(54)
+    comptime tp_descr_set = Int32(55)
+    comptime tp_doc = Int32(56)
+    comptime tp_getattr = Int32(57)
+    comptime tp_getattro = Int32(58)
+    comptime tp_hash = Int32(59)
+    comptime tp_init = Int32(60)
+    comptime tp_is_gc = Int32(61)
+    comptime tp_iter = Int32(62)
+    comptime tp_iternext = Int32(63)
+    comptime tp_methods = Int32(64)
+    comptime tp_new = Int32(65)
+    comptime tp_repr = Int32(66)
+    comptime tp_richcompare = Int32(67)
+    comptime tp_setattr = Int32(68)
+    comptime tp_setattro = Int32(69)
+    comptime tp_str = Int32(70)
+    comptime tp_traverse = Int32(71)
+    comptime tp_members = Int32(72)
+    comptime tp_getset = Int32(73)
+    comptime tp_free = Int32(74)
+    comptime nb_matrix_multiply = Int32(75)
+    comptime nb_inplace_matrix_multiply = Int32(76)
+    # Async protocol (Python 3.5+)
+    comptime am_await = Int32(77)
+    comptime am_aiter = Int32(78)
+    comptime am_anext = Int32(79)
+    comptime tp_finalize = Int32(80)  # Python 3.5+
+    comptime am_send = Int32(81)  # Python 3.10+
+    comptime tp_vectorcall = Int32(82)  # Python 3.14+
+    comptime tp_token = Int32(83)  # Python 3.14+
+
+
 @fieldwise_init
 struct PyType_Slot(ImplicitlyCopyable, RegisterPassable):
     """Structure defining optional functionality of a type, containing a slot ID
@@ -503,31 +600,33 @@ struct PyType_Slot(ImplicitlyCopyable, RegisterPassable):
     @staticmethod
     def tp_dealloc(func: destructor) -> Self:
         return PyType_Slot(
-            Py_tp_dealloc,
+            PySlotIndex.tp_dealloc,
             rebind[OpaquePointer[MutAnyOrigin]](func),
         )
 
     @staticmethod
     def tp_init(func: Typed_initproc) -> Self:
         return PyType_Slot(
-            Py_tp_init, rebind[OpaquePointer[MutAnyOrigin]](func)
+            PySlotIndex.tp_init, rebind[OpaquePointer[MutAnyOrigin]](func)
         )
 
     @staticmethod
     def tp_methods(methods: _CPointer[PyMethodDef, MutAnyOrigin]) -> Self:
         return PyType_Slot(
-            Py_tp_methods,
+            PySlotIndex.tp_methods,
             unsafe_cast[Type=NoneType](methods),
         )
 
     @staticmethod
     def tp_new(func: Typed_newfunc) -> Self:
-        return PyType_Slot(Py_tp_new, rebind[OpaquePointer[MutAnyOrigin]](func))
+        return PyType_Slot(
+            PySlotIndex.tp_new, rebind[OpaquePointer[MutAnyOrigin]](func)
+        )
 
     @staticmethod
     def tp_repr(func: reprfunc) -> Self:
         return PyType_Slot(
-            Py_tp_repr, rebind[OpaquePointer[MutAnyOrigin]](func)
+            PySlotIndex.tp_repr, rebind[OpaquePointer[MutAnyOrigin]](func)
         )
 
     @staticmethod
@@ -1430,6 +1529,8 @@ struct CPython(Defaultable, Movable):
     var _PyType_FromSpec: PyType_FromSpec.type
     # The None Object
     var _Py_None: PyObjectPtr
+    # The NotImplemented Object
+    var _Py_NotImplemented: PyObjectPtr
     # Integer Objects
     var _PyLong_Type: PyTypeObjectPtr
     var _PyLong_FromSsize_t: PyLong_FromSsize_t.type
@@ -1618,11 +1719,20 @@ struct CPython(Defaultable, Movable):
             self._Py_None = self.lib.call[
                 "Py_GetConstantBorrowed", PyObjectPtr
             ](0)
+            self._Py_NotImplemented = self.lib.call[
+                "Py_GetConstantBorrowed", PyObjectPtr
+            ](4)
         else:
             # PyObject *Py_None
             self._Py_None = PyObjectPtr(
                 upcast_from=self.lib.get_symbol[PyObject](
                     "_Py_NoneStruct"
+                ).value()
+            )
+            # PyObject *Py_NotImplemented
+            self._Py_NotImplemented = PyObjectPtr(
+                upcast_from=self.lib.get_symbol[PyObject](
+                    "_Py_NotImplementedStruct"
                 ).value()
             )
         # Integer Objects
@@ -2458,6 +2568,21 @@ struct CPython(Defaultable, Movable):
         - https://docs.python.org/3/c-api/none.html#c.Py_None
         """
         return self._Py_None
+
+    # ===-------------------------------------------------------------------===#
+    # The NotImplemented Object
+    # ref: https://docs.python.org/3/c-api/object.html#c.Py_NotImplemented
+    # ===-------------------------------------------------------------------===#
+
+    def Py_NotImplemented(self) -> PyObjectPtr:
+        """The Python `NotImplemented` singleton, returned from binary special
+        methods to indicate the operation is not supported for the given
+        operands.
+
+        References:
+        - https://docs.python.org/3/c-api/object.html#c.Py_NotImplemented
+        """
+        return self._Py_NotImplemented
 
     # ===-------------------------------------------------------------------===#
     # Integer Objects

--- a/mojo/stdlib/std/python/adapters.mojo
+++ b/mojo/stdlib/std/python/adapters.mojo
@@ -1,0 +1,1325 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# CPython slot adapter functions introduced in:
+# https://github.com/modular/modular/pull/5562
+#
+# These adapt user-friendly Mojo function signatures to the low-level C ABI
+# expected by each CPython type slot.  They are passed to
+# PontoneerTypeBuilder.def_method as template parameters.
+# ===----------------------------------------------------------------------=== #
+
+from std.ffi import c_int, c_long
+from std.memory import OpaquePointer, UnsafePointer
+from std.os import abort
+from std.python import Python, PythonObject
+from std.python._cpython import PyObject, PyObjectPtr, Py_ssize_t, PyType_Slot
+from std.python.bindings import PythonTypeBuilder
+from std.python.conversions import ConvertibleToPython
+from std.utils import Variant
+
+from .utils import NotImplementedError
+
+
+@always_inline
+def _unwrap_self[
+    T: ImplicitlyDestructible
+](py_self: PyObjectPtr) -> UnsafePointer[T, MutAnyOrigin]:
+    """Downcast a raw PyObjectPtr to a typed Mojo pointer, aborting on failure.
+    """
+    try:
+        return PythonObject(from_borrowed=py_self).downcast_value_ptr[T]()
+    except e:
+        abort(
+            String("Python method receiver did not have the expected type: ", e)
+        )
+
+
+def _mp_length_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(UnsafePointer[self_type, MutAnyOrigin]) thin raises -> Int,
+](py_self: PyObjectPtr) abi("C") -> Py_ssize_t:
+    """CPython `lenfunc` adapter for the `mp_length` slot (__len__).
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function `def(self: UnsafePointer[self_type, MutAnyOrigin]) raises -> Int`.
+
+    Returns:
+        Length as `Py_ssize_t`, or -1 with an exception set on error.
+    """
+    ref cpython = Python().cpython()
+    try:
+        var result = method(_unwrap_self[self_type](py_self))
+        return Py_ssize_t(result)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return Py_ssize_t(-1)
+
+
+def _mp_subscript_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject
+    ) thin raises -> PythonObject,
+](py_self: PyObjectPtr, key: PyObjectPtr) abi("C") -> PyObjectPtr:
+    """CPython `binaryfunc` adapter for the `mp_subscript` slot (__getitem__).
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function `def(self: UnsafePointer[self_type, MutAnyOrigin], key: PythonObject) raises -> PythonObject`.
+
+    Returns:
+        New reference to the result, or null with an exception set on error.
+    """
+    ref cpython = Python().cpython()
+    try:
+        var result = method(
+            _unwrap_self[self_type](py_self),
+            PythonObject(from_borrowed=key),
+        )
+        return result.steal_data()
+    except e:
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+
+
+def _mp_ass_subscript_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin],
+        PythonObject,
+        Variant[PythonObject, Int],
+    ) thin raises -> None,
+](py_self: PyObjectPtr, key: PyObjectPtr, value: PyObjectPtr) abi("C") -> c_int:
+    """CPython `objobjargproc` adapter for the `mp_ass_subscript` slot.
+
+    When `value` is NULL the operation is a deletion (__delitem__); the `method`
+    receives `Variant[PythonObject, Int](Int(0))` as the third argument.
+    Otherwise the operation is an assignment (__setitem__) and `method` receives
+    `Variant[PythonObject, Int](value_object)`.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function with signature
+            `def(self, key, value: Variant[PythonObject, Int]) raises -> None`.
+
+    Returns:
+        0 on success, -1 with an exception set on error.
+    """
+    comptime PassedValue = Variant[PythonObject, Int]
+    ref cpython = Python().cpython()
+    try:
+        var passed_value = PassedValue(
+            PythonObject(from_borrowed=value)
+        ) if value else PassedValue(Int(0))
+        method(
+            _unwrap_self[self_type](py_self),
+            PythonObject(from_borrowed=key),
+            passed_value,
+        )
+        return c_int(0)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+
+
+def _unaryfunc_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin]
+    ) thin raises -> PythonObject,
+](py_self: PyObjectPtr) abi("C") -> PyObjectPtr:
+    """CPython `unaryfunc` adapter for unary nb_ slots (__neg__, __abs__, etc.).
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function `def(self: UnsafePointer[self_type, MutAnyOrigin]) raises -> PythonObject`.
+
+    Returns:
+        New reference to the result, or null with an exception set on error.
+    """
+    ref cpython = Python().cpython()
+    try:
+        var result = method(_unwrap_self[self_type](py_self))
+        return result.steal_data()
+    except e:
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+
+
+def _binaryfunc_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject
+    ) thin raises -> PythonObject,
+](lhs: PyObjectPtr, rhs: PyObjectPtr) abi("C") -> PyObjectPtr:
+    """CPython `binaryfunc` adapter for binary nb_ slots (__add__, __mul__, etc.).
+
+    If `method` raises `NotImplementedError` (by name), the wrapper returns
+    `Py_NotImplemented`, signalling Python to try the reflected operation.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function
+            `def(self: UnsafePointer[self_type, MutAnyOrigin], other: PythonObject) raises -> PythonObject`.
+
+    Returns:
+        New reference to the result, `Py_NotImplemented`, or null on error.
+    """
+    ref cpython = Python().cpython()
+    try:
+        var result = method(
+            _unwrap_self[self_type](lhs),
+            PythonObject(from_borrowed=rhs),
+        )
+        return result.steal_data()
+    except e:
+        var msg = String(e)
+        if NotImplementedError.name == msg:
+            var not_implemented = cpython.lib.call[
+                "Py_GetConstantBorrowed", PyObjectPtr
+            ](4)
+            return cpython.Py_NewRef(not_implemented)
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+
+
+def _ternaryfunc_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject, PythonObject
+    ) thin raises -> PythonObject,
+](py_self: PyObjectPtr, other: PyObjectPtr, mod: PyObjectPtr) abi(
+    "C"
+) -> PyObjectPtr:
+    """CPython `ternaryfunc` adapter for nb_power / nb_inplace_power (__pow__).
+
+    If `method` raises `NotImplementedError` (by name), the wrapper returns
+    `Py_NotImplemented`, signalling Python to try the reflected operation.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function
+            `def(self, other, mod: PythonObject) raises -> PythonObject`
+            where `mod` is typically `None` unless the three-argument form
+            `pow(base, exp, mod)` is used.
+
+    Returns:
+        New reference to the result, `Py_NotImplemented`, or null on error.
+    """
+    ref cpython = Python().cpython()
+    try:
+        var result = method(
+            _unwrap_self[self_type](py_self),
+            PythonObject(from_borrowed=other),
+            PythonObject(from_borrowed=mod),
+        )
+        return result.steal_data()
+    except e:
+        var msg = String(e)
+        if NotImplementedError.name == msg:
+            var not_implemented = cpython.lib.call[
+                "Py_GetConstantBorrowed", PyObjectPtr
+            ](4)
+            return cpython.Py_NewRef(not_implemented)
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+
+
+def _inquiry_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(UnsafePointer[self_type, MutAnyOrigin]) thin raises -> Bool,
+](py_self: PyObjectPtr) abi("C") -> c_int:
+    """CPython `inquiry` adapter for the `nb_bool` slot (__bool__).
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function `def(self: UnsafePointer[self_type, MutAnyOrigin]) raises -> Bool`.
+
+    Returns:
+        1 for True, 0 for False, -1 with an exception set on error.
+    """
+    ref cpython = Python().cpython()
+    try:
+        var result = method(_unwrap_self[self_type](py_self))
+        return c_int(1) if result else c_int(0)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+
+
+def _ssizeargfunc_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], Int
+    ) thin raises -> PythonObject,
+](py_self: PyObjectPtr, index: Py_ssize_t) abi("C") -> PyObjectPtr:
+    """CPython `ssizeargfunc` adapter for sq_item, sq_repeat, sq_inplace_repeat.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function `def(self: UnsafePointer[self_type, MutAnyOrigin], index: Int) raises -> PythonObject`.
+
+    Returns:
+        New reference to the result, or null with an exception set on error.
+    """
+    ref cpython = Python().cpython()
+    try:
+        var result = method(_unwrap_self[self_type](py_self), Int(index))
+        return result.steal_data()
+    except e:
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+
+
+def _ssizeobjargproc_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], Int, Variant[PythonObject, Int]
+    ) thin raises -> None,
+](py_self: PyObjectPtr, index: Py_ssize_t, value: PyObjectPtr) abi(
+    "C"
+) -> c_int:
+    """CPython `ssizeobjargproc` adapter for the `sq_ass_item` slot.
+
+    When `value` is NULL the operation is a deletion; the `method` receives
+    `Variant[PythonObject, Int](Int(0))` as the third argument.  Otherwise
+    the operation is an assignment and `method` receives the value object.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function with signature
+            `def(self, index: Int, value: Variant[PythonObject, Int]) raises -> None`.
+
+    Returns:
+        0 on success, -1 with an exception set on error.
+    """
+    comptime PassedValue = Variant[PythonObject, Int]
+    ref cpython = Python().cpython()
+    try:
+        var passed_value = PassedValue(
+            PythonObject(from_borrowed=value)
+        ) if value else PassedValue(Int(0))
+        method(_unwrap_self[self_type](py_self), Int(index), passed_value)
+        return c_int(0)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+
+
+def _objobjproc_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject
+    ) thin raises -> Bool,
+](py_self: PyObjectPtr, other: PyObjectPtr) abi("C") -> c_int:
+    """CPython `objobjproc` adapter for the `sq_contains` slot (__contains__).
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function `def(self: UnsafePointer[self_type, MutAnyOrigin], item: PythonObject) raises -> Bool`.
+
+    Returns:
+        1 if contained, 0 if not, -1 with an exception set on error.
+    """
+    ref cpython = Python().cpython()
+    try:
+        var result = method(
+            _unwrap_self[self_type](py_self),
+            PythonObject(from_borrowed=other),
+        )
+        return c_int(1) if result else c_int(0)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+
+
+def _richcompare_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject, Int
+    ) thin raises -> Bool,
+](py_self: PyObjectPtr, py_other: PyObjectPtr, op: c_int) abi(
+    "C"
+) -> PyObjectPtr:
+    """CPython `richcmpfunc` adapter for the `tp_richcompare` slot.
+
+    If `method` raises `NotImplementedError` (by name), the wrapper returns
+    `Py_NotImplemented`, signalling Python to try the reflected operation.
+    Any other exception sets a Python exception and returns null.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function
+            `def(self, other: PythonObject, op: Int) raises -> Bool`
+            where `op` is one of `RichCompareOps.Py_LT` … `Py_GE`.
+
+    Returns:
+        `Py_True`/`Py_False`, `Py_NotImplemented`, or null on error.
+    """
+    ref cpython = Python().cpython()
+    try:
+        var result = method(
+            _unwrap_self[self_type](py_self),
+            PythonObject(from_borrowed=py_other),
+            Int(op),
+        )
+        return cpython.PyBool_FromLong(c_long(Int(result)))
+    except e:
+        # Mojo lacks multiple except branches; dispatch on the error name.
+        var msg = String(e)
+        if NotImplementedError.name == msg:
+            # Py_CONSTANT_NOT_IMPLEMENTED = 4 (CPython 3.13+ stable ABI)
+            var not_implemented = cpython.lib.call[
+                "Py_GetConstantBorrowed", PyObjectPtr
+            ](4)
+            return cpython.Py_NewRef(not_implemented)
+        var error_type = cpython.get_error_global("PyExc_Exception")
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+
+
+# ===----------------------------------------------------------------------=== #
+# CPython type slot indices — do not renumber; these are part of the stable ABI.
+# ref: https://github.com/python/cpython/blob/main/Include/typeslots.h
+# ===----------------------------------------------------------------------=== #
+
+
+struct _PySlotIndex:
+    """CPython slot index constants for use with `PythonTypeBuilder._insert_slot`.
+
+    These match the values in CPython's `typeslots.h` and are part of the
+    stable ABI — do not renumber them.
+    """
+
+    # Buffer protocol
+    comptime bf_getbuffer = Int32(1)
+    comptime bf_releasebuffer = Int32(2)
+    # Mapping protocol
+    comptime mp_setitem = Int32(3)  # mp_ass_subscript
+    comptime mp_length = Int32(4)
+    comptime mp_getitem = Int32(5)  # mp_subscript
+    # Number protocol
+    comptime nb_absolute = Int32(6)
+    comptime nb_add = Int32(7)
+    comptime nb_and = Int32(8)
+    comptime nb_bool = Int32(9)
+    comptime nb_divmod = Int32(10)
+    comptime nb_float = Int32(11)
+    comptime nb_floor_divide = Int32(12)
+    comptime nb_index = Int32(13)
+    comptime nb_inplace_add = Int32(14)
+    comptime nb_inplace_and = Int32(15)
+    comptime nb_inplace_floor_divide = Int32(16)
+    comptime nb_inplace_lshift = Int32(17)
+    comptime nb_inplace_multiply = Int32(18)
+    comptime nb_inplace_or = Int32(19)
+    comptime nb_inplace_power = Int32(20)
+    comptime nb_inplace_remainder = Int32(21)
+    comptime nb_inplace_rshift = Int32(22)
+    comptime nb_inplace_subtract = Int32(23)
+    comptime nb_inplace_true_divide = Int32(24)
+    comptime nb_inplace_xor = Int32(25)
+    comptime nb_int = Int32(26)
+    comptime nb_invert = Int32(27)
+    comptime nb_lshift = Int32(28)
+    comptime nb_multiply = Int32(29)
+    comptime nb_negative = Int32(30)
+    comptime nb_or = Int32(31)
+    comptime nb_positive = Int32(32)
+    comptime nb_power = Int32(33)
+    comptime nb_remainder = Int32(34)
+    comptime nb_rshift = Int32(35)
+    comptime nb_subtract = Int32(36)
+    comptime nb_true_divide = Int32(37)
+    comptime nb_xor = Int32(38)
+    # Sequence protocol
+    comptime sq_ass_item = Int32(39)
+    comptime sq_concat = Int32(40)
+    comptime sq_contains = Int32(41)
+    comptime sq_inplace_concat = Int32(42)
+    comptime sq_inplace_repeat = Int32(43)
+    comptime sq_item = Int32(44)
+    comptime sq_length = Int32(45)
+    comptime sq_repeat = Int32(46)
+    # Type protocol
+    comptime tp_alloc = Int32(47)
+    comptime tp_base = Int32(48)
+    comptime tp_bases = Int32(49)
+    comptime tp_call = Int32(50)
+    comptime tp_clear = Int32(51)
+    comptime tp_dealloc = Int32(52)
+    comptime tp_del = Int32(53)
+    comptime tp_descr_get = Int32(54)
+    comptime tp_descr_set = Int32(55)
+    comptime tp_doc = Int32(56)
+    comptime tp_getattr = Int32(57)
+    comptime tp_getattro = Int32(58)
+    comptime tp_hash = Int32(59)
+    comptime tp_init = Int32(60)
+    comptime tp_is_gc = Int32(61)
+    comptime tp_iter = Int32(62)
+    comptime tp_iternext = Int32(63)
+    comptime tp_methods = Int32(64)
+    comptime tp_new = Int32(65)
+    comptime tp_repr = Int32(66)
+    comptime tp_richcompare = Int32(67)
+    comptime tp_setattr = Int32(68)
+    comptime tp_setattro = Int32(69)
+    comptime tp_str = Int32(70)
+    comptime tp_traverse = Int32(71)
+    comptime tp_members = Int32(72)
+    comptime tp_getset = Int32(73)
+    comptime tp_free = Int32(74)
+    comptime nb_matrix_multiply = Int32(75)
+    comptime nb_inplace_matrix_multiply = Int32(76)
+    # Async protocol (Python 3.5+)
+    comptime am_await = Int32(77)
+    comptime am_aiter = Int32(78)
+    comptime am_anext = Int32(79)
+    comptime tp_finalize = Int32(80)  # Python 3.5+
+    comptime am_send = Int32(81)  # Python 3.10+
+    comptime tp_vectorcall = Int32(82)  # Python 3.14+
+    comptime tp_token = Int32(83)  # Python 3.14+
+
+
+# ===----------------------------------------------------------------------=== #
+# Slot-install helpers — insert a typed C function pointer into a builder
+# ===----------------------------------------------------------------------=== #
+
+
+def _install_unary[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin]
+    ) thin raises -> PythonObject,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `unaryfunc` slot into the builder pointed to by `ptr`."""
+    comptime _unaryfunc = def(PyObjectPtr) thin abi("C") -> PyObjectPtr
+    var fn_ptr: _unaryfunc = _unaryfunc_wrapper[self_type, method]
+    ptr[]._insert_slot(
+        PyType_Slot(slot, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr))
+    )
+
+
+def _install_binary[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject
+    ) thin raises -> PythonObject,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `binaryfunc` slot into the builder pointed to by `ptr`."""
+    comptime _binaryfunc = def(PyObjectPtr, PyObjectPtr) thin abi(
+        "C"
+    ) -> PyObjectPtr
+    var fn_ptr: _binaryfunc = _binaryfunc_wrapper[self_type, method]
+    ptr[]._insert_slot(
+        PyType_Slot(slot, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr))
+    )
+
+
+def _install_ternary[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject, PythonObject
+    ) thin raises -> PythonObject,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `ternaryfunc` slot into the builder pointed to by `ptr`."""
+    comptime _ternaryfunc = def(PyObjectPtr, PyObjectPtr, PyObjectPtr) thin abi(
+        "C"
+    ) -> PyObjectPtr
+    var fn_ptr: _ternaryfunc = _ternaryfunc_wrapper[self_type, method]
+    ptr[]._insert_slot(
+        PyType_Slot(slot, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr))
+    )
+
+
+def _install_inquiry[
+    self_type: ImplicitlyDestructible,
+    method: def(UnsafePointer[self_type, MutAnyOrigin]) thin raises -> Bool,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert an `inquiry` slot into the builder pointed to by `ptr`."""
+    comptime _inquiry = def(PyObjectPtr) thin abi("C") -> c_int
+    var fn_ptr: _inquiry = _inquiry_wrapper[self_type, method]
+    ptr[]._insert_slot(
+        PyType_Slot(slot, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr))
+    )
+
+
+def _install_richcompare[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject, Int
+    ) thin raises -> Bool,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `richcmpfunc` slot (`tp_richcompare`) into the builder pointed to by `ptr`.
+    """
+    comptime _richcmpfunc = def(PyObjectPtr, PyObjectPtr, c_int) thin abi(
+        "C"
+    ) -> PyObjectPtr
+    var fn_ptr: _richcmpfunc = _richcompare_wrapper[self_type, method]
+    ptr[]._insert_slot(
+        PyType_Slot(
+            _PySlotIndex.tp_richcompare,
+            rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+        )
+    )
+
+
+def _install_lenfunc[
+    self_type: ImplicitlyDestructible,
+    method: def(UnsafePointer[self_type, MutAnyOrigin]) thin raises -> Int,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `lenfunc` slot (`mp_length`) into the builder pointed to by `ptr`.
+    """
+    comptime _lenfunc = def(PyObjectPtr) thin abi("C") -> Py_ssize_t
+    var fn_ptr: _lenfunc = _mp_length_wrapper[self_type, method]
+    ptr[]._insert_slot(
+        PyType_Slot(
+            _PySlotIndex.mp_length, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr)
+        )
+    )
+
+
+def _install_mp_getitem[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject
+    ) thin raises -> PythonObject,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `binaryfunc` slot (`mp_subscript`) into the builder pointed to by `ptr`.
+    """
+    comptime _binaryfunc = def(PyObjectPtr, PyObjectPtr) thin abi(
+        "C"
+    ) -> PyObjectPtr
+    var fn_ptr: _binaryfunc = _mp_subscript_wrapper[self_type, method]
+    ptr[]._insert_slot(
+        PyType_Slot(
+            _PySlotIndex.mp_getitem, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr)
+        )
+    )
+
+
+def _install_objobjargproc[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin],
+        PythonObject,
+        Variant[PythonObject, Int],
+    ) thin raises -> None,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert an `objobjargproc` slot (`mp_ass_subscript`) into the builder pointed to by `ptr`.
+    """
+    comptime _objobjargproc = def(
+        PyObjectPtr, PyObjectPtr, PyObjectPtr
+    ) thin abi("C") -> c_int
+    var fn_ptr: _objobjargproc = _mp_ass_subscript_wrapper[self_type, method]
+    ptr[]._insert_slot(
+        PyType_Slot(
+            _PySlotIndex.mp_setitem, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr)
+        )
+    )
+
+
+def _install_ssizeargfunc[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], Int
+    ) thin raises -> PythonObject,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `ssizeargfunc` slot into the builder pointed to by `ptr`."""
+    comptime _ssizeargfunc = def(PyObjectPtr, Py_ssize_t) thin abi(
+        "C"
+    ) -> PyObjectPtr
+    var fn_ptr: _ssizeargfunc = _ssizeargfunc_wrapper[self_type, method]
+    ptr[]._insert_slot(
+        PyType_Slot(slot, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr))
+    )
+
+
+def _install_ssizeobjargproc[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], Int, Variant[PythonObject, Int]
+    ) thin raises -> None,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert the `ssizeobjargproc` slot (`sq_ass_item`) into the builder pointed to by `ptr`.
+    """
+    comptime _ssizeobjargproc = def(
+        PyObjectPtr, Py_ssize_t, PyObjectPtr
+    ) thin abi("C") -> c_int
+    var fn_ptr: _ssizeobjargproc = _ssizeobjargproc_wrapper[self_type, method]
+    ptr[]._insert_slot(
+        PyType_Slot(
+            _PySlotIndex.sq_ass_item,
+            rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+        )
+    )
+
+
+def _install_objobjproc[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject
+    ) thin raises -> Bool,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert an `objobjproc` slot into the builder pointed to by `ptr`."""
+    comptime _objobjproc = def(PyObjectPtr, PyObjectPtr) thin abi("C") -> c_int
+    var fn_ptr: _objobjproc = _objobjproc_wrapper[self_type, method]
+    ptr[]._insert_slot(
+        PyType_Slot(slot, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr))
+    )
+
+
+# ===----------------------------------------------------------------------=== #
+# Non-raising → raising lift helpers
+# ===----------------------------------------------------------------------=== #
+
+
+def _lift_to_int[
+    T: ImplicitlyDestructible,
+    method: def(UnsafePointer[T, MutAnyOrigin]) thin -> Int,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises -> Int:
+    return method(ptr)
+
+
+def _lift_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(UnsafePointer[T, MutAnyOrigin]) thin -> PythonObject,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises -> PythonObject:
+    return method(ptr)
+
+
+def _lift_to_bool[
+    T: ImplicitlyDestructible,
+    method: def(UnsafePointer[T, MutAnyOrigin]) thin -> Bool,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises -> Bool:
+    return method(ptr)
+
+
+def _lift_obj_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[T, MutAnyOrigin], PythonObject
+    ) thin -> PythonObject,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject
+) raises -> PythonObject:
+    return method(ptr, other)
+
+
+def _lift_obj_to_bool[
+    T: ImplicitlyDestructible,
+    method: def(UnsafePointer[T, MutAnyOrigin], PythonObject) thin -> Bool,
+](ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject) raises -> Bool:
+    return method(ptr, other)
+
+
+def _lift_obj_var_to_none[
+    T: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[T, MutAnyOrigin], PythonObject, Variant[PythonObject, Int]
+    ) thin -> None,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin],
+    key: PythonObject,
+    val: Variant[PythonObject, Int],
+) raises -> None:
+    method(ptr, key, val)
+
+
+def _lift_int_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(UnsafePointer[T, MutAnyOrigin], Int) thin -> PythonObject,
+](ptr: UnsafePointer[T, MutAnyOrigin], index: Int) raises -> PythonObject:
+    return method(ptr, index)
+
+
+def _lift_int_var_to_none[
+    T: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[T, MutAnyOrigin], Int, Variant[PythonObject, Int]
+    ) thin -> None,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin],
+    index: Int,
+    val: Variant[PythonObject, Int],
+) raises -> None:
+    method(ptr, index, val)
+
+
+def _lift_obj_int_to_bool[
+    T: ImplicitlyDestructible,
+    method: def(UnsafePointer[T, MutAnyOrigin], PythonObject, Int) thin -> Bool,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject, op: Int
+) raises -> Bool:
+    return method(ptr, other, op)
+
+
+def _lift_obj_obj_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[T, MutAnyOrigin], PythonObject, PythonObject
+    ) thin -> PythonObject,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], a: PythonObject, b: PythonObject
+) raises -> PythonObject:
+    return method(ptr, a, b)
+
+
+# ===----------------------------------------------------------------------=== #
+# Value-receiver → pointer-receiver lift helpers
+# ===----------------------------------------------------------------------=== #
+
+
+def _lift_val_to_int[
+    T: ImplicitlyDestructible,
+    method: def(T) thin raises -> Int,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises -> Int:
+    return method(ptr[])
+
+
+def _lift_val_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(T) thin raises -> PythonObject,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises -> PythonObject:
+    return method(ptr[])
+
+
+def _lift_val_to_bool[
+    T: ImplicitlyDestructible,
+    method: def(T) thin raises -> Bool,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises -> Bool:
+    return method(ptr[])
+
+
+def _lift_val_obj_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(T, PythonObject) thin raises -> PythonObject,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject
+) raises -> PythonObject:
+    return method(ptr[], other)
+
+
+def _lift_val_obj_to_bool[
+    T: ImplicitlyDestructible,
+    method: def(T, PythonObject) thin raises -> Bool,
+](ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject) raises -> Bool:
+    return method(ptr[], other)
+
+
+def _lift_val_obj_var_to_none[
+    T: ImplicitlyDestructible,
+    method: def(
+        T, PythonObject, Variant[PythonObject, Int]
+    ) thin raises -> None,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin],
+    key: PythonObject,
+    val: Variant[PythonObject, Int],
+) raises -> None:
+    method(ptr[], key, val)
+
+
+def _lift_mut_obj_var_to_none[
+    T: ImplicitlyDestructible,
+    method: def(
+        mut T, PythonObject, Variant[PythonObject, Int]
+    ) thin raises -> None,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin],
+    key: PythonObject,
+    val: Variant[PythonObject, Int],
+) raises -> None:
+    method(ptr[], key, val)
+
+
+def _lift_val_int_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(T, Int) thin raises -> PythonObject,
+](ptr: UnsafePointer[T, MutAnyOrigin], index: Int) raises -> PythonObject:
+    return method(ptr[], index)
+
+
+def _lift_val_int_var_to_none[
+    T: ImplicitlyDestructible,
+    method: def(T, Int, Variant[PythonObject, Int]) thin raises -> None,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin],
+    index: Int,
+    val: Variant[PythonObject, Int],
+) raises -> None:
+    method(ptr[], index, val)
+
+
+def _lift_mut_int_var_to_none[
+    T: ImplicitlyDestructible,
+    method: def(mut T, Int, Variant[PythonObject, Int]) thin raises -> None,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin],
+    index: Int,
+    val: Variant[PythonObject, Int],
+) raises -> None:
+    method(ptr[], index, val)
+
+
+def _lift_val_obj_int_to_bool[
+    T: ImplicitlyDestructible,
+    method: def(T, PythonObject, Int) thin raises -> Bool,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject, op: Int
+) raises -> Bool:
+    return method(ptr[], other, op)
+
+
+def _lift_val_obj_obj_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(T, PythonObject, PythonObject) thin raises -> PythonObject,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], a: PythonObject, b: PythonObject
+) raises -> PythonObject:
+    return method(ptr[], a, b)
+
+
+def _lift_mut_obj_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(mut T, PythonObject) thin raises -> PythonObject,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject
+) raises -> PythonObject:
+    return method(ptr[], other)
+
+
+def _lift_mut_obj_obj_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(mut T, PythonObject, PythonObject) thin raises -> PythonObject,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], a: PythonObject, b: PythonObject
+) raises -> PythonObject:
+    return method(ptr[], a, b)
+
+
+# ===----------------------------------------------------------------------=== #
+# ConvertibleToPython return-type lift helpers
+# ===----------------------------------------------------------------------=== #
+
+comptime _CPython = ConvertibleToPython & ImplicitlyCopyable
+
+
+def _conv_ptr_r_unary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(UnsafePointer[T, MutAnyOrigin]) thin raises -> R,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises -> PythonObject:
+    return method(ptr).to_python_object()
+
+
+def _conv_ptr_nr_unary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(UnsafePointer[T, MutAnyOrigin]) thin -> R,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises -> PythonObject:
+    return method(ptr).to_python_object()
+
+
+def _conv_val_r_unary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(T) thin raises -> R,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises -> PythonObject:
+    return method(ptr[]).to_python_object()
+
+
+def _conv_ptr_r_binary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(UnsafePointer[T, MutAnyOrigin], PythonObject) thin raises -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject
+) raises -> PythonObject:
+    return method(ptr, other).to_python_object()
+
+
+def _conv_ptr_nr_binary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(UnsafePointer[T, MutAnyOrigin], PythonObject) thin -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject
+) raises -> PythonObject:
+    return method(ptr, other).to_python_object()
+
+
+def _conv_val_r_binary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(T, PythonObject) thin raises -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject
+) raises -> PythonObject:
+    return method(ptr[], other).to_python_object()
+
+
+def _conv_ptr_r_int_arg[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(UnsafePointer[T, MutAnyOrigin], Int) thin raises -> R,
+](ptr: UnsafePointer[T, MutAnyOrigin], index: Int) raises -> PythonObject:
+    return method(ptr, index).to_python_object()
+
+
+def _conv_ptr_nr_int_arg[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(UnsafePointer[T, MutAnyOrigin], Int) thin -> R,
+](ptr: UnsafePointer[T, MutAnyOrigin], index: Int) raises -> PythonObject:
+    return method(ptr, index).to_python_object()
+
+
+def _conv_val_r_int_arg[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(T, Int) thin raises -> R,
+](ptr: UnsafePointer[T, MutAnyOrigin], index: Int) raises -> PythonObject:
+    return method(ptr[], index).to_python_object()
+
+
+def _conv_ptr_r_ternary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(
+        UnsafePointer[T, MutAnyOrigin], PythonObject, PythonObject
+    ) thin raises -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], a: PythonObject, b: PythonObject
+) raises -> PythonObject:
+    return method(ptr, a, b).to_python_object()
+
+
+def _conv_ptr_nr_ternary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(
+        UnsafePointer[T, MutAnyOrigin], PythonObject, PythonObject
+    ) thin -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], a: PythonObject, b: PythonObject
+) raises -> PythonObject:
+    return method(ptr, a, b).to_python_object()
+
+
+def _conv_val_r_ternary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(T, PythonObject, PythonObject) thin raises -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], a: PythonObject, b: PythonObject
+) raises -> PythonObject:
+    return method(ptr[], a, b).to_python_object()
+
+
+# ===----------------------------------------------------------------------=== #
+# Wrapped slot-install helpers — variants that compose a lift/conv helper
+# around the caller's method so per-protocol builder call sites become a
+# single line instead of a multi-line `_install_X[..., _lift_Y[...], slot]`.
+# ===----------------------------------------------------------------------=== #
+
+
+# Unary
+
+
+def _install_unary_nr[
+    self_type: ImplicitlyDestructible,
+    method: def(UnsafePointer[self_type, MutAnyOrigin]) thin -> PythonObject,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `unaryfunc` slot from a non-raising method."""
+    _install_unary[self_type, _lift_to_obj[self_type, method], slot](ptr)
+
+
+def _install_unary_val[
+    self_type: ImplicitlyDestructible,
+    method: def(self_type) thin raises -> PythonObject,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `unaryfunc` slot from a value-receiver method."""
+    _install_unary[self_type, _lift_val_to_obj[self_type, method], slot](ptr)
+
+
+def _install_unary_conv_r[
+    self_type: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(UnsafePointer[self_type, MutAnyOrigin]) thin raises -> R,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `unaryfunc` slot from a raising ConvertibleToPython method."""
+    _install_unary[self_type, _conv_ptr_r_unary[self_type, R, method], slot](
+        ptr
+    )
+
+
+def _install_unary_conv_nr[
+    self_type: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(UnsafePointer[self_type, MutAnyOrigin]) thin -> R,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `unaryfunc` slot from a non-raising ConvertibleToPython method.
+    """
+    _install_unary[self_type, _conv_ptr_nr_unary[self_type, R, method], slot](
+        ptr
+    )
+
+
+def _install_unary_conv_val[
+    self_type: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(self_type) thin raises -> R,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `unaryfunc` slot from a value-receiver ConvertibleToPython method.
+    """
+    _install_unary[self_type, _conv_val_r_unary[self_type, R, method], slot](
+        ptr
+    )
+
+
+# Inquiry
+
+
+def _install_inquiry_nr[
+    self_type: ImplicitlyDestructible,
+    method: def(UnsafePointer[self_type, MutAnyOrigin]) thin -> Bool,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert an `inquiry` slot from a non-raising method."""
+    _install_inquiry[self_type, _lift_to_bool[self_type, method], slot](ptr)
+
+
+def _install_inquiry_val[
+    self_type: ImplicitlyDestructible,
+    method: def(self_type) thin raises -> Bool,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert an `inquiry` slot from a value-receiver method."""
+    _install_inquiry[self_type, _lift_val_to_bool[self_type, method], slot](ptr)
+
+
+# Binary
+
+
+def _install_binary_nr[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject
+    ) thin -> PythonObject,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `binaryfunc` slot from a non-raising method."""
+    _install_binary[self_type, _lift_obj_to_obj[self_type, method], slot](ptr)
+
+
+def _install_binary_val[
+    self_type: ImplicitlyDestructible,
+    method: def(self_type, PythonObject) thin raises -> PythonObject,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `binaryfunc` slot from a value-receiver method."""
+    _install_binary[self_type, _lift_val_obj_to_obj[self_type, method], slot](
+        ptr
+    )
+
+
+def _install_binary_mut[
+    self_type: ImplicitlyDestructible,
+    method: def(mut self_type, PythonObject) thin raises -> PythonObject,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `binaryfunc` slot from a mut-receiver method."""
+    _install_binary[self_type, _lift_mut_obj_to_obj[self_type, method], slot](
+        ptr
+    )
+
+
+def _install_binary_conv_r[
+    self_type: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject
+    ) thin raises -> R,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `binaryfunc` slot from a raising ConvertibleToPython method."""
+    _install_binary[self_type, _conv_ptr_r_binary[self_type, R, method], slot](
+        ptr
+    )
+
+
+def _install_binary_conv_nr[
+    self_type: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(UnsafePointer[self_type, MutAnyOrigin], PythonObject) thin -> R,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `binaryfunc` slot from a non-raising ConvertibleToPython method.
+    """
+    _install_binary[self_type, _conv_ptr_nr_binary[self_type, R, method], slot](
+        ptr
+    )
+
+
+def _install_binary_conv_val[
+    self_type: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(self_type, PythonObject) thin raises -> R,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `binaryfunc` slot from a value-receiver ConvertibleToPython method.
+    """
+    _install_binary[self_type, _conv_val_r_binary[self_type, R, method], slot](
+        ptr
+    )
+
+
+# Ternary
+
+
+def _install_ternary_nr[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject, PythonObject
+    ) thin -> PythonObject,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `ternaryfunc` slot from a non-raising method."""
+    _install_ternary[self_type, _lift_obj_obj_to_obj[self_type, method], slot](
+        ptr
+    )
+
+
+def _install_ternary_val[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        self_type, PythonObject, PythonObject
+    ) thin raises -> PythonObject,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `ternaryfunc` slot from a value-receiver method."""
+    _install_ternary[
+        self_type, _lift_val_obj_obj_to_obj[self_type, method], slot
+    ](ptr)
+
+
+def _install_ternary_mut[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        mut self_type, PythonObject, PythonObject
+    ) thin raises -> PythonObject,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `ternaryfunc` slot from a mut-receiver method."""
+    _install_ternary[
+        self_type, _lift_mut_obj_obj_to_obj[self_type, method], slot
+    ](ptr)
+
+
+def _install_ternary_conv_r[
+    self_type: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject, PythonObject
+    ) thin raises -> R,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `ternaryfunc` slot from a raising ConvertibleToPython method."""
+    _install_ternary[
+        self_type, _conv_ptr_r_ternary[self_type, R, method], slot
+    ](ptr)
+
+
+def _install_ternary_conv_nr[
+    self_type: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject, PythonObject
+    ) thin -> R,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `ternaryfunc` slot from a non-raising ConvertibleToPython method.
+    """
+    _install_ternary[
+        self_type, _conv_ptr_nr_ternary[self_type, R, method], slot
+    ](ptr)
+
+
+def _install_ternary_conv_val[
+    self_type: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(self_type, PythonObject, PythonObject) thin raises -> R,
+    slot: Int32,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert a `ternaryfunc` slot from a value-receiver ConvertibleToPython method.
+    """
+    _install_ternary[
+        self_type, _conv_val_r_ternary[self_type, R, method], slot
+    ](ptr)

--- a/mojo/stdlib/std/python/adapters.mojo
+++ b/mojo/stdlib/std/python/adapters.mojo
@@ -1,0 +1,1387 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Implements CPython slot adapter functions.
+
+These adapt user-friendly Mojo function signatures to the low-level C ABI
+expected by each CPython type slot. They are passed to the different type
+builders def_methods as template parameters.
+"""
+
+from std.ffi import c_int, c_long
+from std.memory import OpaquePointer, UnsafePointer
+from std.os import abort
+from std.python import Python, PythonObject
+from std.python._cpython import (
+    PyObject,
+    PyObjectPtr,
+    Py_ssize_t,
+    PySlotIndex,
+    PyType_Slot,
+)
+from std.python.bindings import PythonTypeBuilder
+from std.python.conversions import ConvertibleToPython
+from std.utils import Variant
+
+from .utils import PySlotError
+
+
+@always_inline
+def _unwrap_self[
+    T: ImplicitlyDestructible
+](py_self: PyObjectPtr) raises -> UnsafePointer[T, MutAnyOrigin]:
+    """Downcast a raw PyObjectPtr to a typed Mojo pointer."""
+    return PythonObject(from_borrowed=py_self).downcast_value_ptr[T]()
+
+
+def _mp_length_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin]
+    ) thin raises PySlotError -> Int,
+](py_self: PyObjectPtr) abi("C") -> Py_ssize_t:
+    """CPython `lenfunc` adapter for the `mp_length` slot (__len__).
+
+    `method` declares `raises PySlotError`; the wrapper dispatches on the
+    variant to the matching `PyExc_*` global. `not_implemented` has no
+    Python meaning here and maps to `RuntimeError`.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function
+            `def(self: UnsafePointer[self_type, MutAnyOrigin]) raises PySlotError -> Int`.
+
+    Returns:
+        Length as `Py_ssize_t`, or -1 with an exception set on error.
+    """
+    ref cpython = Python().cpython()
+    var self_ptr: UnsafePointer[self_type, MutAnyOrigin]
+    try:
+        self_ptr = _unwrap_self[self_type](py_self)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_RuntimeError")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return Py_ssize_t(-1)
+    try:
+        return Py_ssize_t(method(self_ptr))
+    except e:
+        var error_type = cpython.get_error_global(e.pyexc_global_name())
+        cpython.PyErr_SetString(
+            error_type, e.msg.as_c_string_slice().unsafe_ptr()
+        )
+        return Py_ssize_t(-1)
+
+
+def _mp_subscript_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject
+    ) thin raises PySlotError -> PythonObject,
+](py_self: PyObjectPtr, key: PyObjectPtr) abi("C") -> PyObjectPtr:
+    """CPython `binaryfunc` adapter for the `mp_subscript` slot (__getitem__).
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function
+            `def(self: UnsafePointer[self_type, MutAnyOrigin], key: PythonObject) raises PySlotError -> PythonObject`.
+
+    Returns:
+        New reference to the result, or null with an exception set on error.
+    """
+    ref cpython = Python().cpython()
+    var self_ptr: UnsafePointer[self_type, MutAnyOrigin]
+    try:
+        self_ptr = _unwrap_self[self_type](py_self)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_RuntimeError")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+    try:
+        var result = method(self_ptr, PythonObject(from_borrowed=key))
+        return result.steal_data()
+    except e:
+        var error_type = cpython.get_error_global(e.pyexc_global_name())
+        cpython.PyErr_SetString(
+            error_type, e.msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+
+
+def _mp_ass_subscript_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin],
+        PythonObject,
+        Variant[PythonObject, Int],
+    ) thin raises PySlotError -> None,
+](py_self: PyObjectPtr, key: PyObjectPtr, value: PyObjectPtr) abi("C") -> c_int:
+    """CPython `objobjargproc` adapter for the `mp_ass_subscript` slot.
+
+    When `value` is NULL the operation is a deletion (__delitem__); the `method`
+    receives `Variant[PythonObject, Int](Int(0))` as the third argument.
+    Otherwise the operation is an assignment (__setitem__) and `method` receives
+    `Variant[PythonObject, Int](value_object)`.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function with signature
+            `def(self, key, value: Variant[PythonObject, Int]) raises PySlotError -> None`.
+
+    Returns:
+        0 on success, -1 with an exception set on error.
+    """
+    comptime PassedValue = Variant[PythonObject, Int]
+    ref cpython = Python().cpython()
+    var self_ptr: UnsafePointer[self_type, MutAnyOrigin]
+    var key_obj: PythonObject
+    var passed_value: PassedValue
+    try:
+        self_ptr = _unwrap_self[self_type](py_self)
+        key_obj = PythonObject(from_borrowed=key)
+        passed_value = PassedValue(
+            PythonObject(from_borrowed=value)
+        ) if value else PassedValue(Int(0))
+    except e:
+        var error_type = cpython.get_error_global("PyExc_RuntimeError")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+    try:
+        method(self_ptr, key_obj, passed_value)
+        return c_int(0)
+    except e:
+        var error_type = cpython.get_error_global(e.pyexc_global_name())
+        cpython.PyErr_SetString(
+            error_type, e.msg.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+
+
+def _unaryfunc_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin]
+    ) thin raises PySlotError -> PythonObject,
+](py_self: PyObjectPtr) abi("C") -> PyObjectPtr:
+    """CPython `unaryfunc` adapter for unary nb_ slots (__neg__, __abs__, etc.).
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function
+            `def(self: UnsafePointer[self_type, MutAnyOrigin]) raises PySlotError -> PythonObject`.
+
+    Returns:
+        New reference to the result, or null with an exception set on error.
+    """
+    ref cpython = Python().cpython()
+    var self_ptr: UnsafePointer[self_type, MutAnyOrigin]
+    try:
+        self_ptr = _unwrap_self[self_type](py_self)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_RuntimeError")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+    try:
+        var result = method(self_ptr)
+        return result.steal_data()
+    except e:
+        var error_type = cpython.get_error_global(e.pyexc_global_name())
+        cpython.PyErr_SetString(
+            error_type, e.msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+
+
+def _binaryfunc_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject
+    ) thin raises PySlotError -> PythonObject,
+](lhs: PyObjectPtr, rhs: PyObjectPtr) abi("C") -> PyObjectPtr:
+    """CPython `binaryfunc` adapter for binary nb_ slots (__add__, __mul__, etc.).
+
+    If `method` raises `PySlotError.not_implemented()` the wrapper returns
+    `Py_NotImplemented`, signalling Python to try the reflected operation.
+    Other variants map to the corresponding `PyExc_*`.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function
+            `def(self: UnsafePointer[self_type, MutAnyOrigin], other: PythonObject) raises PySlotError -> PythonObject`.
+
+    Returns:
+        New reference to the result, `Py_NotImplemented`, or null on error.
+    """
+    ref cpython = Python().cpython()
+    var self_ptr: UnsafePointer[self_type, MutAnyOrigin]
+    var rhs_obj: PythonObject
+    try:
+        self_ptr = _unwrap_self[self_type](lhs)
+        rhs_obj = PythonObject(from_borrowed=rhs)
+    except:
+        # CPython invokes binary `nb_*` slots in reflected dispatch with the
+        # original `(v, w)` order — so the LHS may not be our type. Treat
+        # any prep failure as `NotImplemented` so CPython can try the other
+        # operand or raise `TypeError`.
+        return cpython.Py_NewRef(cpython.Py_NotImplemented())
+    try:
+        var result = method(self_ptr, rhs_obj)
+        return result.steal_data()
+    except e:
+        if e._variant == PySlotError._NOT_IMPLEMENTED:
+            return cpython.Py_NewRef(cpython.Py_NotImplemented())
+        var error_type = cpython.get_error_global(e.pyexc_global_name())
+        cpython.PyErr_SetString(
+            error_type, e.msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+
+
+def _ternaryfunc_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject, PythonObject
+    ) thin raises PySlotError -> PythonObject,
+](py_self: PyObjectPtr, other: PyObjectPtr, mod: PyObjectPtr) abi(
+    "C"
+) -> PyObjectPtr:
+    """CPython `ternaryfunc` adapter for nb_power / nb_inplace_power (__pow__).
+
+    If `method` raises `PySlotError.not_implemented()` the wrapper returns
+    `Py_NotImplemented`, signalling Python to try the reflected operation.
+    Other variants map to the corresponding `PyExc_*`.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function
+            `def(self, other, mod: PythonObject) raises PySlotError -> PythonObject`
+            where `mod` is typically `None` unless the three-argument form
+            `pow(base, exp, mod)` is used.
+
+    Returns:
+        New reference to the result, `Py_NotImplemented`, or null on error.
+    """
+    ref cpython = Python().cpython()
+    var self_ptr: UnsafePointer[self_type, MutAnyOrigin]
+    var other_obj: PythonObject
+    var mod_obj: PythonObject
+    try:
+        self_ptr = _unwrap_self[self_type](py_self)
+        other_obj = PythonObject(from_borrowed=other)
+        mod_obj = PythonObject(from_borrowed=mod)
+    except:
+        # See `_binaryfunc_wrapper`: reflected dispatch may call this slot
+        # with a LHS that isn't our type.
+        return cpython.Py_NewRef(cpython.Py_NotImplemented())
+    try:
+        var result = method(self_ptr, other_obj, mod_obj)
+        return result.steal_data()
+    except e:
+        if e._variant == PySlotError._NOT_IMPLEMENTED:
+            return cpython.Py_NewRef(cpython.Py_NotImplemented())
+        var error_type = cpython.get_error_global(e.pyexc_global_name())
+        cpython.PyErr_SetString(
+            error_type, e.msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+
+
+def _inquiry_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin]
+    ) thin raises PySlotError -> Bool,
+](py_self: PyObjectPtr) abi("C") -> c_int:
+    """CPython `inquiry` adapter for the `nb_bool` slot (__bool__).
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function
+            `def(self: UnsafePointer[self_type, MutAnyOrigin]) raises PySlotError -> Bool`.
+
+    Returns:
+        1 for True, 0 for False, -1 with an exception set on error.
+    """
+    ref cpython = Python().cpython()
+    var self_ptr: UnsafePointer[self_type, MutAnyOrigin]
+    try:
+        self_ptr = _unwrap_self[self_type](py_self)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_RuntimeError")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+    try:
+        var result = method(self_ptr)
+        return c_int(1) if result else c_int(0)
+    except e:
+        var error_type = cpython.get_error_global(e.pyexc_global_name())
+        cpython.PyErr_SetString(
+            error_type, e.msg.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+
+
+def _ssizeargfunc_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], Int
+    ) thin raises PySlotError -> PythonObject,
+](py_self: PyObjectPtr, index: Py_ssize_t) abi("C") -> PyObjectPtr:
+    """CPython `ssizeargfunc` adapter for sq_item, sq_repeat, sq_inplace_repeat.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function
+            `def(self: UnsafePointer[self_type, MutAnyOrigin], index: Int) raises PySlotError -> PythonObject`.
+
+    Returns:
+        New reference to the result, or null with an exception set on error.
+    """
+    ref cpython = Python().cpython()
+    var self_ptr: UnsafePointer[self_type, MutAnyOrigin]
+    try:
+        self_ptr = _unwrap_self[self_type](py_self)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_RuntimeError")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+    try:
+        var result = method(self_ptr, Int(index))
+        return result.steal_data()
+    except e:
+        var error_type = cpython.get_error_global(e.pyexc_global_name())
+        cpython.PyErr_SetString(
+            error_type, e.msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+
+
+def _ssizeobjargproc_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], Int, Variant[PythonObject, Int]
+    ) thin raises PySlotError -> None,
+](py_self: PyObjectPtr, index: Py_ssize_t, value: PyObjectPtr) abi(
+    "C"
+) -> c_int:
+    """CPython `ssizeobjargproc` adapter for the `sq_ass_item` slot.
+
+    When `value` is NULL the operation is a deletion; the `method` receives
+    `Variant[PythonObject, Int](Int(0))` as the third argument.  Otherwise
+    the operation is an assignment and `method` receives the value object.
+
+    The user method declares `raises PySlotError`; the wrapper dispatches on
+    the variant to the matching `PyExc_*` global. Raising
+    `PySlotError.not_implemented()` from this slot has no Python meaning
+    (`sq_ass_item` cannot return `NotImplemented`), so it is mapped to
+    `RuntimeError`.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function with signature
+            `def(self, index: Int, value: Variant[PythonObject, Int]) raises PySlotError -> None`.
+
+    Returns:
+        0 on success, -1 with an exception set on error.
+    """
+    comptime PassedValue = Variant[PythonObject, Int]
+    ref cpython = Python().cpython()
+    # Compute args outside the typed `try` so the only call that can raise
+    # inside it is `method(...)`, which lets the compiler infer
+    # `except e:` as `PySlotError`. `_unwrap_self` and `PythonObject(...)`
+    # construction raise plain `Error`; wrap them in their own block.
+    var self_ptr: UnsafePointer[self_type, MutAnyOrigin]
+    var passed_value: PassedValue
+    try:
+        self_ptr = _unwrap_self[self_type](py_self)
+        passed_value = PassedValue(
+            PythonObject(from_borrowed=value)
+        ) if value else PassedValue(Int(0))
+    except e:
+        var error_type = cpython.get_error_global("PyExc_RuntimeError")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+    try:
+        method(self_ptr, Int(index), passed_value)
+        return c_int(0)
+    except e:
+        # `not_implemented` has no meaning for sq_ass_item; it falls through
+        # to RuntimeError via PySlotError.pyexc_global_name().
+        var error_type = cpython.get_error_global(e.pyexc_global_name())
+        cpython.PyErr_SetString(
+            error_type, e.msg.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+
+
+def _objobjproc_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject
+    ) thin raises PySlotError -> Bool,
+](py_self: PyObjectPtr, other: PyObjectPtr) abi("C") -> c_int:
+    """CPython `objobjproc` adapter for the `sq_contains` slot (__contains__).
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function
+            `def(self: UnsafePointer[self_type, MutAnyOrigin], item: PythonObject) raises PySlotError -> Bool`.
+
+    Returns:
+        1 if contained, 0 if not, -1 with an exception set on error.
+    """
+    ref cpython = Python().cpython()
+    var self_ptr: UnsafePointer[self_type, MutAnyOrigin]
+    var other_obj: PythonObject
+    try:
+        self_ptr = _unwrap_self[self_type](py_self)
+        other_obj = PythonObject(from_borrowed=other)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_RuntimeError")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+    try:
+        var result = method(self_ptr, other_obj)
+        return c_int(1) if result else c_int(0)
+    except e:
+        var error_type = cpython.get_error_global(e.pyexc_global_name())
+        cpython.PyErr_SetString(
+            error_type, e.msg.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+
+
+def _richcompare_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], PythonObject, Int
+    ) thin raises PySlotError -> Bool,
+](py_self: PyObjectPtr, py_other: PyObjectPtr, op: c_int) abi(
+    "C"
+) -> PyObjectPtr:
+    """CPython `richcmpfunc` adapter for the `tp_richcompare` slot.
+
+    If `method` raises `PySlotError.not_implemented()` the wrapper returns
+    `Py_NotImplemented`, signalling Python to try the reflected operation.
+    Other variants map to the corresponding `PyExc_*`.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function
+            `def(self, other: PythonObject, op: Int) raises PySlotError -> Bool`
+            where `op` is one of `RichCompareOps.Py_LT` … `Py_GE`.
+
+    Returns:
+        `Py_True`/`Py_False`, `Py_NotImplemented`, or null on error.
+    """
+    ref cpython = Python().cpython()
+    var self_ptr: UnsafePointer[self_type, MutAnyOrigin]
+    var other_obj: PythonObject
+    try:
+        self_ptr = _unwrap_self[self_type](py_self)
+        other_obj = PythonObject(from_borrowed=py_other)
+    except:
+        # `tp_richcompare` is symmetric in CPython; if the LHS isn't our
+        # type, return `NotImplemented` so the interpreter can try the
+        # reflected comparison on the other operand.
+        return cpython.Py_NewRef(cpython.Py_NotImplemented())
+    try:
+        var result = method(self_ptr, other_obj, Int(op))
+        return cpython.PyBool_FromLong(c_long(Int(result)))
+    except e:
+        if e._variant == PySlotError._NOT_IMPLEMENTED:
+            return cpython.Py_NewRef(cpython.Py_NotImplemented())
+        var error_type = cpython.get_error_global(e.pyexc_global_name())
+        cpython.PyErr_SetString(
+            error_type, e.msg.as_c_string_slice().unsafe_ptr()
+        )
+        return PyObjectPtr()
+
+
+# ===----------------------------------------------------------------------=== #
+# Non-raising → raising lift helpers
+# ===----------------------------------------------------------------------=== #
+
+
+def _lift_to_int[
+    T: ImplicitlyDestructible,
+    method: def(UnsafePointer[T, MutAnyOrigin]) thin -> Int,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises PySlotError -> Int:
+    return method(ptr)
+
+
+def _lift_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(UnsafePointer[T, MutAnyOrigin]) thin -> PythonObject,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises PySlotError -> PythonObject:
+    return method(ptr)
+
+
+def _lift_to_bool[
+    T: ImplicitlyDestructible,
+    method: def(UnsafePointer[T, MutAnyOrigin]) thin -> Bool,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises PySlotError -> Bool:
+    return method(ptr)
+
+
+def _lift_obj_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[T, MutAnyOrigin], PythonObject
+    ) thin -> PythonObject,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject
+) raises PySlotError -> PythonObject:
+    return method(ptr, other)
+
+
+def _lift_obj_to_bool[
+    T: ImplicitlyDestructible,
+    method: def(UnsafePointer[T, MutAnyOrigin], PythonObject) thin -> Bool,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject
+) raises PySlotError -> Bool:
+    return method(ptr, other)
+
+
+def _lift_obj_var_to_none[
+    T: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[T, MutAnyOrigin], PythonObject, Variant[PythonObject, Int]
+    ) thin -> None,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin],
+    key: PythonObject,
+    val: Variant[PythonObject, Int],
+) raises PySlotError -> None:
+    method(ptr, key, val)
+
+
+def _lift_int_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(UnsafePointer[T, MutAnyOrigin], Int) thin -> PythonObject,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], index: Int
+) raises PySlotError -> PythonObject:
+    return method(ptr, index)
+
+
+def _lift_int_var_to_none[
+    T: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[T, MutAnyOrigin], Int, Variant[PythonObject, Int]
+    ) thin -> None,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin],
+    index: Int,
+    val: Variant[PythonObject, Int],
+) raises PySlotError -> None:
+    method(ptr, index, val)
+
+
+def _lift_obj_int_to_bool[
+    T: ImplicitlyDestructible,
+    method: def(UnsafePointer[T, MutAnyOrigin], PythonObject, Int) thin -> Bool,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject, op: Int
+) raises PySlotError -> Bool:
+    return method(ptr, other, op)
+
+
+def _lift_obj_obj_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[T, MutAnyOrigin], PythonObject, PythonObject
+    ) thin -> PythonObject,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], a: PythonObject, b: PythonObject
+) raises PySlotError -> PythonObject:
+    return method(ptr, a, b)
+
+
+# ===----------------------------------------------------------------------=== #
+# Value-receiver → pointer-receiver lift helpers
+# ===----------------------------------------------------------------------=== #
+
+
+def _lift_val_to_int[
+    T: ImplicitlyDestructible,
+    method: def(T) thin raises PySlotError -> Int,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises PySlotError -> Int:
+    return method(ptr[])
+
+
+def _lift_val_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(T) thin raises PySlotError -> PythonObject,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises PySlotError -> PythonObject:
+    return method(ptr[])
+
+
+def _lift_val_to_bool[
+    T: ImplicitlyDestructible,
+    method: def(T) thin raises PySlotError -> Bool,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises PySlotError -> Bool:
+    return method(ptr[])
+
+
+def _lift_val_obj_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(T, PythonObject) thin raises PySlotError -> PythonObject,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject
+) raises PySlotError -> PythonObject:
+    return method(ptr[], other)
+
+
+def _lift_val_obj_to_bool[
+    T: ImplicitlyDestructible,
+    method: def(T, PythonObject) thin raises PySlotError -> Bool,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject
+) raises PySlotError -> Bool:
+    return method(ptr[], other)
+
+
+def _lift_val_obj_var_to_none[
+    T: ImplicitlyDestructible,
+    method: def(
+        T, PythonObject, Variant[PythonObject, Int]
+    ) thin raises PySlotError -> None,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin],
+    key: PythonObject,
+    val: Variant[PythonObject, Int],
+) raises PySlotError -> None:
+    method(ptr[], key, val)
+
+
+def _lift_mut_obj_var_to_none[
+    T: ImplicitlyDestructible,
+    method: def(
+        mut T, PythonObject, Variant[PythonObject, Int]
+    ) thin raises PySlotError -> None,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin],
+    key: PythonObject,
+    val: Variant[PythonObject, Int],
+) raises PySlotError -> None:
+    method(ptr[], key, val)
+
+
+def _lift_val_int_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(T, Int) thin raises PySlotError -> PythonObject,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], index: Int
+) raises PySlotError -> PythonObject:
+    return method(ptr[], index)
+
+
+def _lift_val_int_var_to_none[
+    T: ImplicitlyDestructible,
+    method: def(
+        T, Int, Variant[PythonObject, Int]
+    ) thin raises PySlotError -> None,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin],
+    index: Int,
+    val: Variant[PythonObject, Int],
+) raises PySlotError -> None:
+    method(ptr[], index, val)
+
+
+def _lift_mut_int_var_to_none[
+    T: ImplicitlyDestructible,
+    method: def(
+        mut T, Int, Variant[PythonObject, Int]
+    ) thin raises PySlotError -> None,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin],
+    index: Int,
+    val: Variant[PythonObject, Int],
+) raises PySlotError -> None:
+    method(ptr[], index, val)
+
+
+def _lift_val_obj_int_to_bool[
+    T: ImplicitlyDestructible,
+    method: def(T, PythonObject, Int) thin raises PySlotError -> Bool,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject, op: Int
+) raises PySlotError -> Bool:
+    return method(ptr[], other, op)
+
+
+def _lift_val_obj_obj_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(
+        T, PythonObject, PythonObject
+    ) thin raises PySlotError -> PythonObject,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], a: PythonObject, b: PythonObject
+) raises PySlotError -> PythonObject:
+    return method(ptr[], a, b)
+
+
+def _lift_mut_obj_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(mut T, PythonObject) thin raises PySlotError -> PythonObject,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject
+) raises PySlotError -> PythonObject:
+    return method(ptr[], other)
+
+
+def _lift_mut_obj_obj_to_obj[
+    T: ImplicitlyDestructible,
+    method: def(
+        mut T, PythonObject, PythonObject
+    ) thin raises PySlotError -> PythonObject,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], a: PythonObject, b: PythonObject
+) raises PySlotError -> PythonObject:
+    return method(ptr[], a, b)
+
+
+# ===----------------------------------------------------------------------=== #
+# ConvertibleToPython return-type lift helpers
+# ===----------------------------------------------------------------------=== #
+
+comptime _CPython = ConvertibleToPython & ImplicitlyCopyable
+
+
+def _to_py[R: _CPython](var value: R) raises PySlotError -> PythonObject:
+    """Call `to_python_object` and translate failures to `PySlotError`.
+
+    `ConvertibleToPython.to_python_object` raises plain `Error`; this shim
+    re-raises as `PySlotError.value_error` so it composes with the
+    typed-raises chain inside `_conv_*` helpers.
+    """
+    try:
+        return value^.to_python_object()
+    except e:
+        raise PySlotError.value_error(String(e))
+
+
+def _conv_ptr_r_unary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(UnsafePointer[T, MutAnyOrigin]) thin raises PySlotError -> R,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises PySlotError -> PythonObject:
+    return _to_py[R](method(ptr))
+
+
+def _conv_ptr_nr_unary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(UnsafePointer[T, MutAnyOrigin]) thin -> R,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises PySlotError -> PythonObject:
+    return _to_py[R](method(ptr))
+
+
+def _conv_val_r_unary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(T) thin raises PySlotError -> R,
+](ptr: UnsafePointer[T, MutAnyOrigin]) raises PySlotError -> PythonObject:
+    return _to_py[R](method(ptr[]))
+
+
+def _conv_ptr_r_binary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(
+        UnsafePointer[T, MutAnyOrigin], PythonObject
+    ) thin raises PySlotError -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject
+) raises PySlotError -> PythonObject:
+    return _to_py[R](method(ptr, other))
+
+
+def _conv_ptr_nr_binary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(UnsafePointer[T, MutAnyOrigin], PythonObject) thin -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject
+) raises PySlotError -> PythonObject:
+    return _to_py[R](method(ptr, other))
+
+
+def _conv_val_r_binary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(T, PythonObject) thin raises PySlotError -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject
+) raises PySlotError -> PythonObject:
+    return _to_py[R](method(ptr[], other))
+
+
+def _conv_ptr_r_int_arg[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(
+        UnsafePointer[T, MutAnyOrigin], Int
+    ) thin raises PySlotError -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], index: Int
+) raises PySlotError -> PythonObject:
+    return _to_py[R](method(ptr, index))
+
+
+def _conv_ptr_nr_int_arg[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(UnsafePointer[T, MutAnyOrigin], Int) thin -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], index: Int
+) raises PySlotError -> PythonObject:
+    return _to_py[R](method(ptr, index))
+
+
+def _conv_val_r_int_arg[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(T, Int) thin raises PySlotError -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], index: Int
+) raises PySlotError -> PythonObject:
+    return _to_py[R](method(ptr[], index))
+
+
+def _conv_ptr_r_ternary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(
+        UnsafePointer[T, MutAnyOrigin], PythonObject, PythonObject
+    ) thin raises PySlotError -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], a: PythonObject, b: PythonObject
+) raises PySlotError -> PythonObject:
+    return _to_py[R](method(ptr, a, b))
+
+
+def _conv_ptr_nr_ternary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(
+        UnsafePointer[T, MutAnyOrigin], PythonObject, PythonObject
+    ) thin -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], a: PythonObject, b: PythonObject
+) raises PySlotError -> PythonObject:
+    return _to_py[R](method(ptr, a, b))
+
+
+def _conv_val_r_ternary[
+    T: ImplicitlyDestructible,
+    R: _CPython,
+    method: def(T, PythonObject, PythonObject) thin raises PySlotError -> R,
+](
+    ptr: UnsafePointer[T, MutAnyOrigin], a: PythonObject, b: PythonObject
+) raises PySlotError -> PythonObject:
+    return _to_py[R](method(ptr[], a, b))
+
+
+# Unary
+
+
+# ===----------------------------------------------------------------------=== #
+# Slot-install helpers — insert typed C function pointers into a builder
+# ===----------------------------------------------------------------------=== #
+
+
+struct _SlotInstaller:
+    """Static-method namespace for inserting CPython type-slot function
+    pointers into a `PythonTypeBuilder`. Each method wraps a method
+    template parameter in the matching adapter and registers the result.
+    """
+
+    @staticmethod
+    def unary[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> PythonObject,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `unaryfunc` slot into the builder pointed to by `ptr`."""
+        comptime _unaryfunc = def(PyObjectPtr) thin abi("C") -> PyObjectPtr
+        var fn_ptr: _unaryfunc = _unaryfunc_wrapper[self_type, method]
+        ptr[]._insert_slot(
+            PyType_Slot(slot, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr))
+        )
+
+    @staticmethod
+    def binary[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `binaryfunc` slot into the builder pointed to by `ptr`."""
+        comptime _binaryfunc = def(PyObjectPtr, PyObjectPtr) thin abi(
+            "C"
+        ) -> PyObjectPtr
+        var fn_ptr: _binaryfunc = _binaryfunc_wrapper[self_type, method]
+        ptr[]._insert_slot(
+            PyType_Slot(slot, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr))
+        )
+
+    @staticmethod
+    def ternary[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin], PythonObject, PythonObject
+        ) thin raises PySlotError -> PythonObject,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `ternaryfunc` slot into the builder pointed to by `ptr`."""
+        comptime _ternaryfunc = def(
+            PyObjectPtr, PyObjectPtr, PyObjectPtr
+        ) thin abi("C") -> PyObjectPtr
+        var fn_ptr: _ternaryfunc = _ternaryfunc_wrapper[self_type, method]
+        ptr[]._insert_slot(
+            PyType_Slot(slot, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr))
+        )
+
+    @staticmethod
+    def inquiry[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> Bool,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert an `inquiry` slot into the builder pointed to by `ptr`."""
+        comptime _inquiry = def(PyObjectPtr) thin abi("C") -> c_int
+        var fn_ptr: _inquiry = _inquiry_wrapper[self_type, method]
+        ptr[]._insert_slot(
+            PyType_Slot(slot, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr))
+        )
+
+    @staticmethod
+    def richcompare[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin], PythonObject, Int
+        ) thin raises PySlotError -> Bool,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `richcmpfunc` slot (`tp_richcompare`) into the builder pointed to by `ptr`.
+        """
+        comptime _richcmpfunc = def(PyObjectPtr, PyObjectPtr, c_int) thin abi(
+            "C"
+        ) -> PyObjectPtr
+        var fn_ptr: _richcmpfunc = _richcompare_wrapper[self_type, method]
+        ptr[]._insert_slot(
+            PyType_Slot(
+                PySlotIndex.tp_richcompare,
+                rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+            )
+        )
+
+    @staticmethod
+    def lenfunc[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> Int,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `lenfunc` slot (`mp_length`) into the builder pointed to by `ptr`.
+        """
+        comptime _lenfunc = def(PyObjectPtr) thin abi("C") -> Py_ssize_t
+        var fn_ptr: _lenfunc = _mp_length_wrapper[self_type, method]
+        ptr[]._insert_slot(
+            PyType_Slot(
+                PySlotIndex.mp_length,
+                rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+            )
+        )
+
+    @staticmethod
+    def mp_getitem[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `binaryfunc` slot (`mp_subscript`) into the builder pointed to by `ptr`.
+        """
+        comptime _binaryfunc = def(PyObjectPtr, PyObjectPtr) thin abi(
+            "C"
+        ) -> PyObjectPtr
+        var fn_ptr: _binaryfunc = _mp_subscript_wrapper[self_type, method]
+        ptr[]._insert_slot(
+            PyType_Slot(
+                PySlotIndex.mp_getitem,
+                rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+            )
+        )
+
+    @staticmethod
+    def objobjargproc[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin],
+            PythonObject,
+            Variant[PythonObject, Int],
+        ) thin raises PySlotError -> None,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert an `objobjargproc` slot (`mp_ass_subscript`) into the builder pointed to by `ptr`.
+        """
+        comptime _objobjargproc = def(
+            PyObjectPtr, PyObjectPtr, PyObjectPtr
+        ) thin abi("C") -> c_int
+        var fn_ptr: _objobjargproc = _mp_ass_subscript_wrapper[
+            self_type, method
+        ]
+        ptr[]._insert_slot(
+            PyType_Slot(
+                PySlotIndex.mp_setitem,
+                rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+            )
+        )
+
+    @staticmethod
+    def ssizeargfunc[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin], Int
+        ) thin raises PySlotError -> PythonObject,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `ssizeargfunc` slot into the builder pointed to by `ptr`."""
+        comptime _ssizeargfunc = def(PyObjectPtr, Py_ssize_t) thin abi(
+            "C"
+        ) -> PyObjectPtr
+        var fn_ptr: _ssizeargfunc = _ssizeargfunc_wrapper[self_type, method]
+        ptr[]._insert_slot(
+            PyType_Slot(slot, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr))
+        )
+
+    @staticmethod
+    def ssizeobjargproc[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin],
+            Int,
+            Variant[PythonObject, Int],
+        ) thin raises PySlotError -> None,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert the `ssizeobjargproc` slot (`sq_ass_item`) into the builder pointed to by `ptr`.
+        """
+        comptime _ssizeobjargproc = def(
+            PyObjectPtr, Py_ssize_t, PyObjectPtr
+        ) thin abi("C") -> c_int
+        var fn_ptr: _ssizeobjargproc = _ssizeobjargproc_wrapper[
+            self_type, method
+        ]
+        ptr[]._insert_slot(
+            PyType_Slot(
+                PySlotIndex.sq_ass_item,
+                rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+            )
+        )
+
+    @staticmethod
+    def objobjproc[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> Bool,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert an `objobjproc` slot into the builder pointed to by `ptr`."""
+        comptime _objobjproc = def(PyObjectPtr, PyObjectPtr) thin abi(
+            "C"
+        ) -> c_int
+        var fn_ptr: _objobjproc = _objobjproc_wrapper[self_type, method]
+        ptr[]._insert_slot(
+            PyType_Slot(slot, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr))
+        )
+
+    @staticmethod
+    def unary_nr[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin]
+        ) thin -> PythonObject,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `unaryfunc` slot from a non-raising method."""
+        Self.unary[self_type, _lift_to_obj[self_type, method], slot](ptr)
+
+    @staticmethod
+    def unary_val[
+        self_type: ImplicitlyDestructible,
+        method: def(self_type) thin raises PySlotError -> PythonObject,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `unaryfunc` slot from a value-receiver method."""
+        Self.unary[self_type, _lift_val_to_obj[self_type, method], slot](ptr)
+
+    @staticmethod
+    def unary_conv_r[
+        self_type: ImplicitlyDestructible,
+        R: _CPython,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> R,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `unaryfunc` slot from a raising ConvertibleToPython method.
+        """
+        Self.unary[self_type, _conv_ptr_r_unary[self_type, R, method], slot](
+            ptr
+        )
+
+    @staticmethod
+    def unary_conv_nr[
+        self_type: ImplicitlyDestructible,
+        R: _CPython,
+        method: def(UnsafePointer[self_type, MutAnyOrigin]) thin -> R,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `unaryfunc` slot from a non-raising ConvertibleToPython method.
+        """
+        Self.unary[self_type, _conv_ptr_nr_unary[self_type, R, method], slot](
+            ptr
+        )
+
+    @staticmethod
+    def unary_conv_val[
+        self_type: ImplicitlyDestructible,
+        R: _CPython,
+        method: def(self_type) thin raises PySlotError -> R,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `unaryfunc` slot from a value-receiver ConvertibleToPython method.
+        """
+        Self.unary[self_type, _conv_val_r_unary[self_type, R, method], slot](
+            ptr
+        )
+
+    # Inquiry
+
+    @staticmethod
+    def inquiry_nr[
+        self_type: ImplicitlyDestructible,
+        method: def(UnsafePointer[self_type, MutAnyOrigin]) thin -> Bool,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert an `inquiry` slot from a non-raising method."""
+        Self.inquiry[self_type, _lift_to_bool[self_type, method], slot](ptr)
+
+    @staticmethod
+    def inquiry_val[
+        self_type: ImplicitlyDestructible,
+        method: def(self_type) thin raises PySlotError -> Bool,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert an `inquiry` slot from a value-receiver method."""
+        Self.inquiry[self_type, _lift_val_to_bool[self_type, method], slot](ptr)
+
+    # Binary
+
+    @staticmethod
+    def binary_nr[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `binaryfunc` slot from a non-raising method."""
+        Self.binary[self_type, _lift_obj_to_obj[self_type, method], slot](ptr)
+
+    @staticmethod
+    def binary_val[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `binaryfunc` slot from a value-receiver method."""
+        Self.binary[self_type, _lift_val_obj_to_obj[self_type, method], slot](
+            ptr
+        )
+
+    @staticmethod
+    def binary_mut[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            mut self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `binaryfunc` slot from a mut-receiver method."""
+        Self.binary[self_type, _lift_mut_obj_to_obj[self_type, method], slot](
+            ptr
+        )
+
+    @staticmethod
+    def binary_conv_r[
+        self_type: ImplicitlyDestructible,
+        R: _CPython,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `binaryfunc` slot from a raising ConvertibleToPython method.
+        """
+        Self.binary[self_type, _conv_ptr_r_binary[self_type, R, method], slot](
+            ptr
+        )
+
+    @staticmethod
+    def binary_conv_nr[
+        self_type: ImplicitlyDestructible,
+        R: _CPython,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `binaryfunc` slot from a non-raising ConvertibleToPython method.
+        """
+        Self.binary[self_type, _conv_ptr_nr_binary[self_type, R, method], slot](
+            ptr
+        )
+
+    @staticmethod
+    def binary_conv_val[
+        self_type: ImplicitlyDestructible,
+        R: _CPython,
+        method: def(self_type, PythonObject) thin raises PySlotError -> R,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `binaryfunc` slot from a value-receiver ConvertibleToPython method.
+        """
+        Self.binary[self_type, _conv_val_r_binary[self_type, R, method], slot](
+            ptr
+        )
+
+    # Ternary
+
+    @staticmethod
+    def ternary_nr[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin], PythonObject, PythonObject
+        ) thin -> PythonObject,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `ternaryfunc` slot from a non-raising method."""
+        Self.ternary[self_type, _lift_obj_obj_to_obj[self_type, method], slot](
+            ptr
+        )
+
+    @staticmethod
+    def ternary_val[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            self_type, PythonObject, PythonObject
+        ) thin raises PySlotError -> PythonObject,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `ternaryfunc` slot from a value-receiver method."""
+        Self.ternary[
+            self_type, _lift_val_obj_obj_to_obj[self_type, method], slot
+        ](ptr)
+
+    @staticmethod
+    def ternary_mut[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            mut self_type, PythonObject, PythonObject
+        ) thin raises PySlotError -> PythonObject,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `ternaryfunc` slot from a mut-receiver method."""
+        Self.ternary[
+            self_type, _lift_mut_obj_obj_to_obj[self_type, method], slot
+        ](ptr)
+
+    @staticmethod
+    def ternary_conv_r[
+        self_type: ImplicitlyDestructible,
+        R: _CPython,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin], PythonObject, PythonObject
+        ) thin raises PySlotError -> R,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `ternaryfunc` slot from a raising ConvertibleToPython method.
+        """
+        Self.ternary[
+            self_type, _conv_ptr_r_ternary[self_type, R, method], slot
+        ](ptr)
+
+    @staticmethod
+    def ternary_conv_nr[
+        self_type: ImplicitlyDestructible,
+        R: _CPython,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin], PythonObject, PythonObject
+        ) thin -> R,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `ternaryfunc` slot from a non-raising ConvertibleToPython method.
+        """
+        Self.ternary[
+            self_type, _conv_ptr_nr_ternary[self_type, R, method], slot
+        ](ptr)
+
+    @staticmethod
+    def ternary_conv_val[
+        self_type: ImplicitlyDestructible,
+        R: _CPython,
+        method: def(
+            self_type, PythonObject, PythonObject
+        ) thin raises PySlotError -> R,
+        slot: Int32,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert a `ternaryfunc` slot from a value-receiver ConvertibleToPython method.
+        """
+        Self.ternary[
+            self_type, _conv_val_r_ternary[self_type, R, method], slot
+        ](ptr)

--- a/mojo/stdlib/std/python/buffer.mojo
+++ b/mojo/stdlib/std/python/buffer.mojo
@@ -1,0 +1,356 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# BufferProtocolBuilder — bf_getbuffer / bf_releasebuffer slots
+#
+# Enables Mojo extension module types to expose their internal memory via
+# Python's buffer protocol, allowing zero-copy access from numpy, memoryview,
+# bytes(), and other consumers.
+#
+# Target: 1D C-contiguous buffers (most common use case).
+# ===----------------------------------------------------------------------=== #
+
+from std.ffi import c_int
+from std.memory import OpaquePointer, UnsafePointer
+from std.python import Python, PythonObject
+from std.python._cpython import PyObjectPtr, Py_ssize_t, PyType_Slot
+from std.python.bindings import PythonTypeBuilder
+
+from .adapters import _unwrap_self
+
+
+# Slot indices for the buffer protocol (from CPython Include/typeslots.h).
+comptime _BF_GETBUFFER = Int32(1)
+comptime _BF_RELEASEBUFFER = Int32(2)
+
+# PyBUF_ flag constants (from CPython Include/cpython/object.h).
+comptime _PyBUF_WRITABLE = Int32(0x0001)
+comptime _PyBUF_FORMAT = Int32(0x0004)
+comptime _PyBUF_ND = Int32(0x0008)
+comptime _PyBUF_STRIDES = Int32(0x0018)  # 0x0010 | PyBUF_ND
+
+
+struct BufferInfo:
+    """User-friendly buffer descriptor returned by a `bf_getbuffer` handler.
+
+    Fill this in your handler to describe a 1D C-contiguous buffer.
+    The `buf` pointer must remain valid until the matching `bf_releasebuffer`
+    is called.  Do **not** resize the backing allocation while a buffer view
+    is active.
+
+    Example:
+        ```mojo
+        @staticmethod
+        def get_buffer(
+            self_ptr: UnsafePointer[Self, MutAnyOrigin], flags: Int32
+        ) raises -> BufferInfo:
+            var data_ptr = self_ptr[].data.unsafe_ptr()
+            return BufferInfo(
+                buf=rebind[UnsafePointer[UInt8, MutAnyOrigin]](data_ptr),
+                nitems=len(self_ptr[].data),
+                itemsize=8,
+                format="d",
+                readonly=True,
+            )
+        ```
+    """
+
+    var buf: UnsafePointer[UInt8, MutAnyOrigin]
+    """Pointer to the first byte of the buffer data."""
+    var nitems: Int
+    """Number of elements in the buffer."""
+    var itemsize: Int
+    """Size of one element in bytes (e.g. 8 for `Float64`)."""
+    var format: String
+    """Python struct-module format character (e.g. `"d"` for `Float64`)."""
+    var readonly: Bool
+    """Whether the buffer is read-only."""
+
+    def __init__(
+        out self,
+        buf: UnsafePointer[UInt8, MutAnyOrigin],
+        nitems: Int,
+        itemsize: Int,
+        format: String,
+        readonly: Bool = True,
+    ):
+        self.buf = buf
+        self.nitems = nitems
+        self.itemsize = itemsize
+        self.format = format
+        self.readonly = readonly
+
+
+# ===----------------------------------------------------------------------=== #
+# _PyBuffer — Mojo mirror of CPython's Py_buffer struct
+#
+# Layout (80 bytes on 64-bit platforms) must match Include/cpython/object.h:
+#   offset  0: void *buf              (8 bytes)
+#   offset  8: PyObject *obj          (8 bytes)
+#   offset 16: Py_ssize_t len         (8 bytes)
+#   offset 24: Py_ssize_t itemsize    (8 bytes)
+#   offset 32: int readonly           (4 bytes)
+#   offset 36: int ndim               (4 bytes)
+#   offset 40: char *format           (8 bytes)
+#   offset 48: Py_ssize_t *shape      (8 bytes)
+#   offset 56: Py_ssize_t *strides    (8 bytes)
+#   offset 64: Py_ssize_t *suboffsets (8 bytes)
+#   offset 72: void *internal         (8 bytes)
+# ===----------------------------------------------------------------------=== #
+struct _PyBuffer:
+    var buf: OpaquePointer[MutAnyOrigin]
+    var obj: PyObjectPtr
+    var len: Int
+    var itemsize: Int
+    var readonly: Int32
+    var ndim: Int32
+    var format: UnsafePointer[UInt8, MutAnyOrigin]
+    var shape: UnsafePointer[Int, MutAnyOrigin]
+    var strides: UnsafePointer[Int, MutAnyOrigin]
+    var suboffsets: UnsafePointer[Int, MutAnyOrigin]
+    var internal: OpaquePointer[MutAnyOrigin]
+
+
+# ===----------------------------------------------------------------------=== #
+# Adapter functions
+# ===----------------------------------------------------------------------=== #
+
+
+def _bf_getbuffer_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], Int32
+    ) thin raises -> BufferInfo,
+](
+    raw_self: PyObjectPtr,
+    view: UnsafePointer[_PyBuffer, MutAnyOrigin],
+    flags: c_int,
+) abi("C") -> c_int:
+    """CPython `getbufferproc` adapter for the `bf_getbuffer` slot.
+
+    Calls the user's handler to get a `BufferInfo`, then fills in the
+    `Py_buffer` view.  Allocates a small heap block for shape, strides, and
+    the format string; the pointer is stashed in `view->internal` and freed
+    by `_bf_releasebuffer_impl`.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function
+            `def(self_ptr: UnsafePointer[T, MutAnyOrigin], flags: Int32) raises -> BufferInfo`.
+
+    Returns:
+        0 on success, -1 with an exception set on error.
+    """
+    ref cpython = Python().cpython()
+    try:
+        var self_ptr = _unwrap_self[self_type](raw_self)
+        var info = method(self_ptr, Int32(flags))
+
+        # Reject writable requests for read-only buffers.
+        if Int32(flags) & _PyBUF_WRITABLE and info.readonly:
+            var error_type = cpython.get_error_global("PyExc_BufferError")
+            cpython.PyErr_SetString(
+                error_type,
+                "buffer is not writable".as_c_string_slice().unsafe_ptr(),
+            )
+            return c_int(-1)
+
+        # Allocate storage for: shape[0] (8 bytes) + strides[0] (8 bytes)
+        # + format string (fmt_len bytes) + null terminator (1 byte).
+        # On 64-bit platforms Int = 8 bytes, so the two Int fields occupy 16 bytes.
+        var fmt_bytes = info.format.as_bytes()
+        var fmt_len = len(fmt_bytes)
+        var alloc_size = 16 + fmt_len + 1  # 2 * sizeof(Int64) + format + NUL
+
+        # List.steal_data() gives us an owned UnsafePointer we can free later.
+        var store = List[UInt8](capacity=alloc_size)
+        store.resize(alloc_size, 0)
+        var alloc = store.steal_data()
+
+        # shape[0] = nitems  (Py_ssize_t at byte offset 0)
+        var shape_ptr = rebind[UnsafePointer[Int, MutAnyOrigin]](alloc)
+        shape_ptr[0] = info.nitems
+
+        # strides[0] = itemsize  (Py_ssize_t at byte offset 8)
+        var stride_ptr = shape_ptr + 1
+        stride_ptr[0] = info.itemsize
+
+        # format string: copy bytes then null-terminate (byte offset 16)
+        var fmt_ptr = alloc + 16  # 2 * 8 bytes past the two Int fields
+        for i in range(fmt_len):
+            fmt_ptr[i] = fmt_bytes[i]
+        fmt_ptr[fmt_len] = 0
+
+        # Fill the Py_buffer view.
+        view[].buf = rebind[OpaquePointer[MutAnyOrigin]](info.buf)
+        view[].obj = cpython.Py_NewRef(raw_self)
+        view[].len = info.nitems * info.itemsize
+        view[].itemsize = info.itemsize
+        view[].readonly = Int32(1) if info.readonly else Int32(0)
+        view[].ndim = Int32(1)
+        view[].suboffsets = UnsafePointer[Int, MutAnyOrigin](
+            unsafe_from_address=0
+        )
+
+        # Always provide shape; strides are provided so consumers requesting
+        # PyBUF_STRIDES / PyBUF_FULL_RO (e.g. memoryview) work correctly.
+        view[].shape = shape_ptr
+        view[].strides = stride_ptr
+
+        # Provide format string only when the consumer requests it.
+        if Int32(flags) & _PyBUF_FORMAT:
+            view[].format = rebind[UnsafePointer[UInt8, MutAnyOrigin]](fmt_ptr)
+        else:
+            view[].format = UnsafePointer[UInt8, MutAnyOrigin](
+                unsafe_from_address=0
+            )
+
+        # Stash the allocation for releasebuffer to free.
+        view[].internal = rebind[OpaquePointer[MutAnyOrigin]](alloc)
+
+        return c_int(0)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_BufferError")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+
+
+def _bf_releasebuffer_impl(
+    raw_self: PyObjectPtr, view: UnsafePointer[_PyBuffer, MutAnyOrigin]
+) abi("C") -> None:
+    """Default `releasebufferproc` that frees the shape/strides/format block.
+
+    Called by CPython after a consumer is done with a buffer view.  The
+    heap block allocated by `_bf_getbuffer_wrapper` is stored in
+    `view->internal`; this function frees it and clears the field.
+    """
+    if view[].internal:
+        rebind[UnsafePointer[UInt8, MutAnyOrigin]](view[].internal).free()
+        view[].internal = OpaquePointer[MutAnyOrigin](unsafe_from_address=0)
+
+
+# ===----------------------------------------------------------------------=== #
+# Slot-install helpers
+# ===----------------------------------------------------------------------=== #
+
+
+def _install_bf_getbuffer[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], Int32
+    ) thin raises -> BufferInfo,
+](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+    """Insert the `bf_getbuffer` slot into the builder pointed to by `ptr`."""
+    comptime _getbufferproc = def(
+        PyObjectPtr, UnsafePointer[_PyBuffer, MutAnyOrigin], c_int
+    ) thin abi("C") -> c_int
+    var fn_ptr: _getbufferproc = _bf_getbuffer_wrapper[self_type, method]
+    ptr[]._insert_slot(
+        PyType_Slot(_BF_GETBUFFER, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr))
+    )
+
+
+def _install_bf_releasebuffer(
+    ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]
+):
+    """Insert the default `bf_releasebuffer` slot into the builder pointed to by `ptr`.
+    """
+    comptime _releasebufferproc = def(
+        PyObjectPtr, UnsafePointer[_PyBuffer, MutAnyOrigin]
+    ) thin abi("C") -> None
+    var fn_ptr: _releasebufferproc = _bf_releasebuffer_impl
+    ptr[]._insert_slot(
+        PyType_Slot(
+            _BF_RELEASEBUFFER, rebind[OpaquePointer[MutAnyOrigin]](fn_ptr)
+        )
+    )
+
+
+# ===----------------------------------------------------------------------=== #
+# BufferProtocolBuilder
+# ===----------------------------------------------------------------------=== #
+
+
+struct BufferProtocolBuilder[self_type: ImplicitlyDestructible]:
+    """Wraps a `PythonTypeBuilder` reference and installs CPython buffer protocol slots.
+
+    `BufferProtocolBuilder` holds a pointer to a `PythonTypeBuilder` that is
+    owned by the enclosing `PythonModuleBuilder`.  The caller must ensure the
+    module builder (and its type_builders list) outlives this object, which is
+    naturally satisfied when both are used within the same `PyInit_*` function.
+
+    Only 1D C-contiguous buffers are supported.  The handler must return a
+    `BufferInfo` describing the data; it is called with the `flags` bitmask
+    so the handler can raise `BufferError` for unsupported combinations (e.g.
+    `PyBUF_WRITABLE` against a read-only buffer).
+
+    Usage:
+        ```mojo
+        ref tb = b.add_type[FloatBuf]("FloatBuf")
+            .def_init_defaultable[FloatBuf]()
+            .def_staticmethod[FloatBuf.new]("new")
+        BufferProtocolBuilder[FloatBuf](tb)
+            .def_getbuffer[FloatBuf.get_buffer]()
+            .def_releasebuffer()
+        ```
+    """
+
+    var _ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]
+
+    def __init__(out self, mut inner: PythonTypeBuilder):
+        self._ptr = UnsafePointer(to=inner)
+
+    def __init__(
+        out self,
+        ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin],
+    ):
+        self._ptr = ptr
+
+    def def_getbuffer[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int32
+        ) thin raises -> BufferInfo
+    ](mut self) -> ref[self] Self:
+        """Install `__buffer__` via the `bf_getbuffer` slot.
+
+        Called by `memoryview(obj)`, `numpy.frombuffer(obj)`, etc.
+
+        The handler receives the consumer's `flags` bitmask.  Raise a
+        standard `Error` from the handler to propagate a Python `BufferError`.
+        Raise with message `"buffer is not writable"` — or check
+        `flags & 0x0001` yourself — to reject writable requests.
+
+        Parameters:
+            method: Static method with signature
+                `def(self_ptr: UnsafePointer[T, MutAnyOrigin], flags: Int32) raises -> BufferInfo`.
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyBufferProcs.bf_getbuffer
+        """
+        _install_bf_getbuffer[Self.self_type, method](self._ptr)
+        return self
+
+    def def_releasebuffer(mut self) -> ref[self] Self:
+        """Install the default `bf_releasebuffer` slot.
+
+        The default implementation frees the shape/strides/format block that
+        `def_getbuffer` allocates.  Call this after `def_getbuffer` whenever
+        you install a getbuffer handler.
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyBufferProcs.bf_releasebuffer
+        """
+        _install_bf_releasebuffer(self._ptr)
+        return self

--- a/mojo/stdlib/std/python/buffer.mojo
+++ b/mojo/stdlib/std/python/buffer.mojo
@@ -1,0 +1,395 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Implements the CPython buffer-protocol builder.
+
+Enables Mojo extension module types to expose their internal memory via
+Python's buffer protocol, allowing zero-copy access from `numpy`,
+`memoryview`, `bytes()`, and other consumers. Targets 1D C-contiguous
+buffers (the most common use case).
+"""
+
+from std.ffi import c_int
+from std.memory import OpaquePointer, UnsafePointer, alloc
+from std.python import Python, PythonObject
+from std.python._cpython import (
+    PyObjectPtr,
+    Py_ssize_t,
+    PySlotIndex,
+    PyType_Slot,
+)
+from std.python.bindings import PythonTypeBuilder
+
+from .adapters import _unwrap_self
+
+
+# PyBUF_ flag constants (from CPython Include/cpython/object.h).
+comptime _PyBUF_WRITABLE = Int32(0x0001)
+comptime _PyBUF_FORMAT = Int32(0x0004)
+
+
+struct BufferInfo(Movable):
+    """User-friendly buffer descriptor returned by a `bf_getbuffer` handler.
+
+    Fill this in your handler to describe a 1D C-contiguous buffer.
+    The `buf` pointer must remain valid until the matching `bf_releasebuffer`
+    is called.  Do **not** resize the backing allocation while a buffer view
+    is active.
+
+    The wrapper heap-promotes the returned `BufferInfo` so its address is
+    stable across the `bf_getbuffer` / `bf_releasebuffer` window; the
+    `nitems` and `itemsize` fields are used directly as the single-element
+    `shape` and `strides` arrays (`Py_ssize_t *` of length 1).
+
+    Example:
+        ```mojo
+        @staticmethod
+        def get_buffer(
+            self_ptr: UnsafePointer[Self, MutAnyOrigin], flags: Int32
+        ) raises -> BufferInfo:
+            var data_ptr = self_ptr[].data.unsafe_ptr()
+            return BufferInfo(
+                buf=rebind[UnsafePointer[UInt8, MutAnyOrigin]](data_ptr),
+                nitems=len(self_ptr[].data),
+                itemsize=8,
+                format="d",
+                readonly=True,
+            )
+        ```
+    """
+
+    var buf: UnsafePointer[UInt8, MutAnyOrigin]
+    """Pointer to the first byte of the buffer data."""
+    var nitems: Int
+    """Number of elements in the buffer."""
+    var itemsize: Int
+    """Size of one element in bytes (e.g. 8 for `Float64`)."""
+    var format: String
+    """Python struct-module format character (e.g. `"d"` for `Float64`)."""
+    var readonly: Bool
+    """Whether the buffer is read-only."""
+
+    def __init__(
+        out self,
+        buf: UnsafePointer[UInt8, MutAnyOrigin],
+        nitems: Int,
+        itemsize: Int,
+        format: String,
+        readonly: Bool = True,
+    ):
+        """Initialize a `BufferInfo` describing a 1D C-contiguous buffer.
+
+        Args:
+            buf: Pointer to the first byte of the buffer data.
+            nitems: Number of elements in the buffer.
+            itemsize: Size of one element in bytes.
+            format: Python struct-module format character (e.g. `"d"`).
+            readonly: Whether the buffer is read-only.
+        """
+        self.buf = buf
+        self.nitems = nitems
+        self.itemsize = itemsize
+        self.format = format
+        self.readonly = readonly
+
+
+# ===----------------------------------------------------------------------=== #
+# _PyBuffer — Mojo mirror of CPython's Py_buffer struct
+#
+# Layout (80 bytes on 64-bit platforms) must match Include/cpython/object.h:
+#   offset  0: void *buf              (8 bytes)
+#   offset  8: PyObject *obj          (8 bytes)
+#   offset 16: Py_ssize_t len         (8 bytes)
+#   offset 24: Py_ssize_t itemsize    (8 bytes)
+#   offset 32: int readonly           (4 bytes)
+#   offset 36: int ndim               (4 bytes)
+#   offset 40: char *format           (8 bytes)
+#   offset 48: Py_ssize_t *shape      (8 bytes)
+#   offset 56: Py_ssize_t *strides    (8 bytes)
+#   offset 64: Py_ssize_t *suboffsets (8 bytes)
+#   offset 72: void *internal         (8 bytes)
+# ===----------------------------------------------------------------------=== #
+struct _PyBuffer:
+    var buf: OpaquePointer[MutAnyOrigin]
+    var obj: PyObjectPtr
+    var len: Int
+    var itemsize: Int
+    var readonly: Int32
+    var ndim: Int32
+    var format: UnsafePointer[UInt8, MutAnyOrigin]
+    var shape: UnsafePointer[Int, MutAnyOrigin]
+    var strides: UnsafePointer[Int, MutAnyOrigin]
+    var suboffsets: UnsafePointer[Int, MutAnyOrigin]
+    var internal: Optional[OpaquePointer[MutAnyOrigin]]
+
+
+# ===----------------------------------------------------------------------=== #
+# Adapter functions
+# ===----------------------------------------------------------------------=== #
+
+
+def _bf_getbuffer_wrapper[
+    self_type: ImplicitlyDestructible,
+    method: def(
+        UnsafePointer[self_type, MutAnyOrigin], Int32
+    ) thin raises -> BufferInfo,
+](
+    raw_self: PyObjectPtr,
+    view: UnsafePointer[_PyBuffer, MutAnyOrigin],
+    flags: c_int,
+) abi("C") -> c_int:
+    """CPython `getbufferproc` adapter for the `bf_getbuffer` slot.
+
+    Calls the user's handler to get a `BufferInfo`, then fills in the
+    `Py_buffer` view.  Allocates a small heap block for shape, strides, and
+    the format string; the pointer is stashed in `view->internal` and freed
+    by `_bf_releasebuffer_impl`.
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+        method: User function
+            `def(self_ptr: UnsafePointer[T, MutAnyOrigin], flags: Int32) raises -> BufferInfo`.
+
+    Returns:
+        0 on success, -1 with an exception set on error.
+    """
+    ref cpython = Python().cpython()
+    try:
+        var self_ptr = _unwrap_self[self_type](raw_self)
+        var info = method(self_ptr, Int32(flags))
+
+        # Reject writable requests for read-only buffers.
+        if Int32(flags) & _PyBUF_WRITABLE and info.readonly:
+            var error_type = cpython.get_error_global("PyExc_BufferError")
+            cpython.PyErr_SetString(
+                error_type,
+                "buffer is not writable".as_c_string_slice().unsafe_ptr(),
+            )
+            return c_int(-1)
+
+        # Heap-promote `info` so its address is stable across the
+        # `bf_getbuffer` / `bf_releasebuffer` window. CPython requires that
+        # `view->shape`, `view->strides`, and `view->format` remain valid
+        # until release; pointing them at fields inside the heap-allocated
+        # `BufferInfo` keeps everything alive with a single allocation
+        # (no separate metadata block, no format-string copy).
+        var heap_info = alloc[BufferInfo](1)
+        heap_info.init_pointee_move(info^)
+
+        # Fill the Py_buffer view.
+        view[].buf = rebind[OpaquePointer[MutAnyOrigin]](heap_info[].buf)
+        view[].obj = cpython.Py_NewRef(raw_self)
+        view[].len = heap_info[].nitems * heap_info[].itemsize
+        view[].itemsize = heap_info[].itemsize
+        view[].readonly = Int32(1) if heap_info[].readonly else Int32(0)
+        view[].ndim = Int32(1)
+        view[].suboffsets = UnsafePointer[Int, MutAnyOrigin](
+            unsafe_from_address=0
+        )
+
+        # shape[0] = nitems, strides[0] = itemsize — addresses of the
+        # corresponding Int fields inside the heap BufferInfo serve as the
+        # single-element Py_ssize_t arrays CPython expects.
+        view[].shape = UnsafePointer(to=heap_info[].nitems)
+        view[].strides = UnsafePointer(to=heap_info[].itemsize)
+
+        # Provide format string only when the consumer requests it. Mojo
+        # strings already store a trailing null byte, so the pointer is
+        # safe to hand to CPython directly.
+        if Int32(flags) & _PyBUF_FORMAT:
+            view[].format = rebind[UnsafePointer[UInt8, MutAnyOrigin]](
+                heap_info[].format.unsafe_ptr()
+            )
+        else:
+            view[].format = UnsafePointer[UInt8, MutAnyOrigin](
+                unsafe_from_address=0
+            )
+
+        # Stash the heap_info pointer for releasebuffer to destroy and free.
+        view[].internal = rebind[OpaquePointer[MutAnyOrigin]](heap_info)
+
+        return c_int(0)
+    except e:
+        var error_type = cpython.get_error_global("PyExc_BufferError")
+        var msg = String(e)
+        cpython.PyErr_SetString(
+            error_type, msg.as_c_string_slice().unsafe_ptr()
+        )
+        return c_int(-1)
+
+
+def _bf_releasebuffer_impl(
+    raw_self: PyObjectPtr, view: UnsafePointer[_PyBuffer, MutAnyOrigin]
+) abi("C") -> None:
+    """Default `releasebufferproc` that destroys and frees the heap-
+    promoted `BufferInfo` referenced by `view->internal`.
+
+    Called by CPython after a consumer is done with a buffer view. The
+    `BufferInfo` heap slot allocated by `_bf_getbuffer_wrapper` owns the
+    format `String` and serves as backing storage for the `shape` and
+    `strides` pointers, so we must run its destructor before freeing the
+    slot itself.
+    """
+    if view[].internal:
+        var heap_info = rebind[UnsafePointer[BufferInfo, MutAnyOrigin]](
+            view[].internal
+        )
+        heap_info.destroy_pointee()
+        heap_info.free()
+        view[].internal = OpaquePointer[MutAnyOrigin](unsafe_from_address=0)
+
+
+# ===----------------------------------------------------------------------=== #
+# Slot-install helpers
+# ===----------------------------------------------------------------------=== #
+
+
+struct _BfSlotInstaller:
+    """Static-method namespace for inserting CPython buffer-protocol slot
+    function pointers (`bf_getbuffer`, `bf_releasebuffer`) into a
+    `PythonTypeBuilder`. Kept local to `buffer.mojo` so the generic
+    `_SlotInstaller` in `adapters.mojo` doesn't need to reach into this
+    module's private types.
+    """
+
+    @staticmethod
+    def getbuffer[
+        self_type: ImplicitlyDestructible,
+        method: def(
+            UnsafePointer[self_type, MutAnyOrigin], Int32
+        ) thin raises -> BufferInfo,
+    ](ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]):
+        """Insert the `bf_getbuffer` slot into the builder pointed to by `ptr`.
+        """
+        comptime _getbufferproc = def(
+            PyObjectPtr, UnsafePointer[_PyBuffer, MutAnyOrigin], c_int
+        ) thin abi("C") -> c_int
+        var fn_ptr: _getbufferproc = _bf_getbuffer_wrapper[self_type, method]
+        ptr[]._insert_slot(
+            PyType_Slot(
+                PySlotIndex.bf_getbuffer,
+                rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+            )
+        )
+
+    @staticmethod
+    def releasebuffer(
+        ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]
+    ):
+        """Insert the default `bf_releasebuffer` slot into the builder pointed to by `ptr`.
+        """
+        comptime _releasebufferproc = def(
+            PyObjectPtr, UnsafePointer[_PyBuffer, MutAnyOrigin]
+        ) thin abi("C") -> None
+        var fn_ptr: _releasebufferproc = _bf_releasebuffer_impl
+        ptr[]._insert_slot(
+            PyType_Slot(
+                PySlotIndex.bf_releasebuffer,
+                rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+            )
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# BufferProtocolBuilder
+# ===----------------------------------------------------------------------=== #
+
+
+struct BufferProtocolBuilder[self_type: ImplicitlyDestructible]:
+    """Wraps a `PythonTypeBuilder` reference and installs CPython buffer protocol slots.
+
+    `BufferProtocolBuilder` holds a pointer to a `PythonTypeBuilder` that is
+    owned by the enclosing `PythonModuleBuilder`.  The caller must ensure the
+    module builder (and its type_builders list) outlives this object, which is
+    naturally satisfied when both are used within the same `PyInit_*` function.
+
+    Only 1D C-contiguous buffers are supported.  The handler must return a
+    `BufferInfo` describing the data; it is called with the `flags` bitmask
+    so the handler can raise `BufferError` for unsupported combinations (e.g.
+    `PyBUF_WRITABLE` against a read-only buffer).
+
+    Usage:
+        ```mojo
+        ref tb = b.add_type[FloatBuf]("FloatBuf")
+            .def_init_defaultable[FloatBuf]()
+            .def_staticmethod[FloatBuf.new]("new")
+        BufferProtocolBuilder[FloatBuf](tb)
+            .def_getbuffer[FloatBuf.get_buffer]()
+            .def_releasebuffer()
+        ```
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+    """
+
+    var _ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]
+
+    def __init__(out self, mut inner: PythonTypeBuilder):
+        """Initialize from a `PythonTypeBuilder` reference.
+
+        Args:
+            inner: The `PythonTypeBuilder` to wrap.
+        """
+        self._ptr = UnsafePointer(to=inner)
+
+    def __init__(
+        out self,
+        ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin],
+    ):
+        """Initialize from a raw pointer to a `PythonTypeBuilder`.
+
+        Args:
+            ptr: Pointer to the `PythonTypeBuilder` to wrap.
+        """
+        self._ptr = ptr
+
+    def def_getbuffer[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int32
+        ) thin raises -> BufferInfo
+    ](mut self) -> ref[self] Self:
+        """Install `__buffer__` via the `bf_getbuffer` slot.
+
+        Called by `memoryview(obj)`, `numpy.frombuffer(obj)`, etc.
+
+        The handler receives the consumer's `flags` bitmask.  Raise a
+        standard `Error` from the handler to propagate a Python `BufferError`.
+        Raise with message `"buffer is not writable"` — or check
+        `flags & 0x0001` yourself — to reject writable requests.
+
+        Parameters:
+            method: Static method with signature
+                `def(self_ptr: UnsafePointer[T, MutAnyOrigin], flags: Int32) raises -> BufferInfo`.
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyBufferProcs.bf_getbuffer
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _BfSlotInstaller.getbuffer[Self.self_type, method](self._ptr)
+        return self
+
+    def def_releasebuffer(mut self) -> ref[self] Self:
+        """Install the default `bf_releasebuffer` slot.
+
+        The default implementation frees the shape/strides/format block that
+        `def_getbuffer` allocates.  Call this after `def_getbuffer` whenever
+        you install a getbuffer handler.
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyBufferProcs.bf_releasebuffer
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _BfSlotInstaller.releasebuffer(self._ptr)
+        return self

--- a/mojo/stdlib/std/python/builders.mojo
+++ b/mojo/stdlib/std/python/builders.mojo
@@ -1,0 +1,17 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from .mapping import MappingProtocolBuilder
+from .number import NumberProtocolBuilder
+from .sequence import SequenceProtocolBuilder
+from .type_protocol import TypeProtocolBuilder

--- a/mojo/stdlib/std/python/builders.mojo
+++ b/mojo/stdlib/std/python/builders.mojo
@@ -1,0 +1,24 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Re-exports CPython protocol builder helpers.
+
+This module aggregates the per-protocol builder types so callers can import
+them from a single location.
+"""
+
+from .buffer import BufferInfo, BufferProtocolBuilder
+from .mapping import MappingProtocolBuilder
+from .number import NumberProtocolBuilder
+from .sequence import SequenceProtocolBuilder
+from .type_protocol import TypeProtocolBuilder

--- a/mojo/stdlib/std/python/mapping.mojo
+++ b/mojo/stdlib/std/python/mapping.mojo
@@ -1,0 +1,236 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.memory import UnsafePointer
+from std.python import PythonObject
+from std.python.bindings import PythonTypeBuilder
+from std.utils import Variant
+
+from .adapters import (
+    _CPython,
+    _conv_ptr_nr_binary,
+    _conv_ptr_r_binary,
+    _conv_val_r_binary,
+    _install_lenfunc,
+    _install_mp_getitem,
+    _install_objobjargproc,
+    _lift_mut_obj_var_to_none,
+    _lift_obj_to_obj,
+    _lift_obj_var_to_none,
+    _lift_to_int,
+    _lift_val_obj_to_obj,
+    _lift_val_to_int,
+)
+
+
+struct MappingProtocolBuilder[self_type: ImplicitlyDestructible]:
+    """Installs CPython mapping protocol slots on a `PythonTypeBuilder`.
+
+    Construct directly from a `PythonTypeBuilder`.  The three methods correspond
+    to `__len__`, `__getitem__`, and `__setitem__`/`__delitem__`.
+    Handler functions receive `UnsafePointer[T, MutAnyOrigin]` as their first
+    argument instead of a raw `PythonObject`.
+
+    Usage:
+        ```mojo
+        var mpb = MappingProtocolBuilder[MyStruct](tb)
+        mpb.def_len[MyStruct.py__len__]()
+           .def_getitem[MyStruct.py__getitem__]()
+           .def_setitem[MyStruct.py__setitem__]()
+        ```
+    """
+
+    var _ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]
+
+    def __init__(out self, mut inner: PythonTypeBuilder):
+        self._ptr = UnsafePointer(to=inner)
+
+    def __init__(
+        out self,
+        ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin],
+    ):
+        self._ptr = ptr
+
+    def def_len[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> Int
+    ](mut self) -> ref[self] Self:
+        """Install `__len__` via the `mp_length` slot.
+
+        Called by `len(obj)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_length
+        """
+        _install_lenfunc[Self.self_type, method](self._ptr)
+        return self
+
+    def def_getitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `mp_subscript` slot.
+
+        Called by `obj[key]`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript
+        """
+        _install_mp_getitem[Self.self_type, method](self._ptr)
+        return self
+
+    def def_setitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            Variant[PythonObject, Int],
+        ) thin raises -> None
+    ](mut self) -> ref[self] Self:
+        """Install `__setitem__`/`__delitem__` via the `mp_ass_subscript` slot.
+
+        Called by `obj[key] = value` or `del obj[key]`.
+
+        The third argument to `method` is a `Variant`:
+        - `Variant[PythonObject, Int](value)` for assignment.
+        - `Variant[PythonObject, Int](Int(0))` for deletion (null C pointer).
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_ass_subscript
+        """
+        _install_objobjargproc[Self.self_type, method](self._ptr)
+        return self
+
+    # Non-raising overloads
+
+    def def_len[
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> Int
+    ](mut self) -> ref[self] Self:
+        """Install `__len__` via the `mp_length` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_length
+        """
+        _install_lenfunc[Self.self_type, _lift_to_int[Self.self_type, method]](
+            self._ptr
+        )
+        return self
+
+    def def_getitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `mp_subscript` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript
+        """
+        _install_mp_getitem[
+            Self.self_type, _lift_obj_to_obj[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_setitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            Variant[PythonObject, Int],
+        ) thin -> None
+    ](mut self) -> ref[self] Self:
+        """Install `__setitem__`/`__delitem__` via the `mp_ass_subscript` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_ass_subscript
+        """
+        _install_objobjargproc[
+            Self.self_type, _lift_obj_var_to_none[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    # Value-receiver overloads
+
+    def def_len[
+        method: def(Self.self_type) thin raises -> Int
+    ](mut self) -> ref[self] Self:
+        """Install `__len__` via the `mp_length` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_length
+        """
+        _install_lenfunc[
+            Self.self_type, _lift_val_to_int[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_getitem[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `mp_subscript` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript
+        """
+        _install_mp_getitem[
+            Self.self_type, _lift_val_obj_to_obj[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_setitem[
+        method: def(
+            mut Self.self_type, PythonObject, Variant[PythonObject, Int]
+        ) thin raises -> None
+    ](mut self) -> ref[self] Self:
+        """Install `__setitem__`/`__delitem__` via the `mp_ass_subscript` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_ass_subscript
+        """
+        _install_objobjargproc[
+            Self.self_type, _lift_mut_obj_var_to_none[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    # ConvertibleToPython return overloads
+
+    def def_getitem[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `mp_subscript` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript
+        """
+        _install_mp_getitem[
+            Self.self_type, _conv_ptr_r_binary[Self.self_type, R, method]
+        ](self._ptr)
+        return self
+
+    def def_getitem[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `mp_subscript` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript
+        """
+        _install_mp_getitem[
+            Self.self_type, _conv_ptr_nr_binary[Self.self_type, R, method]
+        ](self._ptr)
+        return self
+
+    def def_getitem[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `mp_subscript` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript
+        """
+        _install_mp_getitem[
+            Self.self_type, _conv_val_r_binary[Self.self_type, R, method]
+        ](self._ptr)
+        return self

--- a/mojo/stdlib/std/python/mapping.mojo
+++ b/mojo/stdlib/std/python/mapping.mojo
@@ -1,0 +1,334 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Implements the CPython mapping-protocol builder.
+
+Provides `MappingProtocolBuilder`, which installs the `mp_length`,
+`mp_subscript`, and `mp_ass_subscript` slots on a `PythonTypeBuilder` so a
+Mojo struct can implement Python's `__len__`, `__getitem__`,
+`__setitem__`, and `__delitem__`.
+"""
+
+from std.memory import UnsafePointer
+from std.python import PythonObject
+from std.python.bindings import PythonTypeBuilder
+from std.utils import Variant
+
+from .utils import PySlotError
+
+from .adapters import (
+    _CPython,
+    _SlotInstaller,
+    _conv_ptr_nr_binary,
+    _conv_ptr_r_binary,
+    _conv_val_r_binary,
+    _lift_mut_obj_var_to_none,
+    _lift_obj_to_obj,
+    _lift_obj_var_to_none,
+    _lift_to_int,
+    _lift_val_obj_to_obj,
+    _lift_val_to_int,
+)
+
+
+struct MappingProtocolBuilder[self_type: ImplicitlyDestructible]:
+    """Installs CPython mapping protocol slots on a `PythonTypeBuilder`.
+
+    Construct directly from a `PythonTypeBuilder`.  The three methods correspond
+    to `__len__`, `__getitem__`, and `__setitem__`/`__delitem__`.
+    Handler functions receive `UnsafePointer[T, MutAnyOrigin]` as their first
+    argument instead of a raw `PythonObject`.
+
+    Usage:
+        ```mojo
+        var mpb = MappingProtocolBuilder[MyStruct](tb)
+        mpb.def_len[MyStruct.py__len__]()
+           .def_getitem[MyStruct.py__getitem__]()
+           .def_setitem[MyStruct.py__setitem__]()
+        ```
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+    """
+
+    var _ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]
+
+    def __init__(out self, mut inner: PythonTypeBuilder):
+        """Initialize from a `PythonTypeBuilder` reference.
+
+        Args:
+            inner: The `PythonTypeBuilder` to wrap.
+        """
+        self._ptr = UnsafePointer(to=inner)
+
+    def __init__(
+        out self,
+        ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin],
+    ):
+        """Initialize from a raw pointer to a `PythonTypeBuilder`.
+
+        Args:
+            ptr: Pointer to the `PythonTypeBuilder` to wrap.
+        """
+        self._ptr = ptr
+
+    def def_len[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> Int
+    ](mut self) -> ref[self] Self:
+        """Install `__len__` via the `mp_length` slot.
+
+        Called by `len(obj)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_length
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.lenfunc[Self.self_type, method](self._ptr)
+        return self
+
+    def def_getitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `mp_subscript` slot.
+
+        Called by `obj[key]`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.mp_getitem[Self.self_type, method](self._ptr)
+        return self
+
+    def def_setitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            Variant[PythonObject, Int],
+        ) thin raises PySlotError -> None
+    ](mut self) -> ref[self] Self:
+        """Install `__setitem__`/`__delitem__` via the `mp_ass_subscript` slot.
+
+        Called by `obj[key] = value` or `del obj[key]`.
+
+        The third argument to `method` is a `Variant`:
+        - `Variant[PythonObject, Int](value)` for assignment.
+        - `Variant[PythonObject, Int](Int(0))` for deletion (null C pointer).
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_ass_subscript
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.objobjargproc[Self.self_type, method](self._ptr)
+        return self
+
+    # Non-raising overloads
+
+    def def_len[
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> Int
+    ](mut self) -> ref[self] Self:
+        """Install `__len__` via the `mp_length` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_length
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.lenfunc[
+            Self.self_type, _lift_to_int[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_getitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `mp_subscript` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.mp_getitem[
+            Self.self_type, _lift_obj_to_obj[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_setitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            Variant[PythonObject, Int],
+        ) thin -> None
+    ](mut self) -> ref[self] Self:
+        """Install `__setitem__`/`__delitem__` via the `mp_ass_subscript` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_ass_subscript
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.objobjargproc[
+            Self.self_type, _lift_obj_var_to_none[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    # Value-receiver overloads
+
+    def def_len[
+        method: def(Self.self_type) thin raises PySlotError -> Int
+    ](mut self) -> ref[self] Self:
+        """Install `__len__` via the `mp_length` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_length
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.lenfunc[
+            Self.self_type, _lift_val_to_int[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_getitem[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `mp_subscript` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.mp_getitem[
+            Self.self_type, _lift_val_obj_to_obj[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_setitem[
+        method: def(
+            mut Self.self_type, PythonObject, Variant[PythonObject, Int]
+        ) thin raises PySlotError -> None
+    ](mut self) -> ref[self] Self:
+        """Install `__setitem__`/`__delitem__` via the `mp_ass_subscript` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_ass_subscript
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.objobjargproc[
+            Self.self_type, _lift_mut_obj_var_to_none[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    # ConvertibleToPython return overloads
+
+    def def_getitem[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `mp_subscript` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.mp_getitem[
+            Self.self_type, _conv_ptr_r_binary[Self.self_type, R, method]
+        ](self._ptr)
+        return self
+
+    def def_getitem[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `mp_subscript` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.mp_getitem[
+            Self.self_type, _conv_ptr_nr_binary[Self.self_type, R, method]
+        ](self._ptr)
+        return self
+
+    def def_getitem[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `mp_subscript` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyMappingMethods.mp_subscript
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.mp_getitem[
+            Self.self_type, _conv_val_r_binary[Self.self_type, R, method]
+        ](self._ptr)
+        return self

--- a/mojo/stdlib/std/python/number.mojo
+++ b/mojo/stdlib/std/python/number.mojo
@@ -1,0 +1,3029 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.memory import UnsafePointer
+from std.python import PythonObject
+from std.python.bindings import PythonTypeBuilder
+
+from .adapters import (
+    _CPython,
+    _PySlotIndex,
+    _install_binary,
+    _install_binary_conv_nr,
+    _install_binary_conv_r,
+    _install_binary_conv_val,
+    _install_binary_mut,
+    _install_binary_nr,
+    _install_binary_val,
+    _install_inquiry,
+    _install_inquiry_nr,
+    _install_inquiry_val,
+    _install_ternary,
+    _install_ternary_conv_nr,
+    _install_ternary_conv_r,
+    _install_ternary_conv_val,
+    _install_ternary_mut,
+    _install_ternary_nr,
+    _install_ternary_val,
+    _install_unary,
+    _install_unary_conv_nr,
+    _install_unary_conv_r,
+    _install_unary_conv_val,
+    _install_unary_nr,
+    _install_unary_val,
+)
+
+
+struct NumberProtocolBuilder[self_type: ImplicitlyDestructible]:
+    """Installs CPython number protocol slots on a `PythonTypeBuilder`.
+
+    Construct directly from a `PythonTypeBuilder`.  Each method is named after the
+    corresponding Python dunder and accepts only the matching function signature.
+    Handler functions receive `UnsafePointer[T, MutAnyOrigin]` as their first
+    argument instead of a raw `PythonObject`.
+
+    Binary methods (`def_add`, `def_mul`, etc.) and ternary methods (`def_pow`,
+    `def_ipow`) support `NotImplementedError`: raise it from your handler to
+    return `Py_NotImplemented` to Python, triggering the reflected operation.
+
+    Usage:
+        ```mojo
+        var npb = NumberProtocolBuilder[MyStruct](tb)
+        npb.def_neg[MyStruct.py__neg__]()
+           .def_bool[MyStruct.py__bool__]()
+           .def_add[MyStruct.py__add__]()
+           .def_pow[MyStruct.py__pow__]()
+        ```
+    """
+
+    var _ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]
+
+    def __init__(out self, mut inner: PythonTypeBuilder):
+        self._ptr = UnsafePointer(to=inner)
+
+    def __init__(
+        out self,
+        ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin],
+    ):
+        self._ptr = ptr
+
+    # ------------------------------------------------------------------
+    # Unary slots — C type: unaryfunc  def(PyObject *) -> PyObject *
+    # ------------------------------------------------------------------
+
+    def def_abs[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__abs__` via the `nb_absolute` slot.
+
+        Called by `abs(obj)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_absolute
+        """
+        _install_unary[Self.self_type, method, _PySlotIndex.nb_absolute](
+            self._ptr
+        )
+        return self
+
+    def def_float[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__float__` via the `nb_float` slot.
+
+        Called by `float(obj)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_float
+        """
+        _install_unary[Self.self_type, method, _PySlotIndex.nb_float](self._ptr)
+        return self
+
+    def def_index[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__index__` via the `nb_index` slot.
+
+        Called by `operator.index(obj)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_index
+        """
+        _install_unary[Self.self_type, method, _PySlotIndex.nb_index](self._ptr)
+        return self
+
+    def def_int[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__int__` via the `nb_int` slot.
+
+        Called by `int(obj)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_int
+        """
+        _install_unary[Self.self_type, method, _PySlotIndex.nb_int](self._ptr)
+        return self
+
+    def def_invert[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__invert__` via the `nb_invert` slot.
+
+        Called by `~obj`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_invert
+        """
+        _install_unary[Self.self_type, method, _PySlotIndex.nb_invert](
+            self._ptr
+        )
+        return self
+
+    def def_neg[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__neg__` via the `nb_negative` slot.
+
+        Called by `-obj`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_negative
+        """
+        _install_unary[Self.self_type, method, _PySlotIndex.nb_negative](
+            self._ptr
+        )
+        return self
+
+    def def_pos[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__pos__` via the `nb_positive` slot.
+
+        Called by `+obj`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_positive
+        """
+        _install_unary[Self.self_type, method, _PySlotIndex.nb_positive](
+            self._ptr
+        )
+        return self
+
+    # Non-raising unary overloads
+
+    def def_abs[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__abs__` via the `nb_absolute` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_absolute
+        """
+        _install_unary_nr[Self.self_type, method, _PySlotIndex.nb_absolute](
+            self._ptr
+        )
+        return self
+
+    def def_float[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__float__` via the `nb_float` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_float
+        """
+        _install_unary_nr[Self.self_type, method, _PySlotIndex.nb_float](
+            self._ptr
+        )
+        return self
+
+    def def_index[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__index__` via the `nb_index` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_index
+        """
+        _install_unary_nr[Self.self_type, method, _PySlotIndex.nb_index](
+            self._ptr
+        )
+        return self
+
+    def def_int[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__int__` via the `nb_int` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_int
+        """
+        _install_unary_nr[Self.self_type, method, _PySlotIndex.nb_int](
+            self._ptr
+        )
+        return self
+
+    def def_invert[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__invert__` via the `nb_invert` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_invert
+        """
+        _install_unary_nr[Self.self_type, method, _PySlotIndex.nb_invert](
+            self._ptr
+        )
+        return self
+
+    def def_neg[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__neg__` via the `nb_negative` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_negative
+        """
+        _install_unary_nr[Self.self_type, method, _PySlotIndex.nb_negative](
+            self._ptr
+        )
+        return self
+
+    def def_pos[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__pos__` via the `nb_positive` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_positive
+        """
+        _install_unary_nr[Self.self_type, method, _PySlotIndex.nb_positive](
+            self._ptr
+        )
+        return self
+
+    # Value-receiver unary overloads
+
+    def def_abs[
+        method: def(Self.self_type) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__abs__` via the `nb_absolute` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_absolute
+        """
+        _install_unary_val[Self.self_type, method, _PySlotIndex.nb_absolute](
+            self._ptr
+        )
+        return self
+
+    def def_float[
+        method: def(Self.self_type) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__float__` via the `nb_float` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_float
+        """
+
+        _install_unary_val[Self.self_type, method, _PySlotIndex.nb_float](
+            self._ptr
+        )
+        return self
+
+    def def_index[
+        method: def(Self.self_type) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__index__` via the `nb_index` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_index
+        """
+        _install_unary_val[Self.self_type, method, _PySlotIndex.nb_index](
+            self._ptr
+        )
+        return self
+
+    def def_int[
+        method: def(Self.self_type) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__int__` via the `nb_int` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_int
+        """
+        _install_unary_val[Self.self_type, method, _PySlotIndex.nb_int](
+            self._ptr
+        )
+        return self
+
+    def def_invert[
+        method: def(Self.self_type) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__invert__` via the `nb_invert` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_invert
+        """
+        _install_unary_val[Self.self_type, method, _PySlotIndex.nb_invert](
+            self._ptr
+        )
+        return self
+
+    def def_neg[
+        method: def(Self.self_type) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__neg__` via the `nb_negative` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_negative
+        """
+        _install_unary_val[Self.self_type, method, _PySlotIndex.nb_negative](
+            self._ptr
+        )
+        return self
+
+    def def_pos[
+        method: def(Self.self_type) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__pos__` via the `nb_positive` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_positive
+        """
+        _install_unary_val[Self.self_type, method, _PySlotIndex.nb_positive](
+            self._ptr
+        )
+        return self
+
+    # ------------------------------------------------------------------
+    # Bool slot — C type: inquiry  int(*)(PyObject *)
+    # ------------------------------------------------------------------
+
+    def def_bool[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install `__bool__` via the `nb_bool` slot.
+
+        Called by `bool(obj)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_bool
+        """
+        _install_inquiry[Self.self_type, method, _PySlotIndex.nb_bool](
+            self._ptr
+        )
+        return self
+
+    def def_bool[
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install `__bool__` via the `nb_bool` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_bool
+        """
+        _install_inquiry_nr[Self.self_type, method, _PySlotIndex.nb_bool](
+            self._ptr
+        )
+        return self
+
+    def def_bool[
+        method: def(Self.self_type) thin raises -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install `__bool__` via the `nb_bool` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_bool
+        """
+        _install_inquiry_val[Self.self_type, method, _PySlotIndex.nb_bool](
+            self._ptr
+        )
+        return self
+
+    # ------------------------------------------------------------------
+    # Binary slots — C type: binaryfunc  def(PyObject *, PyObject *) -> PyObject *
+    # Raise NotImplementedError() to return Py_NotImplemented.
+    # ------------------------------------------------------------------
+
+    def def_add[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `nb_add` slot.
+
+        Called by `obj + other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_add
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_add](self._ptr)
+        return self
+
+    def def_and[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__and__` via the `nb_and` slot.
+
+        Called by `obj & other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_and
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_and](self._ptr)
+        return self
+
+    def def_divmod[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__divmod__` via the `nb_divmod` slot.
+
+        Called by `divmod(obj, other)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_divmod
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_divmod](
+            self._ptr
+        )
+        return self
+
+    def def_floordiv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__floordiv__` via the `nb_floor_divide` slot.
+
+        Called by `obj // other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_floor_divide
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_floor_divide](
+            self._ptr
+        )
+        return self
+
+    def def_lshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__lshift__` via the `nb_lshift` slot.
+
+        Called by `obj << other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_lshift
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_lshift](
+            self._ptr
+        )
+        return self
+
+    def def_matmul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__matmul__` via the `nb_matrix_multiply` slot.
+
+        Called by `obj @ other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_matrix_multiply
+        """
+        _install_binary[
+            Self.self_type, method, _PySlotIndex.nb_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_mod[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mod__` via the `nb_remainder` slot.
+
+        Called by `obj % other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_remainder
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_remainder](
+            self._ptr
+        )
+        return self
+
+    def def_mul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `nb_multiply` slot.
+
+        Called by `obj * other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_multiply
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_multiply](
+            self._ptr
+        )
+        return self
+
+    def def_or[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__or__` via the `nb_or` slot.
+
+        Called by `obj | other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_or
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_or](self._ptr)
+        return self
+
+    def def_rshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__rshift__` via the `nb_rshift` slot.
+
+        Called by `obj >> other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_rshift
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_rshift](
+            self._ptr
+        )
+        return self
+
+    def def_sub[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__sub__` via the `nb_subtract` slot.
+
+        Called by `obj - other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_subtract
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_subtract](
+            self._ptr
+        )
+        return self
+
+    def def_truediv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__truediv__` via the `nb_true_divide` slot.
+
+        Called by `obj / other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_true_divide
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_true_divide](
+            self._ptr
+        )
+        return self
+
+    def def_xor[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__xor__` via the `nb_xor` slot.
+
+        Called by `obj ^ other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_xor
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_xor](self._ptr)
+        return self
+
+    # In-place binary slots
+
+    def def_iadd[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `nb_inplace_add` slot.
+
+        Called by `obj += other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_add
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_inplace_add](
+            self._ptr
+        )
+        return self
+
+    def def_iand[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iand__` via the `nb_inplace_and` slot.
+
+        Called by `obj &= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_and
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_inplace_and](
+            self._ptr
+        )
+        return self
+
+    def def_ifloordiv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ifloordiv__` via the `nb_inplace_floor_divide` slot.
+
+        Called by `obj //= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_floor_divide
+        """
+        _install_binary[
+            Self.self_type, method, _PySlotIndex.nb_inplace_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_ilshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ilshift__` via the `nb_inplace_lshift` slot.
+
+        Called by `obj <<= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_lshift
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_inplace_lshift](
+            self._ptr
+        )
+        return self
+
+    def def_imatmul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imatmul__` via the `nb_inplace_matrix_multiply` slot.
+
+        Called by `obj @= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_matrix_multiply
+        """
+        _install_binary[
+            Self.self_type, method, _PySlotIndex.nb_inplace_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_imod[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imod__` via the `nb_inplace_remainder` slot.
+
+        Called by `obj %= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_remainder
+        """
+        _install_binary[
+            Self.self_type, method, _PySlotIndex.nb_inplace_remainder
+        ](self._ptr)
+        return self
+
+    def def_imul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `nb_inplace_multiply` slot.
+
+        Called by `obj *= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_multiply
+        """
+        _install_binary[
+            Self.self_type, method, _PySlotIndex.nb_inplace_multiply
+        ](self._ptr)
+        return self
+
+    def def_ior[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ior__` via the `nb_inplace_or` slot.
+
+        Called by `obj |= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_or
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_inplace_or](
+            self._ptr
+        )
+        return self
+
+    def def_irshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__irshift__` via the `nb_inplace_rshift` slot.
+
+        Called by `obj >>= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_rshift
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_inplace_rshift](
+            self._ptr
+        )
+        return self
+
+    def def_isub[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__isub__` via the `nb_inplace_subtract` slot.
+
+        Called by `obj -= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_subtract
+        """
+        _install_binary[
+            Self.self_type, method, _PySlotIndex.nb_inplace_subtract
+        ](self._ptr)
+        return self
+
+    def def_itruediv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__itruediv__` via the `nb_inplace_true_divide` slot.
+
+        Called by `obj /= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_true_divide
+        """
+        _install_binary[
+            Self.self_type, method, _PySlotIndex.nb_inplace_true_divide
+        ](self._ptr)
+        return self
+
+    def def_ixor[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ixor__` via the `nb_inplace_xor` slot.
+
+        Called by `obj ^= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_xor
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.nb_inplace_xor](
+            self._ptr
+        )
+        return self
+
+    # Non-raising binary overloads
+
+    def def_add[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `nb_add` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_add
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_add](
+            self._ptr
+        )
+        return self
+
+    def def_and[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__and__` via the `nb_and` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_and
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_and](
+            self._ptr
+        )
+        return self
+
+    def def_divmod[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__divmod__` via the `nb_divmod` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_divmod
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_divmod](
+            self._ptr
+        )
+        return self
+
+    def def_floordiv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__floordiv__` via the `nb_floor_divide` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_floor_divide
+        """
+        _install_binary_nr[
+            Self.self_type, method, _PySlotIndex.nb_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_lshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__lshift__` via the `nb_lshift` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_lshift
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_lshift](
+            self._ptr
+        )
+        return self
+
+    def def_matmul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__matmul__` via the `nb_matrix_multiply` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_matrix_multiply
+        """
+        _install_binary_nr[
+            Self.self_type, method, _PySlotIndex.nb_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_mod[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mod__` via the `nb_remainder` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_remainder
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_remainder](
+            self._ptr
+        )
+        return self
+
+    def def_mul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `nb_multiply` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_multiply
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_multiply](
+            self._ptr
+        )
+        return self
+
+    def def_or[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__or__` via the `nb_or` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_or
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_or](
+            self._ptr
+        )
+        return self
+
+    def def_rshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__rshift__` via the `nb_rshift` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_rshift
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_rshift](
+            self._ptr
+        )
+        return self
+
+    def def_sub[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__sub__` via the `nb_subtract` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_subtract
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_subtract](
+            self._ptr
+        )
+        return self
+
+    def def_truediv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__truediv__` via the `nb_true_divide` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_true_divide
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_true_divide](
+            self._ptr
+        )
+        return self
+
+    def def_xor[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__xor__` via the `nb_xor` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_xor
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_xor](
+            self._ptr
+        )
+        return self
+
+    def def_iadd[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `nb_inplace_add` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_add
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_inplace_add](
+            self._ptr
+        )
+        return self
+
+    def def_iand[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iand__` via the `nb_inplace_and` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_and
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_inplace_and](
+            self._ptr
+        )
+        return self
+
+    def def_ifloordiv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ifloordiv__` via the `nb_inplace_floor_divide` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_floor_divide
+        """
+        _install_binary_nr[
+            Self.self_type, method, _PySlotIndex.nb_inplace_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_ilshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ilshift__` via the `nb_inplace_lshift` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_lshift
+        """
+        _install_binary_nr[
+            Self.self_type, method, _PySlotIndex.nb_inplace_lshift
+        ](self._ptr)
+        return self
+
+    def def_imatmul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imatmul__` via the `nb_inplace_matrix_multiply` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_matrix_multiply
+        """
+        _install_binary_nr[
+            Self.self_type, method, _PySlotIndex.nb_inplace_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_imod[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imod__` via the `nb_inplace_remainder` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_remainder
+        """
+        _install_binary_nr[
+            Self.self_type, method, _PySlotIndex.nb_inplace_remainder
+        ](self._ptr)
+        return self
+
+    def def_imul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `nb_inplace_multiply` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_multiply
+        """
+        _install_binary_nr[
+            Self.self_type, method, _PySlotIndex.nb_inplace_multiply
+        ](self._ptr)
+        return self
+
+    def def_ior[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ior__` via the `nb_inplace_or` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_or
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_inplace_or](
+            self._ptr
+        )
+        return self
+
+    def def_irshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__irshift__` via the `nb_inplace_rshift` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_rshift
+        """
+        _install_binary_nr[
+            Self.self_type, method, _PySlotIndex.nb_inplace_rshift
+        ](self._ptr)
+        return self
+
+    def def_isub[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__isub__` via the `nb_inplace_subtract` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_subtract
+        """
+        _install_binary_nr[
+            Self.self_type, method, _PySlotIndex.nb_inplace_subtract
+        ](self._ptr)
+        return self
+
+    def def_itruediv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__itruediv__` via the `nb_inplace_true_divide` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_true_divide
+        """
+        _install_binary_nr[
+            Self.self_type, method, _PySlotIndex.nb_inplace_true_divide
+        ](self._ptr)
+        return self
+
+    def def_ixor[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ixor__` via the `nb_inplace_xor` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_xor
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.nb_inplace_xor](
+            self._ptr
+        )
+        return self
+
+    # Value-receiver binary overloads
+
+    def def_add[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `nb_add` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_add
+        """
+        _install_binary_val[Self.self_type, method, _PySlotIndex.nb_add](
+            self._ptr
+        )
+        return self
+
+    def def_and[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__and__` via the `nb_and` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_and
+        """
+        _install_binary_val[Self.self_type, method, _PySlotIndex.nb_and](
+            self._ptr
+        )
+        return self
+
+    def def_divmod[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__divmod__` via the `nb_divmod` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_divmod
+        """
+        _install_binary_val[Self.self_type, method, _PySlotIndex.nb_divmod](
+            self._ptr
+        )
+        return self
+
+    def def_floordiv[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__floordiv__` via the `nb_floor_divide` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_floor_divide
+        """
+        _install_binary_val[
+            Self.self_type, method, _PySlotIndex.nb_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_lshift[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__lshift__` via the `nb_lshift` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_lshift
+        """
+        _install_binary_val[Self.self_type, method, _PySlotIndex.nb_lshift](
+            self._ptr
+        )
+        return self
+
+    def def_matmul[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__matmul__` via the `nb_matrix_multiply` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_matrix_multiply
+        """
+        _install_binary_val[
+            Self.self_type, method, _PySlotIndex.nb_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_mod[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mod__` via the `nb_remainder` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_remainder
+        """
+        _install_binary_val[Self.self_type, method, _PySlotIndex.nb_remainder](
+            self._ptr
+        )
+        return self
+
+    def def_mul[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `nb_multiply` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_multiply
+        """
+        _install_binary_val[Self.self_type, method, _PySlotIndex.nb_multiply](
+            self._ptr
+        )
+        return self
+
+    def def_or[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__or__` via the `nb_or` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_or
+        """
+        _install_binary_val[Self.self_type, method, _PySlotIndex.nb_or](
+            self._ptr
+        )
+        return self
+
+    def def_rshift[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__rshift__` via the `nb_rshift` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_rshift
+        """
+        _install_binary_val[Self.self_type, method, _PySlotIndex.nb_rshift](
+            self._ptr
+        )
+        return self
+
+    def def_sub[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__sub__` via the `nb_subtract` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_subtract
+        """
+        _install_binary_val[Self.self_type, method, _PySlotIndex.nb_subtract](
+            self._ptr
+        )
+        return self
+
+    def def_truediv[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__truediv__` via the `nb_true_divide` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_true_divide
+        """
+        _install_binary_val[
+            Self.self_type, method, _PySlotIndex.nb_true_divide
+        ](self._ptr)
+        return self
+
+    def def_xor[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__xor__` via the `nb_xor` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_xor
+        """
+        _install_binary_val[Self.self_type, method, _PySlotIndex.nb_xor](
+            self._ptr
+        )
+        return self
+
+    # ------------------------------------------------------------------
+    # Ternary slots — C type: ternaryfunc  def(PyObject *, PyObject *, PyObject *) -> PyObject *
+    # `mod` is None unless pow(base, exp, mod) was called.
+    # Raise NotImplementedError() to return Py_NotImplemented.
+    # ------------------------------------------------------------------
+
+    def def_pow[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__pow__` via the `nb_power` slot.
+
+        Called by `obj ** exp`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_power
+        """
+        _install_ternary[Self.self_type, method, _PySlotIndex.nb_power](
+            self._ptr
+        )
+        return self
+
+    def def_ipow[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ipow__` via the `nb_inplace_power` slot.
+
+        Called by `obj **= exp`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_power
+        """
+        _install_ternary[Self.self_type, method, _PySlotIndex.nb_inplace_power](
+            self._ptr
+        )
+        return self
+
+    # Non-raising ternary overloads
+
+    def def_pow[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__pow__` via the `nb_power` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_power
+        """
+        _install_ternary_nr[Self.self_type, method, _PySlotIndex.nb_power](
+            self._ptr
+        )
+        return self
+
+    def def_ipow[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ipow__` via the `nb_inplace_power` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_power
+        """
+        _install_ternary_nr[
+            Self.self_type, method, _PySlotIndex.nb_inplace_power
+        ](self._ptr)
+        return self
+
+    def def_pow[
+        method: def(
+            Self.self_type, PythonObject, PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__pow__` via the `nb_power` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_power
+        """
+        _install_ternary_val[Self.self_type, method, _PySlotIndex.nb_power](
+            self._ptr
+        )
+        return self
+
+    # Mut-receiver overloads
+
+    def def_iadd[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `nb_inplace_add` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_add
+        """
+        _install_binary_mut[
+            Self.self_type, method, _PySlotIndex.nb_inplace_add
+        ](self._ptr)
+        return self
+
+    def def_iand[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iand__` via the `nb_inplace_and` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_and
+        """
+        _install_binary_mut[
+            Self.self_type, method, _PySlotIndex.nb_inplace_and
+        ](self._ptr)
+        return self
+
+    def def_ifloordiv[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ifloordiv__` via the `nb_inplace_floor_divide` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_floor_divide
+        """
+        _install_binary_mut[
+            Self.self_type, method, _PySlotIndex.nb_inplace_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_ilshift[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ilshift__` via the `nb_inplace_lshift` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_lshift
+        """
+        _install_binary_mut[
+            Self.self_type, method, _PySlotIndex.nb_inplace_lshift
+        ](self._ptr)
+        return self
+
+    def def_imatmul[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imatmul__` via the `nb_inplace_matrix_multiply` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_matrix_multiply
+        """
+        _install_binary_mut[
+            Self.self_type, method, _PySlotIndex.nb_inplace_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_imod[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imod__` via the `nb_inplace_remainder` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_remainder
+        """
+        _install_binary_mut[
+            Self.self_type, method, _PySlotIndex.nb_inplace_remainder
+        ](self._ptr)
+        return self
+
+    def def_imul[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `nb_inplace_multiply` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_multiply
+        """
+        _install_binary_mut[
+            Self.self_type, method, _PySlotIndex.nb_inplace_multiply
+        ](self._ptr)
+        return self
+
+    def def_ior[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ior__` via the `nb_inplace_or` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_or
+        """
+        _install_binary_mut[Self.self_type, method, _PySlotIndex.nb_inplace_or](
+            self._ptr
+        )
+        return self
+
+    def def_irshift[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__irshift__` via the `nb_inplace_rshift` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_rshift
+        """
+        _install_binary_mut[
+            Self.self_type, method, _PySlotIndex.nb_inplace_rshift
+        ](self._ptr)
+        return self
+
+    def def_isub[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__isub__` via the `nb_inplace_subtract` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_subtract
+        """
+        _install_binary_mut[
+            Self.self_type, method, _PySlotIndex.nb_inplace_subtract
+        ](self._ptr)
+        return self
+
+    def def_itruediv[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__itruediv__` via the `nb_inplace_true_divide` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_true_divide
+        """
+        _install_binary_mut[
+            Self.self_type, method, _PySlotIndex.nb_inplace_true_divide
+        ](self._ptr)
+        return self
+
+    def def_ixor[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ixor__` via the `nb_inplace_xor` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_xor
+        """
+        _install_binary_mut[
+            Self.self_type, method, _PySlotIndex.nb_inplace_xor
+        ](self._ptr)
+        return self
+
+    def def_ipow[
+        method: def(
+            mut Self.self_type, PythonObject, PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ipow__` via the `nb_inplace_power` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_power
+        """
+        _install_ternary_mut[
+            Self.self_type, method, _PySlotIndex.nb_inplace_power
+        ](self._ptr)
+        return self
+
+    # ConvertibleToPython return overloads
+
+    def def_abs[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__abs__` via the `nb_absolute` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_absolute
+        """
+        _install_unary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_absolute
+        ](self._ptr)
+        return self
+
+    def def_abs[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__abs__` via the `nb_absolute` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_absolute
+        """
+        _install_unary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_absolute
+        ](self._ptr)
+        return self
+
+    def def_abs[
+        R: _CPython,
+        method: def(Self.self_type) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__abs__` via the `nb_absolute` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_absolute
+        """
+        _install_unary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_absolute
+        ](self._ptr)
+        return self
+
+    def def_float[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__float__` via the `nb_float` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_float
+        """
+        _install_unary_conv_r[Self.self_type, R, method, _PySlotIndex.nb_float](
+            self._ptr
+        )
+        return self
+
+    def def_float[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__float__` via the `nb_float` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_float
+        """
+        _install_unary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_float
+        ](self._ptr)
+        return self
+
+    def def_float[
+        R: _CPython,
+        method: def(Self.self_type) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__float__` via the `nb_float` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_float
+        """
+        _install_unary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_float
+        ](self._ptr)
+        return self
+
+    def def_index[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__index__` via the `nb_index` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_index
+        """
+        _install_unary_conv_r[Self.self_type, R, method, _PySlotIndex.nb_index](
+            self._ptr
+        )
+        return self
+
+    def def_index[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__index__` via the `nb_index` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_index
+        """
+        _install_unary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_index
+        ](self._ptr)
+        return self
+
+    def def_index[
+        R: _CPython,
+        method: def(Self.self_type) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__index__` via the `nb_index` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_index
+        """
+        _install_unary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_index
+        ](self._ptr)
+        return self
+
+    def def_int[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__int__` via the `nb_int` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_int
+        """
+        _install_unary_conv_r[Self.self_type, R, method, _PySlotIndex.nb_int](
+            self._ptr
+        )
+        return self
+
+    def def_int[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__int__` via the `nb_int` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_int
+        """
+        _install_unary_conv_nr[Self.self_type, R, method, _PySlotIndex.nb_int](
+            self._ptr
+        )
+        return self
+
+    def def_int[
+        R: _CPython,
+        method: def(Self.self_type) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__int__` via the `nb_int` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_int
+        """
+        _install_unary_conv_val[Self.self_type, R, method, _PySlotIndex.nb_int](
+            self._ptr
+        )
+        return self
+
+    def def_invert[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__invert__` via the `nb_invert` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_invert
+        """
+        _install_unary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_invert
+        ](self._ptr)
+        return self
+
+    def def_invert[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__invert__` via the `nb_invert` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_invert
+        """
+        _install_unary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_invert
+        ](self._ptr)
+        return self
+
+    def def_invert[
+        R: _CPython,
+        method: def(Self.self_type) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__invert__` via the `nb_invert` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_invert
+        """
+        _install_unary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_invert
+        ](self._ptr)
+        return self
+
+    def def_neg[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__neg__` via the `nb_negative` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_negative
+        """
+        _install_unary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_negative
+        ](self._ptr)
+        return self
+
+    def def_neg[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__neg__` via the `nb_negative` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_negative
+        """
+        _install_unary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_negative
+        ](self._ptr)
+        return self
+
+    def def_neg[
+        R: _CPython,
+        method: def(Self.self_type) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__neg__` via the `nb_negative` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_negative
+        """
+        _install_unary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_negative
+        ](self._ptr)
+        return self
+
+    def def_pos[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__pos__` via the `nb_positive` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_positive
+        """
+        _install_unary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_positive
+        ](self._ptr)
+        return self
+
+    def def_pos[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__pos__` via the `nb_positive` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_positive
+        """
+        _install_unary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_positive
+        ](self._ptr)
+        return self
+
+    def def_pos[
+        R: _CPython,
+        method: def(Self.self_type) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__pos__` via the `nb_positive` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_positive
+        """
+        _install_unary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_positive
+        ](self._ptr)
+        return self
+
+    def def_add[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `nb_add` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_add
+        """
+        _install_binary_conv_r[Self.self_type, R, method, _PySlotIndex.nb_add](
+            self._ptr
+        )
+        return self
+
+    def def_add[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `nb_add` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_add
+        """
+        _install_binary_conv_nr[Self.self_type, R, method, _PySlotIndex.nb_add](
+            self._ptr
+        )
+        return self
+
+    def def_add[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `nb_add` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_add
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_add
+        ](self._ptr)
+        return self
+
+    def def_and[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__and__` via the `nb_and` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_and
+        """
+        _install_binary_conv_r[Self.self_type, R, method, _PySlotIndex.nb_and](
+            self._ptr
+        )
+        return self
+
+    def def_and[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__and__` via the `nb_and` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_and
+        """
+        _install_binary_conv_nr[Self.self_type, R, method, _PySlotIndex.nb_and](
+            self._ptr
+        )
+        return self
+
+    def def_and[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__and__` via the `nb_and` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_and
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_and
+        ](self._ptr)
+        return self
+
+    def def_divmod[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__divmod__` via the `nb_divmod` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_divmod
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_divmod
+        ](self._ptr)
+        return self
+
+    def def_divmod[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__divmod__` via the `nb_divmod` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_divmod
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_divmod
+        ](self._ptr)
+        return self
+
+    def def_divmod[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__divmod__` via the `nb_divmod` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_divmod
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_divmod
+        ](self._ptr)
+        return self
+
+    def def_floordiv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__floordiv__` via the `nb_floor_divide` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_floor_divide
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_floordiv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__floordiv__` via the `nb_floor_divide` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_floor_divide
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_floordiv[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__floordiv__` via the `nb_floor_divide` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_floor_divide
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_lshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__lshift__` via the `nb_lshift` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_lshift
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_lshift
+        ](self._ptr)
+        return self
+
+    def def_lshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__lshift__` via the `nb_lshift` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_lshift
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_lshift
+        ](self._ptr)
+        return self
+
+    def def_lshift[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__lshift__` via the `nb_lshift` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_lshift
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_lshift
+        ](self._ptr)
+        return self
+
+    def def_matmul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__matmul__` via the `nb_matrix_multiply` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_matrix_multiply
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_matmul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__matmul__` via the `nb_matrix_multiply` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_matrix_multiply
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_matmul[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__matmul__` via the `nb_matrix_multiply` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_matrix_multiply
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_mod[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mod__` via the `nb_remainder` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_remainder
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_remainder
+        ](self._ptr)
+        return self
+
+    def def_mod[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mod__` via the `nb_remainder` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_remainder
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_remainder
+        ](self._ptr)
+        return self
+
+    def def_mod[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mod__` via the `nb_remainder` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_remainder
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_remainder
+        ](self._ptr)
+        return self
+
+    def def_mul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `nb_multiply` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_multiply
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_multiply
+        ](self._ptr)
+        return self
+
+    def def_mul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `nb_multiply` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_multiply
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_multiply
+        ](self._ptr)
+        return self
+
+    def def_mul[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `nb_multiply` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_multiply
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_multiply
+        ](self._ptr)
+        return self
+
+    def def_or[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__or__` via the `nb_or` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_or
+        """
+        _install_binary_conv_r[Self.self_type, R, method, _PySlotIndex.nb_or](
+            self._ptr
+        )
+        return self
+
+    def def_or[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__or__` via the `nb_or` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_or
+        """
+        _install_binary_conv_nr[Self.self_type, R, method, _PySlotIndex.nb_or](
+            self._ptr
+        )
+        return self
+
+    def def_or[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__or__` via the `nb_or` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_or
+        """
+        _install_binary_conv_val[Self.self_type, R, method, _PySlotIndex.nb_or](
+            self._ptr
+        )
+        return self
+
+    def def_rshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__rshift__` via the `nb_rshift` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_rshift
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_rshift
+        ](self._ptr)
+        return self
+
+    def def_rshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__rshift__` via the `nb_rshift` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_rshift
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_rshift
+        ](self._ptr)
+        return self
+
+    def def_rshift[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__rshift__` via the `nb_rshift` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_rshift
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_rshift
+        ](self._ptr)
+        return self
+
+    def def_sub[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__sub__` via the `nb_subtract` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_subtract
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_subtract
+        ](self._ptr)
+        return self
+
+    def def_sub[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__sub__` via the `nb_subtract` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_subtract
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_subtract
+        ](self._ptr)
+        return self
+
+    def def_sub[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__sub__` via the `nb_subtract` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_subtract
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_subtract
+        ](self._ptr)
+        return self
+
+    def def_truediv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__truediv__` via the `nb_true_divide` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_true_divide
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_true_divide
+        ](self._ptr)
+        return self
+
+    def def_truediv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__truediv__` via the `nb_true_divide` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_true_divide
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_true_divide
+        ](self._ptr)
+        return self
+
+    def def_truediv[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__truediv__` via the `nb_true_divide` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_true_divide
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_true_divide
+        ](self._ptr)
+        return self
+
+    def def_xor[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__xor__` via the `nb_xor` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_xor
+        """
+        _install_binary_conv_r[Self.self_type, R, method, _PySlotIndex.nb_xor](
+            self._ptr
+        )
+        return self
+
+    def def_xor[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__xor__` via the `nb_xor` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_xor
+        """
+        _install_binary_conv_nr[Self.self_type, R, method, _PySlotIndex.nb_xor](
+            self._ptr
+        )
+        return self
+
+    def def_xor[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__xor__` via the `nb_xor` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_xor
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_xor
+        ](self._ptr)
+        return self
+
+    def def_iadd[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `nb_inplace_add` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_add
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_add
+        ](self._ptr)
+        return self
+
+    def def_iadd[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `nb_inplace_add` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_add
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_add
+        ](self._ptr)
+        return self
+
+    def def_iadd[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `nb_inplace_add` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_add
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_add
+        ](self._ptr)
+        return self
+
+    def def_iand[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iand__` via the `nb_inplace_and` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_and
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_and
+        ](self._ptr)
+        return self
+
+    def def_iand[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iand__` via the `nb_inplace_and` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_and
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_and
+        ](self._ptr)
+        return self
+
+    def def_iand[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iand__` via the `nb_inplace_and` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_and
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_and
+        ](self._ptr)
+        return self
+
+    def def_ifloordiv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ifloordiv__` via the `nb_inplace_floor_divide` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_floor_divide
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_ifloordiv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ifloordiv__` via the `nb_inplace_floor_divide` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_floor_divide
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_ifloordiv[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ifloordiv__` via the `nb_inplace_floor_divide` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_floor_divide
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_ilshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ilshift__` via the `nb_inplace_lshift` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_lshift
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_lshift
+        ](self._ptr)
+        return self
+
+    def def_ilshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ilshift__` via the `nb_inplace_lshift` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_lshift
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_lshift
+        ](self._ptr)
+        return self
+
+    def def_ilshift[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ilshift__` via the `nb_inplace_lshift` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_lshift
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_lshift
+        ](self._ptr)
+        return self
+
+    def def_imatmul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imatmul__` via the `nb_inplace_matrix_multiply` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_matrix_multiply
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_imatmul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imatmul__` via the `nb_inplace_matrix_multiply` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_matrix_multiply
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_imatmul[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imatmul__` via the `nb_inplace_matrix_multiply` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_matrix_multiply
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_imod[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imod__` via the `nb_inplace_remainder` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_remainder
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_remainder
+        ](self._ptr)
+        return self
+
+    def def_imod[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imod__` via the `nb_inplace_remainder` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_remainder
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_remainder
+        ](self._ptr)
+        return self
+
+    def def_imod[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imod__` via the `nb_inplace_remainder` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_remainder
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_remainder
+        ](self._ptr)
+        return self
+
+    def def_imul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `nb_inplace_multiply` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_multiply
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_multiply
+        ](self._ptr)
+        return self
+
+    def def_imul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `nb_inplace_multiply` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_multiply
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_multiply
+        ](self._ptr)
+        return self
+
+    def def_imul[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `nb_inplace_multiply` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_multiply
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_multiply
+        ](self._ptr)
+        return self
+
+    def def_ior[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ior__` via the `nb_inplace_or` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_or
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_or
+        ](self._ptr)
+        return self
+
+    def def_ior[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ior__` via the `nb_inplace_or` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_or
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_or
+        ](self._ptr)
+        return self
+
+    def def_ior[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ior__` via the `nb_inplace_or` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_or
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_or
+        ](self._ptr)
+        return self
+
+    def def_irshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__irshift__` via the `nb_inplace_rshift` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_rshift
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_rshift
+        ](self._ptr)
+        return self
+
+    def def_irshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__irshift__` via the `nb_inplace_rshift` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_rshift
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_rshift
+        ](self._ptr)
+        return self
+
+    def def_irshift[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__irshift__` via the `nb_inplace_rshift` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_rshift
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_rshift
+        ](self._ptr)
+        return self
+
+    def def_isub[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__isub__` via the `nb_inplace_subtract` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_subtract
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_subtract
+        ](self._ptr)
+        return self
+
+    def def_isub[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__isub__` via the `nb_inplace_subtract` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_subtract
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_subtract
+        ](self._ptr)
+        return self
+
+    def def_isub[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__isub__` via the `nb_inplace_subtract` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_subtract
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_subtract
+        ](self._ptr)
+        return self
+
+    def def_itruediv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__itruediv__` via the `nb_inplace_true_divide` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_true_divide
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_true_divide
+        ](self._ptr)
+        return self
+
+    def def_itruediv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__itruediv__` via the `nb_inplace_true_divide` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_true_divide
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_true_divide
+        ](self._ptr)
+        return self
+
+    def def_itruediv[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__itruediv__` via the `nb_inplace_true_divide` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_true_divide
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_true_divide
+        ](self._ptr)
+        return self
+
+    def def_ixor[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ixor__` via the `nb_inplace_xor` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_xor
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_xor
+        ](self._ptr)
+        return self
+
+    def def_ixor[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ixor__` via the `nb_inplace_xor` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_xor
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_xor
+        ](self._ptr)
+        return self
+
+    def def_ixor[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ixor__` via the `nb_inplace_xor` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_xor
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_xor
+        ](self._ptr)
+        return self
+
+    def def_pow[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__pow__` via the `nb_power` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_power
+        """
+        _install_ternary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_power
+        ](self._ptr)
+        return self
+
+    def def_pow[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__pow__` via the `nb_power` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_power
+        """
+        _install_ternary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_power
+        ](self._ptr)
+        return self
+
+    def def_pow[
+        R: _CPython,
+        method: def(
+            Self.self_type, PythonObject, PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__pow__` via the `nb_power` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_power
+        """
+        _install_ternary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_power
+        ](self._ptr)
+        return self
+
+    def def_ipow[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ipow__` via the `nb_inplace_power` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_power
+        """
+        _install_ternary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_power
+        ](self._ptr)
+        return self
+
+    def def_ipow[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ipow__` via the `nb_inplace_power` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_power
+        """
+        _install_ternary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_power
+        ](self._ptr)
+        return self
+
+    def def_ipow[
+        R: _CPython,
+        method: def(
+            Self.self_type, PythonObject, PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ipow__` via the `nb_inplace_power` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_power
+        """
+        _install_ternary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.nb_inplace_power
+        ](self._ptr)
+        return self

--- a/mojo/stdlib/std/python/number.mojo
+++ b/mojo/stdlib/std/python/number.mojo
@@ -1,0 +1,4415 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Implements the CPython number-protocol builder.
+
+Provides `NumberProtocolBuilder`, which installs the `nb_*` slots (unary,
+binary, and ternary) on a `PythonTypeBuilder` so a Mojo struct can
+implement Python's numeric dunders (`__neg__`, `__add__`, `__pow__`,
+etc.).
+"""
+
+from std.memory import UnsafePointer
+from std.python import PythonObject
+from std.python.bindings import PythonTypeBuilder
+
+from .utils import PySlotError
+
+from std.python._cpython import PySlotIndex
+
+from .adapters import (
+    _CPython,
+    _SlotInstaller,
+)
+
+
+struct NumberProtocolBuilder[self_type: ImplicitlyDestructible]:
+    """Installs CPython number protocol slots on a `PythonTypeBuilder`.
+
+    Construct directly from a `PythonTypeBuilder`.  Each method is named after the
+    corresponding Python dunder and accepts only the matching function signature.
+    Handler functions receive `UnsafePointer[T, MutAnyOrigin]` as their first
+    argument instead of a raw `PythonObject`.
+
+    Binary methods (`def_add`, `def_mul`, etc.) and ternary methods (`def_pow`,
+    `def_ipow`) support `NotImplementedError`: raise it from your handler to
+    return `Py_NotImplemented` to Python, triggering the reflected operation.
+
+    Usage:
+        ```mojo
+        var npb = NumberProtocolBuilder[MyStruct](tb)
+        npb.def_neg[MyStruct.py__neg__]()
+           .def_bool[MyStruct.py__bool__]()
+           .def_add[MyStruct.py__add__]()
+           .def_pow[MyStruct.py__pow__]()
+        ```
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+    """
+
+    var _ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]
+
+    def __init__(out self, mut inner: PythonTypeBuilder):
+        """Initialize from a `PythonTypeBuilder` reference.
+
+        Args:
+            inner: The `PythonTypeBuilder` to wrap.
+        """
+        self._ptr = UnsafePointer(to=inner)
+
+    def __init__(
+        out self,
+        ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin],
+    ):
+        """Initialize from a raw pointer to a `PythonTypeBuilder`.
+
+        Args:
+            ptr: Pointer to the `PythonTypeBuilder` to wrap.
+        """
+        self._ptr = ptr
+
+    # ------------------------------------------------------------------
+    # Unary slots — C type: unaryfunc  def(PyObject *) -> PyObject *
+    # ------------------------------------------------------------------
+
+    def def_abs[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__abs__` via the `nb_absolute` slot.
+
+        Called by `abs(obj)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_absolute
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary[Self.self_type, method, PySlotIndex.nb_absolute](
+            self._ptr
+        )
+        return self
+
+    def def_float[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__float__` via the `nb_float` slot.
+
+        Called by `float(obj)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_float
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary[Self.self_type, method, PySlotIndex.nb_float](
+            self._ptr
+        )
+        return self
+
+    def def_index[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__index__` via the `nb_index` slot.
+
+        Called by `operator.index(obj)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_index
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary[Self.self_type, method, PySlotIndex.nb_index](
+            self._ptr
+        )
+        return self
+
+    def def_int[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__int__` via the `nb_int` slot.
+
+        Called by `int(obj)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_int
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary[Self.self_type, method, PySlotIndex.nb_int](
+            self._ptr
+        )
+        return self
+
+    def def_invert[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__invert__` via the `nb_invert` slot.
+
+        Called by `~obj`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_invert
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary[Self.self_type, method, PySlotIndex.nb_invert](
+            self._ptr
+        )
+        return self
+
+    def def_neg[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__neg__` via the `nb_negative` slot.
+
+        Called by `-obj`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_negative
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary[Self.self_type, method, PySlotIndex.nb_negative](
+            self._ptr
+        )
+        return self
+
+    def def_pos[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__pos__` via the `nb_positive` slot.
+
+        Called by `+obj`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_positive
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary[Self.self_type, method, PySlotIndex.nb_positive](
+            self._ptr
+        )
+        return self
+
+    # Non-raising unary overloads
+
+    def def_abs[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__abs__` via the `nb_absolute` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_absolute
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_nr[
+            Self.self_type, method, PySlotIndex.nb_absolute
+        ](self._ptr)
+        return self
+
+    def def_float[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__float__` via the `nb_float` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_float
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_nr[Self.self_type, method, PySlotIndex.nb_float](
+            self._ptr
+        )
+        return self
+
+    def def_index[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__index__` via the `nb_index` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_index
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_nr[Self.self_type, method, PySlotIndex.nb_index](
+            self._ptr
+        )
+        return self
+
+    def def_int[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__int__` via the `nb_int` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_int
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_nr[Self.self_type, method, PySlotIndex.nb_int](
+            self._ptr
+        )
+        return self
+
+    def def_invert[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__invert__` via the `nb_invert` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_invert
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_nr[Self.self_type, method, PySlotIndex.nb_invert](
+            self._ptr
+        )
+        return self
+
+    def def_neg[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__neg__` via the `nb_negative` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_negative
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_nr[
+            Self.self_type, method, PySlotIndex.nb_negative
+        ](self._ptr)
+        return self
+
+    def def_pos[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__pos__` via the `nb_positive` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_positive
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_nr[
+            Self.self_type, method, PySlotIndex.nb_positive
+        ](self._ptr)
+        return self
+
+    # Value-receiver unary overloads
+
+    def def_abs[
+        method: def(Self.self_type) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__abs__` via the `nb_absolute` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_absolute
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_val[
+            Self.self_type, method, PySlotIndex.nb_absolute
+        ](self._ptr)
+        return self
+
+    def def_float[
+        method: def(Self.self_type) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__float__` via the `nb_float` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_float
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+
+        _SlotInstaller.unary_val[Self.self_type, method, PySlotIndex.nb_float](
+            self._ptr
+        )
+        return self
+
+    def def_index[
+        method: def(Self.self_type) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__index__` via the `nb_index` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_index
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_val[Self.self_type, method, PySlotIndex.nb_index](
+            self._ptr
+        )
+        return self
+
+    def def_int[
+        method: def(Self.self_type) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__int__` via the `nb_int` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_int
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_val[Self.self_type, method, PySlotIndex.nb_int](
+            self._ptr
+        )
+        return self
+
+    def def_invert[
+        method: def(Self.self_type) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__invert__` via the `nb_invert` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_invert
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_val[Self.self_type, method, PySlotIndex.nb_invert](
+            self._ptr
+        )
+        return self
+
+    def def_neg[
+        method: def(Self.self_type) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__neg__` via the `nb_negative` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_negative
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_val[
+            Self.self_type, method, PySlotIndex.nb_negative
+        ](self._ptr)
+        return self
+
+    def def_pos[
+        method: def(Self.self_type) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__pos__` via the `nb_positive` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_positive
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_val[
+            Self.self_type, method, PySlotIndex.nb_positive
+        ](self._ptr)
+        return self
+
+    # ------------------------------------------------------------------
+    # Bool slot — C type: inquiry  int(*)(PyObject *)
+    # ------------------------------------------------------------------
+
+    def def_bool[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install `__bool__` via the `nb_bool` slot.
+
+        Called by `bool(obj)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_bool
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.inquiry[Self.self_type, method, PySlotIndex.nb_bool](
+            self._ptr
+        )
+        return self
+
+    def def_bool[
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install `__bool__` via the `nb_bool` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_bool
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.inquiry_nr[Self.self_type, method, PySlotIndex.nb_bool](
+            self._ptr
+        )
+        return self
+
+    def def_bool[
+        method: def(Self.self_type) thin raises PySlotError -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install `__bool__` via the `nb_bool` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_bool
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.inquiry_val[Self.self_type, method, PySlotIndex.nb_bool](
+            self._ptr
+        )
+        return self
+
+    # ------------------------------------------------------------------
+    # Binary slots — C type: binaryfunc  def(PyObject *, PyObject *) -> PyObject *
+    # Raise NotImplementedError() to return Py_NotImplemented.
+    # ------------------------------------------------------------------
+
+    def def_add[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `nb_add` slot.
+
+        Called by `obj + other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_add
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[Self.self_type, method, PySlotIndex.nb_add](
+            self._ptr
+        )
+        return self
+
+    def def_and[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__and__` via the `nb_and` slot.
+
+        Called by `obj & other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_and
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[Self.self_type, method, PySlotIndex.nb_and](
+            self._ptr
+        )
+        return self
+
+    def def_divmod[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__divmod__` via the `nb_divmod` slot.
+
+        Called by `divmod(obj, other)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_divmod
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[Self.self_type, method, PySlotIndex.nb_divmod](
+            self._ptr
+        )
+        return self
+
+    def def_floordiv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__floordiv__` via the `nb_floor_divide` slot.
+
+        Called by `obj // other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_floor_divide
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_lshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__lshift__` via the `nb_lshift` slot.
+
+        Called by `obj << other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_lshift
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[Self.self_type, method, PySlotIndex.nb_lshift](
+            self._ptr
+        )
+        return self
+
+    def def_matmul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__matmul__` via the `nb_matrix_multiply` slot.
+
+        Called by `obj @ other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_matrix_multiply
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_mod[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mod__` via the `nb_remainder` slot.
+
+        Called by `obj % other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_remainder
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[Self.self_type, method, PySlotIndex.nb_remainder](
+            self._ptr
+        )
+        return self
+
+    def def_mul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `nb_multiply` slot.
+
+        Called by `obj * other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_multiply
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[Self.self_type, method, PySlotIndex.nb_multiply](
+            self._ptr
+        )
+        return self
+
+    def def_or[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__or__` via the `nb_or` slot.
+
+        Called by `obj | other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_or
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[Self.self_type, method, PySlotIndex.nb_or](
+            self._ptr
+        )
+        return self
+
+    def def_rshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__rshift__` via the `nb_rshift` slot.
+
+        Called by `obj >> other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_rshift
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[Self.self_type, method, PySlotIndex.nb_rshift](
+            self._ptr
+        )
+        return self
+
+    def def_sub[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__sub__` via the `nb_subtract` slot.
+
+        Called by `obj - other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_subtract
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[Self.self_type, method, PySlotIndex.nb_subtract](
+            self._ptr
+        )
+        return self
+
+    def def_truediv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__truediv__` via the `nb_true_divide` slot.
+
+        Called by `obj / other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_true_divide
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_true_divide
+        ](self._ptr)
+        return self
+
+    def def_xor[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__xor__` via the `nb_xor` slot.
+
+        Called by `obj ^ other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_xor
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[Self.self_type, method, PySlotIndex.nb_xor](
+            self._ptr
+        )
+        return self
+
+    # In-place binary slots
+
+    def def_iadd[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `nb_inplace_add` slot.
+
+        Called by `obj += other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_add
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_inplace_add
+        ](self._ptr)
+        return self
+
+    def def_iand[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iand__` via the `nb_inplace_and` slot.
+
+        Called by `obj &= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_and
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_inplace_and
+        ](self._ptr)
+        return self
+
+    def def_ifloordiv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ifloordiv__` via the `nb_inplace_floor_divide` slot.
+
+        Called by `obj //= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_floor_divide
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_inplace_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_ilshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ilshift__` via the `nb_inplace_lshift` slot.
+
+        Called by `obj <<= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_lshift
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_inplace_lshift
+        ](self._ptr)
+        return self
+
+    def def_imatmul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imatmul__` via the `nb_inplace_matrix_multiply` slot.
+
+        Called by `obj @= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_matrix_multiply
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_inplace_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_imod[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imod__` via the `nb_inplace_remainder` slot.
+
+        Called by `obj %= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_remainder
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_inplace_remainder
+        ](self._ptr)
+        return self
+
+    def def_imul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `nb_inplace_multiply` slot.
+
+        Called by `obj *= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_multiply
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_inplace_multiply
+        ](self._ptr)
+        return self
+
+    def def_ior[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ior__` via the `nb_inplace_or` slot.
+
+        Called by `obj |= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_or
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_inplace_or
+        ](self._ptr)
+        return self
+
+    def def_irshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__irshift__` via the `nb_inplace_rshift` slot.
+
+        Called by `obj >>= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_rshift
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_inplace_rshift
+        ](self._ptr)
+        return self
+
+    def def_isub[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__isub__` via the `nb_inplace_subtract` slot.
+
+        Called by `obj -= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_subtract
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_inplace_subtract
+        ](self._ptr)
+        return self
+
+    def def_itruediv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__itruediv__` via the `nb_inplace_true_divide` slot.
+
+        Called by `obj /= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_true_divide
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_inplace_true_divide
+        ](self._ptr)
+        return self
+
+    def def_ixor[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ixor__` via the `nb_inplace_xor` slot.
+
+        Called by `obj ^= other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_xor
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.nb_inplace_xor
+        ](self._ptr)
+        return self
+
+    # Non-raising binary overloads
+
+    def def_add[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `nb_add` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_add
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[Self.self_type, method, PySlotIndex.nb_add](
+            self._ptr
+        )
+        return self
+
+    def def_and[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__and__` via the `nb_and` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_and
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[Self.self_type, method, PySlotIndex.nb_and](
+            self._ptr
+        )
+        return self
+
+    def def_divmod[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__divmod__` via the `nb_divmod` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_divmod
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[Self.self_type, method, PySlotIndex.nb_divmod](
+            self._ptr
+        )
+        return self
+
+    def def_floordiv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__floordiv__` via the `nb_floor_divide` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_floor_divide
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_lshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__lshift__` via the `nb_lshift` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_lshift
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[Self.self_type, method, PySlotIndex.nb_lshift](
+            self._ptr
+        )
+        return self
+
+    def def_matmul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__matmul__` via the `nb_matrix_multiply` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_matrix_multiply
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_mod[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mod__` via the `nb_remainder` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_remainder
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_remainder
+        ](self._ptr)
+        return self
+
+    def def_mul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `nb_multiply` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_multiply
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_multiply
+        ](self._ptr)
+        return self
+
+    def def_or[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__or__` via the `nb_or` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_or
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[Self.self_type, method, PySlotIndex.nb_or](
+            self._ptr
+        )
+        return self
+
+    def def_rshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__rshift__` via the `nb_rshift` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_rshift
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[Self.self_type, method, PySlotIndex.nb_rshift](
+            self._ptr
+        )
+        return self
+
+    def def_sub[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__sub__` via the `nb_subtract` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_subtract
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_subtract
+        ](self._ptr)
+        return self
+
+    def def_truediv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__truediv__` via the `nb_true_divide` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_true_divide
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_true_divide
+        ](self._ptr)
+        return self
+
+    def def_xor[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__xor__` via the `nb_xor` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_xor
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[Self.self_type, method, PySlotIndex.nb_xor](
+            self._ptr
+        )
+        return self
+
+    def def_iadd[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `nb_inplace_add` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_add
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_inplace_add
+        ](self._ptr)
+        return self
+
+    def def_iand[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iand__` via the `nb_inplace_and` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_and
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_inplace_and
+        ](self._ptr)
+        return self
+
+    def def_ifloordiv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ifloordiv__` via the `nb_inplace_floor_divide` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_floor_divide
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_inplace_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_ilshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ilshift__` via the `nb_inplace_lshift` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_lshift
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_inplace_lshift
+        ](self._ptr)
+        return self
+
+    def def_imatmul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imatmul__` via the `nb_inplace_matrix_multiply` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_matrix_multiply
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_inplace_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_imod[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imod__` via the `nb_inplace_remainder` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_remainder
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_inplace_remainder
+        ](self._ptr)
+        return self
+
+    def def_imul[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `nb_inplace_multiply` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_multiply
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_inplace_multiply
+        ](self._ptr)
+        return self
+
+    def def_ior[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ior__` via the `nb_inplace_or` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_or
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_inplace_or
+        ](self._ptr)
+        return self
+
+    def def_irshift[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__irshift__` via the `nb_inplace_rshift` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_rshift
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_inplace_rshift
+        ](self._ptr)
+        return self
+
+    def def_isub[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__isub__` via the `nb_inplace_subtract` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_subtract
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_inplace_subtract
+        ](self._ptr)
+        return self
+
+    def def_itruediv[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__itruediv__` via the `nb_inplace_true_divide` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_true_divide
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_inplace_true_divide
+        ](self._ptr)
+        return self
+
+    def def_ixor[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ixor__` via the `nb_inplace_xor` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_xor
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.nb_inplace_xor
+        ](self._ptr)
+        return self
+
+    # Value-receiver binary overloads
+
+    def def_add[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `nb_add` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_add
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[Self.self_type, method, PySlotIndex.nb_add](
+            self._ptr
+        )
+        return self
+
+    def def_and[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__and__` via the `nb_and` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_and
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[Self.self_type, method, PySlotIndex.nb_and](
+            self._ptr
+        )
+        return self
+
+    def def_divmod[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__divmod__` via the `nb_divmod` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_divmod
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[
+            Self.self_type, method, PySlotIndex.nb_divmod
+        ](self._ptr)
+        return self
+
+    def def_floordiv[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__floordiv__` via the `nb_floor_divide` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_floor_divide
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[
+            Self.self_type, method, PySlotIndex.nb_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_lshift[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__lshift__` via the `nb_lshift` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_lshift
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[
+            Self.self_type, method, PySlotIndex.nb_lshift
+        ](self._ptr)
+        return self
+
+    def def_matmul[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__matmul__` via the `nb_matrix_multiply` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_matrix_multiply
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[
+            Self.self_type, method, PySlotIndex.nb_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_mod[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mod__` via the `nb_remainder` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_remainder
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[
+            Self.self_type, method, PySlotIndex.nb_remainder
+        ](self._ptr)
+        return self
+
+    def def_mul[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `nb_multiply` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_multiply
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[
+            Self.self_type, method, PySlotIndex.nb_multiply
+        ](self._ptr)
+        return self
+
+    def def_or[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__or__` via the `nb_or` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_or
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[Self.self_type, method, PySlotIndex.nb_or](
+            self._ptr
+        )
+        return self
+
+    def def_rshift[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__rshift__` via the `nb_rshift` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_rshift
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[
+            Self.self_type, method, PySlotIndex.nb_rshift
+        ](self._ptr)
+        return self
+
+    def def_sub[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__sub__` via the `nb_subtract` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_subtract
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[
+            Self.self_type, method, PySlotIndex.nb_subtract
+        ](self._ptr)
+        return self
+
+    def def_truediv[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__truediv__` via the `nb_true_divide` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_true_divide
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[
+            Self.self_type, method, PySlotIndex.nb_true_divide
+        ](self._ptr)
+        return self
+
+    def def_xor[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__xor__` via the `nb_xor` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_xor
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[Self.self_type, method, PySlotIndex.nb_xor](
+            self._ptr
+        )
+        return self
+
+    # ------------------------------------------------------------------
+    # Ternary slots — C type: ternaryfunc  def(PyObject *, PyObject *, PyObject *) -> PyObject *
+    # `mod` is None unless pow(base, exp, mod) was called.
+    # Raise NotImplementedError() to return Py_NotImplemented.
+    # ------------------------------------------------------------------
+
+    def def_pow[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__pow__` via the `nb_power` slot.
+
+        Called by `obj ** exp`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_power
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ternary[Self.self_type, method, PySlotIndex.nb_power](
+            self._ptr
+        )
+        return self
+
+    def def_ipow[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ipow__` via the `nb_inplace_power` slot.
+
+        Called by `obj **= exp`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_power
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ternary[
+            Self.self_type, method, PySlotIndex.nb_inplace_power
+        ](self._ptr)
+        return self
+
+    # Non-raising ternary overloads
+
+    def def_pow[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__pow__` via the `nb_power` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_power
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ternary_nr[Self.self_type, method, PySlotIndex.nb_power](
+            self._ptr
+        )
+        return self
+
+    def def_ipow[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ipow__` via the `nb_inplace_power` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_power
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ternary_nr[
+            Self.self_type, method, PySlotIndex.nb_inplace_power
+        ](self._ptr)
+        return self
+
+    def def_pow[
+        method: def(
+            Self.self_type, PythonObject, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__pow__` via the `nb_power` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_power
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ternary_val[
+            Self.self_type, method, PySlotIndex.nb_power
+        ](self._ptr)
+        return self
+
+    # Mut-receiver overloads
+
+    def def_iadd[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `nb_inplace_add` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_add
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_mut[
+            Self.self_type, method, PySlotIndex.nb_inplace_add
+        ](self._ptr)
+        return self
+
+    def def_iand[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iand__` via the `nb_inplace_and` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_and
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_mut[
+            Self.self_type, method, PySlotIndex.nb_inplace_and
+        ](self._ptr)
+        return self
+
+    def def_ifloordiv[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ifloordiv__` via the `nb_inplace_floor_divide` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_floor_divide
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_mut[
+            Self.self_type, method, PySlotIndex.nb_inplace_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_ilshift[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ilshift__` via the `nb_inplace_lshift` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_lshift
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_mut[
+            Self.self_type, method, PySlotIndex.nb_inplace_lshift
+        ](self._ptr)
+        return self
+
+    def def_imatmul[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imatmul__` via the `nb_inplace_matrix_multiply` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_matrix_multiply
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_mut[
+            Self.self_type, method, PySlotIndex.nb_inplace_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_imod[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imod__` via the `nb_inplace_remainder` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_remainder
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_mut[
+            Self.self_type, method, PySlotIndex.nb_inplace_remainder
+        ](self._ptr)
+        return self
+
+    def def_imul[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `nb_inplace_multiply` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_multiply
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_mut[
+            Self.self_type, method, PySlotIndex.nb_inplace_multiply
+        ](self._ptr)
+        return self
+
+    def def_ior[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ior__` via the `nb_inplace_or` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_or
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_mut[
+            Self.self_type, method, PySlotIndex.nb_inplace_or
+        ](self._ptr)
+        return self
+
+    def def_irshift[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__irshift__` via the `nb_inplace_rshift` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_rshift
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_mut[
+            Self.self_type, method, PySlotIndex.nb_inplace_rshift
+        ](self._ptr)
+        return self
+
+    def def_isub[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__isub__` via the `nb_inplace_subtract` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_subtract
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_mut[
+            Self.self_type, method, PySlotIndex.nb_inplace_subtract
+        ](self._ptr)
+        return self
+
+    def def_itruediv[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__itruediv__` via the `nb_inplace_true_divide` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_true_divide
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_mut[
+            Self.self_type, method, PySlotIndex.nb_inplace_true_divide
+        ](self._ptr)
+        return self
+
+    def def_ixor[
+        method: def(
+            mut Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ixor__` via the `nb_inplace_xor` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_xor
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_mut[
+            Self.self_type, method, PySlotIndex.nb_inplace_xor
+        ](self._ptr)
+        return self
+
+    def def_ipow[
+        method: def(
+            mut Self.self_type, PythonObject, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__ipow__` via the `nb_inplace_power` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_power
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ternary_mut[
+            Self.self_type, method, PySlotIndex.nb_inplace_power
+        ](self._ptr)
+        return self
+
+    # ConvertibleToPython return overloads
+
+    def def_abs[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__abs__` via the `nb_absolute` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_absolute
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_absolute
+        ](self._ptr)
+        return self
+
+    def def_abs[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__abs__` via the `nb_absolute` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_absolute
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_absolute
+        ](self._ptr)
+        return self
+
+    def def_abs[
+        R: _CPython,
+        method: def(Self.self_type) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__abs__` via the `nb_absolute` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_absolute
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_absolute
+        ](self._ptr)
+        return self
+
+    def def_float[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__float__` via the `nb_float` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_float
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_float
+        ](self._ptr)
+        return self
+
+    def def_float[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__float__` via the `nb_float` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_float
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_float
+        ](self._ptr)
+        return self
+
+    def def_float[
+        R: _CPython,
+        method: def(Self.self_type) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__float__` via the `nb_float` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_float
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_float
+        ](self._ptr)
+        return self
+
+    def def_index[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__index__` via the `nb_index` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_index
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_index
+        ](self._ptr)
+        return self
+
+    def def_index[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__index__` via the `nb_index` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_index
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_index
+        ](self._ptr)
+        return self
+
+    def def_index[
+        R: _CPython,
+        method: def(Self.self_type) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__index__` via the `nb_index` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_index
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_index
+        ](self._ptr)
+        return self
+
+    def def_int[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__int__` via the `nb_int` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_int
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_int
+        ](self._ptr)
+        return self
+
+    def def_int[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__int__` via the `nb_int` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_int
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_int
+        ](self._ptr)
+        return self
+
+    def def_int[
+        R: _CPython,
+        method: def(Self.self_type) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__int__` via the `nb_int` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_int
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_int
+        ](self._ptr)
+        return self
+
+    def def_invert[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__invert__` via the `nb_invert` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_invert
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_invert
+        ](self._ptr)
+        return self
+
+    def def_invert[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__invert__` via the `nb_invert` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_invert
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_invert
+        ](self._ptr)
+        return self
+
+    def def_invert[
+        R: _CPython,
+        method: def(Self.self_type) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__invert__` via the `nb_invert` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_invert
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_invert
+        ](self._ptr)
+        return self
+
+    def def_neg[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__neg__` via the `nb_negative` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_negative
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_negative
+        ](self._ptr)
+        return self
+
+    def def_neg[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__neg__` via the `nb_negative` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_negative
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_negative
+        ](self._ptr)
+        return self
+
+    def def_neg[
+        R: _CPython,
+        method: def(Self.self_type) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__neg__` via the `nb_negative` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_negative
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_negative
+        ](self._ptr)
+        return self
+
+    def def_pos[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__pos__` via the `nb_positive` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_positive
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_positive
+        ](self._ptr)
+        return self
+
+    def def_pos[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__pos__` via the `nb_positive` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_positive
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_positive
+        ](self._ptr)
+        return self
+
+    def def_pos[
+        R: _CPython,
+        method: def(Self.self_type) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__pos__` via the `nb_positive` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_positive
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.unary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_positive
+        ](self._ptr)
+        return self
+
+    def def_add[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `nb_add` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_add
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_add
+        ](self._ptr)
+        return self
+
+    def def_add[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `nb_add` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_add
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_add
+        ](self._ptr)
+        return self
+
+    def def_add[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `nb_add` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_add
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_add
+        ](self._ptr)
+        return self
+
+    def def_and[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__and__` via the `nb_and` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_and
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_and
+        ](self._ptr)
+        return self
+
+    def def_and[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__and__` via the `nb_and` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_and
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_and
+        ](self._ptr)
+        return self
+
+    def def_and[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__and__` via the `nb_and` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_and
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_and
+        ](self._ptr)
+        return self
+
+    def def_divmod[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__divmod__` via the `nb_divmod` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_divmod
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_divmod
+        ](self._ptr)
+        return self
+
+    def def_divmod[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__divmod__` via the `nb_divmod` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_divmod
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_divmod
+        ](self._ptr)
+        return self
+
+    def def_divmod[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__divmod__` via the `nb_divmod` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_divmod
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_divmod
+        ](self._ptr)
+        return self
+
+    def def_floordiv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__floordiv__` via the `nb_floor_divide` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_floor_divide
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_floordiv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__floordiv__` via the `nb_floor_divide` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_floor_divide
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_floordiv[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__floordiv__` via the `nb_floor_divide` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_floor_divide
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_lshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__lshift__` via the `nb_lshift` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_lshift
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_lshift
+        ](self._ptr)
+        return self
+
+    def def_lshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__lshift__` via the `nb_lshift` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_lshift
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_lshift
+        ](self._ptr)
+        return self
+
+    def def_lshift[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__lshift__` via the `nb_lshift` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_lshift
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_lshift
+        ](self._ptr)
+        return self
+
+    def def_matmul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__matmul__` via the `nb_matrix_multiply` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_matrix_multiply
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_matmul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__matmul__` via the `nb_matrix_multiply` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_matrix_multiply
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_matmul[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__matmul__` via the `nb_matrix_multiply` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_matrix_multiply
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_mod[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mod__` via the `nb_remainder` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_remainder
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_remainder
+        ](self._ptr)
+        return self
+
+    def def_mod[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mod__` via the `nb_remainder` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_remainder
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_remainder
+        ](self._ptr)
+        return self
+
+    def def_mod[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mod__` via the `nb_remainder` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_remainder
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_remainder
+        ](self._ptr)
+        return self
+
+    def def_mul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `nb_multiply` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_multiply
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_multiply
+        ](self._ptr)
+        return self
+
+    def def_mul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `nb_multiply` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_multiply
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_multiply
+        ](self._ptr)
+        return self
+
+    def def_mul[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `nb_multiply` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_multiply
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_multiply
+        ](self._ptr)
+        return self
+
+    def def_or[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__or__` via the `nb_or` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_or
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_or
+        ](self._ptr)
+        return self
+
+    def def_or[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__or__` via the `nb_or` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_or
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_or
+        ](self._ptr)
+        return self
+
+    def def_or[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__or__` via the `nb_or` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_or
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_or
+        ](self._ptr)
+        return self
+
+    def def_rshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__rshift__` via the `nb_rshift` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_rshift
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_rshift
+        ](self._ptr)
+        return self
+
+    def def_rshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__rshift__` via the `nb_rshift` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_rshift
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_rshift
+        ](self._ptr)
+        return self
+
+    def def_rshift[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__rshift__` via the `nb_rshift` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_rshift
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_rshift
+        ](self._ptr)
+        return self
+
+    def def_sub[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__sub__` via the `nb_subtract` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_subtract
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_subtract
+        ](self._ptr)
+        return self
+
+    def def_sub[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__sub__` via the `nb_subtract` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_subtract
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_subtract
+        ](self._ptr)
+        return self
+
+    def def_sub[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__sub__` via the `nb_subtract` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_subtract
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_subtract
+        ](self._ptr)
+        return self
+
+    def def_truediv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__truediv__` via the `nb_true_divide` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_true_divide
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_true_divide
+        ](self._ptr)
+        return self
+
+    def def_truediv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__truediv__` via the `nb_true_divide` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_true_divide
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_true_divide
+        ](self._ptr)
+        return self
+
+    def def_truediv[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__truediv__` via the `nb_true_divide` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_true_divide
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_true_divide
+        ](self._ptr)
+        return self
+
+    def def_xor[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__xor__` via the `nb_xor` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_xor
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_xor
+        ](self._ptr)
+        return self
+
+    def def_xor[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__xor__` via the `nb_xor` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_xor
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_xor
+        ](self._ptr)
+        return self
+
+    def def_xor[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__xor__` via the `nb_xor` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_xor
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_xor
+        ](self._ptr)
+        return self
+
+    def def_iadd[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `nb_inplace_add` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_add
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_add
+        ](self._ptr)
+        return self
+
+    def def_iadd[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `nb_inplace_add` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_add
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_add
+        ](self._ptr)
+        return self
+
+    def def_iadd[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `nb_inplace_add` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_add
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_add
+        ](self._ptr)
+        return self
+
+    def def_iand[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iand__` via the `nb_inplace_and` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_and
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_and
+        ](self._ptr)
+        return self
+
+    def def_iand[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iand__` via the `nb_inplace_and` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_and
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_and
+        ](self._ptr)
+        return self
+
+    def def_iand[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iand__` via the `nb_inplace_and` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_and
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_and
+        ](self._ptr)
+        return self
+
+    def def_ifloordiv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ifloordiv__` via the `nb_inplace_floor_divide` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_floor_divide
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_ifloordiv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ifloordiv__` via the `nb_inplace_floor_divide` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_floor_divide
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_ifloordiv[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ifloordiv__` via the `nb_inplace_floor_divide` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_floor_divide
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_floor_divide
+        ](self._ptr)
+        return self
+
+    def def_ilshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ilshift__` via the `nb_inplace_lshift` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_lshift
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_lshift
+        ](self._ptr)
+        return self
+
+    def def_ilshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ilshift__` via the `nb_inplace_lshift` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_lshift
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_lshift
+        ](self._ptr)
+        return self
+
+    def def_ilshift[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ilshift__` via the `nb_inplace_lshift` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_lshift
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_lshift
+        ](self._ptr)
+        return self
+
+    def def_imatmul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imatmul__` via the `nb_inplace_matrix_multiply` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_matrix_multiply
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_imatmul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imatmul__` via the `nb_inplace_matrix_multiply` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_matrix_multiply
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_imatmul[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imatmul__` via the `nb_inplace_matrix_multiply` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_matrix_multiply
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_matrix_multiply
+        ](self._ptr)
+        return self
+
+    def def_imod[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imod__` via the `nb_inplace_remainder` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_remainder
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_remainder
+        ](self._ptr)
+        return self
+
+    def def_imod[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imod__` via the `nb_inplace_remainder` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_remainder
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_remainder
+        ](self._ptr)
+        return self
+
+    def def_imod[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imod__` via the `nb_inplace_remainder` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_remainder
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_remainder
+        ](self._ptr)
+        return self
+
+    def def_imul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `nb_inplace_multiply` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_multiply
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_multiply
+        ](self._ptr)
+        return self
+
+    def def_imul[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `nb_inplace_multiply` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_multiply
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_multiply
+        ](self._ptr)
+        return self
+
+    def def_imul[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `nb_inplace_multiply` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_multiply
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_multiply
+        ](self._ptr)
+        return self
+
+    def def_ior[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ior__` via the `nb_inplace_or` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_or
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_or
+        ](self._ptr)
+        return self
+
+    def def_ior[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ior__` via the `nb_inplace_or` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_or
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_or
+        ](self._ptr)
+        return self
+
+    def def_ior[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ior__` via the `nb_inplace_or` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_or
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_or
+        ](self._ptr)
+        return self
+
+    def def_irshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__irshift__` via the `nb_inplace_rshift` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_rshift
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_rshift
+        ](self._ptr)
+        return self
+
+    def def_irshift[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__irshift__` via the `nb_inplace_rshift` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_rshift
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_rshift
+        ](self._ptr)
+        return self
+
+    def def_irshift[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__irshift__` via the `nb_inplace_rshift` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_rshift
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_rshift
+        ](self._ptr)
+        return self
+
+    def def_isub[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__isub__` via the `nb_inplace_subtract` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_subtract
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_subtract
+        ](self._ptr)
+        return self
+
+    def def_isub[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__isub__` via the `nb_inplace_subtract` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_subtract
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_subtract
+        ](self._ptr)
+        return self
+
+    def def_isub[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__isub__` via the `nb_inplace_subtract` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_subtract
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_subtract
+        ](self._ptr)
+        return self
+
+    def def_itruediv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__itruediv__` via the `nb_inplace_true_divide` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_true_divide
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_true_divide
+        ](self._ptr)
+        return self
+
+    def def_itruediv[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__itruediv__` via the `nb_inplace_true_divide` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_true_divide
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_true_divide
+        ](self._ptr)
+        return self
+
+    def def_itruediv[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__itruediv__` via the `nb_inplace_true_divide` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_true_divide
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_true_divide
+        ](self._ptr)
+        return self
+
+    def def_ixor[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ixor__` via the `nb_inplace_xor` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_xor
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_xor
+        ](self._ptr)
+        return self
+
+    def def_ixor[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ixor__` via the `nb_inplace_xor` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_xor
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_xor
+        ](self._ptr)
+        return self
+
+    def def_ixor[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ixor__` via the `nb_inplace_xor` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_xor
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_xor
+        ](self._ptr)
+        return self
+
+    def def_pow[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__pow__` via the `nb_power` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_power
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ternary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_power
+        ](self._ptr)
+        return self
+
+    def def_pow[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__pow__` via the `nb_power` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_power
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ternary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_power
+        ](self._ptr)
+        return self
+
+    def def_pow[
+        R: _CPython,
+        method: def(
+            Self.self_type, PythonObject, PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__pow__` via the `nb_power` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_power
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ternary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_power
+        ](self._ptr)
+        return self
+
+    def def_ipow[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ipow__` via the `nb_inplace_power` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_power
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ternary_conv_r[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_power
+        ](self._ptr)
+        return self
+
+    def def_ipow[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            PythonObject,
+            PythonObject,
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ipow__` via the `nb_inplace_power` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_power
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ternary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_power
+        ](self._ptr)
+        return self
+
+    def def_ipow[
+        R: _CPython,
+        method: def(
+            Self.self_type, PythonObject, PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__ipow__` via the `nb_inplace_power` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyNumberMethods.nb_inplace_power
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ternary_conv_val[
+            Self.self_type, R, method, PySlotIndex.nb_inplace_power
+        ](self._ptr)
+        return self

--- a/mojo/stdlib/std/python/sequence.mojo
+++ b/mojo/stdlib/std/python/sequence.mojo
@@ -1,0 +1,694 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.memory import OpaquePointer, UnsafePointer
+from std.python import PythonObject
+from std.python._cpython import PyObjectPtr, Py_ssize_t, PyType_Slot
+from std.python.bindings import PythonTypeBuilder
+from std.utils import Variant
+
+from .adapters import (
+    _CPython,
+    _PySlotIndex,
+    _conv_ptr_nr_int_arg,
+    _conv_ptr_r_int_arg,
+    _conv_val_r_int_arg,
+    _install_binary,
+    _install_binary_conv_nr,
+    _install_binary_conv_r,
+    _install_binary_conv_val,
+    _install_binary_nr,
+    _install_binary_val,
+    _install_objobjproc,
+    _install_ssizeargfunc,
+    _install_ssizeobjargproc,
+    _lift_int_to_obj,
+    _lift_int_var_to_none,
+    _lift_mut_int_var_to_none,
+    _lift_obj_to_bool,
+    _lift_to_int,
+    _lift_val_int_to_obj,
+    _lift_val_int_var_to_none,
+    _lift_val_obj_to_bool,
+    _lift_val_to_int,
+    _mp_length_wrapper,
+)
+
+
+struct SequenceProtocolBuilder[self_type: ImplicitlyDestructible]:
+    """Installs CPython sequence protocol slots on a `PythonTypeBuilder`.
+
+    Construct directly from a `PythonTypeBuilder`.  Method names follow the
+    corresponding Python dunders.
+    Handler functions receive `UnsafePointer[T, MutAnyOrigin]` as their first
+    argument instead of a raw `PythonObject`.
+
+    `def_getitem`, `def_repeat`, and `def_irepeat` use `ssizeargfunc`
+    (integer index/count), unlike the mapping protocol which uses a
+    `PythonObject` key.  `def_contains` uses `objobjproc`.
+
+    Usage:
+        ```mojo
+        var spb = SequenceProtocolBuilder[MyStruct](tb)
+        spb.def_len[MyStruct.py__len__]()
+           .def_getitem[MyStruct.py__getitem__]()
+           .def_contains[MyStruct.py__contains__]()
+        ```
+    """
+
+    var _ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]
+
+    def __init__(out self, mut inner: PythonTypeBuilder):
+        self._ptr = UnsafePointer(to=inner)
+
+    def __init__(
+        out self,
+        ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin],
+    ):
+        self._ptr = ptr
+
+    def def_len[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises -> Int
+    ](mut self) -> ref[self] Self:
+        """Install `__len__` via the `sq_length` slot.
+
+        Called by `len(obj)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_length
+        """
+        comptime _lenfunc = def(PyObjectPtr) thin abi("C") -> Py_ssize_t
+        var fn_ptr: _lenfunc = _mp_length_wrapper[Self.self_type, method]
+        self._ptr[]._insert_slot(
+            PyType_Slot(
+                _PySlotIndex.sq_length,
+                rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+            )
+        )
+        return self
+
+    def def_getitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `sq_item` slot (integer index).
+
+        Called by `obj[index]`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_item
+        """
+        _install_ssizeargfunc[Self.self_type, method, _PySlotIndex.sq_item](
+            self._ptr
+        )
+        return self
+
+    def def_setitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            Int,
+            Variant[PythonObject, Int],
+        ) thin raises -> None
+    ](mut self) -> ref[self] Self:
+        """Install `__setitem__`/`__delitem__` via the `sq_ass_item` slot.
+
+        Called by `obj[index] = value` or `del obj[index]`.
+
+        The third argument to `method` is a `Variant`:
+        - `Variant[PythonObject, Int](value)` for assignment.
+        - `Variant[PythonObject, Int](Int(0))` for deletion (null C pointer).
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_ass_item
+        """
+        _install_ssizeobjargproc[Self.self_type, method](self._ptr)
+        return self
+
+    def def_contains[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install `__contains__` via the `sq_contains` slot.
+
+        Called by `item in obj`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_contains
+        """
+        _install_objobjproc[Self.self_type, method, _PySlotIndex.sq_contains](
+            self._ptr
+        )
+        return self
+
+    def def_concat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` (concatenation) via the `sq_concat` slot.
+
+        Called by `obj + other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_concat
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.sq_concat](
+            self._ptr
+        )
+        return self
+
+    def def_repeat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` (repetition) via the `sq_repeat` slot.
+
+        Called by `obj * count`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_repeat
+        """
+        _install_ssizeargfunc[Self.self_type, method, _PySlotIndex.sq_repeat](
+            self._ptr
+        )
+        return self
+
+    def def_iconcat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` (in-place concatenation) via the `sq_inplace_concat` slot.
+
+        Called by `obj += other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_concat
+        """
+        _install_binary[Self.self_type, method, _PySlotIndex.sq_inplace_concat](
+            self._ptr
+        )
+        return self
+
+    def def_irepeat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` (in-place repetition) via the `sq_inplace_repeat` slot.
+
+        Called by `obj *= count`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_repeat
+        """
+        _install_ssizeargfunc[
+            Self.self_type, method, _PySlotIndex.sq_inplace_repeat
+        ](self._ptr)
+        return self
+
+    # Non-raising overloads
+
+    def def_len[
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> Int
+    ](mut self) -> ref[self] Self:
+        """Install `__len__` via the `sq_length` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_length
+        """
+        comptime _lenfunc = def(PyObjectPtr) thin abi("C") -> Py_ssize_t
+        var fn_ptr: _lenfunc = _mp_length_wrapper[
+            Self.self_type, _lift_to_int[Self.self_type, method]
+        ]
+        self._ptr[]._insert_slot(
+            PyType_Slot(
+                _PySlotIndex.sq_length,
+                rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+            )
+        )
+        return self
+
+    def def_getitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `sq_item` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_item
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _lift_int_to_obj[Self.self_type, method],
+            _PySlotIndex.sq_item,
+        ](self._ptr)
+        return self
+
+    def def_setitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            Int,
+            Variant[PythonObject, Int],
+        ) thin -> None
+    ](mut self) -> ref[self] Self:
+        """Install `__setitem__`/`__delitem__` via the `sq_ass_item` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_ass_item
+        """
+        _install_ssizeobjargproc[
+            Self.self_type, _lift_int_var_to_none[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_contains[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install `__contains__` via the `sq_contains` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_contains
+        """
+        _install_objobjproc[
+            Self.self_type,
+            _lift_obj_to_bool[Self.self_type, method],
+            _PySlotIndex.sq_contains,
+        ](self._ptr)
+        return self
+
+    def def_concat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` (concatenation) via the `sq_concat` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_concat
+        """
+        _install_binary_nr[Self.self_type, method, _PySlotIndex.sq_concat](
+            self._ptr
+        )
+        return self
+
+    def def_repeat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` (repetition) via the `sq_repeat` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_repeat
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _lift_int_to_obj[Self.self_type, method],
+            _PySlotIndex.sq_repeat,
+        ](self._ptr)
+        return self
+
+    def def_iconcat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` (in-place concatenation) via the `sq_inplace_concat` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_concat
+        """
+        _install_binary_nr[
+            Self.self_type, method, _PySlotIndex.sq_inplace_concat
+        ](self._ptr)
+        return self
+
+    def def_irepeat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` (in-place repetition) via the `sq_inplace_repeat` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_repeat
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _lift_int_to_obj[Self.self_type, method],
+            _PySlotIndex.sq_inplace_repeat,
+        ](self._ptr)
+        return self
+
+    # Value-receiver overloads
+
+    def def_len[
+        method: def(Self.self_type) thin raises -> Int
+    ](mut self) -> ref[self] Self:
+        """Install `__len__` via the `sq_length` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_length
+        """
+        comptime _lenfunc = def(PyObjectPtr) thin abi("C") -> Py_ssize_t
+        var fn_ptr: _lenfunc = _mp_length_wrapper[
+            Self.self_type, _lift_val_to_int[Self.self_type, method]
+        ]
+        self._ptr[]._insert_slot(
+            PyType_Slot(
+                _PySlotIndex.sq_length,
+                rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+            )
+        )
+        return self
+
+    def def_getitem[
+        method: def(Self.self_type, Int) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `sq_item` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_item
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _lift_val_int_to_obj[Self.self_type, method],
+            _PySlotIndex.sq_item,
+        ](self._ptr)
+        return self
+
+    def def_setitem[
+        method: def(
+            Self.self_type, Int, Variant[PythonObject, Int]
+        ) thin raises -> None
+    ](mut self) -> ref[self] Self:
+        """Install `__setitem__`/`__delitem__` via the `sq_ass_item` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_ass_item
+        """
+        _install_ssizeobjargproc[
+            Self.self_type, _lift_val_int_var_to_none[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_setitem[
+        method: def(
+            mut Self.self_type, Int, Variant[PythonObject, Int]
+        ) thin raises -> None
+    ](mut self) -> ref[self] Self:
+        """Install `__setitem__`/`__delitem__` via the `sq_ass_item` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_ass_item
+        """
+        _install_ssizeobjargproc[
+            Self.self_type, _lift_mut_int_var_to_none[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_contains[
+        method: def(Self.self_type, PythonObject) thin raises -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install `__contains__` via the `sq_contains` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_contains
+        """
+        _install_objobjproc[
+            Self.self_type,
+            _lift_val_obj_to_bool[Self.self_type, method],
+            _PySlotIndex.sq_contains,
+        ](self._ptr)
+        return self
+
+    def def_concat[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` (concatenation) via the `sq_concat` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_concat
+        """
+        _install_binary_val[Self.self_type, method, _PySlotIndex.sq_concat](
+            self._ptr
+        )
+        return self
+
+    def def_repeat[
+        method: def(Self.self_type, Int) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` (repetition) via the `sq_repeat` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_repeat
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _lift_val_int_to_obj[Self.self_type, method],
+            _PySlotIndex.sq_repeat,
+        ](self._ptr)
+        return self
+
+    def def_iconcat[
+        method: def(Self.self_type, PythonObject) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` (in-place concatenation) via the `sq_inplace_concat` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_concat
+        """
+        _install_binary_val[
+            Self.self_type, method, _PySlotIndex.sq_inplace_concat
+        ](self._ptr)
+        return self
+
+    def def_irepeat[
+        method: def(Self.self_type, Int) thin raises -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` (in-place repetition) via the `sq_inplace_repeat` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_repeat
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _lift_val_int_to_obj[Self.self_type, method],
+            _PySlotIndex.sq_inplace_repeat,
+        ](self._ptr)
+        return self
+
+    # ConvertibleToPython return overloads
+
+    def def_getitem[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `sq_item` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_item
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _conv_ptr_r_int_arg[Self.self_type, R, method],
+            _PySlotIndex.sq_item,
+        ](self._ptr)
+        return self
+
+    def def_getitem[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin], Int) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `sq_item` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_item
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _conv_ptr_nr_int_arg[Self.self_type, R, method],
+            _PySlotIndex.sq_item,
+        ](self._ptr)
+        return self
+
+    def def_getitem[
+        R: _CPython,
+        method: def(Self.self_type, Int) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `sq_item` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_item
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _conv_val_r_int_arg[Self.self_type, R, method],
+            _PySlotIndex.sq_item,
+        ](self._ptr)
+        return self
+
+    def def_concat[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `sq_concat` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_concat
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.sq_concat
+        ](self._ptr)
+        return self
+
+    def def_concat[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `sq_concat` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_concat
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.sq_concat
+        ](self._ptr)
+        return self
+
+    def def_concat[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `sq_concat` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_concat
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.sq_concat
+        ](self._ptr)
+        return self
+
+    def def_repeat[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `sq_repeat` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_repeat
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _conv_ptr_r_int_arg[Self.self_type, R, method],
+            _PySlotIndex.sq_repeat,
+        ](self._ptr)
+        return self
+
+    def def_repeat[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin], Int) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `sq_repeat` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_repeat
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _conv_ptr_nr_int_arg[Self.self_type, R, method],
+            _PySlotIndex.sq_repeat,
+        ](self._ptr)
+        return self
+
+    def def_repeat[
+        R: _CPython,
+        method: def(Self.self_type, Int) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `sq_repeat` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_repeat
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _conv_val_r_int_arg[Self.self_type, R, method],
+            _PySlotIndex.sq_repeat,
+        ](self._ptr)
+        return self
+
+    def def_iconcat[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `sq_inplace_concat` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_concat
+        """
+        _install_binary_conv_r[
+            Self.self_type, R, method, _PySlotIndex.sq_inplace_concat
+        ](self._ptr)
+        return self
+
+    def def_iconcat[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `sq_inplace_concat` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_concat
+        """
+        _install_binary_conv_nr[
+            Self.self_type, R, method, _PySlotIndex.sq_inplace_concat
+        ](self._ptr)
+        return self
+
+    def def_iconcat[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `sq_inplace_concat` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_concat
+        """
+        _install_binary_conv_val[
+            Self.self_type, R, method, _PySlotIndex.sq_inplace_concat
+        ](self._ptr)
+        return self
+
+    def def_irepeat[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `sq_inplace_repeat` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_repeat
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _conv_ptr_r_int_arg[Self.self_type, R, method],
+            _PySlotIndex.sq_inplace_repeat,
+        ](self._ptr)
+        return self
+
+    def def_irepeat[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin], Int) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `sq_inplace_repeat` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_repeat
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _conv_ptr_nr_int_arg[Self.self_type, R, method],
+            _PySlotIndex.sq_inplace_repeat,
+        ](self._ptr)
+        return self
+
+    def def_irepeat[
+        R: _CPython,
+        method: def(Self.self_type, Int) thin raises -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `sq_inplace_repeat` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_repeat
+        """
+        _install_ssizeargfunc[
+            Self.self_type,
+            _conv_val_r_int_arg[Self.self_type, R, method],
+            _PySlotIndex.sq_inplace_repeat,
+        ](self._ptr)
+        return self

--- a/mojo/stdlib/std/python/sequence.mojo
+++ b/mojo/stdlib/std/python/sequence.mojo
@@ -1,0 +1,979 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Implements the CPython sequence-protocol builder.
+
+Provides `SequenceProtocolBuilder`, which installs the `sq_*` slots on a
+`PythonTypeBuilder` so a Mojo struct can implement Python's sequence
+dunders (`__len__`, `__getitem__`, `__setitem__`, `__contains__`,
+`__add__`, `__mul__`, etc.).
+"""
+
+from std.memory import OpaquePointer, UnsafePointer
+from std.python import PythonObject
+from std.python._cpython import (
+    PyObjectPtr,
+    Py_ssize_t,
+    PySlotIndex,
+    PyType_Slot,
+)
+from std.python.bindings import PythonTypeBuilder
+from std.utils import Variant
+
+from .utils import PySlotError
+
+from .adapters import (
+    _CPython,
+    _SlotInstaller,
+    _conv_ptr_nr_int_arg,
+    _conv_ptr_r_int_arg,
+    _conv_val_r_int_arg,
+    _lift_int_to_obj,
+    _lift_int_var_to_none,
+    _lift_mut_int_var_to_none,
+    _lift_obj_to_bool,
+    _lift_to_int,
+    _lift_val_int_to_obj,
+    _lift_val_int_var_to_none,
+    _lift_val_obj_to_bool,
+    _lift_val_to_int,
+    _mp_length_wrapper,
+)
+
+
+struct SequenceProtocolBuilder[self_type: ImplicitlyDestructible]:
+    """Installs CPython sequence protocol slots on a `PythonTypeBuilder`.
+
+    Construct directly from a `PythonTypeBuilder`.  Method names follow the
+    corresponding Python dunders.
+    Handler functions receive `UnsafePointer[T, MutAnyOrigin]` as their first
+    argument instead of a raw `PythonObject`.
+
+    `def_getitem`, `def_repeat`, and `def_irepeat` use `ssizeargfunc`
+    (integer index/count), unlike the mapping protocol which uses a
+    `PythonObject` key.  `def_contains` uses `objobjproc`.
+
+    Usage:
+        ```mojo
+        var spb = SequenceProtocolBuilder[MyStruct](tb)
+        spb.def_len[MyStruct.py__len__]()
+           .def_getitem[MyStruct.py__getitem__]()
+           .def_contains[MyStruct.py__contains__]()
+        ```
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+    """
+
+    var _ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]
+
+    def __init__(out self, mut inner: PythonTypeBuilder):
+        """Initialize from a `PythonTypeBuilder` reference.
+
+        Args:
+            inner: The `PythonTypeBuilder` to wrap.
+        """
+        self._ptr = UnsafePointer(to=inner)
+
+    def __init__(
+        out self,
+        ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin],
+    ):
+        """Initialize from a raw pointer to a `PythonTypeBuilder`.
+
+        Args:
+            ptr: Pointer to the `PythonTypeBuilder` to wrap.
+        """
+        self._ptr = ptr
+
+    def def_len[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin]
+        ) thin raises PySlotError -> Int
+    ](mut self) -> ref[self] Self:
+        """Install `__len__` via the `sq_length` slot.
+
+        Called by `len(obj)`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_length
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        comptime _lenfunc = def(PyObjectPtr) thin abi("C") -> Py_ssize_t
+        var fn_ptr: _lenfunc = _mp_length_wrapper[Self.self_type, method]
+        self._ptr[]._insert_slot(
+            PyType_Slot(
+                PySlotIndex.sq_length,
+                rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+            )
+        )
+        return self
+
+    def def_getitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `sq_item` slot (integer index).
+
+        Called by `obj[index]`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_item
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type, method, PySlotIndex.sq_item
+        ](self._ptr)
+        return self
+
+    def def_setitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            Int,
+            Variant[PythonObject, Int],
+        ) thin raises PySlotError -> None
+    ](mut self) -> ref[self] Self:
+        """Install `__setitem__`/`__delitem__` via the `sq_ass_item` slot.
+
+        Called by `obj[index] = value` or `del obj[index]`.
+
+        The third argument to `method` is a `Variant`:
+        - `Variant[PythonObject, Int](value)` for assignment.
+        - `Variant[PythonObject, Int](Int(0))` for deletion (null C pointer).
+
+        `method` declares `raises PySlotError`; raise a variant such as
+        `PySlotError.index_error(...)` or `PySlotError.type_error(...)` and
+        the wrapper maps it to the corresponding Python exception.
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_ass_item
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeobjargproc[Self.self_type, method](self._ptr)
+        return self
+
+    def def_contains[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install `__contains__` via the `sq_contains` slot.
+
+        Called by `item in obj`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_contains
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.objobjproc[
+            Self.self_type, method, PySlotIndex.sq_contains
+        ](self._ptr)
+        return self
+
+    def def_concat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` (concatenation) via the `sq_concat` slot.
+
+        Called by `obj + other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_concat
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[Self.self_type, method, PySlotIndex.sq_concat](
+            self._ptr
+        )
+        return self
+
+    def def_repeat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` (repetition) via the `sq_repeat` slot.
+
+        Called by `obj * count`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_repeat
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type, method, PySlotIndex.sq_repeat
+        ](self._ptr)
+        return self
+
+    def def_iconcat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` (in-place concatenation) via the `sq_inplace_concat` slot.
+
+        Called by `obj += other`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_concat
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary[
+            Self.self_type, method, PySlotIndex.sq_inplace_concat
+        ](self._ptr)
+        return self
+
+    def def_irepeat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` (in-place repetition) via the `sq_inplace_repeat` slot.
+
+        Called by `obj *= count`.
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_repeat
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type, method, PySlotIndex.sq_inplace_repeat
+        ](self._ptr)
+        return self
+
+    # Non-raising overloads
+
+    def def_len[
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin]) thin -> Int
+    ](mut self) -> ref[self] Self:
+        """Install `__len__` via the `sq_length` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_length
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        comptime _lenfunc = def(PyObjectPtr) thin abi("C") -> Py_ssize_t
+        var fn_ptr: _lenfunc = _mp_length_wrapper[
+            Self.self_type, _lift_to_int[Self.self_type, method]
+        ]
+        self._ptr[]._insert_slot(
+            PyType_Slot(
+                PySlotIndex.sq_length,
+                rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+            )
+        )
+        return self
+
+    def def_getitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `sq_item` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_item
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _lift_int_to_obj[Self.self_type, method],
+            PySlotIndex.sq_item,
+        ](self._ptr)
+        return self
+
+    def def_setitem[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin],
+            Int,
+            Variant[PythonObject, Int],
+        ) thin -> None
+    ](mut self) -> ref[self] Self:
+        """Install `__setitem__`/`__delitem__` via the `sq_ass_item` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_ass_item
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeobjargproc[
+            Self.self_type, _lift_int_var_to_none[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_contains[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install `__contains__` via the `sq_contains` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_contains
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.objobjproc[
+            Self.self_type,
+            _lift_obj_to_bool[Self.self_type, method],
+            PySlotIndex.sq_contains,
+        ](self._ptr)
+        return self
+
+    def def_concat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` (concatenation) via the `sq_concat` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_concat
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[Self.self_type, method, PySlotIndex.sq_concat](
+            self._ptr
+        )
+        return self
+
+    def def_repeat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` (repetition) via the `sq_repeat` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_repeat
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _lift_int_to_obj[Self.self_type, method],
+            PySlotIndex.sq_repeat,
+        ](self._ptr)
+        return self
+
+    def def_iconcat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` (in-place concatenation) via the `sq_inplace_concat` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_concat
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_nr[
+            Self.self_type, method, PySlotIndex.sq_inplace_concat
+        ](self._ptr)
+        return self
+
+    def def_irepeat[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` (in-place repetition) via the `sq_inplace_repeat` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_repeat
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _lift_int_to_obj[Self.self_type, method],
+            PySlotIndex.sq_inplace_repeat,
+        ](self._ptr)
+        return self
+
+    # Value-receiver overloads
+
+    def def_len[
+        method: def(Self.self_type) thin raises PySlotError -> Int
+    ](mut self) -> ref[self] Self:
+        """Install `__len__` via the `sq_length` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_length
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        comptime _lenfunc = def(PyObjectPtr) thin abi("C") -> Py_ssize_t
+        var fn_ptr: _lenfunc = _mp_length_wrapper[
+            Self.self_type, _lift_val_to_int[Self.self_type, method]
+        ]
+        self._ptr[]._insert_slot(
+            PyType_Slot(
+                PySlotIndex.sq_length,
+                rebind[OpaquePointer[MutAnyOrigin]](fn_ptr),
+            )
+        )
+        return self
+
+    def def_getitem[
+        method: def(Self.self_type, Int) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `sq_item` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_item
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _lift_val_int_to_obj[Self.self_type, method],
+            PySlotIndex.sq_item,
+        ](self._ptr)
+        return self
+
+    def def_setitem[
+        method: def(
+            Self.self_type, Int, Variant[PythonObject, Int]
+        ) thin raises PySlotError -> None
+    ](mut self) -> ref[self] Self:
+        """Install `__setitem__`/`__delitem__` via the `sq_ass_item` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_ass_item
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeobjargproc[
+            Self.self_type, _lift_val_int_var_to_none[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_setitem[
+        method: def(
+            mut Self.self_type, Int, Variant[PythonObject, Int]
+        ) thin raises PySlotError -> None
+    ](mut self) -> ref[self] Self:
+        """Install `__setitem__`/`__delitem__` via the `sq_ass_item` slot (mut-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_ass_item
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeobjargproc[
+            Self.self_type, _lift_mut_int_var_to_none[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_contains[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install `__contains__` via the `sq_contains` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_contains
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.objobjproc[
+            Self.self_type,
+            _lift_val_obj_to_bool[Self.self_type, method],
+            PySlotIndex.sq_contains,
+        ](self._ptr)
+        return self
+
+    def def_concat[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` (concatenation) via the `sq_concat` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_concat
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[
+            Self.self_type, method, PySlotIndex.sq_concat
+        ](self._ptr)
+        return self
+
+    def def_repeat[
+        method: def(Self.self_type, Int) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` (repetition) via the `sq_repeat` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_repeat
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _lift_val_int_to_obj[Self.self_type, method],
+            PySlotIndex.sq_repeat,
+        ](self._ptr)
+        return self
+
+    def def_iconcat[
+        method: def(
+            Self.self_type, PythonObject
+        ) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` (in-place concatenation) via the `sq_inplace_concat` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_concat
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_val[
+            Self.self_type, method, PySlotIndex.sq_inplace_concat
+        ](self._ptr)
+        return self
+
+    def def_irepeat[
+        method: def(Self.self_type, Int) thin raises PySlotError -> PythonObject
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` (in-place repetition) via the `sq_inplace_repeat` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_repeat
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _lift_val_int_to_obj[Self.self_type, method],
+            PySlotIndex.sq_inplace_repeat,
+        ](self._ptr)
+        return self
+
+    # ConvertibleToPython return overloads
+
+    def def_getitem[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `sq_item` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_item
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _conv_ptr_r_int_arg[Self.self_type, R, method],
+            PySlotIndex.sq_item,
+        ](self._ptr)
+        return self
+
+    def def_getitem[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin], Int) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `sq_item` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_item
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _conv_ptr_nr_int_arg[Self.self_type, R, method],
+            PySlotIndex.sq_item,
+        ](self._ptr)
+        return self
+
+    def def_getitem[
+        R: _CPython,
+        method: def(Self.self_type, Int) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__getitem__` via the `sq_item` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_item
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _conv_val_r_int_arg[Self.self_type, R, method],
+            PySlotIndex.sq_item,
+        ](self._ptr)
+        return self
+
+    def def_concat[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `sq_concat` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_concat
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.sq_concat
+        ](self._ptr)
+        return self
+
+    def def_concat[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `sq_concat` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_concat
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.sq_concat
+        ](self._ptr)
+        return self
+
+    def def_concat[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__add__` via the `sq_concat` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_concat
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.sq_concat
+        ](self._ptr)
+        return self
+
+    def def_repeat[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `sq_repeat` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_repeat
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _conv_ptr_r_int_arg[Self.self_type, R, method],
+            PySlotIndex.sq_repeat,
+        ](self._ptr)
+        return self
+
+    def def_repeat[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin], Int) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `sq_repeat` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_repeat
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _conv_ptr_nr_int_arg[Self.self_type, R, method],
+            PySlotIndex.sq_repeat,
+        ](self._ptr)
+        return self
+
+    def def_repeat[
+        R: _CPython,
+        method: def(Self.self_type, Int) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__mul__` via the `sq_repeat` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_repeat
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _conv_val_r_int_arg[Self.self_type, R, method],
+            PySlotIndex.sq_repeat,
+        ](self._ptr)
+        return self
+
+    def def_iconcat[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `sq_inplace_concat` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_concat
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_r[
+            Self.self_type, R, method, PySlotIndex.sq_inplace_concat
+        ](self._ptr)
+        return self
+
+    def def_iconcat[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject
+        ) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `sq_inplace_concat` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_concat
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_nr[
+            Self.self_type, R, method, PySlotIndex.sq_inplace_concat
+        ](self._ptr)
+        return self
+
+    def def_iconcat[
+        R: _CPython,
+        method: def(Self.self_type, PythonObject) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__iadd__` via the `sq_inplace_concat` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_concat
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.binary_conv_val[
+            Self.self_type, R, method, PySlotIndex.sq_inplace_concat
+        ](self._ptr)
+        return self
+
+    def def_irepeat[
+        R: _CPython,
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], Int
+        ) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `sq_inplace_repeat` slot (ConvertibleToPython return overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_repeat
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _conv_ptr_r_int_arg[Self.self_type, R, method],
+            PySlotIndex.sq_inplace_repeat,
+        ](self._ptr)
+        return self
+
+    def def_irepeat[
+        R: _CPython,
+        method: def(UnsafePointer[Self.self_type, MutAnyOrigin], Int) thin -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `sq_inplace_repeat` slot (ConvertibleToPython return, non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_repeat
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _conv_ptr_nr_int_arg[Self.self_type, R, method],
+            PySlotIndex.sq_inplace_repeat,
+        ](self._ptr)
+        return self
+
+    def def_irepeat[
+        R: _CPython,
+        method: def(Self.self_type, Int) thin raises PySlotError -> R,
+    ](mut self) -> ref[self] Self:
+        """Install `__imul__` via the `sq_inplace_repeat` slot (ConvertibleToPython return, value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PySequenceMethods.sq_inplace_repeat
+
+        Parameters:
+            R: The user-supplied return type, convertible to a `PythonObject`.
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.ssizeargfunc[
+            Self.self_type,
+            _conv_val_r_int_arg[Self.self_type, R, method],
+            PySlotIndex.sq_inplace_repeat,
+        ](self._ptr)
+        return self

--- a/mojo/stdlib/std/python/type_protocol.mojo
+++ b/mojo/stdlib/std/python/type_protocol.mojo
@@ -1,0 +1,105 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.memory import UnsafePointer
+from std.python import PythonObject
+from std.python.bindings import PythonTypeBuilder
+
+from .adapters import (
+    _install_richcompare,
+    _lift_obj_int_to_bool,
+    _lift_val_obj_int_to_bool,
+)
+
+
+struct TypeProtocolBuilder[self_type: ImplicitlyDestructible]:
+    """Wraps a `PythonTypeBuilder` reference and installs CPython type protocol slots.
+
+    `TypeProtocolBuilder` holds a pointer to a `PythonTypeBuilder` that is
+    owned by the enclosing `PythonModuleBuilder`.  The caller must ensure the
+    module builder (and its type_builders list) outlives this object, which is
+    naturally satisfied when both are used within the same `PyInit_*` function.
+
+    Usage:
+        ```mojo
+        ref tb = b.add_type[MyStruct]("MyStruct")
+            .def_init_defaultable[MyStruct]()
+            .def_staticmethod[MyStruct.new]("new")
+        TypeProtocolBuilder[MyStruct](tb).def_richcompare[MyStruct.rich_compare]()
+        MappingProtocolBuilder[MyStruct](tb)
+            .def_len[MyStruct.py__len__]()
+            .def_getitem[MyStruct.py__getitem__]()
+            .def_setitem[MyStruct.py__setitem__]()
+        NumberProtocolBuilder[MyStruct](tb).def_neg[MyStruct.py__neg__]()
+        ```
+    """
+
+    # Unsafe pointer into the module builder's type_builders list.
+    # The pointed-to builder must outlive this TypeProtocolBuilder.
+    var _ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]
+
+    def __init__(out self, mut inner: PythonTypeBuilder):
+        var ptr = UnsafePointer(to=inner)
+        self._ptr = ptr
+
+    # ------------------------------------------------------------------
+    # Type Protocol — tp_richcompare (__lt__, __eq__, etc.)
+    # ------------------------------------------------------------------
+
+    def def_richcompare[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject, Int
+        ) thin raises -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install rich comparison via the `tp_richcompare` slot.
+
+        Called by `obj < other`, `obj == other`, etc.
+
+        Raise `NotImplementedError()` from `method` to return
+        `Py_NotImplemented` to Python (triggering the reflected operation).
+
+        Parameters:
+            method: Static method with signature
+                `def(self_ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject, op: Int) raises -> Bool`
+                where `op` is one of `RichCompareOps.Py_LT` … `Py_GE`.
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_richcompare
+        """
+        _install_richcompare[Self.self_type, method](self._ptr)
+        return self
+
+    def def_richcompare[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject, Int
+        ) thin -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install rich comparison via the `tp_richcompare` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_richcompare
+        """
+        _install_richcompare[
+            Self.self_type, _lift_obj_int_to_bool[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_richcompare[
+        method: def(Self.self_type, PythonObject, Int) thin raises -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install rich comparison via the `tp_richcompare` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_richcompare
+        """
+        _install_richcompare[
+            Self.self_type, _lift_val_obj_int_to_bool[Self.self_type, method]
+        ](self._ptr)
+        return self

--- a/mojo/stdlib/std/python/type_protocol.mojo
+++ b/mojo/stdlib/std/python/type_protocol.mojo
@@ -1,0 +1,140 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Implements the CPython type-protocol builder.
+
+Provides `TypeProtocolBuilder`, which installs the `tp_richcompare` slot on
+a `PythonTypeBuilder` so a Mojo struct can implement Python's rich
+comparison operators (`__lt__`, `__le__`, `__eq__`, `__ne__`, `__gt__`,
+`__ge__`).
+"""
+
+from std.memory import UnsafePointer
+from std.python import PythonObject
+from std.python.bindings import PythonTypeBuilder
+
+from .utils import PySlotError
+
+from .adapters import (
+    _SlotInstaller,
+    _lift_obj_int_to_bool,
+    _lift_val_obj_int_to_bool,
+)
+
+
+struct TypeProtocolBuilder[self_type: ImplicitlyDestructible]:
+    """Wraps a `PythonTypeBuilder` reference and installs CPython type protocol slots.
+
+    `TypeProtocolBuilder` holds a pointer to a `PythonTypeBuilder` that is
+    owned by the enclosing `PythonModuleBuilder`.  The caller must ensure the
+    module builder (and its type_builders list) outlives this object, which is
+    naturally satisfied when both are used within the same `PyInit_*` function.
+
+    Usage:
+        ```mojo
+        ref tb = b.add_type[MyStruct]("MyStruct")
+            .def_init_defaultable[MyStruct]()
+            .def_staticmethod[MyStruct.new]("new")
+        TypeProtocolBuilder[MyStruct](tb).def_richcompare[MyStruct.rich_compare]()
+        MappingProtocolBuilder[MyStruct](tb)
+            .def_len[MyStruct.py__len__]()
+            .def_getitem[MyStruct.py__getitem__]()
+            .def_setitem[MyStruct.py__setitem__]()
+        NumberProtocolBuilder[MyStruct](tb).def_neg[MyStruct.py__neg__]()
+        ```
+
+    Parameters:
+        self_type: The Mojo struct type whose instances back the Python object.
+    """
+
+    # Unsafe pointer into the module builder's type_builders list.
+    # The pointed-to builder must outlive this TypeProtocolBuilder.
+    var _ptr: UnsafePointer[mut=True, PythonTypeBuilder, MutAnyOrigin]
+
+    def __init__(out self, mut inner: PythonTypeBuilder):
+        """Initialize from a `PythonTypeBuilder` reference.
+
+        Args:
+            inner: The `PythonTypeBuilder` to wrap.
+        """
+        var ptr = UnsafePointer(to=inner)
+        self._ptr = ptr
+
+    # ------------------------------------------------------------------
+    # Type Protocol — tp_richcompare (__lt__, __eq__, etc.)
+    # ------------------------------------------------------------------
+
+    def def_richcompare[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject, Int
+        ) thin raises PySlotError -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install rich comparison via the `tp_richcompare` slot.
+
+        Called by `obj < other`, `obj == other`, etc.
+
+        Raise `PySlotError.not_implemented()` from `method` to return
+        `Py_NotImplemented` to Python (triggering the reflected operation).
+
+        Parameters:
+            method: Static method with signature
+                `def(self_ptr: UnsafePointer[T, MutAnyOrigin], other: PythonObject, op: Int) raises -> Bool`
+                where `op` is one of `RichCompareOps.Py_LT` … `Py_GE`.
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_richcompare
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.richcompare[Self.self_type, method](self._ptr)
+        return self
+
+    def def_richcompare[
+        method: def(
+            UnsafePointer[Self.self_type, MutAnyOrigin], PythonObject, Int
+        ) thin -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install rich comparison via the `tp_richcompare` slot (non-raising overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_richcompare
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.richcompare[
+            Self.self_type, _lift_obj_int_to_bool[Self.self_type, method]
+        ](self._ptr)
+        return self
+
+    def def_richcompare[
+        method: def(
+            Self.self_type, PythonObject, Int
+        ) thin raises PySlotError -> Bool
+    ](mut self) -> ref[self] Self:
+        """Install rich comparison via the `tp_richcompare` slot (value-receiver overload).
+
+        See: https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_richcompare
+
+        Parameters:
+            method: The user-supplied handler installed into the slot.
+
+        Returns:
+            A reference to `self` for chaining.
+        """
+        _SlotInstaller.richcompare[
+            Self.self_type, _lift_val_obj_int_to_bool[Self.self_type, method]
+        ](self._ptr)
+        return self

--- a/mojo/stdlib/std/python/utils.mojo
+++ b/mojo/stdlib/std/python/utils.mojo
@@ -1,0 +1,66 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Standalone implementations of types introduced in:
+# https://github.com/modular/modular/pull/5562
+#
+# Provides NotImplementedError and RichCompareOps for use with Python extension
+# modules that require the rich comparison protocol.
+# ===----------------------------------------------------------------------=== #
+
+
+struct RichCompareOps:
+    """Flags used by the tp_richcompare function.
+
+    Pass the `op` argument from your rich compare handler to these constants
+    to determine which comparison is being requested.
+
+    References:
+    - https://github.com/python/cpython/blob/main/Include/object.h#L721
+    - https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_richcompare
+    """
+
+    comptime Py_LT = 0
+    comptime Py_LE = 1
+    comptime Py_EQ = 2
+    comptime Py_NE = 3
+    comptime Py_GT = 4
+    comptime Py_GE = 5
+
+
+@fieldwise_init
+struct NotImplementedError(TrivialRegisterPassable, Writable):
+    """Raise this from a rich compare handler to signal Python's NotImplemented.
+
+    When caught by the `_richcompare_wrapper`, this causes the wrapper to
+    return `Py_NotImplemented` to Python rather than setting an exception,
+    allowing Python to try the reflected operation on the other operand.
+
+    Example:
+        ```mojo
+        @staticmethod
+        def rich_compare(
+            self_ptr: PythonObject, other: PythonObject, op: Int
+        ) raises -> Bool:
+            if op == RichCompareOps.Py_EQ:
+                ...
+            raise NotImplementedError()
+        ```
+    """
+
+    comptime name: String = "NotImplementedError"
+    """Well-known name used by `_richcompare_wrapper` for dispatch."""
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write(Self.name)

--- a/mojo/stdlib/std/python/utils.mojo
+++ b/mojo/stdlib/std/python/utils.mojo
@@ -1,0 +1,215 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Implements `PySlotError` and `RichCompareOps`.
+
+Provides the Mojo-native error type used by Python type-slot handlers and
+the rich-comparison op-code constants consumed by `tp_richcompare`
+handlers.
+"""
+
+
+struct RichCompareOps:
+    """Flags used by the tp_richcompare function.
+
+    Pass the `op` argument from your rich compare handler to these constants
+    to determine which comparison is being requested.
+
+    References:
+    - https://github.com/python/cpython/blob/main/Include/object.h#L721
+    - https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_richcompare
+    """
+
+    comptime Py_LT = 0
+    """Less-than comparison op (`<`)."""
+    comptime Py_LE = 1
+    """Less-than-or-equal comparison op (`<=`)."""
+    comptime Py_EQ = 2
+    """Equality comparison op (`==`)."""
+    comptime Py_NE = 3
+    """Inequality comparison op (`!=`)."""
+    comptime Py_GT = 4
+    """Greater-than comparison op (`>`)."""
+    comptime Py_GE = 5
+    """Greater-than-or-equal comparison op (`>=`)."""
+
+
+@fieldwise_init
+struct PySlotError(Copyable, Movable, Writable):
+    """Mojo-native error type for Python type-slot handlers.
+
+    Raise a variant of this type from a Mojo function bound to a CPython type
+    slot; adapter wrappers that take `raises PySlotError` translate it into
+    the corresponding Python exception (or into `NotImplemented` for the
+    `not_implemented` variant).
+
+    Construct via the staticmethod factories rather than the synthesized
+    fieldwise initializer:
+
+    ```mojo
+    raise PySlotError.index_error("index out of range")
+    raise PySlotError.not_implemented()
+    ```
+    """
+
+    var _variant: Int
+    """Variant tag; one of the `_*` codes below."""
+
+    var msg: String
+    """Human-readable message; ignored for `not_implemented`."""
+
+    # Variant codes — kept private; users go through the factories.
+    comptime _NOT_IMPLEMENTED = 0
+    comptime _INDEX_ERROR = 1
+    comptime _TYPE_ERROR = 2
+    comptime _VALUE_ERROR = 3
+    comptime _KEY_ERROR = 4
+    comptime _ATTRIBUTE_ERROR = 5
+    comptime _OVERFLOW_ERROR = 6
+    comptime _RUNTIME_ERROR = 7
+
+    @staticmethod
+    def not_implemented() -> Self:
+        """Signal Python's `NotImplemented` to the wrapper.
+
+        For binary/ternary/rich-compare slots, this causes the adapter to
+        return `Py_NotImplemented`, prompting Python to try the reflected
+        operation on the other operand.
+
+        Returns:
+            A `PySlotError` with the `not_implemented` variant.
+        """
+        return Self(_variant=Self._NOT_IMPLEMENTED, msg=String())
+
+    @staticmethod
+    def index_error(var msg: String) -> Self:
+        """Map to Python's `IndexError`.
+
+        Args:
+            msg: Human-readable error message.
+
+        Returns:
+            A `PySlotError` configured as an `IndexError`.
+        """
+        return Self(_variant=Self._INDEX_ERROR, msg=msg^)
+
+    @staticmethod
+    def type_error(var msg: String) -> Self:
+        """Map to Python's `TypeError`.
+
+        Args:
+            msg: Human-readable error message.
+
+        Returns:
+            A `PySlotError` configured as a `TypeError`.
+        """
+        return Self(_variant=Self._TYPE_ERROR, msg=msg^)
+
+    @staticmethod
+    def value_error(var msg: String) -> Self:
+        """Map to Python's `ValueError`.
+
+        Args:
+            msg: Human-readable error message.
+
+        Returns:
+            A `PySlotError` configured as a `ValueError`.
+        """
+        return Self(_variant=Self._VALUE_ERROR, msg=msg^)
+
+    @staticmethod
+    def key_error(var msg: String) -> Self:
+        """Map to Python's `KeyError`.
+
+        Args:
+            msg: Human-readable error message.
+
+        Returns:
+            A `PySlotError` configured as a `KeyError`.
+        """
+        return Self(_variant=Self._KEY_ERROR, msg=msg^)
+
+    @staticmethod
+    def attribute_error(var msg: String) -> Self:
+        """Map to Python's `AttributeError`.
+
+        Args:
+            msg: Human-readable error message.
+
+        Returns:
+            A `PySlotError` configured as an `AttributeError`.
+        """
+        return Self(_variant=Self._ATTRIBUTE_ERROR, msg=msg^)
+
+    @staticmethod
+    def overflow_error(var msg: String) -> Self:
+        """Map to Python's `OverflowError`.
+
+        Args:
+            msg: Human-readable error message.
+
+        Returns:
+            A `PySlotError` configured as an `OverflowError`.
+        """
+        return Self(_variant=Self._OVERFLOW_ERROR, msg=msg^)
+
+    @staticmethod
+    def runtime_error(var msg: String) -> Self:
+        """Map to Python's `RuntimeError`.
+
+        Args:
+            msg: Human-readable error message.
+
+        Returns:
+            A `PySlotError` configured as a `RuntimeError`.
+        """
+        return Self(_variant=Self._RUNTIME_ERROR, msg=msg^)
+
+    def write_to(self, mut writer: Some[Writer]):
+        """Write a textual representation of this error to `writer`.
+
+        Args:
+            writer: The destination writer.
+        """
+        if self._variant == Self._NOT_IMPLEMENTED:
+            writer.write("PySlotError.not_implemented")
+        else:
+            writer.write(self.msg)
+
+    def pyexc_global_name(self) -> StaticString:
+        """Return the CPython `PyExc_*` symbol name for this variant.
+
+        Used by adapter wrappers to fetch the matching Python exception
+        global via `cpython.get_error_global(...)`. The `not_implemented`
+        variant has no Python-exception counterpart and maps to
+        `PyExc_RuntimeError` — callers that want the `Py_NotImplemented`
+        singleton must check `_variant == _NOT_IMPLEMENTED` first.
+
+        Returns:
+            The name of the matching `PyExc_*` global as a `StaticString`.
+        """
+        if self._variant == Self._INDEX_ERROR:
+            return "PyExc_IndexError"
+        elif self._variant == Self._TYPE_ERROR:
+            return "PyExc_TypeError"
+        elif self._variant == Self._VALUE_ERROR:
+            return "PyExc_ValueError"
+        elif self._variant == Self._KEY_ERROR:
+            return "PyExc_KeyError"
+        elif self._variant == Self._ATTRIBUTE_ERROR:
+            return "PyExc_AttributeError"
+        elif self._variant == Self._OVERFLOW_ERROR:
+            return "PyExc_OverflowError"
+        else:
+            # _RUNTIME_ERROR or _NOT_IMPLEMENTED
+            return "PyExc_RuntimeError"

--- a/mojo/stdlib/test/python/BUILD.bazel
+++ b/mojo/stdlib/test/python/BUILD.bazel
@@ -1,10 +1,18 @@
 load("@module_versions//:config.bzl", "DEFAULT_PYTHON_VERSION", "PYTHON_VERSIONS_DOTTED")
-load("//bazel:api.bzl", "mojo_test", "requirement")
+load("//bazel:api.bzl", "modular_py_test", "mojo_shared_library", "mojo_test", "requirement")
 
 package(default_visibility = ["//visibility:private"])
 
 _NUMPY_TESTS = [
     "test_python_to_mojo.mojo",
+]
+
+_SHARED_LIB_MOJO_SRCS = [
+    "buffer_mojo_module.mojo",
+    "mapping_mojo_module.mojo",
+    "number_mojo_module.mojo",
+    "sequence_mojo_module.mojo",
+    "type_protocol_mojo_module.mojo",
 ]
 
 [
@@ -30,7 +38,7 @@ _NUMPY_TESTS = [
     )
     for src in glob(
         ["**/*.mojo"],
-        exclude = _NUMPY_TESTS,
+        exclude = _NUMPY_TESTS + _SHARED_LIB_MOJO_SRCS,
     )
     for version in PYTHON_VERSIONS_DOTTED
 ]
@@ -55,4 +63,47 @@ _NUMPY_TESTS = [
     )
     for src in _NUMPY_TESTS
     for version in PYTHON_VERSIONS_DOTTED
+]
+
+_PROTOCOL_TESTS = [
+    "buffer",
+    "mapping",
+    "number",
+    "sequence",
+    "type_protocol",
+]
+
+[
+    mojo_shared_library(
+        name = name + "_mojo_module",
+        testonly = True,
+        srcs = [name + "_mojo_module.mojo"],
+        shared_lib_name = name + "_mojo_module.so",
+        target_compatible_with = select({
+            "//:asan": ["@platforms//:incompatible"],
+            "//:tsan": ["@platforms//:incompatible"],
+            "//:ubsan": ["@platforms//:incompatible"],
+            "//conditions:default": [],
+        }),
+        deps = [
+            "@mojo//:std",
+        ],
+    )
+    for name in _PROTOCOL_TESTS
+]
+
+[
+    modular_py_test(
+        name = "test_" + name,
+        srcs = ["test_" + name + ".py"],
+        data = [":" + name + "_mojo_module"],
+        tags = ["no-pydeps"] if name == "buffer" else [],
+        target_compatible_with = select({
+            "//:asan": ["@platforms//:incompatible"],
+            "//:tsan": ["@platforms//:incompatible"],
+            "//:ubsan": ["@platforms//:incompatible"],
+            "//conditions:default": [],
+        }),
+    )
+    for name in _PROTOCOL_TESTS
 ]

--- a/mojo/stdlib/test/python/buffer_mojo_module.mojo
+++ b/mojo/stdlib/test/python/buffer_mojo_module.mojo
@@ -1,0 +1,78 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Test for BufferProtocolBuilder.
+#
+# Exposes a FloatBuffer type to Python that supports the buffer protocol,
+# allowing zero-copy access via memoryview and numpy.frombuffer.
+# ===----------------------------------------------------------------------=== #
+
+from std.memory import UnsafePointer
+from std.os import abort
+from std.python import PythonObject
+from std.python.bindings import PythonModuleBuilder
+
+from std.python.buffer import BufferInfo, BufferProtocolBuilder
+
+
+struct FloatBuffer(Defaultable, Movable, Writable):
+    """A 1-D array of Float64 values that exposes itself via the buffer protocol.
+    """
+
+    var data: List[Float64]
+
+    def __init__(out self):
+        self.data = []
+
+    @staticmethod
+    def from_count(n: PythonObject) raises -> PythonObject:
+        """Create a FloatBuffer with `n` elements: [0.0, 1.0, ..., n-1.0]."""
+        var result = FloatBuffer()
+        var count = Int(py=n)
+        for i in range(count):
+            result.data.append(Float64(i))
+        return PythonObject(alloc=result^)
+
+    @staticmethod
+    def get_buffer(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], flags: Int32
+    ) raises -> BufferInfo:
+        """Return a BufferInfo describing the internal Float64 array."""
+        var data_ptr = self_ptr[].data.unsafe_ptr()
+        return BufferInfo(
+            buf=rebind[UnsafePointer[UInt8, MutAnyOrigin]](data_ptr),
+            nitems=len(self_ptr[].data),
+            itemsize=8,  # sizeof(Float64)
+            format="d",  # Python struct code for C double
+            readonly=True,
+        )
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("FloatBuffer(len=", len(self.data), ")")
+
+
+@export
+def PyInit_buffer_mojo_module() -> PythonObject:
+    try:
+        var b = PythonModuleBuilder("buffer_mojo_module")
+        ref tb = (
+            b.add_type[FloatBuffer]("FloatBuffer")
+            .def_init_defaultable[FloatBuffer]()
+            .def_staticmethod[FloatBuffer.from_count]("from_count")
+        )
+        var bpb = BufferProtocolBuilder[FloatBuffer](tb)
+        _ = bpb.def_getbuffer[FloatBuffer.get_buffer]().def_releasebuffer()
+        return b.finalize()
+    except e:
+        abort(String("failed to create Python module: ", e))

--- a/mojo/stdlib/test/python/buffer_mojo_module.mojo
+++ b/mojo/stdlib/test/python/buffer_mojo_module.mojo
@@ -1,0 +1,78 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Test for BufferProtocolBuilder.
+#
+# Exposes a FloatBuffer type to Python that supports the buffer protocol,
+# allowing zero-copy access via memoryview and numpy.frombuffer.
+# ===----------------------------------------------------------------------=== #
+
+from std.memory import UnsafePointer
+from std.os import abort
+from std.python import PythonObject
+from std.python.bindings import PythonModuleBuilder
+
+from std.python.builders import BufferInfo, BufferProtocolBuilder
+
+
+struct FloatBuffer(Defaultable, Movable, Writable):
+    """A 1-D array of Float64 values that exposes itself via the buffer protocol.
+    """
+
+    var data: List[Float64]
+
+    def __init__(out self):
+        self.data = []
+
+    @staticmethod
+    def from_count(n: PythonObject) raises -> PythonObject:
+        """Create a FloatBuffer with `n` elements: [0.0, 1.0, ..., n-1.0]."""
+        var result = FloatBuffer()
+        var count = Int(py=n)
+        for i in range(count):
+            result.data.append(Float64(i))
+        return PythonObject(alloc=result^)
+
+    @staticmethod
+    def get_buffer(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], flags: Int32
+    ) raises -> BufferInfo:
+        """Return a BufferInfo describing the internal Float64 array."""
+        var data_ptr = self_ptr[].data.unsafe_ptr()
+        return BufferInfo(
+            buf=rebind[UnsafePointer[UInt8, MutAnyOrigin]](data_ptr),
+            nitems=len(self_ptr[].data),
+            itemsize=8,  # sizeof(Float64)
+            format="d",  # Python struct code for C double
+            readonly=True,
+        )
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("FloatBuffer(len=", len(self.data), ")")
+
+
+@export
+def PyInit_buffer_mojo_module() -> PythonObject:
+    try:
+        var b = PythonModuleBuilder("buffer_mojo_module")
+        ref tb = (
+            b.add_type[FloatBuffer]("FloatBuffer")
+            .def_init_defaultable[FloatBuffer]()
+            .def_staticmethod[FloatBuffer.from_count]("from_count")
+        )
+        var bpb = BufferProtocolBuilder[FloatBuffer](tb)
+        _ = bpb.def_getbuffer[FloatBuffer.get_buffer]().def_releasebuffer()
+        return b.finalize()
+    except e:
+        abort(String("failed to create Python module: ", e))

--- a/mojo/stdlib/test/python/mapping_mojo_module.mojo
+++ b/mojo/stdlib/test/python/mapping_mojo_module.mojo
@@ -1,0 +1,152 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Test for MappingProtocolBuilder.
+#
+# Exposes a SimpleList type to Python that supports:
+#   - len(obj)       via mp_length
+#   - obj[i]         via mp_subscript
+#   - obj[i] = v     via mp_ass_subscript (assignment)
+#   - del obj[i]     via mp_ass_subscript (deletion)
+# ===----------------------------------------------------------------------=== #
+
+from std.os import abort
+from std.memory import UnsafePointer
+from std.utils import Variant
+from std.python import PythonObject
+from std.python.bindings import PythonModuleBuilder
+
+from std.python.builders import MappingProtocolBuilder
+
+
+struct SimpleList(Defaultable, Movable, Writable):
+    var data: List[Int]
+
+    def __init__(out self):
+        self.data = []
+
+    @staticmethod
+    def from_list(items: PythonObject) raises -> PythonObject:
+        var result = SimpleList()
+        for item in items:
+            result.data.append(Int(py=item))
+        return PythonObject(alloc=result^)
+
+    @staticmethod
+    def py__len__(self_ptr: UnsafePointer[Self, MutAnyOrigin]) raises -> Int:
+        return len(self_ptr[].data)
+
+    @staticmethod
+    def py__getitem__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], index: PythonObject
+    ) raises -> PythonObject:
+        var i = Int(py=index)
+        if i < 0 or i >= len(self_ptr[].data):
+            raise Error("index out of range")
+        return PythonObject(self_ptr[].data[i])
+
+    @staticmethod
+    def py__setitem__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin],
+        index: PythonObject,
+        value: Variant[PythonObject, Int],
+    ) raises -> None:
+        var i = Int(py=index)
+        if i < 0 or i >= len(self_ptr[].data):
+            raise Error("index out of range")
+        if value.isa[PythonObject]():
+            self_ptr[].data[i] = Int(py=value[PythonObject])
+        else:
+            _ = self_ptr[].data.pop(i)
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("SimpleList(len=", len(self.data), ")")
+
+
+# SimpleListV uses value-receiver handlers (def(self: Self, ...) instead of
+# def(self_ptr: UnsafePointer[Self, MutAnyOrigin], ...)).
+# Read-only handlers use the non-raising overload; mutating ones use raising
+# ptr-receiver since they need to modify the Python-owned object in place.
+struct SimpleListV(Defaultable, Movable, Writable):
+    var data: List[Int]
+
+    def __init__(out self):
+        self.data = []
+
+    @staticmethod
+    def from_list(items: PythonObject) raises -> PythonObject:
+        var result = SimpleListV()
+        for item in items:
+            result.data.append(Int(py=item))
+        return PythonObject(alloc=result^)
+
+    # Non-raising value receiver
+    def py__len__(self) -> Int:
+        return len(self.data)
+
+    # Raising value receiver
+    def py__getitem__(self, index: PythonObject) raises -> PythonObject:
+        var i = Int(py=index)
+        if i < 0 or i >= len(self.data):
+            raise Error("index out of range")
+        return PythonObject(self.data[i])
+
+    # Mutation still uses pointer receiver so changes are visible on the Python object
+    @staticmethod
+    def py__setitem__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin],
+        index: PythonObject,
+        value: Variant[PythonObject, Int],
+    ) raises -> None:
+        var i = Int(py=index)
+        if i < 0 or i >= len(self_ptr[].data):
+            raise Error("index out of range")
+        if value.isa[PythonObject]():
+            self_ptr[].data[i] = Int(py=value[PythonObject])
+        else:
+            _ = self_ptr[].data.pop(i)
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("SimpleListV(len=", len(self.data), ")")
+
+
+@export
+def PyInit_mapping_mojo_module() -> PythonObject:
+    try:
+        var b = PythonModuleBuilder("mapping_mojo_module")
+        ref tb = (
+            b.add_type[SimpleList]("SimpleList")
+            .def_init_defaultable[SimpleList]()
+            .def_staticmethod[SimpleList.from_list]("from_list")
+        )
+        var mpb = MappingProtocolBuilder[SimpleList](tb)
+        _ = (
+            mpb.def_len[SimpleList.py__len__]()
+            .def_getitem[SimpleList.py__getitem__]()
+            .def_setitem[SimpleList.py__setitem__]()
+        )
+        ref tbv = (
+            b.add_type[SimpleListV]("SimpleListV")
+            .def_init_defaultable[SimpleListV]()
+            .def_staticmethod[SimpleListV.from_list]("from_list")
+        )
+        var mpbv = MappingProtocolBuilder[SimpleListV](tbv)
+        _ = (
+            mpbv.def_len[SimpleListV.py__len__]()
+            .def_getitem[SimpleListV.py__getitem__]()
+            .def_setitem[SimpleListV.py__setitem__]()
+        )
+        return b.finalize()
+    except e:
+        abort(String("failed to create Python module: ", e))

--- a/mojo/stdlib/test/python/mapping_mojo_module.mojo
+++ b/mojo/stdlib/test/python/mapping_mojo_module.mojo
@@ -1,0 +1,185 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Test for MappingProtocolBuilder.
+#
+# Exposes a SimpleList type to Python that supports:
+#   - len(obj)       via mp_length
+#   - obj[i]         via mp_subscript
+#   - obj[i] = v     via mp_ass_subscript (assignment)
+#   - del obj[i]     via mp_ass_subscript (deletion)
+# ===----------------------------------------------------------------------=== #
+
+from std.os import abort
+from std.memory import UnsafePointer
+from std.utils import Variant
+from std.python import PythonObject
+from std.python.bindings import PythonModuleBuilder
+
+from std.python.builders import MappingProtocolBuilder
+from std.python.utils import PySlotError
+
+
+struct SimpleList(Defaultable, Movable, Writable):
+    var data: List[Int]
+
+    def __init__(out self):
+        self.data = []
+
+    @staticmethod
+    def from_list(items: PythonObject) raises -> PythonObject:
+        var result = SimpleList()
+        for item in items:
+            result.data.append(Int(py=item))
+        return PythonObject(alloc=result^)
+
+    @staticmethod
+    def py__len__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises PySlotError -> Int:
+        return len(self_ptr[].data)
+
+    @staticmethod
+    def py__getitem__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], index: PythonObject
+    ) raises PySlotError -> PythonObject:
+        var i: Int
+        try:
+            i = Int(py=index)
+        except e:
+            raise PySlotError.type_error(String(e))
+        if i < 0 or i >= len(self_ptr[].data):
+            raise PySlotError.index_error("index out of range")
+        try:
+            return PythonObject(self_ptr[].data[i])
+        except e:
+            raise PySlotError.runtime_error(String(e))
+
+    @staticmethod
+    def py__setitem__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin],
+        index: PythonObject,
+        value: Variant[PythonObject, Int],
+    ) raises PySlotError -> None:
+        var i: Int
+        try:
+            i = Int(py=index)
+        except e:
+            raise PySlotError.type_error(String(e))
+        if i < 0 or i >= len(self_ptr[].data):
+            raise PySlotError.index_error("index out of range")
+        if value.isa[PythonObject]():
+            try:
+                self_ptr[].data[i] = Int(py=value[PythonObject])
+            except e:
+                raise PySlotError.type_error(String(e))
+        else:
+            _ = self_ptr[].data.pop(i)
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("SimpleList(len=", len(self.data), ")")
+
+
+# SimpleListV uses value-receiver handlers (def(self: Self, ...) instead of
+# def(self_ptr: UnsafePointer[Self, MutAnyOrigin], ...)).
+# Read-only handlers use the non-raising overload; mutating ones use raising
+# ptr-receiver since they need to modify the Python-owned object in place.
+struct SimpleListV(Defaultable, Movable, Writable):
+    var data: List[Int]
+
+    def __init__(out self):
+        self.data = []
+
+    @staticmethod
+    def from_list(items: PythonObject) raises -> PythonObject:
+        var result = SimpleListV()
+        for item in items:
+            result.data.append(Int(py=item))
+        return PythonObject(alloc=result^)
+
+    # Non-raising value receiver
+    def py__len__(self) -> Int:
+        return len(self.data)
+
+    # Raising value receiver
+    def py__getitem__(
+        self, index: PythonObject
+    ) raises PySlotError -> PythonObject:
+        var i: Int
+        try:
+            i = Int(py=index)
+        except e:
+            raise PySlotError.type_error(String(e))
+        if i < 0 or i >= len(self.data):
+            raise PySlotError.index_error("index out of range")
+        try:
+            return PythonObject(self.data[i])
+        except e:
+            raise PySlotError.runtime_error(String(e))
+
+    # Mutation still uses pointer receiver so changes are visible on the Python object
+    @staticmethod
+    def py__setitem__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin],
+        index: PythonObject,
+        value: Variant[PythonObject, Int],
+    ) raises PySlotError -> None:
+        var i: Int
+        try:
+            i = Int(py=index)
+        except e:
+            raise PySlotError.type_error(String(e))
+        if i < 0 or i >= len(self_ptr[].data):
+            raise PySlotError.index_error("index out of range")
+        if value.isa[PythonObject]():
+            try:
+                self_ptr[].data[i] = Int(py=value[PythonObject])
+            except e:
+                raise PySlotError.type_error(String(e))
+        else:
+            _ = self_ptr[].data.pop(i)
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("SimpleListV(len=", len(self.data), ")")
+
+
+@export
+def PyInit_mapping_mojo_module() -> PythonObject:
+    try:
+        var b = PythonModuleBuilder("mapping_mojo_module")
+        ref tb = (
+            b.add_type[SimpleList]("SimpleList")
+            .def_init_defaultable[SimpleList]()
+            .def_staticmethod[SimpleList.from_list]("from_list")
+        )
+        var mpb = MappingProtocolBuilder[SimpleList](tb)
+        _ = (
+            mpb.def_len[SimpleList.py__len__]()
+            .def_getitem[SimpleList.py__getitem__]()
+            .def_setitem[SimpleList.py__setitem__]()
+        )
+        ref tbv = (
+            b.add_type[SimpleListV]("SimpleListV")
+            .def_init_defaultable[SimpleListV]()
+            .def_staticmethod[SimpleListV.from_list]("from_list")
+        )
+        var mpbv = MappingProtocolBuilder[SimpleListV](tbv)
+        _ = (
+            mpbv.def_len[SimpleListV.py__len__]()
+            .def_getitem[SimpleListV.py__getitem__]()
+            .def_setitem[SimpleListV.py__setitem__]()
+        )
+        return b.finalize()
+    except e:
+        abort(String("failed to create Python module: ", e))

--- a/mojo/stdlib/test/python/number_mojo_module.mojo
+++ b/mojo/stdlib/test/python/number_mojo_module.mojo
@@ -1,0 +1,523 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Test for NumberProtocolBuilder.
+#
+# Exposes a Number type (wrapping Int) to Python that supports:
+#   - -n, abs(n), +n, ~n                   via nb_negative/absolute/positive/invert
+#   - bool(n)                              via nb_bool
+#   - int(n), float(n), operator.index(n)  via nb_int/float/index
+#   - n + m, n - m, n * m, n // m, n % m  via nb_add/subtract/multiply/floor_divide/remainder
+#   - n & m, n | m, n ^ m                 via nb_and/or/xor
+#   - n << m, n >> m                       via nb_lshift/rshift
+#   - n ** m                               via nb_power
+# ===----------------------------------------------------------------------=== #
+
+from std.os import abort
+from std.memory import UnsafePointer
+from std.python import PythonObject
+from std.python.bindings import PythonModuleBuilder
+
+from std.python.builders import NumberProtocolBuilder
+from std.python.utils import NotImplementedError
+
+
+struct Number(Defaultable, Movable, Writable):
+    var value: Int
+
+    def __init__(out self):
+        self.value = 0
+
+    def __init__(out self, value: Int):
+        self.value = value
+
+    @staticmethod
+    def _get_self_ptr(
+        py_self: PythonObject,
+    ) -> UnsafePointer[Self, MutAnyOrigin]:
+        try:
+            return py_self.downcast_value_ptr[Self]()
+        except e:
+            abort(String("downcast failed: ", e))
+
+    @staticmethod
+    def new(value: PythonObject) raises -> PythonObject:
+        return PythonObject(alloc=Number(Int(py=value)))
+
+    @staticmethod
+    def get_value(py_self: PythonObject) raises -> PythonObject:
+        return PythonObject(Self._get_self_ptr(py_self)[].value)
+
+    # ------------------------------------------------------------------
+    # Unary slots
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__neg__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises -> PythonObject:
+        return PythonObject(alloc=Number(-self_ptr[].value))
+
+    @staticmethod
+    def py__abs__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises -> PythonObject:
+        return PythonObject(alloc=Number(abs(self_ptr[].value)))
+
+    @staticmethod
+    def py__pos__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises -> PythonObject:
+        return PythonObject(alloc=Number(self_ptr[].value))
+
+    @staticmethod
+    def py__invert__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises -> PythonObject:
+        return PythonObject(alloc=Number(~self_ptr[].value))
+
+    # ------------------------------------------------------------------
+    # Bool slot
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__bool__(self_ptr: UnsafePointer[Self, MutAnyOrigin]) raises -> Bool:
+        return self_ptr[].value != 0
+
+    # ------------------------------------------------------------------
+    # Conversion slots
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__int__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises -> PythonObject:
+        return PythonObject(self_ptr[].value)
+
+    @staticmethod
+    def py__float__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises -> PythonObject:
+        return PythonObject(Float64(self_ptr[].value))
+
+    @staticmethod
+    def py__index__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises -> PythonObject:
+        return PythonObject(self_ptr[].value)
+
+    # ------------------------------------------------------------------
+    # Binary slots — raise NotImplementedError for non-Number operands
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__add__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value + o[].value))
+        except:
+            raise NotImplementedError()
+
+    @staticmethod
+    def py__sub__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value - o[].value))
+        except:
+            raise NotImplementedError()
+
+    @staticmethod
+    def py__mul__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value * o[].value))
+        except:
+            raise NotImplementedError()
+
+    @staticmethod
+    def py__floordiv__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value // o[].value))
+        except:
+            raise NotImplementedError()
+
+    @staticmethod
+    def py__mod__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value % o[].value))
+        except:
+            raise NotImplementedError()
+
+    @staticmethod
+    def py__and__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value & o[].value))
+        except:
+            raise NotImplementedError()
+
+    @staticmethod
+    def py__or__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value | o[].value))
+        except:
+            raise NotImplementedError()
+
+    @staticmethod
+    def py__xor__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value ^ o[].value))
+        except:
+            raise NotImplementedError()
+
+    @staticmethod
+    def py__lshift__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value << o[].value))
+        except:
+            raise NotImplementedError()
+
+    @staticmethod
+    def py__rshift__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value >> o[].value))
+        except:
+            raise NotImplementedError()
+
+    # ------------------------------------------------------------------
+    # Ternary slot
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__pow__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin],
+        exp: PythonObject,
+        mod: PythonObject,
+    ) raises -> PythonObject:
+        try:
+            var e = exp.downcast_value_ptr[Self]()
+            var result = Int(Float64(self_ptr[].value) ** Float64(e[].value))
+            return PythonObject(alloc=Number(result))
+        except:
+            raise NotImplementedError()
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("Number(", self.value, ")")
+
+
+# NumberV uses value-receiver handlers.  Simple unary/bool slots are
+# non-raising; binary slots that need NotImplementedError are raising.
+struct NumberV(Defaultable, Movable, Writable):
+    var value: Int
+
+    def __init__(out self):
+        self.value = 0
+
+    def __init__(out self, value: Int):
+        self.value = value
+
+    @staticmethod
+    def _get_self_ptr(
+        py_self: PythonObject,
+    ) -> UnsafePointer[Self, MutAnyOrigin]:
+        try:
+            return py_self.downcast_value_ptr[Self]()
+        except e:
+            abort(String("downcast failed: ", e))
+
+    @staticmethod
+    def new(value: PythonObject) raises -> PythonObject:
+        return PythonObject(alloc=NumberV(Int(py=value)))
+
+    @staticmethod
+    def get_value(py_self: PythonObject) raises -> PythonObject:
+        return PythonObject(Self._get_self_ptr(py_self)[].value)
+
+    # Value-receiver handlers — unary slots return a new Python-boxed NumberV
+    def py__neg__(self) raises -> PythonObject:
+        return PythonObject(alloc=NumberV(-self.value))
+
+    def py__abs__(self) raises -> PythonObject:
+        return PythonObject(alloc=NumberV(abs(self.value)))
+
+    def py__pos__(self) raises -> PythonObject:
+        return PythonObject(alloc=NumberV(self.value))
+
+    def py__invert__(self) raises -> PythonObject:
+        return PythonObject(alloc=NumberV(~self.value))
+
+    def py__bool__(self) -> Bool:
+        return self.value != 0
+
+    def py__int__(self) raises -> PythonObject:
+        return PythonObject(self.value)
+
+    def py__float__(self) raises -> PythonObject:
+        return PythonObject(Float64(self.value))
+
+    def py__index__(self) raises -> PythonObject:
+        return PythonObject(self.value)
+
+    # Raising value receivers for binary slots (need NotImplementedError)
+    def py__add__(self, other: PythonObject) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value + o[].value))
+        except:
+            raise NotImplementedError()
+
+    def py__sub__(self, other: PythonObject) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value - o[].value))
+        except:
+            raise NotImplementedError()
+
+    def py__mul__(self, other: PythonObject) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value * o[].value))
+        except:
+            raise NotImplementedError()
+
+    def py__floordiv__(self, other: PythonObject) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value // o[].value))
+        except:
+            raise NotImplementedError()
+
+    def py__mod__(self, other: PythonObject) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value % o[].value))
+        except:
+            raise NotImplementedError()
+
+    def py__and__(self, other: PythonObject) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value & o[].value))
+        except:
+            raise NotImplementedError()
+
+    def py__or__(self, other: PythonObject) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value | o[].value))
+        except:
+            raise NotImplementedError()
+
+    def py__xor__(self, other: PythonObject) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value ^ o[].value))
+        except:
+            raise NotImplementedError()
+
+    def py__lshift__(self, other: PythonObject) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value << o[].value))
+        except:
+            raise NotImplementedError()
+
+    def py__rshift__(self, other: PythonObject) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value >> o[].value))
+        except:
+            raise NotImplementedError()
+
+    def py__pow__(
+        self, exp: PythonObject, mod: PythonObject
+    ) raises -> PythonObject:
+        try:
+            var e = exp.downcast_value_ptr[Self]()
+            var result = Int(Float64(self.value) ** Float64(e[].value))
+            return PythonObject(alloc=NumberV(result))
+        except:
+            raise NotImplementedError()
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("NumberV(", self.value, ")")
+
+
+# NumberM uses mut-receiver handlers for in-place operators.
+struct NumberM(Defaultable, Movable, Writable):
+    var value: Int
+
+    def __init__(out self):
+        self.value = 0
+
+    def __init__(out self, value: Int):
+        self.value = value
+
+    @staticmethod
+    def _get_self_ptr(
+        py_self: PythonObject,
+    ) -> UnsafePointer[Self, MutAnyOrigin]:
+        try:
+            return py_self.downcast_value_ptr[Self]()
+        except e:
+            abort(String("downcast failed: ", e))
+
+    @staticmethod
+    def new(value: PythonObject) raises -> PythonObject:
+        return PythonObject(alloc=NumberM(Int(py=value)))
+
+    @staticmethod
+    def get_value(py_self: PythonObject) raises -> PythonObject:
+        return PythonObject(Self._get_self_ptr(py_self)[].value)
+
+    def py__iadd__(mut self, other: PythonObject) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            self.value += o[].value
+            return PythonObject(alloc=NumberM(self.value))
+        except:
+            raise NotImplementedError()
+
+    def py__isub__(mut self, other: PythonObject) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            self.value -= o[].value
+            return PythonObject(alloc=NumberM(self.value))
+        except:
+            raise NotImplementedError()
+
+    def py__imul__(mut self, other: PythonObject) raises -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            self.value *= o[].value
+            return PythonObject(alloc=NumberM(self.value))
+        except:
+            raise NotImplementedError()
+
+    def py__ipow__(
+        mut self, exp: PythonObject, mod: PythonObject
+    ) raises -> PythonObject:
+        try:
+            var e = exp.downcast_value_ptr[Self]()
+            self.value = Int(Float64(self.value) ** Float64(e[].value))
+            return PythonObject(alloc=NumberM(self.value))
+        except:
+            raise NotImplementedError()
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("NumberM(", self.value, ")")
+
+
+@export
+def PyInit_number_mojo_module() -> PythonObject:
+    try:
+        var b = PythonModuleBuilder("number_mojo_module")
+        ref tb = (
+            b.add_type[Number]("Number")
+            .def_init_defaultable[Number]()
+            .def_staticmethod[Number.new]("new")
+            .def_method[Number.get_value]("get_value")
+        )
+        var npb = NumberProtocolBuilder[Number](tb)
+        _ = (
+            npb.def_neg[Number.py__neg__]()
+            .def_abs[Number.py__abs__]()
+            .def_pos[Number.py__pos__]()
+            .def_invert[Number.py__invert__]()
+            .def_bool[Number.py__bool__]()
+            .def_int[Number.py__int__]()
+            .def_float[Number.py__float__]()
+            .def_index[Number.py__index__]()
+            .def_add[Number.py__add__]()
+            .def_sub[Number.py__sub__]()
+            .def_mul[Number.py__mul__]()
+            .def_floordiv[Number.py__floordiv__]()
+            .def_mod[Number.py__mod__]()
+            .def_and[Number.py__and__]()
+            .def_or[Number.py__or__]()
+            .def_xor[Number.py__xor__]()
+            .def_lshift[Number.py__lshift__]()
+            .def_rshift[Number.py__rshift__]()
+            .def_pow[Number.py__pow__]()
+        )
+        ref tbv = (
+            b.add_type[NumberV]("NumberV")
+            .def_init_defaultable[NumberV]()
+            .def_staticmethod[NumberV.new]("new")
+            .def_method[NumberV.get_value]("get_value")
+        )
+        var npbv = NumberProtocolBuilder[NumberV](tbv)
+        _ = (
+            npbv.def_neg[NumberV.py__neg__]()
+            .def_abs[NumberV.py__abs__]()
+            .def_pos[NumberV.py__pos__]()
+            .def_invert[NumberV.py__invert__]()
+            .def_bool[NumberV.py__bool__]()
+            .def_int[NumberV.py__int__]()
+            .def_float[NumberV.py__float__]()
+            .def_index[NumberV.py__index__]()
+            .def_add[NumberV.py__add__]()
+            .def_sub[NumberV.py__sub__]()
+            .def_mul[NumberV.py__mul__]()
+            .def_floordiv[NumberV.py__floordiv__]()
+            .def_mod[NumberV.py__mod__]()
+            .def_and[NumberV.py__and__]()
+            .def_or[NumberV.py__or__]()
+            .def_xor[NumberV.py__xor__]()
+            .def_lshift[NumberV.py__lshift__]()
+            .def_rshift[NumberV.py__rshift__]()
+            .def_pow[NumberV.py__pow__]()
+        )
+        ref tbm = (
+            b.add_type[NumberM]("NumberM")
+            .def_init_defaultable[NumberM]()
+            .def_staticmethod[NumberM.new]("new")
+            .def_method[NumberM.get_value]("get_value")
+        )
+        var npbm = NumberProtocolBuilder[NumberM](tbm)
+        _ = (
+            npbm.def_iadd[NumberM.py__iadd__]()
+            .def_isub[NumberM.py__isub__]()
+            .def_imul[NumberM.py__imul__]()
+            .def_ipow[NumberM.py__ipow__]()
+        )
+        return b.finalize()
+    except e:
+        abort(String("failed to create Python module: ", e))

--- a/mojo/stdlib/test/python/number_mojo_module.mojo
+++ b/mojo/stdlib/test/python/number_mojo_module.mojo
@@ -1,0 +1,560 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Test for NumberProtocolBuilder.
+#
+# Exposes a Number type (wrapping Int) to Python that supports:
+#   - -n, abs(n), +n, ~n                   via nb_negative/absolute/positive/invert
+#   - bool(n)                              via nb_bool
+#   - int(n), float(n), operator.index(n)  via nb_int/float/index
+#   - n + m, n - m, n * m, n // m, n % m  via nb_add/subtract/multiply/floor_divide/remainder
+#   - n & m, n | m, n ^ m                 via nb_and/or/xor
+#   - n << m, n >> m                       via nb_lshift/rshift
+#   - n ** m                               via nb_power
+# ===----------------------------------------------------------------------=== #
+
+from std.os import abort
+from std.memory import UnsafePointer
+from std.python import PythonObject
+from std.python.bindings import PythonModuleBuilder
+
+from std.python.builders import NumberProtocolBuilder
+from std.python.utils import PySlotError
+
+
+def _alloc[
+    T: Movable & ImplicitlyDestructible
+](var value: T) raises PySlotError -> PythonObject:
+    """Translate `PythonObject(alloc=...)`'s plain `Error` into `PySlotError`.
+    """
+    try:
+        return PythonObject(alloc=value^)
+    except e:
+        raise PySlotError.runtime_error(String(e))
+
+
+struct Number(Defaultable, Movable, Writable):
+    var value: Int
+
+    def __init__(out self):
+        self.value = 0
+
+    def __init__(out self, value: Int):
+        self.value = value
+
+    @staticmethod
+    def _get_self_ptr(
+        py_self: PythonObject,
+    ) -> UnsafePointer[Self, MutAnyOrigin]:
+        try:
+            return py_self.downcast_value_ptr[Self]()
+        except e:
+            abort(String("downcast failed: ", e))
+
+    @staticmethod
+    def new(value: PythonObject) raises -> PythonObject:
+        return PythonObject(alloc=Number(Int(py=value)))
+
+    @staticmethod
+    def get_value(py_self: PythonObject) raises -> PythonObject:
+        return PythonObject(Self._get_self_ptr(py_self)[].value)
+
+    # ------------------------------------------------------------------
+    # Unary slots
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__neg__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises PySlotError -> PythonObject:
+        return _alloc(Number(-self_ptr[].value))
+
+    @staticmethod
+    def py__abs__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises PySlotError -> PythonObject:
+        return _alloc(Number(abs(self_ptr[].value)))
+
+    @staticmethod
+    def py__pos__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises PySlotError -> PythonObject:
+        return _alloc(Number(self_ptr[].value))
+
+    @staticmethod
+    def py__invert__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises PySlotError -> PythonObject:
+        return _alloc(Number(~self_ptr[].value))
+
+    # ------------------------------------------------------------------
+    # Bool slot
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__bool__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises PySlotError -> Bool:
+        return self_ptr[].value != 0
+
+    # ------------------------------------------------------------------
+    # Conversion slots
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__int__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises PySlotError -> PythonObject:
+        return PythonObject(self_ptr[].value)
+
+    @staticmethod
+    def py__float__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises PySlotError -> PythonObject:
+        return PythonObject(Float64(self_ptr[].value))
+
+    @staticmethod
+    def py__index__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises PySlotError -> PythonObject:
+        return PythonObject(self_ptr[].value)
+
+    # ------------------------------------------------------------------
+    # Binary slots — raise NotImplementedError for non-Number operands
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__add__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        # Magic value 42 on the LHS exercises the NotImplemented path even
+        # when the operands look compatible. Because CPython reuses `nb_add`
+        # for both `__add__` and `__radd__`, this fires whether `n(42)` is
+        # on the left (direct call) or on the right of a `<other> + n(42)`
+        # expression (reflected call after the LHS slot returns
+        # NotImplemented).
+        if self_ptr[].value == 42:
+            raise PySlotError.not_implemented()
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return _alloc(Number(self_ptr[].value + o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    @staticmethod
+    def py__sub__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value - o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    @staticmethod
+    def py__mul__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value * o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    @staticmethod
+    def py__floordiv__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value // o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    @staticmethod
+    def py__mod__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value % o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    @staticmethod
+    def py__and__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value & o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    @staticmethod
+    def py__or__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value | o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    @staticmethod
+    def py__xor__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value ^ o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    @staticmethod
+    def py__lshift__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value << o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    @staticmethod
+    def py__rshift__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=Number(self_ptr[].value >> o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    # ------------------------------------------------------------------
+    # Ternary slot
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def py__pow__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin],
+        exp: PythonObject,
+        mod: PythonObject,
+    ) raises PySlotError -> PythonObject:
+        # Magic value 42 on the base exercises the NotImplemented path of
+        # the ternary wrapper (`nb_power`).
+        if self_ptr[].value == 42:
+            raise PySlotError.not_implemented()
+        try:
+            var e = exp.downcast_value_ptr[Self]()
+            var result = Int(Float64(self_ptr[].value) ** Float64(e[].value))
+            return _alloc(Number(result))
+        except:
+            raise PySlotError.not_implemented()
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("Number(", self.value, ")")
+
+
+# NumberV uses value-receiver handlers.  Simple unary/bool slots are
+# non-raising; binary slots that need NotImplementedError are raising.
+struct NumberV(Defaultable, Movable, Writable):
+    var value: Int
+
+    def __init__(out self):
+        self.value = 0
+
+    def __init__(out self, value: Int):
+        self.value = value
+
+    @staticmethod
+    def _get_self_ptr(
+        py_self: PythonObject,
+    ) -> UnsafePointer[Self, MutAnyOrigin]:
+        try:
+            return py_self.downcast_value_ptr[Self]()
+        except e:
+            abort(String("downcast failed: ", e))
+
+    @staticmethod
+    def new(value: PythonObject) raises -> PythonObject:
+        return PythonObject(alloc=NumberV(Int(py=value)))
+
+    @staticmethod
+    def get_value(py_self: PythonObject) raises -> PythonObject:
+        return PythonObject(Self._get_self_ptr(py_self)[].value)
+
+    # Value-receiver handlers — unary slots return a new Python-boxed NumberV
+    def py__neg__(self) raises PySlotError -> PythonObject:
+        return _alloc(NumberV(-self.value))
+
+    def py__abs__(self) raises PySlotError -> PythonObject:
+        return _alloc(NumberV(abs(self.value)))
+
+    def py__pos__(self) raises PySlotError -> PythonObject:
+        return _alloc(NumberV(self.value))
+
+    def py__invert__(self) raises PySlotError -> PythonObject:
+        return _alloc(NumberV(~self.value))
+
+    def py__bool__(self) -> Bool:
+        return self.value != 0
+
+    def py__int__(self) raises PySlotError -> PythonObject:
+        return PythonObject(self.value)
+
+    def py__float__(self) raises PySlotError -> PythonObject:
+        return PythonObject(Float64(self.value))
+
+    def py__index__(self) raises PySlotError -> PythonObject:
+        return PythonObject(self.value)
+
+    # Raising value receivers for binary slots (need NotImplementedError)
+    def py__add__(self, other: PythonObject) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value + o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    def py__sub__(self, other: PythonObject) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value - o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    def py__mul__(self, other: PythonObject) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value * o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    def py__floordiv__(
+        self, other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value // o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    def py__mod__(self, other: PythonObject) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value % o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    def py__and__(self, other: PythonObject) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value & o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    def py__or__(self, other: PythonObject) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value | o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    def py__xor__(self, other: PythonObject) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value ^ o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    def py__lshift__(
+        self, other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value << o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    def py__rshift__(
+        self, other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            return PythonObject(alloc=NumberV(self.value >> o[].value))
+        except:
+            raise PySlotError.not_implemented()
+
+    def py__pow__(
+        self, exp: PythonObject, mod: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var e = exp.downcast_value_ptr[Self]()
+            var result = Int(Float64(self.value) ** Float64(e[].value))
+            return PythonObject(alloc=NumberV(result))
+        except:
+            raise PySlotError.not_implemented()
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("NumberV(", self.value, ")")
+
+
+# NumberM uses mut-receiver handlers for in-place operators.
+struct NumberM(Defaultable, Movable, Writable):
+    var value: Int
+
+    def __init__(out self):
+        self.value = 0
+
+    def __init__(out self, value: Int):
+        self.value = value
+
+    @staticmethod
+    def _get_self_ptr(
+        py_self: PythonObject,
+    ) -> UnsafePointer[Self, MutAnyOrigin]:
+        try:
+            return py_self.downcast_value_ptr[Self]()
+        except e:
+            abort(String("downcast failed: ", e))
+
+    @staticmethod
+    def new(value: PythonObject) raises -> PythonObject:
+        return PythonObject(alloc=NumberM(Int(py=value)))
+
+    @staticmethod
+    def get_value(py_self: PythonObject) raises -> PythonObject:
+        return PythonObject(Self._get_self_ptr(py_self)[].value)
+
+    def py__iadd__(
+        mut self, other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            self.value += o[].value
+            return PythonObject(alloc=NumberM(self.value))
+        except:
+            raise PySlotError.not_implemented()
+
+    def py__isub__(
+        mut self, other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            self.value -= o[].value
+            return PythonObject(alloc=NumberM(self.value))
+        except:
+            raise PySlotError.not_implemented()
+
+    def py__imul__(
+        mut self, other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var o = other.downcast_value_ptr[Self]()
+            self.value *= o[].value
+            return PythonObject(alloc=NumberM(self.value))
+        except:
+            raise PySlotError.not_implemented()
+
+    def py__ipow__(
+        mut self, exp: PythonObject, mod: PythonObject
+    ) raises PySlotError -> PythonObject:
+        try:
+            var e = exp.downcast_value_ptr[Self]()
+            self.value = Int(Float64(self.value) ** Float64(e[].value))
+            return PythonObject(alloc=NumberM(self.value))
+        except:
+            raise PySlotError.not_implemented()
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("NumberM(", self.value, ")")
+
+
+@export
+def PyInit_number_mojo_module() -> PythonObject:
+    try:
+        var b = PythonModuleBuilder("number_mojo_module")
+        ref tb = (
+            b.add_type[Number]("Number")
+            .def_init_defaultable[Number]()
+            .def_staticmethod[Number.new]("new")
+            .def_method[Number.get_value]("get_value")
+        )
+        var npb = NumberProtocolBuilder[Number](tb)
+        _ = (
+            npb.def_neg[Number.py__neg__]()
+            .def_abs[Number.py__abs__]()
+            .def_pos[Number.py__pos__]()
+            .def_invert[Number.py__invert__]()
+            .def_bool[Number.py__bool__]()
+            .def_int[Number.py__int__]()
+            .def_float[Number.py__float__]()
+            .def_index[Number.py__index__]()
+            .def_add[Number.py__add__]()
+            .def_sub[Number.py__sub__]()
+            .def_mul[Number.py__mul__]()
+            .def_floordiv[Number.py__floordiv__]()
+            .def_mod[Number.py__mod__]()
+            .def_and[Number.py__and__]()
+            .def_or[Number.py__or__]()
+            .def_xor[Number.py__xor__]()
+            .def_lshift[Number.py__lshift__]()
+            .def_rshift[Number.py__rshift__]()
+            .def_pow[Number.py__pow__]()
+        )
+        ref tbv = (
+            b.add_type[NumberV]("NumberV")
+            .def_init_defaultable[NumberV]()
+            .def_staticmethod[NumberV.new]("new")
+            .def_method[NumberV.get_value]("get_value")
+        )
+        var npbv = NumberProtocolBuilder[NumberV](tbv)
+        _ = (
+            npbv.def_neg[NumberV.py__neg__]()
+            .def_abs[NumberV.py__abs__]()
+            .def_pos[NumberV.py__pos__]()
+            .def_invert[NumberV.py__invert__]()
+            .def_bool[NumberV.py__bool__]()
+            .def_int[NumberV.py__int__]()
+            .def_float[NumberV.py__float__]()
+            .def_index[NumberV.py__index__]()
+            .def_add[NumberV.py__add__]()
+            .def_sub[NumberV.py__sub__]()
+            .def_mul[NumberV.py__mul__]()
+            .def_floordiv[NumberV.py__floordiv__]()
+            .def_mod[NumberV.py__mod__]()
+            .def_and[NumberV.py__and__]()
+            .def_or[NumberV.py__or__]()
+            .def_xor[NumberV.py__xor__]()
+            .def_lshift[NumberV.py__lshift__]()
+            .def_rshift[NumberV.py__rshift__]()
+            .def_pow[NumberV.py__pow__]()
+        )
+        ref tbm = (
+            b.add_type[NumberM]("NumberM")
+            .def_init_defaultable[NumberM]()
+            .def_staticmethod[NumberM.new]("new")
+            .def_method[NumberM.get_value]("get_value")
+        )
+        var npbm = NumberProtocolBuilder[NumberM](tbm)
+        _ = (
+            npbm.def_iadd[NumberM.py__iadd__]()
+            .def_isub[NumberM.py__isub__]()
+            .def_imul[NumberM.py__imul__]()
+            .def_ipow[NumberM.py__ipow__]()
+        )
+        return b.finalize()
+    except e:
+        abort(String("failed to create Python module: ", e))

--- a/mojo/stdlib/test/python/sequence_mojo_module.mojo
+++ b/mojo/stdlib/test/python/sequence_mojo_module.mojo
@@ -1,0 +1,213 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Test for SequenceProtocolBuilder.
+#
+# Exposes a Seq type to Python that supports:
+#   - len(obj)       via sq_length
+#   - obj[i]         via sq_item        (integer index)
+#   - obj[i] = v     via sq_ass_item    (assignment)
+#   - del obj[i]     via sq_ass_item    (deletion)
+#   - v in obj       via sq_contains
+#   - obj + other    via sq_concat
+#   - obj * n        via sq_repeat
+# ===----------------------------------------------------------------------=== #
+
+from std.os import abort
+from std.memory import UnsafePointer
+from std.utils import Variant
+from std.python import PythonObject
+from std.python.bindings import PythonModuleBuilder
+
+from std.python.builders import SequenceProtocolBuilder
+
+
+struct Seq(Defaultable, Movable, Writable):
+    var data: List[Int]
+
+    def __init__(out self):
+        self.data = []
+
+    @staticmethod
+    def from_list(items: PythonObject) raises -> PythonObject:
+        var result = Seq()
+        for item in items:
+            result.data.append(Int(py=item))
+        return PythonObject(alloc=result^)
+
+    @staticmethod
+    def py__len__(self_ptr: UnsafePointer[Self, MutAnyOrigin]) raises -> Int:
+        return len(self_ptr[].data)
+
+    @staticmethod
+    def py__getitem__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], index: Int
+    ) raises -> PythonObject:
+        if index < 0 or index >= len(self_ptr[].data):
+            raise Error("index out of range")
+        return PythonObject(self_ptr[].data[index])
+
+    @staticmethod
+    def py__setitem__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin],
+        index: Int,
+        value: Variant[PythonObject, Int],
+    ) raises -> None:
+        if index < 0 or index >= len(self_ptr[].data):
+            raise Error("index out of range")
+        if value.isa[PythonObject]():
+            self_ptr[].data[index] = Int(py=value[PythonObject])
+        else:
+            _ = self_ptr[].data.pop(index)
+
+    @staticmethod
+    def py__contains__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], item: PythonObject
+    ) raises -> Bool:
+        var v = Int(py=item)
+        for elem in self_ptr[].data:
+            if elem == v:
+                return True
+        return False
+
+    @staticmethod
+    def py__concat__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises -> PythonObject:
+        var other_ptr = other.downcast_value_ptr[Self]()
+        var result = Seq()
+        for v in self_ptr[].data:
+            result.data.append(v)
+        for v in other_ptr[].data:
+            result.data.append(v)
+        return PythonObject(alloc=result^)
+
+    @staticmethod
+    def py__repeat__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], count: Int
+    ) raises -> PythonObject:
+        var result = Seq()
+        for _ in range(count):
+            for v in self_ptr[].data:
+                result.data.append(v)
+        return PythonObject(alloc=result^)
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("Seq(len=", len(self.data), ")")
+
+
+# SeqV uses value-receiver handlers where no mutation is needed, and pointer
+# receivers where the object must be modified in place.
+struct SeqV(Defaultable, Movable, Writable):
+    var data: List[Int]
+
+    def __init__(out self):
+        self.data = []
+
+    @staticmethod
+    def from_list(items: PythonObject) raises -> PythonObject:
+        var result = SeqV()
+        for item in items:
+            result.data.append(Int(py=item))
+        return PythonObject(alloc=result^)
+
+    # Non-raising value receiver
+    def py__len__(self) -> Int:
+        return len(self.data)
+
+    # Raising value receiver
+    def py__getitem__(self, index: Int) raises -> PythonObject:
+        if index < 0 or index >= len(self.data):
+            raise Error("index out of range")
+        return PythonObject(self.data[index])
+
+    # Mutation uses pointer receiver
+    @staticmethod
+    def py__setitem__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin],
+        index: Int,
+        value: Variant[PythonObject, Int],
+    ) raises -> None:
+        if index < 0 or index >= len(self_ptr[].data):
+            raise Error("index out of range")
+        if value.isa[PythonObject]():
+            self_ptr[].data[index] = Int(py=value[PythonObject])
+        else:
+            _ = self_ptr[].data.pop(index)
+
+    # Non-raising value receiver for contains
+    def py__contains__(self, item: PythonObject) raises -> Bool:
+        var v = Int(py=item)
+        for elem in self.data:
+            if elem == v:
+                return True
+        return False
+
+    # Raising value receiver for concat
+    def py__concat__(self, other: PythonObject) raises -> PythonObject:
+        var other_ptr = other.downcast_value_ptr[Self]()
+        var result = SeqV()
+        for v in self.data:
+            result.data.append(v)
+        for v in other_ptr[].data:
+            result.data.append(v)
+        return PythonObject(alloc=result^)
+
+    # Non-raising value receiver for repeat
+    def py__repeat__(self, count: Int) raises -> PythonObject:
+        var result = SeqV()
+        for _ in range(count):
+            for v in self.data:
+                result.data.append(v)
+        return PythonObject(alloc=result^)
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("SeqV(len=", len(self.data), ")")
+
+
+@export
+def PyInit_sequence_mojo_module() -> PythonObject:
+    try:
+        var b = PythonModuleBuilder("sequence_mojo_module")
+        ref tb = (
+            b.add_type[Seq]("Seq")
+            .def_init_defaultable[Seq]()
+            .def_staticmethod[Seq.from_list]("from_list")
+        )
+        var spb = SequenceProtocolBuilder[Seq](tb)
+        _ = (
+            spb.def_len[Seq.py__len__]()
+            .def_getitem[Seq.py__getitem__]()
+            .def_setitem[Seq.py__setitem__]()
+            .def_contains[Seq.py__contains__]()
+            .def_concat[Seq.py__concat__]()
+            .def_repeat[Seq.py__repeat__]()
+        )
+        ref tbv = (
+            b.add_type[SeqV]("SeqV")
+            .def_init_defaultable[SeqV]()
+            .def_staticmethod[SeqV.from_list]("from_list")
+        )
+        var spbv = SequenceProtocolBuilder[SeqV](tbv)
+        _ = (
+            spbv.def_len[SeqV.py__len__]()
+            .def_getitem[SeqV.py__getitem__]()
+            .def_setitem[SeqV.py__setitem__]()
+            .def_contains[SeqV.py__contains__]()
+            .def_concat[SeqV.py__concat__]()
+            .def_repeat[SeqV.py__repeat__]()
+        )
+        return b.finalize()
+    except e:
+        abort(String("failed to create Python module: ", e))

--- a/mojo/stdlib/test/python/sequence_mojo_module.mojo
+++ b/mojo/stdlib/test/python/sequence_mojo_module.mojo
@@ -1,0 +1,257 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Test for SequenceProtocolBuilder.
+#
+# Exposes a Seq type to Python that supports:
+#   - len(obj)       via sq_length
+#   - obj[i]         via sq_item        (integer index)
+#   - obj[i] = v     via sq_ass_item    (assignment)
+#   - del obj[i]     via sq_ass_item    (deletion)
+#   - v in obj       via sq_contains
+#   - obj + other    via sq_concat
+#   - obj * n        via sq_repeat
+# ===----------------------------------------------------------------------=== #
+
+from std.os import abort
+from std.memory import UnsafePointer
+from std.utils import Variant
+from std.python import PythonObject
+from std.python.bindings import PythonModuleBuilder
+
+from std.python.builders import SequenceProtocolBuilder
+from std.python.utils import PySlotError
+
+
+def _alloc[
+    T: Movable & ImplicitlyDestructible
+](var value: T) raises PySlotError -> PythonObject:
+    """Translate `PythonObject(alloc=...)`'s plain `Error` into `PySlotError`.
+    """
+    try:
+        return PythonObject(alloc=value^)
+    except e:
+        raise PySlotError.runtime_error(String(e))
+
+
+struct Seq(Defaultable, Movable, Writable):
+    var data: List[Int]
+
+    def __init__(out self):
+        self.data = []
+
+    @staticmethod
+    def from_list(items: PythonObject) raises -> PythonObject:
+        var result = Seq()
+        for item in items:
+            result.data.append(Int(py=item))
+        return PythonObject(alloc=result^)
+
+    @staticmethod
+    def py__len__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin]
+    ) raises PySlotError -> Int:
+        return len(self_ptr[].data)
+
+    @staticmethod
+    def py__getitem__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], index: Int
+    ) raises PySlotError -> PythonObject:
+        if index < 0 or index >= len(self_ptr[].data):
+            raise PySlotError.index_error("index out of range")
+        try:
+            return PythonObject(self_ptr[].data[index])
+        except e:
+            raise PySlotError.runtime_error(String(e))
+
+    @staticmethod
+    def py__setitem__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin],
+        index: Int,
+        value: Variant[PythonObject, Int],
+    ) raises PySlotError -> None:
+        if index < 0 or index >= len(self_ptr[].data):
+            raise PySlotError.index_error("index out of range")
+        if value.isa[PythonObject]():
+            try:
+                self_ptr[].data[index] = Int(py=value[PythonObject])
+            except e:
+                raise PySlotError.type_error(String(e))
+        else:
+            _ = self_ptr[].data.pop(index)
+
+    @staticmethod
+    def py__contains__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], item: PythonObject
+    ) raises PySlotError -> Bool:
+        var v: Int
+        try:
+            v = Int(py=item)
+        except e:
+            raise PySlotError.type_error(String(e))
+        for elem in self_ptr[].data:
+            if elem == v:
+                return True
+        return False
+
+    @staticmethod
+    def py__concat__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        var other_ptr: UnsafePointer[Self, MutAnyOrigin]
+        try:
+            other_ptr = other.downcast_value_ptr[Self]()
+        except e:
+            raise PySlotError.type_error(String(e))
+        var result = Seq()
+        for v in self_ptr[].data:
+            result.data.append(v)
+        for v in other_ptr[].data:
+            result.data.append(v)
+        return _alloc(result^)
+
+    @staticmethod
+    def py__repeat__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin], count: Int
+    ) raises PySlotError -> PythonObject:
+        var result = Seq()
+        for _ in range(count):
+            for v in self_ptr[].data:
+                result.data.append(v)
+        return _alloc(result^)
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("Seq(len=", len(self.data), ")")
+
+
+# SeqV uses value-receiver handlers where no mutation is needed, and pointer
+# receivers where the object must be modified in place.
+struct SeqV(Defaultable, Movable, Writable):
+    var data: List[Int]
+
+    def __init__(out self):
+        self.data = []
+
+    @staticmethod
+    def from_list(items: PythonObject) raises -> PythonObject:
+        var result = SeqV()
+        for item in items:
+            result.data.append(Int(py=item))
+        return PythonObject(alloc=result^)
+
+    # Non-raising value receiver
+    def py__len__(self) -> Int:
+        return len(self.data)
+
+    # Raising value receiver
+    def py__getitem__(self, index: Int) raises PySlotError -> PythonObject:
+        if index < 0 or index >= len(self.data):
+            raise PySlotError.index_error("index out of range")
+        try:
+            return PythonObject(self.data[index])
+        except e:
+            raise PySlotError.runtime_error(String(e))
+
+    # Mutation uses pointer receiver
+    @staticmethod
+    def py__setitem__(
+        self_ptr: UnsafePointer[Self, MutAnyOrigin],
+        index: Int,
+        value: Variant[PythonObject, Int],
+    ) raises PySlotError -> None:
+        if index < 0 or index >= len(self_ptr[].data):
+            raise PySlotError.index_error("index out of range")
+        if value.isa[PythonObject]():
+            try:
+                self_ptr[].data[index] = Int(py=value[PythonObject])
+            except e:
+                raise PySlotError.type_error(String(e))
+        else:
+            _ = self_ptr[].data.pop(index)
+
+    # Raising value receiver for contains
+    def py__contains__(self, item: PythonObject) raises PySlotError -> Bool:
+        var v: Int
+        try:
+            v = Int(py=item)
+        except e:
+            raise PySlotError.type_error(String(e))
+        for elem in self.data:
+            if elem == v:
+                return True
+        return False
+
+    # Raising value receiver for concat
+    def py__concat__(
+        self, other: PythonObject
+    ) raises PySlotError -> PythonObject:
+        var other_ptr: UnsafePointer[Self, MutAnyOrigin]
+        try:
+            other_ptr = other.downcast_value_ptr[Self]()
+        except e:
+            raise PySlotError.type_error(String(e))
+        var result = SeqV()
+        for v in self.data:
+            result.data.append(v)
+        for v in other_ptr[].data:
+            result.data.append(v)
+        return _alloc(result^)
+
+    # Raising value receiver for repeat
+    def py__repeat__(self, count: Int) raises PySlotError -> PythonObject:
+        var result = SeqV()
+        for _ in range(count):
+            for v in self.data:
+                result.data.append(v)
+        return _alloc(result^)
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("SeqV(len=", len(self.data), ")")
+
+
+@export
+def PyInit_sequence_mojo_module() -> PythonObject:
+    try:
+        var b = PythonModuleBuilder("sequence_mojo_module")
+        ref tb = (
+            b.add_type[Seq]("Seq")
+            .def_init_defaultable[Seq]()
+            .def_staticmethod[Seq.from_list]("from_list")
+        )
+        var spb = SequenceProtocolBuilder[Seq](tb)
+        _ = (
+            spb.def_len[Seq.py__len__]()
+            .def_getitem[Seq.py__getitem__]()
+            .def_setitem[Seq.py__setitem__]()
+            .def_contains[Seq.py__contains__]()
+            .def_concat[Seq.py__concat__]()
+            .def_repeat[Seq.py__repeat__]()
+        )
+        ref tbv = (
+            b.add_type[SeqV]("SeqV")
+            .def_init_defaultable[SeqV]()
+            .def_staticmethod[SeqV.from_list]("from_list")
+        )
+        var spbv = SequenceProtocolBuilder[SeqV](tbv)
+        _ = (
+            spbv.def_len[SeqV.py__len__]()
+            .def_getitem[SeqV.py__getitem__]()
+            .def_setitem[SeqV.py__setitem__]()
+            .def_contains[SeqV.py__contains__]()
+            .def_concat[SeqV.py__concat__]()
+            .def_repeat[SeqV.py__repeat__]()
+        )
+        return b.finalize()
+    except e:
+        abort(String("failed to create Python module: ", e))

--- a/mojo/stdlib/test/python/test_buffer.py
+++ b/mojo/stdlib/test/python/test_buffer.py
@@ -1,0 +1,76 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Integration test for BufferProtocolBuilder (bf_getbuffer, bf_releasebuffer)."""
+
+import buffer_mojo_module as mojo_module  # type: ignore[import-not-found]
+
+
+def test_buffer_protocol() -> None:
+    print("Testing buffer protocol...")
+
+    obj = mojo_module.FloatBuffer.from_count(4)
+
+    # memoryview basics
+    mv = memoryview(obj)
+    assert mv.format == "d", f"expected format 'd', got {mv.format!r}"
+    assert mv.itemsize == 8, f"expected itemsize 8, got {mv.itemsize}"
+    assert len(mv) == 4, f"expected len 4, got {len(mv)}"
+    assert mv.readonly, "expected readonly buffer"
+    print("  memoryview basics: ok")
+
+    # element access via memoryview
+    assert mv[0] == 0.0
+    assert mv[1] == 1.0
+    assert mv[2] == 2.0
+    assert mv[3] == 3.0
+    print("  memoryview element access: ok")
+
+    # tolist()
+    assert mv.tolist() == [0.0, 1.0, 2.0, 3.0]
+    print("  memoryview tolist: ok")
+
+    # bytes() round-trip: struct.unpack should recover the original doubles
+    import struct
+
+    raw = bytes(mv)
+    unpacked = struct.unpack("4d", raw)
+    assert unpacked == (0.0, 1.0, 2.0, 3.0), (
+        f"struct unpack mismatch: {unpacked}"
+    )
+    print("  bytes/struct round-trip: ok")
+
+    # numpy (optional — skip gracefully if not installed)
+    try:
+        import numpy as np  # type: ignore[import-not-found]
+
+        arr = np.frombuffer(obj, dtype=np.float64)
+        assert arr.shape == (4,), f"expected shape (4,), got {arr.shape}"
+        assert list(arr) == [0.0, 1.0, 2.0, 3.0], (
+            f"numpy values mismatch: {list(arr)}"
+        )
+        print("  numpy.frombuffer: ok")
+    except ImportError:
+        print("  numpy not available, skipping numpy test")
+
+    # Empty buffer
+    empty = mojo_module.FloatBuffer.from_count(0)
+    mv_empty = memoryview(empty)
+    assert len(mv_empty) == 0
+    print("  empty buffer: ok")
+
+    print("Buffer protocol tests passed!")
+
+
+if __name__ == "__main__":
+    test_buffer_protocol()

--- a/mojo/stdlib/test/python/test_buffer.py
+++ b/mojo/stdlib/test/python/test_buffer.py
@@ -1,0 +1,97 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Integration test for BufferProtocolBuilder (bf_getbuffer, bf_releasebuffer)."""
+
+import buffer_mojo_module as mojo_module  # type: ignore[import-not-found]
+
+
+def test_buffer_protocol() -> None:
+    print("Testing buffer protocol...")
+
+    obj = mojo_module.FloatBuffer.from_count(4)
+
+    # memoryview basics
+    mv = memoryview(obj)
+    assert mv.format == "d", f"expected format 'd', got {mv.format!r}"
+    assert mv.itemsize == 8, f"expected itemsize 8, got {mv.itemsize}"
+    assert len(mv) == 4, f"expected len 4, got {len(mv)}"
+    assert mv.readonly, "expected readonly buffer"
+    print("  memoryview basics: ok")
+
+    # element access via memoryview
+    assert mv[0] == 0.0
+    assert mv[1] == 1.0
+    assert mv[2] == 2.0
+    assert mv[3] == 3.0
+    print("  memoryview element access: ok")
+
+    # tolist()
+    assert mv.tolist() == [0.0, 1.0, 2.0, 3.0]
+    print("  memoryview tolist: ok")
+
+    # bytes() round-trip: struct.unpack should recover the original doubles
+    import struct
+
+    raw = bytes(mv)
+    unpacked = struct.unpack("4d", raw)
+    assert unpacked == (0.0, 1.0, 2.0, 3.0), (
+        f"struct unpack mismatch: {unpacked}"
+    )
+    print("  bytes/struct round-trip: ok")
+
+    # numpy (optional — skip gracefully if not installed)
+    try:
+        import numpy as np  # type: ignore[import-not-found]
+
+        arr = np.frombuffer(obj, dtype=np.float64)
+        assert arr.shape == (4,), f"expected shape (4,), got {arr.shape}"
+        assert list(arr) == [0.0, 1.0, 2.0, 3.0], (
+            f"numpy values mismatch: {list(arr)}"
+        )
+        print("  numpy.frombuffer: ok")
+    except ImportError:
+        print("  numpy not available, skipping numpy test")
+
+    # Empty buffer
+    empty = mojo_module.FloatBuffer.from_count(0)
+    mv_empty = memoryview(empty)
+    assert len(mv_empty) == 0
+    print("  empty buffer: ok")
+
+    # Writable-rejection branch in `_getbufferproc_wrapper`: requesting
+    # PyBUF_WRITABLE on a read-only FloatBuffer must raise BufferError.
+    # Mutating a memoryview surfaces the rejection as TypeError (memoryview
+    # itself enforces readonly before reaching our slot), so we exercise
+    # the wrapper directly via the PEP 688 `__buffer__` API (3.12+).
+    import sys
+
+    if sys.version_info >= (3, 12):
+        import inspect
+
+        try:
+            obj.__buffer__(inspect.BufferFlags.WRITABLE)
+            raise Exception("BufferError expected for PyBUF_WRITABLE request")
+        except BufferError as ex:
+            assert "not writable" in str(ex), (
+                f"expected 'not writable' message, got {ex!r}"
+            )
+        print("  writable-rejection: ok")
+    else:
+        print("  writable-rejection: skipped (requires Python 3.12+)")
+
+    print("Buffer protocol tests passed!")
+
+
+if __name__ == "__main__":
+    test_buffer_protocol()

--- a/mojo/stdlib/test/python/test_mapping.py
+++ b/mojo/stdlib/test/python/test_mapping.py
@@ -1,0 +1,65 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Integration test for MappingProtocolBuilder (mp_length, mp_subscript, mp_ass_subscript)."""
+
+import mapping_mojo_module as mojo_module  # type: ignore[import-not-found]
+
+
+def _run_mapping_assertions(cls) -> None:
+    obj = cls.from_list([10, 20, 30])
+
+    # __len__ (mp_length)
+    assert len(obj) == 3
+
+    # __getitem__ (mp_subscript)
+    assert obj[0] == 10
+    assert obj[1] == 20
+    assert obj[2] == 30
+
+    # __getitem__ out-of-range raises
+    try:
+        _ = obj[5]
+        raise Exception("Expected an error for out-of-range index")
+    except Exception as ex:
+        assert "range" in str(ex)
+
+    # __setitem__ (mp_ass_subscript — assignment)
+    obj[1] = 99
+    assert obj[1] == 99
+    assert obj[0] == 10  # neighbours unchanged
+    assert obj[2] == 30
+
+    # __delitem__ (mp_ass_subscript — deletion)
+    d = cls.from_list([1, 2, 3])
+    del d[0]
+    assert len(d) == 2
+    assert d[0] == 2
+    assert d[1] == 3
+
+    # Empty list has length 0
+    empty = cls()
+    assert len(empty) == 0
+
+
+def test_mapping_protocol() -> None:
+    print("Testing mapping protocol...")
+    _run_mapping_assertions(mojo_module.SimpleList)
+    print("  ptr-receiver: ok")
+    _run_mapping_assertions(mojo_module.SimpleListV)
+    print("  value-receiver: ok")
+    print("Mapping protocol tests passed!")
+
+
+if __name__ == "__main__":
+    test_mapping_protocol()

--- a/mojo/stdlib/test/python/test_mapping.py
+++ b/mojo/stdlib/test/python/test_mapping.py
@@ -1,0 +1,70 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Integration test for MappingProtocolBuilder (mp_length, mp_subscript, mp_ass_subscript)."""
+
+from typing import Any
+
+import mapping_mojo_module as mojo_module  # type: ignore[import-not-found]
+
+
+def _run_mapping_assertions(cls: Any) -> None:
+    # `cls` is a Mojo-defined Python type; `from_list` is a classmethod
+    # registered via `def_staticmethod` and is not visible to mypy as a
+    # standard `type` attribute.
+    obj = cls.from_list([10, 20, 30])
+
+    # __len__ (mp_length)
+    assert len(obj) == 3
+
+    # __getitem__ (mp_subscript)
+    assert obj[0] == 10
+    assert obj[1] == 20
+    assert obj[2] == 30
+
+    # __getitem__ out-of-range raises
+    try:
+        _ = obj[5]
+        raise Exception("Expected an error for out-of-range index")
+    except Exception as ex:
+        assert "range" in str(ex)
+
+    # __setitem__ (mp_ass_subscript — assignment)
+    obj[1] = 99
+    assert obj[1] == 99
+    assert obj[0] == 10  # neighbours unchanged
+    assert obj[2] == 30
+
+    # __delitem__ (mp_ass_subscript — deletion)
+    d = cls.from_list([1, 2, 3])
+    del d[0]
+    assert len(d) == 2
+    assert d[0] == 2
+    assert d[1] == 3
+
+    # Empty list has length 0
+    empty = cls()
+    assert len(empty) == 0
+
+
+def test_mapping_protocol() -> None:
+    print("Testing mapping protocol...")
+    _run_mapping_assertions(mojo_module.SimpleList)
+    print("  ptr-receiver: ok")
+    _run_mapping_assertions(mojo_module.SimpleListV)
+    print("  value-receiver: ok")
+    print("Mapping protocol tests passed!")
+
+
+if __name__ == "__main__":
+    test_mapping_protocol()

--- a/mojo/stdlib/test/python/test_number.py
+++ b/mojo/stdlib/test/python/test_number.py
@@ -1,0 +1,126 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Integration test for NumberProtocolBuilder (unary, bool, conversion, binary, ternary slots)."""
+
+import operator
+
+import number_mojo_module as mojo_module  # type: ignore[import-not-found]
+
+
+def _run_number_assertions(new_fn, val_fn) -> None:
+    n = new_fn
+
+    # __neg__ (nb_negative)
+    assert val_fn(-n(7)) == -7
+    assert val_fn(-n(-3)) == 3
+
+    # __abs__ (nb_absolute)
+    assert val_fn(abs(n(-5))) == 5
+    assert val_fn(abs(n(5))) == 5
+
+    # __pos__ (nb_positive)
+    assert val_fn(+n(4)) == 4
+
+    # __invert__ (nb_invert)
+    assert val_fn(~n(0)) == -1
+    assert val_fn(~n(6)) == -7
+
+    # __bool__ (nb_bool)
+    assert bool(n(1))
+    assert bool(n(-1))
+    assert not bool(n(0))
+
+    # __int__ (nb_int)
+    assert int(n(42)) == 42
+
+    # __float__ (nb_float)
+    assert float(n(3)) == 3.0
+
+    # __index__ (nb_index)
+    assert operator.index(n(10)) == 10
+    lst = [0, 1, 2, 3]
+    assert lst[n(2)] == 2
+
+    # __add__ (nb_add)
+    assert val_fn(n(3) + n(4)) == 7
+
+    # __add__ with non-type returns NotImplemented → TypeError
+    try:
+        _ = n(1) + 42
+        raise Exception("TypeError expected")
+    except TypeError:
+        pass
+
+    # __sub__ (nb_subtract)
+    assert val_fn(n(10) - n(3)) == 7
+
+    # __mul__ (nb_multiply)
+    assert val_fn(n(6) * n(7)) == 42
+
+    # __floordiv__ (nb_floor_divide)
+    assert val_fn(n(17) // n(5)) == 3
+
+    # __mod__ (nb_remainder)
+    assert val_fn(n(17) % n(5)) == 2
+
+    # __and__ (nb_and)
+    assert val_fn(n(0b1100) & n(0b1010)) == 0b1000
+
+    # __or__ (nb_or)
+    assert val_fn(n(0b1100) | n(0b1010)) == 0b1110
+
+    # __xor__ (nb_xor)
+    assert val_fn(n(0b1100) ^ n(0b1010)) == 0b0110
+
+    # __lshift__ (nb_lshift)
+    assert val_fn(n(1) << n(4)) == 16
+
+    # __rshift__ (nb_rshift)
+    assert val_fn(n(32) >> n(2)) == 8
+
+    # __pow__ (nb_power)
+    assert val_fn(n(2) ** n(10)) == 1024
+    assert val_fn(n(3) ** n(3)) == 27
+
+
+def _run_inplace_assertions(new_fn, val_fn) -> None:
+    n = new_fn(10)
+    m = new_fn(3)
+
+    n += m
+    assert val_fn(n) == 13
+
+    n -= m
+    assert val_fn(n) == 10
+
+    n *= m
+    assert val_fn(n) == 30
+
+    n **= new_fn(2)
+    assert val_fn(n) == 900
+
+
+def test_number_protocol() -> None:
+    print("Testing number protocol...")
+    _run_number_assertions(mojo_module.Number.new, lambda x: x.get_value())
+    print("  ptr-receiver: ok")
+    _run_number_assertions(mojo_module.NumberV.new, lambda x: x.get_value())
+    print("  value-receiver: ok")
+    _run_inplace_assertions(mojo_module.NumberM.new, lambda x: x.get_value())
+    print("  mut-receiver in-place: ok")
+    print("Number protocol tests passed!")
+
+
+if __name__ == "__main__":
+    test_number_protocol()

--- a/mojo/stdlib/test/python/test_number.py
+++ b/mojo/stdlib/test/python/test_number.py
@@ -1,0 +1,168 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Integration test for NumberProtocolBuilder (unary, bool, conversion, binary, ternary slots)."""
+
+import operator
+from collections.abc import Callable
+from typing import Any
+
+import number_mojo_module as mojo_module  # type: ignore[import-not-found]
+
+
+def _run_number_assertions(
+    new_fn: Callable[..., Any], val_fn: Callable[..., Any]
+) -> None:
+    n = new_fn
+
+    # __neg__ (nb_negative)
+    assert val_fn(-n(7)) == -7
+    assert val_fn(-n(-3)) == 3
+
+    # __abs__ (nb_absolute)
+    assert val_fn(abs(n(-5))) == 5
+    assert val_fn(abs(n(5))) == 5
+
+    # __pos__ (nb_positive)
+    assert val_fn(+n(4)) == 4
+
+    # __invert__ (nb_invert)
+    assert val_fn(~n(0)) == -1
+    assert val_fn(~n(6)) == -7
+
+    # __bool__ (nb_bool)
+    assert bool(n(1))
+    assert bool(n(-1))
+    assert not bool(n(0))
+
+    # __int__ (nb_int)
+    assert int(n(42)) == 42
+
+    # __float__ (nb_float)
+    assert float(n(3)) == 3.0
+
+    # __index__ (nb_index)
+    assert operator.index(n(10)) == 10
+    lst = [0, 1, 2, 3]
+    assert lst[n(2)] == 2
+
+    # __add__ (nb_add)
+    assert val_fn(n(3) + n(4)) == 7
+
+    # __add__ with non-type returns NotImplemented → TypeError
+    try:
+        _ = n(1) + 42
+        raise Exception("TypeError expected")
+    except TypeError:
+        pass
+
+    # Magic-value path: `n(42)` on the LHS always returns NotImplemented
+    # from `nb_add`. With a plain `int` on the LHS, CPython first asks
+    # `int.__add__(1, n(42))` (which returns NotImplemented — int doesn't
+    # know about Number), then tries the reflected `Number.nb_add(n(42), 1)`
+    # which also returns NotImplemented because of the magic-42 check. With
+    # neither direction implemented, CPython raises `TypeError`.
+    try:
+        _ = 1 + n(42)
+        raise Exception("TypeError expected for 1 + n(42)")
+    except TypeError:
+        pass
+
+    # Sanity: the magic check is on the LHS only, so `n(42) + n(1)` still
+    # exercises the reflected dispatch (LHS returns NotImplemented, then
+    # CPython tries Number.nb_add(n(1), n(42)) — same-type reflected — which
+    # succeeds and returns 43).
+    # Note: CPython does NOT actually reflect for same-type operands, so
+    # both sides being Number means this raises TypeError too.
+    # Magic check is on LHS only — when n(42) is on the right and the LHS
+    # is also a Number, the LHS slot succeeds normally.
+    assert val_fn(n(1) + n(42)) == 43
+
+    # __sub__ (nb_subtract)
+    assert val_fn(n(10) - n(3)) == 7
+
+    # __mul__ (nb_multiply)
+    assert val_fn(n(6) * n(7)) == 42
+
+    # __floordiv__ (nb_floor_divide)
+    assert val_fn(n(17) // n(5)) == 3
+
+    # __mod__ (nb_remainder)
+    assert val_fn(n(17) % n(5)) == 2
+
+    # __and__ (nb_and)
+    assert val_fn(n(0b1100) & n(0b1010)) == 0b1000
+
+    # __or__ (nb_or)
+    assert val_fn(n(0b1100) | n(0b1010)) == 0b1110
+
+    # __xor__ (nb_xor)
+    assert val_fn(n(0b1100) ^ n(0b1010)) == 0b0110
+
+    # __lshift__ (nb_lshift)
+    assert val_fn(n(1) << n(4)) == 16
+
+    # __rshift__ (nb_rshift)
+    assert val_fn(n(32) >> n(2)) == 8
+
+    # __pow__ (nb_power)
+    assert val_fn(n(2) ** n(10)) == 1024
+    assert val_fn(n(3) ** n(3)) == 27
+
+    # __pow__ NotImplemented path (ternary wrapper). `2 ** n(42)` asks
+    # `int.__pow__(2, n(42))` first → NotImplemented (int doesn't know
+    # Number), then reflected `Number.nb_power(n(42), 2, None)` → magic-42
+    # check returns NotImplemented → TypeError.
+    try:
+        _ = 2 ** n(42)
+        raise Exception("TypeError expected for 2 ** n(42)")
+    except TypeError:
+        pass
+
+    # Sanity: magic check is on the base only, so `n(2) ** n(42)` (LHS=2)
+    # succeeds normally.
+    assert val_fn(n(2) ** n(42)) == 2**42
+
+
+def _run_inplace_assertions(
+    new_fn: Callable[..., Any], val_fn: Callable[..., Any]
+) -> None:
+    n = new_fn(10)
+    m = new_fn(3)
+
+    n += m
+    assert val_fn(n) == 13
+
+    n -= m
+    assert val_fn(n) == 10
+
+    n *= m
+    assert val_fn(n) == 30
+
+    n **= new_fn(2)
+    assert val_fn(n) == 900
+
+
+def test_number_protocol() -> None:
+    print("Testing number protocol...")
+    _run_number_assertions(mojo_module.Number.new, lambda x: x.get_value())
+    print("  ptr-receiver: ok")
+    _run_number_assertions(mojo_module.NumberV.new, lambda x: x.get_value())
+    print("  value-receiver: ok")
+    _run_inplace_assertions(mojo_module.NumberM.new, lambda x: x.get_value())
+    print("  mut-receiver in-place: ok")
+    print("Number protocol tests passed!")
+
+
+if __name__ == "__main__":
+    test_number_protocol()

--- a/mojo/stdlib/test/python/test_python_cpython.mojo
+++ b/mojo/stdlib/test/python/test_python_cpython.mojo
@@ -191,6 +191,22 @@ def _helper_instantiate_derived_class(
     return cpy.PyObject_CallObject(constructor, args)
 
 
+def _test_none_object_api(cpy: CPython) raises:
+    var none = cpy.Py_None()
+    assert_true(none)
+    # `None` is a singleton — fetching it twice yields the same pointer.
+    assert_equal(cpy.Py_None(), none)
+    assert_equal(cpy.PyObject_IsTrue(none), 0)
+
+
+def _test_not_implemented_object_api(cpy: CPython) raises:
+    var ni = cpy.Py_NotImplemented()
+    assert_true(ni)
+    # `NotImplemented` is a singleton — fetching it twice yields the same pointer.
+    assert_equal(cpy.Py_NotImplemented(), ni)
+    assert_true(ni != cpy.Py_None())
+
+
 def _test_integer_object_api(cpy: CPython) raises:
     var n = cpy.PyLong_FromSsize_t(-42)
     assert_true(n)
@@ -450,6 +466,18 @@ def test_with_cpython_type_object_api() raises:
     var python = Python()
     ref cpython = python.cpython()
     _test_type_object_api(cpython)
+
+
+def test_with_cpython_none_object_api() raises:
+    var python = Python()
+    ref cpython = python.cpython()
+    _test_none_object_api(cpython)
+
+
+def test_with_cpython_not_implemented_object_api() raises:
+    var python = Python()
+    ref cpython = python.cpython()
+    _test_not_implemented_object_api(cpython)
 
 
 def test_with_cpython_integer_object_api() raises:

--- a/mojo/stdlib/test/python/test_sequence.py
+++ b/mojo/stdlib/test/python/test_sequence.py
@@ -1,0 +1,89 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Integration test for SequenceProtocolBuilder (sq_length, sq_item, sq_ass_item, sq_contains, sq_concat, sq_repeat)."""
+
+import sequence_mojo_module as mojo_module  # type: ignore[import-not-found]
+
+
+def _run_sequence_assertions(cls) -> None:
+    obj = cls.from_list([10, 20, 30])
+
+    # __len__ (sq_length)
+    assert len(obj) == 3
+
+    # __getitem__ (sq_item — integer index)
+    assert obj[0] == 10
+    assert obj[1] == 20
+    assert obj[2] == 30
+
+    # __getitem__ out-of-range raises
+    try:
+        _ = obj[5]
+        raise Exception("Expected an error for out-of-range index")
+    except Exception as ex:
+        assert "range" in str(ex)
+
+    # __setitem__ (sq_ass_item — assignment)
+    obj[1] = 99
+    assert obj[1] == 99
+    assert obj[0] == 10  # neighbours unchanged
+    assert obj[2] == 30
+
+    # __delitem__ (sq_ass_item — deletion)
+    d = cls.from_list([1, 2, 3])
+    del d[0]
+    assert len(d) == 2
+    assert d[0] == 2
+    assert d[1] == 3
+
+    # __contains__ (sq_contains)
+    s = cls.from_list([1, 2, 3])
+    assert 1 in s
+    assert 3 in s
+    assert 4 not in s
+
+    # __add__ / sq_concat
+    a = cls.from_list([1, 2])
+    b = cls.from_list([3, 4, 5])
+    c = a + b
+    assert len(c) == 5
+    assert c[0] == 1
+    assert c[2] == 3
+    assert c[4] == 5
+
+    # __mul__ / sq_repeat
+    r = cls.from_list([7, 8]) * 3
+    assert len(r) == 6
+    assert r[0] == 7
+    assert r[1] == 8
+    assert r[2] == 7  # second repetition
+    assert r[4] == 7  # third repetition
+
+    # Empty sequence
+    empty = cls()
+    assert len(empty) == 0
+    assert 0 not in empty
+
+
+def test_sequence_protocol() -> None:
+    print("Testing sequence protocol...")
+    _run_sequence_assertions(mojo_module.Seq)
+    print("  ptr-receiver: ok")
+    _run_sequence_assertions(mojo_module.SeqV)
+    print("  value-receiver: ok")
+    print("Sequence protocol tests passed!")
+
+
+if __name__ == "__main__":
+    test_sequence_protocol()

--- a/mojo/stdlib/test/python/test_sequence.py
+++ b/mojo/stdlib/test/python/test_sequence.py
@@ -1,0 +1,102 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Integration test for SequenceProtocolBuilder (sq_length, sq_item, sq_ass_item, sq_contains, sq_concat, sq_repeat)."""
+
+from typing import Any
+
+import sequence_mojo_module as mojo_module  # type: ignore[import-not-found]
+
+
+def _run_sequence_assertions(cls: Any) -> None:
+    # `cls` is a Mojo-defined Python type; `from_list` is a classmethod
+    # registered via `def_staticmethod` and is not visible to mypy as a
+    # standard `type` attribute.
+    obj = cls.from_list([10, 20, 30])
+
+    # __len__ (sq_length)
+    assert len(obj) == 3
+
+    # __getitem__ (sq_item — integer index)
+    assert obj[0] == 10
+    assert obj[1] == 20
+    assert obj[2] == 30
+
+    # __getitem__ out-of-range raises
+    try:
+        _ = obj[5]
+        raise Exception("Expected an error for out-of-range index")
+    except Exception as ex:
+        assert "range" in str(ex)
+
+    # __setitem__ (sq_ass_item — assignment)
+    obj[1] = 99
+    assert obj[1] == 99
+    assert obj[0] == 10  # neighbours unchanged
+    assert obj[2] == 30
+
+    # __setitem__ out-of-range raises IndexError specifically (the
+    # ssizeobjargproc wrapper maps PySlotError.index_error -> PyExc_IndexError).
+    try:
+        obj[99] = 0
+        raise Exception("Expected IndexError for out-of-range setitem")
+    except IndexError as ex:
+        assert "range" in str(ex)
+
+    # __delitem__ (sq_ass_item — deletion)
+    d = cls.from_list([1, 2, 3])
+    del d[0]
+    assert len(d) == 2
+    assert d[0] == 2
+    assert d[1] == 3
+
+    # __contains__ (sq_contains)
+    s = cls.from_list([1, 2, 3])
+    assert 1 in s
+    assert 3 in s
+    assert 4 not in s
+
+    # __add__ / sq_concat
+    a = cls.from_list([1, 2])
+    b = cls.from_list([3, 4, 5])
+    c = a + b
+    assert len(c) == 5
+    assert c[0] == 1
+    assert c[2] == 3
+    assert c[4] == 5
+
+    # __mul__ / sq_repeat
+    r = cls.from_list([7, 8]) * 3
+    assert len(r) == 6
+    assert r[0] == 7
+    assert r[1] == 8
+    assert r[2] == 7  # second repetition
+    assert r[4] == 7  # third repetition
+
+    # Empty sequence
+    empty = cls()
+    assert len(empty) == 0
+    assert 0 not in empty
+
+
+def test_sequence_protocol() -> None:
+    print("Testing sequence protocol...")
+    _run_sequence_assertions(mojo_module.Seq)
+    print("  ptr-receiver: ok")
+    _run_sequence_assertions(mojo_module.SeqV)
+    print("  value-receiver: ok")
+    print("Sequence protocol tests passed!")
+
+
+if __name__ == "__main__":
+    test_sequence_protocol()

--- a/mojo/stdlib/test/python/test_type_protocol.py
+++ b/mojo/stdlib/test/python/test_type_protocol.py
@@ -1,0 +1,70 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Integration test for TypeProtocolBuilder (tp_richcompare — all six operators)."""
+
+import type_protocol_mojo_module as mojo_module  # type: ignore[import-not-found]
+
+
+def _run_richcompare_assertions(new_fn) -> None:
+    lo = new_fn(1.0)
+    hi = new_fn(5.0)
+    eq = new_fn(1.0)
+
+    # __lt__ (Py_LT)
+    assert lo < hi
+    assert not hi < lo
+    assert not lo < eq
+
+    # __le__ (Py_LE)
+    assert lo <= hi
+    assert lo <= eq
+    assert not hi <= lo
+
+    # __eq__ (Py_EQ)
+    assert lo == eq
+    assert not lo == hi
+
+    # __ne__ (Py_NE)
+    assert lo != hi
+    assert not lo != eq
+
+    # __gt__ (Py_GT)
+    assert hi > lo
+    assert not lo > hi
+    assert not lo > eq
+
+    # __ge__ (Py_GE)
+    assert hi >= lo
+    assert lo >= eq
+    assert not lo >= hi
+
+    # Sorting relies on __lt__
+    boxes = [new_fn(3.0), new_fn(1.0), new_fn(2.0)]
+    boxes.sort()
+    assert boxes[0].get_value() == 1.0
+    assert boxes[1].get_value() == 2.0
+    assert boxes[2].get_value() == 3.0
+
+
+def test_type_protocol() -> None:
+    print("Testing type protocol (rich comparison)...")
+    _run_richcompare_assertions(mojo_module.Box.new)
+    print("  ptr-receiver: ok")
+    _run_richcompare_assertions(mojo_module.BoxV.new)
+    print("  value-receiver: ok")
+    print("Type protocol tests passed!")
+
+
+if __name__ == "__main__":
+    test_type_protocol()

--- a/mojo/stdlib/test/python/test_type_protocol.py
+++ b/mojo/stdlib/test/python/test_type_protocol.py
@@ -1,0 +1,100 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Integration test for TypeProtocolBuilder (tp_richcompare — all six operators)."""
+
+from collections.abc import Callable
+from typing import Any
+
+import type_protocol_mojo_module as mojo_module  # type: ignore[import-not-found]
+
+
+def _run_richcompare_assertions(new_fn: Callable[..., Any]) -> None:
+    lo = new_fn(1.0)
+    hi = new_fn(5.0)
+    eq = new_fn(1.0)
+
+    # __lt__ (Py_LT)
+    assert lo < hi
+    assert not hi < lo
+    assert not lo < eq
+
+    # __le__ (Py_LE)
+    assert lo <= hi
+    assert lo <= eq
+    assert not hi <= lo
+
+    # __eq__ (Py_EQ)
+    assert lo == eq
+    assert not lo == hi  # noqa: SIM201
+
+    # __ne__ (Py_NE)
+    assert lo != hi
+    assert not lo != eq  # noqa: SIM202
+
+    # __gt__ (Py_GT)
+    assert hi > lo
+    assert not lo > hi
+    assert not lo > eq
+
+    # __ge__ (Py_GE)
+    assert hi >= lo
+    assert lo >= eq
+    assert not lo >= hi
+
+    # Sorting relies on __lt__
+    boxes = [new_fn(3.0), new_fn(1.0), new_fn(2.0)]
+    boxes.sort()
+    assert boxes[0].get_value() == 1.0
+    assert boxes[1].get_value() == 2.0
+    assert boxes[2].get_value() == 3.0
+
+    # NotImplemented from tp_richcompare. The Box rich_compare implementation
+    # returns NotImplemented when self.value == 42, so CPython tries the
+    # reflected comparison on the other operand with the operator swapped
+    # (e.g. `LT` becomes `GT`). Same-type two-Box case: the reflected slot
+    # is called with `(other, magic)`, where `other.value == 1` so the
+    # magic check doesn't fire — comparison succeeds with a normal answer.
+    magic = new_fn(42.0)
+    other = new_fn(1.0)
+    # `magic < other`: LHS NotImplemented, reflected `other > magic` returns
+    # `1.0 > 42.0` == False.
+    assert not (magic < other)
+    # Symmetrically `magic > other` is reflected to `other < magic` →
+    # `1.0 < 42.0` == True.
+    assert magic > other
+
+    # Cross-type comparison: both sides return NotImplemented (LHS magic
+    # fires OR downcast fails; RHS is `int` which doesn't know `Box`).
+    # CPython falls back to identity for `==`/`!=`; ordering operators
+    # raise TypeError.
+    assert not (new_fn(1.0) == 5)  # noqa: SIM201 downcast failure → NotImplemented → identity
+    assert new_fn(1.0) != 5
+    try:
+        _ = magic < 5
+        raise Exception("TypeError expected for magic < 5")
+    except TypeError:
+        pass
+
+
+def test_type_protocol() -> None:
+    print("Testing type protocol (rich comparison)...")
+    _run_richcompare_assertions(mojo_module.Box.new)
+    print("  ptr-receiver: ok")
+    _run_richcompare_assertions(mojo_module.BoxV.new)
+    print("  value-receiver: ok")
+    print("Type protocol tests passed!")
+
+
+if __name__ == "__main__":
+    test_type_protocol()

--- a/mojo/stdlib/test/python/type_protocol_mojo_module.mojo
+++ b/mojo/stdlib/test/python/type_protocol_mojo_module.mojo
@@ -1,0 +1,159 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Test for TypeProtocolBuilder.
+#
+# Exposes a Box type (wrapping Float64) to Python that supports all six
+# rich comparison operators via tp_richcompare:
+#   - box1 < box2    Py_LT
+#   - box1 <= box2   Py_LE
+#   - box1 == box2   Py_EQ
+#   - box1 != box2   Py_NE
+#   - box1 > box2    Py_GT
+#   - box1 >= box2   Py_GE
+# ===----------------------------------------------------------------------=== #
+
+from std.os import abort
+from std.memory import UnsafePointer
+from std.python import PythonObject
+from std.python.bindings import PythonModuleBuilder
+
+from std.python.builders import TypeProtocolBuilder
+from std.python.utils import NotImplementedError, RichCompareOps
+
+
+struct Box(Defaultable, Movable, Writable):
+    var value: Float64
+
+    def __init__(out self):
+        self.value = 0.0
+
+    def __init__(out self, value: Float64):
+        self.value = value
+
+    @staticmethod
+    def _get_self_ptr(
+        py_self: PythonObject,
+    ) -> UnsafePointer[Self, MutAnyOrigin]:
+        try:
+            return py_self.downcast_value_ptr[Self]()
+        except e:
+            abort(String("downcast failed: ", e))
+
+    @staticmethod
+    def new(value: PythonObject) raises -> PythonObject:
+        return PythonObject(alloc=Box(Float64(py=value)))
+
+    @staticmethod
+    def get_value(py_self: PythonObject) raises -> PythonObject:
+        return PythonObject(Self._get_self_ptr(py_self)[].value)
+
+    @staticmethod
+    def rich_compare(
+        self,
+        other: PythonObject,
+        op: Int,
+    ) raises -> Bool:
+        var a = self.value
+        var b = other.downcast_value_ptr[Self]()[].value
+        if op == RichCompareOps.Py_LT:
+            return a < b
+        if op == RichCompareOps.Py_LE:
+            return a <= b
+        if op == RichCompareOps.Py_EQ:
+            return a == b
+        if op == RichCompareOps.Py_NE:
+            return a != b
+        if op == RichCompareOps.Py_GT:
+            return a > b
+        if op == RichCompareOps.Py_GE:
+            return a >= b
+        raise NotImplementedError()
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("Box(", self.value, ")")
+
+
+# BoxV uses a value-receiver rich_compare handler.
+struct BoxV(Defaultable, Movable, Writable):
+    var value: Float64
+
+    def __init__(out self):
+        self.value = 0.0
+
+    def __init__(out self, value: Float64):
+        self.value = value
+
+    @staticmethod
+    def _get_self_ptr(
+        py_self: PythonObject,
+    ) -> UnsafePointer[Self, MutAnyOrigin]:
+        try:
+            return py_self.downcast_value_ptr[Self]()
+        except e:
+            abort(String("downcast failed: ", e))
+
+    @staticmethod
+    def new(value: PythonObject) raises -> PythonObject:
+        return PythonObject(alloc=BoxV(Float64(py=value)))
+
+    @staticmethod
+    def get_value(py_self: PythonObject) raises -> PythonObject:
+        return PythonObject(Self._get_self_ptr(py_self)[].value)
+
+    # Raising value-receiver rich_compare
+    def rich_compare(self, other: PythonObject, op: Int) raises -> Bool:
+        var a = self.value
+        var b = other.downcast_value_ptr[Self]()[].value
+        if op == RichCompareOps.Py_LT:
+            return a < b
+        if op == RichCompareOps.Py_LE:
+            return a <= b
+        if op == RichCompareOps.Py_EQ:
+            return a == b
+        if op == RichCompareOps.Py_NE:
+            return a != b
+        if op == RichCompareOps.Py_GT:
+            return a > b
+        if op == RichCompareOps.Py_GE:
+            return a >= b
+        raise NotImplementedError()
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("BoxV(", self.value, ")")
+
+
+@export
+def PyInit_type_protocol_mojo_module() -> PythonObject:
+    try:
+        var b = PythonModuleBuilder("type_protocol_mojo_module")
+        ref tb = (
+            b.add_type[Box]("Box")
+            .def_init_defaultable[Box]()
+            .def_staticmethod[Box.new]("new")
+            .def_method[Box.get_value]("get_value")
+        )
+        var tpb = TypeProtocolBuilder[Box](tb)
+        _ = tpb.def_richcompare[Box.rich_compare]()
+        ref tbv = (
+            b.add_type[BoxV]("BoxV")
+            .def_init_defaultable[BoxV]()
+            .def_staticmethod[BoxV.new]("new")
+            .def_method[BoxV.get_value]("get_value")
+        )
+        var tpbv = TypeProtocolBuilder[BoxV](tbv)
+        _ = tpbv.def_richcompare[BoxV.rich_compare]()
+        return b.finalize()
+    except e:
+        abort(String("failed to create Python module: ", e))

--- a/mojo/stdlib/test/python/type_protocol_mojo_module.mojo
+++ b/mojo/stdlib/test/python/type_protocol_mojo_module.mojo
@@ -1,0 +1,181 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# Test for TypeProtocolBuilder.
+#
+# Exposes a Box type (wrapping Float64) to Python that supports all six
+# rich comparison operators via tp_richcompare:
+#   - box1 < box2    Py_LT
+#   - box1 <= box2   Py_LE
+#   - box1 == box2   Py_EQ
+#   - box1 != box2   Py_NE
+#   - box1 > box2    Py_GT
+#   - box1 >= box2   Py_GE
+# ===----------------------------------------------------------------------=== #
+
+from std.os import abort
+from std.memory import UnsafePointer
+from std.python import PythonObject
+from std.python.bindings import PythonModuleBuilder
+
+from std.python.builders import TypeProtocolBuilder
+from std.python.utils import PySlotError, RichCompareOps
+
+
+struct Box(Defaultable, Movable, Writable):
+    var value: Float64
+
+    def __init__(out self):
+        self.value = 0.0
+
+    def __init__(out self, value: Float64):
+        self.value = value
+
+    @staticmethod
+    def _get_self_ptr(
+        py_self: PythonObject,
+    ) -> UnsafePointer[Self, MutAnyOrigin]:
+        try:
+            return py_self.downcast_value_ptr[Self]()
+        except e:
+            abort(String("downcast failed: ", e))
+
+    @staticmethod
+    def new(value: PythonObject) raises -> PythonObject:
+        return PythonObject(alloc=Box(Float64(py=value)))
+
+    @staticmethod
+    def get_value(py_self: PythonObject) raises -> PythonObject:
+        return PythonObject(Self._get_self_ptr(py_self)[].value)
+
+    @staticmethod
+    def rich_compare(
+        self,
+        other: PythonObject,
+        op: Int,
+    ) raises PySlotError -> Bool:
+        var a = self.value
+        # Magic value 42 on the LHS returns NotImplemented from
+        # tp_richcompare, exercising CPython's reflected-comparison fallback.
+        if a == 42.0:
+            raise PySlotError.not_implemented()
+        var b: Float64
+        try:
+            b = other.downcast_value_ptr[Self]()[].value
+        except:
+            # Cross-type compare: returning NotImplemented lets CPython try
+            # the reflected operation rather than raising TypeError.
+            raise PySlotError.not_implemented()
+        if op == RichCompareOps.Py_LT:
+            return a < b
+        if op == RichCompareOps.Py_LE:
+            return a <= b
+        if op == RichCompareOps.Py_EQ:
+            return a == b
+        if op == RichCompareOps.Py_NE:
+            return a != b
+        if op == RichCompareOps.Py_GT:
+            return a > b
+        if op == RichCompareOps.Py_GE:
+            return a >= b
+        raise PySlotError.not_implemented()
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("Box(", self.value, ")")
+
+
+# BoxV uses a value-receiver rich_compare handler.
+struct BoxV(Defaultable, Movable, Writable):
+    var value: Float64
+
+    def __init__(out self):
+        self.value = 0.0
+
+    def __init__(out self, value: Float64):
+        self.value = value
+
+    @staticmethod
+    def _get_self_ptr(
+        py_self: PythonObject,
+    ) -> UnsafePointer[Self, MutAnyOrigin]:
+        try:
+            return py_self.downcast_value_ptr[Self]()
+        except e:
+            abort(String("downcast failed: ", e))
+
+    @staticmethod
+    def new(value: PythonObject) raises -> PythonObject:
+        return PythonObject(alloc=BoxV(Float64(py=value)))
+
+    @staticmethod
+    def get_value(py_self: PythonObject) raises -> PythonObject:
+        return PythonObject(Self._get_self_ptr(py_self)[].value)
+
+    # Raising value-receiver rich_compare
+    def rich_compare(
+        self, other: PythonObject, op: Int
+    ) raises PySlotError -> Bool:
+        var a = self.value
+        # Magic value 42 on the LHS returns NotImplemented from
+        # tp_richcompare, exercising CPython's reflected-comparison fallback.
+        if a == 42.0:
+            raise PySlotError.not_implemented()
+        var b: Float64
+        try:
+            b = other.downcast_value_ptr[Self]()[].value
+        except:
+            # Cross-type compare: returning NotImplemented lets CPython try
+            # the reflected operation rather than raising TypeError.
+            raise PySlotError.not_implemented()
+        if op == RichCompareOps.Py_LT:
+            return a < b
+        if op == RichCompareOps.Py_LE:
+            return a <= b
+        if op == RichCompareOps.Py_EQ:
+            return a == b
+        if op == RichCompareOps.Py_NE:
+            return a != b
+        if op == RichCompareOps.Py_GT:
+            return a > b
+        if op == RichCompareOps.Py_GE:
+            return a >= b
+        raise PySlotError.not_implemented()
+
+    def write_to(self, mut writer: Some[Writer]):
+        writer.write("BoxV(", self.value, ")")
+
+
+@export
+def PyInit_type_protocol_mojo_module() -> PythonObject:
+    try:
+        var b = PythonModuleBuilder("type_protocol_mojo_module")
+        ref tb = (
+            b.add_type[Box]("Box")
+            .def_init_defaultable[Box]()
+            .def_staticmethod[Box.new]("new")
+            .def_method[Box.get_value]("get_value")
+        )
+        var tpb = TypeProtocolBuilder[Box](tb)
+        _ = tpb.def_richcompare[Box.rich_compare]()
+        ref tbv = (
+            b.add_type[BoxV]("BoxV")
+            .def_init_defaultable[BoxV]()
+            .def_staticmethod[BoxV.new]("new")
+            .def_method[BoxV.get_value]("get_value")
+        )
+        var tpbv = TypeProtocolBuilder[BoxV](tbv)
+        _ = tpbv.def_richcompare[BoxV.rich_compare]()
+        return b.finalize()
+    except e:
+        abort(String("failed to create Python module: ", e))


### PR DESCRIPTION
BEGIN_PUBLIC
[Stdlib] Add CPython protocol builders for Mojo-defined Python types

Adds a family of protocol builders under `std.python` that let Mojo structs exposed as Python types implement the standard CPython type protocols without writing CPython slot wrappers by hand.

New builders, each constructed from a `PythonTypeBuilder`:

  - `BufferProtocolBuilder` — `bf_getbuffer` / `bf_releasebuffer`, enabling zero-copy `memoryview(obj)` / `numpy.frombuffer(obj)`.
  - `MappingProtocolBuilder` — `mp_length`, `mp_subscript`, `mp_ass_subscript` (assignment and deletion).
  - `NumberProtocolBuilder` — full `PyNumberMethods` surface: unary (`__abs__`, `__neg__`, `__pos__`, `__invert__`, `__int__`, `__float__`, `__index__`), inquiry (`__bool__`), binary (arithmetic, bitwise, in-place), and ternary (`__pow__`, `__ipow__`).
  - `SequenceProtocolBuilder` — `sq_length`, `sq_item`, `sq_ass_item`, `sq_contains`, `sq_concat`, `sq_repeat`.
  - `TypeProtocolBuilder` — `tp_richcompare` for the six comparison operators.

Each `def_*` method accepts the corresponding Python dunder signature and overloads on receiver kind (pointer, value, mut) and on raising vs non-raising methods. Binary and ternary number methods may raise `NotImplementedError` to return `Py_NotImplemented`, triggering Python's reflected-operation fallback. Number methods may also return any `ConvertibleToPython` type rather than `PythonObject` directly.

Supporting additions:

  - `std.python.adapters` — internal C ABI wrappers, `_PySlotIndex` constants, and lift/conv helpers shared by all builders.
  - `std.python.utils` — `RichCompareOps` constants and a `NotImplementedError` sentinel.
  - `std.python.builders` — re-exports the four `*ProtocolBuilder` types as a convenience entry point.

Adds a `columnar` example under `mojo/examples/python-interop` demonstrating buffer-protocol interop, and integration tests covering each protocol.
END_PUBLIC



## Summary

Extend Python extension capabilities provided by the standard library. This PR adds support for:

 - mapping protocol — obj[key], len(obj), obj[key] = val
 - number protocol — arithmetic operators, abs(), bool(), etc.
 - sequence protocol — indexed access, in operator, concatenation, repetition
 - rich comparison — ==, !=, <, <=, >, >=

Assisted-by: Claude Opus 4.7 (Anthropic) <noreply@anthropic.com>

## Testing

Adds a `columnar` example under `mojo/examples/python-interop` demonstrating buffer-protocol interop, and integration tests covering each protocol.

Additionally the standalone library that this code comes from (https://pontoneer.dev) is used by https://github.com/kszucs/marrow

## Checklist

- [ ] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [ ] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [ ] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
