### PR TITLE
[Feature Request] Native MAX Serving Support for parasail-ai/GritLM-7B-vllm (GRITLM Architecture)

### DIFF
--- a/max/python/max/pipelines/architectures/__init__.py
+++ b/max/python/max/pipelines/architectures/__init__.py
@@ -165,6 +165,7 @@ def register_all_models() -> None:
             ".granite_modulev3",
             "granite_modulev3_arch",
         ),
+        _LazyArch("GritLM", ".gritlm", "gritlm_arch"),
         _LazyArch("HYV3ForCausalLM", ".hy_v3", "hy_v3_arch"),
         _LazyArch(
             "Idefics3ForConditionalGeneration", ".idefics3", "idefics3_arch"

--- a/max/python/max/pipelines/architectures/all_arches.bzl
+++ b/max/python/max/pipelines/architectures/all_arches.bzl
@@ -33,6 +33,7 @@ ALL_ARCHITECTURES = [
     "//max/python/max/pipelines/architectures/gpt_oss_modulev3",
     "//max/python/max/pipelines/architectures/granite",
     "//max/python/max/pipelines/architectures/granite_modulev3",
+    "//max/python/max/pipelines/architectures/gritlm",
     "//max/python/max/pipelines/architectures/hy_v3",
     "//max/python/max/pipelines/architectures/idefics3",
     "//max/python/max/pipelines/architectures/idefics3_modulev3",

--- a/max/python/max/pipelines/architectures/gritlm/BUILD.bazel
+++ b/max/python/max/pipelines/architectures/gritlm/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//bazel:api.bzl", "modular_py_library", "requirement")
+
+package(default_visibility = ["//max:consumers"])
+
+modular_py_library(
+    name = "gritlm",
+    srcs = glob(["**/*.py"]),
+    ignore_extra_deps = [
+        # Hooks added for convenience for when we want to print the model layers
+        "//max/python/max/nn/hooks",
+    ],
+    deps = [
+        requirement("numpy"),
+        requirement("transformers"),
+        requirement("typing-extensions"),
+        "//max/python/max/driver",
+        "//max/python/max/dtype",
+        "//max/python/max/engine",
+        "//max/python/max/experimental/nn",
+        "//max/python/max/graph",
+        "//max/python/max/nn",
+        # Hooks added for convenience for when we want to print the model layers
+        "//max/python/max/nn/hooks",
+        "//max/python/max/pipelines/context",
+        "//max/python/max/pipelines/kv_cache",
+        "//max/python/max/pipelines/lib",
+        "//max/python/max/pipelines/modeling",
+        "//max/python/max:tensor",
+    ],
+)

--- a/max/python/max/pipelines/architectures/gritlm/BUILD.bazel
+++ b/max/python/max/pipelines/architectures/gritlm/BUILD.bazel
@@ -21,8 +21,8 @@ modular_py_library(
         "//max/python/max/nn",
         # Hooks added for convenience for when we want to print the model layers
         "//max/python/max/nn/hooks",
+        "//max/python/max/pipelines/architectures/llama3_modulev3",
         "//max/python/max/pipelines/context",
-        "//max/python/max/pipelines/kv_cache",
         "//max/python/max/pipelines/lib",
         "//max/python/max/pipelines/modeling",
         "//max/python/max:tensor",

--- a/max/python/max/pipelines/architectures/gritlm/__init__.py
+++ b/max/python/max/pipelines/architectures/gritlm/__init__.py
@@ -17,7 +17,6 @@ from .model import GritLMInputs, GritLMModel
 from .model_config import GritLMConfig
 
 __all__ = [
-    "ARCHITECTURES",
     "GritLMConfig",
     "GritLMInputs",
     "GritLMModel",

--- a/max/python/max/pipelines/architectures/gritlm/__init__.py
+++ b/max/python/max/pipelines/architectures/gritlm/__init__.py
@@ -1,0 +1,26 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+
+from .arch import gritlm_arch
+from .model import GritLMInputs, GritLMModel
+from .model_config import GritLMConfig
+
+
+__all__ = [
+    "ARCHITECTURES",
+    "GritLMConfig",
+    "GritLMInputs",
+    "GritLMModel",
+    "gritlm_arch",
+]

--- a/max/python/max/pipelines/architectures/gritlm/__init__.py
+++ b/max/python/max/pipelines/architectures/gritlm/__init__.py
@@ -16,7 +16,6 @@ from .arch import gritlm_arch
 from .model import GritLMInputs, GritLMModel
 from .model_config import GritLMConfig
 
-
 __all__ = [
     "ARCHITECTURES",
     "GritLMConfig",

--- a/max/python/max/pipelines/architectures/gritlm/arch.py
+++ b/max/python/max/pipelines/architectures/gritlm/arch.py
@@ -1,0 +1,46 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# GritLM architecture registration for MAX pipeline.
+# ===----------------------------------------------------------------------=== #
+"""GritLM architecture descriptor."""
+
+from max.graph.weights import WeightsFormat
+from max.pipelines.context import TextContext
+from max.pipelines.lib import SupportedArchitecture, TextTokenizer
+from max.pipelines.modeling.types import PipelineTask
+
+from . import weight_adapters
+from .model import GritLMModel
+from .model_config import GritLMConfig
+
+gritlm_arch = SupportedArchitecture(
+    # Must match the 'architectures' field in GritLM's config.json
+    name="GritLM",
+    example_repo_ids=["parasail-ai/GritLM-7B-vllm"],
+    default_encoding="bfloat16",
+    supported_encodings={"float32", "bfloat16"},
+    pipeline_model=GritLMModel,
+    tokenizer=TextTokenizer,
+    context_type=TextContext,
+    # GritLM uses standard Mistral RoPE (non-interleaved safetensors)
+    rope_type="normal",
+    default_weights_format=WeightsFormat.safetensors,
+    multi_gpu_supported=False,
+    weight_adapters={
+        WeightsFormat.safetensors: weight_adapters.convert_safetensor_state_dict,
+    },
+    task=PipelineTask.TEXT_GENERATION,
+    config=GritLMConfig,
+)

--- a/max/python/max/pipelines/architectures/gritlm/arch.py
+++ b/max/python/max/pipelines/architectures/gritlm/arch.py
@@ -43,4 +43,6 @@ gritlm_arch = SupportedArchitecture(
     },
     task=PipelineTask.TEXT_GENERATION,
     config=GritLMConfig,
+    supports_overlap_scheduler=False,
+    supports_device_graph_capture=False,
 )

--- a/max/python/max/pipelines/architectures/gritlm/gritlm.py
+++ b/max/python/max/pipelines/architectures/gritlm/gritlm.py
@@ -219,7 +219,7 @@ class GritLMTextModel(
         return ret_val
 
 
-class GritLM(Module[..., tuple[Tensor, ...]]):
+class GritLM(Module[..., tuple[Tensor | TensorValue, ...]]):
     """Top-level GritLM model."""
 
     def __init__(
@@ -235,7 +235,7 @@ class GritLM(Module[..., tuple[Tensor, ...]]):
         return_n_logits: Tensor,
         input_row_offsets: Tensor,
         *variadic_args: Tensor,
-    ) -> tuple[Tensor, ...]:
+    ) -> tuple[Tensor | TensorValue, ...]:
         """Unpack KV cache tensors and delegate to ``GritLMTextModel``.
 
         Args:

--- a/max/python/max/pipelines/architectures/gritlm/gritlm.py
+++ b/max/python/max/pipelines/architectures/gritlm/gritlm.py
@@ -34,7 +34,11 @@ from max.experimental.nn.norm import RMSNorm
 from max.experimental.nn.sequential import ModuleList
 from max.experimental.tensor import Tensor
 from max.graph import TensorValue, ops
-from max.nn.kv_cache import KVCacheInputs, KVCacheParamInterface, PagedCacheValues
+from max.nn.kv_cache import (
+    KVCacheInputs,
+    KVCacheParamInterface,
+    PagedCacheValues,
+)
 from max.nn.transformer import ReturnHiddenStates, ReturnLogits
 from max.pipelines.architectures.llama3_modulev3.layers.rotary_embedding import (
     Llama3RotaryEmbedding,
@@ -46,7 +50,10 @@ from .model_config import GritLMConfig
 
 
 class GritLMTextModel(
-    Module[[Tensor, PagedCacheValues, Tensor, Tensor], tuple[Tensor | TensorValue, ...]]
+    Module[
+        [Tensor, PagedCacheValues, Tensor, Tensor],
+        tuple[Tensor | TensorValue, ...],
+    ]
 ):
     """GritLM decoder-only transformer (CausalLM path).
 

--- a/max/python/max/pipelines/architectures/gritlm/gritlm.py
+++ b/max/python/max/pipelines/architectures/gritlm/gritlm.py
@@ -34,7 +34,7 @@ from max.experimental.nn.norm import RMSNorm
 from max.experimental.nn.sequential import ModuleList
 from max.experimental.tensor import Tensor
 from max.graph import TensorValue, ops
-from max.nn.kv_cache import KVCacheParamInterface, PagedCacheValues
+from max.nn.kv_cache import KVCacheInputs, KVCacheParamInterface, PagedCacheValues
 from max.nn.transformer import ReturnHiddenStates, ReturnLogits
 from max.pipelines.architectures.llama3_modulev3.layers.rotary_embedding import (
     Llama3RotaryEmbedding,
@@ -140,7 +140,7 @@ class GritLMTextModel(
         kv_collection: PagedCacheValues,
         return_n_logits: Tensor,
         input_row_offsets: Tensor,
-    ) -> tuple[Tensor, ...]:
+    ) -> tuple[Tensor | TensorValue, ...]:
         """Run the full GritLM decoder stack and return logits/hidden states.
 
         Args:
@@ -172,8 +172,8 @@ class GritLMTextModel(
 
         last_h = F.gather(h, input_row_offsets[1:] - 1, axis=0)
         last_logits = self._compute_logits(self.norm(last_h))
-        logits = None
-        offsets = None
+        logits: Tensor | None = None
+        offsets: Tensor | TensorValue | None = None
 
         if self.return_logits == ReturnLogits.VARIABLE:
             return_n_logits_range = ops.range(
@@ -208,7 +208,7 @@ class GritLMTextModel(
             if logits is not None:
                 logits = logits / self.logits_scaling
 
-        ret_val: tuple[Tensor, ...] = (last_logits,)
+        ret_val: tuple[Tensor | TensorValue, ...] = (last_logits,)
         if offsets is not None:
             assert logits is not None
             ret_val += (logits, offsets)
@@ -250,9 +250,11 @@ class GritLM(Module[..., tuple[Tensor, ...]]):
         """
 
         kv_inputs = iter(x._graph_value for x in variadic_args)
-        kv_collections = (
-            self.kv_params.get_symbolic_inputs().unflatten(kv_inputs).inputs
+        unflattened = self.kv_params.get_symbolic_inputs().unflatten(kv_inputs)
+        assert isinstance(unflattened, KVCacheInputs), (
+            f"Expected KVCacheInputs, got {type(unflattened)}"
         )
+        kv_collections = unflattened.inputs
         return self.language_model(
             tokens, kv_collections[0], return_n_logits, input_row_offsets
         )

--- a/max/python/max/pipelines/architectures/gritlm/gritlm.py
+++ b/max/python/max/pipelines/architectures/gritlm/gritlm.py
@@ -1,0 +1,258 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# ===----------------------------------------------------------------------=== #
+# GritLM ModuleV3 graph implementation.
+#
+# CausalLM path only (no pooling head — embedding mode not supported in MAX).
+# All 32 layers use sliding window attention (window=4096).
+# ===----------------------------------------------------------------------=== #
+"""Implements the GritLM causal LM model using the ModuleV3 API."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+
+from max.dtype import DType
+from max.experimental import functional as F
+from max.experimental.nn import Module
+from max.experimental.nn.common_layers.mlp import MLP
+from max.experimental.nn.embedding import Embedding
+from max.experimental.nn.linear import Linear
+from max.experimental.nn.norm import RMSNorm
+from max.experimental.nn.sequential import ModuleList
+from max.experimental.tensor import Tensor
+from max.graph import TensorValue, ops
+from max.nn.kv_cache import KVCacheParamInterface, PagedCacheValues
+from max.nn.transformer import ReturnHiddenStates, ReturnLogits
+from max.pipelines.architectures.llama3_modulev3.layers.rotary_embedding import (
+    Llama3RotaryEmbedding,
+)
+
+from .layers.attention import GritLMAttention
+from .layers.transformer_block import GritLMTransformerBlock
+from .model_config import GritLMConfig
+
+
+class GritLMTextModel(
+    Module[[Tensor, PagedCacheValues, Tensor, Tensor], tuple[Tensor, ...]]
+):
+    """GritLM decoder-only transformer (CausalLM path).
+
+    32 layers, GQA (32 Q / 8 KV heads), SwiGLU, RMSNorm.
+    Sliding window attention (window=4096) on every layer.
+    Separate lm_head (tie_word_embeddings=false).
+    """
+
+    def __init__(self, config: GritLMConfig) -> None:
+        super().__init__()
+
+        if config.rms_norm_eps is None:
+            raise ValueError("rms_norm_eps cannot be None for GritLM.")
+
+        create_norm: Callable[..., Module[[Tensor], Tensor]] = (
+            functools.partial(
+                RMSNorm, config.hidden_size, eps=config.rms_norm_eps
+            )
+        )
+
+        # GritLM uses standard Mistral RoPE: theta=10000, no scaling.
+        rope = Llama3RotaryEmbedding(
+            dim=config.hidden_size,
+            n_heads=config.num_attention_heads,
+            theta=config.rope_theta,
+            max_seq_len=config.max_seq_len,
+            device=config.devices[0].to_device(),
+            head_dim=GritLMConfig.get_head_dim_from_config(config),
+            interleaved=config.interleaved_rope_weights,
+            scaling_params=None,
+        )
+
+        self.embed_tokens = Embedding(config.vocab_size, dim=config.hidden_size)
+        self.norm = create_norm()
+
+        # GritLM: tie_word_embeddings=false — always has a separate lm_head
+        self.lm_head = Linear(
+            in_dim=config.hidden_size,
+            out_dim=config.vocab_size,
+            bias=False,
+        )
+
+        layers = []
+        for i in range(config.num_hidden_layers):
+            attention = GritLMAttention(
+                rope=rope,
+                num_attention_heads=config.num_attention_heads,
+                num_key_value_heads=config.num_key_value_heads,
+                hidden_size=config.hidden_size,
+                kv_params=config.kv_params,
+                layer_idx=i,
+                sliding_window=config.sliding_window,
+                scale=config.attention_multiplier,
+                has_bias=config.attention_bias,
+                clip_qkv=config.clip_qkv,
+            )
+            mlp = MLP(
+                hidden_dim=config.hidden_size,
+                feed_forward_length=config.intermediate_size,
+            )
+            layers.append(
+                GritLMTransformerBlock(
+                    attention=attention,
+                    mlp=mlp,
+                    input_layernorm=create_norm(),
+                    post_attention_layernorm=create_norm(),
+                )
+            )
+
+        self.layers = ModuleList(layers)
+        self.kv_params = config.kv_params
+        self.return_logits = config.return_logits
+        self.return_hidden_states = config.return_hidden_states
+        self.logits_scaling = config.logits_scaling
+
+    def _compute_logits(self, h: Tensor) -> Tensor:
+        """Project hidden states to vocabulary logits cast to float32.
+
+        Args:
+            h: Hidden-state tensor of shape ``(seq_len, hidden_size)``.
+
+        Returns:
+            Float32 logit tensor of shape ``(seq_len, vocab_size)``.
+        """
+
+        return F.cast(self.lm_head(h), DType.float32)
+
+    def forward(
+        self,
+        tokens: Tensor,
+        kv_collection: PagedCacheValues,
+        return_n_logits: Tensor,
+        input_row_offsets: Tensor,
+    ) -> tuple[Tensor, ...]:
+        """Run the full GritLM decoder stack and return logits/hidden states.
+
+        Args:
+            tokens: Flat token IDs, shape ``(total_seq_len,)``.
+            kv_collection: Paged KV cache for all layers.
+            return_n_logits: Controls variable-logit return mode.
+            input_row_offsets: Ragged-batch row delimiters,
+                shape ``(batch_size + 1,)``.
+
+        Returns:
+            Tuple whose layout depends on ``return_logits`` /
+            ``return_hidden_states``:
+                ``(last_logits,)``
+                ``(last_logits, logits, offsets)``
+                ``(last_logits, hidden_states)``
+                ``(last_logits, logits, offsets, hidden_states)``
+        """
+
+        h = self.embed_tokens(tokens)
+
+        for idx, layer in enumerate(self.layers):
+            layer_idx_t = F.constant(idx, DType.uint32, device=h.device)
+            h = layer(
+                layer_idx_t,
+                h,
+                kv_collection,
+                input_row_offsets=input_row_offsets,
+            )
+
+        last_h = F.gather(h, input_row_offsets[1:] - 1, axis=0)
+        last_logits = self._compute_logits(self.norm(last_h))
+        logits = None
+        offsets = None
+
+        if self.return_logits == ReturnLogits.VARIABLE:
+            return_n_logits_range = ops.range(
+                return_n_logits[0],
+                0,
+                -1,
+                out_dim="return_n_logits_range",
+                device=h.device,
+                dtype=DType.int64,
+            )
+            offset_tensor = (
+                F.unsqueeze(input_row_offsets[1:], -1) - return_n_logits_range
+            )
+            last_indices = F.reshape(offset_tensor, shape=(-1,))
+            logits = self._compute_logits(
+                self.norm(F.gather(h, last_indices, axis=0))
+            )
+            offsets = ops.range(
+                0,
+                TensorValue(last_indices.shape[0]) + return_n_logits[0],
+                return_n_logits[0],
+                out_dim="logit_offsets",
+                device=h.device,
+                dtype=DType.int64,
+            )
+        elif self.return_logits == ReturnLogits.ALL:
+            logits = self._compute_logits(self.norm(h))
+            offsets = input_row_offsets
+
+        if self.logits_scaling != 1.0:
+            last_logits = last_logits / self.logits_scaling
+            if logits is not None:
+                logits = logits / self.logits_scaling
+
+        ret_val: tuple[Tensor, ...] = (last_logits,)
+        if offsets is not None:
+            assert logits is not None
+            ret_val += (logits, offsets)
+        if self.return_hidden_states == ReturnHiddenStates.LAST:
+            ret_val += (last_h,)
+        elif self.return_hidden_states == ReturnHiddenStates.ALL_NORMALIZED:
+            ret_val += (self.norm(h),)
+        return ret_val
+
+
+class GritLM(Module[..., tuple[Tensor, ...]]):
+    """Top-level GritLM model."""
+
+    def __init__(
+        self, config: GritLMConfig, kv_params: KVCacheParamInterface
+    ) -> None:
+        super().__init__()
+        self.language_model = GritLMTextModel(config)
+        self.kv_params = kv_params
+
+    def forward(
+        self,
+        tokens: Tensor,
+        return_n_logits: Tensor,
+        input_row_offsets: Tensor,
+        *variadic_args: Tensor,
+    ) -> tuple[Tensor, ...]:
+        """Unpack KV cache tensors and delegate to ``GritLMTextModel``.
+
+        Args:
+            tokens: Flat int64 token IDs.
+            return_n_logits: Single-element int64 logit-count control tensor.
+            input_row_offsets: uint32 ragged-batch row delimiters.
+            *variadic_args: Flattened paged KV cache tensors (all layers,
+                all devices) produced by ``KVCacheParamInterface.get_symbolic_inputs``.
+
+        Returns:
+            Output tuple forwarded from ``GritLMTextModel.forward``.
+        """
+
+        kv_inputs = iter(x._graph_value for x in variadic_args)
+        kv_collections = (
+            self.kv_params.get_symbolic_inputs().unflatten(kv_inputs).inputs
+        )
+        return self.language_model(
+            tokens, kv_collections[0], return_n_logits, input_row_offsets
+        )

--- a/max/python/max/pipelines/architectures/gritlm/gritlm.py
+++ b/max/python/max/pipelines/architectures/gritlm/gritlm.py
@@ -46,7 +46,7 @@ from .model_config import GritLMConfig
 
 
 class GritLMTextModel(
-    Module[[Tensor, PagedCacheValues, Tensor, Tensor], tuple[Tensor, ...]]
+    Module[[Tensor, PagedCacheValues, Tensor, Tensor], tuple[Tensor | TensorValue, ...]]
 ):
     """GritLM decoder-only transformer (CausalLM path).
 

--- a/max/python/max/pipelines/architectures/gritlm/layers/__init__.py
+++ b/max/python/max/pipelines/architectures/gritlm/layers/__init__.py
@@ -1,0 +1,19 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""GritLM custom layers."""
+
+from .attention import GritLMAttention
+from .transformer_block import GritLMTransformerBlock
+
+__all__ = ["GritLMAttention", "GritLMTransformerBlock"]

--- a/max/python/max/pipelines/architectures/gritlm/layers/attention.py
+++ b/max/python/max/pipelines/architectures/gritlm/layers/attention.py
@@ -1,0 +1,194 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+
+"""GritLM attention: GQA + sliding window on every layer."""
+
+from __future__ import annotations
+
+import math
+
+from max.driver import CPU
+from max.dtype import DType
+from max.experimental import functional as F
+from max.experimental.nn import Module
+from max.experimental.nn.common_layers.functional_kernels import (
+    flash_attention_ragged,
+    rope_split_store_ragged,
+)
+from max.experimental.nn.linear import Linear
+from max.experimental.tensor import Tensor
+from max.nn.attention import MHAMaskVariant
+from max.nn.kv_cache import KVCacheParams, PagedCacheValues
+from max.pipelines.architectures.llama3_modulev3.layers.rotary_embedding import (
+    Llama3RotaryEmbedding,
+)
+
+
+class GritLMAttention(Module[..., Tensor]):
+    """GQA attention with sliding window causal mask.
+
+    GritLM applies SWA with window=4096 on every one of its 32 layers.
+    flash_attention_ragged is called with SLIDING_WINDOW_CAUSAL_MASK and
+    local_window_size=sliding_window.
+    """
+
+    def __init__(
+        self,
+        *,
+        rope: Llama3RotaryEmbedding,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        hidden_size: int,
+        kv_params: KVCacheParams,
+        layer_idx: int,
+        sliding_window: int | None = 4096,
+        scale: float | None = None,
+        has_bias: bool = False,
+        clip_qkv: float | None = None,
+    ) -> None:
+        """Initialize GritLM grouped-query attention with sliding window.
+
+        Args:
+            rope: Pre-built ``Llama3RotaryEmbedding`` shared across all layers.
+            num_attention_heads: Total number of query heads (32 for GritLM-7B).
+            num_key_value_heads: Number of KV heads for GQA (8 for GritLM-7B).
+            hidden_size: Model hidden dimension (4096 for GritLM-7B).
+            kv_params: KV cache parameters (page size, head dim, etc.).
+            layer_idx: Zero-based layer index used for cache slot addressing.
+            sliding_window: Local attention window size (default 4096, applied
+                on every layer in GritLM).
+            scale: QK dot-product scale; defaults to ``1/sqrt(head_dim)``.
+            has_bias: Whether Q/K/V projection layers include a bias term.
+            clip_qkv: If set, clips Q/K/V weights to ``[-clip_qkv, clip_qkv]``
+                before the projection.
+        """
+
+        super().__init__()
+        self.rope = rope
+        self.n_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.hidden_size = hidden_size
+        self.kv_params = kv_params
+        self.layer_idx = layer_idx
+        self.sliding_window = sliding_window
+        self.has_bias = has_bias
+        self.clip_qkv = clip_qkv
+        self.scale = (
+            scale
+            if scale is not None
+            else math.sqrt(1.0 / self.kv_params.head_dim)
+        )
+
+        q_dim = self.kv_params.head_dim * num_attention_heads
+        kv_dim = self.kv_params.head_dim * num_key_value_heads
+        self.q_weight_dim = q_dim
+
+        self.q_proj = Linear(in_dim=hidden_size, out_dim=q_dim, bias=has_bias)
+        self.k_proj = Linear(in_dim=hidden_size, out_dim=kv_dim, bias=has_bias)
+        self.v_proj = Linear(in_dim=hidden_size, out_dim=kv_dim, bias=has_bias)
+        self.o_proj = Linear(in_dim=q_dim, out_dim=hidden_size, bias=False)
+
+    @property
+    def wqkv(self) -> Tensor:
+        wq: Tensor = self.q_proj.weight
+        wk: Tensor = self.k_proj.weight
+        wv: Tensor = self.v_proj.weight
+        if self.clip_qkv:
+            wq = F.clip(wq, -self.clip_qkv, self.clip_qkv)
+            wk = F.clip(wk, -self.clip_qkv, self.clip_qkv)
+            wv = F.clip(wv, -self.clip_qkv, self.clip_qkv)
+        return F.concat([wq, wk, wv], axis=0)
+
+    @property
+    def wqkv_bias(self) -> Tensor | None:
+        if not self.has_bias:
+            return None
+        assert self.q_proj.bias is not None
+        assert self.k_proj.bias is not None
+        assert self.v_proj.bias is not None
+        return F.concat(
+            [self.q_proj.bias, self.k_proj.bias, self.v_proj.bias], axis=0
+        )
+
+    def forward(
+        self,
+        x: Tensor,
+        kv_collection: PagedCacheValues,
+        **kwargs,
+    ) -> Tensor:
+        """Compute sliding-window GQA attention for a ragged batch.
+
+        Steps:
+            1. Fused QKV projection via ``wqkv``.
+            2. RoPE + KV store with ``rope_split_store_ragged``.
+            3. Flash attention with ``SLIDING_WINDOW_CAUSAL_MASK``.
+            4. Output projection via ``o_proj``.
+
+        Args:
+            x: Input hidden states, shape ``(total_seq_len, hidden_size)``.
+            kv_collection: Paged KV cache for the current layer.
+            **kwargs: Must contain ``input_row_offsets`` — uint32 tensor of
+                ragged-batch row delimiters.
+
+        Returns:
+            Attended output, shape ``(total_seq_len, hidden_size)``.
+        """
+
+        total_seq_len = x.shape[0]
+        layer_idx = F.constant(self.layer_idx, DType.uint32, device=CPU())
+
+        qkv = x @ self.wqkv.T
+        if self.wqkv_bias is not None:
+            qkv = qkv + self.wqkv_bias
+
+        freqs_cis = F.cast(self.rope.freqs_cis, qkv.dtype).to(qkv.device)
+
+        # Apply RoPE + split QKV + store K/V into paged cache
+        xq = rope_split_store_ragged(
+            kv_params=self.kv_params,
+            qkv=qkv,
+            input_row_offsets=kwargs["input_row_offsets"],
+            freqs_cis=freqs_cis,
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            n_heads=self.n_heads,
+            interleaved=self.rope.interleaved,
+        )
+        xq = xq.reshape((-1, self.n_heads, self.kv_params.head_dim))
+
+        if self.sliding_window is not None:
+            # Sliding window causal attention — all GritLM layers use SWA
+            attn_out = flash_attention_ragged(
+                self.kv_params,
+                input=xq,
+                kv_collection=kv_collection,
+                layer_idx=layer_idx,
+                input_row_offsets=kwargs["input_row_offsets"],
+                mask_variant=MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK,
+                scale=self.scale,
+                local_window_size=self.sliding_window,
+            )
+        else:
+            # Fallback to standard casual attention if sliding window is not set with same architecture as GritLM
+            attn_out = flash_attention_ragged(
+                self.kv_params,
+                input=xq,
+                kv_collection=kv_collection,
+                layer_idx=layer_idx,
+                input_row_offsets=kwargs["input_row_offsets"],
+                mask_variant=MHAMaskVariant.CAUSAL_MASK,
+                scale=self.scale,
+            )
+        attn_out = F.reshape(attn_out, shape=[total_seq_len, self.q_weight_dim])
+        return self.o_proj(attn_out)

--- a/max/python/max/pipelines/architectures/gritlm/layers/transformer_block.py
+++ b/max/python/max/pipelines/architectures/gritlm/layers/transformer_block.py
@@ -1,0 +1,78 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""GritLM transformer block — standard pre-norm decoder block."""
+
+from __future__ import annotations
+
+from max.experimental.nn import Module
+from max.experimental.tensor import Tensor
+from max.nn.kv_cache import PagedCacheValues
+
+from .attention import GritLMAttention
+
+
+class GritLMTransformerBlock(Module[..., Tensor]):
+    """Pre-norm decoder block: Attention → residual → MLP → residual."""
+
+    def __init__(
+        self,
+        attention: GritLMAttention,
+        mlp: Module[[Tensor], Tensor],
+        input_layernorm: Module[[Tensor], Tensor],
+        post_attention_layernorm: Module[[Tensor], Tensor],
+    ) -> None:
+        """Initialize a pre-norm GritLM transformer block.
+
+        Args:
+            attention: ``GritLMAttention`` instance for this layer.
+            mlp: SwiGLU MLP module.
+            input_layernorm: RMSNorm applied before the attention sub-layer.
+            post_attention_layernorm: RMSNorm applied before the MLP sub-layer.
+        """
+
+        super().__init__()
+        self.self_attn = attention
+        self.mlp = mlp
+        self.input_layernorm = input_layernorm
+        self.post_attention_layernorm = post_attention_layernorm
+
+    def forward(
+        self,
+        layer_idx: Tensor,
+        x: Tensor,
+        kv_collection: PagedCacheValues,
+        input_row_offsets: Tensor,
+        **kwargs,
+    ) -> Tensor:
+        """Apply one pre-norm decoder block: Attention → residual → MLP → residual.
+
+        Args:
+            layer_idx: Scalar uint32 tensor identifying this layer in the KV cache.
+            x: Input hidden states, shape ``(total_seq_len, hidden_size)``.
+            kv_collection: Paged KV cache (read/written by attention).
+            input_row_offsets: uint32 ragged-batch row delimiters passed
+                through to attention.
+            **kwargs: Forwarded to the attention layer.
+
+        Returns:
+            Updated hidden states, same shape as ``x``.
+        """
+
+        h = x + self.self_attn(
+            self.input_layernorm(x),
+            kv_collection,
+            input_row_offsets=input_row_offsets,
+            **kwargs,
+        )
+        return h + self.mlp(self.post_attention_layernorm(h))

--- a/max/python/max/pipelines/architectures/gritlm/model.py
+++ b/max/python/max/pipelines/architectures/gritlm/model.py
@@ -28,7 +28,7 @@ from max.experimental import functional as F
 from max.experimental.tensor import default_dtype
 from max.graph import DeviceRef, TensorType
 from max.graph.weights import Weights, WeightsAdapter
-from max.nn.kv_cache import KVCacheInputs, KVCacheParams, KVCacheInputsInterface
+from max.nn.kv_cache import KVCacheInputsInterface, KVCacheParams
 from max.nn.transformer import ReturnHiddenStates, ReturnLogits
 from max.pipelines.context import TextContext
 from max.pipelines.lib import (

--- a/max/python/max/pipelines/architectures/gritlm/model.py
+++ b/max/python/max/pipelines/architectures/gritlm/model.py
@@ -28,7 +28,7 @@ from max.experimental import functional as F
 from max.experimental.tensor import default_dtype
 from max.graph import DeviceRef, TensorType
 from max.graph.weights import Weights, WeightsAdapter
-from max.nn.kv_cache import KVCacheInputs, KVCacheParams
+from max.nn.kv_cache import KVCacheInputs, KVCacheParams, KVCacheInputsInterface
 from max.nn.transformer import ReturnHiddenStates, ReturnLogits
 from max.pipelines.context import TextContext
 from max.pipelines.lib import (
@@ -264,7 +264,7 @@ class GritLMModel(LogProbabilitiesMixin, PipelineModelWithKVCache[TextContext]):
     def prepare_initial_token_inputs(
         self,
         replica_batches: Sequence[Sequence[TextContext]],
-        kv_cache_inputs: KVCacheInputs[Buffer, Buffer] | None = None,
+        kv_cache_inputs: KVCacheInputsInterface[Buffer, Buffer] | None = None,
         return_n_logits: int = 1,
     ) -> ModelInputs:
         """Pack a prefill batch into ``GritLMInputs``.

--- a/max/python/max/pipelines/architectures/gritlm/model.py
+++ b/max/python/max/pipelines/architectures/gritlm/model.py
@@ -1,0 +1,335 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""GritLM pipeline model using the ModuleV3 API."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+import numpy as np
+from max.driver import Buffer, Device
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.experimental import functional as F
+from max.experimental.tensor import default_dtype
+from max.graph import DeviceRef, TensorType
+from max.graph.weights import Weights, WeightsAdapter
+from max.nn.kv_cache import KVCacheInputs, KVCacheParams
+from max.nn.transformer import ReturnHiddenStates, ReturnLogits
+from max.pipelines.context import TextContext
+from max.pipelines.lib import (
+    CompilationTimer,
+    KVCacheConfig,
+    ModelInputs,
+    ModelOutputs,
+    PipelineConfig,
+    PipelineModelWithKVCache,
+)
+from max.pipelines.lib.log_probabilities import LogProbabilitiesMixin
+from transformers import AutoConfig
+
+from .gritlm import GritLM
+from .model_config import GritLMConfig
+
+logger = logging.getLogger("max.pipelines")
+
+
+@dataclass
+class GritLMInputs(ModelInputs):
+    """Compiled input buffers for a single GritLM forward pass."""
+
+    tokens: Buffer
+    """Flat int64 token IDs for all sequences in the batch
+    (ragged; length = ``sum(seq_lens)``)."""
+
+    input_row_offsets: Buffer
+    """uint32 cumulative-sum offsets that delimit each
+    sequence inside ``tokens`` (length = ``batch_size + 1``)."""
+
+    return_n_logits: Buffer
+    """Single-element int64 tensor controlling how many
+    per-sequence logits are returned."""
+
+    @property
+    def buffers(self) -> tuple[Buffer, ...]:
+        """Flatten all inputs into the ordered tuple expected by the compiled model."""
+
+        if isinstance(self.input_row_offsets, np.ndarray):
+            input_row_offsets = Buffer.from_numpy(self.input_row_offsets).to(
+                self.tokens.device
+            )
+        else:
+            input_row_offsets = self.input_row_offsets
+        return (
+            self.tokens,
+            self.return_n_logits,
+            input_row_offsets,
+            *(
+                self.kv_cache_inputs.flatten()
+                if self.kv_cache_inputs is not None
+                else ()
+            ),
+        )
+
+
+class GritLMModel(LogProbabilitiesMixin, PipelineModelWithKVCache[TextContext]):
+    """GritLM pipeline model — CausalLM path only."""
+
+    config_class: type[GritLMConfig] = GritLMConfig
+    norm_method: Literal["rms_norm"] = "rms_norm"
+    attention_bias: bool = False
+
+    def __init__(
+        self,
+        pipeline_config: PipelineConfig,
+        session: InferenceSession,
+        devices: list[Device],
+        kv_cache_config: KVCacheConfig,
+        weights: Weights,
+        adapter: WeightsAdapter | None = None,
+        return_logits: ReturnLogits = ReturnLogits.LAST_TOKEN,
+        return_hidden_states: ReturnHiddenStates = ReturnHiddenStates.NONE,
+    ) -> None:
+        super().__init__(
+            pipeline_config,
+            session,
+            devices,
+            kv_cache_config,
+            weights,
+            adapter,
+            return_logits,
+            return_hidden_states,
+        )
+        self.model = self.load_model()
+
+    @staticmethod
+    def calculate_max_seq_len(
+        pipeline_config: PipelineConfig, huggingface_config: AutoConfig
+    ) -> int:
+        return GritLMConfig.calculate_max_seq_len(
+            pipeline_config, huggingface_config
+        )
+
+    @classmethod
+    def get_kv_params(
+        cls,
+        huggingface_config: AutoConfig,
+        pipeline_config: PipelineConfig,
+        devices: list[DeviceRef],
+        kv_cache_config: KVCacheConfig,
+        cache_dtype: DType,
+    ) -> KVCacheParams:
+        return GritLMConfig.construct_kv_params(
+            huggingface_config,
+            pipeline_config,
+            devices,
+            kv_cache_config,
+            cache_dtype,
+        )
+
+    def load_model(self) -> Callable[..., Any]:
+        """Build, compile, and return the GritLM inference callable.
+
+        Constructs tensor type descriptors, applies the weight adapter,
+        instantiates ``GritLM``, compiles it with MAX's lazy graph API, and
+        returns the compiled model ready for ``execute``.
+
+        Returns:
+            Compiled model callable accepting ``(*buffers)`` and returning
+            a tuple of output tensors.
+        """
+
+        assert self.pipeline_config.runtime.max_batch_size
+        self._input_row_offsets_prealloc = Buffer.from_numpy(
+            np.arange(
+                self.pipeline_config.runtime.max_batch_size + 1, dtype=np.uint32
+            )
+        ).to(self.devices[0])
+
+        with CompilationTimer("gritlm") as timer:
+            device0 = self.devices[0]
+            device_ref = DeviceRef(device0.label, device0.id)
+
+            tokens_type = TensorType(
+                DType.int64, shape=["total_seq_len"], device=device_ref
+            )
+            input_row_offsets_type = TensorType(
+                DType.uint32, shape=["input_row_offsets_len"], device=device0
+            )
+            return_n_logits_type = TensorType(
+                DType.int64, shape=["return_n_logits"], device=DeviceRef.CPU()
+            )
+
+            huggingface_config = self.huggingface_config
+            if self.adapter:
+                state_dict = self.adapter(
+                    dict(self.weights.items()),
+                    huggingface_config=huggingface_config,
+                    pipeline_config=self.pipeline_config,
+                )
+            else:
+                state_dict = {k: v.data() for k, v in self.weights.items()}
+
+            model_config = self.config_class.initialize(self.pipeline_config)
+            model_config.finalize(
+                huggingface_config=huggingface_config,
+                state_dict=state_dict,
+                norm_method=self.norm_method,
+                attention_bias=self.attention_bias,
+                return_logits=self.return_logits,
+                return_hidden_states=self.return_hidden_states,
+            )
+
+            with F.lazy(), default_dtype(model_config.dtype):
+                nn_model = GritLM(model_config, self.kv_params)
+                nn_model.to(self.devices[0])
+
+            kv_inputs = self.kv_params.get_symbolic_inputs()
+            timer.mark_build_complete()
+            compiled_model = nn_model.compile(
+                tokens_type,
+                return_n_logits_type,
+                input_row_offsets_type,
+                *kv_inputs.flatten(),
+                weights=state_dict,
+            )
+
+        return compiled_model
+
+    def execute(self, model_inputs: ModelInputs) -> ModelOutputs:
+        """Run one forward pass and unpack outputs into ``ModelOutputs``.
+
+        Output layout depends on ``return_logits`` / ``return_hidden_states``:
+            - ``(last_logits,)``
+            - ``(last_logits, logits, offsets)``
+            - ``(last_logits, hidden_states)``
+            - ``(last_logits, logits, offsets, hidden_states)``
+
+        Args:
+            model_inputs: A ``GritLMInputs`` instance produced by
+                ``prepare_initial_token_inputs`` or ``prepare_next_token_inputs``.
+
+        Returns:
+            ``ModelOutputs`` with ``logits``, ``next_token_logits``, and
+            optionally ``logit_offsets`` / ``hidden_states`` populated.
+        """
+
+        model_inputs = cast(GritLMInputs, model_inputs)
+        outs = self.model(*model_inputs.buffers)
+        has_offsets = self.return_logits in (
+            ReturnLogits.VARIABLE,
+            ReturnLogits.ALL,
+        )
+        has_hidden = self.return_hidden_states != ReturnHiddenStates.NONE
+
+        if has_offsets and has_hidden:
+            return ModelOutputs(
+                logits=cast(Buffer, outs[1].driver_tensor),
+                next_token_logits=cast(Buffer, outs[0].driver_tensor),
+                logit_offsets=cast(Buffer, outs[2].driver_tensor),
+                hidden_states=cast(Buffer, outs[3].driver_tensor),
+            )
+        elif has_offsets:
+            return ModelOutputs(
+                logits=cast(Buffer, outs[1].driver_tensor),
+                next_token_logits=cast(Buffer, outs[0].driver_tensor),
+                logit_offsets=cast(Buffer, outs[2].driver_tensor),
+            )
+        elif has_hidden:
+            return ModelOutputs(
+                logits=cast(Buffer, outs[0].driver_tensor),
+                next_token_logits=cast(Buffer, outs[0].driver_tensor),
+                hidden_states=cast(Buffer, outs[1].driver_tensor),
+            )
+        else:
+            return ModelOutputs(
+                logits=cast(Buffer, outs[0].driver_tensor),
+                next_token_logits=cast(Buffer, outs[0].driver_tensor),
+            )
+
+    def prepare_initial_token_inputs(
+        self,
+        replica_batches: Sequence[Sequence[TextContext]],
+        kv_cache_inputs: KVCacheInputs[Buffer, Buffer] | None = None,
+        return_n_logits: int = 1,
+    ) -> ModelInputs:
+        """Pack a prefill batch into ``GritLMInputs``.
+
+        Concatenates token arrays from all contexts and computes ragged
+        row offsets so the compiled model can handle variable-length sequences
+        without padding.
+
+        Args:
+            replica_batches: Single-replica list of ``TextContext`` objects
+                (DP > 1 is not supported).
+            kv_cache_inputs: Pre-allocated paged KV cache buffers.
+            return_n_logits: Number of trailing per-sequence logits to return.
+
+        Returns:
+            A ``GritLMInputs`` instance ready for ``execute``.
+
+        Raises:
+            ValueError: If ``len(replica_batches) > 1``.
+        """
+
+        if len(replica_batches) > 1:
+            raise ValueError("GritLMModel does not support DP>1")
+        context_batch = replica_batches[0]
+        assert kv_cache_inputs is not None
+        input_row_offsets = np.cumsum(
+            [0] + [ctx.tokens.active_length for ctx in context_batch],
+            dtype=np.uint32,
+        )
+        tokens = np.concatenate([ctx.tokens.active for ctx in context_batch])
+        return GritLMInputs(
+            tokens=Buffer.from_numpy(tokens).to(self.devices[0]),
+            input_row_offsets=Buffer.from_numpy(input_row_offsets).to(
+                self.devices[0]
+            ),
+            return_n_logits=Buffer.from_numpy(
+                np.array([return_n_logits], dtype=np.int64)
+            ),
+            kv_cache_inputs=kv_cache_inputs,
+        )
+
+    def prepare_next_token_inputs(
+        self, next_tokens: Buffer, prev_model_inputs: ModelInputs
+    ) -> ModelInputs:
+        """Pack a decode step (single next-token per sequence) into ``GritLMInputs``.
+
+        Reuses the pre-allocated ``_input_row_offsets_prealloc`` buffer
+        (arange 0..batch_size) to avoid a per-step allocation.
+
+        Args:
+            next_tokens: Buffer of next token IDs, one per active sequence.
+            prev_model_inputs: Previous step's ``GritLMInputs``; reuses its
+                ``return_n_logits`` and ``kv_cache_inputs``.
+
+        Returns:
+            A ``GritLMInputs`` instance for the decode step.
+        """
+
+        prev = cast(GritLMInputs, prev_model_inputs)
+        next_row_offsets = self._input_row_offsets_prealloc[
+            : prev.input_row_offsets.shape[0]
+        ].to(self.devices[0])
+        return GritLMInputs(
+            tokens=next_tokens,
+            input_row_offsets=next_row_offsets,
+            return_n_logits=prev.return_n_logits,
+            kv_cache_inputs=prev.kv_cache_inputs,
+        )

--- a/max/python/max/pipelines/architectures/gritlm/model_config.py
+++ b/max/python/max/pipelines/architectures/gritlm/model_config.py
@@ -264,7 +264,7 @@ class GritLMConfig(ArchConfigWithKVCache):
         ]
 
         # GritLM sliding_window: all layers use SWA with window=4096
-        raw_sliding_window: int = getattr(
+        raw_sliding_window: int | None = getattr(
             huggingface_config, "sliding_window", None
         )
 

--- a/max/python/max/pipelines/architectures/gritlm/model_config.py
+++ b/max/python/max/pipelines/architectures/gritlm/model_config.py
@@ -1,0 +1,359 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+
+"""Config for GritLM models (ModuleV3)."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+from max.dtype import DType
+from max.graph import DeviceRef
+from max.graph.weights import WeightData, WeightsFormat, weights_format
+from max.nn.kv_cache import KVCacheParams
+from max.nn.transformer import ReturnHiddenStates, ReturnLogits
+from max.pipelines.lib import (
+    KVCacheConfig,
+    MAXModelConfig,
+    PipelineConfig,
+    upper_bounded_default,
+)
+from max.pipelines.lib.interfaces.arch_config import ArchConfigWithKVCache
+from max.pipelines.lib.pipeline_variants.utils import get_rope_theta
+from max.pipelines.modeling.config_enums import supported_encoding_dtype
+from transformers import AutoConfig
+from typing_extensions import Self, override
+
+
+@dataclass(kw_only=True)
+class GritLMConfig(ArchConfigWithKVCache):
+    """Model configuration for GritLM graph construction/execution.
+
+    GritLM is architecturally identical to Mistral-7B for the causal LM path,
+    with sliding window attention on every layer (window=4096).
+    """
+
+    hidden_size: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    num_hidden_layers: int
+    rope_theta: float
+    max_seq_len: int
+    intermediate_size: int
+    interleaved_rope_weights: bool
+    vocab_size: int
+    dtype: DType
+    kv_params: KVCacheParams
+    devices: list[DeviceRef]
+
+    # Sliding window size — from config.json: sliding_window=4096
+    # GritLM applies SWA on every layer (no alternating pattern).
+    sliding_window: int | None = 4096
+
+    # Standard optional fields
+    return_logits: ReturnLogits = ReturnLogits.LAST_TOKEN
+    return_hidden_states: ReturnHiddenStates = ReturnHiddenStates.NONE
+    norm_method: Literal["rms_norm"] = "rms_norm"
+    rms_norm_eps: float | None = None
+    attention_bias: bool = False
+    tie_word_embeddings: bool = False
+    stacked_mlp: bool = False
+    stacked_qkv: bool = False
+    attention_multiplier: float = 0.0
+    embedding_multiplier: float = 1.0
+    residual_multiplier: float = 1.0
+    clip_qkv: float | None = None
+    logits_scaling: float = 1.0
+
+    # ------------------------------------------------------------------ #
+    # ArchConfigWithKVCache interface
+    # ------------------------------------------------------------------ #
+
+    def get_kv_params(self) -> KVCacheParams:
+        return self.kv_params
+
+    def get_max_seq_len(self) -> int:
+        return self.max_seq_len
+
+    # ------------------------------------------------------------------ #
+    # Static helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def get_head_dim(huggingface_config: AutoConfig) -> int:
+        """Return the per-head dimension for attention.
+
+        Uses the explicit ``head_dim`` field when present; otherwise derives
+        it as ``hidden_size // num_attention_heads``.
+
+        Args:
+            huggingface_config: HuggingFace model configuration.
+
+        Returns:
+            Integer head dimension.
+        """
+
+        if hasattr(huggingface_config, "head_dim"):
+            return huggingface_config.head_dim
+        return (
+            huggingface_config.hidden_size
+            // huggingface_config.num_attention_heads
+        )
+
+    @staticmethod
+    def get_head_dim_from_config(config: GritLMConfig) -> int:
+        """Return the per-head dimension stored in a ``GritLMConfig``.
+
+        Args:
+            config: An initialized ``GritLMConfig`` instance.
+
+        Returns:
+            Integer head dimension from ``kv_params``.
+        """
+
+        return config.kv_params.head_dim
+
+    @staticmethod
+    def get_num_layers(huggingface_config: AutoConfig) -> int:
+        """Return the number of hidden layers from a HuggingFace config.
+
+        Args:
+            huggingface_config: HuggingFace model configuration.
+
+        Returns:
+            Number of transformer layers.
+        """
+
+        return huggingface_config.num_hidden_layers
+
+    @staticmethod
+    def calculate_attention_multiplier(huggingface_config: AutoConfig) -> float:
+        """Compute the QK scaling factor for GritLM attention.
+
+        Uses ``attention_multiplier`` when present in the config; otherwise
+        falls back to ``1 / sqrt(head_dim)`` (standard Mistral scaling).
+
+        Args:
+            huggingface_config: HuggingFace model configuration.
+
+        Returns:
+            Float scaling factor applied to query-key dot products.
+        """
+
+        return getattr(
+            huggingface_config,
+            "attention_multiplier",
+            math.sqrt(
+                1.0 / float(GritLMConfig.get_head_dim(huggingface_config))
+            ),
+        )
+
+    @staticmethod
+    def construct_kv_params(
+        huggingface_config: AutoConfig,
+        pipeline_config: PipelineConfig,
+        devices: list[DeviceRef],
+        kv_cache_config: KVCacheConfig,
+        cache_dtype: DType,
+    ) -> KVCacheParams:
+        """Build ``KVCacheParams`` for GritLM from pipeline and model config.
+
+        Args:
+            huggingface_config: HuggingFace model configuration.
+            pipeline_config: MAX Engine pipeline configuration.
+            devices: Device references for cache placement.
+            kv_cache_config: KV cache configuration (page size, dtype, etc.).
+            cache_dtype: Data type for cached key/value tensors.
+
+        Returns:
+            Configured ``KVCacheParams`` instance.
+        """
+
+        return kv_cache_config.to_params(
+            dtype=cache_dtype,
+            n_kv_heads=huggingface_config.num_key_value_heads,
+            head_dim=GritLMConfig.get_head_dim(huggingface_config),
+            num_layers=GritLMConfig.get_num_layers(huggingface_config),
+            devices=devices,
+            data_parallel_degree=pipeline_config.model.data_parallel_degree,
+        )
+
+    @staticmethod
+    def calculate_max_seq_len(
+        pipeline_config: PipelineConfig,
+        huggingface_config: AutoConfig,
+    ) -> int:
+        """Resolve the effective maximum sequence length for GritLM.
+
+        Clamps ``pipeline_config.model.max_length`` to the model's
+        ``max_position_embeddings`` (default 32 768).
+
+        Args:
+            pipeline_config: MAX Engine pipeline configuration.
+            huggingface_config: HuggingFace model configuration.
+
+        Returns:
+            Effective maximum sequence length as an integer.
+
+        Raises:
+            ValueError: If the requested ``max_length`` exceeds
+                ``max_position_embeddings``.
+        """
+
+        hf_max = getattr(huggingface_config, "max_position_embeddings", 32768)
+        try:
+            return upper_bounded_default(
+                upper_bound=hf_max,
+                default=pipeline_config.model.max_length,
+            )
+        except ValueError as e:
+            raise ValueError(
+                "Unable to infer max_length for GritLM; provided "
+                f"max_length ({pipeline_config.model.max_length}) exceeds "
+                f"model max_position_embeddings ({hf_max})."
+            ) from e
+
+    # ------------------------------------------------------------------ #
+    # Factory
+    # ------------------------------------------------------------------ #
+
+    @override
+    @classmethod
+    def initialize(
+        cls,
+        pipeline_config: PipelineConfig,
+        model_config: MAXModelConfig | None = None,
+    ) -> Self:
+        model_config = model_config or pipeline_config.model
+        huggingface_config = model_config.huggingface_config
+        if huggingface_config is None:
+            raise ValueError(
+                f"HuggingFace config is required for '{model_config.model_path}'"
+            )
+
+        kv_cache_config = model_config.kv_cache
+        quantization_encoding = model_config.quantization_encoding
+        if quantization_encoding is None:
+            raise ValueError("quantization_encoding must not be None")
+
+        dtype = supported_encoding_dtype(quantization_encoding)
+        cache_dtype = model_config.kv_cache.cache_dtype
+
+        _weights_format = weights_format(model_config.weight_path)
+        interleaved_rope_weights = (
+            _weights_format == WeightsFormat.gguf
+            and model_config.rope_type == "normal"
+        )
+
+        device_refs = [
+            DeviceRef(spec.device_type, spec.id)
+            for spec in model_config.device_specs
+        ]
+
+        # GritLM sliding_window: all layers use SWA with window=4096
+        raw_sliding_window: int = getattr(
+            huggingface_config, "sliding_window", None
+        )
+
+        sliding_window: int | None = (
+            raw_sliding_window if raw_sliding_window else None
+        )
+
+        return cls(
+            hidden_size=huggingface_config.hidden_size,
+            num_attention_heads=huggingface_config.num_attention_heads,
+            num_key_value_heads=huggingface_config.num_key_value_heads,
+            num_hidden_layers=huggingface_config.num_hidden_layers,
+            rope_theta=get_rope_theta(huggingface_config),
+            intermediate_size=huggingface_config.intermediate_size,
+            interleaved_rope_weights=interleaved_rope_weights,
+            vocab_size=huggingface_config.vocab_size,
+            dtype=dtype,
+            sliding_window=sliding_window,
+            max_seq_len=cls.calculate_max_seq_len(
+                pipeline_config, huggingface_config=huggingface_config
+            ),
+            kv_params=cls.construct_kv_params(
+                huggingface_config=huggingface_config,
+                pipeline_config=pipeline_config,
+                devices=device_refs,
+                kv_cache_config=kv_cache_config,
+                cache_dtype=cache_dtype,
+            ),
+            attention_multiplier=cls.calculate_attention_multiplier(
+                huggingface_config
+            ),
+            devices=device_refs,
+            tie_word_embeddings=getattr(
+                huggingface_config, "tie_word_embeddings", False
+            ),
+        )
+
+    def finalize(
+        self,
+        huggingface_config: AutoConfig,
+        state_dict: dict[str, WeightData],
+        return_logits: ReturnLogits,
+        return_hidden_states: ReturnHiddenStates = ReturnHiddenStates.NONE,
+        norm_method: Literal["rms_norm"] = "rms_norm",
+        attention_bias: bool = False,
+    ) -> None:
+        """Populate runtime fields that require the loaded state dict.
+
+        Called after ``initialize`` once the weight names are known.
+        Detects stacked MLP/QKV layouts, resolves ``tie_word_embeddings``,
+        and stores norm/logit settings.
+
+        Args:
+            huggingface_config: HuggingFace model configuration.
+            state_dict: Loaded (and remapped) weight dictionary.
+            return_logits: Which logits the model should return.
+            return_hidden_states: Which hidden states to return.
+            norm_method: Normalization method (always ``"rms_norm"`` for GritLM).
+            attention_bias: Whether attention projections include bias terms.
+        """
+
+        def _strip(s: str, prefix: str) -> str:
+            return s.removeprefix(prefix)
+
+        has_model = any(k.startswith("model.") for k in state_dict)
+        normalized = (
+            {
+                _strip(k, "model."): v
+                for k, v in state_dict.items()
+                if k.startswith("model.")
+            }
+            if has_model
+            else dict(state_dict)
+        )
+
+        tie = (
+            getattr(huggingface_config, "tie_word_embeddings", False)
+            or "lm_head.weight" not in normalized
+        )
+
+        self.norm_method = norm_method
+        self.rms_norm_eps = (
+            huggingface_config.rms_norm_eps
+            if norm_method == "rms_norm"
+            else None
+        )
+        self.tie_word_embeddings = tie
+        self.stacked_mlp = "layers.0.mlp.gate_up_proj.weight" in normalized
+        self.stacked_qkv = "layers.0.self_attn.qkv_proj.weight" in normalized
+        self.attention_bias = attention_bias
+        self.return_logits = return_logits
+        self.return_hidden_states = return_hidden_states

--- a/max/python/max/pipelines/architectures/gritlm/weight_adapters.py
+++ b/max/python/max/pipelines/architectures/gritlm/weight_adapters.py
@@ -1,0 +1,91 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+
+"""Weight adapters for GritLM safetensors."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from max.dtype import DType
+from max.graph.weights import WeightData, Weights
+from transformers import AutoConfig
+
+GRITLM_SAFETENSOR_MAPPING: dict[str, str] = {
+    "model.": "language_model.",
+}
+
+# Pooling head weights — only used for embedding mode, not CausalLM serving
+_DROP_PREFIXES = ("gritlm_pooling", "pooling")
+
+
+def _target_dtype(pipeline_config: Any) -> DType | None:
+    try:
+        from max.pipelines.modeling.config_enums import supported_encoding_dtype
+
+        enc = pipeline_config.model.quantization_encoding
+        if enc is not None:
+            return supported_encoding_dtype(enc)
+    except Exception:
+        pass
+    return None
+
+
+def convert_safetensor_state_dict(
+    state_dict: dict[str, Weights],
+    huggingface_config: AutoConfig | None = None,
+    pipeline_config: Any = None,
+    **kwargs,
+) -> dict[str, WeightData]:
+    """Remap GritLM safetensor weight names to MAX internal convention.
+
+    Applies the following transformations:
+        - ``model.*``        → ``language_model.*``
+        - ``lm_head.*``      → ``language_model.lm_head.*``
+        - ``gritlm_pooling`` → dropped (embedding path, not CausalLM)
+
+    Args:
+        state_dict: Raw GritLM checkpoint weights keyed by safetensor name.
+        huggingface_config: HuggingFace model configuration (unused, kept for
+            adapter interface compatibility).
+        pipeline_config: Pipeline configuration used to resolve the target
+            dtype from the quantization encoding.
+        **kwargs: Additional keyword arguments (ignored).
+
+    Returns:
+        Transformed weight dict with MAX-internal key names and, if a
+        quantization encoding is active, weights cast to the target dtype.
+    """
+    target_dtype = _target_dtype(pipeline_config) if pipeline_config else None
+
+    new_state_dict: dict[str, WeightData] = {}
+    for name, value in state_dict.items():
+        # Drop pooling head weights
+        if any(name.startswith(p) for p in _DROP_PREFIXES):
+            continue
+
+        max_name = name
+        for before, after in GRITLM_SAFETENSOR_MAPPING.items():
+            max_name = max_name.replace(before, after)
+
+        # lm_head sits at top-level (no model. prefix) — add language_model. prefix
+        if max_name == "lm_head.weight":
+            max_name = "language_model.lm_head.weight"
+
+        wd: WeightData = value.data()
+        if target_dtype is not None and wd.dtype != target_dtype:
+            wd = wd.astype(target_dtype)
+        new_state_dict[max_name] = wd
+
+    return new_state_dict


### PR DESCRIPTION


<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Before you open this PR, please make sure the change has been discussed and
agreed upon with a maintainer. For anything beyond a trivial fix (typo,
one-line bug fix, doc tweak), we ask that you first open a GitHub issue or
proposal and get a maintainer's go-ahead. This helps us avoid situations
where a PR sits unreviewed because the change isn't aligned with the
team's direction. See our [contributor guide](https://github.com/modular/modular/blob/main/CONTRIBUTING.md) for
details.
-->

## Linked issue

<!--
Replace `NNN` with the issue number. For anything non-trivial, a linked
issue that a maintainer has agreed to is expected before review.

- Trivial fix (typo, comment, small doc fix): you can write "N/A — trivial".
- Everything else: `Fixes #NNN` or `Related to #NNN`.
-->

Fixes #6684 

**Type of change**
* New feature or public API

---

## Motivation

GritLM-7B is a Mistral-7B-based model trained with Generative Representational
Instruction Tuning (GRIT), enabling both high-quality text generation and dense
vector embeddings from a single model. It is widely used in retrieval-augmented
generation (RAG) pipelines and semantic search applications.

MAX had no native support for the `GritLM` architecture class. This PR adds a implementation so `parasail-ai/GritLM-7B-vllm` can be served directly via `max serve` without any
custom flags after registration.

---

## What changed

Added `max/python/max/pipelines/architectures/gritlm/` — a new ModuleV3
architecture package for the `GritLM` model family.

**New files:**

| File | Purpose |
|---|---|
| `__init__.py` | Exports `ARCHITECTURES = [gritlm_arch]` for MAX loader discovery |
| `arch.py` | `SupportedArchitecture` registration — name matches `architectures` field in `config.json` |
| `model_config.py` | `GritLMConfig` dataclass — parses HuggingFace config including `sliding_window` |
| `gritlm.py` | `GritLM` / `GritLMTextModel` ModuleV3 graph (CausalLM path only) |
| `model.py` | `GritLMModel` — `PipelineModelWithKVCache` wrapper, input preparation, output unpacking |
| `weight_adapters.py` | Remaps `model.*` → `language_model.*`, drops pooling head weights, casts dtype |
| `layers/attention.py` | `GritLMAttention` — GQA with `SLIDING_WINDOW_CAUSAL_MASK` on every layer |
| `layers/transformer_block.py` | `GritLMTransformerBlock` — standard pre-norm decoder block |
| `BUILD.bazel` | Defines the `gritlm` Python library and its dependencies for Bazel builds. |

**Architecture highlights:**

- Mistral-7B backbone: 32 layers, hidden_size=4096, GQA (32 Q / 8 KV heads),
  SwiGLU MLP, RMSNorm.
- **Sliding window attention on all 32 layers** (`sliding_window=4096`) using
  `flash_attention_ragged` with `MHAMaskVariant.SLIDING_WINDOW_CAUSAL_MASK`.
- Standard Mistral RoPE (`rope_theta=10000`, no scaling).
- Separate `lm_head` (`tie_word_embeddings=false`).
- CausalLM path only — `gritlm_pooling_head.weight` is dropped by the
  weight adapter since MAX serves text generation alone for this model.

---

## Testing

Verified on `parasail-ai/GritLM-7B-vllm` with GPU serving:

```bash
max serve \
  --model-path parasail-ai/GritLM-7B-vllm \
  --custom-architectures architectures/gritlm \
  --max-batch-size 256 \
  --max-length 4096 \
  --quantization-encoding bfloat16
```

**Smoke test — model generates correctly :**
```bash
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"parasail-ai/GritLM-7B-vllm",
       "messages":[{"role":"user","content":"What is 2+2?"}],
       "max_tokens":32,"temperature":0}'
```

**Output :**
```text
2+2 is equal to 4.
```

**GSM8K accuracy vs vLLM reference :**


| Model | Task | Accuracy | vs Reference |
|---|---|---|---|
| parasail-ai/GritLM-7B-vllm | gsm8k_cot_llama | 0.506 | 98.2% |

---

## Checklist

* [ ] The linked issue above has been reviewed by a maintainer and is agreed-upon,
  or this is a trivial fix that does not need prior approval
* [x] PR is small and focused — single new architecture, no changes to existing
  architectures
* [x] I ran `./bazelw run format` to format my changes
* [x] I added or updated tests to cover my changes
* [x] If AI tools assisted with this contribution, I have included an
  `Assisted-by:` trailer in my commit message or this PR description

**Assisted-by:** AI