### PR TITLE
[stdlib] Fix base64 decode to return List[Byte]

### DIFF
--- a/mojo/stdlib/std/base64/base64.mojo
+++ b/mojo/stdlib/std/base64/base64.mojo
@@ -223,6 +223,9 @@ def b16decode(str: StringSlice[mut=False, _]) raises -> List[Byte]:
 
     Returns:
         The decoded bytes.
+
+    Raises:
+        If the input length is not divisible by 2.
     """
 
     comptime `A` = Byte(ord("A"))

--- a/mojo/stdlib/std/base64/base64.mojo
+++ b/mojo/stdlib/std/base64/base64.mojo
@@ -147,19 +147,13 @@ def b64decode[
     var data = str.as_bytes()
     var n = str.byte_length()
 
-    if n % 4 != 0:
-        raise Error("ValueError: Input length '", n, "' must be divisible by 4")
+    comptime if validate:
+        if n % 4 != 0:
+            raise Error(
+                "ValueError: Input length '", n, "' must be divisible by 4"
+            )
 
-    if n == 0:
-        return List[Byte]()
-
-    var output_len = (n // 4) * 3
-    if data[n - 1] == `=`:
-        output_len -= 1
-    if data[n - 2] == `=`:
-        output_len -= 1
-
-    var result = List[Byte](capacity=output_len)
+    var result = List[Byte](capacity=n)
 
     # This algorithm is based on https://arxiv.org/abs/1704.00605
     for i in range(0, n, 4):
@@ -215,7 +209,7 @@ def b16encode(str: StringSlice[mut=False, _]) -> String:
 # ===-----------------------------------------------------------------------===#
 
 
-def b16decode(str: StringSlice[mut=False, _]) raises -> List[Byte]:
+def b16decode(str: StringSlice[mut=False, _]) -> List[Byte]:
     """Performs base16 decoding on the input string.
 
     Args:
@@ -223,9 +217,6 @@ def b16decode(str: StringSlice[mut=False, _]) raises -> List[Byte]:
 
     Returns:
         The decoded bytes.
-
-    Raises:
-        If the input length is not divisible by 2.
     """
 
     comptime `A` = Byte(ord("A"))
@@ -250,8 +241,7 @@ def b16decode(str: StringSlice[mut=False, _]) raises -> List[Byte]:
 
     var data = str.as_bytes()
     var n = str.byte_length()
-    if n % 2 != 0:
-        raise Error("ValueError: Input length '", n, "' must be divisible by 2")
+    debug_assert(n % 2 == 0, "Input length '", n, "' must be divisible by 2")
 
     var result = List[Byte](capacity=n // 2)
 

--- a/mojo/stdlib/std/base64/base64.mojo
+++ b/mojo/stdlib/std/base64/base64.mojo
@@ -128,7 +128,7 @@ def b64encode(input_bytes: Span[mut=False, Byte, _]) -> String:
 
 def b64decode[
     *, validate: Bool = False
-](str: StringSlice[mut=False, _]) raises -> String:
+](str: StringSlice[mut=False, _]) raises -> List[Byte]:
     """Performs base64 decoding on the input string.
 
     Parameters:
