### PR TITLE
[stdlib] Add Codepoint constructor from StringLiteral

### DIFF
--- a/mojo/stdlib/std/collections/string/codepoint.mojo
+++ b/mojo/stdlib/std/collections/string/codepoint.mojo
@@ -136,6 +136,62 @@ struct Codepoint(Comparable, ImplicitlyCopyable, Intable, Movable, Writable):
         """
         self._scalar_value = UInt32(Int(codepoint))
 
+    @always_inline("nodebug")
+    def __init__(out self, lit: StringLiteral):
+        """Construct a `Codepoint` from a single-codepoint `StringLiteral`.
+
+        This constructor validates at compile-time that the literal contains
+        exactly one Unicode codepoint, and computes the codepoint value as a
+        compile-time constant. This provides an ergonomic and efficient way to
+        create codepoints from string literals without runtime overhead.
+
+        Args:
+            lit: A string literal containing exactly one Unicode codepoint.
+
+        Constraints:
+            The string literal must contain exactly one Unicode codepoint.
+            Multi-byte UTF-8 sequences are supported (e.g., "🔥").
+
+        Examples:
+
+        ```mojo
+        from std.collections.string import Codepoint
+        from std.testing import assert_equal
+
+        # Create codepoints from ASCII literals
+        var a = Codepoint("A")
+        assert_equal(a.to_u32(), 65)
+
+        var space = Codepoint(" ")
+        assert_equal(space, Codepoint.ord(" "))
+
+        # Multi-byte UTF-8 codepoints also work
+        var emoji = Codepoint("🔥")
+        assert_equal(emoji, Codepoint.ord("🔥"))
+        ```
+        """
+        # Reconstruct the literal from the type parameter to force compile-time
+        # evaluation.
+        comptime sl: StringLiteral[lit.value] = {}
+
+        # Compile-time validation for proper UTF-8 codepoint.
+        comptime assert (
+            sl.byte_length() > 0
+        ), "Cannot construct an empty codepoint"
+
+        # SAFETY:
+        #   This is safe because `StringLiteral` is guaranteed to point to
+        #   valid UTF-8.
+        comptime char, num_bytes = Codepoint.unsafe_decode_utf8_codepoint(
+            sl.as_bytes()
+        )
+
+        comptime assert sl.byte_length() == Int(
+            num_bytes
+        ), "input string must be one character"
+
+        self = char
+
     # ===-------------------------------------------------------------------===#
     # Factory methods
     # ===-------------------------------------------------------------------===#

--- a/mojo/stdlib/test/collections/test_codepoint.mojo
+++ b/mojo/stdlib/test/collections/test_codepoint.mojo
@@ -301,5 +301,51 @@ def test_char_comptime() raises:
     assert_equal(c1_bytes, 1)
 
 
+def test_char_from_stringliteral() raises:
+    """Test the constructor from StringLiteral."""
+    # Basic ASCII characters
+    var c_a = Codepoint("A")
+    assert_equal(c_a.to_u32(), 65)
+    assert_equal(c_a, Codepoint.ord("A"))
+
+    var c_z = Codepoint("Z")
+    assert_equal(c_z.to_u32(), 90)
+    assert_equal(c_z, Codepoint.ord("Z"))
+
+    var c_zero = Codepoint("0")
+    assert_equal(c_zero.to_u32(), 48)
+    assert_equal(c_zero, Codepoint.ord("0"))
+
+    # Whitespace characters (motivation from issue #5490)
+    var c_space = Codepoint(" ")
+    assert_equal(c_space.to_u32(), 32)
+    assert_equal(c_space, Codepoint.ord(" "))
+
+    var c_tab = Codepoint("\t")
+    assert_equal(c_tab.to_u32(), 9)
+    assert_equal(c_tab, Codepoint.ord("\t"))
+
+    var c_newline = Codepoint("\n")
+    assert_equal(c_newline.to_u32(), 10)
+    assert_equal(c_newline, Codepoint.ord("\n"))
+
+    var c_carriage = Codepoint("\r")
+    assert_equal(c_carriage.to_u32(), 13)
+    assert_equal(c_carriage, Codepoint.ord("\r"))
+
+    # Special characters
+    var c_null = Codepoint("\0")
+    assert_equal(c_null.to_u32(), 0)
+
+    # Multi-byte UTF-8 codepoints
+    var c_emoji = Codepoint("🔥")
+    assert_equal(c_emoji, Codepoint.ord("🔥"))
+    assert_equal(c_emoji.to_u32(), 0x1F525)
+
+    # Verify it works in compile-time contexts
+    comptime c_comptime = Codepoint("X")
+    assert_equal(c_comptime.to_u32(), 88)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Fixes #5490

Adds a `__init__` overload for `Codepoint` that takes a `StringLiteral`. The literal gets validated at compile time to contain exactly one Unicode codepoint, and the codepoint value is computed as a compile-time constant.

## Why

`Codepoint.ord("X")` works today but it's a runtime call, so you can't use it in a `comptime` context. With this overload you write `Codepoint("A")` directly, and can do `comptime c = Codepoint("X")`. Multi-byte UTF-8 like `"🔥"` works the same way.

## How

- Plain signature, no `@implicit`. ConnorGray's review on #5637 recommended dropping `@implicit` because implicit conversions on `Codepoint` would surprise more than help.
- Uses `comptime assert` (not `__comptime_assert` / `constrained[]`) — stdlib is moving to this.
- Validates UTF-8 by reusing `Codepoint.unsafe_decode_utf8_codepoint` on the literal's bytes.

## Context

PR #5637 (KrxGu) has been working on the same change since December but seems stalled. I incorporated the review feedback that's already accumulated (martinvuyk, NathanSWard, ConnorGray) and am opening fresh to keep things moving. Happy to coordinate if KrxGu wants to drive this to merge instead — I commented on both #5490 and #5637.

## Testing

Added `test_char_from_stringliteral` covering ASCII, whitespace, the null char, multi-byte UTF-8 (`🔥` → `0x1F525`), and `comptime` usage. Full `test_codepoint.mojo` passes (43/43) against a locally rebuilt stdlib.