### PR TITLE
[stdlib] Migrate test_string_span_bounds_abort to use _assert_aborts

### DIFF
--- a/mojo/stdlib/test/collections/string/BUILD.bazel
+++ b/mojo/stdlib/test/collections/string/BUILD.bazel
@@ -19,7 +19,6 @@ _PLATFORM_CONSTRAINTS = {
 _LIT_TESTS = [
     "test_number_parsing_lut_optimization.mojo",
     "test_string_unicode_panic.mojo",
-    "test_string_span_bounds_abort.mojo",
     "test_string_span_codepoint_grapheme_bounds_abort.mojo",
 ]
 

--- a/mojo/stdlib/test/collections/string/test_string_span_bounds_abort.mojo
+++ b/mojo/stdlib/test/collections/string/test_string_span_bounds_abort.mojo
@@ -17,31 +17,57 @@
 #
 # ===----------------------------------------------------------------------=== #
 
-# RUN: not %mojo -D test=1 %s 2>&1 | FileCheck --check-prefix CHECK_1 %s
-# RUN: not %mojo -D test=2 %s 2>&1 | FileCheck --check-prefix CHECK_2 %s
-# RUN: not %mojo -D test=3 %s 2>&1 | FileCheck --check-prefix CHECK_3 %s
-# RUN: not %mojo -D test=4 %s 2>&1 | FileCheck --check-prefix CHECK_4 %s
+from std.testing import _assert_aborts, TestSuite
 
-from std.sys import get_defined_int
+
+def test_slice_end_oob() raises:
+    var s = StringSlice("abc")
+
+    def trigger() raises {s} -> None:
+        _ = s[byte=0:100]
+
+    _assert_aborts(
+        trigger,
+        contains="slice end index 100 is out of bounds, valid range is 0 to 3",
+    )
+
+
+def test_slice_reversed() raises:
+    var s = StringSlice("abc")
+
+    def trigger() raises {s} -> None:
+        _ = s[byte=3:1]
+
+    _assert_aborts(
+        trigger,
+        contains="slice start index 3 is greater than slice end index 1",
+    )
+
+
+def test_slice_negative_start() raises:
+    var s = StringSlice("abc")
+
+    def trigger() raises {s} -> None:
+        _ = s[byte= -1:]
+
+    _assert_aborts(
+        trigger,
+        contains="slice start index -1 is out of bounds, valid range is 0 to 3",
+    )
+
+
+def test_string_accessor_delegates() raises:
+    # Through `String`'s `byte=` accessor, which delegates to `StringSlice`.
+    var s = String("abc")
+
+    def trigger() raises {s} -> None:
+        _ = s[byte=0:100]
+
+    _assert_aborts(
+        trigger,
+        contains="slice end index 100 is out of bounds, valid range is 0 to 3",
+    )
 
 
 def main() raises:
-    comptime if get_defined_int["test"]() == 1:
-        var s = StringSlice("abc")
-        # CHECK_1: {{.*}}: Assert Error: slice end index 100 is out of bounds, valid range is 0 to 3
-        _ = s[byte=0:100]
-    elif get_defined_int["test"]() == 2:
-        var s = StringSlice("abc")
-        # CHECK_2: {{.*}}: Assert Error: slice start index 3 is greater than slice end index 1
-        _ = s[byte=3:1]
-    elif get_defined_int["test"]() == 3:
-        var s = StringSlice("abc")
-        # CHECK_3: {{.*}}: Assert Error: slice start index -1 is out of bounds, valid range is 0 to 3
-        _ = s[byte= -1:]
-    elif get_defined_int["test"]() == 4:
-        # Through `String`'s `byte=` accessor, which delegates to `StringSlice`.
-        var s = String("abc")
-        # CHECK_4: {{.*}}: Assert Error: slice end index 100 is out of bounds, valid range is 0 to 3
-        _ = s[byte=0:100]
-    else:
-        comptime assert False, "unreachable!"
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Linked issue

Part of #6920 (tracked migration; one file per PR, as in #6930)

## Type of change

- [x] Refactor / internal cleanup (no user-visible change)

## Motivation

`std.testing._assert_aborts()` replaced the old `-D test=N` + lit RUN-line pattern for testing code that aborts. This PR migrates one of the remaining stdlib abort tests listed in #6920 — `test_string_span_bounds_abort.mojo` (4 cases: slice end OOB, reversed slice, negative start, and the `String` `byte=` accessor that delegates to `StringSlice`).

## What changed

- Replaced the `comptime if get_defined_int["test"]()` dispatch chain and four `# RUN: not %mojo -D test=N` lit lines with four `_assert_aborts` test functions (`test_slice_end_oob`, `test_slice_reversed`, `test_slice_negative_start`, `test_string_accessor_delegates`) driven by `TestSuite.discover_tests[__functions_in_module__]().run()`.
- Each `_assert_aborts` asserts on the exact abort message already verified by the original `FileCheck` prefixes.
- Dropped the file from `_LIT_TESTS` in `mojo/stdlib/test/collections/string/BUILD.bazel` so it becomes a plain `mojo_test` target.

This follows the same shape as the in-flight #6930 (which migrates `test_list_bounds_abort`), keeping the migration consistent across the `collections/` subtree.

## Testing

Validated mechanically against the pattern accepted in #6930: same imports (`from std.testing import _assert_aborts, TestSuite`), same `trigger` closure capturing the local `StringSlice`/`String`, and same `contains=` assertion strings as the original `FileCheck` CHECK prefixes. The 4 cases map 1:1 to the prior RUN lines:

1. `s[byte=0:100]` (StringSlice) -> "slice end index 100 is out of bounds, valid range is 0 to 3"
2. `s[byte=3:1]` -> "slice start index 3 is greater than slice end index 1"
3. `s[byte=-1:]` -> "slice start index -1 is out of bounds, valid range is 0 to 3"
4. `s[byte=0:100]` (String) -> "slice end index 100 is out of bounds, valid range is 0 to 3"

I do not have a local Mojo build in this environment, so I could not run `./bazelw run format` or the test target end-to-end — flagging that explicitly for review. The change is mechanical and mirrors #6930, but I have not personally observed a green CI run.

## Checklist

- [x] The linked issue (#6920) has been reviewed by a maintainer and is accepted (labeled `accepted`).
- [x] PR is small and focused.
- [ ] I ran `./bazelw run format` to format my changes (no local Mojo toolchain available — formatting follows the #6930 precedent; please run if needed).
- [x] I added or updated tests to cover my changes.
- [x] AI tools assisted with this contribution; `Assisted-by: AI` trailer added to the commit.

Assisted-by: AI
