### PR TITLE
[Stdlib] Use PySequence_Contains for Python membership

### DIFF
--- a/mojo/stdlib/std/python/_cpython.mojo
+++ b/mojo/stdlib/std/python/_cpython.mojo
@@ -950,6 +950,11 @@ comptime PyObject_Hash = ExternalFunction[
     # Py_hash_t PyObject_Hash(PyObject *o)
     def(PyObjectPtr) thin abi("C") -> Py_hash_t,
 ]
+comptime PySequence_Contains = ExternalFunction[
+    "PySequence_Contains",
+    # int PySequence_Contains(PyObject *o, PyObject *value)
+    def(PyObjectPtr, PyObjectPtr) thin abi("C") -> c_int,
+]
 comptime PyObject_IsTrue = ExternalFunction[
     "PyObject_IsTrue",
     # int PyObject_IsTrue(PyObject *o)
@@ -1406,6 +1411,7 @@ struct CPython(Defaultable, Movable):
     var _PyObject_SetAttrString: PyObject_SetAttrString.type
     var _PyObject_Str: PyObject_Str.type
     var _PyObject_Hash: PyObject_Hash.type
+    var _PySequence_Contains: PySequence_Contains.type
     var _PyObject_IsTrue: PyObject_IsTrue.type
     var _PyObject_Type: PyObject_Type.type
     var _PyObject_Length: PyObject_Length.type
@@ -1582,6 +1588,9 @@ struct CPython(Defaultable, Movable):
         )
         self._PyObject_Str = PyObject_Str.load(self.lib.borrow())
         self._PyObject_Hash = PyObject_Hash.load(self.lib.borrow())
+        self._PySequence_Contains = PySequence_Contains.load(
+            self.lib.borrow()
+        )
         self._PyObject_IsTrue = PyObject_IsTrue.load(self.lib.borrow())
         self._PyObject_Type = PyObject_Type.load(self.lib.borrow())
         self._PyObject_Length = PyObject_Length.load(self.lib.borrow())
@@ -2185,6 +2194,19 @@ struct CPython(Defaultable, Movable):
         - https://docs.python.org/3/c-api/object.html#c.PyObject_Hash
         """
         return self._PyObject_Hash(obj)
+
+    def PySequence_Contains(
+        self, obj: PyObjectPtr, value: PyObjectPtr
+    ) -> c_int:
+        """Determine whether `obj` contains `value`.
+
+        Returns `1` if `obj` contains `value`, `0` if it does not, and `-1`
+        on failure.
+
+        References:
+        - https://docs.python.org/3/c-api/sequence.html#c.PySequence_Contains
+        """
+        return self._PySequence_Contains(obj, value)
 
     def PyObject_IsTrue(self, obj: PyObjectPtr) -> c_int:
         """Returns `1` if the object `obj` is considered to be true, and `0`

--- a/mojo/stdlib/std/python/_cpython.mojo
+++ b/mojo/stdlib/std/python/_cpython.mojo
@@ -1588,9 +1588,7 @@ struct CPython(Defaultable, Movable):
         )
         self._PyObject_Str = PyObject_Str.load(self.lib.borrow())
         self._PyObject_Hash = PyObject_Hash.load(self.lib.borrow())
-        self._PySequence_Contains = PySequence_Contains.load(
-            self.lib.borrow()
-        )
+        self._PySequence_Contains = PySequence_Contains.load(self.lib.borrow())
         self._PyObject_IsTrue = PyObject_IsTrue.load(self.lib.borrow())
         self._PyObject_Type = PyObject_Type.load(self.lib.borrow())
         self._PyObject_Length = PyObject_Length.load(self.lib.borrow())

