### PR TITLE
[Stdlib] Add `os.path.normpath`

### DIFF
--- a/mojo/stdlib/std/os/path/__init__.mojo
+++ b/mojo/stdlib/std/os/path/__init__.mojo
@@ -26,6 +26,7 @@ from .path import (
     islink,
     join,
     lexists,
+    normpath,
     realpath,
     split,
     split_extension,

--- a/mojo/stdlib/std/os/path/path.mojo
+++ b/mojo/stdlib/std/os/path/path.mojo
@@ -666,6 +666,70 @@ def splitroot[
 
 
 # ===----------------------------------------------------------------------=== #
+# normpath
+# ===----------------------------------------------------------------------=== #
+
+
+def normpath[PathLike: os.PathLike, //](path: PathLike) -> String:
+    """Normalizes a pathname by collapsing redundant separators and up-level
+    references, so that `A//B`, `A/B/`, `A/./B` and `A/foo/../B` all become
+    `A/B`. On POSIX, two leading slashes are preserved as a special case.
+
+    This string manipulation may change the meaning of a path that contains
+    symbolic links.
+
+    Parameters:
+        PathLike: The type conforming to the os.PathLike trait.
+
+    Args:
+        path: The path to normalize.
+
+    Returns:
+        The normalized path.
+
+    Examples:
+
+    ```mojo
+    from std.os.path import normpath
+
+    print(normpath("foo//bar"))      # "foo/bar"
+    print(normpath("foo/./bar"))     # "foo/bar"
+    print(normpath("foo/../bar"))    # "bar"
+    print(normpath("//foo//bar"))    # "//foo/bar"
+    print(normpath("/.."))           # "/"
+    print(normpath(""))              # "."
+    ```
+    """
+    comptime sep_slice = StringSlice(sep)
+    comptime dot = StringSlice(".")
+    comptime dotdot = StringSlice("..")
+    comptime dot_str = "."
+
+    var path_str = path.__fspath__()
+    if not path_str:
+        return dot_str
+
+    var _, root, tail = splitroot(path_str)
+
+    var comps = tail.split(sep_slice)
+    var new_comps = List[String]()
+    for comp in comps:
+        if not comp or comp == dot:
+            continue
+        if (
+            comp != dotdot
+            or (not root and not new_comps)
+            or (new_comps and new_comps[len(new_comps) - 1] == dotdot)
+        ):
+            new_comps.append(String(comp))
+        elif new_comps:
+            _ = new_comps.pop()
+
+    var new_path_str = root + sep.join(new_comps)
+    return new_path_str or dot_str
+
+
+# ===----------------------------------------------------------------------=== #
 # expandvars
 # ===----------------------------------------------------------------------=== #
 

--- a/mojo/stdlib/test/os/path/test_normpath.mojo
+++ b/mojo/stdlib/test/os/path/test_normpath.mojo
@@ -1,0 +1,111 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.os.path import normpath
+
+from std.testing import TestSuite, assert_equal
+
+
+def test_empty_and_dot() raises:
+    assert_equal(".", normpath(""))
+    assert_equal(".", normpath("."))
+    assert_equal("..", normpath(".."))
+
+
+def test_simple_relative() raises:
+    assert_equal("foo", normpath("foo"))
+    assert_equal("foo/bar", normpath("foo/bar"))
+
+
+def test_trailing_separator() raises:
+    assert_equal("foo", normpath("foo/"))
+    assert_equal("foo/bar", normpath("foo/bar/"))
+
+
+def test_collapse_separators() raises:
+    assert_equal("foo/bar", normpath("foo//bar"))
+    assert_equal("foo/bar", normpath("foo///bar"))
+    assert_equal("foo/bar/baz", normpath("foo//bar///baz"))
+
+
+def test_dot_components() raises:
+    assert_equal("foo/bar", normpath("foo/./bar"))
+    assert_equal("foo/bar", normpath("./foo/bar"))
+    assert_equal("foo", normpath("foo/."))
+    assert_equal("foo", normpath("./foo"))
+
+
+def test_dotdot_components() raises:
+    assert_equal("foo/baz", normpath("foo/bar/../baz"))
+    assert_equal("baz", normpath("foo/bar/../../baz"))
+    assert_equal(".", normpath("foo/.."))
+    assert_equal("..", normpath("foo/../.."))
+    assert_equal("../..", normpath("foo/../../.."))
+    assert_equal("foo", normpath("foo/bar/.."))
+
+
+def test_leading_dotdot() raises:
+    assert_equal("../foo", normpath("../foo"))
+    assert_equal("../../foo", normpath("../../foo"))
+    assert_equal("../../../foo", normpath("../../../foo"))
+    assert_equal("../bar", normpath("../foo/../bar"))
+    assert_equal("..", normpath("../foo/.."))
+
+
+def test_absolute_paths() raises:
+    assert_equal("/foo/bar", normpath("/foo/bar"))
+    assert_equal("/bar", normpath("/foo/../bar"))
+    assert_equal("/", normpath("/foo/bar/../.."))
+    assert_equal("/", normpath("/foo/bar/../../.."))
+    assert_equal("/", normpath("/.."))
+    assert_equal("/", normpath("/../.."))
+    assert_equal("/foo", normpath("/../../foo"))
+
+
+def test_root_directory() raises:
+    assert_equal("/", normpath("/"))
+    assert_equal("/", normpath("/."))
+    assert_equal("/", normpath("/./"))
+    assert_equal("/", normpath("/./."))
+    assert_equal("/foo", normpath("/./foo"))
+
+
+def test_two_leading_slashes() raises:
+    assert_equal("//", normpath("//"))
+    assert_equal("//foo", normpath("//foo"))
+    assert_equal("//foo/bar", normpath("//foo/bar"))
+    assert_equal("//foo/bar", normpath("//foo//bar"))
+    assert_equal("//", normpath("//."))
+    assert_equal("//", normpath("//foo/.."))
+
+
+def test_three_plus_leading_slashes() raises:
+    assert_equal("/", normpath("///"))
+    assert_equal("/foo", normpath("///foo"))
+    assert_equal("/foo", normpath("////foo"))
+
+
+def test_complex_paths() raises:
+    assert_equal("foo/bar/qux", normpath("foo//bar/./baz/../qux"))
+    assert_equal("/a/b", normpath("/a//b/./c/.././d/.."))
+
+
+def test_special_names() raises:
+    assert_equal("foo/...", normpath("foo/..."))
+    assert_equal("foo/....", normpath("foo/...."))
+    assert_equal("foo/..bar", normpath("foo/..bar"))
+    assert_equal("foo/.bar", normpath("foo/.bar"))
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Linked issue

Fixes #2962

## Type of change

- [x] New feature or public API (requires prior proposal or issue approval)

## Motivation

`normpath` is a standard POSIX path utility needed by other stdlib modules, such as `tempfile` (which has a TODO referencing it).

## What changed

Added `os.path.normpath` and a test file.

## Testing

Added `test_normpath.mojo` and all tests pass.


## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy]

Assisted-by: AI
