### PR TITLE
[Pipelines] Handle missing custom ARCHITECTURES list

### DIFF
--- a/max/python/max/pipelines/lib/registry.py
+++ b/max/python/max/pipelines/lib/registry.py
@@ -1113,14 +1113,13 @@ class PipelineRegistry:
                     f"Failed to import custom model from: {module_spec}"
                 ) from e
 
-            if not module.ARCHITECTURES or not isinstance(
-                module.ARCHITECTURES, list
-            ):
+            architectures = getattr(module, "ARCHITECTURES", None)
+            if not architectures or not isinstance(architectures, list):
                 raise ValueError(
                     f"Custom model imported, but did not expose an `ARCHITECTURES` list. Module: {module_spec}"
                 )
 
-            for arch in module.ARCHITECTURES:
+            for arch in architectures:
                 self.register(arch, allow_override=True)
             self._imported_custom_arch_specs.add(module_spec)
 

--- a/max/tests/tests/pipelines/lib/test_registry.py
+++ b/max/tests/tests/pipelines/lib/test_registry.py
@@ -1,0 +1,33 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+import importlib
+import sys
+from types import ModuleType
+
+import pytest
+from max.pipelines.lib.registry import PipelineRegistry
+
+
+def test_import_custom_architectures_requires_architectures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = ModuleType("empty_arch")
+    monkeypatch.setattr(importlib, "import_module", lambda _: module)
+    monkeypatch.setattr(sys, "path", sys.path.copy())
+
+    with pytest.raises(
+        ValueError,
+        match=r"did not expose an `ARCHITECTURES` list\. Module: empty_arch",
+    ):
+        PipelineRegistry([])._import_custom_architectures(["empty_arch"])


### PR DESCRIPTION
## Linked issue

Fixes #6777

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Custom architecture modules that import successfully but omit the required
`ARCHITECTURES` list currently raise a raw `AttributeError`. This bypasses the
actionable `ValueError` already intended by the loader's validation branch.

## What changed

- Read `ARCHITECTURES` once with `getattr()` before validating it.
- Reuse the validated list when registering custom architectures.
- Add a focused regression test for a module missing `ARCHITECTURES`.

## Testing

- `./bazelw run format` passed and made no changes.
- `ruff check max/python/max/pipelines/lib/registry.py max/tests/tests/pipelines/lib/test_registry.py`
- `ruff format --check max/python/max/pipelines/lib/registry.py max/tests/tests/pipelines/lib/test_registry.py`
- Focused source-backed regression test: 1 passed.
- Complete source-backed `max/tests/tests/pipelines/lib` package: 215 passed
  with 5 existing collection warnings.
- `./bazelw test //max/tests/tests/pipelines/... //max/tests/integration/pipelines:tests`
  built successfully: 5 tests passed and 32 macOS-incompatible tests were
  skipped.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior approval
- [x] PR is small and focused
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description

Assisted-by: AI
