### PR TITLE
[Mojo] Add TileTensor atomic helper methods and lowering tests #6731

### DIFF
--- a/max/kernels/src/layout/tile_tensor.mojo
+++ b/max/kernels/src/layout/tile_tensor.mojo
@@ -1085,7 +1085,9 @@ struct TileTensor[
         var scalar_ptr = Self.Storage.unsafe_ptr(
             self._unsafe_storage_cast[to_mut=True](),
         ).unsafe_origin_cast[MutAnyOrigin]()
-        return scalar_ptr + self.layout[linear_idx_type=Self.linear_idx_type](coord)
+        return scalar_ptr + self.layout[linear_idx_type=Self.linear_idx_type](
+            coord
+        )
 
     @always_inline("nodebug")
     def atomic_fetch_add[
@@ -1094,7 +1096,9 @@ struct TileTensor[
         self,
         coord: Coord,
         value: Scalar[Self.dtype],
-    ) raises -> Scalar[Self.dtype] where Self.mut and Self.element_size == 1:
+    ) raises -> Scalar[
+        Self.dtype
+    ] where (Self.mut and Self.element_size == 1):
         """Atomically adds a scalar value at the given coordinate.
 
         Parameters:
@@ -1122,7 +1126,9 @@ struct TileTensor[
         self,
         coord: Coord,
         value: Scalar[Self.dtype],
-    ) raises where Self.mut and Self.element_size == 1:
+    ) raises where (
+        Self.mut and Self.element_size == 1
+    ):
         """Atomically adds a scalar value at the given coordinate.
 
         Parameters:
@@ -1144,7 +1150,9 @@ struct TileTensor[
         self,
         coord: Coord,
         value: Scalar[Self.dtype],
-    ) raises where Self.mut and Self.element_size == 1:
+    ) raises where (
+        Self.mut and Self.element_size == 1
+    ):
         """Atomically updates the value at the given coordinate to the maximum.
 
         Parameters:
@@ -1166,7 +1174,9 @@ struct TileTensor[
         self,
         coord: Coord,
         value: Scalar[Self.dtype],
-    ) raises where Self.mut and Self.element_size == 1:
+    ) raises where (
+        Self.mut and Self.element_size == 1
+    ):
         """Atomically updates the value at the given coordinate to the minimum.
 
         Parameters:
@@ -1191,7 +1201,7 @@ struct TileTensor[
         coord: Coord,
         mut expected: Scalar[Self.dtype],
         desired: Scalar[Self.dtype],
-    ) raises -> Bool where Self.mut and Self.element_size == 1:
+    ) raises -> Bool where (Self.mut and Self.element_size == 1):
         """Atomically compares and exchanges the value at the given coordinate.
 
         Parameters:

--- a/max/kernels/src/layout/tile_tensor.mojo
+++ b/max/kernels/src/layout/tile_tensor.mojo
@@ -1097,7 +1097,18 @@ struct TileTensor[
     ) raises -> Scalar[Self.dtype] where Self.mut and Self.element_size == 1:
         """Atomically adds a scalar value at the given coordinate.
 
