### PR TITLE
[Feature] Added the baidu/ERNIE-4.5-0.3B-PT model to serve natively in MAX

### DIFF
--- a/max/python/max/pipelines/architectures/__init__.py
+++ b/max/python/max/pipelines/architectures/__init__.py
@@ -112,6 +112,7 @@ def register_all_models() -> None:
             "LlamaForCausalLMEagle3", ".eagle_llama3", "eagle3_llama_arch"
         ),
         _LazyArch("LlamaForCausalLMEagle", ".eagle_llama3", "eagle_llama_arch"),
+        _LazyArch("Ernie4_5ForCausalLM", ".ernie4_5", "ernie45_arch"),
         _LazyArch("ExaoneForCausalLM", ".exaone", "exaone_arch"),
         _LazyArch(
             "ExaoneForCausalLM_ModuleV3",

--- a/max/python/max/pipelines/architectures/all_arches.bzl
+++ b/max/python/max/pipelines/architectures/all_arches.bzl
@@ -16,6 +16,7 @@ ALL_ARCHITECTURES = [
     "//max/python/max/pipelines/architectures/diffusion_gemma",
     "//max/python/max/pipelines/architectures/eagle3_deepseekV3",
     "//max/python/max/pipelines/architectures/eagle_llama3",
+    "//max/python/max/pipelines/architectures/ernie4_5",
     "//max/python/max/pipelines/architectures/exaone",
     "//max/python/max/pipelines/architectures/exaone_modulev3",
     "//max/python/max/pipelines/architectures/flux2",

--- a/max/python/max/pipelines/architectures/ernie4_5/BUILD.bazel
+++ b/max/python/max/pipelines/architectures/ernie4_5/BUILD.bazel
@@ -1,0 +1,30 @@
+load("//bazel:api.bzl", "modular_py_library", "requirement")
+
+package(default_visibility = ["//max:consumers"])
+
+modular_py_library(
+    name = "ernie4_5",
+    srcs = glob(["**/*.py"]),
+    ignore_extra_deps = [
+        # Hooks added for convenience for when we want to print the model layers
+        "//max/python/max/nn/hooks",
+    ],
+    deps = [
+        requirement("numpy"),
+        requirement("transformers"),
+        requirement("typing-extensions"),
+        "//max/python/max/driver",
+        "//max/python/max/dtype",
+        "//max/python/max/engine",
+        "//max/python/max/experimental/nn",
+        "//max/python/max/graph",
+        "//max/python/max/nn",
+        # Hooks added for convenience for when we want to print the model layers
+        "//max/python/max/nn/hooks",
+        "//max/python/max/pipelines/context",
+        "//max/python/max/pipelines/kv_cache",
+        "//max/python/max/pipelines/lib",
+        "//max/python/max/pipelines/modeling",
+        "//max/python/max:tensor",
+    ],
+)

--- a/max/python/max/pipelines/architectures/ernie4_5/__init__.py
+++ b/max/python/max/pipelines/architectures/ernie4_5/__init__.py
@@ -1,0 +1,47 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""ERNIE-4.5 (Ernie4_5ForCausalLM) transformer architecture for MAX.
+
+Decoder-only transformer (Llama-style) with actual config defaults:
+  - 18 layers, hidden_size=1024, intermediate_size=3072
+  - GQA: 16 Q heads, 2 KV heads (head_dim=128) → group=8 ✓ GPU OK
+  - SwiGLU MLP (use_bias: false)
+  - RMSNorm (rms_norm_eps=1e-5)
+  - RoPE theta from rope_parameters dict (new-style transformers config)
+  - tie_word_embeddings: true
+  - vocab_size: 103424, max_position_embeddings: 131072
+  - Apache 2.0 license
+
+CLI usage:
+    max serve \\
+        --model-path baidu/ERNIE-4.5-0.3B-PT \\
+        --custom-architectures /path/to/architectures/ernie45 \\
+        --max-batch-size 1 \\
+        --max-length 512 \\
+        --quantization-encoding bfloat16
+"""
+
+from .arch import ernie45_arch
+from .model import ERNIE45Inputs, ERNIE45Model
+from .model_config import ERNIE45Config
+
+ARCHITECTURES = [ernie45_arch]
+
+__all__ = [
+    "ARCHITECTURES",
+    "ERNIE45Config",
+    "ERNIE45Inputs",
+    "ERNIE45Model",
+    "ernie45_arch",
+]

--- a/max/python/max/pipelines/architectures/ernie4_5/arch.py
+++ b/max/python/max/pipelines/architectures/ernie4_5/arch.py
@@ -1,0 +1,45 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""ERNIE-4.5 architecture registration for MAX pipeline."""
+
+from max.graph.weights import WeightsFormat
+from max.pipelines.context import TextContext
+from max.pipelines.lib import SupportedArchitecture, TextTokenizer
+from max.pipelines.modeling.types import PipelineTask
+
+from . import weight_adapters
+from .model import ERNIE45Model
+from .model_config import ERNIE45Config
+
+ernie45_arch = SupportedArchitecture(
+    name="Ernie4_5ForCausalLM",
+    example_repo_ids=[
+        "baidu/ERNIE-4.5-0.3B-PT",
+        "baidu/ERNIE-4.5-0.3B-Base-PT",
+    ],
+    default_encoding="bfloat16",
+    supported_encodings={"float32", "bfloat16"},
+    pipeline_model=ERNIE45Model,
+    tokenizer=TextTokenizer,
+    context_type=TextContext,
+    rope_type="normal",
+    default_weights_format=WeightsFormat.safetensors,
+    multi_gpu_supported=False,
+    weight_adapters={
+        WeightsFormat.safetensors: weight_adapters.convert_safetensor_state_dict,
+        WeightsFormat.gguf: weight_adapters.convert_gguf_state_dict,
+    },
+    task=PipelineTask.TEXT_GENERATION,
+    config=ERNIE45Config,
+)

--- a/max/python/max/pipelines/architectures/ernie4_5/ernie45.py
+++ b/max/python/max/pipelines/architectures/ernie4_5/ernie45.py
@@ -1,0 +1,292 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Implements the ERNIE-4.5 model using the ModuleV3 API."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+
+from max.dtype import DType
+from max.experimental import functional as F
+from max.experimental.nn import Module
+from max.experimental.nn.common_layers.mlp import MLP
+from max.experimental.nn.embedding import Embedding
+from max.experimental.nn.linear import Linear
+from max.experimental.nn.norm import RMSNorm
+from max.experimental.nn.sequential import ModuleList
+from max.experimental.tensor import Tensor
+from max.graph import TensorValue, ops
+from max.nn.kv_cache import KVCacheParamInterface, PagedCacheValues
+from max.nn.transformer import ReturnHiddenStates, ReturnLogits
+
+from .layers.attention import ERNIE45Attention
+from .layers.rope import build_ernie45_freqs_cis
+from .layers.transformer_block import ERNIE45TransformerBlock
+from .model_config import ERNIE45Config
+
+
+class Ernie45Rope:
+    """Lightweight RoPE shim that builds precomputed freqs_cis.
+
+    This object mirrors the small interface expected by the attention
+    layers while deferring construction of the full freqs_cis tensor to
+    the helper builder function.
+    """
+
+    def __init__(
+        self, head_dim: int, max_seq_len: int, rope_theta: float
+    ) -> None:
+        self._head_dim = head_dim
+        self._max_seq_len = max_seq_len
+        self._rope_theta = rope_theta
+        self.interleaved = True
+
+    @property
+    def freqs_cis(self) -> TensorValue:
+        """Return the precomputed ``freqs_cis`` tensor used for RoPE.
+
+        The returned layout matches ERNIE-4.5's interleaved GPT-J style:
+        ``[cos0,sin0,cos1,sin1,...]`` per position.
+        """
+        return build_ernie45_freqs_cis(
+            head_dim=self._head_dim,
+            max_seq_len=self._max_seq_len,
+            rope_theta=self._rope_theta,
+        )
+
+
+class ERNIE45TextModel(
+    Module[[Tensor, PagedCacheValues, Tensor, Tensor], tuple[Tensor, ...]]
+):
+    """ERNIE-4.5 decoder-only transformer.
+
+    0.3B: 18 layers, hidden=1024, GQA 16Q/2KV, head_dim=128, RMSNorm, SwiGLU.
+
+    Key differences from Llama:
+      - GPT-J style interleaved RoPE (swap adjacent pairs, not halves)
+      - freqs_cis layout: [cos0,sin0,cos1,sin1,...] (interleaved pairs)
+      - rope_dim = head_dim * n_heads (not hidden_size) since head_dim != hidden_size//n_heads
+    """
+
+    def __init__(self, config: ERNIE45Config) -> None:
+        super().__init__()
+        self.devices = config.devices
+
+        if config.rms_norm_eps is None:
+            raise ValueError("rms_norm_eps cannot be None for ERNIE-4.5.")
+
+        create_norm: Callable[..., Module[[Tensor], Tensor]] = (
+            functools.partial(
+                RMSNorm, config.hidden_size, eps=config.rms_norm_eps
+            )
+        )
+
+        head_dim = ERNIE45Config.get_head_dim_from_config(config)  # 128
+
+        # Build ERNIE-4.5's custom freqs_cis (GPT-J interleaved layout)
+        rope = Ernie45Rope(
+            head_dim=head_dim,
+            max_seq_len=config.max_seq_len,
+            rope_theta=config.rope_theta,
+        )
+
+        self.embed_tokens = Embedding(config.vocab_size, dim=config.hidden_size)
+        self.norm = create_norm()
+
+        self.tie_word_embeddings = config.tie_word_embeddings
+        if config.tie_word_embeddings:
+            self.lm_head = None
+        else:
+            self.lm_head = Linear(
+                in_dim=config.hidden_size, out_dim=config.vocab_size, bias=False
+            )
+
+        layers = []
+        for i in range(config.num_hidden_layers):
+            attention = ERNIE45Attention(
+                rope=rope,
+                num_attention_heads=config.num_attention_heads,
+                num_key_value_heads=config.num_key_value_heads,
+                hidden_size=config.hidden_size,
+                kv_params=config.kv_params,
+                layer_idx=i,
+                scale=config.attention_multiplier,
+                has_bias=config.attention_bias,
+                clip_qkv=config.clip_qkv,
+            )
+            mlp = MLP(
+                hidden_dim=config.hidden_size,
+                feed_forward_length=config.intermediate_size,
+            )
+            layers.append(
+                ERNIE45TransformerBlock(
+                    attention=attention,
+                    mlp=mlp,
+                    input_layernorm=create_norm(),
+                    post_attention_layernorm=create_norm(),
+                    residual_multiplier=config.residual_multiplier,
+                )
+            )
+
+        self.layers = ModuleList(layers)
+        self.kv_params = config.kv_params
+        self.return_logits = config.return_logits
+        self.return_hidden_states = config.return_hidden_states
+        self.embedding_multiplier = config.embedding_multiplier
+        self.logits_scaling = config.logits_scaling
+
+    def _compute_logits(self, h: Tensor) -> Tensor:
+        """Project hidden states to vocabulary logits cast to float32.
+
+        Uses tied embeddings when ``tie_word_embeddings`` is enabled,
+        otherwise applies the separate ``lm_head`` projection.
+
+        Args:
+            h: Hidden-state tensor of shape ``(seq_len, hidden_size)``.
+
+        Returns:
+            Float32 logit tensor of shape ``(seq_len, vocab_size)``.
+        """
+
+        if self.tie_word_embeddings:
+            logits = F.cast(h @ self.embed_tokens.weight.T, DType.float32)
+        else:
+            assert self.lm_head is not None
+            logits = F.cast(self.lm_head(h), DType.float32)
+        if self.logits_scaling != 1.0:
+            logits = logits / self.logits_scaling
+        return logits
+
+    def forward(
+        self,
+        tokens: Tensor,
+        kv_collection: PagedCacheValues,
+        return_n_logits: Tensor,
+        input_row_offsets: Tensor,
+    ) -> tuple[Tensor, ...]:
+        """Run the ERNIE-4.5 decoder stack and return logits/hidden states.
+
+        Args:
+            tokens: Flat token IDs, shape ``(total_seq_len,)``.
+            kv_collection: Paged KV cache for all layers.
+            return_n_logits: Controls variable-logit return mode.
+            input_row_offsets: Ragged-batch row delimiters,
+                shape ``(batch_size + 1,)``.
+
+        Returns:
+            Tuple whose layout depends on ``return_logits`` /
+            ``return_hidden_states``:
+                ``(last_logits,)``
+                ``(last_logits, logits, offsets)``
+                ``(last_logits, hidden_states)``
+                ``(last_logits, logits, offsets, hidden_states)``
+        """
+
+        h = self.embed_tokens(tokens)
+        if self.embedding_multiplier != 1.0:
+            h = h * F.constant(
+                self.embedding_multiplier, h.dtype, device=h.device
+            )
+
+        for idx, layer in enumerate(self.layers):
+            layer_idx_tensor = F.constant(idx, DType.uint32, device=h.device)
+            h = layer(
+                layer_idx_tensor,
+                h,
+                kv_collection,
+                input_row_offsets=input_row_offsets,
+            )
+
+        last_h = F.gather(h, input_row_offsets[1:] - 1, axis=0)
+        last_logits = self._compute_logits(self.norm(last_h))
+        logits = None
+        offsets = None
+
+        if self.return_logits == ReturnLogits.VARIABLE:
+            return_n_logits_range = ops.range(
+                return_n_logits[0],
+                0,
+                -1,
+                out_dim="return_n_logits_range",
+                device=h.device,
+                dtype=DType.int64,
+            )
+            offsets = (
+                F.unsqueeze(input_row_offsets[1:], -1) - return_n_logits_range
+            )
+            last_indices = F.reshape(offsets, shape=(-1,))
+            last_tokens = F.gather(h, last_indices, axis=0)
+            logits = self._compute_logits(self.norm(last_tokens))
+            offsets = ops.range(
+                0,
+                TensorValue(last_indices.shape[0]) + return_n_logits[0],
+                return_n_logits[0],
+                out_dim="logit_offsets",
+                device=h.device,
+                dtype=DType.int64,
+            )
+        elif self.return_logits == ReturnLogits.ALL:
+            logits = self._compute_logits(self.norm(h))
+            offsets = input_row_offsets
+
+        ret_val: tuple[Tensor, ...] = (last_logits,)
+        if offsets is not None:
+            assert logits is not None
+            ret_val += (logits, offsets)
+        if self.return_hidden_states == ReturnHiddenStates.LAST:
+            ret_val += (last_h,)
+        elif self.return_hidden_states == ReturnHiddenStates.ALL_NORMALIZED:
+            ret_val += (self.norm(h),)
+        return ret_val
+
+
+class ERNIE45(Module[..., tuple[Tensor, ...]]):
+    """Top-level ERNIE-4.5 model."""
+
+    def __init__(
+        self, config: ERNIE45Config, kv_params: KVCacheParamInterface
+    ) -> None:
+        super().__init__()
+        self.language_model = ERNIE45TextModel(config)
+        self.config = config
+        self.kv_params = kv_params
+
+    def forward(
+        self,
+        tokens: Tensor,
+        return_n_logits: Tensor,
+        input_row_offsets: Tensor,
+        *variadic_args: Tensor,
+    ) -> tuple[Tensor, ...]:
+        """Unpack KV cache tensors and delegate to ``ERNIE45TextModel``.
+
+        Args:
+            tokens: Flat int64 token IDs.
+            return_n_logits: Single-element int64 logit-count control tensor.
+            input_row_offsets: uint32 ragged-batch row delimiters.
+            *variadic_args: Flattened paged KV cache tensors (all layers,
+                all devices) produced by ``KVCacheParamInterface.get_symbolic_inputs``.
+
+        Returns:
+            Output tuple forwarded from ``ERNIE45TextModel.forward``.
+        """
+
+        kv_inputs = iter(x._graph_value for x in variadic_args)
+        kv_collections = (
+            self.kv_params.get_symbolic_inputs().unflatten(kv_inputs).inputs
+        )
+        return self.language_model(
+            tokens, kv_collections[0], return_n_logits, input_row_offsets
+        )

--- a/max/python/max/pipelines/architectures/ernie4_5/layers/__init__.py
+++ b/max/python/max/pipelines/architectures/ernie4_5/layers/__init__.py
@@ -1,0 +1,22 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""ERNIE-4.5 custom layers."""
+
+from .attention import ERNIE45Attention
+from .transformer_block import ERNIE45TransformerBlock
+
+__all__ = [
+    "ERNIE45Attention",
+    "ERNIE45TransformerBlock",
+]

--- a/max/python/max/pipelines/architectures/ernie4_5/layers/attention.py
+++ b/max/python/max/pipelines/architectures/ernie4_5/layers/attention.py
@@ -1,0 +1,145 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""ERNIE-4.5 GQA attention with GPT-J style interleaved RoPE."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..ernie45 import Ernie45Rope
+import math
+
+from max.driver import CPU
+from max.dtype import DType
+from max.experimental import functional as F
+from max.experimental.nn import Module
+from max.experimental.nn.common_layers.functional_kernels import (
+    flash_attention_ragged,
+    rope_split_store_ragged,
+)
+from max.experimental.nn.linear import Linear
+from max.experimental.tensor import Tensor
+from max.nn.attention import MHAMaskVariant
+from max.nn.kv_cache import KVCacheParams, PagedCacheValues
+
+
+class ERNIE45Attention(Module[..., Tensor]):
+    """GQA attention for ERNIE-4.5.
+
+    Uses GPT-J style interleaved RoPE (interleaved=True).
+    freqs_cis is pre-built as [cos0,sin0,cos1,sin1,...] per position.
+    group = 16Q/2KV = 8 — within GPU kernel limit.
+    """
+
+    def __init__(
+        self,
+        *,
+        rope: Ernie45Rope,
+        num_attention_heads: int,
+        num_key_value_heads: int,
+        hidden_size: int,
+        kv_params: KVCacheParams,
+        layer_idx: int,
+        scale: float | None = None,
+        has_bias: bool = False,
+        clip_qkv: float | None = None,
+    ) -> None:
+        super().__init__()
+        self.rope = rope
+        self.n_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.hidden_size = hidden_size
+        self.kv_params = kv_params
+        self.layer_idx = layer_idx
+        self.has_bias = has_bias
+        self.clip_qkv = clip_qkv
+        self.scale = (
+            scale
+            if scale is not None
+            else math.sqrt(1.0 / self.kv_params.head_dim)
+        )
+
+        q_dim = self.kv_params.head_dim * num_attention_heads
+        kv_dim = self.kv_params.head_dim * num_key_value_heads
+        self.q_weight_dim = q_dim
+
+        self.q_proj = Linear(in_dim=hidden_size, out_dim=q_dim, bias=has_bias)
+        self.k_proj = Linear(in_dim=hidden_size, out_dim=kv_dim, bias=has_bias)
+        self.v_proj = Linear(in_dim=hidden_size, out_dim=kv_dim, bias=has_bias)
+        self.o_proj = Linear(in_dim=q_dim, out_dim=hidden_size, bias=False)
+
+    def forward(
+        self, x: Tensor, kv_collection: PagedCacheValues, **kwargs
+    ) -> Tensor:
+        """Compute GQA attention for a ragged batch using GPT-J RoPE.
+
+        Steps:
+            1. Project Q/K/V.
+            2. Optionally clip Q/K/V.
+            3. Apply RoPE and store K/V via ``rope_split_store_ragged``.
+            4. Run flash attention with a causal mask.
+            5. Project the attention output back to hidden dimension.
+
+        Args:
+            x: Input hidden states, shape ``(total_seq_len, hidden_size)``.
+            kv_collection: Paged KV cache for the current layer.
+            **kwargs: Must contain ``input_row_offsets`` — uint32 tensor of
+                ragged-batch row delimiters.
+
+        Returns:
+            Attended output, shape ``(total_seq_len, hidden_size)``.
+        """
+
+        total_seq_len = x.shape[0]
+        layer_idx = F.constant(self.layer_idx, DType.uint32, device=CPU())
+
+        q = self.q_proj(x)
+        k = self.k_proj(x)
+        v = self.v_proj(x)
+
+        if self.clip_qkv:
+            q = F.clip(q, -self.clip_qkv, self.clip_qkv)
+            k = F.clip(k, -self.clip_qkv, self.clip_qkv)
+            v = F.clip(v, -self.clip_qkv, self.clip_qkv)
+
+        qkv = F.concat([q, k, v], axis=-1)
+
+        freqs_cis = F.cast(self.rope.freqs_cis, qkv.dtype).to(qkv.device)
+
+        # interleaved=True → GPT-J style rotation (swap adjacent pairs)
+        # This matches ERNIE-4.5's apply_rotary implementation
+        xq = rope_split_store_ragged(
+            kv_params=self.kv_params,
+            qkv=qkv,
+            input_row_offsets=kwargs["input_row_offsets"],
+            freqs_cis=freqs_cis,
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            n_heads=self.n_heads,
+            interleaved=True,  # GPT-J style — ERNIE-4.5 specific
+        )
+        xq = xq.reshape((-1, self.n_heads, self.kv_params.head_dim))
+
+        attn_out = flash_attention_ragged(
+            self.kv_params,
+            input=xq,
+            kv_collection=kv_collection,
+            layer_idx=layer_idx,
+            input_row_offsets=kwargs["input_row_offsets"],
+            mask_variant=MHAMaskVariant.CAUSAL_MASK,
+            scale=self.scale,
+        )
+        attn_out = F.reshape(attn_out, shape=[total_seq_len, self.q_weight_dim])
+        return self.o_proj(attn_out)

--- a/max/python/max/pipelines/architectures/ernie4_5/layers/rope.py
+++ b/max/python/max/pipelines/architectures/ernie4_5/layers/rope.py
@@ -1,0 +1,59 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""ERNIE-4.5 RoPE: builds correct freqs_cis for GPT-J style rotation."""
+
+from __future__ import annotations
+
+from max.dtype import DType
+from max.graph import DeviceRef, TensorValue, ops
+
+
+def build_ernie45_freqs_cis(
+    head_dim: int,
+    max_seq_len: int,
+    rope_theta: float,
+) -> TensorValue:
+    """Build ERNIE-4.5's interleaved GPT-J-style ``freqs_cis`` tensor.
+
+    The returned tensor has layout ``[max_seq_len, head_dim]`` where each
+    head dim is stored as interleaved cosine/sine pairs:
+    ``[cos0,sin0,cos1,sin1,...]`` for every position.
+
+    Args:
+        head_dim: Dimensionality per head (typically 128).
+        max_seq_len: Maximum sequence length to build positions for.
+        rope_theta: RoPE base scaling factor.
+
+    Returns:
+        A ``TensorValue`` containing the interleaved freqs_cis tensor.
+    """
+
+    # [head_dim//2] — inverse frequencies
+    indices = ops.range(
+        0, head_dim, step=2, dtype=DType.float64, device=DeviceRef.CPU()
+    )
+    inv_freqs = ops.cast(
+        1.0 / (rope_theta ** (indices / head_dim)), DType.float32
+    )
+
+    # [max_seq_len] — position ids
+    t = ops.range(0, max_seq_len, dtype=DType.float32, device=DeviceRef.CPU())
+
+    # [max_seq_len, head_dim//2]
+    sinusoid = ops.outer(t, inv_freqs)
+
+    # [max_seq_len, head_dim//2, 2] → [max_seq_len, head_dim]
+    freqs_cis = ops.stack([ops.cos(sinusoid), ops.sin(sinusoid)], axis=-1)
+    s0, s1, s2 = freqs_cis.shape
+    return ops.reshape(freqs_cis, [s0, s1 * s2])

--- a/max/python/max/pipelines/architectures/ernie4_5/layers/transformer_block.py
+++ b/max/python/max/pipelines/architectures/ernie4_5/layers/transformer_block.py
@@ -1,0 +1,81 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""ERNIE-4.5 transformer block — standard sequential pre-norm (Llama-style)."""
+
+from __future__ import annotations
+
+from max.experimental import functional as F
+from max.experimental.nn import Module
+from max.experimental.tensor import Tensor
+from max.nn.kv_cache import PagedCacheValues
+
+from .attention import ERNIE45Attention
+
+
+class ERNIE45TransformerBlock(Module[..., Tensor]):
+    """Pre-norm decoder block: norm → attn → residual → norm → mlp → residual."""
+
+    def __init__(
+        self,
+        attention: ERNIE45Attention,
+        mlp: Module[[Tensor], Tensor],
+        input_layernorm: Module[[Tensor], Tensor],
+        post_attention_layernorm: Module[[Tensor], Tensor],
+        residual_multiplier: float = 1.0,
+    ) -> None:
+        super().__init__()
+        self.self_attn = attention
+        self.mlp = mlp
+        self.input_layernorm = input_layernorm
+        self.post_attention_layernorm = post_attention_layernorm
+        self.residual_multiplier = residual_multiplier
+
+    def forward(
+        self,
+        layer_idx: Tensor,
+        x: Tensor,
+        kv_collection: PagedCacheValues,
+        input_row_offsets: Tensor,
+        **kwargs,
+    ) -> Tensor:
+        """Apply one pre-norm decoder block: Attention → residual → MLP → residual.
+
+        Args:
+            layer_idx: Scalar uint32 tensor identifying this layer in the KV cache.
+            x: Input hidden states, shape ``(total_seq_len, hidden_size)``.
+            kv_collection: Paged KV cache (read/written by attention).
+            input_row_offsets: uint32 ragged-batch row delimiters passed
+                through to attention.
+            **kwargs: Forwarded to the attention layer.
+
+        Returns:
+            Updated hidden states, same shape as ``x``.
+        """
+
+        attn_out = self.self_attn(
+            self.input_layernorm(x),
+            kv_collection,
+            input_row_offsets=input_row_offsets,
+            **kwargs,
+        )
+        if self.residual_multiplier != 1.0:
+            m = F.constant(self.residual_multiplier, x.dtype, device=x.device)
+            attn_out = attn_out * m
+        h = x + attn_out
+
+        mlp_out = self.mlp(self.post_attention_layernorm(h))
+        if self.residual_multiplier != 1.0:
+            m = F.constant(self.residual_multiplier, h.dtype, device=h.device)
+            mlp_out = mlp_out * m
+        return h + mlp_out

--- a/max/python/max/pipelines/architectures/ernie4_5/model.py
+++ b/max/python/max/pipelines/architectures/ernie4_5/model.py
@@ -1,0 +1,336 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""ERNIE-4.5 pipeline model using the ModuleV3 API."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+
+import numpy as np
+from max.driver import Buffer, Device
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.experimental import functional as F
+from max.experimental.tensor import default_dtype
+from max.graph import DeviceRef, TensorType
+from max.graph.weights import Weights, WeightsAdapter
+from max.nn.kv_cache import KVCacheInputs, KVCacheParams
+from max.nn.transformer import ReturnHiddenStates, ReturnLogits
+from max.pipelines.context import TextContext
+from max.pipelines.lib import (
+    CompilationTimer,
+    KVCacheConfig,
+    ModelInputs,
+    ModelOutputs,
+    PipelineConfig,
+    PipelineModelWithKVCache,
+)
+from max.pipelines.lib.log_probabilities import LogProbabilitiesMixin
+from transformers import AutoConfig
+
+from .ernie45 import ERNIE45
+from .model_config import ERNIE45Config
+
+logger = logging.getLogger("max.pipelines")
+
+
+@dataclass
+class ERNIE45Inputs(ModelInputs):
+    tokens: Buffer
+    input_row_offsets: Buffer
+    return_n_logits: Buffer
+
+    @property
+    def buffers(self) -> tuple[Buffer, ...]:
+        """Flatten all inputs into the ordered tuple expected by the compiled model.
+
+        Converts an in-memory ``input_row_offsets`` numpy array into a
+        device-resident ``Buffer`` when necessary and then returns the
+        concatenated input buffer tuple, including flattened KV cache inputs
+        when present.
+
+        Returns:
+            Tuple of ``Buffer`` objects in the order expected by the compiled
+            ERNIE-4.5 callable.
+        """
+
+        if isinstance(self.input_row_offsets, np.ndarray):
+            input_row_offsets = Buffer.from_numpy(self.input_row_offsets).to(
+                self.tokens.device
+            )
+        else:
+            input_row_offsets = self.input_row_offsets
+        return (
+            self.tokens,
+            self.return_n_logits,
+            input_row_offsets,
+            *(
+                self.kv_cache_inputs.flatten()
+                if self.kv_cache_inputs is not None
+                else ()
+            ),
+        )
+
+
+class ERNIE45Model(
+    LogProbabilitiesMixin, PipelineModelWithKVCache[TextContext]
+):
+    """ERNIE-4.5 pipeline model."""
+
+    config_class: type[ERNIE45Config] = ERNIE45Config
+    norm_method: Literal["rms_norm"] = "rms_norm"
+    attention_bias: bool = False
+
+    def __init__(
+        self,
+        pipeline_config: PipelineConfig,
+        session: InferenceSession,
+        devices: list[Device],
+        kv_cache_config: KVCacheConfig,
+        weights: Weights,
+        adapter: WeightsAdapter | None = None,
+        return_logits: ReturnLogits = ReturnLogits.LAST_TOKEN,
+        return_hidden_states: ReturnHiddenStates = ReturnHiddenStates.NONE,
+    ) -> None:
+        super().__init__(
+            pipeline_config,
+            session,
+            devices,
+            kv_cache_config,
+            weights,
+            adapter,
+            return_logits,
+            return_hidden_states,
+        )
+        self.model = self.load_model()
+
+    @staticmethod
+    def calculate_max_seq_len(
+        pipeline_config: PipelineConfig, huggingface_config: AutoConfig
+    ) -> int:
+        return ERNIE45Config.calculate_max_seq_len(
+            pipeline_config, huggingface_config
+        )
+
+    @classmethod
+    def get_kv_params(
+        cls,
+        huggingface_config: AutoConfig,
+        pipeline_config: PipelineConfig,
+        devices: list[DeviceRef],
+        kv_cache_config: KVCacheConfig,
+        cache_dtype: DType,
+    ) -> KVCacheParams:
+        return ERNIE45Config.construct_kv_params(
+            huggingface_config,
+            pipeline_config,
+            devices,
+            kv_cache_config,
+            cache_dtype,
+        )
+
+    def load_model(self) -> Callable[..., Any]:
+        """Build, compile, and return the ERNIE-4.5 inference callable.
+
+        Constructs the tensor type descriptors, applies the optional weight
+        adapter, instantiates the ``ERNIE45`` ModuleV3 model, compiles it using
+        MAX's lazy graph API, and returns the ready-to-execute callable.
+
+        Returns:
+            Compiled model callable accepting the flattened input buffers and
+            returning a tuple of output tensors.
+        """
+
+        assert self.pipeline_config.runtime.max_batch_size
+        self._input_row_offsets_prealloc = Buffer.from_numpy(
+            np.arange(
+                self.pipeline_config.runtime.max_batch_size + 1, dtype=np.uint32
+            )
+        ).to(self.devices[0])
+
+        with CompilationTimer("ernie45") as timer:
+            device0 = self.devices[0]
+            device_ref = DeviceRef(device0.label, device0.id)
+
+            tokens_type = TensorType(
+                DType.int64, shape=["total_seq_len"], device=device_ref
+            )
+            input_row_offsets_type = TensorType(
+                DType.uint32, shape=["input_row_offsets_len"], device=device0
+            )
+            return_n_logits_type = TensorType(
+                DType.int64, shape=["return_n_logits"], device=DeviceRef.CPU()
+            )
+
+            huggingface_config = self.huggingface_config
+            if self.adapter:
+                state_dict = self.adapter(
+                    dict(self.weights.items()),
+                    huggingface_config=huggingface_config,
+                    pipeline_config=self.pipeline_config,
+                )
+            else:
+                state_dict = {
+                    key: value.data() for key, value in self.weights.items()
+                }
+
+            model_config = self.config_class.initialize(self.pipeline_config)
+            model_config.finalize(
+                huggingface_config=huggingface_config,
+                state_dict=state_dict,
+                norm_method=self.norm_method,
+                attention_bias=self.attention_bias,
+                return_logits=self.return_logits,
+                return_hidden_states=self.return_hidden_states,
+            )
+
+            with F.lazy(), default_dtype(model_config.dtype):
+                nn_model = ERNIE45(model_config, self.kv_params)
+                nn_model.to(self.devices[0])
+
+            kv_inputs = self.kv_params.get_symbolic_inputs()
+            timer.mark_build_complete()
+            compiled_model = nn_model.compile(
+                tokens_type,
+                return_n_logits_type,
+                input_row_offsets_type,
+                *kv_inputs.flatten(),
+                weights=state_dict,
+            )
+        return compiled_model
+
+    def execute(self, model_inputs: ModelInputs) -> ModelOutputs:
+        """Run one forward pass and unpack outputs into ``ModelOutputs``.
+
+        The output layout depends on ``return_logits`` / ``return_hidden_states``
+        and is unpacked into the corresponding ``ModelOutputs`` fields.
+
+        Args:
+            model_inputs: An ``ERNIE45Inputs`` instance produced by
+                ``prepare_initial_token_inputs`` or ``prepare_next_token_inputs``.
+
+        Returns:
+            ``ModelOutputs`` with ``logits``, ``next_token_logits``, and
+            optionally ``logit_offsets`` / ``hidden_states`` populated.
+        """
+
+        model_inputs = cast(ERNIE45Inputs, model_inputs)
+        model_outputs = self.model(*model_inputs.buffers)
+        has_offsets = self.return_logits in (
+            ReturnLogits.VARIABLE,
+            ReturnLogits.ALL,
+        )
+        has_hidden = self.return_hidden_states != ReturnHiddenStates.NONE
+
+        if has_offsets and has_hidden:
+            return ModelOutputs(
+                logits=cast(Buffer, model_outputs[1].driver_tensor),
+                next_token_logits=cast(Buffer, model_outputs[0].driver_tensor),
+                logit_offsets=cast(Buffer, model_outputs[2].driver_tensor),
+                hidden_states=cast(Buffer, model_outputs[3].driver_tensor),
+            )
+        elif has_offsets:
+            return ModelOutputs(
+                logits=cast(Buffer, model_outputs[1].driver_tensor),
+                next_token_logits=cast(Buffer, model_outputs[0].driver_tensor),
+                logit_offsets=cast(Buffer, model_outputs[2].driver_tensor),
+            )
+        elif has_hidden:
+            return ModelOutputs(
+                logits=cast(Buffer, model_outputs[0].driver_tensor),
+                next_token_logits=cast(Buffer, model_outputs[0].driver_tensor),
+                hidden_states=cast(Buffer, model_outputs[1].driver_tensor),
+            )
+        else:
+            return ModelOutputs(
+                logits=cast(Buffer, model_outputs[0].driver_tensor),
+                next_token_logits=cast(Buffer, model_outputs[0].driver_tensor),
+            )
+
+    def prepare_initial_token_inputs(
+        self,
+        replica_batches: Sequence[Sequence[TextContext]],
+        kv_cache_inputs: KVCacheInputs[Buffer, Buffer] | None = None,
+        return_n_logits: int = 1,
+    ) -> ModelInputs:
+        """Pack a prefill batch into ``ERNIE45Inputs``.
+
+        Concatenates token arrays from all contexts and computes ragged
+        row offsets so the compiled model can handle variable-length sequences
+        without padding.
+
+        Args:
+            replica_batches: Single-replica list of ``TextContext`` objects
+                (DP > 1 is not supported).
+            kv_cache_inputs: Pre-allocated paged KV cache buffers.
+            return_n_logits: Number of trailing per-sequence logits to return.
+
+        Returns:
+            An ``ERNIE45Inputs`` instance ready for ``execute``.
+
+        Raises:
+            ValueError: If ``len(replica_batches) > 1``.
+        """
+
+        if len(replica_batches) > 1:
+            raise ValueError("ERNIE45Model does not support DP>1")
+        context_batch = replica_batches[0]
+        assert kv_cache_inputs is not None
+        input_row_offsets = np.cumsum(
+            [0] + [ctx.tokens.active_length for ctx in context_batch],
+            dtype=np.uint32,
+        )
+        tokens = np.concatenate([ctx.tokens.active for ctx in context_batch])
+        return ERNIE45Inputs(
+            tokens=Buffer.from_numpy(tokens).to(self.devices[0]),
+            input_row_offsets=Buffer.from_numpy(input_row_offsets).to(
+                self.devices[0]
+            ),
+            return_n_logits=Buffer.from_numpy(
+                np.array([return_n_logits], dtype=np.int64)
+            ),
+            kv_cache_inputs=kv_cache_inputs,
+        )
+
+    def prepare_next_token_inputs(
+        self, next_tokens: Buffer, prev_model_inputs: ModelInputs
+    ) -> ModelInputs:
+        """Pack a decode step (single next-token per sequence) into ``ERNIE45Inputs``.
+
+        Reuses the pre-allocated ``_input_row_offsets_prealloc`` buffer
+        (arange 0..batch_size) to avoid a per-step allocation.
+
+        Args:
+            next_tokens: Buffer of next token IDs, one per active sequence.
+            prev_model_inputs: Previous step's ``ERNIE45Inputs``; reuses its
+                ``return_n_logits`` and ``kv_cache_inputs``.
+
+        Returns:
+            An ``ERNIE45Inputs`` instance for the decode step.
+        """
+
+        prev_model_inputs = cast(ERNIE45Inputs, prev_model_inputs)
+        row_offsets_size = prev_model_inputs.input_row_offsets.shape[0]
+        next_row_offsets = self._input_row_offsets_prealloc[
+            :row_offsets_size
+        ].to(self.devices[0])
+        return ERNIE45Inputs(
+            tokens=next_tokens,
+            input_row_offsets=next_row_offsets,
+            return_n_logits=prev_model_inputs.return_n_logits,
+            kv_cache_inputs=prev_model_inputs.kv_cache_inputs,
+        )

--- a/max/python/max/pipelines/architectures/ernie4_5/model_config.py
+++ b/max/python/max/pipelines/architectures/ernie4_5/model_config.py
@@ -1,0 +1,292 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Config for Ernie4_5ForCausalLM (ERNIE-4.5) models (ModuleV3).
+
+0.3B defaults: 18 layers, hidden=1024, ffn=3072,
+16Q/2KV heads, head_dim=128, vocab=103424, max_position_embeddings=131072.
+
+Notes:
+    - ``rope_theta`` may live inside ``rope_parameters`` (new-style HF config)
+        or at the top level; ``get_rope_theta`` handles both cases.
+    - ``use_bias`` and ``tie_word_embeddings`` are respected when present in
+        the HuggingFace config; defaults mirror the official ERNIE-4.5 setup.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+from max.dtype import DType
+from max.graph import DeviceRef
+from max.graph.weights import WeightData, WeightsFormat, weights_format
+from max.nn.kv_cache import KVCacheParams
+from max.nn.transformer import ReturnHiddenStates, ReturnLogits
+from max.pipelines.lib import (
+    KVCacheConfig,
+    MAXModelConfig,
+    PipelineConfig,
+    upper_bounded_default,
+)
+from max.pipelines.lib.interfaces.arch_config import ArchConfigWithKVCache
+from max.pipelines.modeling.config_enums import supported_encoding_dtype
+from transformers import AutoConfig
+from typing_extensions import Self, override
+
+
+@dataclass(kw_only=True)
+class ERNIE45Config(ArchConfigWithKVCache):
+    """Model configuration for ERNIE-4.5 (Ernie4_5ForCausalLM).
+
+    0.3B defaults: 18 layers, hidden=1024, ffn=3072,
+    16Q/2KV heads, head_dim=128, vocab=103424.
+    """
+
+    hidden_size: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    num_hidden_layers: int
+    rope_theta: float
+    max_seq_len: int
+    intermediate_size: int
+    interleaved_rope_weights: bool
+    vocab_size: int
+    dtype: DType
+    kv_params: KVCacheParams
+    devices: list[DeviceRef]
+
+    # Standard optional fields
+    return_logits: ReturnLogits = ReturnLogits.LAST_TOKEN
+    return_hidden_states: ReturnHiddenStates = ReturnHiddenStates.NONE
+    norm_method: Literal["rms_norm"] = "rms_norm"
+    rms_norm_eps: float | None = None
+    attention_bias: bool = False  # use_bias: false
+    tie_word_embeddings: bool = True  # tie_word_embeddings: true
+    stacked_mlp: bool = False
+    stacked_qkv: bool = False
+    attention_multiplier: float = 0.0
+    embedding_multiplier: float = 1.0
+    residual_multiplier: float = 1.0
+    clip_qkv: float | None = None
+    logits_scaling: float = 1.0
+
+    # ------------------------------------------------------------------ #
+    # ArchConfigWithKVCache interface
+    # ------------------------------------------------------------------ #
+
+    def get_kv_params(self) -> KVCacheParams:
+        return self.kv_params
+
+    def get_max_seq_len(self) -> int:
+        return self.max_seq_len
+
+    # ------------------------------------------------------------------ #
+    # Static helpers
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def get_head_dim(huggingface_config: AutoConfig) -> int:
+        if (
+            hasattr(huggingface_config, "head_dim")
+            and huggingface_config.head_dim
+        ):
+            return huggingface_config.head_dim
+        return (
+            huggingface_config.hidden_size
+            // huggingface_config.num_attention_heads
+        )
+
+    @staticmethod
+    def get_head_dim_from_config(config: ERNIE45Config) -> int:
+        return config.kv_params.head_dim
+
+    @staticmethod
+    def get_num_layers(huggingface_config: AutoConfig) -> int:
+        return huggingface_config.num_hidden_layers
+
+    @staticmethod
+    def calculate_attention_multiplier(huggingface_config: AutoConfig) -> float:
+        return getattr(
+            huggingface_config,
+            "attention_multiplier",
+            math.sqrt(
+                1.0 / float(ERNIE45Config.get_head_dim(huggingface_config))
+            ),
+        )
+
+    @staticmethod
+    def get_rope_theta(huggingface_config: AutoConfig) -> float:
+        """Extract rope_theta from the new-style rope_parameters dict or top-level."""
+        # New-style: rope_parameters = {"rope_type": "default", "rope_theta": 500000.0, ...}
+        rope_params = getattr(huggingface_config, "rope_parameters", None)
+        if isinstance(rope_params, dict):
+            if "rope_theta" in rope_params:
+                return float(rope_params["rope_theta"])
+            if "base" in rope_params:
+                return float(rope_params["base"])
+        # Fallback to top-level rope_theta
+        return float(getattr(huggingface_config, "rope_theta", 500000.0))
+
+    @staticmethod
+    def construct_kv_params(
+        huggingface_config: AutoConfig,
+        pipeline_config: PipelineConfig,
+        devices: list[DeviceRef],
+        kv_cache_config: KVCacheConfig,
+        cache_dtype: DType,
+    ) -> KVCacheParams:
+        # group = 16/2 = 8 — exactly at GPU kernel limit, no expansion needed
+        return kv_cache_config.to_params(
+            dtype=cache_dtype,
+            n_kv_heads=huggingface_config.num_key_value_heads,
+            head_dim=ERNIE45Config.get_head_dim(huggingface_config),
+            num_layers=ERNIE45Config.get_num_layers(huggingface_config),
+            devices=devices,
+            data_parallel_degree=pipeline_config.model.data_parallel_degree,
+        )
+
+    @staticmethod
+    def calculate_max_seq_len(
+        pipeline_config: PipelineConfig,
+        huggingface_config: AutoConfig,
+    ) -> int:
+        hf_max = getattr(huggingface_config, "max_position_embeddings", 131072)
+        try:
+            return upper_bounded_default(
+                upper_bound=hf_max,
+                default=pipeline_config.model.max_length,
+            )
+        except ValueError as e:
+            raise ValueError(
+                f"max_length ({pipeline_config.model.max_length}) exceeds "
+                f"model max_position_embeddings ({hf_max})."
+            ) from e
+
+    # ------------------------------------------------------------------ #
+    # Factory
+    # ------------------------------------------------------------------ #
+
+    @override
+    @classmethod
+    def initialize(
+        cls,
+        pipeline_config: PipelineConfig,
+        model_config: MAXModelConfig | None = None,
+    ) -> Self:
+        model_config = model_config or pipeline_config.model
+        huggingface_config = model_config.huggingface_config
+        if huggingface_config is None:
+            raise ValueError(
+                f"HuggingFace config required for '{model_config.model_path}'"
+            )
+
+        kv_cache_config = model_config.kv_cache
+        quantization_encoding = model_config.quantization_encoding
+        if quantization_encoding is None:
+            raise ValueError("quantization_encoding must not be None")
+
+        dtype = supported_encoding_dtype(quantization_encoding)
+        cache_dtype = model_config.kv_cache.cache_dtype
+
+        _weights_format = weights_format(model_config.weight_path)
+        interleaved_rope_weights = (
+            _weights_format == WeightsFormat.gguf
+            and model_config.rope_type == "normal"
+        )
+
+        device_refs = [
+            DeviceRef(spec.device_type, spec.id)
+            for spec in model_config.device_specs
+        ]
+
+        return cls(
+            hidden_size=huggingface_config.hidden_size,
+            num_attention_heads=huggingface_config.num_attention_heads,
+            num_key_value_heads=huggingface_config.num_key_value_heads,
+            num_hidden_layers=huggingface_config.num_hidden_layers,
+            rope_theta=cls.get_rope_theta(huggingface_config),
+            intermediate_size=huggingface_config.intermediate_size,
+            interleaved_rope_weights=interleaved_rope_weights,
+            vocab_size=huggingface_config.vocab_size,
+            dtype=dtype,
+            max_seq_len=cls.calculate_max_seq_len(
+                pipeline_config, huggingface_config=huggingface_config
+            ),
+            kv_params=cls.construct_kv_params(
+                huggingface_config=huggingface_config,
+                pipeline_config=pipeline_config,
+                devices=device_refs,
+                kv_cache_config=kv_cache_config,
+                cache_dtype=cache_dtype,
+            ),
+            attention_multiplier=cls.calculate_attention_multiplier(
+                huggingface_config
+            ),
+            devices=device_refs,
+            tie_word_embeddings=getattr(
+                huggingface_config, "tie_word_embeddings", True
+            ),
+            clip_qkv=getattr(huggingface_config, "clip_qkv", None),
+            logits_scaling=getattr(huggingface_config, "logits_scaling", 1.0),
+        )
+
+    def finalize(
+        self,
+        huggingface_config: AutoConfig,
+        state_dict: dict[str, WeightData],
+        return_logits: ReturnLogits,
+        return_hidden_states: ReturnHiddenStates = ReturnHiddenStates.NONE,
+        norm_method: Literal["rms_norm"] = "rms_norm",
+        attention_bias: bool = False,
+    ) -> None:
+        def _strip(s: str, prefix: str) -> str:
+            return s.removeprefix(prefix)
+
+        has_lm_prefix = any(k.startswith("language_model.") for k in state_dict)
+        has_model_prefix = any(k.startswith("model.") for k in state_dict)
+
+        if has_lm_prefix:
+            normalized = {
+                _strip(k, "language_model."): v
+                for k, v in state_dict.items()
+                if k.startswith("language_model.")
+            }
+        elif has_model_prefix:
+            normalized = {
+                _strip(k, "model."): v
+                for k, v in state_dict.items()
+                if k.startswith("model.")
+            }
+        else:
+            normalized = dict(state_dict)
+
+        tie_word_embeddings = (
+            getattr(huggingface_config, "tie_word_embeddings", True)
+            or "lm_head.weight" not in normalized
+        )
+        rms_norm_eps = (
+            huggingface_config.rms_norm_eps
+            if norm_method == "rms_norm"
+            else None
+        )
+
+        self.norm_method = norm_method
+        self.rms_norm_eps = rms_norm_eps
+        self.tie_word_embeddings = tie_word_embeddings
+        self.stacked_mlp = "layers.0.mlp.gate_up_proj.weight" in normalized
+        self.stacked_qkv = "layers.0.self_attn.qkv_proj.weight" in normalized
+        self.attention_bias = attention_bias
+        self.return_logits = return_logits
+        self.return_hidden_states = return_hidden_states

--- a/max/python/max/pipelines/architectures/ernie4_5/weight_adapters.py
+++ b/max/python/max/pipelines/architectures/ernie4_5/weight_adapters.py
@@ -1,0 +1,142 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Weight name adapters for ERNIE-4.5 (Ernie4_5ForCausalLM)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from max.dtype import DType
+from max.graph.weights import WeightData, Weights
+from transformers import AutoConfig
+
+# HF safetensors layout (standard):
+#   model.embed_tokens.weight
+#   model.layers.N.self_attn.{q,k,v,o}_proj.weight
+#   model.layers.N.mlp.{gate,up,down}_proj.weight
+#   model.layers.N.{input,post_attention}_layernorm.weight
+#   model.norm.weight
+#   lm_head.weight  (absent when tie_word_embeddings=True)
+
+ERNIE45_SAFETENSOR_MAPPING: dict[str, str] = {
+    "model.": "language_model.",
+}
+
+
+def _target_dtype(pipeline_config: Any) -> DType | None:
+    try:
+        from max.pipelines.modeling.config_enums import supported_encoding_dtype
+
+        enc = pipeline_config.model.quantization_encoding
+        if enc is not None:
+            return supported_encoding_dtype(enc)
+    except Exception:
+        pass
+    return None
+
+
+def convert_safetensor_state_dict(
+    state_dict: dict[str, Weights],
+    huggingface_config: AutoConfig | None = None,
+    pipeline_config: Any = None,
+    **kwargs,
+) -> dict[str, WeightData]:
+    """Remap HF safetensors weight names to MAX internal convention.
+
+    The mapping applies the ERNIE-4.5 safetensor naming rules and also
+    optionally casts weights to the target dtype derived from the
+    ``pipeline_config`` quantization encoding.
+
+    Args:
+        state_dict: Raw HF weights keyed by safetensor name.
+        huggingface_config: Optional HuggingFace config (kept for adapter
+            interface compatibility).
+        pipeline_config: Optional pipeline config used to determine target
+            dtype for casting.
+
+    Returns:
+        Transformed weight dict keyed by MAX-internal names with values as
+        ``WeightData`` objects.
+    """
+
+    target_dtype = _target_dtype(pipeline_config) if pipeline_config else None
+    has_lm_prefix = any(k.startswith("language_model.") for k in state_dict)
+
+    new_state_dict: dict[str, WeightData] = {}
+    for weight_name, value in state_dict.items():
+        if has_lm_prefix:
+            max_name = weight_name
+        else:
+            max_name = weight_name
+            for before, after in ERNIE45_SAFETENSOR_MAPPING.items():
+                max_name = max_name.replace(before, after)
+            if max_name == "lm_head.weight":
+                max_name = "language_model.lm_head.weight"
+
+        wd: WeightData = value.data()
+        if target_dtype is not None and wd.dtype != target_dtype:
+            wd = wd.astype(target_dtype)
+        new_state_dict[max_name] = wd
+    return new_state_dict
+
+
+def convert_gguf_state_dict(
+    state_dict: dict[str, Weights],
+    huggingface_config: AutoConfig | None = None,
+    pipeline_config: Any = None,
+    **unused_kwargs,
+) -> dict[str, WeightData]:
+    """Convert GGUF-style weight names to MAX internal names.
+
+    Applies the GGUF→MAX name mapping and casts weights to the pipeline
+    target dtype when applicable. Removes any GGUF rope frequency weights
+    which are handled separately by the code that constructs freqs_cis.
+
+    Args:
+        state_dict: Raw GGUF weights mapping.
+        huggingface_config: Optional HuggingFace config (unused).
+        pipeline_config: Optional pipeline config used to determine target
+            dtype for casting.
+
+    Returns:
+        Converted weight dict keyed by MAX-internal names.
+    """
+
+    target_dtype = _target_dtype(pipeline_config) if pipeline_config else None
+    gguf_mapping = {
+        "token_embd": "language_model.embed_tokens",
+        "blk": "language_model.layers",
+        "ffn_up": "mlp.up_proj",
+        "ffn_down": "mlp.down_proj",
+        "ffn_gate": "mlp.gate_proj",
+        "ffn_norm": "post_attention_layernorm",
+        "attn_norm": "input_layernorm",
+        "attn_q": "self_attn.q_proj",
+        "attn_v": "self_attn.v_proj",
+        "attn_k": "self_attn.k_proj",
+        "attn_output": "self_attn.o_proj",
+        "output.weight": "language_model.lm_head.weight",
+        "output_norm": "language_model.norm",
+    }
+    new_state_dict: dict[str, WeightData] = {}
+    for gguf_name, value in state_dict.items():
+        max_name = gguf_name
+        for before, after in gguf_mapping.items():
+            max_name = max_name.replace(before, after)
+        wd: WeightData = value.data()
+        if target_dtype is not None and wd.dtype != target_dtype:
+            wd = wd.astype(target_dtype)
+        new_state_dict[max_name] = wd
+    new_state_dict.pop("rope_freqs.weight", None)
+    return new_state_dict

--- a/max/python/max/pipelines/lib/config/config.py
+++ b/max/python/max/pipelines/lib/config/config.py
@@ -187,6 +187,7 @@ _DISABLE_AUTO_DEVICE_GRAPH_CAPTURE_ARCHITECTURES = (
     "DFlashDraftModel",
     "DeepseekV2ForCausalLM",
     "DeepseekV2ForCausalLM_ModuleV3",
+    "Ernie4_5ForCausalLM",
     "ExaoneForCausalLM",
     "ExaoneForCausalLM_ModuleV3",
     "Gemma3ForCausalLM",


### PR DESCRIPTION
Linked issue

Fixes #6685

**Type of change**
* New feature or public API

---

## Motivation

ERNIE-4.5 (Ernie4_5ForCausalLM) is Baidu's family of dense decoder-only LLMs,
released under Apache 2.0.
The dense checkpoints follow a standard Llama-style architecture
with GQA and RoPE. 

It uses GPT-J style interleaved rotary pairing and store rope_theta at the top level of config.json. The implementation also includes a forward-compatible fallback for checkpoints that may use the newer nested rope_parameters dict style.

MAX had no native support for the `Ernie4_5ForCausalLM` architecture class.
This PR adds an implementation so `baidu/ERNIE-4.5-0.3B-PT` (and sibling
checkpoints) can be served directly via `max serve` without any custom flags
after registration.

---

## What changed

Added `max/python/max/pipelines/architectures/ernie4_5/` — a new
architecture package for the `Ernie4_5ForCausalLM` model family.

**New files:**

| File | Purpose |
|---|---|
| `__init__.py` | Exports `ARCHITECTURES = [ernie45_arch]` for MAX loader discovery |
| `arch.py` | `SupportedArchitecture` registration — name matches `architectures` field in `config.json` |
| `model_config.py` | `ERNIE45Config` dataclass — parses HuggingFace config including nested `rope_parameters` |
| `ernie45.py` | `ERNIE45` / `ERNIE45TextModel` 
| `model.py` | `ERNIE45Model` — `PipelineModelWithKVCache` wrapper, input preparation, output unpacking |
| `weight_adapters.py` | Remaps `model.*` → `language_model.*`, handles `lm_head.weight` tying edge case, casts dtype |
| `layers/attention.py` |   GQA with GPT-J style interleaved RoPE via `rope_split_store_ragged` |
| `layers/transformer_block.py` | `ERNIE45TransformerBlock` — standard pre-norm decoder block |
| `layers/rope.py` | Builds `freqs_cis` as `[cos0,sin0,cos1,sin1,...]` interleaved pairs using MAX graph ops |
| `BUILD.bazel` | Defines the `ernie4_5` Python library and its dependencies for Bazel builds (modeled on `llama3_modulev3/BUILD.bazel` due to `experimental/nn` dependency) |

**Architecture highlights:**

- 0.36B dense backbone: 18 layers, hidden_size=1024, intermediate_size=3072,
  GQA (16 Q / 2 KV heads, group=8), head_dim=128, vocab_size=103424
- **GPT-J style interleaved RoPE** (`interleaved=True` in `rope_split_store_ragged`),
  distinct from the standard half-rotation used by most Llama-family models
- rope_theta (500000.0) read from the top-level config field; the implementation also handles the nested rope_parameters dict style used by some newer checkpoint variants
- Standard causal attention (`MHAMaskVariant.CAUSAL_MASK`)
- Tied word embeddings by default (`tie_word_embeddings=true`), with a weight
  adapter edge case to remap a standalone `lm_head.weight` if present

---

## Testing

Verified on `baidu/ERNIE-4.5-0.3B-PT` with GPU serving:

```bash
max serve \
  --model-path baidu/ERNIE-4.5-0.3B-PT \
  --custom-architectures architectures/ernie4_5
```

**Smoke test — model generates correctly:**
```bash
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"baidu/ERNIE-4.5-0.3B-PT",
       "messages":[{"role":"user","content":"What is the capital of france?"}],
       "max_tokens":32,"temperature":0}'
```

**Output:**
```text
The capital of France is Paris.
```

**GSM8K accuracy vs vLLM reference:**


| Model | Task | Accuracy | vs Reference |
|---|---|---|---|
| baidu/ERNIE-4.5-0.3B-PT          | gsm8k_cot_llama | 0.362 | 98.3 |

---

## Checklist

* [ ] The linked issue above has been reviewed by a maintainer and is agreed-upon,
  or this is a trivial fix that does not need prior approval
* [x] PR is small and focused — single new architecture, no changes to existing
  architectures
* [x] I ran `./bazelw run format` to format my changes
* [x] I added or updated tests to cover my changes
* [x] If AI tools assisted with this contribution, I have included an `Assisted-by:` trailer in my commit message or this PR description

**Assisted-by:** AI