### PR TITLE
[doc] Removed extra empty line in __contains__ docstring

### DIFF
--- a/mojo/stdlib/std/collections/dict.mojo
+++ b/mojo/stdlib/std/collections/dict.mojo
@@ -932,7 +932,6 @@ struct Dict[
     def __contains__(self, key: Self.K) -> Bool:
         """Check if a given key is in the dictionary or not.
 
-
         Args:
             key: The key to check.
 


### PR DESCRIPTION
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [x] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

I think the convention is to put one empty line between function description and parameters or arguments.

## What changed

Removed the extra empty line between description and arguments.

## Testing

Not applicable.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
