### PR TITLE
collections/deque: guard `rotate` against empty deque to prevent uninitialized memory reads

### DIFF
--- a/mojo/stdlib/std/collections/deque.mojo
+++ b/mojo/stdlib/std/collections/deque.mojo
@@ -897,6 +897,8 @@ struct Deque[ElementType: Movable & ImplicitlyDestructible](
             n: Number of steps to rotate the deque
                 (defaults to 1).
         """
+        if n == 0 or len(self) == 0:
+            return
         if n < 0:
             for _ in range(-n):
                 (self._data + self._tail).init_pointee_move_from(

--- a/mojo/stdlib/std/collections/deque.mojo
+++ b/mojo/stdlib/std/collections/deque.mojo
@@ -892,6 +892,7 @@ struct Deque[ElementType: Movable & ImplicitlyDestructible](
 
         If `n` is positive, rotates to the right.
         If `n` is negative, rotates to the left.
+        On an empty deque or when `n == 0`, this is a no-op.
 
         Args:
             n: Number of steps to rotate the deque

--- a/mojo/stdlib/test/collections/test_deque.mojo
+++ b/mojo/stdlib/test/collections/test_deque.mojo
@@ -1038,8 +1038,6 @@ def test_rotate() raises:
 
 
 def test_rotate_empty_deque() raises:
-    # Rotating an empty deque must be a no-op; without the guard it reads
-    # from uninitialized memory (undefined behaviour).
     q = Deque[Int]()
     q.rotate(1)
     assert_equal(len(q), 0)
@@ -1047,6 +1045,14 @@ def test_rotate_empty_deque() raises:
     assert_equal(len(q), 0)
     q.rotate(0)
     assert_equal(len(q), 0)
+
+    # n == 0 on a non-empty deque must also be a no-op.
+    q2 = Deque(1, 2, 3)
+    q2.rotate(0)
+    assert_equal(len(q2), 3)
+    assert_equal(q2[0], 1)
+    assert_equal(q2[1], 2)
+    assert_equal(q2[2], 3)
 
 
 def test_iter() raises:

--- a/mojo/stdlib/test/collections/test_deque.mojo
+++ b/mojo/stdlib/test/collections/test_deque.mojo
@@ -1037,6 +1037,18 @@ def test_rotate() raises:
     assert_equal(q[3], 3)
 
 
+def test_rotate_empty_deque() raises:
+    # Rotating an empty deque must be a no-op; without the guard it reads
+    # from uninitialized memory (undefined behaviour).
+    q = Deque[Int]()
+    q.rotate(1)
+    assert_equal(len(q), 0)
+    q.rotate(-1)
+    assert_equal(len(q), 0)
+    q.rotate(0)
+    assert_equal(len(q), 0)
+
+
 def test_iter() raises:
     q = Deque(1, 2, 3)
 


### PR DESCRIPTION
## Linked issue

N/A — trivial fix

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation

`Deque.rotate(n)` on an empty deque reads from uninitialized memory.
When `n > 0` the positive branch decrements `_tail` and reads from
`_data + _tail` (one slot before the empty ring's sole position) before
writing to `_data + _head - 1`; when `n < 0` the negative branch reads
from `_data + _head` and writes to `_data + _tail`. In both cases the
source slot has never been initialized.

Python's `collections.deque` treats `rotate` on an empty (or zero-step)
deque as a no-op. The Mojo implementation had no equivalent guard, so
any call to `rotate` on an empty `Deque` was undefined behavior.

## What changed

Added an early-return guard at the top of `rotate`:

```mojo
if n == 0 or len(self) == 0:
    return
```

`len(self)` evaluates to `(self._tail - self._head) & (self._capacity - 1)`,
which is 0 exactly when the deque is empty regardless of the circular-buffer
wrap state. The guard short-circuits before either loop branch runs, so
no memory is touched. The `n == 0` arm is included for free to match
Python's semantics and eliminate the loop overhead on a trivially
no-op call.

No existing behavior changes — all current `test_rotate` cases use a
non-empty deque with `n` well within bounds.

## Testing

Added `test_rotate_empty_deque` to
`mojo/stdlib/test/collections/test_deque.mojo`, placed immediately after
the existing `test_rotate`. The new test:

- Creates an empty `Deque[Int]()`.
- Calls `rotate(1)`, `rotate(-1)`, and `rotate(0)` in sequence.
- Asserts `len(q) == 0` after each call.

On the unpatched code all three calls read from uninitialized memory;
with the fix they are all no-ops.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [ ] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description

