### PR TITLE
[stdlib] Optimize `SIMD.write_to`

### DIFF
--- a/mojo/stdlib/benchmarks/README.md
+++ b/mojo/stdlib/benchmarks/README.md
@@ -55,15 +55,15 @@ See `python/bench_bindings/` for an example. Conventions for these:
 Run a single benchmark with full measurements:
 
 ```bash
-./bazelw test //mojo/stdlib/benchmarks/collections:bench_dict.mojo.bench \
-  --test_output=all
+./bazelw test //mojo/stdlib/benchmarks:collections/bench_dict.mojo.bench \
+  --test_output=all --cache_test_results=no
 ```
 
 Run every stdlib benchmark with full measurements:
 
 ```bash
 ./bazelw test //mojo/stdlib/benchmarks:all_benchmarks \
-  --local_test_jobs=1 --test_output=all
+  --local_test_jobs=1 --test_output=all --cache_test_results=no
 ```
 
 `--local_test_jobs=1` serializes execution so concurrent benchmarks do not

--- a/mojo/stdlib/benchmarks/utils/bench_formatter.mojo
+++ b/mojo/stdlib/benchmarks/utils/bench_formatter.mojo
@@ -13,11 +13,13 @@
 
 from std.sys import simd_width_of
 
-from std.benchmark import Bench, BenchConfig, Bencher, BenchId
+from std.benchmark import Bench, BenchConfig, Bencher, BenchId, black_box, keep
 
-# ===-----------------------------------------------------------------------===#
-# Benchmark Data
-# ===-----------------------------------------------------------------------===#
+
+@fieldwise_init
+struct NullWriter(ImplicitlyCopyable, Writer):
+    def write_string(mut self, string: StringSlice):
+        keep(string)
 
 
 # ===-----------------------------------------------------------------------===#
@@ -28,9 +30,10 @@ def bench_writer_int[n: Int](mut b: Bencher) raises:
     @always_inline
     @parameter
     def call_fn():
-        var s1 = String()
-        s1.write(n)
-        _ = s1^
+        for _ in range(10**6):
+            var writer = NullWriter()
+            writer.write(black_box(n))
+            keep(writer)
 
     b.iter[call_fn]()
 
@@ -40,9 +43,12 @@ def bench_writer_simd[n: Int](mut b: Bencher) raises:
     @always_inline
     @parameter
     def call_fn():
-        var s1 = String()
-        s1.write(SIMD[DType.int32, simd_width_of[DType.int32]()](n))
-        _ = s1^
+        for _ in range(10**6):
+            var writer = NullWriter()
+            writer.write(
+                black_box(SIMD[DType.int32, simd_width_of[DType.int32]()](n))
+            )
+            keep(writer)
 
     b.iter[call_fn]()
 

