### PR TITLE
[Stdlib][GPU] Fix warp shuffles for Int/UInt on Apple and NVIDIA GPUs

### DIFF
--- a/max/kernels/test/gpu/basics/test_shuffle.mojo
+++ b/max/kernels/test/gpu/basics/test_shuffle.mojo
@@ -112,6 +112,14 @@ def test_shuffle_idx_int64(ctx: DeviceContext) raises:
     _shuffle_idx_launch_helper[DType.int64, 1](ctx)
 
 
+def test_shuffle_idx_int(ctx: DeviceContext) raises:
+    _shuffle_idx_launch_helper[DType.int, 1](ctx)
+
+
+def test_shuffle_idx_uint(ctx: DeviceContext) raises:
+    _shuffle_idx_launch_helper[DType.uint, 1](ctx)
+
+
 def _shuffle_up_launch_helper[
     dtype: DType, simd_width: Int
 ](ctx: DeviceContext) raises:
@@ -172,6 +180,14 @@ def test_shuffle_up_fp16_packed(ctx: DeviceContext) raises:
 
 def test_shuffle_up_int64(ctx: DeviceContext) raises:
     _shuffle_up_launch_helper[DType.int64, 1](ctx)
+
+
+def test_shuffle_up_int(ctx: DeviceContext) raises:
+    _shuffle_up_launch_helper[DType.int, 1](ctx)
+
+
+def test_shuffle_up_uint(ctx: DeviceContext) raises:
+    _shuffle_up_launch_helper[DType.uint, 1](ctx)
 
 
 def _shuffle_down_launch_helper[
@@ -236,6 +252,14 @@ def test_shuffle_down_int64(ctx: DeviceContext) raises:
     _shuffle_down_launch_helper[DType.int64, 1](ctx)
 
 
+def test_shuffle_down_int(ctx: DeviceContext) raises:
+    _shuffle_down_launch_helper[DType.int, 1](ctx)
+
+
+def test_shuffle_down_uint(ctx: DeviceContext) raises:
+    _shuffle_down_launch_helper[DType.uint, 1](ctx)
+
+
 def _shuffle_xor_launch_helper[
     dtype: DType, simd_width: Int
 ](ctx: DeviceContext) raises:
@@ -290,6 +314,14 @@ def test_shuffle_xor_fp16_packed(ctx: DeviceContext) raises:
 
 def test_shuffle_xor_int64(ctx: DeviceContext) raises:
     _shuffle_xor_launch_helper[DType.int64, 1](ctx)
+
+
+def test_shuffle_xor_int(ctx: DeviceContext) raises:
+    _shuffle_xor_launch_helper[DType.int, 1](ctx)
+
+
+def test_shuffle_xor_uint(ctx: DeviceContext) raises:
+    _shuffle_xor_launch_helper[DType.uint, 1](ctx)
 
 
 def _warp_reduce_launch_helper[
@@ -638,24 +670,32 @@ def main() raises:
         test_shuffle_idx_fp16(ctx)
         test_shuffle_idx_fp16_packed(ctx)
         test_shuffle_idx_int64(ctx)
+        test_shuffle_idx_int(ctx)
+        test_shuffle_idx_uint(ctx)
         test_shuffle_up_fp32(ctx)
         test_shuffle_up_bf16(ctx)
         test_shuffle_up_bf16_packed(ctx)
         test_shuffle_up_fp16(ctx)
         test_shuffle_up_fp16_packed(ctx)
         test_shuffle_up_int64(ctx)
+        test_shuffle_up_int(ctx)
+        test_shuffle_up_uint(ctx)
         test_shuffle_down_fp32(ctx)
         test_shuffle_down_bf16(ctx)
         test_shuffle_down_bf16_packed(ctx)
         test_shuffle_down_fp16(ctx)
         test_shuffle_down_fp16_packed(ctx)
         test_shuffle_down_int64(ctx)
+        test_shuffle_down_int(ctx)
+        test_shuffle_down_uint(ctx)
         test_shuffle_xor_fp32(ctx)
         test_shuffle_xor_bf16(ctx)
         test_shuffle_xor_bf16_packed(ctx)
         test_shuffle_xor_fp16(ctx)
         test_shuffle_xor_fp16_packed(ctx)
         test_shuffle_xor_int64(ctx)
+        test_shuffle_xor_int(ctx)
+        test_shuffle_xor_uint(ctx)
         test_warp_reduce_fp32(ctx)
         test_warp_reduce_bf16(ctx)
         test_warp_reduce_bf16_packed(ctx)

--- a/mojo/stdlib/std/gpu/primitives/warp.mojo
+++ b/mojo/stdlib/std/gpu/primitives/warp.mojo
@@ -326,7 +326,7 @@ def _shuffle[
         return llvm_intrinsic[
             "llvm.nvvm.shfl.sync." + mnemonic + ".i32", Scalar[dtype]
         ](Int32(mask), val, offset, WIDTH_MASK)
-    elif dtype in (DType.int64, DType.uint64):
+    elif dtype.is_integral() and bit_width_of[dtype]() == 64:
         var val_bitcast = bitcast[DType.uint32, simd_width * 2](val)
         var val_half1, val_half2 = val_bitcast.deinterleave()
         var shuffle1 = _shuffle[mnemonic, WIDTH_MASK=WIDTH_MASK](
@@ -417,7 +417,7 @@ def _shuffle_apple_helper[
 
     var arg = UInt16(offset)  # AIR intrinsics use 16-bit offsets
 
-    comptime if dtype in (DType.int64, DType.uint64):
+    comptime if dtype.is_integral() and bit_width_of[dtype]() == 64:
         var bits = bitcast[DType.uint32, simd_width * 2](val)
         var half1, half2 = bits.deinterleave()
 


### PR DESCRIPTION
## Linked issue

`Fixes #6799 `

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

On Apple silicon GPUs, `warp.prefix_sum` (and `shuffle_up` / `shuffle_down` /
`shuffle_idx` / `shuffle_xor`) with an `Int` or `UInt` value fails at kernel
launch with a Metal backend internal error:

```
Failed to create compute pipeline state (GPU machine code generation): Compiler encountered an internal error
```

The Apple and NVIDIA shuffle helpers select the 64-bit
split-into-two-32-bit-shuffles path by enumerating dtypes
(`dtype in (DType.int64, DType.uint64)`). The index dtypes `DType.int` /
`DType.uint` compare unequal to `int64` / `uint64` but are also 64-bit wide on
GPU targets, so they fell through: on Apple to the generic branch that emits
`llvm.air.simd_shuffle*` with an `i64` operand (an overload that doesn't exist
in AIR, crashing Metal codegen), and on NVIDIA to the
`comptime assert False, "unhandled shuffle dtype"` catch-all.

The AMD helpers (`_shuffle_amd_helper`, `_dpp_move`) already dispatch on bit
width and are unaffected.

## What changed

- `_shuffle` (NVIDIA) and `_shuffle_apple_helper`: select the 64-bit split
  path with `dtype.is_integral() and bit_width_of[dtype]() == 64` instead of
  enumerating dtypes — a one-line condition change per backend, unifying all
  three backends on the width-based approach already used by the AMD helpers.
- `test_shuffle.mojo`: added `Int` / `UInt` variants of the
  `shuffle_idx` / `shuffle_up` / `shuffle_down` / `shuffle_xor` tests,
  mirroring the existing `int64` ones. These exercise the fixed helpers
  directly; `warp.prefix_sum` is built on `shuffle_up` on the affected
  backends.

## Testing

On an Apple M2 Pro (macOS 15.7.7, Mojo nightly `1.0.0b3.dev2026072306`):

- `max/kernels/test/gpu/basics/test_shuffle.mojo` passes with the patched
  stdlib and reproduces the failure against the unpatched stdlib (Metal
  internal error on the `DType.int` cases), confirming the new tests cover
  the bug.
- Also verified `warp.prefix_sum[exclusive=True/False]` with `Int` / `UInt`
  values produces correct scans on-device with the patched stdlib.
- NVIDIA/AMD paths validated by code inspection and CI (no NVIDIA/AMD
  hardware locally); the NVIDIA change is the same split path already used
  for `int64`/`uint64`, now also selected for the index dtypes.
- Note: `test_shuffle.mojo` is excluded on Apple GPU in CI (pre-existing
  Metal backend limitation unrelated to this change), so the Apple path was
  verified manually on-device; CI exercises the new tests on the NVIDIA/AMD
  paths.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
