### PR TITLE
[Pipelines] Support compressed-tensors NVFP4 checkpoints

### DIFF
--- a/max/python/max/nn/quant_config.py
+++ b/max/python/max/nn/quant_config.py
@@ -350,7 +350,7 @@ class QuantConfig:
 
     @property
     def is_nvfp4(self) -> bool:
-        """``True`` if this config represents modelopt NVFP4."""
+        """``True`` if this config represents NVFP4 quantization."""
         return self.format == QuantFormat.NVFP4
 
     @property

--- a/max/python/max/pipelines/architectures/laguna/model.py
+++ b/max/python/max/pipelines/architectures/laguna/model.py
@@ -171,39 +171,16 @@ class LagunaModel(AlwaysSignalBuffersMixin, LlamaModelBase):
 
         The compute dtype is bf16 (embedding, attention, norms, lm_head), so the
         base ``finalize`` calls ``parse_quant_config`` with bf16 and gets
-        ``None``. Laguna ships compressed-tensors NVFP4, which is numerically
-        identical to modelopt NVFP4 (group_size 16, e4m3 per-group scales, fp32
-        global scale) but is not recognised by MAX's FP4 parser, which only
-        handles the modelopt flavor. Present a modelopt-shaped
-        ``quantization_config`` to the parser so the dense/MoE Linears pack via
-        ``quant_config.is_fp4``; the non-quant layers stay bf16 from
-        ``config.dtype``.
+        ``None``. Parse again with the checkpoint's packed FP4 dtype; the
+        generic compressed-tensors parser translates its target scope into the
+        per-layer ``QuantConfig`` representation.
         """
         hf_qc = getattr(self.huggingface_config, "quantization_config", None)
         if model_config.quant_config is not None or not hf_qc:
             return
-        # The MAX parser reads only from ``huggingface_config``, so present the
-        # modelopt-shaped config to it and restore the original afterwards.
-        # compressed-tensors defines quant scope by ``targets`` (only MLP/MoE
-        # gate/up/down_proj are FP4); the modelopt parser uses inverse
-        # ``ignore`` semantics (quantize all Linears except ignore), so ignore
-        # everything that is NOT a target: attention, the router gate, lm_head.
-        orig_qc = self.huggingface_config.quantization_config
-        try:
-            self.huggingface_config.quantization_config = {
-                "quant_method": "modelopt",
-                "quant_algo": "NVFP4",
-                "ignore": [
-                    "re:.*self_attn\\..*",
-                    "re:.*\\.mlp\\.gate$",
-                    "lm_head",
-                ],
-            }
-            model_config.quant_config = parse_quant_config(
-                self.huggingface_config, state_dict, DType.uint8
-            )
-        finally:
-            self.huggingface_config.quantization_config = orig_qc
+        model_config.quant_config = parse_quant_config(
+            self.huggingface_config, state_dict, DType.uint8
+        )
 
     @staticmethod
     def _detect_state_dict_dtypes(

--- a/max/python/max/pipelines/architectures/laguna/weight_adapters.py
+++ b/max/python/max/pipelines/architectures/laguna/weight_adapters.py
@@ -25,8 +25,9 @@ The checkpoint is compressed-tensors NVFP4: MLP/MoE ``gate_proj``/``up_proj``/
 
 MAX's ``MoEQuantized`` / ``Linear(quant_config=...)`` declare each expert's
 projection as a per-expert quantized Linear expecting ``.weight`` (packed),
-``.weight_scale``, ``.weight_scale_2`` (global), ``.input_scale``. So the NVFP4
-mapping is a pure suffix rename:
+``.weight_scale``, ``.weight_scale_2`` (global), ``.input_scale``. The suffixes
+map as follows; the two global scales are also reciprocated into MAX's
+multiplicative convention:
 
 .. code-block:: text
 
@@ -46,23 +47,16 @@ the bf16 donor.
 
 from __future__ import annotations
 
-import dataclasses
-
-import numpy as np
-from max.dtype import DType
 from max.graph.weights import WeightData, Weights
 from max.pipelines.lib import PipelineConfig
+from max.pipelines.weights._compressed_tensors import (
+    convert_compressed_tensors_nvfp4_weight,
+)
 from transformers import AutoConfig
 
-# Checkpoint -> MAX weight name mapping, applied in order with ``str.replace``
-# semantics (``dict`` preserves insertion order). Order matters: do the NVFP4
-# suffix renames before the structural ones so neither re-matches the other.
+# Checkpoint -> MAX weight name mapping, applied with ``str.replace`` semantics.
 LAGUNA_SAFETENSOR_MAP: dict[str, str] = {
     "model.": "",
-    # NVFP4 compressed-tensors suffixes -> MAX quantized-Linear suffixes.
-    ".weight_packed": ".weight",
-    ".weight_global_scale": ".weight_scale_2",
-    ".input_global_scale": ".input_scale",
     # Laguna structural renames (same as the bf16 donor).
     ".mlp.gate.weight": ".mlp.gate.gate_score.weight",
     ".mlp.experts.e_score_correction_bias": ".mlp.gate.e_score_correction_bias",
@@ -93,30 +87,6 @@ def convert_safetensor_state_dict(
         for before, after in LAGUNA_SAFETENSOR_MAP.items():
             max_name = max_name.replace(before, after)
         data = value.data()
-        # NVFP4 GLOBAL scales: compressed-tensors stores the *reciprocal* of
-        # modelopt's convention. MAX's NVFP4 matmul uses weight_scale_2 and
-        # input_scale as MULTIPLICATIVE dequant factors (modelopt:
-        # weight_scale_2 = amax/(448*6), input_scale = act_amax/448 — small),
-        # but compressed-tensors stores weight_global_scale = (448*6)/amax and
-        # input_global_scale = 448/act_amax (large, e.g. 5504 / 1184). Passing
-        # them through unchanged inflates every weight ~5504x → gibberish.
-        # Reciprocate the two F32 scalar globals. The per-group ``weight_scale``
-        # (e4m3) is identical in both conventions — do NOT touch it.
-        if max_name.endswith(".weight_scale_2") or max_name.endswith(
-            ".input_scale"
-        ):
-            arr = np.from_dlpack(data)
-            # np.reciprocal on a 0-d array returns a numpy *scalar* (no
-            # __dlpack__); force a 0-d ndarray so to_buffer() works downstream.
-            recip = np.asarray(
-                np.reciprocal(arr.astype(np.float32)), dtype=np.float32
-            ).reshape(arr.shape)
-            data = WeightData.from_numpy(recip, max_name)
-        # Per-group NVFP4 scales are float8_e4m3fn; some exporters store them
-        # as raw uint8. Reinterpret so the kernel reads the right dtype. (This
-        # is the NVFP4 analogue of the MXFP4 path, where per-group scales are
-        # instead reinterpreted as float8_e8m0fnu — see minimax_m2.)
-        elif max_name.endswith(".weight_scale") and data.dtype == DType.uint8:
-            data = dataclasses.replace(data, dtype=DType.float8_e4m3fn)
+        max_name, data = convert_compressed_tensors_nvfp4_weight(max_name, data)
         out[max_name] = data
     return out

--- a/max/python/max/pipelines/architectures/llama3/BUILD.bazel
+++ b/max/python/max/pipelines/architectures/llama3/BUILD.bazel
@@ -31,6 +31,7 @@ modular_py_library(
         "//max/python/max/pipelines/lib",
         "//max/python/max/pipelines/lora",
         "//max/python/max/pipelines/modeling",
+        "//max/python/max/pipelines/weights",
         "//max/python/max/profiler",
         "//max/python/max/support",
     ],

--- a/max/python/max/pipelines/architectures/llama3/weight_adapters.py
+++ b/max/python/max/pipelines/architectures/llama3/weight_adapters.py
@@ -18,6 +18,10 @@ from max.dtype import DType
 from max.graph.weights import WeightData, Weights
 from max.pipelines.lib import MAXModelConfig, PipelineConfig
 from max.pipelines.modeling.config_enums import supported_encoding_dtype
+from max.pipelines.weights._compressed_tensors import (
+    convert_compressed_tensors_nvfp4_weight,
+    is_compressed_tensors_nvfp4_config,
+)
 from transformers import LlamaConfig
 
 # Maps from Safetensor to MAX weight names.
@@ -37,12 +41,20 @@ def _convert_safetensor_with_model_config(
     This allows the same conversion logic to be used for both target and draft models.
     """
     new_state_dict: dict[str, WeightData] = {}
