### PR TITLE
[Stdlib] Fast-path `PythonObject(string)` for all-ASCII input

### DIFF
--- a/mojo/docs/nightly-changelog.md
+++ b/mojo/docs/nightly-changelog.md
@@ -80,8 +80,9 @@ This version is still a work in progress.
 
   - `PythonObject(string)` SIMD-scans for ASCII and uses
     `PyUnicode_FromKindAndData(kind=1, ...)` directly for the
-    all-ASCII case, skipping CPython's UTF-8 validation pass. Non-ASCII
-    input continues to go through `PyUnicode_DecodeUTF8`.
+    all-ASCII case, skipping CPython's UTF-8 decoder (validation,
+    error callback setup). Non-ASCII input continues to go through
+    `PyUnicode_DecodeUTF8`.
 
 - Added `TileTensor.copy_from()` and `TileTensor.split()` for copying between
   compatible tile views and splitting tiles into static or runtime-sized

--- a/mojo/docs/nightly-changelog.md
+++ b/mojo/docs/nightly-changelog.md
@@ -78,6 +78,11 @@ This version is still a work in progress.
   - `Int(py=obj)` and `Scalar[IntDType](py=obj)` fast-path exact
     Python `int` via `PyLong_AsSsize_t`.
 
+  - `PythonObject(string)` SIMD-scans for ASCII and uses
+    `PyUnicode_FromKindAndData(kind=1, ...)` directly for the
+    all-ASCII case, skipping CPython's UTF-8 validation pass. Non-ASCII
+    input continues to go through `PyUnicode_DecodeUTF8`.
+
 - Added `TileTensor.copy_from()` and `TileTensor.split()` for copying between
   compatible tile views and splitting tiles into static or runtime-sized
   partitions.

--- a/mojo/stdlib/benchmarks/python/bench_bindings/bench.py
+++ b/mojo/stdlib/benchmarks/python/bench_bindings/bench.py
@@ -58,6 +58,10 @@ def py_add(a, b):  # noqa: ANN001, ANN201
     return a + b
 
 
+def py_echo_str(s):  # noqa: ANN001, ANN201
+    return str(s)
+
+
 def _measure(label: str, stmt: str, globals_: dict[str, object]) -> None:
     times = timeit.repeat(
         stmt, number=ITERATIONS, repeat=REPEATS, globals=globals_
@@ -75,6 +79,10 @@ def _sanity_check() -> None:
     assert mojo_module.add_def(1, 2) == 3
     assert mojo_module.add_raw(1, 2) == 3
     assert mojo_module.add_raw_fastcall(1, 2) == 3
+    assert mojo_module.echo_str_def("hello world") == "hello world"
+    assert (
+        mojo_module.echo_str_raw_fastcall("hello world") == "hello world"
+    )
 
 
 def main() -> int:
@@ -87,8 +95,11 @@ def main() -> int:
         "add_def": mojo_module.add_def,
         "add_raw": mojo_module.add_raw,
         "add_raw_fastcall": mojo_module.add_raw_fastcall,
+        "echo_str_def": mojo_module.echo_str_def,
+        "echo_str_raw_fastcall": mojo_module.echo_str_raw_fastcall,
         "py_noop": py_noop,
         "py_add": py_add,
+        "py_echo_str": py_echo_str,
     }
 
     print(
@@ -133,9 +144,25 @@ def main() -> int:
         g,
     )
 
+    # String round-trip: covers `String(py=...)` (Python -> Mojo) and
+    # `PythonObject(string)` (Mojo -> Python).
+    _measure(
+        "Python -> Mojo  echo_str_def(s)         [def_function/FASTCALL]",
+        "echo_str_def('hello world')",
+        g,
+    )
+    _measure(
+        "Python -> Mojo  echo_str_raw_fastcall(s) [def_py_c_function/FASTCALL]",
+        "echo_str_raw_fastcall('hello world')",
+        g,
+    )
+
     # Pure-Python baselines.
     _measure("Python -> Python py_noop(x)", "py_noop(1)", g)
     _measure("Python -> Python py_add(1, 2)", "py_add(1, 2)", g)
+    _measure(
+        "Python -> Python py_echo_str(s)", "py_echo_str('hello world')", g
+    )
 
     # timeit floor: no call at all.
     _measure("Python builtin: 1 + 2  (no call)", "1 + 2", g)

--- a/mojo/stdlib/benchmarks/python/bench_bindings/bench.py
+++ b/mojo/stdlib/benchmarks/python/bench_bindings/bench.py
@@ -80,9 +80,7 @@ def _sanity_check() -> None:
     assert mojo_module.add_raw(1, 2) == 3
     assert mojo_module.add_raw_fastcall(1, 2) == 3
     assert mojo_module.echo_str_def("hello world") == "hello world"
-    assert (
-        mojo_module.echo_str_raw_fastcall("hello world") == "hello world"
-    )
+    assert mojo_module.echo_str_raw_fastcall("hello world") == "hello world"
 
 
 def main() -> int:
@@ -160,9 +158,7 @@ def main() -> int:
     # Pure-Python baselines.
     _measure("Python -> Python py_noop(x)", "py_noop(1)", g)
     _measure("Python -> Python py_add(1, 2)", "py_add(1, 2)", g)
-    _measure(
-        "Python -> Python py_echo_str(s)", "py_echo_str('hello world')", g
-    )
+    _measure("Python -> Python py_echo_str(s)", "py_echo_str('hello world')", g)
 
     # timeit floor: no call at all.
     _measure("Python builtin: 1 + 2  (no call)", "1 + 2", g)