-        Returns the previous value stored at the location.
+        Parameters:
+            ordering: Memory ordering for the atomic operation.
+
+        Args:
+            coord: Coordinate of the element to update.
+            value: The value to add.
+
+        Returns:
+            The previous value stored at the location.
+
+        Raises:
+            If the atomic pointer operation fails.
         """
         return Atomic.fetch_add[ordering=ordering](
             self._atomic_ptr(coord),
@@ -1112,7 +1123,18 @@ struct TileTensor[
         coord: Coord,
         value: Scalar[Self.dtype],
     ) raises where Self.mut and Self.element_size == 1:
-        """Atomically adds a scalar value at the given coordinate."""
+        """Atomically adds a scalar value at the given coordinate.
+
+        Parameters:
+            ordering: Memory ordering for the atomic operation.
+
+        Args:
+            coord: Coordinate of the element to update.
+            value: The value to add.
+
+        Raises:
+            If the atomic pointer operation fails.
+        """
         _ = self.atomic_fetch_add[ordering=ordering](coord, value)
 
     @always_inline("nodebug")
@@ -1123,7 +1145,18 @@ struct TileTensor[
         coord: Coord,
         value: Scalar[Self.dtype],
     ) raises where Self.mut and Self.element_size == 1:
-        """Atomically updates the value at the given coordinate to the maximum."""
+        """Atomically updates the value at the given coordinate to the maximum.
+
+        Parameters:
+            ordering: Memory ordering for the atomic operation.
+
+        Args:
+            coord: Coordinate of the element to update.
+            value: The value to compare.
+
+        Raises:
+            If the atomic pointer operation fails.
+        """
         Atomic.max[ordering=ordering](self._atomic_ptr(coord), value)
 
     @always_inline("nodebug")
@@ -1134,7 +1167,18 @@ struct TileTensor[
         coord: Coord,
         value: Scalar[Self.dtype],
     ) raises where Self.mut and Self.element_size == 1:
-        """Atomically updates the value at the given coordinate to the minimum."""
+        """Atomically updates the value at the given coordinate to the minimum.
+
+        Parameters:
+            ordering: Memory ordering for the atomic operation.
+
+        Args:
+            coord: Coordinate of the element to update.
+            value: The value to compare.
+
+        Raises:
+            If the atomic pointer operation fails.
+        """
         Atomic.min[ordering=ordering](self._atomic_ptr(coord), value)
 
     @always_inline("nodebug")
@@ -1150,7 +1194,20 @@ struct TileTensor[
     ) raises -> Bool where Self.mut and Self.element_size == 1:
         """Atomically compares and exchanges the value at the given coordinate.
 
