### PR TITLE
[docs] Refactor import of std.math in mojo-from-python.mdx

### DIFF
--- a/mojo/docs/manual/python/mojo-from-python.mdx
+++ b/mojo/docs/manual/python/mojo-from-python.mdx
@@ -66,7 +66,7 @@ So the complete Mojo code looks like this:
 ```mojo title="mojo_module.mojo"
 from std.python import PythonObject
 from std.python.bindings import PythonModuleBuilder
-import std.math
+from std import math  # import std.math as math
 from std.os import abort
 
 @export


### PR DESCRIPTION
Updated import statement from incomplete/broken std.math to std. following pattern of imported library

<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Before you open this PR, please make sure the change has been discussed and
agreed upon with a maintainer. For anything beyond a trivial fix (typo,
one-line bug fix, doc tweak), we ask that you first open a GitHub issue or
proposal and get a maintainer's go-ahead. This helps us avoid situations
where a PR sits unreviewed because the change isn't aligned with the
team's direction. See our [contributor guide](../CONTRIBUTING.md) for
details.
-->

## Linked issue

<!--
Replace `NNN` with the issue number. For anything non-trivial, a linked
issue that a maintainer has agreed to is expected before review.

- Trivial fix (typo, comment, small doc fix): you can write "N/A — trivial".
- Everything else: `Fixes #NNN` or `Related to #NNN`.
-->


## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [x] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation
Part of the current python interop does not compile because the documentation is carrying incomplete python syntax. On compilation you get this type of error.
<img width="830" height="159" alt="shot from modman.pages.dev" src="https://github.com/user-attachments/assets/710aa489-925c-4654-a000-b3614488c59d" />


<!--
Why is this change needed? What problem does it solve, or what use case
does it enable? If this is a bug fix, describe the bug and how a user
would hit it. If this is a new feature, explain the user-facing value.

Please write prose here — don't just restate the PR title.
-->

## What changed
the previous doc contain this syntax
```mojo
    import std.math
```
and I currently move it to this
```mojo
   from std import math # import std.math as math
```
with an alternative syntax placed as comment.
<!--
Describe the change at a high level. Call out anything non-obvious: API
changes, behavior changes, performance characteristics, or tricky
implementation details.
-->

## Testing
Below is a shot of running the new code
<img width="840" height="179" alt="shot from modman.pages.dev" src="https://github.com/user-attachments/assets/5a7578ce-2c07-4e09-93bc-4cf8c7d16a82" />


<!--
Describe how you validated your changes.

- Code changes: what tests did you run, and what were the results? Did
  you add a new test that would have caught the bug?
- Performance changes: include before/after numbers from a benchmark.
- Documentation: describe how you verified accuracy (built the docs,
  ran the example, etc.).
-->

## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](../mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [ ] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description
      (see [AI Tool Use Policy](../AI_TOOL_POLICY.md))
