### PR TITLE
[bazel] Fix modular_shared_library for path mapping

### DIFF
--- a/bazel/internal/cc-toolchain/args/interface-libraries/BUILD.bazel
+++ b/bazel/internal/cc-toolchain/args/interface-libraries/BUILD.bazel
@@ -34,8 +34,8 @@ cc_feature(
     name = "build_interface_libraries",
     args = [
         ":enabled_env",
-        ":input_env",
-        ":output_env",
+        ":input_arg",
+        ":output_arg",
     ],
     overrides = "@rules_cc//cc/toolchains/features/legacy:build_interface_libraries",
 )
@@ -56,18 +56,18 @@ cc_args(
 )
 
 cc_args(
-    name = "input_env",
+    name = "input_arg",
     actions = ["@rules_cc//cc/toolchains/actions:dynamic_library_link_actions"],
-    env = {"IFS_INPUT": "{interface_library_input_path}"},
+    args = ["--modular-ifs-input={interface_library_input_path}"],
     format = {"interface_library_input_path": "@rules_cc//cc/toolchains/variables:interface_library_input_path"},
     requires_any_of = [":supports_interface_shared_libraries"],
     requires_not_none = "@rules_cc//cc/toolchains/variables:interface_library_input_path",
 )
 
 cc_args(
-    name = "output_env",
+    name = "output_arg",
     actions = ["@rules_cc//cc/toolchains/actions:dynamic_library_link_actions"],
-    env = {"IFS_OUTPUT": "{interface_library_output_path}"},
+    args = ["--modular-ifs-output={interface_library_output_path}"],
     format = {"interface_library_output_path": "@rules_cc//cc/toolchains/variables:interface_library_output_path"},
     requires_any_of = [":supports_interface_shared_libraries"],
     requires_not_none = "@rules_cc//cc/toolchains/variables:interface_library_output_path",

--- a/bazel/internal/cc-toolchain/tools/linker-driver.sh
+++ b/bazel/internal/cc-toolchain/tools/linker-driver.sh
@@ -31,7 +31,18 @@ fi
 readonly clang="$clang_root/bin/clang++"
 readonly dsymutil="$clang_root/bin/dsymutil"
 
-"$clang" "$@"
+ifs_input=""
+ifs_output=""
+linker_args=()
+for arg in "$@"; do
+  case "$arg" in
+    --modular-ifs-input=*) ifs_input="${arg#*=}" ;;
+    --modular-ifs-output=*) ifs_output="${arg#*=}" ;;
+    *) linker_args+=("$arg") ;;
+  esac
+done
+
+"$clang" "${linker_args[@]}"
 
 readonly dsym_path="${MODULAR_DSYM_PATH:-}"
 if [[ -n "$dsym_path" ]]; then
@@ -39,6 +50,11 @@ if [[ -n "$dsym_path" ]]; then
 fi
 
 if [[ "${BUILD_IFS:-}" == "yes" ]]; then
+  if [[ -z "$ifs_input" || -z "$ifs_output" ]]; then
+    echo "error: interface library input and output paths are required" >&2
+    exit 1
+  fi
+
   if [[ $OSTYPE == darwin* ]]; then
     ifs_platform=mac
   elif [[ $(uname -m) == "x86_64" ]]; then
@@ -50,8 +66,8 @@ if [[ "${BUILD_IFS:-}" == "yes" ]]; then
   ifs_root="$PWD/external/+http_archive+llvm-ifs/tools/$ifs_platform"
 
   if [[ "${MACOS:-}" == "true" ]]; then
-    "$ifs_root/llvm-readtapi.stripped" -arch arm64 -extract "$IFS_INPUT" -o "$IFS_OUTPUT"
+    "$ifs_root/llvm-readtapi.stripped" -arch arm64 -extract "$ifs_input" -o "$ifs_output"
   else
-    "$ifs_root/llvm-ifs.stripped" "$IFS_INPUT" --output-elf="$IFS_OUTPUT"
+    "$ifs_root/llvm-ifs.stripped" "$ifs_input" --output-elf="$ifs_output"
   fi
 fi


### PR DESCRIPTION
The env vars we were using previously are nicer but are not compatible
with CppLink path mapping.
