### PR TITLE
[stdlib] Migrate `List` bounds abort tests to `_assert_aborts`

### DIFF
--- a/mojo/stdlib/test/collections/BUILD.bazel
+++ b/mojo/stdlib/test/collections/BUILD.bazel
@@ -22,7 +22,6 @@ _FILECHECK_TESTS = [
 
 _LIT_TESTS = [
     "test_asan_annotations_list.mojo",
-    "test_list_bounds_abort.mojo",
 ]
 
 _MOJO_COMPILE_OPTS = {

--- a/mojo/stdlib/test/collections/test_list_bounds_abort.mojo
+++ b/mojo/stdlib/test/collections/test_list_bounds_abort.mojo
@@ -16,32 +16,70 @@
 #
 # ===----------------------------------------------------------------------=== #
 
-# RUN: not %mojo -D test=1 %s 2>&1 | FileCheck --check-prefix CHECK_1 %s
-# RUN: not %mojo -D test=2 %s 2>&1 | FileCheck --check-prefix CHECK_2 %s
-# RUN: not %mojo -D test=3 %s 2>&1 | FileCheck --check-prefix CHECK_3 %s
-# RUN: not %mojo -D test=4 %s 2>&1 | FileCheck --check-prefix CHECK_4 %s
-# RUN: not %mojo -D test=5 %s 2>&1 | FileCheck --check-prefix CHECK_5 %s
+from std.testing import _assert_aborts, TestSuite
 
-from std.sys import get_defined_int
+
+def test_end_oob() raises:
+    var l: List = [1, 2, 3]
+
+    def trigger() raises {l} -> None:
+        _ = l[0:100]
+
+    _assert_aborts(
+        trigger,
+        contains="slice end index 100 is out of bounds, valid range is 0 to 3",
+    )
+
+
+def test_start_oob() raises:
+    var l: List = [1, 2, 3]
+
+    def trigger() raises {l} -> None:
+        _ = l[100:200]
+
+    _assert_aborts(
+        trigger,
+        contains=(
+            "slice start index 100 is out of bounds, valid range is 0 to 3"
+        ),
+    )
+
+
+def test_reversed() raises:
+    var l: List = [1, 2, 3]
+
+    def trigger() raises {l} -> None:
+        _ = l[3:1]
+
+    _assert_aborts(
+        trigger,
+        contains="slice start index 3 is greater than slice end index 1",
+    )
+
+
+def test_negative_start() raises:
+    var l: List = [1, 2, 3]
+
+    def trigger() raises {l} -> None:
+        _ = l[-1:]
+
+    _assert_aborts(
+        trigger,
+        contains="slice start index -1 is out of bounds, valid range is 0 to 3",
+    )
+
+
+def test_negative_end() raises:
+    var l: List = [1, 2, 3]
+
+    def trigger() raises {l} -> None:
+        _ = l[:-1]
+
+    _assert_aborts(
+        trigger,
+        contains="slice end index -1 is out of bounds, valid range is 0 to 3",
+    )
 
 
 def main() raises:
-    var l: List = [1, 2, 3]
-
-    comptime if get_defined_int["test"]() == 1:
-        # CHECK_1: {{.*}}: Assert Error: slice end index 100 is out of bounds, valid range is 0 to 3
-        _ = l[0:100]
-    elif get_defined_int["test"]() == 2:
-        # CHECK_2: {{.*}}: Assert Error: slice start index 100 is out of bounds, valid range is 0 to 3
-        _ = l[100:200]
-    elif get_defined_int["test"]() == 3:
-        # CHECK_3: {{.*}}: Assert Error: slice start index 3 is greater than slice end index 1
-        _ = l[3:1]
-    elif get_defined_int["test"]() == 4:
-        # CHECK_4: {{.*}}: Assert Error: slice start index -1 is out of bounds, valid range is 0 to 3
-        _ = l[-1:]
-    elif get_defined_int["test"]() == 5:
-        # CHECK_5: {{.*}}: Assert Error: slice end index -1 is out of bounds, valid range is 0 to 3
-        _ = l[:-1]
-    else:
-        comptime assert False, "unreachable!"
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Linked issue

Works towards #6920

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [x] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

#6920 asks to migrate the remaining abort tests to `_assert_aborts()`. As the
issue puts it, a single bounds-check assertion currently costs "a RUN line
plus a branch in a comptime dispatch chain, or a source file and a bazel
target of its own".

`test_list_bounds_abort.mojo` is one of those files: five assertions spread
across five `RUN` lines and a `-D test=N` dispatch chain. Its `Span`
counterpart, `test_span_bounds_abort.mojo`, has already been migrated and
covers the identical assertions, so this is a mechanical 1:1 conversion
against an in-tree reference.

The issue recommends a phased migration starting with the simpler
bounds-checking files under `collections/`, so this PR does exactly one file
rather than attempting all ~40 cases at once.

## What changed

- Rewrote `test_list_bounds_abort.mojo` as five ordinary `def test_*()`
  functions, each defining a local `trigger()` closure passed to
  `_assert_aborts(..., contains=...)`, following
  `test_span_bounds_abort.mojo` exactly. The asserted messages are unchanged.
- Dropped `test_list_bounds_abort.mojo` from `_LIT_TESTS` in
  `mojo/stdlib/test/collections/BUILD.bazel` so it falls through to the
  default `mojo_test` glob, which is how `test_span_bounds_abort.mojo` is
  already built. No new BUILD entry is needed.

Net effect: five lit `RUN` lines and their FileCheck prefixes collapse into
one standard test target, and each assertion now sits next to the code it
exercises.

One consequence worth noting: the lit target was marked incompatible with
asan and macOS because of differing signal exit codes. As a regular
`mojo_test` using `_assert_aborts()` the file now builds on those
configurations. `_assert_aborts()` early-returns under `SanitizeAddress`, so
the assertions are skipped rather than checked in asan builds — the same
tradeoff the already-migrated `Span` file makes.

## Testing

`./bazelw test //mojo/stdlib/test/collections:test_list_bounds_abort.mojo.test`
passes, as does the full `//mojo/stdlib/test/collections/...` suite. Ran the
`base64`, `os` and `pathlib` suites too: 91 tests pass, 0 failures. Ran
`./bazelw run format`; no changes.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description

> Note: this contribution was AI-assisted (`Assisted-by: AI` trailer is in the
> commit). Flagging it explicitly so reviewers can calibrate their review.
