### PR TITLE
[docs] Fix figure 3 caption on architecture.mdx 

### DIFF
--- a/mojo/docs/manual/gpu/architecture.mdx
+++ b/mojo/docs/manual/gpu/architecture.mdx
@@ -118,7 +118,7 @@ that execute the kernel function concurrently.
 relationship of the grid, thread blocks, warps, and individual threads, based
 on <cite><a
 href="https://rocm.docs.amd.com/projects/HIP/en/latest/understand/programming_model.html">HIP
-Programming Guide</a></cite></figcaption>
+Programming Guide</a></cite>.</figcaption>
 
 </figure>
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Before you open this PR, please make sure the change has been discussed and
agreed upon with a maintainer. For anything beyond a trivial fix (typo,
one-line bug fix, doc tweak), we ask that you first open a GitHub issue or
proposal and get a maintainer's go-ahead. This helps us avoid situations
where a PR sits unreviewed because the change isn't aligned with the
team's direction. See our [contributor guide](../CONTRIBUTING.md) for
details.
-->

## Linked issue

N/A -- trivial.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [x] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Just fixing the subtitle referencing the image for better docs consistency as other figure captions on the page use complete sentences.

## What changed

Just the one-line fix of the period.

## Testing

Opened MDX preview locally in Cursor:

<img width="1000" height="507" alt="Screenshot 2026-05-10 at 7 42 23 PM" src="https://github.com/user-attachments/assets/de99436b-70c5-4dbd-aeac-599919b668c1" />


## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](../mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [ ] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