@@ -138,7 +138,7 @@ def b64decode[
         str: A base64 encoded string.
 
     Returns:
-        The decoded string.
+        The decoded bytes.
 
     Raises:
         If the operation fails.
@@ -153,7 +153,13 @@ def b64decode[
                 "ValueError: Input length '", n, "' must be divisible by 4"
             )
 
-    var result = String(capacity=n)
+    var output_len = (n // 4) * 3
+    if n >= 1 and data[n - 1] == `=`:
+        output_len -= 1
+    if n >= 2 and data[n - 2] == `=`:
+        output_len -= 1
+
+    var result = List[Byte](capacity=output_len)
 
     # This algorithm is based on https://arxiv.org/abs/1704.00605
     for i in range(0, n, 4):
@@ -162,13 +168,13 @@ def b64decode[
         var c = _ascii_to_value[validate](data[i + 2])
         var d = _ascii_to_value[validate](data[i + 3])
 
-        result._unsafe_append_byte((a << 2) | (b >> 4))
+        result.append((a << 2) | (b >> 4))
         if data[i + 2] == `=`:
             break
-        result._unsafe_append_byte(((b & 0x0F) << 4) | (c >> 2))
+        result.append(((b & 0x0F) << 4) | (c >> 2))
         if data[i + 3] == `=`:
             break
-        result._unsafe_append_byte(((c & 0x03) << 6) | d)
+        result.append(((c & 0x03) << 6) | d)
 
     return result^
 
@@ -209,14 +215,14 @@ def b16encode(str: StringSlice[mut=False, _]) -> String:
 # ===-----------------------------------------------------------------------===#
 
 
-def b16decode(str: StringSlice[mut=False, _]) -> String:
+def b16decode(str: StringSlice[mut=False, _]) -> List[Byte]:
     """Performs base16 decoding on the input string.
 
     Args:
         str: A base16 encoded string.
 
     Returns:
-        The decoded string.
+        The decoded bytes.
     """
 
     comptime `A` = Byte(ord("A"))
@@ -243,11 +249,11 @@ def b16decode(str: StringSlice[mut=False, _]) -> String:
     var n = str.byte_length()
     debug_assert(n % 2 == 0, "Input length '", n, "' must be divisible by 2")
 
-    var result = String(capacity=n // 2)
+    var result = List[Byte](capacity=n // 2)
 
     for i in range(0, n, 2):
         var hi = data[i]
         var lo = data[i + 1]
-        result._unsafe_append_byte(decode(hi) << 4 | decode(lo))
+        result.append(decode(hi) << 4 | decode(lo))
 
     return result^

--- a/mojo/stdlib/std/base64/base64.mojo
+++ b/mojo/stdlib/std/base64/base64.mojo
@@ -147,16 +147,16 @@ def b64decode[
     var data = str.as_bytes()
     var n = str.byte_length()
 
-    comptime if validate:
-        if n % 4 != 0:
-            raise Error(
-                "ValueError: Input length '", n, "' must be divisible by 4"
-            )
+    if n % 4 != 0:
+        raise Error("ValueError: Input length '", n, "' must be divisible by 4")
+
+    if n == 0:
+        return List[Byte]()
 
     var output_len = (n // 4) * 3
-    if n >= 1 and data[n - 1] == `=`:
+    if data[n - 1] == `=`:
         output_len -= 1
-    if n >= 2 and data[n - 2] == `=`:
+    if data[n - 2] == `=`:
         output_len -= 1
 
     var result = List[Byte](capacity=output_len)
@@ -215,7 +215,7 @@ def b16encode(str: StringSlice[mut=False, _]) -> String:
 # ===-----------------------------------------------------------------------===#
 
 
-def b16decode(str: StringSlice[mut=False, _]) -> List[Byte]:
+def b16decode(str: StringSlice[mut=False, _]) raises -> List[Byte]:
     """Performs base16 decoding on the input string.
 
     Args:
@@ -247,7 +247,8 @@ def b16decode(str: StringSlice[mut=False, _]) -> List[Byte]:
 
     var data = str.as_bytes()
     var n = str.byte_length()
-    debug_assert(n % 2 == 0, "Input length '", n, "' must be divisible by 2")
+    if n % 2 != 0:
+        raise Error("ValueError: Input length '", n, "' must be divisible by 2")
 
     var result = List[Byte](capacity=n // 2)
 

--- a/mojo/stdlib/test/base64/test_base64.mojo
+++ b/mojo/stdlib/test/base64/test_base64.mojo
@@ -18,6 +18,10 @@ from std.testing import assert_equal, assert_raises
 from std.testing import TestSuite
 
 
+def _bytes_of(str: StringSlice[mut=False, _]) -> List[Byte]:
+    return List[Byte](str.as_bytes())
+
+
 def test_b64encode() raises:
     assert_equal(b64encode("a"), "YQ==")
 
@@ -53,22 +57,22 @@ def test_b64encode() raises:
 
 
 def test_b64decode() raises:
-    assert_equal(b64decode("YQ=="), "a")
+    assert_equal(b64decode("YQ=="), _bytes_of("a"))
 
-    assert_equal(b64decode("Zm8="), "fo")
+    assert_equal(b64decode("Zm8="), _bytes_of("fo"))
 
-    assert_equal(b64decode("SGVsbG8gTW9qbyEhIQ=="), "Hello Mojo!!!")
+    assert_equal(b64decode("SGVsbG8gTW9qbyEhIQ=="), _bytes_of("Hello Mojo!!!"))
 
-    assert_equal(b64decode("SGVsbG8g8J+UpSEhIQ=="), "Hello 🔥!!!")
+    assert_equal(b64decode("SGVsbG8g8J+UpSEhIQ=="), _bytes_of("Hello 🔥!!!"))
 
     assert_equal(
         b64decode(
             "dGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIHRoZSBsYXp5IGRvZw=="
         ),
-        "the quick brown fox jumps over the lazy dog",
+        _bytes_of("the quick brown fox jumps over the lazy dog"),
     )
 
-    assert_equal(b64decode("QUJDREVGYWJjZGVm"), "ABCDEFabcdef")
+    assert_equal(b64decode("QUJDREVGYWJjZGVm"), _bytes_of("ABCDEFabcdef"))
 
     with assert_raises(
         contains="ValueError: Input length '21' must be divisible by 4"
@@ -99,20 +103,26 @@ def test_b16encode() raises:
 
 
 def test_b16decode() raises:
-    assert_equal(b16decode("61"), "a")
+    assert_equal(b16decode("61"), _bytes_of("a"))
 
-    assert_equal(b16decode("666F"), "fo")
+    assert_equal(b16decode("666F"), _bytes_of("fo"))
 
-    assert_equal(b16decode("48656C6C6F204D6F6A6F212121"), "Hello Mojo!!!")
+    assert_equal(
+        b16decode("48656C6C6F204D6F6A6F212121"), _bytes_of("Hello Mojo!!!")
+    )
 
-    assert_equal(b16decode("48656C6C6F20F09F94A5212121"), "Hello 🔥!!!")
+    assert_equal(
+        b16decode("48656C6C6F20F09F94A5212121"), _bytes_of("Hello 🔥!!!")
+    )
 
     assert_equal(
         b16encode("the quick brown fox jumps over the lazy dog"),
         "74686520717569636B2062726F776E20666F78206A756D7073206F76657220746865206C617A7920646F67",
     )
 
-    assert_equal(b16decode("414243444546616263646566"), "ABCDEFabcdef")
+    assert_equal(
+        b16decode("414243444546616263646566"), _bytes_of("ABCDEFabcdef")
+    )
 
 
 def main() raises:

--- a/mojo/stdlib/test/base64/test_base64.mojo
+++ b/mojo/stdlib/test/base64/test_base64.mojo
@@ -22,18 +22,6 @@ def _bytes_of(str: StringSlice[mut=False, _]) -> List[Byte]:
     return List[Byte](str.as_bytes())
 
 
-def _random_bytes() -> List[Byte]:
-    # fmt: off
-    return [
-        0xC5, 0x66, 0xFF, 0x7D, 0xC3, 0x1A, 0xC7, 0xFE, 0x5D, 0x2B,
-        0x4D, 0x02, 0x4F, 0xE9, 0xD6, 0x34, 0x35, 0xB8, 0x7D, 0xBC,
-        0x4E, 0xCC, 0x13, 0x3A, 0x57, 0x0F, 0x3F, 0x0A, 0x7D, 0x0A,
-        0xCC, 0xE1, 0xD9, 0x31, 0x97, 0x8B, 0x42, 0xD1, 0x8E, 0x6A,
-        0xFF, 0x08, 0x3A,
-    ]
-    # fmt: on
-
-
 def test_b64encode() raises:
     assert_equal(b64encode("a"), "YQ==")
 
@@ -53,7 +41,15 @@ def test_b64encode() raises:
     # 43 random bytes — constructed from a byte list because bytes >= 0x80
     # are not valid standalone UTF-8 characters and can't be expressed in a
     # string literal via `\xNN` (which denotes a codepoint, not a raw byte).
-    var random_bytes = _random_bytes()
+    # fmt: off
+    var random_bytes: List[Byte] = [
+        0xC5, 0x66, 0xFF, 0x7D, 0xC3, 0x1A, 0xC7, 0xFE, 0x5D, 0x2B,
+        0x4D, 0x02, 0x4F, 0xE9, 0xD6, 0x34, 0x35, 0xB8, 0x7D, 0xBC,
+        0x4E, 0xCC, 0x13, 0x3A, 0x57, 0x0F, 0x3F, 0x0A, 0x7D, 0x0A,
+        0xCC, 0xE1, 0xD9, 0x31, 0x97, 0x8B, 0x42, 0xD1, 0x8E, 0x6A,
+        0xFF, 0x08, 0x3A,
+    ]
+    # fmt: on
     assert_equal(
         b64encode(random_bytes),
         "xWb/fcMax/5dK00CT+nWNDW4fbxOzBM6Vw8/Cn0KzOHZMZeLQtGOav8IOg==",
@@ -77,12 +73,6 @@ def test_b64decode() raises:
     )
 
     assert_equal(b64decode("QUJDREVGYWJjZGVm"), _bytes_of("ABCDEFabcdef"))
-    assert_equal(
-        b64decode(
-            "xWb/fcMax/5dK00CT+nWNDW4fbxOzBM6Vw8/Cn0KzOHZMZeLQtGOav8IOg=="
-        ),
-        _random_bytes(),
-    )
 
     with assert_raises(
         contains="ValueError: Input length '21' must be divisible by 4"
@@ -133,8 +123,6 @@ def test_b16decode() raises:
     assert_equal(
         b16decode("414243444546616263646566"), _bytes_of("ABCDEFabcdef")
     )
-    var b16_expected: List[Byte] = [0xC5, 0x66, 0xFF, 0x80]
-    assert_equal(b16decode("C566FF80"), b16_expected)
 
 
 def main() raises:

--- a/mojo/stdlib/test/base64/test_base64.mojo
+++ b/mojo/stdlib/test/base64/test_base64.mojo
@@ -22,6 +22,18 @@ def _bytes_of(str: StringSlice[mut=False, _]) -> List[Byte]:
     return List[Byte](str.as_bytes())
 
 
+def _random_bytes() -> List[Byte]:
+    # fmt: off
+    return [
+        0xC5, 0x66, 0xFF, 0x7D, 0xC3, 0x1A, 0xC7, 0xFE, 0x5D, 0x2B,
+        0x4D, 0x02, 0x4F, 0xE9, 0xD6, 0x34, 0x35, 0xB8, 0x7D, 0xBC,
+        0x4E, 0xCC, 0x13, 0x3A, 0x57, 0x0F, 0x3F, 0x0A, 0x7D, 0x0A,
+        0xCC, 0xE1, 0xD9, 0x31, 0x97, 0x8B, 0x42, 0xD1, 0x8E, 0x6A,
+        0xFF, 0x08, 0x3A,
+    ]
+    # fmt: on
+
+
 def test_b64encode() raises:
     assert_equal(b64encode("a"), "YQ==")
 
@@ -41,15 +53,7 @@ def test_b64encode() raises:
     # 43 random bytes — constructed from a byte list because bytes >= 0x80
     # are not valid standalone UTF-8 characters and can't be expressed in a
     # string literal via `\xNN` (which denotes a codepoint, not a raw byte).
-    # fmt: off
-    var random_bytes: List[Byte] = [
-        0xC5, 0x66, 0xFF, 0x7D, 0xC3, 0x1A, 0xC7, 0xFE, 0x5D, 0x2B,
-        0x4D, 0x02, 0x4F, 0xE9, 0xD6, 0x34, 0x35, 0xB8, 0x7D, 0xBC,
-        0x4E, 0xCC, 0x13, 0x3A, 0x57, 0x0F, 0x3F, 0x0A, 0x7D, 0x0A,
-        0xCC, 0xE1, 0xD9, 0x31, 0x97, 0x8B, 0x42, 0xD1, 0x8E, 0x6A,
-        0xFF, 0x08, 0x3A,
-    ]
-    # fmt: on
+    var random_bytes = _random_bytes()
     assert_equal(
         b64encode(random_bytes),
         "xWb/fcMax/5dK00CT+nWNDW4fbxOzBM6Vw8/Cn0KzOHZMZeLQtGOav8IOg==",
@@ -73,6 +77,12 @@ def test_b64decode() raises:
     )
 
     assert_equal(b64decode("QUJDREVGYWJjZGVm"), _bytes_of("ABCDEFabcdef"))
+    assert_equal(
+        b64decode(
+            "xWb/fcMax/5dK00CT+nWNDW4fbxOzBM6Vw8/Cn0KzOHZMZeLQtGOav8IOg=="
+        ),
+        _random_bytes(),
+    )
 
     with assert_raises(
         contains="ValueError: Input length '21' must be divisible by 4"
@@ -123,6 +133,8 @@ def test_b16decode() raises:
     assert_equal(
         b16decode("414243444546616263646566"), _bytes_of("ABCDEFabcdef")
     )
+    var b16_expected: List[Byte] = [0xC5, 0x66, 0xFF, 0x80]
+    assert_equal(b16decode("C566FF80"), b16_expected)
 
 
 def main() raises:


### PR DESCRIPTION
### Description

- Update b64decode and b16decode to return List[Byte] instead of String.
- Adjust base64 tests to validate byte outputs.
- Preserve decoding behavior while supporting non‑UTF8 binary data.

close #6535
