### PR TITLE
[stdlib] Fix `List` docstring examples for Array-by-default literals

### DIFF
--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -188,9 +188,9 @@ struct List[T: Movable, /](
     # With initial size and fill value
     var filled = List[Float64](length=10, fill=0.0)
 
-    # From a list literal, with an explicit type annotation (without the
-    # annotation, a list literal constructs a fixed-size `Array`)
-    var numbers: List[Int] = [1, 2, 3, 4, 5]
+    # With initial values and inferred type (Int).
+    # The `List` annotation is needed otherwise this creates a fixed-size `Array`.
+    var numbers: List = [1, 2, 3, 4, 5]
     ```
 
     Be aware of the following characteristics:
@@ -200,10 +200,9 @@ struct List[T: Movable, /](
       improves performance:
 
       ```mojo
-      var int_list: List[Int] = [1, 2, 3]
-      var str_list: List[String] = ["a", "b", "c"]
-      # Error! All elements must be the same type:
-      # var mixed: List[Int] = [1, "hello"]
+      var int_list: List = [1, 2, 3]        # List[Int]
+      var str_list: List = ["a", "b", "c"]  # List[String]
+      # var mixed: List = [1, "hello"]      # Error! All elements must be same type
       ```
 
       However, you can get around this by defining your list type as
@@ -215,7 +214,7 @@ struct List[T: Movable, /](
       assignment creates a deep copy of all elements:
 
       ```mojo
-      var list1: List[Int] = [1, 2, 3]
+      var list1: List = [1, 2, 3]
       var list2 = list1.copy()        # Deep copy
       list2.append(4)
       print(list1)   # => [1, 2, 3]
@@ -231,7 +230,7 @@ struct List[T: Movable, /](
       you specify `ref`:
 
       ```mojo
-      var numbers: List[Int] = [10, 20, 30]
+      var numbers: List = [10, 20, 30]
 
       # Default behavior creates immutable (read-only) references:
       # for num in numbers:
@@ -248,7 +247,7 @@ struct List[T: Movable, /](
       original list is no longer accessible after the loop:
 
       ```mojo
-      var names: List[String] = ["alice", "bob"]
+      var names: List = ["alice", "bob"]
       for x in names^:
           # `x` is an owned `String` value.
           print(x)
@@ -259,7 +258,7 @@ struct List[T: Movable, /](
       abort:
 
       ```mojo
-      var my_list: List[Int] = [1, 2, 3]
+      var my_list: List = [1, 2, 3]
       print(my_list[5])  # Aborts with an Assert Error: index 5 is
                          # out of bounds, valid range is 0 to 2
       ```
@@ -268,7 +267,7 @@ struct List[T: Movable, /](
       handle errors gracefully:
 
       ```mojo
-      var my_list: List[Int] = [1, 2, 3]
+      var my_list: List = [1, 2, 3]
       if 5 < len(my_list):
           print(my_list[5])  # Safe: check bounds first
       else:
@@ -285,7 +284,7 @@ struct List[T: Movable, /](
     Examples:
 
     ```mojo
-    var my_list: List[Int] = [10, 20, 30]
+    var my_list: List = [10, 20, 30]
 
     # Add elements
     my_list.append(40)           # [10, 20, 30, 40]
@@ -306,12 +305,12 @@ struct List[T: Movable, /](
     print('cap:', my_list.capacity())    # Current allocated capacity
 
     # Multiply a list
-    var pair: List[Int] = [1, 2]
+    var pair: List = [1, 2]
     var repeated = pair * 3
     print(repeated)    # [1, 2, 1, 2, 1, 2]
 
     # Iterate over a list:
-    var fruits: List[String] = ["apple", "banana", "orange"]
+    var fruits: List = ["apple", "banana", "orange"]
 
     # Iterate by reference (immutable)
     for fruit in fruits:
@@ -326,7 +325,7 @@ struct List[T: Movable, /](
         print(i, fruits[i])
 
     # Iterate by ownership (consumes the list)
-    var temps: List[String] = ["a", "b", "c"]
+    var temps: List = ["a", "b", "c"]
     for x in temps^:
         print(x)
     # `temps` is no longer accessible here
@@ -666,7 +665,7 @@ struct List[T: Movable, /](
         x is <= 0.
 
         ```mojo
-        var a: List[Int] = [1, 2]
+        var a: List = [1, 2]
         a *= 2 # a = [1, 2, 1, 2]
         ```
 
@@ -841,7 +840,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var my_list: List[Int] = [1, 2, 3]
+        var my_list: List = [1, 2, 3]
         print(my_list.capacity())  # Current allocated capacity
         ```
         """
@@ -882,7 +881,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list: List[Int] = [1, 2, 3, 4, 5]
+        var list: List = [1, 2, 3, 4, 5]
         list.append(6)
         print(list) # [1, 2, 3, 4, 5, 6]
         ```
@@ -905,7 +904,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list: List[String] = ["one", "three"]
+        var list: List = ["one", "three"]
         list.insert(1, "two")
         print(list) # ['one', 'two', 'three']
         ```
@@ -939,8 +938,8 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list: List[String] = ["one", "two", "three"]
-        var more: List[String] = ["four", "five"]
+        var list: List = ["one", "two", "three"]
+        var more: List = ["four", "five"]
         list.extend(more^) # more's values are consumed
         # print(more)      # Error: use of initialized value
         print(list)        # ['one', 'two', 'three', 'four', 'five']
@@ -978,8 +977,8 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var numbers: List[Int] = [1, 2, 3]
-        var more: List[Int] = [4, 5, 6]
+        var numbers: List = [1, 2, 3]
+        var more: List = [4, 5, 6]
         numbers.extend(Span(more))
         print(numbers)   # [1, 2, 3, 4, 5, 6]
         ```
@@ -1079,7 +1078,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var numbers: List[String] = ["1", "2", "3", "4", "5"]
+        var numbers: List = ["1", "2", "3", "4", "5"]
         var value = numbers.pop(); print(value)   # 5
         print("length", len(numbers))             # length 4
         ```
@@ -1099,7 +1098,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var numbers: List[String] = ["1", "2", "3", "4", "5"]
+        var numbers: List = ["1", "2", "3", "4", "5"]
         var value = numbers.pop(2); print(value)  # 3
         print(numbers)                            # ['1', '2', '4', '5']
         ```
@@ -1148,7 +1147,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list: List[String] = ["z", "y", "x", "w"]
+        var list: List = ["z", "y", "x", "w"]
         list.resize(3, "v")
         print(list)                  # ['z', 'y', 'x']
         list.resize(6, "v")
@@ -1187,7 +1186,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list: List[Int] = [1, 2, 3]
+        var list: List = [1, 2, 3]
         list.resize(unsafe_uninit_length=5) # Indices 3 and 4 are uninitialized memory
         print(len(list))                    # 5
         list[3] = 10; list[4] = 20
@@ -1216,7 +1215,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var numbers: List[Int] = [1, 2, 3, 4, 5, 6]
+        var numbers: List = [1, 2, 3, 4, 5, 6]
         numbers.shrink(2); print(numbers) # [1, 2]
         # numbers.shrink(8)               # Error: new size is bigger than current
         ```
@@ -1244,7 +1243,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list: List[String] = ["o", "l", "l", "e", "H"]
+        var list: List = ["o", "l", "l", "e", "H"]
         list.reverse()
         print("".join(list)) # Hello
         ```
@@ -1289,7 +1288,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var my_list: List[Int] = [1, 2, 3]
+        var my_list: List = [1, 2, 3]
         print(my_list.index(2)) # prints `1`
         ```
         """
@@ -1340,7 +1339,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var my_list: List[Int] = [1, 2, 3]
+        var my_list: List = [1, 2, 3]
         print(my_list.index(2)) # prints `1`
         ```
         """
@@ -1357,7 +1356,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list: List[String] = ["o", "l", "l", "e", "H"]
+        var list: List = ["o", "l", "l", "e", "H"]
         print(len(list))  # 5
         list.clear()
         print(len(list))  # 0
@@ -1597,7 +1596,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list: List[String] = ["a", "b", "c", "b", "b", "a", "c"]
+        var list: List = ["a", "b", "c", "b", "b", "a", "c"]
         print(list.count("b")) # 3
         ```
         """
@@ -1617,7 +1616,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var my_list: List[Int] = [1, 2, 3]
+        var my_list: List = [1, 2, 3]
         my_list.swap_elements(0, 2)
         print(my_list) # 3, 2, 1
         ```

--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -188,8 +188,9 @@ struct List[T: Movable, /](
     # With initial size and fill value
     var filled = List[Float64](length=10, fill=0.0)
 
-    # With initial values and inferred type (Int)
-    var numbers = [1, 2, 3, 4, 5]
+    # From a list literal, with an explicit type annotation (without the
+    # annotation, a list literal constructs a fixed-size `Array`)
+    var numbers: List[Int] = [1, 2, 3, 4, 5]
     ```
 
     Be aware of the following characteristics:
@@ -199,9 +200,10 @@ struct List[T: Movable, /](
       improves performance:
 
       ```mojo
-      var int_list = [1, 2, 3]        # List[Int]
-      var str_list = ["a", "b", "c"]  # List[String]
-      # var mixed = [1, "hello"]      # Error! All elements must be same type
+      var int_list: List[Int] = [1, 2, 3]
+      var str_list: List[String] = ["a", "b", "c"]
+      # Error! All elements must be the same type:
+      # var mixed: List[Int] = [1, "hello"]
       ```
 
       However, you can get around this by defining your list type as
@@ -213,7 +215,7 @@ struct List[T: Movable, /](
       assignment creates a deep copy of all elements:
 
       ```mojo
-      var list1 = [1, 2, 3]
+      var list1: List[Int] = [1, 2, 3]
       var list2 = list1.copy()        # Deep copy
       list2.append(4)
       print(list1)   # => [1, 2, 3]
@@ -229,7 +231,7 @@ struct List[T: Movable, /](
       you specify `ref`:
 
       ```mojo
-      var numbers = [10, 20, 30]
+      var numbers: List[Int] = [10, 20, 30]
 
       # Default behavior creates immutable (read-only) references:
       # for num in numbers:
@@ -246,10 +248,10 @@ struct List[T: Movable, /](
       original list is no longer accessible after the loop:
 
       ```mojo
-      var names = ["alice", "bob"]
+      var names: List[String] = ["alice", "bob"]
       for x in names^:
           # `x` is an owned `String` value.
-          print(x^)
+          print(x)
       # `names` is consumed and can no longer be used here
       ```
 
@@ -257,7 +259,7 @@ struct List[T: Movable, /](
       abort:
 
       ```mojo
-      var my_list = [1, 2, 3]
+      var my_list: List[Int] = [1, 2, 3]
       print(my_list[5])  # Aborts with an Assert Error: index 5 is
                          # out of bounds, valid range is 0 to 2
       ```
@@ -266,7 +268,7 @@ struct List[T: Movable, /](
       handle errors gracefully:
 
       ```mojo
-      var my_list = [1, 2, 3]
+      var my_list: List[Int] = [1, 2, 3]
       if 5 < len(my_list):
           print(my_list[5])  # Safe: check bounds first
       else:
@@ -283,7 +285,7 @@ struct List[T: Movable, /](
     Examples:
 
     ```mojo
-    var my_list = [10, 20, 30]
+    var my_list: List[Int] = [10, 20, 30]
 
     # Add elements
     my_list.append(40)           # [10, 20, 30, 40]
@@ -304,11 +306,12 @@ struct List[T: Movable, /](
     print('cap:', my_list.capacity())    # Current allocated capacity
 
     # Multiply a list
-    var repeated = [1, 2] * 3
+    var pair: List[Int] = [1, 2]
+    var repeated = pair * 3
     print(repeated)    # [1, 2, 1, 2, 1, 2]
 
     # Iterate over a list:
-    var fruits = ["apple", "banana", "orange"]
+    var fruits: List[String] = ["apple", "banana", "orange"]
 
     # Iterate by reference (immutable)
     for fruit in fruits:
@@ -323,9 +326,9 @@ struct List[T: Movable, /](
         print(i, fruits[i])
 
     # Iterate by ownership (consumes the list)
-    var temps = ["a", "b", "c"]
+    var temps: List[String] = ["a", "b", "c"]
     for x in temps^:
-        print(x^)
+        print(x)
     # `temps` is no longer accessible here
 
     # Concatenate with + and +=
@@ -663,7 +666,7 @@ struct List[T: Movable, /](
         x is <= 0.
 
         ```mojo
-        var a = [1, 2]
+        var a: List[Int] = [1, 2]
         a *= 2 # a = [1, 2, 1, 2]
         ```
 
@@ -838,7 +841,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var my_list = [1, 2, 3]
+        var my_list: List[Int] = [1, 2, 3]
         print(my_list.capacity())  # Current allocated capacity
         ```
         """
@@ -879,7 +882,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list = [1, 2, 3, 4, 5]
+        var list: List[Int] = [1, 2, 3, 4, 5]
         list.append(6)
         print(list) # [1, 2, 3, 4, 5, 6]
         ```
@@ -902,7 +905,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list = ["one", "three"]
+        var list: List[String] = ["one", "three"]
         list.insert(1, "two")
         print(list) # ['one', 'two', 'three']
         ```
@@ -936,8 +939,8 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list = ["one", "two", "three"]
-        var more = ["four", "five"]
+        var list: List[String] = ["one", "two", "three"]
+        var more: List[String] = ["four", "five"]
         list.extend(more^) # more's values are consumed
         # print(more)      # Error: use of initialized value
         print(list)        # ['one', 'two', 'three', 'four', 'five']
@@ -975,8 +978,8 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var numbers = [1, 2, 3]
-        var more = [4, 5, 6]
+        var numbers: List[Int] = [1, 2, 3]
+        var more: List[Int] = [4, 5, 6]
         numbers.extend(Span(more))
         print(numbers)   # [1, 2, 3, 4, 5, 6]
         ```
@@ -1076,7 +1079,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var numbers = ["1", "2", "3", "4", "5"]
+        var numbers: List[String] = ["1", "2", "3", "4", "5"]
         var value = numbers.pop(); print(value)   # 5
         print("length", len(numbers))             # length 4
         ```
@@ -1096,7 +1099,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var numbers = ["1", "2", "3", "4", "5"]
+        var numbers: List[String] = ["1", "2", "3", "4", "5"]
         var value = numbers.pop(2); print(value)  # 3
         print(numbers)                            # ['1', '2', '4', '5']
         ```
@@ -1145,7 +1148,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list = ["z", "y", "x", "w"]
+        var list: List[String] = ["z", "y", "x", "w"]
         list.resize(3, "v")
         print(list)                  # ['z', 'y', 'x']
         list.resize(6, "v")
@@ -1184,7 +1187,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list = [1, 2, 3]
+        var list: List[Int] = [1, 2, 3]
         list.resize(unsafe_uninit_length=5) # Indices 3 and 4 are uninitialized memory
         print(len(list))                    # 5
         list[3] = 10; list[4] = 20
@@ -1213,7 +1216,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var numbers = [1, 2, 3, 4, 5, 6]
+        var numbers: List[Int] = [1, 2, 3, 4, 5, 6]
         numbers.shrink(2); print(numbers) # [1, 2]
         # numbers.shrink(8)               # Error: new size is bigger than current
         ```
@@ -1241,7 +1244,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list = ["o", "l", "l", "e", "H"]
+        var list: List[String] = ["o", "l", "l", "e", "H"]
         list.reverse()
         print("".join(list)) # Hello
         ```
@@ -1286,7 +1289,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var my_list = [1, 2, 3]
+        var my_list: List[Int] = [1, 2, 3]
         print(my_list.index(2)) # prints `1`
         ```
         """
@@ -1337,7 +1340,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var my_list = [1, 2, 3]
+        var my_list: List[Int] = [1, 2, 3]
         print(my_list.index(2)) # prints `1`
         ```
         """
@@ -1354,7 +1357,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list = ["o", "l", "l", "e", "H"]
+        var list: List[String] = ["o", "l", "l", "e", "H"]
         print(len(list))  # 5
         list.clear()
         print(len(list))  # 0
@@ -1594,7 +1597,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var list = ["a", "b", "c", "b", "b", "a", "c"]
+        var list: List[String] = ["a", "b", "c", "b", "b", "a", "c"]
         print(list.count("b")) # 3
         ```
         """
@@ -1614,7 +1617,7 @@ struct List[T: Movable, /](
         Examples:
 
         ```mojo
-        var my_list = [1, 2, 3]
+        var my_list: List[Int] = [1, 2, 3]
         my_list.swap_elements(0, 2)
         print(my_list) # 3, 2, 1
         ```


### PR DESCRIPTION
## Linked issue

Related to #3572

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [x] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Since the Mojo 1.0 release, you need to specify the type for a list, otherwise it becomes an array.
The examples use methods that don't exist on array (`append`, `pop`, ...), so the docstrings no longer compiled.

## What changed

Docstring-only changes:
- Added the explicit `List` annotation on the variables in the examples
- Fixed the ownership example with `print`
- Fixed a multiplication example by going through a variable to specify the type before the `*`

## Testing

- Ran each example block against the nightly build
- Ran `mojo format` on the file

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))

Assisted-by: Claude