### PR TITLE
[stdlib] Fix _assert_aborts skipping later loop iterations

### DIFF
--- a/Mojo/stdlib/std/testing/assert_aborts.mojo
+++ b/Mojo/stdlib/std/testing/assert_aborts.mojo
@@ -17,6 +17,7 @@ can't be caught with `try`/`except`. This runs the code under test in a
 re-exec'd child and checks that the child crashed with the expected message.
 """
 
+from std.ffi import _Global
 from std.os import abort, remove
 from std.os.env import getenv, setenv, unsetenv
 from std.os.path import exists
@@ -29,7 +30,7 @@ from std.sys.compile import SanitizeAddress
 from std.tempfile import NamedTemporaryFile
 from std.time import perf_counter, sleep
 
-# Which call site (file:line:col) the re-exec'd child should run.
+# Which visit (file:line:col#n) of a call site the re-exec'd child should run.
 comptime _LOCATION_ENV = "__MOJO_TEST_EXPECT_ABORT_LOCATION_TARGET"
 # Path the child's stdout/stderr get redirected to before running.
 comptime _OUTPUT_ENV = "__MOJO_TEST_EXPECT_ABORT_OUTPUT"
@@ -37,6 +38,22 @@ comptime _OUTPUT_ENV = "__MOJO_TEST_EXPECT_ABORT_OUTPUT"
 comptime _DEFAULT_TIMEOUT = 30.0
 # How often to check on the child while waiting for it.
 comptime _POLL_INTERVAL = 0.01
+
+# How many times this process has reached each call site.
+comptime _VISITS = _Global["assert_aborts_visits", _init_visits]
+
+
+def _init_visits() -> Dict[String, Int]:
+    return Dict[String, Int]()
+
+
+def _next_visit(location: SourceLocation) raises -> String:
+    """Returns the key for this process's next visit to `location`."""
+    var visits = _VISITS.get_or_create_ptr()
+    var loc = String(location)
+    var n = visits[].get(loc, 0)
+    visits[][loc] = n + 1
+    return String(t"{loc}#{n}")
 
 
 @always_inline
@@ -103,18 +120,25 @@ def _assert_aborts_impl(
 ) raises:
     var target = getenv(_LOCATION_ENV)
 
-    # We're the re-exec'd child for this exact call site, run it.
-    if target == String(location):
+    # A loop body is a single call site executed many times, so the location on
+    # its own can't tell those executions apart and every child would re-run the
+    # first one. Number the visits instead: the parent and the child run the
+    # same code in the same order, so this process's Nth visit to a location is
+    # the same assertion as the other process's Nth visit to it.
+    var key = _next_visit(location)
+
+    # We're the re-exec'd child for this exact visit, run it.
+    if target == key:
         _run(f)
         return
 
-    # No location set: this is the original, top-level call.
+    # No target set: this is the original, top-level call.
     if not target:
-        _spawn_and_check(location, contains, timeout)
+        _spawn_and_check(key, contains, timeout)
         return
 
-    # A different (sibling) call site, so we should skip.
-    # The child spawned for that call site will check it.
+    # A different (sibling) visit, so we should skip.
+    # The child spawned for that visit will check it.
     return
 
 
@@ -129,9 +153,9 @@ def _run(f: Some[def() raises]) raises:
 
 
 def _spawn_and_check(
-    location: SourceLocation, contains: Optional[String], timeout: Float64
+    key: String, contains: Optional[String], timeout: Float64
 ) raises:
