### PR TITLE
[stdlib] Read unsigned SIMD dtypes from Python via `PyLong_AsSize_t`

### DIFF
--- a/mojo/docs/nightly-changelog.md
+++ b/mojo/docs/nightly-changelog.md
@@ -376,6 +376,11 @@ This release completes the removal of APIs deprecated during the v1.0 cycle.
 
 ## Fixed
 
+- `SIMD.__init__(py=...)` now reads unsigned dtypes through the unsigned CPython
+  entry point (`PyLong_AsSize_t`). Constructing an unsigned `SIMD` from a Python
+  int in `[2**63, 2**64)` no longer overflows, and a negative Python int now
+  raises instead of silently wrapping to the maximum value.
+
 - A `where` clause naming a type that an enclosing `where` clause constrained
   to a tighter trait can now be proven. Calling a method declared
   `where Ts.contains[T]()` with such a `T` failed with `lacking evidence to

--- a/mojo/stdlib/std/builtin/simd.mojo
+++ b/mojo/stdlib/std/builtin/simd.mojo
@@ -1003,7 +1003,19 @@ struct SIMD[dtype: DType, length: SIMDLength](
             # NOTE: if dtype is not float64, we truncate.
             self = Scalar[Self.dtype](float_value)
         elif Self.dtype.is_integral() and bit_width_of[Self.dtype]() <= 64:
-            self = Scalar[Self.dtype](Python.py_long_as_ssize_t(py.__int__()))
+            comptime if Self.dtype.is_unsigned():
+                # Read unsigned dtypes through the unsigned entry point so that
+                # values in `[2**63, 2**64)` round-trip (the signed path
+                # overflows on them) and negative Python ints raise instead of
+                # silently wrapping. Mirrors the Mojo -> Python direction, which
+                # already uses the unsigned `PyLong_FromSize_t`.
+                self = Scalar[Self.dtype](
+                    Python.py_long_as_size_t(py.__int__())
+                )
+            else:
+                self = Scalar[Self.dtype](
+                    Python.py_long_as_ssize_t(py.__int__())
+                )
         else:
             self = Scalar[Self.dtype]()
             comptime assert False, "unsupported dtype"

--- a/mojo/stdlib/std/builtin/simd.mojo
+++ b/mojo/stdlib/std/builtin/simd.mojo
@@ -990,7 +990,8 @@ struct SIMD[dtype: DType, length: SIMDLength](
             py: The PythonObject to convert.
 
         Raises:
-            If the conversion to double fails.
+            If the conversion to double fails, or if the value is out of range
+            for an unsigned dtype (a negative or too-large Python int).
         """
 
         comptime if Self.dtype.is_floating_point():

--- a/mojo/stdlib/std/python/_cpython.mojo
+++ b/mojo/stdlib/std/python/_cpython.mojo
@@ -1216,6 +1216,11 @@ comptime PyLong_AsSsize_t = ExternalFunction[
     # Py_ssize_t PyLong_AsSsize_t(PyObject *pylong)
     def(PyObjectPtr) thin abi("C") -> Py_ssize_t,
 ]
+comptime PyLong_AsSize_t = ExternalFunction[
+    "PyLong_AsSize_t",
+    # size_t PyLong_AsSize_t(PyObject *pylong)
+    def(PyObjectPtr) thin abi("C") -> c_size_t,
+]
 
 # Boolean Objects
 comptime PyBool_FromLong = ExternalFunction[
@@ -1659,6 +1664,7 @@ struct CPython(Defaultable, Movable):
     var _PyLong_FromSsize_t: PyLong_FromSsize_t.type
     var _PyLong_FromSize_t: PyLong_FromSize_t.type
     var _PyLong_AsSsize_t: PyLong_AsSsize_t.type
+    var _PyLong_AsSize_t: PyLong_AsSize_t.type
     # Boolean Objects
     var _PyBool_Type: PyTypeObjectPtr
     var _PyBool_FromLong: PyBool_FromLong.type
@@ -1910,6 +1916,7 @@ struct CPython(Defaultable, Movable):
         self._PyLong_FromSsize_t = PyLong_FromSsize_t.load(self.lib.borrow())
         self._PyLong_FromSize_t = PyLong_FromSize_t.load(self.lib.borrow())
         self._PyLong_AsSsize_t = PyLong_AsSsize_t.load(self.lib.borrow())
+        self._PyLong_AsSize_t = PyLong_AsSize_t.load(self.lib.borrow())
         # Boolean Objects
         # PyTypeObject PyBool_Type
         self._PyBool_Type = _untracked_symbol[PyTypeObject](
@@ -3243,6 +3250,19 @@ struct CPython(Defaultable, Movable):
         - https://docs.python.org/3/c-api/long.html#c.PyLong_AsSsize_t
         """
         return self._PyLong_AsSsize_t(pylong)
+
+    def PyLong_AsSize_t(self, pylong: PyObjectPtr) -> c_size_t:
+        """Return a C `size_t` representation of `pylong`.
+
+        Raise `OverflowError` if the value of `pylong` is out of range for
+        a `size_t`, including when `pylong` is negative.
+
+        Returns `(size_t)-1` on error. Use `PyErr_Occurred()` to disambiguate.
+
+        References:
+        - https://docs.python.org/3/c-api/long.html#c.PyLong_AsSize_t
+        """
+        return self._PyLong_AsSize_t(pylong)
 
     # ===-------------------------------------------------------------------===#
     # Boolean Objects

--- a/mojo/stdlib/std/python/python.mojo
+++ b/mojo/stdlib/std/python/python.mojo
@@ -20,7 +20,7 @@ from std.python import Python
 """
 
 from std.os import abort
-from std.ffi import _Global
+from std.ffi import _Global, c_size_t
 
 from ._cpython import (
     CPython,
@@ -587,6 +587,29 @@ struct Python(Defaultable, ImplicitlyCopyable):
         if num == -1 and cpy.PyErr_Occurred():
             # Note that -1 does not guarantee an error, it just means we need to
             # check if there was an exception.
+            raise cpy.unsafe_get_error()
+        return num
+
+    @staticmethod
+    def py_long_as_size_t(obj: PythonObject) raises -> c_size_t:
+        """Get the value of a Python `long` object as an unsigned `size_t`.
+
+        Args:
+            obj: The Python `long` object.
+
+        Returns:
+            The value of the `long` object as a `size_t`.
+
+        Raises:
+            If `obj` is not a Python `long` object, if the `long` object value
+            is negative, or if it overflows `size_t`.
+        """
+        ref cpy = Self().cpython()
+        var num = cpy.PyLong_AsSize_t(obj._obj_ptr)
+        # `PyLong_AsSize_t` returns `(size_t)-1` on error (e.g. a negative
+        # input, which raises `OverflowError`). Unlike the signed path, the
+        # sentinel is the maximum `size_t`, so we must check `PyErr_Occurred`.
+        if num == c_size_t.MAX and cpy.PyErr_Occurred():
             raise cpy.unsafe_get_error()
         return num
 

--- a/mojo/stdlib/test/python/test_python_to_mojo.mojo
+++ b/mojo/stdlib/test/python/test_python_to_mojo.mojo
@@ -88,11 +88,6 @@ def test_numpy_float() raises:
 
 
 def test_scalar_from_python_unsigned() raises:
-    # Unsigned scalars must read through the unsigned CPython entry point so
-    # that Mojo -> Python -> Mojo round-trips for values >= 2**63 and negative
-    # Python ints raise instead of silently wrapping (regression test for
-    # #6850).
-
     # Values in [2**63, 2**64) survived the Mojo -> Python leg (via the
     # unsigned `PyLong_FromSize_t`) and must survive the read-back too.
     assert_equal(UInt64(py=PythonObject(UInt64.MAX)), UInt64.MAX)

--- a/mojo/stdlib/test/python/test_python_to_mojo.mojo
+++ b/mojo/stdlib/test/python/test_python_to_mojo.mojo
@@ -87,5 +87,28 @@ def test_numpy_float() raises:
     assert_equal(Float64(py=py_numpy_float), mojo_float)
 
 
+def test_scalar_from_python_unsigned() raises:
+    # Unsigned scalars must read through the unsigned CPython entry point so
+    # that Mojo -> Python -> Mojo round-trips for values >= 2**63 and negative
+    # Python ints raise instead of silently wrapping (regression test for
+    # #6850).
+
+    # Values in [2**63, 2**64) survived the Mojo -> Python leg (via the
+    # unsigned `PyLong_FromSize_t`) and must survive the read-back too.
+    assert_equal(UInt64(py=PythonObject(UInt64.MAX)), UInt64.MAX)
+    var two_63 = UInt64(1) << 63
+    assert_equal(UInt64(py=PythonObject(two_63)), two_63)
+    assert_equal(UInt32(py=PythonObject(UInt32.MAX)), UInt32.MAX)
+
+    # A negative Python int must raise for an unsigned scalar, matching
+    # CPython's `PyLong_AsSize_t` (`OverflowError` for negatives), rather than
+    # wrapping to `UInt64.MAX`.
+    with assert_raises():
+        _ = UInt64(py=PythonObject(-1))
+
+    # Signed scalars still accept negatives.
+    assert_equal(Int64(py=PythonObject(-1)), -1)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
## Problem

`SIMD.__init__(*, py=)` converts every integral dtype through the **signed** `PyLong_AsSsize_t`, with no unsigned branch. Two bugs follow:

1. A negative Python int silently wraps into an unsigned Mojo scalar instead of raising.
2. `Mojo -> Python -> Mojo` does not round-trip for unsigned values `>= 2**63`. The Mojo→Python leg deliberately uses the unsigned `PyLong_FromSize_t`, but the read-back overflows `Py_ssize_t`:

```mojo
from std.python import PythonObject