+    is_compressed_tensors_nvfp4 = is_compressed_tensors_nvfp4_config(
+        getattr(huggingface_config, "quantization_config", None)
+    )
     # Map the weight names.
     for safetensor_name, value in state_dict.items():
         max_name = safetensor_name
         for before, after in LLAMA_SAFETENSOR_MAPPING.items():
             max_name = max_name.replace(before, after)
-        new_state_dict[max_name] = value.data()
+        data = value.data()
+        if is_compressed_tensors_nvfp4:
+            max_name, data = convert_compressed_tensors_nvfp4_weight(
+                max_name, data
+            )
+        new_state_dict[max_name] = data
     if model_config._quant:
         # hack: argsort the perm_idx array
         for key, weight_data in new_state_dict.items():

--- a/max/python/max/pipelines/weights/_compressed_tensors.py
+++ b/max/python/max/pipelines/weights/_compressed_tensors.py
@@ -1,0 +1,94 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Shared compressed-tensors checkpoint normalization helpers."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+from max.dtype import DType
+from max.graph.weights import WeightData
+
+
+def is_compressed_tensors_nvfp4_config(
+    config: Mapping[str, Any] | None,
+) -> bool:
+    """Whether a compressed-tensors config describes NVFP4 weights."""
+    if (
+        not isinstance(config, Mapping)
+        or config.get("quant_method") != "compressed-tensors"
+    ):
+        return False
+
+    config_groups = config.get("config_groups")
+    if not isinstance(config_groups, Mapping):
+        return False
+    group = config_groups.get("group_0")
+    if not isinstance(group, Mapping):
+        return False
+
+    weights = group.get("weights")
+    inputs = group.get("input_activations")
+    if not isinstance(weights, Mapping) or not isinstance(inputs, Mapping):
+        return False
+
+    format_name = config.get("format") or group.get("format")
+    return bool(
+        format_name == "nvfp4-pack-quantized"
+        and weights.get("type") == "float"
+        and weights.get("num_bits") == 4
+        and weights.get("strategy") == "tensor_group"
+        and weights.get("group_size") == 16
+        and weights.get("dynamic") is False
+        and inputs.get("type") == "float"
+        and inputs.get("num_bits") == 4
+        and inputs.get("strategy") == "tensor_group"
+        and inputs.get("group_size") == 16
+    )
+
+
+def convert_compressed_tensors_nvfp4_weight(
+    name: str, data: WeightData
+) -> tuple[str, WeightData]:
+    """Normalize one compressed-tensors NVFP4 weight for MAX.
+
+    Global scales use the reciprocal of MAX's multiplicative convention, so
+    they are inverted once while their raw compressed-tensors suffix is still
+    present. Per-group E4M3 scales have identical values in both conventions;
+    only exporters that store their bytes as ``uint8`` need a dtype
+    reinterpretation.
+    """
+    if name.endswith(".weight_packed"):
+        name = name.removesuffix(".weight_packed") + ".weight"
+    elif name.endswith(".weight_global_scale"):
+        name = name.removesuffix(".weight_global_scale") + ".weight_scale_2"
+        arr = np.from_dlpack(data)
+        reciprocal = np.asarray(
+            np.reciprocal(arr.astype(np.float32)), dtype=np.float32
+        ).reshape(arr.shape)
+        data = WeightData.from_numpy(reciprocal, name)
+    elif name.endswith(".input_global_scale"):
+        name = name.removesuffix(".input_global_scale") + ".input_scale"
+        arr = np.from_dlpack(data)
+        reciprocal = np.asarray(
+            np.reciprocal(arr.astype(np.float32)), dtype=np.float32
+        ).reshape(arr.shape)
+        data = WeightData.from_numpy(reciprocal, name)
+    elif name.endswith(".weight_scale") and data.dtype == DType.uint8:
+        data = dataclasses.replace(data, dtype=DType.float8_e4m3fn)
+
+    return name, data

