### PR TITLE
[Kernel][GPU] Fix AMD GEVM launch grid

### DIFF
--- a/max/kernels/src/linalg/gemv.mojo
+++ b/max/kernels/src/linalg/gemv.mojo
@@ -1040,7 +1040,7 @@ def gemv_gpu_dispatch[
             m,
             n,
             k,
-            grid_dim=ceildiv(n, WARPS_PER_BLOCK),
+            grid_dim=ceildiv(n, WARP_SIZE),
             block_dim=WARP_SIZE * WARPS_PER_BLOCK,
             attributes=pdl_launch_attributes(pdl_level),
         )

--- a/max/kernels/test/gpu/linalg/BUILD.bazel
+++ b/max/kernels/test/gpu/linalg/BUILD.bazel
@@ -36,6 +36,7 @@ _EXTRA_CONSTRAINTS = {
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),  # FIXME: MOCO-3587 — Metal compilation failure
+    "test_gevm_grid_oob_amd.mojo": ["//:amd_gpu"],
     "test_gemv2.mojo": select({
         "//:h100_gpu": ["@platforms//:incompatible"],
         "//:apple_gpu": ["@platforms//:incompatible"],  # FIXME: PRDT-506

--- a/max/kernels/test/gpu/linalg/test_gemv.mojo
+++ b/max/kernels/test/gpu/linalg/test_gemv.mojo
@@ -106,7 +106,7 @@ def run_matvec[
             M,
             N,
             K,
-            grid_dim=ceildiv(N, WARPS_PER_BLOCK),
+            grid_dim=ceildiv(N, WARP_SIZE),
             block_dim=WARP_SIZE * WARPS_PER_BLOCK,
         )
 
@@ -271,7 +271,7 @@ def run_matvec_with_epilogue_fn(
             M,
             N,
             K,
-            grid_dim=ceildiv(N, WARPS_PER_BLOCK),
+            grid_dim=ceildiv(N, WARP_SIZE),
             block_dim=WARP_SIZE * WARPS_PER_BLOCK,
         )
 

--- a/max/kernels/test/gpu/linalg/test_gevm_grid_oob_amd.mojo
+++ b/max/kernels/test/gpu/linalg/test_gevm_grid_oob_amd.mojo
@@ -1,0 +1,66 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Regression test for the AMD GEVM grid writing past its output view."""
+
+from layout import TileTensor, row_major
+from linalg.gemv import gemv_gpu
+from std.gpu.host import DeviceContext
+from std.testing import assert_equal
+
+
+def main() raises:
+    comptime N = 64
+    comptime K = 64
+    comptime GUARD_VALUE = Float32(-7)
+
+    var a_host = alloc[Float32](K)
+    # Pad B so the buggy extra blocks read deterministic values rather than
+    # relying on neighboring allocator contents.
+    var b_host = alloc[Float32]((K + 3) * N)
+    # Expose only the first N elements through C's TileTensor view. The
+    # remaining 3 * N elements are a canary for out-of-bounds GEVM writes.
+    var c_host = alloc[Float32](4 * N)
+
+    for i in range(K):
+        a_host[i] = 1
+    for i in range((K + 3) * N):
+        b_host[i] = 1
+    for i in range(4 * N):
+        c_host[i] = GUARD_VALUE
+
+    with DeviceContext() as ctx:
+        var a_device = ctx.enqueue_create_buffer[DType.float32](K)
+        var b_device = ctx.enqueue_create_buffer[DType.float32]((K + 3) * N)
+        var c_device = ctx.enqueue_create_buffer[DType.float32](4 * N)
+
+        ctx.enqueue_copy(a_device, a_host)
+        ctx.enqueue_copy(b_device, b_host)
+        ctx.enqueue_copy(c_device, c_host)
+
+        var a = TileTensor(a_device, row_major(1, K)).as_immut()
+        var b = TileTensor(b_device, row_major(K, N)).as_immut()
+        var c = TileTensor(c_device, row_major(1, N))
+        gemv_gpu(c, a, b, ctx)
+
+        ctx.enqueue_copy(c_host, c_device)
+        ctx.synchronize()
+
+    for i in range(N):
+        assert_equal(c_host[i], Float32(K))
+    for i in range(N, 4 * N):
+        assert_equal(
+            c_host[i],
+            GUARD_VALUE,
+            "GEVM wrote beyond its 1xN output",
+        )


### PR DESCRIPTION
Launch one GEVM block per warp-sized output tile so wave64 targets do not write past the output. Add an AMD regression with padded input and output guard regions.



## Linked issue

<!--
Replace `NNN` with the issue number. For anything non-trivial, a linked
issue that a maintainer has agreed to is expected before review.

- Trivial fix (typo, comment, small doc fix): you can write "N/A — trivial".
- Everything else: `Fixes #NNN` or `Related to #NNN`.
-->

Fixes #6776

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

<!--
Why is this change needed? What problem does it solve, or what use case
does it enable? If this is a bug fix, describe the bug and how a user
would hit it. If this is a new feature, explain the user-facing value.

Please write prose here — don't just restate the PR title.
-->
Bugfix

## What changed

See code

## Testing

Added a test with sentinel values to detect the out of bounds

## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))

Assisted-by codex