### PR TITLE
[stdlib] Fix `SIMD.__pow__` with float literal exponents

### DIFF
--- a/mojo/stdlib/std/builtin/simd.mojo
+++ b/mojo/stdlib/std/builtin/simd.mojo
@@ -1260,6 +1260,9 @@ struct SIMD[dtype: DType, length: SIMDLength](
         The literal is converted to `Self`, so the exponent always has the
         same dtype as the base.
 
+        Constraints:
+            The SIMD dtype must be floating point.
+
         Args:
             exp: The exponent value.
 
@@ -1267,6 +1270,9 @@ struct SIMD[dtype: DType, length: SIMDLength](
             A SIMD vector where each element is raised to the power of the
             specified exponent value.
         """
+        comptime assert (
+            Self.dtype.is_floating_point()
+        ), "a float literal exponent requires a floating point SIMD type"
         return _pow(self, Self(exp))
 
     # TODO(#22771): remove this overload.

--- a/mojo/stdlib/std/builtin/simd.mojo
+++ b/mojo/stdlib/std/builtin/simd.mojo
@@ -1247,6 +1247,13 @@ struct SIMD[dtype: DType, length: SIMDLength](
         )
         comptime if Self.length == exp.length and self.dtype == exp.dtype:
             return _pow(self, rebind[Self](exp))
+        elif exp.dtype.is_floating_point() and Self.dtype.is_floating_point():
+            # `_pow` asks the base and exponent dtypes to match, so cast
+            # a mismatched float exponent (e.g. a float literal, which
+            # defaults to float64) to the base dtype.
+            return _pow(
+                self, Self(rebind[Scalar[exp.dtype]](exp).cast[Self.dtype]())
+            )
         else:
             return _pow(
                 self,

--- a/mojo/stdlib/std/builtin/simd.mojo
+++ b/mojo/stdlib/std/builtin/simd.mojo
@@ -1247,18 +1247,27 @@ struct SIMD[dtype: DType, length: SIMDLength](
         )
         comptime if Self.length == exp.length and self.dtype == exp.dtype:
             return _pow(self, rebind[Self](exp))
-        elif exp.dtype.is_floating_point() and Self.dtype.is_floating_point():
-            # `_pow` asks the base and exponent dtypes to match, so cast
-            # a mismatched float exponent (e.g. a float literal, which
-            # defaults to float64) to the base dtype.
-            return _pow(
-                self, Self(rebind[Scalar[exp.dtype]](exp).cast[Self.dtype]())
-            )
         else:
             return _pow(
                 self,
                 SIMD[exp.dtype, self.length](rebind[Scalar[exp.dtype]](exp)),
             )
+
+    @always_inline("nodebug")
+    def __pow__(self, exp: FloatLiteral) -> Self:
+        """Computes the vector raised to the power of a float literal.
+
+        The literal is converted to `Self`, so the exponent always has the
+        same dtype as the base.
+
+        Args:
+            exp: The exponent value.
+
+        Returns:
+            A SIMD vector where each element is raised to the power of the
+            specified exponent value.
+        """
+        return _pow(self, Self(exp))
 
     # TODO(#22771): remove this overload.
     @always_inline("nodebug")

--- a/mojo/stdlib/test/builtin/BUILD.bazel
+++ b/mojo/stdlib/test/builtin/BUILD.bazel
@@ -48,6 +48,7 @@ _LIT_TESTS = [
     "test_issue_3908.mojo",
     "test_print_long_string.mojo",
     "test_print_stderr.mojo",
+    "test_simd_pow_compile_fail.mojo",
     "test_stdin.mojo",
 ]
 

--- a/mojo/stdlib/test/builtin/test_simd.mojo
+++ b/mojo/stdlib/test/builtin/test_simd.mojo
@@ -1752,6 +1752,13 @@ def test_pow() raises:
         F32x4(0.0, 1.0, 1.414213562, 1.732050808),
     )
 
+    assert_almost_equal(Float16(4.0) ** 0.5, Float16(2.0))
+    assert_almost_equal(BFloat16(4.0) ** 0.5, BFloat16(2.0))
+    assert_almost_equal(Float32(4.0) ** 0.5, Float32(2.0))
+    assert_almost_equal(
+        f32x4_val**0.5, F32x4(0.0, 1.0, 1.414213562, 1.732050808)
+    )
+
     assert_almost_equal(
         F32x4(1, 2, 3, 4).__pow__(F32x4(2, 3, 2, 1)), F32x4(1.0, 8.0, 9.0, 4.0)
     )

--- a/mojo/stdlib/test/builtin/test_simd_pow_compile_fail.mojo
+++ b/mojo/stdlib/test/builtin/test_simd_pow_compile_fail.mojo
@@ -1,0 +1,23 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+# RUN: not %mojo %s 2>&1 | FileCheck %s
+
+# Test that a non-literal float exponent of a different dtype is rejected,
+# so `SIMD.__pow__` never narrows a runtime exponent to the base dtype. Only
+# float literals are converted, via the `FloatLiteral` overload.
+
+
+# CHECK: constraint failed: unsupported type combination
+def main():
+    _ = Float32(4.0) ** Float64(0.5)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Before you open this PR, please make sure the change has been discussed and
agreed upon with a maintainer. For anything beyond a trivial fix (typo,
one-line bug fix, doc tweak), we ask that you first open a GitHub issue or
proposal and get a maintainer's go-ahead. This helps us avoid situations
where a PR sits unreviewed because the change isn't aligned with the
team's direction. See our [contributor guide](https://github.com/modular/modular/blob/main/CONTRIBUTING.md) for
details.
-->

## Linked issue

<!--
Replace `NNN` with the issue number. For anything non-trivial, a linked
issue that a maintainer has agreed to is expected before review.

- Trivial fix (typo, comment, small doc fix): you can write "N/A — trivial".
- Everything else: `Fixes #NNN` or `Related to #NNN`.
-->

Fixes #6940

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Fixes what appears to be a regression caused by b6c836e725
## What changed

<!--
Describe the change at a high level. Call out anything non-obvious: API
changes, behavior changes, performance characteristics, or tricky
implementation details.
-->

## Testing

1. I tested by running the example in the issue.
2. I added a test case in `[mojo/stdlib/test/builtin/test_simd.mojo](https://github.com/modular/modular/compare/main...iMostfa:modular:fix-simd-pow-float-literal?expand=1#diff-aadb21e1549244f42cf08a5f6b5c64db3e08bf6475db2531f078fc0071db3ad3)`

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
