### PR TITLE
[Kernels][Benchmarking] bump vendor libraries versions for benchmark

### DIFF
--- a/bazel/common.MODULE.bazel
+++ b/bazel/common.MODULE.bazel
@@ -455,20 +455,6 @@ http_file(
     urls = ["https://modular-bazel-artifacts-public.s3.amazonaws.com/artifacts/deep_gemm/sm100/91a898b8704b91726646e98403f6028b1e601603b2d34f8e4530370072e474cf/deep_gemm-2.2.0_38f8ef7-cp312-cp312-linux_x86_64.whl"],
 )
 
-http_file(
-    name = "flashinfer_sm100_wheel",
-    downloaded_file_path = "flashinfer_python-0.6.7.post3-py3-none-any.whl",
-    sha256 = "9d3f1aa0313cf9e5cf99f7560b8e003c57876088c8abfe7a3d330cccd4873052",
-    urls = ["https://files.pythonhosted.org/packages/01/6b/4117cd7cbeff07818ae7c6b8bf5a6d1ee3eed29356672b731b55af3d4453/flashinfer_python-0.6.7.post3-py3-none-any.whl"],
-)
-
-http_file(
-    name = "flash_attn_sm100_wheel",
-    downloaded_file_path = "flash_attn_4-4.0.0b4-py3-none-any.whl",
-    sha256 = "daaec7e76e9aed0bbc717228b4b8461387a99fa71629fb34a8dd00fc56e291e4",
-    urls = ["https://files.pythonhosted.org/packages/73/8e/b27eed4f2dcb9e5a89719e2233be36e86faa64fd1bead802265c7a7b046c/flash_attn_4-4.0.0b4-py3-none-any.whl"],
-)
-
 # https://github.com/modularml/breathe
 http_archive(
     name = "breathe",

--- a/bazel/common.MODULE.bazel
+++ b/bazel/common.MODULE.bazel
@@ -457,16 +457,16 @@ http_file(
 
 http_file(
     name = "flashinfer_sm100_wheel",
-    downloaded_file_path = "flashinfer_python-0.5.2-py3-none-any.whl",
-    sha256 = "0afdb8f536a3a101ac7f653d66a5f4f63991f820352daf64950dab89f9806c1c",
-    urls = ["https://modular-bazel-artifacts-public.s3.amazonaws.com/artifacts/flashinfer/sm100/0afdb8f536a3a101ac7f653d66a5f4f63991f820352daf64950dab89f9806c1c/flashinfer_python-0.5.2-py3-none-any.whl"],
+    downloaded_file_path = "flashinfer_python-0.6.7.post3-py3-none-any.whl",
+    sha256 = "9d3f1aa0313cf9e5cf99f7560b8e003c57876088c8abfe7a3d330cccd4873052",
+    urls = ["https://files.pythonhosted.org/packages/01/6b/4117cd7cbeff07818ae7c6b8bf5a6d1ee3eed29356672b731b55af3d4453/flashinfer_python-0.6.7.post3-py3-none-any.whl"],
 )
 
 http_file(
     name = "flash_attn_sm100_wheel",
-    downloaded_file_path = "flash_attn-2.8.3-py3-none-any.whl",
-    sha256 = "3f4db99ab00437fb50c61da11d0647e5ab7aeab1b0b7337ae048dd8ee1b308b2",
-    urls = ["https://modular-bazel-artifacts-public.s3.amazonaws.com/artifacts/flash_attn/sm100/3f4db99ab00437fb50c61da11d0647e5ab7aeab1b0b7337ae048dd8ee1b308b2/flash_attn-2.8.3-py3-none-any.whl"],
+    downloaded_file_path = "flash_attn_4-4.0.0b4-py3-none-any.whl",
+    sha256 = "daaec7e76e9aed0bbc717228b4b8461387a99fa71629fb34a8dd00fc56e291e4",
+    urls = ["https://files.pythonhosted.org/packages/73/8e/b27eed4f2dcb9e5a89719e2233be36e86faa64fd1bead802265c7a7b046c/flash_attn_4-4.0.0b4-py3-none-any.whl"],
 )
 
 # https://github.com/modularml/breathe

--- a/bazel/pip/requirements/pycross_lock_file.bzl
+++ b/bazel/pip/requirements/pycross_lock_file.bzl
@@ -60,7 +60,7 @@ PINS = {
     "fire": "fire@0.7.0",
     "flash-attn-4": "flash-attn-4@4.0.0b4",
     "flashinfer-cubin": "flashinfer-cubin@0.6.7.post3",
-    "flashinfer-python": "flashinfer-python@0.6.3",
+    "flashinfer-python": "flashinfer-python@0.6.7.post3",
     "flask": "flask@3.0.3",
     "gguf": "gguf@0.17.1",
     "google-auth": "google-auth@2.48.0",
@@ -1988,6 +1988,50 @@ def targets():
         testonly = "cuda-python" in _TESTONLY_DEPS,
     )
 
+    _cuda_tile_1_3_0_deps = [
+    ] + select({
+        ":_env_python_3.10_x86_64-unknown-linux-gnu_nvidia_gpu": [
+            ":typing-extensions@4.15.0",
+        ],
+        ":_env_python_3.11_x86_64-unknown-linux-gnu_nvidia_gpu": [
+            ":typing-extensions@4.15.0",
+        ],
+        ":_env_python_3.12_x86_64-unknown-linux-gnu_nvidia_gpu": [
+            ":typing-extensions@4.15.0",
+        ],
+        ":_env_python_3.13_x86_64-unknown-linux-gnu_nvidia_gpu": [
+            ":typing-extensions@4.15.0",
+        ],
+        ":_env_python_3.14_x86_64-unknown-linux-gnu-freethreaded_nvidia_gpu": [
+            ":typing-extensions@4.15.0",
+        ],
+        ":_env_python_3.14_x86_64-unknown-linux-gnu_nvidia_gpu": [
+            ":typing-extensions@4.15.0",
+        ],
+        "//conditions:default": [],
+    })
+
+    native.alias(
+        name = "_wheel_cuda-tile@1.3.0",
+        actual = select({
+            ":_env_python_3.10_aarch64-unknown-linux-gnu": "@pycross_lock_file_wheel_cuda_tile_1.3.0_cp310_cp310_manylinux2014_aarch64//file",
+            ":_env_python_3.10_x86_64-unknown-linux-gnu": "@pycross_lock_file_wheel_cuda_tile_1.3.0_cp310_cp310_manylinux2014_x86_64//file",
+            ":_env_python_3.11_aarch64-unknown-linux-gnu": "@pycross_lock_file_wheel_cuda_tile_1.3.0_cp311_cp311_manylinux2014_aarch64//file",
+            ":_env_python_3.11_x86_64-unknown-linux-gnu": "@pycross_lock_file_wheel_cuda_tile_1.3.0_cp311_cp311_manylinux2014_x86_64//file",
+            ":_env_python_3.12_aarch64-unknown-linux-gnu": "@pycross_lock_file_wheel_cuda_tile_1.3.0_cp312_cp312_manylinux2014_aarch64//file",
+            ":_env_python_3.12_x86_64-unknown-linux-gnu": "@pycross_lock_file_wheel_cuda_tile_1.3.0_cp312_cp312_manylinux2014_x86_64//file",
+            ":_env_python_3.13_aarch64-unknown-linux-gnu": "@pycross_lock_file_wheel_cuda_tile_1.3.0_cp313_cp313_manylinux2014_aarch64//file",
+            ":_env_python_3.13_x86_64-unknown-linux-gnu": "@pycross_lock_file_wheel_cuda_tile_1.3.0_cp313_cp313_manylinux2014_x86_64//file",
+        }),
+    )
+
+    pycross_wheel_library(
+        name = "cuda-tile@1.3.0",
+        deps = _cuda_tile_1_3_0_deps,
+        wheel = ":_wheel_cuda-tile@1.3.0",
+        testonly = "cuda-tile" in _TESTONLY_DEPS,
+    )
+
     native.alias(
         name = "_wheel_cufile-python@0.2.0",
         actual = "@pycross_lock_file_wheel_cufile_python_0.2.0_py3_none_any//file",
@@ -2771,13 +2815,14 @@ def targets():
         testonly = "flashinfer-cubin" in _TESTONLY_DEPS,
     )
 
-    _flashinfer_python_0_6_3_deps = [
+    _flashinfer_python_0_6_7_post3_deps = [
         ":numpy@multiple",
         ":torch@multiple",
     ] + select({
         ":_env_python_3.10_x86_64-unknown-linux-gnu_nvidia_gpu": [
             ":apache-tvm-ffi@0.1.9",
             ":click@8.1.7",
+            ":cuda-tile@1.3.0",
             ":einops@0.8.0",
             ":ninja@1.13.0",
             ":nvidia-cudnn-frontend@1.16.0",
@@ -2791,6 +2836,7 @@ def targets():
         ":_env_python_3.11_x86_64-unknown-linux-gnu_nvidia_gpu": [
             ":apache-tvm-ffi@0.1.9",
             ":click@8.1.7",
+            ":cuda-tile@1.3.0",
             ":einops@0.8.0",
             ":ninja@1.13.0",
             ":nvidia-cudnn-frontend@1.16.0",
@@ -2804,6 +2850,7 @@ def targets():
         ":_env_python_3.12_x86_64-unknown-linux-gnu_nvidia_gpu": [
             ":apache-tvm-ffi@0.1.9",
             ":click@8.1.7",
+            ":cuda-tile@1.3.0",
             ":einops@0.8.0",
             ":ninja@1.13.0",
             ":nvidia-cudnn-frontend@1.16.0",
@@ -2817,6 +2864,7 @@ def targets():
         ":_env_python_3.13_x86_64-unknown-linux-gnu_nvidia_gpu": [
             ":apache-tvm-ffi@0.1.9",
             ":click@8.1.7",
+            ":cuda-tile@1.3.0",
             ":einops@0.8.0",
             ":ninja@1.13.0",
             ":nvidia-cudnn-frontend@1.16.0",
@@ -2830,6 +2878,7 @@ def targets():
         ":_env_python_3.14_x86_64-unknown-linux-gnu-freethreaded_nvidia_gpu": [
             ":apache-tvm-ffi@0.1.9",
             ":click@8.1.7",
+            ":cuda-tile@1.3.0",
             ":einops@0.8.0",
             ":ninja@1.13.0",
             ":nvidia-cudnn-frontend@1.16.0",
@@ -2843,6 +2892,7 @@ def targets():
         ":_env_python_3.14_x86_64-unknown-linux-gnu_nvidia_gpu": [
             ":apache-tvm-ffi@0.1.9",
             ":click@8.1.7",
+            ":cuda-tile@1.3.0",
             ":einops@0.8.0",
             ":ninja@1.13.0",
             ":nvidia-cudnn-frontend@1.16.0",
@@ -2857,14 +2907,14 @@ def targets():
     })
 
     native.alias(
-        name = "_wheel_flashinfer-python@0.6.3",
-        actual = "@pycross_lock_file_wheel_flashinfer_python_0.6.3_py3_none_any//file",
+        name = "_wheel_flashinfer-python@0.6.7.post3",
+        actual = "@pycross_lock_file_wheel_flashinfer_python_0.6.7.post3_py3_none_any//file",
     )
 
     pycross_wheel_library(
-        name = "flashinfer-python@0.6.3",
-        deps = _flashinfer_python_0_6_3_deps,
-        wheel = ":_wheel_flashinfer-python@0.6.3",
+        name = "flashinfer-python@0.6.7.post3",
+        deps = _flashinfer_python_0_6_7_post3_deps,
+        wheel = ":_wheel_flashinfer-python@0.6.7.post3",
         testonly = "flashinfer-python" in _TESTONLY_DEPS,
     )
 
@@ -10327,7 +10377,7 @@ def targets():
             ":fastapi@0.124.4",
             ":flash-attn-4@4.0.0b4",
             ":flashinfer-cubin@0.6.7.post3",
-            ":flashinfer-python@0.6.3",
+            ":flashinfer-python@0.6.7.post3",
             ":gguf@0.17.1",
             ":interegular@0.3.3",
             ":ipython@8.18.1",
@@ -10383,7 +10433,7 @@ def targets():
             ":fastapi@0.124.4",
             ":flash-attn-4@4.0.0b4",
             ":flashinfer-cubin@0.6.7.post3",
-            ":flashinfer-python@0.6.3",
+            ":flashinfer-python@0.6.7.post3",
             ":gguf@0.17.1",
             ":interegular@0.3.3",
             ":ipython@8.18.1",
@@ -10439,7 +10489,7 @@ def targets():
             ":fastapi@0.124.4",
             ":flash-attn-4@4.0.0b4",
             ":flashinfer-cubin@0.6.7.post3",
-            ":flashinfer-python@0.6.3",
+            ":flashinfer-python@0.6.7.post3",
             ":gguf@0.17.1",
             ":interegular@0.3.3",
             ":ipython@8.18.1",
@@ -10495,7 +10545,7 @@ def targets():
             ":fastapi@0.124.4",
             ":flash-attn-4@4.0.0b4",
             ":flashinfer-cubin@0.6.7.post3",
-            ":flashinfer-python@0.6.3",
+            ":flashinfer-python@0.6.7.post3",
             ":gguf@0.17.1",
             ":interegular@0.3.3",
             ":ipython@8.18.1",
@@ -10551,7 +10601,7 @@ def targets():
             ":fastapi@0.124.4",
             ":flash-attn-4@4.0.0b4",
             ":flashinfer-cubin@0.6.7.post3",
-            ":flashinfer-python@0.6.3",
+            ":flashinfer-python@0.6.7.post3",
             ":gguf@0.17.1",
             ":interegular@0.3.3",
             ":ipython@8.18.1",
@@ -10607,7 +10657,7 @@ def targets():
             ":fastapi@0.124.4",
             ":flash-attn-4@4.0.0b4",
             ":flashinfer-cubin@0.6.7.post3",
-            ":flashinfer-python@0.6.3",
+            ":flashinfer-python@0.6.7.post3",
             ":gguf@0.17.1",
             ":interegular@0.3.3",
             ":ipython@8.18.1",
@@ -13848,7 +13898,7 @@ def targets():
             ":diskcache@5.6.3",
             ":einops@0.8.0",
             ":filelock@3.16.1",
-            ":flashinfer-python@0.6.3",
+            ":flashinfer-python@0.6.7.post3",
             ":gguf@0.17.1",
             ":grpcio-reflection@1.80.0",
             ":grpcio@1.80.0",
@@ -13906,7 +13956,7 @@ def targets():
             ":diskcache@5.6.3",
             ":einops@0.8.0",
             ":filelock@3.16.1",
-            ":flashinfer-python@0.6.3",
+            ":flashinfer-python@0.6.7.post3",
             ":gguf@0.17.1",
             ":grpcio-reflection@1.80.0",
             ":grpcio@1.80.0",
@@ -13966,7 +14016,7 @@ def targets():
             ":diskcache@5.6.3",
             ":einops@0.8.0",
             ":filelock@3.16.1",
-            ":flashinfer-python@0.6.3",
+            ":flashinfer-python@0.6.7.post3",
             ":gguf@0.17.1",
             ":grpcio-reflection@1.80.0",
             ":grpcio@1.80.0",
@@ -14026,7 +14076,7 @@ def targets():
             ":diskcache@5.6.3",
             ":einops@0.8.0",
             ":filelock@3.16.1",
-            ":flashinfer-python@0.6.3",
+            ":flashinfer-python@0.6.7.post3",
             ":gguf@0.17.1",
             ":grpcio-reflection@1.80.0",
             ":grpcio@1.80.0",
@@ -14086,7 +14136,7 @@ def targets():
             ":diskcache@5.6.3",
             ":einops@0.8.0",
             ":filelock@3.16.1",
-            ":flashinfer-python@0.6.3",
+            ":flashinfer-python@0.6.7.post3",
             ":gguf@0.17.1",
             ":grpcio-reflection@1.80.0",
             ":grpcio@1.80.0",
@@ -17646,6 +17696,86 @@ def repositories():
 
     maybe(
         http_file,
+        name = "pycross_lock_file_wheel_cuda_tile_1.3.0_cp310_cp310_manylinux2014_aarch64",
+        urls = [
+            "https://files.pythonhosted.org/packages/46/c8/1687a83d0739151ca410a5716b5f1dfb6f8feb6381c7c695d72264f17e1c/cuda_tile-1.3.0-cp310-cp310-manylinux2014_aarch64.whl",
+        ],
+        sha256 = "c55616c648f06f84808648a521c67f2d7c790574d6b53ddf8c3bfbc995d36d45",
+        downloaded_file_path = "cuda_tile-1.3.0-cp310-cp310-manylinux2014_aarch64.whl",
+    )
+
+    maybe(
+        http_file,
+        name = "pycross_lock_file_wheel_cuda_tile_1.3.0_cp310_cp310_manylinux2014_x86_64",
+        urls = [
+            "https://files.pythonhosted.org/packages/ab/d0/0e4790cc7a536a685a961d2e04f26be54f86f0974e1eaea71c1b64ec4032/cuda_tile-1.3.0-cp310-cp310-manylinux2014_x86_64.whl",
+        ],
+        sha256 = "8c71c2fd9b96c054c126a218f9927c8c8dde72441a532464551b865b416d452a",
+        downloaded_file_path = "cuda_tile-1.3.0-cp310-cp310-manylinux2014_x86_64.whl",
+    )
+
+    maybe(
+        http_file,
+        name = "pycross_lock_file_wheel_cuda_tile_1.3.0_cp311_cp311_manylinux2014_aarch64",
+        urls = [
+            "https://files.pythonhosted.org/packages/f4/d6/753aecb3e8fcee80d20f9d32b4504276691c2f77fc10abbbd8e82197e24c/cuda_tile-1.3.0-cp311-cp311-manylinux2014_aarch64.whl",
+        ],
+        sha256 = "59d9843fa723ceb4d680ec246e12e3ded857266e4c2bf5c5d21e530d6d765060",
+        downloaded_file_path = "cuda_tile-1.3.0-cp311-cp311-manylinux2014_aarch64.whl",
+    )
+
+    maybe(
+        http_file,
+        name = "pycross_lock_file_wheel_cuda_tile_1.3.0_cp311_cp311_manylinux2014_x86_64",
+        urls = [
+            "https://files.pythonhosted.org/packages/c5/2d/8b416239413bf11d17d42ccee43258f3787da13bcea7b2e42e8bbf04b3da/cuda_tile-1.3.0-cp311-cp311-manylinux2014_x86_64.whl",
+        ],
+        sha256 = "2888d6b89fae053a53ca7bb703c508a5cf90671d266934573c5b6c25978022c4",
+        downloaded_file_path = "cuda_tile-1.3.0-cp311-cp311-manylinux2014_x86_64.whl",
+    )
+
+    maybe(
+        http_file,
+        name = "pycross_lock_file_wheel_cuda_tile_1.3.0_cp312_cp312_manylinux2014_aarch64",
+        urls = [
+            "https://files.pythonhosted.org/packages/f3/49/4592bc94ca05a07c7947ea114fd12734c8497f2daffee9faa79a03e39fb5/cuda_tile-1.3.0-cp312-cp312-manylinux2014_aarch64.whl",
+        ],
+        sha256 = "375316b64c51ee7cfadb2f170a30c1547bc41eb39f1e233a6556713857d2e81f",
+        downloaded_file_path = "cuda_tile-1.3.0-cp312-cp312-manylinux2014_aarch64.whl",
+    )
+
+    maybe(
+        http_file,
+        name = "pycross_lock_file_wheel_cuda_tile_1.3.0_cp312_cp312_manylinux2014_x86_64",
+        urls = [
+            "https://files.pythonhosted.org/packages/40/76/84cb68be463c827bf79da9fa0aa5140838de6455ef6f438bbe0ffa75d378/cuda_tile-1.3.0-cp312-cp312-manylinux2014_x86_64.whl",
+        ],
+        sha256 = "e4865acbff1172aaee304bf9c550586088d8b4545a384423597a590899386709",
+        downloaded_file_path = "cuda_tile-1.3.0-cp312-cp312-manylinux2014_x86_64.whl",
+    )
+
+    maybe(
+        http_file,
+        name = "pycross_lock_file_wheel_cuda_tile_1.3.0_cp313_cp313_manylinux2014_aarch64",
+        urls = [
+            "https://files.pythonhosted.org/packages/9d/7d/ee943554f83d6a143d9e0a5cf27cd7f5f8f6ef447c7e8366d9ad6a5d1bf2/cuda_tile-1.3.0-cp313-cp313-manylinux2014_aarch64.whl",
+        ],
+        sha256 = "8a9bd4dae193cddf438f55d617b6f25b4b0b0fcf4ac4acde7d2695898e396c30",
+        downloaded_file_path = "cuda_tile-1.3.0-cp313-cp313-manylinux2014_aarch64.whl",
+    )
+
+    maybe(
+        http_file,
+        name = "pycross_lock_file_wheel_cuda_tile_1.3.0_cp313_cp313_manylinux2014_x86_64",
+        urls = [
+            "https://files.pythonhosted.org/packages/35/20/e1daea2dc4e094290ba727750f8342095ae857ff3ba4f81c489f48688613/cuda_tile-1.3.0-cp313-cp313-manylinux2014_x86_64.whl",
+        ],
+        sha256 = "a44a81e255fdb7bf8e1f7511fe3a019e6045024574509ea8548e0f71f25f8473",
+        downloaded_file_path = "cuda_tile-1.3.0-cp313-cp313-manylinux2014_x86_64.whl",
+    )
+
+    maybe(
+        http_file,
         name = "pycross_lock_file_wheel_cufile_python_0.2.0_py3_none_any",
         urls = [
             "https://files.pythonhosted.org/packages/99/ce/14f95b3176ef603921e0583c72f6d909c75a7b2cce34b4918ef05d633af0/cufile_python-0.2.0-py3-none-any.whl",
@@ -18576,12 +18706,12 @@ def repositories():
 
     maybe(
         http_file,
-        name = "pycross_lock_file_wheel_flashinfer_python_0.6.3_py3_none_any",
+        name = "pycross_lock_file_wheel_flashinfer_python_0.6.7.post3_py3_none_any",
         urls = [
-            "https://files.pythonhosted.org/packages/33/13/2d95248101d8cb978db9000a4dceafb5b122484a694b53e84df1ac2a7b3d/flashinfer_python-0.6.3-py3-none-any.whl",
+            "https://files.pythonhosted.org/packages/01/6b/4117cd7cbeff07818ae7c6b8bf5a6d1ee3eed29356672b731b55af3d4453/flashinfer_python-0.6.7.post3-py3-none-any.whl",
         ],
-        sha256 = "0fe2de934a4b3690c543dafb03f38d7bb4a762431abe8ae4f7292d6fef10c65d",
-        downloaded_file_path = "flashinfer_python-0.6.3-py3-none-any.whl",
+        sha256 = "9d3f1aa0313cf9e5cf99f7560b8e003c57876088c8abfe7a3d330cccd4873052",
+        downloaded_file_path = "flashinfer_python-0.6.7.post3-py3-none-any.whl",
     )
 
     maybe(

--- a/bazel/pip/requirements/pyproject.toml
+++ b/bazel/pip/requirements/pyproject.toml
@@ -267,7 +267,7 @@ override-dependencies = [
   # Pin packages to avoid duplicates after vllm 0.16.0 update
   "aiohttp==3.13.3",
   "apache-tvm-ffi==0.1.9",
-  "flashinfer-python==0.6.3",
+  "flashinfer-python==0.6.7.post3",
   "nvidia-cutlass-dsl==4.4.1",
 
   # Various duplicates between groups

--- a/max/kernels/benchmarks/misc/blackwell_bench/BUILD.bazel
+++ b/max/kernels/benchmarks/misc/blackwell_bench/BUILD.bazel
@@ -42,48 +42,27 @@ pycross_wheel_library(
     ],
 )
 
-pycross_wheel_library(
+modular_py_library(
     name = "flashinfer",
     target_compatible_with = [
         "//:nvidia_gpu",
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
-    wheel = "@flashinfer_sm100_wheel//file",
     deps = [
-        requirement("apache-tvm-ffi"),
-        requirement("click"),
-        requirement("einops"),
-        requirement("ninja"),  # JIT compilation at runtime
-        requirement("numpy"),
-        requirement("nvidia-cudnn-frontend"),
-        requirement("nvidia-cutlass-dsl"),
-        requirement("nvitop"),  # provides pynvml via nvidia-ml-py
-        requirement("packaging"),
-        requirement("requests"),
-        requirement("tabulate"),
-        requirement("torch"),
-        requirement("tqdm"),
+        requirement("flashinfer-python"),
     ],
 )
 
-pycross_wheel_library(
+modular_py_library(
     name = "flash-attn",
     target_compatible_with = [
         "//:nvidia_gpu",
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
-    wheel = "@flash_attn_sm100_wheel//file",
     deps = [
         ":cutlass-imports",  # adds nvidia_cutlass_dsl/python_packages to sys.path
-        requirement("apache-tvm-ffi"),
-        requirement("einops"),
-        requirement("nvidia-cutlass-dsl"),
-        requirement("setuptools"),
-        requirement("torch"),
-        requirement("typing-extensions"),
-        "@modular_pip_lock_file_repo//deps:quack-kernels@0.3.3",
-        "@modular_pip_lock_file_repo//deps:torch-c-dlpack-ext@0.1.5",
+        requirement("flash-attn-4"),
     ],
 )

--- a/max/kernels/benchmarks/misc/blackwell_bench/BUILD.bazel
+++ b/max/kernels/benchmarks/misc/blackwell_bench/BUILD.bazel
@@ -77,8 +77,13 @@ pycross_wheel_library(
     wheel = "@flash_attn_sm100_wheel//file",
     deps = [
         ":cutlass-imports",  # adds nvidia_cutlass_dsl/python_packages to sys.path
+        requirement("apache-tvm-ffi"),
         requirement("einops"),
         requirement("nvidia-cutlass-dsl"),
+        requirement("setuptools"),
         requirement("torch"),
+        requirement("typing-extensions"),
+        "@modular_pip_lock_file_repo//deps:quack-kernels@0.3.3",
+        "@modular_pip_lock_file_repo//deps:torch-c-dlpack-ext@0.1.5",
     ],
 )

--- a/max/kernels/benchmarks/misc/comparison/bench_blackwell_prefill.py
+++ b/max/kernels/benchmarks/misc/comparison/bench_blackwell_prefill.py
@@ -50,14 +50,14 @@ _flash_attn_varlen_func: Callable[..., Any] | None
 try:
     # FA4 beta4 still reaches distutils-era imports on Python 3.12+.
     # Import setuptools first so its compatibility shim is available.
-    import setuptools  # noqa: F401
-
     # The pure Python flash-attention wheel's __init__.py tries to import
     # flash_attn_2_cuda (CUDA extension not in pure wheel).
     # Bypass this by creating a stub flash_attn module with valid __path__
     # but no imports.
     import importlib.util
     import sys
+
+    import setuptools  # noqa: F401
 
     flash_attn_spec = importlib.util.find_spec("flash_attn")
     if (

--- a/max/kernels/benchmarks/misc/comparison/bench_blackwell_prefill.py
+++ b/max/kernels/benchmarks/misc/comparison/bench_blackwell_prefill.py
@@ -48,6 +48,10 @@ except ImportError as e:
 
 _flash_attn_varlen_func: Callable[..., Any] | None
 try:
+    # FA4 beta4 still reaches distutils-era imports on Python 3.12+.
+    # Import setuptools first so its compatibility shim is available.
+    import setuptools  # noqa: F401
+
     # The pure Python flash-attention wheel's __init__.py tries to import
     # flash_attn_2_cuda (CUDA extension not in pure wheel).
     # Bypass this by creating a stub flash_attn module with valid __path__

--- a/max/kernels/benchmarks/misc/comparison/setup_bench_env.py
+++ b/max/kernels/benchmarks/misc/comparison/setup_bench_env.py
@@ -444,8 +444,9 @@ def build_flashattn_wheel(
         "FLASH_ATTENTION_SKIP_CUDA_BUILD": "TRUE",
     }
 
+    cute_src = src / "flash_attn" / "cute"
     return build_wheel_generic(
-        python, src, wheel_dir, "flash_attn", env_extras, clean
+        python, cute_src, wheel_dir, "flash-attn-4", env_extras, clean
     )
 
 
@@ -601,8 +602,9 @@ def install_flashinfer(python: Path, src: Path) -> None:
 
 
 def install_flashattn(python: Path, src: Path) -> None:
-    if not src.exists():
-        print(f"[warn] flash-attention not found at {src}, skipping")
+    cute_src = src / "flash_attn" / "cute"
+    if not cute_src.exists():
+        print(f"[warn] flash-attention FA4 package not found at {cute_src}, skipping")
         return
 
     env = build_env(python)
@@ -635,7 +637,7 @@ def install_flashattn(python: Path, src: Path) -> None:
                 "install",
                 "--no-build-isolation",
                 "-v",
-                str(src),
+                str(cute_src),
             ],
             env=env,
         )

--- a/max/kernels/benchmarks/misc/comparison/setup_bench_env.py
+++ b/max/kernels/benchmarks/misc/comparison/setup_bench_env.py
@@ -604,7 +604,9 @@ def install_flashinfer(python: Path, src: Path) -> None:
 def install_flashattn(python: Path, src: Path) -> None:
     cute_src = src / "flash_attn" / "cute"
     if not cute_src.exists():
-        print(f"[warn] flash-attention FA4 package not found at {cute_src}, skipping")
+        print(
+            f"[warn] flash-attention FA4 package not found at {cute_src}, skipping"
+        )
         return
 
     env = build_env(python)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Please fill out the sections below to help reviewers understand your change.
For guidance on writing a good PR, see our
[contributor guide](../CONTRIBUTING.md).
-->

## Summary

Upgrade the following vendor libraries versions:

- FlashInfer 0.5.2 -> 0.6.7.post3
- FlashAttention 2.8.3 -> 4.0.0b4

I'm not bumping FlashAttention to the absolute latest (4.0.0b11) because later version requires cutedsl 4.4.2, which will require a huge changes for our lockfile.

<!-- Describe what this PR does and why. Link to any related issues. -->

## Testing

<!--
Describe how you validated your changes. For code changes, this should include
what tests you ran and any relevant results. For documentation changes, describe
how you verified accuracy.
-->

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))

Assisted-by: Claude