### PR TITLE
[Kernels][GPU] NVFP4: emit rank-5 activation scales on consumer Blackwell (sm_120/sm_121)

### DIFF
--- a/max/python/max/nn/kernels.py
+++ b/max/python/max/nn/kernels.py
@@ -6552,6 +6552,14 @@ def _is_sm10x_gpu() -> bool:
         return False
 
 
+def _is_sm12x_gpu() -> bool:
+    """Checks if the current accelerator is NVIDIA SM120/SM121 (consumer Blackwell)."""
+    try:
+        return accelerator_architecture_name().startswith("sm_12")
+    except Exception:
+        return False
+
+
 def _is_apple_gpu() -> bool:
     """Checks if the current accelerator is an Apple (Metal) GPU."""
     try:
@@ -6634,8 +6642,8 @@ def quantize_dynamic_block_scaled(
     if int(input.shape[1]) % k_alignment != 0:
         raise ValueError(f"input.shape[1] must be a multiple of {k_alignment}")
 
-    if _is_sm10x_gpu():
-        # SM100 TCGEN05: rank-5 interleaved scales layout.
+    if _is_sm10x_gpu() or _is_sm12x_gpu():
+        # SM100 / SM120 TCGEN05: rank-5 interleaved scales layout.
         SF_ATOM_M = [32, 4]
         SF_ATOM_K = 4
         SF_MN_GROUP_SIZE = SF_ATOM_M[0] * SF_ATOM_M[1]  # 128


### PR DESCRIPTION
### Summary
`quantize_dynamic_block_scaled` (`max/python/max/nn/kernels.py`) emits **rank-5** interleaved activation scales only for `_is_sm10x_gpu()` (B200); on consumer Blackwell (`sm_120`/`sm_121`) it falls to the **rank-2** else-branch, which then trips `dynamic_block_scaled_matmul`'s "both a_scales and b_scales must be rank 5" check — blocking NVFP4 end-to-end on consumer Blackwell.

`reroute_v2` taught the **Mojo kernel** to emit rank-5 activation scales for `sm_12x`, but the matching **Python graph op** stayed on the else-branch — this is the half that was removed during the #6596 cleanup. This restores it: one `_is_sm12x_gpu()` helper (mirroring `_is_sm10x_gpu()`) + including it in the rank-5 branch.

Contributes to #6570 (consumer Blackwell sm_120/sm_121 support); pairs with the reroute_v2 kernel side.

### Verification (real hardware, all three points)
- **`sm_121a` (DGX Spark GB10)** — without this fix, `nvidia/Llama-3.1-8B-Instruct-NVFP4` fails with the rank-5 `ValueError` at the first NVFP4 layer.
- **B200** — the same model runs clean (367 tok/s, no rank error) → confirms the break is **`sm_12x`-specific**, not device-independent.
- **`sm_121a` with this fix** — the model now generates coherent text ("The sky appears blue to us because of…") at ~41 tok/s.

Because `_matmul_float4` is the path every NVFP4 layer takes, this single branch unblocks the whole forward.
