### PR TITLE
[Kernels] fix `ops.conv2d` on CPU with padded input

### DIFF
--- a/max/kernels/src/nn/conv/conv.mojo
+++ b/max/kernels/src/nn/conv/conv.mojo
@@ -1736,42 +1736,71 @@ struct ConvDirectNHWC[
                 )
             # The row is split into multiple micro kernels.
             else:
-                # micro kernel height for left and right boundaries.
-                # IF WO is just 1-2 points more than micro kernel height, the
-                # following would divide the row evely by two micro kernels.
-                comptime micro_kernel_height_lbound = min(
-                    micro_kernel_height, WO // 2
+                # Divide each row into the true padding-affected regions:
+                # [0, left_pad_impact_end), [left_pad_impact_end,
+                # right_pad_impact_start), [right_pad_impact_start, WO).
+                comptime left_pad_impact_end = ceildiv(
+                    Self.conv_attr.pad_left(), Self.conv_attr.strides()[1]
                 )
-                comptime micro_kernel_height_rbound = min(
-                    micro_kernel_height, WO - WO // 2
+                comptime effective_filter_width = (
+                    (S - 1) * Self.conv_attr.dilations()[1] + 1
                 )
-                # Left boundary
-                self._inner_loops_static[
-                    micro_kernel_height_lbound,
-                    micro_kernel_width,
-                    True,
-                    False,
-                    has_residual,
-                    last_c_tile,
-                ](
-                    input_base,
-                    filter_base,
-                    # Safety: turn off mutable aliasing pointer check
-                    output_base.unsafe_origin_cast[AnyOrigin[mut=True]](),
-                    f_tile_offset,
-                    f_tile_size,
-                    c_tile_offset,
-                    c_tile_size,
-                    n,
-                    ho,
-                    0,  # beginning of wo dimension
+                comptime right_pad_impact_start = (
+                    W
+                    + Self.conv_attr.pad_left()
+                    - effective_filter_width
+                ) // Self.conv_attr.strides()[1] + 1
+                comptime left_boundary_end = min(left_pad_impact_end, WO)
+                comptime middle_start = left_boundary_end
+                comptime middle_end = min(
+                    max(right_pad_impact_start, middle_start), WO
                 )
-                input_base = input_base + (
-                    micro_kernel_height_lbound * conv_attr_dyn.strides()[1] * C
-                )
-                output_base = output_base + micro_kernel_height_lbound * F
+                comptime middle_points = middle_end - middle_start
+                comptime middle_residual = middle_points % micro_kernel_height
+                comptime micro_kernel_height_middle = middle_residual if (
+                    middle_residual > 0
+                ) else 1
 
-                # Update middle points if any. They aren't effected by padding.
+                @__copy_capture(filter_base)
+                @always_inline
+                @parameter
+                def update_boundary[height: Int](wo: Int):
+                    # Boundary tiles are intentionally pointwise so each output
+                    # column can skip exactly the filter taps that fall in
+                    # padding.
+                    comptime assert height == 1
+                    conv2d_update_wo_tile[
+                        height,
+                        micro_kernel_width,
+                        simd_size,
+                        Self.filter_packed,
+                        True,
+                        has_residual,
+                        last_c_tile,
+                        elementwise_epilogue=Self.elementwise_epilogue,
+                    ](
+                        output_base,
+                        input_base,
+                        filter_base,
+                        self.is_new_c_accum(c_tile_offset),
+                        c_tile_size,
+                        f_tile_offset,
+                        f_tile_size,
+                        rebind[ConvShape[2]](self.conv_shape),
+                        n,
+                        Index(ho, wo),
+                    )
+
+                    input_base = input_base + (
+                        height * conv_attr_dyn.strides()[1] * C
+                    )
+                    output_base = output_base + height * F
+
+                # Left boundary.
+                for wo in range(0, left_boundary_end):
+                    update_boundary[1](wo)
+
+                # Middle points aren't affected by padding.
                 @__copy_capture(filter_base)
                 @always_inline
                 @parameter
@@ -1796,42 +1825,20 @@ struct ConvDirectNHWC[
                         ho,
                         wo,
                     )
+
                     input_base = input_base + (
                         height * conv_attr_dyn.strides()[1] * C
                     )
                     output_base = output_base + height * F
 
-                # Middle points are the points not updated by micro kernels
-                # on left or right boundary
-                comptime num_middle_points = WO - micro_kernel_height_lbound - micro_kernel_height_rbound
-                # `tile` can't handle zero tile size.
-                comptime micro_kernel_height_middle = num_middle_points % micro_kernel_height if num_middle_points % micro_kernel_height > 0 else 1
                 tile[
                     update_middle,
                     [micro_kernel_height, micro_kernel_height_middle],
-                ](micro_kernel_height_lbound, WO - micro_kernel_height_rbound)
+                ](middle_start, middle_end)
 
                 # Right boundary.
-                self._inner_loops_static[
-                    micro_kernel_height_rbound,
-                    micro_kernel_width,
-                    False,
-                    True,
-                    has_residual,
-                    last_c_tile,
-                ](
-                    input_base,
-                    filter_base,
-                    # Safety: turn off mutable aliasing pointer check
-                    output_base.unsafe_origin_cast[AnyOrigin[mut=True]](),
-                    f_tile_offset,
-                    f_tile_size,
-                    c_tile_offset,
-                    c_tile_size,
-                    n,
-                    ho,
-                    WO - micro_kernel_height_rbound,  # offset in wo dimension
-                )
+                for wo in range(middle_end, WO):
+                    update_boundary[1](wo)
 
     @always_inline
     def _inner_loops_static[

--- a/max/kernels/src/nn/conv/conv.mojo
+++ b/max/kernels/src/nn/conv/conv.mojo
@@ -1746,9 +1746,7 @@ struct ConvDirectNHWC[
                     (S - 1) * Self.conv_attr.dilations()[1] + 1
                 )
                 comptime right_pad_impact_start = (
-                    W
-                    + Self.conv_attr.pad_left()
-                    - effective_filter_width
+                    W + Self.conv_attr.pad_left() - effective_filter_width
                 ) // Self.conv_attr.strides()[1] + 1
                 comptime left_boundary_end = min(left_pad_impact_end, WO)
                 comptime middle_start = left_boundary_end

--- a/max/kernels/test/nn/test_static_conv.mojo
+++ b/max/kernels/test/nn/test_static_conv.mojo
@@ -12,7 +12,6 @@
 # ===----------------------------------------------------------------------=== #
 
 from std.math import ceildiv, isclose
-from std.random import rand
 from std.sys.info import simd_width_of
 
 from std.itertools import product
@@ -48,8 +47,8 @@ def test[
 ]() raises:
     # Output Shape.
     # fmt: off
-    comptime HO = (H + pad_h[0] + pad_h[1] - dilation[1] * (R - 1) - 1) // stride[0] + 1
-    comptime WO = (W + pad_w[0] + pad_w[1] - dilation[0] * (S - 1) - 1) // stride[1] + 1
+    comptime HO = (H + pad_h[0] + pad_h[1] - dilation[0] * (R - 1) - 1) // stride[0] + 1
+    comptime WO = (W + pad_w[0] + pad_w[1] - dilation[1] * (S - 1) - 1) // stride[1] + 1
     # fmt: on
     comptime type = DType.float32
     comptime simd_size = simd_width_of[type]()
@@ -70,15 +69,39 @@ def test[
         num_groups=num_groups,
     )
 
-    var input_ptr = List(length=N * H * W * C, fill=Scalar[type](0))
+    var input_size = N * H * W * C
+    var input_guard_size = C * (
+        W * max(pad_h[0], pad_h[1]) + max(pad_w[0], pad_w[1])
+    )
+    var input_storage_ptr = List(
+        length=input_size + 2 * input_guard_size, fill=Scalar[type](0)
+    )
+    var input_ptr = input_storage_ptr.unsafe_ptr() + input_guard_size
     var filter_ptr = List(length=R * S * C * F, fill=Scalar[type](0))
 
     # output from conv w/ dynamic and static shapes.
     var output_ptr_static = List(length=N * HO * WO * F, fill=Scalar[type](0))
     var output_ptr_dynamic = List(length=N * HO * WO * F, fill=Scalar[type](0))
 
-    rand(input_ptr)
-    rand(filter_ptr)
+    for i in range(input_guard_size):
+        input_storage_ptr[i] = Scalar[type](100.0)
+        input_storage_ptr[input_guard_size + input_size + i] = Scalar[type](
+            -100.0
+        )
+
+    var input_value = -8
+    for i in range(input_size):
+        input_ptr[i] = Scalar[type](Float64(input_value) * 0.01)
+        input_value += 1
+        if input_value > 8:
+            input_value = -8
+
+    var filter_value = -6
+    for i in range(R * S * C * F):
+        filter_ptr[i] = Scalar[type](Float64(filter_value) * 0.01)
+        filter_value += 1
+        if filter_value > 6:
+            filter_value = -6
 
     comptime layout_4d = Layout.row_major[4]()
     comptime layout_5d = Layout.row_major[5]()
@@ -204,7 +227,7 @@ def test[
                 "rerr",
                 abs(actual - expected) / abs(expected + 1e-10),
             )
-            return
+            raise Error("static conv output mismatch")
 
     # CHECK: Succeed
     print("Succeed")
@@ -213,7 +236,7 @@ def test[
     _ = packed_filter_ptr_static^
     _ = packed_filter_ptr_dynamic^
     _ = filter_ptr^
-    _ = input_ptr^
+    _ = input_storage_ptr^
 
 
 def main() raises:
@@ -242,6 +265,19 @@ def main() raises:
         Index(1, 1),  # dilation
         Index(1, 1),  # pad_h
         Index(1, 1),  # pad_w
+    ]()
+    test[
+        1,  # N
+        1,  # H
+        50,  # W
+        8,  # C
+        1,  # R
+        14,  # S
+        64,  # F
+        Index(1, 1),  # stride
+        Index(1, 3),  # dilation
+        Index(0, 0),  # pad_h
+        Index(13, 13),  # pad_w
     ]()
 
     # Each test will build a specialization of the conv kernel.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Before you open this PR, please make sure the change has been discussed and
agreed upon with a maintainer. For anything beyond a trivial fix (typo,
one-line bug fix, doc tweak), we ask that you first open a GitHub issue or
proposal and get a maintainer's go-ahead. This helps us avoid situations
where a PR sits unreviewed because the change isn't aligned with the
team's direction. See our [contributor guide](../CONTRIBUTING.md) for
details.
-->

## Linked issue

<!--
Replace `NNN` with the issue number. For anything non-trivial, a linked
issue that a maintainer has agreed to is expected before review.

- Trivial fix (typo, comment, small doc fix): you can write "N/A — trivial".
- Everything else: `Fixes #NNN` or `Related to #NNN`.
-->

Fixes #6461

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

<!--
Why is this change needed? What problem does it solve, or what use case
does it enable? If this is a bug fix, describe the bug and how a user
would hit it. If this is a new feature, explain the user-facing value.

Please write prose here — don't just restate the PR title.
-->

Fix 2d convolution on CPU with heavily padded input.

## What changed

<!--
Describe the change at a high level. Call out anything non-obvious: API
changes, behavior changes, performance characteristics, or tricky
implementation details.
-->

- in `max/kernels/src/nn/conv/conv.mojo`, `_h_loop_static` used to assume padding size is always smaller than `micro_kernel_height`, hence sending middle of the row still contains padding-affected output columns to `_inner_loops_static`. This PR fix this problem by 
- This PR also fix `max/kernels/test/nn/test_static_conv.mojo` only return when failed without raising an error

## Testing

<!--
Describe how you validated your changes.

- Code changes: what tests did you run, and what were the results? Did
  you add a new test that would have caught the bug?
- Performance changes: include before/after numbers from a benchmark.
- Documentation: describe how you verified accuracy (built the docs,
  ran the example, etc.).
-->

 This PR added a static 2D conv regression case in `max/kernels/test/nn/test_static_conv.mojo`:

- `H=1, W=50, R=1, S=14`
- `dilation=(1, 3)`
- `pad_w=(13, 13)`

This shape has output affecting padding wider than the old static boundary micro-kernel split, so it will catch the bug directly. 

## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](../mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))

Assisted-by: Claude