### PR TITLE
Fix "vm" typo in local-to-cloud documentation

### DIFF
--- a/docs/max/deploy/local-to-cloud.mdx
+++ b/docs/max/deploy/local-to-cloud.mdx
@@ -336,7 +336,7 @@ on Azure, you can use the
 file defines the appropriate image and settings for AMD-based inference
 workloads on an
 [ND MI300X v5 series](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/ndmi300xv5-series)
-vm.
+VM.
 :::
 
 ```bash


### PR DESCRIPTION
## Linked issue

N/A — trivial.

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [x] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Just normalizing the "VM" shortening to match the other parts of the documentation.

## What changed

That's it; one line change to capitalize "vm" to fit the rest of the documentation.

## Testing

Previewed locally.

## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [ ] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [ ] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
