### PR TITLE
[stdlib] Update tile_io.mojo to fix bug which only wrote 1/8 of the output on dense bf16 matmul tile copy from SMEM to GMEM on Hopper/sm_90

### DIFF
--- a/max/kernels/src/layout/tile_io.mojo
+++ b/max/kernels/src/layout/tile_io.mojo
@@ -288,14 +288,14 @@ struct SharedToGenericTileCopier[
                 src_fragments._distance(src)
             )
             comptime num_stores_per_thread = (
-                src_fragments.LayoutType.static_product // simd_size
+                src_fragments.LayoutType.static_product
             )
 
             comptime for i in range(num_stores_per_thread):
                 var src_idx = src_fragments.layout[
                     linear_idx_type=src.linear_idx_type
                 ](Idx[i * simd_size])
-                var dst_idx = dst_fragments.layout(Idx[i * simd_size])
+                var dst_idx = dst_fragments.layout(Idx[i])
                 var src_idx_base = umod(
                     src_idx,
                     Scalar[src.linear_idx_type](swizzle_fn.size()),

--- a/max/kernels/src/layout/tile_io.mojo
+++ b/max/kernels/src/layout/tile_io.mojo
@@ -260,14 +260,14 @@ struct SharedToGenericTileCopier[
                 src_fragments._distance(src)
             )
             comptime num_stores_per_thread = (
-                src_fragments.LayoutType.static_product // simd_size
+                src_fragments.LayoutType.static_product
             )
 
             comptime for i in range(num_stores_per_thread):
                 var src_idx = src_fragments.layout[
                     linear_idx_type=src.linear_idx_type
-                ](Idx[i * simd_size])
-                var dst_idx = dst_fragments.layout(Idx[i * simd_size])
+                ](Idx[i])
+                var dst_idx = dst_fragments.layout(Idx[i])
                 var src_idx_base = umod(
                     src_idx,
                     Scalar[src.linear_idx_type](swizzle_fn.size()),

--- a/max/kernels/test/gpu/layout/test_tile_io.mojo
+++ b/max/kernels/test/gpu/layout/test_tile_io.mojo
@@ -37,7 +37,9 @@ Coverage:
   half-precision matmul prologue shape.
 - GENERIC -> SHARED (async cp.async, swizzled) -> GENERIC (swizzled)
   (exercises the swizzled write path of GenericToSharedAsyncTileCopier
-  against the existing swizzled SharedToGeneric reader).
+  against the existing swizzled SharedToGeneric reader). The bf16 case
+  has multiple 8-element SIMD vectors per thread to verify every logical
+  vector is copied exactly once.
 - GENERIC -> SHARED (async cp.async, masked=True with full src) ->
   GENERIC (smoke-tests the masked write path of
   GenericToSharedAsyncTileCopier; runtime-shape zero-fill verification
@@ -265,6 +267,11 @@ def async_generic_to_shared_to_generic_16b_kernel(
 comptime _BF16_ROWS = 4
 comptime _BF16_COLS = 8
 comptime _BF16_NUM_ELEMENTS = _BF16_ROWS * _BF16_COLS
+comptime _BF16_SWIZZLED_ROWS = 2
+comptime _BF16_SWIZZLED_COLS = 16
+comptime _BF16_SWIZZLED_NUM_ELEMENTS = (
+    _BF16_SWIZZLED_ROWS * _BF16_SWIZZLED_COLS
+)
 
 
 def async_generic_to_shared_to_generic_16b_bf16_kernel(
@@ -294,6 +301,42 @@ def async_generic_to_shared_to_generic_16b_bf16_kernel(
     async_copy_wait_all()
     barrier()
     SharedToGenericTileCopier[thread_layout]().copy(dst, smem)
+
+
+def access_size_swizzled_vectorized_async_bf16_kernel(
+    src_ptr: MutPointer[BFloat16, MutAnyOrigin],
+    dst_ptr: MutPointer[BFloat16, MutAnyOrigin],
+):
+    """Roundtrip multiple swizzled 8-element bf16 vectors per thread."""
+    comptime thread_layout = row_major(Idx[2], Idx[1])
+    comptime simd_size = 8
+    comptime swizzle = make_swizzle[
+        num_rows=_BF16_SWIZZLED_ROWS,
+        row_size=_BF16_SWIZZLED_COLS,
+        access_size=simd_size,
+    ]()
+
+    var src = TileTensor(
+        src_ptr, row_major[_BF16_SWIZZLED_ROWS, _BF16_SWIZZLED_COLS]()
+    )
+    var dst = TileTensor(
+        dst_ptr, row_major[_BF16_SWIZZLED_ROWS, _BF16_SWIZZLED_COLS]()
+    )
+    var smem = stack_allocation[dtype=DType.bfloat16, address_space=.SHARED](
+        row_major[_BF16_SWIZZLED_ROWS, _BF16_SWIZZLED_COLS]()
+    )
+
+    GenericToSharedAsyncTileCopier[thread_layout, swizzle=swizzle]().copy(
+        smem.vectorize[1, simd_size](),
+        src.vectorize[1, simd_size](),
+    )
+    async_copy_commit_group()
+    async_copy_wait_all()
+    barrier()
+    SharedToGenericTileCopier[thread_layout, swizzle=swizzle]().copy(
+        dst.vectorize[1, simd_size](),
+        smem.vectorize[1, simd_size](),
+    )
 
 
 def masked_async_generic_to_shared_to_generic_kernel(
@@ -412,6 +455,7 @@ def _run_roundtrip[
     var src_dev = ctx.enqueue_create_buffer[.float32](_NUM_ELEMENTS)
     var dst_dev = ctx.enqueue_create_buffer[.float32](_NUM_ELEMENTS)
     ctx.enqueue_copy(src_dev, src_host)
+    dst_dev.enqueue_fill(Float32(0))
 
     ctx.enqueue_function[kernel_fn](
         src_dev, dst_dev, grid_dim=(1), block_dim=(_BLOCK_DIM)
@@ -480,6 +524,7 @@ def test_async_generic_to_shared_to_generic_16b_bf16(
     var src_dev = ctx.enqueue_create_buffer[.bfloat16](_BF16_NUM_ELEMENTS)
     var dst_dev = ctx.enqueue_create_buffer[.bfloat16](_BF16_NUM_ELEMENTS)
     ctx.enqueue_copy(src_dev, src_host)
+    dst_dev.enqueue_fill(BFloat16(0))
 
     ctx.enqueue_function[async_generic_to_shared_to_generic_16b_bf16_kernel](
         src_dev, dst_dev, grid_dim=(1), block_dim=(_BF16_ROWS)
@@ -515,6 +560,41 @@ def test_access_size_swizzled_vectorized_async(ctx: DeviceContext) raises:
     )
 
 
+def test_access_size_swizzled_vectorized_async_bf16(
+    ctx: DeviceContext,
+) raises:
+    var name = "test_access_size_swizzled_vectorized_async_bf16"
+    print("==", name)
+
+    var src_host = ctx.enqueue_create_host_buffer[.bfloat16](
+        _BF16_SWIZZLED_NUM_ELEMENTS
+    )
+    for i in range(_BF16_SWIZZLED_NUM_ELEMENTS):
+        src_host[i] = BFloat16(i + 1)
+
+    var src_dev = ctx.enqueue_create_buffer[.bfloat16](
+        _BF16_SWIZZLED_NUM_ELEMENTS
+    )
+    var dst_dev = ctx.enqueue_create_buffer[.bfloat16](
+        _BF16_SWIZZLED_NUM_ELEMENTS
+    )
+    ctx.enqueue_copy(src_dev, src_host)
+    dst_dev.enqueue_fill(BFloat16(0))
+
+    ctx.enqueue_function[
+        access_size_swizzled_vectorized_async_bf16_kernel
+    ](src_dev, dst_dev, grid_dim=(1), block_dim=(_BF16_SWIZZLED_ROWS))
+
+    var dst_host = ctx.enqueue_create_host_buffer[.bfloat16](
+        _BF16_SWIZZLED_NUM_ELEMENTS
+    )
+    ctx.enqueue_copy(dst_host, dst_dev)
+    ctx.synchronize()
+
+    for i in range(_BF16_SWIZZLED_NUM_ELEMENTS):
+        assert_equal(dst_host[i], src_host[i])
+
+
 def main() raises:
     with DeviceContext() as ctx:
         test_generic_to_shared_to_generic(ctx)
@@ -528,3 +608,4 @@ def main() raises:
         test_swizzled_async_generic_to_shared_to_generic(ctx)
         test_masked_async_generic_to_shared_to_generic(ctx)
         test_access_size_swizzled_vectorized_async(ctx)
+        test_access_size_swizzled_vectorized_async_bf16(ctx)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Before you open this PR, please make sure the change has been discussed and
agreed upon with a maintainer. For anything beyond a trivial fix (typo,
one-line bug fix, doc tweak), we ask that you first open a GitHub issue or
proposal and get a maintainer's go-ahead. This helps us avoid situations
where a PR sits unreviewed because the change isn't aligned with the
team's direction. See our [contributor guide](https://github.com/modular/modular/blob/main/CONTRIBUTING.md) for
details.
-->

## Linked issue

<!--
Replace `NNN` with the issue number. For anything non-trivial, a linked
issue that a maintainer has agreed to is expected before review.

- Trivial fix (typo, comment, small doc fix): you can write "N/A — trivial".
- Everything else: `Fixes #NNN` or `Related to #NNN`.
-->

N/A — trivial

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

<!--
Why is this change needed? What problem does it solve, or what use case
does it enable? If this is a bug fix, describe the bug and how a user
would hit it. If this is a new feature, explain the user-facing value.

Please write prose here — don't just restate the PR title.
-->

I was benchmarking perf of a 4096x4096 GEMM on an H100 when I ran into the issue of mismatched outputs after pulling the repo.

SM90 BF16 matmul kernels using the swizzled, vectorized shared-to-global copy path wrote only one eighth of the output.

After `TileTensor.vectorize[1, simd_size]()`, each logical layout element represents an entire SIMD vector. However, SharedToGenericTileCopier divided the fragment's logical element count by simd_size again and advanced its layout index by simd_size.

  For the eight-lane BF16 stores used by this matmul, this caused each thread to issue only one eighth of the required vector stores. The vectors that were not visited remained unwritten.


## What changed

<!--
Describe the change at a high level. Call out anything non-obvious: API
changes, behavior changes, performance characteristics, or tricky
implementation details.
-->

The swizzled branch of SharedToGenericTileCopier now iterates over every logical vector element:

```
  comptime num_stores_per_thread = (
      src_fragments.LayoutType.static_product
  )

  comptime for i in range(num_stores_per_thread):
      var src_idx = src_fragments.layout[
          linear_idx_type=src.linear_idx_type
      ](Idx[i])
      var dst_idx = dst_fragments.layout(Idx[i])
```

Previously, it divided the iteration count by simd_size and used ` Idx[i * simd_size]` for the stride.

The vectorized layout already accounts for the SIMD width in its shape and strides, while each raw_load[width=simd_size] and raw_store transfers the complete vector. Applying simd_size again skips logical vector entries.

This only changes the swizzled shared-to-global path with element_size > 1. Unswizzled copies use copy_from, and scalar swizzled copies are unchanged because their element_size is one.

## Testing

<!--
Describe how you validated your changes.

- Code changes: what tests did you run, and what were the results? Did
  you add a new test that would have caught the bug?
- Performance changes: include before/after numbers from a benchmark.
- Documentation: describe how you verified accuracy (built the docs,
  ran the example, etc.).
-->

I regenerated and benchmarked the SM90 BF16 4096×4096 matmul using the corrected tile copy. The output matched the reference.

On the tested H100 configuration @ 650W, the corrected kernel ran in approximately 200.52 μs, corresponding to 685.4 TFLOP/s which is very reasonable.

I think this should be covered by the test in "access_size_swizzled_vectorized_async_kernel", but for some reason either the CI is broken, this is a special case, or we need to check something more strictly. I am not sure.

## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [ ] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [ ] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
