### PR TITLE
[stdlib] Migrate test_list_bounds_abort to use assert_aborts

### DIFF
--- a/mojo/stdlib/test/collections/BUILD.bazel
+++ b/mojo/stdlib/test/collections/BUILD.bazel
@@ -22,7 +22,6 @@ _FILECHECK_TESTS = [
 
 _LIT_TESTS = [
     "test_asan_annotations_list.mojo",
-    "test_list_bounds_abort.mojo",
 ]
 
 _MOJO_COMPILE_OPTS = {

--- a/mojo/stdlib/test/collections/test_list_bounds_abort.mojo
+++ b/mojo/stdlib/test/collections/test_list_bounds_abort.mojo
@@ -16,32 +16,70 @@
 #
 # ===----------------------------------------------------------------------=== #
 
-# RUN: not %mojo -D test=1 %s 2>&1 | FileCheck --check-prefix CHECK_1 %s
-# RUN: not %mojo -D test=2 %s 2>&1 | FileCheck --check-prefix CHECK_2 %s
-# RUN: not %mojo -D test=3 %s 2>&1 | FileCheck --check-prefix CHECK_3 %s
-# RUN: not %mojo -D test=4 %s 2>&1 | FileCheck --check-prefix CHECK_4 %s
-# RUN: not %mojo -D test=5 %s 2>&1 | FileCheck --check-prefix CHECK_5 %s
+from std.testing import _assert_aborts, TestSuite
 
-from std.sys import get_defined_int
+
+def test_end_oob() raises:
+    var l: List = [1, 2, 3]
+
+    def trigger() raises {l} -> None:
+        _ = l[0:100]
+
+    _assert_aborts(
+        trigger,
+        contains="slice end index 100 is out of bounds, valid range is 0 to 3",
+    )
+
+
+def test_start_oob() raises:
+    var l: List = [1, 2, 3]
+
+    def trigger() raises {l} -> None:
+        _ = l[100:200]
+
+    _assert_aborts(
+        trigger,
+        contains=(
+            "slice start index 100 is out of bounds, valid range is 0 to 3"
+        ),
+    )
+
+
+def test_reversed() raises:
+    var l: List = [1, 2, 3]
+
+    def trigger() raises {l} -> None:
+        _ = l[3:1]
+
+    _assert_aborts(
+        trigger,
+        contains="slice start index 3 is greater than slice end index 1",
+    )
+
+
+def test_negative_start() raises:
+    var l: List = [1, 2, 3]
+
+    def trigger() raises {l} -> None:
+        _ = l[-1:]
+
+    _assert_aborts(
+        trigger,
+        contains="slice start index -1 is out of bounds, valid range is 0 to 3",
+    )
+
+
+def test_negative_end() raises:
+    var l: List = [1, 2, 3]
+
+    def trigger() raises {l} -> None:
+        _ = l[:-1]
+
+    _assert_aborts(
+        trigger,
+        contains="slice end index -1 is out of bounds, valid range is 0 to 3",
+    )
 
 
 def main() raises:
-    var l: List = [1, 2, 3]
-
-    comptime if get_defined_int["test"]() == 1:
-        # CHECK_1: {{.*}}: Assert Error: slice end index 100 is out of bounds, valid range is 0 to 3
-        _ = l[0:100]
-    elif get_defined_int["test"]() == 2:
-        # CHECK_2: {{.*}}: Assert Error: slice start index 100 is out of bounds, valid range is 0 to 3
-        _ = l[100:200]
-    elif get_defined_int["test"]() == 3:
-        # CHECK_3: {{.*}}: Assert Error: slice start index 3 is greater than slice end index 1
-        _ = l[3:1]
-    elif get_defined_int["test"]() == 4:
-        # CHECK_4: {{.*}}: Assert Error: slice start index -1 is out of bounds, valid range is 0 to 3
-        _ = l[-1:]
-    elif get_defined_int["test"]() == 5:
-        # CHECK_5: {{.*}}: Assert Error: slice end index -1 is out of bounds, valid range is 0 to 3
-        _ = l[:-1]
-    else:
-        comptime assert False, "unreachable!"
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Before you open this PR, please make sure the change has been discussed and
agreed upon with a maintainer. For anything beyond a trivial fix (typo,
one-line bug fix, doc tweak), we ask that you first open a GitHub issue or
proposal and get a maintainer's go-ahead. This helps us avoid situations
where a PR sits unreviewed because the change isn't aligned with the
team's direction. See our [contributor guide](https://github.com/modular/modular/blob/main/CONTRIBUTING.md) for
details.
-->

## Linked issue

<!--
Replace `NNN` with the issue number. For anything non-trivial, a linked
issue that a maintainer has agreed to is expected before review.

- Trivial fix (typo, comment, small doc fix): you can write "N/A — trivial".
- Everything else: `Fixes #NNN` or `Related to #6920`.
-->

Related to #6920

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [x] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

<!--
Why is this change needed? What problem does it solve, or what use case
does it enable? If this is a bug fix, describe the bug and how a user
would hit it. If this is a new feature, explain the user-facing value.

Please write prose here — don't just restate the PR title.
-->

A single bounds-check assertion currently costs either a RUN line plus a branch in a comptime dispatch chain, or a source file and a bazel target of its own. That is a lot of ceremony for one assertion, and it keeps these checks out of the file where the rest of the type's tests live, so nobody reads them together.

## What changed

<!--
Describe the change at a high level. Call out anything non-obvious: API
changes, behavior changes, performance characteristics, or tricky
implementation details.
-->

Migrate stdlib collections test: test_list_bounds_abort.mojo from using `-D test=N + lit RUN-line pattern` to `use std.testing.assert_aborts`

## Testing

<!--
Describe how you validated your changes.

- Code changes: what tests did you run, and what were the results? Did
  you add a new test that would have caught the bug?
- Performance changes: include before/after numbers from a benchmark.
- Documentation: describe how you verified accuracy (built the docs,
  ran the example, etc.).
-->

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [ ] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