--- a/mojo/stdlib/benchmarks/python/bench_bindings/mojo_module.mojo
+++ b/mojo/stdlib/benchmarks/python/bench_bindings/mojo_module.mojo
@@ -12,16 +12,17 @@
 # ===----------------------------------------------------------------------=== #
 """Microbenchmark surface for Python -> Mojo FFI overhead.
 
-This module exposes the same trivial calls (`noop`, `add`) through several
-binding paths so that `bench.py` can attribute per-call overhead to specific
-parts of the dispatch chain:
+This module exposes the same trivial calls (`noop`, `add`, `echo_str`)
+through several binding paths so that `bench.py` can attribute per-call
+overhead to specific parts of the dispatch chain:
 
-- `noop_def` / `add_def`: the high-level `def_function` path that most users
-  will hit. Regression target.
-- `noop_raw` / `add_raw`: hand-written wrappers registered via the lower-level
-  `def_py_c_function` path. Lower bound for the current `METH_VARARGS`-based
-  architecture; isolates the cost contributed by Mojo's generic dispatch
-  wrapper from the cost of CPython's tuple-packing call convention itself.
+- `noop_def` / `add_def` / `echo_str_def`: the high-level `def_function`
+  path that most users will hit. Regression target.
+- `noop_raw` / `add_raw`: hand-written wrappers registered via the
+  lower-level `def_py_c_function` path. Lower bound for the current
+  `METH_VARARGS`-based architecture; isolates the cost contributed by
+  Mojo's generic dispatch wrapper from the cost of CPython's
+  tuple-packing call convention itself.
 
 See https://github.com/modular/modular/issues/6521.
 """
@@ -29,7 +30,11 @@ See https://github.com/modular/modular/issues/6521.
 from std.os import abort
 
 from std.python import Python, PythonObject
-from std.python._cpython import PyObjectPtr, Py_ssize_t
+from std.python._cpython import (
+    PyObjectPtr,
+    Py_ssize_t,
+    PyUnicode_1BYTE_KIND,
+)
 from std.python.bindings import PythonModuleBuilder
 
 
@@ -41,6 +46,7 @@ def PyInit_mojo_module() -> PythonObject:
         # High-level `def_function` path (the regression target).
         b.def_function[noop_def]("noop_def")
         b.def_function[add_def]("add_def")
+        b.def_function[echo_str_def]("echo_str_def")
 
         # Low-level `def_py_c_function` path. Same observable behavior, but
         # bypasses the generic PyObjectFunction dispatch.
@@ -53,6 +59,7 @@ def PyInit_mojo_module() -> PythonObject:
         b.def_py_c_function(add_raw, "add_raw")
         b.def_py_c_function(noop_raw_fastcall, "noop_raw_fastcall")
         b.def_py_c_function(add_raw_fastcall, "add_raw_fastcall")
+        b.def_py_c_function(echo_str_raw_fastcall, "echo_str_raw_fastcall")
 
         return b.finalize()
     except e:
@@ -72,6 +79,13 @@ def add_def(a: PythonObject, b: PythonObject) raises -> PythonObject:
     var ai = Int(py=a)
     var bi = Int(py=b)
     return PythonObject(ai + bi)
+
+
+def echo_str_def(s: PythonObject) raises -> PythonObject:
+    # Round-trip a Python `str` through `String` and back. Exercises both
+    # `String.__init__(py=...)` (Python -> Mojo) and `PythonObject(string)`
+    # (Mojo -> Python), so an end-to-end win on either side shows up here.
+    return PythonObject(String(py=s))
 
 
 # ===-----------------------------------------------------------------------===#
