### PR TITLE
[stdlib][docs] Fix List docstring examples to annotate list literals

### DIFF
--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -188,8 +188,8 @@ struct List[T: AnyType, /](
     # With initial size and fill value
     var filled = List[Float64](length=10, fill=0.0)
 
-    # With initial values and inferred type (Int)
-    var numbers = [1, 2, 3, 4, 5]
+    # With initial values and an explicit element type
+    var numbers: List[Int] = [1, 2, 3, 4, 5
     ```
 
     Be aware of the following characteristics:
@@ -199,8 +199,8 @@ struct List[T: AnyType, /](
       improves performance:
 
       ```mojo
-      var int_list = [1, 2, 3]        # List[Int]
-      var str_list = ["a", "b", "c"]  # List[String]
+      var int_list: List[Int] = [1, 2, 3]
+      var str_list: List[String] = ["a", "b", "c"]
       # var mixed = [1, "hello"]      # Error! All elements must be same type
       ```
 
@@ -213,7 +213,7 @@ struct List[T: AnyType, /](
       assignment creates a deep copy of all elements:
 
       ```mojo
-      var list1 = [1, 2, 3]
+      var list1: List[Int] = [1, 2, 3]
       var list2 = list1.copy()        # Deep copy
       list2.append(4)
       print(list1)   # => [1, 2, 3]
@@ -229,7 +229,7 @@ struct List[T: AnyType, /](
       you specify `ref`:
 
       ```mojo
-      var numbers = [10, 20, 30]
+      var numbers: List[Int] = [10, 20, 30]
 
       # Default behavior creates immutable (read-only) references:
       # for num in numbers:
@@ -246,10 +246,10 @@ struct List[T: AnyType, /](
       original list is no longer accessible after the loop:
 
       ```mojo
-      var names = ["alice", "bob"]
+      var names: List[String] = ["alice", "bob"]
       for x in names^:
           # `x` is an owned `String` value.
-          print(x^)
+          print(x)
       # `names` is consumed and can no longer be used here
       ```
 
@@ -257,7 +257,7 @@ struct List[T: AnyType, /](
       abort:
 
       ```mojo
-      var my_list = [1, 2, 3]
+      var my_list: List[Int] = [1, 2, 3]
       print(my_list[5])  # Aborts with an Assert Error: index 5 is
                          # out of bounds, valid range is 0 to 2
       ```
@@ -266,7 +266,7 @@ struct List[T: AnyType, /](
       handle errors gracefully:
 
       ```mojo
-      var my_list = [1, 2, 3]
+      var my_list: List[Int] = [1, 2, 3]
       if 5 < len(my_list):
           print(my_list[5])  # Safe: check bounds first
       else:
@@ -283,7 +283,7 @@ struct List[T: AnyType, /](
     Examples:
 
     ```mojo
-    var my_list = [10, 20, 30]
+    var my_list: List[Int] = [10, 20, 30]
 
     # Add elements
     my_list.append(40)           # [10, 20, 30, 40]
@@ -304,11 +304,12 @@ struct List[T: AnyType, /](
     print('cap:', my_list.capacity())    # Current allocated capacity
 
     # Multiply a list
-    var repeated = [1, 2] * 3
+    var base: List[Int] = [1, 2]
+    var repeated = base * 3
     print(repeated)    # [1, 2, 1, 2, 1, 2]
 
     # Iterate over a list:
-    var fruits = ["apple", "banana", "orange"]
+    var fruits: List[String] = ["apple", "banana", "orange"]
 
     # Iterate by reference (immutable)
     for fruit in fruits:
@@ -323,9 +324,9 @@ struct List[T: AnyType, /](
         print(i, fruits[i])
 
     # Iterate by ownership (consumes the list)
-    var temps = ["a", "b", "c"]
+    var temps: List[String] = ["a", "b", "c"]
     for x in temps^:
-        print(x^)
+        print(x)
     # `temps` is no longer accessible here
 
     # Concatenate with + and +=

--- a/mojo/stdlib/std/collections/list.mojo
+++ b/mojo/stdlib/std/collections/list.mojo
@@ -189,7 +189,7 @@ struct List[T: AnyType, /](
     var filled = List[Float64](length=10, fill=0.0)
 
     # With initial values and an explicit element type
-    var numbers: List[Int] = [1, 2, 3, 4, 5
+    var numbers: List[Int] = [1, 2, 3, 4, 5]
     ```
 
     Be aware of the following characteristics:


### PR DESCRIPTION
This fixes the `List` documentation examples in `mojo/stdlib/std/collections/list.mojo`.

In Mojo 1.0.0, bare bracket literals such as `[1, 2, 3]` create an `Array`, not a `List`. I updated the affected documentation examples to explicitly specify `List[T]` and corrected the owned-iteration examples so they match the current Mojo behavior.

## Linked issue

Fixes #6875

## Type of change

* [ ] Bug fix (non-breaking change that fixes an issue)
* [ ] Performance improvement (includes benchmark results below)
* [x] Documentation update
* [ ] New feature or public API (requires prior proposal or issue approval)
* [ ] Refactor / internal cleanup (no user-visible change)
* [ ] Build, CI, or tooling change

## Motivation

The `List` documentation currently contains examples that use bare bracket literals without specifying the `List` type. In Mojo 1.0.0, these literals are inferred as fixed-size `Array` values rather than `List` values. As a result, some of the documented examples do not work as described.

## What changed

* Added explicit `List[Int]` and `List[String]` type annotations to the affected examples.
* Corrected the owned-iteration examples to print the already-owned value directly.
* Updated the list multiplication example so that the `List` type is established before multiplication.

The changes are limited to the `List` class-level documentation examples.

## Testing

I tested the updated examples with Mojo 1.0.0 and verified that the corrected examples compile and run as expected.

## Checklist

* [x] The linked issue above has been reviewed by a maintainer and is
  agreed-upon, or this is a trivial fix that does not need prior
  approval
* [x] PR is small and focused — I've split larger changes into a sequence of
  smaller PRs where possible (see
  [[pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes)](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
* [ ] I ran `./bazelw run format` to format my changes
* [ ] I added or updated tests to cover my changes
* [x] If AI tools assisted with this contribution, I have included an
  `Assisted-by:` trailer in my commit message or this PR description