### PR TITLE
[Serve] Fix logprobs lost for multimodal-tokenizer architectures

### DIFF
--- a/max/python/max/pipelines/architectures/gemma4/tokenizer.py
+++ b/max/python/max/pipelines/architectures/gemma4/tokenizer.py
@@ -290,7 +290,7 @@ class Gemma4Tokenizer(TextAndVisionTokenizer):
         return templated_message
 
     async def decode(
-        self, encoded: npt.NDArray[np.integer[Any]], **kwargs
+        self, encoded: npt.NDArray[np.integer[Any]] | int, **kwargs
     ) -> str:
         """Decode tokens, preserving tool-related special tokens.
 
@@ -298,6 +298,10 @@ class Gemma4Tokenizer(TextAndVisionTokenizer):
         to selectively preserve them when skip_special_tokens=True by filtering
         unwanted special tokens before decoding.
         """
+        # Log-probability responses decode one token id (a plain int) at a
+        # time; match the text tokenizer's handling.
+        if isinstance(encoded, int):
+            encoded = np.array(encoded)
         skip_special_tokens = kwargs.get("skip_special_tokens", True)
 
         if not skip_special_tokens:
@@ -519,6 +523,8 @@ class Gemma4Tokenizer(TextAndVisionTokenizer):
             json_schema=json_schema,
             grammar=grammar,
             grammar_state=grammar_state,
+            log_probabilities=request.logprobs,
+            log_probabilities_echo=request.echo,
             sampling_params=request.sampling_params,
             images=image_metadata,
             vision_token_ids=self.vision_token_ids,

--- a/max/python/max/pipelines/architectures/idefics3/tokenizer.py
+++ b/max/python/max/pipelines/architectures/idefics3/tokenizer.py
@@ -96,9 +96,13 @@ class Idefics3Tokenizer(TextAndVisionTokenizer):
         self._default_eos_token_ids = set([self.eos])
 
     async def decode(
-        self, encoded: npt.NDArray[np.integer[Any]], **kwargs
+        self, encoded: npt.NDArray[np.integer[Any]] | int, **kwargs
     ) -> str:
         """Decode token array back into readable text, filtering out special tokens."""
+        # Log-probability responses decode one token id (a plain int) at a
+        # time; match the text tokenizer's handling.
+        if isinstance(encoded, int):
+            encoded = np.array(encoded)
         # Force skip_special_tokens=True to filter out tokens like <end_of_utterance>
         kwargs_with_special_filter = kwargs.copy()
         kwargs_with_special_filter["skip_special_tokens"] = True
@@ -295,6 +299,8 @@ class Idefics3Tokenizer(TextAndVisionTokenizer):
             if max_gen_tokens is not None
             else self.max_length,
             json_schema=json_schema,
