### PR TITLE
[BUG] Reproducer for #6971 — JIT codegen SIGSEGV: cross-module raises factory, InlineArray struct by value

### DIFF
--- a/compiler-repro/jit-segv-cross-module-raises/README.md
+++ b/compiler-repro/jit-segv-cross-module-raises/README.md
@@ -1,0 +1,21 @@
+# Reproducer: JIT SIGSEGV — cross-module `raises` factory, InlineArray struct by value
+
+Reproduces https://github.com/modular/modular/issues/6971
+
+`mojo run` (JIT) SIGSEGVs in libKGENCompilerRTShared at codegen when module B
+calls a module-level `raises` factory in module A that returns a struct with an
+`InlineArray` field by value and contains `raise Error(msg + String(x))`
+(string concatenation) in its raise path. Replacing the concatenated message
+with a literal stops the crash (8/8 vs 10/10+3/3).
+
+## Run
+
+```sh
+cc -dynamiclib -o libmsstack.dylib shim.c
+mojo run -I . -Xlinker ./libmsstack.dylib crash_main.mojo   # exit 139 + stack dump
+# edit crash_lib.mojo: raise Error("alloc failed")           # literal
+mojo run -I . -Xlinker ./libmsstack.dylib crash_main.mojo   # exit 0, "survived <addr>"
+```
+
+This directory exists solely to reproduce the linked issue for triage; it is
+not intended to be merged as-is. Mojo 1.0.0b2 (2cf4d08a), macOS arm64.

--- a/compiler-repro/jit-segv-cross-module-raises/crash_lib.mojo
+++ b/compiler-repro/jit-segv-cross-module-raises/crash_lib.mojo
@@ -1,0 +1,29 @@
+# crash_lib.mojo — reproducer for the Mojo 1.0.0b2 JIT instability.
+from std.memory import stack_allocation
+
+
+@extern("ms_stack_alloc")
+def _ms_stack_alloc(
+    bytes: Int,
+    out_base: UnsafePointer[UnsafePointer[Byte, MutAnyOrigin], MutUntrackedOrigin],
+    out_top: UnsafePointer[UnsafePointer[Byte, MutAnyOrigin], MutUntrackedOrigin],
+) abi("C") -> Int32:
+    ...
+
+
+struct S(ImplicitlyCopyable, ImplicitlyDeletable):
+    var a: Int
+    var arr: InlineArray[Int, 21]
+
+    def __init__(out self, a: Int):
+        self.a = a
+        self.arr = InlineArray[Int, 21](fill=0)
+
+
+def make(n: Int) raises -> S:
+    var slots = stack_allocation[2, UnsafePointer[Byte, MutAnyOrigin]]()
+    var rc = _ms_stack_alloc(n, slots, slots + 1)
+    if rc != 0:
+        raise Error("alloc failed rc=" + String(rc))
+    var s = S(Int(slots[]))
+    return s^

--- a/compiler-repro/jit-segv-cross-module-raises/crash_main.mojo
+++ b/compiler-repro/jit-segv-cross-module-raises/crash_main.mojo
@@ -1,0 +1,7 @@
+# crash_main.mojo — imports and CALLS crash_lib.make().
+from crash_lib import S, make
+
+
+def main() raises:
+    var s = make(65536)
+    print("survived", s.a)

--- a/compiler-repro/jit-segv-cross-module-raises/shim.c
+++ b/compiler-repro/jit-segv-cross-module-raises/shim.c
@@ -1,0 +1,10 @@
+#include <stdint.h>
+#include <stdlib.h>
+int32_t ms_stack_alloc(int64_t bytes, void** out_base, void** out_top) {
+    void* p = malloc((size_t)bytes + 64);
+    if (!p) return 1;
+    *out_base = p;
+    *out_top = (char*)p + bytes;
+    return 0;
+}
+void ms_stack_free(void* base) { free(base); }


### PR DESCRIPTION
Reproduces #6971. **Draft, not intended for merge** — adds
`compiler-repro/jit-segv-cross-module-raises/` with the minimal three-file
reproducer (two Mojo files + a tiny C shim providing the extern symbol):

```sh
cc -dynamiclib -o libmsstack.dylib shim.c
mojo run -I . -Xlinker ./libmsstack.dylib crash_main.mojo   # exit 139 + stack dump
# change crash_lib.mojo raise line to literal Error("alloc failed"):
mojo run -I . -Xlinker ./libmsstack.dylib crash_main.mojo   # exit 0, "survived <addr>"
```

Trigger summary + A/B evidence in the linked issue. Happy to relocate the files
or convert into a regression test after a fix lands.