--- a/mojo/stdlib/std/python/python_object.mojo
+++ b/mojo/stdlib/std/python/python_object.mojo
@@ -1246,15 +1246,11 @@ struct PythonObject(
         Raises:
             If the operation fails.
         """
-        # TODO: replace/optimize with c-python function.
-        # TODO: implement __getitem__ step for cpython membership test operator.
         ref cpy = Python().cpython()
-        if cpy.PyObject_HasAttrString(self._obj_ptr, "__contains__"):
-            return self.__getattr__("__contains__")(rhs^).__bool__()
-        for v in self:
-            if v == rhs:
-                return True
-        return False
+        var res = cpy.PySequence_Contains(self._obj_ptr, rhs._obj_ptr)
+        if res == -1:
+            raise cpy.unsafe_get_error()
+        return res == 1
 
     # see https://github.com/python/cpython/blob/main/Objects/call.c
     # for decrement rules

--- a/mojo/stdlib/test/python/test_python_cpython.mojo
+++ b/mojo/stdlib/test/python/test_python_cpython.mojo
@@ -113,6 +113,8 @@ def _test_object_protocol_api(cpy: CPython) raises:
 
     assert_true(cpy.PyObject_Str(n))
     assert_equal(cpy.PyObject_Hash(n), 42)
+    assert_equal(cpy.PySequence_Contains(l, n), 0)
+    assert_equal(cpy.PySequence_Contains(l, z), 1)
     assert_equal(cpy.PyObject_IsTrue(n), 1)
     assert_true(cpy.PyObject_Type(n))
     assert_equal(cpy.PyObject_Length(l), 1)
@@ -120,6 +122,8 @@ def _test_object_protocol_api(cpy: CPython) raises:
     assert_equal(cpy.PyObject_GetItem(l, z), z)
     assert_equal(cpy.PyObject_SetItem(l, z, n), 0)
     assert_equal(cpy.PyObject_GetItem(l, z), n)
+    assert_equal(cpy.PySequence_Contains(l, n), 1)
+    assert_equal(cpy.PySequence_Contains(l, z), 0)
 
     var it = cpy.PyObject_GetIter(l)
     assert_true(it)

--- a/mojo/stdlib/test/python/test_python_object.mojo
+++ b/mojo/stdlib/test/python/test_python_object.mojo
@@ -570,7 +570,7 @@ def test_py_slice() raises:
 
 
 def test_contains_dunder() raises:
-    with assert_raises(contains="'int' object is not iterable"):
+    with assert_raises(contains="not iterable"):
         var z = PythonObject(0)
         _ = 5 in z
 
@@ -589,6 +589,26 @@ def test_contains_dunder() raises:
     assert_true("A" in y)
     assert_false("C" in y)
     assert_true("B" in y)
+
+    comptime CONTAINS_SOURCE = """
+class ContainsOnly:
+  def __contains__(self, value):
+    return value == 'hit'
+
+class IterOnly:
+  def __iter__(self):
+    return iter([1, 2, 3])
+"""
+
+    var python = Python()
+    _ = python.eval(CONTAINS_SOURCE)
+    var contains_only = python.evaluate("ContainsOnly()")
+    assert_true("hit" in contains_only)
+    assert_false("miss" in contains_only)
+
+    var iter_only = python.evaluate("IterOnly()")
+    assert_true(2 in iter_only)
+    assert_false(4 in iter_only)
 
 
 @fieldwise_init

--- a/mojo/stdlib/test/python/test_python_object.mojo
+++ b/mojo/stdlib/test/python/test_python_object.mojo
@@ -570,7 +570,7 @@ def test_py_slice() raises:
 
 
 def test_contains() raises:
-    with assert_raises(contains="argument of type 'int' is not iterable"):
+    with assert_raises(contains="argument of type 'int' is not"):
         var z = PythonObject(0)
         _ = 5 in z
 

--- a/mojo/stdlib/test/python/test_python_object.mojo
+++ b/mojo/stdlib/test/python/test_python_object.mojo
@@ -569,8 +569,8 @@ def test_py_slice() raises:
         _ = with_2d[0:1][4]
 
 
-def test_contains_dunder() raises:
-    with assert_raises(contains="not iterable"):
+def test_contains() raises:
+    with assert_raises(contains="argument of type 'int' is not iterable"):
         var z = PythonObject(0)
         _ = 5 in z
 
@@ -590,7 +590,7 @@ def test_contains_dunder() raises:
     assert_false("C" in y)
     assert_true("B" in y)
 
-    comptime CONTAINS_SOURCE = """
+    var CONTAINS_SOURCE = """
 class ContainsOnly:
   def __contains__(self, value):
     return value == 'hit'

--- a/mojo/stdlib/test/python/test_python_object.mojo
+++ b/mojo/stdlib/test/python/test_python_object.mojo
@@ -595,6 +595,10 @@ class ContainsOnly:
   def __contains__(self, value):
     return value == 'hit'
 
+class ContainsRaises:
+  def __contains__(self, value):
+    raise ValueError('boom')
+
 class IterOnly:
   def __iter__(self):
     return iter([1, 2, 3])
@@ -605,6 +609,10 @@ class IterOnly:
     var contains_only = python.evaluate("ContainsOnly()")
     assert_true("hit" in contains_only)
     assert_false("miss" in contains_only)
+
+    var contains_raises = python.evaluate("ContainsRaises()")
+    with assert_raises(contains="boom"):
+        _ = "hit" in contains_raises
 
     var iter_only = python.evaluate("IterOnly()")
     assert_true(2 in iter_only)


### PR DESCRIPTION
## Linked issue

Fixes #3806

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

`PythonObject.__contains__` currently implements membership in Mojo by checking `__contains__` and otherwise iterating. The linked issue and maintainer guidance call for delegating membership to CPython through `PySequence_Contains`, which uses CPython sequence slots and fallback behavior directly.

## What changed

- Added a `PySequence_Contains` CPython binding, loader field, and wrapper.
- Replaced `PythonObject.__contains__` with a single `PySequence_Contains` call and Python error propagation on `-1`.
- Added coverage for the raw binding, list/dict membership, a Python `__contains__` implementation, iterator fallback, and non-iterable error propagation.

## Testing

- `git diff --check HEAD~1..HEAD`
- `./bazelw test //mojo/stdlib/test/python:test_python_object.mojo.test //mojo/stdlib/test/python:test_python_cpython.mojo.test` could not run on this machine because Bazel exits before target analysis: `error: a fully Xcode install must be selected globally, run sudo xcode-select -s /path/to/Xcode.app`. This machine only has `/Library/Developer/CommandLineTools` selected and no `/Applications/Xcode*.app`.
- `./bazelw run format` is blocked by the same Xcode preflight error.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is agreed-upon, or this is a trivial fix that does not need prior approval
- [x] PR is small and focused -- I have split larger changes into a sequence of smaller PRs where possible
- [ ] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an `Assisted-by:` trailer in my commit message or this PR description

Assisted-by: AI