### PR TITLE
[KGEN] Enable WebAssembly object emission [Filip]

### DIFF
--- a/KGEN/lib/Target/Host/HostTraits.h
+++ b/KGEN/lib/Target/Host/HostTraits.h
@@ -26,7 +26,7 @@ struct HostTraits final : TargetTraits {
     // Covers the CPU targets the shipped build carries an LLVM backend for
     // (see BACKENDS in bazel/public-patches/llvm_project.bzl)
     return triple.isX86() || triple.isAArch64() || triple.isARM() ||
-           triple.isRISCV();
+           triple.isRISCV() || triple.isWasm();
   }
   llvm::StringRef getAsmExtension() const override { return ".s"; }
   llvm::StringRef getLLVMExtension() const override { return ".ll"; }

--- a/KGEN/test/mojo-integration/BUILD.bazel
+++ b/KGEN/test/mojo-integration/BUILD.bazel
@@ -29,7 +29,7 @@ lit_tests(
             "**/*.mlir",
             "**/*.mojo",
         ],
-        exclude = _DATA,
+        exclude = _DATA + ["mojo_build_wasm_object.mojo"],
     ),
     data = [":fixtures"],
     mojo_deps = [
@@ -53,6 +53,15 @@ lit_tests(
         "@llvm-project//llvm:llvm-nm",
         "@llvm-project//llvm:llvm-objdump",
     ],
+)
+
+# Keep this compiler-only smoke test independent of MAX so it can validate the
+# WebAssembly backend without downloading or building the runtime stack.
+lit_tests(
+    name = "wasm_object_test",
+    srcs = ["mojo_build_wasm_object.mojo"],
+    mojo_deps = ["@mojo//:std"],
+    tools = ["//KGEN/tools/mojo"],
 )
 
 lit_tests(

--- a/KGEN/test/mojo-integration/mojo_build_wasm_object.mojo
+++ b/KGEN/test/mojo-integration/mojo_build_wasm_object.mojo
@@ -1,0 +1,21 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# RUN: %mojo-build %s -o %t.o --emit object --target-triple=wasm32-unknown-unknown
+# RUN: file %t.o | FileCheck %s
+# CHECK: WebAssembly (wasm) binary module
+
+
+@export("add_one")
+def add_one(value: Int32) abi("C") -> Int32:
+    return value + 1

--- a/bazel/public-patches/llvm_project.bzl
+++ b/bazel/public-patches/llvm_project.bzl
@@ -5,6 +5,7 @@ load("@llvm-raw//utils/bazel:configure.bzl", _llvm_configure = "llvm_configure")
 BACKENDS = [
     "AArch64",
     "RISCV",
+    "WebAssembly",
     "X86",
 ]
 


### PR DESCRIPTION
Handler: Filip | [agent-fgrom-mxlabs-ai-mojo-6087](https://agents.shen.ai/jupyter/europe-west4-a/agent-fgrom-mxlabs-ai-mojo-6087/lab)
---

## Motivation

Mojo can already lower freestanding C-ABI code to LLVM IR suitable for WebAssembly, but the public build does not include LLVM’s WebAssembly backend and KGEN rejects wasm triples. Enabling object emission is useful for embedding ahead-of-time Mojo kernels in browser and other WebAssembly hosts without shipping a general-purpose inference runtime.

## Summary

- Build LLVM with the WebAssembly target backend.
- Recognize wasm32/wasm64 as supported host-style CPU targets in KGEN.
- Add an isolated compiler integration test that emits a wasm32 object from an exported C-ABI function.
- Keep the smoke test independent of the MAX runtime dependency graph.

## Validation

- `./bazelw test //KGEN/test/mojo-integration:mojo_build_wasm_object.mojo.test --config=build-mojo --jobs=16 --test_output=errors`
- Source-built compiler emits valid objects for x86-64 Linux, AArch64 Linux, Android ARM64, iOS ARM64, and wasm32.
- Linked the wasm32 object with `wasm-ld`, loaded it through Node WebAssembly, and verified the exported function returns 42.