### PR TITLE
[docs] Revise release notes for v1.0.0b2: ImplicitlyDeletable

### DIFF
--- a/mojo/docs/releases/v1.0.0b2.md
+++ b/mojo/docs/releases/v1.0.0b2.md
@@ -8,7 +8,7 @@ date: 2026-06-18
 
 - **Collections no longer require `Copyable` elements.** The core collection
   types — `List`, `Deque`, `LinkedList`, `InlineArray`, `Dict`, and `Set` — now
-  accept move-only elements, with `Movable & ImplicitlyDestructible` as the new
+  accept move-only elements, with `Movable & ImplicitlyDeletable` as the new
   minimum bound instead of `Copyable`. This removes a longstanding source of
   friction where storing a value in a collection forced it, and its contents, to
   become copyable. Copy-requiring methods stay gated on `Copyable`. See
@@ -165,12 +165,12 @@ date: 2026-06-18
       pass
   ```
 
-- Types may now be conditionally "ImplicitlyDestructible" with a where clause:
+- Types may now be conditionally "ImplicitlyDeletable" with a where clause:
 
   ```mojo
   @explicit_destroy("Message when implicitly destroyed")
   struct ConditionallyLinearType[T: AnyType](
-      ImplicitlyDestructible where conforms_to(T, ImplicitlyDestructible)
+      ImplicitlyDeletable where conforms_to(T, ImplicitlyDeletable)
   ):
       var data: Self.T
   ```
@@ -263,13 +263,13 @@ date: 2026-06-18
   [`Equatable`](/docs/std/builtin/comparable/Equatable/),
   [`Indexer`](/docs/std/builtin/int/Indexer/), and
   [`Writer`](/docs/std/format/Writer/) traits no longer inherit from
-  [`ImplicitlyDestructible`](/docs/std/builtin/anytype/#implicitlydestructible).
+  [`ImplicitlyDeletable`](/docs/std/builtin/anytype/#implicitlydeletable).
   Generic code that relied on receiving the destructor bound transitively
   through these traits (or through
   [`Comparable`](/docs/std/builtin/comparable/Comparable/), which inherits from
   `Equatable`) must now spell it out explicitly, for example
-  `T: ImplicitlyCopyable & ImplicitlyDestructible` or
-  `T: Indexer & ImplicitlyDestructible`. In practice, most generic code should
+  `T: ImplicitlyCopyable & ImplicitlyDeletable` or
+  `T: Indexer & ImplicitlyDeletable`. In practice, most generic code should
   prefer `T: Copyable` instead, per the guidance in `ImplicitlyCopyable`'s
   docstring.
 
@@ -415,7 +415,7 @@ date: 2026-06-18
 
 - The core collection types no longer require their element type to be
   [`Copyable`](/docs/std/builtin/value/Copyable/) —
-  `Movable & ImplicitlyDestructible` is now the minimum bound. This applies to
+  `Movable & ImplicitlyDeletable` is now the minimum bound. This applies to
   [`List[T]`](/docs/std/collections/list/List/),
   [`Deque[T]`](/docs/std/collections/deque/Deque/),
   [`LinkedList[T]`](/docs/std/collections/linked_list/LinkedList/),
@@ -429,16 +429,16 @@ date: 2026-06-18
   `var T`; for move-only types call them as `d.setdefault(key^, default)` or
   `set.add(value^)`.
 
-- `List[T]` now conditionally conforms to `ImplicitlyDestructible`: a `List`
-  is implicitly destructible only when its element type `T` is. This lets a
+- `List[T]` now conditionally conforms to `ImplicitlyDeletable`: a `List`
+  is implicitlydeletable only when its element type `T` is. This lets a
   `List` hold elements that must be explicitly destroyed (dropping such a
   `List` would otherwise leak them), at the cost of a stricter check in
   generic code.
 
   Generic code that takes a `List` by value with only a `Movable` element
   bound now fails to compile for every `T`. Previously the error was deferred
-  and only fired when `T` was instantiated with a non-`ImplicitlyDestructible`
-  type. Add `& ImplicitlyDestructible` to the element bound:
+  and only fired when `T` was instantiated with a non-`ImplicitlyDeletable`
+  type. Add `& ImplicitlyDeletable` to the element bound:
 
   ```mojo
   # Now errors for every `T` (previously only when `T` lacked a destructor):
@@ -446,7 +446,7 @@ date: 2026-06-18
       pass
 
   # Fix: require the destructor bound explicitly.
-  def foo[T: Movable & ImplicitlyDestructible, //](var list: List[T]):
+  def foo[T: Movable & ImplicitlyDeletable, //](var list: List[T]):
       pass
   ```
 
@@ -456,14 +456,14 @@ date: 2026-06-18
   `destroy_with()`:
 
   ```mojo
-  # Option 1: require the element type to be implicitly destructible.
-  struct Foo[T: Movable & ImplicitlyDestructible]:
+  # Option 1: require the element type to be implicitly deletable.
+  struct Foo[T: Movable & ImplicitlyDeletable]:
       var list: List[Self.T]
 
   # Option 2: conditionally conform, and forward explicit destruction.
   @explicit_destroy("...")
   struct Foo[T: Movable](
-      ImplicitlyDestructible where conforms_to(T, ImplicitlyDestructible),
+      ImplicitlyDeletable where conforms_to(T, ImplicitlyDeletable),
   ):
       var list: List[Self.T]
 

--- a/mojo/docs/releases/v1.0.0b2.md
+++ b/mojo/docs/releases/v1.0.0b2.md
@@ -430,7 +430,7 @@ date: 2026-06-18
   `set.add(value^)`.
 
 - `List[T]` now conditionally conforms to `ImplicitlyDeletable`: a `List`
-  is implicitlydeletable only when its element type `T` is. This lets a
+  is implicitly deletable only when its element type `T` is. This lets a
   `List` hold elements that must be explicitly destroyed (dropping such a
   `List` would otherwise leak them), at the cost of a stricter check in
   generic code.


### PR DESCRIPTION
Updated documentation to reflect changed trait name, replacing 'ImplicitlyDestructible' with 'ImplicitlyDeletable'.

## Linked issue
N/A — trivial

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [x] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

