### PR TITLE
Fix/5614 grouped conv cpu lowering

### DIFF
--- a/max/kernels/src/graph_compiler/builtin_kernels/conv.mojo
+++ b/max/kernels/src/graph_compiler/builtin_kernels/conv.mojo
@@ -24,9 +24,16 @@ import extensibility as compiler
 
 from std.gpu.host import DeviceContext
 from std.gpu.host.info import is_cpu, is_gpu
-from layout import IntTuple
+from layout import IntTuple, Layout, LayoutTensor, RuntimeLayout, lt_to_tt
 from linalg.fp8_quantization import convert_e4m3fn_to_e4m3fnuz
-from nn.conv.conv import ConvInfoStatic, conv_gpu, conv_nhwc_direct, conv_shape
+from nn.conv.conv import (
+    ConvInfoStatic,
+    conv_gpu,
+    conv_nhwc_direct,
+    conv_shape,
+    pack_conv_filter_shape,
+    pack_filter,
+)
 from nn.conv.conv import pack_filter_shape as pack_filter_shape_conv
 from nn.conv.conv_transpose import (
     conv_transpose_shape,
@@ -411,6 +418,50 @@ struct Conv:
             comptime _input_layout = input.static_spec.to_layout()
             comptime _filter_layout = filter.static_spec.to_layout()
             comptime _output_layout = output.static_spec.to_layout()
+
+            # direct CPU conv kernel only supports grouped convolution with
+            # a *packed* (FRSCf) filter.
+            comptime if not filter_packed:
+                if Int(num_groups) > 1:
+                    var packed_shape = pack_conv_filter_shape(
+                        filter_tt, Int(num_groups)
+                    )
+                    var packed_buf = List(
+                        length=packed_shape.flattened_length(),
+                        fill=Scalar[filter.dtype](0),
+                    )
+                    comptime _packed_layout = Layout.row_major[filter.rank + 1]()
+                    var packed_lt = LayoutTensor[filter.dtype, _packed_layout](
+                        packed_buf,
+                        RuntimeLayout[_packed_layout].row_major(packed_shape),
+                    )
+                    var packed_tt = lt_to_tt(packed_lt)
+                    pack_filter(filter_tt, packed_tt, Int(num_groups))
+                    conv_nhwc_direct[
+                        _input_layout,
+                        _packed_layout,
+                        _output_layout,
+                        input.dtype,
+                        filter.dtype,
+                        output.dtype,
+                        True,
+                        conv_attr,
+                        has_epilogue_fusion,
+                        output_fn,
+                    ](
+                        input_tt,
+                        packed_tt,
+                        output_tt,
+                        stride_tuple,
+                        dilation_tuple,
+                        pad_d_tuple,
+                        pad_h_tuple,
+                        pad_w_tuple,
+                        Int(num_groups),
+                        Optional[DeviceContext](ctx),
+                    )
+                    return
+
             conv_nhwc_direct[
                 _input_layout,
                 _filter_layout,

--- a/max/tests/integration/graph/test_conv.py
+++ b/max/tests/integration/graph/test_conv.py
@@ -50,27 +50,48 @@ def torch_conv2d(  # noqa: ANN201
     return torch.permute(out, (0, 2, 3, 1))
 
 
-# TODO(KERN-1066): Fix and enable test
+# Grouped (groups > 1) cases are a regression test for #5614, where grouped
+# convolution failed to compile: the `mo.conv` lowering forwarded the unpacked
+# RSCF filter to a kernel that requires a packed (FRSCf) filter for grouped conv.
+# `modular_graph_test` calls `session.load(graph)`, so such a regression would
+# reappear as a compile failure here.
+# TODO(KERN-1066): Fix and enable test.
 @pytest.mark.skip(reason="Errors are larger than usual (10^-2)")
 @pytest.mark.parametrize(
-    "input_type, filter_type",
+    "input_type, filter_type, groups",
     [
         (
             TensorType(DType.float32, [1, 16, 16, 4], device=device_ref),
             TensorType(DType.float32, [16, 16, 4, 5], device=device_ref),
+            1,
+        ),
+        (
+            TensorType(DType.float32, [1, 8, 8, 4], device=device_ref),
+            TensorType(DType.float32, [3, 3, 2, 8], device=device_ref),
+            2,
         ),
     ],
 )
 def test_conv2d(
-    session: InferenceSession, input_type: TensorType, filter_type: TensorType
+    session: InferenceSession,
+    input_type: TensorType,
+    filter_type: TensorType,
+    groups: int,
 ) -> None:
+    stride = (16, 16)
+    padding = (0, 0)
+    dilation = (1, 1)
+
     with Graph("conv2d", input_types=[input_type, filter_type]) as graph:
         x, filter = graph.inputs
-        stride = (16, 16)
-        padding = (0, 0)
-        dilation = (1, 1)
-
-        conv = conv2d(x.tensor, filter.tensor, stride, dilation, (0, 0, 0, 0))
+        conv = conv2d(
+            x.tensor,
+            filter.tensor,
+            stride,
+            dilation,
+            (padding[0], padding[0], padding[1], padding[1]),
+            groups,
+        )
         graph.output(conv)
 
         @modular_graph_test(session, graph)
@@ -82,7 +103,7 @@ def test_conv2d(
             result = execute(inputs).to_numpy()
             x, w = torch_inputs
             expected = (
-                torch_conv2d(x, w, stride, dilation, padding)
+                torch_conv2d(x, w, stride, dilation, padding, groups)
                 .detach()
                 .cpu()
                 .numpy()


### PR DESCRIPTION
Assisted-by: Claude Opus 4.8

## Linked issue

Fixes #5614 (PR opened without pre-approval as seems trivial? happy to close and discuss if preferred)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

MAX models with grouped convs would fail to compile despite the kernels supporting grouped conv

repro:

```python
import os
from importlib.metadata import version

from max.driver import CPU
from max.dtype import DType
from max.engine import InferenceSession
from max.graph import DeviceRef, Graph, TensorType, ops

os.environ.setdefault("MODULAR_MAX_DEBUG", "True")
print(f"modular = {version('modular')},  max = {version('max')}, mojo = {version('mojo')}\n")

dev = DeviceRef.CPU()
x = TensorType(DType.float32, [1, 8, 8, 4], device=dev)        # NHWC
f = TensorType(DType.float32, [3, 3, 2, 4], device=dev)        # RSCF
with Graph("g", input_types=[x, f]) as g:
    xi, fi = g.inputs
    g.output(ops.conv2d(xi, fi, padding=(1, 1, 1, 1), groups=2))
InferenceSession(devices=[CPU()]).load(g)   # <-- raises "Failed to compile the model"
```

```sh
uv run --with modular==26.4.0 --prerelease allow repro_5614_tiny.py
```

## What changed
- pack the filter before passing to the conv kernel
- added a test case to the existing test, note that this test is currently skipped

## Testing

I have not built max against the contents of this PR, I don't think this is currently possible with what has been open sourced?

To prove the fix I wrote a small custom op that does exactly
what the grouped CPU lowering should do — `pack_conv_filter_shape` → `pack_filter`
(RSCF→FRSCf) → `ConvDirectNHWC[..., filter_packed=True].run(...)` — and called it
from the graph API. It compiles and matches a NumPy grouped-conv reference:

```
input NHWC = (1, 8, 8, 8), out_channels = 8, kernel = 3x3, groups = 4
[OK] grouped_conv2d custom op compiled + ran -> output shape (1, 8, 8, 8)
     max abs diff vs NumPy grouped-conv reference: 1.49e-07
     equivalent: True
```

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [ ] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))


tried to run ./bazelw run format but hit some git error, I think due to my branch naming convention differing from what's expected?
