### PR TITLE
[stdlib] Fix `os.path.join` with trailing separator and add regression test

### DIFF
--- a/mojo/stdlib/std/os/path/path.mojo
+++ b/mojo/stdlib/std/os/path/path.mojo
@@ -461,7 +461,7 @@ def join(var path: String, *paths: String) -> String:
     for cur_path in paths:
         if cur_path.startswith(sep):
             joined_path = cur_path
-        elif not joined_path or path.endswith(sep):
+        elif not joined_path or joined_path.endswith(sep):
             joined_path += cur_path
         else:
             joined_path += sep + cur_path

--- a/mojo/stdlib/test/os/path/test_join.mojo
+++ b/mojo/stdlib/test/os/path/test_join.mojo
@@ -26,6 +26,7 @@ def test_join() raises:
     assert_equal("path/to/file", join("path/to", "file"))
     # assert_equal("path/to/file", join(Path("path/to"), Path("file")))
     assert_equal("path/to/file", join("path/", "to/", "file"))
+    assert_equal("path/to/file", join("path/", "to", "file"))
 
     assert_equal("path/", join("path", ""))
     # assert_equal("path/", join(Path("path"), Path("")))


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Before you open this PR, please make sure the change has been discussed and
agreed upon with a maintainer. For anything beyond a trivial fix (typo,
one-line bug fix, doc tweak), we ask that you first open a GitHub issue or
proposal and get a maintainer's go-ahead. This helps us avoid situations
where a PR sits unreviewed because the change isn't aligned with the
team's direction. See our [contributor guide](https://github.com/modular/modular/blob/main/CONTRIBUTING.md) for
details.
-->

## Linked issue

<!--
Replace `NNN` with the issue number. For anything non-trivial, a linked
issue that a maintainer has agreed to is expected before review.

- Trivial fix (typo, comment, small doc fix): you can write "N/A — trivial".
- Everything else: `Fixes #NNN` or `Related to #NNN`.
-->
N/A — trivial fix

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

<!--
Why is this change needed? What problem does it solve, or what use case
does it enable? If this is a bug fix, describe the bug and how a user
would hit it. If this is a new feature, explain the user-facing value.

Please write prose here — don't just restate the PR title.
-->
Fix a bug where `os.path.join()` omitted a separator because it checked the wrong variable (`path` instead of `joined_path`).

## What changed

<!--
Describe the change at a high level. Call out anything non-obvious: API
changes, behavior changes, performance characteristics, or tricky
implementation details.
-->
- `mojo/stdlib/std/os/path/path.mojo`: changed
  `path.endswith(sep)` → `joined_path.endswith(sep)` in the
  multi-segment loop of `join()`.
- `mojo/stdlib/test/os/path/test_join.mojo`: added regression
  test `join("path/", "to", "file")`.

## Testing

<!--
Describe how you validated your changes.

- Code changes: what tests did you run, and what were the results? Did
  you add a new test that would have caught the bug?
- Performance changes: include before/after numbers from a benchmark.
- Documentation: describe how you verified accuracy (built the docs,
  ran the example, etc.).
-->
All join tests pass locally, including the new regression case.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
Assisted-by: DeepSeek