### PR TITLE
Fix constructing integral SIMD types from float literals

### DIFF
--- a/mojo/stdlib/std/builtin/simd.mojo
+++ b/mojo/stdlib/std/builtin/simd.mojo
@@ -954,13 +954,27 @@ struct SIMD[dtype: DType, length: SIMDLength](
             value: The input value.
         """
         _simd_construction_checks[Self.dtype, Self.length]()
-        comptime assert (
-            Self.dtype.is_floating_point()
-        ), "the SIMD type must be floating point"
-        var res = __mlir_attr[
-            `#pop<float_literal_convert<`, value.value, `>> : `, Self._mlir_type
-        ]
-        self = Self(mlir_value=res)
+        comptime if Self.dtype.is_floating_point():
+            var res = __mlir_attr[
+                `#pop<float_literal_convert<`, value.value, `>> : `, Self._mlir_type
+            ]
+            self = Self(mlir_value=res)
+        else:
+            # Integral types: convert the literal at compile time, truncating
+            # towards zero like `FloatLiteral.__int__()` (e.g. `Int(4.5) == 4`,
+            # `Int(-3.7) == -3`). Values outside the type's range wrap,
+            # matching the runtime `SIMD.cast` behavior (e.g. `UInt(-3.7)`
+            # wraps to 2**64 - 3).
+            self._mlir_value = __mlir_attr[
+                `#pop.int_literal_convert<`,
+                __mlir_attr[
+                    `#pop<float_to_int_literal<`,
+                    value.value,
+                    `>> : !pop.int_literal`,
+                ],
+                `> : `,
+                Self._mlir_type,
+            ]
 
     @staticmethod
     def __init__[

--- a/mojo/stdlib/test/builtin/test_simd.mojo
+++ b/mojo/stdlib/test/builtin/test_simd.mojo
@@ -2594,6 +2594,16 @@ def test_float_literal_init() raises:
         atol=1e-3,
     )
 
+    # Test integral types: truncate towards zero, matching runtime cast
+    assert_equal(SIMD[DType.int64, 1](4.5)[0], Int64(4))
+    assert_equal(SIMD[DType.int64, 1](-3.7)[0], Int64(-3))
+    assert_equal(SIMD[DType.uint64, 1](400.7)[0], UInt64(400))
+    # Values outside the type's range wrap, matching `UInt64(Float64(-3.7))`
+    assert_equal(SIMD[DType.uint64, 1](-3.7)[0], UInt64(-3))
+    assert_equal(SIMD[DType.int8, 1](-7.9)[0], Int8(-7))
+    # Float literals in comptime contexts (e.g. array sizes)
+    assert_equal(SIMD[DType.uint, 1](400. / 0.1)[0], UInt(4000))
+
 
 def test_int_literal_init() raises:
     assert_equal(UInt8(255), UInt8(-1))


### PR DESCRIPTION
Fixes #5290.

`Int(400.)`, `UInt(400.)`, `Int(-3.7)` and similar conversions fail to compile with `the SIMD type must be floating point`: the implicit `FloatLiteral` constructor on `SIMD` only handled floating-point dtypes. The failure also hits comptime contexts, e.g. `InlineArray[Float64, UInt(400. / 0.1) * 512](...)` where the conversion must fold at compile time.

## Change

In `simd.mojo`, the implicit `__init__(FloatLiteral)` now branches on `Self.dtype`:

- floating-point dtypes: unchanged (`#pop.float_literal_convert`).
- integral dtypes: convert the literal at compile time via `#pop.float_to_int_literal` → `#pop.int_literal_convert`, truncating towards zero — matching `FloatLiteral.__int__()` and the existing runtime `SIMD.cast` semantics:
  - `Int(4.5) == 4`, `Int(-3.7) == -3`
  - values outside the target range wrap: `UInt(-3.7)` → `2**64 - 3`, identical to `UInt(Float64(-3.7))` at runtime

## Tests

Extended `test_float_literal_init` in `test_simd.mojo` with integral-literal cases (signed/unsigned, narrowing, wrap-around, and a comptime-constant case). Full `mojo/stdlib/test/builtin/...` suite passes (55/55).

```
$ ./bazelw test mojo/stdlib/test/builtin/...
Executed 52 out of 55 tests: 55 tests pass.
```