### PR TITLE
[Kernels] Add Mamba2 SSD chunk-state kernel (fused tensor-core path) with tests and benches

### DIFF
--- a/max/kernels/benchmarks/BUILD.bazel
+++ b/max/kernels/benchmarks/BUILD.bazel
@@ -235,6 +235,7 @@ _CPU_TESTS = glob(
             "//max:max_mojo",
             "//max:nn",
             "//max:shmem",
+            "//max:state_space",
             "//max:structured_kernels",
             "@mojo//:std",
         ],

--- a/max/kernels/benchmarks/gpu/state_space/bench_ssd_chunk_state.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/bench_ssd_chunk_state.mojo
@@ -1,0 +1,334 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Microbenchmark sweep for ``ssd_chunk_state_fwd_gpu``.
+
+Stage 2 of the chunked SSD prefill: reduce each chunk to its
+``[head_dim, state_dim]`` end-state. Sweeps a few dim configs to isolate where
+time goes and reports the Mamba2-130m prefill profile used by the intra-chunk
+optimization notes (B=1, n_chunks=4, n_heads=24, L=256, P=64, N=128). Times
+wall-clock per call (kernel enqueue + sync).
+"""
+
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+from layout import TileTensor, row_major
+
+from state_space.ssd_chunk_state import (
+    ssd_chunk_state_fwd_gpu,
+    ssd_chunk_state_fwd_gpu_static,
+    ssd_chunk_state_fwd_gpu_fused,
+)
+
+
+def time_one[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int, num_p_tiles: Int = 1) raises:
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_state_fwd_gpu[
+            dtype,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ]
+    ]()
+
+    for _ in range(warmups):
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+    ctx.synchronize()
+
+    var min_ns: Int = -1
+    var sum_ns: Int = 0
+    for _ in range(iters):
+        var t0 = perf_counter_ns()
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+        ctx.synchronize()
+        var t1 = perf_counter_ns()
+        var elapsed = Int(t1 - t0)
+        sum_ns += elapsed
+        if min_ns < 0 or elapsed < min_ns:
+            min_ns = elapsed
+
+    var min_ms = Float64(min_ns) / 1.0e6
+    var mean_ms = Float64(sum_ns) / Float64(iters) / 1.0e6
+    print(
+        "  nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        " p_tiles=",
+        num_p_tiles,
+        "  min=",
+        min_ms,
+        "ms  mean=",
+        mean_ms,
+        "ms",
+        sep="",
+    )
+
+
+def time_one_static[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    """Time the static tensor-core path (decay-transpose + batched_matmul)."""
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    for _ in range(warmups):
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+
+    # Pipelined timing (enqueue all iters, sync once) to match the Triton
+    # bench's methodology for a fair throughput comparison.
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    print(
+        "  [tensor-core] nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  ",
+        Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6,
+        "ms/iter (pipelined)",
+        sep="",
+    )
+
+
+def time_one_fused[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    """Time the fused single-pass tensor-core path (pipelined throughput)."""
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    for _ in range(warmups):
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    print(
+        "  [fused] nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  ",
+        Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6,
+        "ms/iter (pipelined)",
+        sep="",
+    )
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    # Single-slice baselines to expose where time goes.
+    print("Single-slice (batch=1, n_chunks=1, n_heads=1) sweep:")
+    time_one[DType.float32, 1, 1, 1, 64, 64, 32](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 64, 64, 128](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 128, 64, 128](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 256, 64, 128](ctx, 5, 20)
+
+    # Mamba2-130m prefill profile, swept over p-tile counts (block count =
+    # 96 * p_tiles) to find the GB10 occupancy sweet spot.
+    print("Multi-slice sweep (Mamba2-130m prefill profile), p-tile sweep:")
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 1)
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 2)
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 4)
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 8)
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 16)
+
+    # Tensor-core path (decay-transpose + batched_matmul) at the same profile,
+    # plus longer prefills, to compare head-to-head with Triton _chunk_state_fwd.
+    print("Tensor-core path (static), pipelined throughput:")
+    time_one_static[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 10, 200)
+    time_one_static[DType.float32, 1, 8, 24, 256, 64, 128](ctx, 10, 200)
+    time_one_static[DType.float32, 1, 16, 24, 256, 64, 128](ctx, 10, 200)
+
+    print("Fused single-pass tensor-core path, pipelined throughput:")
+    time_one_fused[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 10, 200)
+    time_one_fused[DType.float32, 1, 8, 24, 256, 64, 128](ctx, 10, 200)
+    time_one_fused[DType.float32, 1, 16, 24, 256, 64, 128](ctx, 10, 200)

--- a/max/kernels/benchmarks/gpu/state_space/bench_ssd_intra_chunk.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/bench_ssd_intra_chunk.mojo
@@ -1,0 +1,156 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Microbenchmark sweep for ``ssd_intra_chunk_fwd_gpu``.
+
+Sweeps several dim configs to isolate where time goes: small/medium/large
+chunk_len, head_dim, state_dim. Times wall-clock per call (kernel + sync).
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+
+from state_space.ssd_chunk import (
+    ssd_intra_chunk_fwd_gpu,
+    ssd_intra_chunk_fwd_gpu_fused,
+    ssd_intra_chunk_fwd_gpu_static,
+)
+
+
+def time_one[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+    use_fused: Bool = False,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    comptime cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y_device = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    var C_tt = TileTensor(
+        C_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var Y_tt = TileTensor(
+        Y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(warmups):
+        comptime if use_fused:
+            ssd_intra_chunk_fwd_gpu_fused[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        else:
+            ssd_intra_chunk_fwd_gpu_static[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+    ctx.synchronize()
+
+    var min_ns: Int = -1
+    var sum_ns: Int = 0
+    for _ in range(iters):
+        var t0 = perf_counter_ns()
+        comptime if use_fused:
+            ssd_intra_chunk_fwd_gpu_fused[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        else:
+            ssd_intra_chunk_fwd_gpu_static[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        ctx.synchronize()
+        var t1 = perf_counter_ns()
+        var elapsed = Int(t1 - t0)
+        sum_ns += elapsed
+        if min_ns < 0 or elapsed < min_ns:
+            min_ns = elapsed
+
+    var min_ms = Float64(min_ns) / 1.0e6
+    var mean_ms = Float64(sum_ns) / Float64(iters) / 1.0e6
+    print(
+        "  nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  min=",
+        min_ms,
+        "ms  mean=",
+        mean_ms,
+        "ms",
+        sep="",
+    )
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    # Single-slice baselines to expose where time goes.
+    print("Single-slice (batch=1, n_chunks=1, n_heads=1) sweep:")
+    time_one[DType.float32, 1, 1, 1, 64, 64, 32](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 64, 64, 128](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 128, 64, 128](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 256, 64, 128](ctx, 5, 20)
+
+    print("Multi-slice sweep (Mamba2-130m prefill profile) — two-kernel:")
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 10)
+
+    print("Multi-slice sweep (Mamba2-130m prefill profile) — FUSED (RFC 0009):")
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128, use_fused=True](ctx, 5, 50)
+    time_one[DType.float32, 1, 8, 24, 256, 64, 128, use_fused=True](ctx, 5, 50)

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_fused_only.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_fused_only.mojo
@@ -1,0 +1,62 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Minimal driver: run ONLY the fused intra-chunk MMA path (RFC 0009).
+
+Scoped target for ncu single-metric roofline collection on GB10. Mamba2-130m
+prefill profile.
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+
+from state_space.ssd_chunk import ssd_intra_chunk_fwd_gpu_fused
+
+
+def main() raises:
+    var ctx = DeviceContext()
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    comptime cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    var C_tt = TileTensor(
+        C, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var B_tt = TileTensor(
+        B, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(A, row_major(batch, n_chunks, n_heads, chunk_len))
+    var Y_tt = TileTensor(
+        Y, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(4):
+        ssd_intra_chunk_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            C_tt.LayoutType,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            Y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+    ctx.synchronize()

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_scan_only.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_scan_only.mojo
@@ -1,0 +1,64 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Minimal driver: run ONLY the multi-slice ssd_intra static path a few times.
+
+Used as a tightly-scoped target for ``ncu`` single-metric roofline collection
+(no full-set replay — that crashes the GB10). Every launch is the Mamba2-130m
+prefill profile so the per-kernel rows are unambiguous.
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+
+from state_space.ssd_chunk import ssd_intra_chunk_fwd_gpu_static
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    comptime cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    var C_tt = TileTensor(
+        C, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var B_tt = TileTensor(
+        B, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(A, row_major(batch, n_chunks, n_heads, chunk_len))
+    var Y_tt = TileTensor(
+        Y, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(4):
+        ssd_intra_chunk_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            C_tt.LayoutType,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            Y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+    ctx.synchronize()

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_fused.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_fused.mojo
@@ -1,0 +1,100 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Single-kernel profiling driver for the fused tensor-core chunk-state entry.
+
+Runs ssd_chunk_state_fwd_gpu_fused (one fused MMA kernel) in a long loop at the
+Mamba2-130m prefill profile so its ncu row is unambiguous. argv[1] = iters.
+"""
+
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+from std.sys import argv
+from layout import TileTensor, row_major
+
+from state_space.ssd_chunk_state import ssd_chunk_state_fwd_gpu_fused
+
+
+def main() raises:
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    var iters = 2000
+    var args = argv()
+    if len(args) > 1:
+        iters = atol(args[1])
+
+    var ctx = DeviceContext()
+
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    for _ in range(5):
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    print(
+        "ssd_chunk_state fused prof: ",
+        iters,
+        " iters, ",
+        Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6,
+        " ms/iter",
+    )

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_only.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_only.mojo
@@ -1,0 +1,128 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Single-kernel profiling driver for ``ssd_chunk_state_fwd_gpu``.
+
+Runs ONLY the chunk-state kernel in a long loop at the Mamba2-130m prefill
+profile (B=1, n_chunks=4, n_heads=24, L=256, P=64, N=128) so per-kernel ncu
+rows are unambiguous and the nsys 10 kHz sampler lands on a sustained busy
+window. See ``.planning/ssd-intra-optimization-notes.md`` for the GB10
+profiling method (ncu single-metric + ``-c N`` is safe; ``--set full`` crashes
+the box).
+
+Iter count is read from argv[1] (default 20000) so the same binary serves both
+a quick latency check and a multi-second nsys capture window.
+"""
+
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+from std.sys import argv
+from layout import TileTensor, row_major
+
+from state_space.ssd_chunk_state import ssd_chunk_state_fwd_gpu
+
+
+def main() raises:
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    var iters = 20000
+    var num_p_tiles = 8  # GB10 sweet spot at this profile (see bench sweep).
+    var args = argv()
+    if len(args) > 1:
+        iters = atol(args[1])
+    if len(args) > 2:
+        num_p_tiles = atol(args[2])
+
+    var ctx = DeviceContext()
+
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_state_fwd_gpu[
+            dtype,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ]
+    ]()
+
+    # Warmup.
+    for _ in range(5):
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+    ctx.synchronize()
+
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    var per_iter_ms = Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6
+    print("ssd_chunk_state prof: ", iters, " iters, ", per_iter_ms, " ms/iter")

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_static.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_static.mojo
@@ -1,0 +1,101 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Single-path profiling driver for the static tensor-core chunk-state entry.
+
+Runs ssd_chunk_state_fwd_gpu_static (decay-transpose kernel + batched_matmul)
+in a long loop at the Mamba2-130m prefill profile so ncu rows for the two
+kernels (the decay-transpose and the matmul) are unambiguous. argv[1] = iters.
+"""
+
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+from std.sys import argv
+from layout import TileTensor, row_major
+
+from state_space.ssd_chunk_state import ssd_chunk_state_fwd_gpu_static
+
+
+def main() raises:
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    var iters = 2000
+    var args = argv()
+    if len(args) > 1:
+        iters = atol(args[1])
+
+    var ctx = DeviceContext()
+
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    for _ in range(5):
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    print(
+        "ssd_chunk_state static prof: ",
+        iters,
+        " iters, ",
+        Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6,
+        " ms/iter",
+    )