-        Returns true if the exchange succeeded.
+        Parameters:
+            success_ordering: Memory ordering on success.
+            failure_ordering: Memory ordering on failure.
+
+        Args:
+            coord: Coordinate of the element to update.
+            expected: Expected value to compare against.
+            desired: Desired value to store if the comparison succeeds.
+
+        Returns:
+            True if the exchange succeeded.
+
+        Raises:
+            If the atomic pointer operation fails.
         """
         return Atomic.compare_exchange[
             success_ordering=success_ordering,

--- a/max/kernels/src/layout/tile_tensor.mojo
+++ b/max/kernels/src/layout/tile_tensor.mojo
@@ -1095,6 +1095,10 @@ struct TileTensor[
         coord: Coord,
         value: Scalar[Self.dtype],
     ) raises -> Scalar[Self.dtype] where Self.mut and Self.element_size == 1:
+        """Atomically adds a scalar value at the given coordinate.
+
+        Returns the previous value stored at the location.
+        """
         return Atomic.fetch_add[ordering=ordering](
             self._atomic_ptr(coord),
             value,
@@ -1108,6 +1112,7 @@ struct TileTensor[
         coord: Coord,
         value: Scalar[Self.dtype],
     ) raises where Self.mut and Self.element_size == 1:
+        """Atomically adds a scalar value at the given coordinate."""
         _ = self.atomic_fetch_add[ordering=ordering](coord, value)
 
     @always_inline("nodebug")
@@ -1118,6 +1123,7 @@ struct TileTensor[
         coord: Coord,
         value: Scalar[Self.dtype],
     ) raises where Self.mut and Self.element_size == 1:
+        """Atomically updates the value at the given coordinate to the maximum."""
         Atomic.max[ordering=ordering](self._atomic_ptr(coord), value)
 
     @always_inline("nodebug")
@@ -1128,6 +1134,7 @@ struct TileTensor[
         coord: Coord,
         value: Scalar[Self.dtype],
     ) raises where Self.mut and Self.element_size == 1:
+        """Atomically updates the value at the given coordinate to the minimum."""
         Atomic.min[ordering=ordering](self._atomic_ptr(coord), value)
 
     @always_inline("nodebug")
@@ -1141,6 +1148,10 @@ struct TileTensor[
         mut expected: Scalar[Self.dtype],
         desired: Scalar[Self.dtype],
     ) raises -> Bool where Self.mut and Self.element_size == 1:
+        """Atomically compares and exchanges the value at the given coordinate.
+
+        Returns true if the exchange succeeded.
+        """
         return Atomic.compare_exchange[
             success_ordering=success_ordering,
             failure_ordering=failure_ordering,

--- a/max/kernels/src/layout/tile_tensor.mojo
+++ b/max/kernels/src/layout/tile_tensor.mojo
@@ -15,6 +15,7 @@
 from std.math import align_up, ceildiv
 from std.sys import align_of, simd_width_of, is_gpu, size_of
 from std.os import abort
+from std.atomic import Atomic, Ordering
 
 from std.builtin.builtin_slice import ContiguousSlice
 from std.builtin.device_passable import DevicePassable, DeviceTypeEncoder
@@ -1061,6 +1062,93 @@ struct TileTensor[
         return rebind[type_of(result)](self._storage) + self.layout[
             linear_idx_type=Self.linear_idx_type
         ](coords)
+
+    @always_inline("nodebug")
+    def _atomic_ptr(
+        self,
+        coord: Coord,
+    ) raises -> UnsafePointer[
+        mut=True,
+        Scalar[Self.dtype],
+        MutAnyOrigin,
+        address_space=Self.address_space,
+    ] where Self.mut:
+        comptime assert (
+            Self.is_compatible_with[coord.element_types]
+            or coord.rank == Self.flat_rank
+            or coord.rank == 1
+        )
+        comptime assert (
+            Self.element_size == 1
+        ), "TileTensor atomic operations only support scalar elements"
+
+        var scalar_ptr = Self.Storage.unsafe_ptr(
+            self._unsafe_storage_cast[to_mut=True](),
+        ).unsafe_origin_cast[MutAnyOrigin]()
+        return scalar_ptr + self.layout[linear_idx_type=Self.linear_idx_type](coord)
+
+    @always_inline("nodebug")
+    def atomic_fetch_add[
+        *, ordering: Ordering = Ordering.SEQUENTIAL
+    ](
+        self,
+        coord: Coord,
+        value: Scalar[Self.dtype],
+    ) raises -> Scalar[Self.dtype] where Self.mut and Self.element_size == 1:
+        return Atomic.fetch_add[ordering=ordering](
+            self._atomic_ptr(coord),
+            value,
+        )
+
+    @always_inline("nodebug")
+    def atomic_add[
+        *, ordering: Ordering = Ordering.SEQUENTIAL
+    ](
+        self,
+        coord: Coord,
+        value: Scalar[Self.dtype],
+    ) raises where Self.mut and Self.element_size == 1:
+        _ = self.atomic_fetch_add[ordering=ordering](coord, value)
+
+    @always_inline("nodebug")
+    def atomic_max[
+        *, ordering: Ordering = Ordering.SEQUENTIAL
+    ](
+        self,
+        coord: Coord,
+        value: Scalar[Self.dtype],
+    ) raises where Self.mut and Self.element_size == 1:
+        Atomic.max[ordering=ordering](self._atomic_ptr(coord), value)
+
+    @always_inline("nodebug")
+    def atomic_min[
+        *, ordering: Ordering = Ordering.SEQUENTIAL
+    ](
+        self,
+        coord: Coord,
+        value: Scalar[Self.dtype],
+    ) raises where Self.mut and Self.element_size == 1:
+        Atomic.min[ordering=ordering](self._atomic_ptr(coord), value)
+
+    @always_inline("nodebug")
+    def atomic_compare_exchange[
+        *,
+        success_ordering: Ordering = Ordering.SEQUENTIAL,
+        failure_ordering: Ordering = Ordering.SEQUENTIAL,
+    ](
+        self,
+        coord: Coord,
+        mut expected: Scalar[Self.dtype],
+        desired: Scalar[Self.dtype],
+    ) raises -> Bool where Self.mut and Self.element_size == 1:
+        return Atomic.compare_exchange[
+            success_ordering=success_ordering,
+            failure_ordering=failure_ordering,
+        ](
+            self._atomic_ptr(coord),
+            expected,
+            desired,
+        )
 
     @always_inline
     def prefetch(

--- a/max/kernels/test/layout/test_tile_tensor_load_store.mojo
+++ b/max/kernels/test/layout/test_tile_tensor_load_store.mojo
@@ -132,6 +132,50 @@ def vectorized_load_store_kernel(
     tensor.store[width=4](coord[1, 0], val)
 
 
+def atomic_add_kernel(
+    tensor: TileTensor[
+        mut=True,
+        DType.int32,
+        _4x4,
+        MutAnyOrigin,
+        address_space=AddressSpace.GLOBAL,
+    ],
+) raises:
+    """Perform an atomic add through TileTensor to test lowering."""
+    tensor.atomic_add(coord[0, 0], Scalar[DType.int32](1))
+
+
+def atomic_max_kernel(
+    tensor: TileTensor[
+        mut=True,
+        DType.int32,
+        _4x4,
+        MutAnyOrigin,
+        address_space=AddressSpace.GLOBAL,
+    ],
+) raises:
+    """Perform an atomic max through TileTensor to test lowering."""
+    tensor.atomic_max(coord[0, 0], Scalar[DType.int32](0))
+
+
+def atomic_compare_exchange_kernel(
+    tensor: TileTensor[
+        mut=True,
+        DType.int32,
+        _4x4,
+        MutAnyOrigin,
+        address_space=AddressSpace.GLOBAL,
+    ],
+) raises:
+    """Perform an atomic compare-exchange through TileTensor to test lowering."""
+    var expected = Scalar[DType.int32](0)
+    _ = tensor.atomic_compare_exchange(
+        coord[0, 0],
+        expected,
+        Scalar[DType.int32](1),
+    )
+
+
 # ===-----------------------------------------------------------------------===#
 # Tests
 # ===-----------------------------------------------------------------------===#
@@ -183,6 +227,33 @@ def test_tile_tensor_vectorized_load_store() raises:
     assert_true(
         ".v4." in asm,
         "expected .v4. for vectorized TileTensor load/store",
+    )
+
+
+def test_tile_tensor_atomic_add() raises:
+    """TileTensor atomic add emits an atomic add instruction."""
+    var asm = _compile_code[atomic_add_kernel, target=_SM80]()
+    assert_true(
+        "atom.acquire.sys.global.add" in asm,
+        "expected atom.acquire.sys.global.add for TileTensor atomic_add",
+    )
+
+
+def test_tile_tensor_atomic_max() raises:
+    """TileTensor atomic max emits an atomic max instruction."""
+    var asm = _compile_code[atomic_max_kernel, target=_SM80]()
+    assert_true(
+        "atom.acquire.sys.global.max" in asm,
+        "expected atom.acquire.sys.global.max for TileTensor atomic_max",
+    )
+
+
+def test_tile_tensor_atomic_compare_exchange() raises:
+    """TileTensor atomic compare_exchange emits a compare-and-swap instruction."""
+    var asm = _compile_code[atomic_compare_exchange_kernel, target=_SM80]()
+    assert_true(
+        "atom.acquire.sys.global" in asm and ("cas" in asm or "cmpxchg" in asm),
+        "expected an atomic compare-exchange instruction for TileTensor atomic_compare_exchange",
     )
 
 

--- a/max/kernels/test/layout/test_tile_tensor_load_store.mojo
+++ b/max/kernels/test/layout/test_tile_tensor_load_store.mojo
@@ -167,7 +167,8 @@ def atomic_compare_exchange_kernel(
         address_space=AddressSpace.GLOBAL,
     ],
 ) raises:
-    """Perform an atomic compare-exchange through TileTensor to test lowering."""
+    """Perform an atomic compare-exchange through TileTensor to test lowering.
+    """
     var expected = Scalar[DType.int32](0)
     _ = tensor.atomic_compare_exchange(
         coord[0, 0],
@@ -249,11 +250,15 @@ def test_tile_tensor_atomic_max() raises:
 
 
 def test_tile_tensor_atomic_compare_exchange() raises:
-    """TileTensor atomic compare_exchange emits a compare-and-swap instruction."""
+    """TileTensor atomic compare_exchange emits a compare-and-swap instruction.
+    """
     var asm = _compile_code[atomic_compare_exchange_kernel, target=_SM80]()
     assert_true(
         "atom.acquire.sys.global" in asm and ("cas" in asm or "cmpxchg" in asm),
-        "expected an atomic compare-exchange instruction for TileTensor atomic_compare_exchange",
+        (
+            "expected an atomic compare-exchange instruction for TileTensor"
+            " atomic_compare_exchange"
+        ),
     )
 
 


### PR DESCRIPTION
- Added TileTensor atomic helper methods:
 1 atomic_fetch_add
 2 atomic_add
 3 atomic_max
 4 atomic_min
 5 atomic_compare_exchange
- Added lowering tests in [test_tile_tensor_load_store.mojo](vscode-file://vscode-app/home/msr/Desktop/VSCode-linux-x64/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Ensures atomic helper calls compile and lower correctly for TileTensor scalar integer operations
- References issue #6731 for TileTensor atomic helper support