### PR TITLE
[Kernels] Fix static conv width-padding boundaries

### DIFF
--- a/max/kernels/src/nn/conv/conv.mojo
+++ b/max/kernels/src/nn/conv/conv.mojo
@@ -1723,15 +1723,34 @@ struct ConvDirectNHWC[
             # Point to (n, 0, ho, f_tile_offset) mapped in input
             var output_base = output_curr_image + (f_tile_offset + F * WO * ho)
 
-            # The entire row fits in one micro kernel.
-            comptime if WO <= micro_kernel_height:
+            comptime left_pad_impact_end = min(
+                ceildiv(Self.conv_attr.pad_left(), Self.conv_attr.strides()[1]),
+                WO,
+            )
+            comptime right_pad_impact_start = max(
+                (
+                    W
+                    + Self.conv_attr.pad_left()
+                    - S * Self.conv_attr.dilations()[1]
+                )
+                // Self.conv_attr.strides()[1]
+                + 1,
+                left_pad_impact_end,
+            )
+            comptime for tile_wo in range(0, WO, micro_kernel_height):
+                comptime tile_height = min(micro_kernel_height, WO - tile_wo)
+                comptime padded_left = tile_wo < left_pad_impact_end
+                comptime padded_right = (
+                    tile_wo + tile_height > right_pad_impact_start
+                )
                 self._inner_loops_static[
-                    WO,
+                    tile_height,
                     micro_kernel_width,
-                    True,
-                    True,
+                    padded_left,
+                    padded_right,
                     has_residual,
                     last_c_tile,
+                    tile_wo,
                 ](
                     input_base,
                     filter_base,
@@ -1743,106 +1762,12 @@ struct ConvDirectNHWC[
                     c_tile_size,
                     n,
                     ho,
-                    0,  # wo
-                )
-            # The row is split into multiple micro kernels.
-            else:
-                # micro kernel height for left and right boundaries.
-                # IF WO is just 1-2 points more than micro kernel height, the
-                # following would divide the row evely by two micro kernels.
-                comptime micro_kernel_height_lbound = min(
-                    micro_kernel_height, WO // 2
-                )
-                comptime micro_kernel_height_rbound = min(
-                    micro_kernel_height, WO - WO // 2
-                )
-                # Left boundary
-                self._inner_loops_static[
-                    micro_kernel_height_lbound,
-                    micro_kernel_width,
-                    True,
-                    False,
-                    has_residual,
-                    last_c_tile,
-                ](
-                    input_base,
-                    filter_base,
-                    # Safety: turn off mutable aliasing pointer check
-                    output_base.unsafe_origin_cast[AnyOrigin[mut=True]](),
-                    f_tile_offset,
-                    f_tile_size,
-                    c_tile_offset,
-                    c_tile_size,
-                    n,
-                    ho,
-                    0,  # beginning of wo dimension
+                    tile_wo,
                 )
                 input_base = input_base + (
-                    micro_kernel_height_lbound * conv_attr_dyn.strides()[1] * C
+                    tile_height * conv_attr_dyn.strides()[1] * C
                 )
-                output_base = output_base + micro_kernel_height_lbound * F
-
-                # Update middle points if any. They aren't effected by padding.
-                @__copy_capture(filter_base)
-                @always_inline
-                @parameter
-                def update_middle[height: Int](wo: Int):
-                    self._inner_loops_static[
-                        height,
-                        micro_kernel_width,
-                        False,
-                        False,
-                        has_residual,
-                        last_c_tile,
-                    ](
-                        input_base,
-                        filter_base,
-                        # Safety: turn off mutable aliasing pointer check
-                        output_base.unsafe_origin_cast[AnyOrigin[mut=True]](),
-                        f_tile_offset,
-                        f_tile_size,
-                        c_tile_offset,
-                        c_tile_size,
-                        n,
-                        ho,
-                        wo,
-                    )
-                    input_base = input_base + (
-                        height * conv_attr_dyn.strides()[1] * C
-                    )
-                    output_base = output_base + height * F
-
-                # Middle points are the points not updated by micro kernels
-                # on left or right boundary
-                comptime num_middle_points = WO - micro_kernel_height_lbound - micro_kernel_height_rbound
-                # `tile` can't handle zero tile size.
-                comptime micro_kernel_height_middle = num_middle_points % micro_kernel_height if num_middle_points % micro_kernel_height > 0 else 1
-                tile[
-                    update_middle,
-                    [micro_kernel_height, micro_kernel_height_middle],
-                ](micro_kernel_height_lbound, WO - micro_kernel_height_rbound)
-
-                # Right boundary.
-                self._inner_loops_static[
-                    micro_kernel_height_rbound,
-                    micro_kernel_width,
-                    False,
-                    True,
-                    has_residual,
-                    last_c_tile,
-                ](
-                    input_base,
-                    filter_base,
-                    # Safety: turn off mutable aliasing pointer check
-                    output_base.unsafe_origin_cast[AnyOrigin[mut=True]](),
-                    f_tile_offset,
-                    f_tile_size,
-                    c_tile_offset,
-                    c_tile_size,
-                    n,
-                    ho,
-                    WO - micro_kernel_height_rbound,  # offset in wo dimension
-                )
+                output_base = output_base + tile_height * F
 
     @always_inline
     def _inner_loops_static[
@@ -1852,6 +1777,7 @@ struct ConvDirectNHWC[
         padded_right: Bool,
         has_residual: Bool,
         last_c_tile: Bool,
+        tile_wo: Int = 0,
     ](
         self,
         input_base: UnsafePointer[
@@ -1936,20 +1862,23 @@ struct ConvDirectNHWC[
                 # Adjustment of micro kernel height for left padding
                 # The first left_adjust x micro_kernel_width registers are
                 # ignored because they fall in padding.
+                comptime left_valid_start = ceildiv(
+                    Self.conv_attr.pad_left()
+                    - s * Self.conv_attr.dilations()[1],
+                    Self.conv_attr.strides()[1],
+                )
                 comptime left_adjust = max(
-                    ceildiv(
-                        Self.conv_attr.pad_left()
-                        - s * Self.conv_attr.dilations()[1],
-                        Self.conv_attr.strides()[1],
-                    ),
-                    0,
+                    left_valid_start - tile_wo, 0
                 ) if padded_left else 0
                 # Adjustment of micro kernel height for right padding
                 # The last left_adjust x micro_kernel_width registers are ignored.
                 # fmt: off
+                comptime right_valid_end = (
+                    W - 1 + Self.conv_attr.pad_left()
+                    - s * Self.conv_attr.dilations()[1]
+                ) // Self.conv_attr.strides()[1] + 1
                 comptime right_adjust = max(
-                    WO - 1 - (W - 1 + Self.conv_attr.pad_left() - s * Self.conv_attr.dilations()[1])
-                             // Self.conv_attr.strides()[1],
+                    tile_wo + micro_kernel_height - right_valid_end,
                     0,
                 ) if padded_right else 0
                 # fmt: on

--- a/max/kernels/test/nn/BUILD.bazel
+++ b/max/kernels/test/nn/BUILD.bazel
@@ -37,6 +37,7 @@ _FILECHECK_TESTS = [
     "test_scatter_elements.mojo",
     "test_softmax.mojo",
     "test_static_conv.mojo",
+    "test_static_conv_large_width_padding.mojo",
     "test_static_conv_small_shapes.mojo",
     "test_tile.mojo",
     "test_top_k.mojo",

--- a/max/kernels/test/nn/test_static_conv_large_width_padding.mojo
+++ b/max/kernels/test/nn/test_static_conv_large_width_padding.mojo
@@ -44,11 +44,7 @@ def run_case[
 ]() raises:
     comptime HO = 1
     comptime WO = (
-        W
-        + pad_left
-        + pad_right
-        - dilation_w * (K - 1)
-        - 1
+        W + pad_left + pad_right - dilation_w * (K - 1) - 1
     ) // stride_w + 1
     comptime conv_attr = ConvInfoStatic[2](
         IntTuple(0, pad_left, 0, pad_right),
@@ -62,9 +58,7 @@ def run_case[
     comptime micro_kernel_f_size = micro_kernel_shape[1] * simd_size
     comptime num_micro_tiles = ceildiv(F, micro_kernel_f_size)
 
-    var input_storage = InlineArray[Scalar[value_type], N * H * W * C](
-        fill=1.0
-    )
+    var input_storage = InlineArray[Scalar[value_type], N * H * W * C](fill=1.0)
     var filter_storage = InlineArray[
         Scalar[value_type],
         num_micro_tiles * R * K * C * micro_kernel_f_size,
@@ -72,25 +66,23 @@ def run_case[
     var unpacked_filter_storage = InlineArray[
         Scalar[value_type], R * K * C * F
     ](fill=1.0)
-    var output_storage = InlineArray[
-        Scalar[value_type], N * HO * WO * F
-    ](fill=0.0)
+    var output_storage = InlineArray[Scalar[value_type], N * HO * WO * F](
+        fill=0.0
+    )
 
-    var input = LayoutTensor[
-        value_type, Layout.row_major(N, H, W, C)
-    ](input_storage)
+    var input = LayoutTensor[value_type, Layout.row_major(N, H, W, C)](
+        input_storage
+    )
     var filter = LayoutTensor[
         value_type,
-        Layout.row_major(
-            num_micro_tiles, R, K, C, micro_kernel_f_size
-        ),
+        Layout.row_major(num_micro_tiles, R, K, C, micro_kernel_f_size),
     ](filter_storage)
     var unpacked_filter = LayoutTensor[
         value_type, Layout.row_major(R, K, C, F)
     ](unpacked_filter_storage)
-    var output = LayoutTensor[
-        value_type, Layout.row_major(N, HO, WO, F)
-    ](output_storage)
+    var output = LayoutTensor[value_type, Layout.row_major(N, HO, WO, F)](
+        output_storage
+    )
     var conv_shape = ConvShape[2](
         n=N,
         input_dims=Index(H, W),
@@ -106,15 +98,11 @@ def run_case[
         num_groups=1,
     )
 
-    pack_filter_lt[simd_size, micro_kernel_f_size](
-        unpacked_filter, filter, 1
-    )
+    pack_filter_lt[simd_size, micro_kernel_f_size](unpacked_filter, filter, 1)
 
     ConvDirectNHWC[
         Layout.row_major(N, H, W, C),
-        Layout.row_major(
-            num_micro_tiles, R, K, C, micro_kernel_f_size
-        ),
+        Layout.row_major(num_micro_tiles, R, K, C, micro_kernel_f_size),
         Layout.row_major(N, HO, WO, F),
         value_type,
         value_type,

--- a/max/kernels/test/nn/test_static_conv_large_width_padding.mojo
+++ b/max/kernels/test/nn/test_static_conv_large_width_padding.mojo
@@ -1,0 +1,153 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Regression sweep for static conv2d with wide width padding."""
+
+from std.math import ceildiv
+from std.sys.info import simd_width_of
+from std.testing import assert_equal
+
+from layout import IntTuple, Layout, LayoutTensor
+from nn.conv.conv import ConvDirectNHWC, ConvInfoStatic, pack_filter_lt
+from nn.conv.conv_utils import ConvShape, get_micro_kernel_shape
+from std.utils.index import Index
+
+
+comptime N = 1
+comptime H = 1
+comptime W = 16
+comptime C = 3
+comptime R = 1
+comptime F = 2
+comptime stride_h = 1
+comptime dilation_h = 1
+comptime value_type = DType.float32
+comptime simd_size = simd_width_of[value_type]()
+
+
+def run_case[
+    K: Int,
+    stride_w: Int,
+    dilation_w: Int,
+    pad_left: Int,
+    pad_right: Int,
+]() raises:
+    comptime HO = 1
+    comptime WO = (
+        W
+        + pad_left
+        + pad_right
+        - dilation_w * (K - 1)
+        - 1
+    ) // stride_w + 1
+    comptime conv_attr = ConvInfoStatic[2](
+        IntTuple(0, pad_left, 0, pad_right),
+        IntTuple(stride_h, stride_w),
+        IntTuple(dilation_h, dilation_w),
+        1,
+    )
+    comptime micro_kernel_shape = get_micro_kernel_shape[
+        2, WO, F, conv_attr, simd_size
+    ]()
+    comptime micro_kernel_f_size = micro_kernel_shape[1] * simd_size
+    comptime num_micro_tiles = ceildiv(F, micro_kernel_f_size)
+
+    var input_storage = InlineArray[Scalar[value_type], N * H * W * C](
+        fill=1.0
+    )
+    var filter_storage = InlineArray[
+        Scalar[value_type],
+        num_micro_tiles * R * K * C * micro_kernel_f_size,
+    ](fill=0.0)
+    var unpacked_filter_storage = InlineArray[
+        Scalar[value_type], R * K * C * F
+    ](fill=1.0)
+    var output_storage = InlineArray[
+        Scalar[value_type], N * HO * WO * F
+    ](fill=0.0)
+
+    var input = LayoutTensor[
+        value_type, Layout.row_major(N, H, W, C)
+    ](input_storage)
+    var filter = LayoutTensor[
+        value_type,
+        Layout.row_major(
+            num_micro_tiles, R, K, C, micro_kernel_f_size
+        ),
+    ](filter_storage)
+    var unpacked_filter = LayoutTensor[
+        value_type, Layout.row_major(R, K, C, F)
+    ](unpacked_filter_storage)
+    var output = LayoutTensor[
+        value_type, Layout.row_major(N, HO, WO, F)
+    ](output_storage)
+    var conv_shape = ConvShape[2](
+        n=N,
+        input_dims=Index(H, W),
+        output_dims=Index(HO, WO),
+        filter_dims=Index(R, K),
+        c=C,
+        f=F,
+        stride=Index(stride_h, stride_w),
+        dilation=Index(dilation_h, dilation_w),
+        pad_d=Index(0, 0),
+        pad_h=Index(0, 0),
+        pad_w=Index(pad_left, pad_right),
+        num_groups=1,
+    )
+
+    pack_filter_lt[simd_size, micro_kernel_f_size](
+        unpacked_filter, filter, 1
+    )
+
+    ConvDirectNHWC[
+        Layout.row_major(N, H, W, C),
+        Layout.row_major(
+            num_micro_tiles, R, K, C, micro_kernel_f_size
+        ),
+        Layout.row_major(N, HO, WO, F),
+        value_type,
+        value_type,
+        value_type,
+        True,
+        conv_attr,
+    ].run(output, input, filter, conv_shape)
+
+    for wo in range(WO):
+        var valid_count = 0
+        for s in range(K):
+            var input_w = wo * stride_w + s * dilation_w - pad_left
+            if 0 <= input_w < W:
+                valid_count += 1
+        var expected = Float32(valid_count * C)
+        for f in range(F):
+            var actual = output_storage[wo * F + f]
+            assert_equal(
+                actual,
+                expected,
+                msg=String(
+                    t"K={K} stride={stride_w} dilation={dilation_w} pads={pad_left},{pad_right} wo={wo} f={f}"
+                ),
+            )
+
+
+# CHECK: PASS
+def main() raises:
+    comptime for k in range(2, 13):
+        run_case[k, 1, 1, k - 1, k - 1]()
+    run_case[8, 2, 1, 14, 14]()
+    run_case[8, 1, 2, 14, 14]()
+    run_case[8, 2, 2, 14, 14]()
+    run_case[8, 2, 1, 13, 9]()
+    run_case[8, 2, 1, 9, 15]()
+    print("PASS")


### PR DESCRIPTION
## Linked issue

Fixes #6712

(#6712 is currently unassigned and `Needs Triage` — no maintainer review yet. Opening this to surface the concrete fix; happy to hold for direction on the approach.)

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation

The static conv padding path miscomputes outputs near the padding boundary. At `wo=16` (K=8) it returns 23 where the correct value is 21, because the static path doesn't derive per-tile padding adjustments the way the non-static path does. (I picked this up as an entry point into the conv kernels — small and self-contained.)

## What changed

Compute the left and right padding-impact boundaries from the convolution's padding, stride, dilation, input width, and kernel width — the same geometry the non-static path already uses. The static path keeps its fixed-width micro-kernel tiles, but now: marks every tile that has a true padding boundary, passes the tile's output-width offset into `_inner_loops_static`, and computes each tap's padding adjustment relative to that tile offset. Net −71 lines in `conv.mojo` (37 added, 108 removed).

## Testing

Added a deterministic 16-case regression sweep. All-ones inputs with packed filters give an analytical oracle: each output must equal the exact number of valid taps times the channel count, which checks every output element and inherently rejects NaNs. The fixed kernel passes all 16 cases exactly. As a negative control, the same test fails against the original implementation in 3/3 uncached runs at the K=8 boundary (`wo=16`, expected 21, actual 23).

## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is agreed-upon, or this is a trivial fix that does not need prior approval
- [x] PR is small and focused
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an `Assisted-by:` trailer

Assisted-by: AI

---
