### PR TITLE
[Lint] Fix lint_docstrings to skip get_changed_files when FAST=0

### DIFF
--- a/bazel/lint/lint_docstrings.py
+++ b/bazel/lint/lint_docstrings.py
@@ -313,11 +313,16 @@ def get_python_files() -> list[Path]:
     When FAST=0, every tracked Python file is always returned. Both paths
     exclude files matched by :func:`should_skip_file`.
     """
-    changed = get_changed_files()
-    if not is_fast() or _linter_changed(changed):
+    if not is_fast():
+        # FAST=0: Always return all files, no need to call get_changed_files()
         all_files = get_all_files()
     else:
-        all_files = changed
+        # FAST=1: Only check changed files, unless linter itself changed
+        changed = get_changed_files()
+        if _linter_changed(changed):
+            all_files = get_all_files()
+        else:
+            all_files = changed
     return [Path(f) for f in all_files if Path(f).suffix == ".py"]
 
 


### PR DESCRIPTION
Fixes #6656

## Problem

`lint_docstrings.py` calls `get_changed_files()` unconditionally, even when `FAST=0`. This requires `origin/main`, causing contributor PRs to fail in CI.

## Root Cause

The current logic:
```python
changed = get_changed_files()  # Always called, even when FAST=0
if not is_fast() or _linter_changed(changed):
    all_files = get_all_files()
```

When `FAST=0` (set by `//:lint-all`), we check all files anyway, so computing changed files is unnecessary.

## Solution

Only call `get_changed_files()` when `FAST=1`:
```python
if not is_fast():
    all_files = get_all_files()  # No need for origin/main
else:
    changed = get_changed_files()  # Only when needed
    ...
```

This restores the behavior where `//:lint-all` doesn't require `origin/main`, matching how it worked before commit 317eb29535.

## Alternative

PR #6657 fixes this by fetching `origin/main` in CI, but that requires downloading full git history. This fix is cleaner and more efficient.