### PR TITLE
[stdlib] Add grapheme indexing

### DIFF
--- a/mojo/docs/nightly-changelog.md
+++ b/mojo/docs/nightly-changelog.md
@@ -263,6 +263,9 @@ This version is still a work in progress.
   - `offset_of[T, index=...]()` → `reflect[T]().field_offset[index=...]()`
   - `ReflectedType[T]` → `Reflected[T]`
 
+- `String` and `StringSlice` can now be indexed by graphemes, e.g.
+  `String("👨‍🚀🧑‍🌾क्षि")[grapheme=1]` returns `"🧑‍🌾"`.
+
 ## Fixed
 
 - Reduced the virtual address space reserved by every `mojo` invocation by

--- a/mojo/stdlib/scripts/run-tests.sh
+++ b/mojo/stdlib/scripts/run-tests.sh
@@ -22,8 +22,7 @@ FILTER=""
 if [[ $# -gt 0 ]]; then
   FILTER="${1#./}" # remove leading relative file path if it has one
   if [[ -f ${FILTER} ]]; then # specific file
-    FILTER="//mojo/$(dirname "$FILTER"):$(basename "$FILTER")"
-    FILTER=$("$REPO_ROOT"/bazelw query "$FILTER")
+    FILTER="//mojo/$(dirname "$FILTER"):$(basename "$FILTER").test"
   else
     # specific test directory
     FILTER="${FILTER%/}" # remove trailing / if it has one

--- a/mojo/stdlib/std/collections/string/string.mojo
+++ b/mojo/stdlib/std/collections/string/string.mojo
@@ -838,6 +838,21 @@ struct String(
         """
         return StringSlice(self)[codepoint=codepoint]
 
+    @always_inline
+    def __getitem__(
+        self, *, grapheme: Some[Indexer]
+    ) -> StringSlice[origin_of(self)]:
+        """Gets the character at the specified position.
+
+        Args:
+            grapheme: The grapheme index.
+
+        Returns:
+            A `StringSlice` view containing the unicode grapheme at the
+            specified position.
+        """
+        return StringSlice(self)[grapheme=grapheme]
+
     def __eq__(self, rhs: String) -> Bool:
         """Compares two Strings if they have the same values.
 
@@ -1205,18 +1220,6 @@ struct String(
             An iterator yielding `(byte_offset, grapheme)` pairs.
         """
         return StringSlice(self).grapheme_indices()
-
-    def nth_grapheme(self, n: Int) -> Optional[StringSlice[origin_of(self)]]:
-        """Return the `n`-th grapheme cluster (0-indexed), or `None` if out
-        of range.
-
-        Args:
-            n: The zero-based grapheme index. Must be non-negative.
-
-        Returns:
-            The `n`-th grapheme cluster, or `None` if `n` is out of range.
-        """
-        return StringSlice(self).nth_grapheme(n)
 
     def split_at_grapheme(
         self, n: Int

--- a/mojo/stdlib/std/collections/string/string_slice.mojo
+++ b/mojo/stdlib/std/collections/string/string_slice.mojo
@@ -522,6 +522,22 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
                 c_count += 1
             abort(String("codepoint index is out of bounds: ", c_idx))
 
+    @always_inline
+    def __getitem__(self, *, grapheme: Some[Indexer]) -> Self:
+        """Gets the character at the specified position.
+
+        Args:
+            grapheme: The grapheme index.
+
+        Returns:
+            A `StringSlice` view containing the unicode grapheme at the
+            specified position.
+        """
+
+        var char = self.graphemes().nth(index(grapheme))
+        debug_assert[assert_mode="safe"](Bool(char), "Invalid grapheme index")
+        return char.take()
+
     @doc_hidden
     def __init__(
         out self: StringSlice[ImmutAnyOrigin],
@@ -1357,29 +1373,6 @@ struct StringSlice[mut: Bool, //, origin: Origin[mut=mut]](
         ```
         """
         return GraphemeIndicesIter[Self.origin](self)
-
-    def nth_grapheme(self, n: Int) -> Optional[Self]:
-        """Return the `n`-th grapheme cluster (0-indexed), or `None` if out
-        of range.
-
-        Args:
-            n: The zero-based grapheme index. Must be non-negative.
-
-        Returns:
-            The `n`-th grapheme cluster, or `None` if `n` is out of range.
-
-        Example:
-
-        ```mojo
-        from std.testing import assert_equal, assert_true
-
-        var s = StringSlice("abc")
-        assert_equal(s.nth_grapheme(0).value(), "a")
-        assert_equal(s.nth_grapheme(2).value(), "c")
-        assert_true(s.nth_grapheme(3) is None)
-        ```
-        """
-        return self.graphemes().nth(n)
 
     def split_at_grapheme(
         self, n: Int

--- a/mojo/stdlib/test/collections/string/test_grapheme.mojo
+++ b/mojo/stdlib/test/collections/string/test_grapheme.mojo
@@ -604,16 +604,16 @@ def test_grapheme_indices_crlf() raises:
 
 def test_nth_grapheme_ascii() raises:
     var s = StringSlice("abc")
-    assert_equal(s.nth_grapheme(0).value(), "a")
-    assert_equal(s.nth_grapheme(1).value(), "b")
-    assert_equal(s.nth_grapheme(2).value(), "c")
-    assert_true(s.nth_grapheme(3) is None)
-    assert_true(s.nth_grapheme(99) is None)
+    assert_equal(s.graphemes().nth(0).value(), "a")
+    assert_equal(s.graphemes().nth(1).value(), "b")
+    assert_equal(s.graphemes().nth(2).value(), "c")
+    assert_true(s.graphemes().nth(3) is None)
+    assert_true(s.graphemes().nth(99) is None)
 
 
 def test_nth_grapheme_empty() raises:
     var s = StringSlice("")
-    assert_true(s.nth_grapheme(0) is None)
+    assert_true(s.graphemes().nth(0) is None)
 
 
 def test_nth_grapheme_combining_mark() raises:
@@ -621,18 +621,18 @@ def test_nth_grapheme_combining_mark() raises:
     var e_acute = _string_from_codepoints(0x65, 0x0301)
     var s = String("caf") + e_acute
     var slc = StringSlice(s)
-    assert_equal(slc.nth_grapheme(3).value(), e_acute)
-    assert_true(slc.nth_grapheme(4) is None)
+    assert_equal(slc.graphemes().nth(3).value(), e_acute)
+    assert_true(slc.graphemes().nth(4) is None)
 
 
 def test_nth_grapheme_flag_emoji() raises:
     var flag = _string_from_codepoints(0x1F1FA, 0x1F1F8)
     var s = String("A") + flag + String("B")
     var slc = StringSlice(s)
-    assert_equal(slc.nth_grapheme(0).value(), "A")
-    assert_equal(slc.nth_grapheme(1).value(), flag)
-    assert_equal(slc.nth_grapheme(2).value(), "B")
-    assert_true(slc.nth_grapheme(3) is None)
+    assert_equal(slc.graphemes().nth(0).value(), "A")
+    assert_equal(slc.graphemes().nth(1).value(), flag)
+    assert_equal(slc.graphemes().nth(2).value(), "B")
+    assert_true(slc.graphemes().nth(3) is None)
 
 
 # ===----------------------------------------------------------------------=== #

--- a/mojo/stdlib/test/collections/string/test_string_slice.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_slice.mojo
@@ -1105,5 +1105,17 @@ def test_codepoint_indexing() raises:
     assert_equal(StringSlice("🔄🔥🔄")[codepoint=2], "🔄")
 
 
+def test_grapheme_indexing() raises:
+    assert_equal(StringSlice("abc")[grapheme=0], "a")
+    assert_equal(StringSlice("abc")[grapheme=1], "b")
+    assert_equal(StringSlice("abc")[grapheme=2], "c")
+    assert_equal(StringSlice("🔄🔥🔄")[grapheme=0], "🔄")
+    assert_equal(StringSlice("🔄🔥🔄")[grapheme=1], "🔥")
+    assert_equal(StringSlice("🔄🔥🔄")[grapheme=2], "🔄")
+    assert_equal(StringSlice("👨‍🚀🧑‍🌾क्षि")[grapheme=0], "👨‍🚀")
+    assert_equal(StringSlice("👨‍🚀🧑‍🌾क्षि")[grapheme=1], "🧑‍🌾")
+    assert_equal(StringSlice("👨‍🚀🧑‍🌾क्षि")[grapheme=2], "क्षि")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Add grapheme indexing

Remove the `def nth_grapheme(self, n: Int) -> Optional[Self]:` API from `String` and `StringSlice` and replace it with indexing similar to what we have for codepoints and bytes. We need to keep these APIs consistent. Users should use `self.graphemes.nth()` if they want to use an `Optional`-based API