### PR TITLE
[stdlib] Fix `MaybeUninit` docstring examples (missing imports)

### DIFF
--- a/mojo/stdlib/std/memory/maybe_uninit.mojo
+++ b/mojo/stdlib/std/memory/maybe_uninit.mojo
@@ -53,6 +53,8 @@ struct MaybeUninit[T: AnyType](
     `MaybeUninit[T]` helps enable low level code deal with uninitialized data.
 
     ```mojo
+    from std.memory import MaybeUninit
+
     # The compiler knows `uninit` may contain uninitialized data, so it
     # makes no assumptions.
     var uninit = MaybeUninit[Int]()
@@ -65,6 +67,8 @@ struct MaybeUninit[T: AnyType](
     However, improper usage of this type can lead to undefined behavior:
 
     ```mojo
+    from std.memory import MaybeUninit
+
     var uninit = MaybeUninit[Int]()
     # Undefined Behavior: reading uninitialized memory 👻
     print(uninit.unsafe_assume_init())
@@ -165,14 +169,19 @@ struct MaybeUninit[T: AnyType](
     `Deinitable`.
 
     ```mojo
+    from std.memory import MaybeUninit
+
     var uninit = MaybeUninit[String]()
-    # error: `uninit` abandoned without being explicitly destroyed
+    # Error if never consumed: `uninit` abandoned without being destroyed
+    uninit^.unsafe_forget()
     ```
 
     Use `unsafe_deinit()` when the storage contains a live `T` whose
     deinitializer must run.
 
     ```mojo
+    from std.memory import MaybeUninit
+
     var uninit = MaybeUninit[String]()
     uninit.unsafe_write("hello")
     # SAFETY: `uninit` contains a live `String`.
@@ -182,6 +191,8 @@ struct MaybeUninit[T: AnyType](
     Use `unsafe_forget()` when the storage does not contain a live `T`:
 
     ```mojo
+    from std.memory import MaybeUninit
+
     var uninit = MaybeUninit[String]()
     # SAFETY: Nothing was ever written into the storage, so there is no `String`
     # to destroy.
@@ -193,17 +204,24 @@ struct MaybeUninit[T: AnyType](
     moved:
 
     ```mojo
+    from std.memory import MaybeUninit
+
     var uninit = MaybeUninit[String]()
     uninit.unsafe_write("hello")
     var moved = uninit^ # OK: `String` is trivially movable.
+    # SAFETY: `moved` now holds the live `String`.
+    moved^.unsafe_deinit()
     ```
 
     However, `String` is not trivially copyable so `MaybeUninit[String]` is not
     `ImplicitlyCopyable`. Copying it implicitly is a compile-time error.
 
     ```mojo
+    from std.memory import MaybeUninit
+
     var uninit = MaybeUninit[String]()
-    var copy = uninit # error: `MaybeUninit[String]` is not `ImplicitlyCopyable`
+    # var copy = uninit  # Error: MaybeUninit[String] is not ImplicitlyCopyable
+    uninit^.unsafe_forget()
     ```
 
     For types such as `Int` that are trivially movable, copyable, and
@@ -211,6 +229,8 @@ struct MaybeUninit[T: AnyType](
     `MaybeUninit[Int]` behaves like an ordinary trivial value.
 
     ```mojo
+    from std.memory import MaybeUninit
+
     var uninit = MaybeUninit[Int]()
     var copy = uninit # OK: Int is trivially copyable
     var moved = uninit^ # OK: Int is trivially movable


### PR DESCRIPTION
## Linked issue

Related to #3572

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [x] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

8 of the 10 ```mojo blocks in the `MaybeUninit` struct docstring do not compile because they use `MaybeUninit` without importing it, so the LSP flags each of them — the situation #3572 tracks. Two of those blocks additionally demonstrate intentional compile errors as live code, and one move example leaves the moved-to storage unconsumed, tripping the same explicitly-destroyed check the surrounding prose describes.

## What changed

Docstring-only changes in `mojo/stdlib/std/memory/maybe_uninit.mojo`:

- Added `from std.memory import MaybeUninit` to the eight examples missing it, matching the two examples in the same file that already carry it (and the prevailing stdlib convention — 331 of 594 stdlib docstring examples start with their imports).
- Converted the two intentional compile-error demonstrations to the existing stdlib pattern (see `dict.mojo`, `list.mojo`): the offending line commented out with a short inline error note, followed by the consumption that makes the block legal.
- Consumed the moved storage in the move example (`moved^.unsafe_deinit()`), which otherwise fails the explicitly-destroyed check.

## Testing

- Extracted all 10 ```mojo blocks from the file and compiled each (wrapped in `def main() raises:` where statement-only) against nightly `1.1.0.dev2026081705`: 0 failures, versus 8 before this change.
- Ran `mojo format` on the file (no changes). No tests added: the change touches only docstrings.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))

Assisted-by: Claude