--- a/max/python/max/pipelines/weights/quant.py
+++ b/max/python/max/pipelines/weights/quant.py
@@ -19,6 +19,7 @@ import fnmatch
 import json
 import logging
 import os
+import re
 from collections.abc import Mapping, Sequence
 from typing import Any
 
@@ -33,6 +34,9 @@ from max.nn.quant_config import (
     ScaleGranularity,
     ScaleOrigin,
     WeightScaleSpec,
+)
+from max.pipelines.weights._compressed_tensors import (
+    is_compressed_tensors_nvfp4_config,
 )
 from transformers import AutoConfig
 
@@ -141,6 +145,175 @@ def _modelopt_ignore_patterns(
     if not isinstance(ignore, Sequence) or isinstance(ignore, str):
         return []
     return [_normalize_modelopt_ignore_pattern(str(entry)) for entry in ignore]
+
+
+def _compressed_tensors_patterns(value: Any) -> tuple[str, ...]:
+    """Normalize a compressed-tensors target/ignore value to patterns."""
+    if isinstance(value, str):
+        return (value,)
+    if not isinstance(value, Sequence):
+        return ()
+    return tuple(str(pattern) for pattern in value)
+
+
+def _compressed_tensors_pattern_matches(
+    pattern: str,
+    module_path: str,
+    *,
+    modules_prefix: str,
+) -> bool:
+    """Match one compressed-tensors target against a known Linear path."""
+    candidates = (module_path, module_path.removeprefix(modules_prefix))
+    if pattern == "Linear":
+        return True
+    if pattern.startswith("re:"):
+        return any(
+            re.fullmatch(pattern.removeprefix("re:"), candidate) is not None
+            for candidate in candidates
+        )
+    return any(fnmatch.fnmatch(candidate, pattern) for candidate in candidates)
+
+
+def _compressed_tensors_module_selected(
+    module_paths: Sequence[str],
+    targets: Sequence[str],
+    ignore_patterns: Sequence[str],
+    *,
+    modules_prefix: str,
+) -> bool:
+    """Whether a logical Linear has a target match and no ignore match."""
+    is_targeted = any(
+        _compressed_tensors_pattern_matches(
+            pattern, module_path, modules_prefix=modules_prefix
+        )
+        for module_path in module_paths
+        for pattern in targets
+    )
+    is_ignored = any(
+        _compressed_tensors_pattern_matches(
+            pattern, module_path, modules_prefix=modules_prefix
+        )
+        for module_path in module_paths
+        for pattern in ignore_patterns
+    )
+    return is_targeted and not is_ignored
+
+
+def _compressed_tensors_targets_to_modelopt_ignore(
+    huggingface_config: AutoConfig,
+    hf_quant_config: Mapping[str, Any],
+    *,
+    modules_prefix: str,
+) -> list[str]:
+    """Invert compressed-tensors targets into modelopt-style ignore globs.
+
+    ``QuantConfig`` represents MLP and attention quantization per layer, so each
+    subtree must be wholly selected or wholly excluded. Compressed-tensors can
+    express selection per module; reject configurations that select only part
+    of a subtree instead of silently quantizing modules absent from the
+    checkpoint.
+    """
+    config_groups = hf_quant_config.get("config_groups")
+    assert isinstance(config_groups, Mapping)
+    group = config_groups.get("group_0")
+    assert isinstance(group, Mapping)
+
+    targets = _compressed_tensors_patterns(group.get("targets", ()))
+    source_ignore = _compressed_tensors_patterns(
+        hf_quant_config.get("ignore", ())
+    )
+
+    # Keep source ignore entries for representable exceptions such as BF16
+    # shared experts. The generated subtree globs below are what the existing
+    # modelopt parser uses for its per-layer sets.
+    translated_ignore = [
+        re.sub(
+            r"shared_expert(?!s)",
+            "shared_experts",
+            _normalize_modelopt_ignore_pattern(pattern),
+        )
+        for pattern in source_ignore
+    ]
+
+    projection_aliases: dict[str, dict[str, tuple[str, ...]]] = {
+        "mlp": {
+            "gate_proj": (
+                "mlp.gate_proj",
+                "mlp.gate_up_proj",
+                "mlp.experts.0.gate_proj",
+                "mlp.shared_expert.gate_proj",
+                "mlp.shared_experts.gate_proj",
+                "mlp.shared_expert.gate_up_proj",
+                "mlp.shared_experts.gate_up_proj",
+            ),
+            "up_proj": (
+                "mlp.up_proj",
+                "mlp.gate_up_proj",
+                "mlp.experts.0.up_proj",
+                "mlp.shared_expert.up_proj",
+                "mlp.shared_experts.up_proj",
+                "mlp.shared_expert.gate_up_proj",
+                "mlp.shared_experts.gate_up_proj",
+            ),
+            "down_proj": (
+                "mlp.down_proj",
+                "mlp.experts.0.down_proj",
+                "mlp.shared_expert.down_proj",
+                "mlp.shared_experts.down_proj",
+            ),
+        },
+        "self_attn": {
+            "q_proj": ("self_attn.q_proj",),
+            "k_proj": ("self_attn.k_proj",),
+            "v_proj": ("self_attn.v_proj",),
+            "o_proj": ("self_attn.o_proj",),
+        },
+    }
+
+    for layer_idx in range(_get_num_hidden_layers(huggingface_config)):
+        layer_prefix = f"{modules_prefix}layers.{layer_idx}."
+        for subtree, projections in projection_aliases.items():
+            selected = {
+                projection: _compressed_tensors_module_selected(
+                    tuple(layer_prefix + alias for alias in aliases),
+                    targets,
+                    source_ignore,
+                    modules_prefix=modules_prefix,
+                )
+                for projection, aliases in projections.items()
+            }
+            if all(selected.values()):
+                continue
+            if any(selected.values()):
+                selected_names = ", ".join(
+                    name
+                    for name, is_selected in selected.items()
+                    if is_selected
+                )
+                unselected_names = ", ".join(
+                    name
+                    for name, is_selected in selected.items()
+                    if not is_selected
+                )
+                raise ValueError(
+                    "compressed-tensors NVFP4 requires all-or-nothing "
+                    f"quantization for layer {layer_idx} {subtree}; selected: "
+                    f"{selected_names}; unselected: {unselected_names}"
+                )
+            translated_ignore.append(f"{layer_prefix}{subtree}*")
+
+    lm_head = f"{modules_prefix}lm_head"
+    if not _compressed_tensors_module_selected(
+        (lm_head,),
+        targets,
+        source_ignore,
+        modules_prefix=modules_prefix,
+    ):
+        translated_ignore.append(lm_head)
+
+    # Preserve order for deterministic configs while avoiding duplicate exact
+    # entries (for example, an explicit ``model.lm_head`` source ignore).
+    return list(dict.fromkeys(translated_ignore))
 
 
 def _modelopt_layer_subtree_ignored(
@@ -812,11 +985,14 @@ def _parse_modelopt_float4_config(
     *,
     quant_method_override: str | None = None,
     quant_algo_override: str | None = None,
+    resolved_quant_config_override: Mapping[str, Any] | None = None,
     state_dict_name_prefix: str = "",
     ignored_modules_prefix: str = "model.",
 ) -> QuantConfig | None:
-    resolved_quant_config = _resolve_quant_config(
-        huggingface_config, state_dict
+    resolved_quant_config = (
+        resolved_quant_config_override
+        if resolved_quant_config_override is not None
+        else _resolve_quant_config(huggingface_config, state_dict)
     )
     quant_method = quant_method_override
     quant_algo = quant_algo_override
@@ -871,6 +1047,41 @@ def _parse_modelopt_float4_config(
         bias_dtype=bias_dtype,
         shared_experts_weight_dtype=shared_experts_weight_dtype,
         format=QuantFormat.NVFP4,
+    )
+
+
+def _parse_compressed_tensors_float4_config(
+    huggingface_config: AutoConfig,
+    state_dict: Mapping[str, WeightData],
+    dtype: DType,
+    *,
+    state_dict_name_prefix: str = "",
+    ignored_modules_prefix: str = "model.",
+) -> QuantConfig | None:
+    """Parse compressed-tensors NVFP4 through the common NVFP4 builder."""
+    hf_quant_config = getattr(huggingface_config, "quantization_config", None)
+    if not is_compressed_tensors_nvfp4_config(hf_quant_config):
+        return None
+    # ``is_compressed_tensors_nvfp4_config`` already verified the mapping shape;
+    # narrow ``Any | None`` for the typed helper call below.
+    assert isinstance(hf_quant_config, Mapping)
+
+    modelopt_equivalent = {
+        "quant_method": "modelopt",
+        "quant_algo": "NVFP4",
+        "ignore": _compressed_tensors_targets_to_modelopt_ignore(
+            huggingface_config,
+            hf_quant_config,
+            modules_prefix=ignored_modules_prefix,
+        ),
+    }
+    return _parse_modelopt_float4_config(
+        huggingface_config,
+        state_dict,
+        dtype,
+        resolved_quant_config_override=modelopt_equivalent,
+        state_dict_name_prefix=state_dict_name_prefix,
+        ignored_modules_prefix=ignored_modules_prefix,
     )
 
 
@@ -959,6 +1170,14 @@ def _parse_float4_config(
             dtype,
             quant_method_override=quant_method,
             quant_algo_override=quant_config.get("quant_algo"),
+            state_dict_name_prefix=state_dict_name_prefix,
+            ignored_modules_prefix=ignored_modules_prefix,
+        )
+    if quant_method == "compressed-tensors":
+        return _parse_compressed_tensors_float4_config(
+            huggingface_config,
+            state_dict,
+            dtype,
             state_dict_name_prefix=state_dict_name_prefix,
             ignored_modules_prefix=ignored_modules_prefix,
         )

--- a/max/tests/tests/pipelines/test_llama3_weight_adapters.py
+++ b/max/tests/tests/pipelines/test_llama3_weight_adapters.py
@@ -14,17 +14,26 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import SimpleNamespace
 from unittest.mock import NonCallableMock
 
+import numpy as np
+from max.dtype import DType
 from max.graph.quantization import QuantizationEncoding
+from max.graph.weights import WeightData
 from max.pipelines.architectures.llama3.weight_adapters import (
     convert_gguf_state_dict,
+    convert_safetensor_state_dict,
 )
 
 
 @dataclass
 class _ModelConfigStub:
-    graph_quantization_encoding: QuantizationEncoding | None
+    graph_quantization_encoding: QuantizationEncoding | None = None
+    _quant: bool = False
+    quantization_encoding: str | None = None
+    _applied_dtype_cast_from: str | None = None
+    _applied_dtype_cast_to: str | None = None
 
 
 @dataclass
@@ -36,6 +45,40 @@ def _weight_mock() -> NonCallableMock:
     weight = NonCallableMock()
     weight.data.return_value = "mock_weight_data"
     return weight
+
+
+def _weight_data_mock(data: WeightData) -> NonCallableMock:
+    weight = NonCallableMock()
+    weight.data.return_value = data
+    return weight
+
+
+def _compressed_tensors_nvfp4_hf_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        quantization_config={
+            "quant_method": "compressed-tensors",
+            "format": "nvfp4-pack-quantized",
+            "config_groups": {
+                "group_0": {
+                    "format": "nvfp4-pack-quantized",
+                    "weights": {
+                        "dynamic": False,
+                        "group_size": 16,
+                        "num_bits": 4,
+                        "strategy": "tensor_group",
+                        "type": "float",
+                    },
+                    "input_activations": {
+                        "dynamic": "local",
+                        "group_size": 16,
+                        "num_bits": 4,
+                        "strategy": "tensor_group",
+                        "type": "float",
+                    },
+                }
+            },
+        }
+    )
 
 
 def test_convert_gguf_state_dict_non_quantized_uses_stacked_linear_keys() -> (
@@ -82,3 +125,97 @@ def test_convert_gguf_state_dict_quantized_keeps_legacy_qkv_keys() -> None:
     assert "layers.0.self_attn.q_proj.weight" in converted
     assert "layers.0.self_attn.k_proj.weight" in converted
     assert "layers.0.self_attn.v_proj.weight" in converted
+
+
+def test_convert_safetensor_state_dict_normalizes_compressed_tensors_nvfp4() -> (
+    None
+):
+    prefix = "model.layers.0.mlp.down_proj"
+    packed = WeightData.from_numpy(
+        np.array([[0x21, 0x43]], dtype=np.uint8), "packed"
+    )
+    group_scale = WeightData(
+        data=np.array([[0x38, 0x40]], dtype=np.uint8),
+        name="group_scale",
+        dtype=DType.float8_e4m3fn,
+        shape=packed.shape,
+    )
+    weight_global_scale = WeightData.from_numpy(
+        np.array([5408.0], dtype=np.float32), "weight_global_scale"
+    )
+    input_global_scale = WeightData.from_numpy(
+        np.array([300.0], dtype=np.float32), "input_global_scale"
+    )
+    lm_head = WeightData(
+        data=np.zeros((1, 2), dtype=np.uint16),
+        name="lm_head.weight",
+        dtype=DType.bfloat16,
+        shape=packed.shape,
+    )
+    state_dict = {
+        f"{prefix}.weight_packed": _weight_data_mock(packed),
+        f"{prefix}.weight_scale": _weight_data_mock(group_scale),
+        f"{prefix}.weight_global_scale": _weight_data_mock(weight_global_scale),
+        f"{prefix}.input_global_scale": _weight_data_mock(input_global_scale),
+        "lm_head.weight": _weight_data_mock(lm_head),
+    }
+
+    converted = convert_safetensor_state_dict(
+        state_dict,  # type: ignore[arg-type]
+        _compressed_tensors_nvfp4_hf_config(),
+        _PipelineConfigStub(model=_ModelConfigStub()),  # type: ignore[arg-type]
+    )
+
+    canonical = "layers.0.mlp.down_proj"
+    assert converted[f"{canonical}.weight"] is packed
+    assert converted[f"{canonical}.weight_scale"] is group_scale
+    assert converted["lm_head.weight"] is lm_head
+    assert converted["lm_head.weight"].dtype == DType.bfloat16
+    weight_scale_2 = converted[f"{canonical}.weight_scale_2"]
+    input_scale = converted[f"{canonical}.input_scale"]
+    assert tuple(weight_scale_2.shape) == (1,)
+    assert tuple(input_scale.shape) == (1,)
+    np.testing.assert_allclose(
+        np.from_dlpack(weight_scale_2), 1.0 / 5408.0, rtol=1e-6
+    )
+    np.testing.assert_allclose(
+        np.from_dlpack(input_scale), 1.0 / 300.0, rtol=1e-6
+    )
+
+
+def test_convert_safetensor_state_dict_reinterprets_raw_nvfp4_scale() -> None:
+    raw_scale = WeightData.from_numpy(
+        np.array([[0x38, 0x40]], dtype=np.uint8), "raw_scale"
+    )
+    converted = convert_safetensor_state_dict(
+        {
+            "model.layers.0.mlp.down_proj.weight_scale": _weight_data_mock(
+                raw_scale
+            )
+        },
+        _compressed_tensors_nvfp4_hf_config(),
+        _PipelineConfigStub(model=_ModelConfigStub()),  # type: ignore[arg-type]
+    )
+
+    scale = converted["layers.0.mlp.down_proj.weight_scale"]
+    assert scale.dtype == DType.float8_e4m3fn
+    assert scale.data is raw_scale.data
+
+
+def test_convert_safetensor_state_dict_does_not_reinvert_canonical_scale() -> (
+    None
+):
+    canonical_scale = WeightData.from_numpy(
+        np.array([1.0 / 5408.0], dtype=np.float32), "canonical_scale"
+    )
+    converted = convert_safetensor_state_dict(
+        {
+            "model.layers.0.mlp.down_proj.weight_scale_2": _weight_data_mock(
+                canonical_scale
+            )
+        },
+        _compressed_tensors_nvfp4_hf_config(),
+        _PipelineConfigStub(model=_ModelConfigStub()),  # type: ignore[arg-type]
+    )
+
+    assert converted["layers.0.mlp.down_proj.weight_scale_2"] is canonical_scale

--- a/max/tests/tests/pipelines/test_parse_quant_config.py
+++ b/max/tests/tests/pipelines/test_parse_quant_config.py
@@ -23,8 +23,9 @@ import pytest
 import torch
 from max.dtype import DType
 from max.experimental.torch import max_dtype_to_torch
-from max.graph import Shape
+from max.graph import DeviceRef, Shape
 from max.graph.weights import WeightData
+from max.nn import Linear
 from max.nn.quant_config import (
     InputScaleSpec,
     QuantConfig,
@@ -34,6 +35,7 @@ from max.nn.quant_config import (
     WeightScaleSpec,
 )
 from max.pipelines.weights.quant import (
+    _compressed_tensors_targets_to_modelopt_ignore,
     _modelopt_ignore_patterns,
     _modelopt_shared_experts_quantized_dtype,
     parse_quant_config,
@@ -862,6 +864,180 @@ def test_modelopt_ignore_normalizes_block_sparse_moe_shared_experts() -> None:
         _modelopt_shared_experts_quantized_dtype(global_ignore)
         == DType.bfloat16
     )
+
+
+@pytest.fixture
+def hf_config_compressed_tensors_nvfp4() -> SimpleNamespace:
+    """Minimal RedHatAI Llama compressed-tensors NVFP4 config."""
+    return SimpleNamespace(
+        num_hidden_layers=2,
+        quantization_config={
+            "quant_method": "compressed-tensors",
+            "format": "nvfp4-pack-quantized",
+            "config_groups": {
+                "group_0": {
+                    "format": "nvfp4-pack-quantized",
+                    "targets": ["Linear"],
+                    "weights": {
+                        "dynamic": False,
+                        "group_size": 16,
+                        "num_bits": 4,
+                        "strategy": "tensor_group",
+                        "type": "float",
+                    },
+                    "input_activations": {
+                        "dynamic": "local",
+                        "group_size": 16,
+                        "num_bits": 4,
+                        "strategy": "tensor_group",
+                        "type": "float",
+                    },
+                }
+            },
+            "ignore": ["lm_head"],
+        },
+    )
+
+
+@pytest.fixture
+def nvfp4_embedding_state_dict() -> dict[str, WeightData]:
+    return {
+        "embed_tokens.weight": WeightData(
+            name="embed_tokens.weight",
+            shape=Shape((1, 1)),
+            dtype=DType.bfloat16,
+            data=torch.zeros((1, 1), dtype=max_dtype_to_torch(DType.bfloat16)),
+        ),
+        "lm_head.weight": WeightData(
+            name="lm_head.weight",
+            shape=Shape((1, 1)),
+            dtype=DType.bfloat16,
+            data=torch.zeros((1, 1), dtype=max_dtype_to_torch(DType.bfloat16)),
+        ),
+    }
+
+
+def test_parse_compressed_tensors_nvfp4_linear_targets(
+    hf_config_compressed_tensors_nvfp4: SimpleNamespace,
+    nvfp4_embedding_state_dict: dict[str, WeightData],
+) -> None:
+    quant_config = parse_quant_config(
+        hf_config_compressed_tensors_nvfp4,
+        nvfp4_embedding_state_dict,
+        DType.uint8,
+    )
+
+    assert quant_config is not None
+    assert quant_config.format == QuantFormat.NVFP4
+    assert quant_config.input_scale.granularity == ScaleGranularity.BLOCK
+    assert quant_config.input_scale.origin == ScaleOrigin.STATIC
+    assert quant_config.input_scale.block_size == (1, 16)
+    assert quant_config.weight_scale.granularity == ScaleGranularity.BLOCK
+    assert quant_config.weight_scale.block_size == (1, 16)
+    assert quant_config.mlp_quantized_layers == {0, 1}
+    assert quant_config.attn_quantized_layers == {0, 1}
+    assert quant_config.embedding_output_dtype == DType.bfloat16
+    assert quant_config.scales_pre_interleaved is False
+
+    translated_ignore = _compressed_tensors_targets_to_modelopt_ignore(
+        hf_config_compressed_tensors_nvfp4,
+        hf_config_compressed_tensors_nvfp4.quantization_config,
+        modules_prefix="model.",
+    )
+    assert "model.lm_head" in translated_ignore
+
+    # Llama3 uses ``embedding_output_dtype`` for its output Linear without
+    # passing the body quant_config. This is the graph-facing declaration that
+    # must match the checkpoint's BF16 ``lm_head.weight``.
+    lm_head = Linear(
+        in_dim=1,
+        out_dim=1,
+        dtype=quant_config.embedding_output_dtype,
+        device=DeviceRef.CPU(),
+    )
+    assert lm_head.weight.dtype == DType.bfloat16
+
+
+def test_parse_compressed_tensors_nvfp4_regex_targets(
+    hf_config_compressed_tensors_nvfp4: SimpleNamespace,
+    nvfp4_embedding_state_dict: dict[str, WeightData],
+) -> None:
+    config = deepcopy(hf_config_compressed_tensors_nvfp4)
+    config.quantization_config["config_groups"]["group_0"]["targets"] = [
+        r"re:.*mlp\.(gate_proj|up_proj|down_proj)$",
+        r"re:.*experts\.[0-9]+\.(gate_proj|up_proj|down_proj)$",
+        r"re:.*shared_expert\.(gate_proj|up_proj|down_proj)$",
+        r"re:.*mlp\.(gate_up_proj|down_proj)$",
+        r"re:.*shared_expert\.(gate_up_proj|down_proj)$",
+    ]
+    config.quantization_config["ignore"] = [
+        "lm_head",
+        r"re:.*\.self_attn\.q_proj$",
+        r"re:.*\.self_attn\.k_proj$",
+        r"re:.*\.self_attn\.v_proj$",
+        r"re:.*\.self_attn\.o_proj$",
+        r"re:.*\.mlp\.gate$",
+    ]
+
+    translated_ignore = _compressed_tensors_targets_to_modelopt_ignore(
+        config,
+        config.quantization_config,
+        modules_prefix="model.",
+    )
+    assert "model.layers.0.self_attn*" in translated_ignore
+    assert "model.layers.1.self_attn*" in translated_ignore
+    assert "model.layers.0.mlp*" not in translated_ignore
+    assert "model.layers.1.mlp*" not in translated_ignore
+    assert "model.lm_head" in translated_ignore
+
+    quant_config = parse_quant_config(
+        config,
+        nvfp4_embedding_state_dict,
+        DType.uint8,
+    )
+    assert quant_config is not None
+    assert quant_config.mlp_quantized_layers == {0, 1}
+    assert quant_config.attn_quantized_layers == set()
+
+
+@pytest.mark.parametrize(
+    ("target", "subtree"),
+    [
+        (r"re:.*\.self_attn\.q_proj$", "self_attn"),
+        ("model.layers.*.mlp.gate_proj", "mlp"),
+    ],
+)
+def test_parse_compressed_tensors_nvfp4_rejects_partial_subtree(
+    hf_config_compressed_tensors_nvfp4: SimpleNamespace,
+    nvfp4_embedding_state_dict: dict[str, WeightData],
+    target: str,
+    subtree: str,
+) -> None:
+    config = deepcopy(hf_config_compressed_tensors_nvfp4)
+    config.quantization_config["config_groups"]["group_0"]["targets"] = [target]
+    config.quantization_config["ignore"] = ["lm_head"]
+
+    with pytest.raises(
+        ValueError,
+        match=rf"all-or-nothing quantization for layer 0 {subtree}",
+    ):
+        parse_quant_config(
+            config,
+            nvfp4_embedding_state_dict,
+            DType.uint8,
+        )
+
+
+def test_parse_float4_skips_non_nvfp4_compressed_tensors(
+    hf_config_compressed_tensors_nvfp4: SimpleNamespace,
+) -> None:
+    config = deepcopy(hf_config_compressed_tensors_nvfp4)
+    config.quantization_config["format"] = "pack-quantized"
+    config.quantization_config["config_groups"]["group_0"]["format"] = (
+        "pack-quantized"
+    )
+
+    assert parse_quant_config(config, {}, DType.uint8) is None
 
 
 def test_parse_float4_skips_gptq_quant_method(


### PR DESCRIPTION
## Summary

MAX's FP4 config parser only recognizes the modelopt NVFP4 flavor, so
compressed-tensors NVFP4 checkpoints (e.g. `RedHatAI/Llama-3.1-8B-Instruct-NVFP4`)
fail to load. This adds a compressed-tensors NVFP4 load path.

Two independent problems block serving these checkpoints on a DGX Spark:

1. **Loading (this PR).** The checkpoint is *mixed precision* — an NVFP4 body with a
   **bf16 lm-head** — and its global scales are stored as the reciprocal of MAX's
   multiplicative dequant convention. MAX doesn't recognize the compressed-tensors
   schema, so the graph expects packed `uint8` where the checkpoint ships `bfloat16`.
2. **Math (already merged, #91570).** On consumer Blackwell (sm_120/sm_121), NVFP4
   activation scales must be emitted rank-5.

## What it does

- New shared `weights/_compressed_tensors.py` helper: compressed-tensors NVFP4 schema
  recognition; weight-suffix renames; **one-time global-scale reciprocation keyed on the
  raw suffix** (so it is idempotent); optional `uint8`→`e4m3` per-group scale reinterpret.
- `weights/quant.py`: recognizes `quant_method == "compressed-tensors"` and translates its
  `targets`/`ignore` scope into MAX's existing per-layer modelopt `QuantConfig`
  representation, then reuses the modelopt builder. Each MLP/attention subtree is
  quantized **all-or-nothing** (partial selection raises `ValueError`); an unquantized
  `lm_head` is excluded independently so it stays `bf16`.
- `architectures/llama3/weight_adapters.py` applies the helper; the `laguna` architecture
  now shares it instead of mutating the HF quantization config in place.

## Validation

### Unit tests (`//max/tests/tests/pipelines:...`)

- `test_parse_quant_config`: **35 passed**
- `test_llama3_weight_adapters`: **5 passed**

Coverage: global-scale reciprocation, idempotency (canonical scale not re-inverted),
`uint8`→`e4m3` reinterpret, `Linear`-targets, regex/MoE targets, all-or-nothing subtree
rejection, non-NVFP4 compressed-tensors fall-through, and a graph-level assertion that
`lm_head.weight` is built as `bfloat16`.

### Hardware — DGX Spark (GB10, sm_121a), `RedHatAI/Llama-3.1-8B-Instruct-NVFP4`, identical command

```
A) upstream, pre-fix
   ValueError: 'lm_head.weight' dtype (expected=uint8, actual=bfloat16)
   -> reached generation: 0

B) this fix, WITHOUT #91570 underneath
   lm_head crash cleared; fails one bug later:
   ValueError: Both a_scales and b_scales must be rank 5 tensors   (the sm_12x NVFP4 math, = #91570)
   -> reached generation: 0

C) this fix + #91570
   prompt : "The capital of France is"
   output : "Paris."
   14.04 tok/s   ·   TTFT 1112 ms   ·   prefill 35.97 tok/s
```

The failure moving A→B→C shows what each fix contributes: pre-fix, MAX can't *load* a
mixed-precision compressed-tensors checkpoint; this fix clears that, and the very next
thing to break is the sm_12x NVFP4 *math*; with #91570 underneath, the math is right and
the model serves. Neither fix alone serves a RedHat/compressed-tensors NVFP4 model on a
DGX Spark; both together do. (Including the three-way trace so a reviewer on consumer
Blackwell who lands on B doesn't conclude the change is broken.)

Fixes #6600.
