### PR TITLE
[bazel] Set modular_config scope for host_modular_config

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -236,6 +236,7 @@ platform(
 string_flag(
     name = "modular_config",
     build_setting_default = "default",
+    scope = "exec:--//:host_modular_config",
     values = MODULAR_CONFIGS,
 )
 


### PR DESCRIPTION
This sets `modular_config` to be inherited from `host_modular_config`
when in the exec configuration. This stuff is still changing upstream
but since this repo uses such a new bazel version this works.

Before this any places that `select()` on `modular_config` in the exec
transition would get the default value.

https://github.com/bazelbuild/bazel/issues/28320
