### PR TITLE
[stdlib] Add `os.path.normpath`

### DIFF
--- a/mojo/stdlib/std/os/path/__init__.mojo
+++ b/mojo/stdlib/std/os/path/__init__.mojo
@@ -26,6 +26,7 @@ from .path import (
     islink,
     join,
     lexists,
+    normpath,
     realpath,
     split,
     split_extension,

--- a/mojo/stdlib/std/os/path/path.mojo
+++ b/mojo/stdlib/std/os/path/path.mojo
@@ -671,6 +671,57 @@ def splitroot[
 
 
 # ===----------------------------------------------------------------------=== #
+# normpath
+# ===----------------------------------------------------------------------=== #
+
+
+def normpath[PathLike: stdPathLike, //](path: PathLike) -> String:
+    """Normalizes `path` by collapsing redundant separators, dropping `.`
+    components, and resolving `..` components where possible.
+
+    This is a purely lexical operation: it does not touch the filesystem, so
+    it does not resolve symlinks and may change the meaning of a path that
+    contains a symlinked directory.
+
+    Parameters:
+        PathLike: The type conforming to the os.PathLike trait.
+
+    Args:
+        path: The path to normalize.
+
+    Returns:
+        The normalized path.
+
+    Example:
+    ```mojo
+    from std.os.path import normpath
+
+    print(normpath("a//b/./c/../d"))  # "a/b/d"
+    print(normpath("../a/b"))  # "../a/b"
+    print(normpath(""))  # "."
+    ```
+    """
+    var _drive, root, tail = splitroot(path.__fspath__())
+
+    var parts = List[String]()
+    for comp_slice in tail.split(sep):
+        var comp = String(comp_slice)
+        if not comp or comp == ".":
+            continue
+        if (
+            comp != ".."
+            or (not root and not parts)
+            or (parts and parts[len(parts) - 1] == "..")
+        ):
+            parts.append(comp^)
+        elif parts:
+            _ = parts.pop()
+
+    var result = root + sep.join(parts)
+    return result if result else "."
+
+
+# ===----------------------------------------------------------------------=== #
 # expandvars
 # ===----------------------------------------------------------------------=== #
 

--- a/mojo/stdlib/std/os/path/path.mojo
+++ b/mojo/stdlib/std/os/path/path.mojo
@@ -701,8 +701,7 @@ def normpath[PathLike: stdPathLike, //](path: PathLike) -> String:
     print(normpath(""))  # "."
     ```
     """
-    var _drive, root, tail = splitroot(path.__fspath__())
-
+    var _drive, root, tail = splitroot(path)
     var parts = List[String]()
     for comp_slice in tail.split(sep):
         var comp = String(comp_slice)

--- a/mojo/stdlib/test/os/path/test_normpath.mojo
+++ b/mojo/stdlib/test/os/path/test_normpath.mojo
@@ -1,0 +1,53 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.os.path import normpath
+
+from std.testing import TestSuite, assert_equal
+
+
+def test_empty_path() raises:
+    assert_equal(normpath(""), ".")
+
+
+def test_dot_and_double_slashes() raises:
+    assert_equal(normpath("."), ".")
+    assert_equal(normpath("a//b/./c"), "a/b/c")
+    assert_equal(normpath("a/./b/"), "a/b")
+
+
+def test_parent_references() raises:
+    assert_equal(normpath("a//b/./c/../d"), "a/b/d")
+    assert_equal(normpath("a/b/../../../c"), "../c")
+    assert_equal(normpath(".."), "..")
+    assert_equal(normpath("../a/b"), "../a/b")
+
+
+def test_absolute_paths() raises:
+    assert_equal(normpath("/a/b/../c"), "/a/c")
+
+    # A `..` above the root is clamped, matching Python's `posixpath`.
+    assert_equal(normpath("/../a"), "/a")
+    assert_equal(normpath("/.."), "/")
+
+
+def test_leading_slashes() raises:
+    # Per POSIX, exactly two leading slashes is implementation-defined and
+    # preserved; one, or three-or-more, collapse to a single slash.
+    assert_equal(normpath("/foo/bar"), "/foo/bar")
+    assert_equal(normpath("//foo/bar"), "//foo/bar")
+    assert_equal(normpath("///foo/bar"), "/foo/bar")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Linked issue

Fixes #2962

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [x] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

`os.path` is missing `normpath`, one of the more commonly reached-for path
helpers. Today the only way to clean up a path in Mojo is `realpath()`, which
is a very different tool: it calls into libc, requires the path to actually
exist, and resolves symlinks. If you just want to turn `a//b/./c/../d` into
`a/b/d` — for display, comparison, or building a path that has not been
created yet — there is nothing available.

`tempfile.mojo` already has two comments pointing at the gap ("i.e. abspath,
normpath").

## What changed

Adds `normpath()` to `os.path` and exports it from the package.

It is purely lexical: collapses redundant separators, drops `.` components,
and resolves `..` where possible, without touching the filesystem. It follows
Python's `posixpath.normpath` semantics:

- an empty path normalizes to `"."`
- `..` above the root is clamped (`/../a` → `/a`)
- leading `..` in a relative path is preserved (`../a/b` stays as-is)
- exactly two leading slashes are preserved, one or three-or-more collapse to
  one, which is the POSIX implementation-defined case

The implementation reuses the existing `splitroot()` to peel off the root
(which already handles the two-slash rule) and `sep.join()` to rebuild, so
the function itself only has to filter the components.

Because it is lexical, `normpath` can change the meaning of a path that
traverses a symlinked directory. That caveat is called out in the docstring,
along with a pointer to what makes it different from `realpath`.

## Testing

Added `mojo/stdlib/test/os/path/test_normpath.mojo` covering empty paths,
`.` components and doubled separators, `..` resolution including the
clamped-at-root and preserved-leading-`..` cases, and the one/two/three
leading slash cases. Expected values were taken from Python's
`posixpath.normpath`.

`./bazelw test //mojo/stdlib/test/os/...` passes. Also ran `base64`,
`collections` and `pathlib`: 91 tests pass, 0 failures. Ran
`./bazelw run format`; no changes.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description

> Note: this contribution was AI-assisted (`Assisted-by: AI` trailer is in the
> commit). Flagging it explicitly so reviewers can calibrate their review.

I have read the CLA Document and I hereby sign the CLA
