### PR TITLE
[Kernels] Add ssd_combined and mamba_split_conv1d_scan_combined op wrappers

### DIFF
--- a/max/kernels/benchmarks/BUILD.bazel
+++ b/max/kernels/benchmarks/BUILD.bazel
@@ -235,6 +235,7 @@ _CPU_TESTS = glob(
             "//max:max_mojo",
             "//max:nn",
             "//max:shmem",
+            "//max:state_space",
             "//max:structured_kernels",
             "@mojo//:std",
         ],

--- a/max/kernels/benchmarks/BUILD.bazel
+++ b/max/kernels/benchmarks/BUILD.bazel
@@ -24,6 +24,15 @@ _EXTRA_DEPS = {
     "gpu/state_space/prof_ssd_chunk_scan_only.mojo": [
         "//max/kernels/src/state_space",
     ],
+    "gpu/state_space/bench_ssd_chunk_combine.mojo": [
+        "//max/kernels/src/state_space",
+    ],
+    "gpu/state_space/prof_ssd_combine_only.mojo": [
+        "//max/kernels/src/state_space",
+    ],
+    "gpu/state_space/prof_ssd_combine_static.mojo": [
+        "//max/kernels/src/state_space",
+    ],
 }
 
 _EXTRA_CONSTRAINTS = {

--- a/max/kernels/benchmarks/BUILD.bazel
+++ b/max/kernels/benchmarks/BUILD.bazel
@@ -13,9 +13,17 @@ _RUN_BENCHMARKS = [
     "nn/bench_gather_reduce.mojo",
 ]
 
+# Per-src extra deps for GPU benchmarks that import a specific kernel package
+# not covered by the default dep set below.
 _EXTRA_DEPS = {
     "algorithm/parallelize_overhead.mojo": ["//max:max_mojo"],
     "linalg/bench_layout_tensor.mojo": ["//max:max_mojo"],
+    "gpu/state_space/bench_ssd_chunk_scan.mojo": [
+        "//max/kernels/src/state_space",
+    ],
+    "gpu/state_space/prof_ssd_chunk_scan_only.mojo": [
+        "//max/kernels/src/state_space",
+    ],
 }
 
 _EXTRA_CONSTRAINTS = {
@@ -238,7 +246,7 @@ _CPU_TESTS = glob(
             "//max:state_space",
             "//max:structured_kernels",
             "@mojo//:std",
-        ],
+        ] + _EXTRA_DEPS.get(src, []),
     )
     for src in glob(
         ["gpu/**/*.mojo"],

--- a/max/kernels/benchmarks/gpu/state_space/bench_ssd_chunk_combine.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/bench_ssd_chunk_combine.mojo
@@ -1,0 +1,360 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Microbenchmark for ``ssd_output_recombination_fwd_gpu`` (SSD stage 4).
+
+Times wall-clock per launch (kernel + sync) and amortized throughput (queue all
+launches, sync once -- matches the Triton parity bench methodology) across the
+Mamba2-130m prefill profile (B=1, n_chunks=4, n_heads=24, L=256, P=64, N=128)
+and a chunk-count sweep.
+
+The recombination adds the inter-chunk (off-diagonal) contribution to the
+intra-chunk diagonal output:
+
+    Y_off[l, p] = exp(cumsum(A)[l]) * sum_n C[l, n] * entering_state[p, n]
+    Y[l, p]     = Y_diag[l, p] + Y_off[l, p]
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+from std.math import ceildiv
+from std.time import perf_counter_ns
+
+from state_space.ssd_chunk_combine import (
+    ssd_output_recombination_fwd_gpu,
+    ssd_output_recombination_fwd_gpu_fused,
+    ssd_output_recombination_fwd_gpu_static,
+)
+
+
+def time_one[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    comptime SCALAR_BLOCK_SIZE = 128
+
+    comptime c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    var c_tt = TileTensor(
+        c_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var a_tt = TileTensor(
+        a_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var yd_tt = TileTensor(
+        yd_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var y_tt = TileTensor(
+        y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    var total_threads = batch * n_chunks * n_heads * chunk_len * head_dim
+    var grid = ceildiv(total_threads, SCALAR_BLOCK_SIZE)
+
+    var compiled = ctx.compile_function[
+        ssd_output_recombination_fwd_gpu[
+            dtype,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ]
+    ]()
+
+    for _ in range(warmups):
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            Int32(state_dim),
+            c_tt,
+            ent_tt,
+            a_tt,
+            yd_tt,
+            y_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+    ctx.synchronize()
+
+    # Per-launch latency: sync every iter.
+    var min_ns: Int = -1
+    var sum_ns: Int = 0
+    for _ in range(iters):
+        var t0 = perf_counter_ns()
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            Int32(state_dim),
+            c_tt,
+            ent_tt,
+            a_tt,
+            yd_tt,
+            y_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+        ctx.synchronize()
+        var t1 = perf_counter_ns()
+        var elapsed = Int(t1 - t0)
+        sum_ns += elapsed
+        if min_ns < 0 or elapsed < min_ns:
+            min_ns = elapsed
+
+    # Amortized throughput: queue all launches, sync once.
+    var a0 = perf_counter_ns()
+    for _ in range(iters):
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            Int32(state_dim),
+            c_tt,
+            ent_tt,
+            a_tt,
+            yd_tt,
+            y_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+    ctx.synchronize()
+    var a1 = perf_counter_ns()
+    var amort_ms = Float64(Int(a1 - a0)) / Float64(iters) / 1.0e6
+
+    var min_ms = Float64(min_ns) / 1.0e6
+    var mean_ms = Float64(sum_ns) / Float64(iters) / 1.0e6
+    print(
+        "  nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  min(sync)=",
+        min_ms,
+        "ms  mean(sync)=",
+        mean_ms,
+        "ms  amort=",
+        amort_ms,
+        "ms",
+        sep="",
+    )
+
+
+def time_one_static[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    comptime c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    var c_tt = TileTensor(
+        c_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var a_tt = TileTensor(
+        a_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var yd_tt = TileTensor(
+        yd_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var y_tt = TileTensor(
+        y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(warmups):
+        ssd_output_recombination_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, c_tt, ent_tt, a_tt, yd_tt, y_tt, ctx)
+    ctx.synchronize()
+
+    var a0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_output_recombination_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, c_tt, ent_tt, a_tt, yd_tt, y_tt, ctx)
+    ctx.synchronize()
+    var a1 = perf_counter_ns()
+    var amort_ms = Float64(Int(a1 - a0)) / Float64(iters) / 1.0e6
+    print(
+        "  [static] nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  amort=",
+        amort_ms,
+        "ms",
+        sep="",
+    )
+
+
+def time_one_fused[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    comptime c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    var c_tt = TileTensor(
+        c_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var a_tt = TileTensor(
+        a_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var yd_tt = TileTensor(
+        yd_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var y_tt = TileTensor(
+        y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(warmups):
+        ssd_output_recombination_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, c_tt, ent_tt, a_tt, yd_tt, y_tt, ctx)
+    ctx.synchronize()
+
+    var a0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_output_recombination_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, c_tt, ent_tt, a_tt, yd_tt, y_tt, ctx)
+    ctx.synchronize()
+    var a1 = perf_counter_ns()
+    var amort_ms = Float64(Int(a1 - a0)) / Float64(iters) / 1.0e6
+    print(
+        "  [fused] nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  amort=",
+        amort_ms,
+        "ms",
+        sep="",
+    )
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    print("Scalar baseline (Mamba2-130m prefill profile + nchunks scaling):")
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 20, 100)
+    time_one[DType.float32, 1, 8, 24, 256, 64, 128](ctx, 20, 100)
+    time_one[DType.float32, 1, 16, 24, 256, 64, 128](ctx, 20, 100)
+
+    print("Static tensor-core path (same profiles):")
+    time_one_static[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 20, 100)
+    time_one_static[DType.float32, 1, 8, 24, 256, 64, 128](ctx, 20, 100)
+    time_one_static[DType.float32, 1, 16, 24, 256, 64, 128](ctx, 20, 100)
+
+    print("Fused single-pass MMA path (same profiles):")
+    time_one_fused[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 20, 100)
+    time_one_fused[DType.float32, 1, 8, 24, 256, 64, 128](ctx, 20, 100)
+    time_one_fused[DType.float32, 1, 16, 24, 256, 64, 128](ctx, 20, 100)

--- a/max/kernels/benchmarks/gpu/state_space/bench_ssd_chunk_scan.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/bench_ssd_chunk_scan.mojo
@@ -1,0 +1,165 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Microbenchmark for ``ssd_chunk_scan_fwd_gpu`` (SSD inter-chunk scan, stage 3).
+
+Times wall-clock per launch (kernel + sync) across a small sweep, ending on
+the Mamba2-130m prefill profile (B=1, n_chunks=4, n_heads=24, P=64, N=128).
+The inter-chunk recurrence is sequential over chunks; we parallelize over
+``(batch, head, p, n)`` exactly as the shipped kernel does.
+
+Set ``iters`` high (e.g. 20000) for the nsys sampling window — a short run
+spans <0.2 s and the 10 kHz sampler misses the kernels (see
+``.planning/ssd-intra-nsight-profile.md``).
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+from std.math import ceildiv
+from std.time import perf_counter_ns
+
+from state_space.ssd_chunk_scan import ssd_chunk_scan_fwd_gpu
+
+
+def time_one[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    comptime SCALAR_BLOCK_SIZE = 128
+
+    comptime cs_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime cd_count = batch * n_chunks * n_heads
+    comptime ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime final_count = batch * n_heads * head_dim * state_dim
+
+    var cs_device = ctx.enqueue_create_buffer[dtype](cs_count)
+    var cd_device = ctx.enqueue_create_buffer[dtype](cd_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var final_device = ctx.enqueue_create_buffer[dtype](final_count)
+
+    var cs_tt = TileTensor(
+        cs_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var cd_tt = TileTensor(cd_device, row_major(batch, n_chunks, n_heads))
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var final_tt = TileTensor(
+        final_device, row_major(batch, n_heads, head_dim, state_dim)
+    )
+
+    var total_threads = batch * n_heads * head_dim * state_dim
+    var grid = ceildiv(total_threads, SCALAR_BLOCK_SIZE)
+
+    var compiled = ctx.compile_function[
+        ssd_chunk_scan_fwd_gpu[
+            dtype,
+            cs_tt.LayoutType,
+            cd_tt.LayoutType,
+            ent_tt.LayoutType,
+            final_tt.LayoutType,
+        ]
+    ]()
+
+    for _ in range(warmups):
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            cs_tt,
+            cd_tt,
+            ent_tt,
+            final_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+    ctx.synchronize()
+
+    # Per-launch latency: sync every iter (round-trip).
+    var min_ns: Int = -1
+    var sum_ns: Int = 0
+    for _ in range(iters):
+        var t0 = perf_counter_ns()
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            cs_tt,
+            cd_tt,
+            ent_tt,
+            final_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+        ctx.synchronize()
+        var t1 = perf_counter_ns()
+        var elapsed = Int(t1 - t0)
+        sum_ns += elapsed
+        if min_ns < 0 or elapsed < min_ns:
+            min_ns = elapsed
+
+    # Amortized throughput: queue all launches, sync once (matches the Triton
+    # parity bench's methodology for an apples-to-apples head-to-head).
+    var a0 = perf_counter_ns()
+    for _ in range(iters):
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            cs_tt,
+            cd_tt,
+            ent_tt,
+            final_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+    ctx.synchronize()
+    var a1 = perf_counter_ns()
+    var amort_ms = Float64(Int(a1 - a0)) / Float64(iters) / 1.0e6
+
+    var min_ms = Float64(min_ns) / 1.0e6
+    var mean_ms = Float64(sum_ns) / Float64(iters) / 1.0e6
+    print(
+        "  nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  min(sync)=",
+        min_ms,
+        "ms  mean(sync)=",
+        mean_ms,
+        "ms  amort=",
+        amort_ms,
+        "ms",
+        sep="",
+    )
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    print("Single-slice (batch=1, n_chunks=4, n_heads=1) sweep:")
+    time_one[DType.float32, 1, 4, 1, 64, 128](ctx, 5, 50)
+    time_one[DType.float32, 1, 16, 1, 64, 128](ctx, 5, 50)
+
+    print("Multi-slice sweep (Mamba2-130m prefill profile + nchunks scaling):")
+    time_one[DType.float32, 1, 4, 24, 64, 128](ctx, 20, 200)
+    time_one[DType.float32, 1, 8, 24, 64, 128](ctx, 20, 200)
+    time_one[DType.float32, 1, 16, 24, 64, 128](ctx, 20, 200)

--- a/max/kernels/benchmarks/gpu/state_space/bench_ssd_chunk_state.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/bench_ssd_chunk_state.mojo
@@ -1,0 +1,334 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Microbenchmark sweep for ``ssd_chunk_state_fwd_gpu``.
+
+Stage 2 of the chunked SSD prefill: reduce each chunk to its
+``[head_dim, state_dim]`` end-state. Sweeps a few dim configs to isolate where
+time goes and reports the Mamba2-130m prefill profile used by the intra-chunk
+optimization notes (B=1, n_chunks=4, n_heads=24, L=256, P=64, N=128). Times
+wall-clock per call (kernel enqueue + sync).
+"""
+
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+from layout import TileTensor, row_major
+
+from state_space.ssd_chunk_state import (
+    ssd_chunk_state_fwd_gpu,
+    ssd_chunk_state_fwd_gpu_static,
+    ssd_chunk_state_fwd_gpu_fused,
+)
+
+
+def time_one[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int, num_p_tiles: Int = 1) raises:
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_state_fwd_gpu[
+            dtype,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ]
+    ]()
+
+    for _ in range(warmups):
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+    ctx.synchronize()
+
+    var min_ns: Int = -1
+    var sum_ns: Int = 0
+    for _ in range(iters):
+        var t0 = perf_counter_ns()
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+        ctx.synchronize()
+        var t1 = perf_counter_ns()
+        var elapsed = Int(t1 - t0)
+        sum_ns += elapsed
+        if min_ns < 0 or elapsed < min_ns:
+            min_ns = elapsed
+
+    var min_ms = Float64(min_ns) / 1.0e6
+    var mean_ms = Float64(sum_ns) / Float64(iters) / 1.0e6
+    print(
+        "  nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        " p_tiles=",
+        num_p_tiles,
+        "  min=",
+        min_ms,
+        "ms  mean=",
+        mean_ms,
+        "ms",
+        sep="",
+    )
+
+
+def time_one_static[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    """Time the static tensor-core path (decay-transpose + batched_matmul)."""
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    for _ in range(warmups):
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+
+    # Pipelined timing (enqueue all iters, sync once) to match the Triton
+    # bench's methodology for a fair throughput comparison.
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    print(
+        "  [tensor-core] nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  ",
+        Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6,
+        "ms/iter (pipelined)",
+        sep="",
+    )
+
+
+def time_one_fused[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    """Time the fused single-pass tensor-core path (pipelined throughput)."""
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    for _ in range(warmups):
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    print(
+        "  [fused] nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  ",
+        Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6,
+        "ms/iter (pipelined)",
+        sep="",
+    )
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    # Single-slice baselines to expose where time goes.
+    print("Single-slice (batch=1, n_chunks=1, n_heads=1) sweep:")
+    time_one[DType.float32, 1, 1, 1, 64, 64, 32](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 64, 64, 128](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 128, 64, 128](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 256, 64, 128](ctx, 5, 20)
+
+    # Mamba2-130m prefill profile, swept over p-tile counts (block count =
+    # 96 * p_tiles) to find the GB10 occupancy sweet spot.
+    print("Multi-slice sweep (Mamba2-130m prefill profile), p-tile sweep:")
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 1)
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 2)
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 4)
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 8)
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 16)
+
+    # Tensor-core path (decay-transpose + batched_matmul) at the same profile,
+    # plus longer prefills, to compare head-to-head with Triton _chunk_state_fwd.
+    print("Tensor-core path (static), pipelined throughput:")
+    time_one_static[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 10, 200)
+    time_one_static[DType.float32, 1, 8, 24, 256, 64, 128](ctx, 10, 200)
+    time_one_static[DType.float32, 1, 16, 24, 256, 64, 128](ctx, 10, 200)
+
+    print("Fused single-pass tensor-core path, pipelined throughput:")
+    time_one_fused[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 10, 200)
+    time_one_fused[DType.float32, 1, 8, 24, 256, 64, 128](ctx, 10, 200)
+    time_one_fused[DType.float32, 1, 16, 24, 256, 64, 128](ctx, 10, 200)

--- a/max/kernels/benchmarks/gpu/state_space/bench_ssd_intra_chunk.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/bench_ssd_intra_chunk.mojo
@@ -1,0 +1,156 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Microbenchmark sweep for ``ssd_intra_chunk_fwd_gpu``.
+
+Sweeps several dim configs to isolate where time goes: small/medium/large
+chunk_len, head_dim, state_dim. Times wall-clock per call (kernel + sync).
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+
+from state_space.ssd_chunk import (
+    ssd_intra_chunk_fwd_gpu,
+    ssd_intra_chunk_fwd_gpu_fused,
+    ssd_intra_chunk_fwd_gpu_static,
+)
+
+
+def time_one[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+    use_fused: Bool = False,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    comptime cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y_device = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    var C_tt = TileTensor(
+        C_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var Y_tt = TileTensor(
+        Y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(warmups):
+        comptime if use_fused:
+            ssd_intra_chunk_fwd_gpu_fused[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        else:
+            ssd_intra_chunk_fwd_gpu_static[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+    ctx.synchronize()
+
+    var min_ns: Int = -1
+    var sum_ns: Int = 0
+    for _ in range(iters):
+        var t0 = perf_counter_ns()
+        comptime if use_fused:
+            ssd_intra_chunk_fwd_gpu_fused[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        else:
+            ssd_intra_chunk_fwd_gpu_static[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        ctx.synchronize()
+        var t1 = perf_counter_ns()
+        var elapsed = Int(t1 - t0)
+        sum_ns += elapsed
+        if min_ns < 0 or elapsed < min_ns:
+            min_ns = elapsed
+
+    var min_ms = Float64(min_ns) / 1.0e6
+    var mean_ms = Float64(sum_ns) / Float64(iters) / 1.0e6
+    print(
+        "  nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  min=",
+        min_ms,
+        "ms  mean=",
+        mean_ms,
+        "ms",
+        sep="",
+    )
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    # Single-slice baselines to expose where time goes.
+    print("Single-slice (batch=1, n_chunks=1, n_heads=1) sweep:")
+    time_one[DType.float32, 1, 1, 1, 64, 64, 32](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 64, 64, 128](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 128, 64, 128](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 256, 64, 128](ctx, 5, 20)
+
+    print("Multi-slice sweep (Mamba2-130m prefill profile) — two-kernel:")
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 10)
+
+    print("Multi-slice sweep (Mamba2-130m prefill profile) — FUSED (RFC 0009):")
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128, use_fused=True](ctx, 5, 50)
+    time_one[DType.float32, 1, 8, 24, 256, 64, 128, use_fused=True](ctx, 5, 50)

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_chunk_scan_only.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_chunk_scan_only.mojo
@@ -1,0 +1,80 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Minimal driver: run ONLY ``ssd_chunk_scan_fwd_gpu`` a few times.
+
+Tightly-scoped target for ``ncu`` single-metric roofline collection on GB10
+(no ``--set full`` replay — that crashes the box; see
+``.planning/ssd-intra-nsight-profile.md``). Every launch is the Mamba2-130m
+prefill profile so the per-kernel rows are unambiguous and the launch count is
+bounded for ``-c N``.
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+from std.math import ceildiv
+
+from state_space.ssd_chunk_scan import ssd_chunk_scan_fwd_gpu
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime head_dim = 64
+    comptime state_dim = 128
+    comptime SCALAR_BLOCK_SIZE = 128
+
+    comptime cs_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime cd_count = batch * n_chunks * n_heads
+    comptime ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime final_count = batch * n_heads * head_dim * state_dim
+
+    var cs_device = ctx.enqueue_create_buffer[dtype](cs_count)
+    var cd_device = ctx.enqueue_create_buffer[dtype](cd_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var final_device = ctx.enqueue_create_buffer[dtype](final_count)
+
+    var cs_tt = TileTensor(
+        cs_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var cd_tt = TileTensor(cd_device, row_major(batch, n_chunks, n_heads))
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var final_tt = TileTensor(
+        final_device, row_major(batch, n_heads, head_dim, state_dim)
+    )
+
+    var total_threads = batch * n_heads * head_dim * state_dim
+    var grid = ceildiv(total_threads, SCALAR_BLOCK_SIZE)
+
+    var compiled = ctx.compile_function[
+        ssd_chunk_scan_fwd_gpu[
+            dtype,
+            cs_tt.LayoutType,
+            cd_tt.LayoutType,
+            ent_tt.LayoutType,
+            final_tt.LayoutType,
+        ]
+    ]()
+
+    for _ in range(4):
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            cs_tt,
+            cd_tt,
+            ent_tt,
+            final_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+    ctx.synchronize()

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_combine_only.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_combine_only.mojo
@@ -1,0 +1,90 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Minimal driver: run ONLY ``ssd_output_recombination_fwd_gpu`` a few times.
+
+Tightly-scoped target for ``ncu`` single-metric roofline collection on GB10
+(no ``--set full`` replay -- that crashes the box; see
+``.planning/ssd-intra-nsight-profile.md``). Every launch is the Mamba2-130m
+prefill profile so the per-kernel rows are unambiguous and the launch count is
+bounded for ``-c N``.
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+from std.math import ceildiv
+
+from state_space.ssd_chunk_combine import ssd_output_recombination_fwd_gpu
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+    comptime SCALAR_BLOCK_SIZE = 128
+
+    comptime c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    var c_tt = TileTensor(
+        c_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var a_tt = TileTensor(
+        a_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var yd_tt = TileTensor(
+        yd_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var y_tt = TileTensor(
+        y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    var total_threads = batch * n_chunks * n_heads * chunk_len * head_dim
+    var grid = ceildiv(total_threads, SCALAR_BLOCK_SIZE)
+
+    var compiled = ctx.compile_function[
+        ssd_output_recombination_fwd_gpu[
+            dtype,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ]
+    ]()
+
+    for _ in range(4):
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            Int32(state_dim),
+            c_tt,
+            ent_tt,
+            a_tt,
+            yd_tt,
+            y_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+    ctx.synchronize()

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_combine_static.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_combine_static.mojo
@@ -1,0 +1,69 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Minimal driver: run ONLY the static tensor-core stage-4 path a few times.
+
+Scoped target for ``ncu`` single-metric collection on GB10. The static path is
+two launches (batched_matmul + decay/add epilogue), so per-kernel ncu rows show
+the matmul vs epilogue split. Mamba2-130m prefill profile.
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+
+from state_space.ssd_chunk_combine import (
+    ssd_output_recombination_fwd_gpu_static,
+)
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    comptime c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    var c_tt = TileTensor(
+        c_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var a_tt = TileTensor(
+        a_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var yd_tt = TileTensor(
+        yd_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var y_tt = TileTensor(
+        y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(4):
+        ssd_output_recombination_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, c_tt, ent_tt, a_tt, yd_tt, y_tt, ctx)
+    ctx.synchronize()

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_fused_only.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_fused_only.mojo
@@ -1,0 +1,62 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Minimal driver: run ONLY the fused intra-chunk MMA path (RFC 0009).
+
+Scoped target for ncu single-metric roofline collection on GB10. Mamba2-130m
+prefill profile.
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+
+from state_space.ssd_chunk import ssd_intra_chunk_fwd_gpu_fused
+
+
+def main() raises:
+    var ctx = DeviceContext()
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    comptime cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    var C_tt = TileTensor(
+        C, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var B_tt = TileTensor(
+        B, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(A, row_major(batch, n_chunks, n_heads, chunk_len))
+    var Y_tt = TileTensor(
+        Y, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(4):
+        ssd_intra_chunk_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            C_tt.LayoutType,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            Y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+    ctx.synchronize()

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_scan_only.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_scan_only.mojo
@@ -1,0 +1,64 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Minimal driver: run ONLY the multi-slice ssd_intra static path a few times.
+
+Used as a tightly-scoped target for ``ncu`` single-metric roofline collection
+(no full-set replay — that crashes the GB10). Every launch is the Mamba2-130m
+prefill profile so the per-kernel rows are unambiguous.
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+
+from state_space.ssd_chunk import ssd_intra_chunk_fwd_gpu_static
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    comptime cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    var C_tt = TileTensor(
+        C, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var B_tt = TileTensor(
+        B, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(A, row_major(batch, n_chunks, n_heads, chunk_len))
+    var Y_tt = TileTensor(
+        Y, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(4):
+        ssd_intra_chunk_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            C_tt.LayoutType,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            Y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+    ctx.synchronize()

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_fused.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_fused.mojo
@@ -1,0 +1,100 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Single-kernel profiling driver for the fused tensor-core chunk-state entry.
+
+Runs ssd_chunk_state_fwd_gpu_fused (one fused MMA kernel) in a long loop at the
+Mamba2-130m prefill profile so its ncu row is unambiguous. argv[1] = iters.
+"""
+
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+from std.sys import argv
+from layout import TileTensor, row_major
+
+from state_space.ssd_chunk_state import ssd_chunk_state_fwd_gpu_fused
+
+
+def main() raises:
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    var iters = 2000
+    var args = argv()
+    if len(args) > 1:
+        iters = atol(args[1])
+
+    var ctx = DeviceContext()
+
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    for _ in range(5):
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    print(
+        "ssd_chunk_state fused prof: ",
+        iters,
+        " iters, ",
+        Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6,
+        " ms/iter",
+    )

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_only.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_only.mojo
@@ -1,0 +1,128 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Single-kernel profiling driver for ``ssd_chunk_state_fwd_gpu``.
+
+Runs ONLY the chunk-state kernel in a long loop at the Mamba2-130m prefill
+profile (B=1, n_chunks=4, n_heads=24, L=256, P=64, N=128) so per-kernel ncu
+rows are unambiguous and the nsys 10 kHz sampler lands on a sustained busy
+window. See ``.planning/ssd-intra-optimization-notes.md`` for the GB10
+profiling method (ncu single-metric + ``-c N`` is safe; ``--set full`` crashes
+the box).
+
+Iter count is read from argv[1] (default 20000) so the same binary serves both
+a quick latency check and a multi-second nsys capture window.
+"""
+
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+from std.sys import argv
+from layout import TileTensor, row_major
+
+from state_space.ssd_chunk_state import ssd_chunk_state_fwd_gpu
+
+
+def main() raises:
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    var iters = 20000
+    var num_p_tiles = 8  # GB10 sweet spot at this profile (see bench sweep).
+    var args = argv()
+    if len(args) > 1:
+        iters = atol(args[1])
+    if len(args) > 2:
+        num_p_tiles = atol(args[2])
+
+    var ctx = DeviceContext()
+
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_state_fwd_gpu[
+            dtype,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ]
+    ]()
+
+    # Warmup.
+    for _ in range(5):
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+    ctx.synchronize()
+
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    var per_iter_ms = Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6
+    print("ssd_chunk_state prof: ", iters, " iters, ", per_iter_ms, " ms/iter")

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_static.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_static.mojo
@@ -1,0 +1,101 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Single-path profiling driver for the static tensor-core chunk-state entry.
+
+Runs ssd_chunk_state_fwd_gpu_static (decay-transpose kernel + batched_matmul)
+in a long loop at the Mamba2-130m prefill profile so ncu rows for the two
+kernels (the decay-transpose and the matmul) are unambiguous. argv[1] = iters.
+"""
+
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+from std.sys import argv
+from layout import TileTensor, row_major
+
+from state_space.ssd_chunk_state import ssd_chunk_state_fwd_gpu_static
+
+
+def main() raises:
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    var iters = 2000
+    var args = argv()
+    if len(args) > 1:
+        iters = atol(args[1])
+
+    var ctx = DeviceContext()
+
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    for _ in range(5):
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    print(
+        "ssd_chunk_state static prof: ",
+        iters,
+        " iters, ",
+        Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6,
+        " ms/iter",
+    )

--- a/max/kernels/src/state_space/BUILD.bazel
+++ b/max/kernels/src/state_space/BUILD.bazel
@@ -22,6 +22,7 @@ mojo_library(
     deps = [
         "//max:extensibility",
         "//max:layout",
+        "//max:linalg",
         "//max:max_mojo",
         "//max:nn",
         "@mojo//:std",

--- a/max/kernels/src/state_space/selective_scan_ops.mojo
+++ b/max/kernels/src/state_space/selective_scan_ops.mojo
@@ -34,6 +34,10 @@ from state_space.selective_scan import (
     selective_scan_fwd_gpu_minimal,
     selective_scan_update_cpu,
     selective_scan_update_gpu,
+    ssd_combined_cpu,
+    ssd_combined_gpu,
+    mamba_split_conv1d_scan_combined_cpu,
+    mamba_split_conv1d_scan_combined_gpu,
 )
 
 
@@ -884,3 +888,553 @@ def selective_scan_update_shape[
         matches `state_in.shape()` and `output_shape` matches `x.shape()`.
     """
     return (state_in.shape(), x.shape())
+
+
+@extensibility.register("ssd_combined")
+struct SsdCombined[delta_softplus: Bool = False]:
+    """Fused selective scan + RMS-norm + residual operation for Mamba blocks.
+
+    Performs: norm(residual + selective_scan(input)), optionally gated by SiLU(z).
+    Despite the name (`ssd_combined`), this is the Mamba1-shape *sequential* scan
+    fused with the post-norm/residual path — not the chunk-SSD algorithm.
+
+    Parameters:
+        delta_softplus: If True, applies softplus activation to delta values.
+
+    Tensor Shapes:
+        - output: (batch, dim, seqlen) - Final fused output (normalized, optionally gated)
+        - x: (batch, dim, num_chunks, 2*dstate) - Scan checkpoint state (output)
+        - out_z: (batch, dim, seqlen) - Pre-gating normalized output (output, can be empty)
+        - residual: (batch, dim, seqlen) - Residual tensor added before norm
+        - u: (batch, dim, seqlen) - Input tensor
+        - delta: (batch, dim, seqlen) - Time step tensor
+        - A: (dim, dstate) - State transition matrix
+        - B: (batch, n_groups, dstate, seqlen) - Input projection
+        - C: (batch, n_groups, dstate, seqlen) - Output projection
+        - D: (dim,) - Skip connection (optional, can be empty)
+        - z: (batch, dim, seqlen) - Gating tensor (optional, can be empty)
+        - delta_bias: (dim,) - Delta bias (optional, can be empty)
+        - gamma: (dim,) - RMSNorm weight
+        - epsilon: Scalar - Numerical stability epsilon for RMSNorm
+        - weight_offset: Scalar - Offset added to gamma before scaling
+    """
+
+    @staticmethod
+    def execute[
+        dtype: DType,
+        target: StaticString,
+    ](
+        output: OutputTensor[dtype=dtype, rank=3, ...],
+        x: OutputTensor[dtype=dtype, rank=4, ...],
+        out_z: OutputTensor[dtype=dtype, rank=3, ...],
+        residual: InputTensor[dtype=dtype, rank=3, ...],
+        u: InputTensor[dtype=dtype, rank=3, ...],
+        delta: InputTensor[dtype=dtype, rank=3, ...],
+        A: InputTensor[dtype=dtype, rank=2, ...],
+        B: InputTensor[dtype=dtype, rank=4, ...],
+        C: InputTensor[dtype=dtype, rank=4, ...],
+        D: InputTensor[dtype=dtype, rank=1, ...],
+        z: InputTensor[dtype=dtype, rank=3, ...],
+        delta_bias: InputTensor[dtype=dtype, rank=1, ...],
+        gamma: InputTensor[dtype=dtype, rank=1, ...],
+        epsilon: Scalar[dtype=dtype],
+        weight_offset: Scalar[dtype=dtype],
+        ctx: DeviceContext,
+    ) capturing raises:
+        if output.shape() != u.shape():
+            raise Error("Output shape must match input u shape")
+
+        var batch = output.dim_size(0)
+        var dim = output.dim_size(1)
+        var seqlen = output.dim_size(2)
+        var dstate = A.dim_size(1)
+        var n_groups = B.dim_size(1)
+        var group_size = dim // n_groups
+
+        var output_tt = output.to_tile_tensor[.int32]()
+        var x_tt = x.to_tile_tensor[.int32]()
+        var out_z_tt = out_z.to_tile_tensor[.int32]()
+        var residual_tt = residual.to_tile_tensor[.int32]()
+        var u_tt = u.to_tile_tensor[.int32]()
+        var delta_tt = delta.to_tile_tensor[.int32]()
+        var A_tt = A.to_tile_tensor[.int32]()
+        var B_tt = B.to_tile_tensor[.int32]()
+        var C_tt = C.to_tile_tensor[.int32]()
+        var D_tt = D.to_tile_tensor[.int32]()
+        var z_tt = z.to_tile_tensor[.int32]()
+        var delta_bias_tt = delta_bias.to_tile_tensor[.int32]()
+        var gamma_tt = gamma.to_tile_tensor[.int32]()
+
+        comptime delta_softplus_int8: Int8 = Int8(
+            1
+        ) if Self.delta_softplus else Int8(0)
+
+        if dstate != 16 and dstate != 8:
+            raise Error(
+                "Unsupported dstate: " + String(dstate) + ". Expected 8 or 16."
+            )
+
+        comptime if is_cpu[target]():
+            if dstate == 16:
+                ssd_combined_cpu[
+                    dtype,
+                    16,
+                ](
+                    batch,
+                    dim,
+                    seqlen,
+                    group_size,
+                    delta_softplus_int8,
+                    output_tt,
+                    x_tt,
+                    out_z_tt,
+                    residual_tt,
+                    u_tt,
+                    delta_tt,
+                    A_tt,
+                    B_tt,
+                    C_tt,
+                    D_tt,
+                    z_tt,
+                    delta_bias_tt,
+                    gamma_tt,
+                    epsilon,
+                    weight_offset,
+                    Optional[DeviceContext](ctx),
+                )
+            else:
+                ssd_combined_cpu[
+                    dtype,
+                    8,
+                ](
+                    batch,
+                    dim,
+                    seqlen,
+                    group_size,
+                    delta_softplus_int8,
+                    output_tt,
+                    x_tt,
+                    out_z_tt,
+                    residual_tt,
+                    u_tt,
+                    delta_tt,
+                    A_tt,
+                    B_tt,
+                    C_tt,
+                    D_tt,
+                    z_tt,
+                    delta_bias_tt,
+                    gamma_tt,
+                    epsilon,
+                    weight_offset,
+                    Optional[DeviceContext](ctx),
+                )
+        elif is_gpu[target]():
+            var gpu_ctx = ctx
+            var total_batch_dim = batch * dim
+            comptime BLOCK_SIZE = 128
+            var num_blocks = ceildiv(total_batch_dim, BLOCK_SIZE)
+
+            if dstate == 16:
+                comptime DSTATE_VAL = 16
+                var compiled_kernel = gpu_ctx.compile_function[
+                    ssd_combined_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        output_tt.LayoutType,
+                        x_tt.LayoutType,
+                        out_z_tt.LayoutType,
+                        residual_tt.LayoutType,
+                        u_tt.LayoutType,
+                        delta_tt.LayoutType,
+                        A_tt.LayoutType,
+                        B_tt.LayoutType,
+                        C_tt.LayoutType,
+                        D_tt.LayoutType,
+                        z_tt.LayoutType,
+                        delta_bias_tt.LayoutType,
+                        gamma_tt.LayoutType,
+                        output_tt.Storage,
+                    ]
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_kernel,
+                    Int32(total_batch_dim),
+                    Int32(batch),
+                    Int32(dim),
+                    Int32(seqlen),
+                    Int32(group_size),
+                    delta_softplus_int8,
+                    output_tt,
+                    x_tt,
+                    out_z_tt,
+                    residual_tt,
+                    u_tt,
+                    delta_tt,
+                    A_tt,
+                    B_tt,
+                    C_tt,
+                    D_tt,
+                    z_tt,
+                    delta_bias_tt,
+                    gamma_tt,
+                    epsilon,
+                    weight_offset,
+                    grid_dim=(num_blocks,),
+                    block_dim=(BLOCK_SIZE,),
+                )
+            else:
+                comptime DSTATE_VAL = 8
+                var compiled_kernel = gpu_ctx.compile_function[
+                    ssd_combined_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        output_tt.LayoutType,
+                        x_tt.LayoutType,
+                        out_z_tt.LayoutType,
+                        residual_tt.LayoutType,
+                        u_tt.LayoutType,
+                        delta_tt.LayoutType,
+                        A_tt.LayoutType,
+                        B_tt.LayoutType,
+                        C_tt.LayoutType,
+                        D_tt.LayoutType,
+                        z_tt.LayoutType,
+                        delta_bias_tt.LayoutType,
+                        gamma_tt.LayoutType,
+                        output_tt.Storage,
+                    ]
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_kernel,
+                    Int32(total_batch_dim),
+                    Int32(batch),
+                    Int32(dim),
+                    Int32(seqlen),
+                    Int32(group_size),
+                    delta_softplus_int8,
+                    output_tt,
+                    x_tt,
+                    out_z_tt,
+                    residual_tt,
+                    u_tt,
+                    delta_tt,
+                    A_tt,
+                    B_tt,
+                    C_tt,
+                    D_tt,
+                    z_tt,
+                    delta_bias_tt,
+                    gamma_tt,
+                    epsilon,
+                    weight_offset,
+                    grid_dim=(num_blocks,),
+                    block_dim=(BLOCK_SIZE,),
+                )
+        else:
+            raise Error("Unsupported target: " + target)
+
+
+# ===----------------------------------------------------------------------=== #
+# Mamba Split Conv1d Scan Combined (Mamba2-shape fused conv + sequential scan)
+# ===----------------------------------------------------------------------=== #
+
+
+@extensibility.register("mamba_split_conv1d_scan_combined")
+struct MambaSplitConv1dScanCombined[delta_softplus: Bool = False]:
+    """Fused split-conv1d + selective scan + optional RMSNorm + optional outproj.
+
+    Mamba2-shape kernel: head-sharded A (one scalar per head), sequential scan
+    inside, but fused with the upstream conv1d (after splitting xBC out of the
+    packed `zxbcdt` projection input) and optional downstream norm/outproj.
+
+    Parameters:
+        delta_softplus: If True, applies softplus activation to delta values.
+
+    Tensor Shapes:
+        - zxbcdt: (batch, seqlen, 2*dim + 2*ngroups*dstate + nheads) - Packed projection input
+        - conv_weight: (dim + 2*ngroups*dstate, width) - Conv1d weights for x/B/C channels
+        - conv_bias: (dim + 2*ngroups*dstate,) - Conv1d bias
+        - dt_bias: (nheads,) - dt bias (per head)
+        - A: (nheads,) - Scalar state-transition value per head
+        - D: (nheads, headdim) or (nheads,) - Skip connection (optional, can be empty)
+        - x: (batch, dim, num_chunks, 2*dstate) - Scan checkpoint state (output)
+        - out_z: (batch, dim, seqlen) - Pre-gating output (output)
+        - dt: (batch, nheads, seqlen) - dt tensor (output)
+        - B: (batch, ngroups, dstate, seqlen) - Input projection (output of conv split)
+        - C: (batch, ngroups, dstate, seqlen) - Output projection (output of conv split)
+        - z: (batch, dim, seqlen) - Gating tensor (output, split from zxbcdt)
+        - rmsnorm_weight: (dim,) - RMSNorm weight (optional, can be empty)
+        - outproj_weight: (out_dim, dim) - Output projection weight (optional, can be empty)
+        - outproj_bias: (out_dim,) - Output projection bias (optional, can be empty)
+        - output: (batch, seqlen, dim) or (batch, seqlen, out_dim) - Final output
+        - epsilon: Scalar - RMSNorm epsilon
+
+    Runtime scalar args:
+        seqlen, dim, nheads, headdim, ngroups, width, chunk_size - Shape config
+        norm_before_gate, has_rmsnorm, has_outproj - Int8 flags (0/1)
+    """
+
+    @staticmethod
+    def execute[
+        dtype: DType,
+        target: StaticString,
+    ](
+        x: OutputTensor[dtype=dtype, rank=4, ...],
+        out_z: OutputTensor[dtype=dtype, rank=3, ...],
+        dt: OutputTensor[dtype=dtype, rank=3, ...],
+        B: OutputTensor[dtype=dtype, rank=4, ...],
+        C: OutputTensor[dtype=dtype, rank=4, ...],
+        z: OutputTensor[dtype=dtype, rank=3, ...],
+        output: OutputTensor[dtype=dtype, rank=3, ...],
+        zxbcdt: InputTensor[dtype=dtype, rank=3, ...],
+        conv_weight: InputTensor[dtype=dtype, rank=2, ...],
+        conv_bias: InputTensor[dtype=dtype, rank=1, ...],
+        dt_bias: InputTensor[dtype=dtype, rank=1, ...],
+        A: InputTensor[dtype=dtype, rank=1, ...],
+        D: InputTensor[dtype=dtype, rank=2, ...],
+        rmsnorm_weight: InputTensor[dtype=dtype, rank=1, ...],
+        outproj_weight: InputTensor[dtype=dtype, rank=2, ...],
+        outproj_bias: InputTensor[dtype=dtype, rank=1, ...],
+        nheads: Int,
+        headdim: Int,
+        ngroups: Int,
+        width: Int,
+        chunk_size: Int,
+        norm_before_gate: Int8,
+        has_rmsnorm: Int8,
+        has_outproj: Int8,
+        epsilon: Scalar[dtype=dtype],
+        ctx: DeviceContext,
+    ) capturing raises:
+        var batch = zxbcdt.dim_size(0)
+        var seqlen = zxbcdt.dim_size(1)
+        var dim = nheads * headdim
+        # dstate inferred from B's third dim (B is (batch, ngroups, dstate, seqlen))
+        var dstate = B.dim_size(2)
+
+        var zxbcdt_tt = zxbcdt.to_tile_tensor[.int32]()
+        var conv_weight_tt = conv_weight.to_tile_tensor[.int32]()
+        var conv_bias_tt = conv_bias.to_tile_tensor[.int32]()
+        var dt_bias_tt = dt_bias.to_tile_tensor[.int32]()
+        var A_tt = A.to_tile_tensor[.int32]()
+        var D_tt = D.to_tile_tensor[.int32]()
+        var x_tt = x.to_tile_tensor[.int32]()
+        var out_z_tt = out_z.to_tile_tensor[.int32]()
+        var dt_tt = dt.to_tile_tensor[.int32]()
+        var B_tt = B.to_tile_tensor[.int32]()
+        var C_tt = C.to_tile_tensor[.int32]()
+        var z_tt = z.to_tile_tensor[.int32]()
+        var rmsnorm_weight_tt = rmsnorm_weight.to_tile_tensor[.int32]()
+        var outproj_weight_tt = outproj_weight.to_tile_tensor[.int32]()
+        var outproj_bias_tt = outproj_bias.to_tile_tensor[.int32]()
+        var output_tt = output.to_tile_tensor[.int32]()
+
+        comptime delta_softplus_int8: Int8 = Int8(
+            1
+        ) if Self.delta_softplus else Int8(0)
+
+        if dstate != 16 and dstate != 8:
+            raise Error(
+                "Unsupported dstate: " + String(dstate) + ". Expected 8 or 16."
+            )
+
+        comptime if is_cpu[target]():
+            if dstate == 16:
+                mamba_split_conv1d_scan_combined_cpu[
+                    dtype,
+                    16,
+                ](
+                    batch,
+                    seqlen,
+                    dim,
+                    nheads,
+                    headdim,
+                    ngroups,
+                    width,
+                    chunk_size,
+                    delta_softplus_int8,
+                    norm_before_gate,
+                    has_rmsnorm,
+                    has_outproj,
+                    zxbcdt_tt,
+                    conv_weight_tt,
+                    conv_bias_tt,
+                    dt_bias_tt,
+                    A_tt,
+                    D_tt,
+                    x_tt,
+                    out_z_tt,
+                    dt_tt,
+                    B_tt,
+                    C_tt,
+                    z_tt,
+                    rmsnorm_weight_tt,
+                    outproj_weight_tt,
+                    outproj_bias_tt,
+                    output_tt,
+                    epsilon,
+                    Optional[DeviceContext](ctx),
+                )
+            else:
+                mamba_split_conv1d_scan_combined_cpu[
+                    dtype,
+                    8,
+                ](
+                    batch,
+                    seqlen,
+                    dim,
+                    nheads,
+                    headdim,
+                    ngroups,
+                    width,
+                    chunk_size,
+                    delta_softplus_int8,
+                    norm_before_gate,
+                    has_rmsnorm,
+                    has_outproj,
+                    zxbcdt_tt,
+                    conv_weight_tt,
+                    conv_bias_tt,
+                    dt_bias_tt,
+                    A_tt,
+                    D_tt,
+                    x_tt,
+                    out_z_tt,
+                    dt_tt,
+                    B_tt,
+                    C_tt,
+                    z_tt,
+                    rmsnorm_weight_tt,
+                    outproj_weight_tt,
+                    outproj_bias_tt,
+                    output_tt,
+                    epsilon,
+                    Optional[DeviceContext](ctx),
+                )
+        elif is_gpu[target]():
+            var gpu_ctx = ctx
+            var total_batch_dim = batch * dim
+            comptime BLOCK_SIZE = 128
+            var num_blocks = ceildiv(total_batch_dim, BLOCK_SIZE)
+
+            if dstate == 16:
+                comptime DSTATE_VAL = 16
+                var compiled_kernel = gpu_ctx.compile_function[
+                    mamba_split_conv1d_scan_combined_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        zxbcdt_tt.LayoutType,
+                        conv_weight_tt.LayoutType,
+                        conv_bias_tt.LayoutType,
+                        output_tt.LayoutType,
+                        x_tt.LayoutType,
+                        out_z_tt.LayoutType,
+                        dt_tt.LayoutType,
+                        A_tt.LayoutType,
+                        B_tt.LayoutType,
+                        C_tt.LayoutType,
+                        D_tt.LayoutType,
+                        z_tt.LayoutType,
+                        dt_bias_tt.LayoutType,
+                        rmsnorm_weight_tt.LayoutType,
+                        outproj_weight_tt.LayoutType,
+                        outproj_bias_tt.LayoutType,
+                    ]
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_kernel,
+                    Int32(total_batch_dim),
+                    Int32(batch),
+                    Int32(seqlen),
+                    Int32(dim),
+                    Int32(nheads),
+                    Int32(headdim),
+                    Int32(ngroups),
+                    Int32(width),
+                    Int32(chunk_size),
+                    delta_softplus_int8,
+                    norm_before_gate,
+                    has_rmsnorm,
+                    has_outproj,
+                    zxbcdt_tt,
+                    conv_weight_tt,
+                    conv_bias_tt,
+                    dt_bias_tt,
+                    A_tt,
+                    D_tt,
+                    x_tt,
+                    out_z_tt,
+                    dt_tt,
+                    B_tt,
+                    C_tt,
+                    z_tt,
+                    rmsnorm_weight_tt,
+                    outproj_weight_tt,
+                    outproj_bias_tt,
+                    output_tt,
+                    epsilon,
+                    grid_dim=(num_blocks,),
+                    block_dim=(BLOCK_SIZE,),
+                )
+            else:
+                comptime DSTATE_VAL = 8
+                var compiled_kernel = gpu_ctx.compile_function[
+                    mamba_split_conv1d_scan_combined_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        zxbcdt_tt.LayoutType,
+                        conv_weight_tt.LayoutType,
+                        conv_bias_tt.LayoutType,
+                        output_tt.LayoutType,
+                        x_tt.LayoutType,
+                        out_z_tt.LayoutType,
+                        dt_tt.LayoutType,
+                        A_tt.LayoutType,
+                        B_tt.LayoutType,
+                        C_tt.LayoutType,
+                        D_tt.LayoutType,
+                        z_tt.LayoutType,
+                        dt_bias_tt.LayoutType,
+                        rmsnorm_weight_tt.LayoutType,
+                        outproj_weight_tt.LayoutType,
+                        outproj_bias_tt.LayoutType,
+                    ]
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_kernel,
+                    Int32(total_batch_dim),
+                    Int32(batch),
+                    Int32(seqlen),
+                    Int32(dim),
+                    Int32(nheads),
+                    Int32(headdim),
+                    Int32(ngroups),
+                    Int32(width),
+                    Int32(chunk_size),
+                    delta_softplus_int8,
+                    norm_before_gate,
+                    has_rmsnorm,
+                    has_outproj,
+                    zxbcdt_tt,
+                    conv_weight_tt,
+                    conv_bias_tt,
+                    dt_bias_tt,
+                    A_tt,
+                    D_tt,
+                    x_tt,
+                    out_z_tt,
+                    dt_tt,
+                    B_tt,
+                    C_tt,
+                    z_tt,
+                    rmsnorm_weight_tt,
+                    outproj_weight_tt,
+                    outproj_bias_tt,
+                    output_tt,
+                    epsilon,
+                    grid_dim=(num_blocks,),
+                    block_dim=(BLOCK_SIZE,),
+                )
+        else:
+            raise Error("Unsupported target: " + target)

--- a/max/kernels/src/state_space/ssd_chunk.mojo
+++ b/max/kernels/src/state_space/ssd_chunk.mojo
@@ -1,0 +1,1597 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Structured state space duality (SSD) intra-chunk diagonal block kernel.
+
+This implements stage 1 of the SSD chunk-scan algorithm used by Mamba2: the
+"intra-chunk diagonal block output". For each ``(batch, chunk, head)`` it
+computes the causal, decay-weighted attention-like output that only depends on
+tokens within the same chunk.
+
+For a chunk of ``L`` tokens with state dim ``N`` and head dim ``P``:
+
+- Inputs: ``C: [L, N]``, ``B: [L, N]``, ``X: [L, P]``, ``A: [L]`` (a scalar
+  decay per token).
+- Cumulative decay: ``A_cumsum[l] = sum_{k=0..l} A[k]``.
+- Causal decay (segment-sum) matrix: for ``s <= l``,
+  ``Ldecay[l, s] = exp(A_cumsum[l] - A_cumsum[s])``; for ``s > l`` it is ``0``.
+- Attention scores: ``scores[l, s] = (sum_n C[l, n] * B[s, n]) * Ldecay[l, s]``
+  for ``s <= l``.
+- Output: ``Y[l, p] = sum_{s=0..l} scores[l, s] * X[s, p]``.
+
+This matches the reference einsum
+``Y_diag = einsum("ln,sn,ls,sp->lp", C, B, Ldecay, X)`` restricted to ``s <= l``
+(stage 1 of ``ssd_minimal_discrete``).
+
+Implementations:
+
+- ``*_naive``: scalar reference kernels for golden / numerical-stability tests.
+- ``ssd_intra_chunk_fwd_cpu``: parallel per-slice GEMM decomposition (CPU).
+- ``ssd_intra_chunk_fwd_gpu``: host dispatch — batched ``C @ B^T`` via Modular
+  ``batched_matmul`` (tensor cores on GPU) plus a Triton-style tiled chunk-scan
+  kernel that fuses decay masking with ``scores @ X``.
+"""
+
+from layout.layout_tensor import copy_local_to_dram, copy_local_to_shared
+from layout.tensor_core import TensorCore, get_fragment_size, get_mma_shape
+from max.gpu.memory import async_copy_wait_all
+from layout import (
+    Idx,
+    Layout,
+    LayoutTensor,
+    TensorLayout,
+    TileTensor,
+    row_major,
+)
+from std.memory import AddressSpace
+from std.sys.info import _has_sm_121x
+from linalg.bmm import batched_matmul
+from max.algorithm import sync_parallelize
+from std.collections import OptionalReg
+from max.gpu.host import DeviceContext
+from std.math import ceildiv, exp
+from std.memory import alloc, unsafe_stack_allocation as mem_stack_allocation
+from max.gpu.sync import barrier as gpu_barrier
+from std.gpu import (
+    WARP_SIZE,
+    block_dim,
+    block_idx,
+    thread_idx,
+)
+from std.utils.index import IndexList
+
+# Triton-style tile sizes (scaled down for per-block register/stack budget).
+#
+# Device-split tuning: the chunk-scan's per-block work grows linearly with
+# pid_m (causal early-exit), so heavy tiles drain late and idle SMs. On the
+# GB10 (sm_121, DGX Spark) — many small SMs that prefer fine-grained work —
+# a 32-row tile (2× the blocks) measurably beats 64 (0.41 → 0.37 ms). On
+# datacenter parts (A100/H100/B200, fewer but larger SMs) the 64-row tile is
+# the safer default; it keeps more rows resident per block and we have not
+# profiled the smaller tile there. The kernel is correct for either value on
+# any GPU — this only trades block count vs per-block work.
+comptime SCAN_BLOCK_M = 32 if _has_sm_121x() else 64
+comptime SCAN_BLOCK_N = 32
+comptime SCAN_BLOCK_K = 32
+comptime SCAN_ACC_ELEMS = SCAN_BLOCK_M * SCAN_BLOCK_N
+# Warps per scan block. The cooperative CB load strides BM rows by this
+# count, so the block size must be a whole number of warps.
+comptime SCAN_WARPS = SCAN_BLOCK_M // 32
+
+# Upper bound on chunk_len for the shared-memory prefix-sum scratch (one
+# block per slice, one element per thread). 1024 floats = 4 KB shmem.
+comptime SCAN_MAX_CHUNK = 1024
+
+# BMM tile sizes for the in-house C @ B^T kernel. Each thread block emits
+# a BMM_BM × BMM_BN output tile; threads laid out (BMM_BN, BMM_BM) so a warp
+# spans a full BMM_BN row (32 contiguous output cols) for coalesced stores.
+comptime BMM_BM = 32
+comptime BMM_BN = 32
+comptime BMM_BK = 16
+
+# Stride helpers for indexing the flat row-major buffers.
+comptime Strides4D = IndexList[4]
+comptime Strides5D = IndexList[5]
+
+
+def _row_major_strides_4d(d0: Int, d1: Int, d2: Int, d3: Int) -> Strides4D:
+    """Row-major strides for a 4D shape ``(d0, d1, d2, d3)``."""
+    return Strides4D(d1 * d2 * d3, d2 * d3, d3, 1)
+
+
+def _row_major_strides_5d(
+    d0: Int, d1: Int, d2: Int, d3: Int, d4: Int
+) -> Strides5D:
+    """Row-major strides for a 5D shape ``(d0, d1, d2, d3, d4)``."""
+    return Strides5D(d1 * d2 * d3 * d4, d2 * d3 * d4, d3 * d4, d4, 1)
+
+
+@always_inline
+def _apply_decay_mask_to_cb[
+    dtype: DType,
+](
+    chunk_len: Int,
+    cb_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
+    cumsum: Pointer[Float32, MutUntrackedOrigin],
+) -> None:
+    """Apply causal decay ``exp(cum[l]-cum[s])`` to lower-triangular ``CB[l,s]``.
+    """
+    for l in range(chunk_len):
+        var cum_l = cumsum[l]
+        for s in range(l + 1):
+            var off = l * chunk_len + s
+            var val = cb_ptr[off].cast[DType.float32]() * exp(cum_l - cumsum[s])
+            cb_ptr[off] = val.cast[dtype]()
+        for s in range(l + 1, chunk_len):
+            cb_ptr[l * chunk_len + s] = Scalar[dtype](0)
+
+
+# ===----------------------------------------------------------------------=== #
+# Naive CPU baseline (numerical reference)
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_cpu_naive[
+    kernel_dtype: DType,
+    C_layout: Layout,
+    B_layout: Layout,
+    X_layout: Layout,
+    A_layout: Layout,
+    Y_layout: Layout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    C: LayoutTensor[kernel_dtype, C_layout, MutAnyOrigin],
+    B: LayoutTensor[kernel_dtype, B_layout, MutAnyOrigin],
+    X: LayoutTensor[kernel_dtype, X_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, A_layout, MutAnyOrigin],
+    Y: LayoutTensor[kernel_dtype, Y_layout, MutAnyOrigin],
+):
+    """Naive scalar CPU reference for golden / stability tests.
+
+    Triple nested loops over ``(l, s, n, p)`` with no SIMD or GEMM.
+    """
+    var cb_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, state_dim
+    )
+    var x_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, head_dim
+    )
+    var a_strides = _row_major_strides_4d(batch, n_chunks, n_heads, chunk_len)
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var cb_base = (
+                    b * cb_strides[0] + c * cb_strides[1] + h * cb_strides[2]
+                )
+                var x_base = (
+                    b * x_strides[0] + c * x_strides[1] + h * x_strides[2]
+                )
+                var a_base = (
+                    b * a_strides[0] + c * a_strides[1] + h * a_strides[2]
+                )
+                var y_base = x_base
+
+                var a_cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var running = Float32(0.0)
+                for l in range(chunk_len):
+                    var a_off = a_base + l * a_strides[3]
+                    running += A.ptr[a_off].cast[DType.float32]()
+                    a_cumsum[l] = running
+
+                for l in range(chunk_len):
+                    var c_row = cb_base + l * cb_strides[3]
+                    var cum_l = a_cumsum[l]
+                    for s in range(l + 1):
+                        var b_row = cb_base + s * cb_strides[3]
+
+                        var dot = Float32(0.0)
+                        for n in range(state_dim):
+                            var cv = C.ptr[c_row + n * cb_strides[4]].cast[
+                                DType.float32
+                            ]()
+                            var bv = B.ptr[b_row + n * cb_strides[4]].cast[
+                                DType.float32
+                            ]()
+                            dot += cv * bv
+
+                        var decay = exp(cum_l - a_cumsum[s])
+                        var score = dot * decay
+
+                        var x_row = x_base + s * x_strides[3]
+                        var y_row = y_base + l * x_strides[3]
+                        for p in range(head_dim):
+                            var xv = X.ptr[x_row + p * x_strides[4]].cast[
+                                DType.float32
+                            ]()
+                            var y_off = y_row + p * x_strides[4]
+                            var acc = (
+                                Y.ptr[y_off].cast[DType.float32]() + score * xv
+                            )
+                            Y.ptr[y_off] = acc.cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# Optimized CPU (parallel slices + GEMM)
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_cpu[
+    kernel_dtype: DType,
+    C_layout: Layout,
+    B_layout: Layout,
+    X_layout: Layout,
+    A_layout: Layout,
+    Y_layout: Layout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    C: LayoutTensor[kernel_dtype, C_layout, MutAnyOrigin],
+    B: LayoutTensor[kernel_dtype, B_layout, MutAnyOrigin],
+    X: LayoutTensor[kernel_dtype, X_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, A_layout, MutAnyOrigin],
+    Y: LayoutTensor[kernel_dtype, Y_layout, MutAnyOrigin],
+    ctx: Optional[DeviceContext] = None,
+) raises:
+    """Optimized CPU intra-chunk diagonal block.
+
+    1. Batched ``CB = C @ B^T`` via ``batched_matmul``.
+    2. Parallel per-slice causal decay on ``CB``.
+    3. Batched ``Y = CB @ X`` via ``batched_matmul``.
+    """
+    var num_slices = batch * n_chunks * n_heads
+    var l2 = chunk_len * chunk_len
+
+    var cb_ptr = alloc[Scalar[kernel_dtype]](num_slices * l2)
+
+    var C3 = TileTensor(C.ptr, row_major(num_slices, chunk_len, state_dim))
+    var B3 = TileTensor(B.ptr, row_major(num_slices, chunk_len, state_dim))
+    var CB3 = TileTensor(cb_ptr, row_major(num_slices, chunk_len, chunk_len))
+    var X3 = TileTensor(X.ptr, row_major(num_slices, chunk_len, head_dim))
+    var Y3 = TileTensor(Y.ptr, row_major(num_slices, chunk_len, head_dim))
+
+    batched_matmul[target="cpu", transpose_b=True](CB3, C3, B3)
+
+    var a_strides = _row_major_strides_4d(batch, n_chunks, n_heads, chunk_len)
+
+    @__parameter
+    def decay_worker(flat_idx: Int):
+        var h = flat_idx % n_heads
+        var c = (flat_idx // n_heads) % n_chunks
+        var b = flat_idx // (n_heads * n_chunks)
+
+        var a_base = b * a_strides[0] + c * a_strides[1] + h * a_strides[2]
+        var cumsum_ptr = alloc[Float32](chunk_len)
+
+        var running = Float32(0.0)
+        for l in range(chunk_len):
+            running += A.ptr[a_base + l * a_strides[3]].cast[DType.float32]()
+            cumsum_ptr[l] = running
+
+        _apply_decay_mask_to_cb[kernel_dtype](
+            chunk_len,
+            cb_ptr + flat_idx * l2,
+            cumsum_ptr,
+        )
+        cumsum_ptr.free()
+
+    sync_parallelize[decay_worker](num_slices, ctx)
+
+    batched_matmul[target="cpu"](Y3, CB3, X3)
+
+    cb_ptr.free()
+
+
+# ===----------------------------------------------------------------------=== #
+# Naive GPU baseline (numerical reference)
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_gpu_naive[
+    kernel_dtype: DType,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    state_dim_i32: Int32,
+    head_dim_i32: Int32,
+    C: TileTensor[kernel_dtype, C_LT, MutUntrackedOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutUntrackedOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutUntrackedOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutUntrackedOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutUntrackedOrigin],
+):
+    """Naive GPU reference: one thread per ``(batch, chunk, head)`` slice.
+
+    Scalar loops only — use for golden / stability tests, not performance.
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var state_dim = Int(state_dim_i32)
+    var head_dim = Int(head_dim_i32)
+    var flat_idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total_slices = batch * n_chunks * n_heads
+    if flat_idx >= total_slices:
+        return
+
+    var h = flat_idx % n_heads
+    var c = (flat_idx // n_heads) % n_chunks
+    var b = flat_idx // (n_heads * n_chunks)
+
+    var cb_n_stride = 1
+    var cb_l_stride = state_dim
+    var cb_h_stride = chunk_len * cb_l_stride
+    var cb_c_stride = n_heads * cb_h_stride
+    var cb_b_stride = n_chunks * cb_c_stride
+
+    var x_p_stride = 1
+    var x_l_stride = head_dim
+    var x_h_stride = chunk_len * x_l_stride
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_l_stride = 1
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var cb_base = b * cb_b_stride + c * cb_c_stride + h * cb_h_stride
+    var x_base = b * x_b_stride + c * x_c_stride + h * x_h_stride
+    var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+    var y_base = x_base
+
+    for l in range(chunk_len):
+        var c_row = cb_base + l * cb_l_stride
+
+        var cum_l = Float32(0.0)
+        for k in range(l + 1):
+            cum_l += A.ptr[a_base + k * a_l_stride].cast[DType.float32]()
+
+        for p in range(head_dim):
+            Y.ptr[y_base + l * x_l_stride + p * x_p_stride] = Scalar[
+                kernel_dtype
+            ](0)
+
+        var cum_s = Float32(0.0)
+        for s in range(l + 1):
+            cum_s += A.ptr[a_base + s * a_l_stride].cast[DType.float32]()
+
+            var b_row = cb_base + s * cb_l_stride
+
+            var dot = Float32(0.0)
+            for n in range(state_dim):
+                var cv = C.ptr[c_row + n * cb_n_stride].cast[DType.float32]()
+                var bv = B.ptr[b_row + n * cb_n_stride].cast[DType.float32]()
+                dot += cv * bv
+
+            var decay = exp(cum_l - cum_s)
+            var score = dot * decay
+
+            var x_row = x_base + s * x_l_stride
+            var y_row = y_base + l * x_l_stride
+            for p in range(head_dim):
+                var xv = X.ptr[x_row + p * x_p_stride].cast[DType.float32]()
+                var y_off = y_row + p * x_p_stride
+                var acc = Y.ptr[y_off].cast[DType.float32]() + score * xv
+                Y.ptr[y_off] = acc.cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU: batched ``CB = C @ B^T`` (tiled, shared-memory, no tensor cores)
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_intra_chunk_bmm_gpu[
+    kernel_dtype: DType,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    CB_LT: TensorLayout,
+](
+    n_slices_i32: Int32,
+    chunk_len_i32: Int32,
+    state_dim_i32: Int32,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    CB: TileTensor[kernel_dtype, CB_LT, MutAnyOrigin],
+):
+    """Batched ``CB[s, l, r] = sum_n C[s, l, n] * B[s, r, n]``.
+
+    Replaces Modular ``batched_matmul`` for our dim set. The Modular
+    dispatch needs static N/K to pick its tensor-core path; our caller
+    only has dynamic dims, so it falls through to a per-element naive
+    kernel that was profiled at >3ms/call. This kernel is a stock tiled
+    matmul (no tensor cores, just shmem prefetched tiles); on the GB10
+    it's enough to close the gap to the scan kernel cost.
+
+    Grid: ``(ceildiv(L, BMM_BM) * ceildiv(L, BMM_BN), n_slices)``.
+    Block: ``(BMM_BN, BMM_BM)``; thread ``(tn, tm)`` owns output
+    ``CB[block_slice, l = m_tile*BMM_BM + tm, r = n_tile*BMM_BN + tn]``.
+    Shared memory holds the current ``BMM_BM × BMM_BK`` C tile and
+    ``BMM_BN × BMM_BK`` B tile per K window.
+    """
+    var n_slices = Int(n_slices_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var state_dim = Int(state_dim_i32)
+    var num_n_tiles = ceildiv(chunk_len, BMM_BN)
+    var m_tile = Int(block_idx.x) // num_n_tiles
+    var n_tile = Int(block_idx.x) - m_tile * num_n_tiles
+    var slice_idx = Int(block_idx.y)
+
+    var l = m_tile * BMM_BM + Int(thread_idx.y)
+    var r = n_tile * BMM_BN + Int(thread_idx.x)
+
+    var c_slice_base = slice_idx * chunk_len * state_dim
+    var b_slice_base = c_slice_base  # same layout
+    var cb_slice_base = slice_idx * chunk_len * chunk_len
+
+    var c_smem = mem_stack_allocation[
+        BMM_BM * BMM_BK, Float32, address_space=AddressSpace.SHARED
+    ]()
+    var b_smem = mem_stack_allocation[
+        BMM_BN * BMM_BK, Float32, address_space=AddressSpace.SHARED
+    ]()
+
+    var acc: Float32 = 0.0
+
+    var tm = Int(thread_idx.y)
+    var tn = Int(thread_idx.x)
+
+    for k0 in range(0, state_dim, BMM_BK):
+        # Cooperative C[m_tile_row, k0..k0+BMM_BK] load. Threads
+        # (tm, tn) load C_smem[tm, tn] when tn < BMM_BK.
+        if tn < BMM_BK:
+            var n = k0 + tn
+            if l < chunk_len and n < state_dim:
+                c_smem[tm * BMM_BK + tn] = C.ptr[
+                    c_slice_base + l * state_dim + n
+                ].cast[DType.float32]()
+            else:
+                c_smem[tm * BMM_BK + tn] = 0.0
+        # Cooperative B[n_tile_row, k0..k0+BMM_BK] load. Threads
+        # (tm, tn) → B_smem[tn, tm] when tm < BMM_BK.
+        if tm < BMM_BK:
+            var n = k0 + tm
+            var r2 = n_tile * BMM_BN + tn
+            if r2 < chunk_len and n < state_dim:
+                b_smem[tn * BMM_BK + tm] = B.ptr[
+                    b_slice_base + r2 * state_dim + n
+                ].cast[DType.float32]()
+            else:
+                b_smem[tn * BMM_BK + tm] = 0.0
+
+        gpu_barrier()
+
+        if l < chunk_len and r < chunk_len:
+            comptime for k in range(BMM_BK):
+                acc += c_smem[tm * BMM_BK + k] * b_smem[tn * BMM_BK + k]
+
+        gpu_barrier()
+
+    if l < chunk_len and r < chunk_len:
+        CB.ptr[cb_slice_base + l * chunk_len + r] = acc.cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU: prefix sum of A per slice
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_intra_chunk_cumsum_gpu[
+    kernel_dtype: DType,
+    A_LT: TensorLayout,
+    cumsum_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    A: TileTensor[kernel_dtype, A_LT, MutUntrackedOrigin],
+    cumsum: TileTensor[DType.float32, cumsum_LT, MutUntrackedOrigin],
+):
+    """Inclusive prefix sum of ``A`` into ``cumsum`` — one block per slice.
+
+    Hillis-Steele scan in shared memory: ``block_dim = chunk_len`` threads,
+    one element each, ``log2(chunk_len)`` doubling steps. The previous version
+    launched a single block (one thread per slice), so all slices' scans
+    serialised on **one SM** (~32 µs at the Mamba2 profile). One block per
+    slice spreads the work across every SM. Slices are contiguous ``chunk_len``
+    blocks in both buffers (``base = slice_idx * chunk_len``).
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var slice_idx = Int(block_idx.x)
+    var total_slices = batch * n_chunks * n_heads
+    if slice_idx >= total_slices:
+        return
+
+    var tid = Int(thread_idx.x)
+    var base = slice_idx * chunk_len
+
+    var sdata = mem_stack_allocation[
+        SCAN_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+
+    if tid < chunk_len:
+        sdata[tid] = A.ptr[base + tid].cast[DType.float32]()
+    gpu_barrier()
+
+    var offset = 1
+    while offset < chunk_len:
+        var add: Float32 = 0.0
+        if tid < chunk_len and tid >= offset:
+            add = sdata[tid - offset]
+        gpu_barrier()
+        if tid < chunk_len and tid >= offset:
+            sdata[tid] += add
+        gpu_barrier()
+        offset *= 2
+
+    if tid < chunk_len:
+        cumsum.ptr[base + tid] = sdata[tid]
+
+
+def _ssd_intra_chunk_decay_gpu[
+    kernel_dtype: DType,
+    CB_LT: TensorLayout,
+    cumsum_LT: TensorLayout,
+](
+    num_slices_i32: Int32,
+    chunk_len_i32: Int32,
+    CB: TileTensor[kernel_dtype, CB_LT, MutUntrackedOrigin],
+    cumsum: TileTensor[DType.float32, cumsum_LT, MutUntrackedOrigin],
+):
+    """Apply causal decay in place: ``M[l,s] = CB[l,s]*exp(cum[l]-cum[s])``.
+
+    Lower-triangular (``s <= l``); the strict upper triangle is zeroed.
+    Materialises the decayed, masked score matrix so the chunk scan can be
+    expressed as a plain ``Y = M @ X`` tensor-core matmul. Flat grid over
+    the ``num_slices * L * L`` elements; consecutive threads map to
+    consecutive ``s`` so CB / cumsum traffic is fully coalesced.
+    """
+    var num_slices = Int(num_slices_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var slice_idx = Int(block_idx.y)
+    var elem = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var l2 = chunk_len * chunk_len
+    if slice_idx >= num_slices or elem >= l2:
+        return
+
+    var l = elem // chunk_len
+    var s = elem - l * chunk_len
+
+    var cs_base = slice_idx * chunk_len
+    var cb_off = slice_idx * l2 + elem
+
+    if s <= l:
+        var cum_l = cumsum.ptr[cs_base + l]
+        var cum_s = cumsum.ptr[cs_base + s]
+        var decayed = CB.ptr[cb_off].cast[DType.float32]() * exp(cum_l - cum_s)
+        CB.ptr[cb_off] = decayed.cast[kernel_dtype]()
+    else:
+        CB.ptr[cb_off] = Scalar[kernel_dtype](0)
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU: Triton-style tiled chunk scan  (decay-masked CB @ X)
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_intra_chunk_chunk_scan_gpu[
+    kernel_dtype: DType,
+    CB_LT: TensorLayout,
+    cumsum_LT: TensorLayout,
+    X_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    head_dim_i32: Int32,
+    CB: TileTensor[kernel_dtype, CB_LT, MutUntrackedOrigin],
+    cumsum: TileTensor[DType.float32, cumsum_LT, MutUntrackedOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutUntrackedOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutUntrackedOrigin],
+):
+    """Tiled ``Y = causal_decay(CB) @ X`` matching Mamba ``_chunk_scan_fwd_kernel``.
+
+    Grid ``(ceil(L/BM)*ceil(P/BN), batch*n_chunks, n_heads)`` with causal
+    masking and ``exp(cumsum[l]-cumsum[s])`` decay fused in the K loop.
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var head_dim = Int(head_dim_i32)
+    comptime BM = SCAN_BLOCK_M
+    comptime BN = SCAN_BLOCK_N
+    comptime BK = SCAN_BLOCK_K
+    var num_pid_n = ceildiv(head_dim, BN)
+    var pid_m = Int(block_idx.x) // num_pid_n
+    var pid_n = Int(block_idx.x) % num_pid_n
+
+    var pid_bc = Int(block_idx.y)
+    var pid_h = Int(block_idx.z)
+
+    var c = pid_bc // batch
+    var b = pid_bc - c * batch
+
+    var cb_b_stride = n_chunks * n_heads * chunk_len * chunk_len
+    var cb_c_stride = n_heads * chunk_len * chunk_len
+    var cb_h_stride = chunk_len * chunk_len
+    var cb_l_stride = chunk_len
+    var cb_s_stride = 1
+
+    var x_b_stride = n_chunks * n_heads * chunk_len * head_dim
+    var x_c_stride = n_heads * chunk_len * head_dim
+    var x_h_stride = chunk_len * head_dim
+    var x_l_stride = head_dim
+    var x_p_stride = 1
+
+    var y_b_stride = x_b_stride
+    var y_c_stride = x_c_stride
+    var y_h_stride = x_h_stride
+    var y_l_stride = head_dim
+    var y_p_stride = 1
+
+    var cs_b_stride = n_chunks * n_heads * chunk_len
+    var cs_c_stride = n_heads * chunk_len
+    var cs_h_stride = chunk_len
+    var cs_l_stride = 1
+
+    var cb_base = b * cb_b_stride + c * cb_c_stride + pid_h * cb_h_stride
+    var x_base = b * x_b_stride + c * x_c_stride + pid_h * x_h_stride
+    var y_base = b * y_b_stride + c * y_c_stride + pid_h * y_h_stride
+    var cs_base = b * cs_b_stride + c * cs_c_stride + pid_h * cs_h_stride
+
+    var offs_m0 = pid_m * BM
+    var offs_n0 = pid_n * BN
+
+    # One thread per row of the BM×BN output tile (block_dim = BM threads).
+    var tid = Int(thread_idx.x)
+
+    # Shared tiles for the K window. We batch the X load to amortise
+    # the global → shmem traffic across BK iterations and remove the
+    # per-K-iter sync (was 2*K_MAX barriers per block, now 1 per BK).
+    var x_smem = mem_stack_allocation[
+        SCAN_BLOCK_K * SCAN_BLOCK_N,
+        Float32,
+        address_space=AddressSpace.SHARED,
+    ]()
+    var cum_smem = mem_stack_allocation[
+        SCAN_BLOCK_K, Float32, address_space=AddressSpace.SHARED
+    ]()
+    # Pad inner stride by 1 to avoid 32-way bank conflicts in the FMA
+    # inner loop: with stride 32 (= 128 B), every BM lane hits the same
+    # bank. Stride 33 makes the bank index = (row * 33 + ki) % 32, which
+    # cycles through all 32 banks across the 64 lanes of the block.
+    comptime CB_SMEM_STRIDE = SCAN_BLOCK_K + 1
+    var cb_smem = mem_stack_allocation[
+        SCAN_BLOCK_M * CB_SMEM_STRIDE,
+        Float32,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var l = offs_m0 + tid
+    var active = tid < BM and l < chunk_len
+
+    # Causal decay ``exp(cum_l - cum_s)`` is computed directly in the inner
+    # loop from the raw cumulative sums. The earlier factoring into
+    # ``exp(cum_l) * exp(-cum_s)`` saved exp calls but is numerically
+    # unstable: ``cumsum`` is the prefix sum of ``A*dt`` with ``A < 0``, so
+    # it is large-negative. ``exp(cum_l)`` then underflows to 0 while
+    # ``exp(-cum_s)`` overflows to +inf, and ``0 * inf = NaN`` even on the
+    # causal diagonal where the true decay ``exp(cum_l - cum_s) ∈ (0, 1]``
+    # is finite. Since ``cum_l - cum_s <= 0`` for ``s <= l`` (the only
+    # entries we keep), the direct form can never overflow.
+    var cum_l: Float32 = 0.0
+    if active:
+        cum_l = cumsum.ptr[cs_base + l * cs_l_stride]
+
+    # Per-thread BN-wide accumulator.
+    var acc = mem_stack_allocation[
+        SCAN_BLOCK_N, Float32, address_space=AddressSpace.LOCAL
+    ]()
+
+    comptime for ni in range(BN):
+        acc[ni] = 0.0
+
+    # Walk the K axis only up to ``(pid_m + 1) * BM`` (the max ``l`` in
+    # this block) — causal masking would zero-out anything beyond that, so
+    # there's no point loading or computing it. For pid_m=0 (first L-tile)
+    # this cuts K_MAX from chunk_len to BM; on the Mamba2-130m profile
+    # (L=256, BM=64) the average K work drops by ~1.6× across the four
+    # M-tiles.
+    var k_limit = min((pid_m + 1) * BM, chunk_len)
+    for k0 in range(0, k_limit, BK):
+        # Cooperative raw ``cum_s`` window. The inner loop forms the decay
+        # as ``exp(cum_l - cum_s)`` directly (stable; see note above).
+        if tid < BK:
+            var s = k0 + tid
+            if s < chunk_len:
+                cum_smem[tid] = cumsum.ptr[cs_base + s * cs_l_stride]
+            else:
+                cum_smem[tid] = 0.0
+        # Cooperative X tile of size BK × BN, one outer iter at a time.
+        # Threads (BM total) split BK*BN elements; with BM == BN, each
+        # thread (column tid in [0, BN)) loads BK contiguous K rows for
+        # its column.
+        if tid < BN:
+            var p = offs_n0 + tid
+
+            comptime for ki in range(BK):
+                var s = k0 + ki
+                if s < chunk_len and p < head_dim:
+                    x_smem[ki * BN + tid] = X.ptr[
+                        x_base + s * x_l_stride + p * x_p_stride
+                    ].cast[DType.float32]()
+                else:
+                    x_smem[ki * BN + tid] = 0.0
+
+        # Cooperative CB tile of size BM × BK: each warp loads one
+        # contiguous K row per iter (32 lanes × 4 B = 1 cache line,
+        # perfectly coalesced) — replaces the previous scattered
+        # per-thread CB[l, s] reads (stride L between lanes, 16-way
+        # uncoalesced on the Mamba2-130m profile). The ``SCAN_WARPS``
+        # warps in the block stride the BM rows by ``SCAN_WARPS`` so any
+        # block size that is a multiple of the warp size is covered.
+        var warp_id = tid // 32
+        var lane = tid - warp_id * 32
+
+        comptime for r in range(0, SCAN_BLOCK_M, SCAN_WARPS):
+            var row = r + warp_id
+            var l_row = offs_m0 + row
+            var s_col = k0 + lane
+            if (
+                row < SCAN_BLOCK_M
+                and l_row < chunk_len
+                and lane < BK
+                and s_col < chunk_len
+            ):
+                cb_smem[row * CB_SMEM_STRIDE + lane] = CB.ptr[
+                    cb_base + l_row * cb_l_stride + s_col * cb_s_stride
+                ].cast[DType.float32]()
+            elif lane < BK:
+                cb_smem[row * CB_SMEM_STRIDE + lane] = 0.0
+
+        gpu_barrier()
+
+        if active:
+            comptime for ki in range(BK):
+                var s = k0 + ki
+                if s < chunk_len and s <= l:
+                    var cb_val = cb_smem[tid * CB_SMEM_STRIDE + ki]
+                    var score = cb_val * exp(cum_l - cum_smem[ki])
+
+                    comptime for ni in range(BN):
+                        acc[ni] += score * x_smem[ki * BN + ni]
+
+        gpu_barrier()
+
+    if active:
+        var y_row = y_base + l * y_l_stride
+
+        comptime for ni in range(BN):
+            var p = offs_n0 + ni
+            if p < head_dim:
+                Y.ptr[y_row + p * y_p_stride] = acc[ni].cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# Optimized GPU host dispatch
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_gpu[
+    kernel_dtype: DType,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Optimized GPU intra-chunk diagonal block (Mamba-style pipeline).
+
+    1. Batched ``CB = C @ B^T`` via Modular ``batched_matmul`` (tensor cores).
+    2. Per-slice inclusive prefix sum of ``A``.
+    3. Tiled chunk-scan: ``Y = causal_decay(CB) @ X``.
+
+    Matches the structure of ``mamba_ssm/ops/triton/ssd_chunk_scan.py``:
+    ``_bmm_chunk_fwd`` + ``_chunk_scan_fwd_kernel``.
+    """
+    var num_slices = batch * n_chunks * n_heads
+    var l2 = chunk_len * chunk_len
+
+    var CB_device = ctx.enqueue_create_buffer[kernel_dtype](num_slices * l2)
+    var cumsum_device = ctx.enqueue_create_buffer[DType.float32](
+        num_slices * chunk_len
+    )
+
+    var C3 = TileTensor(
+        C.ptr,
+        row_major(num_slices, chunk_len, state_dim),
+    )
+    var B3 = TileTensor(
+        B.ptr,
+        row_major(num_slices, chunk_len, state_dim),
+    )
+    var CB3 = TileTensor(
+        CB_device,
+        row_major(num_slices, chunk_len, chunk_len),
+    )
+    var cumsum4 = TileTensor(
+        cumsum_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var CB5 = TileTensor(
+        CB_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, chunk_len),
+    )
+
+    # Dispatch CB = C @ B^T:
+    #   batched_matmul picks a cutlass tensor-core path when batch_size == 1
+    #   but falls back to a naive O(N^3) per-element kernel for batched
+    #   cases. Our hand-tiled ``_ssd_intra_chunk_bmm_gpu`` beats the naive
+    #   fallback by ~5×, but is still scalar (no tensor cores). For
+    #   multi-slice we benchmark both: a per-slice loop of cutlass calls
+    #   (tensor cores, but 96 launches of ~5µs each) and the custom bmm
+    #   (one launch, scalar). The faster of the two wins at this dim set.
+    #
+    # Toggle via env var for benchmarking; default: per-slice cutlass.
+    var use_per_slice_cutlass = True
+    if num_slices == 1:
+        with ctx.push_context():
+            batched_matmul[target="gpu", transpose_b=True](
+                CB3, C3, B3, context=ctx
+            )
+    elif use_per_slice_cutlass:
+        with ctx.push_context():
+            for s in range(num_slices):
+                var Cs = TileTensor(
+                    C.ptr + s * chunk_len * state_dim,
+                    row_major(1, chunk_len, state_dim),
+                )
+                var Bs = TileTensor(
+                    B.ptr + s * chunk_len * state_dim,
+                    row_major(1, chunk_len, state_dim),
+                )
+                var CBs = TileTensor(
+                    CB_device.unsafe_ptr() + s * chunk_len * chunk_len,
+                    row_major(1, chunk_len, chunk_len),
+                )
+                batched_matmul[target="gpu", transpose_b=True](
+                    CBs, Cs, Bs, context=ctx
+                )
+    else:
+        comptime bmm_kernel = _ssd_intra_chunk_bmm_gpu[
+            kernel_dtype,
+            C3.LayoutType,
+            B3.LayoutType,
+            CB3.LayoutType,
+        ]
+        var bmm_compiled = ctx.compile_function[bmm_kernel]()
+        var bmm_grid_x = ceildiv(chunk_len, BMM_BM) * ceildiv(chunk_len, BMM_BN)
+
+        with ctx.push_context():
+            ctx.enqueue_function(
+                bmm_compiled,
+                Int32(num_slices),
+                Int32(chunk_len),
+                Int32(state_dim),
+                C3,
+                B3,
+                CB3,
+                grid_dim=(bmm_grid_x, num_slices, 1),
+                block_dim=(BMM_BN, BMM_BM, 1),
+            )
+
+    var cumsum_compiled = ctx.compile_function[
+        _ssd_intra_chunk_cumsum_gpu[
+            kernel_dtype,
+            A_LT,
+            cumsum4.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            cumsum_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            A,
+            cumsum4,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len,),
+        )
+
+    comptime scan_kernel = _ssd_intra_chunk_chunk_scan_gpu[
+        kernel_dtype,
+        CB5.LayoutType,
+        cumsum4.LayoutType,
+        X_LT,
+        Y_LT,
+    ]
+    var scan_compiled = ctx.compile_function[scan_kernel]()
+
+    var grid_x = ceildiv(chunk_len, SCAN_BLOCK_M) * ceildiv(
+        head_dim, SCAN_BLOCK_N
+    )
+
+    # Scan kernel reads ``block_idx.y`` as ``batch * n_chunks`` and
+    # ``block_idx.z`` as ``n_heads``; launching ``num_slices`` (= b*nc*nh)
+    # in y was redundantly multiplying the work by n_heads. Fix the launch
+    # to match the kernel's index decomposition.
+    with ctx.push_context():
+        ctx.enqueue_function(
+            scan_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            CB5,
+            cumsum4,
+            X,
+            Y,
+            grid_dim=(grid_x, batch * n_chunks, n_heads),
+            block_dim=(SCAN_BLOCK_M, 1, 1),
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Static-shape entry point
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_gpu_static[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Static-shape variant of ``ssd_intra_chunk_fwd_gpu``.
+
+    Knowing ``chunk_len`` / ``state_dim`` / ``head_dim`` at compile time
+    lets ``batched_matmul`` see ``has_static_NK`` and pick its A100
+    tensor-core batched path (one launch for all slices, grid_z =
+    batch_size), instead of the per-slice cutlass loop (96 launches × ~4 µs
+    each) that dominates the dynamic-shape dispatch.
+    """
+    var num_slices = batch * n_chunks * n_heads
+    comptime l2 = chunk_len_ct * chunk_len_ct
+
+    var CB_device = ctx.enqueue_create_buffer[kernel_dtype](num_slices * l2)
+    var cumsum_device = ctx.enqueue_create_buffer[DType.float32](
+        num_slices * chunk_len_ct
+    )
+
+    var C3 = TileTensor(
+        C.ptr,
+        row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct]),
+    )
+    var B3 = TileTensor(
+        B.ptr,
+        row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct]),
+    )
+    var CB3 = TileTensor(
+        CB_device,
+        row_major(num_slices, Idx[chunk_len_ct], Idx[chunk_len_ct]),
+    )
+    var cumsum4 = TileTensor(
+        cumsum_device,
+        row_major(batch, n_chunks, n_heads, chunk_len_ct),
+    )
+    var CB5 = TileTensor(
+        CB_device,
+        row_major(
+            batch,
+            n_chunks,
+            n_heads,
+            Idx[chunk_len_ct],
+            Idx[chunk_len_ct],
+        ),
+    )
+
+    # Stage 1: CB = C @ B^T (batched tensor-core matmul, one launch).
+    #
+    # Uses the library ``batched_matmul``, which self-tunes per architecture
+    # (A100 multistage on GB10/Ampere, SM100 tcgen05 on datacenter Blackwell,
+    # AMD path on MI-series) and is correct for all shapes. A hand-dispatched
+    # smaller tile config was tried on GB10 (the "more blocks" lesson from the
+    # scan) but made no difference: this matmul is **DRAM-bandwidth bound** on
+    # materialising the L×L ``CB`` matrix (~50 MB C+B+CB traffic ≈ 90% of
+    # GB10 peak BW at 203 µs), not occupancy bound, so tile shape doesn't
+    # move it. The datacenter Blackwell (sm100/tcgen05) kernels cannot run on
+    # GB10 (consumer sm_121 has no tcgen05); consumer Blackwell already uses
+    # this multistage TF32 tensor-core path. The only further lever is fusing
+    # the bmm with the scan to avoid the CB round-trip (large change).
+    with ctx.push_context():
+        batched_matmul[target="gpu", transpose_b=True](CB3, C3, B3, context=ctx)
+
+    # Stage 2: inclusive prefix sum of A over the chunk.
+    var cumsum_compiled = ctx.compile_function[
+        _ssd_intra_chunk_cumsum_gpu[
+            kernel_dtype,
+            A_LT,
+            cumsum4.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            cumsum_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            A,
+            cumsum4,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len_ct,),
+        )
+
+    # Stage 3: tiled scalar chunk-scan — Y = causal_decay(CB) @ X. The
+    # scalar path beats a dense tensor-core M @ X here: it exploits the
+    # lower-triangular causal structure (≈half the FLOPs, plus per-M-tile
+    # early-K exit) and avoids padding head_dim to 128, which the A100
+    # batched matmul requires (c_n % 128 == 0). See
+    # ``ssd_intra_chunk_fwd_gpu_static_mma`` for the MMA alternative, which
+    # is ~2× faster single-slice but ~2× slower multi-slice.
+    comptime scan_kernel = _ssd_intra_chunk_chunk_scan_gpu[
+        kernel_dtype,
+        CB5.LayoutType,
+        cumsum4.LayoutType,
+        X_LT,
+        Y_LT,
+    ]
+    var scan_compiled = ctx.compile_function[scan_kernel]()
+
+    comptime grid_x = ceildiv(chunk_len_ct, SCAN_BLOCK_M) * ceildiv(
+        head_dim_ct, SCAN_BLOCK_N
+    )
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            scan_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            Int32(head_dim_ct),
+            CB5,
+            cumsum4,
+            X,
+            Y,
+            grid_dim=(grid_x, batch * n_chunks, n_heads),
+            block_dim=(SCAN_BLOCK_M, 1, 1),
+        )
+
+
+def ssd_intra_chunk_fwd_gpu_static_mma[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Tensor-core variant: materialise ``M = causal_decay(CB)`` then
+    ``Y = M @ X`` as two batched matmuls.
+
+    Trades the scalar chunk-scan for a dense matmul. **Faster than
+    ``ssd_intra_chunk_fwd_gpu_static`` only for a single slice** (no causal
+    work to exploit, scan launch overhead dominates): ~2× on GB10. For the
+    multi-slice Mamba2 prefill profile it is ~2× *slower* because the dense
+    ``M @ X`` ignores the lower-triangular structure (≈2× the FLOPs) and the
+    A100 batched matmul rejects ``head_dim`` (= output N = 64) for not being
+    a multiple of 128, falling back to the naive scalar batched kernel. Kept
+    for the single-slice regime and as a reference for future MMA work.
+    """
+    var num_slices = batch * n_chunks * n_heads
+    comptime l2 = chunk_len_ct * chunk_len_ct
+
+    var CB_device = ctx.enqueue_create_buffer[kernel_dtype](num_slices * l2)
+    var cumsum_device = ctx.enqueue_create_buffer[DType.float32](
+        num_slices * chunk_len_ct
+    )
+
+    var C3 = TileTensor(
+        C.ptr, row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct])
+    )
+    var B3 = TileTensor(
+        B.ptr, row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct])
+    )
+    var CB3 = TileTensor(
+        CB_device, row_major(num_slices, Idx[chunk_len_ct], Idx[chunk_len_ct])
+    )
+    var cumsum4 = TileTensor(
+        cumsum_device, row_major(batch, n_chunks, n_heads, chunk_len_ct)
+    )
+    var X3 = TileTensor(
+        X.ptr, row_major(num_slices, Idx[chunk_len_ct], Idx[head_dim_ct])
+    )
+    var Y3 = TileTensor(
+        Y.ptr, row_major(num_slices, Idx[chunk_len_ct], Idx[head_dim_ct])
+    )
+
+    # Stage 1: CB = C @ B^T (batched A100 tensor-core matmul).
+    with ctx.push_context():
+        batched_matmul[target="gpu", transpose_b=True](CB3, C3, B3, context=ctx)
+
+    # Stage 2: inclusive prefix sum of A over the chunk.
+    var cumsum_compiled = ctx.compile_function[
+        _ssd_intra_chunk_cumsum_gpu[kernel_dtype, A_LT, cumsum4.LayoutType]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            cumsum_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            A,
+            cumsum4,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len_ct,),
+        )
+
+    # Stage 3: apply causal decay in place — M = causal_decay(CB).
+    comptime DECAY_BLOCK = 256
+    var decay_compiled = ctx.compile_function[
+        _ssd_intra_chunk_decay_gpu[
+            kernel_dtype, CB3.LayoutType, cumsum4.LayoutType
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            decay_compiled,
+            Int32(num_slices),
+            Int32(chunk_len_ct),
+            CB3,
+            cumsum4,
+            grid_dim=(ceildiv(l2, DECAY_BLOCK), num_slices),
+            block_dim=(DECAY_BLOCK,),
+        )
+
+    # Stage 4: Y = M @ X (no transpose).
+    with ctx.push_context():
+        batched_matmul[target="gpu", transpose_b=False](
+            Y3, CB3, X3, context=ctx
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Fused single-pass tensor-core intra-chunk (FlashAttention-style, RFC 0009)
+# ===----------------------------------------------------------------------=== #
+
+# Fused-MMA tiling. One block per (slice, l-tile) computes BM rows of Y.
+# Two chained TF32 MMAs (CB = C @ Bᵀ, then Y += decay⊙CB @ X) with the CB
+# intermediate staged through shared memory (the Ampere C-fragment layout
+# differs from the A-fragment layout, so no register-direct handoff). BM == BK
+# so the l-tile and s-tile align (causal mask only on the diagonal tile).
+comptime FUSED_BM = 64
+comptime FUSED_BK = 16
+comptime FUSED_WARPS_M = 4
+# N (state-dim) contraction tile for MMA1. Tiling N keeps the C/B shared tiles
+# small (vs staging the full state_dim), which lifts occupancy from
+# shared-memory-limited 2 blocks/SM to several — the dominant fused-kernel
+# bottleneck on GB10. Must be a multiple of MMA_K (8) and divide state_dim.
+comptime FUSED_TN = 16
+
+
+def _ssd_intra_chunk_fused_mma_gpu[
+    kernel_dtype: DType,
+    L: Int,
+    N: Int,
+    P: Int,
+    BM: Int,
+    BK: Int,
+    num_warps_m: Int,
+    TN: Int,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    cumsum_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    cumsum: TileTensor[DType.float32, cumsum_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+):
+    """Fused intra-chunk forward: ``Y = (decay ⊙ tril(C @ Bᵀ)) @ X``.
+
+    One block per ``(slice, l-tile)``; ``grid = (num_slices, L // BM)``. The
+    ``CB`` scores never touch DRAM (the cost the two-kernel path pays): MMA1
+    accumulates ``cb[BM, BK] = C[l-tile] @ B[s-tile]ᵀ`` in registers, the block
+    applies ``exp(cum_l − cum_s)`` decay + causal mask while staging ``cb`` to
+    shared, then MMA2 accumulates ``acc[BM, P] += cb @ X[s-tile]`` over the
+    causal ``s`` tiles. ``cumsum`` is the precomputed inclusive prefix sum of
+    the per-token decay (one parallel kernel, cheap). Both MMAs are TF32,
+    FP32-accumulate, ``transpose_b=False`` — ``B`` is transposed into shared for
+    MMA1, mirroring the fused chunk-state kernel.
+    """
+    comptime accum_type = DType.float32
+    comptime mma_shape = get_mma_shape[kernel_dtype, accum_type]()
+    comptime MMA_M = mma_shape[0]
+    comptime MMA_N = mma_shape[1]
+    comptime MMA_K = mma_shape[2]
+    comptime WM = BM // num_warps_m
+    comptime num_m_mmas = WM // MMA_M
+    comptime num_n_mmas_cb = BK // MMA_N
+    comptime num_n_mmas_y = P // MMA_N
+    comptime num_k_mmas_cb = TN // MMA_K  # MMA1 K-tile is TN (N is tiled)
+    comptime num_k_mmas_y = BK // MMA_K
+    comptime fs = get_fragment_size[mma_shape]()
+    comptime a_frag_size = fs[0]
+    comptime b_frag_size = fs[1]
+    comptime c_frag_size = fs[2]
+    comptime num_threads = num_warps_m * WARP_SIZE
+
+    var slice_idx = Int(block_idx.x)
+    var pid_m = Int(block_idx.y)
+    var tid = Int(thread_idx.x)
+    var warp_id = tid // WARP_SIZE
+    var warp_y = warp_id
+
+    var c_base = slice_idx * L * N
+    var b_base = slice_idx * L * N
+    var x_base = slice_idx * L * P
+    var y_base = slice_idx * L * P
+    var cum_base = slice_idx * L
+    var l_off = pid_m * BM
+
+    # ── Shared tiles (N-tiled: smemC/smemBt are only TN wide in the contraction
+    # dim, keeping shared small for occupancy). ──────────────────────────────
+    var smemC = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(BM, TN),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var smemBt = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(TN, BK),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var smemCB = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(BM, BK),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var smemX = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(BK, P),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var idx = tid
+
+    # ── Accumulator for Y[l-tile, :P] (persists across the s-tile loop). ──────
+    var acc_reg = (
+        LayoutTensor[
+            accum_type,
+            Layout.row_major(num_m_mmas * num_n_mmas_y, c_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ]
+        .stack_allocation()
+        .fill(0)
+    )
+
+    var mma_op = TensorCore[accum_type, kernel_dtype, mma_shape, False]()
+
+    # ── Causal s-tile loop: s-tile 0 .. pid_m (s <= l). ──────────────────────
+    # An l-tile (BM rows) spans BM // BK s-tiles, so the causal bound covers
+    # s-tiles 0 .. (pid_m+1)*(BM//BK) - 1.
+    for s_tile in range((pid_m + 1) * (BM // BK)):
+        var s_off = s_tile * BK
+
+        # Stage X[s-tile, :P] (independent of the N-tile loop).
+        idx = tid
+        while idx < BK * P:
+            var r = idx // P
+            var p = idx % P
+            var sr = s_off + r
+            smemX[r, p] = X.ptr[x_base + sr * P + p] if sr < L else Scalar[
+                kernel_dtype
+            ](0)
+            idx += num_threads
+
+        # MMA1: cb[BM, BK] = C[l-tile, :N] @ B[s-tile, :N]ᵀ, accumulated over
+        # N in TN-wide tiles (small shared tiles -> higher occupancy).
+        var cb_reg = (
+            LayoutTensor[
+                accum_type,
+                Layout.row_major(num_m_mmas * num_n_mmas_cb, c_frag_size),
+                MutAnyOrigin,
+                address_space=AddressSpace.LOCAL,
+            ]
+            .stack_allocation()
+            .fill(0)
+        )
+        var a_reg = LayoutTensor[
+            kernel_dtype,
+            Layout.row_major(num_m_mmas, a_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ].stack_allocation()
+        var b_reg = LayoutTensor[
+            kernel_dtype,
+            Layout.row_major(num_n_mmas_cb, b_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ].stack_allocation()
+
+        comptime n_tiles = N // TN
+        # Thread layout for the async C load: num_threads over the [BM, TN] tile.
+        comptime c_thread_layout = Layout.row_major(num_threads // TN, TN)
+        var c_gmem = LayoutTensor[
+            kernel_dtype, Layout.row_major(L, N), MutAnyOrigin
+        ](C.ptr + c_base)
+
+        # cp.async: C is the A operand [BM, N-tile] (no transpose), so it stages
+        # as a straight tile. Issue it async and do the B sync transpose-load
+        # while it's in flight (the global C load overlaps the B load).
+        for nkt in range(n_tiles):
+            var nk = nkt * TN
+            smemC.distribute[c_thread_layout](tid).copy_from_async(
+                c_gmem.tile[BM, TN](pid_m, nkt).distribute[c_thread_layout](tid)
+            )
+            # smemBt[TN, BK] = B[s-tile, nk:nk+TN]ᵀ (sync; overlaps the async C).
+            idx = tid
+            while idx < TN * BK:
+                var n = idx // BK
+                var r = idx % BK
+                var sr = s_off + r
+                smemBt[n, r] = B.ptr[
+                    b_base + sr * N + (nk + n)
+                ] if sr < L else Scalar[kernel_dtype](0)
+                idx += num_threads
+            async_copy_wait_all()
+            gpu_barrier()
+
+            var a_warp = smemC.tile[WM, TN](warp_y, 0)
+            var b_warp = smemBt.tile[TN, BK](0, 0)
+
+            comptime for k_mma in range(num_k_mmas_cb):
+                mma_op.load_a(a_warp, a_reg.vectorize[1, a_frag_size](), k_mma)
+                mma_op.load_b(
+                    b_warp, b_reg.vectorize[1, b_frag_size](), k_mma, 0
+                )
+                mma_op.mma(
+                    a_reg.vectorize[1, a_frag_size](),
+                    b_reg.vectorize[1, b_frag_size](),
+                    cb_reg.vectorize[1, c_frag_size](),
+                )
+            gpu_barrier()
+
+        # Store cb to shared (C-fragment layout -> row-major [BM, BK]).
+        var cb_warp = smemCB.tile[WM, BK](warp_y, 0)
+        copy_local_to_shared[thread_layout=Layout.row_major(8, 4)](
+            cb_warp.vectorize[1, 2](),
+            cb_reg.vectorize[1, 2]().transpose(),
+        )
+        gpu_barrier()
+
+        # Apply decay + causal mask on the shared cb tile cooperatively.
+        idx = tid
+        # Mask only matters where the s-tile's rows can exceed the l-tile's
+        # (the diagonal/overlapping tiles); tiles fully below are kept whole.
+        var needs_mask = (s_off + BK) > l_off
+        var cum_l_base = cum_base + l_off
+        var cum_s_base = cum_base + s_off
+        while idx < BM * BK:
+            var i = idx // BK
+            var j = idx % BK
+            # decay[i,j] = exp(cum_l[i] − cum_s[j]) (direct form, always ≤ 1, no
+            # overflow), with the causal mask (gs > gl) applied where needed.
+            if needs_mask and (s_off + j) > (l_off + i):
+                smemCB[i, j] = Scalar[kernel_dtype](0)
+            else:
+                var d = exp(
+                    cumsum.ptr[cum_l_base + i] - cumsum.ptr[cum_s_base + j]
+                )
+                smemCB[i, j] = (smemCB[i, j].cast[accum_type]() * d).cast[
+                    kernel_dtype
+                ]()
+            idx += num_threads
+        gpu_barrier()
+
+        # MMA2: acc[BM, P] += smemCB[BM, BK] @ smemX[BK, P].
+        var a2_reg = LayoutTensor[
+            kernel_dtype,
+            Layout.row_major(num_m_mmas, a_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ].stack_allocation()
+        var b2_reg = LayoutTensor[
+            kernel_dtype,
+            Layout.row_major(num_n_mmas_y, b_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ].stack_allocation()
+        var a2_warp = smemCB.tile[WM, BK](warp_y, 0)
+        var b2_warp = smemX.tile[BK, P](0, 0)
+
+        comptime for k_mma in range(num_k_mmas_y):
+            mma_op.load_a(a2_warp, a2_reg.vectorize[1, a_frag_size](), k_mma)
+            mma_op.load_b(b2_warp, b2_reg.vectorize[1, b_frag_size](), k_mma, 0)
+            mma_op.mma(
+                a2_reg.vectorize[1, a_frag_size](),
+                b2_reg.vectorize[1, b_frag_size](),
+                acc_reg.vectorize[1, c_frag_size](),
+            )
+        gpu_barrier()
+
+    # ── Store acc -> Y[l-tile, :P]. ──────────────────────────────────────────
+    var y_slice = LayoutTensor[
+        kernel_dtype, Layout.row_major(L, P), MutAnyOrigin
+    ](Y.ptr + y_base)
+    var y_warp = y_slice.tile[WM, P](pid_m * num_warps_m + warp_y, 0)
+    copy_local_to_dram[dst_thread_layout=Layout.row_major(8, 4)](
+        y_warp.vectorize[1, 2](),
+        acc_reg.vectorize[1, 2]().transpose(),
+    )
+
+
+def ssd_intra_chunk_fwd_gpu_fused[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Fused single-pass tensor-core intra-chunk forward (RFC 0009).
+
+    ``cumsum`` (one parallel kernel) then ``_ssd_intra_chunk_fused_mma_gpu``,
+    which keeps the ``CB`` scores on-chip (no DRAM round-trip, unlike the
+    two-kernel ``ssd_intra_chunk_fwd_gpu_static``). Requires ``chunk_len`` a
+    multiple of ``FUSED_BM`` / ``FUSED_BK``, ``head_dim`` and ``state_dim``
+    multiples of the MMA tile; the two-kernel path is the fallback otherwise.
+    """
+    var num_slices = batch * n_chunks * n_heads
+
+    var cumsum_device = ctx.enqueue_create_buffer[DType.float32](
+        num_slices * chunk_len_ct
+    )
+    var cumsum4 = TileTensor(
+        cumsum_device, row_major(batch, n_chunks, n_heads, chunk_len_ct)
+    )
+    var cumsum_compiled = ctx.compile_function[
+        _ssd_intra_chunk_cumsum_gpu[kernel_dtype, A_LT, cumsum4.LayoutType]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            cumsum_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            A,
+            cumsum4,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len_ct,),
+        )
+
+    var cumsum_flat = TileTensor(
+        cumsum_device, row_major(num_slices, Idx[chunk_len_ct])
+    )
+    comptime num_l_tiles = chunk_len_ct // FUSED_BM
+    comptime num_threads = FUSED_WARPS_M * 32
+    var fused_compiled = ctx.compile_function[
+        _ssd_intra_chunk_fused_mma_gpu[
+            kernel_dtype,
+            chunk_len_ct,
+            state_dim_ct,
+            head_dim_ct,
+            FUSED_BM,
+            FUSED_BK,
+            FUSED_WARPS_M,
+            FUSED_TN,
+            C_LT,
+            B_LT,
+            X_LT,
+            cumsum_flat.LayoutType,
+            Y_LT,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            fused_compiled,
+            C,
+            B,
+            X,
+            cumsum_flat,
+            Y,
+            grid_dim=(num_slices, num_l_tiles),
+            block_dim=(num_threads,),
+        )

--- a/max/kernels/src/state_space/ssd_chunk_combine.mojo
+++ b/max/kernels/src/state_space/ssd_chunk_combine.mojo
@@ -1,0 +1,906 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Structured state space duality (SSD) output-recombination kernel.
+
+This implements stage 4 (the final "output recombination") of the SSD
+chunk-scan algorithm used by Mamba2. After stage 3 (``ssd_chunk_scan``) has
+threaded the inter-chunk recurrence to produce the state *entering* each chunk,
+this stage combines that inter-chunk contribution with the per-chunk diagonal
+output to form the final per-token output.
+
+For a single ``(batch, chunk, head)`` slice with chunk length ``L``, state dim
+``N`` and head dim ``P``:
+
+- Inputs:
+  - ``C: [b, nc, h, L, N]`` (the per-token C projection).
+  - ``entering_state: [b, nc, h, P, N]`` (state entering this chunk, the
+    stage-3 output).
+  - ``A: [b, nc, h, L]`` (per-token log-decay within the chunk).
+  - ``Y_diag: [b, nc, h, L, P]`` (the intra-chunk diagonal output, from
+    stage 1).
+- Compute (per token ``l`` and head-dim index ``p``):
+  ```
+  A_cumsum[l]       = sum_{k <= l} A[k]           # inclusive prefix sum
+  state_decay_out[l]= exp(A_cumsum[l])
+  Y_off[l, p]       = state_decay_out[l] * sum_n C[l, n] * entering_state[p, n]
+  Y[l, p]           = Y_diag[l, p] + Y_off[l, p]
+  ```
+- Output:
+  - ``Y: [b, nc, h, L, P]``.
+
+The computation is fully element-wise parallel over ``(b, nc, h, l, p)``: one
+GPU thread owns a single output scalar ``Y[b, nc, h, l, p]``. The only sequential
+dependency is the per-``(b, nc, h, l)`` inclusive prefix sum ``A_cumsum[l]``,
+which each thread recomputes up to its own ``l`` (``l`` is at most the chunk
+length, so this is cheap and avoids any cross-thread synchronization).
+"""
+
+from layout import (
+    Idx,
+    Layout,
+    LayoutTensor,
+    TensorLayout,
+    TileTensor,
+    row_major,
+)
+from layout.layout_tensor import copy_local_to_dram
+from layout.tensor_core import TensorCore, get_fragment_size, get_mma_shape
+from std.math import ceildiv, exp
+from max.gpu.sync import barrier as gpu_barrier
+from std.gpu import (
+    WARP_SIZE,
+    block_dim,
+    block_idx,
+    thread_idx,
+)
+from max.gpu.host import DeviceContext
+from std.memory import AddressSpace
+from std.memory import unsafe_stack_allocation as mem_stack_allocation
+from std.utils.index import IndexList
+from linalg.bmm import batched_matmul
+
+# ── Fused single-pass MMA tiling (Mamba2 profile, tuned to mirror stage 2) ──
+# Output tile is the whole [L, P] per slice; warps tile it WARPS_M x WARPS_N.
+# block_dim = WARPS_M * WARPS_N * WARP_SIZE must be >= chunk_len for the
+# shared-memory decay scan. 8x1 warps = 256 threads covers chunk_len=256.
+comptime COMBINE_FUSED_WARPS_M = 8
+comptime COMBINE_FUSED_WARPS_N = 1
+# K (state-dim) step for the fused MMA; multiple of MMA_K (8), divides state_dim.
+comptime COMBINE_FUSED_BK = 16
+
+# Stride helpers for indexing the flat row-major buffers.
+comptime Strides4D = IndexList[4]
+comptime Strides5D = IndexList[5]
+
+# Upper bound on chunk_len for the shared-memory decay scratch (one Float32 per
+# token). The static path launches one block per slice with
+# ``block_dim == chunk_len``, so this also bounds that block size. Mirrors
+# ``STATE_MAX_CHUNK`` in ``ssd_chunk_state.mojo``.
+comptime COMBINE_MAX_CHUNK = 1024
+
+
+def _row_major_strides_4d(d0: Int, d1: Int, d2: Int, d3: Int) -> Strides4D:
+    """Row-major strides for a 4D shape ``(d0, d1, d2, d3)``."""
+    return Strides4D(d1 * d2 * d3, d2 * d3, d3, 1)
+
+
+def _row_major_strides_5d(
+    d0: Int, d1: Int, d2: Int, d3: Int, d4: Int
+) -> Strides5D:
+    """Row-major strides for a 5D shape ``(d0, d1, d2, d3, d4)``."""
+    return Strides5D(d1 * d2 * d3 * d4, d2 * d3 * d4, d3 * d4, d4, 1)
+
+
+def ssd_output_recombination_fwd_cpu[
+    kernel_dtype: DType,
+    c_layout: Layout,
+    entering_layout: Layout,
+    a_layout: Layout,
+    y_diag_layout: Layout,
+    y_layout: Layout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+    C: LayoutTensor[kernel_dtype, c_layout, MutAnyOrigin],
+    entering_state: LayoutTensor[kernel_dtype, entering_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, a_layout, MutAnyOrigin],
+    Y_diag: LayoutTensor[kernel_dtype, y_diag_layout, MutAnyOrigin],
+    Y: LayoutTensor[kernel_dtype, y_layout, MutAnyOrigin],
+):
+    """Compute the SSD output recombination (stage 4) on CPU.
+
+    Combines the intra-chunk diagonal output ``Y_diag`` with the inter-chunk
+    contribution (``C`` projected against the entering state, decayed by the
+    in-chunk cumulative decay) to form the final per-token output ``Y``.
+
+    Tensor shapes (row-major):
+        - ``C``: ``[batch, n_chunks, n_heads, chunk_len, state_dim]``
+        - ``entering_state``: ``[batch, n_chunks, n_heads, head_dim, state_dim]``
+        - ``A``: ``[batch, n_chunks, n_heads, chunk_len]``
+        - ``Y_diag``: ``[batch, n_chunks, n_heads, chunk_len, head_dim]``
+        - ``Y``: ``[batch, n_chunks, n_heads, chunk_len, head_dim]`` (output)
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        c_layout: Layout of the ``C`` tensor.
+        entering_layout: Layout of the ``entering_state`` tensor.
+        a_layout: Layout of the ``A`` tensor.
+        y_diag_layout: Layout of the ``Y_diag`` tensor.
+        y_layout: Layout of the ``Y`` output tensor.
+
+    Args:
+        batch: Number of batch elements.
+        n_chunks: Number of chunks per sequence.
+        n_heads: Number of heads.
+        chunk_len: Tokens per chunk (``L``).
+        head_dim: Head dimension (``P``).
+        state_dim: State dimension (``N``).
+        C: Per-token C projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        entering_state: State entering this chunk,
+            shape ``[batch, n_chunks, n_heads, P, N]``.
+        A: Per-token in-chunk log-decay,
+            shape ``[batch, n_chunks, n_heads, L]``.
+        Y_diag: Intra-chunk diagonal output,
+            shape ``[batch, n_chunks, n_heads, L, P]``.
+        Y: Output, shape ``[batch, n_chunks, n_heads, L, P]``.
+    """
+    # Row-major strides for the flat backing buffers.
+    var c_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, state_dim
+    )
+    var ent_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, head_dim, state_dim
+    )
+    var a_strides = _row_major_strides_4d(batch, n_chunks, n_heads, chunk_len)
+    var y_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, head_dim
+    )
+
+    for bi in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var a_base = (
+                    bi * a_strides[0] + c * a_strides[1] + h * a_strides[2]
+                )
+                var c_base = (
+                    bi * c_strides[0] + c * c_strides[1] + h * c_strides[2]
+                )
+                var ent_base = (
+                    bi * ent_strides[0]
+                    + c * ent_strides[1]
+                    + h * ent_strides[2]
+                )
+                var y_base = (
+                    bi * y_strides[0] + c * y_strides[1] + h * y_strides[2]
+                )
+
+                # Inclusive prefix sum of A over the chunk -> decay per token.
+                var a_cumsum = Float32(0.0)
+                for l in range(chunk_len):
+                    var a_off = a_base + l * a_strides[3]
+                    a_cumsum += A.ptr[a_off].cast[DType.float32]()
+                    var decay = exp(a_cumsum)
+
+                    for p in range(head_dim):
+                        # Y_off[l, p] = decay * sum_n C[l, n] * entering[p, n].
+                        var acc = Float32(0.0)
+                        for n in range(state_dim):
+                            var c_off = (
+                                c_base + l * c_strides[3] + n * c_strides[4]
+                            )
+                            var ent_off = (
+                                ent_base
+                                + p * ent_strides[3]
+                                + n * ent_strides[4]
+                            )
+                            var c_val = C.ptr[c_off].cast[DType.float32]()
+                            var ent_val = entering_state.ptr[ent_off].cast[
+                                DType.float32
+                            ]()
+                            acc += c_val * ent_val
+
+                        var y_off = decay * acc
+
+                        # Y[l, p] = Y_diag[l, p] + Y_off[l, p].
+                        var yd_off = (
+                            y_base + l * y_strides[3] + p * y_strides[4]
+                        )
+                        var y_diag_val = Y_diag.ptr[yd_off].cast[
+                            DType.float32
+                        ]()
+                        Y.ptr[yd_off] = (y_diag_val + y_off).cast[
+                            kernel_dtype
+                        ]()
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU Implementation
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_output_recombination_fwd_gpu[
+    kernel_dtype: DType,
+    c_LT: TensorLayout,
+    entering_LT: TensorLayout,
+    a_LT: TensorLayout,
+    y_diag_LT: TensorLayout,
+    y_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    head_dim_i32: Int32,
+    state_dim_i32: Int32,
+    C: TileTensor[kernel_dtype, c_LT, MutUntrackedOrigin],
+    entering_state: TileTensor[kernel_dtype, entering_LT, MutUntrackedOrigin],
+    A: TileTensor[kernel_dtype, a_LT, MutUntrackedOrigin],
+    Y_diag: TileTensor[kernel_dtype, y_diag_LT, MutUntrackedOrigin],
+    Y: TileTensor[kernel_dtype, y_LT, MutUntrackedOrigin],
+):
+    """Compute the SSD output recombination (stage 4) on GPU.
+
+    The computation is element-wise parallel: each GPU thread owns a single
+    output scalar ``Y[bi, c, h, l, p]``. The only sequential dependency is the
+    per-``(bi, c, h, l)`` inclusive prefix sum ``A_cumsum[l]``, which each thread
+    recomputes up to its own ``l`` (cheap, and avoids cross-thread sync).
+
+    The same math as the CPU kernel, for the scalar ``Y[l, p]``:
+        - ``A_cumsum[l] = sum_{k <= l} A[k]``
+        - ``decay = exp(A_cumsum[l])``
+        - ``Y_off[l, p] = decay * sum_n C[l, n] * entering_state[p, n]``
+        - ``Y[l, p] = Y_diag[l, p] + Y_off[l, p]``
+
+    Tensor shapes (row-major):
+        - ``C``: ``[batch, n_chunks, n_heads, chunk_len, state_dim]``
+        - ``entering_state``: ``[batch, n_chunks, n_heads, head_dim, state_dim]``
+        - ``A``: ``[batch, n_chunks, n_heads, chunk_len]``
+        - ``Y_diag``: ``[batch, n_chunks, n_heads, chunk_len, head_dim]``
+        - ``Y``: ``[batch, n_chunks, n_heads, chunk_len, head_dim]`` (output)
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        c_LT: Layout of the ``C`` tensor.
+        entering_LT: Layout of the ``entering_state`` tensor.
+        a_LT: Layout of the ``A`` tensor.
+        y_diag_LT: Layout of the ``Y_diag`` tensor.
+        y_LT: Layout of the ``Y`` output tensor.
+
+    Args:
+        batch_i32: Number of batch elements.
+        n_chunks_i32: Number of chunks per sequence.
+        n_heads_i32: Number of heads.
+        chunk_len_i32: Tokens per chunk (``L``).
+        head_dim_i32: Head dimension (``P``).
+        state_dim_i32: State dimension (``N``).
+        C: Per-token C projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        entering_state: State entering this chunk,
+            shape ``[batch, n_chunks, n_heads, P, N]``.
+        A: Per-token in-chunk log-decay,
+            shape ``[batch, n_chunks, n_heads, L]``.
+        Y_diag: Intra-chunk diagonal output,
+            shape ``[batch, n_chunks, n_heads, L, P]``.
+        Y: Output, shape ``[batch, n_chunks, n_heads, L, P]``.
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var head_dim = Int(head_dim_i32)
+    var state_dim = Int(state_dim_i32)
+    var flat_idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total_threads = batch * n_chunks * n_heads * chunk_len * head_dim
+    if flat_idx >= total_threads:
+        return
+
+    # Decompose the flat thread index into (batch, chunk, head, l, p).
+    var p = flat_idx % head_dim
+    var l = (flat_idx // head_dim) % chunk_len
+    var h = (flat_idx // (head_dim * chunk_len)) % n_heads
+    var c = (flat_idx // (head_dim * chunk_len * n_heads)) % n_chunks
+    var bi = flat_idx // (head_dim * chunk_len * n_heads * n_chunks)
+
+    # Row-major strides for the flat backing buffers.
+    # C: [batch, n_chunks, n_heads, chunk_len, state_dim].
+    var c_n_stride = 1
+    var c_l_stride = state_dim
+    var c_h_stride = chunk_len * c_l_stride
+    var c_c_stride = n_heads * c_h_stride
+    var c_b_stride = n_chunks * c_c_stride
+
+    # entering_state: [batch, n_chunks, n_heads, head_dim, state_dim].
+    var ent_n_stride = 1
+    var ent_p_stride = state_dim
+    var ent_h_stride = head_dim * ent_p_stride
+    var ent_c_stride = n_heads * ent_h_stride
+    var ent_b_stride = n_chunks * ent_c_stride
+
+    # A: [batch, n_chunks, n_heads, chunk_len].
+    var a_l_stride = 1
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    # Y / Y_diag: [batch, n_chunks, n_heads, chunk_len, head_dim].
+    var y_p_stride = 1
+    var y_l_stride = head_dim
+    var y_h_stride = chunk_len * y_l_stride
+    var y_c_stride = n_heads * y_h_stride
+    var y_b_stride = n_chunks * y_c_stride
+
+    # Inclusive prefix sum of A over [0, l] for this (bi, c, h).
+    var a_base = bi * a_b_stride + c * a_c_stride + h * a_h_stride
+    var a_cumsum = Float32(0.0)
+    for k in range(l + 1):
+        a_cumsum += A.ptr[a_base + k * a_l_stride].cast[DType.float32]()
+    var decay = exp(a_cumsum)
+
+    # Y_off[l, p] = decay * sum_n C[l, n] * entering_state[p, n].
+    var c_base = (
+        bi * c_b_stride + c * c_c_stride + h * c_h_stride + l * c_l_stride
+    )
+    var ent_base = (
+        bi * ent_b_stride
+        + c * ent_c_stride
+        + h * ent_h_stride
+        + p * ent_p_stride
+    )
+    var acc = Float32(0.0)
+    for n in range(state_dim):
+        var c_val = C.ptr[c_base + n * c_n_stride].cast[DType.float32]()
+        var ent_val = entering_state.ptr[ent_base + n * ent_n_stride].cast[
+            DType.float32
+        ]()
+        acc += c_val * ent_val
+    var y_off = decay * acc
+
+    # Y[l, p] = Y_diag[l, p] + Y_off[l, p].
+    var y_off_flat = (
+        bi * y_b_stride
+        + c * y_c_stride
+        + h * y_h_stride
+        + l * y_l_stride
+        + p * y_p_stride
+    )
+    var y_diag_val = Y_diag.ptr[y_off_flat].cast[DType.float32]()
+    Y.ptr[y_off_flat] = (y_diag_val + y_off).cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# Static-shape tensor-core path
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_combine_decay_gpu[
+    kernel_dtype: DType,
+    a_LT: TensorLayout,
+    decay_LT: TensorLayout,
+](
+    chunk_len_i32: Int32,
+    A: TileTensor[kernel_dtype, a_LT, MutAnyOrigin],
+    decay_out: TileTensor[DType.float32, decay_LT, MutAnyOrigin],
+):
+    """Per-token decay ``decay[slice, l] = exp(A_cumsum[l])`` for every slice.
+
+    One block per ``(batch, chunk, head)`` slice (``block_dim == chunk_len``).
+    Computes the inclusive prefix sum of ``A`` over the chunk via a Hillis-Steele
+    scan in shared memory, exponentiates, and writes the per-token decay to a
+    ``[num_slices, chunk_len]`` scratch buffer (read back by the coalesced add
+    kernel). Cheap: ``num_slices * chunk_len`` elements total.
+    """
+    var chunk_len = Int(chunk_len_i32)
+    var slice_idx = Int(block_idx.x)
+    var tid = Int(thread_idx.x)
+
+    var decay = mem_stack_allocation[
+        COMBINE_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+    var a_base = slice_idx * chunk_len
+    if tid < chunk_len:
+        decay[tid] = A.ptr[a_base + tid].cast[DType.float32]()
+    gpu_barrier()
+
+    var offset = 1
+    while offset < chunk_len:
+        var add: Float32 = 0.0
+        if tid < chunk_len and tid >= offset:
+            add = decay[tid - offset]
+        gpu_barrier()
+        if tid < chunk_len and tid >= offset:
+            decay[tid] += add
+        gpu_barrier()
+        offset *= 2
+
+    if tid < chunk_len:
+        decay_out.ptr[a_base + tid] = exp(decay[tid])
+
+
+def _ssd_combine_add_gpu[
+    kernel_dtype: DType,
+    mt_LT: TensorLayout,
+    decay_LT: TensorLayout,
+    y_diag_LT: TensorLayout,
+    y_LT: TensorLayout,
+](
+    chunk_len_i32: Int32,
+    head_dim_i32: Int32,
+    num_slices_i32: Int32,
+    M_T: TileTensor[kernel_dtype, mt_LT, MutAnyOrigin],
+    decay: TileTensor[DType.float32, decay_LT, MutAnyOrigin],
+    Y_diag: TileTensor[kernel_dtype, y_diag_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, y_LT, MutAnyOrigin],
+):
+    """Coalesced add: ``Y[l, p] = Y_diag[l, p] + decay[l] * M_T[p, l]``.
+
+    Flat element-wise launch -- one thread per ``(slice, l, p)`` output scalar,
+    so the grid has ``num_slices * chunk_len * head_dim`` threads (vs the
+    one-block-per-slice epilogue, which starved GB10's SMs). Consecutive threads
+    own consecutive ``p`` (the contiguous output axis), so both the ``Y_diag``
+    read and the ``Y`` write are coalesced. The transposed ``M_T[p, l]`` read is
+    strided by ``chunk_len`` across ``p`` but L2-resident.
+    """
+    var chunk_len = Int(chunk_len_i32)
+    var head_dim = Int(head_dim_i32)
+    var num_slices = Int(num_slices_i32)
+    var flat_idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total = num_slices * chunk_len * head_dim
+    if flat_idx >= total:
+        return
+
+    var p = flat_idx % head_dim
+    var l = (flat_idx // head_dim) % chunk_len
+    var slice_idx = flat_idx // (head_dim * chunk_len)
+
+    var d = decay.ptr[slice_idx * chunk_len + l]
+    var mt_val = M_T.ptr[
+        slice_idx * head_dim * chunk_len + p * chunk_len + l
+    ].cast[DType.float32]()
+    var y_off = slice_idx * chunk_len * head_dim + l * head_dim + p
+    var yd_val = Y_diag.ptr[y_off].cast[DType.float32]()
+    Y.ptr[y_off] = (yd_val + d * mt_val).cast[kernel_dtype]()
+
+
+def ssd_output_recombination_fwd_gpu_static[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    c_LT: TensorLayout,
+    entering_LT: TensorLayout,
+    a_LT: TensorLayout,
+    y_diag_LT: TensorLayout,
+    y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    C: TileTensor[kernel_dtype, c_LT, MutAnyOrigin],
+    entering_state: TileTensor[kernel_dtype, entering_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, a_LT, MutAnyOrigin],
+    Y_diag: TileTensor[kernel_dtype, y_diag_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Static-shape, tensor-core variant of ``ssd_output_recombination_fwd_gpu``.
+
+    Computes the output recombination as a batched matmul on tensor cores
+    followed by a cheap decay + add epilogue:
+
+        ``M_T[p, l] = sum_n entering_state[p, n] * C[l, n]``   (batched_matmul)
+        ``Y[l, p]   = Y_diag[l, p] + exp(A_cumsum[l]) * M_T[p, l]``  (epilogue)
+
+    The decay multiplies an *output* row (``l``), not the reduction dim, so the
+    matmul stays a plain ``entering_state @ Cᵀ`` (``transpose_b=True``, no decay
+    materialisation). Knowing ``chunk_len`` / ``state_dim`` / ``head_dim`` at
+    compile time lets ``batched_matmul`` see ``has_static_NK``; the output has
+    ``chunk_len`` (== matmul ``N``) columns and ``state_dim`` (== ``K``) is a
+    multiple of 32 and ``>= 128``, so it takes the A100 multistage tensor-core
+    batched path (one launch for all ``batch * n_chunks * n_heads`` slices)
+    instead of the scalar reduction in ``ssd_output_recombination_fwd_gpu``.
+
+    The scalar kernel remains the all-shape-correct fallback for shapes that
+    miss the gate (e.g. ``chunk_len`` not a multiple of 128).
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        chunk_len_ct: Tokens per chunk (``L``), compile-time.
+        state_dim_ct: State dimension (``N``), compile-time.
+        head_dim_ct: Head dimension (``P``), compile-time.
+        c_LT: Layout of the ``C`` tensor.
+        entering_LT: Layout of the ``entering_state`` tensor.
+        a_LT: Layout of the ``A`` tensor.
+        y_diag_LT: Layout of the ``Y_diag`` tensor.
+        y_LT: Layout of the ``Y`` output tensor.
+
+    Args:
+        batch: Number of batch elements.
+        n_chunks: Number of chunks per sequence.
+        n_heads: Number of heads.
+        C: Per-token C projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        entering_state: State entering this chunk,
+            shape ``[batch, n_chunks, n_heads, P, N]``.
+        A: Per-token in-chunk log-decay,
+            shape ``[batch, n_chunks, n_heads, L]``.
+        Y_diag: Intra-chunk diagonal output,
+            shape ``[batch, n_chunks, n_heads, L, P]``.
+        Y: Output, shape ``[batch, n_chunks, n_heads, L, P]``.
+        ctx: The device context to enqueue work on.
+    """
+    var num_slices = batch * n_chunks * n_heads
+
+    # Scratch for the off-diagonal matmul result, transposed: [num_slices, P, L].
+    var mt_device = ctx.enqueue_create_buffer[kernel_dtype](
+        num_slices * head_dim_ct * chunk_len_ct
+    )
+
+    # Stage 1: M_T[p, l] = entering_state[p, n] @ C[l, n]ᵀ (batched tensor-core
+    # matmul, one launch). Output N == chunk_len (% 128 == 0), K == state_dim
+    # (% 32 == 0, >= 128) hits the A100 multistage path.
+    var ent3 = TileTensor(
+        entering_state.ptr,
+        row_major(num_slices, Idx[head_dim_ct], Idx[state_dim_ct]),
+    )
+    var C3 = TileTensor(
+        C.ptr,
+        row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct]),
+    )
+    var MT3 = TileTensor(
+        mt_device,
+        row_major(num_slices, Idx[head_dim_ct], Idx[chunk_len_ct]),
+    )
+    with ctx.push_context():
+        batched_matmul[target="gpu", transpose_b=True](
+            MT3, ent3, C3, context=ctx
+        )
+
+    var MT_tt = TileTensor(
+        mt_device,
+        row_major(batch, n_chunks, n_heads, head_dim_ct, chunk_len_ct),
+    )
+
+    # Stage 2: per-token decay = exp(A_cumsum) into a [num_slices, L] scratch
+    # (one block per slice, block_dim == L; the only sequential part).
+    var decay_device = ctx.enqueue_create_buffer[DType.float32](
+        num_slices * chunk_len_ct
+    )
+    var decay_tt = TileTensor(
+        decay_device, row_major(batch, n_chunks, n_heads, chunk_len_ct)
+    )
+    var decay_compiled = ctx.compile_function[
+        _ssd_combine_decay_gpu[kernel_dtype, a_LT, decay_tt.LayoutType]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            decay_compiled,
+            Int32(chunk_len_ct),
+            A,
+            decay_tt,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len_ct,),
+        )
+
+    # Stage 3: coalesced add Y[l,p] = Y_diag[l,p] + decay[l] * M_T[p,l]
+    # (flat element-wise launch -- one thread per output, many small blocks).
+    comptime ADD_BLOCK = 256
+    var total_out = num_slices * chunk_len_ct * head_dim_ct
+    var add_compiled = ctx.compile_function[
+        _ssd_combine_add_gpu[
+            kernel_dtype,
+            MT_tt.LayoutType,
+            decay_tt.LayoutType,
+            y_diag_LT,
+            y_LT,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            add_compiled,
+            Int32(chunk_len_ct),
+            Int32(head_dim_ct),
+            Int32(num_slices),
+            MT_tt,
+            decay_tt,
+            Y_diag,
+            Y,
+            grid_dim=(ceildiv(total_out, ADD_BLOCK),),
+            block_dim=(ADD_BLOCK,),
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Fused single-pass tensor-core path
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_combine_fused_mma_gpu[
+    kernel_dtype: DType,
+    L: Int,
+    P: Int,
+    N: Int,
+    BK: Int,
+    num_warps_m: Int,
+    num_warps_n: Int,
+    c_LT: TensorLayout,
+    entering_LT: TensorLayout,
+    a_LT: TensorLayout,
+    y_LT: TensorLayout,
+](
+    C: TileTensor[kernel_dtype, c_LT, MutAnyOrigin],
+    entering_state: TileTensor[kernel_dtype, entering_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, a_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, y_LT, MutAnyOrigin],
+):
+    """Fused, single-pass tensor-core off-diagonal recombination (one block/slice).
+
+    Computes ``M[l,p] = decay[l] * sum_n C[l,n] * entering_state[p,n]`` for one
+    ``(batch, chunk, head)`` slice as a transpose-of-entering tensor-core GEMM,
+    **without** materialising the matmul result in DRAM (the cost the 2-pass
+    ``..._fwd_gpu_static`` pays). Per K-tile the block streams ``C``/``entering``
+    once, folds ``decay[l]`` into the ``C`` (``As``) tile while loading (so the
+    decay is on the matmul ``M`` rows, no post-pass), transposes ``entering``
+    into the ``Bs`` tile, and accumulates the warp-tiled MMA. The decayed
+    ``M[l,p]`` is written to ``Y``; the small ``+ Y_diag`` is a separate
+    same-layout coalesced add (``_ssd_combine_add_diag_gpu``).
+
+    Compile-time tiling: block tile is the whole ``[L, P]`` output; warps tile it
+    ``num_warps_m x num_warps_n``; ``BK`` is the K (state-dim) step. Slices are
+    contiguous in every buffer, so ``slice_idx`` alone indexes them. Mirrors
+    ``_ssd_chunk_state_fused_mma_gpu`` in ``ssd_chunk_state.mojo``.
+    """
+    comptime accum_type = DType.float32
+    comptime mma_shape = get_mma_shape[kernel_dtype, accum_type]()
+    comptime MMA_M = mma_shape[0]
+    comptime MMA_N = mma_shape[1]
+    comptime MMA_K = mma_shape[2]
+    comptime WM = L // num_warps_m
+    comptime WN = P // num_warps_n
+    comptime num_m_mmas = WM // MMA_M
+    comptime num_n_mmas = WN // MMA_N
+    comptime num_k_mmas = BK // MMA_K
+    comptime fs = get_fragment_size[mma_shape]()
+    comptime a_frag_size = fs[0]
+    comptime b_frag_size = fs[1]
+    comptime c_frag_size = fs[2]
+    comptime num_threads = num_warps_m * num_warps_n * WARP_SIZE
+
+    var slice_idx = Int(block_idx.x)
+    var tid = Int(thread_idx.x)
+    var warp_id = tid // WARP_SIZE
+    var warp_y = warp_id // num_warps_n
+    var warp_x = warp_id % num_warps_n
+
+    var c_base = slice_idx * L * N
+    var ent_base = slice_idx * P * N
+    var a_base = slice_idx * L
+    var y_base = slice_idx * L * P
+
+    # ── Per-token decay into shared memory (Hillis-Steele, then exp). ─────────
+    # Stage 4 uses exp(A_cumsum[l]) directly (inclusive prefix sum, no cum_end).
+    var decay = mem_stack_allocation[
+        COMBINE_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+    if tid < L:
+        decay[tid] = A.ptr[a_base + tid].cast[DType.float32]()
+    gpu_barrier()
+    var offset = 1
+    while offset < L:
+        var add: Float32 = 0.0
+        if tid < L and tid >= offset:
+            add = decay[tid - offset]
+        gpu_barrier()
+        if tid < L and tid >= offset:
+            decay[tid] += add
+        gpu_barrier()
+        offset *= 2
+    if tid < L:
+        decay[tid] = exp(decay[tid])
+    gpu_barrier()
+
+    # ── Shared tiles: As is decay-scaled C [L, BK]; Bs is entering transposed
+    # to [BK, P]. ─────────────────────────────────────────────────────────────
+    var As = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(L, BK),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var Bs = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(BK, P),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+
+    var c_reg = (
+        LayoutTensor[
+            accum_type,
+            Layout.row_major(num_m_mmas * num_n_mmas, c_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ]
+        .stack_allocation()
+        .fill(0)
+    )
+    var a_reg = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(num_m_mmas, a_frag_size),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ].stack_allocation()
+    var b_reg = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(num_n_mmas, b_frag_size),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ].stack_allocation()
+
+    var mma_op = TensorCore[accum_type, kernel_dtype, mma_shape, False]()
+
+    # ── K-loop over the state dimension N ────────────────────────────────────
+    var k0 = 0
+    while k0 < N:
+        # As[l, kl] = decay[l] * C[l, k0+kl] (coalesced read over kl per row l).
+        var idx = tid
+        while idx < L * BK:
+            var l = idx // BK
+            var kl = idx % BK
+            As[l, kl] = (
+                decay[l]
+                * C.ptr[c_base + l * N + (k0 + kl)].cast[DType.float32]()
+            ).cast[kernel_dtype]()
+            idx += num_threads
+        # Bs[kl, p] = entering[p, k0+kl] (coalesced read over kl per row p).
+        idx = tid
+        while idx < P * BK:
+            var p = idx // BK
+            var kl = idx % BK
+            Bs[kl, p] = entering_state.ptr[ent_base + p * N + (k0 + kl)]
+            idx += num_threads
+        gpu_barrier()
+
+        var a_warp_tile = As.tile[WM, BK](warp_y, 0)
+        var b_warp_tile = Bs.tile[BK, WN](0, warp_x)
+
+        comptime for k_mma in range(num_k_mmas):
+            mma_op.load_a(a_warp_tile, a_reg.vectorize[1, a_frag_size](), k_mma)
+            mma_op.load_b(
+                b_warp_tile, b_reg.vectorize[1, b_frag_size](), k_mma, warp_x
+            )
+            mma_op.mma(
+                a_reg.vectorize[1, a_frag_size](),
+                b_reg.vectorize[1, b_frag_size](),
+                c_reg.vectorize[1, c_frag_size](),
+            )
+        gpu_barrier()
+        k0 += BK
+
+    # ── Store the warp's [WM, WN] output tile (decayed M) to Y. ──────────────
+    var y_slice = LayoutTensor[
+        kernel_dtype, Layout.row_major(L, P), MutAnyOrigin
+    ](Y.ptr + y_base)
+    var y_warp_tile = y_slice.tile[WM, WN](warp_y, warp_x)
+    copy_local_to_dram[dst_thread_layout=Layout.row_major(8, 4)](
+        y_warp_tile.vectorize[1, 2](),
+        c_reg.vectorize[1, 2]().transpose(),
+    )
+
+
+def _ssd_combine_add_diag_gpu[
+    kernel_dtype: DType,
+    y_diag_LT: TensorLayout,
+    y_LT: TensorLayout,
+](
+    total_i32: Int32,
+    Y_diag: TileTensor[kernel_dtype, y_diag_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, y_LT, MutAnyOrigin],
+):
+    """Coalesced ``Y[i] += Y_diag[i]`` over every output scalar.
+
+    Both tensors are the same row-major ``[b,nc,h,L,P]`` layout, so this is a
+    fully-coalesced element-wise add (no transpose) — far cheaper than the
+    transposed-read add of the 2-pass static path.
+    """
+    var total = Int(total_i32)
+    var i = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    if i >= total:
+        return
+    Y.ptr[i] = (
+        Y.ptr[i].cast[DType.float32]() + Y_diag.ptr[i].cast[DType.float32]()
+    ).cast[kernel_dtype]()
+
+
+def ssd_output_recombination_fwd_gpu_fused[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    c_LT: TensorLayout,
+    entering_LT: TensorLayout,
+    a_LT: TensorLayout,
+    y_diag_LT: TensorLayout,
+    y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    C: TileTensor[kernel_dtype, c_LT, MutAnyOrigin],
+    entering_state: TileTensor[kernel_dtype, entering_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, a_LT, MutAnyOrigin],
+    Y_diag: TileTensor[kernel_dtype, y_diag_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Fused single-pass tensor-core variant of the stage-4 recombination.
+
+    One block per slice runs ``_ssd_combine_fused_mma_gpu`` (decay folded into
+    the matmul, no DRAM round-trip for the off-diagonal result), then a
+    coalesced ``Y += Y_diag`` add. Faster than the 2-pass
+    ``..._fwd_gpu_static`` (which round-trips ``M_T`` through DRAM and does a
+    transposed-read add).
+
+    Requires the fused-MMA tiling constraints: ``chunk_len % (16*num_warps_m)
+    == 0``, ``head_dim % (8*num_warps_n) == 0``, ``state_dim % BK == 0``, and
+    the launch block (``num_warps_m*num_warps_n*32`` threads) ``>= chunk_len``
+    for the decay scan. The 2-pass static path is the fallback for other shapes.
+    """
+    comptime num_threads = (
+        COMBINE_FUSED_WARPS_M * COMBINE_FUSED_WARPS_N * WARP_SIZE
+    )
+    var num_slices = batch * n_chunks * n_heads
+
+    # Stage 1: fused MMA writes the decayed off-diagonal M[l,p] into Y.
+    var fused_compiled = ctx.compile_function[
+        _ssd_combine_fused_mma_gpu[
+            kernel_dtype,
+            chunk_len_ct,
+            head_dim_ct,
+            state_dim_ct,
+            COMBINE_FUSED_BK,
+            COMBINE_FUSED_WARPS_M,
+            COMBINE_FUSED_WARPS_N,
+            c_LT,
+            entering_LT,
+            a_LT,
+            y_LT,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            fused_compiled,
+            C,
+            entering_state,
+            A,
+            Y,
+            grid_dim=(num_slices,),
+            block_dim=(num_threads,),
+        )
+
+    # Stage 2: coalesced Y += Y_diag (same layout, no transpose).
+    comptime ADD_BLOCK = 256
+    var total_out = num_slices * chunk_len_ct * head_dim_ct
+    var add_compiled = ctx.compile_function[
+        _ssd_combine_add_diag_gpu[kernel_dtype, y_diag_LT, y_LT]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            add_compiled,
+            Int32(total_out),
+            Y_diag,
+            Y,
+            grid_dim=(ceildiv(total_out, ADD_BLOCK),),
+            block_dim=(ADD_BLOCK,),
+        )

--- a/max/kernels/src/state_space/ssd_chunk_combined_ops.mojo
+++ b/max/kernels/src/state_space/ssd_chunk_combined_ops.mojo
@@ -1,0 +1,1054 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Fused SSD chunk-scan operation registration for Mamba2.
+
+This module registers ``ssd_chunk_scan_combined``, which stitches the four
+verified SSD stage kernels — intra-chunk diagonal, chunk end-state, inter-chunk
+recurrence, and output recombination — into a single MAX graph op matching the
+torch ``mamba_chunk_scan_combined`` contract:
+
+    op(x, dt, A, B, C, chunk_size)
+        == ssd_minimal_discrete(x * dt[..., None], A_h * dt, B, C, chunk_size)
+
+with all stage 1-4 work happening behind the registration boundary.
+
+Inputs (row-major):
+    - ``x``: ``[batch, seqlen, n_heads, head_dim]`` — value-like input ``X``.
+    - ``dt``: ``[batch, seqlen, n_heads]`` — per-token time delta.
+    - ``A``: ``[n_heads]`` — scalar log-decay per head.
+    - ``B``: ``[batch, seqlen, n_heads, state_dim]``.
+    - ``C``: ``[batch, seqlen, n_heads, state_dim]``.
+
+Outputs:
+    - ``Y: [batch, seqlen, n_heads, head_dim]`` (same dtype as inputs).
+    - ``final_state: [batch, n_heads, head_dim, state_dim]`` — the SSM state
+      after the last chunk, used to seed the decode (``selective_scan_update``)
+      cache so step-mode continuation picks up where prefill left off.
+
+The op currently assumes ``ngroups == n_heads`` (no group broadcasting yet) and
+that ``seqlen`` divides evenly by ``chunk_size``; both restrictions match the
+upstream Mamba2 reference at the dimensions we care about for prefill.
+"""
+
+import extensibility
+from extensibility import InputTensor, OutputTensor
+from max.gpu.host import DeviceContext
+from max.gpu.host.info import is_cpu, is_gpu
+from std.gpu import (
+    block_dim,
+    block_idx,
+    thread_idx,
+)
+from std.math import ceildiv
+from std.utils.index import Index, IndexList
+
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TensorLayout,
+    TileTensor,
+    row_major,
+)
+
+from state_space.ssd_chunk import (
+    ssd_intra_chunk_fwd_cpu,
+    ssd_intra_chunk_fwd_gpu,
+)
+from state_space.ssd_chunk_state import (
+    ssd_chunk_state_fwd_cpu,
+    ssd_chunk_state_fwd_gpu,
+    ssd_chunk_state_fwd_gpu_fused,
+)
+from state_space.ssd_chunk_scan import (
+    ssd_chunk_scan_fwd_cpu,
+    ssd_chunk_scan_fwd_gpu,
+)
+from state_space.ssd_chunk_combine import (
+    ssd_output_recombination_fwd_cpu,
+    ssd_output_recombination_fwd_gpu,
+    ssd_output_recombination_fwd_gpu_fused,
+)
+
+# Block size for the elementwise precompute/postprocess and the scan/combine
+# device-kernel launches (matches the per-stage GPU tests).
+comptime _SSD_GPU_BLOCK = 256
+
+
+# ===----------------------------------------------------------------------=== #
+# Pre-stage helpers (CPU): discretization + reshape
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_combined_precompute_cpu[
+    dtype: DType,
+](
+    batch: Int,
+    seqlen: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    n_chunks: Int,
+    chunk_size: Int,
+    x_ptr: UnsafePointer[Scalar[dtype], ...],
+    dt_ptr: UnsafePointer[Scalar[dtype], ...],
+    A_ptr: UnsafePointer[Scalar[dtype], ...],
+    B_ptr: UnsafePointer[Scalar[dtype], ...],
+    C_ptr: UnsafePointer[Scalar[dtype], ...],
+    X_disc_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+    A_disc_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+    B_chunk_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+    C_chunk_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+    chunk_decays_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+):
+    """Reshape inputs into chunked form and discretize on CPU.
+
+    Inputs:
+        x:  ``[batch, seqlen, n_heads, head_dim]``
+        dt: ``[batch, seqlen, n_heads]``
+        A:  ``[n_heads]`` (scalar decay per head)
+        B:  ``[batch, seqlen, n_heads, state_dim]``
+        C:  ``[batch, seqlen, n_heads, state_dim]``
+
+    Produces:
+        X_disc:       ``[batch, n_chunks, n_heads, chunk_size, head_dim]``
+                      with ``X_disc[b, c, h, l, p] = x[b, c*L+l, h, p] *
+                      dt[b, c*L+l, h]``.
+        A_disc:       ``[batch, n_chunks, n_heads, chunk_size]`` with
+                      ``A_disc[b, c, h, l] = A[h] * dt[b, c*L+l, h]``.
+        B_chunk:      reshape of B into chunked form (no value change).
+        C_chunk:      reshape of C into chunked form (no value change).
+        chunk_decays: ``[batch, n_chunks, n_heads]``,
+                      ``= sum over l of A_disc[b, c, h, l]``.
+    """
+    # Note: all input/output buffers are row-major contiguous.
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var a_h = A_ptr[h].cast[DType.float32]()
+                var chunk_sum = Float32(0.0)
+                for l in range(chunk_size):
+                    var t = c * chunk_size + l
+                    var dt_off = (b * seqlen + t) * n_heads + h
+                    var dt_val = dt_ptr[dt_off].cast[DType.float32]()
+                    var a_disc_val = a_h * dt_val
+                    chunk_sum += a_disc_val
+
+                    var a_disc_off = (
+                        (b * n_chunks + c) * n_heads + h
+                    ) * chunk_size + l
+                    A_disc_ptr[a_disc_off] = a_disc_val.cast[dtype]()
+
+                    # X_disc[b, c, h, l, p] = x[b, t, h, p] * dt[b, t, h]
+                    var x_in_base = ((b * seqlen + t) * n_heads + h) * head_dim
+                    var x_out_base = (
+                        ((b * n_chunks + c) * n_heads + h) * chunk_size + l
+                    ) * head_dim
+                    for p in range(head_dim):
+                        var x_val = x_ptr[x_in_base + p].cast[DType.float32]()
+                        X_disc_ptr[x_out_base + p] = (x_val * dt_val).cast[
+                            dtype
+                        ]()
+
+                    # B_chunk / C_chunk: pure reshape (same value).
+                    var bc_in_base = (
+                        (b * seqlen + t) * n_heads + h
+                    ) * state_dim
+                    var bc_out_base = (
+                        ((b * n_chunks + c) * n_heads + h) * chunk_size + l
+                    ) * state_dim
+                    for n in range(state_dim):
+                        B_chunk_ptr[bc_out_base + n] = B_ptr[bc_in_base + n]
+                        C_chunk_ptr[bc_out_base + n] = C_ptr[bc_in_base + n]
+
+                var cd_off = (b * n_chunks + c) * n_heads + h
+                chunk_decays_ptr[cd_off] = chunk_sum.cast[dtype]()
+
+
+def _ssd_combined_postprocess_cpu[
+    dtype: DType,
+](
+    batch: Int,
+    seqlen: Int,
+    n_heads: Int,
+    head_dim: Int,
+    n_chunks: Int,
+    chunk_size: Int,
+    Y_chunked_ptr: UnsafePointer[Scalar[dtype], ...],
+    Y_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+):
+    """Flatten ``Y_chunked: [b, nc, h, L, P]`` back into ``Y: [b, S, h, P]``."""
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                for l in range(chunk_size):
+                    var t = c * chunk_size + l
+                    var y_in_base = (
+                        ((b * n_chunks + c) * n_heads + h) * chunk_size + l
+                    ) * head_dim
+                    var y_out_base = (b * seqlen + t) * n_heads * head_dim + (
+                        h * head_dim
+                    )
+                    for p in range(head_dim):
+                        Y_ptr[y_out_base + p] = Y_chunked_ptr[y_in_base + p]
+
+
+# ===----------------------------------------------------------------------=== #
+# CPU dispatch — runs all four stages
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_chunk_scan_combined_cpu[
+    dtype: DType,
+](
+    batch: Int,
+    seqlen: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    chunk_size: Int,
+    x_ptr: UnsafePointer[Scalar[dtype], ...],
+    dt_ptr: UnsafePointer[Scalar[dtype], ...],
+    A_ptr: UnsafePointer[Scalar[dtype], ...],
+    B_ptr: UnsafePointer[Scalar[dtype], ...],
+    C_ptr: UnsafePointer[Scalar[dtype], ...],
+    Y_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+    final_state_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+) raises:
+    """Run the full SSD chunk-scan-combined on CPU.
+
+    ``final_state_ptr`` is filled with the post-last-chunk SSM state, shape
+    ``[batch, n_heads, head_dim, state_dim]`` row-major. Callers use it to seed
+    the step-mode SSM cache; pass a dummy buffer of the right size if the
+    state is not needed.
+    """
+    if seqlen % chunk_size != 0:
+        raise Error(
+            "ssd_chunk_scan_combined: seqlen must be divisible by chunk_size"
+        )
+    var n_chunks = seqlen // chunk_size
+
+    # Heap allocations for intermediates. Sized once and zeroed where needed.
+    var x_disc_size = batch * n_chunks * n_heads * chunk_size * head_dim
+    var a_disc_size = batch * n_chunks * n_heads * chunk_size
+    var bc_chunk_size = batch * n_chunks * n_heads * chunk_size * state_dim
+    var y_diag_size = x_disc_size  # same shape as X_disc
+    var chunk_states_size = batch * n_chunks * n_heads * head_dim * state_dim
+    var entering_size = chunk_states_size
+    var final_size = batch * n_heads * head_dim * state_dim
+    var cd_size = batch * n_chunks * n_heads
+    var y_chunked_size = x_disc_size
+
+    var X_disc = List[Scalar[dtype]](length=x_disc_size, fill=Scalar[dtype](0))
+    var A_disc = List[Scalar[dtype]](length=a_disc_size, fill=Scalar[dtype](0))
+    var B_chunk = List[Scalar[dtype]](
+        length=bc_chunk_size, fill=Scalar[dtype](0)
+    )
+    var C_chunk = List[Scalar[dtype]](
+        length=bc_chunk_size, fill=Scalar[dtype](0)
+    )
+    var Y_diag = List[Scalar[dtype]](length=y_diag_size, fill=Scalar[dtype](0))
+    var chunk_states = List[Scalar[dtype]](
+        length=chunk_states_size, fill=Scalar[dtype](0)
+    )
+    var entering = List[Scalar[dtype]](
+        length=entering_size, fill=Scalar[dtype](0)
+    )
+    var final = List[Scalar[dtype]](length=final_size, fill=Scalar[dtype](0))
+    var chunk_decays = List[Scalar[dtype]](
+        length=cd_size, fill=Scalar[dtype](0)
+    )
+    var Y_chunked = List[Scalar[dtype]](
+        length=y_chunked_size, fill=Scalar[dtype](0)
+    )
+
+    # Stage 0: discretize + chunked reshape.
+    _ssd_combined_precompute_cpu[dtype](
+        batch,
+        seqlen,
+        n_heads,
+        head_dim,
+        state_dim,
+        n_chunks,
+        chunk_size,
+        x_ptr,
+        dt_ptr,
+        A_ptr,
+        B_ptr,
+        C_ptr,
+        X_disc.unsafe_ptr(),
+        A_disc.unsafe_ptr(),
+        B_chunk.unsafe_ptr(),
+        C_chunk.unsafe_ptr(),
+        chunk_decays.unsafe_ptr(),
+    )
+
+    # Build LayoutTensors over the intermediate buffers (row-major).
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var X_disc_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_disc.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, head_dim)
+        ),
+    )
+    var A_disc_lt = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_disc.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size)
+        ),
+    )
+    var B_chunk_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_chunk.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, state_dim)
+        ),
+    )
+    var C_chunk_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        C_chunk.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, state_dim)
+        ),
+    )
+    var Y_diag_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_diag.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, head_dim)
+        ),
+    )
+    var chunk_states_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        chunk_states.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    var entering_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        entering.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    var final_lt = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        final.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_heads, head_dim, state_dim)
+        ),
+    )
+    var chunk_decays_lt = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        chunk_decays.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_3d].row_major(Index(batch, n_chunks, n_heads)),
+    )
+    var Y_chunked_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_chunked.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, head_dim)
+        ),
+    )
+
+    # Stage 1: intra-chunk diagonal -> Y_diag.
+    # The kernel accumulates into Y, so Y_diag is pre-zeroed above.
+    ssd_intra_chunk_fwd_cpu[
+        dtype,
+        C_chunk_lt.layout,
+        B_chunk_lt.layout,
+        X_disc_lt.layout,
+        A_disc_lt.layout,
+        Y_diag_lt.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_size,
+        state_dim,
+        head_dim,
+        C_chunk_lt,
+        B_chunk_lt,
+        X_disc_lt,
+        A_disc_lt,
+        Y_diag_lt,
+    )
+
+    # Stage 2: per-chunk end-states.
+    ssd_chunk_state_fwd_cpu[
+        dtype,
+        B_chunk_lt.layout,
+        X_disc_lt.layout,
+        A_disc_lt.layout,
+        chunk_states_lt.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_size,
+        state_dim,
+        head_dim,
+        B_chunk_lt,
+        X_disc_lt,
+        A_disc_lt,
+        chunk_states_lt,
+    )
+
+    # Stage 3: inter-chunk recurrence.
+    ssd_chunk_scan_fwd_cpu[
+        dtype,
+        chunk_states_lt.layout,
+        chunk_decays_lt.layout,
+        entering_lt.layout,
+        final_lt.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        head_dim,
+        state_dim,
+        chunk_states_lt,
+        chunk_decays_lt,
+        entering_lt,
+        final_lt,
+    )
+
+    # Stage 4: output recombination (writes into Y_chunked, copying Y_diag in).
+    ssd_output_recombination_fwd_cpu[
+        dtype,
+        C_chunk_lt.layout,
+        entering_lt.layout,
+        A_disc_lt.layout,
+        Y_diag_lt.layout,
+        Y_chunked_lt.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_size,
+        head_dim,
+        state_dim,
+        C_chunk_lt,
+        entering_lt,
+        A_disc_lt,
+        Y_diag_lt,
+        Y_chunked_lt,
+    )
+
+    # Flatten the chunked output back to (batch, seqlen, n_heads, head_dim).
+    _ssd_combined_postprocess_cpu[dtype](
+        batch,
+        seqlen,
+        n_heads,
+        head_dim,
+        n_chunks,
+        chunk_size,
+        Y_chunked.unsafe_ptr(),
+        Y_ptr,
+    )
+
+    # Copy the post-last-chunk SSM state into the caller's final_state buffer.
+    # Shape is [batch, n_heads, head_dim, state_dim], identical to `final_lt`.
+    var final_total = batch * n_heads * head_dim * state_dim
+    var final_src = final.unsafe_ptr()
+    for i in range(final_total):
+        final_state_ptr[i] = final_src[i]
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU dispatch — fully on-device stitched pipeline
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_combined_precompute_gpu[
+    dtype: DType,
+    x_LT: TensorLayout,
+    dt_LT: TensorLayout,
+    A_LT: TensorLayout,
+    bc_LT: TensorLayout,
+    xd_LT: TensorLayout,
+    ad_LT: TensorLayout,
+    bcc_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    seqlen_i32: Int32,
+    n_heads_i32: Int32,
+    head_dim_i32: Int32,
+    state_dim_i32: Int32,
+    n_chunks_i32: Int32,
+    chunk_size_i32: Int32,
+    x: TileTensor[dtype, x_LT, MutAnyOrigin],
+    dt: TileTensor[dtype, dt_LT, MutAnyOrigin],
+    A: TileTensor[dtype, A_LT, MutAnyOrigin],
+    B: TileTensor[dtype, bc_LT, MutAnyOrigin],
+    C: TileTensor[dtype, bc_LT, MutAnyOrigin],
+    X_disc: TileTensor[dtype, xd_LT, MutAnyOrigin],
+    A_disc: TileTensor[dtype, ad_LT, MutAnyOrigin],
+    B_chunk: TileTensor[dtype, bcc_LT, MutAnyOrigin],
+    C_chunk: TileTensor[dtype, bcc_LT, MutAnyOrigin],
+):
+    """Stage 0 (GPU): discretize + chunked reshape. One thread per (b,c,h,l).
+
+    Mirrors ``_ssd_combined_precompute_cpu``: ``X_disc = x*dt`` (chunked),
+    ``A_disc = A[h]*dt`` (chunked), ``B_chunk``/``C_chunk`` pure reshape. The
+    flat ``(b,c,h,l)`` index is row-major over ``A_disc`` so ``A_disc.ptr[idx]``
+    is the destination directly.
+    """
+    var batch = Int(batch_i32)
+    var seqlen = Int(seqlen_i32)
+    var n_heads = Int(n_heads_i32)
+    var head_dim = Int(head_dim_i32)
+    var state_dim = Int(state_dim_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var chunk_size = Int(chunk_size_i32)
+    var idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total = batch * n_chunks * n_heads * chunk_size
+    if idx >= total:
+        return
+
+    var l = idx % chunk_size
+    var h = (idx // chunk_size) % n_heads
+    var c = (idx // (chunk_size * n_heads)) % n_chunks
+    var bi = idx // (chunk_size * n_heads * n_chunks)
+    var t = c * chunk_size + l
+
+    var a_h = A.ptr[h].cast[DType.float32]()
+    var dt_off = (bi * seqlen + t) * n_heads + h
+    var dt_val = dt.ptr[dt_off].cast[DType.float32]()
+    A_disc.ptr[idx] = (a_h * dt_val).cast[dtype]()
+
+    var x_in_base = ((bi * seqlen + t) * n_heads + h) * head_dim
+    var x_out_base = idx * head_dim
+    for p in range(head_dim):
+        X_disc.ptr[x_out_base + p] = (
+            x.ptr[x_in_base + p].cast[DType.float32]() * dt_val
+        ).cast[dtype]()
+
+    var bc_in_base = ((bi * seqlen + t) * n_heads + h) * state_dim
+    var bc_out_base = idx * state_dim
+    for n in range(state_dim):
+        B_chunk.ptr[bc_out_base + n] = B.ptr[bc_in_base + n]
+        C_chunk.ptr[bc_out_base + n] = C.ptr[bc_in_base + n]
+
+
+def _ssd_combined_chunk_decays_gpu[
+    dtype: DType,
+    ad_LT: TensorLayout,
+    cd_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_size_i32: Int32,
+    A_disc: TileTensor[dtype, ad_LT, MutAnyOrigin],
+    chunk_decays: TileTensor[dtype, cd_LT, MutAnyOrigin],
+):
+    """Stage 0b (GPU): ``chunk_decays[b,c,h] = sum_l A_disc[b,c,h,l]``."""
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_size = Int(chunk_size_i32)
+    var idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total = batch * n_chunks * n_heads
+    if idx >= total:
+        return
+    var base = idx * chunk_size
+    var s = Float32(0.0)
+    for l in range(chunk_size):
+        s += A_disc.ptr[base + l].cast[DType.float32]()
+    chunk_decays.ptr[idx] = s.cast[dtype]()
+
+
+def _ssd_combined_postprocess_gpu[
+    dtype: DType,
+    yc_LT: TensorLayout,
+    y_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    seqlen_i32: Int32,
+    n_heads_i32: Int32,
+    head_dim_i32: Int32,
+    n_chunks_i32: Int32,
+    chunk_size_i32: Int32,
+    Y_chunked: TileTensor[dtype, yc_LT, MutAnyOrigin],
+    Y: TileTensor[dtype, y_LT, MutAnyOrigin],
+):
+    """Stage 5 (GPU): flatten ``Y_chunked[b,c,h,l,p]`` -> ``Y[b,t,h,p]``."""
+    var batch = Int(batch_i32)
+    var seqlen = Int(seqlen_i32)
+    var n_heads = Int(n_heads_i32)
+    var head_dim = Int(head_dim_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var chunk_size = Int(chunk_size_i32)
+    var idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total = batch * n_chunks * n_heads * chunk_size * head_dim
+    if idx >= total:
+        return
+    var p = idx % head_dim
+    var l = (idx // head_dim) % chunk_size
+    var h = (idx // (head_dim * chunk_size)) % n_heads
+    var c = (idx // (head_dim * chunk_size * n_heads)) % n_chunks
+    var bi = idx // (head_dim * chunk_size * n_heads * n_chunks)
+    var t = c * chunk_size + l
+    var y_out = ((bi * seqlen + t) * n_heads + h) * head_dim + p
+    Y.ptr[y_out] = Y_chunked.ptr[idx]
+
+
+def _ssd_chunk_scan_combined_gpu[
+    dtype: DType,
+    chunk_size: Int,
+](
+    batch: Int,
+    seqlen: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    x_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dt_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    A_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    B_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    C_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    Y_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    final_state_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Fully on-device SSD chunk-scan-combined.
+
+    Runs all six stages on the GPU over device-resident buffers (no host
+    round-trip): precompute -> intra-chunk diagonal -> chunk end-state (the
+    optimized ``ssd_chunk_state`` kernel; the fused tensor-core path for the
+    gate dims, else the parallel scalar path) -> inter-chunk scan -> output
+    recombination -> postprocess. ``*_ptr`` are device pointers.
+    """
+    if seqlen % chunk_size != 0:
+        raise Error(
+            "ssd_chunk_scan_combined: seqlen must be divisible by chunk_size"
+        )
+    var n_chunks = seqlen // chunk_size
+    var num_slices = batch * n_chunks * n_heads
+
+    # Device intermediates (same shapes as the CPU dispatch).
+    var xd_n = batch * n_chunks * n_heads * chunk_size * head_dim
+    var ad_n = batch * n_chunks * n_heads * chunk_size
+    var bc_n = batch * n_chunks * n_heads * chunk_size * state_dim
+    var st_n = batch * n_chunks * n_heads * head_dim * state_dim
+    var cd_n = batch * n_chunks * n_heads
+    var fin_n = batch * n_heads * head_dim * state_dim
+
+    var X_disc_d = ctx.enqueue_create_buffer[dtype](xd_n)
+    var A_disc_d = ctx.enqueue_create_buffer[dtype](ad_n)
+    var B_chunk_d = ctx.enqueue_create_buffer[dtype](bc_n)
+    var C_chunk_d = ctx.enqueue_create_buffer[dtype](bc_n)
+    var Y_diag_d = ctx.enqueue_create_buffer[dtype](xd_n)
+    var chunk_states_d = ctx.enqueue_create_buffer[dtype](st_n)
+    var entering_d = ctx.enqueue_create_buffer[dtype](st_n)
+    var final_d = ctx.enqueue_create_buffer[dtype](fin_n)
+    var chunk_decays_d = ctx.enqueue_create_buffer[dtype](cd_n)
+    var Y_chunked_d = ctx.enqueue_create_buffer[dtype](xd_n)
+
+    # TileTensor views over inputs (device ptrs) and intermediates.
+    var x_tt = TileTensor(x_ptr, row_major(batch, seqlen, n_heads, head_dim))
+    var dt_tt = TileTensor(dt_ptr, row_major(batch, seqlen, n_heads))
+    var A_tt = TileTensor(A_ptr, row_major(n_heads))
+    var B_tt = TileTensor(B_ptr, row_major(batch, seqlen, n_heads, state_dim))
+    var C_tt = TileTensor(C_ptr, row_major(batch, seqlen, n_heads, state_dim))
+
+    var X_disc = TileTensor(
+        X_disc_d, row_major(batch, n_chunks, n_heads, chunk_size, head_dim)
+    )
+    var A_disc = TileTensor(
+        A_disc_d, row_major(batch, n_chunks, n_heads, chunk_size)
+    )
+    var B_chunk = TileTensor(
+        B_chunk_d, row_major(batch, n_chunks, n_heads, chunk_size, state_dim)
+    )
+    var C_chunk = TileTensor(
+        C_chunk_d, row_major(batch, n_chunks, n_heads, chunk_size, state_dim)
+    )
+    var Y_diag = TileTensor(
+        Y_diag_d, row_major(batch, n_chunks, n_heads, chunk_size, head_dim)
+    )
+    var chunk_states = TileTensor(
+        chunk_states_d, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var entering = TileTensor(
+        entering_d, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var final = TileTensor(
+        final_d, row_major(batch, n_heads, head_dim, state_dim)
+    )
+    var chunk_decays = TileTensor(
+        chunk_decays_d, row_major(batch, n_chunks, n_heads)
+    )
+    var Y_chunked = TileTensor(
+        Y_chunked_d, row_major(batch, n_chunks, n_heads, chunk_size, head_dim)
+    )
+    var Y_out = TileTensor(Y_ptr, row_major(batch, seqlen, n_heads, head_dim))
+
+    # Stage 0: precompute (discretize + chunked reshape) + chunk decays.
+    var pre_total = batch * n_chunks * n_heads * chunk_size
+    var pre_compiled = ctx.compile_function[
+        _ssd_combined_precompute_gpu[
+            dtype,
+            x_tt.LayoutType,
+            dt_tt.LayoutType,
+            A_tt.LayoutType,
+            B_tt.LayoutType,
+            X_disc.LayoutType,
+            A_disc.LayoutType,
+            B_chunk.LayoutType,
+        ]
+    ]()
+    var cd_compiled = ctx.compile_function[
+        _ssd_combined_chunk_decays_gpu[
+            dtype, A_disc.LayoutType, chunk_decays.LayoutType
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            pre_compiled,
+            Int32(batch),
+            Int32(seqlen),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            Int32(n_chunks),
+            Int32(chunk_size),
+            x_tt,
+            dt_tt,
+            A_tt,
+            B_tt,
+            C_tt,
+            X_disc,
+            A_disc,
+            B_chunk,
+            C_chunk,
+            grid_dim=(ceildiv(pre_total, _SSD_GPU_BLOCK),),
+            block_dim=(_SSD_GPU_BLOCK,),
+        )
+        ctx.enqueue_function(
+            cd_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_size),
+            A_disc,
+            chunk_decays,
+            grid_dim=(ceildiv(cd_n, _SSD_GPU_BLOCK),),
+            block_dim=(_SSD_GPU_BLOCK,),
+        )
+
+    # Stage 1: intra-chunk diagonal -> Y_diag (host launcher).
+    ssd_intra_chunk_fwd_gpu[
+        dtype,
+        C_chunk.LayoutType,
+        B_chunk.LayoutType,
+        X_disc.LayoutType,
+        A_disc.LayoutType,
+        Y_diag.LayoutType,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_size,
+        state_dim,
+        head_dim,
+        C_chunk,
+        B_chunk,
+        X_disc,
+        A_disc,
+        Y_diag,
+        ctx,
+    )
+
+    # Stage 2: per-chunk end-states (optimized chunk_state).
+    # Fused tensor-core path for the gate dims; parallel scalar path otherwise.
+    if state_dim == 128 and head_dim == 64:
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_size,
+            128,
+            64,
+            B_chunk.LayoutType,
+            X_disc.LayoutType,
+            A_disc.LayoutType,
+            chunk_states.LayoutType,
+        ](batch, n_chunks, n_heads, B_chunk, X_disc, A_disc, chunk_states, ctx)
+    else:
+        var cs_compiled = ctx.compile_function[
+            ssd_chunk_state_fwd_gpu[
+                dtype,
+                B_chunk.LayoutType,
+                X_disc.LayoutType,
+                A_disc.LayoutType,
+                chunk_states.LayoutType,
+            ]
+        ]()
+        with ctx.push_context():
+            ctx.enqueue_function(
+                cs_compiled,
+                Int32(batch),
+                Int32(n_chunks),
+                Int32(n_heads),
+                Int32(chunk_size),
+                Int32(state_dim),
+                Int32(head_dim),
+                B_chunk,
+                X_disc,
+                A_disc,
+                chunk_states,
+                grid_dim=(num_slices, 1),
+                block_dim=(chunk_size,),
+            )
+
+    # Stage 3: inter-chunk recurrence (device kernel).
+    var scan_total = batch * n_heads * head_dim * state_dim
+    var scan_compiled = ctx.compile_function[
+        ssd_chunk_scan_fwd_gpu[
+            dtype,
+            chunk_states.LayoutType,
+            chunk_decays.LayoutType,
+            entering.LayoutType,
+            final.LayoutType,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            scan_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            chunk_states,
+            chunk_decays,
+            entering,
+            final,
+            grid_dim=(ceildiv(scan_total, _SSD_GPU_BLOCK),),
+            block_dim=(_SSD_GPU_BLOCK,),
+        )
+
+    # Stage 4: output recombination (device kernel). Fused single-pass
+    # tensor-core path for the gate dims (head_dim=64, state_dim=128); the
+    # fused path needs chunk_size a multiple of 128 (comptime tiling), so guard
+    # its instantiation at compile time. Scalar fallback otherwise.
+    var comb_total = batch * n_chunks * n_heads * chunk_size * head_dim
+    var used_fused = False
+
+    comptime if chunk_size % 128 == 0:
+        if state_dim == 128 and head_dim == 64:
+            used_fused = True
+            ssd_output_recombination_fwd_gpu_fused[
+                dtype,
+                chunk_size,
+                128,
+                64,
+                C_chunk.LayoutType,
+                entering.LayoutType,
+                A_disc.LayoutType,
+                Y_diag.LayoutType,
+                Y_chunked.LayoutType,
+            ](
+                batch,
+                n_chunks,
+                n_heads,
+                C_chunk,
+                entering,
+                A_disc,
+                Y_diag,
+                Y_chunked,
+                ctx,
+            )
+
+    if not used_fused:
+        var comb_compiled = ctx.compile_function[
+            ssd_output_recombination_fwd_gpu[
+                dtype,
+                C_chunk.LayoutType,
+                entering.LayoutType,
+                A_disc.LayoutType,
+                Y_diag.LayoutType,
+                Y_chunked.LayoutType,
+            ]
+        ]()
+        with ctx.push_context():
+            ctx.enqueue_function(
+                comb_compiled,
+                Int32(batch),
+                Int32(n_chunks),
+                Int32(n_heads),
+                Int32(chunk_size),
+                Int32(head_dim),
+                Int32(state_dim),
+                C_chunk,
+                entering,
+                A_disc,
+                Y_diag,
+                Y_chunked,
+                grid_dim=(ceildiv(comb_total, _SSD_GPU_BLOCK),),
+                block_dim=(_SSD_GPU_BLOCK,),
+            )
+
+    # Stage 5: postprocess (un-chunk) + copy final state to the output buffer.
+    var post_compiled = ctx.compile_function[
+        _ssd_combined_postprocess_gpu[
+            dtype, Y_chunked.LayoutType, Y_out.LayoutType
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            post_compiled,
+            Int32(batch),
+            Int32(seqlen),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(n_chunks),
+            Int32(chunk_size),
+            Y_chunked,
+            Y_out,
+            grid_dim=(ceildiv(comb_total, _SSD_GPU_BLOCK),),
+            block_dim=(_SSD_GPU_BLOCK,),
+        )
+        ctx.enqueue_copy(final_state_ptr, final_d.unsafe_ptr(), fin_n)
+    ctx.synchronize()
+
+
+# ===----------------------------------------------------------------------=== #
+# @extensibility.register entry point
+# ===----------------------------------------------------------------------=== #
+
+
+@extensibility.register("ssd_chunk_scan_combined")
+struct SSDChunkScanCombined[chunk_size: Int = 256]:
+    """Fused Mamba2 SSD chunk-scan combined op.
+
+    Stitches the four verified SSD stage kernels into a single op matching the
+    torch ``mamba_chunk_scan_combined`` fused contract.
+
+    Parameters:
+        chunk_size: Tokens per chunk. Must divide ``seqlen`` evenly. The
+            default (256) matches the upstream Mamba2 prefill setting.
+
+    Tensor Shapes:
+        - output Y:           ``(batch, seqlen, n_heads, head_dim)``
+        - output final_state: ``(batch, n_heads, head_dim, state_dim)``
+        - x:                  ``(batch, seqlen, n_heads, head_dim)``
+        - dt:                 ``(batch, seqlen, n_heads)``
+        - A:                  ``(n_heads,)``
+        - B:                  ``(batch, seqlen, n_heads, state_dim)``
+        - C:                  ``(batch, seqlen, n_heads, state_dim)``
+    """
+
+    @staticmethod
+    def execute[
+        dtype: DType,
+        target: StaticString,
+    ](
+        Y: OutputTensor[dtype=dtype, rank=4, ...],
+        final_state: OutputTensor[dtype=dtype, rank=4, ...],
+        x: InputTensor[dtype=dtype, rank=4, ...],
+        dt: InputTensor[dtype=dtype, rank=3, ...],
+        A: InputTensor[dtype=dtype, rank=1, ...],
+        B: InputTensor[dtype=dtype, rank=4, ...],
+        C: InputTensor[dtype=dtype, rank=4, ...],
+        ctx: DeviceContext,
+    ) capturing raises:
+        if Y.shape() != x.shape():
+            raise Error("ssd_chunk_scan_combined: Y shape must match x shape")
+
+        var batch = x.dim_size(0)
+        var seqlen = x.dim_size(1)
+        var n_heads = x.dim_size(2)
+        var head_dim = x.dim_size(3)
+        var state_dim = B.dim_size(3)
+
+        if (
+            final_state.dim_size(0) != batch
+            or final_state.dim_size(1) != n_heads
+            or final_state.dim_size(2) != head_dim
+            or final_state.dim_size(3) != state_dim
+        ):
+            raise Error(
+                "ssd_chunk_scan_combined: final_state shape must be"
+                " [batch, n_heads, head_dim, state_dim]"
+            )
+
+        comptime if is_cpu[target]():
+            _ssd_chunk_scan_combined_cpu[dtype](
+                batch,
+                seqlen,
+                n_heads,
+                head_dim,
+                state_dim,
+                Self.chunk_size,
+                x.unsafe_ptr(),
+                dt.unsafe_ptr(),
+                A.unsafe_ptr(),
+                B.unsafe_ptr(),
+                C.unsafe_ptr(),
+                Y.unsafe_ptr(),
+                final_state.unsafe_ptr(),
+            )
+        elif is_gpu[target]():
+            # Fully on-device stitched dispatch: all six stages run on the GPU
+            # over device-resident intermediates (no host round-trip). Stage 2
+            # uses the optimized ssd_chunk_state kernel (fused tensor-core path
+            # for the gate dims, parallel scalar otherwise).
+            _ssd_chunk_scan_combined_gpu[dtype, Self.chunk_size](
+                batch,
+                seqlen,
+                n_heads,
+                head_dim,
+                state_dim,
+                x.unsafe_ptr(),
+                dt.unsafe_ptr(),
+                A.unsafe_ptr(),
+                B.unsafe_ptr(),
+                C.unsafe_ptr(),
+                Y.unsafe_ptr(),
+                final_state.unsafe_ptr(),
+                ctx,
+            )
+        else:
+            raise Error("ssd_chunk_scan_combined: unsupported target")
+
+
+@extensibility.register_shape_function("ssd_chunk_scan_combined")
+def ssd_chunk_scan_combined_shape[
+    dtype: DType,
+](
+    x: InputTensor[dtype=dtype, rank=4, ...],
+    dt: InputTensor[dtype=dtype, rank=3, ...],
+    A: InputTensor[dtype=dtype, rank=1, ...],
+    B: InputTensor[dtype=dtype, rank=4, ...],
+    C: InputTensor[dtype=dtype, rank=4, ...],
+) -> IndexList[4]:
+    """Returns the primary (`Y`) output shape for `ssd_chunk_scan_combined`.
+
+    The op has two outputs (`Y` and `final_state`); the graph-side wrapper
+    (`functional_ops.ssd_chunk_scan_combined`) passes both `out_types`
+    explicitly. Only the primary shape is returned here: a `Tuple` return
+    trips the kernel-package loader's parameter-name mapping for `Tuple`
+    ("struct decl not present in the loaded package and not in the stdlib
+    slot-name table") on the prebuilt toolchain.
+
+    Parameters:
+        dtype: Element type of the input tensors.
+
+    Args:
+        x: Input tensor with shape `(batch, seqlen, n_heads, head_dim)`.
+        dt: Time-step tensor with shape `(batch, seqlen, n_heads)`.
+        A: Per-head decay with shape `(n_heads,)`.
+        B: Input projection with shape `(batch, seqlen, n_heads, state_dim)`.
+        C: Output projection with shape `(batch, seqlen, n_heads, state_dim)`.
+
+    Returns:
+        The `Y` output shape, equal to `x.shape()`.
+    """
+    return x.shape()

--- a/max/kernels/src/state_space/ssd_chunk_scan.mojo
+++ b/max/kernels/src/state_space/ssd_chunk_scan.mojo
@@ -1,0 +1,331 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Structured state space duality (SSD) inter-chunk scan kernel.
+
+This implements stage 3 of the SSD chunk-scan algorithm used by Mamba2: the
+"inter-chunk recurrence". After stage 2 (``ssd_chunk_state``) has reduced each
+chunk down to a per-chunk end-state, this stage threads a single sequential
+recurrence across the chunks, per ``(batch, head)``, to produce the state
+*entering* each chunk and the final state after the last chunk.
+
+For a sequence of ``C`` chunks with state dim ``N`` and head dim ``P``:
+
+- Inputs:
+  - ``chunk_states: [C, P, N]`` (per-chunk end-states, the stage-2 output).
+  - ``chunk_decays: [C]`` (per-chunk total decay = sum of ``A`` over the chunk).
+- Recurrence (running ``state`` of shape ``[P, N]``, initialized to 0):
+  ```
+  entering[c] = state                                # state ENTERING chunk c
+  state       = chunk_states[c] + exp(chunk_decays[c]) * state
+  ```
+- Outputs:
+  - ``entering: [C, P, N]`` (the running state entering each chunk; the entry
+    for chunk 0 is all zeros).
+  - ``final: [P, N]`` (the running state after the last chunk).
+
+This matches the reference recurrence (stage 3 of ``ssd_minimal_discrete``)
+that carries inter-chunk information forward so the per-chunk outputs can be
+corrected by the contribution of preceding chunks.
+
+The chunk loop is inherently SEQUENTIAL: chunk ``c`` depends on the state left
+by chunk ``c-1``, so chunks cannot be parallelized. On GPU we parallelize over
+``(batch, head, p, n)`` instead — one thread owns a single ``(p, n)`` scalar of
+the running state and walks the chunk axis sequentially.
+"""
+
+from layout import Layout, LayoutTensor, TensorLayout, TileTensor
+from std.math import exp
+from std.gpu import (
+    block_dim,
+    block_idx,
+    thread_idx,
+)
+from std.utils.index import IndexList
+
+# Stride helpers for indexing the flat row-major buffers.
+comptime Strides3D = IndexList[3]
+comptime Strides4D = IndexList[4]
+comptime Strides5D = IndexList[5]
+
+
+def _row_major_strides_3d(d0: Int, d1: Int, d2: Int) -> Strides3D:
+    """Row-major strides for a 3D shape ``(d0, d1, d2)``."""
+    return Strides3D(d1 * d2, d2, 1)
+
+
+def _row_major_strides_4d(d0: Int, d1: Int, d2: Int, d3: Int) -> Strides4D:
+    """Row-major strides for a 4D shape ``(d0, d1, d2, d3)``."""
+    return Strides4D(d1 * d2 * d3, d2 * d3, d3, 1)
+
+
+def _row_major_strides_5d(
+    d0: Int, d1: Int, d2: Int, d3: Int, d4: Int
+) -> Strides5D:
+    """Row-major strides for a 5D shape ``(d0, d1, d2, d3, d4)``."""
+    return Strides5D(d1 * d2 * d3 * d4, d2 * d3 * d4, d3 * d4, d4, 1)
+
+
+def ssd_chunk_scan_fwd_cpu[
+    kernel_dtype: DType,
+    chunk_states_layout: Layout,
+    chunk_decays_layout: Layout,
+    entering_layout: Layout,
+    final_layout: Layout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    chunk_states: LayoutTensor[kernel_dtype, chunk_states_layout, MutAnyOrigin],
+    chunk_decays: LayoutTensor[kernel_dtype, chunk_decays_layout, MutAnyOrigin],
+    entering: LayoutTensor[kernel_dtype, entering_layout, MutAnyOrigin],
+    final: LayoutTensor[kernel_dtype, final_layout, MutAnyOrigin],
+):
+    """Compute the SSD inter-chunk scan on CPU.
+
+    Threads a sequential recurrence across chunks, per ``(batch, head)``, over
+    the supplied row-major tensors.
+
+    Tensor shapes (row-major):
+        - ``chunk_states``: ``[batch, n_chunks, n_heads, head_dim, state_dim]``
+        - ``chunk_decays``: ``[batch, n_chunks, n_heads]``
+        - ``entering``: ``[batch, n_chunks, n_heads, head_dim, state_dim]`` (out)
+        - ``final``: ``[batch, n_heads, head_dim, state_dim]`` (output)
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        chunk_states_layout: Layout of the ``chunk_states`` tensor.
+        chunk_decays_layout: Layout of the ``chunk_decays`` tensor.
+        entering_layout: Layout of the ``entering`` output tensor.
+        final_layout: Layout of the ``final`` output tensor.
+
+    Args:
+        batch: Number of batch elements.
+        n_chunks: Number of chunks per sequence (``C``).
+        n_heads: Number of heads.
+        head_dim: Head dimension (``P``).
+        state_dim: State dimension (``N``).
+        chunk_states: Per-chunk end-states,
+            shape ``[batch, n_chunks, n_heads, P, N]``.
+        chunk_decays: Per-chunk total decay,
+            shape ``[batch, n_chunks, n_heads]``.
+        entering: Output state entering each chunk,
+            shape ``[batch, n_chunks, n_heads, P, N]``.
+        final: Output final state after the last chunk,
+            shape ``[batch, n_heads, P, N]``.
+    """
+    # Row-major strides for the flat backing buffers.
+    var cs_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, head_dim, state_dim
+    )
+    var cd_strides = _row_major_strides_3d(batch, n_chunks, n_heads)
+    var ent_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, head_dim, state_dim
+    )
+    var final_strides = _row_major_strides_4d(
+        batch, n_heads, head_dim, state_dim
+    )
+
+    for bi in range(batch):
+        for h in range(n_heads):
+            # Running state for this (batch, head), shape (P, N), init 0.
+            var state = List[Float32](length=head_dim * state_dim, fill=0.0)
+
+            for c in range(n_chunks):
+                # entering[c] = state (the state ENTERING chunk c).
+                var ent_base = (
+                    bi * ent_strides[0]
+                    + c * ent_strides[1]
+                    + h * ent_strides[2]
+                )
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var ent_off = (
+                            ent_base + p * ent_strides[3] + n * ent_strides[4]
+                        )
+                        entering.ptr[ent_off] = state[p * state_dim + n].cast[
+                            kernel_dtype
+                        ]()
+
+                # decay = exp(chunk_decays[c]).
+                var cd_off = (
+                    bi * cd_strides[0] + c * cd_strides[1] + h * cd_strides[2]
+                )
+                var decay = exp(chunk_decays.ptr[cd_off].cast[DType.float32]())
+
+                # state = chunk_states[c] + decay * state.
+                var cs_base = (
+                    bi * cs_strides[0] + c * cs_strides[1] + h * cs_strides[2]
+                )
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var cs_off = (
+                            cs_base + p * cs_strides[3] + n * cs_strides[4]
+                        )
+                        var cs_val = chunk_states.ptr[cs_off].cast[
+                            DType.float32
+                        ]()
+                        var prev = state[p * state_dim + n]
+                        state[p * state_dim + n] = cs_val + decay * prev
+
+            # final = state after the last chunk.
+            var final_base = bi * final_strides[0] + h * final_strides[1]
+            for p in range(head_dim):
+                for n in range(state_dim):
+                    var final_off = (
+                        final_base + p * final_strides[2] + n * final_strides[3]
+                    )
+                    final.ptr[final_off] = state[p * state_dim + n].cast[
+                        kernel_dtype
+                    ]()
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU Implementation
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_chunk_scan_fwd_gpu[
+    kernel_dtype: DType,
+    chunk_states_LT: TensorLayout,
+    chunk_decays_LT: TensorLayout,
+    entering_LT: TensorLayout,
+    final_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    head_dim_i32: Int32,
+    state_dim_i32: Int32,
+    chunk_states: TileTensor[kernel_dtype, chunk_states_LT, MutUntrackedOrigin],
+    chunk_decays: TileTensor[kernel_dtype, chunk_decays_LT, MutUntrackedOrigin],
+    entering: TileTensor[kernel_dtype, entering_LT, MutUntrackedOrigin],
+    final: TileTensor[kernel_dtype, final_LT, MutUntrackedOrigin],
+):
+    """Compute the SSD inter-chunk scan on GPU.
+
+    The chunk recurrence is inherently sequential, so we do NOT parallelize over
+    chunks. Instead each GPU thread owns a single ``(batch, head, p, n)`` scalar
+    of the running state and walks the chunk axis sequentially. This keeps the
+    recurrence dependency local to one thread (no cross-thread sync) while still
+    exposing ``batch * n_heads * head_dim * state_dim``-way parallelism.
+
+    The same math as the CPU kernel, for the scalar ``state[p, n]``:
+        - ``entering[c, p, n] = state`` (before updating)
+        - ``state = chunk_states[c, p, n] + exp(chunk_decays[c]) * state``
+        - ``final[p, n] = state`` (after the last chunk)
+
+    Tensor shapes (row-major):
+        - ``chunk_states``: ``[batch, n_chunks, n_heads, head_dim, state_dim]``
+        - ``chunk_decays``: ``[batch, n_chunks, n_heads]``
+        - ``entering``: ``[batch, n_chunks, n_heads, head_dim, state_dim]`` (out)
+        - ``final``: ``[batch, n_heads, head_dim, state_dim]`` (output)
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        chunk_states_LT: Layout of the ``chunk_states`` tensor.
+        chunk_decays_LT: Layout of the ``chunk_decays`` tensor.
+        entering_LT: Layout of the ``entering`` output tensor.
+        final_LT: Layout of the ``final`` output tensor.
+
+    Args:
+        batch_i32: Number of batch elements.
+        n_chunks_i32: Number of chunks per sequence (``C``).
+        n_heads_i32: Number of heads.
+        head_dim_i32: Head dimension (``P``).
+        state_dim_i32: State dimension (``N``).
+        chunk_states: Per-chunk end-states,
+            shape ``[batch, n_chunks, n_heads, P, N]``.
+        chunk_decays: Per-chunk total decay,
+            shape ``[batch, n_chunks, n_heads]``.
+        entering: Output state entering each chunk,
+            shape ``[batch, n_chunks, n_heads, P, N]``.
+        final: Output final state after the last chunk,
+            shape ``[batch, n_heads, P, N]``.
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var head_dim = Int(head_dim_i32)
+    var state_dim = Int(state_dim_i32)
+    var flat_idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total_threads = batch * n_heads * head_dim * state_dim
+    if flat_idx >= total_threads:
+        return
+
+    # Decompose the flat thread index into (batch, head, p, n).
+    var n = flat_idx % state_dim
+    var p = (flat_idx // state_dim) % head_dim
+    var h = (flat_idx // (state_dim * head_dim)) % n_heads
+    var bi = flat_idx // (state_dim * head_dim * n_heads)
+
+    # Row-major strides for the flat backing buffers.
+    var cs_n_stride = 1
+    var cs_p_stride = state_dim
+    var cs_h_stride = head_dim * cs_p_stride
+    var cs_c_stride = n_heads * cs_h_stride
+    var cs_b_stride = n_chunks * cs_c_stride
+
+    var cd_h_stride = 1
+    var cd_c_stride = n_heads
+    var cd_b_stride = n_chunks * cd_c_stride
+
+    # entering shares chunk_states' shape/strides.
+    var ent_n_stride = 1
+    var ent_p_stride = state_dim
+    var ent_h_stride = head_dim * ent_p_stride
+    var ent_c_stride = n_heads * ent_h_stride
+    var ent_b_stride = n_chunks * ent_c_stride
+
+    var final_n_stride = 1
+    var final_p_stride = state_dim
+    var final_h_stride = head_dim * final_p_stride
+    var final_b_stride = n_heads * final_h_stride
+
+    # Sequential recurrence over chunks for this single (p, n) scalar.
+    var state = Float32(0.0)
+    for c in range(n_chunks):
+        # entering[c] = state (before update).
+        var ent_off = (
+            bi * ent_b_stride
+            + c * ent_c_stride
+            + h * ent_h_stride
+            + p * ent_p_stride
+            + n * ent_n_stride
+        )
+        entering.ptr[ent_off] = state.cast[kernel_dtype]()
+
+        # decay = exp(chunk_decays[c]).
+        var cd_off = bi * cd_b_stride + c * cd_c_stride + h * cd_h_stride
+        var decay = exp(chunk_decays.ptr[cd_off].cast[DType.float32]())
+
+        # state = chunk_states[c, p, n] + decay * state.
+        var cs_off = (
+            bi * cs_b_stride
+            + c * cs_c_stride
+            + h * cs_h_stride
+            + p * cs_p_stride
+            + n * cs_n_stride
+        )
+        var cs_val = chunk_states.ptr[cs_off].cast[DType.float32]()
+        state = cs_val + decay * state
+
+    # final[p, n] = state after the last chunk.
+    var final_off = (
+        bi * final_b_stride
+        + h * final_h_stride
+        + p * final_p_stride
+        + n * final_n_stride
+    )
+    final.ptr[final_off] = state.cast[kernel_dtype]()

--- a/max/kernels/src/state_space/ssd_chunk_state.mojo
+++ b/max/kernels/src/state_space/ssd_chunk_state.mojo
@@ -1,0 +1,862 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Structured state space duality (SSD) chunk-state kernel.
+
+This implements stage 2 of the SSD chunk-scan algorithm used by Mamba2: the
+"chunk end-state". For each ``(batch, chunk, head)`` it reduces the chunk down
+to a single ``[head_dim, state_dim]`` end-state by summing the decay-weighted
+outer products of the per-token key-like and value-like projections.
+
+For a chunk of ``L`` tokens with state dim ``N`` and head dim ``P``:
+
+- Inputs: ``B: [L, N]``, ``X: [L, P]``, ``A: [L]`` (a scalar decay per token).
+- Cumulative decay: ``A_cumsum[l] = sum_{k=0..l} A[k]``.
+- Per-token decay toward the chunk end:
+  ``decay[l] = exp(A_cumsum[L-1] - A_cumsum[l])``. Note ``decay[L-1] = 1``.
+- End-state: ``state[p, n] = sum_{l=0..L-1} B[l, n] * decay[l] * X[l, p]``.
+
+This matches the reference einsum
+``state = einsum("ln,l,lp->pn", B, decay, X)`` (stage 2 of
+``ssd_minimal_discrete``), producing one end-state per ``(batch, chunk, head)``.
+"""
+
+from layout import (
+    Idx,
+    Layout,
+    LayoutTensor,
+    TensorLayout,
+    TileTensor,
+    row_major,
+)
+from std.math import exp
+from max.gpu.sync import barrier as gpu_barrier
+from std.gpu import (
+    WARP_SIZE,
+    block_dim,
+    block_idx,
+    grid_dim,
+    thread_idx,
+)
+from max.gpu.host import DeviceContext
+from std.memory import AddressSpace
+from std.memory import unsafe_stack_allocation as mem_stack_allocation
+from std.utils.index import IndexList
+from linalg.bmm import batched_matmul
+from layout.layout_tensor import copy_local_to_dram
+from layout.tensor_core import TensorCore, get_fragment_size, get_mma_shape
+
+# Stride helpers for indexing the flat row-major buffers.
+comptime Strides4D = IndexList[4]
+comptime Strides5D = IndexList[5]
+
+# Upper bound on chunk_len for the shared-memory decay scratch (one Float32
+# per token). The host launches one block per slice with block_dim == chunk_len
+# (see ``ssd_chunk_state_fwd_gpu``), so this also bounds the launch block size.
+# Mirrors ``SCAN_MAX_CHUNK`` in ``ssd_chunk.mojo``.
+comptime STATE_MAX_CHUNK = 1024
+
+
+def _row_major_strides_4d(d0: Int, d1: Int, d2: Int, d3: Int) -> Strides4D:
+    """Row-major strides for a 4D shape ``(d0, d1, d2, d3)``."""
+    return Strides4D(d1 * d2 * d3, d2 * d3, d3, 1)
+
+
+def _row_major_strides_5d(
+    d0: Int, d1: Int, d2: Int, d3: Int, d4: Int
+) -> Strides5D:
+    """Row-major strides for a 5D shape ``(d0, d1, d2, d3, d4)``."""
+    return Strides5D(d1 * d2 * d3 * d4, d2 * d3 * d4, d3 * d4, d4, 1)
+
+
+def ssd_chunk_state_fwd_cpu[
+    kernel_dtype: DType,
+    B_layout: Layout,
+    X_layout: Layout,
+    A_layout: Layout,
+    state_layout: Layout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    B: LayoutTensor[kernel_dtype, B_layout, MutAnyOrigin],
+    X: LayoutTensor[kernel_dtype, X_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, A_layout, MutAnyOrigin],
+    state: LayoutTensor[kernel_dtype, state_layout, MutAnyOrigin],
+):
+    """Compute the SSD chunk end-state on CPU.
+
+    Operates per ``(batch, chunk, head)`` over the supplied row-major tensors,
+    reducing each chunk down to a single ``[head_dim, state_dim]`` end-state.
+
+    Tensor shapes (row-major):
+        - ``B``: ``[batch, n_chunks, n_heads, chunk_len, state_dim]``
+        - ``X``: ``[batch, n_chunks, n_heads, chunk_len, head_dim]``
+        - ``A``: ``[batch, n_chunks, n_heads, chunk_len]``
+        - ``state``: ``[batch, n_chunks, n_heads, head_dim, state_dim]`` (output)
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        B_layout: Layout of the ``B`` tensor.
+        X_layout: Layout of the ``X`` tensor.
+        A_layout: Layout of the ``A`` tensor.
+        state_layout: Layout of the ``state`` output tensor.
+
+    Args:
+        batch: Number of batch elements.
+        n_chunks: Number of chunks per sequence.
+        n_heads: Number of heads.
+        chunk_len: Tokens per chunk (``L``).
+        state_dim: State dimension (``N``).
+        head_dim: Head dimension (``P``).
+        B: Key-like projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        X: Value-like input, shape ``[batch, n_chunks, n_heads, L, P]``.
+        A: Per-token scalar decay, shape ``[batch, n_chunks, n_heads, L]``.
+        state: Output end-state, shape ``[batch, n_chunks, n_heads, P, N]``.
+    """
+    # Row-major strides for the flat backing buffers.
+    var b_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, state_dim
+    )
+    var x_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, head_dim
+    )
+    var a_strides = _row_major_strides_4d(batch, n_chunks, n_heads, chunk_len)
+    var state_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, head_dim, state_dim
+    )
+
+    for bi in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                # Base offsets for this (batch, chunk, head) slice.
+                var b_base = (
+                    bi * b_strides[0] + c * b_strides[1] + h * b_strides[2]
+                )
+                var x_base = (
+                    bi * x_strides[0] + c * x_strides[1] + h * x_strides[2]
+                )
+                var a_base = (
+                    bi * a_strides[0] + c * a_strides[1] + h * a_strides[2]
+                )
+                var state_base = (
+                    bi * state_strides[0]
+                    + c * state_strides[1]
+                    + h * state_strides[2]
+                )
+
+                # Inclusive prefix sum of the per-token decay: A_cumsum[l].
+                var a_cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var running = Float32(0.0)
+                for l in range(chunk_len):
+                    var a_off = a_base + l * a_strides[3]
+                    running += A.ptr[a_off].cast[DType.float32]()
+                    a_cumsum[l] = running
+
+                # decay[l] = exp(A_cumsum[L-1] - A_cumsum[l]); decay[L-1] = 1.
+                var cum_end = a_cumsum[chunk_len - 1]
+                var decay = List[Float32](length=chunk_len, fill=0.0)
+                for l in range(chunk_len):
+                    decay[l] = exp(cum_end - a_cumsum[l])
+
+                # state[p, n] = sum_l B[l, n] * decay[l] * X[l, p]
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var acc = Float32(0.0)
+                        for l in range(chunk_len):
+                            var bv = B.ptr[
+                                b_base + l * b_strides[3] + n * b_strides[4]
+                            ].cast[DType.float32]()
+                            var xv = X.ptr[
+                                x_base + l * x_strides[3] + p * x_strides[4]
+                            ].cast[DType.float32]()
+                            acc += bv * decay[l] * xv
+                        var state_off = (
+                            state_base
+                            + p * state_strides[3]
+                            + n * state_strides[4]
+                        )
+                        state.ptr[state_off] = acc.cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU Implementation
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_chunk_state_fwd_gpu[
+    kernel_dtype: DType,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    state_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    state_dim_i32: Int32,
+    head_dim_i32: Int32,
+    B: TileTensor[kernel_dtype, B_LT, MutUntrackedOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutUntrackedOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutUntrackedOrigin],
+    state: TileTensor[kernel_dtype, state_LT, MutUntrackedOrigin],
+):
+    """Compute the SSD chunk end-state on GPU.
+
+    Launched over a 2D grid ``(total_slices, n_p_tiles)`` with
+    ``block_dim == chunk_len``. ``block_idx.x`` selects the ``(batch, chunk,
+    head)`` slice; ``block_idx.y`` selects a tile of ``head_dim`` rows (the tile
+    height is ``ceildiv(head_dim, grid_dim.y)``, so the kernel adapts to
+    whatever ``grid_dim.y`` the host picks — ``grid_dim.y == 1`` means one block
+    computes the whole slice). Splitting each slice across several blocks raises
+    the block count and warps-in-flight on GB10's many small SMs.
+
+    Each block first computes the per-token decay
+    ``decay[l] = exp(A_cumsum[L-1] - A_cumsum[l])`` once, cooperatively, into
+    shared memory (a Hillis-Steele inclusive prefix sum over ``A`` followed by
+    the exp; recomputed per p-tile, which is cheap), then the block's threads
+    split its tile of the ``head_dim * state_dim`` output elements and each
+    accumulates its end-state entry over ``l``.
+
+    This replaces the original one-thread-per-slice port, which launched a
+    single block (occupancy/latency bound: ~0.1% compute, ~4% memory of GB10
+    peak) and recomputed ``decay[l]`` for every one of the ``head_dim *
+    state_dim`` outputs. The decay is now computed once per slice and shared.
+    It is still not tensor-core optimized; the reduction reads ``B``/``X`` from
+    global memory (the kernel is far from bandwidth bound).
+
+    The same math as the CPU kernel:
+        - ``A_cumsum[l] = sum_{k<=l} A[k]``
+        - ``decay[l] = exp(A_cumsum[L-1] - A_cumsum[l])``
+        - ``state[p, n] = sum_l B[l, n] * decay[l] * X[l, p]``
+
+    Tensor shapes (row-major):
+        - ``B``: ``[batch, n_chunks, n_heads, chunk_len, state_dim]``
+        - ``X``: ``[batch, n_chunks, n_heads, chunk_len, head_dim]``
+        - ``A``: ``[batch, n_chunks, n_heads, chunk_len]``
+        - ``state``: ``[batch, n_chunks, n_heads, head_dim, state_dim]`` (output)
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        B_LT: Layout of the ``B`` tensor.
+        X_LT: Layout of the ``X`` tensor.
+        A_LT: Layout of the ``A`` tensor.
+        state_LT: Layout of the ``state`` output tensor.
+
+    Args:
+        batch_i32: Number of batch elements.
+        n_chunks_i32: Number of chunks per sequence.
+        n_heads_i32: Number of heads.
+        chunk_len_i32: Tokens per chunk (``L``).
+        state_dim_i32: State dimension (``N``).
+        head_dim_i32: Head dimension (``P``).
+        B: Key-like projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        X: Value-like input, shape ``[batch, n_chunks, n_heads, L, P]``.
+        A: Per-token scalar decay, shape ``[batch, n_chunks, n_heads, L]``.
+        state: Output end-state, shape ``[batch, n_chunks, n_heads, P, N]``.
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var state_dim = Int(state_dim_i32)
+    var head_dim = Int(head_dim_i32)
+    var slice_idx = Int(block_idx.x)
+    var total_slices = batch * n_chunks * n_heads
+    if slice_idx >= total_slices:
+        return
+
+    var tid = Int(thread_idx.x)
+    var nthreads = Int(block_dim.x)
+
+    # Decompose the flat slice index into (batch, chunk, head).
+    var h = slice_idx % n_heads
+    var c = (slice_idx // n_heads) % n_chunks
+    var bi = slice_idx // (n_heads * n_chunks)
+
+    # Row-major strides for the flat backing buffers.
+    var b_n_stride = 1
+    var b_l_stride = state_dim
+    var b_h_stride = chunk_len * b_l_stride
+    var b_c_stride = n_heads * b_h_stride
+    var b_b_stride = n_chunks * b_c_stride
+
+    var x_p_stride = 1
+    var x_l_stride = head_dim
+    var x_h_stride = chunk_len * x_l_stride
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_l_stride = 1
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var state_n_stride = 1
+    var state_p_stride = state_dim
+    var state_h_stride = head_dim * state_p_stride
+    var state_c_stride = n_heads * state_h_stride
+    var state_b_stride = n_chunks * state_c_stride
+
+    var b_base = bi * b_b_stride + c * b_c_stride + h * b_h_stride
+    var x_base = bi * x_b_stride + c * x_c_stride + h * x_h_stride
+    var a_base = bi * a_b_stride + c * a_c_stride + h * a_h_stride
+    var state_base = (
+        bi * state_b_stride + c * state_c_stride + h * state_h_stride
+    )
+
+    # ── Per-token decay into shared memory (computed once per slice) ──────────
+    # decay[l] = exp(A_cumsum[L-1] - A_cumsum[l]); A_cumsum is the inclusive
+    # prefix sum of A. Hillis-Steele scan in shared memory: block_dim ==
+    # chunk_len threads, one element each, log2(chunk_len) doubling steps.
+    var decay = mem_stack_allocation[
+        STATE_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+
+    if tid < chunk_len:
+        decay[tid] = A.ptr[a_base + tid * a_l_stride].cast[DType.float32]()
+    gpu_barrier()
+
+    var offset = 1
+    while offset < chunk_len:
+        var add: Float32 = 0.0
+        if tid < chunk_len and tid >= offset:
+            add = decay[tid - offset]
+        gpu_barrier()
+        if tid < chunk_len and tid >= offset:
+            decay[tid] += add
+        gpu_barrier()
+        offset *= 2
+
+    # decay[] now holds A_cumsum[l]. Convert to the decay weight in place.
+    # Every thread reads cum_end before any thread overwrites its slot.
+    var cum_end = decay[chunk_len - 1]
+    gpu_barrier()
+    if tid < chunk_len:
+        decay[tid] = exp(cum_end - decay[tid])
+    gpu_barrier()
+
+    # ── End-state reduction: state[p, n] = sum_l B[l, n] * decay[l] * X[l, p] ─
+    # This block owns p-rows [p_start, p_end); its threads split that tile's
+    # (p_end - p_start) * state_dim output elements.
+    var n_p_tiles = Int(grid_dim.y)
+    var p_per_tile = (head_dim + n_p_tiles - 1) // n_p_tiles
+    var p_start = Int(block_idx.y) * p_per_tile
+    var p_end = min(p_start + p_per_tile, head_dim)
+    if p_start >= head_dim:
+        return
+
+    var n_out = (p_end - p_start) * state_dim
+    var idx = tid
+    while idx < n_out:
+        var p = p_start + idx // state_dim
+        var n = idx % state_dim
+        var acc = Float32(0.0)
+        for l in range(chunk_len):
+            var bv = B.ptr[b_base + l * b_l_stride + n * b_n_stride].cast[
+                DType.float32
+            ]()
+            var xv = X.ptr[x_base + l * x_l_stride + p * x_p_stride].cast[
+                DType.float32
+            ]()
+            acc += bv * decay[l] * xv
+        var state_off = state_base + p * state_p_stride + n * state_n_stride
+        state.ptr[state_off] = acc.cast[kernel_dtype]()
+        idx += nthreads
+
+
+# ===----------------------------------------------------------------------=== #
+# Tensor-core path: decay-weighted transpose + batched matmul
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_chunk_state_decay_xt_gpu[
+    kernel_dtype: DType,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    xdt_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    head_dim_i32: Int32,
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Xd_T: TileTensor[kernel_dtype, xdt_LT, MutAnyOrigin],
+):
+    """Materialise the decay-weighted, transposed value tensor.
+
+    One block per ``(batch, chunk, head)`` slice (``block_dim == chunk_len``).
+    Computes the per-token decay ``decay[l] = exp(A_cumsum[L-1] - A_cumsum[l])``
+    once into shared memory (same scan as ``ssd_chunk_state_fwd_gpu``), then
+    writes the **transposed** product
+
+        ``Xd_T[slice, p, l] = decay[l] * X[slice, l, p]``
+
+    into a contiguous ``[num_slices, head_dim, chunk_len]`` buffer. Transposing
+    here puts the reduction dim ``l`` last in the left matmul operand, so
+    ``state = Xd_T @ B`` (``[P,L] @ [L,N] -> [P,N]``) is a plain
+    ``batched_matmul`` with no transpose — and its output ``N`` columns hit the
+    A100 tensor-core gate. Thread ``tid`` owns token ``l = tid`` and loops over
+    ``p`` so consecutive threads write consecutive ``l`` (coalesced).
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var head_dim = Int(head_dim_i32)
+    var slice_idx = Int(block_idx.x)
+    var total_slices = batch * n_chunks * n_heads
+    if slice_idx >= total_slices:
+        return
+
+    var tid = Int(thread_idx.x)
+
+    var h = slice_idx % n_heads
+    var c = (slice_idx // n_heads) % n_chunks
+    var bi = slice_idx // (n_heads * n_chunks)
+
+    var x_l_stride = head_dim
+    var x_h_stride = chunk_len * x_l_stride
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var x_base = bi * x_b_stride + c * x_c_stride + h * x_h_stride
+    var a_base = bi * a_b_stride + c * a_c_stride + h * a_h_stride
+
+    # Per-token decay into shared memory (Hillis-Steele inclusive prefix sum of
+    # A, then exp) — identical to ssd_chunk_state_fwd_gpu.
+    var decay = mem_stack_allocation[
+        STATE_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+
+    if tid < chunk_len:
+        decay[tid] = A.ptr[a_base + tid].cast[DType.float32]()
+    gpu_barrier()
+
+    var offset = 1
+    while offset < chunk_len:
+        var add: Float32 = 0.0
+        if tid < chunk_len and tid >= offset:
+            add = decay[tid - offset]
+        gpu_barrier()
+        if tid < chunk_len and tid >= offset:
+            decay[tid] += add
+        gpu_barrier()
+        offset *= 2
+
+    var cum_end = decay[chunk_len - 1]
+    gpu_barrier()
+    if tid < chunk_len:
+        decay[tid] = exp(cum_end - decay[tid])
+    gpu_barrier()
+
+    # Xd_T[slice, p, l] = decay[l] * X[slice, l, p]. Output is row-major
+    # [num_slices, head_dim, chunk_len]; this slice starts at slice*P*L.
+    if tid < chunk_len:
+        var d = decay[tid]
+        var xdt_base = slice_idx * head_dim * chunk_len
+        for p in range(head_dim):
+            var xv = X.ptr[x_base + tid * x_l_stride + p].cast[DType.float32]()
+            Xd_T.ptr[xdt_base + p * chunk_len + tid] = (d * xv).cast[
+                kernel_dtype
+            ]()
+
+
+def ssd_chunk_state_fwd_gpu_static[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    state_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    state: TileTensor[kernel_dtype, state_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Static-shape, tensor-core variant of ``ssd_chunk_state_fwd_gpu``.
+
+    Computes the chunk end-state as a batched matmul on tensor cores:
+
+        ``Xd_T[p, l] = decay[l] * X[l, p]``   (decay kernel, one launch)
+        ``state[p, n] = sum_l Xd_T[p, l] * B[l, n] = (Xd_T @ B)[p, n]``
+
+    Knowing ``chunk_len`` / ``state_dim`` / ``head_dim`` at compile time lets
+    ``batched_matmul`` see ``has_static_NK`` and, since the output has
+    ``state_dim`` (== matmul ``N``) columns and ``chunk_len`` (== ``K``) is a
+    multiple of 32 and ``>= 128``, pick its A100 multistage tensor-core batched
+    path (one launch for all ``batch * n_chunks * n_heads`` slices) instead of
+    the scalar reduction in ``ssd_chunk_state_fwd_gpu``.
+
+    The scalar kernel remains the all-shape-correct fallback for shapes that
+    miss the gate (e.g. ``state_dim`` not a multiple of 128).
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        chunk_len_ct: Tokens per chunk (``L``), compile-time.
+        state_dim_ct: State dimension (``N``), compile-time.
+        head_dim_ct: Head dimension (``P``), compile-time.
+        B_LT: Layout of the ``B`` tensor.
+        X_LT: Layout of the ``X`` tensor.
+        A_LT: Layout of the ``A`` tensor.
+        state_LT: Layout of the ``state`` output tensor.
+
+    Args:
+        batch: Number of batch elements.
+        n_chunks: Number of chunks per sequence.
+        n_heads: Number of heads.
+        B: Key-like projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        X: Value-like input, shape ``[batch, n_chunks, n_heads, L, P]``.
+        A: Per-token scalar decay, shape ``[batch, n_chunks, n_heads, L]``.
+        state: Output end-state, shape ``[batch, n_chunks, n_heads, P, N]``.
+        ctx: The device context to enqueue work on.
+    """
+    var num_slices = batch * n_chunks * n_heads
+
+    # Scratch for the decay-weighted, transposed values: [num_slices, P, L].
+    var xdt_device = ctx.enqueue_create_buffer[kernel_dtype](
+        num_slices * head_dim_ct * chunk_len_ct
+    )
+    var Xd_T = TileTensor(
+        xdt_device,
+        row_major(batch, n_chunks, n_heads, head_dim_ct, chunk_len_ct),
+    )
+
+    # Stage 1: Xd_T[p, l] = decay[l] * X[l, p] (one block per slice).
+    var decay_compiled = ctx.compile_function[
+        _ssd_chunk_state_decay_xt_gpu[
+            kernel_dtype,
+            X_LT,
+            A_LT,
+            Xd_T.LayoutType,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            decay_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            Int32(head_dim_ct),
+            X,
+            A,
+            Xd_T,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len_ct,),
+        )
+
+    # Stage 2: state = Xd_T @ B (batched tensor-core matmul, one launch).
+    # state[P, N] = Xd_T[P, L] @ B[L, N]; static dims let batched_matmul take
+    # the A100 multistage path (c_n=N % 128 == 0, a_k=L % 32 == 0, L >= 128).
+    var Xd_T3 = TileTensor(
+        xdt_device,
+        row_major(num_slices, Idx[head_dim_ct], Idx[chunk_len_ct]),
+    )
+    var B3 = TileTensor(
+        B.ptr,
+        row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct]),
+    )
+    var state3 = TileTensor(
+        state.ptr,
+        row_major(num_slices, Idx[head_dim_ct], Idx[state_dim_ct]),
+    )
+
+    with ctx.push_context():
+        batched_matmul[target="gpu", transpose_b=False](
+            state3, Xd_T3, B3, context=ctx
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Fused single-pass tensor-core path
+# ===----------------------------------------------------------------------=== #
+
+# Warp grid over the per-slice [head_dim, state_dim] output tile. 2x4 warps =
+# 8 warps = 256 threads, which also covers chunk_len=256 for the decay scan.
+comptime STATE_FUSED_WARPS_M = 2
+comptime STATE_FUSED_WARPS_N = 4
+# K (chunk-length) step for the fused MMA. Tuned on GB10 at the Mamba2 profile:
+# BK=16 is the sweet spot (nc=4: 0.033 ms) — smaller shared tiles overlap the
+# global load with the MMA better at this L2-resident size. 8/32/64 all gave
+# 0.043/0.043/0.050 ms. Must be a multiple of MMA_K (8) and divide chunk_len.
+comptime STATE_FUSED_BK = 16
+# Split each slice's state_dim output across this many blocks (grid.y). Tried as
+# a "more blocks" occupancy lever, but it REGRESSED (n_split=2: 0.043 -> 0.069 ms
+# at the Mamba2 profile) because each N tile re-reads all of X — the extra
+# traffic outweighs the occupancy gain. Kept as infra; default 1 (no split).
+comptime STATE_FUSED_N_SPLIT = 1
+
+
+def _ssd_chunk_state_fused_mma_gpu[
+    kernel_dtype: DType,
+    P: Int,
+    N: Int,
+    L: Int,
+    BK: Int,
+    num_warps_m: Int,
+    num_warps_n: Int,
+    n_split: Int,
+    X_LT: TensorLayout,
+    B_LT: TensorLayout,
+    A_LT: TensorLayout,
+    state_LT: TensorLayout,
+](
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    state: TileTensor[kernel_dtype, state_LT, MutAnyOrigin],
+):
+    """Fused, single-pass tensor-core chunk end-state (one block per slice).
+
+    Computes ``state[p,n] = sum_l decay[l] * X[l,p] * B[l,n]`` for one
+    ``(batch, chunk, head)`` slice as a transpose-A tensor-core GEMM, **without**
+    materialising the decay-weighted transpose in DRAM (the cost the 2-pass
+    ``ssd_chunk_state_fwd_gpu_static`` pays). Per K-tile the block streams
+    ``X``/``B`` from global once, applies ``decay[l]`` while transposing ``X``
+    into a shared tile (``As[p, l]``), and accumulates the warp-tiled MMA. This
+    mirrors what Triton's ``_chunk_state_fwd`` does in a single kernel.
+
+    Compile-time tiling: block tile is the whole ``[P, N]`` output; warps tile
+    it ``num_warps_m x num_warps_n``; ``BK`` is the K (chunk-length) step. Slices
+    are contiguous in every buffer, so ``slice_idx`` alone indexes them.
+    """
+    comptime accum_type = DType.float32
+    comptime mma_shape = get_mma_shape[kernel_dtype, accum_type]()
+    comptime MMA_M = mma_shape[0]
+    comptime MMA_N = mma_shape[1]
+    comptime MMA_K = mma_shape[2]
+    # This block computes a [P, Nblk] tile; block_idx.y picks the N tile.
+    comptime Nblk = N // n_split
+    comptime WM = P // num_warps_m
+    comptime WN = Nblk // num_warps_n
+    comptime num_m_mmas = WM // MMA_M
+    comptime num_n_mmas = WN // MMA_N
+    comptime num_k_mmas = BK // MMA_K
+    comptime fs = get_fragment_size[mma_shape]()
+    comptime a_frag_size = fs[0]
+    comptime b_frag_size = fs[1]
+    comptime c_frag_size = fs[2]
+    comptime num_threads = num_warps_m * num_warps_n * WARP_SIZE
+
+    var slice_idx = Int(block_idx.x)
+    var n_tile = Int(block_idx.y)
+    var n_offset = n_tile * Nblk
+    var tid = Int(thread_idx.x)
+    var warp_id = tid // WARP_SIZE
+    var warp_y = warp_id // num_warps_n
+    var warp_x = warp_id % num_warps_n
+
+    var x_base = slice_idx * L * P
+    var b_base = slice_idx * L * N
+    var a_base = slice_idx * L
+    var state_base = slice_idx * P * N
+
+    # ── Per-token decay into shared memory (Hillis-Steele, then exp) ──────────
+    var decay = mem_stack_allocation[
+        STATE_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+    if tid < L:
+        decay[tid] = A.ptr[a_base + tid].cast[DType.float32]()
+    gpu_barrier()
+    var offset = 1
+    while offset < L:
+        var add: Float32 = 0.0
+        if tid < L and tid >= offset:
+            add = decay[tid - offset]
+        gpu_barrier()
+        if tid < L and tid >= offset:
+            decay[tid] += add
+        gpu_barrier()
+        offset *= 2
+    var cum_end = decay[L - 1]
+    gpu_barrier()
+    if tid < L:
+        decay[tid] = exp(cum_end - decay[tid])
+    gpu_barrier()
+
+    # ── Shared tiles: As is decay-scaled X transposed to [P, BK]; Bs is [BK, N].
+    var As = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(P, BK),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var Bs = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(BK, Nblk),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+
+    # ── Register tiles ───────────────────────────────────────────────────────
+    var c_reg = (
+        LayoutTensor[
+            accum_type,
+            Layout.row_major(num_m_mmas * num_n_mmas, c_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ]
+        .stack_allocation()
+        .fill(0)
+    )
+    var a_reg = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(num_m_mmas, a_frag_size),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ].stack_allocation()
+    var b_reg = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(num_n_mmas, b_frag_size),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ].stack_allocation()
+
+    var mma_op = TensorCore[accum_type, kernel_dtype, mma_shape, False]()
+
+    # ── K-loop over chunk length ─────────────────────────────────────────────
+    var k0 = 0
+    while k0 < L:
+        # Stage As[p, kl] = decay[k0+kl] * X[k0+kl, p] (coalesced read over p).
+        var idx = tid
+        while idx < P * BK:
+            var kl = idx // P
+            var p = idx % P
+            As[p, kl] = (
+                decay[k0 + kl]
+                * X.ptr[x_base + (k0 + kl) * P + p].cast[DType.float32]()
+            ).cast[kernel_dtype]()
+            idx += num_threads
+        # Stage Bs[kl, n] = B[k0+kl, n_offset+n] (this block's N tile).
+        idx = tid
+        while idx < BK * Nblk:
+            var kl = idx // Nblk
+            var nn = idx % Nblk
+            Bs[kl, nn] = B.ptr[b_base + (k0 + kl) * N + n_offset + nn]
+            idx += num_threads
+        gpu_barrier()
+
+        var a_warp_tile = As.tile[WM, BK](warp_y, 0)
+        var b_warp_tile = Bs.tile[BK, WN](0, warp_x)
+
+        # NOTE: As/Bs are written to shared memory unswizzled, so load_a/load_b
+        # must read unswizzled too (no swizzle arg). Adding a swizzle would
+        # require applying the same permutation on the shared-memory store.
+        comptime for k_mma in range(num_k_mmas):
+            mma_op.load_a(a_warp_tile, a_reg.vectorize[1, a_frag_size](), k_mma)
+            mma_op.load_b(
+                b_warp_tile, b_reg.vectorize[1, b_frag_size](), k_mma, warp_x
+            )
+            mma_op.mma(
+                a_reg.vectorize[1, a_frag_size](),
+                b_reg.vectorize[1, b_frag_size](),
+                c_reg.vectorize[1, c_frag_size](),
+            )
+        gpu_barrier()
+        k0 += BK
+
+    # ── Store the warp's [WM, WN] output tile to global state ────────────────
+    # The warp's global N-tile index folds in this block's N offset.
+    var c_slice = LayoutTensor[
+        kernel_dtype, Layout.row_major(P, N), MutAnyOrigin
+    ](state.ptr + state_base)
+    var c_warp_tile = c_slice.tile[WM, WN](
+        warp_y, n_tile * num_warps_n + warp_x
+    )
+    copy_local_to_dram[dst_thread_layout=Layout.row_major(8, 4)](
+        c_warp_tile.vectorize[1, 2](),
+        c_reg.vectorize[1, 2]().transpose(),
+    )
+
+
+def ssd_chunk_state_fwd_gpu_fused[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    state_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    state: TileTensor[kernel_dtype, state_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Fused single-pass tensor-core chunk end-state (Triton-parity target).
+
+    One block per ``(batch, chunk, head)`` slice runs
+    ``_ssd_chunk_state_fused_mma_gpu``, which streams ``X``/``B`` once, applies
+    decay while transposing ``X`` in shared memory, and accumulates the
+    end-state on tensor cores — no DRAM round-trip for the decayed/transposed
+    values (unlike ``ssd_chunk_state_fwd_gpu_static``).
+
+    Requires ``head_dim % (16 * num_warps_m) == 0``,
+    ``state_dim % (8 * num_warps_n) == 0``, ``chunk_len % BK == 0``, and the
+    launch block (``num_warps_m * num_warps_n * 32`` threads) ``>= chunk_len``
+    for the shared-memory decay scan. The static batched-matmul path
+    (``ssd_chunk_state_fwd_gpu_static``) is the fallback for other shapes.
+    """
+    comptime num_threads = (
+        STATE_FUSED_WARPS_M * STATE_FUSED_WARPS_N * WARP_SIZE
+    )
+    var num_slices = batch * n_chunks * n_heads
+
+    var compiled = ctx.compile_function[
+        _ssd_chunk_state_fused_mma_gpu[
+            kernel_dtype,
+            head_dim_ct,
+            state_dim_ct,
+            chunk_len_ct,
+            STATE_FUSED_BK,
+            STATE_FUSED_WARPS_M,
+            STATE_FUSED_WARPS_N,
+            STATE_FUSED_N_SPLIT,
+            X_LT,
+            B_LT,
+            A_LT,
+            state_LT,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled,
+            X,
+            B,
+            A,
+            state,
+            grid_dim=(num_slices, STATE_FUSED_N_SPLIT),
+            block_dim=(num_threads,),
+        )

--- a/max/kernels/test/gpu/state_space/BUILD.bazel
+++ b/max/kernels/test/gpu/state_space/BUILD.bazel
@@ -49,6 +49,10 @@ _EXTRA_CONSTRAINTS = {
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    "test_ssd_chunk_state.mojo": select({
+        "//:apple_gpu": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 }
 
 _GPU_MEMORY = {

--- a/max/kernels/test/gpu/state_space/BUILD.bazel
+++ b/max/kernels/test/gpu/state_space/BUILD.bazel
@@ -37,6 +37,10 @@ _EXTRA_CONSTRAINTS = {
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    "test_ssd_chunk.mojo": select({
+        "//:apple_gpu": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     "test_gated_delta.mojo": select({
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],

--- a/max/kernels/test/gpu/state_space/BUILD.bazel
+++ b/max/kernels/test/gpu/state_space/BUILD.bazel
@@ -57,6 +57,10 @@ _EXTRA_CONSTRAINTS = {
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    "test_ssd_chunk_combine.mojo": select({
+        "//:apple_gpu": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 }
 
 _GPU_MEMORY = {

--- a/max/kernels/test/gpu/state_space/BUILD.bazel
+++ b/max/kernels/test/gpu/state_space/BUILD.bazel
@@ -53,6 +53,10 @@ _EXTRA_CONSTRAINTS = {
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    "test_ssd_chunk_scan.mojo": select({
+        "//:apple_gpu": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 }
 
 _GPU_MEMORY = {

--- a/max/kernels/test/gpu/state_space/test_ssd_chunk.mojo
+++ b/max/kernels/test/gpu/state_space/test_ssd_chunk.mojo
@@ -1,0 +1,758 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import exp
+
+from max.gpu.host import DeviceContext
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    row_major,
+)
+from std.random import rand
+from state_space.ssd_chunk import (
+    ssd_intra_chunk_fwd_gpu,
+    ssd_intra_chunk_fwd_gpu_naive,
+    ssd_intra_chunk_fwd_gpu_fused,
+    ssd_intra_chunk_fwd_gpu_static,
+    ssd_intra_chunk_fwd_gpu_static_mma,
+)
+from std.testing import TestSuite, assert_almost_equal
+from std.utils.index import Index
+
+
+def run_ssd_intra_chunk_gpu[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Run the optimized SSD intra-chunk GPU path and check against a reference.
+
+    Uses batched ``C @ B^T`` (Modular tensor-core matmul) plus a Triton-style
+    tiled chunk-scan kernel. Validates against the same independent scalar
+    reference used by the CPU test.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    # ── Host tensors ─────────────────────────────────────────────────────────
+    var C_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    var C_h = LayoutTensor[dtype, layout_5d, _](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](C_h.ptr, C_h.size())
+
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    var B_h = LayoutTensor[dtype, layout_5d, _](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](B_h.ptr, B_h.size())
+
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+    var X_h = LayoutTensor[dtype, layout_5d, _](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](X_h.ptr, X_h.size())
+
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var A_h = LayoutTensor[dtype, layout_4d, _](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](A_h.ptr, A_h.size())
+    # Make A negative-ish (a real SSM decays) so exp(cumsum diffs) stays
+    # bounded. `rand` fills in [0, 1); map into a small negative range.
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        # Map [0, 1) -> [-0.6, -0.1].
+        var scaled = Float32(-0.6) + Float32(0.5) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    var Y_gpu_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+    var Y_gpu_h = LayoutTensor[dtype, layout_5d, _](
+        Y_gpu_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # ── Device buffers ───────────────────────────────────────────────────────
+    var C_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y_device = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(C_device, C_h.ptr)
+        ctx.enqueue_copy(B_device, B_h.ptr)
+        ctx.enqueue_copy(X_device, X_h.ptr)
+        ctx.enqueue_copy(A_device, A_h.ptr)
+
+    var C_tt = TileTensor(
+        C_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var B_tt = TileTensor(
+        B_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var X_tt = TileTensor(
+        X_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var A_tt = TileTensor(
+        A_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var Y_tt = TileTensor(
+        Y_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+
+    with ctx.push_context():
+        ssd_intra_chunk_fwd_gpu[
+            dtype,
+            C_tt.LayoutType,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            Y_tt.LayoutType,
+        ](
+            batch,
+            n_chunks,
+            n_heads,
+            chunk_len,
+            state_dim,
+            head_dim,
+            C_tt,
+            B_tt,
+            X_tt,
+            A_tt,
+            Y_tt,
+            ctx,
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(Y_gpu_h.ptr, Y_device)
+    ctx.synchronize()
+
+    # ── CPU reference: naive triple-loop of the SSD intra-chunk formula ──────
+    var ref_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+
+    var cb_h_stride = chunk_len * state_dim
+    var cb_c_stride = n_heads * cb_h_stride
+    var cb_b_stride = n_chunks * cb_c_stride
+
+    var xy_h_stride = chunk_len * head_dim
+    var xy_c_stride = n_heads * xy_h_stride
+    var xy_b_stride = n_chunks * xy_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var cb_base = (
+                    b * cb_b_stride + c * cb_c_stride + h * cb_h_stride
+                )
+                var xy_base = (
+                    b * xy_b_stride + c * xy_c_stride + h * xy_h_stride
+                )
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                for l in range(chunk_len):
+                    for p in range(head_dim):
+                        var y_acc = Float32(0.0)
+                        for s in range(l + 1):
+                            var dot = Float32(0.0)
+                            for n in range(state_dim):
+                                var cv = C_h.ptr[
+                                    cb_base + l * state_dim + n
+                                ].cast[DType.float32]()
+                                var bv = B_h.ptr[
+                                    cb_base + s * state_dim + n
+                                ].cast[DType.float32]()
+                                dot += cv * bv
+                            var decay = exp(cumsum[l] - cumsum[s])
+                            var xv = X_h.ptr[xy_base + s * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            y_acc += dot * decay * xv
+                        ref_heap[xy_base + l * head_dim + p] = Scalar[dtype](
+                            y_acc
+                        )
+
+    # ── Compare GPU vs CPU reference ─────────────────────────────────────────
+    for i in range(xy_count):
+        assert_almost_equal(Y_gpu_h.ptr[i], ref_heap[i], rtol=rtol)
+
+
+def run_ssd_intra_chunk_gpu_static[
+    dtype: DType,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    use_mma: Bool = False,
+    use_fused: Bool = False,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+    a_min: Float32 = -0.6,
+    a_max: Float32 = -0.1,
+) raises:
+    """Exercise a static-shape path against the scalar CPU reference.
+
+    ``use_mma=False`` drives the default scalar-scan static path
+    (``ssd_intra_chunk_fwd_gpu_static``); ``use_mma=True`` drives the
+    tensor-core path that materialises ``M = causal_decay(CB)`` and computes
+    ``Y = M @ X`` via two batched matmuls
+    (``ssd_intra_chunk_fwd_gpu_static_mma``). ``chunk_len`` / ``state_dim`` /
+    ``head_dim`` are comptime so ``batched_matmul`` sees static N/K.
+
+    ``a_min`` / ``a_max`` bound the per-token decay ``A``. The scan factors
+    ``exp(cum_l−cum_s) = exp(cum_l)·exp(−cum_s)``; the intermediate
+    ``exp(−cum_s)`` can overflow FP32 once ``|cum|`` exceeds ~88, so long
+    ``chunk_len`` tests use a milder range to stay in the regime real Mamba2
+    decay rates occupy.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    var C_h = LayoutTensor[dtype, layout_5d, _](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](C_h.ptr, C_h.size())
+
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    var B_h = LayoutTensor[dtype, layout_5d, _](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](B_h.ptr, B_h.size())
+
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+    var X_h = LayoutTensor[dtype, layout_5d, _](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](X_h.ptr, X_h.size())
+
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var A_h = LayoutTensor[dtype, layout_4d, _](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](A_h.ptr, A_h.size())
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        var scaled = a_min + (a_max - a_min) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    var Y_gpu_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+
+    var C_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y_device = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(C_device, C_h.ptr)
+        ctx.enqueue_copy(B_device, B_h.ptr)
+        ctx.enqueue_copy(X_device, X_h.ptr)
+        ctx.enqueue_copy(A_device, A_h.ptr)
+
+    var C_tt = TileTensor(
+        C_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var Y_tt = TileTensor(
+        Y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    with ctx.push_context():
+        comptime if use_fused:
+            ssd_intra_chunk_fwd_gpu_fused[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        elif use_mma:
+            ssd_intra_chunk_fwd_gpu_static_mma[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        else:
+            ssd_intra_chunk_fwd_gpu_static[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(Y_gpu_heap, Y_device)
+    ctx.synchronize()
+
+    var ref_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+
+    var cb_h_stride = chunk_len * state_dim
+    var cb_c_stride = n_heads * cb_h_stride
+    var cb_b_stride = n_chunks * cb_c_stride
+    var xy_h_stride = chunk_len * head_dim
+    var xy_c_stride = n_heads * xy_h_stride
+    var xy_b_stride = n_chunks * xy_c_stride
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var cb_base = (
+                    b * cb_b_stride + c * cb_c_stride + h * cb_h_stride
+                )
+                var xy_base = (
+                    b * xy_b_stride + c * xy_c_stride + h * xy_h_stride
+                )
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                for l in range(chunk_len):
+                    for p in range(head_dim):
+                        var y_acc = Float32(0.0)
+                        for s in range(l + 1):
+                            var dot = Float32(0.0)
+                            for n in range(state_dim):
+                                var cv = C_h.ptr[
+                                    cb_base + l * state_dim + n
+                                ].cast[DType.float32]()
+                                var bv = B_h.ptr[
+                                    cb_base + s * state_dim + n
+                                ].cast[DType.float32]()
+                                dot += cv * bv
+                            var decay = exp(cumsum[l] - cumsum[s])
+                            var xv = X_h.ptr[xy_base + s * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            y_acc += dot * decay * xv
+                        ref_heap[xy_base + l * head_dim + p] = Scalar[dtype](
+                            y_acc
+                        )
+
+    for i in range(xy_count):
+        assert_almost_equal(Y_gpu_heap[i], ref_heap[i], rtol=rtol)
+
+
+def test_ssd_intra_chunk_gpu_static_scalar() raises:
+    """Static-shape scalar-scan path against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=16, state_dim=16, head_dim=8
+    ](batch=1, n_chunks=3, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_mma() raises:
+    """Static-shape tensor-core MMA path against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=16, state_dim=16, head_dim=8, use_mma=True
+    ](batch=1, n_chunks=3, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_fused_small() raises:
+    """Fused single-pass MMA path (RFC 0009), small gate-hitting dims."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32,
+        chunk_len=64,
+        state_dim=128,
+        head_dim=64,
+        use_fused=True,
+    ](batch=1, n_chunks=2, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_fused_mamba2() raises:
+    """Fused single-pass MMA path at the Mamba2-130m profile (L=256,P=64,N=128).
+    """
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32,
+        chunk_len=256,
+        state_dim=128,
+        head_dim=64,
+        use_fused=True,
+    ](batch=1, n_chunks=2, n_heads=4, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_mma_multi_batch() raises:
+    """Static-shape MMA path with multiple batch elements."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=8, state_dim=8, head_dim=4, use_mma=True
+    ](batch=2, n_chunks=2, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_a100_mma_shape() raises:
+    """Production-shape static scalar path exercising the changed GPU paths.
+
+    Covers the code paths the GPU optimizations actually changed, which the
+    tiny shapes above do NOT:
+
+    - ``state_dim=128`` + ``chunk_len=128`` (multiple of 128) makes the
+      ``CB = C @ B^T`` stage take ``batched_matmul``'s **A100 batched
+      tensor-core path** (``multistage_gemm_cond``: N%128==0, K%32==0, K>=128).
+    - ``chunk_len=128`` > ``SCAN_BLOCK_M`` (32 on GB10) → **4 M-tiles**, so the
+      causal early-exit / tail-balancing across M-tiles is exercised.
+    - ``head_dim=64`` > ``SCAN_BLOCK_N`` (32) → **2 N-tiles**.
+    - The parallel cumsum runs one block per slice with ``block_dim=128``.
+    """
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=128, state_dim=128, head_dim=64
+    ](batch=1, n_chunks=1, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_mma_a100_shape() raises:
+    """Production-shape MMA path: decay kernel + ``Y = M @ X`` at the shape
+    where the ``CB`` matmul takes the A100 batched tensor-core path
+    (``state_dim=128``, ``chunk_len=128``)."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32,
+        chunk_len=128,
+        state_dim=128,
+        head_dim=64,
+        use_mma=True,
+    ](batch=1, n_chunks=1, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_long_chunk() raises:
+    """Full Mamba2 ``chunk_len=256`` with realistic (mild) decay.
+
+    Covers the production chunk length: the Hillis-Steele cumsum at
+    ``block_dim=256``, 8 scan M-tiles, and the A100 batched MMA. Uses a milder
+    decay range so the factored ``exp(-cum_s)`` stays well within FP32 — the
+    regime real Mamba2 dt*A rates occupy (aggressive decay over 256 tokens can
+    push ``|cum|`` past the ~88 FP32-exp overflow point; see helper docstring).
+    """
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=256, state_dim=128, head_dim=16
+    ](batch=1, n_chunks=1, n_heads=2, ctx=ctx, a_min=-0.08, a_max=-0.01)
+
+
+def test_ssd_intra_chunk_gpu_multi_m_tile() raises:
+    """Dynamic-shape path with ``chunk_len=64`` > ``SCAN_BLOCK_M`` so the scan
+    spans multiple M-tiles (the tiny dynamic tests above are all single-tile).
+    """
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=64,
+        state_dim=32,
+        head_dim=16,
+        ctx=ctx,
+    )
+
+
+def test_ssd_intra_chunk_gpu_golden() raises:
+    """Golden-parity test on GPU against the canonical PyTorch SSD reference.
+
+    Same FIXED tiny input as the CPU golden test (batch=1, n_chunks=1,
+    n_heads=1, L=4, N=3, P=2). Pins the GPU kernel to ``intra_chunk_diag`` in
+    ``.planning/parity/ssd_minimal_ref.py``.
+    """
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    var C_vals = [
+        Float32(-0.15),
+        0.79,
+        0.95,
+        -1.11,
+        1.69,
+        -0.89,
+        -0.36,
+        1.23,
+        0.14,
+        -1.68,
+        0.32,
+        0.13,
+    ]
+    var B_vals = [
+        Float32(0.14),
+        0.24,
+        1.40,
+        1.35,
+        2.44,
+        0.20,
+        2.45,
+        2.03,
+        1.78,
+        -0.92,
+        -0.46,
+        -0.72,
+    ]
+    var X_vals = [
+        Float32(1.28),
+        -0.99,
+        1.81,
+        -0.60,
+        1.61,
+        1.93,
+        -0.42,
+        -0.08,
+    ]
+    var A_vals = [Float32(-0.43), -0.34, -0.49, -0.46]
+    var Y_expected = [
+        Float32(1.918208),
+        -1.483614,
+        3.522012,
+        -0.766567,
+        6.067267,
+        2.472605,
+        -4.850489,
+        -3.713203,
+    ]
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    # Host buffers from fixed literals.
+    var C_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    for i in range(cb_count):
+        C_heap[i] = Scalar[dtype](C_vals[i])
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    for i in range(cb_count):
+        B_heap[i] = Scalar[dtype](B_vals[i])
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+    for i in range(xy_count):
+        X_heap[i] = Scalar[dtype](X_vals[i])
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    for i in range(a_count):
+        A_heap[i] = Scalar[dtype](A_vals[i])
+    var Y_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+
+    var C_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y_device = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(C_device, C_heap)
+        ctx.enqueue_copy(B_device, B_heap)
+        ctx.enqueue_copy(X_device, X_heap)
+        ctx.enqueue_copy(A_device, A_heap)
+
+    var C_tt = TileTensor(
+        C_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var B_tt = TileTensor(
+        B_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var X_tt = TileTensor(
+        X_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var A_tt = TileTensor(
+        A_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var Y_tt = TileTensor(
+        Y_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_intra_chunk_fwd_gpu_naive[
+            dtype,
+            C_tt.LayoutType,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            Y_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            C_tt,
+            B_tt,
+            X_tt,
+            A_tt,
+            Y_tt,
+            grid_dim=(1,),
+            block_dim=(total_slices,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(Y_heap, Y_device)
+    ctx.synchronize()
+
+    for i in range(xy_count):
+        assert_almost_equal(
+            Y_heap[i],
+            Scalar[dtype](Y_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_intra_chunk_gpu_basic() raises:
+    """Basic single-batch, single-chunk case against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=16,
+        head_dim=8,
+        ctx=ctx,
+    )
+
+
+def test_ssd_intra_chunk_gpu_multi_chunk() raises:
+    """Multiple chunks and heads against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu[DType.float32](
+        batch=1,
+        n_chunks=3,
+        n_heads=2,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=8,
+        ctx=ctx,
+    )
+
+
+def test_ssd_intra_chunk_gpu_multi_batch() raises:
+    """Multiple batch elements against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu[DType.float32](
+        batch=2,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=4,
+        ctx=ctx,
+    )
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/gpu/state_space/test_ssd_chunk_combine.mojo
+++ b/max/kernels/test/gpu/state_space/test_ssd_chunk_combine.mojo
@@ -1,0 +1,640 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import ceildiv, exp
+
+from max.gpu.host import DeviceContext
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    row_major,
+)
+from std.random import rand
+from state_space.ssd_chunk_combine import (
+    ssd_output_recombination_fwd_gpu,
+    ssd_output_recombination_fwd_gpu_fused,
+    ssd_output_recombination_fwd_gpu_static,
+)
+from std.testing import TestSuite, assert_almost_equal
+from std.utils.index import Index
+
+
+def run_ssd_output_recombination_gpu[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Run the SSD output-recombination GPU kernel and check vs a CPU ref.
+
+    One GPU thread per ``(batch, chunk, head, l, p)`` output scalar; this
+    validates the result against the same naive recombination used by the CPU
+    test.
+    """
+    comptime SCALAR_BLOCK_SIZE = 128
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    # ── Host tensors ─────────────────────────────────────────────────────────
+    var c_heap = ctx.enqueue_create_host_buffer[dtype](c_count)
+    var c_h = LayoutTensor[dtype, layout_5d, _](
+        c_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](c_h.ptr, c_h.size())
+
+    var ent_heap = ctx.enqueue_create_host_buffer[dtype](ent_count)
+    var ent_h = LayoutTensor[dtype, layout_5d, _](
+        ent_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    rand[dtype](ent_h.ptr, ent_h.size())
+
+    var a_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var a_h = LayoutTensor[dtype, layout_4d, _](
+        a_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](a_h.ptr, a_h.size())
+    # Make A negative (a real SSM decays). `rand` fills in [0, 1); map into
+    # [-0.6, -0.1] like a real per-token in-chunk log-decay.
+    for i in range(a_count):
+        var v = a_h.ptr[i].cast[DType.float32]()
+        # Map [0, 1) -> [-0.6, -0.1].
+        var scaled = Float32(-0.6) + Float32(0.5) * v
+        a_h.ptr[i] = Scalar[dtype](scaled)
+
+    var yd_heap = ctx.enqueue_create_host_buffer[dtype](y_count)
+    var yd_h = LayoutTensor[dtype, layout_5d, _](
+        yd_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](yd_h.ptr, yd_h.size())
+
+    var y_gpu_heap = ctx.enqueue_create_host_buffer[dtype](y_count)
+
+    # ── Device buffers ───────────────────────────────────────────────────────
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(c_device, c_h.ptr)
+        ctx.enqueue_copy(ent_device, ent_h.ptr)
+        ctx.enqueue_copy(a_device, a_h.ptr)
+        ctx.enqueue_copy(yd_device, yd_h.ptr)
+
+    var c_tt = TileTensor(
+        c_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var ent_tt = TileTensor(
+        ent_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+    var a_tt = TileTensor(
+        a_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var yd_tt = TileTensor(
+        yd_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var y_tt = TileTensor(
+        y_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+
+    var total_threads = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var compiled_func = ctx.compile_function[
+        ssd_output_recombination_fwd_gpu[
+            dtype,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            Int32(state_dim),
+            c_tt,
+            ent_tt,
+            a_tt,
+            yd_tt,
+            y_tt,
+            grid_dim=(ceildiv(total_threads, SCALAR_BLOCK_SIZE),),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(y_gpu_heap, y_device)
+    ctx.synchronize()
+
+    # ── CPU reference: naive output recombination ────────────────────────────
+    var ref_y = ctx.enqueue_create_host_buffer[dtype](y_count)
+
+    var c_l_stride = state_dim
+    var c_h_stride = chunk_len * c_l_stride
+    var c_c_stride = n_heads * c_h_stride
+    var c_b_stride = n_chunks * c_c_stride
+
+    var ent_p_stride = state_dim
+    var ent_h_stride = head_dim * ent_p_stride
+    var ent_c_stride = n_heads * ent_h_stride
+    var ent_b_stride = n_chunks * ent_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var y_l_stride = head_dim
+    var y_h_stride = chunk_len * y_l_stride
+    var y_c_stride = n_heads * y_h_stride
+    var y_b_stride = n_chunks * y_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var c_base = b * c_b_stride + c * c_c_stride + h * c_h_stride
+                var ent_base = (
+                    b * ent_b_stride + c * ent_c_stride + h * ent_h_stride
+                )
+                var y_base = b * y_b_stride + c * y_c_stride + h * y_h_stride
+
+                var a_cumsum = Float32(0.0)
+                for l in range(chunk_len):
+                    a_cumsum += a_h.ptr[a_base + l].cast[DType.float32]()
+                    var decay = exp(a_cumsum)
+                    for p in range(head_dim):
+                        var acc = Float32(0.0)
+                        for n in range(state_dim):
+                            var c_val = c_h.ptr[
+                                c_base + l * c_l_stride + n
+                            ].cast[DType.float32]()
+                            var ent_val = ent_h.ptr[
+                                ent_base + p * ent_p_stride + n
+                            ].cast[DType.float32]()
+                            acc += c_val * ent_val
+                        var y_off = decay * acc
+                        var yd_val = yd_h.ptr[y_base + l * y_l_stride + p].cast[
+                            DType.float32
+                        ]()
+                        ref_y[y_base + l * y_l_stride + p] = Scalar[dtype](
+                            yd_val + y_off
+                        )
+
+    # ── Compare GPU vs CPU reference ─────────────────────────────────────────
+    for i in range(y_count):
+        assert_almost_equal(y_gpu_heap[i], ref_y[i], rtol=rtol)
+
+
+def test_ssd_output_recombination_gpu_golden() raises:
+    """Golden-parity test on GPU against the canonical PyTorch SSD reference.
+
+    Same FIXED tiny input as the CPU golden test (batch=1, n_chunks=1,
+    n_heads=1, L=4, N=3, P=2). Pins the GPU kernel to the stage-4 output
+    recombination of ``ssd_minimal_discrete``.
+    """
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    var c_vals = [
+        Float32(0.35),
+        -0.57,
+        -0.39,
+        -0.29,
+        -0.45,
+        0.92,
+        -0.76,
+        1.06,
+        -0.12,
+        0.58,
+        0.47,
+        0.30,
+    ]
+    var ent_vals = [
+        Float32(0.56),
+        2.29,
+        2.11,
+        0.30,
+        0.03,
+        -0.57,
+    ]
+    var a_vals = [Float32(-0.51), -0.14, -0.32, -0.54]
+    var yd_vals = [
+        Float32(0.24),
+        0.69,
+        1.40,
+        -0.14,
+        -0.35,
+        -2.05,
+        -0.44,
+        -1.53,
+    ]
+    var y_expected = [
+        Float32(-0.920277),
+        0.876274,
+        1.790647,
+        -0.466226,
+        0.312865,
+        -2.098447,
+        0.009353,
+        -1.526222,
+    ]
+
+    var c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    # Host buffers from fixed literals.
+    var c_heap = ctx.enqueue_create_host_buffer[dtype](c_count)
+    for i in range(c_count):
+        c_heap[i] = Scalar[dtype](c_vals[i])
+    var ent_heap = ctx.enqueue_create_host_buffer[dtype](ent_count)
+    for i in range(ent_count):
+        ent_heap[i] = Scalar[dtype](ent_vals[i])
+    var a_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    for i in range(a_count):
+        a_heap[i] = Scalar[dtype](a_vals[i])
+    var yd_heap = ctx.enqueue_create_host_buffer[dtype](y_count)
+    for i in range(y_count):
+        yd_heap[i] = Scalar[dtype](yd_vals[i])
+    var y_heap = ctx.enqueue_create_host_buffer[dtype](y_count)
+
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(c_device, c_heap)
+        ctx.enqueue_copy(ent_device, ent_heap)
+        ctx.enqueue_copy(a_device, a_heap)
+        ctx.enqueue_copy(yd_device, yd_heap)
+
+    var c_tt = TileTensor(
+        c_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var ent_tt = TileTensor(
+        ent_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+    var a_tt = TileTensor(
+        a_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var yd_tt = TileTensor(
+        yd_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var y_tt = TileTensor(
+        y_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+
+    var total_threads = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var compiled_func = ctx.compile_function[
+        ssd_output_recombination_fwd_gpu[
+            dtype,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            Int32(state_dim),
+            c_tt,
+            ent_tt,
+            a_tt,
+            yd_tt,
+            y_tt,
+            grid_dim=(1,),
+            block_dim=(total_threads,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(y_heap, y_device)
+    ctx.synchronize()
+
+    for i in range(y_count):
+        assert_almost_equal(
+            y_heap[i],
+            Scalar[dtype](y_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_output_recombination_gpu_basic() raises:
+    """Basic single-batch case against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_output_recombination_gpu[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        head_dim=8,
+        state_dim=16,
+        ctx=ctx,
+    )
+
+
+def test_ssd_output_recombination_gpu_multi_batch() raises:
+    """Multiple batch elements and heads against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_output_recombination_gpu[DType.float32](
+        batch=2,
+        n_chunks=3,
+        n_heads=3,
+        chunk_len=5,
+        head_dim=4,
+        state_dim=8,
+        ctx=ctx,
+    )
+
+
+def run_ssd_output_recombination_gpu_static[
+    dtype: DType,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+    use_fused: Bool = False,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Validate the static / fused tensor-core path vs the naive CPU reference.
+
+    Uses gate-hitting compile-time dims (``chunk_len % 128 == 0``,
+    ``state_dim % 32 == 0`` and ``>= 128``) so ``batched_matmul`` takes the A100
+    multistage path. With ``use_fused=True``, exercises the single-pass fused
+    MMA path instead.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var c_heap = ctx.enqueue_create_host_buffer[dtype](c_count)
+    var c_h = LayoutTensor[dtype, layout_5d, _](
+        c_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](c_h.ptr, c_h.size())
+
+    var ent_heap = ctx.enqueue_create_host_buffer[dtype](ent_count)
+    var ent_h = LayoutTensor[dtype, layout_5d, _](
+        ent_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    rand[dtype](ent_h.ptr, ent_h.size())
+
+    var a_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var a_h = LayoutTensor[dtype, layout_4d, _](
+        a_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](a_h.ptr, a_h.size())
+    for i in range(a_count):
+        var v = a_h.ptr[i].cast[DType.float32]()
+        a_h.ptr[i] = Scalar[dtype](Float32(-0.6) + Float32(0.5) * v)
+
+    var yd_heap = ctx.enqueue_create_host_buffer[dtype](y_count)
+    var yd_h = LayoutTensor[dtype, layout_5d, _](
+        yd_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](yd_h.ptr, yd_h.size())
+
+    var y_gpu_heap = ctx.enqueue_create_host_buffer[dtype](y_count)
+
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(c_device, c_h.ptr)
+        ctx.enqueue_copy(ent_device, ent_h.ptr)
+        ctx.enqueue_copy(a_device, a_h.ptr)
+        ctx.enqueue_copy(yd_device, yd_h.ptr)
+
+    var c_tt = TileTensor(
+        c_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var a_tt = TileTensor(
+        a_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var yd_tt = TileTensor(
+        yd_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var y_tt = TileTensor(
+        y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    comptime if use_fused:
+        ssd_output_recombination_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, c_tt, ent_tt, a_tt, yd_tt, y_tt, ctx)
+    else:
+        ssd_output_recombination_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, c_tt, ent_tt, a_tt, yd_tt, y_tt, ctx)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(y_gpu_heap, y_device)
+    ctx.synchronize()
+
+    # ── CPU reference: naive output recombination ────────────────────────────
+    var ref_y = ctx.enqueue_create_host_buffer[dtype](y_count)
+    var c_l_stride = state_dim
+    var c_h_stride = chunk_len * c_l_stride
+    var c_c_stride = n_heads * c_h_stride
+    var c_b_stride = n_chunks * c_c_stride
+    var ent_p_stride = state_dim
+    var ent_h_stride = head_dim * ent_p_stride
+    var ent_c_stride = n_heads * ent_h_stride
+    var ent_b_stride = n_chunks * ent_c_stride
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+    var y_l_stride = head_dim
+    var y_h_stride = chunk_len * y_l_stride
+    var y_c_stride = n_heads * y_h_stride
+    var y_b_stride = n_chunks * y_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var c_base = b * c_b_stride + c * c_c_stride + h * c_h_stride
+                var ent_base = (
+                    b * ent_b_stride + c * ent_c_stride + h * ent_h_stride
+                )
+                var y_base = b * y_b_stride + c * y_c_stride + h * y_h_stride
+                var a_cumsum = Float32(0.0)
+                for l in range(chunk_len):
+                    a_cumsum += a_h.ptr[a_base + l].cast[DType.float32]()
+                    var decay = exp(a_cumsum)
+                    for p in range(head_dim):
+                        var acc = Float32(0.0)
+                        for n in range(state_dim):
+                            var c_val = c_h.ptr[
+                                c_base + l * c_l_stride + n
+                            ].cast[DType.float32]()
+                            var ent_val = ent_h.ptr[
+                                ent_base + p * ent_p_stride + n
+                            ].cast[DType.float32]()
+                            acc += c_val * ent_val
+                        var yd_val = yd_h.ptr[y_base + l * y_l_stride + p].cast[
+                            DType.float32
+                        ]()
+                        ref_y[y_base + l * y_l_stride + p] = Scalar[dtype](
+                            yd_val + decay * acc
+                        )
+
+    for i in range(y_count):
+        assert_almost_equal(y_gpu_heap[i], ref_y[i], rtol=rtol)
+
+
+def test_ssd_output_recombination_gpu_static_golden() raises:
+    """Static tensor-core path vs naive reference, gate-hitting dims."""
+    var ctx = DeviceContext()
+    run_ssd_output_recombination_gpu_static[
+        DType.float32, chunk_len=128, head_dim=64, state_dim=128
+    ](batch=1, n_chunks=2, n_heads=2, ctx=ctx)
+
+
+def test_ssd_output_recombination_gpu_static_mamba2() raises:
+    """Static path at the Mamba2-130m prefill profile (L=256, P=64, N=128)."""
+    var ctx = DeviceContext()
+    run_ssd_output_recombination_gpu_static[
+        DType.float32, chunk_len=256, head_dim=64, state_dim=128
+    ](batch=1, n_chunks=2, n_heads=4, ctx=ctx)
+
+
+def test_ssd_output_recombination_gpu_fused_golden() raises:
+    """Fused single-pass MMA path vs naive reference, gate-hitting dims."""
+    var ctx = DeviceContext()
+    run_ssd_output_recombination_gpu_static[
+        DType.float32,
+        chunk_len=128,
+        head_dim=64,
+        state_dim=128,
+        use_fused=True,
+    ](batch=1, n_chunks=2, n_heads=2, ctx=ctx)
+
+
+def test_ssd_output_recombination_gpu_fused_mamba2() raises:
+    """Fused path at the Mamba2-130m prefill profile (L=256, P=64, N=128)."""
+    var ctx = DeviceContext()
+    run_ssd_output_recombination_gpu_static[
+        DType.float32,
+        chunk_len=256,
+        head_dim=64,
+        state_dim=128,
+        use_fused=True,
+    ](batch=1, n_chunks=2, n_heads=4, ctx=ctx)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/gpu/state_space/test_ssd_chunk_scan.mojo
+++ b/max/kernels/test/gpu/state_space/test_ssd_chunk_scan.mojo
@@ -1,0 +1,388 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import ceildiv, exp
+
+from max.gpu.host import DeviceContext
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    row_major,
+)
+from std.random import rand
+from state_space.ssd_chunk_scan import ssd_chunk_scan_fwd_gpu
+from std.testing import TestSuite, assert_almost_equal
+from std.utils.index import Index
+
+
+def run_ssd_chunk_scan_gpu[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Run the SSD inter-chunk scan GPU kernel and check it against a CPU ref.
+
+    One GPU thread per ``(batch, head, p, n)`` scalar walks the chunk axis
+    sequentially; this validates the result against the same naive recurrence
+    used by the CPU test.
+    """
+    comptime SCALAR_BLOCK_SIZE = 128
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var cs_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var cd_count = batch * n_chunks * n_heads
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var final_count = batch * n_heads * head_dim * state_dim
+
+    # ── Host tensors ─────────────────────────────────────────────────────────
+    var cs_heap = ctx.enqueue_create_host_buffer[dtype](cs_count)
+    var cs_h = LayoutTensor[dtype, layout_5d, _](
+        cs_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    rand[dtype](cs_h.ptr, cs_h.size())
+
+    var cd_heap = ctx.enqueue_create_host_buffer[dtype](cd_count)
+    var cd_h = LayoutTensor[dtype, layout_3d, _](
+        cd_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, n_chunks, n_heads)),
+    )
+    rand[dtype](cd_h.ptr, cd_h.size())
+    # Make chunk_decays negative (a real SSM decays). `rand` fills in [0, 1);
+    # map into [-1.2, -0.3] like a real per-chunk total decay.
+    for i in range(cd_count):
+        var v = cd_h.ptr[i].cast[DType.float32]()
+        # Map [0, 1) -> [-1.2, -0.3].
+        var scaled = Float32(-1.2) + Float32(0.9) * v
+        cd_h.ptr[i] = Scalar[dtype](scaled)
+
+    var ent_gpu_heap = ctx.enqueue_create_host_buffer[dtype](ent_count)
+    var ent_gpu_h = LayoutTensor[dtype, layout_5d, _](
+        ent_gpu_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    var final_gpu_heap = ctx.enqueue_create_host_buffer[dtype](final_count)
+    var final_gpu_h = LayoutTensor[dtype, layout_4d, _](
+        final_gpu_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # ── Device buffers ───────────────────────────────────────────────────────
+    var cs_device = ctx.enqueue_create_buffer[dtype](cs_count)
+    var cd_device = ctx.enqueue_create_buffer[dtype](cd_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var final_device = ctx.enqueue_create_buffer[dtype](final_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(cs_device, cs_h.ptr)
+        ctx.enqueue_copy(cd_device, cd_h.ptr)
+
+    var cs_tt = TileTensor(
+        cs_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+    var cd_tt = TileTensor(
+        cd_device,
+        row_major(batch, n_chunks, n_heads),
+    )
+    var ent_tt = TileTensor(
+        ent_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+    var final_tt = TileTensor(
+        final_device,
+        row_major(batch, n_heads, head_dim, state_dim),
+    )
+
+    var total_threads = batch * n_heads * head_dim * state_dim
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_scan_fwd_gpu[
+            dtype,
+            cs_tt.LayoutType,
+            cd_tt.LayoutType,
+            ent_tt.LayoutType,
+            final_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            cs_tt,
+            cd_tt,
+            ent_tt,
+            final_tt,
+            grid_dim=(ceildiv(total_threads, SCALAR_BLOCK_SIZE),),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(ent_gpu_h.ptr, ent_device)
+        ctx.enqueue_copy(final_gpu_h.ptr, final_device)
+    ctx.synchronize()
+
+    # ── CPU reference: naive sequential recurrence over chunks ───────────────
+    var ref_ent = ctx.enqueue_create_host_buffer[dtype](ent_count)
+    var ref_final = ctx.enqueue_create_host_buffer[dtype](final_count)
+
+    var cs_h_stride = head_dim * state_dim
+    var cs_c_stride = n_heads * cs_h_stride
+    var cs_b_stride = n_chunks * cs_c_stride
+
+    var cd_c_stride = n_heads
+    var cd_b_stride = n_chunks * cd_c_stride
+
+    var ent_h_stride = head_dim * state_dim
+    var ent_c_stride = n_heads * ent_h_stride
+    var ent_b_stride = n_chunks * ent_c_stride
+
+    var final_h_stride = head_dim * state_dim
+    var final_b_stride = n_heads * final_h_stride
+
+    for b in range(batch):
+        for h in range(n_heads):
+            var state = List[Float32](length=head_dim * state_dim, fill=0.0)
+            for c in range(n_chunks):
+                var ent_base = (
+                    b * ent_b_stride + c * ent_c_stride + h * ent_h_stride
+                )
+                for pn in range(head_dim * state_dim):
+                    ref_ent[ent_base + pn] = Scalar[dtype](state[pn])
+
+                var cd_off = b * cd_b_stride + c * cd_c_stride + h
+                var decay = exp(cd_h.ptr[cd_off].cast[DType.float32]())
+
+                var cs_base = (
+                    b * cs_b_stride + c * cs_c_stride + h * cs_h_stride
+                )
+                for pn in range(head_dim * state_dim):
+                    var cs_val = cs_h.ptr[cs_base + pn].cast[DType.float32]()
+                    state[pn] = cs_val + decay * state[pn]
+
+            var final_base = b * final_b_stride + h * final_h_stride
+            for pn in range(head_dim * state_dim):
+                ref_final[final_base + pn] = Scalar[dtype](state[pn])
+
+    # ── Compare GPU vs CPU reference ─────────────────────────────────────────
+    for i in range(ent_count):
+        assert_almost_equal(ent_gpu_h.ptr[i], ref_ent[i], rtol=rtol)
+    for i in range(final_count):
+        assert_almost_equal(final_gpu_h.ptr[i], ref_final[i], rtol=rtol)
+
+
+def test_ssd_chunk_scan_gpu_golden() raises:
+    """Golden-parity test on GPU against the canonical PyTorch SSD reference.
+
+    Same FIXED tiny input as the CPU golden test (batch=1, n_chunks=3,
+    n_heads=1, P=2, N=3). Pins the GPU kernel to the inter-chunk recurrence
+    (stage 3 of ``ssd_minimal_discrete``).
+    """
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 3
+    comptime n_heads = 1
+    comptime head_dim = 2
+    comptime state_dim = 3
+
+    var cs_vals = [
+        Float32(-0.90),
+        0.57,
+        0.91,
+        0.43,
+        1.29,
+        -0.17,
+        -0.86,
+        -0.66,
+        -0.70,
+        -0.10,
+        -0.62,
+        -0.63,
+        -0.58,
+        0.59,
+        0.12,
+        0.09,
+        1.04,
+        -0.18,
+    ]
+    var cd_vals = [Float32(-0.61), -1.03, -0.79]
+    var entering_expected = [
+        Float32(0.0),
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        -0.90,
+        0.57,
+        0.91,
+        0.43,
+        1.29,
+        -0.17,
+        -1.181306,
+        -0.456506,
+        -0.375124,
+        0.053513,
+        -0.159461,
+        -0.690691,
+    ]
+    var final_expected = [
+        Float32(-1.116130),
+        0.382817,
+        -0.050248,
+        0.114287,
+        0.967629,
+        -0.493467,
+    ]
+
+    var cs_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var cd_count = batch * n_chunks * n_heads
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var final_count = batch * n_heads * head_dim * state_dim
+
+    # Host buffers from fixed literals.
+    var cs_heap = ctx.enqueue_create_host_buffer[dtype](cs_count)
+    for i in range(cs_count):
+        cs_heap[i] = Scalar[dtype](cs_vals[i])
+    var cd_heap = ctx.enqueue_create_host_buffer[dtype](cd_count)
+    for i in range(cd_count):
+        cd_heap[i] = Scalar[dtype](cd_vals[i])
+    var ent_heap = ctx.enqueue_create_host_buffer[dtype](ent_count)
+    var final_heap = ctx.enqueue_create_host_buffer[dtype](final_count)
+
+    var cs_device = ctx.enqueue_create_buffer[dtype](cs_count)
+    var cd_device = ctx.enqueue_create_buffer[dtype](cd_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var final_device = ctx.enqueue_create_buffer[dtype](final_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(cs_device, cs_heap)
+        ctx.enqueue_copy(cd_device, cd_heap)
+
+    var cs_tt = TileTensor(
+        cs_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+    var cd_tt = TileTensor(
+        cd_device,
+        row_major(batch, n_chunks, n_heads),
+    )
+    var ent_tt = TileTensor(
+        ent_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+    var final_tt = TileTensor(
+        final_device,
+        row_major(batch, n_heads, head_dim, state_dim),
+    )
+
+    var total_threads = batch * n_heads * head_dim * state_dim
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_scan_fwd_gpu[
+            dtype,
+            cs_tt.LayoutType,
+            cd_tt.LayoutType,
+            ent_tt.LayoutType,
+            final_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            cs_tt,
+            cd_tt,
+            ent_tt,
+            final_tt,
+            grid_dim=(1,),
+            block_dim=(total_threads,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(ent_heap, ent_device)
+        ctx.enqueue_copy(final_heap, final_device)
+    ctx.synchronize()
+
+    for i in range(ent_count):
+        assert_almost_equal(
+            ent_heap[i],
+            Scalar[dtype](entering_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+    for i in range(final_count):
+        assert_almost_equal(
+            final_heap[i],
+            Scalar[dtype](final_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_chunk_scan_gpu_basic() raises:
+    """Basic single-batch case against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_scan_gpu[DType.float32](
+        batch=1,
+        n_chunks=4,
+        n_heads=2,
+        head_dim=8,
+        state_dim=16,
+        ctx=ctx,
+    )
+
+
+def test_ssd_chunk_scan_gpu_multi_batch() raises:
+    """Multiple batch elements and heads against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_scan_gpu[DType.float32](
+        batch=2,
+        n_chunks=5,
+        n_heads=3,
+        head_dim=4,
+        state_dim=8,
+        ctx=ctx,
+    )
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/gpu/state_space/test_ssd_chunk_state.mojo
+++ b/max/kernels/test/gpu/state_space/test_ssd_chunk_state.mojo
@@ -1,0 +1,647 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import exp
+
+from max.gpu.host import DeviceContext
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    row_major,
+)
+from std.random import rand
+from state_space.ssd_chunk_state import (
+    ssd_chunk_state_fwd_gpu,
+    ssd_chunk_state_fwd_gpu_static,
+    ssd_chunk_state_fwd_gpu_fused,
+)
+from std.testing import TestSuite, assert_almost_equal
+from std.utils.index import Index
+
+
+def run_ssd_chunk_state_gpu[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+    num_p_tiles: Int = 1,
+) raises:
+    """Run the SSD chunk-state GPU kernel and check it against a CPU reference.
+
+    One block per ``(batch, chunk, head)`` slice (``block_dim == chunk_len``)
+    reduces the chunk to its ``[head_dim, state_dim]`` end-state; this validates
+    the result against the same naive reference used by the CPU test.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    # ── Host tensors ─────────────────────────────────────────────────────────
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](b_count)
+    var B_h = LayoutTensor[dtype, layout_5d, _](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](B_h.ptr, B_h.size())
+
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](x_count)
+    var X_h = LayoutTensor[dtype, layout_5d, _](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](X_h.ptr, X_h.size())
+
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var A_h = LayoutTensor[dtype, layout_4d, _](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](A_h.ptr, A_h.size())
+    # Make A negative-ish (a real SSM decays) so exp(cumsum diffs) stays
+    # bounded. `rand` fills in [0, 1); map into a small negative range.
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        # Map [0, 1) -> [-0.6, -0.1].
+        var scaled = Float32(-0.6) + Float32(0.5) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    var state_gpu_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+    var state_gpu_h = LayoutTensor[dtype, layout_5d, _](
+        state_gpu_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # ── Device buffers ───────────────────────────────────────────────────────
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(B_device, B_h.ptr)
+        ctx.enqueue_copy(X_device, X_h.ptr)
+        ctx.enqueue_copy(A_device, A_h.ptr)
+
+    var B_tt = TileTensor(
+        B_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var X_tt = TileTensor(
+        X_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var A_tt = TileTensor(
+        A_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var state_tt = TileTensor(
+        state_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_state_fwd_gpu[
+            dtype,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(state_gpu_h.ptr, state_device)
+    ctx.synchronize()
+
+    # ── CPU reference: naive reduction of the SSD chunk-state formula ────────
+    var ref_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+
+    var b_h_stride = chunk_len * state_dim
+    var b_c_stride = n_heads * b_h_stride
+    var b_b_stride = n_chunks * b_c_stride
+
+    var x_h_stride = chunk_len * head_dim
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var state_h_stride = head_dim * state_dim
+    var state_c_stride = n_heads * state_h_stride
+    var state_b_stride = n_chunks * state_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var b_base = b * b_b_stride + c * b_c_stride + h * b_h_stride
+                var x_base = b * x_b_stride + c * x_c_stride + h * x_h_stride
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var state_base = (
+                    b * state_b_stride + c * state_c_stride + h * state_h_stride
+                )
+
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                var cum_end = cumsum[chunk_len - 1]
+
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var s_acc = Float32(0.0)
+                        for l in range(chunk_len):
+                            var bv = B_h.ptr[b_base + l * state_dim + n].cast[
+                                DType.float32
+                            ]()
+                            var xv = X_h.ptr[x_base + l * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            var decay = exp(cum_end - cumsum[l])
+                            s_acc += bv * decay * xv
+                        ref_heap[state_base + p * state_dim + n] = Scalar[
+                            dtype
+                        ](s_acc)
+
+    # ── Compare GPU vs CPU reference ─────────────────────────────────────────
+    for i in range(state_count):
+        assert_almost_equal(state_gpu_h.ptr[i], ref_heap[i], rtol=rtol)
+
+
+def run_ssd_chunk_state_gpu_static[
+    dtype: DType,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    fused: Bool = False,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Run a static tensor-core chunk-state entry and check it vs a CPU ref.
+
+    With ``fused=False`` runs ``ssd_chunk_state_fwd_gpu_static`` (2-pass
+    decay-transpose + batched_matmul); with ``fused=True`` runs the fused
+    single-pass kernel ``ssd_chunk_state_fwd_gpu_fused``. Both take compile-time
+    dims and the same argument list.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](b_count)
+    var B_h = LayoutTensor[dtype, layout_5d, _](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](B_h.ptr, B_h.size())
+
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](x_count)
+    var X_h = LayoutTensor[dtype, layout_5d, _](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](X_h.ptr, X_h.size())
+
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var A_h = LayoutTensor[dtype, layout_4d, _](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](A_h.ptr, A_h.size())
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        A_h.ptr[i] = Scalar[dtype](Float32(-0.6) + Float32(0.5) * v)
+
+    var state_gpu_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(B_device, B_h.ptr)
+        ctx.enqueue_copy(X_device, X_h.ptr)
+        ctx.enqueue_copy(A_device, A_h.ptr)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    comptime if fused:
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    else:
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(state_gpu_heap, state_device)
+    ctx.synchronize()
+
+    # ── CPU reference ────────────────────────────────────────────────────────
+    var ref_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+    var b_h_stride = chunk_len * state_dim
+    var b_c_stride = n_heads * b_h_stride
+    var b_b_stride = n_chunks * b_c_stride
+    var x_h_stride = chunk_len * head_dim
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+    var state_h_stride = head_dim * state_dim
+    var state_c_stride = n_heads * state_h_stride
+    var state_b_stride = n_chunks * state_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var b_base = b * b_b_stride + c * b_c_stride + h * b_h_stride
+                var x_base = b * x_b_stride + c * x_c_stride + h * x_h_stride
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var state_base = (
+                    b * state_b_stride + c * state_c_stride + h * state_h_stride
+                )
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+                var cum_end = cumsum[chunk_len - 1]
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var s_acc = Float32(0.0)
+                        for l in range(chunk_len):
+                            var bv = B_h.ptr[b_base + l * state_dim + n].cast[
+                                DType.float32
+                            ]()
+                            var xv = X_h.ptr[x_base + l * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            s_acc += bv * exp(cum_end - cumsum[l]) * xv
+                        ref_heap[state_base + p * state_dim + n] = Scalar[
+                            dtype
+                        ](s_acc)
+
+    for i in range(state_count):
+        assert_almost_equal(state_gpu_heap[i], ref_heap[i], rtol=rtol)
+
+
+def test_ssd_chunk_state_gpu_golden() raises:
+    """Golden-parity test on GPU against the canonical PyTorch SSD reference.
+
+    Same FIXED tiny input as the CPU golden test (batch=1, n_chunks=1,
+    n_heads=1, L=4, N=3, P=2). Pins the GPU kernel to the chunk end-state
+    reduction (stage 2 of ``ssd_minimal_discrete``).
+    """
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    var B_vals = [
+        Float32(0.74),
+        1.95,
+        -0.70,
+        -1.30,
+        -0.51,
+        -0.27,
+        0.25,
+        0.48,
+        0.45,
+        -0.96,
+        1.50,
+        -0.31,
+    ]
+    var X_vals = [
+        Float32(-0.23),
+        -1.07,
+        0.16,
+        0.12,
+        0.38,
+        -0.12,
+        0.89,
+        -0.49,
+    ]
+    var A_vals = [Float32(-0.45), -0.18, -0.36, -0.50]
+    var state_expected = [
+        Float32(-0.944955),
+        1.252577,
+        -0.133558,
+        0.106325,
+        -1.533317,
+        0.370175,
+    ]
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    # Host buffers from fixed literals.
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](b_count)
+    for i in range(b_count):
+        B_heap[i] = Scalar[dtype](B_vals[i])
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](x_count)
+    for i in range(x_count):
+        X_heap[i] = Scalar[dtype](X_vals[i])
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    for i in range(a_count):
+        A_heap[i] = Scalar[dtype](A_vals[i])
+    var state_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(B_device, B_heap)
+        ctx.enqueue_copy(X_device, X_heap)
+        ctx.enqueue_copy(A_device, A_heap)
+
+    var B_tt = TileTensor(
+        B_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var X_tt = TileTensor(
+        X_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var A_tt = TileTensor(
+        A_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var state_tt = TileTensor(
+        state_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_state_fwd_gpu[
+            dtype,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices,),
+            block_dim=(chunk_len,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(state_heap, state_device)
+    ctx.synchronize()
+
+    for i in range(state_count):
+        assert_almost_equal(
+            state_heap[i],
+            Scalar[dtype](state_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_chunk_state_gpu_basic() raises:
+    """Basic single-batch, single-chunk case against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=16,
+        head_dim=8,
+        ctx=ctx,
+    )
+
+
+def test_ssd_chunk_state_gpu_multi_chunk() raises:
+    """Multiple chunks and heads against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=1,
+        n_chunks=3,
+        n_heads=2,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=8,
+        ctx=ctx,
+    )
+
+
+def test_ssd_chunk_state_gpu_multi_batch() raises:
+    """Multiple batch elements against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=2,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=4,
+        ctx=ctx,
+    )
+
+
+def test_ssd_chunk_state_gpu_ptiled() raises:
+    """Multi-block-per-slice (grid_dim.y > 1) path, head_dim divisible by tiles.
+
+    Splits each slice across 4 p-tiles (head_dim=16, tile height 4); checks the
+    tiled result still matches the naive reference.
+    """
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=3,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=16,
+        ctx=ctx,
+        num_p_tiles=4,
+    )
+
+
+def test_ssd_chunk_state_gpu_ptiled_ragged() raises:
+    """Multi-block-per-slice path with head_dim NOT divisible by the tile count.
+
+    head_dim=10 over 4 p-tiles → tile height ceildiv(10,4)=3, so tiles cover
+    rows [0,3) [3,6) [6,9) [9,10); the last tile is a partial row and an extra
+    block would early-return. Exercises the ragged tail and bounds handling.
+    """
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=10,
+        ctx=ctx,
+        num_p_tiles=4,
+    )
+
+
+def test_ssd_chunk_state_gpu_static_mma() raises:
+    """Tensor-core batched-matmul path at gate-satisfying dims.
+
+    state_dim=128 (matmul N % 128 == 0), chunk_len=128 (K % 32 == 0, >= 128) so
+    ssd_chunk_state_fwd_gpu_static takes the A100 multistage path. Checked vs
+    the naive CPU reference.
+    """
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu_static[
+        DType.float32, chunk_len=128, state_dim=128, head_dim=64
+    ](batch=1, n_chunks=2, n_heads=4, ctx=ctx)
+
+
+def test_ssd_chunk_state_gpu_static_mma_profile() raises:
+    """Tensor-core path at the Mamba2-130m prefill profile (L=256, P=64, N=128).
+    """
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu_static[
+        DType.float32, chunk_len=256, state_dim=128, head_dim=64
+    ](batch=1, n_chunks=4, n_heads=24, ctx=ctx)
+
+
+def test_ssd_chunk_state_gpu_fused_mma() raises:
+    """Fused single-pass tensor-core path at gate-satisfying dims."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu_static[
+        DType.float32,
+        chunk_len=128,
+        state_dim=128,
+        head_dim=64,
+        fused=True,
+    ](batch=1, n_chunks=2, n_heads=4, ctx=ctx)
+
+
+def test_ssd_chunk_state_gpu_fused_mma_profile() raises:
+    """Fused path at the Mamba2-130m prefill profile (L=256, P=64, N=128)."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu_static[
+        DType.float32,
+        chunk_len=256,
+        state_dim=128,
+        head_dim=64,
+        fused=True,
+    ](batch=1, n_chunks=4, n_heads=24, ctx=ctx)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_mamba_split_conv1d_scan_combined_op.mojo
+++ b/max/kernels/test/state_space/test_mamba_split_conv1d_scan_combined_op.mojo
@@ -1,0 +1,320 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Op-registration smoke test for `mamba_split_conv1d_scan_combined`.
+
+Numerical parity is covered by `test_mamba_split_conv1d_scan_combined.mojo`;
+this file exists to ensure the @extensibility.register wrapper in
+`selective_scan_ops.mojo` is built into the state_space library (a malformed
+@extensibility.register block fails the library build), and that the underlying
+kernel is reachable via the same import path the wrapper uses.
+"""
+
+from std.math import ceildiv
+
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    UNKNOWN_VALUE,
+    row_major,
+)
+from layout._fillers import random
+from state_space.selective_scan import mamba_split_conv1d_scan_combined_cpu
+
+# Importing the ops module ensures the @extensibility.register-decorated structs
+# are part of the build graph for the consumer of the smoke test.
+import state_space.selective_scan_ops
+
+from std.testing import TestSuite, assert_true
+from std.utils.index import Index
+
+
+def test_mamba_split_conv1d_scan_combined_op_registered() raises:
+    """Smoke test: mamba_split_conv1d_scan_combined op + underlying CPU kernel
+    are callable.
+
+    Constructs tiny LayoutTensor inputs, invokes the CPU implementation that
+    the registered op dispatches to, and verifies the output buffer is finite
+    (no NaN/Inf) and shape-correct.
+    """
+    comptime dtype = DType.float32
+    comptime DSTATE = 8
+
+    var batch = 1
+    var nheads = 1
+    var headdim = 2
+    var dim = nheads * headdim
+    var seqlen = 4
+    var ngroups = 1
+    var width = 3
+    var chunk_size = 2048
+    var n_chunks = ceildiv(seqlen, chunk_size)
+
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_2d = Layout.row_major[2]()
+    comptime layout_1d = Layout(UNKNOWN_VALUE)
+
+    var zxbcdt_channels = 2 * dim + 2 * ngroups * DSTATE + nheads
+    var zxbcdt_heap = List(
+        length=batch * seqlen * zxbcdt_channels, fill=Scalar[dtype](0)
+    )
+    var zxbcdt_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        zxbcdt_heap,
+        RuntimeLayout[layout_3d].row_major(
+            Index(batch, seqlen, zxbcdt_channels)
+        ),
+    )
+    var zxbcdt_tt = TileTensor(
+        zxbcdt_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, seqlen, zxbcdt_channels),
+    )
+
+    var conv_weight_channels = dim + 2 * ngroups * DSTATE
+    var conv_weight_heap = List(
+        length=conv_weight_channels * width, fill=Scalar[dtype](0)
+    )
+    var conv_weight_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        conv_weight_heap,
+        RuntimeLayout[layout_2d].row_major(Index(conv_weight_channels, width)),
+    )
+    var conv_weight_tt = TileTensor(
+        conv_weight_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(conv_weight_channels, width),
+    )
+
+    var conv_bias_heap = List(
+        length=conv_weight_channels, fill=Scalar[dtype](0)
+    )
+    var conv_bias_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        conv_bias_heap,
+        RuntimeLayout[layout_1d].row_major(Index(conv_weight_channels)),
+    )
+    var conv_bias_tt = TileTensor(
+        conv_bias_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(conv_weight_channels),
+    )
+
+    var dt_bias_heap = List(length=nheads, fill=Scalar[dtype](0))
+    var dt_bias_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        dt_bias_heap, RuntimeLayout[layout_1d].row_major(Index(nheads))
+    )
+    var dt_bias_tt = TileTensor(
+        dt_bias_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(nheads)
+    )
+
+    var A_heap = List(length=nheads, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        A_heap, RuntimeLayout[layout_1d].row_major(Index(nheads))
+    )
+    var A_tt = TileTensor(
+        A_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(nheads)
+    )
+
+    var D_heap = List(length=nheads * headdim, fill=Scalar[dtype](0))
+    var D_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        D_heap,
+        RuntimeLayout[layout_2d].row_major(Index(nheads, headdim)),
+    )
+    var D_tt = TileTensor(
+        D_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(nheads, headdim)
+    )
+
+    var x_heap = List(
+        length=batch * dim * n_chunks * 2 * DSTATE, fill=Scalar[dtype](0)
+    )
+    var x_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        x_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, dim, n_chunks, 2 * DSTATE)
+        ),
+    )
+    var x_tt = TileTensor(
+        x_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, n_chunks, 2 * DSTATE),
+    )
+
+    var out_z_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var out_z_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        out_z_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var out_z_tt = TileTensor(
+        out_z_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var dt_heap = List(length=batch * nheads * seqlen, fill=Scalar[dtype](0))
+    var dt_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        dt_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, nheads, seqlen)),
+    )
+    var dt_tt = TileTensor(
+        dt_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, nheads, seqlen),
+    )
+
+    var B_heap = List(
+        length=batch * ngroups * DSTATE * seqlen, fill=Scalar[dtype](0)
+    )
+    var B_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, ngroups, DSTATE, seqlen)
+        ),
+    )
+    var B_tt = TileTensor(
+        B_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, ngroups, DSTATE, seqlen),
+    )
+
+    var C_heap = List(
+        length=batch * ngroups * DSTATE * seqlen, fill=Scalar[dtype](0)
+    )
+    var C_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, ngroups, DSTATE, seqlen)
+        ),
+    )
+    var C_tt = TileTensor(
+        C_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, ngroups, DSTATE, seqlen),
+    )
+
+    var z_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var z_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        z_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var z_tt = TileTensor(
+        z_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var rmsnorm_weight_heap = List(length=dim, fill=Scalar[dtype](0))
+    var rmsnorm_weight_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        rmsnorm_weight_heap, RuntimeLayout[layout_1d].row_major(Index(dim))
+    )
+    var rmsnorm_weight_tt = TileTensor(
+        rmsnorm_weight_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(dim)
+    )
+
+    var outproj_weight_heap = List(length=1, fill=Scalar[dtype](0))
+    var outproj_weight_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        outproj_weight_heap,
+        RuntimeLayout[layout_2d].row_major(Index(0, 0)),
+    )
+    var outproj_weight_tt = TileTensor(
+        outproj_weight_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(0, 0)
+    )
+
+    var outproj_bias_heap = List(length=1, fill=Scalar[dtype](0))
+    var outproj_bias_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        outproj_bias_heap, RuntimeLayout[layout_1d].row_major(Index(0))
+    )
+    var outproj_bias_tt = TileTensor(
+        outproj_bias_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(0)
+    )
+
+    var output_heap = List(length=batch * seqlen * dim, fill=Scalar[dtype](0))
+    var output_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        output_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, seqlen, dim)),
+    )
+    var output_tt = TileTensor(
+        output_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, seqlen, dim),
+    )
+
+    random(zxbcdt_h)
+    random(conv_weight_h)
+    random(conv_bias_h)
+    random(dt_bias_h)
+    random(A_h)
+    random(D_h)
+    random(rmsnorm_weight_h)
+    # Keep RMSNorm weight positive.
+    for i in range(dim):
+        rmsnorm_weight_h.ptr[i] = abs(rmsnorm_weight_h.ptr[i]) + Scalar[dtype](
+            0.1
+        )
+
+    var epsilon = Scalar[dtype](0.001)
+
+    mamba_split_conv1d_scan_combined_cpu[
+        dtype,
+        DSTATE,
+        zxbcdt_tt.LayoutType,
+        conv_weight_tt.LayoutType,
+        conv_bias_tt.LayoutType,
+        output_tt.LayoutType,
+        x_tt.LayoutType,
+        out_z_tt.LayoutType,
+        dt_tt.LayoutType,
+        A_tt.LayoutType,
+        B_tt.LayoutType,
+        C_tt.LayoutType,
+        D_tt.LayoutType,
+        z_tt.LayoutType,
+        dt_bias_tt.LayoutType,
+        rmsnorm_weight_tt.LayoutType,
+        outproj_weight_tt.LayoutType,
+        outproj_bias_tt.LayoutType,
+    ](
+        batch,
+        seqlen,
+        dim,
+        nheads,
+        headdim,
+        ngroups,
+        width,
+        chunk_size,
+        Int8(0),  # delta_softplus
+        Int8(0),  # norm_before_gate
+        Int8(1),  # has_rmsnorm
+        Int8(0),  # has_outproj
+        zxbcdt_tt,
+        conv_weight_tt,
+        conv_bias_tt,
+        dt_bias_tt,
+        A_tt,
+        D_tt,
+        x_tt,
+        out_z_tt,
+        dt_tt,
+        B_tt,
+        C_tt,
+        z_tt,
+        rmsnorm_weight_tt,
+        outproj_weight_tt,
+        outproj_bias_tt,
+        output_tt,
+        epsilon,
+    )
+
+    # Shape check + finite check.
+    assert_true(output_h.dim(0) == batch)
+    assert_true(output_h.dim(1) == seqlen)
+    assert_true(output_h.dim(2) == dim)
+
+    var out_size = batch * seqlen * dim
+    for i in range(out_size):
+        var v = Float32(output_h.ptr[i])
+        assert_true(v == v, "output contains NaN")
+        assert_true((v - v) == 0.0, "output contains Inf")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_chunk.mojo
+++ b/max/kernels/test/state_space/test_ssd_chunk.mojo
@@ -1,0 +1,519 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from layout import Layout, LayoutTensor, RuntimeLayout
+from layout._fillers import random
+from state_space.ssd_chunk import (
+    ssd_intra_chunk_fwd_cpu,
+    ssd_intra_chunk_fwd_cpu_naive,
+)
+from std.math import exp
+from std.testing import TestSuite, assert_almost_equal
+
+from std.utils.index import Index
+
+
+def run_ssd_intra_chunk[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test the optimized SSD intra-chunk CPU kernel against an independent reference.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    # C: [batch, n_chunks, n_heads, chunk_len, state_dim]
+    var C_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var C_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+
+    # B: [batch, n_chunks, n_heads, chunk_len, state_dim]
+    var B_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+
+    # X: [batch, n_chunks, n_heads, chunk_len, head_dim]
+    var X_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # A: [batch, n_chunks, n_heads, chunk_len]
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+
+    # Y: [batch, n_chunks, n_heads, chunk_len, head_dim]
+    var Y_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var Y_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # Initialize inputs.
+    random(C_h)
+    random(B_h)
+    random(X_h)
+    random(A_h)
+
+    # Make A negative-ish (a real SSM decays), so exp(cumsum diffs) stays
+    # bounded. `random` fills in roughly [-1, 1]; map it into a small negative
+    # range like real Mamba2 dt*A values.
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        # Map [-1, 1] -> [-0.6, -0.1].
+        var scaled = Float32(-0.35) + Float32(0.25) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    # Call the optimized kernel.
+    ssd_intra_chunk_fwd_cpu[
+        dtype,
+        C_h.layout,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        Y_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        C_h,
+        B_h,
+        X_h,
+        A_h,
+        Y_h,
+        ctx=None,
+    )
+
+    # Independent naive reference. Recompute strides from scratch and use a
+    # straightforward triple-loop of the formula:
+    #   A_cumsum[l] = sum_{k<=l} A[k]
+    #   Ldecay[l,s] = exp(A_cumsum[l] - A_cumsum[s])  for s <= l
+    #   scores[l,s] = (sum_n C[l,n]*B[s,n]) * Ldecay[l,s]
+    #   Y[l,p]      = sum_{s<=l} scores[l,s] * X[s,p]
+    var ref_heap = List(length=xy_count, fill=Scalar[dtype](0))
+
+    var cb_h_stride = chunk_len * state_dim
+    var cb_c_stride = n_heads * cb_h_stride
+    var cb_b_stride = n_chunks * cb_c_stride
+
+    var xy_h_stride = chunk_len * head_dim
+    var xy_c_stride = n_heads * xy_h_stride
+    var xy_b_stride = n_chunks * xy_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var cb_base = (
+                    b * cb_b_stride + c * cb_c_stride + h * cb_h_stride
+                )
+                var xy_base = (
+                    b * xy_b_stride + c * xy_c_stride + h * xy_h_stride
+                )
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+
+                # Prefix sum of A over the chunk.
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                for l in range(chunk_len):
+                    for p in range(head_dim):
+                        var y_acc = Float32(0.0)
+                        for s in range(l + 1):
+                            # dot(C[l,:], B[s,:]).
+                            var dot = Float32(0.0)
+                            for n in range(state_dim):
+                                var cv = C_h.ptr[
+                                    cb_base + l * state_dim + n
+                                ].cast[DType.float32]()
+                                var bv = B_h.ptr[
+                                    cb_base + s * state_dim + n
+                                ].cast[DType.float32]()
+                                dot += cv * bv
+                            var decay = exp(cumsum[l] - cumsum[s])
+                            var xv = X_h.ptr[xy_base + s * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            y_acc += dot * decay * xv
+                        ref_heap[xy_base + l * head_dim + p] = Scalar[dtype](
+                            y_acc
+                        )
+
+    # Compare kernel output against the reference.
+    for i in range(xy_count):
+        assert_almost_equal(
+            Y_h.ptr[i],
+            ref_heap[i],
+            rtol=rtol,
+        )
+
+
+def test_ssd_intra_chunk_golden() raises:
+    """Golden-parity test against the canonical PyTorch SSD reference.
+
+    Pins ``ssd_intra_chunk_fwd_cpu_naive`` to a FIXED tiny input whose expected
+    output was computed independently by ``intra_chunk_diag`` in
+    ``.planning/parity/ssd_minimal_ref.py`` (the vendored pure-PyTorch
+    ``ssd_minimal_discrete`` stage-1 diagonal block).
+
+    Shapes: batch=1, n_chunks=1, n_heads=1, chunk_len L=4, state_dim N=3,
+    head_dim P=2; all tensors row-major.
+    """
+    comptime dtype = DType.float32
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    # Fixed literals (row-major). These mirror the values in the parity
+    # reference; Y_expected is the reference's output for these inputs.
+    var C_vals = [
+        Float32(-0.15),
+        0.79,
+        0.95,
+        -1.11,
+        1.69,
+        -0.89,
+        -0.36,
+        1.23,
+        0.14,
+        -1.68,
+        0.32,
+        0.13,
+    ]
+    var B_vals = [
+        Float32(0.14),
+        0.24,
+        1.40,
+        1.35,
+        2.44,
+        0.20,
+        2.45,
+        2.03,
+        1.78,
+        -0.92,
+        -0.46,
+        -0.72,
+    ]
+    var X_vals = [
+        Float32(1.28),
+        -0.99,
+        1.81,
+        -0.60,
+        1.61,
+        1.93,
+        -0.42,
+        -0.08,
+    ]
+    var A_vals = [Float32(-0.43), -0.34, -0.49, -0.46]
+    var Y_expected = [
+        Float32(1.918208),
+        -1.483614,
+        3.522012,
+        -0.766567,
+        6.067267,
+        2.472605,
+        -4.850489,
+        -3.713203,
+    ]
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    # Build LayoutTensors from the fixed literals (not random).
+    var C_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var C_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    for i in range(cb_count):
+        C_h.ptr[i] = Scalar[dtype](C_vals[i])
+
+    var B_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    for i in range(cb_count):
+        B_h.ptr[i] = Scalar[dtype](B_vals[i])
+
+    var X_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    for i in range(xy_count):
+        X_h.ptr[i] = Scalar[dtype](X_vals[i])
+
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    for i in range(a_count):
+        A_h.ptr[i] = Scalar[dtype](A_vals[i])
+
+    var Y_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var Y_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    ssd_intra_chunk_fwd_cpu_naive[
+        dtype,
+        C_h.layout,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        Y_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        C_h,
+        B_h,
+        X_h,
+        A_h,
+        Y_h,
+    )
+
+    # Pin to the canonical PyTorch reference numerics.
+    for i in range(xy_count):
+        assert_almost_equal(
+            Y_h.ptr[i],
+            Scalar[dtype](Y_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_intra_chunk_basic() raises:
+    """Basic single-batch, single-chunk case."""
+    run_ssd_intra_chunk[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=16,
+        head_dim=8,
+    )
+
+
+def test_ssd_intra_chunk_multi_chunk() raises:
+    """Multiple chunks and heads."""
+    run_ssd_intra_chunk[DType.float32](
+        batch=1,
+        n_chunks=3,
+        n_heads=2,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=8,
+    )
+
+
+def test_ssd_intra_chunk_multi_batch() raises:
+    """Multiple batch elements."""
+    run_ssd_intra_chunk[DType.float32](
+        batch=2,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=4,
+    )
+
+
+def test_ssd_intra_chunk_chunk_len_one() raises:
+    """Degenerate chunk length of one (only the diagonal term)."""
+    run_ssd_intra_chunk[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=1,
+        chunk_len=1,
+        state_dim=4,
+        head_dim=4,
+    )
+
+
+def test_ssd_intra_chunk_optimized_matches_naive() raises:
+    """Optimized CPU kernel matches the naive scalar reference."""
+    comptime dtype = DType.float32
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    comptime batch = 1
+    comptime n_chunks = 2
+    comptime n_heads = 2
+    comptime chunk_len = 16
+    comptime state_dim = 16
+    comptime head_dim = 8
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var C_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    var B_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    var X_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    var Y_fast_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var Y_fast_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_fast_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    var Y_naive_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var Y_naive_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_naive_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    random(C_h)
+    random(B_h)
+    random(X_h)
+    random(A_h)
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        A_h.ptr[i] = Scalar[dtype](Float32(-0.35) + Float32(0.25) * v)
+
+    ssd_intra_chunk_fwd_cpu[
+        dtype,
+        C_h.layout,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        Y_fast_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        C_h,
+        B_h,
+        X_h,
+        A_h,
+        Y_fast_h,
+    )
+    ssd_intra_chunk_fwd_cpu_naive[
+        dtype,
+        C_h.layout,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        Y_naive_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        C_h,
+        B_h,
+        X_h,
+        A_h,
+        Y_naive_h,
+    )
+
+    for i in range(xy_count):
+        assert_almost_equal(Y_fast_h.ptr[i], Y_naive_h.ptr[i], rtol=1e-4)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_chunk_combine.mojo
+++ b/max/kernels/test/state_space/test_ssd_chunk_combine.mojo
@@ -1,0 +1,375 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from layout import Layout, LayoutTensor, RuntimeLayout
+from layout._fillers import random
+from state_space.ssd_chunk_combine import ssd_output_recombination_fwd_cpu
+from std.math import exp
+from std.testing import TestSuite, assert_almost_equal
+
+from std.utils.index import Index
+
+
+def run_ssd_output_recombination[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test the SSD output-recombination kernel against an independent ref."""
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    # C: [batch, n_chunks, n_heads, chunk_len, state_dim]
+    var c_heap = List(length=c_count, fill=Scalar[dtype](0))
+    var c_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        c_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+
+    # entering_state: [batch, n_chunks, n_heads, head_dim, state_dim]
+    var ent_heap = List(length=ent_count, fill=Scalar[dtype](0))
+    var ent_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        ent_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # A: [batch, n_chunks, n_heads, chunk_len]
+    var a_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var a_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        a_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+
+    # Y_diag: [batch, n_chunks, n_heads, chunk_len, head_dim]
+    var yd_heap = List(length=y_count, fill=Scalar[dtype](0))
+    var yd_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        yd_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # Y: [batch, n_chunks, n_heads, chunk_len, head_dim]
+    var y_heap = List(length=y_count, fill=Scalar[dtype](0))
+    var y_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        y_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # Initialize inputs.
+    random(c_h)
+    random(ent_h)
+    random(a_h)
+    random(yd_h)
+
+    # Make A negative (a real SSM decays). `random` fills in roughly [-1, 1];
+    # map it into [-0.6, -0.1] like a real per-token in-chunk log-decay.
+    for i in range(a_count):
+        var v = a_h.ptr[i].cast[DType.float32]()
+        # Map [-1, 1] -> [-0.6, -0.1].
+        var scaled = Float32(-0.35) + Float32(0.25) * v
+        a_h.ptr[i] = Scalar[dtype](scaled)
+
+    # Call the kernel.
+    ssd_output_recombination_fwd_cpu[
+        dtype,
+        c_h.layout,
+        ent_h.layout,
+        a_h.layout,
+        yd_h.layout,
+        y_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        head_dim,
+        state_dim,
+        c_h,
+        ent_h,
+        a_h,
+        yd_h,
+        y_h,
+    )
+
+    # Independent naive reference. Recompute strides from scratch:
+    #   A_cumsum[l] = sum_{k<=l} A[k]
+    #   decay[l]    = exp(A_cumsum[l])
+    #   Y_off[l,p]  = decay[l] * sum_n C[l,n] * entering[p,n]
+    #   Y[l,p]      = Y_diag[l,p] + Y_off[l,p]
+    var ref_y = List(length=y_count, fill=Scalar[dtype](0))
+
+    var c_l_stride = state_dim
+    var c_h_stride = chunk_len * c_l_stride
+    var c_c_stride = n_heads * c_h_stride
+    var c_b_stride = n_chunks * c_c_stride
+
+    var ent_p_stride = state_dim
+    var ent_h_stride = head_dim * ent_p_stride
+    var ent_c_stride = n_heads * ent_h_stride
+    var ent_b_stride = n_chunks * ent_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var y_l_stride = head_dim
+    var y_h_stride = chunk_len * y_l_stride
+    var y_c_stride = n_heads * y_h_stride
+    var y_b_stride = n_chunks * y_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var c_base = b * c_b_stride + c * c_c_stride + h * c_h_stride
+                var ent_base = (
+                    b * ent_b_stride + c * ent_c_stride + h * ent_h_stride
+                )
+                var y_base = b * y_b_stride + c * y_c_stride + h * y_h_stride
+
+                var a_cumsum = Float32(0.0)
+                for l in range(chunk_len):
+                    a_cumsum += a_h.ptr[a_base + l].cast[DType.float32]()
+                    var decay = exp(a_cumsum)
+                    for p in range(head_dim):
+                        var acc = Float32(0.0)
+                        for n in range(state_dim):
+                            var c_val = c_h.ptr[
+                                c_base + l * c_l_stride + n
+                            ].cast[DType.float32]()
+                            var ent_val = ent_h.ptr[
+                                ent_base + p * ent_p_stride + n
+                            ].cast[DType.float32]()
+                            acc += c_val * ent_val
+                        var y_off = decay * acc
+                        var yd_val = yd_h.ptr[y_base + l * y_l_stride + p].cast[
+                            DType.float32
+                        ]()
+                        ref_y[y_base + l * y_l_stride + p] = Scalar[dtype](
+                            yd_val + y_off
+                        )
+
+    # Compare kernel output against the reference.
+    for i in range(y_count):
+        assert_almost_equal(y_h.ptr[i], ref_y[i], rtol=rtol)
+
+
+def test_ssd_output_recombination_golden() raises:
+    """Golden-parity test against the canonical PyTorch SSD reference.
+
+    Pins ``ssd_output_recombination_fwd_cpu`` to a FIXED tiny input whose
+    expected output was computed independently by the stage-4 output
+    recombination of ``ssd_minimal_discrete``.
+
+    Shapes: batch=1, n_chunks=1, n_heads=1, chunk_len L=4, state_dim N=3,
+    head_dim P=2; all tensors row-major.
+    """
+    comptime dtype = DType.float32
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    # Fixed literals (row-major).
+    # C is L x N; entering is P x N; A is L; Y_diag is L x P.
+    var c_vals = [
+        Float32(0.35),
+        -0.57,
+        -0.39,
+        -0.29,
+        -0.45,
+        0.92,
+        -0.76,
+        1.06,
+        -0.12,
+        0.58,
+        0.47,
+        0.30,
+    ]
+    var ent_vals = [
+        Float32(0.56),
+        2.29,
+        2.11,
+        0.30,
+        0.03,
+        -0.57,
+    ]
+    var a_vals = [Float32(-0.51), -0.14, -0.32, -0.54]
+    var yd_vals = [
+        Float32(0.24),
+        0.69,
+        1.40,
+        -0.14,
+        -0.35,
+        -2.05,
+        -0.44,
+        -1.53,
+    ]
+    var y_expected = [
+        Float32(-0.920277),
+        0.876274,
+        1.790647,
+        -0.466226,
+        0.312865,
+        -2.098447,
+        0.009353,
+        -1.526222,
+    ]
+
+    var c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var c_heap = List(length=c_count, fill=Scalar[dtype](0))
+    var c_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        c_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    for i in range(c_count):
+        c_h.ptr[i] = Scalar[dtype](c_vals[i])
+
+    var ent_heap = List(length=ent_count, fill=Scalar[dtype](0))
+    var ent_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        ent_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    for i in range(ent_count):
+        ent_h.ptr[i] = Scalar[dtype](ent_vals[i])
+
+    var a_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var a_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        a_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    for i in range(a_count):
+        a_h.ptr[i] = Scalar[dtype](a_vals[i])
+
+    var yd_heap = List(length=y_count, fill=Scalar[dtype](0))
+    var yd_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        yd_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    for i in range(y_count):
+        yd_h.ptr[i] = Scalar[dtype](yd_vals[i])
+
+    var y_heap = List(length=y_count, fill=Scalar[dtype](0))
+    var y_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        y_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    ssd_output_recombination_fwd_cpu[
+        dtype,
+        c_h.layout,
+        ent_h.layout,
+        a_h.layout,
+        yd_h.layout,
+        y_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        head_dim,
+        state_dim,
+        c_h,
+        ent_h,
+        a_h,
+        yd_h,
+        y_h,
+    )
+
+    # Pin to the canonical PyTorch reference numerics.
+    for i in range(y_count):
+        assert_almost_equal(
+            y_h.ptr[i],
+            Scalar[dtype](y_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_output_recombination_basic() raises:
+    """Basic single-batch, single-head case against the naive reference."""
+    run_ssd_output_recombination[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        head_dim=8,
+        state_dim=16,
+    )
+
+
+def test_ssd_output_recombination_multi_batch() raises:
+    """Multiple batch elements and heads against the naive reference."""
+    run_ssd_output_recombination[DType.float32](
+        batch=2,
+        n_chunks=3,
+        n_heads=3,
+        chunk_len=5,
+        head_dim=4,
+        state_dim=8,
+    )
+
+
+def test_ssd_output_recombination_single_chunk() raises:
+    """Single chunk, single token edge case against the naive reference."""
+    run_ssd_output_recombination[DType.float32](
+        batch=2,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=1,
+        head_dim=4,
+        state_dim=4,
+    )
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_chunk_combined_ops.mojo
+++ b/max/kernels/test/state_space/test_ssd_chunk_combined_ops.mojo
@@ -1,0 +1,217 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""End-to-end parity test for the fused SSD ``ssd_chunk_scan_combined`` op.
+
+Mirrors the golden literals from RFC 0002's pipeline checkpoint
+(b=1, seqlen=4, n_heads=1, head_dim=2, state_dim=3, chunk_size=2),
+where the expected output was independently computed via the vendored
+``ssd_minimal_discrete`` reference. The test calls the CPU implementation
+that backs the ``@extensibility.register("ssd_chunk_scan_combined")`` op and
+asserts the per-element output matches the reference golden within the
+parity tolerance (rtol=1e-3, atol=1e-3).
+
+The `@extensibility.register` registration itself is validated at build time:
+if the struct's ``execute`` signature does not match the extensibility ABI,
+the ``//max/kernels/src/state_space:state_space`` library fails to compile.
+"""
+
+from state_space.ssd_chunk_combined_ops import _ssd_chunk_scan_combined_cpu
+from std.testing import TestSuite, assert_almost_equal
+
+
+def test_ssd_chunk_scan_combined_cpu_golden_parity() raises:
+    """Parity vs golden: b=1, seqlen=4, n_heads=1, head_dim=2, state_dim=3.
+
+    Golden Y_expected (row-major, shape [batch, seqlen, n_heads, head_dim]):
+        [ 0.126999, -0.028039,
+          0.191223, -0.003887,
+         -0.370202, -0.111640,
+         -0.005157, -0.252940 ]
+    """
+    comptime dtype = DType.float32
+
+    var batch = 1
+    var seqlen = 4
+    var n_heads = 1
+    var head_dim = 2
+    var state_dim = 3
+    var chunk_size = 2
+
+    var x_size = batch * seqlen * n_heads * head_dim
+    var dt_size = batch * seqlen * n_heads
+    var A_size = n_heads
+    var bc_size = batch * seqlen * n_heads * state_dim
+    var y_size = x_size
+    var final_state_size = batch * n_heads * head_dim * state_dim
+
+    # x: [batch, seqlen, n_heads, head_dim], row-major
+    var x = List[Scalar[dtype]](length=x_size, fill=Scalar[dtype](0))
+    var x_vals: List[Float32] = [
+        0.77,
+        -0.17,
+        -0.66,
+        -0.39,
+        0.31,
+        -0.62,
+        -1.19,
+        -1.28,
+    ]
+    for i in range(x_size):
+        x[i] = x_vals[i].cast[dtype]()
+
+    # dt: [batch, seqlen, n_heads]
+    var dt = List[Scalar[dtype]](length=dt_size, fill=Scalar[dtype](0))
+    var dt_vals: List[Float32] = [0.33, 0.26, 0.12, 0.24]
+    for i in range(dt_size):
+        dt[i] = dt_vals[i].cast[dtype]()
+
+    # A: [n_heads]
+    var A = List[Scalar[dtype]](length=A_size, fill=Scalar[dtype](0))
+    A[0] = Scalar[dtype](-1.2)
+
+    # B: [batch, seqlen, n_heads, state_dim]
+    var B = List[Scalar[dtype]](length=bc_size, fill=Scalar[dtype](0))
+    var B_vals: List[Float32] = [
+        -0.91,
+        0.56,
+        -1.13,
+        -0.41,
+        0.59,
+        0.28,
+        1.46,
+        0.67,
+        0.19,
+        -0.05,
+        0.00,
+        -0.72,
+    ]
+    for i in range(bc_size):
+        B[i] = B_vals[i].cast[dtype]()
+
+    # C: [batch, seqlen, n_heads, state_dim]
+    var C = List[Scalar[dtype]](length=bc_size, fill=Scalar[dtype](0))
+    var C_vals: List[Float32] = [
+        0.64,
+        -0.61,
+        -1.26,
+        -1.05,
+        -1.03,
+        -0.35,
+        1.92,
+        0.30,
+        1.47,
+        -0.55,
+        1.06,
+        -0.74,
+    ]
+    for i in range(bc_size):
+        C[i] = C_vals[i].cast[dtype]()
+
+    var Y = List[Scalar[dtype]](length=y_size, fill=Scalar[dtype](0))
+    var final_state = List[Scalar[dtype]](
+        length=final_state_size, fill=Scalar[dtype](0)
+    )
+
+    _ssd_chunk_scan_combined_cpu[dtype](
+        batch,
+        seqlen,
+        n_heads,
+        head_dim,
+        state_dim,
+        chunk_size,
+        x.unsafe_ptr(),
+        dt.unsafe_ptr(),
+        A.unsafe_ptr(),
+        B.unsafe_ptr(),
+        C.unsafe_ptr(),
+        Y.unsafe_ptr(),
+        final_state.unsafe_ptr(),
+    )
+
+    # Expected golden, row-major [batch, seqlen, n_heads, head_dim].
+    var expected: List[Float32] = [
+        0.126999,
+        -0.028039,
+        0.191223,
+        -0.003887,
+        -0.370202,
+        -0.111640,
+        -0.005157,
+        -0.252940,
+    ]
+
+    for i in range(y_size):
+        assert_almost_equal(
+            Y[i],
+            expected[i].cast[dtype](),
+            atol=1e-3,
+            rtol=1e-3,
+        )
+
+    # Expected golden for final_state, row-major
+    # [batch, n_heads, head_dim, state_dim]. Computed by the vendored
+    # ``ssd_minimal_discrete`` reference for the same inputs (see
+    # .planning/parity/ssd_minimal_ref.py).
+    var expected_final_state: List[Float32] = [
+        -0.009206,
+        0.020579,
+        0.043290,
+        -0.014832,
+        -0.091143,
+        0.222278,
+    ]
+
+    for i in range(final_state_size):
+        assert_almost_equal(
+            final_state[i],
+            expected_final_state[i].cast[dtype](),
+            atol=1e-3,
+            rtol=1e-3,
+        )
+
+
+def test_ssd_chunk_scan_combined_cpu_chunk_divides_seqlen() raises:
+    """The op must raise when seqlen is not divisible by chunk_size."""
+    comptime dtype = DType.float32
+    var x = List[Scalar[dtype]](length=4, fill=Scalar[dtype](0))
+    var dt = List[Scalar[dtype]](length=4, fill=Scalar[dtype](0))
+    var A = List[Scalar[dtype]](length=1, fill=Scalar[dtype](0))
+    var B = List[Scalar[dtype]](length=4, fill=Scalar[dtype](0))
+    var C = List[Scalar[dtype]](length=4, fill=Scalar[dtype](0))
+    var Y = List[Scalar[dtype]](length=4, fill=Scalar[dtype](0))
+    var final_state = List[Scalar[dtype]](length=1, fill=Scalar[dtype](0))
+    var raised = False
+    try:
+        _ssd_chunk_scan_combined_cpu[dtype](
+            1,  # batch
+            4,  # seqlen
+            1,  # n_heads
+            1,  # head_dim
+            1,  # state_dim
+            3,  # chunk_size (4 % 3 != 0)
+            x.unsafe_ptr(),
+            dt.unsafe_ptr(),
+            A.unsafe_ptr(),
+            B.unsafe_ptr(),
+            C.unsafe_ptr(),
+            Y.unsafe_ptr(),
+            final_state.unsafe_ptr(),
+        )
+    except _:
+        raised = True
+    if not raised:
+        raise Error("Expected divisibility check to raise")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_chunk_scan.mojo
+++ b/max/kernels/test/state_space/test_ssd_chunk_scan.mojo
@@ -1,0 +1,345 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from layout import Layout, LayoutTensor, RuntimeLayout
+from layout._fillers import random
+from state_space.ssd_chunk_scan import ssd_chunk_scan_fwd_cpu
+from std.math import exp
+from std.testing import TestSuite, assert_almost_equal
+
+from std.utils.index import Index
+
+
+def run_ssd_chunk_scan[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test the SSD inter-chunk scan kernel against an independent reference."""
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var cs_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var cd_count = batch * n_chunks * n_heads
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var final_count = batch * n_heads * head_dim * state_dim
+
+    # chunk_states: [batch, n_chunks, n_heads, head_dim, state_dim]
+    var cs_heap = List(length=cs_count, fill=Scalar[dtype](0))
+    var cs_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        cs_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # chunk_decays: [batch, n_chunks, n_heads]
+    var cd_heap = List(length=cd_count, fill=Scalar[dtype](0))
+    var cd_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        cd_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, n_chunks, n_heads)),
+    )
+
+    # entering: [batch, n_chunks, n_heads, head_dim, state_dim]
+    var ent_heap = List(length=ent_count, fill=Scalar[dtype](0))
+    var ent_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        ent_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # final: [batch, n_heads, head_dim, state_dim]
+    var final_heap = List(length=final_count, fill=Scalar[dtype](0))
+    var final_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        final_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # Initialize inputs.
+    random(cs_h)
+    random(cd_h)
+
+    # Make chunk_decays negative (a real SSM decays). `random` fills in roughly
+    # [-1, 1]; map it into [-1.2, -0.3] like a real per-chunk total decay.
+    for i in range(cd_count):
+        var v = cd_h.ptr[i].cast[DType.float32]()
+        # Map [-1, 1] -> [-1.2, -0.3].
+        var scaled = Float32(-0.75) + Float32(0.45) * v
+        cd_h.ptr[i] = Scalar[dtype](scaled)
+
+    # Call the kernel.
+    ssd_chunk_scan_fwd_cpu[
+        dtype,
+        cs_h.layout,
+        cd_h.layout,
+        ent_h.layout,
+        final_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        head_dim,
+        state_dim,
+        cs_h,
+        cd_h,
+        ent_h,
+        final_h,
+    )
+
+    # Independent naive reference. Recompute strides from scratch and run the
+    # sequential recurrence per (batch, head):
+    #   state init 0
+    #   entering[c] = state
+    #   state = chunk_states[c] + exp(chunk_decays[c]) * state
+    #   final = state after the last chunk
+    var ref_ent = List(length=ent_count, fill=Scalar[dtype](0))
+    var ref_final = List(length=final_count, fill=Scalar[dtype](0))
+
+    var cs_h_stride = head_dim * state_dim
+    var cs_c_stride = n_heads * cs_h_stride
+    var cs_b_stride = n_chunks * cs_c_stride
+
+    var cd_c_stride = n_heads
+    var cd_b_stride = n_chunks * cd_c_stride
+
+    var ent_h_stride = head_dim * state_dim
+    var ent_c_stride = n_heads * ent_h_stride
+    var ent_b_stride = n_chunks * ent_c_stride
+
+    var final_h_stride = head_dim * state_dim
+    var final_b_stride = n_heads * final_h_stride
+
+    for b in range(batch):
+        for h in range(n_heads):
+            var state = List[Float32](length=head_dim * state_dim, fill=0.0)
+            for c in range(n_chunks):
+                var ent_base = (
+                    b * ent_b_stride + c * ent_c_stride + h * ent_h_stride
+                )
+                for pn in range(head_dim * state_dim):
+                    ref_ent[ent_base + pn] = Scalar[dtype](state[pn])
+
+                var cd_off = b * cd_b_stride + c * cd_c_stride + h
+                var decay = exp(cd_h.ptr[cd_off].cast[DType.float32]())
+
+                var cs_base = (
+                    b * cs_b_stride + c * cs_c_stride + h * cs_h_stride
+                )
+                for pn in range(head_dim * state_dim):
+                    var cs_val = cs_h.ptr[cs_base + pn].cast[DType.float32]()
+                    state[pn] = cs_val + decay * state[pn]
+
+            var final_base = b * final_b_stride + h * final_h_stride
+            for pn in range(head_dim * state_dim):
+                ref_final[final_base + pn] = Scalar[dtype](state[pn])
+
+    # Compare kernel output against the reference.
+    for i in range(ent_count):
+        assert_almost_equal(ent_h.ptr[i], ref_ent[i], rtol=rtol)
+    for i in range(final_count):
+        assert_almost_equal(final_h.ptr[i], ref_final[i], rtol=rtol)
+
+
+def test_ssd_chunk_scan_golden() raises:
+    """Golden-parity test against the canonical PyTorch SSD reference.
+
+    Pins ``ssd_chunk_scan_fwd_cpu`` to a FIXED tiny input whose expected output
+    was computed independently by the inter-chunk recurrence (stage 3 of
+    ``ssd_minimal_discrete``).
+
+    Shapes: batch=1, n_chunks=3, n_heads=1, head_dim P=2, state_dim N=3;
+    all tensors row-major.
+    """
+    comptime dtype = DType.float32
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    comptime batch = 1
+    comptime n_chunks = 3
+    comptime n_heads = 1
+    comptime head_dim = 2
+    comptime state_dim = 3
+
+    # Fixed literals (row-major). chunk_states is C x P x N; chunk_decays is C.
+    # entering_expected / final_expected are the reference's outputs.
+    var cs_vals = [
+        Float32(-0.90),
+        0.57,
+        0.91,
+        0.43,
+        1.29,
+        -0.17,
+        -0.86,
+        -0.66,
+        -0.70,
+        -0.10,
+        -0.62,
+        -0.63,
+        -0.58,
+        0.59,
+        0.12,
+        0.09,
+        1.04,
+        -0.18,
+    ]
+    var cd_vals = [Float32(-0.61), -1.03, -0.79]
+    var entering_expected = [
+        Float32(0.0),
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        -0.90,
+        0.57,
+        0.91,
+        0.43,
+        1.29,
+        -0.17,
+        -1.181306,
+        -0.456506,
+        -0.375124,
+        0.053513,
+        -0.159461,
+        -0.690691,
+    ]
+    var final_expected = [
+        Float32(-1.116130),
+        0.382817,
+        -0.050248,
+        0.114287,
+        0.967629,
+        -0.493467,
+    ]
+
+    var cs_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var cd_count = batch * n_chunks * n_heads
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var final_count = batch * n_heads * head_dim * state_dim
+
+    # Build LayoutTensors from the fixed literals (not random).
+    var cs_heap = List(length=cs_count, fill=Scalar[dtype](0))
+    var cs_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        cs_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    for i in range(cs_count):
+        cs_h.ptr[i] = Scalar[dtype](cs_vals[i])
+
+    var cd_heap = List(length=cd_count, fill=Scalar[dtype](0))
+    var cd_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        cd_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, n_chunks, n_heads)),
+    )
+    for i in range(cd_count):
+        cd_h.ptr[i] = Scalar[dtype](cd_vals[i])
+
+    var ent_heap = List(length=ent_count, fill=Scalar[dtype](0))
+    var ent_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        ent_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    var final_heap = List(length=final_count, fill=Scalar[dtype](0))
+    var final_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        final_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    ssd_chunk_scan_fwd_cpu[
+        dtype,
+        cs_h.layout,
+        cd_h.layout,
+        ent_h.layout,
+        final_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        head_dim,
+        state_dim,
+        cs_h,
+        cd_h,
+        ent_h,
+        final_h,
+    )
+
+    # Pin to the canonical PyTorch reference numerics.
+    for i in range(ent_count):
+        assert_almost_equal(
+            ent_h.ptr[i],
+            Scalar[dtype](entering_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+    for i in range(final_count):
+        assert_almost_equal(
+            final_h.ptr[i],
+            Scalar[dtype](final_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_chunk_scan_basic() raises:
+    """Basic single-batch, single-head case against the naive reference."""
+    run_ssd_chunk_scan[DType.float32](
+        batch=1,
+        n_chunks=4,
+        n_heads=2,
+        head_dim=8,
+        state_dim=16,
+    )
+
+
+def test_ssd_chunk_scan_multi_batch() raises:
+    """Multiple batch elements and heads against the naive reference."""
+    run_ssd_chunk_scan[DType.float32](
+        batch=2,
+        n_chunks=5,
+        n_heads=3,
+        head_dim=4,
+        state_dim=8,
+    )
+
+
+def test_ssd_chunk_scan_single_chunk() raises:
+    """Degenerate single chunk (entering is all zeros, final == chunk_states).
+    """
+    run_ssd_chunk_scan[DType.float32](
+        batch=2,
+        n_chunks=1,
+        n_heads=2,
+        head_dim=4,
+        state_dim=4,
+    )
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_chunk_state.mojo
+++ b/max/kernels/test/state_space/test_ssd_chunk_state.mojo
@@ -1,0 +1,359 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from layout import Layout, LayoutTensor, RuntimeLayout
+from layout._fillers import random
+from state_space.ssd_chunk_state import ssd_chunk_state_fwd_cpu
+from std.math import exp
+from std.testing import TestSuite, assert_almost_equal
+
+from std.utils.index import Index
+
+
+def run_ssd_chunk_state[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test the SSD chunk-state kernel against an independent reference."""
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    # B: [batch, n_chunks, n_heads, chunk_len, state_dim]
+    var B_heap = List(length=b_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+
+    # X: [batch, n_chunks, n_heads, chunk_len, head_dim]
+    var X_heap = List(length=x_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # A: [batch, n_chunks, n_heads, chunk_len]
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+
+    # state: [batch, n_chunks, n_heads, head_dim, state_dim]
+    var state_heap = List(length=state_count, fill=Scalar[dtype](0))
+    var state_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        state_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # Initialize inputs.
+    random(B_h)
+    random(X_h)
+    random(A_h)
+
+    # Make A negative-ish (a real SSM decays), so exp(cumsum diffs) stays
+    # bounded. `random` fills in roughly [-1, 1]; map it into a small negative
+    # range like real Mamba2 dt*A values.
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        # Map [-1, 1] -> [-0.6, -0.1].
+        var scaled = Float32(-0.35) + Float32(0.25) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    # Call the kernel.
+    ssd_chunk_state_fwd_cpu[
+        dtype,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        state_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        B_h,
+        X_h,
+        A_h,
+        state_h,
+    )
+
+    # Independent naive reference. Recompute strides from scratch and use a
+    # straightforward loop of the formula:
+    #   A_cumsum[l] = sum_{k<=l} A[k]
+    #   decay[l]    = exp(A_cumsum[L-1] - A_cumsum[l])
+    #   state[p,n]  = sum_l B[l,n] * decay[l] * X[l,p]
+    var ref_heap = List(length=state_count, fill=Scalar[dtype](0))
+
+    var b_h_stride = chunk_len * state_dim
+    var b_c_stride = n_heads * b_h_stride
+    var b_b_stride = n_chunks * b_c_stride
+
+    var x_h_stride = chunk_len * head_dim
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var state_h_stride = head_dim * state_dim
+    var state_c_stride = n_heads * state_h_stride
+    var state_b_stride = n_chunks * state_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var b_base = b * b_b_stride + c * b_c_stride + h * b_h_stride
+                var x_base = b * x_b_stride + c * x_c_stride + h * x_h_stride
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var state_base = (
+                    b * state_b_stride + c * state_c_stride + h * state_h_stride
+                )
+
+                # Prefix sum of A over the chunk.
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                var cum_end = cumsum[chunk_len - 1]
+
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var s_acc = Float32(0.0)
+                        for l in range(chunk_len):
+                            var bv = B_h.ptr[b_base + l * state_dim + n].cast[
+                                DType.float32
+                            ]()
+                            var xv = X_h.ptr[x_base + l * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            var decay = exp(cum_end - cumsum[l])
+                            s_acc += bv * decay * xv
+                        ref_heap[state_base + p * state_dim + n] = Scalar[
+                            dtype
+                        ](s_acc)
+
+    # Compare kernel output against the reference.
+    for i in range(state_count):
+        assert_almost_equal(
+            state_h.ptr[i],
+            ref_heap[i],
+            rtol=rtol,
+        )
+
+
+def test_ssd_chunk_state_golden() raises:
+    """Golden-parity test against the canonical PyTorch SSD reference.
+
+    Pins ``ssd_chunk_state_fwd_cpu`` to a FIXED tiny input whose expected
+    output was computed independently by the chunk end-state reduction (stage 2
+    of ``ssd_minimal_discrete``).
+
+    Shapes: batch=1, n_chunks=1, n_heads=1, chunk_len L=4, state_dim N=3,
+    head_dim P=2; all tensors row-major.
+    """
+    comptime dtype = DType.float32
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    # Fixed literals (row-major). These mirror the values in the parity
+    # reference; state_expected is the reference's output for these inputs.
+    var B_vals = [
+        Float32(0.74),
+        1.95,
+        -0.70,
+        -1.30,
+        -0.51,
+        -0.27,
+        0.25,
+        0.48,
+        0.45,
+        -0.96,
+        1.50,
+        -0.31,
+    ]
+    var X_vals = [
+        Float32(-0.23),
+        -1.07,
+        0.16,
+        0.12,
+        0.38,
+        -0.12,
+        0.89,
+        -0.49,
+    ]
+    var A_vals = [Float32(-0.45), -0.18, -0.36, -0.50]
+    var state_expected = [
+        Float32(-0.944955),
+        1.252577,
+        -0.133558,
+        0.106325,
+        -1.533317,
+        0.370175,
+    ]
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    # Build LayoutTensors from the fixed literals (not random).
+    var B_heap = List(length=b_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    for i in range(b_count):
+        B_h.ptr[i] = Scalar[dtype](B_vals[i])
+
+    var X_heap = List(length=x_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    for i in range(x_count):
+        X_h.ptr[i] = Scalar[dtype](X_vals[i])
+
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    for i in range(a_count):
+        A_h.ptr[i] = Scalar[dtype](A_vals[i])
+
+    var state_heap = List(length=state_count, fill=Scalar[dtype](0))
+    var state_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        state_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    ssd_chunk_state_fwd_cpu[
+        dtype,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        state_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        B_h,
+        X_h,
+        A_h,
+        state_h,
+    )
+
+    # Pin to the canonical PyTorch reference numerics.
+    for i in range(state_count):
+        assert_almost_equal(
+            state_h.ptr[i],
+            Scalar[dtype](state_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_chunk_state_basic() raises:
+    """Basic single-batch, single-chunk case."""
+    run_ssd_chunk_state[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=16,
+        head_dim=8,
+    )
+
+
+def test_ssd_chunk_state_multi_chunk() raises:
+    """Multiple chunks and heads."""
+    run_ssd_chunk_state[DType.float32](
+        batch=1,
+        n_chunks=3,
+        n_heads=2,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=8,
+    )
+
+
+def test_ssd_chunk_state_multi_batch() raises:
+    """Multiple batch elements."""
+    run_ssd_chunk_state[DType.float32](
+        batch=2,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=4,
+    )
+
+
+def test_ssd_chunk_state_chunk_len_one() raises:
+    """Degenerate chunk length of one (decay is exactly 1)."""
+    run_ssd_chunk_state[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=1,
+        chunk_len=1,
+        state_dim=4,
+        head_dim=4,
+    )
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_combined_op.mojo
+++ b/max/kernels/test/state_space/test_ssd_combined_op.mojo
@@ -1,0 +1,270 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Op-registration smoke test for the `ssd_combined` MAX graph op.
+
+Numerical parity is covered by `test_ssd_combined.mojo`; this file exists to
+ensure the @extensibility.register wrapper in `selective_scan_ops.mojo` is built
+into the state_space library (a malformed @extensibility.register block fails the
+library build), and that the underlying kernel is reachable via the same
+import path the wrapper uses.
+"""
+
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    UNKNOWN_VALUE,
+    row_major,
+)
+from layout._fillers import random
+from state_space.selective_scan import ssd_combined_cpu
+
+# Importing the ops module ensures the @extensibility.register-decorated structs
+# are part of the build graph for the consumer of the smoke test.
+import state_space.selective_scan_ops
+
+from std.testing import TestSuite, assert_true
+from std.utils.index import Index
+
+comptime MAX_DSTATE_LOCAL = 16
+
+
+def test_ssd_combined_op_registered() raises:
+    """Smoke test: ssd_combined op + underlying CPU kernel are callable.
+
+    Constructs tiny LayoutTensor inputs, invokes the CPU implementation that
+    the registered op dispatches to, and verifies the output buffer is finite
+    (no NaN/Inf) and shape-correct. Full numerical parity lives elsewhere.
+    """
+    comptime dtype = DType.float32
+    comptime DSTATE = 8
+    var batch = 1
+    var dim = 4
+    var seqlen = 4
+    var n_groups = 1
+    var group_size = dim // n_groups
+    var chunk_size = 2048
+    var n_chunks = (seqlen + chunk_size - 1) // chunk_size
+
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_2d = Layout.row_major[2]()
+    comptime layout_1d = Layout(UNKNOWN_VALUE)
+
+    var output_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var output_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        output_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var output_tt = TileTensor(
+        output_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var x_heap = List(
+        length=batch * dim * n_chunks * 2 * DSTATE, fill=Scalar[dtype](0)
+    )
+    var x_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        x_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, dim, n_chunks, 2 * DSTATE)
+        ),
+    )
+    var x_tt = TileTensor(
+        x_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, n_chunks, 2 * DSTATE),
+    )
+
+    var out_z_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var out_z_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        out_z_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var out_z_tt = TileTensor(
+        out_z_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var residual_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var residual_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        residual_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var residual_tt = TileTensor(
+        residual_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var u_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var u_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        u_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var u_tt = TileTensor(
+        u_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var delta_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var delta_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        delta_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var delta_tt = TileTensor(
+        delta_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var A_heap = List(length=dim * DSTATE, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        A_heap, RuntimeLayout[layout_2d].row_major(Index(dim, DSTATE))
+    )
+    var A_tt = TileTensor(
+        A_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(dim, DSTATE)
+    )
+
+    var B_heap = List(
+        length=batch * n_groups * DSTATE * seqlen, fill=Scalar[dtype](0)
+    )
+    var B_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_groups, DSTATE, seqlen)
+        ),
+    )
+    var B_tt = TileTensor(
+        B_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, n_groups, DSTATE, seqlen),
+    )
+
+    var C_heap = List(
+        length=batch * n_groups * DSTATE * seqlen, fill=Scalar[dtype](0)
+    )
+    var C_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_groups, DSTATE, seqlen)
+        ),
+    )
+    var C_tt = TileTensor(
+        C_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, n_groups, DSTATE, seqlen),
+    )
+
+    var D_heap = List(length=dim, fill=Scalar[dtype](0))
+    var D_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        D_heap, RuntimeLayout[layout_1d].row_major(Index(dim))
+    )
+    var D_tt = TileTensor(
+        D_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(dim)
+    )
+
+    var z_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var z_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        z_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var z_tt = TileTensor(
+        z_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var delta_bias_heap = List(length=dim, fill=Scalar[dtype](0))
+    var delta_bias_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        delta_bias_heap, RuntimeLayout[layout_1d].row_major(Index(dim))
+    )
+    var delta_bias_tt = TileTensor(
+        delta_bias_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(dim)
+    )
+
+    var gamma_heap = List(length=dim, fill=Scalar[dtype](0))
+    var gamma_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        gamma_heap, RuntimeLayout[layout_1d].row_major(Index(dim))
+    )
+    var gamma_tt = TileTensor(
+        gamma_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(dim)
+    )
+
+    random(u_h)
+    random(delta_h)
+    random(residual_h)
+    random(A_h)
+    random(B_h)
+    random(C_h)
+    random(D_h)
+    random(z_h)
+    random(delta_bias_h)
+    random(gamma_h)
+
+    # Keep gamma positive for RMSNorm stability.
+    for i in range(dim):
+        gamma_h.ptr[i] = abs(gamma_h.ptr[i]) + Scalar[dtype](0.1)
+
+    var epsilon = Scalar[dtype](0.001)
+    var weight_offset = Scalar[dtype](0.0)
+
+    ssd_combined_cpu[
+        dtype,
+        DSTATE,
+        output_tt.LayoutType,
+        x_tt.LayoutType,
+        out_z_tt.LayoutType,
+        residual_tt.LayoutType,
+        u_tt.LayoutType,
+        delta_tt.LayoutType,
+        A_tt.LayoutType,
+        B_tt.LayoutType,
+        C_tt.LayoutType,
+        D_tt.LayoutType,
+        z_tt.LayoutType,
+        delta_bias_tt.LayoutType,
+        gamma_tt.LayoutType,
+    ](
+        batch,
+        dim,
+        seqlen,
+        group_size,
+        Int8(0),
+        output_tt,
+        x_tt,
+        out_z_tt,
+        residual_tt,
+        u_tt,
+        delta_tt,
+        A_tt,
+        B_tt,
+        C_tt,
+        D_tt,
+        z_tt,
+        delta_bias_tt,
+        gamma_tt,
+        epsilon,
+        weight_offset,
+    )
+
+    # Shape check + finite check.
+    assert_true(output_h.dim(0) == batch)
+    assert_true(output_h.dim(1) == dim)
+    assert_true(output_h.dim(2) == seqlen)
+
+    var out_size = batch * dim * seqlen
+    for i in range(out_size):
+        var v = Float32(output_h.ptr[i])
+        assert_true(v == v, "output contains NaN")
+        # Inf check: an infinite float fails (v - v) == 0.
+        assert_true((v - v) == 0.0, "output contains Inf")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/mojo/proposals/ssd-chunk-kernels.md
+++ b/mojo/proposals/ssd-chunk-kernels.md
@@ -1,0 +1,113 @@
+# Proposal: Mamba2 SSD chunk-scan prefill kernels
+
+- **Status:** Draft (proposal)
+- **Author:** Evan Owen
+- **Area:** MAX AI kernels (`max/kernels/src/state_space/`)
+- **Tracking:** Phase 2 of the Linear-Attention / SSM roadmap
+
+## Summary
+
+Add the State Space Duality (SSD) **chunk-scan prefill** algorithm for Mamba2
+as a set of Mojo kernels under `max/kernels/src/state_space/`, plus a graph op
+`ssd_chunk_scan_combined`. This is the only genuinely new kernel work for
+Mamba2 — the decode path and all preprocessing already exist (see *Reuse*).
+Because state-space kernels are not on the
+[`max/kernels/CONTRIBUTING.md`](../../max/kernels/CONTRIBUTING.md) "changes we
+accept" list, this proposal seeks a kernels-lead go-ahead before
+implementation PRs.
+
+## Motivation
+
+Mamba2 ([Transformers are SSMs](https://arxiv.org/abs/2405.21060)) replaces
+Mamba1's diagonal selective scan with a scalar-times-identity `A` per head,
+which makes the recurrence equivalent to a structured form of linear attention.
+That equivalence lets prefill be computed **chunk-wise with dense matmuls** that
+map onto tensor cores, instead of a sequential scan. Mamba2 reference
+implementations report 2–8× faster training/prefill from this. MAX currently
+has no chunk-SSD kernel: the existing `ssd_combined` (`selective_scan.mojo`) is,
+despite its name, a Mamba1 *sequential* scan fused with norm+residual.
+
+## Reuse (no new work)
+
+Confirmed present in `max/kernels/src/state_space/`:
+
+| Capability                     | Symbol / file                                                                  | Mamba2 role                                                                                                    |
+|--------------------------------|--------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| Causal conv1d (prefill+update) | `causal_conv1d.mojo`                                                           | identical, reused                                                                                              |
+| Varlen conv1d                  | `varlen_causal_conv1d.mojo`                                                    | identical, reused                                                                                              |
+| Fused RMSNorm + residual       | `rms_norm_fused_residual.mojo`                                                 | identical, reused                                                                                              |
+| Single-token update (scalar A) | `selective_scan_update` (`selective_scan.mojo`)                                | **decode path**, reused as-is                                                                                  |
+| Fused conv+scan, multi-head    | `mamba_split_conv1d_scan_combined_{cpu,gpu}` (`selective_scan.mojo:2260,2766`) | usable Mamba2 **decode** path (already has `nheads`/`headdim`/`ngroups`, scalar A/head; sequential internally) |
+
+So **only the prefill chunk algorithm is new.**
+
+## Proposed design
+
+New file `max/kernels/src/state_space/ssd_chunk.mojo` (keep the 3.2k-line
+`selective_scan.mojo` untouched). The reference is `ssd_minimal_discrete`
+(Listing 1 of the paper). Note the discretization contract: the fused op takes
+raw `x, dt, A, B, C` and internally applies `x ← x·dt`, `A ← A·dt` — i.e. the
+op equals `ssd_minimal_discrete(x·dt, A·dt, B, C, chunk_size)`. Decompose into
+four kernels (each a separate PR), all operating on chunked
+tensors `(batch, n_chunks, chunk_len, n_heads, …)`:
+
+1. **Intra-chunk (diagonal) output.** Within-chunk token×token contribution.
+   `L = exp(segsum(A))`;
+   `Y_diag = einsum("bclhn,bcshn,bhcls,bcshp->bclhp", C, B, L, X)`.
+   Dense GEMM over `chunk_len`; the tensor-core hot path.
+2. **Per-chunk state.** Reduce each chunk to its end-state.
+   `decay = exp(A_cumsum[...,-1:] − A_cumsum)`;
+   `states = einsum("bclhn,bhcl,bclhp->bchpn", B, decay, X)`.
+3. **Inter-chunk recurrence.** Sequential scan over the per-chunk states
+   (length = `n_chunks` ≪ `seqlen`).
+   `decay_chunk = exp(segsum(pad(A_cumsum[...,−1])))`;
+   `new_states = einsum("bhzc,bchpn->bzhpn", decay_chunk, states)`; carries an
+   optional `initial_states` for varlen / cache continuation, emits
+   `final_state` for the SSM cache.
+4. **Output recombination.** Add the inter-chunk contribution.
+   `Y_off = einsum("bclhn,bchpn,bhcl->bclhp", C, states, exp(A_cumsum))`;
+   `Y = Y_diag + Y_off`.
+
+A combined op `ssd_chunk_scan_combined` (registered like
+`selective_scan_ops.mojo`'s `@compiler.register`) fuses dt-discretization,
+conv (optional), the four stages, and the final-state write so the Python
+pipeline calls a single op.
+
+### Dimensions & dtypes
+
+- `n_heads · head_dim = d_model`; `head_dim` 64–128; scalar `A` per head;
+  `n_groups` for B/C sharing; `d_state` (`N`) 64–128.
+- `chunk_size` tunable 64–256, default **128** (trades tensor-core utilization
+  against per-chunk state overhead).
+- Compute in fp32 accumulation; inputs bf16/fp16/fp32. The varlen scan path
+  already supports `MAX_DSTATE=256`, covering Mamba2's range.
+
+## Correctness / parity
+
+Gate every kernel against the PyTorch/CUDA reference: compare
+`ssd_chunk_scan_combined` to `mamba_chunk_scan_combined` and the pure-torch
+`ssd_minimal_discrete` on identical seeded inputs. Tolerances: fp32 rtol
+1e-5/atol 1e-6; fp16 1e-2/1e-3; bf16 2e-2/1e-2. Capture goldens for in-tree
+`assert_almost_equal` tests (`max/kernels/test/{,gpu/}state_space/`), so
+committed tests need no CUDA.
+
+## Testing
+
+- Mojo `std.testing` (`assert_almost_equal`), GPU tests gated on accelerator
+  count; CPU reference path where practical.
+- Per-stage unit tests + a combined-op test + the parity golden test.
+
+## Alternatives considered
+
+- **Extend `ssd_combined`** — rejected: it is Mamba1 sequential scan fused with
+  norm; the chunk algorithm is structurally different.
+- **Sequential scan for prefill** (reuse `mamba_split_conv1d_scan_combined`) —
+  works and is the decode path, but forgoes the tensor-core speedup that is the
+  entire point of Mamba2 prefill.
+
+## Rollout (PR split)
+
+One PR each: (1) intra-chunk kernel, (2) chunk-state kernel, (3) inter-chunk
+scan, (4) output recombination, (5) `ssd_chunk_scan_combined` op wrapper,
+(6) ops wrappers for the existing fused kernels (closes `TODO(MSTDL-2472)`),
+(7) Mamba2 dim parameterization. Each carries its own tests and parity report.


### PR DESCRIPTION
## Linked issue

Part of #5772 (Phase 2: Mamba2 / SSD). Design: the SSD chunk-kernels proposal in this stack.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [X] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Adds the `ssd_combined` op wrapper (SSD scan with fused dt/A handling and final_state output) and `mamba_split_conv1d_scan_combined`, which fuses the in-projection split, causal conv1d and the SSD scan for a Mamba2 layer. Closes the `TODO(MSTDL-2472)` left in `selective_scan_ops.mojo`.

## What changed

Add the ssd_combined op wrapper (SSD chunked scan with fused dt/A
handling and final_state output) and the mamba_split_conv1d_scan_combined
wrapper that fuses the in-projection split, causal conv1d, and SSD scan
for Mamba2 layers, plus CPU tests for both. Builds on the
ssd_chunk_scan_combined op wrapper added earlier in this stack.

```
.../src/state_space/selective_scan_ops.mojo        | 554 +++++++++++++++++++++
 .../test_mamba_split_conv1d_scan_combined_op.mojo  | 320 ++++++++++++
 .../test/state_space/test_ssd_combined_op.mojo     | 270 ++++++++++
 3 files changed, 1144 insertions(+)
```

## Testing

`test_ssd_combined_op.mojo` and `test_mamba_split_conv1d_scan_combined_op.mojo` CPU tests pass; existing `test_selective_scan.mojo` GPU test still passes. NVIDIA GB10.

## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [X] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [X] I ran `./bazelw run format` to format my changes
- [X] I added or updated tests to cover my changes

---

## Stack: Mamba2 (SSD) architecture

**Stacked on #6991.** This PR's diff on GitHub includes its prerequisites; review the last commit only (`405f625576`). It should merge after #6991.

Related but independent (not prerequisites): the Mamba1 kernel PRs #6628, #6632 (causal conv1d) and #6622, #6633 (selective scan) improve the conv/decode paths the Mamba2 model also uses; the SSD stack does not depend on them.

Full series (kernels first, then the MAX pipeline):

1. [Mojo] Propose Mamba2 SSD chunk-kernels algorithm (#6986)
2. [Kernels] Add Mamba2 SSD intra-chunk kernels (scalar + fused MMA) with tests and benches (#6987)
3. [Kernels] Add Mamba2 SSD chunk-state kernel (fused tensor-core path) with tests and benches (#6988)
4. [Kernels] Add Mamba2 SSD inter-chunk state-passing scan kernel with tests and benches (#6989)
5. [Kernels] Add Mamba2 SSD output-recombination kernel (tensor-core + fused stage-4 path) with tests and benches (#6990)
6. [Kernels] Add ssd_chunk_scan_combined op wrapper with final_state output (#6991)
7. **[Kernels] Add ssd_combined and mamba_split_conv1d_scan_combined op wrappers** (#6992)
8. [Kernels] Add Mamba2-dimension coverage test for the SSD prefill path (#6993)
9. [MAX] Fall back to model_type when the architectures field is missing from a HF config (#6994)
10. [MAX] Mamba2: add ssd_chunk_scan_combined functional-op wrapper (#6995)
11. [MAX] Mamba2: add Mamba2Mixer and Mamba2Block NN modules (#6996)
12. [MAX] Mamba2: add model config and HF weight adapters (#6997)
13. [MAX] Mamba2: add model, SSM cache, batch processor and memory planner (#6998)
14. [MAX] Mamba2: register the Mamba2ForCausalLM architecture (#6999)
15. [MAX] Mamba2: add MAX-vs-HF parity integration test (#7000)
