### PR TITLE
[Stdlib][GPU] Add sm_121/sm_121a platform detection predicates

### DIFF
--- a/mojo/stdlib/std/sys/info.mojo
+++ b/mojo/stdlib/std/sys/info.mojo
@@ -564,6 +564,19 @@ def _has_sm_120x() -> Bool:
     return _has_nvidia_gpu_any[_SM_120X_ARCHS]()
 
 
+comptime _SM_121X_ARCHS: List[String] = ["sm_121", "sm_121a"]
+
+
+@always_inline("nodebug")
+def _is_sm_121x() -> Bool:
+    return _is_nvidia_gpu_any[_SM_121X_ARCHS]()
+
+
+@always_inline("nodebug")
+def _has_sm_121x() -> Bool:
+    return _has_nvidia_gpu_any[_SM_121X_ARCHS]()
+
+
 @always_inline("nodebug")
 def _has_blackwell_tcgen05() -> Bool:
     return _has_nvidia_gpu_any[
@@ -618,12 +631,12 @@ def _has_sm_110x_or_newer() -> Bool:
 
 @always_inline("nodebug")
 def _is_sm_120x_or_newer() -> Bool:
-    return _is_sm_120x()
+    return _is_sm_120x() or _is_sm_121x()
 
 
 @always_inline("nodebug")
 def _has_sm_120x_or_newer() -> Bool:
-    return _has_sm_120x()
+    return _has_sm_120x() or _has_sm_121x()
 
 
 @always_inline("nodebug")


### PR DESCRIPTION
Split out from #6594 at @BradLarson's request, so the platform-detection changes can land in isolation.

Adds `_SM_121X_ARCHS = ["sm_121", "sm_121a"]` and the `_is_sm_121x()` / `_has_sm_121x()` predicates in `sys/info.mojo`, and wires them into `_is_sm_120x_or_newer()` / `_has_sm_120x_or_newer()` so the consumer-Blackwell GB10 (sm_121) is recognized alongside sm_120.

Part of #6570 (consumer Blackwell support). The NVFP4 enablement that depends on these predicates (#6594) will be rebased on top once this lands.
