### PR TITLE
[stdlib] Updated abort msg and removed reserve no-op in `List.shrink`

### DIFF
--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -1102,7 +1102,7 @@ struct List[T: Copyable](
         """
         if len(self) < new_size:
             abort(
-                "You are calling List.resize with a new_size bigger than the"
+                "You are calling List.shrink with a new_size bigger than the"
                 " current size. If you want to make the List bigger, provide a"
                 " value to fill the new slots with. If not, make sure the new"
                 " size is smaller than the current size."
@@ -1118,7 +1118,6 @@ struct List[T: Copyable](
         var old_size: Int = self._len
         self._len = new_size
         self._annotate_shrink(old_size)
-        self.reserve(new_size)
 
     def reverse(mut self):
         """Reverses the elements of the list.


### PR DESCRIPTION
## Summary

### Updated `List.shrink` abort message

I updated the abort message in `List.shrink`. The abort message stated that the user called `List.resize` with a `new_size` bigger than the current one. However, `List.shrink` is a public, user-facing method and can be called directly from the user. Thus the message in that case is not accurate. 

`List.shrink` is used in `List.resize` but its call is guarded for only `new_size <= self._len`. Therefore, I feel like `List.shrink` in the message is more accurate and helpful for the user.

### Removed `List.reserve` from `List.shrink`

In `List.shrink` the last operation that is called is `List.reserve`. However, this is a no-op. The current capacity is at least as big as the current length. After shrinking, the length becomes possibly smaller. Therefore `self.reserve(new_size) simply returns (no-op).

## Testing

There was no need for additional testing. I changed an abort message, and removed a no-op. All existing tests passed.

## Checklist

- [x] PR is small and focused — consider splitting larger changes into a
      sequence of smaller PRs
- [x] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