@@ -123,3 +137,21 @@ def add_raw_fastcall(
     var ai = cpy.PyLong_AsSsize_t(args[0])
     var bi = cpy.PyLong_AsSsize_t(args[1])
     return cpy.PyLong_FromSsize_t(ai + bi)
+
+
+@export
+def echo_str_raw_fastcall(
+    py_self: PyObjectPtr,
+    args: UnsafePointer[PyObjectPtr, MutExternalOrigin],
+    nargs: Py_ssize_t,
+) -> PyObjectPtr:
+    # Lower bound for `echo_str_def`: read the UTF-8 buffer of the input
+    # PyUnicode and feed it back through `PyUnicode_FromKindAndData(kind=1)`
+    # without going through any `String` / `PythonObject` wrapping.
+    ref cpy = Python().cpython()
+    var maybe_slice = cpy.PyUnicode_AsUTF8AndSize(args[0])
+    if not maybe_slice:
+        return PyObjectPtr()
+    return cpy.PyUnicode_FromKindAndData(
+        PyUnicode_1BYTE_KIND, maybe_slice.value().as_bytes()
+    )

--- a/mojo/stdlib/benchmarks/python/bench_bindings/mojo_module.mojo
+++ b/mojo/stdlib/benchmarks/python/bench_bindings/mojo_module.mojo
@@ -30,11 +30,7 @@ See https://github.com/modular/modular/issues/6521.
 from std.os import abort
 
 from std.python import Python, PythonObject
-from std.python._cpython import (
-    PyObjectPtr,
-    Py_ssize_t,
-    PyUnicode_1BYTE_KIND,
-)
+from std.python._cpython import PyObjectPtr, Py_ssize_t
 from std.python.bindings import PythonModuleBuilder
 
 
@@ -145,13 +141,14 @@ def echo_str_raw_fastcall(
     args: UnsafePointer[PyObjectPtr, MutExternalOrigin],
     nargs: Py_ssize_t,
 ) -> PyObjectPtr:
-    # Lower bound for `echo_str_def`: read the UTF-8 buffer of the input
-    # PyUnicode and feed it back through `PyUnicode_FromKindAndData(kind=1)`
-    # without going through any `String` / `PythonObject` wrapping.
+    # Lower bound for `echo_str_def`: round-trip a Python `str` through
+    # CPython's UTF-8 codec without any `String` / `PythonObject` wrapping.
+    # Uses `PyUnicode_DecodeUTF8` rather than
+    # `PyUnicode_FromKindAndData(kind=1, ...)` so multi-byte UTF-8 inputs
+    # are decoded correctly (kind=1 would treat each UTF-8 byte as a
+    # Latin-1 code point and corrupt non-ASCII strings).
     ref cpy = Python().cpython()
     var maybe_slice = cpy.PyUnicode_AsUTF8AndSize(args[0])
     if not maybe_slice:
         return PyObjectPtr()
-    return cpy.PyUnicode_FromKindAndData(
-        PyUnicode_1BYTE_KIND, maybe_slice.value().as_bytes()
-    )
+    return cpy.PyUnicode_DecodeUTF8(maybe_slice.value())

--- a/mojo/stdlib/benchmarks/python/bench_bindings/test_module.py
+++ b/mojo/stdlib/benchmarks/python/bench_bindings/test_module.py
@@ -58,3 +58,6 @@ def test_echo_str_def_round_trips() -> None:
 
 def test_echo_str_raw_fastcall_round_trips() -> None:
     assert mojo_module.echo_str_raw_fastcall("hello world") == "hello world"
+    # Non-ASCII must decode correctly through PyUnicode_DecodeUTF8 - the
+    # previous kind=1 path would corrupt multi-byte UTF-8.
+    assert mojo_module.echo_str_raw_fastcall("héllo") == "héllo"

--- a/mojo/stdlib/benchmarks/python/bench_bindings/test_module.py
+++ b/mojo/stdlib/benchmarks/python/bench_bindings/test_module.py
@@ -49,3 +49,12 @@ def test_noop_raw_fastcall_returns_argument() -> None:
 def test_add_raw_fastcall_sums_ints() -> None:
     assert mojo_module.add_raw_fastcall(1, 2) == 3
     assert mojo_module.add_raw_fastcall(-5, 10) == 5
+
+
+def test_echo_str_def_round_trips() -> None:
+    assert mojo_module.echo_str_def("hello world") == "hello world"
+    assert mojo_module.echo_str_def("héllo") == "héllo"
+
+
+def test_echo_str_raw_fastcall_round_trips() -> None:
+    assert mojo_module.echo_str_raw_fastcall("hello world") == "hello world"

--- a/mojo/stdlib/benchmarks/python/bench_string_to_pyobject.mojo
+++ b/mojo/stdlib/benchmarks/python/bench_string_to_pyobject.mojo
@@ -92,7 +92,7 @@ def bench_string_to_pyobject_non_ascii(mut b: Bencher) raises:
 
 def main() raises:
     _ = Python()
-    var m = Bench(BenchConfig(num_repetitions=20, max_runtime_secs=2.0))
+    var m = Bench(BenchConfig(num_repetitions=50, max_runtime_secs=5.0))
     m.bench_function[bench_string_to_pyobject_ascii_short](
         BenchId("string_to_pyobject_ascii_short")
     )

--- a/mojo/stdlib/benchmarks/python/bench_string_to_pyobject.mojo
+++ b/mojo/stdlib/benchmarks/python/bench_string_to_pyobject.mojo
@@ -1,0 +1,78 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Benchmark `PythonObject(string)` conversion.
+
+Measures the per-call cost of converting a Mojo `String` to a
+`PythonObject`. The fast path SIMD-scans for ASCII and calls
+`PyUnicode_FromKindAndData(kind=1, ...)` directly, skipping the UTF-8
+validation pass that `PyUnicode_DecodeUTF8` performs internally.
+"""
+
+from std.benchmark import (
+    Bench,
+    BenchConfig,
+    Bencher,
+    BenchId,
+    black_box,
+    keep,
+)
+from std.os import abort
+from std.python import Python, PythonObject
+
+
+@parameter
+def bench_string_to_pyobject_ascii(mut b: Bencher) raises:
+    """`PythonObject(string)` on a pure-ASCII input (fast path)."""
+    _ = Python()
+    var s = String("hello world")
+
+    @always_inline
+    def call_fn() {read}:
+        try:
+            for _ in range(1000):
+                var x = PythonObject(black_box(s.as_string_slice()))
+                keep(x)
+        except e:
+            abort(String(e))
+
+    b.iter(call_fn)
+
+
+@parameter
+def bench_string_to_pyobject_non_ascii(mut b: Bencher) raises:
+    """`PythonObject(string)` on a non-ASCII input (UTF-8 fallback)."""
+    _ = Python()
+    var s = String("héllo \U0001F525")
+
+    @always_inline
+    def call_fn() {read}:
+        try:
+            for _ in range(1000):
+                var x = PythonObject(black_box(s.as_string_slice()))
+                keep(x)
+        except e:
+            abort(String(e))
+
+    b.iter(call_fn)
+
+
+def main() raises:
+    _ = Python()
+    var m = Bench(BenchConfig(num_repetitions=5, max_runtime_secs=2.0))
+    m.bench_function[bench_string_to_pyobject_ascii](
+        BenchId("string_to_pyobject_ascii")
+    )
+    m.bench_function[bench_string_to_pyobject_non_ascii](
+        BenchId("string_to_pyobject_non_ascii")
+    )
+    print(m)

--- a/mojo/stdlib/benchmarks/python/bench_string_to_pyobject.mojo
+++ b/mojo/stdlib/benchmarks/python/bench_string_to_pyobject.mojo
@@ -14,8 +14,9 @@
 
 Measures the per-call cost of converting a Mojo `String` to a
 `PythonObject`. The fast path SIMD-scans for ASCII and calls
-`PyUnicode_FromKindAndData(kind=1, ...)` directly, skipping the UTF-8
-validation pass that `PyUnicode_DecodeUTF8` performs internally.
+`PyUnicode_FromKindAndData(kind=1, ...)` directly, skipping CPython's
+UTF-8 decoder (validation, error callback setup) that
+`PyUnicode_DecodeUTF8` runs.
 """
 
 from std.benchmark import (
@@ -31,10 +32,33 @@ from std.python import Python, PythonObject
 
 
 @parameter
-def bench_string_to_pyobject_ascii(mut b: Bencher) raises:
-    """`PythonObject(string)` on a pure-ASCII input (fast path)."""
+def bench_string_to_pyobject_ascii_short(mut b: Bencher) raises:
+    """`PythonObject(string)` on a short pure-ASCII input (fast path)."""
     _ = Python()
     var s = String("hello world")
+
+    @always_inline
+    def call_fn() {read}:
+        try:
+            for _ in range(1000):
+                var x = PythonObject(black_box(s.as_string_slice()))
+                keep(x)
+        except e:
+            abort(String(e))
+
+    b.iter(call_fn)
+
+
+@parameter
+def bench_string_to_pyobject_ascii_large(mut b: Bencher) raises:
+    """`PythonObject(string)` on a ~1 KiB pure-ASCII input (fast path).
+
+    Exercises the vectorized SIMD loop in `_is_ascii` and the
+    `PyUnicode_FromKindAndData` memcpy at a length where the scan is
+    no longer dominated by entry/exit overhead.
+    """
+    _ = Python()
+    var s = String("0123456789abcdef" * 64)  # 1024 bytes
 
     @always_inline
     def call_fn() {read}:
@@ -68,9 +92,12 @@ def bench_string_to_pyobject_non_ascii(mut b: Bencher) raises:
 
 def main() raises:
     _ = Python()
-    var m = Bench(BenchConfig(num_repetitions=5, max_runtime_secs=2.0))
-    m.bench_function[bench_string_to_pyobject_ascii](
-        BenchId("string_to_pyobject_ascii")
+    var m = Bench(BenchConfig(num_repetitions=20, max_runtime_secs=2.0))
+    m.bench_function[bench_string_to_pyobject_ascii_short](
+        BenchId("string_to_pyobject_ascii_short")
+    )
+    m.bench_function[bench_string_to_pyobject_ascii_large](
+        BenchId("string_to_pyobject_ascii_large")
     )
     m.bench_function[bench_string_to_pyobject_non_ascii](
         BenchId("string_to_pyobject_non_ascii")

--- a/mojo/stdlib/std/collections/string/string_slice.mojo
+++ b/mojo/stdlib/std/collections/string/string_slice.mojo
@@ -2670,6 +2670,52 @@ def _memchr_impl[
 
 
 @always_inline
+def _is_ascii(source: Span[mut=False, Byte, ...]) -> Bool:
+    """Return True if every byte of `source` is in `[0, 128)`.
+
+    Dispatches to a scalar loop in the comptime interpreter and for inputs
+    smaller than the bool-mask SIMD width; otherwise the SIMD body in
+    `_is_ascii_impl` runs. Mirrors the `_memchr` dispatch pattern.
+
+    Args:
+        source: The byte span to scan.
+
+    Returns:
+        `True` if all bytes are ASCII; `False` if any byte has the high bit set.
+    """
+    if (
+        __is_run_in_comptime_interpreter
+        or len(source) < simd_width_of[DType.bool]()
+    ):
+        var ptr = source.unsafe_ptr()
+        for i in range(len(source)):
+            if ptr[i] >= UInt8(128):
+                return False
+        return True
+    else:
+        return _is_ascii_impl(source)
+
+
+@always_inline
+def _is_ascii_impl(source: Span[mut=False, Byte, ...]) -> Bool:
+    """SIMD body for `_is_ascii`."""
+    var haystack = source.unsafe_ptr()
+    var length = len(source)
+    comptime bool_mask_width = simd_width_of[DType.bool]()
+    var vectorized_end = align_down(length, bool_mask_width)
+
+    for i in range(0, vectorized_end, bool_mask_width):
+        var block = haystack.load[width=bool_mask_width](i)
+        if pack_bits(block.ge(UInt8(128))):
+            return False
+
+    for i in range(vectorized_end, length):
+        if haystack[i] >= UInt8(128):
+            return False
+    return True
+
+
+@always_inline
 def _memmem[
     dtype: DType, //
 ](

--- a/mojo/stdlib/std/python/_cpython.mojo
+++ b/mojo/stdlib/std/python/_cpython.mojo
@@ -2656,15 +2656,20 @@ struct CPython(Defaultable, Movable):
     # ===-------------------------------------------------------------------===#
 
     def PyUnicode_FromKindAndData(
-        self, kind: c_int, buffer: Span[Byte, _]
+        self,
+        kind: c_int,
+        buffer: Span[Byte, _],
+        size: Py_ssize_t,
     ) -> PyObjectPtr:
         """Create a Unicode object from `buffer` of pre-decoded `kind`-sized
         code units. `kind` is one of `PyUnicode_1BYTE_KIND`,
-        `PyUnicode_2BYTE_KIND`, or `PyUnicode_4BYTE_KIND`. Bypasses UTF-8
-        validation; the buffer is treated as raw code units, not encoded
-        bytes, so the caller is responsible for ensuring the byte values are
-        valid for the selected kind. `Span[Byte, _]` is used (rather than
-        `StringSlice`) because for `kind=2` and `kind=4` the buffer is a
+        `PyUnicode_2BYTE_KIND`, or `PyUnicode_4BYTE_KIND`. `size` is the
+        number of *code units* (NOT bytes); for `kind=2`/`kind=4` callers
+        must pass `len(buffer) // 2` / `// 4`. Bypasses UTF-8 validation;
+        the buffer is treated as raw code units, not encoded bytes, so the
+        caller is responsible for ensuring the byte values are valid for
+        the selected kind. `Span[Byte, _]` is used (rather than
+        `StringSlice`) because for `kind=2`/`kind=4` the buffer is a
         sequence of 2- or 4-byte code units, not UTF-8 text.
 
         Return value: New reference.
@@ -2675,7 +2680,7 @@ struct CPython(Defaultable, Movable):
         return self._PyUnicode_FromKindAndData(
             kind,
             buffer.unsafe_ptr().bitcast[c_char](),
-            Py_ssize_t(len(buffer)),
+            size,
         )
 
     # TODO: fix the signature to take str, size, and errors as args

--- a/mojo/stdlib/std/python/_cpython.mojo
+++ b/mojo/stdlib/std/python/_cpython.mojo
@@ -1109,6 +1109,11 @@ comptime PyUnicode_FromKindAndData = ExternalFunction[
     ) thin -> PyObjectPtr,
 ]
 
+# `kind` values for `PyUnicode_FromKindAndData`.
+comptime PyUnicode_1BYTE_KIND: c_int = c_int(1)
+comptime PyUnicode_2BYTE_KIND: c_int = c_int(2)
+comptime PyUnicode_4BYTE_KIND: c_int = c_int(4)
+
 # Tuple Objects
 comptime PyTuple_New = ExternalFunction[
     "PyTuple_New",
@@ -2654,9 +2659,13 @@ struct CPython(Defaultable, Movable):
         self, kind: c_int, buffer: Span[Byte, _]
     ) -> PyObjectPtr:
         """Create a Unicode object from `buffer` of pre-decoded `kind`-sized
-        code units. `kind` is 1, 2, or 4 (`PyUnicode_1BYTE_KIND` and friends).
-        Bypasses UTF-8 validation and is the fast path for known-ASCII input
-        with `kind=1`.
+        code units. `kind` is one of `PyUnicode_1BYTE_KIND`,
+        `PyUnicode_2BYTE_KIND`, or `PyUnicode_4BYTE_KIND`. Bypasses UTF-8
+        validation; the buffer is treated as raw code units, not encoded
+        bytes, so the caller is responsible for ensuring the byte values are
+        valid for the selected kind. `Span[Byte, _]` is used (rather than
+        `StringSlice`) because for `kind=2` and `kind=4` the buffer is a
+        sequence of 2- or 4-byte code units, not UTF-8 text.
 
         Return value: New reference.
 

--- a/mojo/stdlib/std/python/_cpython.mojo
+++ b/mojo/stdlib/std/python/_cpython.mojo
@@ -1099,6 +1099,15 @@ comptime PyUnicode_AsUTF8AndSize = ExternalFunction[
         _CPointer[Py_ssize_t, MutAnyOrigin],
     ) thin -> _CPointer[c_char, ImmutAnyOrigin],
 ]
+comptime PyUnicode_FromKindAndData = ExternalFunction[
+    "PyUnicode_FromKindAndData",
+    # PyObject *PyUnicode_FromKindAndData(int kind, const void *buffer, Py_ssize_t size)
+    def(
+        c_int,
+        _CPointer[c_char, ImmutAnyOrigin],
+        Py_ssize_t,
+    ) thin -> PyObjectPtr,
+]
 
 # Tuple Objects
 comptime PyTuple_New = ExternalFunction[
@@ -1441,6 +1450,7 @@ struct CPython(Defaultable, Movable):
     # Unicode Objects and Codecs
     var _PyUnicode_DecodeUTF8: PyUnicode_DecodeUTF8.type
     var _PyUnicode_AsUTF8AndSize: PyUnicode_AsUTF8AndSize.type
+    var _PyUnicode_FromKindAndData: PyUnicode_FromKindAndData.type
     # Tuple Objects
     var _PyTuple_New: PyTuple_New.type
     var _PyTuple_GetItem: PyTuple_GetItem.type
@@ -1647,6 +1657,9 @@ struct CPython(Defaultable, Movable):
             self.lib.borrow()
         )
         self._PyUnicode_AsUTF8AndSize = PyUnicode_AsUTF8AndSize.load(
+            self.lib.borrow()
+        )
+        self._PyUnicode_FromKindAndData = PyUnicode_FromKindAndData.load(
             self.lib.borrow()
         )
         # Tuple Objects
@@ -2636,6 +2649,25 @@ struct CPython(Defaultable, Movable):
     # Unicode Objects and Codecs
     # ref: https://docs.python.org/3/c-api/unicode.html
     # ===-------------------------------------------------------------------===#
+
+    def PyUnicode_FromKindAndData(
+        self, kind: c_int, buffer: Span[Byte, _]
+    ) -> PyObjectPtr:
+        """Create a Unicode object from `buffer` of pre-decoded `kind`-sized
+        code units. `kind` is 1, 2, or 4 (`PyUnicode_1BYTE_KIND` and friends).
+        Bypasses UTF-8 validation and is the fast path for known-ASCII input
+        with `kind=1`.
+
+        Return value: New reference.
+
+        References:
+        - https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_FromKindAndData
+        """
+        return self._PyUnicode_FromKindAndData(
+            kind,
+            buffer.unsafe_ptr().bitcast[c_char](),
+            Py_ssize_t(len(buffer)),
+        )
 
     # TODO: fix the signature to take str, size, and errors as args
     def PyUnicode_DecodeUTF8(self, s: StringSlice) -> PyObjectPtr:

--- a/mojo/stdlib/std/python/python_object.mojo
+++ b/mojo/stdlib/std/python/python_object.mojo
@@ -34,6 +34,7 @@ from ._cpython import (
     PyObjectPtr,
     PyTypeObject,
     PyUnicode_1BYTE_KIND,
+    Py_ssize_t,
 )
 from .bindings import PyMojoObject, _get_type_name, lookup_py_type_object
 from .python import Python
@@ -286,13 +287,16 @@ struct PythonObject(
         # Fast path: pure-ASCII input feeds each byte as a 1-byte code point
         # via `PyUnicode_FromKindAndData`, skipping CPython's UTF-8 decoder
         # (validation, error callback setup) that `PyUnicode_DecodeUTF8` runs.
-        # `StringSlice` is guaranteed valid UTF-8 so the fallback path will
-        # not raise on non-ASCII either.
+        # The fallback handles non-ASCII (`StringSlice` is guaranteed valid
+        # UTF-8 so `PyUnicode_DecodeUTF8` cannot fail on encoding; it can
+        # still raise on out-of-memory or similar runtime failures, which
+        # the `if not unicode:` check propagates).
         ref cpy = Python().cpython()
         var unicode: PyObjectPtr
-        if _is_ascii(string.as_bytes()):
+        var bytes = string.as_bytes()
+        if _is_ascii(bytes):
             unicode = cpy.PyUnicode_FromKindAndData(
-                PyUnicode_1BYTE_KIND, string.as_bytes()
+                PyUnicode_1BYTE_KIND, bytes, Py_ssize_t(len(bytes))
             )
         else:
             unicode = cpy.PyUnicode_DecodeUTF8(string)

--- a/mojo/stdlib/std/python/python_object.mojo
+++ b/mojo/stdlib/std/python/python_object.mojo
@@ -19,9 +19,11 @@ from std.python import PythonObject
 ```
 """
 
+from std.math import align_down
+from std.memory import pack_bits
 from std.os import abort
-from std.sys import bit_width_of
-from std.ffi import _CPointer, c_double, c_long, c_size_t, c_ssize_t
+from std.sys import bit_width_of, simd_width_of
+from std.ffi import _CPointer, c_double, c_int, c_long, c_size_t, c_ssize_t
 import std.format._utils as fmt
 
 from std.reflection import reflect
@@ -29,6 +31,26 @@ from std.reflection import reflect
 from ._cpython import CPython, GILAcquired, PyObject, PyObjectPtr, PyTypeObject
 from .bindings import PyMojoObject, _get_type_name, lookup_py_type_object
 from .python import Python
+
+
+@always_inline
+def _all_ascii(s: StringSlice) -> Bool:
+    """Return True if every byte of `s` is in `[0, 128)`. SIMD-scans for
+    any byte with the high bit set."""
+    var ptr = s.unsafe_ptr()
+    var length = s.byte_length()
+    comptime bool_mask_width = simd_width_of[DType.bool]()
+    var vectorized_end = align_down(length, bool_mask_width)
+
+    for i in range(0, vectorized_end, bool_mask_width):
+        var block = ptr.load[width=bool_mask_width](i)
+        if pack_bits(block.ge(UInt8(128))):
+            return False
+
+    for i in range(vectorized_end, length):
+        if ptr[i] >= UInt8(128):
+            return False
+    return True
 
 
 struct _PyIter(ImplicitlyCopyable, Iterable, Iterator):
@@ -273,12 +295,20 @@ struct PythonObject(
             string: The string value.
 
         Raises:
-            If the string is not valid UTF-8.
+            If the conversion to a Python `str` fails.
         """
+        # Fast path: pure-ASCII input feeds each byte as a 1-byte code point
+        # via `PyUnicode_FromKindAndData`, skipping CPython's UTF-8 validation
+        # inside `PyUnicode_DecodeUTF8`. `StringSlice` is guaranteed valid
+        # UTF-8 so the fallback path will not raise on non-ASCII either.
         ref cpy = Python().cpython()
-        # TODO: This should not be necessary, as `StringSlice` is guaranteed to
-        # be valid UTF-8.
-        var unicode = cpy.PyUnicode_DecodeUTF8(string)
+        var unicode: PyObjectPtr
+        if _all_ascii(string):
+            unicode = cpy.PyUnicode_FromKindAndData(
+                c_int(1), string.as_bytes()
+            )
+        else:
+            unicode = cpy.PyUnicode_DecodeUTF8(string)
         if not unicode:
             raise cpy.unsafe_get_error()
         self = Self(from_owned=unicode)

--- a/mojo/stdlib/std/python/python_object.mojo
+++ b/mojo/stdlib/std/python/python_object.mojo
@@ -19,38 +19,24 @@ from std.python import PythonObject
 ```
 """
 
-from std.math import align_down
-from std.memory import pack_bits
 from std.os import abort
-from std.sys import bit_width_of, simd_width_of
-from std.ffi import _CPointer, c_double, c_int, c_long, c_size_t, c_ssize_t
+from std.sys import bit_width_of
+from std.ffi import _CPointer, c_double, c_long, c_size_t, c_ssize_t
 import std.format._utils as fmt
 
+from std.collections.string.string_slice import _is_ascii
 from std.reflection import reflect
 
-from ._cpython import CPython, GILAcquired, PyObject, PyObjectPtr, PyTypeObject
+from ._cpython import (
+    CPython,
+    GILAcquired,
+    PyObject,
+    PyObjectPtr,
+    PyTypeObject,
+    PyUnicode_1BYTE_KIND,
+)
 from .bindings import PyMojoObject, _get_type_name, lookup_py_type_object
 from .python import Python
-
-
-@always_inline
-def _all_ascii(s: StringSlice) -> Bool:
-    """Return True if every byte of `s` is in `[0, 128)`. SIMD-scans for
-    any byte with the high bit set."""
-    var ptr = s.unsafe_ptr()
-    var length = s.byte_length()
-    comptime bool_mask_width = simd_width_of[DType.bool]()
-    var vectorized_end = align_down(length, bool_mask_width)
-
-    for i in range(0, vectorized_end, bool_mask_width):
-        var block = ptr.load[width=bool_mask_width](i)
-        if pack_bits(block.ge(UInt8(128))):
-            return False
-
-    for i in range(vectorized_end, length):
-        if ptr[i] >= UInt8(128):
-            return False
-    return True
 
 
 struct _PyIter(ImplicitlyCopyable, Iterable, Iterator):
@@ -298,14 +284,15 @@ struct PythonObject(
             If the conversion to a Python `str` fails.
         """
         # Fast path: pure-ASCII input feeds each byte as a 1-byte code point
-        # via `PyUnicode_FromKindAndData`, skipping CPython's UTF-8 validation
-        # inside `PyUnicode_DecodeUTF8`. `StringSlice` is guaranteed valid
-        # UTF-8 so the fallback path will not raise on non-ASCII either.
+        # via `PyUnicode_FromKindAndData`, skipping CPython's UTF-8 decoder
+        # (validation, error callback setup) that `PyUnicode_DecodeUTF8` runs.
+        # `StringSlice` is guaranteed valid UTF-8 so the fallback path will
+        # not raise on non-ASCII either.
         ref cpy = Python().cpython()
         var unicode: PyObjectPtr
-        if _all_ascii(string):
+        if _is_ascii(string.as_bytes()):
             unicode = cpy.PyUnicode_FromKindAndData(
-                c_int(1), string.as_bytes()
+                PyUnicode_1BYTE_KIND, string.as_bytes()
             )
         else:
             unicode = cpy.PyUnicode_DecodeUTF8(string)
@@ -321,7 +308,7 @@ struct PythonObject(
             value: The string literal value.
 
         Raises:
-            If the string is not valid UTF-8.
+            If the conversion to a Python `str` fails.
         """
         self = Self(StringSlice(value))
 
@@ -333,7 +320,7 @@ struct PythonObject(
             value: The string value.
 
         Raises:
-            If the string is not valid UTF-8.
+            If the conversion to a Python `str` fails.
         """
         self = Self(StringSlice(value))
 

--- a/mojo/stdlib/test/python/test_python_to_mojo.mojo
+++ b/mojo/stdlib/test/python/test_python_to_mojo.mojo
@@ -65,9 +65,7 @@ def test_string_construction_non_ascii_fallback() raises:
     # Long ASCII prefix followed by a high byte. Exercises the
     # non-first-iteration miss case in whichever loop the SIMD-mask width
     # makes active on the host (vectorized body or scalar tail).
-    var long_then_nonascii = (
-        "0123456789abcdef0123456789abcdef01234567" + "é"
-    )
+    var long_then_nonascii = "0123456789abcdef0123456789abcdef01234567" + "é"
     assert_equal(
         String(py=PythonObject(long_then_nonascii)), long_then_nonascii
     )

--- a/mojo/stdlib/test/python/test_python_to_mojo.mojo
+++ b/mojo/stdlib/test/python/test_python_to_mojo.mojo
@@ -37,23 +37,40 @@ def test_string() raises:
 def test_string_construction_ascii_fast_path() raises:
     # All-ASCII input goes through PyUnicode_FromKindAndData(kind=1).
     assert_equal(String(py=PythonObject("hello world")), "hello world")
-    # Empty string is the SIMD-tail-only edge.
+    # Empty string is the scalar-only edge (length < SIMD block width).
     assert_equal(String(py=PythonObject("")), "")
-    # Length exactly at the SIMD block width (uses the vectorized loop with
-    # zero tail).
+    # Length exceeding typical SIMD block width exercises the vectorized loop.
     assert_equal(
         String(py=PythonObject("0123456789abcdef0123456789abcdef")),
         "0123456789abcdef0123456789abcdef",
     )
+    # 0x7F is the highest ASCII byte and must take the fast path.
+    assert_equal(String(py=PythonObject("\x7F")), "\x7F")
+    # Embedded NUL bytes are within `[0, 128)` so they also take the fast
+    # path; verify the explicit length is honored rather than C-string-style
+    # truncation.
+    assert_equal(String(py=PythonObject("foo\0bar")).byte_length(), 7)
 
 
 def test_string_construction_non_ascii_fallback() raises:
-    # Non-ASCII input falls through to PyUnicode_DecodeUTF8 which handles
-    # multi-byte UTF-8 sequences. 2-byte (héllo), 4-byte (fire emoji), and
-    # embedded NUL all round-trip.
+    # Inputs with any byte >= 128 fall through to PyUnicode_DecodeUTF8 so
+    # multi-byte UTF-8 sequences decode to their proper code points.
+    # 2-byte sequence (`é` = U+00E9 = 0xC3 0xA9).
     assert_equal(String(py=PythonObject("héllo")), "héllo")
+    # 4-byte sequence (fire emoji).
     assert_equal(String(py=PythonObject("\U0001F525 fire")), "\U0001F525 fire")
-    assert_equal(String(py=PythonObject("foo\0bar")).byte_length(), 7)
+    # U+0080 = 0xC2 0x80, the smallest non-ASCII code point. 0x80 alone is
+    # not valid UTF-8, so the 2-byte sequence is the boundary case.
+    assert_equal(String(py=PythonObject("\u0080")), "\u0080")
+    # Long ASCII prefix followed by a high byte. Exercises the
+    # non-first-iteration miss case in whichever loop the SIMD-mask width
+    # makes active on the host (vectorized body or scalar tail).
+    var long_then_nonascii = (
+        "0123456789abcdef0123456789abcdef01234567" + "é"
+    )
+    assert_equal(
+        String(py=PythonObject(long_then_nonascii)), long_then_nonascii
+    )
 
 
 def test_int() raises:

--- a/mojo/stdlib/test/python/test_python_to_mojo.mojo
+++ b/mojo/stdlib/test/python/test_python_to_mojo.mojo
@@ -34,6 +34,28 @@ def test_string() raises:
     assert_true(String(os.environ).startswith("environ({"))
 
 
+def test_string_construction_ascii_fast_path() raises:
+    # All-ASCII input goes through PyUnicode_FromKindAndData(kind=1).
+    assert_equal(String(py=PythonObject("hello world")), "hello world")
+    # Empty string is the SIMD-tail-only edge.
+    assert_equal(String(py=PythonObject("")), "")
+    # Length exactly at the SIMD block width (uses the vectorized loop with
+    # zero tail).
+    assert_equal(
+        String(py=PythonObject("0123456789abcdef0123456789abcdef")),
+        "0123456789abcdef0123456789abcdef",
+    )
+
+
+def test_string_construction_non_ascii_fallback() raises:
+    # Non-ASCII input falls through to PyUnicode_DecodeUTF8 which handles
+    # multi-byte UTF-8 sequences. 2-byte (héllo), 4-byte (fire emoji), and
+    # embedded NUL all round-trip.
+    assert_equal(String(py=PythonObject("héllo")), "héllo")
+    assert_equal(String(py=PythonObject("\U0001F525 fire")), "\U0001F525 fire")
+    assert_equal(String(py=PythonObject("foo\0bar")).byte_length(), 7)
+
+
 def test_int() raises:
     assert_equal(Int(py=PythonObject(5)), 5)
     assert_equal(Int(py=PythonObject(-1)), -1)


### PR DESCRIPTION
## Context

`PythonObject.__init__(out self, string: StringSlice)` previously always called `PyUnicode_DecodeUTF8`, which runs CPython's full UTF-8 decoder (validation pass, error callback setup, multi-byte state machine). The `StringSlice` argument is guaranteed valid UTF-8 by construction, so the decoder's work is largely wasted for the common ASCII case.

For all-ASCII input, CPython exposes `PyUnicode_FromKindAndData(kind, buffer, size)` (stable ABI). With `kind=PyUnicode_1BYTE_KIND` each input byte is taken as a single code point, so feeding raw ASCII bytes is correct and skips the decoder entirely.

## Changes

- `_cpython.mojo`: bind `PyUnicode_FromKindAndData`; expose `PyUnicode_{1,2,4}BYTE_KIND` constants.
- `string_slice.mojo`: add private `_is_ascii(span)` SIMD scanner with a `_memchr`-style dispatcher (`__is_run_in_comptime_interpreter or len < width` → scalar fallback; else `_is_ascii_impl` SIMD body).
- `python_object.mojo`: `PythonObject.__init__(string: StringSlice)` gates on `_is_ascii`. Fast path calls `PyUnicode_FromKindAndData(PyUnicode_1BYTE_KIND, bytes)`; non-ASCII still goes through `PyUnicode_DecodeUTF8`. `StringLiteral` and `String` overloads' `Raises:` docstrings synced.
- Tests: ASCII fast path (`hello world`, empty, `\x7F` boundary, embedded NUL, 32-byte vectorized-loop case). Non-ASCII fallback (2-byte `é`, 4-byte `\U0001F525`, `` boundary, long ASCII + late `é` to exercise non-first-iteration miss).
- `bench_string_to_pyobject.mojo`: short ASCII, 1 KiB ASCII, non-ASCII. 20 repetitions for tighter noise bounds.
- `bench_bindings/`: new `echo_str_def(s) -> PythonObject(String(py=s))` exercising the round-trip end-to-end via the existing `def_function` harness, plus a `echo_str_raw_fastcall(s)` hand-written lower bound and a `py_echo_str(s)` Python baseline.
- Changelog entry under the existing FFI fast-path bullet group.

## Benchmarks

### Microbench (`bench_string_to_pyobject.mojo`)

`bazelw test //mojo/stdlib/benchmarks:python/bench_string_to_pyobject.mojo.bench -c opt`, Mojo `1.0.0b2`, single core (`taskset -c 2`), 20 repetitions × 100 iterations × 1000 conversions per iter. Min-of-min per side.

| Variant | Input | Before | After | Δ |
|---|---|---|---|---|
| `string_to_pyobject_ascii_short` | `"hello world"` (11 bytes) | ~141.5 ns | **~80.0 ns** | −61 ns (~43% faster) |
| `string_to_pyobject_ascii_large` | 1 KiB ASCII | ~238.2 ns | **~211.1 ns** | −27 ns (~11% faster) |
| `string_to_pyobject_non_ascii` | `"héllo \U0001F525"` (mixed) | ~164.5 ns | ~122.3 ns | within run-to-run variance |

### End-to-end (`bench_bindings/`)

`bazelw test //mojo/stdlib/benchmarks/python/bench_bindings:bench_bindings -c opt`, 2M iter × 7 repeats via `timeit.repeat`, min of repeats. Per-Python-call from the `mojo_module` extension. ASCII input `"hello world"`.

| Variant | Before | After | Δ |
|---|---|---|---|
| `echo_str_def` (`def_function`) | ~168.9 ns | **~146.4 ns** | **−22 ns (~13% faster) end-to-end** |
| `echo_str_raw_fastcall` (lower bound) | ~36-60 ns (noisy across runs) | ~36-60 ns | unchanged (independent path) |
| `py_echo_str(s)` (pure Python) | ~37-62 ns | ~37-62 ns | baseline reference |

The microbench's ~25 ns win composes through the full FFI dispatch to ~22 ns end-to-end. ASCII strings round-tripped through `def_function`-bound Mojo functions get ~13% faster.

Assisted-by: AI