### PR TITLE
[Kernels] Fix UInt32 overflow in flash attention benchmark FLOP count

### DIFF
--- a/max/kernels/benchmarks/gpu/nn/bench_kv_cache_ragged_flash_attention.mojo
+++ b/max/kernels/benchmarks/gpu/nn/bench_kv_cache_ragged_flash_attention.mojo
@@ -149,11 +149,12 @@ def execute_kv_cache_ragged_flash_attention[
                 cache_lengths_host[i] = curr_cache_length
                 total_seq_len += curr_seq_length
 
-                flop_count += Int(
-                    UInt32(4 * num_q_heads)
-                    * (curr_cache_length + curr_seq_length)
-                    * curr_seq_length
-                    * UInt32(head_dim)
+                flop_count += (
+                    4
+                    * num_q_heads
+                    * Int(curr_cache_length + curr_seq_length)
+                    * Int(curr_seq_length)
+                    * head_dim
                 )
 
             row_offsets_host[batch_size] = total_seq_len


### PR DESCRIPTION
## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [x] Build, CI, or tooling change

## Motivation

<!--
Why is this change needed? What problem does it solve, or what use case
does it enable? If this is a bug fix, describe the bug and how a user
would hit it. If this is a new feature, explain the user-facing value.

Please write prose here — don't just restate the PR title.
-->

## What changed

bench_kv_cache_ragged_flash_attention computed 4 * num_q_heads * (cache+seq) * seq * head_dim in UInt32 before casting to Int. At large shapes this intermediate exceeds 2³² and wraps, reporting bogus throughput — e.g. a bs=8, seq=2048,  cache=2048 prefill landed exactly on a multiple of 2³² and printed 0.0 GFLOPS/s.

## Testing

After the fix the same shape reports ~529 TFLOP/s (~53% of H100 bf16 peak); decode shapes (small products, never overflowed) are unchanged.

## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [ ] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
Assisted-by Claude
