### PR TITLE
[Docs] Add macOS Metal toolchain tip to GPU intro tutorial

### DIFF
--- a/mojo/docs/manual/gpu/intro-tutorial.mdx
+++ b/mojo/docs/manual/gpu/intro-tutorial.mdx
@@ -850,6 +850,25 @@ def main() raises:
 
 </details>
 
+:::tip macOS
+
+If you're on Apple silicon and getting:
+
+```output
+error: Metal Compiler failed to compile metallib. Please submit a bug report.
+from std.gpu.host import DeviceContext
+^
+mojo: error: failed to run the pass manager
+```
+
+Please try:
+
+```bash
+xcodebuild -downloadComponent MetalToolchain
+```
+
+:::
+
 The `enqueue_function()` method enqueues the compilation and invocation
 of the `vector_addition()` kernel function, passing the input and output tensors
 as arguments. The `grid_dim` and `block_dim` arguments use the `num_blocks` and


### PR DESCRIPTION
## Summary

Adds a `:::tip` admonition to the [Get started with GPU programming](https://docs.modular.com/mojo/manual/gpu/intro-tutorial) tutorial, placed right below the complete `vector_addition.mojo` example.

Apple silicon users can hit the following error when compiling the example:

```
error: Metal Compiler failed to compile metallib. Please submit a bug report.
from std.gpu.host import DeviceContext
^
mojo: error: failed to run the pass manager
```

The tip points them to the fix:

```bash
xcodebuild -downloadComponent MetalToolchain
```

## Motivation

Relates to #6728. A maintainer noted this is "a frequent issue with targeting Apple silicon GPUs" and suggested making the fix more prominent in the docs — this PR does that by surfacing it directly in the tutorial where users hit the error.

## Notes

- Docs-only change; no code affected.
- Passes `./bazelw run format` (rumdl/lint: "No issues found").

🤖 Generated with [Claude Code](https://claude.com/claude-code) - Claude helped me with MDX formatting and stuff.