### PR TITLE
[Stdlib][GPU] Use arch-specific sm_121a target for DGX Spark (GB10)

### DIFF
--- a/mojo/stdlib/std/gpu/host/info.mojo
+++ b/mojo/stdlib/std/gpu/host/info.mojo
@@ -762,9 +762,9 @@ def _get_dgx_spark_target() -> _TargetType:
     """
     return __mlir_attr[
         `#kgen.target<triple = "nvptx64-nvidia-cuda", `,
-        `arch = "sm_121", `,
-        `features = "+ptx88,+sm_121", `,
-        `tune_cpu = "sm_121", `,
+        `arch = "sm_121a", `,
+        `features = "+ptx88,+sm_121a", `,
+        `tune_cpu = "sm_121a", `,
         `data_layout = "e-p3:32:32-p4:32:32-p5:32:32-p6:32:32-p7:32:32-i64:64-i128:128-i256:256-v16:16-v32:32-n16:32:64",`,
         `index_bit_width = 64,`,
         `simd_bit_width = 128`,


### PR DESCRIPTION
Part of #6570 (sm_120 / sm_121 consumer Blackwell support epic).

## Problem

The DGX Spark (GB10, sm_121) codegen target (`_get_dgx_spark_target()`) uses the **base** `sm_121` arch string. Base targets don't enable architecture-specific Blackwell instructions, so the GB10 driver JIT rejects any kernel that emits one (`CUDA_ERROR_INVALID_PTX` at module load).

Concretely, the FP4 decode instruction `cvt.rn.f16x2.e2m1x2` is rejected for the base target but accepted for the arch-specific one:

```
$ ptxas -arch=sm_121  probe.ptx   # .target sm_121
ptxas error: Feature 'cvt.f16x2.e2m1x2' not supported on .target 'sm_121'
$ ptxas -arch=sm_121a probe.ptx   # .target sm_121a
(ok)
```

The sibling Blackwell targets already use their arch-specific variant (`sm_100a`, `sm_120a`); `sm_121` was the odd one out.

## Fix

Switch the DGX Spark target's `arch` / `features` / `tune_cpu` to `sm_121a` (`+ptx88,+sm_121a`).

## Verification (on a DGX Spark / GB10)

- **Codegen-neutral for non-arch-specific kernels.** An existing GPU kernel compiles to an identical PTX body under `sm_121` and `sm_121a` — same **40 registers, 1 barrier, 592 B shared memory** (the only PTX delta is auto-incremented symbol IDs). So normal kernels see zero register/memory/perf impact.
- **Unlocks previously-unusable arch-specific paths.** A block-scaled FP4 (NVFP4) GEMM that failed to load under the base target now compiles, launches, and is numerically correct on the GB10 (known-answer test: all 65,536 output elements exact).

This is a prerequisite for any architecture-specific (FP4, etc.) kernel support on the GB10.