### PR TITLE
[Stdlib] Add non-static store method to Atomic

### DIFF
--- a/mojo/stdlib/std/atomic/atomic.mojo
+++ b/mojo/stdlib/std/atomic/atomic.mojo
@@ -396,6 +396,21 @@ struct Atomic[dtype: DType, *, scope: StaticString = ""]:
         ](value._mlir_value, ptr.address)
 
     @always_inline
+    def store[
+        *, ordering: Ordering = _DEFAULT_MEMORY_ORDERING
+    ](mut self, value: Scalar[Self.dtype]):
+        """Performs an atomic store.
+
+        Parameters:
+            ordering: The memory ordering of the store.
+
+        Args:
+            value: The value to store.
+        """
+        var value_addr = UnsafePointer(to=self.value)
+        Self.store[ordering=ordering](value_addr, value)
+
+    @always_inline
     def fetch_add[
         *, ordering: Ordering = _DEFAULT_ARITHMETIC_ORDERING
     ](mut self, rhs: Scalar[Self.dtype]) -> Scalar[Self.dtype]:

--- a/mojo/stdlib/test/atomic/test_atomic.mojo
+++ b/mojo/stdlib/test/atomic/test_atomic.mojo
@@ -83,6 +83,9 @@ def _test_atomic[dtype: DType]() raises:
     atom.min(scalar(0))
     assert_equal(atom.value, scalar(0))
 
+    atom.store(scalar(99))
+    assert_equal(atom.load(), scalar(99))
+
 
 def test_atomic() raises:
     _test_atomic[DType.int32]()


### PR DESCRIPTION
## Linked issue

Fixes #6634

## Type of change

- [x] New feature or public API (requires prior proposal or issue approval)

The linked issue [#6634](https://github.com/modular/modular/issues/6634) is labeled `accepted` and was endorsed by maintainer @NathanSWard ("This seem like a great addition we should add :)").

## Motivation

`Atomic` exposes both static and non-static forms of `load` (lines 243 / 274) and `fetch_add` (lines 288 / 398), but `store` only has the static form (line 371). Users currently have to write the verbose `Atomic.store(UnsafePointer(to=atom.value), value)` to store into an `Atomic` they own, while every other operation supports the ergonomic `atom.op(value)` form. Issue #6634 reports this asymmetry; this PR closes it.

## What changed

Added a non-static `store` method to `Atomic` that delegates to the existing static `store`, mirroring the exact pattern used by the non-static `fetch_add` (line 398). Behavior, ordering semantics, and constraints are unchanged — this is a pure ergonomic addition with no impact on existing call sites.

```mojo
var atom = Atomic[DType.int32](0)
atom.store(42)              # new
# previously required:
# Atomic.store(UnsafePointer(to=atom.value), 42)
```

## Testing

- Extended `_test_atomic[dtype]` in `mojo/stdlib/test/atomic/test_atomic.mojo` with `atom.store(scalar(99))` followed by `assert_equal(atom.load(), scalar(99))`. The helper is invoked from `test_atomic` for both `DType.int32` and `DType.float64`, so the new method is exercised against both an integral and a floating-point dtype.
- Ran `./bazelw test //mojo/stdlib/test/atomic:test_atomic.mojo.test` locally — passes (`Executed 1 out of 1 test: 1 test passes.`).

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is agreed-upon (issue #6634 carries the `accepted` label)
- [x] PR is small and focused (18-line diff across 2 files)
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an `Assisted-by:` trailer in my commit message

> Note on `./bazelw run format`: I ran it, but it produced spurious changes unrelated to my diff (the markdown linter reinterprets the file's `# ===---` banner comments and the `comptime` declarations on line 49 cannot be parsed by `mblack`). I reverted those formatter-induced changes and verified my 18-line diff matches the surrounding style exactly. Happy to apply any specific formatting adjustments a reviewer requests.

---

Assisted-by: Claude (claude-opus-4.7)
