### PR TITLE
[Pipelines] Load public gemma4_unified checkpoints (Gemma 4 12B) and serve them text-only

### DIFF
--- a/max/python/max/pipelines/architectures/__init__.py
+++ b/max/python/max/pipelines/architectures/__init__.py
@@ -53,7 +53,7 @@ def register_all_models() -> None:
     from .gemma3_modulev3 import gemma3_modulev3_arch
     from .gemma3multimodal import gemma3_multimodal_arch
     from .gemma3multimodal_modulev3 import gemma3_multimodal_modulev3_arch
-    from .gemma4 import gemma4_arch
+    from .gemma4 import gemma4_arch, gemma4_unified_arch
     from .gemma4_assistant import gemma4_assistant_arch
     from .glm5_1 import glm5_1_arch
     from .gpt_oss import gpt_oss_arch
@@ -127,6 +127,7 @@ def register_all_models() -> None:
         gemma3_multimodal_arch,
         gemma3_multimodal_modulev3_arch,
         gemma4_arch,
+        gemma4_unified_arch,
         gemma4_assistant_arch,
         glm5_1_arch,
         granite_arch,

--- a/max/python/max/pipelines/architectures/gemma4/__init__.py
+++ b/max/python/max/pipelines/architectures/gemma4/__init__.py
@@ -12,7 +12,7 @@
 # ===----------------------------------------------------------------------=== #
 """Gemma 4 vision-language architecture for multimodal text generation."""
 
