### PR TITLE
[Stdlib] Fix `read()` Span overload to handle large reads via short read loop

### DIFF
--- a/mojo/stdlib/std/io/file.mojo
+++ b/mojo/stdlib/std/io/file.mojo
@@ -326,17 +326,24 @@ struct FileHandle(Defaultable, Movable, Writer):
             raise Error("invalid file handle")
 
         var fd = self._get_raw_fd()
-        var bytes_read = external_call["read", c_ssize_t](
-            fd,
-            buffer.unsafe_ptr(),
-            len(buffer) * size_of[dtype](),
-        )
+        var total_bytes = len(buffer) * size_of[dtype]()
+        var total_read = 0
 
-        if bytes_read < 0:
-            var err = get_errno()
-            raise Error("Failed to read from file: " + String(err))
+        while total_read < total_bytes:
+            var bytes_read = external_call["read", c_ssize_t](
+                fd,
+                buffer.unsafe_ptr().bitcast[UInt8]() + total_read,
+                total_bytes - total_read,
+            )
 
-        return bytes_read
+            if bytes_read < 0:
+                var err = get_errno()
+                raise Error("Failed to read from file: " + String(err))
+            if bytes_read == 0:
+                break  # EOF
+            total_read += bytes_read
+
+        return total_read
 
     def read_bytes(self, size: Int = -1) raises -> List[UInt8]:
         """Reads data from a file and sets the file handle seek position. If


### PR DESCRIPTION
## Linked issue
Fixes #1622

## Type of change
- [X] Bug fix

## What changed
The Span-based `read()` method on `FileHandle` called the `read()` syscall only once, hitting the Linux kernel limit of ~2GB per call. Changed to a while loop that accumulates partial reads until the buffer is filled or EOF is reached, matching the existing behavior of `read_bytes()` for `List[UInt8]`.

The `FileHandle.read_bytes()` method already has this loop; `FileDescriptor.read_bytes()` was left as-is since its one-shot semantics are correct for pipes and other non-regular-file use cases.

## Testing
All existing tests pass (`test_file`, `test_process`, `test_pathlib`).

Assisted-by: AI