### PR TITLE
[mojo-parser] Fix nested try/except mis-parsed as owning outer finally

### DIFF
--- a/KGEN/lib/MojoParser/ParserStmts.cpp
+++ b/KGEN/lib/MojoParser/ParserStmts.cpp
@@ -2220,10 +2220,12 @@ ParseResult StmtParser::parseTryStmt(size_t curIndent) {
     }
     TryYieldOp::create(builder, translateLocation(getToken().getLoc()));
 
-    hasFinally = consumeIf(Token::kw_finally);
+    hasFinally = isTokenInCurrentStatement(curIndent, /*allowSameIndent=*/true) &&
+                 consumeIf(Token::kw_finally);
   } else {
     SMLoc finallyLoc;
-    hasFinally = consumeIf(Token::kw_finally, &finallyLoc);
+    hasFinally = isTokenInCurrentStatement(curIndent, /*allowSameIndent=*/true) &&
+                 consumeIf(Token::kw_finally, &finallyLoc);
     if (!hasFinally)
       return emitTokenError("expected 'except' or 'finally' block");
     // In a raising context, the default 'except' block just forwards the error.

--- a/KGEN/test/mojo-parser/statements/raise_and_try.mojo
+++ b/KGEN/test/mojo-parser/statements/raise_and_try.mojo
@@ -92,6 +92,36 @@ def tryFinally():
         pass
 
 
+# Regression test for https://github.com/modular/modular/issues/6718: a
+# nested try/except that is the last statement of an outer try-with-finally
+# body used to be misparsed, with the outer 'finally' wrongly attached to the
+# inner try, because the 'finally' keyword wasn't checked against the try's
+# own indentation before being consumed.
+# CHECK-LABEL: lit.fn @"tryExceptLastStmtOfTryFinally
+def tryExceptLastStmtOfTryFinally():
+    # CHECK: lit.try
+    try:
+        # CHECK: lit.try
+        try:
+            # CHECK-NEXT: lit.try.yield
+            pass
+        # CHECK-NEXT: except
+        except:
+            # CHECK-NEXT: lit.try.yield
+            pass
+        # CHECK-NEXT: else
+        # CHECK-NEXT: lit.try.yield
+        # CHECK-NEXT: finally
+        # CHECK-NEXT: lit.try.yield
+        # CHECK-NEXT: }
+        # CHECK-NEXT: lit.try.yield
+    # CHECK-NEXT: except
+    # CHECK-NEXT: unreachable
+    # CHECK: finally
+    finally:
+        pass
+
+
 def maybeRaises() raises -> Int:
     return 0
 


### PR DESCRIPTION
Fixes #6718

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation

A nested `try/except` (no local `finally`) as the last statement of an outer `try`-with-`finally` body fails to parse, with misleading diagnostics ("body must not be empty", "expected 'except' or 'finally' block") that don't describe the actual source (#6718).

## What changed
  
`parseTryStmt` in `KGEN/lib/MojoParser/ParserStmts.cpp` consumed a `finally` keyword unconditionally, without checking it's actually at this `try`'s own indentation unlike every other continuation keyword (`else`) in the same parser, which is indentation-guarded. This let an inner `try` steal the *outer* `try`'s `finally` token. Added the missing indentation check.

## Testing
- Added a regression test (`KGEN/test/mojo-parser/statements/raise_and_try.mojo`) reproducing the issue; verified it fails without the fix and passes with it.
- Ran all repros from #6718 against a from-source build - all parse and run correctly now.
- Full `mojo-parser` suite (352 tests) passes, no regressions.