### PR TITLE
[stdlib] Normalize signed zero in floating-point `SIMD.__hash__`

### DIFF
--- a/mojo/stdlib/std/builtin/simd.mojo
+++ b/mojo/stdlib/std/builtin/simd.mojo
@@ -2120,7 +2120,18 @@ struct SIMD[dtype: DType, length: SIMDLength](
         Args:
             hasher: The hasher instance.
         """
-        hasher._update_with_simd(self)
+
+        comptime if Self.dtype.is_floating_point():
+            # `-0.0 == 0.0` is `True`, but the two have different bit patterns,
+            # so hashing the raw bits would break the `Hashable`/`Equatable`
+            # contract (equal values must hash equally) and let a `Dict` hold
+            # both signed zeros as distinct keys. Adding `+0.0` normalizes
+            # `-0.0` to `+0.0` while leaving every finite value, infinity, and
+            # NaN unchanged. (NaN never compares equal to itself, so it does not
+            # constrain the contract regardless.)
+            hasher._update_with_simd(self + 0)
+        else:
+            hasher._update_with_simd(self)
 
     @always_inline
     def __ceildiv__(self, denominator: Self) -> Self:

--- a/mojo/stdlib/test/builtin/test_simd.mojo
+++ b/mojo/stdlib/test/builtin/test_simd.mojo
@@ -2501,6 +2501,17 @@ def test_hash() raises:
     # Hash should be consistent for same values
     assert_equal(hash(float_simd), float_hash)
 
+    # Signed zero must hash equally to positive zero: `-0.0 == 0.0` is `True`,
+    # so the `Hashable`/`Equatable` contract requires equal hashes even though
+    # the two have different bit patterns (regression test for #6851).
+    assert_equal(hash(Float64(-0.0)), hash(Float64(0.0)))
+    assert_equal(hash(Float32(-0.0)), hash(Float32(0.0)))
+    assert_equal(hash(Float16(-0.0)), hash(Float16(0.0)))
+    assert_equal(hash(BFloat16(-0.0)), hash(BFloat16(0.0)))
+    assert_equal(
+        hash(SIMD[.float64, 2](-0.0, 0.0)), hash(SIMD[.float64, 2](0.0, -0.0))
+    )
+
 
 def test_reduce_bitwise_ops() raises:
     # Test reduce_and


### PR DESCRIPTION
## Problem

`SIMD.__hash__` hashes the raw bit pattern, but `SIMD.__eq__` is a value comparison. Since `-0.0 == 0.0` is `True` while the two have different bit patterns, `hash(-0.0) != hash(0.0)` — a direct violation of the `Hashable`/`Equatable` contract documented in `hashlib/hash.mojo` ("if `a == b` then `hash(a) == hash(b)`").

The user-visible consequence is a `Dict` holding two keys that compare equal, so a lookup under one signed zero misses an entry inserted under the other:

```mojo
def main() raises:
    var d: Dict[Float64, String] = {}
    d[Float64(0.0)] = "zero"
    d[Float64(-0.0)] = "negzero"
    print(Float64(0.0) == Float64(-0.0), len(d))   # was: True 2 ; now: True 1
```

Applies to `Float64`, `Float32`, `Float16` and `BFloat16`.

## Fix

Normalize `-0.0` to `+0.0` in the floating-point hash path by adding `+0.0`. This is branchless (no hot-path branch beyond a `comptime` dtype dispatch) and leaves every finite value, infinity, and NaN bit-unchanged — only the negative-zero encoding is folded onto positive zero. Integer dtypes keep the original raw-bits path, so integer hashing is byte-for-byte identical to before.

NaN needs no special handling: `NaN != NaN`, so NaN keys never constrain the equal-implies-equal-hash contract.

## Test

Extends the existing `test_hash` in `test_simd.mojo` with signed-zero regressions across all four float dtypes plus a multi-lane SIMD case.

Verified locally against a patched `std` built with the pinned nightly (`Mojo 1.1.0.dev2026082405`):
- Full `test_simd.mojo` suite: **77 passed, 0 failed** with the fix.
- Sabotage check: reverting `__hash__` to the raw-bits version makes `test_hash` fail on the first signed-zero assertion (76 passed, 1 failed), confirming the test bites.
- The Dict repro now prints `True 1`; distinct values still hash distinctly; integer hashing unchanged.

I could not run the full Bazel suite in my environment, so CI here is the authoritative signal for the broader stdlib.

Fixes #6851
