### PR TITLE
[Stdlib] Add `wall_clock()` and `wall_clock_ns()` to time module

### DIFF
--- a/mojo/stdlib/std/time/__init__.mojo
+++ b/mojo/stdlib/std/time/__init__.mojo
@@ -10,12 +10,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
-"""Timing operations: monotonic clocks, performance counters, sleep, time_function.
+"""Timing operations: monotonic clocks, performance counters, wall clock, sleep, time_function.
 
-The `time` package provides utilities for measuring elapsed time, benchmarking
-code performance, and introducing delays. It offers monotonic clocks that are
-unaffected by system clock adjustments, making them suitable for measuring
-intervals and profiling execution time.
+The `time` package provides utilities for measuring elapsed time, getting the
+current wall clock time, benchmarking code performance, and introducing delays.
+It offers monotonic clocks that are unaffected by system clock adjustments,
+making them suitable for measuring intervals and profiling execution time, as
+well as a wall clock for real (calendar) time queries.
 
 Use this package for performance measurement, benchmarking, profiling, or when
 you need to introduce delays in your code.
@@ -28,4 +29,6 @@ from .time import (
     perf_counter_ns,
     sleep,
     time_function,
+    wall_clock,
+    wall_clock_ns,
 )

--- a/mojo/stdlib/std/time/time.mojo
+++ b/mojo/stdlib/std/time/time.mojo
@@ -291,6 +291,39 @@ def time_function[FuncType: def() -> None](func: FuncType) -> UInt:
 
 
 # ===-----------------------------------------------------------------------===#
+# wall_clock
+# ===-----------------------------------------------------------------------===#
+
+
+@always_inline
+def wall_clock() -> Float64:
+    """Returns the current wall clock time in fractional seconds.
+
+    This returns the real (calendar) time, which may be affected by system
+    time adjustments (e.g., NTP synchronization). Use `perf_counter()` or
+    `monotonic()` for measuring durations.
+
+    Returns:
+        The current wall clock time in seconds.
+    """
+    return Float64(_realtime_nanoseconds()) / _NSEC_PER_SEC
+
+
+@always_inline
+def wall_clock_ns() -> UInt:
+    """Returns the current wall clock time in nanoseconds.
+
+    This returns the real (calendar) time, which may be affected by system
+    time adjustments (e.g., NTP synchronization). Use `perf_counter_ns()` or
+    `monotonic()` for measuring durations.
+
+    Returns:
+        The current wall clock time in nanoseconds.
+    """
+    return _realtime_nanoseconds()
+
+
+# ===-----------------------------------------------------------------------===#
 # sleep
 # ===-----------------------------------------------------------------------===#
 

--- a/mojo/stdlib/test/time/test_time.mojo
+++ b/mojo/stdlib/test/time/test_time.mojo
@@ -17,6 +17,8 @@ from std.time import (
     perf_counter_ns,
     sleep,
     time_function,
+    wall_clock,
+    wall_clock_ns,
 )
 
 from std.testing import assert_true, TestSuite
@@ -47,6 +49,27 @@ def time_capturing_function(iters: Int) -> Int:
         sleep(1.0)
 
     return Int(time_function(time_fn))
+
+
+def test_wall_clock() raises:
+    """Test that wall_clock returns plausible real-world timestamps."""
+    comptime ns_per_sec = 1_000_000_000
+
+    var t_ns = wall_clock_ns()
+    # Wall clock should return a positive value (since Unix epoch).
+    assert_true(t_ns > 0)
+    # Should be well past the year 2000 (~946 billion seconds since epoch).
+    assert_true(t_ns > 946_684_800 * ns_per_sec)
+
+    var t_sec = wall_clock()
+    assert_true(t_sec > 946_684_800)
+
+
+def test_wall_clock_ordering() raises:
+    """Test that two consecutive wall_clock calls are non-decreasing."""
+    var t1 = wall_clock_ns()
+    var t2 = wall_clock_ns()
+    assert_true(t2 >= t1)
 
 
 def test_time() raises:


### PR DESCRIPTION
## Linked issue
Fixes #6606

## Type of change
- [X] New feature or public API (requires prior issue or proposal approval)

## Motivation
The `time` module lacks a way to get real (calendar) time. A wall clock is essential for building `datetime` libraries.

## What changed
Added `wall_clock()` and `wall_clock_ns()` to the `time` module, backed by the existing `_realtime_nanoseconds()` helper that queries `CLOCK_REALTIME`.

## Testing
All tests pass, including new cases for wall clock plausibility and call ordering.

## Checklist
- [X] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [X] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [X] I ran `./bazelw run format` to format my changes
- [X] I added or updated tests to cover my changes
- [X] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
Assisted-by: AI
