### PR TITLE
[stdlib] Added `once` iterator

### DIFF
--- a/mojo/stdlib/std/iter/__init__.mojo
+++ b/mojo/stdlib/std/iter/__init__.mojo
@@ -339,6 +339,7 @@ struct _Once[T: Movable](
     Iterable where conforms_to(T, Copyable),
     IterableOwned,
     Iterator,
+    Movable,
 ):
     """An iterator that yields an element exactly once."""
 
@@ -366,12 +367,11 @@ struct _Once[T: Movable](
         return next(self._inner)
 
     def bounds(self) -> Tuple[Int, Optional[Int]]:
-        var n_remaining = Int(Bool(self._inner))
-        return Tuple(n_remaining, Optional(n_remaining))
+        return self._inner.bounds()
 
 
 @always_inline
-def once[T: Movable](var element: T) -> _Once[T]:
+def once[T: Movable, //](var element: T, /) -> _Once[T]:
     """Creates an iterator that yields an element exactly once.
 
     Parameters:

--- a/mojo/stdlib/std/iter/__init__.mojo
+++ b/mojo/stdlib/std/iter/__init__.mojo
@@ -370,6 +370,7 @@ struct _Once[T: Movable](
         return Tuple(n_remaining, Optional(n_remaining))
 
 
+@always_inline
 def once[T: Movable](var element: T) -> _Once[T]:
     """Creates an iterator that yields an element exactly once.
 

--- a/mojo/stdlib/std/iter/__init__.mojo
+++ b/mojo/stdlib/std/iter/__init__.mojo
@@ -329,6 +329,53 @@ def empty[T: Movable]() -> _Empty[T]:
 
 
 # ===-----------------------------------------------------------------------===#
+# once
+# ===-----------------------------------------------------------------------===#
+
+
+@fieldwise_init
+struct _Once[T: Movable](
+    Copyable where conforms_to(T, Copyable),
+    Iterable where conforms_to(T, Copyable),
+    IterableOwned,
+    Iterator,
+):
+    """An iterator that yields an element exactly once."""
+
+    comptime Element = Self.T
+
+    comptime IteratorType[
+        iterable_mut: Bool, //, iterable_origin: Origin[mut=iterable_mut]
+    ]: Iterator = Self
+
+    comptime IteratorOwnedType: Iterator = Self
+
+    var _inner: Optional[Self.T]
+
+    def __iter__(var self) -> Self.IteratorOwnedType:
+        return self^
+
+    def __iter__(
+        ref self,
+    ) -> Self.IteratorType[origin_of(self)] where conforms_to(
+        Self.Element, Copyable
+    ):
+        return self.copy()
+
+    def __next__(mut self) raises StopIteration -> Self.Element:
+        return next(self._inner)
+
+    def bounds(self) -> Tuple[Int, Optional[Int]]:
+        var n_remaining = Int(Bool(self._inner))
+        return Tuple(n_remaining, Optional(n_remaining))
+
+
+def once[T: Movable](var value: T) -> _Once[T]:
+    """Creates an iterator that yields an element exactly once."""
+    return _Once(value^)
+
+
+# ===-----------------------------------------------------------------------===#
 # enumerate
 # ===-----------------------------------------------------------------------===#
 

--- a/mojo/stdlib/std/iter/__init__.mojo
+++ b/mojo/stdlib/std/iter/__init__.mojo
@@ -370,9 +370,19 @@ struct _Once[T: Movable](
         return Tuple(n_remaining, Optional(n_remaining))
 
 
-def once[T: Movable](var value: T) -> _Once[T]:
-    """Creates an iterator that yields an element exactly once."""
-    return _Once(value^)
+def once[T: Movable](var element: T) -> _Once[T]:
+    """Creates an iterator that yields an element exactly once.
+
+    Parameters:
+        T: The type of the element to be yielded exactly once.
+
+    Args:
+        element: The element to be yielded exactly once.
+
+    Returns:
+        An iterator that yields the specified element exactly once.
+    """
+    return _Once(element^)
 
 
 # ===-----------------------------------------------------------------------===#

--- a/mojo/stdlib/test/iter/test_once.mojo
+++ b/mojo/stdlib/test/iter/test_once.mojo
@@ -1,0 +1,61 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.testing import TestSuite, assert_equal, assert_raises
+
+from std.iter import once
+
+
+def test_once() raises:
+    var it = once(10)
+    assert_equal(next(it), 10)
+    with assert_raises():
+        _ = next(it)
+
+
+def test_once_owned() raises:
+    var it = iter(once(10))
+    assert_equal(next(it), 10)
+    with assert_raises():
+        _ = next(it)
+
+
+def test_once_iter() raises:
+    var it = once(10)
+    var it_copy = iter(it)
+
+    assert_equal(next(it), 10)
+    with assert_raises():
+        _ = next(it)
+
+    assert_equal(next(it_copy), 10)
+    with assert_raises():
+        _ = next(it_copy)
+
+
+def test_once_bounds() raises:
+    var it = once(10)
+
+    var lower, upper = it.bounds()
+    assert_equal(lower, 1)
+    assert_equal(upper, Optional(1))
+
+    _ = next(it)
+
+    lower, upper = it.bounds()
+    assert_equal(lower, 0)
+    assert_equal(upper, Optional(0))
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/mojo/stdlib/test/iter/test_once.mojo
+++ b/mojo/stdlib/test/iter/test_once.mojo
@@ -30,7 +30,7 @@ def test_once_owned() raises:
         _ = next(it)
 
 
-def test_once_iter() raises:
+def test_once_iter_copyable() raises:
     var it = once(10)
     var it_copy = iter(it)
 


### PR DESCRIPTION
## Linked issue

Partly addresses #6589 along with PR #6603. 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [x] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Discussed in #6589.

## What changed

Added the `once` iterator, that yields an element exactly once. For instance

```mojo
from std.iter import once
from std.testing import assert_equal, assert_raises

var it = once(10)
assert_equal(next(it), 10)
with assert_raises():
   _ = next(it)
```

## Testing

Added new tests and successfully ran the full test suite.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
