### PR TITLE
[Stdlib] Support arithmetic between IntLiteral and FloatLiteral

### DIFF
--- a/mojo/stdlib/std/builtin/int_literal.mojo
+++ b/mojo/stdlib/std/builtin/int_literal.mojo
@@ -212,6 +212,18 @@ struct IntLiteral[value: __mlir_type.`!pop.int_literal`](
         return {}
 
     @always_inline("builtin")
+    def __add__(self, rhs: FloatLiteral) -> type_of(FloatLiteral(self) + rhs):
+        """Return `self + rhs`.
+
+        Args:
+            rhs: The value to add.
+
+        Returns:
+            `self + rhs` value.
+        """
+        return {}
+
+    @always_inline("builtin")
     def __sub__(
         self, rhs: IntLiteral[_]
     ) -> IntLiteral[
@@ -223,6 +235,18 @@ struct IntLiteral[value: __mlir_type.`!pop.int_literal`](
             `>> : !pop.int_literal`,
         ]
     ]:
+        """Return `self - rhs`.
+
+        Args:
+            rhs: The value to subtract.
+
+        Returns:
+            `self - rhs` value.
+        """
+        return {}
+
+    @always_inline("builtin")
+    def __sub__(self, rhs: FloatLiteral) -> type_of(FloatLiteral(self) - rhs):
         """Return `self - rhs`.
 
         Args:
@@ -252,6 +276,32 @@ struct IntLiteral[value: __mlir_type.`!pop.int_literal`](
 
         Returns:
             `self * rhs` value.
+        """
+        return {}
+
+    @always_inline("builtin")
+    def __mul__(self, rhs: FloatLiteral) -> type_of(FloatLiteral(self) * rhs):
+        """Return `self * rhs`.
+
+        Args:
+            rhs: The value to multiply with.
+
+        Returns:
+            `self * rhs` value.
+        """
+        return {}
+
+    @always_inline("builtin")
+    def __truediv__(
+        self, rhs: FloatLiteral
+    ) -> type_of(FloatLiteral(self) / rhs):
+        """Return `self / rhs`.
+
+        Args:
+            rhs: The value to divide with.
+
+        Returns:
+            `self / rhs` value.
         """
         return {}
 

--- a/mojo/stdlib/test/builtin/test_int_literal.mojo
+++ b/mojo/stdlib/test/builtin/test_int_literal.mojo
@@ -142,5 +142,29 @@ def test_pow() raises:
     assert_equal(IntLiteral.__pow__(-1, -2), 1)
 
 
+def test_add_float_literal() raises:
+    assert_equal(2 + 0.5, 2.5)
+    assert_equal(IntLiteral.__add__(3, 2.0), 5.0)
+    assert_equal(IntLiteral.__add__(-2, 0.5), -1.5)
+
+
+def test_sub_float_literal() raises:
+    assert_equal(2 - 0.5, 1.5)
+    assert_equal(IntLiteral.__sub__(3, 2.0), 1.0)
+    assert_equal(IntLiteral.__sub__(-2, 0.5), -2.5)
+
+
+def test_mul_float_literal() raises:
+    assert_equal(2 * 0.5, 1.0)
+    assert_equal(IntLiteral.__mul__(3, 2.0), 6.0)
+    assert_equal(IntLiteral.__mul__(-2, 0.5), -1.0)
+
+
+def test_truediv_float_literal() raises:
+    assert_equal(2 / 0.5, 4.0)
+    assert_equal(IntLiteral.__truediv__(3, 2.0), 1.5)
+    assert_equal(IntLiteral.__truediv__(-2, 0.5), -4.0)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Linked issue

Fixes modular/modular#6690

## Type of change

- [X] Bug fix (non-breaking change that fixes an issue)

## Motivation

Mixed int/float literal arithmetic failed to compile in one direction: `2 * 0.5`<br>errored while `0.5 * 2` worked, and the same held for `+`, `-`, and `/`.<br>`FloatLiteral` already accepts an implicit `IntLiteral` conversion and has the<br>reversed operators, but `IntLiteral` had no forward overload taking a<br>`FloatLiteral`, so `2 <op> 0.5` resolved toward an integer SIMD type and tripped<br>the floating-point-only `SIMD.__init__(FloatLiteral)` constraint in simd.mojo<br>before the reversed fallback could apply. The reversed forms (`0.5 <op> 2`)<br>already worked through the implicit `IntLiteral`-to-`FloatLiteral` conversion.

I checked that the reversed-operator route doesn't fix this on its own: adding<br>`FloatLiteral.__rmul__(IntLiteral)` and dropping the forward overload still fails<br>with the same SIMD constraint, since the forward `IntLiteral.__mul__` is resolved<br>before the reversed op is considered.

## What changed

Added `IntLiteral` overloads for `+`, `-`, `*`, and `/` that take a<br>`FloatLiteral` and return a `FloatLiteral`, so `2 <op> 0.5` now lowers to a<br>`FloatLiteral` like `0.5 <op> 2`. Each overload promotes `self` to a<br>`FloatLiteral` and defers to `FloatLiteral`'s operator, which keeps the result<br>order-correct for the non-commutative `-` and `/`. No existing operators were<br>modified (`IntLiteral` had no `__truediv__` before, so `/` is new).

## Testing

Added regression tests to `test_int_literal.mojo` for all four operators,<br>covering the infix form, the explicit dunder, negative operands, and the<br>order-sensitive `-` / `/` values (`2 - 0.5 == 1.5`, `2 / 0.5 == 4.0`). The full<br>file passes (17/17) against a locally rebuilt stdlib, and I confirmed the new<br>tests fail to compile without the overloads. `mojo format` leaves the changes<br>clean.

## Checklist

- [X] The linked issue above has been reviewed by a maintainer and is<br>    agreed-upon (issue modular/modular#6690 carries the `accepted` label; the four-operator<br>    scope was confirmed by @soraros)
- [X] PR is small and focused (74-line change)
- [X] I ran the formatter on my changes (`mojo format`, clean)
- [X] I added or updated tests to cover my changes
- [X] AI tools assisted this contribution; `Assisted-by: Claude Code` is in the<br>    commit trailer (per AI_TOOL_POLICY.md)

Assisted-by: Claude Code