### PR TITLE
[Stdlib] Typed-arg fast-path bindings: Int <-> PyLong

### DIFF
--- a/mojo/docs/manual/python/mojo-from-python.mdx
+++ b/mojo/docs/manual/python/mojo-from-python.mdx
@@ -624,7 +624,7 @@ through `__int__()` and allocates a fresh `PyLong` per argument per call.
 
 When a binding's signature is just simple numeric types, register it with
 [`def_typed_function()`](/docs/std/python/bindings/PythonModuleBuilder/#def_typed_function)
-instead. The trampoline calls the type-specific CPython API directly on each
+instead. The wrapper calls the type-specific CPython API directly on each
 borrowed argument (e.g. `PyLong_AsSsize_t` for `Int`), skipping the
 `PythonObject` wrap and the conversion allocation:
 

--- a/mojo/docs/manual/python/mojo-from-python.mdx
+++ b/mojo/docs/manual/python/mojo-from-python.mdx
@@ -643,7 +643,7 @@ Initial shapes supported: `def f(a: Int) -> Int` and `def f(a: Int, b: Int) -> I
 with or without `raises` (non-raising functions are implicitly compatible with
 the raising signature).
 
-On the `add(Int, Int) -> Int` shape this is roughly 70% faster than the
+On the `add(Int, Int) -> Int` shape this is roughly 60-70% faster than the
 equivalent `def_function` registration with `PythonObject` arguments. The
 regular `def_function` path remains the right choice when a binding needs the
 full `PythonObject` API (attribute access, calling methods, downcasting to

--- a/mojo/docs/manual/python/mojo-from-python.mdx
+++ b/mojo/docs/manual/python/mojo-from-python.mdx
@@ -639,9 +639,9 @@ def PyInit_mojo_module() -> PythonObject:
     return m.finalize()
 ```
 
-Initial shapes supported: `def f(a: Int) -> Int` and `def f(a: Int, b: Int) -> Int`,
-with or without `raises` (non-raising functions are implicitly compatible with
-the raising signature).
+Initial shapes supported: `def f(a: Int) -> Int` and
+`def f(a: Int, b: Int) -> Int`, with or without `raises` (non-raising
+functions are implicitly compatible with the raising signature).
 
 On the `add(Int, Int) -> Int` shape this is roughly 60-70% faster than the
 equivalent `def_function` registration with `PythonObject` arguments. The

--- a/mojo/docs/manual/python/mojo-from-python.mdx
+++ b/mojo/docs/manual/python/mojo-from-python.mdx
@@ -615,6 +615,40 @@ def lookup(py_self: PythonObject, args_tuple: PythonObject) raises:
             raise e
 ```
 
+### Typed-argument fast paths
+
+[`def_function()`](/docs/std/python/bindings/PythonModuleBuilder/#def_function)
+exposes user code with `PythonObject` arguments, which the function body then
+converts to native Mojo values (e.g. `Int(py=arg)`). That conversion routes
+through `__int__()` and allocates a fresh `PyLong` per argument per call.
+
+When a binding's signature is just simple numeric types, register it with
+[`def_typed_function()`](/docs/std/python/bindings/PythonModuleBuilder/#def_typed_function)
+instead. The trampoline calls the type-specific CPython API directly on each
+borrowed argument (e.g. `PyLong_AsSsize_t` for `Int`), skipping the
+`PythonObject` wrap and the conversion allocation:
+
+```mojo
+def add(a: Int, b: Int) -> Int:
+    return a + b
+
+@export
+def PyInit_mojo_module() -> PythonObject:
+    var m = PythonModuleBuilder("mojo_module")
+    m.def_typed_function[add]("add")
+    return m.finalize()
+```
+
+Initial shapes supported: `def f(a: Int) -> Int` and `def f(a: Int, b: Int) -> Int`,
+with or without `raises` (non-raising functions are implicitly compatible with
+the raising signature).
+
+On the `add(Int, Int) -> Int` shape this is roughly 70% faster than the
+equivalent `def_function` registration with `PythonObject` arguments. The
+regular `def_function` path remains the right choice when a binding needs the
+full `PythonObject` API (attribute access, calling methods, downcasting to
+custom Mojo types, etc.).
+
 ## Strategies for porting Python to Mojo
 
 ### Writing Pythonic code in Mojo

--- a/mojo/docs/nightly-changelog.md
+++ b/mojo/docs/nightly-changelog.md
@@ -129,6 +129,33 @@ This version is still a work in progress.
   free(ptr, layout)
   ```
 
+- Added `PythonModuleBuilder.def_typed_function`, a fast-path registration
+  for Python bindings whose Mojo signature uses concrete types instead of
+  `PythonObject`. The trampoline unwraps positional arguments with the
+  matching CPython C API directly (e.g. `PyLong_AsSsize_t` for `Int`),
+  skipping the `PythonObject` wrap and the `__int__()` -> `PyNumber_Long`
+  allocation that `Int(py=...)` would otherwise pay. Initial shapes
+  supported: `def f(a: Int) -> Int` and `def f(a: Int, b: Int) -> Int`
+  (with or without `raises`).
+
+  ```mojo
+  from python import PythonObject
+  from python.bindings import PythonModuleBuilder
+
+  def add(a: Int, b: Int) -> Int:
+      return a + b
+
+  @export
+  def PyInit_my_mod() -> PythonObject:
+      var m = PythonModuleBuilder("my_mod")
+      m.def_typed_function[add]("add")
+      return m.finalize()
+  ```
+
+  On `add(Int, Int) -> Int`, the typed fast path measures ~71% faster than
+  the equivalent `def_function` registration with `PythonObject` args
+  (see `mojo/stdlib/benchmarks/python/bench_python_ffi_typed.mojo`).
+
 ## Tooling changes
 
 ## GPU programming

--- a/mojo/docs/nightly-changelog.md
+++ b/mojo/docs/nightly-changelog.md
@@ -152,9 +152,10 @@ This version is still a work in progress.
       return m.finalize()
   ```
 
-  On `add(Int, Int) -> Int`, the typed fast path measures ~71% faster than
-  the equivalent `def_function` registration with `PythonObject` args
-  (see `mojo/stdlib/benchmarks/python/bench_python_ffi_typed.mojo`).
+  On `add(Int, Int) -> Int`, the typed fast path measures roughly 60-70%
+  faster than the equivalent `def_function` registration with
+  `PythonObject` args (see
+  `mojo/stdlib/benchmarks/python/bench_python_ffi_typed.mojo`).
 
 ## Tooling changes
 

--- a/mojo/docs/nightly-changelog.md
+++ b/mojo/docs/nightly-changelog.md
@@ -131,7 +131,7 @@ This version is still a work in progress.
 
 - Added `PythonModuleBuilder.def_typed_function`, a fast-path registration
   for Python bindings whose Mojo signature uses concrete types instead of
-  `PythonObject`. The trampoline unwraps positional arguments with the
+  `PythonObject`. The wrapper unwraps positional arguments with the
   matching CPython C API directly (e.g. `PyLong_AsSsize_t` for `Int`),
   skipping the `PythonObject` wrap and the `__int__()` -> `PyNumber_Long`
   allocation that `Int(py=...)` would otherwise pay. Initial shapes

--- a/mojo/stdlib/benchmarks/python/bench_python_ffi_typed.mojo
+++ b/mojo/stdlib/benchmarks/python/bench_python_ffi_typed.mojo
@@ -1,3 +1,15 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
 """Benchmark typed-argument fast-path wrappers vs the standard
 `def_function[user_func]` path.
 
@@ -92,7 +104,5 @@ def main() raises:
     _ = Python()
     var m = Bench(BenchConfig(num_repetitions=5, max_runtime_secs=2.0))
     m.bench_function[bench_a_def_function_add](BenchId("a_def_function_add"))
-    m.bench_function[bench_b_typed_int_int_add](
-        BenchId("b_typed_int_int_add")
-    )
+    m.bench_function[bench_b_typed_int_int_add](BenchId("b_typed_int_int_add"))
     print(m)

--- a/mojo/stdlib/benchmarks/python/bench_python_ffi_typed.mojo
+++ b/mojo/stdlib/benchmarks/python/bench_python_ffi_typed.mojo
@@ -32,8 +32,8 @@ def add_pyobj(a: PythonObject, b: PythonObject) raises -> PythonObject:
     return PythonObject(Int(py=a) + Int(py=b))
 
 
-# --- Variant B: typed fast-path — `def_function` overload picks the
-# right wrapper based on the user's function signature.
+# --- Variant B: typed fast-path via `def_typed_function`, which picks
+# the right wrapper based on the user's function signature.
 
 
 def add_int(a: Int, b: Int) -> Int:

--- a/mojo/stdlib/benchmarks/python/bench_python_ffi_typed.mojo
+++ b/mojo/stdlib/benchmarks/python/bench_python_ffi_typed.mojo
@@ -1,0 +1,98 @@
+"""Benchmark typed-argument fast-path trampolines vs the standard
+`def_function[user_func]` path.
+
+A: stdlib `def_function[add]` where `add` is
+   `def(PythonObject, PythonObject) raises -> PythonObject` and the body
+   does `Int(py=a) + Int(py=b)` (allocates two PyLongs internally
+   via PyNumber_Long).
+
+B: typed trampoline registered via `def_py_c_function`, with `add`
+   declared as `def(Int, Int) -> Int`. The trampoline calls
+   `PyLong_AsSsize_t` directly on each tuple slot, skipping the
+   PythonObject + PyNumber_Long round-trip.
+
+This is item 6 from issue #6521.
+"""
+
+from std.benchmark import (
+    Bench,
+    BenchConfig,
+    Bencher,
+    BenchId,
+    keep,
+)
+from std.python import Python, PythonObject
+from std.python.bindings import PythonModuleBuilder
+
+
+# --- Variant A: current def_function path with PythonObject args ---
+
+
+def add_pyobj(a: PythonObject, b: PythonObject) raises -> PythonObject:
+    return PythonObject(Int(py=a) + Int(py=b))
+
+
+# --- Variant B: typed fast-path — `def_function` overload picks the
+# right trampoline based on the user's function signature.
+
+
+def add_int(a: Int, b: Int) -> Int:
+    return a + b
+
+
+@parameter
+def bench_a_def_function_add(mut b: Bencher) raises:
+    _ = Python()
+    var m = PythonModuleBuilder("_ffi_typed_bench_a")
+    m.def_function[add_pyobj]("add")
+    var mod = m.finalize()
+    var f = mod.add
+    var arg_a = PythonObject(1)
+    var arg_b = PythonObject(2)
+
+    @always_inline
+    @parameter
+    def call_fn() raises:
+        for _ in range(1000):
+            var r = f(arg_a, arg_b)
+            keep(r)
+
+    b.iter[call_fn]()
+    keep(mod)
+    keep(arg_a)
+    keep(arg_b)
+    keep(f)
+
+
+@parameter
+def bench_b_typed_int_int_add(mut b: Bencher) raises:
+    _ = Python()
+    var m = PythonModuleBuilder("_ffi_typed_bench_b")
+    m.def_typed_function[add_int]("add")
+    var mod = m.finalize()
+    var f = mod.add
+    var arg_a = PythonObject(1)
+    var arg_b = PythonObject(2)
+
+    @always_inline
+    @parameter
+    def call_fn() raises:
+        for _ in range(1000):
+            var r = f(arg_a, arg_b)
+            keep(r)
+
+    b.iter[call_fn]()
+    keep(mod)
+    keep(arg_a)
+    keep(arg_b)
+    keep(f)
+
+
+def main() raises:
+    _ = Python()
+    var m = Bench(BenchConfig(num_repetitions=5, max_runtime_secs=2.0))
+    m.bench_function[bench_a_def_function_add](BenchId("a_def_function_add"))
+    m.bench_function[bench_b_typed_int_int_add](
+        BenchId("b_typed_int_int_add")
+    )
+    print(m)

--- a/mojo/stdlib/benchmarks/python/bench_python_ffi_typed.mojo
+++ b/mojo/stdlib/benchmarks/python/bench_python_ffi_typed.mojo
@@ -1,4 +1,4 @@
-"""Benchmark typed-argument fast-path trampolines vs the standard
+"""Benchmark typed-argument fast-path wrappers vs the standard
 `def_function[user_func]` path.
 
 A: stdlib `def_function[add]` where `add` is
@@ -6,8 +6,8 @@ A: stdlib `def_function[add]` where `add` is
    does `Int(py=a) + Int(py=b)` (allocates two PyLongs internally
    via PyNumber_Long).
 
-B: typed trampoline registered via `def_py_c_function`, with `add`
-   declared as `def(Int, Int) -> Int`. The trampoline calls
+B: typed wrapper registered via `def_py_c_function`, with `add`
+   declared as `def(Int, Int) -> Int`. The wrapper calls
    `PyLong_AsSsize_t` directly on each tuple slot, skipping the
    PythonObject + PyNumber_Long round-trip.
 
@@ -33,7 +33,7 @@ def add_pyobj(a: PythonObject, b: PythonObject) raises -> PythonObject:
 
 
 # --- Variant B: typed fast-path — `def_function` overload picks the
-# right trampoline based on the user's function signature.
+# right wrapper based on the user's function signature.
 
 
 def add_int(a: Int, b: Int) -> Int:

--- a/mojo/stdlib/std/python/_python_func_typed.mojo
+++ b/mojo/stdlib/std/python/_python_func_typed.mojo
@@ -47,9 +47,7 @@ def _set_exception(cpy: CPython, var msg: String):
 
 
 @always_inline
-def _check_arity(
-    cpy: CPython, args: PyObjectPtr, expected: Py_ssize_t
-) -> Bool:
+def _check_arity(cpy: CPython, args: PyObjectPtr, expected: Py_ssize_t) -> Bool:
     """Return True if `args` (a tuple) has exactly `expected` items.
 
     On mismatch, sets `PyExc_TypeError` and returns False so the caller

--- a/mojo/stdlib/std/python/_python_func_typed.mojo
+++ b/mojo/stdlib/std/python/_python_func_typed.mojo
@@ -27,7 +27,6 @@ plumbing lands (see issue #6521 / Joe's stack), switching them over is a
 single-line change of the underlying `PyMethodDef` flags.
 """
 
-from std.ffi import c_char
 from std.python import Python
 from std.python._cpython import (
     CPython,

--- a/mojo/stdlib/std/python/_python_func_typed.mojo
+++ b/mojo/stdlib/std/python/_python_func_typed.mojo
@@ -10,10 +10,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-"""Typed-argument fast-path trampolines for `PythonModuleBuilder`.
+"""Typed-argument fast-path wrappers for `PythonModuleBuilder`.
 
 For a Mojo function whose Python-facing signature is *concrete* (e.g.
-`def f(a: Int, b: Int) -> Int`), we can build a CPython trampoline that
+`def f(a: Int, b: Int) -> Int`), we can build a CPython wrapper that
 unwraps positional arguments with the type-specific CPython API
 directly (`PyLong_AsSsize_t`, `PyFloat_AsDouble`, ...) instead of
 routing through `PythonObject` and `Int(py=...)`. The latter goes
@@ -22,7 +22,7 @@ object per call.
 
 This is item 6 from issue #6521's decomposition.
 
-The trampolines here use `METH_VARARGS` for now. Once the `METH_FASTCALL`
+These wrappers use `METH_VARARGS` for now. Once the `METH_FASTCALL`
 plumbing lands (see issue #6521 / Joe's stack), switching them over is a
 single-line change of the underlying `PyMethodDef` flags.
 """
@@ -72,7 +72,7 @@ def _get_int_arg(
 # ===-----------------------------------------------------------------------===#
 
 
-def _trampoline_int_to_int[
+def _typed_int_to_int_wrapper[
     user_func: _FnIntToInt
 ](_self: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr:
     ref cpy = Python().cpython()
@@ -91,7 +91,7 @@ def _trampoline_int_to_int[
 # ===-----------------------------------------------------------------------===#
 
 
-def _trampoline_int_int_to_int[
+def _typed_int_int_to_int_wrapper[
     user_func: _FnIntIntToInt
 ](_self: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr:
     ref cpy = Python().cpython()

--- a/mojo/stdlib/std/python/_python_func_typed.mojo
+++ b/mojo/stdlib/std/python/_python_func_typed.mojo
@@ -1,0 +1,109 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Typed-argument fast-path trampolines for `PythonModuleBuilder`.
+
+For a Mojo function whose Python-facing signature is *concrete* (e.g.
+`def f(a: Int, b: Int) -> Int`), we can build a CPython trampoline that
+unwraps positional arguments with the type-specific CPython API
+directly (`PyLong_AsSsize_t`, `PyFloat_AsDouble`, ...) instead of
+routing through `PythonObject` and `Int(py=...)`. The latter goes
+through `__int__()` -> `PyNumber_Long`, which allocates a fresh `int`
+object per call.
+
+This is item 6 from issue #6521's decomposition.
+
+The trampolines here use `METH_VARARGS` for now. Once the `METH_FASTCALL`
+plumbing lands (see issue #6521 / Joe's stack), switching them over is a
+single-line change of the underlying `PyMethodDef` flags.
+"""
+
+from std.ffi import c_char
+from std.python import Python
+from std.python._cpython import (
+    CPython,
+    PyObjectPtr,
+    Py_ssize_t,
+)
+
+
+# Compile-time aliases for the supported user-function shapes.
+# A single raising signature per arity; non-raising user functions are
+# implicitly compatible with the raising form (they simply never raise),
+# which avoids overload ambiguity between raises and non-raises shapes.
+comptime _FnIntToInt = def(Int) thin raises -> Int
+comptime _FnIntIntToInt = def(Int, Int) thin raises -> Int
+
+
+@always_inline
+def _set_exception(cpy: CPython, var msg: String):
+    var exc_type = cpy.get_error_global("PyExc_Exception")
+    cpy.PyErr_SetString(exc_type, msg.as_c_string_slice().unsafe_ptr())
+
+
+@always_inline
+def _get_int_arg(
+    cpy: CPython, args: PyObjectPtr, i: Py_ssize_t
+) -> Tuple[Int, Bool]:
+    """Fetch the i-th positional arg and unwrap it as an Int.
+
+    Returns `(value, ok)`. On error (out-of-range index, non-int arg,
+    overflow), `ok` is False and a Python exception is already set.
+    """
+    var ptr = cpy.PyTuple_GetItem(args, i)  # borrowed; NULL + IndexError if OOR
+    if not ptr:
+        return (0, False)
+    var raw = cpy.PyLong_AsSsize_t(ptr)
+    if raw == -1 and cpy.PyErr_Occurred():
+        return (0, False)
+    return (raw, True)
+
+
+# ===-----------------------------------------------------------------------===#
+# (Int) -> Int  /  (Int) raises -> Int
+# ===-----------------------------------------------------------------------===#
+
+
+def _trampoline_int_to_int[
+    user_func: _FnIntToInt
+](_self: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr:
+    ref cpy = Python().cpython()
+    try:
+        var a = _get_int_arg(cpy, args, 0)
+        if not a[1]:
+            return PyObjectPtr()
+        return cpy.PyLong_FromSsize_t(user_func(a[0]))
+    except e:
+        _set_exception(cpy, String(e))
+        return PyObjectPtr()
+
+
+# ===-----------------------------------------------------------------------===#
+# (Int, Int) -> Int  /  (Int, Int) raises -> Int
+# ===-----------------------------------------------------------------------===#
+
+
+def _trampoline_int_int_to_int[
+    user_func: _FnIntIntToInt
+](_self: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr:
+    ref cpy = Python().cpython()
+    try:
+        var a = _get_int_arg(cpy, args, 0)
+        if not a[1]:
+            return PyObjectPtr()
+        var b = _get_int_arg(cpy, args, 1)
+        if not b[1]:
+            return PyObjectPtr()
+        return cpy.PyLong_FromSsize_t(user_func(a[0], b[0]))
+    except e:
+        _set_exception(cpy, String(e))
+        return PyObjectPtr()

--- a/mojo/stdlib/std/python/_python_func_typed.mojo
+++ b/mojo/stdlib/std/python/_python_func_typed.mojo
@@ -19,14 +19,11 @@ directly (`PyLong_AsSsize_t`, `PyFloat_AsDouble`, ...) instead of
 routing through `PythonObject` and `Int(py=...)`. The latter goes
 through `__int__()` -> `PyNumber_Long`, which allocates a fresh `int`
 object per call.
-
-This is item 6 from issue #6521's decomposition.
-
-These wrappers use `METH_VARARGS` for now. Once the `METH_FASTCALL`
-plumbing lands (see issue #6521 / Joe's stack), switching them over is a
-single-line change of the underlying `PyMethodDef` flags.
 """
 
+# TODO: These wrappers use `METH_VARARGS` for now. Once the `METH_FASTCALL`
+# plumbing lands (see issue #6521 / Joe's stack), switching them over is a
+# single-line change of the underlying `PyMethodDef` flags.
 from std.python import Python
 from std.python._cpython import (
     CPython,

--- a/mojo/stdlib/std/python/_python_func_typed.mojo
+++ b/mojo/stdlib/std/python/_python_func_typed.mojo
@@ -47,6 +47,30 @@ def _set_exception(cpy: CPython, var msg: String):
 
 
 @always_inline
+def _check_arity(
+    cpy: CPython, args: PyObjectPtr, expected: Py_ssize_t
+) -> Bool:
+    """Return True if `args` (a tuple) has exactly `expected` items.
+
+    On mismatch, sets `PyExc_TypeError` and returns False so the caller
+    can return NULL to surface the error to Python (matching the
+    `TypeError: f() takes N positional arguments but M were given`
+    convention).
+    """
+    var got = cpy.PyObject_Length(args)
+    if got == expected:
+        return True
+    var exc_type = cpy.get_error_global("PyExc_TypeError")
+    cpy.PyErr_SetString(
+        exc_type,
+        StaticString("wrong number of positional arguments")
+        .unsafe_ptr()
+        .bitcast[Int8](),
+    )
+    return False
+
+
+@always_inline
 def _get_int_arg(
     cpy: CPython, args: PyObjectPtr, i: Py_ssize_t
 ) -> Tuple[Int, Bool]:
@@ -74,6 +98,8 @@ def _typed_int_to_int_wrapper[
 ](_self: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr:
     ref cpy = Python().cpython()
     try:
+        if not _check_arity(cpy, args, 1):
+            return PyObjectPtr()
         var a = _get_int_arg(cpy, args, 0)
         if not a[1]:
             return PyObjectPtr()
@@ -93,6 +119,8 @@ def _typed_int_int_to_int_wrapper[
 ](_self: PyObjectPtr, args: PyObjectPtr) -> PyObjectPtr:
     ref cpy = Python().cpython()
     try:
+        if not _check_arity(cpy, args, 2):
+            return PyObjectPtr()
         var a = _get_int_arg(cpy, args, 0)
         if not a[1]:
             return PyObjectPtr()

--- a/mojo/stdlib/std/python/bindings.mojo
+++ b/mojo/stdlib/std/python/bindings.mojo
@@ -44,8 +44,8 @@ from std.python._python_func import PyObjectFunction
 from std.python._python_func_typed import (
     _FnIntToInt,
     _FnIntIntToInt,
-    _trampoline_int_to_int,
-    _trampoline_int_int_to_int,
+    _typed_int_to_int_wrapper,
+    _typed_int_int_to_int_wrapper,
 )
 from std.python.python_object import _unsafe_alloc, _unsafe_init
 
@@ -476,7 +476,7 @@ struct PythonModuleBuilder:
     # ===-------------------------------------------------------------------===#
     # Users who declare their function with concrete Mojo types like
     # `def f(a: Int, b: Int) -> Int` can register via `def_typed_function`
-    # to get a trampoline that converts via `PyLong_AsSsize_t` /
+    # to get a wrapper that converts via `PyLong_AsSsize_t` /
     # `PyLong_FromSsize_t` directly, bypassing the `PythonObject` wrap
     # and the `__int__()` -> `PyNumber_Long` allocation chain. See issue
     # #6521 item 6.
@@ -488,7 +488,7 @@ struct PythonModuleBuilder:
         (or its `raises` variant). Non-raising functions are implicitly
         compatible with this raising signature."""
         self.def_py_c_function(
-            _trampoline_int_to_int[func], func_name, docstring
+            _typed_int_to_int_wrapper[func], func_name, docstring
         )
 
     def def_typed_function[
@@ -498,7 +498,7 @@ struct PythonModuleBuilder:
         (or its `raises` variant). Non-raising functions are implicitly
         compatible with this raising signature."""
         self.def_py_c_function(
-            _trampoline_int_int_to_int[func], func_name, docstring
+            _typed_int_int_to_int_wrapper[func], func_name, docstring
         )
 
     def finalize(mut self) raises -> PythonObject:

--- a/mojo/stdlib/std/python/bindings.mojo
+++ b/mojo/stdlib/std/python/bindings.mojo
@@ -41,6 +41,12 @@ from std.python._cpython import (
     PyTypeObjectPtr,
 )
 from std.python._python_func import PyObjectFunction
+from std.python._python_func_typed import (
+    _FnIntToInt,
+    _FnIntIntToInt,
+    _trampoline_int_to_int,
+    _trampoline_int_int_to_int,
+)
 from std.python.python_object import _unsafe_alloc, _unsafe_init
 
 from std.utils import Variant
@@ -463,6 +469,36 @@ struct PythonModuleBuilder:
         """
         self._generic_def_py_function[_py_function_wrapper[func]()](
             func_name, docstring
+        )
+
+    # ===-------------------------------------------------------------------===#
+    # Typed-argument fast-path API
+    # ===-------------------------------------------------------------------===#
+    # Users who declare their function with concrete Mojo types like
+    # `def f(a: Int, b: Int) -> Int` can register via `def_typed_function`
+    # to get a trampoline that converts via `PyLong_AsSsize_t` /
+    # `PyLong_FromSsize_t` directly, bypassing the `PythonObject` wrap
+    # and the `__int__()` -> `PyNumber_Long` allocation chain. See issue
+    # #6521 item 6.
+
+    def def_typed_function[
+        func: _FnIntToInt
+    ](mut self, func_name: StaticString, docstring: StaticString = ""):
+        """Register a typed fast-path binding for `def f(a: Int) -> Int`
+        (or its `raises` variant). Non-raising functions are implicitly
+        compatible with this raising signature."""
+        self.def_py_c_function(
+            _trampoline_int_to_int[func], func_name, docstring
+        )
+
+    def def_typed_function[
+        func: _FnIntIntToInt
+    ](mut self, func_name: StaticString, docstring: StaticString = ""):
+        """Register a typed fast-path binding for `def f(a: Int, b: Int) -> Int`
+        (or its `raises` variant). Non-raising functions are implicitly
+        compatible with this raising signature."""
+        self.def_py_c_function(
+            _trampoline_int_int_to_int[func], func_name, docstring
         )
 
     def finalize(mut self) raises -> PythonObject:

--- a/mojo/stdlib/std/python/bindings.mojo
+++ b/mojo/stdlib/std/python/bindings.mojo
@@ -478,8 +478,7 @@ struct PythonModuleBuilder:
     # `def f(a: Int, b: Int) -> Int` can register via `def_typed_function`
     # to get a wrapper that converts via `PyLong_AsSsize_t` /
     # `PyLong_FromSsize_t` directly, bypassing the `PythonObject` wrap
-    # and the `__int__()` -> `PyNumber_Long` allocation chain. See issue
-    # #6521 item 6.
+    # and the `__int__()` -> `PyNumber_Long` allocation chain.
 
     def def_typed_function[
         func: _FnIntToInt

--- a/mojo/stdlib/std/python/bindings.mojo
+++ b/mojo/stdlib/std/python/bindings.mojo
@@ -483,9 +483,19 @@ struct PythonModuleBuilder:
     def def_typed_function[
         func: _FnIntToInt
     ](mut self, func_name: StaticString, docstring: StaticString = ""):
-        """Register a typed fast-path binding for `def f(a: Int) -> Int`
-        (or its `raises` variant). Non-raising functions are implicitly
-        compatible with this raising signature."""
+        """Register a typed fast-path binding for `def f(a: Int) -> Int`.
+
+        Non-raising functions are implicitly compatible with this
+        raising signature.
+
+        Parameters:
+            func: The Mojo function to expose to Python.
+
+        Args:
+            func_name: The name with which the function will be exposed
+                in the module.
+            docstring: The docstring for the function in the module.
+        """
         self.def_py_c_function(
             _typed_int_to_int_wrapper[func], func_name, docstring
         )
@@ -493,9 +503,19 @@ struct PythonModuleBuilder:
     def def_typed_function[
         func: _FnIntIntToInt
     ](mut self, func_name: StaticString, docstring: StaticString = ""):
-        """Register a typed fast-path binding for `def f(a: Int, b: Int) -> Int`
-        (or its `raises` variant). Non-raising functions are implicitly
-        compatible with this raising signature."""
+        """Register a typed fast-path binding for `def f(a: Int, b: Int) -> Int`.
+
+        Non-raising functions are implicitly compatible with this
+        raising signature.
+
+        Parameters:
+            func: The Mojo function to expose to Python.
+
+        Args:
+            func_name: The name with which the function will be exposed
+                in the module.
+            docstring: The docstring for the function in the module.
+        """
         self.def_py_c_function(
             _typed_int_int_to_int_wrapper[func], func_name, docstring
         )


### PR DESCRIPTION
## Linked issue

Related to #6521. This PR addresses **item 6** of @JoeLoser's decomposition (typed-argument fast paths for `Int(py=...)`).

## Type of change

- [x] Performance improvement (measurements below)
- [x] New user-facing API: `PythonModuleBuilder.def_typed_function`

## Motivation

When users expose a Mojo function to Python via `PythonModuleBuilder.def_function`, they currently have to declare `PythonObject` arguments and convert internally:

```mojo
def add(a: PythonObject, b: PythonObject) raises -> PythonObject:
    return PythonObject(Int(py=a) + Int(py=b))
m.def_function[add]("add")
```

`Int(py=a)` goes through `__int__()` -> `PyNumber_Long`, which **allocates a fresh `PyLong` per argument per call** before extracting the `Py_ssize_t`. For `add(a, b)` that's two allocations on the args plus one for the return.

## What this PR adds

A typed-argument fast path that lets users declare concrete types:

```mojo
def add(a: Int, b: Int) -> Int:
    return a + b
m.def_typed_function[add]("add")
```

The trampoline calls `PyLong_AsSsize_t` directly on each borrowed tuple slot and `PyLong_FromSsize_t` on the return, so no `PythonObject` wraps, no `PyNumber_Long` allocation.

## Shapes supported in this PR

| Signature | Trampoline |
|---|---|
| `def f(a: Int) -> Int` (with or without `raises`) | `_trampoline_int_to_int` |
| `def f(a: Int, b: Int) -> Int` (with or without `raises`) | `_trampoline_int_int_to_int` |

Non-raising user functions are implicitly compatible with the raising signature; one overload per arity is enough.

Extension to `Float64` (via `PyFloat_AsDouble`/`PyFloat_FromDouble`), `Bool` (via `PyObject_IsTrue`/`PyBool_FromLong`), `UInt`, and `StringSlice` (via `PyUnicode_AsUTF8AndSize`) follows the same pattern. Left as follow-ups.

## Bench results

`./bazelw test //mojo/stdlib/benchmarks:python/bench_python_ffi_typed.mojo.bench --test_output=all`, Mojo `1.0.0b2.dev2026051106 (aff922aa)` bazel toolchain, CPython 3.13, single core (`taskset -c 2`):

| Variant | min ns/iter | median ns/iter |
|---|---|---|
| `a_def_function_add` (PythonObject + `Int(py=...)`) | 566 | 880 |
| `b_typed_int_int_add` (typed fast path) | **164** | 250 |

**Min delta: ~400 ns/iter saved (~71%)** on the `add(Int, Int) -> Int` shape.

Assisted-by: AI