### PR TITLE
[docs] Fix broken MAX custom operations links

### DIFF
--- a/mojo/stdlib/std/gpu/__init__.mojo
+++ b/mojo/stdlib/std/gpu/__init__.mojo
@@ -21,7 +21,7 @@ A _kernel_ is a function that runs on the GPU in parallel across many threads.
 Currently, the
 [`DeviceContext`](/docs/std/gpu/host/device_context/DeviceContext/) struct
 provides the interface for compiling and launching GPU kernels inside MAX
-[custom operations](/max/develop/custom-ops/).
+[custom operations](https://docs.modular.com/max/develop/custom-ops/).
 
 The [`gpu.host`](/docs/std/gpu/host/) package includes APIs to manage
 interaction between the _host_ (that is, the CPU) and _device_ (that is, the GPU

--- a/mojo/stdlib/std/gpu/host/device_context.mojo
+++ b/mojo/stdlib/std/gpu/host/device_context.mojo
@@ -3539,7 +3539,7 @@ struct DeviceContext(ImplicitlyCopyable, RegisterPassable, _FunctionEnqueuer):
     (GPU).
 
     A `DeviceContext` serves as the low-level interface to the
-    accelerator inside a MAX [custom operation](/max/develop/custom-ops/) and provides
+    accelerator inside a MAX [custom operation](https://docs.modular.com/max/develop/custom-ops/) and provides
     methods for allocating buffers on the device, copying data between host and
     device, and for compiling and running functions (also known as kernels) on
     the device.


### PR DESCRIPTION
## Linked issue

N/A — trivial.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [x] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Was reading the public docs and noticed the 404. For example following the link here:

https://mojolang.org/docs/std/gpu/ 

leads to

<img width="1115" height="362" alt="Screenshot 2026-05-11 at 7 46 36 PM" src="https://github.com/user-attachments/assets/b654d0a3-aeac-4c60-9e3d-84f60aebb669" />

## What changed

Pointed the links to the deployed docs.

## Testing

Tested manually.

## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](../mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [ ] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