-    """Re-execs this binary scoped to `location`, then checks how it died."""
+    """Re-execs this binary scoped to `key`, then checks how it died."""
     var self_argv = argv()
     if self_argv[0].endswith(".mojo"):
         raise Error(
@@ -153,7 +177,7 @@ def _spawn_and_check(
 
     # `setenv` mutates our own environment, which `Process.run` inherits
     # into the child.
-    _ = setenv(_LOCATION_ENV, String(location))
+    _ = setenv(_LOCATION_ENV, key)
     _ = setenv(_OUTPUT_ENV, out_path)
 
     def unsetenvs():

--- a/Mojo/stdlib/test/testing/test_assert_aborts.mojo
+++ b/Mojo/stdlib/test/testing/test_assert_aborts.mojo
@@ -68,5 +68,18 @@ def test_raises_when_closure_does_not_abort_in_time() raises:
         _assert_aborts(hangs, timeout=0.5)
 
 
+def test_distinguishes_iterations_of_the_same_loop() raises:
+    for name in [
+        "assert_aborts self-test: loop case 0",
+        "assert_aborts self-test: loop case 1",
+        "assert_aborts self-test: loop case 2",
+    ]:
+
+        def aborts() {imm}:
+            abort(name)
+
+        _assert_aborts(aborts, contains=name)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Linked issue

Fixes #6913

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation

`_assert_aborts` decides which assertion the re-exec'd child should run by
comparing `call_location()` against a target string it reads from the
environment. That is enough when every call site runs once, but a loop body is a
single call site that runs N times, so every child matches on the loop's first
pass and re-runs iteration 0's closure instead of its own.

What you actually see depends on whether you passed `contains`:

- With a per-iteration message, iterations after the first fail with a confusing
  mismatch, because the parent is checking iteration 1's expected text against a
  child that aborted with iteration 0's message.
- Without `contains`, or when every iteration aborts with the same message, all
  the assertions pass while only the first iteration was ever run.

The second case is the one that worries me, since the test reports a pass. It
also has a bearing on #6920, which is moving about 40 stdlib tests onto
`_assert_aborts`. Several of those files are groups of near-identical bounds
checks that would be natural to write as a loop over indices, and written that
way today the migrated test would report a pass having exercised one case out of
N.

## What changed

The dispatch key gains a visit number, so it goes from `file:line:col` to
`file:line:col#n`, where `n` is the number of times the current process has
already reached that call site.

- `_next_visit()` holds the per-location counts in a `_Global[Dict[String, Int]]`
  and returns the key for the next visit.
- `_assert_aborts_impl` computes that key once and uses it for all three
  branches, so a sibling call site still skips exactly as before.
- `_spawn_and_check` takes the key string instead of a `SourceLocation`, since
  the only thing it did with the location was stringify it into the env var.

Parent and child run the same code in the same order, so the parent's Nth visit
to a location and the child's Nth visit to it are the same assertion.

I kept the count per location rather than using one global invocation counter,
which would be simpler but is easier to knock out of sync: if an assertion raises
partway through a test the parent stops there while the child carries on, and a
single counter would then be off for every later call site in the binary, whereas
per-location counts only lose alignment inside the call site that already failed.

Cost for the existing non-loop case is unchanged. A loop of N assertions still
spawns N children, and each child now walks past the earlier visits before
reaching its own, which is cheap because a skipped visit returns immediately.

## Testing

- Added `test_distinguishes_iterations_of_the_same_loop`, which loops over three
  different abort messages and asserts each one. On main it fails with
  `Expected substring: '...loop case 1'` against `Actual output: ...loop case 0`,
  which is the behaviour described in the issue, and it passes with this change.
- `//mojo/stdlib/test/testing/...` and
  `//mojo/stdlib/test/collections:test_span_bounds_abort.mojo.test` all pass. The
  latter is the only other caller of `_assert_aborts` and has 5 call sites.
- `./bazelw run format` is clean.

## Open questions

- The issue lists three options and I went with the call counter. If you would
  rather `_assert_aborts` detect a reused location and raise instead, that check
  needs the same per-location state this adds, so it is a short step from here.
- This puts a `Dict` global into the module. A test binary has few call sites so
  I did not worry about the allocation, but tell me if you would rather not add a
  global here at all.
- Not part of this change: `assert_aborts.mojo` imports `exists` from
  `std.os.path` and never uses it. I left it to keep the diff focused.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description

Assisted-by: AI