def main() raises:
    print(UInt64(py=PythonObject(-1)))          # was: 18446744073709551615 (silent wrap)
    var py = PythonObject(UInt64.MAX)           # Mojo -> Python: fine
    print(UInt64(py=py))                         # was: raises "too large to convert to C ssize_t"
```

Left uncaught, the second case terminates the program.

## Fix

- Bind CPython's `PyLong_AsSize_t` in `_cpython.mojo` (declaration + field + load + wrapper), mirroring the existing `PyLong_AsSsize_t` binding exactly.
- Add `Python.py_long_as_size_t`, which surfaces the `(size_t)-1` error sentinel via `PyErr_Occurred()` (the unsigned sentinel is `size_t.MAX`, not `-1`).
- Route **unsigned** integral dtypes in `SIMD(py=)` through the unsigned helper via a `comptime` branch; signed dtypes keep the signed path, so negative values still convert correctly for them.

This matches CPython semantics: `PyLong_AsSize_t` raises `OverflowError` for negative inputs, and unsigned values up to `2**64 - 1` read back losslessly — symmetric with the `PyLong_FromSize_t` used on the way out.

## Test

Adds `test_scalar_from_python_unsigned` to `test_python_to_mojo.mojo`: `UInt64.MAX` and `2**63` round-trips, `UInt32.MAX`, the negative-raises case, and that signed `Int64` still accepts `-1`.

Verified locally against a patched `std` built with the pinned nightly (`Mojo 1.1.0.dev2026082405`), with a real CPython:
- Full `test_python_to_mojo.mojo`: **8 passed, 0 failed** with the fix.
- Sabotage check: reverting the SIMD branch to signed-only makes `test_scalar_from_python_unsigned` fail (7 passed, 1 failed), confirming the test bites.

I could not run the full Bazel suite in my environment, so CI here is the authoritative signal for the broader stdlib.

Fixes #6850