--- a/max/kernels/src/state_space/BUILD.bazel
+++ b/max/kernels/src/state_space/BUILD.bazel
@@ -22,6 +22,7 @@ mojo_library(
     deps = [
         "//max:extensibility",
         "//max:layout",
+        "//max:linalg",
         "//max:max_mojo",
         "//max:nn",
         "@mojo//:std",

--- a/max/kernels/src/state_space/ssd_chunk.mojo
+++ b/max/kernels/src/state_space/ssd_chunk.mojo
@@ -1,0 +1,1597 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Structured state space duality (SSD) intra-chunk diagonal block kernel.
+
+This implements stage 1 of the SSD chunk-scan algorithm used by Mamba2: the
+"intra-chunk diagonal block output". For each ``(batch, chunk, head)`` it
+computes the causal, decay-weighted attention-like output that only depends on
+tokens within the same chunk.
+
+For a chunk of ``L`` tokens with state dim ``N`` and head dim ``P``:
+
+- Inputs: ``C: [L, N]``, ``B: [L, N]``, ``X: [L, P]``, ``A: [L]`` (a scalar
+  decay per token).
+- Cumulative decay: ``A_cumsum[l] = sum_{k=0..l} A[k]``.
+- Causal decay (segment-sum) matrix: for ``s <= l``,
+  ``Ldecay[l, s] = exp(A_cumsum[l] - A_cumsum[s])``; for ``s > l`` it is ``0``.
+- Attention scores: ``scores[l, s] = (sum_n C[l, n] * B[s, n]) * Ldecay[l, s]``
+  for ``s <= l``.
+- Output: ``Y[l, p] = sum_{s=0..l} scores[l, s] * X[s, p]``.
+
+This matches the reference einsum
+``Y_diag = einsum("ln,sn,ls,sp->lp", C, B, Ldecay, X)`` restricted to ``s <= l``
+(stage 1 of ``ssd_minimal_discrete``).
+
+Implementations:
+
+- ``*_naive``: scalar reference kernels for golden / numerical-stability tests.
+- ``ssd_intra_chunk_fwd_cpu``: parallel per-slice GEMM decomposition (CPU).
+- ``ssd_intra_chunk_fwd_gpu``: host dispatch — batched ``C @ B^T`` via Modular
+  ``batched_matmul`` (tensor cores on GPU) plus a Triton-style tiled chunk-scan
+  kernel that fuses decay masking with ``scores @ X``.
+"""
+
+from layout.layout_tensor import copy_local_to_dram, copy_local_to_shared
+from layout.tensor_core import TensorCore, get_fragment_size, get_mma_shape
+from max.gpu.memory import async_copy_wait_all
+from layout import (
+    Idx,
+    Layout,
+    LayoutTensor,
+    TensorLayout,
+    TileTensor,
+    row_major,
+)
+from std.memory import AddressSpace
+from std.sys.info import _has_sm_121x
+from linalg.bmm import batched_matmul
+from max.algorithm import sync_parallelize
+from std.collections import OptionalReg
+from max.gpu.host import DeviceContext
+from std.math import ceildiv, exp
+from std.memory import alloc, unsafe_stack_allocation as mem_stack_allocation
+from max.gpu.sync import barrier as gpu_barrier
+from std.gpu import (
+    WARP_SIZE,
+    block_dim,
+    block_idx,
+    thread_idx,
+)
+from std.utils.index import IndexList
+
+# Triton-style tile sizes (scaled down for per-block register/stack budget).
+#
+# Device-split tuning: the chunk-scan's per-block work grows linearly with
+# pid_m (causal early-exit), so heavy tiles drain late and idle SMs. On the
+# GB10 (sm_121, DGX Spark) — many small SMs that prefer fine-grained work —
+# a 32-row tile (2× the blocks) measurably beats 64 (0.41 → 0.37 ms). On
+# datacenter parts (A100/H100/B200, fewer but larger SMs) the 64-row tile is
+# the safer default; it keeps more rows resident per block and we have not
+# profiled the smaller tile there. The kernel is correct for either value on
+# any GPU — this only trades block count vs per-block work.
+comptime SCAN_BLOCK_M = 32 if _has_sm_121x() else 64
+comptime SCAN_BLOCK_N = 32
+comptime SCAN_BLOCK_K = 32
+comptime SCAN_ACC_ELEMS = SCAN_BLOCK_M * SCAN_BLOCK_N
+# Warps per scan block. The cooperative CB load strides BM rows by this
+# count, so the block size must be a whole number of warps.
+comptime SCAN_WARPS = SCAN_BLOCK_M // 32
+
+# Upper bound on chunk_len for the shared-memory prefix-sum scratch (one
+# block per slice, one element per thread). 1024 floats = 4 KB shmem.
+comptime SCAN_MAX_CHUNK = 1024
+
+# BMM tile sizes for the in-house C @ B^T kernel. Each thread block emits
+# a BMM_BM × BMM_BN output tile; threads laid out (BMM_BN, BMM_BM) so a warp
+# spans a full BMM_BN row (32 contiguous output cols) for coalesced stores.
+comptime BMM_BM = 32
+comptime BMM_BN = 32
+comptime BMM_BK = 16
+
+# Stride helpers for indexing the flat row-major buffers.
+comptime Strides4D = IndexList[4]
+comptime Strides5D = IndexList[5]
+
+
+def _row_major_strides_4d(d0: Int, d1: Int, d2: Int, d3: Int) -> Strides4D:
+    """Row-major strides for a 4D shape ``(d0, d1, d2, d3)``."""
+    return Strides4D(d1 * d2 * d3, d2 * d3, d3, 1)
+
+
+def _row_major_strides_5d(
+    d0: Int, d1: Int, d2: Int, d3: Int, d4: Int
+) -> Strides5D:
+    """Row-major strides for a 5D shape ``(d0, d1, d2, d3, d4)``."""
+    return Strides5D(d1 * d2 * d3 * d4, d2 * d3 * d4, d3 * d4, d4, 1)
+
+
+@always_inline
+def _apply_decay_mask_to_cb[
+    dtype: DType,
+](
+    chunk_len: Int,
+    cb_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
+    cumsum: Pointer[Float32, MutUntrackedOrigin],
+) -> None:
+    """Apply causal decay ``exp(cum[l]-cum[s])`` to lower-triangular ``CB[l,s]``.
+    """
+    for l in range(chunk_len):
+        var cum_l = cumsum[l]
+        for s in range(l + 1):
+            var off = l * chunk_len + s
+            var val = cb_ptr[off].cast[DType.float32]() * exp(cum_l - cumsum[s])
+            cb_ptr[off] = val.cast[dtype]()
+        for s in range(l + 1, chunk_len):
+            cb_ptr[l * chunk_len + s] = Scalar[dtype](0)
+
+
+# ===----------------------------------------------------------------------=== #
+# Naive CPU baseline (numerical reference)
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_cpu_naive[
+    kernel_dtype: DType,
+    C_layout: Layout,
+    B_layout: Layout,
+    X_layout: Layout,
+    A_layout: Layout,
+    Y_layout: Layout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    C: LayoutTensor[kernel_dtype, C_layout, MutAnyOrigin],
+    B: LayoutTensor[kernel_dtype, B_layout, MutAnyOrigin],
+    X: LayoutTensor[kernel_dtype, X_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, A_layout, MutAnyOrigin],
+    Y: LayoutTensor[kernel_dtype, Y_layout, MutAnyOrigin],
+):
+    """Naive scalar CPU reference for golden / stability tests.
+
+    Triple nested loops over ``(l, s, n, p)`` with no SIMD or GEMM.
+    """
+    var cb_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, state_dim
+    )
+    var x_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, head_dim
+    )
+    var a_strides = _row_major_strides_4d(batch, n_chunks, n_heads, chunk_len)
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var cb_base = (
+                    b * cb_strides[0] + c * cb_strides[1] + h * cb_strides[2]
+                )
+                var x_base = (
+                    b * x_strides[0] + c * x_strides[1] + h * x_strides[2]
+                )
+                var a_base = (
+                    b * a_strides[0] + c * a_strides[1] + h * a_strides[2]
+                )
+                var y_base = x_base
+
+                var a_cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var running = Float32(0.0)
+                for l in range(chunk_len):
+                    var a_off = a_base + l * a_strides[3]
+                    running += A.ptr[a_off].cast[DType.float32]()
+                    a_cumsum[l] = running
+
+                for l in range(chunk_len):
+                    var c_row = cb_base + l * cb_strides[3]
+                    var cum_l = a_cumsum[l]
+                    for s in range(l + 1):
+                        var b_row = cb_base + s * cb_strides[3]
+
+                        var dot = Float32(0.0)
+                        for n in range(state_dim):
+                            var cv = C.ptr[c_row + n * cb_strides[4]].cast[
+                                DType.float32
+                            ]()
+                            var bv = B.ptr[b_row + n * cb_strides[4]].cast[
+                                DType.float32
+                            ]()
+                            dot += cv * bv
+
+                        var decay = exp(cum_l - a_cumsum[s])
+                        var score = dot * decay
+
+                        var x_row = x_base + s * x_strides[3]
+                        var y_row = y_base + l * x_strides[3]
+                        for p in range(head_dim):
+                            var xv = X.ptr[x_row + p * x_strides[4]].cast[
+                                DType.float32
+                            ]()
+                            var y_off = y_row + p * x_strides[4]
+                            var acc = (
+                                Y.ptr[y_off].cast[DType.float32]() + score * xv
+                            )
+                            Y.ptr[y_off] = acc.cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# Optimized CPU (parallel slices + GEMM)
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_cpu[
+    kernel_dtype: DType,
+    C_layout: Layout,
+    B_layout: Layout,
+    X_layout: Layout,
+    A_layout: Layout,
+    Y_layout: Layout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    C: LayoutTensor[kernel_dtype, C_layout, MutAnyOrigin],
+    B: LayoutTensor[kernel_dtype, B_layout, MutAnyOrigin],
+    X: LayoutTensor[kernel_dtype, X_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, A_layout, MutAnyOrigin],
+    Y: LayoutTensor[kernel_dtype, Y_layout, MutAnyOrigin],
+    ctx: Optional[DeviceContext] = None,
+) raises:
+    """Optimized CPU intra-chunk diagonal block.
+
+    1. Batched ``CB = C @ B^T`` via ``batched_matmul``.
+    2. Parallel per-slice causal decay on ``CB``.
+    3. Batched ``Y = CB @ X`` via ``batched_matmul``.
+    """
+    var num_slices = batch * n_chunks * n_heads
+    var l2 = chunk_len * chunk_len
+
+    var cb_ptr = alloc[Scalar[kernel_dtype]](num_slices * l2)
+
+    var C3 = TileTensor(C.ptr, row_major(num_slices, chunk_len, state_dim))
+    var B3 = TileTensor(B.ptr, row_major(num_slices, chunk_len, state_dim))
+    var CB3 = TileTensor(cb_ptr, row_major(num_slices, chunk_len, chunk_len))
+    var X3 = TileTensor(X.ptr, row_major(num_slices, chunk_len, head_dim))
+    var Y3 = TileTensor(Y.ptr, row_major(num_slices, chunk_len, head_dim))
+
+    batched_matmul[target="cpu", transpose_b=True](CB3, C3, B3)
+
+    var a_strides = _row_major_strides_4d(batch, n_chunks, n_heads, chunk_len)
+
+    @__parameter
+    def decay_worker(flat_idx: Int):
+        var h = flat_idx % n_heads
+        var c = (flat_idx // n_heads) % n_chunks
+        var b = flat_idx // (n_heads * n_chunks)
+
+        var a_base = b * a_strides[0] + c * a_strides[1] + h * a_strides[2]
+        var cumsum_ptr = alloc[Float32](chunk_len)
+
+        var running = Float32(0.0)
+        for l in range(chunk_len):
+            running += A.ptr[a_base + l * a_strides[3]].cast[DType.float32]()
+            cumsum_ptr[l] = running
+
+        _apply_decay_mask_to_cb[kernel_dtype](
+            chunk_len,
+            cb_ptr + flat_idx * l2,
+            cumsum_ptr,
+        )
+        cumsum_ptr.free()
+
+    sync_parallelize[decay_worker](num_slices, ctx)
+
+    batched_matmul[target="cpu"](Y3, CB3, X3)
+
+    cb_ptr.free()
+
+
+# ===----------------------------------------------------------------------=== #
+# Naive GPU baseline (numerical reference)
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_gpu_naive[
+    kernel_dtype: DType,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    state_dim_i32: Int32,
+    head_dim_i32: Int32,
+    C: TileTensor[kernel_dtype, C_LT, MutUntrackedOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutUntrackedOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutUntrackedOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutUntrackedOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutUntrackedOrigin],
+):
+    """Naive GPU reference: one thread per ``(batch, chunk, head)`` slice.
+
+    Scalar loops only — use for golden / stability tests, not performance.
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var state_dim = Int(state_dim_i32)
+    var head_dim = Int(head_dim_i32)
+    var flat_idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total_slices = batch * n_chunks * n_heads
+    if flat_idx >= total_slices:
+        return
+
+    var h = flat_idx % n_heads
+    var c = (flat_idx // n_heads) % n_chunks
+    var b = flat_idx // (n_heads * n_chunks)
+
+    var cb_n_stride = 1
+    var cb_l_stride = state_dim
+    var cb_h_stride = chunk_len * cb_l_stride
+    var cb_c_stride = n_heads * cb_h_stride
+    var cb_b_stride = n_chunks * cb_c_stride
+
+    var x_p_stride = 1
+    var x_l_stride = head_dim
+    var x_h_stride = chunk_len * x_l_stride
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_l_stride = 1
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var cb_base = b * cb_b_stride + c * cb_c_stride + h * cb_h_stride
+    var x_base = b * x_b_stride + c * x_c_stride + h * x_h_stride
+    var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+    var y_base = x_base
+
+    for l in range(chunk_len):
+        var c_row = cb_base + l * cb_l_stride
+
+        var cum_l = Float32(0.0)
+        for k in range(l + 1):
+            cum_l += A.ptr[a_base + k * a_l_stride].cast[DType.float32]()
+
+        for p in range(head_dim):
+            Y.ptr[y_base + l * x_l_stride + p * x_p_stride] = Scalar[
+                kernel_dtype
+            ](0)
+
+        var cum_s = Float32(0.0)
+        for s in range(l + 1):
+            cum_s += A.ptr[a_base + s * a_l_stride].cast[DType.float32]()
+
+            var b_row = cb_base + s * cb_l_stride
+
+            var dot = Float32(0.0)
+            for n in range(state_dim):
+                var cv = C.ptr[c_row + n * cb_n_stride].cast[DType.float32]()
+                var bv = B.ptr[b_row + n * cb_n_stride].cast[DType.float32]()
+                dot += cv * bv
+
+            var decay = exp(cum_l - cum_s)
+            var score = dot * decay
+
+            var x_row = x_base + s * x_l_stride
+            var y_row = y_base + l * x_l_stride
+            for p in range(head_dim):
+                var xv = X.ptr[x_row + p * x_p_stride].cast[DType.float32]()
+                var y_off = y_row + p * x_p_stride
+                var acc = Y.ptr[y_off].cast[DType.float32]() + score * xv
+                Y.ptr[y_off] = acc.cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU: batched ``CB = C @ B^T`` (tiled, shared-memory, no tensor cores)
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_intra_chunk_bmm_gpu[
+    kernel_dtype: DType,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    CB_LT: TensorLayout,
+](
+    n_slices_i32: Int32,
+    chunk_len_i32: Int32,
+    state_dim_i32: Int32,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    CB: TileTensor[kernel_dtype, CB_LT, MutAnyOrigin],
+):
+    """Batched ``CB[s, l, r] = sum_n C[s, l, n] * B[s, r, n]``.
+
+    Replaces Modular ``batched_matmul`` for our dim set. The Modular
+    dispatch needs static N/K to pick its tensor-core path; our caller
+    only has dynamic dims, so it falls through to a per-element naive
+    kernel that was profiled at >3ms/call. This kernel is a stock tiled
+    matmul (no tensor cores, just shmem prefetched tiles); on the GB10
+    it's enough to close the gap to the scan kernel cost.
+
+    Grid: ``(ceildiv(L, BMM_BM) * ceildiv(L, BMM_BN), n_slices)``.
+    Block: ``(BMM_BN, BMM_BM)``; thread ``(tn, tm)`` owns output
+    ``CB[block_slice, l = m_tile*BMM_BM + tm, r = n_tile*BMM_BN + tn]``.
+    Shared memory holds the current ``BMM_BM × BMM_BK`` C tile and
+    ``BMM_BN × BMM_BK`` B tile per K window.
+    """
+    var n_slices = Int(n_slices_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var state_dim = Int(state_dim_i32)
+    var num_n_tiles = ceildiv(chunk_len, BMM_BN)
+    var m_tile = Int(block_idx.x) // num_n_tiles
+    var n_tile = Int(block_idx.x) - m_tile * num_n_tiles
+    var slice_idx = Int(block_idx.y)
+
+    var l = m_tile * BMM_BM + Int(thread_idx.y)
+    var r = n_tile * BMM_BN + Int(thread_idx.x)
+
+    var c_slice_base = slice_idx * chunk_len * state_dim
+    var b_slice_base = c_slice_base  # same layout
+    var cb_slice_base = slice_idx * chunk_len * chunk_len
+
+    var c_smem = mem_stack_allocation[
+        BMM_BM * BMM_BK, Float32, address_space=AddressSpace.SHARED
+    ]()
+    var b_smem = mem_stack_allocation[
+        BMM_BN * BMM_BK, Float32, address_space=AddressSpace.SHARED
+    ]()
+
+    var acc: Float32 = 0.0
+
+    var tm = Int(thread_idx.y)
+    var tn = Int(thread_idx.x)
+
+    for k0 in range(0, state_dim, BMM_BK):
+        # Cooperative C[m_tile_row, k0..k0+BMM_BK] load. Threads
+        # (tm, tn) load C_smem[tm, tn] when tn < BMM_BK.
+        if tn < BMM_BK:
+            var n = k0 + tn
+            if l < chunk_len and n < state_dim:
+                c_smem[tm * BMM_BK + tn] = C.ptr[
+                    c_slice_base + l * state_dim + n
+                ].cast[DType.float32]()
+            else:
+                c_smem[tm * BMM_BK + tn] = 0.0
+        # Cooperative B[n_tile_row, k0..k0+BMM_BK] load. Threads
+        # (tm, tn) → B_smem[tn, tm] when tm < BMM_BK.
+        if tm < BMM_BK:
+            var n = k0 + tm
+            var r2 = n_tile * BMM_BN + tn
+            if r2 < chunk_len and n < state_dim:
+                b_smem[tn * BMM_BK + tm] = B.ptr[
+                    b_slice_base + r2 * state_dim + n
+                ].cast[DType.float32]()
+            else:
+                b_smem[tn * BMM_BK + tm] = 0.0
+
+        gpu_barrier()
+
+        if l < chunk_len and r < chunk_len:
+            comptime for k in range(BMM_BK):
+                acc += c_smem[tm * BMM_BK + k] * b_smem[tn * BMM_BK + k]
+
+        gpu_barrier()
+
+    if l < chunk_len and r < chunk_len:
+        CB.ptr[cb_slice_base + l * chunk_len + r] = acc.cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU: prefix sum of A per slice
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_intra_chunk_cumsum_gpu[
+    kernel_dtype: DType,
+    A_LT: TensorLayout,
+    cumsum_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    A: TileTensor[kernel_dtype, A_LT, MutUntrackedOrigin],
+    cumsum: TileTensor[DType.float32, cumsum_LT, MutUntrackedOrigin],
+):
+    """Inclusive prefix sum of ``A`` into ``cumsum`` — one block per slice.
+
+    Hillis-Steele scan in shared memory: ``block_dim = chunk_len`` threads,
+    one element each, ``log2(chunk_len)`` doubling steps. The previous version
+    launched a single block (one thread per slice), so all slices' scans
+    serialised on **one SM** (~32 µs at the Mamba2 profile). One block per
+    slice spreads the work across every SM. Slices are contiguous ``chunk_len``
+    blocks in both buffers (``base = slice_idx * chunk_len``).
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var slice_idx = Int(block_idx.x)
+    var total_slices = batch * n_chunks * n_heads
+    if slice_idx >= total_slices:
+        return
+
+    var tid = Int(thread_idx.x)
+    var base = slice_idx * chunk_len
+
+    var sdata = mem_stack_allocation[
+        SCAN_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+
+    if tid < chunk_len:
+        sdata[tid] = A.ptr[base + tid].cast[DType.float32]()
+    gpu_barrier()
+
+    var offset = 1
+    while offset < chunk_len:
+        var add: Float32 = 0.0
+        if tid < chunk_len and tid >= offset:
+            add = sdata[tid - offset]
+        gpu_barrier()
+        if tid < chunk_len and tid >= offset:
+            sdata[tid] += add
+        gpu_barrier()
+        offset *= 2
+
+    if tid < chunk_len:
+        cumsum.ptr[base + tid] = sdata[tid]
+
+
+def _ssd_intra_chunk_decay_gpu[
+    kernel_dtype: DType,
+    CB_LT: TensorLayout,
+    cumsum_LT: TensorLayout,
+](
+    num_slices_i32: Int32,
+    chunk_len_i32: Int32,
+    CB: TileTensor[kernel_dtype, CB_LT, MutUntrackedOrigin],
+    cumsum: TileTensor[DType.float32, cumsum_LT, MutUntrackedOrigin],
+):
+    """Apply causal decay in place: ``M[l,s] = CB[l,s]*exp(cum[l]-cum[s])``.
+
+    Lower-triangular (``s <= l``); the strict upper triangle is zeroed.
+    Materialises the decayed, masked score matrix so the chunk scan can be
+    expressed as a plain ``Y = M @ X`` tensor-core matmul. Flat grid over
+    the ``num_slices * L * L`` elements; consecutive threads map to
+    consecutive ``s`` so CB / cumsum traffic is fully coalesced.
+    """
+    var num_slices = Int(num_slices_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var slice_idx = Int(block_idx.y)
+    var elem = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var l2 = chunk_len * chunk_len
+    if slice_idx >= num_slices or elem >= l2:
+        return
+
+    var l = elem // chunk_len
+    var s = elem - l * chunk_len
+
+    var cs_base = slice_idx * chunk_len
+    var cb_off = slice_idx * l2 + elem
+
+    if s <= l:
+        var cum_l = cumsum.ptr[cs_base + l]
+        var cum_s = cumsum.ptr[cs_base + s]
+        var decayed = CB.ptr[cb_off].cast[DType.float32]() * exp(cum_l - cum_s)
+        CB.ptr[cb_off] = decayed.cast[kernel_dtype]()
+    else:
+        CB.ptr[cb_off] = Scalar[kernel_dtype](0)
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU: Triton-style tiled chunk scan  (decay-masked CB @ X)
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_intra_chunk_chunk_scan_gpu[
+    kernel_dtype: DType,
+    CB_LT: TensorLayout,
+    cumsum_LT: TensorLayout,
+    X_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    head_dim_i32: Int32,
+    CB: TileTensor[kernel_dtype, CB_LT, MutUntrackedOrigin],
+    cumsum: TileTensor[DType.float32, cumsum_LT, MutUntrackedOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutUntrackedOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutUntrackedOrigin],
+):
+    """Tiled ``Y = causal_decay(CB) @ X`` matching Mamba ``_chunk_scan_fwd_kernel``.
+
+    Grid ``(ceil(L/BM)*ceil(P/BN), batch*n_chunks, n_heads)`` with causal
+    masking and ``exp(cumsum[l]-cumsum[s])`` decay fused in the K loop.
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var head_dim = Int(head_dim_i32)
+    comptime BM = SCAN_BLOCK_M
+    comptime BN = SCAN_BLOCK_N
+    comptime BK = SCAN_BLOCK_K
+    var num_pid_n = ceildiv(head_dim, BN)
+    var pid_m = Int(block_idx.x) // num_pid_n
+    var pid_n = Int(block_idx.x) % num_pid_n
+
+    var pid_bc = Int(block_idx.y)
+    var pid_h = Int(block_idx.z)
+
+    var c = pid_bc // batch
+    var b = pid_bc - c * batch
+
+    var cb_b_stride = n_chunks * n_heads * chunk_len * chunk_len
+    var cb_c_stride = n_heads * chunk_len * chunk_len
+    var cb_h_stride = chunk_len * chunk_len
+    var cb_l_stride = chunk_len
+    var cb_s_stride = 1
+
+    var x_b_stride = n_chunks * n_heads * chunk_len * head_dim
+    var x_c_stride = n_heads * chunk_len * head_dim
+    var x_h_stride = chunk_len * head_dim
+    var x_l_stride = head_dim
+    var x_p_stride = 1
+
+    var y_b_stride = x_b_stride
+    var y_c_stride = x_c_stride
+    var y_h_stride = x_h_stride
+    var y_l_stride = head_dim
+    var y_p_stride = 1
+
+    var cs_b_stride = n_chunks * n_heads * chunk_len
+    var cs_c_stride = n_heads * chunk_len
+    var cs_h_stride = chunk_len
+    var cs_l_stride = 1
+
+    var cb_base = b * cb_b_stride + c * cb_c_stride + pid_h * cb_h_stride
+    var x_base = b * x_b_stride + c * x_c_stride + pid_h * x_h_stride
+    var y_base = b * y_b_stride + c * y_c_stride + pid_h * y_h_stride
+    var cs_base = b * cs_b_stride + c * cs_c_stride + pid_h * cs_h_stride
+
+    var offs_m0 = pid_m * BM
+    var offs_n0 = pid_n * BN
+
+    # One thread per row of the BM×BN output tile (block_dim = BM threads).
+    var tid = Int(thread_idx.x)
+
+    # Shared tiles for the K window. We batch the X load to amortise
+    # the global → shmem traffic across BK iterations and remove the
+    # per-K-iter sync (was 2*K_MAX barriers per block, now 1 per BK).
+    var x_smem = mem_stack_allocation[
+        SCAN_BLOCK_K * SCAN_BLOCK_N,
+        Float32,
+        address_space=AddressSpace.SHARED,
+    ]()
+    var cum_smem = mem_stack_allocation[
+        SCAN_BLOCK_K, Float32, address_space=AddressSpace.SHARED
+    ]()
+    # Pad inner stride by 1 to avoid 32-way bank conflicts in the FMA
+    # inner loop: with stride 32 (= 128 B), every BM lane hits the same
+    # bank. Stride 33 makes the bank index = (row * 33 + ki) % 32, which
+    # cycles through all 32 banks across the 64 lanes of the block.
+    comptime CB_SMEM_STRIDE = SCAN_BLOCK_K + 1
+    var cb_smem = mem_stack_allocation[
+        SCAN_BLOCK_M * CB_SMEM_STRIDE,
+        Float32,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var l = offs_m0 + tid
+    var active = tid < BM and l < chunk_len
+
+    # Causal decay ``exp(cum_l - cum_s)`` is computed directly in the inner
+    # loop from the raw cumulative sums. The earlier factoring into
+    # ``exp(cum_l) * exp(-cum_s)`` saved exp calls but is numerically
+    # unstable: ``cumsum`` is the prefix sum of ``A*dt`` with ``A < 0``, so
+    # it is large-negative. ``exp(cum_l)`` then underflows to 0 while
+    # ``exp(-cum_s)`` overflows to +inf, and ``0 * inf = NaN`` even on the
+    # causal diagonal where the true decay ``exp(cum_l - cum_s) ∈ (0, 1]``
+    # is finite. Since ``cum_l - cum_s <= 0`` for ``s <= l`` (the only
+    # entries we keep), the direct form can never overflow.
+    var cum_l: Float32 = 0.0
+    if active:
+        cum_l = cumsum.ptr[cs_base + l * cs_l_stride]
+
+    # Per-thread BN-wide accumulator.
+    var acc = mem_stack_allocation[
+        SCAN_BLOCK_N, Float32, address_space=AddressSpace.LOCAL
+    ]()
+
+    comptime for ni in range(BN):
+        acc[ni] = 0.0
+
+    # Walk the K axis only up to ``(pid_m + 1) * BM`` (the max ``l`` in
+    # this block) — causal masking would zero-out anything beyond that, so
+    # there's no point loading or computing it. For pid_m=0 (first L-tile)
+    # this cuts K_MAX from chunk_len to BM; on the Mamba2-130m profile
+    # (L=256, BM=64) the average K work drops by ~1.6× across the four
+    # M-tiles.
+    var k_limit = min((pid_m + 1) * BM, chunk_len)
+    for k0 in range(0, k_limit, BK):
+        # Cooperative raw ``cum_s`` window. The inner loop forms the decay
+        # as ``exp(cum_l - cum_s)`` directly (stable; see note above).
+        if tid < BK:
+            var s = k0 + tid
+            if s < chunk_len:
+                cum_smem[tid] = cumsum.ptr[cs_base + s * cs_l_stride]
+            else:
+                cum_smem[tid] = 0.0
+        # Cooperative X tile of size BK × BN, one outer iter at a time.
+        # Threads (BM total) split BK*BN elements; with BM == BN, each
+        # thread (column tid in [0, BN)) loads BK contiguous K rows for
+        # its column.
+        if tid < BN:
+            var p = offs_n0 + tid
+
+            comptime for ki in range(BK):
+                var s = k0 + ki
+                if s < chunk_len and p < head_dim:
+                    x_smem[ki * BN + tid] = X.ptr[
+                        x_base + s * x_l_stride + p * x_p_stride
+                    ].cast[DType.float32]()
+                else:
+                    x_smem[ki * BN + tid] = 0.0
+
+        # Cooperative CB tile of size BM × BK: each warp loads one
+        # contiguous K row per iter (32 lanes × 4 B = 1 cache line,
+        # perfectly coalesced) — replaces the previous scattered
+        # per-thread CB[l, s] reads (stride L between lanes, 16-way
+        # uncoalesced on the Mamba2-130m profile). The ``SCAN_WARPS``
+        # warps in the block stride the BM rows by ``SCAN_WARPS`` so any
+        # block size that is a multiple of the warp size is covered.
+        var warp_id = tid // 32
+        var lane = tid - warp_id * 32
+
+        comptime for r in range(0, SCAN_BLOCK_M, SCAN_WARPS):
+            var row = r + warp_id
+            var l_row = offs_m0 + row
+            var s_col = k0 + lane
+            if (
+                row < SCAN_BLOCK_M
+                and l_row < chunk_len
+                and lane < BK
+                and s_col < chunk_len
+            ):
+                cb_smem[row * CB_SMEM_STRIDE + lane] = CB.ptr[
+                    cb_base + l_row * cb_l_stride + s_col * cb_s_stride
+                ].cast[DType.float32]()
+            elif lane < BK:
+                cb_smem[row * CB_SMEM_STRIDE + lane] = 0.0
+
+        gpu_barrier()
+
+        if active:
+            comptime for ki in range(BK):
+                var s = k0 + ki
+                if s < chunk_len and s <= l:
+                    var cb_val = cb_smem[tid * CB_SMEM_STRIDE + ki]
+                    var score = cb_val * exp(cum_l - cum_smem[ki])
+
+                    comptime for ni in range(BN):
+                        acc[ni] += score * x_smem[ki * BN + ni]
+
+        gpu_barrier()
+
+    if active:
+        var y_row = y_base + l * y_l_stride
+
+        comptime for ni in range(BN):
+            var p = offs_n0 + ni
+            if p < head_dim:
+                Y.ptr[y_row + p * y_p_stride] = acc[ni].cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# Optimized GPU host dispatch
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_gpu[
+    kernel_dtype: DType,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Optimized GPU intra-chunk diagonal block (Mamba-style pipeline).
+
+    1. Batched ``CB = C @ B^T`` via Modular ``batched_matmul`` (tensor cores).
+    2. Per-slice inclusive prefix sum of ``A``.
+    3. Tiled chunk-scan: ``Y = causal_decay(CB) @ X``.
+
+    Matches the structure of ``mamba_ssm/ops/triton/ssd_chunk_scan.py``:
+    ``_bmm_chunk_fwd`` + ``_chunk_scan_fwd_kernel``.
+    """
+    var num_slices = batch * n_chunks * n_heads
+    var l2 = chunk_len * chunk_len
+
+    var CB_device = ctx.enqueue_create_buffer[kernel_dtype](num_slices * l2)
+    var cumsum_device = ctx.enqueue_create_buffer[DType.float32](
+        num_slices * chunk_len
+    )
+
+    var C3 = TileTensor(
+        C.ptr,
+        row_major(num_slices, chunk_len, state_dim),
+    )
+    var B3 = TileTensor(
+        B.ptr,
+        row_major(num_slices, chunk_len, state_dim),
+    )
+    var CB3 = TileTensor(
+        CB_device,
+        row_major(num_slices, chunk_len, chunk_len),
+    )
+    var cumsum4 = TileTensor(
+        cumsum_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var CB5 = TileTensor(
+        CB_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, chunk_len),
+    )
+
+    # Dispatch CB = C @ B^T:
+    #   batched_matmul picks a cutlass tensor-core path when batch_size == 1
+    #   but falls back to a naive O(N^3) per-element kernel for batched
+    #   cases. Our hand-tiled ``_ssd_intra_chunk_bmm_gpu`` beats the naive
+    #   fallback by ~5×, but is still scalar (no tensor cores). For
+    #   multi-slice we benchmark both: a per-slice loop of cutlass calls
+    #   (tensor cores, but 96 launches of ~5µs each) and the custom bmm
+    #   (one launch, scalar). The faster of the two wins at this dim set.
+    #
+    # Toggle via env var for benchmarking; default: per-slice cutlass.
+    var use_per_slice_cutlass = True
+    if num_slices == 1:
+        with ctx.push_context():
+            batched_matmul[target="gpu", transpose_b=True](
+                CB3, C3, B3, context=ctx
+            )
+    elif use_per_slice_cutlass:
+        with ctx.push_context():
+            for s in range(num_slices):
+                var Cs = TileTensor(
+                    C.ptr + s * chunk_len * state_dim,
+                    row_major(1, chunk_len, state_dim),
+                )
+                var Bs = TileTensor(
+                    B.ptr + s * chunk_len * state_dim,
+                    row_major(1, chunk_len, state_dim),
+                )
+                var CBs = TileTensor(
+                    CB_device.unsafe_ptr() + s * chunk_len * chunk_len,
+                    row_major(1, chunk_len, chunk_len),
+                )
+                batched_matmul[target="gpu", transpose_b=True](
+                    CBs, Cs, Bs, context=ctx
+                )
+    else:
+        comptime bmm_kernel = _ssd_intra_chunk_bmm_gpu[
+            kernel_dtype,
+            C3.LayoutType,
+            B3.LayoutType,
+            CB3.LayoutType,
+        ]
+        var bmm_compiled = ctx.compile_function[bmm_kernel]()
+        var bmm_grid_x = ceildiv(chunk_len, BMM_BM) * ceildiv(chunk_len, BMM_BN)
+
+        with ctx.push_context():
+            ctx.enqueue_function(
+                bmm_compiled,
+                Int32(num_slices),
+                Int32(chunk_len),
+                Int32(state_dim),
+                C3,
+                B3,
+                CB3,
+                grid_dim=(bmm_grid_x, num_slices, 1),
+                block_dim=(BMM_BN, BMM_BM, 1),
+            )
+
+    var cumsum_compiled = ctx.compile_function[
+        _ssd_intra_chunk_cumsum_gpu[
+            kernel_dtype,
+            A_LT,
+            cumsum4.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            cumsum_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            A,
+            cumsum4,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len,),
+        )
+
+    comptime scan_kernel = _ssd_intra_chunk_chunk_scan_gpu[
+        kernel_dtype,
+        CB5.LayoutType,
+        cumsum4.LayoutType,
+        X_LT,
+        Y_LT,
+    ]
+    var scan_compiled = ctx.compile_function[scan_kernel]()
+
+    var grid_x = ceildiv(chunk_len, SCAN_BLOCK_M) * ceildiv(
+        head_dim, SCAN_BLOCK_N
+    )
+
+    # Scan kernel reads ``block_idx.y`` as ``batch * n_chunks`` and
+    # ``block_idx.z`` as ``n_heads``; launching ``num_slices`` (= b*nc*nh)
+    # in y was redundantly multiplying the work by n_heads. Fix the launch
+    # to match the kernel's index decomposition.
+    with ctx.push_context():
+        ctx.enqueue_function(
+            scan_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            CB5,
+            cumsum4,
+            X,
+            Y,
+            grid_dim=(grid_x, batch * n_chunks, n_heads),
+            block_dim=(SCAN_BLOCK_M, 1, 1),
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Static-shape entry point
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_gpu_static[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Static-shape variant of ``ssd_intra_chunk_fwd_gpu``.
+
+    Knowing ``chunk_len`` / ``state_dim`` / ``head_dim`` at compile time
+    lets ``batched_matmul`` see ``has_static_NK`` and pick its A100
+    tensor-core batched path (one launch for all slices, grid_z =
+    batch_size), instead of the per-slice cutlass loop (96 launches × ~4 µs
+    each) that dominates the dynamic-shape dispatch.
+    """
+    var num_slices = batch * n_chunks * n_heads
+    comptime l2 = chunk_len_ct * chunk_len_ct
+
+    var CB_device = ctx.enqueue_create_buffer[kernel_dtype](num_slices * l2)
+    var cumsum_device = ctx.enqueue_create_buffer[DType.float32](
+        num_slices * chunk_len_ct
+    )
+
+    var C3 = TileTensor(
+        C.ptr,
+        row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct]),
+    )
+    var B3 = TileTensor(
+        B.ptr,
+        row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct]),
+    )
+    var CB3 = TileTensor(
+        CB_device,
+        row_major(num_slices, Idx[chunk_len_ct], Idx[chunk_len_ct]),
+    )
+    var cumsum4 = TileTensor(
+        cumsum_device,
+        row_major(batch, n_chunks, n_heads, chunk_len_ct),
+    )
+    var CB5 = TileTensor(
+        CB_device,
+        row_major(
+            batch,
+            n_chunks,
+            n_heads,
+            Idx[chunk_len_ct],
+            Idx[chunk_len_ct],
+        ),
+    )
+
+    # Stage 1: CB = C @ B^T (batched tensor-core matmul, one launch).
+    #
+    # Uses the library ``batched_matmul``, which self-tunes per architecture
+    # (A100 multistage on GB10/Ampere, SM100 tcgen05 on datacenter Blackwell,
+    # AMD path on MI-series) and is correct for all shapes. A hand-dispatched
+    # smaller tile config was tried on GB10 (the "more blocks" lesson from the
+    # scan) but made no difference: this matmul is **DRAM-bandwidth bound** on
+    # materialising the L×L ``CB`` matrix (~50 MB C+B+CB traffic ≈ 90% of
+    # GB10 peak BW at 203 µs), not occupancy bound, so tile shape doesn't
+    # move it. The datacenter Blackwell (sm100/tcgen05) kernels cannot run on
+    # GB10 (consumer sm_121 has no tcgen05); consumer Blackwell already uses
+    # this multistage TF32 tensor-core path. The only further lever is fusing
+    # the bmm with the scan to avoid the CB round-trip (large change).
+    with ctx.push_context():
+        batched_matmul[target="gpu", transpose_b=True](CB3, C3, B3, context=ctx)
+
+    # Stage 2: inclusive prefix sum of A over the chunk.
+    var cumsum_compiled = ctx.compile_function[
+        _ssd_intra_chunk_cumsum_gpu[
+            kernel_dtype,
+            A_LT,
+            cumsum4.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            cumsum_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            A,
+            cumsum4,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len_ct,),
+        )
+
+    # Stage 3: tiled scalar chunk-scan — Y = causal_decay(CB) @ X. The
+    # scalar path beats a dense tensor-core M @ X here: it exploits the
+    # lower-triangular causal structure (≈half the FLOPs, plus per-M-tile
+    # early-K exit) and avoids padding head_dim to 128, which the A100
+    # batched matmul requires (c_n % 128 == 0). See
+    # ``ssd_intra_chunk_fwd_gpu_static_mma`` for the MMA alternative, which
+    # is ~2× faster single-slice but ~2× slower multi-slice.
+    comptime scan_kernel = _ssd_intra_chunk_chunk_scan_gpu[
+        kernel_dtype,
+        CB5.LayoutType,
+        cumsum4.LayoutType,
+        X_LT,
+        Y_LT,
+    ]
+    var scan_compiled = ctx.compile_function[scan_kernel]()
+
+    comptime grid_x = ceildiv(chunk_len_ct, SCAN_BLOCK_M) * ceildiv(
+        head_dim_ct, SCAN_BLOCK_N
+    )
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            scan_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            Int32(head_dim_ct),
+            CB5,
+            cumsum4,
+            X,
+            Y,
+            grid_dim=(grid_x, batch * n_chunks, n_heads),
+            block_dim=(SCAN_BLOCK_M, 1, 1),
+        )
+
+
+def ssd_intra_chunk_fwd_gpu_static_mma[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Tensor-core variant: materialise ``M = causal_decay(CB)`` then
+    ``Y = M @ X`` as two batched matmuls.
+
+    Trades the scalar chunk-scan for a dense matmul. **Faster than
+    ``ssd_intra_chunk_fwd_gpu_static`` only for a single slice** (no causal
+    work to exploit, scan launch overhead dominates): ~2× on GB10. For the
+    multi-slice Mamba2 prefill profile it is ~2× *slower* because the dense
+    ``M @ X`` ignores the lower-triangular structure (≈2× the FLOPs) and the
+    A100 batched matmul rejects ``head_dim`` (= output N = 64) for not being
+    a multiple of 128, falling back to the naive scalar batched kernel. Kept
+    for the single-slice regime and as a reference for future MMA work.
+    """
+    var num_slices = batch * n_chunks * n_heads
+    comptime l2 = chunk_len_ct * chunk_len_ct
+
+    var CB_device = ctx.enqueue_create_buffer[kernel_dtype](num_slices * l2)
+    var cumsum_device = ctx.enqueue_create_buffer[DType.float32](
+        num_slices * chunk_len_ct
+    )
+
+    var C3 = TileTensor(
+        C.ptr, row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct])
+    )
+    var B3 = TileTensor(
+        B.ptr, row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct])
+    )
+    var CB3 = TileTensor(
+        CB_device, row_major(num_slices, Idx[chunk_len_ct], Idx[chunk_len_ct])
+    )
+    var cumsum4 = TileTensor(
+        cumsum_device, row_major(batch, n_chunks, n_heads, chunk_len_ct)
+    )
+    var X3 = TileTensor(
+        X.ptr, row_major(num_slices, Idx[chunk_len_ct], Idx[head_dim_ct])
+    )
+    var Y3 = TileTensor(
+        Y.ptr, row_major(num_slices, Idx[chunk_len_ct], Idx[head_dim_ct])
+    )
+
+    # Stage 1: CB = C @ B^T (batched A100 tensor-core matmul).
+    with ctx.push_context():
+        batched_matmul[target="gpu", transpose_b=True](CB3, C3, B3, context=ctx)
+
+    # Stage 2: inclusive prefix sum of A over the chunk.
+    var cumsum_compiled = ctx.compile_function[
+        _ssd_intra_chunk_cumsum_gpu[kernel_dtype, A_LT, cumsum4.LayoutType]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            cumsum_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            A,
+            cumsum4,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len_ct,),
+        )
+
+    # Stage 3: apply causal decay in place — M = causal_decay(CB).
+    comptime DECAY_BLOCK = 256
+    var decay_compiled = ctx.compile_function[
+        _ssd_intra_chunk_decay_gpu[
+            kernel_dtype, CB3.LayoutType, cumsum4.LayoutType
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            decay_compiled,
+            Int32(num_slices),
+            Int32(chunk_len_ct),
+            CB3,
+            cumsum4,
+            grid_dim=(ceildiv(l2, DECAY_BLOCK), num_slices),
+            block_dim=(DECAY_BLOCK,),
+        )
+
+    # Stage 4: Y = M @ X (no transpose).
+    with ctx.push_context():
+        batched_matmul[target="gpu", transpose_b=False](
+            Y3, CB3, X3, context=ctx
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Fused single-pass tensor-core intra-chunk (FlashAttention-style, RFC 0009)
+# ===----------------------------------------------------------------------=== #
+
+# Fused-MMA tiling. One block per (slice, l-tile) computes BM rows of Y.
+# Two chained TF32 MMAs (CB = C @ Bᵀ, then Y += decay⊙CB @ X) with the CB
+# intermediate staged through shared memory (the Ampere C-fragment layout
+# differs from the A-fragment layout, so no register-direct handoff). BM == BK
+# so the l-tile and s-tile align (causal mask only on the diagonal tile).
+comptime FUSED_BM = 64
+comptime FUSED_BK = 16
+comptime FUSED_WARPS_M = 4
+# N (state-dim) contraction tile for MMA1. Tiling N keeps the C/B shared tiles
+# small (vs staging the full state_dim), which lifts occupancy from
+# shared-memory-limited 2 blocks/SM to several — the dominant fused-kernel
+# bottleneck on GB10. Must be a multiple of MMA_K (8) and divide state_dim.
+comptime FUSED_TN = 16
+
+
+def _ssd_intra_chunk_fused_mma_gpu[
+    kernel_dtype: DType,
+    L: Int,
+    N: Int,
+    P: Int,
+    BM: Int,
+    BK: Int,
+    num_warps_m: Int,
+    TN: Int,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    cumsum_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    cumsum: TileTensor[DType.float32, cumsum_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+):
+    """Fused intra-chunk forward: ``Y = (decay ⊙ tril(C @ Bᵀ)) @ X``.
+
+    One block per ``(slice, l-tile)``; ``grid = (num_slices, L // BM)``. The
+    ``CB`` scores never touch DRAM (the cost the two-kernel path pays): MMA1
+    accumulates ``cb[BM, BK] = C[l-tile] @ B[s-tile]ᵀ`` in registers, the block
+    applies ``exp(cum_l − cum_s)`` decay + causal mask while staging ``cb`` to
+    shared, then MMA2 accumulates ``acc[BM, P] += cb @ X[s-tile]`` over the
+    causal ``s`` tiles. ``cumsum`` is the precomputed inclusive prefix sum of
+    the per-token decay (one parallel kernel, cheap). Both MMAs are TF32,
+    FP32-accumulate, ``transpose_b=False`` — ``B`` is transposed into shared for
+    MMA1, mirroring the fused chunk-state kernel.
+    """
+    comptime accum_type = DType.float32
+    comptime mma_shape = get_mma_shape[kernel_dtype, accum_type]()
+    comptime MMA_M = mma_shape[0]
+    comptime MMA_N = mma_shape[1]
+    comptime MMA_K = mma_shape[2]
+    comptime WM = BM // num_warps_m
+    comptime num_m_mmas = WM // MMA_M
+    comptime num_n_mmas_cb = BK // MMA_N
+    comptime num_n_mmas_y = P // MMA_N
+    comptime num_k_mmas_cb = TN // MMA_K  # MMA1 K-tile is TN (N is tiled)
+    comptime num_k_mmas_y = BK // MMA_K
+    comptime fs = get_fragment_size[mma_shape]()
+    comptime a_frag_size = fs[0]
+    comptime b_frag_size = fs[1]
+    comptime c_frag_size = fs[2]
+    comptime num_threads = num_warps_m * WARP_SIZE
+
+    var slice_idx = Int(block_idx.x)
+    var pid_m = Int(block_idx.y)
+    var tid = Int(thread_idx.x)
+    var warp_id = tid // WARP_SIZE
+    var warp_y = warp_id
+
+    var c_base = slice_idx * L * N
+    var b_base = slice_idx * L * N
+    var x_base = slice_idx * L * P
+    var y_base = slice_idx * L * P
+    var cum_base = slice_idx * L
+    var l_off = pid_m * BM
+
+    # ── Shared tiles (N-tiled: smemC/smemBt are only TN wide in the contraction
+    # dim, keeping shared small for occupancy). ──────────────────────────────
+    var smemC = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(BM, TN),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var smemBt = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(TN, BK),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var smemCB = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(BM, BK),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var smemX = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(BK, P),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var idx = tid
+
+    # ── Accumulator for Y[l-tile, :P] (persists across the s-tile loop). ──────
+    var acc_reg = (
+        LayoutTensor[
+            accum_type,
+            Layout.row_major(num_m_mmas * num_n_mmas_y, c_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ]
+        .stack_allocation()
+        .fill(0)
+    )
+
+    var mma_op = TensorCore[accum_type, kernel_dtype, mma_shape, False]()
+
+    # ── Causal s-tile loop: s-tile 0 .. pid_m (s <= l). ──────────────────────
+    # An l-tile (BM rows) spans BM // BK s-tiles, so the causal bound covers
+    # s-tiles 0 .. (pid_m+1)*(BM//BK) - 1.
+    for s_tile in range((pid_m + 1) * (BM // BK)):
+        var s_off = s_tile * BK
+
+        # Stage X[s-tile, :P] (independent of the N-tile loop).
+        idx = tid
+        while idx < BK * P:
+            var r = idx // P
+            var p = idx % P
+            var sr = s_off + r
+            smemX[r, p] = X.ptr[x_base + sr * P + p] if sr < L else Scalar[
+                kernel_dtype
+            ](0)
+            idx += num_threads
+
+        # MMA1: cb[BM, BK] = C[l-tile, :N] @ B[s-tile, :N]ᵀ, accumulated over
+        # N in TN-wide tiles (small shared tiles -> higher occupancy).
+        var cb_reg = (
+            LayoutTensor[
+                accum_type,
+                Layout.row_major(num_m_mmas * num_n_mmas_cb, c_frag_size),
+                MutAnyOrigin,
+                address_space=AddressSpace.LOCAL,
+            ]
+            .stack_allocation()
+            .fill(0)
+        )
+        var a_reg = LayoutTensor[
+            kernel_dtype,
+            Layout.row_major(num_m_mmas, a_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ].stack_allocation()
+        var b_reg = LayoutTensor[
+            kernel_dtype,
+            Layout.row_major(num_n_mmas_cb, b_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ].stack_allocation()
+
+        comptime n_tiles = N // TN
+        # Thread layout for the async C load: num_threads over the [BM, TN] tile.
+        comptime c_thread_layout = Layout.row_major(num_threads // TN, TN)
+        var c_gmem = LayoutTensor[
+            kernel_dtype, Layout.row_major(L, N), MutAnyOrigin
+        ](C.ptr + c_base)
+
+        # cp.async: C is the A operand [BM, N-tile] (no transpose), so it stages
+        # as a straight tile. Issue it async and do the B sync transpose-load
+        # while it's in flight (the global C load overlaps the B load).
+        for nkt in range(n_tiles):
+            var nk = nkt * TN
+            smemC.distribute[c_thread_layout](tid).copy_from_async(
+                c_gmem.tile[BM, TN](pid_m, nkt).distribute[c_thread_layout](tid)
+            )
+            # smemBt[TN, BK] = B[s-tile, nk:nk+TN]ᵀ (sync; overlaps the async C).
+            idx = tid
+            while idx < TN * BK:
+                var n = idx // BK
+                var r = idx % BK
+                var sr = s_off + r
+                smemBt[n, r] = B.ptr[
+                    b_base + sr * N + (nk + n)
+                ] if sr < L else Scalar[kernel_dtype](0)
+                idx += num_threads
+            async_copy_wait_all()
+            gpu_barrier()
+
+            var a_warp = smemC.tile[WM, TN](warp_y, 0)
+            var b_warp = smemBt.tile[TN, BK](0, 0)
+
+            comptime for k_mma in range(num_k_mmas_cb):
+                mma_op.load_a(a_warp, a_reg.vectorize[1, a_frag_size](), k_mma)
+                mma_op.load_b(
+                    b_warp, b_reg.vectorize[1, b_frag_size](), k_mma, 0
+                )
+                mma_op.mma(
+                    a_reg.vectorize[1, a_frag_size](),
+                    b_reg.vectorize[1, b_frag_size](),
+                    cb_reg.vectorize[1, c_frag_size](),
+                )
+            gpu_barrier()
+
+        # Store cb to shared (C-fragment layout -> row-major [BM, BK]).
+        var cb_warp = smemCB.tile[WM, BK](warp_y, 0)
+        copy_local_to_shared[thread_layout=Layout.row_major(8, 4)](
+            cb_warp.vectorize[1, 2](),
+            cb_reg.vectorize[1, 2]().transpose(),
+        )
+        gpu_barrier()
+
+        # Apply decay + causal mask on the shared cb tile cooperatively.
+        idx = tid
+        # Mask only matters where the s-tile's rows can exceed the l-tile's
+        # (the diagonal/overlapping tiles); tiles fully below are kept whole.
+        var needs_mask = (s_off + BK) > l_off
+        var cum_l_base = cum_base + l_off
+        var cum_s_base = cum_base + s_off
+        while idx < BM * BK:
+            var i = idx // BK
+            var j = idx % BK
+            # decay[i,j] = exp(cum_l[i] − cum_s[j]) (direct form, always ≤ 1, no
+            # overflow), with the causal mask (gs > gl) applied where needed.
+            if needs_mask and (s_off + j) > (l_off + i):
+                smemCB[i, j] = Scalar[kernel_dtype](0)
+            else:
+                var d = exp(
+                    cumsum.ptr[cum_l_base + i] - cumsum.ptr[cum_s_base + j]
+                )
+                smemCB[i, j] = (smemCB[i, j].cast[accum_type]() * d).cast[
+                    kernel_dtype
+                ]()
+            idx += num_threads
+        gpu_barrier()
+
+        # MMA2: acc[BM, P] += smemCB[BM, BK] @ smemX[BK, P].
+        var a2_reg = LayoutTensor[
+            kernel_dtype,
+            Layout.row_major(num_m_mmas, a_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ].stack_allocation()
+        var b2_reg = LayoutTensor[
+            kernel_dtype,
+            Layout.row_major(num_n_mmas_y, b_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ].stack_allocation()
+        var a2_warp = smemCB.tile[WM, BK](warp_y, 0)
+        var b2_warp = smemX.tile[BK, P](0, 0)
+
+        comptime for k_mma in range(num_k_mmas_y):
+            mma_op.load_a(a2_warp, a2_reg.vectorize[1, a_frag_size](), k_mma)
+            mma_op.load_b(b2_warp, b2_reg.vectorize[1, b_frag_size](), k_mma, 0)
+            mma_op.mma(
+                a2_reg.vectorize[1, a_frag_size](),
+                b2_reg.vectorize[1, b_frag_size](),
+                acc_reg.vectorize[1, c_frag_size](),
+            )
+        gpu_barrier()
+
+    # ── Store acc -> Y[l-tile, :P]. ──────────────────────────────────────────
+    var y_slice = LayoutTensor[
+        kernel_dtype, Layout.row_major(L, P), MutAnyOrigin
+    ](Y.ptr + y_base)
+    var y_warp = y_slice.tile[WM, P](pid_m * num_warps_m + warp_y, 0)
+    copy_local_to_dram[dst_thread_layout=Layout.row_major(8, 4)](
+        y_warp.vectorize[1, 2](),
+        acc_reg.vectorize[1, 2]().transpose(),
+    )
+
+
+def ssd_intra_chunk_fwd_gpu_fused[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Fused single-pass tensor-core intra-chunk forward (RFC 0009).
+
+    ``cumsum`` (one parallel kernel) then ``_ssd_intra_chunk_fused_mma_gpu``,
+    which keeps the ``CB`` scores on-chip (no DRAM round-trip, unlike the
+    two-kernel ``ssd_intra_chunk_fwd_gpu_static``). Requires ``chunk_len`` a
+    multiple of ``FUSED_BM`` / ``FUSED_BK``, ``head_dim`` and ``state_dim``
+    multiples of the MMA tile; the two-kernel path is the fallback otherwise.
+    """
+    var num_slices = batch * n_chunks * n_heads
+
+    var cumsum_device = ctx.enqueue_create_buffer[DType.float32](
+        num_slices * chunk_len_ct
+    )
+    var cumsum4 = TileTensor(
+        cumsum_device, row_major(batch, n_chunks, n_heads, chunk_len_ct)
+    )
+    var cumsum_compiled = ctx.compile_function[
+        _ssd_intra_chunk_cumsum_gpu[kernel_dtype, A_LT, cumsum4.LayoutType]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            cumsum_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            A,
+            cumsum4,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len_ct,),
+        )
+
+    var cumsum_flat = TileTensor(
+        cumsum_device, row_major(num_slices, Idx[chunk_len_ct])
+    )
+    comptime num_l_tiles = chunk_len_ct // FUSED_BM
+    comptime num_threads = FUSED_WARPS_M * 32
+    var fused_compiled = ctx.compile_function[
+        _ssd_intra_chunk_fused_mma_gpu[
+            kernel_dtype,
+            chunk_len_ct,
+            state_dim_ct,
+            head_dim_ct,
+            FUSED_BM,
+            FUSED_BK,
+            FUSED_WARPS_M,
+            FUSED_TN,
+            C_LT,
+            B_LT,
+            X_LT,
+            cumsum_flat.LayoutType,
+            Y_LT,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            fused_compiled,
+            C,
+            B,
+            X,
+            cumsum_flat,
+            Y,
+            grid_dim=(num_slices, num_l_tiles),
+            block_dim=(num_threads,),
+        )

--- a/max/kernels/src/state_space/ssd_chunk_state.mojo
+++ b/max/kernels/src/state_space/ssd_chunk_state.mojo
@@ -1,0 +1,862 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Structured state space duality (SSD) chunk-state kernel.
+
+This implements stage 2 of the SSD chunk-scan algorithm used by Mamba2: the
+"chunk end-state". For each ``(batch, chunk, head)`` it reduces the chunk down
+to a single ``[head_dim, state_dim]`` end-state by summing the decay-weighted
+outer products of the per-token key-like and value-like projections.
+
+For a chunk of ``L`` tokens with state dim ``N`` and head dim ``P``:
+
+- Inputs: ``B: [L, N]``, ``X: [L, P]``, ``A: [L]`` (a scalar decay per token).
+- Cumulative decay: ``A_cumsum[l] = sum_{k=0..l} A[k]``.
+- Per-token decay toward the chunk end:
+  ``decay[l] = exp(A_cumsum[L-1] - A_cumsum[l])``. Note ``decay[L-1] = 1``.
+- End-state: ``state[p, n] = sum_{l=0..L-1} B[l, n] * decay[l] * X[l, p]``.
+
+This matches the reference einsum
+``state = einsum("ln,l,lp->pn", B, decay, X)`` (stage 2 of
+``ssd_minimal_discrete``), producing one end-state per ``(batch, chunk, head)``.
+"""
+
+from layout import (
+    Idx,
+    Layout,
+    LayoutTensor,
+    TensorLayout,
+    TileTensor,
+    row_major,
+)
+from std.math import exp
+from max.gpu.sync import barrier as gpu_barrier
+from std.gpu import (
+    WARP_SIZE,
+    block_dim,
+    block_idx,
+    grid_dim,
+    thread_idx,
+)
+from max.gpu.host import DeviceContext
+from std.memory import AddressSpace
+from std.memory import unsafe_stack_allocation as mem_stack_allocation
+from std.utils.index import IndexList
+from linalg.bmm import batched_matmul
+from layout.layout_tensor import copy_local_to_dram
+from layout.tensor_core import TensorCore, get_fragment_size, get_mma_shape
+
+# Stride helpers for indexing the flat row-major buffers.
+comptime Strides4D = IndexList[4]
+comptime Strides5D = IndexList[5]
+
+# Upper bound on chunk_len for the shared-memory decay scratch (one Float32
+# per token). The host launches one block per slice with block_dim == chunk_len
+# (see ``ssd_chunk_state_fwd_gpu``), so this also bounds the launch block size.
+# Mirrors ``SCAN_MAX_CHUNK`` in ``ssd_chunk.mojo``.
+comptime STATE_MAX_CHUNK = 1024
+
+
+def _row_major_strides_4d(d0: Int, d1: Int, d2: Int, d3: Int) -> Strides4D:
+    """Row-major strides for a 4D shape ``(d0, d1, d2, d3)``."""
+    return Strides4D(d1 * d2 * d3, d2 * d3, d3, 1)
+
+
+def _row_major_strides_5d(
+    d0: Int, d1: Int, d2: Int, d3: Int, d4: Int
+) -> Strides5D:
+    """Row-major strides for a 5D shape ``(d0, d1, d2, d3, d4)``."""
+    return Strides5D(d1 * d2 * d3 * d4, d2 * d3 * d4, d3 * d4, d4, 1)
+
+
+def ssd_chunk_state_fwd_cpu[
+    kernel_dtype: DType,
+    B_layout: Layout,
+    X_layout: Layout,
+    A_layout: Layout,
+    state_layout: Layout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    B: LayoutTensor[kernel_dtype, B_layout, MutAnyOrigin],
+    X: LayoutTensor[kernel_dtype, X_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, A_layout, MutAnyOrigin],
+    state: LayoutTensor[kernel_dtype, state_layout, MutAnyOrigin],
+):
+    """Compute the SSD chunk end-state on CPU.
+
+    Operates per ``(batch, chunk, head)`` over the supplied row-major tensors,
+    reducing each chunk down to a single ``[head_dim, state_dim]`` end-state.
+
+    Tensor shapes (row-major):
+        - ``B``: ``[batch, n_chunks, n_heads, chunk_len, state_dim]``
+        - ``X``: ``[batch, n_chunks, n_heads, chunk_len, head_dim]``
+        - ``A``: ``[batch, n_chunks, n_heads, chunk_len]``
+        - ``state``: ``[batch, n_chunks, n_heads, head_dim, state_dim]`` (output)
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        B_layout: Layout of the ``B`` tensor.
+        X_layout: Layout of the ``X`` tensor.
+        A_layout: Layout of the ``A`` tensor.
+        state_layout: Layout of the ``state`` output tensor.
+
+    Args:
+        batch: Number of batch elements.
+        n_chunks: Number of chunks per sequence.
+        n_heads: Number of heads.
+        chunk_len: Tokens per chunk (``L``).
+        state_dim: State dimension (``N``).
+        head_dim: Head dimension (``P``).
+        B: Key-like projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        X: Value-like input, shape ``[batch, n_chunks, n_heads, L, P]``.
+        A: Per-token scalar decay, shape ``[batch, n_chunks, n_heads, L]``.
+        state: Output end-state, shape ``[batch, n_chunks, n_heads, P, N]``.
+    """
+    # Row-major strides for the flat backing buffers.
+    var b_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, state_dim
+    )
+    var x_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, head_dim
+    )
+    var a_strides = _row_major_strides_4d(batch, n_chunks, n_heads, chunk_len)
+    var state_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, head_dim, state_dim
+    )
+
+    for bi in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                # Base offsets for this (batch, chunk, head) slice.
+                var b_base = (
+                    bi * b_strides[0] + c * b_strides[1] + h * b_strides[2]
+                )
+                var x_base = (
+                    bi * x_strides[0] + c * x_strides[1] + h * x_strides[2]
+                )
+                var a_base = (
+                    bi * a_strides[0] + c * a_strides[1] + h * a_strides[2]
+                )
+                var state_base = (
+                    bi * state_strides[0]
+                    + c * state_strides[1]
+                    + h * state_strides[2]
+                )
+
+                # Inclusive prefix sum of the per-token decay: A_cumsum[l].
+                var a_cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var running = Float32(0.0)
+                for l in range(chunk_len):
+                    var a_off = a_base + l * a_strides[3]
+                    running += A.ptr[a_off].cast[DType.float32]()
+                    a_cumsum[l] = running
+
+                # decay[l] = exp(A_cumsum[L-1] - A_cumsum[l]); decay[L-1] = 1.
+                var cum_end = a_cumsum[chunk_len - 1]
+                var decay = List[Float32](length=chunk_len, fill=0.0)
+                for l in range(chunk_len):
+                    decay[l] = exp(cum_end - a_cumsum[l])
+
+                # state[p, n] = sum_l B[l, n] * decay[l] * X[l, p]
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var acc = Float32(0.0)
+                        for l in range(chunk_len):
+                            var bv = B.ptr[
+                                b_base + l * b_strides[3] + n * b_strides[4]
+                            ].cast[DType.float32]()
+                            var xv = X.ptr[
+                                x_base + l * x_strides[3] + p * x_strides[4]
+                            ].cast[DType.float32]()
+                            acc += bv * decay[l] * xv
+                        var state_off = (
+                            state_base
+                            + p * state_strides[3]
+                            + n * state_strides[4]
+                        )
+                        state.ptr[state_off] = acc.cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU Implementation
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_chunk_state_fwd_gpu[
+    kernel_dtype: DType,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    state_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    state_dim_i32: Int32,
+    head_dim_i32: Int32,
+    B: TileTensor[kernel_dtype, B_LT, MutUntrackedOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutUntrackedOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutUntrackedOrigin],
+    state: TileTensor[kernel_dtype, state_LT, MutUntrackedOrigin],
+):
+    """Compute the SSD chunk end-state on GPU.
+
+    Launched over a 2D grid ``(total_slices, n_p_tiles)`` with
+    ``block_dim == chunk_len``. ``block_idx.x`` selects the ``(batch, chunk,
+    head)`` slice; ``block_idx.y`` selects a tile of ``head_dim`` rows (the tile
+    height is ``ceildiv(head_dim, grid_dim.y)``, so the kernel adapts to
+    whatever ``grid_dim.y`` the host picks — ``grid_dim.y == 1`` means one block
+    computes the whole slice). Splitting each slice across several blocks raises
+    the block count and warps-in-flight on GB10's many small SMs.
+
+    Each block first computes the per-token decay
+    ``decay[l] = exp(A_cumsum[L-1] - A_cumsum[l])`` once, cooperatively, into
+    shared memory (a Hillis-Steele inclusive prefix sum over ``A`` followed by
+    the exp; recomputed per p-tile, which is cheap), then the block's threads
+    split its tile of the ``head_dim * state_dim`` output elements and each
+    accumulates its end-state entry over ``l``.
+
+    This replaces the original one-thread-per-slice port, which launched a
+    single block (occupancy/latency bound: ~0.1% compute, ~4% memory of GB10
+    peak) and recomputed ``decay[l]`` for every one of the ``head_dim *
+    state_dim`` outputs. The decay is now computed once per slice and shared.
+    It is still not tensor-core optimized; the reduction reads ``B``/``X`` from
+    global memory (the kernel is far from bandwidth bound).
+
+    The same math as the CPU kernel:
+        - ``A_cumsum[l] = sum_{k<=l} A[k]``
+        - ``decay[l] = exp(A_cumsum[L-1] - A_cumsum[l])``
+        - ``state[p, n] = sum_l B[l, n] * decay[l] * X[l, p]``
+
+    Tensor shapes (row-major):
+        - ``B``: ``[batch, n_chunks, n_heads, chunk_len, state_dim]``
+        - ``X``: ``[batch, n_chunks, n_heads, chunk_len, head_dim]``
+        - ``A``: ``[batch, n_chunks, n_heads, chunk_len]``
+        - ``state``: ``[batch, n_chunks, n_heads, head_dim, state_dim]`` (output)
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        B_LT: Layout of the ``B`` tensor.
+        X_LT: Layout of the ``X`` tensor.
+        A_LT: Layout of the ``A`` tensor.
+        state_LT: Layout of the ``state`` output tensor.
+
+    Args:
+        batch_i32: Number of batch elements.
+        n_chunks_i32: Number of chunks per sequence.
+        n_heads_i32: Number of heads.
+        chunk_len_i32: Tokens per chunk (``L``).
+        state_dim_i32: State dimension (``N``).
+        head_dim_i32: Head dimension (``P``).
+        B: Key-like projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        X: Value-like input, shape ``[batch, n_chunks, n_heads, L, P]``.
+        A: Per-token scalar decay, shape ``[batch, n_chunks, n_heads, L]``.
+        state: Output end-state, shape ``[batch, n_chunks, n_heads, P, N]``.
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var state_dim = Int(state_dim_i32)
+    var head_dim = Int(head_dim_i32)
+    var slice_idx = Int(block_idx.x)
+    var total_slices = batch * n_chunks * n_heads
+    if slice_idx >= total_slices:
+        return
+
+    var tid = Int(thread_idx.x)
+    var nthreads = Int(block_dim.x)
+
+    # Decompose the flat slice index into (batch, chunk, head).
+    var h = slice_idx % n_heads
+    var c = (slice_idx // n_heads) % n_chunks
+    var bi = slice_idx // (n_heads * n_chunks)
+
+    # Row-major strides for the flat backing buffers.
+    var b_n_stride = 1
+    var b_l_stride = state_dim
+    var b_h_stride = chunk_len * b_l_stride
+    var b_c_stride = n_heads * b_h_stride
+    var b_b_stride = n_chunks * b_c_stride
+
+    var x_p_stride = 1
+    var x_l_stride = head_dim
+    var x_h_stride = chunk_len * x_l_stride
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_l_stride = 1
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var state_n_stride = 1
+    var state_p_stride = state_dim
+    var state_h_stride = head_dim * state_p_stride
+    var state_c_stride = n_heads * state_h_stride
+    var state_b_stride = n_chunks * state_c_stride
+
+    var b_base = bi * b_b_stride + c * b_c_stride + h * b_h_stride
+    var x_base = bi * x_b_stride + c * x_c_stride + h * x_h_stride
+    var a_base = bi * a_b_stride + c * a_c_stride + h * a_h_stride
+    var state_base = (
+        bi * state_b_stride + c * state_c_stride + h * state_h_stride
+    )
+
+    # ── Per-token decay into shared memory (computed once per slice) ──────────
+    # decay[l] = exp(A_cumsum[L-1] - A_cumsum[l]); A_cumsum is the inclusive
+    # prefix sum of A. Hillis-Steele scan in shared memory: block_dim ==
+    # chunk_len threads, one element each, log2(chunk_len) doubling steps.
+    var decay = mem_stack_allocation[
+        STATE_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+
+    if tid < chunk_len:
+        decay[tid] = A.ptr[a_base + tid * a_l_stride].cast[DType.float32]()
+    gpu_barrier()
+
+    var offset = 1
+    while offset < chunk_len:
+        var add: Float32 = 0.0
+        if tid < chunk_len and tid >= offset:
+            add = decay[tid - offset]
+        gpu_barrier()
+        if tid < chunk_len and tid >= offset:
+            decay[tid] += add
+        gpu_barrier()
+        offset *= 2
+
+    # decay[] now holds A_cumsum[l]. Convert to the decay weight in place.
+    # Every thread reads cum_end before any thread overwrites its slot.
+    var cum_end = decay[chunk_len - 1]
+    gpu_barrier()
+    if tid < chunk_len:
+        decay[tid] = exp(cum_end - decay[tid])
+    gpu_barrier()
+
+    # ── End-state reduction: state[p, n] = sum_l B[l, n] * decay[l] * X[l, p] ─
+    # This block owns p-rows [p_start, p_end); its threads split that tile's
+    # (p_end - p_start) * state_dim output elements.
+    var n_p_tiles = Int(grid_dim.y)
+    var p_per_tile = (head_dim + n_p_tiles - 1) // n_p_tiles
+    var p_start = Int(block_idx.y) * p_per_tile
+    var p_end = min(p_start + p_per_tile, head_dim)
+    if p_start >= head_dim:
+        return
+
+    var n_out = (p_end - p_start) * state_dim
+    var idx = tid
+    while idx < n_out:
+        var p = p_start + idx // state_dim
+        var n = idx % state_dim
+        var acc = Float32(0.0)
+        for l in range(chunk_len):
+            var bv = B.ptr[b_base + l * b_l_stride + n * b_n_stride].cast[
+                DType.float32
+            ]()
+            var xv = X.ptr[x_base + l * x_l_stride + p * x_p_stride].cast[
+                DType.float32
+            ]()
+            acc += bv * decay[l] * xv
+        var state_off = state_base + p * state_p_stride + n * state_n_stride
+        state.ptr[state_off] = acc.cast[kernel_dtype]()
+        idx += nthreads
+
+
+# ===----------------------------------------------------------------------=== #
+# Tensor-core path: decay-weighted transpose + batched matmul
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_chunk_state_decay_xt_gpu[
+    kernel_dtype: DType,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    xdt_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    head_dim_i32: Int32,
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Xd_T: TileTensor[kernel_dtype, xdt_LT, MutAnyOrigin],
+):
+    """Materialise the decay-weighted, transposed value tensor.
+
+    One block per ``(batch, chunk, head)`` slice (``block_dim == chunk_len``).
+    Computes the per-token decay ``decay[l] = exp(A_cumsum[L-1] - A_cumsum[l])``
+    once into shared memory (same scan as ``ssd_chunk_state_fwd_gpu``), then
+    writes the **transposed** product
+
+        ``Xd_T[slice, p, l] = decay[l] * X[slice, l, p]``
+
+    into a contiguous ``[num_slices, head_dim, chunk_len]`` buffer. Transposing
+    here puts the reduction dim ``l`` last in the left matmul operand, so
+    ``state = Xd_T @ B`` (``[P,L] @ [L,N] -> [P,N]``) is a plain
+    ``batched_matmul`` with no transpose — and its output ``N`` columns hit the
+    A100 tensor-core gate. Thread ``tid`` owns token ``l = tid`` and loops over
+    ``p`` so consecutive threads write consecutive ``l`` (coalesced).
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var head_dim = Int(head_dim_i32)
+    var slice_idx = Int(block_idx.x)
+    var total_slices = batch * n_chunks * n_heads
+    if slice_idx >= total_slices:
+        return
+
+    var tid = Int(thread_idx.x)
+
+    var h = slice_idx % n_heads
+    var c = (slice_idx // n_heads) % n_chunks
+    var bi = slice_idx // (n_heads * n_chunks)
+
+    var x_l_stride = head_dim
+    var x_h_stride = chunk_len * x_l_stride
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var x_base = bi * x_b_stride + c * x_c_stride + h * x_h_stride
+    var a_base = bi * a_b_stride + c * a_c_stride + h * a_h_stride
+
+    # Per-token decay into shared memory (Hillis-Steele inclusive prefix sum of
+    # A, then exp) — identical to ssd_chunk_state_fwd_gpu.
+    var decay = mem_stack_allocation[
+        STATE_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+
+    if tid < chunk_len:
+        decay[tid] = A.ptr[a_base + tid].cast[DType.float32]()
+    gpu_barrier()
+
+    var offset = 1
+    while offset < chunk_len:
+        var add: Float32 = 0.0
+        if tid < chunk_len and tid >= offset:
+            add = decay[tid - offset]
+        gpu_barrier()
+        if tid < chunk_len and tid >= offset:
+            decay[tid] += add
+        gpu_barrier()
+        offset *= 2
+
+    var cum_end = decay[chunk_len - 1]
+    gpu_barrier()
+    if tid < chunk_len:
+        decay[tid] = exp(cum_end - decay[tid])
+    gpu_barrier()
+
+    # Xd_T[slice, p, l] = decay[l] * X[slice, l, p]. Output is row-major
+    # [num_slices, head_dim, chunk_len]; this slice starts at slice*P*L.
+    if tid < chunk_len:
+        var d = decay[tid]
+        var xdt_base = slice_idx * head_dim * chunk_len
+        for p in range(head_dim):
+            var xv = X.ptr[x_base + tid * x_l_stride + p].cast[DType.float32]()
+            Xd_T.ptr[xdt_base + p * chunk_len + tid] = (d * xv).cast[
+                kernel_dtype
+            ]()
+
+
+def ssd_chunk_state_fwd_gpu_static[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    state_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    state: TileTensor[kernel_dtype, state_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Static-shape, tensor-core variant of ``ssd_chunk_state_fwd_gpu``.
+
+    Computes the chunk end-state as a batched matmul on tensor cores:
+
+        ``Xd_T[p, l] = decay[l] * X[l, p]``   (decay kernel, one launch)
+        ``state[p, n] = sum_l Xd_T[p, l] * B[l, n] = (Xd_T @ B)[p, n]``
+
+    Knowing ``chunk_len`` / ``state_dim`` / ``head_dim`` at compile time lets
+    ``batched_matmul`` see ``has_static_NK`` and, since the output has
+    ``state_dim`` (== matmul ``N``) columns and ``chunk_len`` (== ``K``) is a
+    multiple of 32 and ``>= 128``, pick its A100 multistage tensor-core batched
+    path (one launch for all ``batch * n_chunks * n_heads`` slices) instead of
+    the scalar reduction in ``ssd_chunk_state_fwd_gpu``.
+
+    The scalar kernel remains the all-shape-correct fallback for shapes that
+    miss the gate (e.g. ``state_dim`` not a multiple of 128).
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        chunk_len_ct: Tokens per chunk (``L``), compile-time.
+        state_dim_ct: State dimension (``N``), compile-time.
+        head_dim_ct: Head dimension (``P``), compile-time.
+        B_LT: Layout of the ``B`` tensor.
+        X_LT: Layout of the ``X`` tensor.
+        A_LT: Layout of the ``A`` tensor.
+        state_LT: Layout of the ``state`` output tensor.
+
+    Args:
+        batch: Number of batch elements.
+        n_chunks: Number of chunks per sequence.
+        n_heads: Number of heads.
+        B: Key-like projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        X: Value-like input, shape ``[batch, n_chunks, n_heads, L, P]``.
+        A: Per-token scalar decay, shape ``[batch, n_chunks, n_heads, L]``.
+        state: Output end-state, shape ``[batch, n_chunks, n_heads, P, N]``.
+        ctx: The device context to enqueue work on.
+    """
+    var num_slices = batch * n_chunks * n_heads
+
+    # Scratch for the decay-weighted, transposed values: [num_slices, P, L].
+    var xdt_device = ctx.enqueue_create_buffer[kernel_dtype](
+        num_slices * head_dim_ct * chunk_len_ct
+    )
+    var Xd_T = TileTensor(
+        xdt_device,
+        row_major(batch, n_chunks, n_heads, head_dim_ct, chunk_len_ct),
+    )
+
+    # Stage 1: Xd_T[p, l] = decay[l] * X[l, p] (one block per slice).
+    var decay_compiled = ctx.compile_function[
+        _ssd_chunk_state_decay_xt_gpu[
+            kernel_dtype,
+            X_LT,
+            A_LT,
+            Xd_T.LayoutType,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            decay_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            Int32(head_dim_ct),
+            X,
+            A,
+            Xd_T,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len_ct,),
+        )
+
+    # Stage 2: state = Xd_T @ B (batched tensor-core matmul, one launch).
+    # state[P, N] = Xd_T[P, L] @ B[L, N]; static dims let batched_matmul take
+    # the A100 multistage path (c_n=N % 128 == 0, a_k=L % 32 == 0, L >= 128).
+    var Xd_T3 = TileTensor(
+        xdt_device,
+        row_major(num_slices, Idx[head_dim_ct], Idx[chunk_len_ct]),
+    )
+    var B3 = TileTensor(
+        B.ptr,
+        row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct]),
+    )
+    var state3 = TileTensor(
+        state.ptr,
+        row_major(num_slices, Idx[head_dim_ct], Idx[state_dim_ct]),
+    )
+
+    with ctx.push_context():
+        batched_matmul[target="gpu", transpose_b=False](
+            state3, Xd_T3, B3, context=ctx
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Fused single-pass tensor-core path
+# ===----------------------------------------------------------------------=== #
+
+# Warp grid over the per-slice [head_dim, state_dim] output tile. 2x4 warps =
+# 8 warps = 256 threads, which also covers chunk_len=256 for the decay scan.
+comptime STATE_FUSED_WARPS_M = 2
+comptime STATE_FUSED_WARPS_N = 4
+# K (chunk-length) step for the fused MMA. Tuned on GB10 at the Mamba2 profile:
+# BK=16 is the sweet spot (nc=4: 0.033 ms) — smaller shared tiles overlap the
+# global load with the MMA better at this L2-resident size. 8/32/64 all gave
+# 0.043/0.043/0.050 ms. Must be a multiple of MMA_K (8) and divide chunk_len.
+comptime STATE_FUSED_BK = 16
+# Split each slice's state_dim output across this many blocks (grid.y). Tried as
+# a "more blocks" occupancy lever, but it REGRESSED (n_split=2: 0.043 -> 0.069 ms
+# at the Mamba2 profile) because each N tile re-reads all of X — the extra
+# traffic outweighs the occupancy gain. Kept as infra; default 1 (no split).
+comptime STATE_FUSED_N_SPLIT = 1
+
+
+def _ssd_chunk_state_fused_mma_gpu[
+    kernel_dtype: DType,
+    P: Int,
+    N: Int,
+    L: Int,
+    BK: Int,
+    num_warps_m: Int,
+    num_warps_n: Int,
+    n_split: Int,
+    X_LT: TensorLayout,
+    B_LT: TensorLayout,
+    A_LT: TensorLayout,
+    state_LT: TensorLayout,
+](
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    state: TileTensor[kernel_dtype, state_LT, MutAnyOrigin],
+):
+    """Fused, single-pass tensor-core chunk end-state (one block per slice).
+
+    Computes ``state[p,n] = sum_l decay[l] * X[l,p] * B[l,n]`` for one
+    ``(batch, chunk, head)`` slice as a transpose-A tensor-core GEMM, **without**
+    materialising the decay-weighted transpose in DRAM (the cost the 2-pass
+    ``ssd_chunk_state_fwd_gpu_static`` pays). Per K-tile the block streams
+    ``X``/``B`` from global once, applies ``decay[l]`` while transposing ``X``
+    into a shared tile (``As[p, l]``), and accumulates the warp-tiled MMA. This
+    mirrors what Triton's ``_chunk_state_fwd`` does in a single kernel.
+
+    Compile-time tiling: block tile is the whole ``[P, N]`` output; warps tile
+    it ``num_warps_m x num_warps_n``; ``BK`` is the K (chunk-length) step. Slices
+    are contiguous in every buffer, so ``slice_idx`` alone indexes them.
+    """
+    comptime accum_type = DType.float32
+    comptime mma_shape = get_mma_shape[kernel_dtype, accum_type]()
+    comptime MMA_M = mma_shape[0]
+    comptime MMA_N = mma_shape[1]
+    comptime MMA_K = mma_shape[2]
+    # This block computes a [P, Nblk] tile; block_idx.y picks the N tile.
+    comptime Nblk = N // n_split
+    comptime WM = P // num_warps_m
+    comptime WN = Nblk // num_warps_n
+    comptime num_m_mmas = WM // MMA_M
+    comptime num_n_mmas = WN // MMA_N
+    comptime num_k_mmas = BK // MMA_K
+    comptime fs = get_fragment_size[mma_shape]()
+    comptime a_frag_size = fs[0]
+    comptime b_frag_size = fs[1]
+    comptime c_frag_size = fs[2]
+    comptime num_threads = num_warps_m * num_warps_n * WARP_SIZE
+
+    var slice_idx = Int(block_idx.x)
+    var n_tile = Int(block_idx.y)
+    var n_offset = n_tile * Nblk
+    var tid = Int(thread_idx.x)
+    var warp_id = tid // WARP_SIZE
+    var warp_y = warp_id // num_warps_n
+    var warp_x = warp_id % num_warps_n
+
+    var x_base = slice_idx * L * P
+    var b_base = slice_idx * L * N
+    var a_base = slice_idx * L
+    var state_base = slice_idx * P * N
+
+    # ── Per-token decay into shared memory (Hillis-Steele, then exp) ──────────
+    var decay = mem_stack_allocation[
+        STATE_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+    if tid < L:
+        decay[tid] = A.ptr[a_base + tid].cast[DType.float32]()
+    gpu_barrier()
+    var offset = 1
+    while offset < L:
+        var add: Float32 = 0.0
+        if tid < L and tid >= offset:
+            add = decay[tid - offset]
+        gpu_barrier()
+        if tid < L and tid >= offset:
+            decay[tid] += add
+        gpu_barrier()
+        offset *= 2
+    var cum_end = decay[L - 1]
+    gpu_barrier()
+    if tid < L:
+        decay[tid] = exp(cum_end - decay[tid])
+    gpu_barrier()
+
+    # ── Shared tiles: As is decay-scaled X transposed to [P, BK]; Bs is [BK, N].
+    var As = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(P, BK),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var Bs = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(BK, Nblk),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+
+    # ── Register tiles ───────────────────────────────────────────────────────
+    var c_reg = (
+        LayoutTensor[
+            accum_type,
+            Layout.row_major(num_m_mmas * num_n_mmas, c_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ]
+        .stack_allocation()
+        .fill(0)
+    )
+    var a_reg = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(num_m_mmas, a_frag_size),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ].stack_allocation()
+    var b_reg = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(num_n_mmas, b_frag_size),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ].stack_allocation()
+
+    var mma_op = TensorCore[accum_type, kernel_dtype, mma_shape, False]()
+
+    # ── K-loop over chunk length ─────────────────────────────────────────────
+    var k0 = 0
+    while k0 < L:
+        # Stage As[p, kl] = decay[k0+kl] * X[k0+kl, p] (coalesced read over p).
+        var idx = tid
+        while idx < P * BK:
+            var kl = idx // P
+            var p = idx % P
+            As[p, kl] = (
+                decay[k0 + kl]
+                * X.ptr[x_base + (k0 + kl) * P + p].cast[DType.float32]()
+            ).cast[kernel_dtype]()
+            idx += num_threads
+        # Stage Bs[kl, n] = B[k0+kl, n_offset+n] (this block's N tile).
+        idx = tid
+        while idx < BK * Nblk:
+            var kl = idx // Nblk
+            var nn = idx % Nblk
+            Bs[kl, nn] = B.ptr[b_base + (k0 + kl) * N + n_offset + nn]
+            idx += num_threads
+        gpu_barrier()
+
+        var a_warp_tile = As.tile[WM, BK](warp_y, 0)
+        var b_warp_tile = Bs.tile[BK, WN](0, warp_x)
+
+        # NOTE: As/Bs are written to shared memory unswizzled, so load_a/load_b
+        # must read unswizzled too (no swizzle arg). Adding a swizzle would
+        # require applying the same permutation on the shared-memory store.
+        comptime for k_mma in range(num_k_mmas):
+            mma_op.load_a(a_warp_tile, a_reg.vectorize[1, a_frag_size](), k_mma)
+            mma_op.load_b(
+                b_warp_tile, b_reg.vectorize[1, b_frag_size](), k_mma, warp_x
+            )
+            mma_op.mma(
+                a_reg.vectorize[1, a_frag_size](),
+                b_reg.vectorize[1, b_frag_size](),
+                c_reg.vectorize[1, c_frag_size](),
+            )
+        gpu_barrier()
+        k0 += BK
+
+    # ── Store the warp's [WM, WN] output tile to global state ────────────────
+    # The warp's global N-tile index folds in this block's N offset.
+    var c_slice = LayoutTensor[
+        kernel_dtype, Layout.row_major(P, N), MutAnyOrigin
+    ](state.ptr + state_base)
+    var c_warp_tile = c_slice.tile[WM, WN](
+        warp_y, n_tile * num_warps_n + warp_x
+    )
+    copy_local_to_dram[dst_thread_layout=Layout.row_major(8, 4)](
+        c_warp_tile.vectorize[1, 2](),
+        c_reg.vectorize[1, 2]().transpose(),
+    )
+
+
+def ssd_chunk_state_fwd_gpu_fused[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    state_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    state: TileTensor[kernel_dtype, state_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Fused single-pass tensor-core chunk end-state (Triton-parity target).
+
+    One block per ``(batch, chunk, head)`` slice runs
+    ``_ssd_chunk_state_fused_mma_gpu``, which streams ``X``/``B`` once, applies
+    decay while transposing ``X`` in shared memory, and accumulates the
+    end-state on tensor cores — no DRAM round-trip for the decayed/transposed
+    values (unlike ``ssd_chunk_state_fwd_gpu_static``).
+
+    Requires ``head_dim % (16 * num_warps_m) == 0``,
+    ``state_dim % (8 * num_warps_n) == 0``, ``chunk_len % BK == 0``, and the
+    launch block (``num_warps_m * num_warps_n * 32`` threads) ``>= chunk_len``
+    for the shared-memory decay scan. The static batched-matmul path
+    (``ssd_chunk_state_fwd_gpu_static``) is the fallback for other shapes.
+    """
+    comptime num_threads = (
+        STATE_FUSED_WARPS_M * STATE_FUSED_WARPS_N * WARP_SIZE
+    )
+    var num_slices = batch * n_chunks * n_heads
+
+    var compiled = ctx.compile_function[
+        _ssd_chunk_state_fused_mma_gpu[
+            kernel_dtype,
+            head_dim_ct,
+            state_dim_ct,
+            chunk_len_ct,
+            STATE_FUSED_BK,
+            STATE_FUSED_WARPS_M,
+            STATE_FUSED_WARPS_N,
+            STATE_FUSED_N_SPLIT,
+            X_LT,
+            B_LT,
+            A_LT,
+            state_LT,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled,
+            X,
+            B,
+            A,
+            state,
+            grid_dim=(num_slices, STATE_FUSED_N_SPLIT),
+            block_dim=(num_threads,),
+        )

--- a/max/kernels/test/gpu/state_space/BUILD.bazel
+++ b/max/kernels/test/gpu/state_space/BUILD.bazel
@@ -49,6 +49,10 @@ _EXTRA_CONSTRAINTS = {
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    "test_ssd_chunk_state.mojo": select({
+        "//:apple_gpu": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 }
 
 _GPU_MEMORY = {

--- a/max/kernels/test/gpu/state_space/BUILD.bazel
+++ b/max/kernels/test/gpu/state_space/BUILD.bazel
@@ -37,6 +37,10 @@ _EXTRA_CONSTRAINTS = {
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    "test_ssd_chunk.mojo": select({
+        "//:apple_gpu": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     "test_gated_delta.mojo": select({
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],

--- a/max/kernels/test/gpu/state_space/test_ssd_chunk.mojo
+++ b/max/kernels/test/gpu/state_space/test_ssd_chunk.mojo
@@ -1,0 +1,758 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import exp
+
+from max.gpu.host import DeviceContext
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    row_major,
+)
+from std.random import rand
+from state_space.ssd_chunk import (
+    ssd_intra_chunk_fwd_gpu,
+    ssd_intra_chunk_fwd_gpu_naive,
+    ssd_intra_chunk_fwd_gpu_fused,
+    ssd_intra_chunk_fwd_gpu_static,
+    ssd_intra_chunk_fwd_gpu_static_mma,
+)
+from std.testing import TestSuite, assert_almost_equal
+from std.utils.index import Index
+
+
+def run_ssd_intra_chunk_gpu[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Run the optimized SSD intra-chunk GPU path and check against a reference.
+
+    Uses batched ``C @ B^T`` (Modular tensor-core matmul) plus a Triton-style
+    tiled chunk-scan kernel. Validates against the same independent scalar
+    reference used by the CPU test.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    # ── Host tensors ─────────────────────────────────────────────────────────
+    var C_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    var C_h = LayoutTensor[dtype, layout_5d, _](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](C_h.ptr, C_h.size())
+
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    var B_h = LayoutTensor[dtype, layout_5d, _](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](B_h.ptr, B_h.size())
+
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+    var X_h = LayoutTensor[dtype, layout_5d, _](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](X_h.ptr, X_h.size())
+
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var A_h = LayoutTensor[dtype, layout_4d, _](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](A_h.ptr, A_h.size())
+    # Make A negative-ish (a real SSM decays) so exp(cumsum diffs) stays
+    # bounded. `rand` fills in [0, 1); map into a small negative range.
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        # Map [0, 1) -> [-0.6, -0.1].
+        var scaled = Float32(-0.6) + Float32(0.5) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    var Y_gpu_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+    var Y_gpu_h = LayoutTensor[dtype, layout_5d, _](
+        Y_gpu_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # ── Device buffers ───────────────────────────────────────────────────────
+    var C_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y_device = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(C_device, C_h.ptr)
+        ctx.enqueue_copy(B_device, B_h.ptr)
+        ctx.enqueue_copy(X_device, X_h.ptr)
+        ctx.enqueue_copy(A_device, A_h.ptr)
+
+    var C_tt = TileTensor(
+        C_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var B_tt = TileTensor(
+        B_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var X_tt = TileTensor(
+        X_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var A_tt = TileTensor(
+        A_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var Y_tt = TileTensor(
+        Y_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+
+    with ctx.push_context():
+        ssd_intra_chunk_fwd_gpu[
+            dtype,
+            C_tt.LayoutType,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            Y_tt.LayoutType,
+        ](
+            batch,
+            n_chunks,
+            n_heads,
+            chunk_len,
+            state_dim,
+            head_dim,
+            C_tt,
+            B_tt,
+            X_tt,
+            A_tt,
+            Y_tt,
+            ctx,
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(Y_gpu_h.ptr, Y_device)
+    ctx.synchronize()
+
+    # ── CPU reference: naive triple-loop of the SSD intra-chunk formula ──────
+    var ref_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+
+    var cb_h_stride = chunk_len * state_dim
+    var cb_c_stride = n_heads * cb_h_stride
+    var cb_b_stride = n_chunks * cb_c_stride
+
+    var xy_h_stride = chunk_len * head_dim
+    var xy_c_stride = n_heads * xy_h_stride
+    var xy_b_stride = n_chunks * xy_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var cb_base = (
+                    b * cb_b_stride + c * cb_c_stride + h * cb_h_stride
+                )
+                var xy_base = (
+                    b * xy_b_stride + c * xy_c_stride + h * xy_h_stride
+                )
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                for l in range(chunk_len):
+                    for p in range(head_dim):
+                        var y_acc = Float32(0.0)
+                        for s in range(l + 1):
+                            var dot = Float32(0.0)
+                            for n in range(state_dim):
+                                var cv = C_h.ptr[
+                                    cb_base + l * state_dim + n
+                                ].cast[DType.float32]()
+                                var bv = B_h.ptr[
+                                    cb_base + s * state_dim + n
+                                ].cast[DType.float32]()
+                                dot += cv * bv
+                            var decay = exp(cumsum[l] - cumsum[s])
+                            var xv = X_h.ptr[xy_base + s * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            y_acc += dot * decay * xv
+                        ref_heap[xy_base + l * head_dim + p] = Scalar[dtype](
+                            y_acc
+                        )
+
+    # ── Compare GPU vs CPU reference ─────────────────────────────────────────
+    for i in range(xy_count):
+        assert_almost_equal(Y_gpu_h.ptr[i], ref_heap[i], rtol=rtol)
+
+
+def run_ssd_intra_chunk_gpu_static[
+    dtype: DType,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    use_mma: Bool = False,
+    use_fused: Bool = False,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+    a_min: Float32 = -0.6,
+    a_max: Float32 = -0.1,
+) raises:
+    """Exercise a static-shape path against the scalar CPU reference.
+
+    ``use_mma=False`` drives the default scalar-scan static path
+    (``ssd_intra_chunk_fwd_gpu_static``); ``use_mma=True`` drives the
+    tensor-core path that materialises ``M = causal_decay(CB)`` and computes
+    ``Y = M @ X`` via two batched matmuls
+    (``ssd_intra_chunk_fwd_gpu_static_mma``). ``chunk_len`` / ``state_dim`` /
+    ``head_dim`` are comptime so ``batched_matmul`` sees static N/K.
+
+    ``a_min`` / ``a_max`` bound the per-token decay ``A``. The scan factors
+    ``exp(cum_l−cum_s) = exp(cum_l)·exp(−cum_s)``; the intermediate
+    ``exp(−cum_s)`` can overflow FP32 once ``|cum|`` exceeds ~88, so long
+    ``chunk_len`` tests use a milder range to stay in the regime real Mamba2
+    decay rates occupy.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    var C_h = LayoutTensor[dtype, layout_5d, _](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](C_h.ptr, C_h.size())
+
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    var B_h = LayoutTensor[dtype, layout_5d, _](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](B_h.ptr, B_h.size())
+
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+    var X_h = LayoutTensor[dtype, layout_5d, _](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](X_h.ptr, X_h.size())
+
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var A_h = LayoutTensor[dtype, layout_4d, _](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](A_h.ptr, A_h.size())
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        var scaled = a_min + (a_max - a_min) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    var Y_gpu_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+
+    var C_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y_device = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(C_device, C_h.ptr)
+        ctx.enqueue_copy(B_device, B_h.ptr)
+        ctx.enqueue_copy(X_device, X_h.ptr)
+        ctx.enqueue_copy(A_device, A_h.ptr)
+
+    var C_tt = TileTensor(
+        C_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var Y_tt = TileTensor(
+        Y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    with ctx.push_context():
+        comptime if use_fused:
+            ssd_intra_chunk_fwd_gpu_fused[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        elif use_mma:
+            ssd_intra_chunk_fwd_gpu_static_mma[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        else:
+            ssd_intra_chunk_fwd_gpu_static[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(Y_gpu_heap, Y_device)
+    ctx.synchronize()
+
+    var ref_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+
+    var cb_h_stride = chunk_len * state_dim
+    var cb_c_stride = n_heads * cb_h_stride
+    var cb_b_stride = n_chunks * cb_c_stride
+    var xy_h_stride = chunk_len * head_dim
+    var xy_c_stride = n_heads * xy_h_stride
+    var xy_b_stride = n_chunks * xy_c_stride
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var cb_base = (
+                    b * cb_b_stride + c * cb_c_stride + h * cb_h_stride
+                )
+                var xy_base = (
+                    b * xy_b_stride + c * xy_c_stride + h * xy_h_stride
+                )
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                for l in range(chunk_len):
+                    for p in range(head_dim):
+                        var y_acc = Float32(0.0)
+                        for s in range(l + 1):
+                            var dot = Float32(0.0)
+                            for n in range(state_dim):
+                                var cv = C_h.ptr[
+                                    cb_base + l * state_dim + n
+                                ].cast[DType.float32]()
+                                var bv = B_h.ptr[
+                                    cb_base + s * state_dim + n
+                                ].cast[DType.float32]()
+                                dot += cv * bv
+                            var decay = exp(cumsum[l] - cumsum[s])
+                            var xv = X_h.ptr[xy_base + s * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            y_acc += dot * decay * xv
+                        ref_heap[xy_base + l * head_dim + p] = Scalar[dtype](
+                            y_acc
+                        )
+
+    for i in range(xy_count):
+        assert_almost_equal(Y_gpu_heap[i], ref_heap[i], rtol=rtol)
+
+
+def test_ssd_intra_chunk_gpu_static_scalar() raises:
+    """Static-shape scalar-scan path against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=16, state_dim=16, head_dim=8
+    ](batch=1, n_chunks=3, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_mma() raises:
+    """Static-shape tensor-core MMA path against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=16, state_dim=16, head_dim=8, use_mma=True
+    ](batch=1, n_chunks=3, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_fused_small() raises:
+    """Fused single-pass MMA path (RFC 0009), small gate-hitting dims."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32,
+        chunk_len=64,
+        state_dim=128,
+        head_dim=64,
+        use_fused=True,
+    ](batch=1, n_chunks=2, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_fused_mamba2() raises:
+    """Fused single-pass MMA path at the Mamba2-130m profile (L=256,P=64,N=128).
+    """
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32,
+        chunk_len=256,
+        state_dim=128,
+        head_dim=64,
+        use_fused=True,
+    ](batch=1, n_chunks=2, n_heads=4, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_mma_multi_batch() raises:
+    """Static-shape MMA path with multiple batch elements."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=8, state_dim=8, head_dim=4, use_mma=True
+    ](batch=2, n_chunks=2, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_a100_mma_shape() raises:
+    """Production-shape static scalar path exercising the changed GPU paths.
+
+    Covers the code paths the GPU optimizations actually changed, which the
+    tiny shapes above do NOT:
+
+    - ``state_dim=128`` + ``chunk_len=128`` (multiple of 128) makes the
+      ``CB = C @ B^T`` stage take ``batched_matmul``'s **A100 batched
+      tensor-core path** (``multistage_gemm_cond``: N%128==0, K%32==0, K>=128).
+    - ``chunk_len=128`` > ``SCAN_BLOCK_M`` (32 on GB10) → **4 M-tiles**, so the
+      causal early-exit / tail-balancing across M-tiles is exercised.
+    - ``head_dim=64`` > ``SCAN_BLOCK_N`` (32) → **2 N-tiles**.
+    - The parallel cumsum runs one block per slice with ``block_dim=128``.
+    """
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=128, state_dim=128, head_dim=64
+    ](batch=1, n_chunks=1, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_mma_a100_shape() raises:
+    """Production-shape MMA path: decay kernel + ``Y = M @ X`` at the shape
+    where the ``CB`` matmul takes the A100 batched tensor-core path
+    (``state_dim=128``, ``chunk_len=128``)."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32,
+        chunk_len=128,
+        state_dim=128,
+        head_dim=64,
+        use_mma=True,
+    ](batch=1, n_chunks=1, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_long_chunk() raises:
+    """Full Mamba2 ``chunk_len=256`` with realistic (mild) decay.
+
+    Covers the production chunk length: the Hillis-Steele cumsum at
+    ``block_dim=256``, 8 scan M-tiles, and the A100 batched MMA. Uses a milder
+    decay range so the factored ``exp(-cum_s)`` stays well within FP32 — the
+    regime real Mamba2 dt*A rates occupy (aggressive decay over 256 tokens can
+    push ``|cum|`` past the ~88 FP32-exp overflow point; see helper docstring).
+    """
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=256, state_dim=128, head_dim=16
+    ](batch=1, n_chunks=1, n_heads=2, ctx=ctx, a_min=-0.08, a_max=-0.01)
+
+
+def test_ssd_intra_chunk_gpu_multi_m_tile() raises:
+    """Dynamic-shape path with ``chunk_len=64`` > ``SCAN_BLOCK_M`` so the scan
+    spans multiple M-tiles (the tiny dynamic tests above are all single-tile).
+    """
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=64,
+        state_dim=32,
+        head_dim=16,
+        ctx=ctx,
+    )
+
+
+def test_ssd_intra_chunk_gpu_golden() raises:
+    """Golden-parity test on GPU against the canonical PyTorch SSD reference.
+
+    Same FIXED tiny input as the CPU golden test (batch=1, n_chunks=1,
+    n_heads=1, L=4, N=3, P=2). Pins the GPU kernel to ``intra_chunk_diag`` in
+    ``.planning/parity/ssd_minimal_ref.py``.
+    """
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    var C_vals = [
+        Float32(-0.15),
+        0.79,
+        0.95,
+        -1.11,
+        1.69,
+        -0.89,
+        -0.36,
+        1.23,
+        0.14,
+        -1.68,
+        0.32,
+        0.13,
+    ]
+    var B_vals = [
+        Float32(0.14),
+        0.24,
+        1.40,
+        1.35,
+        2.44,
+        0.20,
+        2.45,
+        2.03,
+        1.78,
+        -0.92,
+        -0.46,
+        -0.72,
+    ]
+    var X_vals = [
+        Float32(1.28),
+        -0.99,
+        1.81,
+        -0.60,
+        1.61,
+        1.93,
+        -0.42,
+        -0.08,
+    ]
+    var A_vals = [Float32(-0.43), -0.34, -0.49, -0.46]
+    var Y_expected = [
+        Float32(1.918208),
+        -1.483614,
+        3.522012,
+        -0.766567,
+        6.067267,
+        2.472605,
+        -4.850489,
+        -3.713203,
+    ]
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    # Host buffers from fixed literals.
+    var C_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    for i in range(cb_count):
+        C_heap[i] = Scalar[dtype](C_vals[i])
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    for i in range(cb_count):
+        B_heap[i] = Scalar[dtype](B_vals[i])
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+    for i in range(xy_count):
+        X_heap[i] = Scalar[dtype](X_vals[i])
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    for i in range(a_count):
+        A_heap[i] = Scalar[dtype](A_vals[i])
+    var Y_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+
+    var C_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y_device = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(C_device, C_heap)
+        ctx.enqueue_copy(B_device, B_heap)
+        ctx.enqueue_copy(X_device, X_heap)
+        ctx.enqueue_copy(A_device, A_heap)
+
+    var C_tt = TileTensor(
+        C_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var B_tt = TileTensor(
+        B_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var X_tt = TileTensor(
+        X_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var A_tt = TileTensor(
+        A_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var Y_tt = TileTensor(
+        Y_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_intra_chunk_fwd_gpu_naive[
+            dtype,
+            C_tt.LayoutType,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            Y_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            C_tt,
+            B_tt,
+            X_tt,
+            A_tt,
+            Y_tt,
+            grid_dim=(1,),
+            block_dim=(total_slices,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(Y_heap, Y_device)
+    ctx.synchronize()
+
+    for i in range(xy_count):
+        assert_almost_equal(
+            Y_heap[i],
+            Scalar[dtype](Y_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_intra_chunk_gpu_basic() raises:
+    """Basic single-batch, single-chunk case against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=16,
+        head_dim=8,
+        ctx=ctx,
+    )
+
+
+def test_ssd_intra_chunk_gpu_multi_chunk() raises:
+    """Multiple chunks and heads against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu[DType.float32](
+        batch=1,
+        n_chunks=3,
+        n_heads=2,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=8,
+        ctx=ctx,
+    )
+
+
+def test_ssd_intra_chunk_gpu_multi_batch() raises:
+    """Multiple batch elements against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu[DType.float32](
+        batch=2,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=4,
+        ctx=ctx,
+    )
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/gpu/state_space/test_ssd_chunk_state.mojo
+++ b/max/kernels/test/gpu/state_space/test_ssd_chunk_state.mojo
@@ -1,0 +1,647 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import exp
+
+from max.gpu.host import DeviceContext
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    row_major,
+)
+from std.random import rand
+from state_space.ssd_chunk_state import (
+    ssd_chunk_state_fwd_gpu,
+    ssd_chunk_state_fwd_gpu_static,
+    ssd_chunk_state_fwd_gpu_fused,
+)
+from std.testing import TestSuite, assert_almost_equal
+from std.utils.index import Index
+
+
+def run_ssd_chunk_state_gpu[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+    num_p_tiles: Int = 1,
+) raises:
+    """Run the SSD chunk-state GPU kernel and check it against a CPU reference.
+
+    One block per ``(batch, chunk, head)`` slice (``block_dim == chunk_len``)
+    reduces the chunk to its ``[head_dim, state_dim]`` end-state; this validates
+    the result against the same naive reference used by the CPU test.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    # ── Host tensors ─────────────────────────────────────────────────────────
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](b_count)
+    var B_h = LayoutTensor[dtype, layout_5d, _](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](B_h.ptr, B_h.size())
+
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](x_count)
+    var X_h = LayoutTensor[dtype, layout_5d, _](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](X_h.ptr, X_h.size())
+
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var A_h = LayoutTensor[dtype, layout_4d, _](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](A_h.ptr, A_h.size())
+    # Make A negative-ish (a real SSM decays) so exp(cumsum diffs) stays
+    # bounded. `rand` fills in [0, 1); map into a small negative range.
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        # Map [0, 1) -> [-0.6, -0.1].
+        var scaled = Float32(-0.6) + Float32(0.5) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    var state_gpu_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+    var state_gpu_h = LayoutTensor[dtype, layout_5d, _](
+        state_gpu_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # ── Device buffers ───────────────────────────────────────────────────────
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(B_device, B_h.ptr)
+        ctx.enqueue_copy(X_device, X_h.ptr)
+        ctx.enqueue_copy(A_device, A_h.ptr)
+
+    var B_tt = TileTensor(
+        B_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var X_tt = TileTensor(
+        X_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var A_tt = TileTensor(
+        A_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var state_tt = TileTensor(
+        state_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_state_fwd_gpu[
+            dtype,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(state_gpu_h.ptr, state_device)
+    ctx.synchronize()
+
+    # ── CPU reference: naive reduction of the SSD chunk-state formula ────────
+    var ref_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+
+    var b_h_stride = chunk_len * state_dim
+    var b_c_stride = n_heads * b_h_stride
+    var b_b_stride = n_chunks * b_c_stride
+
+    var x_h_stride = chunk_len * head_dim
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var state_h_stride = head_dim * state_dim
+    var state_c_stride = n_heads * state_h_stride
+    var state_b_stride = n_chunks * state_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var b_base = b * b_b_stride + c * b_c_stride + h * b_h_stride
+                var x_base = b * x_b_stride + c * x_c_stride + h * x_h_stride
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var state_base = (
+                    b * state_b_stride + c * state_c_stride + h * state_h_stride
+                )
+
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                var cum_end = cumsum[chunk_len - 1]
+
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var s_acc = Float32(0.0)
+                        for l in range(chunk_len):
+                            var bv = B_h.ptr[b_base + l * state_dim + n].cast[
+                                DType.float32
+                            ]()
+                            var xv = X_h.ptr[x_base + l * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            var decay = exp(cum_end - cumsum[l])
+                            s_acc += bv * decay * xv
+                        ref_heap[state_base + p * state_dim + n] = Scalar[
+                            dtype
+                        ](s_acc)
+
+    # ── Compare GPU vs CPU reference ─────────────────────────────────────────
+    for i in range(state_count):
+        assert_almost_equal(state_gpu_h.ptr[i], ref_heap[i], rtol=rtol)
+
+
+def run_ssd_chunk_state_gpu_static[
+    dtype: DType,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    fused: Bool = False,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Run a static tensor-core chunk-state entry and check it vs a CPU ref.
+
+    With ``fused=False`` runs ``ssd_chunk_state_fwd_gpu_static`` (2-pass
+    decay-transpose + batched_matmul); with ``fused=True`` runs the fused
+    single-pass kernel ``ssd_chunk_state_fwd_gpu_fused``. Both take compile-time
+    dims and the same argument list.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](b_count)
+    var B_h = LayoutTensor[dtype, layout_5d, _](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](B_h.ptr, B_h.size())
+
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](x_count)
+    var X_h = LayoutTensor[dtype, layout_5d, _](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](X_h.ptr, X_h.size())
+
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var A_h = LayoutTensor[dtype, layout_4d, _](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](A_h.ptr, A_h.size())
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        A_h.ptr[i] = Scalar[dtype](Float32(-0.6) + Float32(0.5) * v)
+
+    var state_gpu_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(B_device, B_h.ptr)
+        ctx.enqueue_copy(X_device, X_h.ptr)
+        ctx.enqueue_copy(A_device, A_h.ptr)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    comptime if fused:
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    else:
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(state_gpu_heap, state_device)
+    ctx.synchronize()
+
+    # ── CPU reference ────────────────────────────────────────────────────────
+    var ref_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+    var b_h_stride = chunk_len * state_dim
+    var b_c_stride = n_heads * b_h_stride
+    var b_b_stride = n_chunks * b_c_stride
+    var x_h_stride = chunk_len * head_dim
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+    var state_h_stride = head_dim * state_dim
+    var state_c_stride = n_heads * state_h_stride
+    var state_b_stride = n_chunks * state_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var b_base = b * b_b_stride + c * b_c_stride + h * b_h_stride
+                var x_base = b * x_b_stride + c * x_c_stride + h * x_h_stride
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var state_base = (
+                    b * state_b_stride + c * state_c_stride + h * state_h_stride
+                )
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+                var cum_end = cumsum[chunk_len - 1]
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var s_acc = Float32(0.0)
+                        for l in range(chunk_len):
+                            var bv = B_h.ptr[b_base + l * state_dim + n].cast[
+                                DType.float32
+                            ]()
+                            var xv = X_h.ptr[x_base + l * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            s_acc += bv * exp(cum_end - cumsum[l]) * xv
+                        ref_heap[state_base + p * state_dim + n] = Scalar[
+                            dtype
+                        ](s_acc)
+
+    for i in range(state_count):
+        assert_almost_equal(state_gpu_heap[i], ref_heap[i], rtol=rtol)
+
+
+def test_ssd_chunk_state_gpu_golden() raises:
+    """Golden-parity test on GPU against the canonical PyTorch SSD reference.
+
+    Same FIXED tiny input as the CPU golden test (batch=1, n_chunks=1,
+    n_heads=1, L=4, N=3, P=2). Pins the GPU kernel to the chunk end-state
+    reduction (stage 2 of ``ssd_minimal_discrete``).
+    """
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    var B_vals = [
+        Float32(0.74),
+        1.95,
+        -0.70,
+        -1.30,
+        -0.51,
+        -0.27,
+        0.25,
+        0.48,
+        0.45,
+        -0.96,
+        1.50,
+        -0.31,
+    ]
+    var X_vals = [
+        Float32(-0.23),
+        -1.07,
+        0.16,
+        0.12,
+        0.38,
+        -0.12,
+        0.89,
+        -0.49,
+    ]
+    var A_vals = [Float32(-0.45), -0.18, -0.36, -0.50]
+    var state_expected = [
+        Float32(-0.944955),
+        1.252577,
+        -0.133558,
+        0.106325,
+        -1.533317,
+        0.370175,
+    ]
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    # Host buffers from fixed literals.
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](b_count)
+    for i in range(b_count):
+        B_heap[i] = Scalar[dtype](B_vals[i])
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](x_count)
+    for i in range(x_count):
+        X_heap[i] = Scalar[dtype](X_vals[i])
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    for i in range(a_count):
+        A_heap[i] = Scalar[dtype](A_vals[i])
+    var state_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(B_device, B_heap)
+        ctx.enqueue_copy(X_device, X_heap)
+        ctx.enqueue_copy(A_device, A_heap)
+
+    var B_tt = TileTensor(
+        B_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var X_tt = TileTensor(
+        X_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var A_tt = TileTensor(
+        A_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var state_tt = TileTensor(
+        state_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_state_fwd_gpu[
+            dtype,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices,),
+            block_dim=(chunk_len,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(state_heap, state_device)
+    ctx.synchronize()
+
+    for i in range(state_count):
+        assert_almost_equal(
+            state_heap[i],
+            Scalar[dtype](state_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_chunk_state_gpu_basic() raises:
+    """Basic single-batch, single-chunk case against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=16,
+        head_dim=8,
+        ctx=ctx,
+    )
+
+
+def test_ssd_chunk_state_gpu_multi_chunk() raises:
+    """Multiple chunks and heads against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=1,
+        n_chunks=3,
+        n_heads=2,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=8,
+        ctx=ctx,
+    )
+
+
+def test_ssd_chunk_state_gpu_multi_batch() raises:
+    """Multiple batch elements against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=2,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=4,
+        ctx=ctx,
+    )
+
+
+def test_ssd_chunk_state_gpu_ptiled() raises:
+    """Multi-block-per-slice (grid_dim.y > 1) path, head_dim divisible by tiles.
+
+    Splits each slice across 4 p-tiles (head_dim=16, tile height 4); checks the
+    tiled result still matches the naive reference.
+    """
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=3,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=16,
+        ctx=ctx,
+        num_p_tiles=4,
+    )
+
+
+def test_ssd_chunk_state_gpu_ptiled_ragged() raises:
+    """Multi-block-per-slice path with head_dim NOT divisible by the tile count.
+
+    head_dim=10 over 4 p-tiles → tile height ceildiv(10,4)=3, so tiles cover
+    rows [0,3) [3,6) [6,9) [9,10); the last tile is a partial row and an extra
+    block would early-return. Exercises the ragged tail and bounds handling.
+    """
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=10,
+        ctx=ctx,
+        num_p_tiles=4,
+    )
+
+
+def test_ssd_chunk_state_gpu_static_mma() raises:
+    """Tensor-core batched-matmul path at gate-satisfying dims.
+
+    state_dim=128 (matmul N % 128 == 0), chunk_len=128 (K % 32 == 0, >= 128) so
+    ssd_chunk_state_fwd_gpu_static takes the A100 multistage path. Checked vs
+    the naive CPU reference.
+    """
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu_static[
+        DType.float32, chunk_len=128, state_dim=128, head_dim=64
+    ](batch=1, n_chunks=2, n_heads=4, ctx=ctx)
+
+
+def test_ssd_chunk_state_gpu_static_mma_profile() raises:
+    """Tensor-core path at the Mamba2-130m prefill profile (L=256, P=64, N=128).
+    """
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu_static[
+        DType.float32, chunk_len=256, state_dim=128, head_dim=64
+    ](batch=1, n_chunks=4, n_heads=24, ctx=ctx)
+
+
+def test_ssd_chunk_state_gpu_fused_mma() raises:
+    """Fused single-pass tensor-core path at gate-satisfying dims."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu_static[
+        DType.float32,
+        chunk_len=128,
+        state_dim=128,
+        head_dim=64,
+        fused=True,
+    ](batch=1, n_chunks=2, n_heads=4, ctx=ctx)
+
+
+def test_ssd_chunk_state_gpu_fused_mma_profile() raises:
+    """Fused path at the Mamba2-130m prefill profile (L=256, P=64, N=128)."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu_static[
+        DType.float32,
+        chunk_len=256,
+        state_dim=128,
+        head_dim=64,
+        fused=True,
+    ](batch=1, n_chunks=4, n_heads=24, ctx=ctx)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_chunk.mojo
+++ b/max/kernels/test/state_space/test_ssd_chunk.mojo
@@ -1,0 +1,519 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from layout import Layout, LayoutTensor, RuntimeLayout
+from layout._fillers import random
+from state_space.ssd_chunk import (
+    ssd_intra_chunk_fwd_cpu,
+    ssd_intra_chunk_fwd_cpu_naive,
+)
+from std.math import exp
+from std.testing import TestSuite, assert_almost_equal
+
+from std.utils.index import Index
+
+
+def run_ssd_intra_chunk[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test the optimized SSD intra-chunk CPU kernel against an independent reference.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    # C: [batch, n_chunks, n_heads, chunk_len, state_dim]
+    var C_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var C_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+
+    # B: [batch, n_chunks, n_heads, chunk_len, state_dim]
+    var B_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+
+    # X: [batch, n_chunks, n_heads, chunk_len, head_dim]
+    var X_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # A: [batch, n_chunks, n_heads, chunk_len]
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+
+    # Y: [batch, n_chunks, n_heads, chunk_len, head_dim]
+    var Y_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var Y_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # Initialize inputs.
+    random(C_h)
+    random(B_h)
+    random(X_h)
+    random(A_h)
+
+    # Make A negative-ish (a real SSM decays), so exp(cumsum diffs) stays
+    # bounded. `random` fills in roughly [-1, 1]; map it into a small negative
+    # range like real Mamba2 dt*A values.
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        # Map [-1, 1] -> [-0.6, -0.1].
+        var scaled = Float32(-0.35) + Float32(0.25) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    # Call the optimized kernel.
+    ssd_intra_chunk_fwd_cpu[
+        dtype,
+        C_h.layout,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        Y_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        C_h,
+        B_h,
+        X_h,
+        A_h,
+        Y_h,
+        ctx=None,
+    )
+
+    # Independent naive reference. Recompute strides from scratch and use a
+    # straightforward triple-loop of the formula:
+    #   A_cumsum[l] = sum_{k<=l} A[k]
+    #   Ldecay[l,s] = exp(A_cumsum[l] - A_cumsum[s])  for s <= l
+    #   scores[l,s] = (sum_n C[l,n]*B[s,n]) * Ldecay[l,s]
+    #   Y[l,p]      = sum_{s<=l} scores[l,s] * X[s,p]
+    var ref_heap = List(length=xy_count, fill=Scalar[dtype](0))
+
+    var cb_h_stride = chunk_len * state_dim
+    var cb_c_stride = n_heads * cb_h_stride
+    var cb_b_stride = n_chunks * cb_c_stride
+
+    var xy_h_stride = chunk_len * head_dim
+    var xy_c_stride = n_heads * xy_h_stride
+    var xy_b_stride = n_chunks * xy_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var cb_base = (
+                    b * cb_b_stride + c * cb_c_stride + h * cb_h_stride
+                )
+                var xy_base = (
+                    b * xy_b_stride + c * xy_c_stride + h * xy_h_stride
+                )
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+
+                # Prefix sum of A over the chunk.
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                for l in range(chunk_len):
+                    for p in range(head_dim):
+                        var y_acc = Float32(0.0)
+                        for s in range(l + 1):
+                            # dot(C[l,:], B[s,:]).
+                            var dot = Float32(0.0)
+                            for n in range(state_dim):
+                                var cv = C_h.ptr[
+                                    cb_base + l * state_dim + n
+                                ].cast[DType.float32]()
+                                var bv = B_h.ptr[
+                                    cb_base + s * state_dim + n
+                                ].cast[DType.float32]()
+                                dot += cv * bv
+                            var decay = exp(cumsum[l] - cumsum[s])
+                            var xv = X_h.ptr[xy_base + s * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            y_acc += dot * decay * xv
+                        ref_heap[xy_base + l * head_dim + p] = Scalar[dtype](
+                            y_acc
+                        )
+
+    # Compare kernel output against the reference.
+    for i in range(xy_count):
+        assert_almost_equal(
+            Y_h.ptr[i],
+            ref_heap[i],
+            rtol=rtol,
+        )
+
+
+def test_ssd_intra_chunk_golden() raises:
+    """Golden-parity test against the canonical PyTorch SSD reference.
+
+    Pins ``ssd_intra_chunk_fwd_cpu_naive`` to a FIXED tiny input whose expected
+    output was computed independently by ``intra_chunk_diag`` in
+    ``.planning/parity/ssd_minimal_ref.py`` (the vendored pure-PyTorch
+    ``ssd_minimal_discrete`` stage-1 diagonal block).
+
+    Shapes: batch=1, n_chunks=1, n_heads=1, chunk_len L=4, state_dim N=3,
+    head_dim P=2; all tensors row-major.
+    """
+    comptime dtype = DType.float32
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    # Fixed literals (row-major). These mirror the values in the parity
+    # reference; Y_expected is the reference's output for these inputs.
+    var C_vals = [
+        Float32(-0.15),
+        0.79,
+        0.95,
+        -1.11,
+        1.69,
+        -0.89,
+        -0.36,
+        1.23,
+        0.14,
+        -1.68,
+        0.32,
+        0.13,
+    ]
+    var B_vals = [
+        Float32(0.14),
+        0.24,
+        1.40,
+        1.35,
+        2.44,
+        0.20,
+        2.45,
+        2.03,
+        1.78,
+        -0.92,
+        -0.46,
+        -0.72,
+    ]
+    var X_vals = [
+        Float32(1.28),
+        -0.99,
+        1.81,
+        -0.60,
+        1.61,
+        1.93,
+        -0.42,
+        -0.08,
+    ]
+    var A_vals = [Float32(-0.43), -0.34, -0.49, -0.46]
+    var Y_expected = [
+        Float32(1.918208),
+        -1.483614,
+        3.522012,
+        -0.766567,
+        6.067267,
+        2.472605,
+        -4.850489,
+        -3.713203,
+    ]
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    # Build LayoutTensors from the fixed literals (not random).
+    var C_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var C_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    for i in range(cb_count):
+        C_h.ptr[i] = Scalar[dtype](C_vals[i])
+
+    var B_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    for i in range(cb_count):
+        B_h.ptr[i] = Scalar[dtype](B_vals[i])
+
+    var X_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    for i in range(xy_count):
+        X_h.ptr[i] = Scalar[dtype](X_vals[i])
+
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    for i in range(a_count):
+        A_h.ptr[i] = Scalar[dtype](A_vals[i])
+
+    var Y_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var Y_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    ssd_intra_chunk_fwd_cpu_naive[
+        dtype,
+        C_h.layout,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        Y_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        C_h,
+        B_h,
+        X_h,
+        A_h,
+        Y_h,
+    )
+
+    # Pin to the canonical PyTorch reference numerics.
+    for i in range(xy_count):
+        assert_almost_equal(
+            Y_h.ptr[i],
+            Scalar[dtype](Y_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_intra_chunk_basic() raises:
+    """Basic single-batch, single-chunk case."""
+    run_ssd_intra_chunk[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=16,
+        head_dim=8,
+    )
+
+
+def test_ssd_intra_chunk_multi_chunk() raises:
+    """Multiple chunks and heads."""
+    run_ssd_intra_chunk[DType.float32](
+        batch=1,
+        n_chunks=3,
+        n_heads=2,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=8,
+    )
+
+
+def test_ssd_intra_chunk_multi_batch() raises:
+    """Multiple batch elements."""
+    run_ssd_intra_chunk[DType.float32](
+        batch=2,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=4,
+    )
+
+
+def test_ssd_intra_chunk_chunk_len_one() raises:
+    """Degenerate chunk length of one (only the diagonal term)."""
+    run_ssd_intra_chunk[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=1,
+        chunk_len=1,
+        state_dim=4,
+        head_dim=4,
+    )
+
+
+def test_ssd_intra_chunk_optimized_matches_naive() raises:
+    """Optimized CPU kernel matches the naive scalar reference."""
+    comptime dtype = DType.float32
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    comptime batch = 1
+    comptime n_chunks = 2
+    comptime n_heads = 2
+    comptime chunk_len = 16
+    comptime state_dim = 16
+    comptime head_dim = 8
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var C_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    var B_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    var X_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    var Y_fast_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var Y_fast_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_fast_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    var Y_naive_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var Y_naive_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_naive_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    random(C_h)
+    random(B_h)
+    random(X_h)
+    random(A_h)
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        A_h.ptr[i] = Scalar[dtype](Float32(-0.35) + Float32(0.25) * v)
+
+    ssd_intra_chunk_fwd_cpu[
+        dtype,
+        C_h.layout,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        Y_fast_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        C_h,
+        B_h,
+        X_h,
+        A_h,
+        Y_fast_h,
+    )
+    ssd_intra_chunk_fwd_cpu_naive[
+        dtype,
+        C_h.layout,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        Y_naive_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        C_h,
+        B_h,
+        X_h,
+        A_h,
+        Y_naive_h,
+    )
+
+    for i in range(xy_count):
+        assert_almost_equal(Y_fast_h.ptr[i], Y_naive_h.ptr[i], rtol=1e-4)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_chunk_state.mojo
+++ b/max/kernels/test/state_space/test_ssd_chunk_state.mojo
@@ -1,0 +1,359 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from layout import Layout, LayoutTensor, RuntimeLayout
+from layout._fillers import random
+from state_space.ssd_chunk_state import ssd_chunk_state_fwd_cpu
+from std.math import exp
+from std.testing import TestSuite, assert_almost_equal
+
+from std.utils.index import Index
+
+
+def run_ssd_chunk_state[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test the SSD chunk-state kernel against an independent reference."""
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    # B: [batch, n_chunks, n_heads, chunk_len, state_dim]
+    var B_heap = List(length=b_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+
+    # X: [batch, n_chunks, n_heads, chunk_len, head_dim]
+    var X_heap = List(length=x_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # A: [batch, n_chunks, n_heads, chunk_len]
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+
+    # state: [batch, n_chunks, n_heads, head_dim, state_dim]
+    var state_heap = List(length=state_count, fill=Scalar[dtype](0))
+    var state_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        state_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # Initialize inputs.
+    random(B_h)
+    random(X_h)
+    random(A_h)
+
+    # Make A negative-ish (a real SSM decays), so exp(cumsum diffs) stays
+    # bounded. `random` fills in roughly [-1, 1]; map it into a small negative
+    # range like real Mamba2 dt*A values.
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        # Map [-1, 1] -> [-0.6, -0.1].
+        var scaled = Float32(-0.35) + Float32(0.25) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    # Call the kernel.
+    ssd_chunk_state_fwd_cpu[
+        dtype,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        state_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        B_h,
+        X_h,
+        A_h,
+        state_h,
+    )
+
+    # Independent naive reference. Recompute strides from scratch and use a
+    # straightforward loop of the formula:
+    #   A_cumsum[l] = sum_{k<=l} A[k]
+    #   decay[l]    = exp(A_cumsum[L-1] - A_cumsum[l])
+    #   state[p,n]  = sum_l B[l,n] * decay[l] * X[l,p]
+    var ref_heap = List(length=state_count, fill=Scalar[dtype](0))
+
+    var b_h_stride = chunk_len * state_dim
+    var b_c_stride = n_heads * b_h_stride
+    var b_b_stride = n_chunks * b_c_stride
+
+    var x_h_stride = chunk_len * head_dim
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var state_h_stride = head_dim * state_dim
+    var state_c_stride = n_heads * state_h_stride
+    var state_b_stride = n_chunks * state_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var b_base = b * b_b_stride + c * b_c_stride + h * b_h_stride
+                var x_base = b * x_b_stride + c * x_c_stride + h * x_h_stride
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var state_base = (
+                    b * state_b_stride + c * state_c_stride + h * state_h_stride
+                )
+
+                # Prefix sum of A over the chunk.
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                var cum_end = cumsum[chunk_len - 1]
+
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var s_acc = Float32(0.0)
+                        for l in range(chunk_len):
+                            var bv = B_h.ptr[b_base + l * state_dim + n].cast[
+                                DType.float32
+                            ]()
+                            var xv = X_h.ptr[x_base + l * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            var decay = exp(cum_end - cumsum[l])
+                            s_acc += bv * decay * xv
+                        ref_heap[state_base + p * state_dim + n] = Scalar[
+                            dtype
+                        ](s_acc)
+
+    # Compare kernel output against the reference.
+    for i in range(state_count):
+        assert_almost_equal(
+            state_h.ptr[i],
+            ref_heap[i],
+            rtol=rtol,
+        )
+
+
+def test_ssd_chunk_state_golden() raises:
+    """Golden-parity test against the canonical PyTorch SSD reference.
+
+    Pins ``ssd_chunk_state_fwd_cpu`` to a FIXED tiny input whose expected
+    output was computed independently by the chunk end-state reduction (stage 2
+    of ``ssd_minimal_discrete``).
+
+    Shapes: batch=1, n_chunks=1, n_heads=1, chunk_len L=4, state_dim N=3,
+    head_dim P=2; all tensors row-major.
+    """
+    comptime dtype = DType.float32
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    # Fixed literals (row-major). These mirror the values in the parity
+    # reference; state_expected is the reference's output for these inputs.
+    var B_vals = [
+        Float32(0.74),
+        1.95,
+        -0.70,
+        -1.30,
+        -0.51,
+        -0.27,
+        0.25,
+        0.48,
+        0.45,
+        -0.96,
+        1.50,
+        -0.31,
+    ]
+    var X_vals = [
+        Float32(-0.23),
+        -1.07,
+        0.16,
+        0.12,
+        0.38,
+        -0.12,
+        0.89,
+        -0.49,
+    ]
+    var A_vals = [Float32(-0.45), -0.18, -0.36, -0.50]
+    var state_expected = [
+        Float32(-0.944955),
+        1.252577,
+        -0.133558,
+        0.106325,
+        -1.533317,
+        0.370175,
+    ]
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    # Build LayoutTensors from the fixed literals (not random).
+    var B_heap = List(length=b_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    for i in range(b_count):
+        B_h.ptr[i] = Scalar[dtype](B_vals[i])
+
+    var X_heap = List(length=x_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    for i in range(x_count):
+        X_h.ptr[i] = Scalar[dtype](X_vals[i])
+
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    for i in range(a_count):
+        A_h.ptr[i] = Scalar[dtype](A_vals[i])
+
+    var state_heap = List(length=state_count, fill=Scalar[dtype](0))
+    var state_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        state_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    ssd_chunk_state_fwd_cpu[
+        dtype,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        state_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        B_h,
+        X_h,
+        A_h,
+        state_h,
+    )
+
+    # Pin to the canonical PyTorch reference numerics.
+    for i in range(state_count):
+        assert_almost_equal(
+            state_h.ptr[i],
+            Scalar[dtype](state_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_chunk_state_basic() raises:
+    """Basic single-batch, single-chunk case."""
+    run_ssd_chunk_state[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=16,
+        head_dim=8,
+    )
+
+
+def test_ssd_chunk_state_multi_chunk() raises:
+    """Multiple chunks and heads."""
+    run_ssd_chunk_state[DType.float32](
+        batch=1,
+        n_chunks=3,
+        n_heads=2,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=8,
+    )
+
+
+def test_ssd_chunk_state_multi_batch() raises:
+    """Multiple batch elements."""
+    run_ssd_chunk_state[DType.float32](
+        batch=2,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=4,
+    )
+
+
+def test_ssd_chunk_state_chunk_len_one() raises:
+    """Degenerate chunk length of one (decay is exactly 1)."""
+    run_ssd_chunk_state[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=1,
+        chunk_len=1,
+        state_dim=4,
+        head_dim=4,
+    )
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/mojo/proposals/ssd-chunk-kernels.md
+++ b/mojo/proposals/ssd-chunk-kernels.md
@@ -1,0 +1,113 @@
+# Proposal: Mamba2 SSD chunk-scan prefill kernels
+
+- **Status:** Draft (proposal)
+- **Author:** Evan Owen
+- **Area:** MAX AI kernels (`max/kernels/src/state_space/`)
+- **Tracking:** Phase 2 of the Linear-Attention / SSM roadmap
+
+## Summary
+
+Add the State Space Duality (SSD) **chunk-scan prefill** algorithm for Mamba2
+as a set of Mojo kernels under `max/kernels/src/state_space/`, plus a graph op
+`ssd_chunk_scan_combined`. This is the only genuinely new kernel work for
+Mamba2 — the decode path and all preprocessing already exist (see *Reuse*).
+Because state-space kernels are not on the
+[`max/kernels/CONTRIBUTING.md`](../../max/kernels/CONTRIBUTING.md) "changes we
+accept" list, this proposal seeks a kernels-lead go-ahead before
+implementation PRs.
+
+## Motivation
+
+Mamba2 ([Transformers are SSMs](https://arxiv.org/abs/2405.21060)) replaces
+Mamba1's diagonal selective scan with a scalar-times-identity `A` per head,
+which makes the recurrence equivalent to a structured form of linear attention.
+That equivalence lets prefill be computed **chunk-wise with dense matmuls** that
+map onto tensor cores, instead of a sequential scan. Mamba2 reference
+implementations report 2–8× faster training/prefill from this. MAX currently
+has no chunk-SSD kernel: the existing `ssd_combined` (`selective_scan.mojo`) is,
+despite its name, a Mamba1 *sequential* scan fused with norm+residual.
+
+## Reuse (no new work)
+
+Confirmed present in `max/kernels/src/state_space/`:
+
+| Capability                     | Symbol / file                                                                  | Mamba2 role                                                                                                    |
+|--------------------------------|--------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| Causal conv1d (prefill+update) | `causal_conv1d.mojo`                                                           | identical, reused                                                                                              |
+| Varlen conv1d                  | `varlen_causal_conv1d.mojo`                                                    | identical, reused                                                                                              |
+| Fused RMSNorm + residual       | `rms_norm_fused_residual.mojo`                                                 | identical, reused                                                                                              |
+| Single-token update (scalar A) | `selective_scan_update` (`selective_scan.mojo`)                                | **decode path**, reused as-is                                                                                  |
+| Fused conv+scan, multi-head    | `mamba_split_conv1d_scan_combined_{cpu,gpu}` (`selective_scan.mojo:2260,2766`) | usable Mamba2 **decode** path (already has `nheads`/`headdim`/`ngroups`, scalar A/head; sequential internally) |
+
+So **only the prefill chunk algorithm is new.**
+
+## Proposed design
+
+New file `max/kernels/src/state_space/ssd_chunk.mojo` (keep the 3.2k-line
+`selective_scan.mojo` untouched). The reference is `ssd_minimal_discrete`
+(Listing 1 of the paper). Note the discretization contract: the fused op takes
+raw `x, dt, A, B, C` and internally applies `x ← x·dt`, `A ← A·dt` — i.e. the
+op equals `ssd_minimal_discrete(x·dt, A·dt, B, C, chunk_size)`. Decompose into
+four kernels (each a separate PR), all operating on chunked
+tensors `(batch, n_chunks, chunk_len, n_heads, …)`:
+
+1. **Intra-chunk (diagonal) output.** Within-chunk token×token contribution.
+   `L = exp(segsum(A))`;
+   `Y_diag = einsum("bclhn,bcshn,bhcls,bcshp->bclhp", C, B, L, X)`.
+   Dense GEMM over `chunk_len`; the tensor-core hot path.
+2. **Per-chunk state.** Reduce each chunk to its end-state.
+   `decay = exp(A_cumsum[...,-1:] − A_cumsum)`;
+   `states = einsum("bclhn,bhcl,bclhp->bchpn", B, decay, X)`.
+3. **Inter-chunk recurrence.** Sequential scan over the per-chunk states
+   (length = `n_chunks` ≪ `seqlen`).
+   `decay_chunk = exp(segsum(pad(A_cumsum[...,−1])))`;
+   `new_states = einsum("bhzc,bchpn->bzhpn", decay_chunk, states)`; carries an
+   optional `initial_states` for varlen / cache continuation, emits
+   `final_state` for the SSM cache.
+4. **Output recombination.** Add the inter-chunk contribution.
+   `Y_off = einsum("bclhn,bchpn,bhcl->bclhp", C, states, exp(A_cumsum))`;
+   `Y = Y_diag + Y_off`.
+
+A combined op `ssd_chunk_scan_combined` (registered like
+`selective_scan_ops.mojo`'s `@compiler.register`) fuses dt-discretization,
+conv (optional), the four stages, and the final-state write so the Python
+pipeline calls a single op.
+
+### Dimensions & dtypes
+
+- `n_heads · head_dim = d_model`; `head_dim` 64–128; scalar `A` per head;
+  `n_groups` for B/C sharing; `d_state` (`N`) 64–128.
+- `chunk_size` tunable 64–256, default **128** (trades tensor-core utilization
+  against per-chunk state overhead).
+- Compute in fp32 accumulation; inputs bf16/fp16/fp32. The varlen scan path
+  already supports `MAX_DSTATE=256`, covering Mamba2's range.
+
+## Correctness / parity
+
+Gate every kernel against the PyTorch/CUDA reference: compare
+`ssd_chunk_scan_combined` to `mamba_chunk_scan_combined` and the pure-torch
+`ssd_minimal_discrete` on identical seeded inputs. Tolerances: fp32 rtol
+1e-5/atol 1e-6; fp16 1e-2/1e-3; bf16 2e-2/1e-2. Capture goldens for in-tree
+`assert_almost_equal` tests (`max/kernels/test/{,gpu/}state_space/`), so
+committed tests need no CUDA.
+
+## Testing
+
+- Mojo `std.testing` (`assert_almost_equal`), GPU tests gated on accelerator
+  count; CPU reference path where practical.
+- Per-stage unit tests + a combined-op test + the parity golden test.
+
+## Alternatives considered
+
+- **Extend `ssd_combined`** — rejected: it is Mamba1 sequential scan fused with
+  norm; the chunk algorithm is structurally different.
+- **Sequential scan for prefill** (reuse `mamba_split_conv1d_scan_combined`) —
+  works and is the decode path, but forgoes the tensor-core speedup that is the
+  entire point of Mamba2 prefill.
+
+## Rollout (PR split)
+
+One PR each: (1) intra-chunk kernel, (2) chunk-state kernel, (3) inter-chunk
+scan, (4) output recombination, (5) `ssd_chunk_scan_combined` op wrapper,
+(6) ops wrappers for the existing fused kernels (closes `TODO(MSTDL-2472)`),
+(7) Mamba2 dim parameterization. Each carries its own tests and parity report.


### PR DESCRIPTION
## Linked issue

Part of #5772 (Phase 2: Mamba2 / SSD). Design: the SSD chunk-kernels proposal in this stack.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [X] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Second SSD stage: per-chunk state `S_c = Σ_t decay(t) · Bₜᵀ Xₜ`. Includes a fused tensor-core path and a scalar reference so the fast path can be checked in-tree.

## What changed

Adds ssd_chunk_state, the per-chunk state computation of the Mamba2 SSD
algorithm, with a fused tensor-core (MMA) path plus a scalar reference.
Includes CPU and GPU parity tests, a benchmark, and three profiling
harnesses. Builds on the SSD intra-chunk kernels and shared state_space
library scaffolding added earlier in this stack.

```
.../gpu/state_space/bench_ssd_chunk_state.mojo     | 334 ++++++++
 .../gpu/state_space/prof_ssd_state_fused.mojo      | 100 +++
 .../gpu/state_space/prof_ssd_state_only.mojo       | 128 +++
 .../gpu/state_space/prof_ssd_state_static.mojo     | 101 +++
 max/kernels/src/state_space/ssd_chunk_state.mojo   | 862 +++++++++++++++++++++
 max/kernels/test/gpu/state_space/BUILD.bazel       |   4 +
 .../test/gpu/state_space/test_ssd_chunk_state.mojo | 647 ++++++++++++++++
 .../test/state_space/test_ssd_chunk_state.mojo     | 359 +++++++++
 8 files changed, 2535 insertions(+)
```

## Testing

`test_ssd_chunk_state.mojo` CPU and GPU tests pass (scalar, static tensor-core and fused paths against the reference). `bench_ssd_chunk_state` and the three `prof_ssd_state_*` targets build. NVIDIA GB10.

## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [X] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [X] I ran `./bazelw run format` to format my changes
- [X] I added or updated tests to cover my changes

---

## Stack: Mamba2 (SSD) architecture

**Stacked on #6987.** This PR's diff on GitHub includes its prerequisites; review the last commit only (`78a5092487`). It should merge after #6987.

Related but independent (not prerequisites): the Mamba1 kernel PRs #6628, #6632 (causal conv1d) and #6622, #6633 (selective scan) improve the conv/decode paths the Mamba2 model also uses; the SSD stack does not depend on them.

Full series (kernels first, then the MAX pipeline):

1. [Mojo] Propose Mamba2 SSD chunk-kernels algorithm (#6986)
2. [Kernels] Add Mamba2 SSD intra-chunk kernels (scalar + fused MMA) with tests and benches (#6987)
3. **[Kernels] Add Mamba2 SSD chunk-state kernel (fused tensor-core path) with tests and benches** (#6988)
4. [Kernels] Add Mamba2 SSD inter-chunk state-passing scan kernel with tests and benches (#6989)
5. [Kernels] Add Mamba2 SSD output-recombination kernel (tensor-core + fused stage-4 path) with tests and benches (#6990)
6. [Kernels] Add ssd_chunk_scan_combined op wrapper with final_state output (#6991)
7. [Kernels] Add ssd_combined and mamba_split_conv1d_scan_combined op wrappers (#6992)
8. [Kernels] Add Mamba2-dimension coverage test for the SSD prefill path (#6993)
9. [MAX] Fall back to model_type when the architectures field is missing from a HF config (#6994)
10. [MAX] Mamba2: add ssd_chunk_scan_combined functional-op wrapper (#6995)
11. [MAX] Mamba2: add Mamba2Mixer and Mamba2Block NN modules (#6996)
12. [MAX] Mamba2: add model config and HF weight adapters (#6997)
13. [MAX] Mamba2: add model, SSM cache, batch processor and memory planner (#6998)
14. [MAX] Mamba2: register the Mamba2ForCausalLM architecture (#6999)
15. [MAX] Mamba2: add MAX-vs-HF parity integration test (#7000)