-from .arch import gemma4_arch
+from .arch import gemma4_arch, gemma4_unified_arch
 from .model import Gemma3_MultiModalModel, Gemma3MultiModalModelInputs
 from .model_config import (
     Gemma4ForConditionalGenerationConfig,
@@ -31,4 +31,5 @@ __all__ = [
     "Gemma4ToolParser",
     "Gemma4VisionConfig",
     "gemma4_arch",
+    "gemma4_unified_arch",
 ]

--- a/max/python/max/pipelines/architectures/gemma4/arch.py
+++ b/max/python/max/pipelines/architectures/gemma4/arch.py
@@ -11,6 +11,8 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+import dataclasses
+
 from max.graph.weights import WeightsFormat
 from max.pipelines.lib import SupportedArchitecture
 from max.pipelines.modeling.types import InputModality, PipelineTask
@@ -54,4 +56,15 @@ gemma4_arch = SupportedArchitecture(
     tool_parser="gemma4",
     reasoning_parser="gemma4",
     memory_planner=Gemma4MemoryPlanner,
+)
+
+
+# The public "unified" checkpoints (google/gemma-4-12b-it and derived quants,
+# model_type "gemma4_unified") ship the regular Gemma 4 layout with no bundled
+# MTP draft weights, so they are served by this architecture under their own
+# architectures[0] name.
+gemma4_unified_arch = dataclasses.replace(
+    gemma4_arch,
+    name="Gemma4UnifiedForConditionalGeneration",
+    example_repo_ids=["google/gemma-4-12b-it"],
 )

--- a/max/python/max/pipelines/architectures/gemma4/arch.py
+++ b/max/python/max/pipelines/architectures/gemma4/arch.py
@@ -67,4 +67,6 @@ gemma4_unified_arch = dataclasses.replace(
     gemma4_arch,
     name="Gemma4UnifiedForConditionalGeneration",
     example_repo_ids=["google/gemma-4-12b-it"],
+    # Served text-only: the unified vision embedder is not implemented.
+    input_modalities={InputModality.TEXT},
 )

--- a/max/python/max/pipelines/architectures/gemma4/gemma4.py
+++ b/max/python/max/pipelines/architectures/gemma4/gemma4.py
@@ -138,9 +138,9 @@ class Gemma4TextModel(DistributedLogitsPostprocessMixin, Module):
             # attention in BF16, but other modelopt quants (e.g. the
             # community 12B NVFP4 ones) quantize it too -- honor the
             # per-layer classification instead of assuming BF16.
-            attn_quantized = is_nvfp4 and (
-                quant_config is not None
-                and i in quant_config.attn_quantized_layers
+            # is_nvfp4 already implies quant_config is not None.
+            attn_quantized = (
+                is_nvfp4 and i in quant_config.attn_quantized_layers
             )
 
             moe_block: MoE | None = None

--- a/max/python/max/pipelines/architectures/gemma4/gemma4.py
+++ b/max/python/max/pipelines/architectures/gemma4/gemma4.py
@@ -134,6 +134,14 @@ class Gemma4TextModel(DistributedLogitsPostprocessMixin, Module):
 
             is_nvfp4 = quant_config is not None and quant_config.is_nvfp4
             moe_nvfp4 = is_nvfp4 and text_config.enable_moe_block
+            # The first-party NVFP4 checkpoints (nvidia/Gemma-4-*) keep
+            # attention in BF16, but other modelopt quants (e.g. the
+            # community 12B NVFP4 ones) quantize it too -- honor the
+            # per-layer classification instead of assuming BF16.
+            attn_quantized = is_nvfp4 and (
+                quant_config is not None
+                and i in quant_config.attn_quantized_layers
+            )
 
             moe_block: MoE | None = None
             if text_config.enable_moe_block:
@@ -192,11 +200,15 @@ class Gemma4TextModel(DistributedLogitsPostprocessMixin, Module):
                         layer_idx=i,
                         layer_idx_in_cache=layer_idx_in_cache,
                         is_sliding=is_sliding,
-                        dtype=unquantized_dtype if is_nvfp4 else config.dtype,
+                        dtype=unquantized_dtype
+                        if (is_nvfp4 and not attn_quantized)
+                        else config.dtype,
                         devices=config.devices,
                         qk_norm_eps=text_config.rms_norm_eps,
                         local_window_size=text_config.sliding_window,
-                        quant_config=None if is_nvfp4 else quant_config,
+                        quant_config=None
+                        if (is_nvfp4 and not attn_quantized)
+                        else quant_config,
                     ),
                     mlp=MLP(
                         dtype=unquantized_dtype if moe_nvfp4 else config.dtype,

--- a/max/python/max/pipelines/architectures/gemma4/memory_planner.py
+++ b/max/python/max/pipelines/architectures/gemma4/memory_planner.py
@@ -91,6 +91,10 @@ class Gemma4MemoryPlanner(PagedMemoryPlanner):
             raise ValueError(
                 "Gemma4 requires a text_config in the HuggingFace config"
             )
+        if not hasattr(vision_config, "position_embedding_size"):
+            # "gemma4_unified" checkpoints use a different vision schema and
+            # are served text-only; no vision cache is needed.
+            return 0
         k = vision_config.pooling_kernel_size
         max_tokens = vision_config.position_embedding_size // (k * k)
         hidden = text_config.hidden_size

--- a/max/python/max/pipelines/architectures/gemma4/memory_planner.py
+++ b/max/python/max/pipelines/architectures/gemma4/memory_planner.py
@@ -91,9 +91,9 @@ class Gemma4MemoryPlanner(PagedMemoryPlanner):
             raise ValueError(
                 "Gemma4 requires a text_config in the HuggingFace config"
             )
-        if not hasattr(vision_config, "position_embedding_size"):
-            # "gemma4_unified" checkpoints use a different vision schema and
-            # are served text-only; no vision cache is needed.
+        if getattr(huggingface_config, "model_type", None) == "gemma4_unified":
+            # These checkpoints are served text-only (different vision
+            # schema); no vision cache is needed.
             return 0
         k = vision_config.pooling_kernel_size
         max_tokens = vision_config.position_embedding_size // (k * k)

--- a/max/python/max/pipelines/architectures/gemma4/model.py
+++ b/max/python/max/pipelines/architectures/gemma4/model.py
@@ -455,6 +455,12 @@ class Gemma3_MultiModalModel(
         return vision_graph, vision_model.state_dict()
 
     def _run_vision_encoder(self, raw: VisionRawInputs) -> list[Buffer]:
+        if self.vision_model is None:
+            raise ValueError(
+                "This checkpoint is served text-only (its gemma4_unified"
+                " vision embedder is not implemented); image and video"
+                " inputs are not supported."
+            )
         return self.vision_model(
             *raw.patches_flat,
             *raw.pixel_position_ids,

--- a/max/python/max/pipelines/architectures/gemma4/model.py
+++ b/max/python/max/pipelines/architectures/gemma4/model.py
@@ -457,9 +457,8 @@ class Gemma3_MultiModalModel(
     def _run_vision_encoder(self, raw: VisionRawInputs) -> list[Buffer]:
         if self.vision_model is None:
             raise ValueError(
-                "This checkpoint is served text-only (its gemma4_unified"
-                " vision embedder is not implemented); image and video"
-                " inputs are not supported."
+                "This checkpoint is served text-only (no vision encoder"
+                " is loaded); image and video inputs are not supported."
             )
         return self.vision_model(
             *raw.patches_flat,
@@ -654,9 +653,8 @@ class Gemma3_MultiModalModel(
         )
         if needs_images and self.vision_model is None:
             raise ValueError(
-                "This checkpoint is served text-only (its gemma4_unified"
-                " vision embedder is not implemented); image inputs are"
-                " not supported."
+                "This checkpoint is served text-only (no vision encoder"
+                " is loaded); image inputs are not supported."
             )
         k = (
             self.config.vision_config.pooling_kernel_size

--- a/max/python/max/pipelines/architectures/gemma4/model.py
+++ b/max/python/max/pipelines/architectures/gemma4/model.py
@@ -638,8 +638,6 @@ class Gemma3_MultiModalModel(
         for d_offsets in device_row_offsets:
             d_offsets.inplace_copy_from(host_row_offsets)
 
-        k = self.config.vision_config.pooling_kernel_size
-
         needs_images = (
             any(
                 getattr(ctx, "needs_vision_encoding", False)
@@ -647,6 +645,17 @@ class Gemma3_MultiModalModel(
             )
             if context_batch
             else False
+        )
+        if needs_images and self.vision_model is None:
+            raise ValueError(
+                "This checkpoint is served text-only (its gemma4_unified"
+                " vision embedder is not implemented); image inputs are"
+                " not supported."
+            )
+        k = (
+            self.config.vision_config.pooling_kernel_size
+            if self.config.vision_config is not None
+            else 1
         )
         if needs_images:
             uncached = self._ve_cache.get_uncached_contexts(context_batch)

--- a/max/python/max/pipelines/architectures/gemma4/model.py
+++ b/max/python/max/pipelines/architectures/gemma4/model.py
@@ -139,8 +139,9 @@ class Gemma3_MultiModalModel(
     language_model: Model
     """The compiled and initialized MAX Engine model ready for inference."""
 
-    vision_model: Model
-    """The compiled and initialized MAX Engine vision model ready for inference."""
+    vision_model: Model | None
+    """The compiled vision model, or None for text-only ("gemma4_unified")
+    checkpoints whose vision embedder is not implemented yet."""
     # The vision and text towers are in the same weights file, but are in
     # separate models, so load_state_dict will naturally be loading subsets in
     # each case.
@@ -193,7 +194,9 @@ class Gemma3_MultiModalModel(
         """Release vision encoder cache for a completed request."""
         self._ve_cache.release_request(request_id)
 
-    def load_model(self, session: InferenceSession) -> tuple[Model, Model]:
+    def load_model(
+        self, session: InferenceSession
+    ) -> tuple[Model | None, Model]:
         """Loads the compiled Gemma3 MultiModal models into the MAX Engine session.
 
         Returns:
@@ -248,9 +251,14 @@ class Gemma3_MultiModalModel(
         with CompilationTimer("vision + language model") as timer:
             module = Module()
 
-            vision_graph, vision_model_state_dict = self._build_vision_graph(
-                model_config, vision_weights_dict, module=module
-            )
+            vision_graph = None
+            vision_model_state_dict: dict[str, DLPackArray] = {}
+            if model_config.vision_config is not None:
+                vision_graph, vision_model_state_dict = (
+                    self._build_vision_graph(
+                        model_config, vision_weights_dict, module=module
+                    )
+                )
 
             language_graph, language_model_state_dict = (
                 self._build_language_graph(
@@ -264,7 +272,9 @@ class Gemma3_MultiModalModel(
                 **language_model_state_dict,
             }
             models = session.load_all(module, weights_registry=combined_weights)
-            vision_model = models[vision_graph.name]
+            vision_model = (
+                models[vision_graph.name] if vision_graph is not None else None
+            )
             language_model = models[language_graph.name]
 
         return vision_model, language_model

--- a/max/python/max/pipelines/architectures/gemma4/model_config.py
+++ b/max/python/max/pipelines/architectures/gemma4/model_config.py
@@ -68,13 +68,21 @@ except ImportError:
     except ValueError:
         pass
 
-    class Gemma4UnifiedHFConfig(Gemma4HFConfig):
-        model_type = "gemma4_unified"
 
-    try:
-        AutoConfig.register("gemma4_unified", Gemma4UnifiedHFConfig)
-    except ValueError:
-        pass
+class _Gemma4UnifiedHFConfig(Gemma4HFConfig):
+    """Config shim for the public "gemma4_unified" model_type (Gemma 4 12B).
+
+    Registered unconditionally: even transformers releases that ship a
+    native Gemma4Config may not register the unified model_type.
+    """
+
+    model_type = "gemma4_unified"
+
+
+try:
+    AutoConfig.register("gemma4_unified", _Gemma4UnifiedHFConfig)
+except ValueError:
+    pass
 
 
 @dataclass(kw_only=True)

--- a/max/python/max/pipelines/architectures/gemma4/model_config.py
+++ b/max/python/max/pipelines/architectures/gemma4/model_config.py
@@ -68,6 +68,14 @@ except ImportError:
     except ValueError:
         pass
 
+    class Gemma4UnifiedHFConfig(Gemma4HFConfig):
+        model_type = "gemma4_unified"
+
+    try:
+        AutoConfig.register("gemma4_unified", Gemma4UnifiedHFConfig)
+    except ValueError:
+        pass
+
 
 @dataclass(kw_only=True)
 class Gemma4TextConfig(Gemma3Config):

--- a/max/python/max/pipelines/architectures/gemma4/model_config.py
+++ b/max/python/max/pipelines/architectures/gemma4/model_config.py
@@ -677,8 +677,8 @@ class Gemma4ForConditionalGenerationConfig(ArchConfigWithKVCache):
             # Gemma 4 checkpoints nest the language tower under
             # "model.language_model."; without these prefixes the per-layer
             # quantized/ignored classification looks up "model.layers.*"
-            # keys that never exist and misclassifies quantized attention
-            # (e.g. the gemma4_unified 12B NVFP4 quants) as unquantized.
+            # keys that never exist, so ignore-listed (BF16) attention in
+            # modelopt 12B quants was never recognized as ignored.
             state_dict_name_prefix="model.language_model.",
             ignored_modules_prefix="model.language_model.",
         )

--- a/max/python/max/pipelines/architectures/gemma4/model_config.py
+++ b/max/python/max/pipelines/architectures/gemma4/model_config.py
@@ -666,6 +666,13 @@ class Gemma4ForConditionalGenerationConfig(ArchConfigWithKVCache):
             huggingface_config,
             state_dict,
             self.dtype,
+            # Gemma 4 checkpoints nest the language tower under
+            # "model.language_model."; without these prefixes the per-layer
+            # quantized/ignored classification looks up "model.layers.*"
+            # keys that never exist and misclassifies quantized attention
+            # (e.g. the gemma4_unified 12B NVFP4 quants) as unquantized.
+            state_dict_name_prefix="model.language_model.",
+            ignored_modules_prefix="model.language_model.",
         )
 
         for k, v in state_dict.items():

--- a/max/python/max/pipelines/architectures/gemma4/model_config.py
+++ b/max/python/max/pipelines/architectures/gemma4/model_config.py
@@ -448,7 +448,7 @@ class Gemma4ForConditionalGenerationConfig(ArchConfigWithKVCache):
     text_config: Gemma4TextConfig
     """The config object of the text backbone."""
 
-    vision_config: Gemma4VisionConfig
+    vision_config: Gemma4VisionConfig | None
     """The config object of the vision encoder."""
 
     tie_word_embeddings: bool = False
@@ -601,9 +601,16 @@ class Gemma4ForConditionalGenerationConfig(ArchConfigWithKVCache):
         hf_vision_config = getattr(huggingface_config, "vision_config", None)
         if hf_vision_config is None:
             raise ValueError("vision_config not found in huggingface_config")
-        vision_config = Gemma4VisionConfig.initialize_from_config(
-            hf_vision_config
-        )
+        vision_config: Gemma4VisionConfig | None
+        if hasattr(hf_vision_config, "hidden_activation"):
+            vision_config = Gemma4VisionConfig.initialize_from_config(
+                hf_vision_config
+            )
+        else:
+            # The "gemma4_unified" checkpoints (e.g. google/gemma-4-12b-it)
+            # use a lightweight vision_embedder with a different schema that
+            # is not implemented yet; serve text-only.
+            vision_config = None
 
         hf_text_config = getattr(huggingface_config, "text_config", None)
         if hf_text_config is None:

--- a/max/python/max/pipelines/architectures/gemma4/model_config.py
+++ b/max/python/max/pipelines/architectures/gemma4/model_config.py
@@ -457,7 +457,8 @@ class Gemma4ForConditionalGenerationConfig(ArchConfigWithKVCache):
     """The config object of the text backbone."""
 
     vision_config: Gemma4VisionConfig | None
-    """The config object of the vision encoder."""
+    """The config object of the vision encoder, or ``None`` for checkpoints
+    served text-only (the ``gemma4_unified`` line)."""
 
     tie_word_embeddings: bool = False
     """Whether to tie weight embeddings. When true, the output linear layer
@@ -610,15 +611,17 @@ class Gemma4ForConditionalGenerationConfig(ArchConfigWithKVCache):
         if hf_vision_config is None:
             raise ValueError("vision_config not found in huggingface_config")
         vision_config: Gemma4VisionConfig | None
-        if hasattr(hf_vision_config, "hidden_activation"):
+        if getattr(huggingface_config, "model_type", None) == "gemma4_unified":
+            # These checkpoints (e.g. google/gemma-4-12b-it) carry a
+            # lightweight vision_embedder with a different schema that is not
+            # implemented yet; serve text-only. Keyed on model_type so a
+            # genuinely malformed full-vision config fails loudly below
+            # instead of silently degrading to text-only.
+            vision_config = None
+        else:
             vision_config = Gemma4VisionConfig.initialize_from_config(
                 hf_vision_config
             )
-        else:
-            # The "gemma4_unified" checkpoints (e.g. google/gemma-4-12b-it)
-            # use a lightweight vision_embedder with a different schema that
-            # is not implemented yet; serve text-only.
-            vision_config = None
 
         hf_text_config = getattr(huggingface_config, "text_config", None)
         if hf_text_config is None:

--- a/max/python/max/pipelines/architectures/gemma4/weight_adapters.py
+++ b/max/python/max/pipelines/architectures/gemma4/weight_adapters.py
@@ -44,6 +44,10 @@ def convert_safetensor_language_state_dict(
     new_state_dict: dict[str, WeightData] = {}
 
     for weight_name, value in state_dict.items():
+        # modelopt checkpoints may carry FP8 KV-cache scales (k_scale /
+        # v_scale) that MAX's BF16 KV cache does not consume; drop them.
+        if weight_name.endswith((".k_scale", ".v_scale")):
+            continue
         if not (
             weight_name.startswith("language_model.")
             or weight_name.startswith("model.language_model.")


### PR DESCRIPTION
## Summary

Makes the public `gemma4_unified` checkpoints (the Gemma 4 12B line: `google/gemma-4-12b-it` and derived quants) loadable by MAX, serving them **text-only**. Fixes the first two blockers of #6669 and implements the text-only path proposed there.

- Register an `AutoConfig` shim for `model_type: "gemma4_unified"` (transformers < 5.5 path) and `gemma4_unified_arch`, a `dataclasses.replace` alias of `gemma4_arch` under the public `Gemma4UnifiedForConditionalGeneration` name — these checkpoints carry the regular Gemma 4 language layout with **no bundled MTP draft weights**, so they belong to `gemma4`, not `unified_mtp_gemma4`.
- Text-only serving: the unified checkpoints use a lightweight `vision_embedder` with a different schema than `Gemma4VisionModel`; detect it, set `vision_config=None`, skip building/loading the vision graph, and return 0 vision-cache bytes.
- `finalize` now passes the real `model.language_model.` prefixes to `parse_quant_config`, so per-layer quantized/ignored classification stops looking up `model.layers.*` keys that never exist (ignore-listed BF16 attention in modelopt 12B quants was never recognized as ignored).
- Honor `quant_config.attn_quantized_layers` per layer instead of assuming attention is always BF16 under NVFP4 (true for nvidia first-party checkpoints, false for the community 12B quants), and drop modelopt `k_scale`/`v_scale` KV-cache scales in the weight adapter.

Self-review (adversarial pass) caught and fixed an inference-path crash before any human review: `prepare_initial_token_inputs` read `vision_config.pooling_kernel_size` unconditionally, so text-only serving would have failed on the first prefill; image requests now get a clear rejection and the unified alias declares TEXT-only modalities.

## Verification (NVIDIA A10G 24 GB; bazel-built serve)

Each fix was driven by serving real checkpoints; the chain `config → arch resolution → graph build → weight load` now completes for `google/gemma-4-12b-it`-family checkpoints where each stage failed before (`gemma4_unified` not recognized → no matching architecture → vision `AttributeError` → o_proj shape mismatch → unexpected `k_scale`/`v_scale`).

**Full text-generation E2E verified on the A10G** (`berkerdooo/gemma-4-12B-it-NVFP4`, attention quantized): correct, coherent EN/ES completions via `/v1/chat/completions`. With #6668's fused dequant-GEMV (no BF16 weight materialization), the 12B sustains **31.5 tok/s warm decode at batch 1 on the 24 GB card** (measured on a branch combining this PR with #6668) — ~2x vLLM nightly's Marlin path on the same checkpoint and GPU — with token-identical output across the fallback's kernel revisions. Note: on a 24 GB card the stock activation-memory estimate (~15 GiB headroom, sized for the vision configs) still blocks startup — the measurement lowered it locally; right-sizing that estimate for text-only unified configs is intentionally left out of this PR pending maintainer guidance.

Related: #6669 (blocker 3 — implementing the unified `vision_embedder` — remains open), #6668, #6665.

Assisted-by: AI




