### PR TITLE
Update ownership.mdx default arg conventions

### DIFF
--- a/mojo/docs/manual/values/ownership.mdx
+++ b/mojo/docs/manual/values/ownership.mdx
@@ -200,7 +200,7 @@ def print_list(list: List[Int]):
     print(list.__str__())
 
 def mutate_copy(l: List[Int]) -> List[Int]:
-    # def creates an implicit copy of the list because it's mutated
+    # this will give error, since l borrwed as real only, so it can't be changed
     l.append(5)
     return l
 


### PR DESCRIPTION
The default argument pass convention is to read-only, So it can't change the passed variable.

<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Before you open this PR, please make sure the change has been discussed and
agreed upon with a maintainer. For anything beyond a trivial fix (typo,
one-line bug fix, doc tweak), we ask that you first open a GitHub issue or
proposal and get a maintainer's go-ahead. This helps us avoid situations
where a PR sits unreviewed because the change isn't aligned with the
team's direction. See our [contributor guide](https://github.com/modular/modular/blob/main/CONTRIBUTING.md) for
details.
-->

## Linked issue

<!--
Replace `NNN` with the issue number. For anything non-trivial, a linked
issue that a maintainer has agreed to is expected before review.

- Trivial fix (typo, comment, small doc fix): you can write "N/A — trivial".
- Everything else: `Fixes #NNN` or `Related to #NNN`.
-->

Fixes #

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [x] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

<!--
Why is this change needed? What problem does it solve, or what use case
does it enable? If this is a bug fix, describe the bug and how a user
would hit it. If this is a new feature, explain the user-facing value.

Please write prose here — don't just restate the PR title.
-->

## What changed

<!--
Describe the change at a high level. Call out anything non-obvious: API
changes, behavior changes, performance characteristics, or tricky
implementation details.
-->

## Testing

<!--
Describe how you validated your changes.

- Code changes: what tests did you run, and what were the results? Did
  you add a new test that would have caught the bug?
- Performance changes: include before/after numbers from a benchmark.
- Documentation: describe how you verified accuracy (built the docs,
  ran the example, etc.).
-->

## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [ ] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [ ] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [ ] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