--- a/mojo/stdlib/std/builtin/int.mojo
+++ b/mojo/stdlib/std/builtin/int.mojo
@@ -1036,14 +1036,14 @@ struct Int(
         """
         return (self & (self - 1) == 0) & (self > 0)
 
+    @always_inline
     def write_to(self, mut writer: Some[Writer]):
         """Formats this integer to the provided Writer.
 
         Args:
             writer: The object to write to.
         """
-
-        writer.write(Int64(self))
+        writer.write(Scalar[DType.int](self))
 
     def write_repr_to(self, mut writer: Some[Writer]):
         """Write the string representation of the Int".

--- a/mojo/stdlib/std/builtin/simd.mojo
+++ b/mojo/stdlib/std/builtin/simd.mojo
@@ -72,8 +72,8 @@ from std.sys.intrinsics import _type_is_eq
 from std.bit import bit_width, byte_swap, pop_count
 from std.builtin._format_float import _write_float
 from std.builtin.device_passable import DevicePassable, DeviceTypeEncoder
-from std.builtin.format_int import _write_int
 from std.builtin.int import _FromInt
+from std.format._utils import _WriteBufferStack, _write_int_base_10
 from std.math import DivModable, Powable
 from std.memory import bitcast, memcpy, pack_bits
 from std.python import Python, PythonObject
@@ -2178,21 +2178,17 @@ struct SIMD[dtype: DType, size: Int](
         Args:
             writer: The object to write to.
         """
-
-        # Write an opening `[`.
-        comptime if Self.size > 1:
+        comptime if Self.size == 1:
+            _write_scalar(writer, self[0])
+        else:
             writer.write("[")
 
-        # Write each element.
-        for i in range(Self.size):
-            var element = self[i]
-            # Write separators between each element.
-            if i != 0:
-                writer.write(", ")
-            _write_scalar(writer, element)
+            for i in range(Self.size):
+                var element = self[i]
+                if i != 0:
+                    writer.write(", ")
+                _write_scalar(writer, element)
 
-        # Write a closing `]`.
-        comptime if Self.size > 1:
             writer.write("]")
 
     @no_inline
@@ -2205,56 +2201,42 @@ struct SIMD[dtype: DType, size: Int](
         writer.write_string("SIMD[")
         Self.dtype.write_repr_to(writer)
         writer.write(", ", Self.size, "](")
-        # Write each element.
+
         for i in range(Self.size):
             var element = self[i]
-            # Write separators between each element.
             if i != 0:
                 writer.write_string(", ")
             _write_scalar(writer, element)
+
         writer.write_string(")")
 
     def write_padded[
-        W: Writer
-    ](self, mut writer: W, width: Int) where self.dtype.is_integral():
+        pad_str: StaticString = " "
+    ](
+        self, mut writer: Some[Writer], width: Int
+    ) where self.dtype.is_integral():
         """Write the integral SIMD with each element right-aligned to a set
         padding. No additional space between elements is inserted.
 
         Parameters:
-            W: A type conforming to the Writable trait.
+            pad_str: The string to pad with.
 
         Args:
             writer: The object to write to.
             width: The amount to pad to the left.
         """
 
-        # Write an opening `[`.
-        comptime if Self.size > 1:
+        comptime if Self.size == 1:
+            _write_int_base_10[pad_str](writer, self[0], width)
+        else:
             writer.write("[")
 
-        # Write each element.
-        for i in range(Self.size):
-            var element = self[i]
-            # _calc_initial_buffer_size adds an extra 1 for the terminator,
-            # which we want to remove, but also doesn't include 1 for a
-            # negative sign.
-            var int_width = _calc_initial_buffer_size(abs(element)) - (
-                1 if element >= 0 else 0
-            )
+            for i in range(Self.size):
+                if i != 0:
+                    writer.write(",")
 
-            # Write separators between each element.
-            if i != 0:
-                writer.write(",")
+                _write_int_base_10[pad_str](writer, self[i], width)
 
-            # TODO: Assumes user wants right-aligned content.
-            if int_width < width:
-                for _ in range(width - int_width):
-                    writer.write(" ")
-
-            _write_scalar(writer, element)
-
-        # Write a closing `]`.
-        comptime if Self.size > 1:
             writer.write("]")
 
     @always_inline
@@ -4066,23 +4048,16 @@ def _floor(x: SIMD) -> type_of(x):
     return type_of(x)(from_bits=bits)
 
 
+@always_inline
 def _write_scalar[
-    dtype: DType,
-    W: Writer,
-    //,
+    dtype: DType, W: Writer, //
 ](mut writer: W, value: Scalar[dtype]):
     comptime if dtype == DType.bool:
-        if value:
-            writer.write("True")
-        else:
-            writer.write("False")
-
+        writer.write("True" if value else "False")
     elif dtype.is_floating_point():
         _write_float(writer, value)
-
-    # TODO(MSTDL-1039): bring in performant integer to string formatter
     elif dtype.is_integral():
-        _ = _write_int(writer, value)
+        _write_int_base_10(writer, value)
     else:
         comptime assert (
             False

--- a/mojo/stdlib/std/format/_utils.mojo
+++ b/mojo/stdlib/std/format/_utils.mojo
@@ -18,11 +18,13 @@ intended for public use and may change without notice.
 """
 
 from std.builtin.constrained import _constrained_conforms_to
+from std.builtin.dtype import _uint_type_of_width
 from std.io.io import _printf
+from std.math.math import _llvm_unary_fn
 from std.os import abort
 from std.reflection.type_info import _unqualified_type_name
 from std.sys import align_of, size_of
-from std.sys.info import is_gpu
+from std.sys.info import is_gpu, bit_width_of
 from std.sys.defines import get_defined_int
 from std.ffi import CStringSlice
 
@@ -562,6 +564,11 @@ struct _TotalWritableBytes(Writer):
         self.size += string.byte_length()
 
 
+# ===----------------------------------------------------------------------=== #
+# Integer formatting utilities
+# ===----------------------------------------------------------------------=== #
+
+
 def _ord_ascii(s: StringSlice) -> UInt8:
     return UInt8(ord(s))
 
@@ -660,3 +667,74 @@ def _write_hex[
         buf[1] = `U`
         (buf.unsafe_ptr() + 2).store(chars)
         writer.write_string(StringSlice(unsafe_from_utf8=Span(buf)))
+
+
+comptime _100_digits = (
+    "00010203040506070809101112131415161718192021222324"
+    "25262728293031323334353637383940414243444546474849"
+    "50515253545556575859606162636465666768697071727374"
+    "75767778798081828384858687888990919293949596979899"
+)
+
+
+def _max_int_base_10_digits_and_sign[dtype: DType]() -> Int:
+    # FIXME(#5856): once log10 can be run at comptime
+    return 1 + (
+        Int(_llvm_unary_fn["llvm.log10"](Float64(Scalar[dtype].MAX)))
+        + Int(dtype.is_signed())
+    )
+
+
+@always_inline
+def _write_int_base_10[
+    pad_str: StaticString = ""
+](mut writer: Some[Writer], decimal: Scalar, pad_width: Int = 0):
+    """A function that writes a base 10 integer with the lowest possible
+    latency. Anything that needs higher throughput should look elsewhere."""
+    # NOTE: can't use Byte(ord()) here due to recursion
+    comptime `0` = 0x30
+    comptime `-` = 0x2D
+
+    comptime buf_size = _max_int_base_10_digits_and_sign[decimal.dtype]()
+    var buf = InlineArray[Byte, buf_size](uninitialized=True)
+    var ptr = buf.unsafe_ptr()
+
+    comptime dtype = _uint_type_of_width[bit_width_of[decimal.dtype]()]()
+    var remainder: Scalar[dtype]
+    comptime if decimal.dtype.is_signed():
+        var d = decimal.cast[dtype]()
+        remainder = (~d + 1) if decimal < 0 else d
+    else:
+        remainder = decimal.cast[dtype]()
+
+    var lut_ptr = _100_digits.unsafe_ptr()
+    var offset = buf_size - 1
+
+    while remainder >= 100:
+        var rem100 = remainder % 100
+        remainder //= 100
+
+        ptr.store(offset - 1, lut_ptr.load[2](rem100 * 2))
+        offset -= 2
+
+    if remainder >= 10:
+        ptr.store(offset - 1, lut_ptr.load[2](remainder * 2))
+        offset -= 2
+    else:
+        ptr[offset] = `0` | UInt8(remainder)
+        offset -= 1
+
+    comptime if decimal.dtype.is_signed():
+        ptr[offset] = `-`
+        offset -= Int(decimal < 0)
+
+    comptime if pad_str.byte_length() > 0:
+        var pad_i = buf_size - (offset + 1)
+        while pad_width > pad_i:
+            writer.write(pad_str)
+            pad_i += 1
+
+    offset += 1
+    writer.write_string(
+        {unsafe_from_utf8 = Span(ptr=ptr + offset, length=buf_size - offset)}
+    )

--- a/mojo/stdlib/test/io/test_write.mojo
+++ b/mojo/stdlib/test/io/test_write.mojo
@@ -12,8 +12,11 @@
 # ===----------------------------------------------------------------------=== #
 
 from std.format import Writable, Writer
-from std.format._utils import _hex_digits_to_hex_chars, _write_hex
-from std.memory import Span
+from std.format._utils import (
+    _hex_digits_to_hex_chars,
+    _write_hex,
+    _write_int_base_10,
+)
 from std.memory.memory import memset_zero
 from std.testing import assert_equal, TestSuite
 
@@ -61,21 +64,13 @@ def test_stringable_based_on_format() raises:
 
 def test_write_int_padded() raises:
     var s1 = String()
-
     Int(5).write_padded(s1, width=5)
-
     assert_equal(s1, "    5")
-
     Int(-5).write_padded(s1, width=5)
-
     assert_equal(s1, "    5   -5")
-
     Int(123).write_padded(s1, width=5)
-
     assert_equal(s1, "    5   -5  123")
-
     Int(0).write_padded(s1, width=5)
-
     assert_equal(s1, "    5   -5  123    0")
 
     # ----------------------------------
@@ -83,17 +78,11 @@ def test_write_int_padded() raises:
     # ----------------------------------
 
     var s2 = String()
-
     Int(12345).write_padded(s2, width=3)
-
     assert_equal(s2, "12345")
-
     Int(-1).write_padded(s2, width=1)
-
     assert_equal(s2, "12345-1")
-
     Int(-1).write_padded(s2, width=0)
-
     assert_equal(s2, "12345-1-1")
 
 
@@ -102,18 +91,13 @@ def test_write_simd_padded() raises:
     # Test writing scalar Int32
     # ----------------------------------
     var s1 = String()
-
     Int32(5).write_padded(s1, width=5)
-
     assert_equal(s1, "    5")
 
     # Test negative integers - note that negative signs aren't counted
     Int32(-5).write_padded(s1, width=5)
-
     assert_equal(s1, "    5   -5")
-
     Int32(123).write_padded(s1, width=5)
-
     assert_equal(s1, "    5   -5  123")
 
     # ----------------------------------
@@ -123,15 +107,10 @@ def test_write_simd_padded() raises:
     var s2 = String()
 
     Int32(12345).write_padded(s2, width=3)
-
     assert_equal(s2, "12345")
-
     Int32(-1).write_padded(s2, width=1)
-
     assert_equal(s2, "12345-1")
-
     Int32(-1).write_padded(s2, width=0)
-
     assert_equal(s2, "12345-1-1")
 
     # ----------------------------------
@@ -142,21 +121,80 @@ def test_write_simd_padded() raises:
     SIMD[DType.int32, 2](12345).write_padded(s3, width=3)
     assert_equal(s3, "[12345,12345]")
 
-    s3 = String()
+    s3.resize(0)
     SIMD[DType.int32, 2](12345).write_padded(s3, width=5)
     assert_equal(s3, "[12345,12345]")
 
-    s3 = String()
+    s3.resize(0)
     SIMD[DType.int32, 2](12345).write_padded(s3, width=6)
     assert_equal(s3, "[ 12345, 12345]")
 
-    s3 = String()
+    s3.resize(0)
     SIMD[DType.int32, 2](-12345).write_padded(s3, width=7)
     assert_equal(s3, "[ -12345, -12345]")
 
-    s3 = String()
+    s3.resize(0)
     SIMD[DType.int8, 4](127, 1, 10, 0).write_padded(s3, width=6)
     assert_equal(s3, "[   127,     1,    10,     0]")
+
+
+def test_write_int_base_10() raises:
+    var res = String()
+    _write_int_base_10(res, UInt8(255))
+    assert_equal(res, "255")
+    res.resize(0)
+    _write_int_base_10(res, UInt8(1))
+    assert_equal(res, "1")
+    res.resize(0)
+    _write_int_base_10(res, UInt8(11))
+    assert_equal(res, "11")
+    res.resize(0)
+    _write_int_base_10(res, UInt8(111))
+    assert_equal(res, "111")
+    res.resize(0)
+    _write_int_base_10(res, UInt8(0))
+    assert_equal(res, "0")
+    res.resize(0)
+    _write_int_base_10(res, Int8(-2))
+    assert_equal(res, "-2")
+    res.resize(0)
+    _write_int_base_10(res, UInt64(123456789))
+    assert_equal(res, "123456789")
+    res.resize(0)
+    _write_int_base_10(res, Int64(-123456789))
+    assert_equal(res, "-123456789")
+
+    res.resize(0)
+    _write_int_base_10(res, UInt8.MAX)
+    assert_equal(res, "255")
+    res.resize(0)
+    _write_int_base_10(res, UInt16.MAX)
+    assert_equal(res, "65535")
+    res.resize(0)
+    _write_int_base_10(res, UInt32.MAX)
+    assert_equal(res, "4294967295")
+    res.resize(0)
+    _write_int_base_10(res, UInt64.MAX)
+    assert_equal(res, "18446744073709551615")
+    res.resize(0)
+    _write_int_base_10(res, UInt128.MAX)
+    assert_equal(res, "340282366920938463463374607431768211455")
+
+    res.resize(0)
+    _write_int_base_10(res, Int8.MIN)
+    assert_equal(res, "-128")
+    res.resize(0)
+    _write_int_base_10(res, Int16.MIN)
+    assert_equal(res, "-32768")
+    res.resize(0)
+    _write_int_base_10(res, Int32.MIN)
+    assert_equal(res, "-2147483648")
+    res.resize(0)
+    _write_int_base_10(res, Int64.MIN)
+    assert_equal(res, "-9223372036854775808")
+    res.resize(0)
+    _write_int_base_10(res, Int128.MIN)
+    assert_equal(res, "-170141183460469231731687303715884105728")
 
 
 def test_hex_digits_to_hex_chars() raises:


### PR DESCRIPTION
The highest priority for this function should be to have low latency.

I spent a long time coming up with a very fancy vectorized approach where it processed by power_of_ten chunks, but it turned out a good old scalar while loop was faster.

The approach uses a lookup table for the first 100 digit pairs to be able to extract 2 digits at a time, this is the sweet spot because the next power of two (to be able to use vec loads) for the amount of digits would be 10000 which requires ~40 KiB of memory for the LUT.

## Benchmark results

CPU: Intel® Core™ i7-7700HQ

name | old value (ms) | new value (ms) | markdown perc. | magnitude
-- | -- | -- | -- | --
bench_writer_int_42 | 5.37 | 3.42 | 0.36 | 1.57
bench_writer_int_2**64 | 2.63 | 2.27 | 0.14 | 1.16
bench_writer_simd | 40.42 | 23.21 | 0.43 | 1.74
bench_writer_simd_2**16 | 60.29 | 37.56 | 0.38 | 1.61

