### PR TITLE
[stdlib] Add `List(Some[IterableOwned])`

### DIFF
--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -453,15 +453,38 @@ struct List[T: Movable](
         """Constructs a list from an iterable of values.
 
         Parameters:
-            IterableType: The type of the `iterable` argument.
+            IterableType: The type of the `Iterable` argument.
 
         Args:
             iterable: The iterable of values to populate the list with.
         """
-        var lower, _ = iter(iterable).bounds()
-        self = type_of(self)(capacity=lower)
-        for var value in iterable:
-            self.append(rebind_var[type_of(self).T](value^))
+        var iterator = iter(iterable)
+        var lower, _ = iterator.bounds()
+        self = {capacity = lower}
+        for var value in iterator^:
+            self.append(value^)
+
+    def __init__[
+        IterableType: IterableOwned,
+    ](
+        var iterable: IterableType,
+        out self: List[
+            downcast[IterableType.IteratorOwnedType.Element, Copyable]
+        ],
+    ) where conforms_to(IterableType.IteratorOwnedType.Element, Copyable):
+        """Constructs a list from an iterable of values.
+
+        Parameters:
+            IterableType: The type of the `IterableOwned` argument.
+
+        Args:
+            iterable: The iterable of values to populate the list with.
+        """
+        var iterator = iter(iterable^)
+        var lower, _ = iterator.bounds()
+        self = {capacity = lower}
+        for var value in iterator^:
+            self.append(value^)
 
     @always_inline
     def __init__(out self, *, unsafe_uninit_length: Int):

--- a/mojo/stdlib/std/iter/__init__.mojo
+++ b/mojo/stdlib/std/iter/__init__.mojo
@@ -142,6 +142,14 @@ trait Iterator(ImplicitlyDestructible, Movable):
 
     comptime Element: Movable
 
+    def __iter__(var self) -> Self:
+        """Returns the iterator.
+
+        Returns:
+            An iterator.
+        """
+        return self^
+
     def __next__(mut self) raises StopIteration -> Self.Element:
         """Returns the next element from the iterator.
 

--- a/mojo/stdlib/test/collections/test_list.mojo
+++ b/mojo/stdlib/test/collections/test_list.mojo
@@ -792,6 +792,26 @@ def test_list_iter_bounds() raises:
     _test_list_iter_bounds(reversed(list), len(list))
 
 
+def test_list_iter_ctors() raises:
+    var elems = [0, 1, 2, 3]
+    var res = List(iter(elems))
+    for i in range(4):
+        assert_equal(elems[i], res[i])
+
+    var str_elems = ["0", "1", "2", "3"]
+    var str_res = List(iter(str_elems))
+    for i in range(4):
+        assert_equal(str_res[i], str_elems[i])
+
+    var res_owned = List(iter([0, 1, 2, 3]))
+    for i in range(4):
+        assert_equal(elems[i], res_owned[i])
+
+    var str_res_owned = List(iter(["0", "1", "2", "3"]))
+    for i in range(4):
+        assert_equal(str_res[i], str_res_owned[i])
+
+
 def test_list_span() raises:
     var vs = [1, 2, 3]
 


### PR DESCRIPTION
Add `List(Some[IterableOwned])`

Adds `def __iter__(var self) -> Self:` to the `Iterator` trait to be able to use it in iteration after creation in generic code.