+            log_probabilities=request.logprobs,
+            log_probabilities_echo=request.echo,
             sampling_params=request.sampling_params,
             target_endpoint=request.target_endpoint,
             images=[

--- a/max/python/max/pipelines/architectures/kimik2_5/tokenizer.py
+++ b/max/python/max/pipelines/architectures/kimik2_5/tokenizer.py
@@ -467,6 +467,8 @@ class KimiK2_5VLTokenizer(TextAndVisionTokenizer):
             json_schema=json_schema,
             grammar=grammar,
             grammar_state=grammar_state,
+            log_probabilities=request.logprobs,
+            log_probabilities_echo=request.echo,
             sampling_params=request.sampling_params,
             target_endpoint=request.target_endpoint,
             grid_thws=grid_thws,

--- a/max/python/max/pipelines/architectures/qwen2_5vl/tokenizer.py
+++ b/max/python/max/pipelines/architectures/qwen2_5vl/tokenizer.py
@@ -590,6 +590,8 @@ class Qwen2_5VLTokenizer(TextAndVisionTokenizer):
             tokens=TokenBuffer(input_ids),
             max_length=max_length,
             json_schema=json_schema,
+            log_probabilities=request.logprobs,
+            log_probabilities_echo=request.echo,
             sampling_params=request.sampling_params,
             target_endpoint=request.target_endpoint,
             images=images,

--- a/max/python/max/pipelines/architectures/qwen3vl_moe/tokenizer.py
+++ b/max/python/max/pipelines/architectures/qwen3vl_moe/tokenizer.py
@@ -747,6 +747,8 @@ class Qwen3VLTokenizer(TextAndVisionTokenizer):
             if max_gen_tokens is not None
             else self.max_length,
             json_schema=json_schema,
+            log_probabilities=request.logprobs,
+            log_probabilities_echo=request.echo,
             sampling_params=request.sampling_params,
             target_endpoint=request.target_endpoint,
             images=images,

--- a/max/python/max/pipelines/lib/tokenizer.py
+++ b/max/python/max/pipelines/lib/tokenizer.py
@@ -832,9 +832,13 @@ class TextAndVisionTokenizer(
         return encoded_prompt
 
     async def decode(
-        self, encoded: npt.NDArray[np.integer[Any]], **kwargs
+        self, encoded: npt.NDArray[np.integer[Any]] | int, **kwargs
     ) -> str:
         """Transforms a provided encoded token array back into readable text."""
+        # Log-probability responses decode one token id (a plain int) at a
+        # time; match the text tokenizer's handling.
+        if isinstance(encoded, int):
+            encoded = np.array(encoded)
         try:
             return self.delegate.decode(encoded.tolist(), **kwargs)
         except OverflowError as e:
@@ -981,6 +985,8 @@ class TextAndVisionTokenizer(
             max_length=encoded_prompt.shape[0] + max_gen_tokens
             if max_gen_tokens is not None
             else self.max_length,
+            log_probabilities=request.logprobs,
+            log_probabilities_echo=request.echo,
             json_schema=json_schema,
             grammar=grammar,
             grammar_state=grammar_state,

--- a/max/tests/integration/architectures/qwen3_5/test_tokenizer.py
+++ b/max/tests/integration/architectures/qwen3_5/test_tokenizer.py
@@ -162,3 +162,28 @@ def test_new_context_default_enables_thinking(
         "Default request behavior must be enable_thinking=True. "
         f"Decoded prompt: {prompt!r}"
     )
+
+
+def test_new_context_forwards_logprobs(tokenizer: Qwen3_5Tokenizer) -> None:
+    """``request.logprobs``/``request.echo`` reach the context.
+
+    Regression test: ``Qwen3VLTokenizer.new_context`` (and several sibling
+    multimodal tokenizers) dropped both fields, so
+    ``TextGenerationInputs.enable_log_probs`` stayed ``False`` and logprob
+    responses came back empty.
+    """
+    request = TextGenerationRequest(
+        request_id=RequestID("test-logprobs"),
+        model_name=tokenizer.model_path,
+        messages=[
+            TextGenerationRequestMessage(
+                role="user",
+                content=[TextContentPart(text="What is 2+2?")],
+            )
+        ],
+        logprobs=2,
+        echo=True,
+    )
+    context = asyncio.run(tokenizer.new_context(request))
+    assert context.log_probabilities == 2
+    assert context.log_probabilities_echo is True


### PR DESCRIPTION
## Summary

Fixes #6676. Three chained breaks left logprob responses empty (null/empty arrays) for any architecture whose tokenizer is vision-capable — Qwen3VL, Qwen3.5, and anything on `TextAndVisionTokenizer` — even for text-only requests:

1. `Qwen3VLTokenizer.new_context` did not forward `request.logprobs`/`request.echo` into the context, so `TextGenerationInputs.enable_log_probs` stayed `False` and the pipeline never computed log probabilities (traced live: router emits `logprobs=1`, scheduler sees `top=[0]`).
2. `TextAndVisionTokenizer.new_context` has the same omission.
3. Once logprobs flow, `TextAndVisionTokenizer.decode` crashes with `AttributeError: 'int' object has no attribute 'tolist'` — logprob assembly decodes one bare-int token id at a time, which the text tokenizer already guards.

A follow-up commit (from adversarial self-review) extends the same two fixes to the remaining multimodal tokenizers that drop the fields — **gemma4, idefics3, kimik2_5 and qwen2_5vl** (gemma4/idefics3 also lacked the bare-int decode guard) — and adds a regression test next to the existing `chat_template_options` field-drop test for the same function (`max/tests/integration/architectures/qwen3_5/test_tokenizer.py`).

## Verification

`Qwen/Qwen3.5-4B` on an A10G with `--no-enable-overlap-scheduler --force`: `/v1/completions` with `"logprobs": 1` now returns populated `token_logprobs`/`top_logprobs` (e.g. `[-0.209, -0.019]` for a one-word answer); previously the arrays came back null. Downstream use case (label-logprob gating for a classifier) produces a clean coverage/precision curve (100% precision at p≥0.95 on a 46-call validation set).

Known remaining gaps, intentionally out of scope: the `tokens` array in the completions logprobs payload is still null (assembly fills only `token_logprobs`/`top_logprobs`), and #6677 (non-overlap scheduler changes generation at temperature 0) affects anything measured in this mode.

Assisted-by: AI
