### PR TITLE
[MAX] Mamba2: register the Mamba2ForCausalLM architecture

### DIFF
--- a/max/kernels/benchmarks/BUILD.bazel
+++ b/max/kernels/benchmarks/BUILD.bazel
@@ -235,6 +235,7 @@ _CPU_TESTS = glob(
             "//max:max_mojo",
             "//max:nn",
             "//max:shmem",
+            "//max:state_space",
             "//max:structured_kernels",
             "@mojo//:std",
         ],

--- a/max/kernels/benchmarks/BUILD.bazel
+++ b/max/kernels/benchmarks/BUILD.bazel
@@ -24,6 +24,15 @@ _EXTRA_DEPS = {
     "gpu/state_space/prof_ssd_chunk_scan_only.mojo": [
         "//max/kernels/src/state_space",
     ],
+    "gpu/state_space/bench_ssd_chunk_combine.mojo": [
+        "//max/kernels/src/state_space",
+    ],
+    "gpu/state_space/prof_ssd_combine_only.mojo": [
+        "//max/kernels/src/state_space",
+    ],
+    "gpu/state_space/prof_ssd_combine_static.mojo": [
+        "//max/kernels/src/state_space",
+    ],
 }
 
 _EXTRA_CONSTRAINTS = {

--- a/max/kernels/benchmarks/BUILD.bazel
+++ b/max/kernels/benchmarks/BUILD.bazel
@@ -13,9 +13,17 @@ _RUN_BENCHMARKS = [
     "nn/bench_gather_reduce.mojo",
 ]
 
+# Per-src extra deps for GPU benchmarks that import a specific kernel package
+# not covered by the default dep set below.
 _EXTRA_DEPS = {
     "algorithm/parallelize_overhead.mojo": ["//max:max_mojo"],
     "linalg/bench_layout_tensor.mojo": ["//max:max_mojo"],
+    "gpu/state_space/bench_ssd_chunk_scan.mojo": [
+        "//max/kernels/src/state_space",
+    ],
+    "gpu/state_space/prof_ssd_chunk_scan_only.mojo": [
+        "//max/kernels/src/state_space",
+    ],
 }
 
 _EXTRA_CONSTRAINTS = {
@@ -238,7 +246,7 @@ _CPU_TESTS = glob(
             "//max:state_space",
             "//max:structured_kernels",
             "@mojo//:std",
-        ],
+        ] + _EXTRA_DEPS.get(src, []),
     )
     for src in glob(
         ["gpu/**/*.mojo"],

--- a/max/kernels/benchmarks/gpu/state_space/bench_ssd_chunk_combine.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/bench_ssd_chunk_combine.mojo
@@ -1,0 +1,360 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Microbenchmark for ``ssd_output_recombination_fwd_gpu`` (SSD stage 4).
+
+Times wall-clock per launch (kernel + sync) and amortized throughput (queue all
+launches, sync once -- matches the Triton parity bench methodology) across the
+Mamba2-130m prefill profile (B=1, n_chunks=4, n_heads=24, L=256, P=64, N=128)
+and a chunk-count sweep.
+
+The recombination adds the inter-chunk (off-diagonal) contribution to the
+intra-chunk diagonal output:
+
+    Y_off[l, p] = exp(cumsum(A)[l]) * sum_n C[l, n] * entering_state[p, n]
+    Y[l, p]     = Y_diag[l, p] + Y_off[l, p]
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+from std.math import ceildiv
+from std.time import perf_counter_ns
+
+from state_space.ssd_chunk_combine import (
+    ssd_output_recombination_fwd_gpu,
+    ssd_output_recombination_fwd_gpu_fused,
+    ssd_output_recombination_fwd_gpu_static,
+)
+
+
+def time_one[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    comptime SCALAR_BLOCK_SIZE = 128
+
+    comptime c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    var c_tt = TileTensor(
+        c_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var a_tt = TileTensor(
+        a_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var yd_tt = TileTensor(
+        yd_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var y_tt = TileTensor(
+        y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    var total_threads = batch * n_chunks * n_heads * chunk_len * head_dim
+    var grid = ceildiv(total_threads, SCALAR_BLOCK_SIZE)
+
+    var compiled = ctx.compile_function[
+        ssd_output_recombination_fwd_gpu[
+            dtype,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ]
+    ]()
+
+    for _ in range(warmups):
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            Int32(state_dim),
+            c_tt,
+            ent_tt,
+            a_tt,
+            yd_tt,
+            y_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+    ctx.synchronize()
+
+    # Per-launch latency: sync every iter.
+    var min_ns: Int = -1
+    var sum_ns: Int = 0
+    for _ in range(iters):
+        var t0 = perf_counter_ns()
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            Int32(state_dim),
+            c_tt,
+            ent_tt,
+            a_tt,
+            yd_tt,
+            y_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+        ctx.synchronize()
+        var t1 = perf_counter_ns()
+        var elapsed = Int(t1 - t0)
+        sum_ns += elapsed
+        if min_ns < 0 or elapsed < min_ns:
+            min_ns = elapsed
+
+    # Amortized throughput: queue all launches, sync once.
+    var a0 = perf_counter_ns()
+    for _ in range(iters):
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            Int32(state_dim),
+            c_tt,
+            ent_tt,
+            a_tt,
+            yd_tt,
+            y_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+    ctx.synchronize()
+    var a1 = perf_counter_ns()
+    var amort_ms = Float64(Int(a1 - a0)) / Float64(iters) / 1.0e6
+
+    var min_ms = Float64(min_ns) / 1.0e6
+    var mean_ms = Float64(sum_ns) / Float64(iters) / 1.0e6
+    print(
+        "  nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  min(sync)=",
+        min_ms,
+        "ms  mean(sync)=",
+        mean_ms,
+        "ms  amort=",
+        amort_ms,
+        "ms",
+        sep="",
+    )
+
+
+def time_one_static[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    comptime c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    var c_tt = TileTensor(
+        c_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var a_tt = TileTensor(
+        a_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var yd_tt = TileTensor(
+        yd_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var y_tt = TileTensor(
+        y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(warmups):
+        ssd_output_recombination_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, c_tt, ent_tt, a_tt, yd_tt, y_tt, ctx)
+    ctx.synchronize()
+
+    var a0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_output_recombination_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, c_tt, ent_tt, a_tt, yd_tt, y_tt, ctx)
+    ctx.synchronize()
+    var a1 = perf_counter_ns()
+    var amort_ms = Float64(Int(a1 - a0)) / Float64(iters) / 1.0e6
+    print(
+        "  [static] nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  amort=",
+        amort_ms,
+        "ms",
+        sep="",
+    )
+
+
+def time_one_fused[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    comptime c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    var c_tt = TileTensor(
+        c_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var a_tt = TileTensor(
+        a_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var yd_tt = TileTensor(
+        yd_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var y_tt = TileTensor(
+        y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(warmups):
+        ssd_output_recombination_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, c_tt, ent_tt, a_tt, yd_tt, y_tt, ctx)
+    ctx.synchronize()
+
+    var a0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_output_recombination_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, c_tt, ent_tt, a_tt, yd_tt, y_tt, ctx)
+    ctx.synchronize()
+    var a1 = perf_counter_ns()
+    var amort_ms = Float64(Int(a1 - a0)) / Float64(iters) / 1.0e6
+    print(
+        "  [fused] nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  amort=",
+        amort_ms,
+        "ms",
+        sep="",
+    )
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    print("Scalar baseline (Mamba2-130m prefill profile + nchunks scaling):")
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 20, 100)
+    time_one[DType.float32, 1, 8, 24, 256, 64, 128](ctx, 20, 100)
+    time_one[DType.float32, 1, 16, 24, 256, 64, 128](ctx, 20, 100)
+
+    print("Static tensor-core path (same profiles):")
+    time_one_static[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 20, 100)
+    time_one_static[DType.float32, 1, 8, 24, 256, 64, 128](ctx, 20, 100)
+    time_one_static[DType.float32, 1, 16, 24, 256, 64, 128](ctx, 20, 100)
+
+    print("Fused single-pass MMA path (same profiles):")
+    time_one_fused[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 20, 100)
+    time_one_fused[DType.float32, 1, 8, 24, 256, 64, 128](ctx, 20, 100)
+    time_one_fused[DType.float32, 1, 16, 24, 256, 64, 128](ctx, 20, 100)

--- a/max/kernels/benchmarks/gpu/state_space/bench_ssd_chunk_scan.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/bench_ssd_chunk_scan.mojo
@@ -1,0 +1,165 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Microbenchmark for ``ssd_chunk_scan_fwd_gpu`` (SSD inter-chunk scan, stage 3).
+
+Times wall-clock per launch (kernel + sync) across a small sweep, ending on
+the Mamba2-130m prefill profile (B=1, n_chunks=4, n_heads=24, P=64, N=128).
+The inter-chunk recurrence is sequential over chunks; we parallelize over
+``(batch, head, p, n)`` exactly as the shipped kernel does.
+
+Set ``iters`` high (e.g. 20000) for the nsys sampling window — a short run
+spans <0.2 s and the 10 kHz sampler misses the kernels (see
+``.planning/ssd-intra-nsight-profile.md``).
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+from std.math import ceildiv
+from std.time import perf_counter_ns
+
+from state_space.ssd_chunk_scan import ssd_chunk_scan_fwd_gpu
+
+
+def time_one[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    comptime SCALAR_BLOCK_SIZE = 128
+
+    comptime cs_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime cd_count = batch * n_chunks * n_heads
+    comptime ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime final_count = batch * n_heads * head_dim * state_dim
+
+    var cs_device = ctx.enqueue_create_buffer[dtype](cs_count)
+    var cd_device = ctx.enqueue_create_buffer[dtype](cd_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var final_device = ctx.enqueue_create_buffer[dtype](final_count)
+
+    var cs_tt = TileTensor(
+        cs_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var cd_tt = TileTensor(cd_device, row_major(batch, n_chunks, n_heads))
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var final_tt = TileTensor(
+        final_device, row_major(batch, n_heads, head_dim, state_dim)
+    )
+
+    var total_threads = batch * n_heads * head_dim * state_dim
+    var grid = ceildiv(total_threads, SCALAR_BLOCK_SIZE)
+
+    var compiled = ctx.compile_function[
+        ssd_chunk_scan_fwd_gpu[
+            dtype,
+            cs_tt.LayoutType,
+            cd_tt.LayoutType,
+            ent_tt.LayoutType,
+            final_tt.LayoutType,
+        ]
+    ]()
+
+    for _ in range(warmups):
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            cs_tt,
+            cd_tt,
+            ent_tt,
+            final_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+    ctx.synchronize()
+
+    # Per-launch latency: sync every iter (round-trip).
+    var min_ns: Int = -1
+    var sum_ns: Int = 0
+    for _ in range(iters):
+        var t0 = perf_counter_ns()
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            cs_tt,
+            cd_tt,
+            ent_tt,
+            final_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+        ctx.synchronize()
+        var t1 = perf_counter_ns()
+        var elapsed = Int(t1 - t0)
+        sum_ns += elapsed
+        if min_ns < 0 or elapsed < min_ns:
+            min_ns = elapsed
+
+    # Amortized throughput: queue all launches, sync once (matches the Triton
+    # parity bench's methodology for an apples-to-apples head-to-head).
+    var a0 = perf_counter_ns()
+    for _ in range(iters):
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            cs_tt,
+            cd_tt,
+            ent_tt,
+            final_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+    ctx.synchronize()
+    var a1 = perf_counter_ns()
+    var amort_ms = Float64(Int(a1 - a0)) / Float64(iters) / 1.0e6
+
+    var min_ms = Float64(min_ns) / 1.0e6
+    var mean_ms = Float64(sum_ns) / Float64(iters) / 1.0e6
+    print(
+        "  nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  min(sync)=",
+        min_ms,
+        "ms  mean(sync)=",
+        mean_ms,
+        "ms  amort=",
+        amort_ms,
+        "ms",
+        sep="",
+    )
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    print("Single-slice (batch=1, n_chunks=4, n_heads=1) sweep:")
+    time_one[DType.float32, 1, 4, 1, 64, 128](ctx, 5, 50)
+    time_one[DType.float32, 1, 16, 1, 64, 128](ctx, 5, 50)
+
+    print("Multi-slice sweep (Mamba2-130m prefill profile + nchunks scaling):")
+    time_one[DType.float32, 1, 4, 24, 64, 128](ctx, 20, 200)
+    time_one[DType.float32, 1, 8, 24, 64, 128](ctx, 20, 200)
+    time_one[DType.float32, 1, 16, 24, 64, 128](ctx, 20, 200)

--- a/max/kernels/benchmarks/gpu/state_space/bench_ssd_chunk_state.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/bench_ssd_chunk_state.mojo
@@ -1,0 +1,334 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Microbenchmark sweep for ``ssd_chunk_state_fwd_gpu``.
+
+Stage 2 of the chunked SSD prefill: reduce each chunk to its
+``[head_dim, state_dim]`` end-state. Sweeps a few dim configs to isolate where
+time goes and reports the Mamba2-130m prefill profile used by the intra-chunk
+optimization notes (B=1, n_chunks=4, n_heads=24, L=256, P=64, N=128). Times
+wall-clock per call (kernel enqueue + sync).
+"""
+
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+from layout import TileTensor, row_major
+
+from state_space.ssd_chunk_state import (
+    ssd_chunk_state_fwd_gpu,
+    ssd_chunk_state_fwd_gpu_static,
+    ssd_chunk_state_fwd_gpu_fused,
+)
+
+
+def time_one[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int, num_p_tiles: Int = 1) raises:
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_state_fwd_gpu[
+            dtype,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ]
+    ]()
+
+    for _ in range(warmups):
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+    ctx.synchronize()
+
+    var min_ns: Int = -1
+    var sum_ns: Int = 0
+    for _ in range(iters):
+        var t0 = perf_counter_ns()
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+        ctx.synchronize()
+        var t1 = perf_counter_ns()
+        var elapsed = Int(t1 - t0)
+        sum_ns += elapsed
+        if min_ns < 0 or elapsed < min_ns:
+            min_ns = elapsed
+
+    var min_ms = Float64(min_ns) / 1.0e6
+    var mean_ms = Float64(sum_ns) / Float64(iters) / 1.0e6
+    print(
+        "  nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        " p_tiles=",
+        num_p_tiles,
+        "  min=",
+        min_ms,
+        "ms  mean=",
+        mean_ms,
+        "ms",
+        sep="",
+    )
+
+
+def time_one_static[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    """Time the static tensor-core path (decay-transpose + batched_matmul)."""
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    for _ in range(warmups):
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+
+    # Pipelined timing (enqueue all iters, sync once) to match the Triton
+    # bench's methodology for a fair throughput comparison.
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    print(
+        "  [tensor-core] nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  ",
+        Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6,
+        "ms/iter (pipelined)",
+        sep="",
+    )
+
+
+def time_one_fused[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    """Time the fused single-pass tensor-core path (pipelined throughput)."""
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    for _ in range(warmups):
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    print(
+        "  [fused] nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  ",
+        Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6,
+        "ms/iter (pipelined)",
+        sep="",
+    )
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    # Single-slice baselines to expose where time goes.
+    print("Single-slice (batch=1, n_chunks=1, n_heads=1) sweep:")
+    time_one[DType.float32, 1, 1, 1, 64, 64, 32](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 64, 64, 128](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 128, 64, 128](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 256, 64, 128](ctx, 5, 20)
+
+    # Mamba2-130m prefill profile, swept over p-tile counts (block count =
+    # 96 * p_tiles) to find the GB10 occupancy sweet spot.
+    print("Multi-slice sweep (Mamba2-130m prefill profile), p-tile sweep:")
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 1)
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 2)
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 4)
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 8)
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 20, 16)
+
+    # Tensor-core path (decay-transpose + batched_matmul) at the same profile,
+    # plus longer prefills, to compare head-to-head with Triton _chunk_state_fwd.
+    print("Tensor-core path (static), pipelined throughput:")
+    time_one_static[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 10, 200)
+    time_one_static[DType.float32, 1, 8, 24, 256, 64, 128](ctx, 10, 200)
+    time_one_static[DType.float32, 1, 16, 24, 256, 64, 128](ctx, 10, 200)
+
+    print("Fused single-pass tensor-core path, pipelined throughput:")
+    time_one_fused[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 10, 200)
+    time_one_fused[DType.float32, 1, 8, 24, 256, 64, 128](ctx, 10, 200)
+    time_one_fused[DType.float32, 1, 16, 24, 256, 64, 128](ctx, 10, 200)

--- a/max/kernels/benchmarks/gpu/state_space/bench_ssd_intra_chunk.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/bench_ssd_intra_chunk.mojo
@@ -1,0 +1,156 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Microbenchmark sweep for ``ssd_intra_chunk_fwd_gpu``.
+
+Sweeps several dim configs to isolate where time goes: small/medium/large
+chunk_len, head_dim, state_dim. Times wall-clock per call (kernel + sync).
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+
+from state_space.ssd_chunk import (
+    ssd_intra_chunk_fwd_gpu,
+    ssd_intra_chunk_fwd_gpu_fused,
+    ssd_intra_chunk_fwd_gpu_static,
+)
+
+
+def time_one[
+    dtype: DType,
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+    use_fused: Bool = False,
+](ctx: DeviceContext, warmups: Int, iters: Int) raises:
+    comptime cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y_device = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    var C_tt = TileTensor(
+        C_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var Y_tt = TileTensor(
+        Y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(warmups):
+        comptime if use_fused:
+            ssd_intra_chunk_fwd_gpu_fused[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        else:
+            ssd_intra_chunk_fwd_gpu_static[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+    ctx.synchronize()
+
+    var min_ns: Int = -1
+    var sum_ns: Int = 0
+    for _ in range(iters):
+        var t0 = perf_counter_ns()
+        comptime if use_fused:
+            ssd_intra_chunk_fwd_gpu_fused[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        else:
+            ssd_intra_chunk_fwd_gpu_static[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        ctx.synchronize()
+        var t1 = perf_counter_ns()
+        var elapsed = Int(t1 - t0)
+        sum_ns += elapsed
+        if min_ns < 0 or elapsed < min_ns:
+            min_ns = elapsed
+
+    var min_ms = Float64(min_ns) / 1.0e6
+    var mean_ms = Float64(sum_ns) / Float64(iters) / 1.0e6
+    print(
+        "  nc=",
+        n_chunks,
+        " nh=",
+        n_heads,
+        " L=",
+        chunk_len,
+        " P=",
+        head_dim,
+        " N=",
+        state_dim,
+        "  min=",
+        min_ms,
+        "ms  mean=",
+        mean_ms,
+        "ms",
+        sep="",
+    )
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    # Single-slice baselines to expose where time goes.
+    print("Single-slice (batch=1, n_chunks=1, n_heads=1) sweep:")
+    time_one[DType.float32, 1, 1, 1, 64, 64, 32](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 64, 64, 128](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 128, 64, 128](ctx, 5, 20)
+    time_one[DType.float32, 1, 1, 1, 256, 64, 128](ctx, 5, 20)
+
+    print("Multi-slice sweep (Mamba2-130m prefill profile) — two-kernel:")
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128](ctx, 3, 10)
+
+    print("Multi-slice sweep (Mamba2-130m prefill profile) — FUSED (RFC 0009):")
+    time_one[DType.float32, 1, 4, 24, 256, 64, 128, use_fused=True](ctx, 5, 50)
+    time_one[DType.float32, 1, 8, 24, 256, 64, 128, use_fused=True](ctx, 5, 50)

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_chunk_scan_only.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_chunk_scan_only.mojo
@@ -1,0 +1,80 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Minimal driver: run ONLY ``ssd_chunk_scan_fwd_gpu`` a few times.
+
+Tightly-scoped target for ``ncu`` single-metric roofline collection on GB10
+(no ``--set full`` replay — that crashes the box; see
+``.planning/ssd-intra-nsight-profile.md``). Every launch is the Mamba2-130m
+prefill profile so the per-kernel rows are unambiguous and the launch count is
+bounded for ``-c N``.
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+from std.math import ceildiv
+
+from state_space.ssd_chunk_scan import ssd_chunk_scan_fwd_gpu
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime head_dim = 64
+    comptime state_dim = 128
+    comptime SCALAR_BLOCK_SIZE = 128
+
+    comptime cs_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime cd_count = batch * n_chunks * n_heads
+    comptime ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime final_count = batch * n_heads * head_dim * state_dim
+
+    var cs_device = ctx.enqueue_create_buffer[dtype](cs_count)
+    var cd_device = ctx.enqueue_create_buffer[dtype](cd_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var final_device = ctx.enqueue_create_buffer[dtype](final_count)
+
+    var cs_tt = TileTensor(
+        cs_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var cd_tt = TileTensor(cd_device, row_major(batch, n_chunks, n_heads))
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var final_tt = TileTensor(
+        final_device, row_major(batch, n_heads, head_dim, state_dim)
+    )
+
+    var total_threads = batch * n_heads * head_dim * state_dim
+    var grid = ceildiv(total_threads, SCALAR_BLOCK_SIZE)
+
+    var compiled = ctx.compile_function[
+        ssd_chunk_scan_fwd_gpu[
+            dtype,
+            cs_tt.LayoutType,
+            cd_tt.LayoutType,
+            ent_tt.LayoutType,
+            final_tt.LayoutType,
+        ]
+    ]()
+
+    for _ in range(4):
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            cs_tt,
+            cd_tt,
+            ent_tt,
+            final_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+    ctx.synchronize()

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_combine_only.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_combine_only.mojo
@@ -1,0 +1,90 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Minimal driver: run ONLY ``ssd_output_recombination_fwd_gpu`` a few times.
+
+Tightly-scoped target for ``ncu`` single-metric roofline collection on GB10
+(no ``--set full`` replay -- that crashes the box; see
+``.planning/ssd-intra-nsight-profile.md``). Every launch is the Mamba2-130m
+prefill profile so the per-kernel rows are unambiguous and the launch count is
+bounded for ``-c N``.
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+from std.math import ceildiv
+
+from state_space.ssd_chunk_combine import ssd_output_recombination_fwd_gpu
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+    comptime SCALAR_BLOCK_SIZE = 128
+
+    comptime c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    var c_tt = TileTensor(
+        c_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var a_tt = TileTensor(
+        a_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var yd_tt = TileTensor(
+        yd_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var y_tt = TileTensor(
+        y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    var total_threads = batch * n_chunks * n_heads * chunk_len * head_dim
+    var grid = ceildiv(total_threads, SCALAR_BLOCK_SIZE)
+
+    var compiled = ctx.compile_function[
+        ssd_output_recombination_fwd_gpu[
+            dtype,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ]
+    ]()
+
+    for _ in range(4):
+        ctx.enqueue_function(
+            compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            Int32(state_dim),
+            c_tt,
+            ent_tt,
+            a_tt,
+            yd_tt,
+            y_tt,
+            grid_dim=(grid,),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+    ctx.synchronize()

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_combine_static.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_combine_static.mojo
@@ -1,0 +1,69 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Minimal driver: run ONLY the static tensor-core stage-4 path a few times.
+
+Scoped target for ``ncu`` single-metric collection on GB10. The static path is
+two launches (batched_matmul + decay/add epilogue), so per-kernel ncu rows show
+the matmul vs epilogue split. Mamba2-130m prefill profile.
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+
+from state_space.ssd_chunk_combine import (
+    ssd_output_recombination_fwd_gpu_static,
+)
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    comptime c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    var c_tt = TileTensor(
+        c_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var a_tt = TileTensor(
+        a_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var yd_tt = TileTensor(
+        yd_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var y_tt = TileTensor(
+        y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(4):
+        ssd_output_recombination_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, c_tt, ent_tt, a_tt, yd_tt, y_tt, ctx)
+    ctx.synchronize()

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_fused_only.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_fused_only.mojo
@@ -1,0 +1,62 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Minimal driver: run ONLY the fused intra-chunk MMA path (RFC 0009).
+
+Scoped target for ncu single-metric roofline collection on GB10. Mamba2-130m
+prefill profile.
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+
+from state_space.ssd_chunk import ssd_intra_chunk_fwd_gpu_fused
+
+
+def main() raises:
+    var ctx = DeviceContext()
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    comptime cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    var C_tt = TileTensor(
+        C, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var B_tt = TileTensor(
+        B, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(A, row_major(batch, n_chunks, n_heads, chunk_len))
+    var Y_tt = TileTensor(
+        Y, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(4):
+        ssd_intra_chunk_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            C_tt.LayoutType,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            Y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+    ctx.synchronize()

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_scan_only.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_scan_only.mojo
@@ -1,0 +1,64 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+# ===----------------------------------------------------------------------=== #
+"""Minimal driver: run ONLY the multi-slice ssd_intra static path a few times.
+
+Used as a tightly-scoped target for ``ncu`` single-metric roofline collection
+(no full-set replay — that crashes the GB10). Every launch is the Mamba2-130m
+prefill profile so the per-kernel rows are unambiguous.
+"""
+
+from layout import TileTensor, row_major
+from max.gpu.host import DeviceContext
+
+from state_space.ssd_chunk import ssd_intra_chunk_fwd_gpu_static
+
+
+def main() raises:
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    comptime cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    var C_tt = TileTensor(
+        C, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var B_tt = TileTensor(
+        B, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(A, row_major(batch, n_chunks, n_heads, chunk_len))
+    var Y_tt = TileTensor(
+        Y, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    for _ in range(4):
+        ssd_intra_chunk_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            C_tt.LayoutType,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            Y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+    ctx.synchronize()

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_fused.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_fused.mojo
@@ -1,0 +1,100 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Single-kernel profiling driver for the fused tensor-core chunk-state entry.
+
+Runs ssd_chunk_state_fwd_gpu_fused (one fused MMA kernel) in a long loop at the
+Mamba2-130m prefill profile so its ncu row is unambiguous. argv[1] = iters.
+"""
+
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+from std.sys import argv
+from layout import TileTensor, row_major
+
+from state_space.ssd_chunk_state import ssd_chunk_state_fwd_gpu_fused
+
+
+def main() raises:
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    var iters = 2000
+    var args = argv()
+    if len(args) > 1:
+        iters = atol(args[1])
+
+    var ctx = DeviceContext()
+
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    for _ in range(5):
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    print(
+        "ssd_chunk_state fused prof: ",
+        iters,
+        " iters, ",
+        Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6,
+        " ms/iter",
+    )

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_only.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_only.mojo
@@ -1,0 +1,128 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Single-kernel profiling driver for ``ssd_chunk_state_fwd_gpu``.
+
+Runs ONLY the chunk-state kernel in a long loop at the Mamba2-130m prefill
+profile (B=1, n_chunks=4, n_heads=24, L=256, P=64, N=128) so per-kernel ncu
+rows are unambiguous and the nsys 10 kHz sampler lands on a sustained busy
+window. See ``.planning/ssd-intra-optimization-notes.md`` for the GB10
+profiling method (ncu single-metric + ``-c N`` is safe; ``--set full`` crashes
+the box).
+
+Iter count is read from argv[1] (default 20000) so the same binary serves both
+a quick latency check and a multi-second nsys capture window.
+"""
+
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+from std.sys import argv
+from layout import TileTensor, row_major
+
+from state_space.ssd_chunk_state import ssd_chunk_state_fwd_gpu
+
+
+def main() raises:
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    var iters = 20000
+    var num_p_tiles = 8  # GB10 sweet spot at this profile (see bench sweep).
+    var args = argv()
+    if len(args) > 1:
+        iters = atol(args[1])
+    if len(args) > 2:
+        num_p_tiles = atol(args[2])
+
+    var ctx = DeviceContext()
+
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_state_fwd_gpu[
+            dtype,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ]
+    ]()
+
+    # Warmup.
+    for _ in range(5):
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+    ctx.synchronize()
+
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    var per_iter_ms = Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6
+    print("ssd_chunk_state prof: ", iters, " iters, ", per_iter_ms, " ms/iter")

--- a/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_static.mojo
+++ b/max/kernels/benchmarks/gpu/state_space/prof_ssd_state_static.mojo
@@ -1,0 +1,101 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Single-path profiling driver for the static tensor-core chunk-state entry.
+
+Runs ssd_chunk_state_fwd_gpu_static (decay-transpose kernel + batched_matmul)
+in a long loop at the Mamba2-130m prefill profile so ncu rows for the two
+kernels (the decay-transpose and the matmul) are unambiguous. argv[1] = iters.
+"""
+
+from max.gpu.host import DeviceContext
+from std.time import perf_counter_ns
+from std.sys import argv
+from layout import TileTensor, row_major
+
+from state_space.ssd_chunk_state import ssd_chunk_state_fwd_gpu_static
+
+
+def main() raises:
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 4
+    comptime n_heads = 24
+    comptime chunk_len = 256
+    comptime head_dim = 64
+    comptime state_dim = 128
+
+    var iters = 2000
+    var args = argv()
+    if len(args) > 1:
+        iters = atol(args[1])
+
+    var ctx = DeviceContext()
+
+    comptime b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    comptime x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    comptime a_count = batch * n_chunks * n_heads * chunk_len
+    comptime state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    for _ in range(5):
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+
+    var t0 = perf_counter_ns()
+    for _ in range(iters):
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    ctx.synchronize()
+    var t1 = perf_counter_ns()
+
+    print(
+        "ssd_chunk_state static prof: ",
+        iters,
+        " iters, ",
+        Float64(Int(t1 - t0)) / Float64(iters) / 1.0e6,
+        " ms/iter",
+    )

--- a/max/kernels/src/state_space/BUILD.bazel
+++ b/max/kernels/src/state_space/BUILD.bazel
@@ -22,6 +22,7 @@ mojo_library(
     deps = [
         "//max:extensibility",
         "//max:layout",
+        "//max:linalg",
         "//max:max_mojo",
         "//max:nn",
         "@mojo//:std",

--- a/max/kernels/src/state_space/selective_scan_ops.mojo
+++ b/max/kernels/src/state_space/selective_scan_ops.mojo
@@ -34,6 +34,10 @@ from state_space.selective_scan import (
     selective_scan_fwd_gpu_minimal,
     selective_scan_update_cpu,
     selective_scan_update_gpu,
+    ssd_combined_cpu,
+    ssd_combined_gpu,
+    mamba_split_conv1d_scan_combined_cpu,
+    mamba_split_conv1d_scan_combined_gpu,
 )
 
 
@@ -884,3 +888,553 @@ def selective_scan_update_shape[
         matches `state_in.shape()` and `output_shape` matches `x.shape()`.
     """
     return (state_in.shape(), x.shape())
+
+
+@extensibility.register("ssd_combined")
+struct SsdCombined[delta_softplus: Bool = False]:
+    """Fused selective scan + RMS-norm + residual operation for Mamba blocks.
+
+    Performs: norm(residual + selective_scan(input)), optionally gated by SiLU(z).
+    Despite the name (`ssd_combined`), this is the Mamba1-shape *sequential* scan
+    fused with the post-norm/residual path — not the chunk-SSD algorithm.
+
+    Parameters:
+        delta_softplus: If True, applies softplus activation to delta values.
+
+    Tensor Shapes:
+        - output: (batch, dim, seqlen) - Final fused output (normalized, optionally gated)
+        - x: (batch, dim, num_chunks, 2*dstate) - Scan checkpoint state (output)
+        - out_z: (batch, dim, seqlen) - Pre-gating normalized output (output, can be empty)
+        - residual: (batch, dim, seqlen) - Residual tensor added before norm
+        - u: (batch, dim, seqlen) - Input tensor
+        - delta: (batch, dim, seqlen) - Time step tensor
+        - A: (dim, dstate) - State transition matrix
+        - B: (batch, n_groups, dstate, seqlen) - Input projection
+        - C: (batch, n_groups, dstate, seqlen) - Output projection
+        - D: (dim,) - Skip connection (optional, can be empty)
+        - z: (batch, dim, seqlen) - Gating tensor (optional, can be empty)
+        - delta_bias: (dim,) - Delta bias (optional, can be empty)
+        - gamma: (dim,) - RMSNorm weight
+        - epsilon: Scalar - Numerical stability epsilon for RMSNorm
+        - weight_offset: Scalar - Offset added to gamma before scaling
+    """
+
+    @staticmethod
+    def execute[
+        dtype: DType,
+        target: StaticString,
+    ](
+        output: OutputTensor[dtype=dtype, rank=3, ...],
+        x: OutputTensor[dtype=dtype, rank=4, ...],
+        out_z: OutputTensor[dtype=dtype, rank=3, ...],
+        residual: InputTensor[dtype=dtype, rank=3, ...],
+        u: InputTensor[dtype=dtype, rank=3, ...],
+        delta: InputTensor[dtype=dtype, rank=3, ...],
+        A: InputTensor[dtype=dtype, rank=2, ...],
+        B: InputTensor[dtype=dtype, rank=4, ...],
+        C: InputTensor[dtype=dtype, rank=4, ...],
+        D: InputTensor[dtype=dtype, rank=1, ...],
+        z: InputTensor[dtype=dtype, rank=3, ...],
+        delta_bias: InputTensor[dtype=dtype, rank=1, ...],
+        gamma: InputTensor[dtype=dtype, rank=1, ...],
+        epsilon: Scalar[dtype=dtype],
+        weight_offset: Scalar[dtype=dtype],
+        ctx: DeviceContext,
+    ) capturing raises:
+        if output.shape() != u.shape():
+            raise Error("Output shape must match input u shape")
+
+        var batch = output.dim_size(0)
+        var dim = output.dim_size(1)
+        var seqlen = output.dim_size(2)
+        var dstate = A.dim_size(1)
+        var n_groups = B.dim_size(1)
+        var group_size = dim // n_groups
+
+        var output_tt = output.to_tile_tensor[.int32]()
+        var x_tt = x.to_tile_tensor[.int32]()
+        var out_z_tt = out_z.to_tile_tensor[.int32]()
+        var residual_tt = residual.to_tile_tensor[.int32]()
+        var u_tt = u.to_tile_tensor[.int32]()
+        var delta_tt = delta.to_tile_tensor[.int32]()
+        var A_tt = A.to_tile_tensor[.int32]()
+        var B_tt = B.to_tile_tensor[.int32]()
+        var C_tt = C.to_tile_tensor[.int32]()
+        var D_tt = D.to_tile_tensor[.int32]()
+        var z_tt = z.to_tile_tensor[.int32]()
+        var delta_bias_tt = delta_bias.to_tile_tensor[.int32]()
+        var gamma_tt = gamma.to_tile_tensor[.int32]()
+
+        comptime delta_softplus_int8: Int8 = Int8(
+            1
+        ) if Self.delta_softplus else Int8(0)
+
+        if dstate != 16 and dstate != 8:
+            raise Error(
+                "Unsupported dstate: " + String(dstate) + ". Expected 8 or 16."
+            )
+
+        comptime if is_cpu[target]():
+            if dstate == 16:
+                ssd_combined_cpu[
+                    dtype,
+                    16,
+                ](
+                    batch,
+                    dim,
+                    seqlen,
+                    group_size,
+                    delta_softplus_int8,
+                    output_tt,
+                    x_tt,
+                    out_z_tt,
+                    residual_tt,
+                    u_tt,
+                    delta_tt,
+                    A_tt,
+                    B_tt,
+                    C_tt,
+                    D_tt,
+                    z_tt,
+                    delta_bias_tt,
+                    gamma_tt,
+                    epsilon,
+                    weight_offset,
+                    Optional[DeviceContext](ctx),
+                )
+            else:
+                ssd_combined_cpu[
+                    dtype,
+                    8,
+                ](
+                    batch,
+                    dim,
+                    seqlen,
+                    group_size,
+                    delta_softplus_int8,
+                    output_tt,
+                    x_tt,
+                    out_z_tt,
+                    residual_tt,
+                    u_tt,
+                    delta_tt,
+                    A_tt,
+                    B_tt,
+                    C_tt,
+                    D_tt,
+                    z_tt,
+                    delta_bias_tt,
+                    gamma_tt,
+                    epsilon,
+                    weight_offset,
+                    Optional[DeviceContext](ctx),
+                )
+        elif is_gpu[target]():
+            var gpu_ctx = ctx
+            var total_batch_dim = batch * dim
+            comptime BLOCK_SIZE = 128
+            var num_blocks = ceildiv(total_batch_dim, BLOCK_SIZE)
+
+            if dstate == 16:
+                comptime DSTATE_VAL = 16
+                var compiled_kernel = gpu_ctx.compile_function[
+                    ssd_combined_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        output_tt.LayoutType,
+                        x_tt.LayoutType,
+                        out_z_tt.LayoutType,
+                        residual_tt.LayoutType,
+                        u_tt.LayoutType,
+                        delta_tt.LayoutType,
+                        A_tt.LayoutType,
+                        B_tt.LayoutType,
+                        C_tt.LayoutType,
+                        D_tt.LayoutType,
+                        z_tt.LayoutType,
+                        delta_bias_tt.LayoutType,
+                        gamma_tt.LayoutType,
+                        output_tt.Storage,
+                    ]
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_kernel,
+                    Int32(total_batch_dim),
+                    Int32(batch),
+                    Int32(dim),
+                    Int32(seqlen),
+                    Int32(group_size),
+                    delta_softplus_int8,
+                    output_tt,
+                    x_tt,
+                    out_z_tt,
+                    residual_tt,
+                    u_tt,
+                    delta_tt,
+                    A_tt,
+                    B_tt,
+                    C_tt,
+                    D_tt,
+                    z_tt,
+                    delta_bias_tt,
+                    gamma_tt,
+                    epsilon,
+                    weight_offset,
+                    grid_dim=(num_blocks,),
+                    block_dim=(BLOCK_SIZE,),
+                )
+            else:
+                comptime DSTATE_VAL = 8
+                var compiled_kernel = gpu_ctx.compile_function[
+                    ssd_combined_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        output_tt.LayoutType,
+                        x_tt.LayoutType,
+                        out_z_tt.LayoutType,
+                        residual_tt.LayoutType,
+                        u_tt.LayoutType,
+                        delta_tt.LayoutType,
+                        A_tt.LayoutType,
+                        B_tt.LayoutType,
+                        C_tt.LayoutType,
+                        D_tt.LayoutType,
+                        z_tt.LayoutType,
+                        delta_bias_tt.LayoutType,
+                        gamma_tt.LayoutType,
+                        output_tt.Storage,
+                    ]
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_kernel,
+                    Int32(total_batch_dim),
+                    Int32(batch),
+                    Int32(dim),
+                    Int32(seqlen),
+                    Int32(group_size),
+                    delta_softplus_int8,
+                    output_tt,
+                    x_tt,
+                    out_z_tt,
+                    residual_tt,
+                    u_tt,
+                    delta_tt,
+                    A_tt,
+                    B_tt,
+                    C_tt,
+                    D_tt,
+                    z_tt,
+                    delta_bias_tt,
+                    gamma_tt,
+                    epsilon,
+                    weight_offset,
+                    grid_dim=(num_blocks,),
+                    block_dim=(BLOCK_SIZE,),
+                )
+        else:
+            raise Error("Unsupported target: " + target)
+
+
+# ===----------------------------------------------------------------------=== #
+# Mamba Split Conv1d Scan Combined (Mamba2-shape fused conv + sequential scan)
+# ===----------------------------------------------------------------------=== #
+
+
+@extensibility.register("mamba_split_conv1d_scan_combined")
+struct MambaSplitConv1dScanCombined[delta_softplus: Bool = False]:
+    """Fused split-conv1d + selective scan + optional RMSNorm + optional outproj.
+
+    Mamba2-shape kernel: head-sharded A (one scalar per head), sequential scan
+    inside, but fused with the upstream conv1d (after splitting xBC out of the
+    packed `zxbcdt` projection input) and optional downstream norm/outproj.
+
+    Parameters:
+        delta_softplus: If True, applies softplus activation to delta values.
+
+    Tensor Shapes:
+        - zxbcdt: (batch, seqlen, 2*dim + 2*ngroups*dstate + nheads) - Packed projection input
+        - conv_weight: (dim + 2*ngroups*dstate, width) - Conv1d weights for x/B/C channels
+        - conv_bias: (dim + 2*ngroups*dstate,) - Conv1d bias
+        - dt_bias: (nheads,) - dt bias (per head)
+        - A: (nheads,) - Scalar state-transition value per head
+        - D: (nheads, headdim) or (nheads,) - Skip connection (optional, can be empty)
+        - x: (batch, dim, num_chunks, 2*dstate) - Scan checkpoint state (output)
+        - out_z: (batch, dim, seqlen) - Pre-gating output (output)
+        - dt: (batch, nheads, seqlen) - dt tensor (output)
+        - B: (batch, ngroups, dstate, seqlen) - Input projection (output of conv split)
+        - C: (batch, ngroups, dstate, seqlen) - Output projection (output of conv split)
+        - z: (batch, dim, seqlen) - Gating tensor (output, split from zxbcdt)
+        - rmsnorm_weight: (dim,) - RMSNorm weight (optional, can be empty)
+        - outproj_weight: (out_dim, dim) - Output projection weight (optional, can be empty)
+        - outproj_bias: (out_dim,) - Output projection bias (optional, can be empty)
+        - output: (batch, seqlen, dim) or (batch, seqlen, out_dim) - Final output
+        - epsilon: Scalar - RMSNorm epsilon
+
+    Runtime scalar args:
+        seqlen, dim, nheads, headdim, ngroups, width, chunk_size - Shape config
+        norm_before_gate, has_rmsnorm, has_outproj - Int8 flags (0/1)
+    """
+
+    @staticmethod
+    def execute[
+        dtype: DType,
+        target: StaticString,
+    ](
+        x: OutputTensor[dtype=dtype, rank=4, ...],
+        out_z: OutputTensor[dtype=dtype, rank=3, ...],
+        dt: OutputTensor[dtype=dtype, rank=3, ...],
+        B: OutputTensor[dtype=dtype, rank=4, ...],
+        C: OutputTensor[dtype=dtype, rank=4, ...],
+        z: OutputTensor[dtype=dtype, rank=3, ...],
+        output: OutputTensor[dtype=dtype, rank=3, ...],
+        zxbcdt: InputTensor[dtype=dtype, rank=3, ...],
+        conv_weight: InputTensor[dtype=dtype, rank=2, ...],
+        conv_bias: InputTensor[dtype=dtype, rank=1, ...],
+        dt_bias: InputTensor[dtype=dtype, rank=1, ...],
+        A: InputTensor[dtype=dtype, rank=1, ...],
+        D: InputTensor[dtype=dtype, rank=2, ...],
+        rmsnorm_weight: InputTensor[dtype=dtype, rank=1, ...],
+        outproj_weight: InputTensor[dtype=dtype, rank=2, ...],
+        outproj_bias: InputTensor[dtype=dtype, rank=1, ...],
+        nheads: Int,
+        headdim: Int,
+        ngroups: Int,
+        width: Int,
+        chunk_size: Int,
+        norm_before_gate: Int8,
+        has_rmsnorm: Int8,
+        has_outproj: Int8,
+        epsilon: Scalar[dtype=dtype],
+        ctx: DeviceContext,
+    ) capturing raises:
+        var batch = zxbcdt.dim_size(0)
+        var seqlen = zxbcdt.dim_size(1)
+        var dim = nheads * headdim
+        # dstate inferred from B's third dim (B is (batch, ngroups, dstate, seqlen))
+        var dstate = B.dim_size(2)
+
+        var zxbcdt_tt = zxbcdt.to_tile_tensor[.int32]()
+        var conv_weight_tt = conv_weight.to_tile_tensor[.int32]()
+        var conv_bias_tt = conv_bias.to_tile_tensor[.int32]()
+        var dt_bias_tt = dt_bias.to_tile_tensor[.int32]()
+        var A_tt = A.to_tile_tensor[.int32]()
+        var D_tt = D.to_tile_tensor[.int32]()
+        var x_tt = x.to_tile_tensor[.int32]()
+        var out_z_tt = out_z.to_tile_tensor[.int32]()
+        var dt_tt = dt.to_tile_tensor[.int32]()
+        var B_tt = B.to_tile_tensor[.int32]()
+        var C_tt = C.to_tile_tensor[.int32]()
+        var z_tt = z.to_tile_tensor[.int32]()
+        var rmsnorm_weight_tt = rmsnorm_weight.to_tile_tensor[.int32]()
+        var outproj_weight_tt = outproj_weight.to_tile_tensor[.int32]()
+        var outproj_bias_tt = outproj_bias.to_tile_tensor[.int32]()
+        var output_tt = output.to_tile_tensor[.int32]()
+
+        comptime delta_softplus_int8: Int8 = Int8(
+            1
+        ) if Self.delta_softplus else Int8(0)
+
+        if dstate != 16 and dstate != 8:
+            raise Error(
+                "Unsupported dstate: " + String(dstate) + ". Expected 8 or 16."
+            )
+
+        comptime if is_cpu[target]():
+            if dstate == 16:
+                mamba_split_conv1d_scan_combined_cpu[
+                    dtype,
+                    16,
+                ](
+                    batch,
+                    seqlen,
+                    dim,
+                    nheads,
+                    headdim,
+                    ngroups,
+                    width,
+                    chunk_size,
+                    delta_softplus_int8,
+                    norm_before_gate,
+                    has_rmsnorm,
+                    has_outproj,
+                    zxbcdt_tt,
+                    conv_weight_tt,
+                    conv_bias_tt,
+                    dt_bias_tt,
+                    A_tt,
+                    D_tt,
+                    x_tt,
+                    out_z_tt,
+                    dt_tt,
+                    B_tt,
+                    C_tt,
+                    z_tt,
+                    rmsnorm_weight_tt,
+                    outproj_weight_tt,
+                    outproj_bias_tt,
+                    output_tt,
+                    epsilon,
+                    Optional[DeviceContext](ctx),
+                )
+            else:
+                mamba_split_conv1d_scan_combined_cpu[
+                    dtype,
+                    8,
+                ](
+                    batch,
+                    seqlen,
+                    dim,
+                    nheads,
+                    headdim,
+                    ngroups,
+                    width,
+                    chunk_size,
+                    delta_softplus_int8,
+                    norm_before_gate,
+                    has_rmsnorm,
+                    has_outproj,
+                    zxbcdt_tt,
+                    conv_weight_tt,
+                    conv_bias_tt,
+                    dt_bias_tt,
+                    A_tt,
+                    D_tt,
+                    x_tt,
+                    out_z_tt,
+                    dt_tt,
+                    B_tt,
+                    C_tt,
+                    z_tt,
+                    rmsnorm_weight_tt,
+                    outproj_weight_tt,
+                    outproj_bias_tt,
+                    output_tt,
+                    epsilon,
+                    Optional[DeviceContext](ctx),
+                )
+        elif is_gpu[target]():
+            var gpu_ctx = ctx
+            var total_batch_dim = batch * dim
+            comptime BLOCK_SIZE = 128
+            var num_blocks = ceildiv(total_batch_dim, BLOCK_SIZE)
+
+            if dstate == 16:
+                comptime DSTATE_VAL = 16
+                var compiled_kernel = gpu_ctx.compile_function[
+                    mamba_split_conv1d_scan_combined_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        zxbcdt_tt.LayoutType,
+                        conv_weight_tt.LayoutType,
+                        conv_bias_tt.LayoutType,
+                        output_tt.LayoutType,
+                        x_tt.LayoutType,
+                        out_z_tt.LayoutType,
+                        dt_tt.LayoutType,
+                        A_tt.LayoutType,
+                        B_tt.LayoutType,
+                        C_tt.LayoutType,
+                        D_tt.LayoutType,
+                        z_tt.LayoutType,
+                        dt_bias_tt.LayoutType,
+                        rmsnorm_weight_tt.LayoutType,
+                        outproj_weight_tt.LayoutType,
+                        outproj_bias_tt.LayoutType,
+                    ]
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_kernel,
+                    Int32(total_batch_dim),
+                    Int32(batch),
+                    Int32(seqlen),
+                    Int32(dim),
+                    Int32(nheads),
+                    Int32(headdim),
+                    Int32(ngroups),
+                    Int32(width),
+                    Int32(chunk_size),
+                    delta_softplus_int8,
+                    norm_before_gate,
+                    has_rmsnorm,
+                    has_outproj,
+                    zxbcdt_tt,
+                    conv_weight_tt,
+                    conv_bias_tt,
+                    dt_bias_tt,
+                    A_tt,
+                    D_tt,
+                    x_tt,
+                    out_z_tt,
+                    dt_tt,
+                    B_tt,
+                    C_tt,
+                    z_tt,
+                    rmsnorm_weight_tt,
+                    outproj_weight_tt,
+                    outproj_bias_tt,
+                    output_tt,
+                    epsilon,
+                    grid_dim=(num_blocks,),
+                    block_dim=(BLOCK_SIZE,),
+                )
+            else:
+                comptime DSTATE_VAL = 8
+                var compiled_kernel = gpu_ctx.compile_function[
+                    mamba_split_conv1d_scan_combined_gpu[
+                        dtype,
+                        DSTATE_VAL,
+                        zxbcdt_tt.LayoutType,
+                        conv_weight_tt.LayoutType,
+                        conv_bias_tt.LayoutType,
+                        output_tt.LayoutType,
+                        x_tt.LayoutType,
+                        out_z_tt.LayoutType,
+                        dt_tt.LayoutType,
+                        A_tt.LayoutType,
+                        B_tt.LayoutType,
+                        C_tt.LayoutType,
+                        D_tt.LayoutType,
+                        z_tt.LayoutType,
+                        dt_bias_tt.LayoutType,
+                        rmsnorm_weight_tt.LayoutType,
+                        outproj_weight_tt.LayoutType,
+                        outproj_bias_tt.LayoutType,
+                    ]
+                ]()
+                gpu_ctx.enqueue_function(
+                    compiled_kernel,
+                    Int32(total_batch_dim),
+                    Int32(batch),
+                    Int32(seqlen),
+                    Int32(dim),
+                    Int32(nheads),
+                    Int32(headdim),
+                    Int32(ngroups),
+                    Int32(width),
+                    Int32(chunk_size),
+                    delta_softplus_int8,
+                    norm_before_gate,
+                    has_rmsnorm,
+                    has_outproj,
+                    zxbcdt_tt,
+                    conv_weight_tt,
+                    conv_bias_tt,
+                    dt_bias_tt,
+                    A_tt,
+                    D_tt,
+                    x_tt,
+                    out_z_tt,
+                    dt_tt,
+                    B_tt,
+                    C_tt,
+                    z_tt,
+                    rmsnorm_weight_tt,
+                    outproj_weight_tt,
+                    outproj_bias_tt,
+                    output_tt,
+                    epsilon,
+                    grid_dim=(num_blocks,),
+                    block_dim=(BLOCK_SIZE,),
+                )
+        else:
+            raise Error("Unsupported target: " + target)

--- a/max/kernels/src/state_space/ssd_chunk.mojo
+++ b/max/kernels/src/state_space/ssd_chunk.mojo
@@ -1,0 +1,1597 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Structured state space duality (SSD) intra-chunk diagonal block kernel.
+
+This implements stage 1 of the SSD chunk-scan algorithm used by Mamba2: the
+"intra-chunk diagonal block output". For each ``(batch, chunk, head)`` it
+computes the causal, decay-weighted attention-like output that only depends on
+tokens within the same chunk.
+
+For a chunk of ``L`` tokens with state dim ``N`` and head dim ``P``:
+
+- Inputs: ``C: [L, N]``, ``B: [L, N]``, ``X: [L, P]``, ``A: [L]`` (a scalar
+  decay per token).
+- Cumulative decay: ``A_cumsum[l] = sum_{k=0..l} A[k]``.
+- Causal decay (segment-sum) matrix: for ``s <= l``,
+  ``Ldecay[l, s] = exp(A_cumsum[l] - A_cumsum[s])``; for ``s > l`` it is ``0``.
+- Attention scores: ``scores[l, s] = (sum_n C[l, n] * B[s, n]) * Ldecay[l, s]``
+  for ``s <= l``.
+- Output: ``Y[l, p] = sum_{s=0..l} scores[l, s] * X[s, p]``.
+
+This matches the reference einsum
+``Y_diag = einsum("ln,sn,ls,sp->lp", C, B, Ldecay, X)`` restricted to ``s <= l``
+(stage 1 of ``ssd_minimal_discrete``).
+
+Implementations:
+
+- ``*_naive``: scalar reference kernels for golden / numerical-stability tests.
+- ``ssd_intra_chunk_fwd_cpu``: parallel per-slice GEMM decomposition (CPU).
+- ``ssd_intra_chunk_fwd_gpu``: host dispatch — batched ``C @ B^T`` via Modular
+  ``batched_matmul`` (tensor cores on GPU) plus a Triton-style tiled chunk-scan
+  kernel that fuses decay masking with ``scores @ X``.
+"""
+
+from layout.layout_tensor import copy_local_to_dram, copy_local_to_shared
+from layout.tensor_core import TensorCore, get_fragment_size, get_mma_shape
+from max.gpu.memory import async_copy_wait_all
+from layout import (
+    Idx,
+    Layout,
+    LayoutTensor,
+    TensorLayout,
+    TileTensor,
+    row_major,
+)
+from std.memory import AddressSpace
+from std.sys.info import _has_sm_121x
+from linalg.bmm import batched_matmul
+from max.algorithm import sync_parallelize
+from std.collections import OptionalReg
+from max.gpu.host import DeviceContext
+from std.math import ceildiv, exp
+from std.memory import alloc, unsafe_stack_allocation as mem_stack_allocation
+from max.gpu.sync import barrier as gpu_barrier
+from std.gpu import (
+    WARP_SIZE,
+    block_dim,
+    block_idx,
+    thread_idx,
+)
+from std.utils.index import IndexList
+
+# Triton-style tile sizes (scaled down for per-block register/stack budget).
+#
+# Device-split tuning: the chunk-scan's per-block work grows linearly with
+# pid_m (causal early-exit), so heavy tiles drain late and idle SMs. On the
+# GB10 (sm_121, DGX Spark) — many small SMs that prefer fine-grained work —
+# a 32-row tile (2× the blocks) measurably beats 64 (0.41 → 0.37 ms). On
+# datacenter parts (A100/H100/B200, fewer but larger SMs) the 64-row tile is
+# the safer default; it keeps more rows resident per block and we have not
+# profiled the smaller tile there. The kernel is correct for either value on
+# any GPU — this only trades block count vs per-block work.
+comptime SCAN_BLOCK_M = 32 if _has_sm_121x() else 64
+comptime SCAN_BLOCK_N = 32
+comptime SCAN_BLOCK_K = 32
+comptime SCAN_ACC_ELEMS = SCAN_BLOCK_M * SCAN_BLOCK_N
+# Warps per scan block. The cooperative CB load strides BM rows by this
+# count, so the block size must be a whole number of warps.
+comptime SCAN_WARPS = SCAN_BLOCK_M // 32
+
+# Upper bound on chunk_len for the shared-memory prefix-sum scratch (one
+# block per slice, one element per thread). 1024 floats = 4 KB shmem.
+comptime SCAN_MAX_CHUNK = 1024
+
+# BMM tile sizes for the in-house C @ B^T kernel. Each thread block emits
+# a BMM_BM × BMM_BN output tile; threads laid out (BMM_BN, BMM_BM) so a warp
+# spans a full BMM_BN row (32 contiguous output cols) for coalesced stores.
+comptime BMM_BM = 32
+comptime BMM_BN = 32
+comptime BMM_BK = 16
+
+# Stride helpers for indexing the flat row-major buffers.
+comptime Strides4D = IndexList[4]
+comptime Strides5D = IndexList[5]
+
+
+def _row_major_strides_4d(d0: Int, d1: Int, d2: Int, d3: Int) -> Strides4D:
+    """Row-major strides for a 4D shape ``(d0, d1, d2, d3)``."""
+    return Strides4D(d1 * d2 * d3, d2 * d3, d3, 1)
+
+
+def _row_major_strides_5d(
+    d0: Int, d1: Int, d2: Int, d3: Int, d4: Int
+) -> Strides5D:
+    """Row-major strides for a 5D shape ``(d0, d1, d2, d3, d4)``."""
+    return Strides5D(d1 * d2 * d3 * d4, d2 * d3 * d4, d3 * d4, d4, 1)
+
+
+@always_inline
+def _apply_decay_mask_to_cb[
+    dtype: DType,
+](
+    chunk_len: Int,
+    cb_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
+    cumsum: Pointer[Float32, MutUntrackedOrigin],
+) -> None:
+    """Apply causal decay ``exp(cum[l]-cum[s])`` to lower-triangular ``CB[l,s]``.
+    """
+    for l in range(chunk_len):
+        var cum_l = cumsum[l]
+        for s in range(l + 1):
+            var off = l * chunk_len + s
+            var val = cb_ptr[off].cast[DType.float32]() * exp(cum_l - cumsum[s])
+            cb_ptr[off] = val.cast[dtype]()
+        for s in range(l + 1, chunk_len):
+            cb_ptr[l * chunk_len + s] = Scalar[dtype](0)
+
+
+# ===----------------------------------------------------------------------=== #
+# Naive CPU baseline (numerical reference)
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_cpu_naive[
+    kernel_dtype: DType,
+    C_layout: Layout,
+    B_layout: Layout,
+    X_layout: Layout,
+    A_layout: Layout,
+    Y_layout: Layout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    C: LayoutTensor[kernel_dtype, C_layout, MutAnyOrigin],
+    B: LayoutTensor[kernel_dtype, B_layout, MutAnyOrigin],
+    X: LayoutTensor[kernel_dtype, X_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, A_layout, MutAnyOrigin],
+    Y: LayoutTensor[kernel_dtype, Y_layout, MutAnyOrigin],
+):
+    """Naive scalar CPU reference for golden / stability tests.
+
+    Triple nested loops over ``(l, s, n, p)`` with no SIMD or GEMM.
+    """
+    var cb_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, state_dim
+    )
+    var x_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, head_dim
+    )
+    var a_strides = _row_major_strides_4d(batch, n_chunks, n_heads, chunk_len)
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var cb_base = (
+                    b * cb_strides[0] + c * cb_strides[1] + h * cb_strides[2]
+                )
+                var x_base = (
+                    b * x_strides[0] + c * x_strides[1] + h * x_strides[2]
+                )
+                var a_base = (
+                    b * a_strides[0] + c * a_strides[1] + h * a_strides[2]
+                )
+                var y_base = x_base
+
+                var a_cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var running = Float32(0.0)
+                for l in range(chunk_len):
+                    var a_off = a_base + l * a_strides[3]
+                    running += A.ptr[a_off].cast[DType.float32]()
+                    a_cumsum[l] = running
+
+                for l in range(chunk_len):
+                    var c_row = cb_base + l * cb_strides[3]
+                    var cum_l = a_cumsum[l]
+                    for s in range(l + 1):
+                        var b_row = cb_base + s * cb_strides[3]
+
+                        var dot = Float32(0.0)
+                        for n in range(state_dim):
+                            var cv = C.ptr[c_row + n * cb_strides[4]].cast[
+                                DType.float32
+                            ]()
+                            var bv = B.ptr[b_row + n * cb_strides[4]].cast[
+                                DType.float32
+                            ]()
+                            dot += cv * bv
+
+                        var decay = exp(cum_l - a_cumsum[s])
+                        var score = dot * decay
+
+                        var x_row = x_base + s * x_strides[3]
+                        var y_row = y_base + l * x_strides[3]
+                        for p in range(head_dim):
+                            var xv = X.ptr[x_row + p * x_strides[4]].cast[
+                                DType.float32
+                            ]()
+                            var y_off = y_row + p * x_strides[4]
+                            var acc = (
+                                Y.ptr[y_off].cast[DType.float32]() + score * xv
+                            )
+                            Y.ptr[y_off] = acc.cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# Optimized CPU (parallel slices + GEMM)
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_cpu[
+    kernel_dtype: DType,
+    C_layout: Layout,
+    B_layout: Layout,
+    X_layout: Layout,
+    A_layout: Layout,
+    Y_layout: Layout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    C: LayoutTensor[kernel_dtype, C_layout, MutAnyOrigin],
+    B: LayoutTensor[kernel_dtype, B_layout, MutAnyOrigin],
+    X: LayoutTensor[kernel_dtype, X_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, A_layout, MutAnyOrigin],
+    Y: LayoutTensor[kernel_dtype, Y_layout, MutAnyOrigin],
+    ctx: Optional[DeviceContext] = None,
+) raises:
+    """Optimized CPU intra-chunk diagonal block.
+
+    1. Batched ``CB = C @ B^T`` via ``batched_matmul``.
+    2. Parallel per-slice causal decay on ``CB``.
+    3. Batched ``Y = CB @ X`` via ``batched_matmul``.
+    """
+    var num_slices = batch * n_chunks * n_heads
+    var l2 = chunk_len * chunk_len
+
+    var cb_ptr = alloc[Scalar[kernel_dtype]](num_slices * l2)
+
+    var C3 = TileTensor(C.ptr, row_major(num_slices, chunk_len, state_dim))
+    var B3 = TileTensor(B.ptr, row_major(num_slices, chunk_len, state_dim))
+    var CB3 = TileTensor(cb_ptr, row_major(num_slices, chunk_len, chunk_len))
+    var X3 = TileTensor(X.ptr, row_major(num_slices, chunk_len, head_dim))
+    var Y3 = TileTensor(Y.ptr, row_major(num_slices, chunk_len, head_dim))
+
+    batched_matmul[target="cpu", transpose_b=True](CB3, C3, B3)
+
+    var a_strides = _row_major_strides_4d(batch, n_chunks, n_heads, chunk_len)
+
+    @__parameter
+    def decay_worker(flat_idx: Int):
+        var h = flat_idx % n_heads
+        var c = (flat_idx // n_heads) % n_chunks
+        var b = flat_idx // (n_heads * n_chunks)
+
+        var a_base = b * a_strides[0] + c * a_strides[1] + h * a_strides[2]
+        var cumsum_ptr = alloc[Float32](chunk_len)
+
+        var running = Float32(0.0)
+        for l in range(chunk_len):
+            running += A.ptr[a_base + l * a_strides[3]].cast[DType.float32]()
+            cumsum_ptr[l] = running
+
+        _apply_decay_mask_to_cb[kernel_dtype](
+            chunk_len,
+            cb_ptr + flat_idx * l2,
+            cumsum_ptr,
+        )
+        cumsum_ptr.free()
+
+    sync_parallelize[decay_worker](num_slices, ctx)
+
+    batched_matmul[target="cpu"](Y3, CB3, X3)
+
+    cb_ptr.free()
+
+
+# ===----------------------------------------------------------------------=== #
+# Naive GPU baseline (numerical reference)
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_gpu_naive[
+    kernel_dtype: DType,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    state_dim_i32: Int32,
+    head_dim_i32: Int32,
+    C: TileTensor[kernel_dtype, C_LT, MutUntrackedOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutUntrackedOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutUntrackedOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutUntrackedOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutUntrackedOrigin],
+):
+    """Naive GPU reference: one thread per ``(batch, chunk, head)`` slice.
+
+    Scalar loops only — use for golden / stability tests, not performance.
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var state_dim = Int(state_dim_i32)
+    var head_dim = Int(head_dim_i32)
+    var flat_idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total_slices = batch * n_chunks * n_heads
+    if flat_idx >= total_slices:
+        return
+
+    var h = flat_idx % n_heads
+    var c = (flat_idx // n_heads) % n_chunks
+    var b = flat_idx // (n_heads * n_chunks)
+
+    var cb_n_stride = 1
+    var cb_l_stride = state_dim
+    var cb_h_stride = chunk_len * cb_l_stride
+    var cb_c_stride = n_heads * cb_h_stride
+    var cb_b_stride = n_chunks * cb_c_stride
+
+    var x_p_stride = 1
+    var x_l_stride = head_dim
+    var x_h_stride = chunk_len * x_l_stride
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_l_stride = 1
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var cb_base = b * cb_b_stride + c * cb_c_stride + h * cb_h_stride
+    var x_base = b * x_b_stride + c * x_c_stride + h * x_h_stride
+    var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+    var y_base = x_base
+
+    for l in range(chunk_len):
+        var c_row = cb_base + l * cb_l_stride
+
+        var cum_l = Float32(0.0)
+        for k in range(l + 1):
+            cum_l += A.ptr[a_base + k * a_l_stride].cast[DType.float32]()
+
+        for p in range(head_dim):
+            Y.ptr[y_base + l * x_l_stride + p * x_p_stride] = Scalar[
+                kernel_dtype
+            ](0)
+
+        var cum_s = Float32(0.0)
+        for s in range(l + 1):
+            cum_s += A.ptr[a_base + s * a_l_stride].cast[DType.float32]()
+
+            var b_row = cb_base + s * cb_l_stride
+
+            var dot = Float32(0.0)
+            for n in range(state_dim):
+                var cv = C.ptr[c_row + n * cb_n_stride].cast[DType.float32]()
+                var bv = B.ptr[b_row + n * cb_n_stride].cast[DType.float32]()
+                dot += cv * bv
+
+            var decay = exp(cum_l - cum_s)
+            var score = dot * decay
+
+            var x_row = x_base + s * x_l_stride
+            var y_row = y_base + l * x_l_stride
+            for p in range(head_dim):
+                var xv = X.ptr[x_row + p * x_p_stride].cast[DType.float32]()
+                var y_off = y_row + p * x_p_stride
+                var acc = Y.ptr[y_off].cast[DType.float32]() + score * xv
+                Y.ptr[y_off] = acc.cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU: batched ``CB = C @ B^T`` (tiled, shared-memory, no tensor cores)
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_intra_chunk_bmm_gpu[
+    kernel_dtype: DType,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    CB_LT: TensorLayout,
+](
+    n_slices_i32: Int32,
+    chunk_len_i32: Int32,
+    state_dim_i32: Int32,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    CB: TileTensor[kernel_dtype, CB_LT, MutAnyOrigin],
+):
+    """Batched ``CB[s, l, r] = sum_n C[s, l, n] * B[s, r, n]``.
+
+    Replaces Modular ``batched_matmul`` for our dim set. The Modular
+    dispatch needs static N/K to pick its tensor-core path; our caller
+    only has dynamic dims, so it falls through to a per-element naive
+    kernel that was profiled at >3ms/call. This kernel is a stock tiled
+    matmul (no tensor cores, just shmem prefetched tiles); on the GB10
+    it's enough to close the gap to the scan kernel cost.
+
+    Grid: ``(ceildiv(L, BMM_BM) * ceildiv(L, BMM_BN), n_slices)``.
+    Block: ``(BMM_BN, BMM_BM)``; thread ``(tn, tm)`` owns output
+    ``CB[block_slice, l = m_tile*BMM_BM + tm, r = n_tile*BMM_BN + tn]``.
+    Shared memory holds the current ``BMM_BM × BMM_BK`` C tile and
+    ``BMM_BN × BMM_BK`` B tile per K window.
+    """
+    var n_slices = Int(n_slices_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var state_dim = Int(state_dim_i32)
+    var num_n_tiles = ceildiv(chunk_len, BMM_BN)
+    var m_tile = Int(block_idx.x) // num_n_tiles
+    var n_tile = Int(block_idx.x) - m_tile * num_n_tiles
+    var slice_idx = Int(block_idx.y)
+
+    var l = m_tile * BMM_BM + Int(thread_idx.y)
+    var r = n_tile * BMM_BN + Int(thread_idx.x)
+
+    var c_slice_base = slice_idx * chunk_len * state_dim
+    var b_slice_base = c_slice_base  # same layout
+    var cb_slice_base = slice_idx * chunk_len * chunk_len
+
+    var c_smem = mem_stack_allocation[
+        BMM_BM * BMM_BK, Float32, address_space=AddressSpace.SHARED
+    ]()
+    var b_smem = mem_stack_allocation[
+        BMM_BN * BMM_BK, Float32, address_space=AddressSpace.SHARED
+    ]()
+
+    var acc: Float32 = 0.0
+
+    var tm = Int(thread_idx.y)
+    var tn = Int(thread_idx.x)
+
+    for k0 in range(0, state_dim, BMM_BK):
+        # Cooperative C[m_tile_row, k0..k0+BMM_BK] load. Threads
+        # (tm, tn) load C_smem[tm, tn] when tn < BMM_BK.
+        if tn < BMM_BK:
+            var n = k0 + tn
+            if l < chunk_len and n < state_dim:
+                c_smem[tm * BMM_BK + tn] = C.ptr[
+                    c_slice_base + l * state_dim + n
+                ].cast[DType.float32]()
+            else:
+                c_smem[tm * BMM_BK + tn] = 0.0
+        # Cooperative B[n_tile_row, k0..k0+BMM_BK] load. Threads
+        # (tm, tn) → B_smem[tn, tm] when tm < BMM_BK.
+        if tm < BMM_BK:
+            var n = k0 + tm
+            var r2 = n_tile * BMM_BN + tn
+            if r2 < chunk_len and n < state_dim:
+                b_smem[tn * BMM_BK + tm] = B.ptr[
+                    b_slice_base + r2 * state_dim + n
+                ].cast[DType.float32]()
+            else:
+                b_smem[tn * BMM_BK + tm] = 0.0
+
+        gpu_barrier()
+
+        if l < chunk_len and r < chunk_len:
+            comptime for k in range(BMM_BK):
+                acc += c_smem[tm * BMM_BK + k] * b_smem[tn * BMM_BK + k]
+
+        gpu_barrier()
+
+    if l < chunk_len and r < chunk_len:
+        CB.ptr[cb_slice_base + l * chunk_len + r] = acc.cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU: prefix sum of A per slice
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_intra_chunk_cumsum_gpu[
+    kernel_dtype: DType,
+    A_LT: TensorLayout,
+    cumsum_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    A: TileTensor[kernel_dtype, A_LT, MutUntrackedOrigin],
+    cumsum: TileTensor[DType.float32, cumsum_LT, MutUntrackedOrigin],
+):
+    """Inclusive prefix sum of ``A`` into ``cumsum`` — one block per slice.
+
+    Hillis-Steele scan in shared memory: ``block_dim = chunk_len`` threads,
+    one element each, ``log2(chunk_len)`` doubling steps. The previous version
+    launched a single block (one thread per slice), so all slices' scans
+    serialised on **one SM** (~32 µs at the Mamba2 profile). One block per
+    slice spreads the work across every SM. Slices are contiguous ``chunk_len``
+    blocks in both buffers (``base = slice_idx * chunk_len``).
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var slice_idx = Int(block_idx.x)
+    var total_slices = batch * n_chunks * n_heads
+    if slice_idx >= total_slices:
+        return
+
+    var tid = Int(thread_idx.x)
+    var base = slice_idx * chunk_len
+
+    var sdata = mem_stack_allocation[
+        SCAN_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+
+    if tid < chunk_len:
+        sdata[tid] = A.ptr[base + tid].cast[DType.float32]()
+    gpu_barrier()
+
+    var offset = 1
+    while offset < chunk_len:
+        var add: Float32 = 0.0
+        if tid < chunk_len and tid >= offset:
+            add = sdata[tid - offset]
+        gpu_barrier()
+        if tid < chunk_len and tid >= offset:
+            sdata[tid] += add
+        gpu_barrier()
+        offset *= 2
+
+    if tid < chunk_len:
+        cumsum.ptr[base + tid] = sdata[tid]
+
+
+def _ssd_intra_chunk_decay_gpu[
+    kernel_dtype: DType,
+    CB_LT: TensorLayout,
+    cumsum_LT: TensorLayout,
+](
+    num_slices_i32: Int32,
+    chunk_len_i32: Int32,
+    CB: TileTensor[kernel_dtype, CB_LT, MutUntrackedOrigin],
+    cumsum: TileTensor[DType.float32, cumsum_LT, MutUntrackedOrigin],
+):
+    """Apply causal decay in place: ``M[l,s] = CB[l,s]*exp(cum[l]-cum[s])``.
+
+    Lower-triangular (``s <= l``); the strict upper triangle is zeroed.
+    Materialises the decayed, masked score matrix so the chunk scan can be
+    expressed as a plain ``Y = M @ X`` tensor-core matmul. Flat grid over
+    the ``num_slices * L * L`` elements; consecutive threads map to
+    consecutive ``s`` so CB / cumsum traffic is fully coalesced.
+    """
+    var num_slices = Int(num_slices_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var slice_idx = Int(block_idx.y)
+    var elem = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var l2 = chunk_len * chunk_len
+    if slice_idx >= num_slices or elem >= l2:
+        return
+
+    var l = elem // chunk_len
+    var s = elem - l * chunk_len
+
+    var cs_base = slice_idx * chunk_len
+    var cb_off = slice_idx * l2 + elem
+
+    if s <= l:
+        var cum_l = cumsum.ptr[cs_base + l]
+        var cum_s = cumsum.ptr[cs_base + s]
+        var decayed = CB.ptr[cb_off].cast[DType.float32]() * exp(cum_l - cum_s)
+        CB.ptr[cb_off] = decayed.cast[kernel_dtype]()
+    else:
+        CB.ptr[cb_off] = Scalar[kernel_dtype](0)
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU: Triton-style tiled chunk scan  (decay-masked CB @ X)
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_intra_chunk_chunk_scan_gpu[
+    kernel_dtype: DType,
+    CB_LT: TensorLayout,
+    cumsum_LT: TensorLayout,
+    X_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    head_dim_i32: Int32,
+    CB: TileTensor[kernel_dtype, CB_LT, MutUntrackedOrigin],
+    cumsum: TileTensor[DType.float32, cumsum_LT, MutUntrackedOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutUntrackedOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutUntrackedOrigin],
+):
+    """Tiled ``Y = causal_decay(CB) @ X`` matching Mamba ``_chunk_scan_fwd_kernel``.
+
+    Grid ``(ceil(L/BM)*ceil(P/BN), batch*n_chunks, n_heads)`` with causal
+    masking and ``exp(cumsum[l]-cumsum[s])`` decay fused in the K loop.
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var head_dim = Int(head_dim_i32)
+    comptime BM = SCAN_BLOCK_M
+    comptime BN = SCAN_BLOCK_N
+    comptime BK = SCAN_BLOCK_K
+    var num_pid_n = ceildiv(head_dim, BN)
+    var pid_m = Int(block_idx.x) // num_pid_n
+    var pid_n = Int(block_idx.x) % num_pid_n
+
+    var pid_bc = Int(block_idx.y)
+    var pid_h = Int(block_idx.z)
+
+    var c = pid_bc // batch
+    var b = pid_bc - c * batch
+
+    var cb_b_stride = n_chunks * n_heads * chunk_len * chunk_len
+    var cb_c_stride = n_heads * chunk_len * chunk_len
+    var cb_h_stride = chunk_len * chunk_len
+    var cb_l_stride = chunk_len
+    var cb_s_stride = 1
+
+    var x_b_stride = n_chunks * n_heads * chunk_len * head_dim
+    var x_c_stride = n_heads * chunk_len * head_dim
+    var x_h_stride = chunk_len * head_dim
+    var x_l_stride = head_dim
+    var x_p_stride = 1
+
+    var y_b_stride = x_b_stride
+    var y_c_stride = x_c_stride
+    var y_h_stride = x_h_stride
+    var y_l_stride = head_dim
+    var y_p_stride = 1
+
+    var cs_b_stride = n_chunks * n_heads * chunk_len
+    var cs_c_stride = n_heads * chunk_len
+    var cs_h_stride = chunk_len
+    var cs_l_stride = 1
+
+    var cb_base = b * cb_b_stride + c * cb_c_stride + pid_h * cb_h_stride
+    var x_base = b * x_b_stride + c * x_c_stride + pid_h * x_h_stride
+    var y_base = b * y_b_stride + c * y_c_stride + pid_h * y_h_stride
+    var cs_base = b * cs_b_stride + c * cs_c_stride + pid_h * cs_h_stride
+
+    var offs_m0 = pid_m * BM
+    var offs_n0 = pid_n * BN
+
+    # One thread per row of the BM×BN output tile (block_dim = BM threads).
+    var tid = Int(thread_idx.x)
+
+    # Shared tiles for the K window. We batch the X load to amortise
+    # the global → shmem traffic across BK iterations and remove the
+    # per-K-iter sync (was 2*K_MAX barriers per block, now 1 per BK).
+    var x_smem = mem_stack_allocation[
+        SCAN_BLOCK_K * SCAN_BLOCK_N,
+        Float32,
+        address_space=AddressSpace.SHARED,
+    ]()
+    var cum_smem = mem_stack_allocation[
+        SCAN_BLOCK_K, Float32, address_space=AddressSpace.SHARED
+    ]()
+    # Pad inner stride by 1 to avoid 32-way bank conflicts in the FMA
+    # inner loop: with stride 32 (= 128 B), every BM lane hits the same
+    # bank. Stride 33 makes the bank index = (row * 33 + ki) % 32, which
+    # cycles through all 32 banks across the 64 lanes of the block.
+    comptime CB_SMEM_STRIDE = SCAN_BLOCK_K + 1
+    var cb_smem = mem_stack_allocation[
+        SCAN_BLOCK_M * CB_SMEM_STRIDE,
+        Float32,
+        address_space=AddressSpace.SHARED,
+    ]()
+
+    var l = offs_m0 + tid
+    var active = tid < BM and l < chunk_len
+
+    # Causal decay ``exp(cum_l - cum_s)`` is computed directly in the inner
+    # loop from the raw cumulative sums. The earlier factoring into
+    # ``exp(cum_l) * exp(-cum_s)`` saved exp calls but is numerically
+    # unstable: ``cumsum`` is the prefix sum of ``A*dt`` with ``A < 0``, so
+    # it is large-negative. ``exp(cum_l)`` then underflows to 0 while
+    # ``exp(-cum_s)`` overflows to +inf, and ``0 * inf = NaN`` even on the
+    # causal diagonal where the true decay ``exp(cum_l - cum_s) ∈ (0, 1]``
+    # is finite. Since ``cum_l - cum_s <= 0`` for ``s <= l`` (the only
+    # entries we keep), the direct form can never overflow.
+    var cum_l: Float32 = 0.0
+    if active:
+        cum_l = cumsum.ptr[cs_base + l * cs_l_stride]
+
+    # Per-thread BN-wide accumulator.
+    var acc = mem_stack_allocation[
+        SCAN_BLOCK_N, Float32, address_space=AddressSpace.LOCAL
+    ]()
+
+    comptime for ni in range(BN):
+        acc[ni] = 0.0
+
+    # Walk the K axis only up to ``(pid_m + 1) * BM`` (the max ``l`` in
+    # this block) — causal masking would zero-out anything beyond that, so
+    # there's no point loading or computing it. For pid_m=0 (first L-tile)
+    # this cuts K_MAX from chunk_len to BM; on the Mamba2-130m profile
+    # (L=256, BM=64) the average K work drops by ~1.6× across the four
+    # M-tiles.
+    var k_limit = min((pid_m + 1) * BM, chunk_len)
+    for k0 in range(0, k_limit, BK):
+        # Cooperative raw ``cum_s`` window. The inner loop forms the decay
+        # as ``exp(cum_l - cum_s)`` directly (stable; see note above).
+        if tid < BK:
+            var s = k0 + tid
+            if s < chunk_len:
+                cum_smem[tid] = cumsum.ptr[cs_base + s * cs_l_stride]
+            else:
+                cum_smem[tid] = 0.0
+        # Cooperative X tile of size BK × BN, one outer iter at a time.
+        # Threads (BM total) split BK*BN elements; with BM == BN, each
+        # thread (column tid in [0, BN)) loads BK contiguous K rows for
+        # its column.
+        if tid < BN:
+            var p = offs_n0 + tid
+
+            comptime for ki in range(BK):
+                var s = k0 + ki
+                if s < chunk_len and p < head_dim:
+                    x_smem[ki * BN + tid] = X.ptr[
+                        x_base + s * x_l_stride + p * x_p_stride
+                    ].cast[DType.float32]()
+                else:
+                    x_smem[ki * BN + tid] = 0.0
+
+        # Cooperative CB tile of size BM × BK: each warp loads one
+        # contiguous K row per iter (32 lanes × 4 B = 1 cache line,
+        # perfectly coalesced) — replaces the previous scattered
+        # per-thread CB[l, s] reads (stride L between lanes, 16-way
+        # uncoalesced on the Mamba2-130m profile). The ``SCAN_WARPS``
+        # warps in the block stride the BM rows by ``SCAN_WARPS`` so any
+        # block size that is a multiple of the warp size is covered.
+        var warp_id = tid // 32
+        var lane = tid - warp_id * 32
+
+        comptime for r in range(0, SCAN_BLOCK_M, SCAN_WARPS):
+            var row = r + warp_id
+            var l_row = offs_m0 + row
+            var s_col = k0 + lane
+            if (
+                row < SCAN_BLOCK_M
+                and l_row < chunk_len
+                and lane < BK
+                and s_col < chunk_len
+            ):
+                cb_smem[row * CB_SMEM_STRIDE + lane] = CB.ptr[
+                    cb_base + l_row * cb_l_stride + s_col * cb_s_stride
+                ].cast[DType.float32]()
+            elif lane < BK:
+                cb_smem[row * CB_SMEM_STRIDE + lane] = 0.0
+
+        gpu_barrier()
+
+        if active:
+            comptime for ki in range(BK):
+                var s = k0 + ki
+                if s < chunk_len and s <= l:
+                    var cb_val = cb_smem[tid * CB_SMEM_STRIDE + ki]
+                    var score = cb_val * exp(cum_l - cum_smem[ki])
+
+                    comptime for ni in range(BN):
+                        acc[ni] += score * x_smem[ki * BN + ni]
+
+        gpu_barrier()
+
+    if active:
+        var y_row = y_base + l * y_l_stride
+
+        comptime for ni in range(BN):
+            var p = offs_n0 + ni
+            if p < head_dim:
+                Y.ptr[y_row + p * y_p_stride] = acc[ni].cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# Optimized GPU host dispatch
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_gpu[
+    kernel_dtype: DType,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Optimized GPU intra-chunk diagonal block (Mamba-style pipeline).
+
+    1. Batched ``CB = C @ B^T`` via Modular ``batched_matmul`` (tensor cores).
+    2. Per-slice inclusive prefix sum of ``A``.
+    3. Tiled chunk-scan: ``Y = causal_decay(CB) @ X``.
+
+    Matches the structure of ``mamba_ssm/ops/triton/ssd_chunk_scan.py``:
+    ``_bmm_chunk_fwd`` + ``_chunk_scan_fwd_kernel``.
+    """
+    var num_slices = batch * n_chunks * n_heads
+    var l2 = chunk_len * chunk_len
+
+    var CB_device = ctx.enqueue_create_buffer[kernel_dtype](num_slices * l2)
+    var cumsum_device = ctx.enqueue_create_buffer[DType.float32](
+        num_slices * chunk_len
+    )
+
+    var C3 = TileTensor(
+        C.ptr,
+        row_major(num_slices, chunk_len, state_dim),
+    )
+    var B3 = TileTensor(
+        B.ptr,
+        row_major(num_slices, chunk_len, state_dim),
+    )
+    var CB3 = TileTensor(
+        CB_device,
+        row_major(num_slices, chunk_len, chunk_len),
+    )
+    var cumsum4 = TileTensor(
+        cumsum_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var CB5 = TileTensor(
+        CB_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, chunk_len),
+    )
+
+    # Dispatch CB = C @ B^T:
+    #   batched_matmul picks a cutlass tensor-core path when batch_size == 1
+    #   but falls back to a naive O(N^3) per-element kernel for batched
+    #   cases. Our hand-tiled ``_ssd_intra_chunk_bmm_gpu`` beats the naive
+    #   fallback by ~5×, but is still scalar (no tensor cores). For
+    #   multi-slice we benchmark both: a per-slice loop of cutlass calls
+    #   (tensor cores, but 96 launches of ~5µs each) and the custom bmm
+    #   (one launch, scalar). The faster of the two wins at this dim set.
+    #
+    # Toggle via env var for benchmarking; default: per-slice cutlass.
+    var use_per_slice_cutlass = True
+    if num_slices == 1:
+        with ctx.push_context():
+            batched_matmul[target="gpu", transpose_b=True](
+                CB3, C3, B3, context=ctx
+            )
+    elif use_per_slice_cutlass:
+        with ctx.push_context():
+            for s in range(num_slices):
+                var Cs = TileTensor(
+                    C.ptr + s * chunk_len * state_dim,
+                    row_major(1, chunk_len, state_dim),
+                )
+                var Bs = TileTensor(
+                    B.ptr + s * chunk_len * state_dim,
+                    row_major(1, chunk_len, state_dim),
+                )
+                var CBs = TileTensor(
+                    CB_device.unsafe_ptr() + s * chunk_len * chunk_len,
+                    row_major(1, chunk_len, chunk_len),
+                )
+                batched_matmul[target="gpu", transpose_b=True](
+                    CBs, Cs, Bs, context=ctx
+                )
+    else:
+        comptime bmm_kernel = _ssd_intra_chunk_bmm_gpu[
+            kernel_dtype,
+            C3.LayoutType,
+            B3.LayoutType,
+            CB3.LayoutType,
+        ]
+        var bmm_compiled = ctx.compile_function[bmm_kernel]()
+        var bmm_grid_x = ceildiv(chunk_len, BMM_BM) * ceildiv(chunk_len, BMM_BN)
+
+        with ctx.push_context():
+            ctx.enqueue_function(
+                bmm_compiled,
+                Int32(num_slices),
+                Int32(chunk_len),
+                Int32(state_dim),
+                C3,
+                B3,
+                CB3,
+                grid_dim=(bmm_grid_x, num_slices, 1),
+                block_dim=(BMM_BN, BMM_BM, 1),
+            )
+
+    var cumsum_compiled = ctx.compile_function[
+        _ssd_intra_chunk_cumsum_gpu[
+            kernel_dtype,
+            A_LT,
+            cumsum4.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            cumsum_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            A,
+            cumsum4,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len,),
+        )
+
+    comptime scan_kernel = _ssd_intra_chunk_chunk_scan_gpu[
+        kernel_dtype,
+        CB5.LayoutType,
+        cumsum4.LayoutType,
+        X_LT,
+        Y_LT,
+    ]
+    var scan_compiled = ctx.compile_function[scan_kernel]()
+
+    var grid_x = ceildiv(chunk_len, SCAN_BLOCK_M) * ceildiv(
+        head_dim, SCAN_BLOCK_N
+    )
+
+    # Scan kernel reads ``block_idx.y`` as ``batch * n_chunks`` and
+    # ``block_idx.z`` as ``n_heads``; launching ``num_slices`` (= b*nc*nh)
+    # in y was redundantly multiplying the work by n_heads. Fix the launch
+    # to match the kernel's index decomposition.
+    with ctx.push_context():
+        ctx.enqueue_function(
+            scan_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            CB5,
+            cumsum4,
+            X,
+            Y,
+            grid_dim=(grid_x, batch * n_chunks, n_heads),
+            block_dim=(SCAN_BLOCK_M, 1, 1),
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Static-shape entry point
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_intra_chunk_fwd_gpu_static[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Static-shape variant of ``ssd_intra_chunk_fwd_gpu``.
+
+    Knowing ``chunk_len`` / ``state_dim`` / ``head_dim`` at compile time
+    lets ``batched_matmul`` see ``has_static_NK`` and pick its A100
+    tensor-core batched path (one launch for all slices, grid_z =
+    batch_size), instead of the per-slice cutlass loop (96 launches × ~4 µs
+    each) that dominates the dynamic-shape dispatch.
+    """
+    var num_slices = batch * n_chunks * n_heads
+    comptime l2 = chunk_len_ct * chunk_len_ct
+
+    var CB_device = ctx.enqueue_create_buffer[kernel_dtype](num_slices * l2)
+    var cumsum_device = ctx.enqueue_create_buffer[DType.float32](
+        num_slices * chunk_len_ct
+    )
+
+    var C3 = TileTensor(
+        C.ptr,
+        row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct]),
+    )
+    var B3 = TileTensor(
+        B.ptr,
+        row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct]),
+    )
+    var CB3 = TileTensor(
+        CB_device,
+        row_major(num_slices, Idx[chunk_len_ct], Idx[chunk_len_ct]),
+    )
+    var cumsum4 = TileTensor(
+        cumsum_device,
+        row_major(batch, n_chunks, n_heads, chunk_len_ct),
+    )
+    var CB5 = TileTensor(
+        CB_device,
+        row_major(
+            batch,
+            n_chunks,
+            n_heads,
+            Idx[chunk_len_ct],
+            Idx[chunk_len_ct],
+        ),
+    )
+
+    # Stage 1: CB = C @ B^T (batched tensor-core matmul, one launch).
+    #
+    # Uses the library ``batched_matmul``, which self-tunes per architecture
+    # (A100 multistage on GB10/Ampere, SM100 tcgen05 on datacenter Blackwell,
+    # AMD path on MI-series) and is correct for all shapes. A hand-dispatched
+    # smaller tile config was tried on GB10 (the "more blocks" lesson from the
+    # scan) but made no difference: this matmul is **DRAM-bandwidth bound** on
+    # materialising the L×L ``CB`` matrix (~50 MB C+B+CB traffic ≈ 90% of
+    # GB10 peak BW at 203 µs), not occupancy bound, so tile shape doesn't
+    # move it. The datacenter Blackwell (sm100/tcgen05) kernels cannot run on
+    # GB10 (consumer sm_121 has no tcgen05); consumer Blackwell already uses
+    # this multistage TF32 tensor-core path. The only further lever is fusing
+    # the bmm with the scan to avoid the CB round-trip (large change).
+    with ctx.push_context():
+        batched_matmul[target="gpu", transpose_b=True](CB3, C3, B3, context=ctx)
+
+    # Stage 2: inclusive prefix sum of A over the chunk.
+    var cumsum_compiled = ctx.compile_function[
+        _ssd_intra_chunk_cumsum_gpu[
+            kernel_dtype,
+            A_LT,
+            cumsum4.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            cumsum_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            A,
+            cumsum4,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len_ct,),
+        )
+
+    # Stage 3: tiled scalar chunk-scan — Y = causal_decay(CB) @ X. The
+    # scalar path beats a dense tensor-core M @ X here: it exploits the
+    # lower-triangular causal structure (≈half the FLOPs, plus per-M-tile
+    # early-K exit) and avoids padding head_dim to 128, which the A100
+    # batched matmul requires (c_n % 128 == 0). See
+    # ``ssd_intra_chunk_fwd_gpu_static_mma`` for the MMA alternative, which
+    # is ~2× faster single-slice but ~2× slower multi-slice.
+    comptime scan_kernel = _ssd_intra_chunk_chunk_scan_gpu[
+        kernel_dtype,
+        CB5.LayoutType,
+        cumsum4.LayoutType,
+        X_LT,
+        Y_LT,
+    ]
+    var scan_compiled = ctx.compile_function[scan_kernel]()
+
+    comptime grid_x = ceildiv(chunk_len_ct, SCAN_BLOCK_M) * ceildiv(
+        head_dim_ct, SCAN_BLOCK_N
+    )
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            scan_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            Int32(head_dim_ct),
+            CB5,
+            cumsum4,
+            X,
+            Y,
+            grid_dim=(grid_x, batch * n_chunks, n_heads),
+            block_dim=(SCAN_BLOCK_M, 1, 1),
+        )
+
+
+def ssd_intra_chunk_fwd_gpu_static_mma[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Tensor-core variant: materialise ``M = causal_decay(CB)`` then
+    ``Y = M @ X`` as two batched matmuls.
+
+    Trades the scalar chunk-scan for a dense matmul. **Faster than
+    ``ssd_intra_chunk_fwd_gpu_static`` only for a single slice** (no causal
+    work to exploit, scan launch overhead dominates): ~2× on GB10. For the
+    multi-slice Mamba2 prefill profile it is ~2× *slower* because the dense
+    ``M @ X`` ignores the lower-triangular structure (≈2× the FLOPs) and the
+    A100 batched matmul rejects ``head_dim`` (= output N = 64) for not being
+    a multiple of 128, falling back to the naive scalar batched kernel. Kept
+    for the single-slice regime and as a reference for future MMA work.
+    """
+    var num_slices = batch * n_chunks * n_heads
+    comptime l2 = chunk_len_ct * chunk_len_ct
+
+    var CB_device = ctx.enqueue_create_buffer[kernel_dtype](num_slices * l2)
+    var cumsum_device = ctx.enqueue_create_buffer[DType.float32](
+        num_slices * chunk_len_ct
+    )
+
+    var C3 = TileTensor(
+        C.ptr, row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct])
+    )
+    var B3 = TileTensor(
+        B.ptr, row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct])
+    )
+    var CB3 = TileTensor(
+        CB_device, row_major(num_slices, Idx[chunk_len_ct], Idx[chunk_len_ct])
+    )
+    var cumsum4 = TileTensor(
+        cumsum_device, row_major(batch, n_chunks, n_heads, chunk_len_ct)
+    )
+    var X3 = TileTensor(
+        X.ptr, row_major(num_slices, Idx[chunk_len_ct], Idx[head_dim_ct])
+    )
+    var Y3 = TileTensor(
+        Y.ptr, row_major(num_slices, Idx[chunk_len_ct], Idx[head_dim_ct])
+    )
+
+    # Stage 1: CB = C @ B^T (batched A100 tensor-core matmul).
+    with ctx.push_context():
+        batched_matmul[target="gpu", transpose_b=True](CB3, C3, B3, context=ctx)
+
+    # Stage 2: inclusive prefix sum of A over the chunk.
+    var cumsum_compiled = ctx.compile_function[
+        _ssd_intra_chunk_cumsum_gpu[kernel_dtype, A_LT, cumsum4.LayoutType]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            cumsum_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            A,
+            cumsum4,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len_ct,),
+        )
+
+    # Stage 3: apply causal decay in place — M = causal_decay(CB).
+    comptime DECAY_BLOCK = 256
+    var decay_compiled = ctx.compile_function[
+        _ssd_intra_chunk_decay_gpu[
+            kernel_dtype, CB3.LayoutType, cumsum4.LayoutType
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            decay_compiled,
+            Int32(num_slices),
+            Int32(chunk_len_ct),
+            CB3,
+            cumsum4,
+            grid_dim=(ceildiv(l2, DECAY_BLOCK), num_slices),
+            block_dim=(DECAY_BLOCK,),
+        )
+
+    # Stage 4: Y = M @ X (no transpose).
+    with ctx.push_context():
+        batched_matmul[target="gpu", transpose_b=False](
+            Y3, CB3, X3, context=ctx
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Fused single-pass tensor-core intra-chunk (FlashAttention-style, RFC 0009)
+# ===----------------------------------------------------------------------=== #
+
+# Fused-MMA tiling. One block per (slice, l-tile) computes BM rows of Y.
+# Two chained TF32 MMAs (CB = C @ Bᵀ, then Y += decay⊙CB @ X) with the CB
+# intermediate staged through shared memory (the Ampere C-fragment layout
+# differs from the A-fragment layout, so no register-direct handoff). BM == BK
+# so the l-tile and s-tile align (causal mask only on the diagonal tile).
+comptime FUSED_BM = 64
+comptime FUSED_BK = 16
+comptime FUSED_WARPS_M = 4
+# N (state-dim) contraction tile for MMA1. Tiling N keeps the C/B shared tiles
+# small (vs staging the full state_dim), which lifts occupancy from
+# shared-memory-limited 2 blocks/SM to several — the dominant fused-kernel
+# bottleneck on GB10. Must be a multiple of MMA_K (8) and divide state_dim.
+comptime FUSED_TN = 16
+
+
+def _ssd_intra_chunk_fused_mma_gpu[
+    kernel_dtype: DType,
+    L: Int,
+    N: Int,
+    P: Int,
+    BM: Int,
+    BK: Int,
+    num_warps_m: Int,
+    TN: Int,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    cumsum_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    cumsum: TileTensor[DType.float32, cumsum_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+):
+    """Fused intra-chunk forward: ``Y = (decay ⊙ tril(C @ Bᵀ)) @ X``.
+
+    One block per ``(slice, l-tile)``; ``grid = (num_slices, L // BM)``. The
+    ``CB`` scores never touch DRAM (the cost the two-kernel path pays): MMA1
+    accumulates ``cb[BM, BK] = C[l-tile] @ B[s-tile]ᵀ`` in registers, the block
+    applies ``exp(cum_l − cum_s)`` decay + causal mask while staging ``cb`` to
+    shared, then MMA2 accumulates ``acc[BM, P] += cb @ X[s-tile]`` over the
+    causal ``s`` tiles. ``cumsum`` is the precomputed inclusive prefix sum of
+    the per-token decay (one parallel kernel, cheap). Both MMAs are TF32,
+    FP32-accumulate, ``transpose_b=False`` — ``B`` is transposed into shared for
+    MMA1, mirroring the fused chunk-state kernel.
+    """
+    comptime accum_type = DType.float32
+    comptime mma_shape = get_mma_shape[kernel_dtype, accum_type]()
+    comptime MMA_M = mma_shape[0]
+    comptime MMA_N = mma_shape[1]
+    comptime MMA_K = mma_shape[2]
+    comptime WM = BM // num_warps_m
+    comptime num_m_mmas = WM // MMA_M
+    comptime num_n_mmas_cb = BK // MMA_N
+    comptime num_n_mmas_y = P // MMA_N
+    comptime num_k_mmas_cb = TN // MMA_K  # MMA1 K-tile is TN (N is tiled)
+    comptime num_k_mmas_y = BK // MMA_K
+    comptime fs = get_fragment_size[mma_shape]()
+    comptime a_frag_size = fs[0]
+    comptime b_frag_size = fs[1]
+    comptime c_frag_size = fs[2]
+    comptime num_threads = num_warps_m * WARP_SIZE
+
+    var slice_idx = Int(block_idx.x)
+    var pid_m = Int(block_idx.y)
+    var tid = Int(thread_idx.x)
+    var warp_id = tid // WARP_SIZE
+    var warp_y = warp_id
+
+    var c_base = slice_idx * L * N
+    var b_base = slice_idx * L * N
+    var x_base = slice_idx * L * P
+    var y_base = slice_idx * L * P
+    var cum_base = slice_idx * L
+    var l_off = pid_m * BM
+
+    # ── Shared tiles (N-tiled: smemC/smemBt are only TN wide in the contraction
+    # dim, keeping shared small for occupancy). ──────────────────────────────
+    var smemC = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(BM, TN),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var smemBt = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(TN, BK),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var smemCB = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(BM, BK),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var smemX = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(BK, P),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var idx = tid
+
+    # ── Accumulator for Y[l-tile, :P] (persists across the s-tile loop). ──────
+    var acc_reg = (
+        LayoutTensor[
+            accum_type,
+            Layout.row_major(num_m_mmas * num_n_mmas_y, c_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ]
+        .stack_allocation()
+        .fill(0)
+    )
+
+    var mma_op = TensorCore[accum_type, kernel_dtype, mma_shape, False]()
+
+    # ── Causal s-tile loop: s-tile 0 .. pid_m (s <= l). ──────────────────────
+    # An l-tile (BM rows) spans BM // BK s-tiles, so the causal bound covers
+    # s-tiles 0 .. (pid_m+1)*(BM//BK) - 1.
+    for s_tile in range((pid_m + 1) * (BM // BK)):
+        var s_off = s_tile * BK
+
+        # Stage X[s-tile, :P] (independent of the N-tile loop).
+        idx = tid
+        while idx < BK * P:
+            var r = idx // P
+            var p = idx % P
+            var sr = s_off + r
+            smemX[r, p] = X.ptr[x_base + sr * P + p] if sr < L else Scalar[
+                kernel_dtype
+            ](0)
+            idx += num_threads
+
+        # MMA1: cb[BM, BK] = C[l-tile, :N] @ B[s-tile, :N]ᵀ, accumulated over
+        # N in TN-wide tiles (small shared tiles -> higher occupancy).
+        var cb_reg = (
+            LayoutTensor[
+                accum_type,
+                Layout.row_major(num_m_mmas * num_n_mmas_cb, c_frag_size),
+                MutAnyOrigin,
+                address_space=AddressSpace.LOCAL,
+            ]
+            .stack_allocation()
+            .fill(0)
+        )
+        var a_reg = LayoutTensor[
+            kernel_dtype,
+            Layout.row_major(num_m_mmas, a_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ].stack_allocation()
+        var b_reg = LayoutTensor[
+            kernel_dtype,
+            Layout.row_major(num_n_mmas_cb, b_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ].stack_allocation()
+
+        comptime n_tiles = N // TN
+        # Thread layout for the async C load: num_threads over the [BM, TN] tile.
+        comptime c_thread_layout = Layout.row_major(num_threads // TN, TN)
+        var c_gmem = LayoutTensor[
+            kernel_dtype, Layout.row_major(L, N), MutAnyOrigin
+        ](C.ptr + c_base)
+
+        # cp.async: C is the A operand [BM, N-tile] (no transpose), so it stages
+        # as a straight tile. Issue it async and do the B sync transpose-load
+        # while it's in flight (the global C load overlaps the B load).
+        for nkt in range(n_tiles):
+            var nk = nkt * TN
+            smemC.distribute[c_thread_layout](tid).copy_from_async(
+                c_gmem.tile[BM, TN](pid_m, nkt).distribute[c_thread_layout](tid)
+            )
+            # smemBt[TN, BK] = B[s-tile, nk:nk+TN]ᵀ (sync; overlaps the async C).
+            idx = tid
+            while idx < TN * BK:
+                var n = idx // BK
+                var r = idx % BK
+                var sr = s_off + r
+                smemBt[n, r] = B.ptr[
+                    b_base + sr * N + (nk + n)
+                ] if sr < L else Scalar[kernel_dtype](0)
+                idx += num_threads
+            async_copy_wait_all()
+            gpu_barrier()
+
+            var a_warp = smemC.tile[WM, TN](warp_y, 0)
+            var b_warp = smemBt.tile[TN, BK](0, 0)
+
+            comptime for k_mma in range(num_k_mmas_cb):
+                mma_op.load_a(a_warp, a_reg.vectorize[1, a_frag_size](), k_mma)
+                mma_op.load_b(
+                    b_warp, b_reg.vectorize[1, b_frag_size](), k_mma, 0
+                )
+                mma_op.mma(
+                    a_reg.vectorize[1, a_frag_size](),
+                    b_reg.vectorize[1, b_frag_size](),
+                    cb_reg.vectorize[1, c_frag_size](),
+                )
+            gpu_barrier()
+
+        # Store cb to shared (C-fragment layout -> row-major [BM, BK]).
+        var cb_warp = smemCB.tile[WM, BK](warp_y, 0)
+        copy_local_to_shared[thread_layout=Layout.row_major(8, 4)](
+            cb_warp.vectorize[1, 2](),
+            cb_reg.vectorize[1, 2]().transpose(),
+        )
+        gpu_barrier()
+
+        # Apply decay + causal mask on the shared cb tile cooperatively.
+        idx = tid
+        # Mask only matters where the s-tile's rows can exceed the l-tile's
+        # (the diagonal/overlapping tiles); tiles fully below are kept whole.
+        var needs_mask = (s_off + BK) > l_off
+        var cum_l_base = cum_base + l_off
+        var cum_s_base = cum_base + s_off
+        while idx < BM * BK:
+            var i = idx // BK
+            var j = idx % BK
+            # decay[i,j] = exp(cum_l[i] − cum_s[j]) (direct form, always ≤ 1, no
+            # overflow), with the causal mask (gs > gl) applied where needed.
+            if needs_mask and (s_off + j) > (l_off + i):
+                smemCB[i, j] = Scalar[kernel_dtype](0)
+            else:
+                var d = exp(
+                    cumsum.ptr[cum_l_base + i] - cumsum.ptr[cum_s_base + j]
+                )
+                smemCB[i, j] = (smemCB[i, j].cast[accum_type]() * d).cast[
+                    kernel_dtype
+                ]()
+            idx += num_threads
+        gpu_barrier()
+
+        # MMA2: acc[BM, P] += smemCB[BM, BK] @ smemX[BK, P].
+        var a2_reg = LayoutTensor[
+            kernel_dtype,
+            Layout.row_major(num_m_mmas, a_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ].stack_allocation()
+        var b2_reg = LayoutTensor[
+            kernel_dtype,
+            Layout.row_major(num_n_mmas_y, b_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ].stack_allocation()
+        var a2_warp = smemCB.tile[WM, BK](warp_y, 0)
+        var b2_warp = smemX.tile[BK, P](0, 0)
+
+        comptime for k_mma in range(num_k_mmas_y):
+            mma_op.load_a(a2_warp, a2_reg.vectorize[1, a_frag_size](), k_mma)
+            mma_op.load_b(b2_warp, b2_reg.vectorize[1, b_frag_size](), k_mma, 0)
+            mma_op.mma(
+                a2_reg.vectorize[1, a_frag_size](),
+                b2_reg.vectorize[1, b_frag_size](),
+                acc_reg.vectorize[1, c_frag_size](),
+            )
+        gpu_barrier()
+
+    # ── Store acc -> Y[l-tile, :P]. ──────────────────────────────────────────
+    var y_slice = LayoutTensor[
+        kernel_dtype, Layout.row_major(L, P), MutAnyOrigin
+    ](Y.ptr + y_base)
+    var y_warp = y_slice.tile[WM, P](pid_m * num_warps_m + warp_y, 0)
+    copy_local_to_dram[dst_thread_layout=Layout.row_major(8, 4)](
+        y_warp.vectorize[1, 2](),
+        acc_reg.vectorize[1, 2]().transpose(),
+    )
+
+
+def ssd_intra_chunk_fwd_gpu_fused[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    C_LT: TensorLayout,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    Y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    C: TileTensor[kernel_dtype, C_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, Y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Fused single-pass tensor-core intra-chunk forward (RFC 0009).
+
+    ``cumsum`` (one parallel kernel) then ``_ssd_intra_chunk_fused_mma_gpu``,
+    which keeps the ``CB`` scores on-chip (no DRAM round-trip, unlike the
+    two-kernel ``ssd_intra_chunk_fwd_gpu_static``). Requires ``chunk_len`` a
+    multiple of ``FUSED_BM`` / ``FUSED_BK``, ``head_dim`` and ``state_dim``
+    multiples of the MMA tile; the two-kernel path is the fallback otherwise.
+    """
+    var num_slices = batch * n_chunks * n_heads
+
+    var cumsum_device = ctx.enqueue_create_buffer[DType.float32](
+        num_slices * chunk_len_ct
+    )
+    var cumsum4 = TileTensor(
+        cumsum_device, row_major(batch, n_chunks, n_heads, chunk_len_ct)
+    )
+    var cumsum_compiled = ctx.compile_function[
+        _ssd_intra_chunk_cumsum_gpu[kernel_dtype, A_LT, cumsum4.LayoutType]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            cumsum_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            A,
+            cumsum4,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len_ct,),
+        )
+
+    var cumsum_flat = TileTensor(
+        cumsum_device, row_major(num_slices, Idx[chunk_len_ct])
+    )
+    comptime num_l_tiles = chunk_len_ct // FUSED_BM
+    comptime num_threads = FUSED_WARPS_M * 32
+    var fused_compiled = ctx.compile_function[
+        _ssd_intra_chunk_fused_mma_gpu[
+            kernel_dtype,
+            chunk_len_ct,
+            state_dim_ct,
+            head_dim_ct,
+            FUSED_BM,
+            FUSED_BK,
+            FUSED_WARPS_M,
+            FUSED_TN,
+            C_LT,
+            B_LT,
+            X_LT,
+            cumsum_flat.LayoutType,
+            Y_LT,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            fused_compiled,
+            C,
+            B,
+            X,
+            cumsum_flat,
+            Y,
+            grid_dim=(num_slices, num_l_tiles),
+            block_dim=(num_threads,),
+        )

--- a/max/kernels/src/state_space/ssd_chunk_combine.mojo
+++ b/max/kernels/src/state_space/ssd_chunk_combine.mojo
@@ -1,0 +1,906 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Structured state space duality (SSD) output-recombination kernel.
+
+This implements stage 4 (the final "output recombination") of the SSD
+chunk-scan algorithm used by Mamba2. After stage 3 (``ssd_chunk_scan``) has
+threaded the inter-chunk recurrence to produce the state *entering* each chunk,
+this stage combines that inter-chunk contribution with the per-chunk diagonal
+output to form the final per-token output.
+
+For a single ``(batch, chunk, head)`` slice with chunk length ``L``, state dim
+``N`` and head dim ``P``:
+
+- Inputs:
+  - ``C: [b, nc, h, L, N]`` (the per-token C projection).
+  - ``entering_state: [b, nc, h, P, N]`` (state entering this chunk, the
+    stage-3 output).
+  - ``A: [b, nc, h, L]`` (per-token log-decay within the chunk).
+  - ``Y_diag: [b, nc, h, L, P]`` (the intra-chunk diagonal output, from
+    stage 1).
+- Compute (per token ``l`` and head-dim index ``p``):
+  ```
+  A_cumsum[l]       = sum_{k <= l} A[k]           # inclusive prefix sum
+  state_decay_out[l]= exp(A_cumsum[l])
+  Y_off[l, p]       = state_decay_out[l] * sum_n C[l, n] * entering_state[p, n]
+  Y[l, p]           = Y_diag[l, p] + Y_off[l, p]
+  ```
+- Output:
+  - ``Y: [b, nc, h, L, P]``.
+
+The computation is fully element-wise parallel over ``(b, nc, h, l, p)``: one
+GPU thread owns a single output scalar ``Y[b, nc, h, l, p]``. The only sequential
+dependency is the per-``(b, nc, h, l)`` inclusive prefix sum ``A_cumsum[l]``,
+which each thread recomputes up to its own ``l`` (``l`` is at most the chunk
+length, so this is cheap and avoids any cross-thread synchronization).
+"""
+
+from layout import (
+    Idx,
+    Layout,
+    LayoutTensor,
+    TensorLayout,
+    TileTensor,
+    row_major,
+)
+from layout.layout_tensor import copy_local_to_dram
+from layout.tensor_core import TensorCore, get_fragment_size, get_mma_shape
+from std.math import ceildiv, exp
+from max.gpu.sync import barrier as gpu_barrier
+from std.gpu import (
+    WARP_SIZE,
+    block_dim,
+    block_idx,
+    thread_idx,
+)
+from max.gpu.host import DeviceContext
+from std.memory import AddressSpace
+from std.memory import unsafe_stack_allocation as mem_stack_allocation
+from std.utils.index import IndexList
+from linalg.bmm import batched_matmul
+
+# ── Fused single-pass MMA tiling (Mamba2 profile, tuned to mirror stage 2) ──
+# Output tile is the whole [L, P] per slice; warps tile it WARPS_M x WARPS_N.
+# block_dim = WARPS_M * WARPS_N * WARP_SIZE must be >= chunk_len for the
+# shared-memory decay scan. 8x1 warps = 256 threads covers chunk_len=256.
+comptime COMBINE_FUSED_WARPS_M = 8
+comptime COMBINE_FUSED_WARPS_N = 1
+# K (state-dim) step for the fused MMA; multiple of MMA_K (8), divides state_dim.
+comptime COMBINE_FUSED_BK = 16
+
+# Stride helpers for indexing the flat row-major buffers.
+comptime Strides4D = IndexList[4]
+comptime Strides5D = IndexList[5]
+
+# Upper bound on chunk_len for the shared-memory decay scratch (one Float32 per
+# token). The static path launches one block per slice with
+# ``block_dim == chunk_len``, so this also bounds that block size. Mirrors
+# ``STATE_MAX_CHUNK`` in ``ssd_chunk_state.mojo``.
+comptime COMBINE_MAX_CHUNK = 1024
+
+
+def _row_major_strides_4d(d0: Int, d1: Int, d2: Int, d3: Int) -> Strides4D:
+    """Row-major strides for a 4D shape ``(d0, d1, d2, d3)``."""
+    return Strides4D(d1 * d2 * d3, d2 * d3, d3, 1)
+
+
+def _row_major_strides_5d(
+    d0: Int, d1: Int, d2: Int, d3: Int, d4: Int
+) -> Strides5D:
+    """Row-major strides for a 5D shape ``(d0, d1, d2, d3, d4)``."""
+    return Strides5D(d1 * d2 * d3 * d4, d2 * d3 * d4, d3 * d4, d4, 1)
+
+
+def ssd_output_recombination_fwd_cpu[
+    kernel_dtype: DType,
+    c_layout: Layout,
+    entering_layout: Layout,
+    a_layout: Layout,
+    y_diag_layout: Layout,
+    y_layout: Layout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+    C: LayoutTensor[kernel_dtype, c_layout, MutAnyOrigin],
+    entering_state: LayoutTensor[kernel_dtype, entering_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, a_layout, MutAnyOrigin],
+    Y_diag: LayoutTensor[kernel_dtype, y_diag_layout, MutAnyOrigin],
+    Y: LayoutTensor[kernel_dtype, y_layout, MutAnyOrigin],
+):
+    """Compute the SSD output recombination (stage 4) on CPU.
+
+    Combines the intra-chunk diagonal output ``Y_diag`` with the inter-chunk
+    contribution (``C`` projected against the entering state, decayed by the
+    in-chunk cumulative decay) to form the final per-token output ``Y``.
+
+    Tensor shapes (row-major):
+        - ``C``: ``[batch, n_chunks, n_heads, chunk_len, state_dim]``
+        - ``entering_state``: ``[batch, n_chunks, n_heads, head_dim, state_dim]``
+        - ``A``: ``[batch, n_chunks, n_heads, chunk_len]``
+        - ``Y_diag``: ``[batch, n_chunks, n_heads, chunk_len, head_dim]``
+        - ``Y``: ``[batch, n_chunks, n_heads, chunk_len, head_dim]`` (output)
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        c_layout: Layout of the ``C`` tensor.
+        entering_layout: Layout of the ``entering_state`` tensor.
+        a_layout: Layout of the ``A`` tensor.
+        y_diag_layout: Layout of the ``Y_diag`` tensor.
+        y_layout: Layout of the ``Y`` output tensor.
+
+    Args:
+        batch: Number of batch elements.
+        n_chunks: Number of chunks per sequence.
+        n_heads: Number of heads.
+        chunk_len: Tokens per chunk (``L``).
+        head_dim: Head dimension (``P``).
+        state_dim: State dimension (``N``).
+        C: Per-token C projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        entering_state: State entering this chunk,
+            shape ``[batch, n_chunks, n_heads, P, N]``.
+        A: Per-token in-chunk log-decay,
+            shape ``[batch, n_chunks, n_heads, L]``.
+        Y_diag: Intra-chunk diagonal output,
+            shape ``[batch, n_chunks, n_heads, L, P]``.
+        Y: Output, shape ``[batch, n_chunks, n_heads, L, P]``.
+    """
+    # Row-major strides for the flat backing buffers.
+    var c_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, state_dim
+    )
+    var ent_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, head_dim, state_dim
+    )
+    var a_strides = _row_major_strides_4d(batch, n_chunks, n_heads, chunk_len)
+    var y_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, head_dim
+    )
+
+    for bi in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var a_base = (
+                    bi * a_strides[0] + c * a_strides[1] + h * a_strides[2]
+                )
+                var c_base = (
+                    bi * c_strides[0] + c * c_strides[1] + h * c_strides[2]
+                )
+                var ent_base = (
+                    bi * ent_strides[0]
+                    + c * ent_strides[1]
+                    + h * ent_strides[2]
+                )
+                var y_base = (
+                    bi * y_strides[0] + c * y_strides[1] + h * y_strides[2]
+                )
+
+                # Inclusive prefix sum of A over the chunk -> decay per token.
+                var a_cumsum = Float32(0.0)
+                for l in range(chunk_len):
+                    var a_off = a_base + l * a_strides[3]
+                    a_cumsum += A.ptr[a_off].cast[DType.float32]()
+                    var decay = exp(a_cumsum)
+
+                    for p in range(head_dim):
+                        # Y_off[l, p] = decay * sum_n C[l, n] * entering[p, n].
+                        var acc = Float32(0.0)
+                        for n in range(state_dim):
+                            var c_off = (
+                                c_base + l * c_strides[3] + n * c_strides[4]
+                            )
+                            var ent_off = (
+                                ent_base
+                                + p * ent_strides[3]
+                                + n * ent_strides[4]
+                            )
+                            var c_val = C.ptr[c_off].cast[DType.float32]()
+                            var ent_val = entering_state.ptr[ent_off].cast[
+                                DType.float32
+                            ]()
+                            acc += c_val * ent_val
+
+                        var y_off = decay * acc
+
+                        # Y[l, p] = Y_diag[l, p] + Y_off[l, p].
+                        var yd_off = (
+                            y_base + l * y_strides[3] + p * y_strides[4]
+                        )
+                        var y_diag_val = Y_diag.ptr[yd_off].cast[
+                            DType.float32
+                        ]()
+                        Y.ptr[yd_off] = (y_diag_val + y_off).cast[
+                            kernel_dtype
+                        ]()
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU Implementation
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_output_recombination_fwd_gpu[
+    kernel_dtype: DType,
+    c_LT: TensorLayout,
+    entering_LT: TensorLayout,
+    a_LT: TensorLayout,
+    y_diag_LT: TensorLayout,
+    y_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    head_dim_i32: Int32,
+    state_dim_i32: Int32,
+    C: TileTensor[kernel_dtype, c_LT, MutUntrackedOrigin],
+    entering_state: TileTensor[kernel_dtype, entering_LT, MutUntrackedOrigin],
+    A: TileTensor[kernel_dtype, a_LT, MutUntrackedOrigin],
+    Y_diag: TileTensor[kernel_dtype, y_diag_LT, MutUntrackedOrigin],
+    Y: TileTensor[kernel_dtype, y_LT, MutUntrackedOrigin],
+):
+    """Compute the SSD output recombination (stage 4) on GPU.
+
+    The computation is element-wise parallel: each GPU thread owns a single
+    output scalar ``Y[bi, c, h, l, p]``. The only sequential dependency is the
+    per-``(bi, c, h, l)`` inclusive prefix sum ``A_cumsum[l]``, which each thread
+    recomputes up to its own ``l`` (cheap, and avoids cross-thread sync).
+
+    The same math as the CPU kernel, for the scalar ``Y[l, p]``:
+        - ``A_cumsum[l] = sum_{k <= l} A[k]``
+        - ``decay = exp(A_cumsum[l])``
+        - ``Y_off[l, p] = decay * sum_n C[l, n] * entering_state[p, n]``
+        - ``Y[l, p] = Y_diag[l, p] + Y_off[l, p]``
+
+    Tensor shapes (row-major):
+        - ``C``: ``[batch, n_chunks, n_heads, chunk_len, state_dim]``
+        - ``entering_state``: ``[batch, n_chunks, n_heads, head_dim, state_dim]``
+        - ``A``: ``[batch, n_chunks, n_heads, chunk_len]``
+        - ``Y_diag``: ``[batch, n_chunks, n_heads, chunk_len, head_dim]``
+        - ``Y``: ``[batch, n_chunks, n_heads, chunk_len, head_dim]`` (output)
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        c_LT: Layout of the ``C`` tensor.
+        entering_LT: Layout of the ``entering_state`` tensor.
+        a_LT: Layout of the ``A`` tensor.
+        y_diag_LT: Layout of the ``Y_diag`` tensor.
+        y_LT: Layout of the ``Y`` output tensor.
+
+    Args:
+        batch_i32: Number of batch elements.
+        n_chunks_i32: Number of chunks per sequence.
+        n_heads_i32: Number of heads.
+        chunk_len_i32: Tokens per chunk (``L``).
+        head_dim_i32: Head dimension (``P``).
+        state_dim_i32: State dimension (``N``).
+        C: Per-token C projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        entering_state: State entering this chunk,
+            shape ``[batch, n_chunks, n_heads, P, N]``.
+        A: Per-token in-chunk log-decay,
+            shape ``[batch, n_chunks, n_heads, L]``.
+        Y_diag: Intra-chunk diagonal output,
+            shape ``[batch, n_chunks, n_heads, L, P]``.
+        Y: Output, shape ``[batch, n_chunks, n_heads, L, P]``.
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var head_dim = Int(head_dim_i32)
+    var state_dim = Int(state_dim_i32)
+    var flat_idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total_threads = batch * n_chunks * n_heads * chunk_len * head_dim
+    if flat_idx >= total_threads:
+        return
+
+    # Decompose the flat thread index into (batch, chunk, head, l, p).
+    var p = flat_idx % head_dim
+    var l = (flat_idx // head_dim) % chunk_len
+    var h = (flat_idx // (head_dim * chunk_len)) % n_heads
+    var c = (flat_idx // (head_dim * chunk_len * n_heads)) % n_chunks
+    var bi = flat_idx // (head_dim * chunk_len * n_heads * n_chunks)
+
+    # Row-major strides for the flat backing buffers.
+    # C: [batch, n_chunks, n_heads, chunk_len, state_dim].
+    var c_n_stride = 1
+    var c_l_stride = state_dim
+    var c_h_stride = chunk_len * c_l_stride
+    var c_c_stride = n_heads * c_h_stride
+    var c_b_stride = n_chunks * c_c_stride
+
+    # entering_state: [batch, n_chunks, n_heads, head_dim, state_dim].
+    var ent_n_stride = 1
+    var ent_p_stride = state_dim
+    var ent_h_stride = head_dim * ent_p_stride
+    var ent_c_stride = n_heads * ent_h_stride
+    var ent_b_stride = n_chunks * ent_c_stride
+
+    # A: [batch, n_chunks, n_heads, chunk_len].
+    var a_l_stride = 1
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    # Y / Y_diag: [batch, n_chunks, n_heads, chunk_len, head_dim].
+    var y_p_stride = 1
+    var y_l_stride = head_dim
+    var y_h_stride = chunk_len * y_l_stride
+    var y_c_stride = n_heads * y_h_stride
+    var y_b_stride = n_chunks * y_c_stride
+
+    # Inclusive prefix sum of A over [0, l] for this (bi, c, h).
+    var a_base = bi * a_b_stride + c * a_c_stride + h * a_h_stride
+    var a_cumsum = Float32(0.0)
+    for k in range(l + 1):
+        a_cumsum += A.ptr[a_base + k * a_l_stride].cast[DType.float32]()
+    var decay = exp(a_cumsum)
+
+    # Y_off[l, p] = decay * sum_n C[l, n] * entering_state[p, n].
+    var c_base = (
+        bi * c_b_stride + c * c_c_stride + h * c_h_stride + l * c_l_stride
+    )
+    var ent_base = (
+        bi * ent_b_stride
+        + c * ent_c_stride
+        + h * ent_h_stride
+        + p * ent_p_stride
+    )
+    var acc = Float32(0.0)
+    for n in range(state_dim):
+        var c_val = C.ptr[c_base + n * c_n_stride].cast[DType.float32]()
+        var ent_val = entering_state.ptr[ent_base + n * ent_n_stride].cast[
+            DType.float32
+        ]()
+        acc += c_val * ent_val
+    var y_off = decay * acc
+
+    # Y[l, p] = Y_diag[l, p] + Y_off[l, p].
+    var y_off_flat = (
+        bi * y_b_stride
+        + c * y_c_stride
+        + h * y_h_stride
+        + l * y_l_stride
+        + p * y_p_stride
+    )
+    var y_diag_val = Y_diag.ptr[y_off_flat].cast[DType.float32]()
+    Y.ptr[y_off_flat] = (y_diag_val + y_off).cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# Static-shape tensor-core path
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_combine_decay_gpu[
+    kernel_dtype: DType,
+    a_LT: TensorLayout,
+    decay_LT: TensorLayout,
+](
+    chunk_len_i32: Int32,
+    A: TileTensor[kernel_dtype, a_LT, MutAnyOrigin],
+    decay_out: TileTensor[DType.float32, decay_LT, MutAnyOrigin],
+):
+    """Per-token decay ``decay[slice, l] = exp(A_cumsum[l])`` for every slice.
+
+    One block per ``(batch, chunk, head)`` slice (``block_dim == chunk_len``).
+    Computes the inclusive prefix sum of ``A`` over the chunk via a Hillis-Steele
+    scan in shared memory, exponentiates, and writes the per-token decay to a
+    ``[num_slices, chunk_len]`` scratch buffer (read back by the coalesced add
+    kernel). Cheap: ``num_slices * chunk_len`` elements total.
+    """
+    var chunk_len = Int(chunk_len_i32)
+    var slice_idx = Int(block_idx.x)
+    var tid = Int(thread_idx.x)
+
+    var decay = mem_stack_allocation[
+        COMBINE_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+    var a_base = slice_idx * chunk_len
+    if tid < chunk_len:
+        decay[tid] = A.ptr[a_base + tid].cast[DType.float32]()
+    gpu_barrier()
+
+    var offset = 1
+    while offset < chunk_len:
+        var add: Float32 = 0.0
+        if tid < chunk_len and tid >= offset:
+            add = decay[tid - offset]
+        gpu_barrier()
+        if tid < chunk_len and tid >= offset:
+            decay[tid] += add
+        gpu_barrier()
+        offset *= 2
+
+    if tid < chunk_len:
+        decay_out.ptr[a_base + tid] = exp(decay[tid])
+
+
+def _ssd_combine_add_gpu[
+    kernel_dtype: DType,
+    mt_LT: TensorLayout,
+    decay_LT: TensorLayout,
+    y_diag_LT: TensorLayout,
+    y_LT: TensorLayout,
+](
+    chunk_len_i32: Int32,
+    head_dim_i32: Int32,
+    num_slices_i32: Int32,
+    M_T: TileTensor[kernel_dtype, mt_LT, MutAnyOrigin],
+    decay: TileTensor[DType.float32, decay_LT, MutAnyOrigin],
+    Y_diag: TileTensor[kernel_dtype, y_diag_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, y_LT, MutAnyOrigin],
+):
+    """Coalesced add: ``Y[l, p] = Y_diag[l, p] + decay[l] * M_T[p, l]``.
+
+    Flat element-wise launch -- one thread per ``(slice, l, p)`` output scalar,
+    so the grid has ``num_slices * chunk_len * head_dim`` threads (vs the
+    one-block-per-slice epilogue, which starved GB10's SMs). Consecutive threads
+    own consecutive ``p`` (the contiguous output axis), so both the ``Y_diag``
+    read and the ``Y`` write are coalesced. The transposed ``M_T[p, l]`` read is
+    strided by ``chunk_len`` across ``p`` but L2-resident.
+    """
+    var chunk_len = Int(chunk_len_i32)
+    var head_dim = Int(head_dim_i32)
+    var num_slices = Int(num_slices_i32)
+    var flat_idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total = num_slices * chunk_len * head_dim
+    if flat_idx >= total:
+        return
+
+    var p = flat_idx % head_dim
+    var l = (flat_idx // head_dim) % chunk_len
+    var slice_idx = flat_idx // (head_dim * chunk_len)
+
+    var d = decay.ptr[slice_idx * chunk_len + l]
+    var mt_val = M_T.ptr[
+        slice_idx * head_dim * chunk_len + p * chunk_len + l
+    ].cast[DType.float32]()
+    var y_off = slice_idx * chunk_len * head_dim + l * head_dim + p
+    var yd_val = Y_diag.ptr[y_off].cast[DType.float32]()
+    Y.ptr[y_off] = (yd_val + d * mt_val).cast[kernel_dtype]()
+
+
+def ssd_output_recombination_fwd_gpu_static[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    c_LT: TensorLayout,
+    entering_LT: TensorLayout,
+    a_LT: TensorLayout,
+    y_diag_LT: TensorLayout,
+    y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    C: TileTensor[kernel_dtype, c_LT, MutAnyOrigin],
+    entering_state: TileTensor[kernel_dtype, entering_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, a_LT, MutAnyOrigin],
+    Y_diag: TileTensor[kernel_dtype, y_diag_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Static-shape, tensor-core variant of ``ssd_output_recombination_fwd_gpu``.
+
+    Computes the output recombination as a batched matmul on tensor cores
+    followed by a cheap decay + add epilogue:
+
+        ``M_T[p, l] = sum_n entering_state[p, n] * C[l, n]``   (batched_matmul)
+        ``Y[l, p]   = Y_diag[l, p] + exp(A_cumsum[l]) * M_T[p, l]``  (epilogue)
+
+    The decay multiplies an *output* row (``l``), not the reduction dim, so the
+    matmul stays a plain ``entering_state @ Cᵀ`` (``transpose_b=True``, no decay
+    materialisation). Knowing ``chunk_len`` / ``state_dim`` / ``head_dim`` at
+    compile time lets ``batched_matmul`` see ``has_static_NK``; the output has
+    ``chunk_len`` (== matmul ``N``) columns and ``state_dim`` (== ``K``) is a
+    multiple of 32 and ``>= 128``, so it takes the A100 multistage tensor-core
+    batched path (one launch for all ``batch * n_chunks * n_heads`` slices)
+    instead of the scalar reduction in ``ssd_output_recombination_fwd_gpu``.
+
+    The scalar kernel remains the all-shape-correct fallback for shapes that
+    miss the gate (e.g. ``chunk_len`` not a multiple of 128).
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        chunk_len_ct: Tokens per chunk (``L``), compile-time.
+        state_dim_ct: State dimension (``N``), compile-time.
+        head_dim_ct: Head dimension (``P``), compile-time.
+        c_LT: Layout of the ``C`` tensor.
+        entering_LT: Layout of the ``entering_state`` tensor.
+        a_LT: Layout of the ``A`` tensor.
+        y_diag_LT: Layout of the ``Y_diag`` tensor.
+        y_LT: Layout of the ``Y`` output tensor.
+
+    Args:
+        batch: Number of batch elements.
+        n_chunks: Number of chunks per sequence.
+        n_heads: Number of heads.
+        C: Per-token C projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        entering_state: State entering this chunk,
+            shape ``[batch, n_chunks, n_heads, P, N]``.
+        A: Per-token in-chunk log-decay,
+            shape ``[batch, n_chunks, n_heads, L]``.
+        Y_diag: Intra-chunk diagonal output,
+            shape ``[batch, n_chunks, n_heads, L, P]``.
+        Y: Output, shape ``[batch, n_chunks, n_heads, L, P]``.
+        ctx: The device context to enqueue work on.
+    """
+    var num_slices = batch * n_chunks * n_heads
+
+    # Scratch for the off-diagonal matmul result, transposed: [num_slices, P, L].
+    var mt_device = ctx.enqueue_create_buffer[kernel_dtype](
+        num_slices * head_dim_ct * chunk_len_ct
+    )
+
+    # Stage 1: M_T[p, l] = entering_state[p, n] @ C[l, n]ᵀ (batched tensor-core
+    # matmul, one launch). Output N == chunk_len (% 128 == 0), K == state_dim
+    # (% 32 == 0, >= 128) hits the A100 multistage path.
+    var ent3 = TileTensor(
+        entering_state.ptr,
+        row_major(num_slices, Idx[head_dim_ct], Idx[state_dim_ct]),
+    )
+    var C3 = TileTensor(
+        C.ptr,
+        row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct]),
+    )
+    var MT3 = TileTensor(
+        mt_device,
+        row_major(num_slices, Idx[head_dim_ct], Idx[chunk_len_ct]),
+    )
+    with ctx.push_context():
+        batched_matmul[target="gpu", transpose_b=True](
+            MT3, ent3, C3, context=ctx
+        )
+
+    var MT_tt = TileTensor(
+        mt_device,
+        row_major(batch, n_chunks, n_heads, head_dim_ct, chunk_len_ct),
+    )
+
+    # Stage 2: per-token decay = exp(A_cumsum) into a [num_slices, L] scratch
+    # (one block per slice, block_dim == L; the only sequential part).
+    var decay_device = ctx.enqueue_create_buffer[DType.float32](
+        num_slices * chunk_len_ct
+    )
+    var decay_tt = TileTensor(
+        decay_device, row_major(batch, n_chunks, n_heads, chunk_len_ct)
+    )
+    var decay_compiled = ctx.compile_function[
+        _ssd_combine_decay_gpu[kernel_dtype, a_LT, decay_tt.LayoutType]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            decay_compiled,
+            Int32(chunk_len_ct),
+            A,
+            decay_tt,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len_ct,),
+        )
+
+    # Stage 3: coalesced add Y[l,p] = Y_diag[l,p] + decay[l] * M_T[p,l]
+    # (flat element-wise launch -- one thread per output, many small blocks).
+    comptime ADD_BLOCK = 256
+    var total_out = num_slices * chunk_len_ct * head_dim_ct
+    var add_compiled = ctx.compile_function[
+        _ssd_combine_add_gpu[
+            kernel_dtype,
+            MT_tt.LayoutType,
+            decay_tt.LayoutType,
+            y_diag_LT,
+            y_LT,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            add_compiled,
+            Int32(chunk_len_ct),
+            Int32(head_dim_ct),
+            Int32(num_slices),
+            MT_tt,
+            decay_tt,
+            Y_diag,
+            Y,
+            grid_dim=(ceildiv(total_out, ADD_BLOCK),),
+            block_dim=(ADD_BLOCK,),
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Fused single-pass tensor-core path
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_combine_fused_mma_gpu[
+    kernel_dtype: DType,
+    L: Int,
+    P: Int,
+    N: Int,
+    BK: Int,
+    num_warps_m: Int,
+    num_warps_n: Int,
+    c_LT: TensorLayout,
+    entering_LT: TensorLayout,
+    a_LT: TensorLayout,
+    y_LT: TensorLayout,
+](
+    C: TileTensor[kernel_dtype, c_LT, MutAnyOrigin],
+    entering_state: TileTensor[kernel_dtype, entering_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, a_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, y_LT, MutAnyOrigin],
+):
+    """Fused, single-pass tensor-core off-diagonal recombination (one block/slice).
+
+    Computes ``M[l,p] = decay[l] * sum_n C[l,n] * entering_state[p,n]`` for one
+    ``(batch, chunk, head)`` slice as a transpose-of-entering tensor-core GEMM,
+    **without** materialising the matmul result in DRAM (the cost the 2-pass
+    ``..._fwd_gpu_static`` pays). Per K-tile the block streams ``C``/``entering``
+    once, folds ``decay[l]`` into the ``C`` (``As``) tile while loading (so the
+    decay is on the matmul ``M`` rows, no post-pass), transposes ``entering``
+    into the ``Bs`` tile, and accumulates the warp-tiled MMA. The decayed
+    ``M[l,p]`` is written to ``Y``; the small ``+ Y_diag`` is a separate
+    same-layout coalesced add (``_ssd_combine_add_diag_gpu``).
+
+    Compile-time tiling: block tile is the whole ``[L, P]`` output; warps tile it
+    ``num_warps_m x num_warps_n``; ``BK`` is the K (state-dim) step. Slices are
+    contiguous in every buffer, so ``slice_idx`` alone indexes them. Mirrors
+    ``_ssd_chunk_state_fused_mma_gpu`` in ``ssd_chunk_state.mojo``.
+    """
+    comptime accum_type = DType.float32
+    comptime mma_shape = get_mma_shape[kernel_dtype, accum_type]()
+    comptime MMA_M = mma_shape[0]
+    comptime MMA_N = mma_shape[1]
+    comptime MMA_K = mma_shape[2]
+    comptime WM = L // num_warps_m
+    comptime WN = P // num_warps_n
+    comptime num_m_mmas = WM // MMA_M
+    comptime num_n_mmas = WN // MMA_N
+    comptime num_k_mmas = BK // MMA_K
+    comptime fs = get_fragment_size[mma_shape]()
+    comptime a_frag_size = fs[0]
+    comptime b_frag_size = fs[1]
+    comptime c_frag_size = fs[2]
+    comptime num_threads = num_warps_m * num_warps_n * WARP_SIZE
+
+    var slice_idx = Int(block_idx.x)
+    var tid = Int(thread_idx.x)
+    var warp_id = tid // WARP_SIZE
+    var warp_y = warp_id // num_warps_n
+    var warp_x = warp_id % num_warps_n
+
+    var c_base = slice_idx * L * N
+    var ent_base = slice_idx * P * N
+    var a_base = slice_idx * L
+    var y_base = slice_idx * L * P
+
+    # ── Per-token decay into shared memory (Hillis-Steele, then exp). ─────────
+    # Stage 4 uses exp(A_cumsum[l]) directly (inclusive prefix sum, no cum_end).
+    var decay = mem_stack_allocation[
+        COMBINE_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+    if tid < L:
+        decay[tid] = A.ptr[a_base + tid].cast[DType.float32]()
+    gpu_barrier()
+    var offset = 1
+    while offset < L:
+        var add: Float32 = 0.0
+        if tid < L and tid >= offset:
+            add = decay[tid - offset]
+        gpu_barrier()
+        if tid < L and tid >= offset:
+            decay[tid] += add
+        gpu_barrier()
+        offset *= 2
+    if tid < L:
+        decay[tid] = exp(decay[tid])
+    gpu_barrier()
+
+    # ── Shared tiles: As is decay-scaled C [L, BK]; Bs is entering transposed
+    # to [BK, P]. ─────────────────────────────────────────────────────────────
+    var As = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(L, BK),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var Bs = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(BK, P),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+
+    var c_reg = (
+        LayoutTensor[
+            accum_type,
+            Layout.row_major(num_m_mmas * num_n_mmas, c_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ]
+        .stack_allocation()
+        .fill(0)
+    )
+    var a_reg = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(num_m_mmas, a_frag_size),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ].stack_allocation()
+    var b_reg = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(num_n_mmas, b_frag_size),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ].stack_allocation()
+
+    var mma_op = TensorCore[accum_type, kernel_dtype, mma_shape, False]()
+
+    # ── K-loop over the state dimension N ────────────────────────────────────
+    var k0 = 0
+    while k0 < N:
+        # As[l, kl] = decay[l] * C[l, k0+kl] (coalesced read over kl per row l).
+        var idx = tid
+        while idx < L * BK:
+            var l = idx // BK
+            var kl = idx % BK
+            As[l, kl] = (
+                decay[l]
+                * C.ptr[c_base + l * N + (k0 + kl)].cast[DType.float32]()
+            ).cast[kernel_dtype]()
+            idx += num_threads
+        # Bs[kl, p] = entering[p, k0+kl] (coalesced read over kl per row p).
+        idx = tid
+        while idx < P * BK:
+            var p = idx // BK
+            var kl = idx % BK
+            Bs[kl, p] = entering_state.ptr[ent_base + p * N + (k0 + kl)]
+            idx += num_threads
+        gpu_barrier()
+
+        var a_warp_tile = As.tile[WM, BK](warp_y, 0)
+        var b_warp_tile = Bs.tile[BK, WN](0, warp_x)
+
+        comptime for k_mma in range(num_k_mmas):
+            mma_op.load_a(a_warp_tile, a_reg.vectorize[1, a_frag_size](), k_mma)
+            mma_op.load_b(
+                b_warp_tile, b_reg.vectorize[1, b_frag_size](), k_mma, warp_x
+            )
+            mma_op.mma(
+                a_reg.vectorize[1, a_frag_size](),
+                b_reg.vectorize[1, b_frag_size](),
+                c_reg.vectorize[1, c_frag_size](),
+            )
+        gpu_barrier()
+        k0 += BK
+
+    # ── Store the warp's [WM, WN] output tile (decayed M) to Y. ──────────────
+    var y_slice = LayoutTensor[
+        kernel_dtype, Layout.row_major(L, P), MutAnyOrigin
+    ](Y.ptr + y_base)
+    var y_warp_tile = y_slice.tile[WM, WN](warp_y, warp_x)
+    copy_local_to_dram[dst_thread_layout=Layout.row_major(8, 4)](
+        y_warp_tile.vectorize[1, 2](),
+        c_reg.vectorize[1, 2]().transpose(),
+    )
+
+
+def _ssd_combine_add_diag_gpu[
+    kernel_dtype: DType,
+    y_diag_LT: TensorLayout,
+    y_LT: TensorLayout,
+](
+    total_i32: Int32,
+    Y_diag: TileTensor[kernel_dtype, y_diag_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, y_LT, MutAnyOrigin],
+):
+    """Coalesced ``Y[i] += Y_diag[i]`` over every output scalar.
+
+    Both tensors are the same row-major ``[b,nc,h,L,P]`` layout, so this is a
+    fully-coalesced element-wise add (no transpose) — far cheaper than the
+    transposed-read add of the 2-pass static path.
+    """
+    var total = Int(total_i32)
+    var i = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    if i >= total:
+        return
+    Y.ptr[i] = (
+        Y.ptr[i].cast[DType.float32]() + Y_diag.ptr[i].cast[DType.float32]()
+    ).cast[kernel_dtype]()
+
+
+def ssd_output_recombination_fwd_gpu_fused[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    c_LT: TensorLayout,
+    entering_LT: TensorLayout,
+    a_LT: TensorLayout,
+    y_diag_LT: TensorLayout,
+    y_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    C: TileTensor[kernel_dtype, c_LT, MutAnyOrigin],
+    entering_state: TileTensor[kernel_dtype, entering_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, a_LT, MutAnyOrigin],
+    Y_diag: TileTensor[kernel_dtype, y_diag_LT, MutAnyOrigin],
+    Y: TileTensor[kernel_dtype, y_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Fused single-pass tensor-core variant of the stage-4 recombination.
+
+    One block per slice runs ``_ssd_combine_fused_mma_gpu`` (decay folded into
+    the matmul, no DRAM round-trip for the off-diagonal result), then a
+    coalesced ``Y += Y_diag`` add. Faster than the 2-pass
+    ``..._fwd_gpu_static`` (which round-trips ``M_T`` through DRAM and does a
+    transposed-read add).
+
+    Requires the fused-MMA tiling constraints: ``chunk_len % (16*num_warps_m)
+    == 0``, ``head_dim % (8*num_warps_n) == 0``, ``state_dim % BK == 0``, and
+    the launch block (``num_warps_m*num_warps_n*32`` threads) ``>= chunk_len``
+    for the decay scan. The 2-pass static path is the fallback for other shapes.
+    """
+    comptime num_threads = (
+        COMBINE_FUSED_WARPS_M * COMBINE_FUSED_WARPS_N * WARP_SIZE
+    )
+    var num_slices = batch * n_chunks * n_heads
+
+    # Stage 1: fused MMA writes the decayed off-diagonal M[l,p] into Y.
+    var fused_compiled = ctx.compile_function[
+        _ssd_combine_fused_mma_gpu[
+            kernel_dtype,
+            chunk_len_ct,
+            head_dim_ct,
+            state_dim_ct,
+            COMBINE_FUSED_BK,
+            COMBINE_FUSED_WARPS_M,
+            COMBINE_FUSED_WARPS_N,
+            c_LT,
+            entering_LT,
+            a_LT,
+            y_LT,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            fused_compiled,
+            C,
+            entering_state,
+            A,
+            Y,
+            grid_dim=(num_slices,),
+            block_dim=(num_threads,),
+        )
+
+    # Stage 2: coalesced Y += Y_diag (same layout, no transpose).
+    comptime ADD_BLOCK = 256
+    var total_out = num_slices * chunk_len_ct * head_dim_ct
+    var add_compiled = ctx.compile_function[
+        _ssd_combine_add_diag_gpu[kernel_dtype, y_diag_LT, y_LT]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            add_compiled,
+            Int32(total_out),
+            Y_diag,
+            Y,
+            grid_dim=(ceildiv(total_out, ADD_BLOCK),),
+            block_dim=(ADD_BLOCK,),
+        )

--- a/max/kernels/src/state_space/ssd_chunk_combined_ops.mojo
+++ b/max/kernels/src/state_space/ssd_chunk_combined_ops.mojo
@@ -1,0 +1,1054 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Fused SSD chunk-scan operation registration for Mamba2.
+
+This module registers ``ssd_chunk_scan_combined``, which stitches the four
+verified SSD stage kernels — intra-chunk diagonal, chunk end-state, inter-chunk
+recurrence, and output recombination — into a single MAX graph op matching the
+torch ``mamba_chunk_scan_combined`` contract:
+
+    op(x, dt, A, B, C, chunk_size)
+        == ssd_minimal_discrete(x * dt[..., None], A_h * dt, B, C, chunk_size)
+
+with all stage 1-4 work happening behind the registration boundary.
+
+Inputs (row-major):
+    - ``x``: ``[batch, seqlen, n_heads, head_dim]`` — value-like input ``X``.
+    - ``dt``: ``[batch, seqlen, n_heads]`` — per-token time delta.
+    - ``A``: ``[n_heads]`` — scalar log-decay per head.
+    - ``B``: ``[batch, seqlen, n_heads, state_dim]``.
+    - ``C``: ``[batch, seqlen, n_heads, state_dim]``.
+
+Outputs:
+    - ``Y: [batch, seqlen, n_heads, head_dim]`` (same dtype as inputs).
+    - ``final_state: [batch, n_heads, head_dim, state_dim]`` — the SSM state
+      after the last chunk, used to seed the decode (``selective_scan_update``)
+      cache so step-mode continuation picks up where prefill left off.
+
+The op currently assumes ``ngroups == n_heads`` (no group broadcasting yet) and
+that ``seqlen`` divides evenly by ``chunk_size``; both restrictions match the
+upstream Mamba2 reference at the dimensions we care about for prefill.
+"""
+
+import extensibility
+from extensibility import InputTensor, OutputTensor
+from max.gpu.host import DeviceContext
+from max.gpu.host.info import is_cpu, is_gpu
+from std.gpu import (
+    block_dim,
+    block_idx,
+    thread_idx,
+)
+from std.math import ceildiv
+from std.utils.index import Index, IndexList
+
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TensorLayout,
+    TileTensor,
+    row_major,
+)
+
+from state_space.ssd_chunk import (
+    ssd_intra_chunk_fwd_cpu,
+    ssd_intra_chunk_fwd_gpu,
+)
+from state_space.ssd_chunk_state import (
+    ssd_chunk_state_fwd_cpu,
+    ssd_chunk_state_fwd_gpu,
+    ssd_chunk_state_fwd_gpu_fused,
+)
+from state_space.ssd_chunk_scan import (
+    ssd_chunk_scan_fwd_cpu,
+    ssd_chunk_scan_fwd_gpu,
+)
+from state_space.ssd_chunk_combine import (
+    ssd_output_recombination_fwd_cpu,
+    ssd_output_recombination_fwd_gpu,
+    ssd_output_recombination_fwd_gpu_fused,
+)
+
+# Block size for the elementwise precompute/postprocess and the scan/combine
+# device-kernel launches (matches the per-stage GPU tests).
+comptime _SSD_GPU_BLOCK = 256
+
+
+# ===----------------------------------------------------------------------=== #
+# Pre-stage helpers (CPU): discretization + reshape
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_combined_precompute_cpu[
+    dtype: DType,
+](
+    batch: Int,
+    seqlen: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    n_chunks: Int,
+    chunk_size: Int,
+    x_ptr: UnsafePointer[Scalar[dtype], ...],
+    dt_ptr: UnsafePointer[Scalar[dtype], ...],
+    A_ptr: UnsafePointer[Scalar[dtype], ...],
+    B_ptr: UnsafePointer[Scalar[dtype], ...],
+    C_ptr: UnsafePointer[Scalar[dtype], ...],
+    X_disc_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+    A_disc_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+    B_chunk_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+    C_chunk_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+    chunk_decays_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+):
+    """Reshape inputs into chunked form and discretize on CPU.
+
+    Inputs:
+        x:  ``[batch, seqlen, n_heads, head_dim]``
+        dt: ``[batch, seqlen, n_heads]``
+        A:  ``[n_heads]`` (scalar decay per head)
+        B:  ``[batch, seqlen, n_heads, state_dim]``
+        C:  ``[batch, seqlen, n_heads, state_dim]``
+
+    Produces:
+        X_disc:       ``[batch, n_chunks, n_heads, chunk_size, head_dim]``
+                      with ``X_disc[b, c, h, l, p] = x[b, c*L+l, h, p] *
+                      dt[b, c*L+l, h]``.
+        A_disc:       ``[batch, n_chunks, n_heads, chunk_size]`` with
+                      ``A_disc[b, c, h, l] = A[h] * dt[b, c*L+l, h]``.
+        B_chunk:      reshape of B into chunked form (no value change).
+        C_chunk:      reshape of C into chunked form (no value change).
+        chunk_decays: ``[batch, n_chunks, n_heads]``,
+                      ``= sum over l of A_disc[b, c, h, l]``.
+    """
+    # Note: all input/output buffers are row-major contiguous.
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var a_h = A_ptr[h].cast[DType.float32]()
+                var chunk_sum = Float32(0.0)
+                for l in range(chunk_size):
+                    var t = c * chunk_size + l
+                    var dt_off = (b * seqlen + t) * n_heads + h
+                    var dt_val = dt_ptr[dt_off].cast[DType.float32]()
+                    var a_disc_val = a_h * dt_val
+                    chunk_sum += a_disc_val
+
+                    var a_disc_off = (
+                        (b * n_chunks + c) * n_heads + h
+                    ) * chunk_size + l
+                    A_disc_ptr[a_disc_off] = a_disc_val.cast[dtype]()
+
+                    # X_disc[b, c, h, l, p] = x[b, t, h, p] * dt[b, t, h]
+                    var x_in_base = ((b * seqlen + t) * n_heads + h) * head_dim
+                    var x_out_base = (
+                        ((b * n_chunks + c) * n_heads + h) * chunk_size + l
+                    ) * head_dim
+                    for p in range(head_dim):
+                        var x_val = x_ptr[x_in_base + p].cast[DType.float32]()
+                        X_disc_ptr[x_out_base + p] = (x_val * dt_val).cast[
+                            dtype
+                        ]()
+
+                    # B_chunk / C_chunk: pure reshape (same value).
+                    var bc_in_base = (
+                        (b * seqlen + t) * n_heads + h
+                    ) * state_dim
+                    var bc_out_base = (
+                        ((b * n_chunks + c) * n_heads + h) * chunk_size + l
+                    ) * state_dim
+                    for n in range(state_dim):
+                        B_chunk_ptr[bc_out_base + n] = B_ptr[bc_in_base + n]
+                        C_chunk_ptr[bc_out_base + n] = C_ptr[bc_in_base + n]
+
+                var cd_off = (b * n_chunks + c) * n_heads + h
+                chunk_decays_ptr[cd_off] = chunk_sum.cast[dtype]()
+
+
+def _ssd_combined_postprocess_cpu[
+    dtype: DType,
+](
+    batch: Int,
+    seqlen: Int,
+    n_heads: Int,
+    head_dim: Int,
+    n_chunks: Int,
+    chunk_size: Int,
+    Y_chunked_ptr: UnsafePointer[Scalar[dtype], ...],
+    Y_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+):
+    """Flatten ``Y_chunked: [b, nc, h, L, P]`` back into ``Y: [b, S, h, P]``."""
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                for l in range(chunk_size):
+                    var t = c * chunk_size + l
+                    var y_in_base = (
+                        ((b * n_chunks + c) * n_heads + h) * chunk_size + l
+                    ) * head_dim
+                    var y_out_base = (b * seqlen + t) * n_heads * head_dim + (
+                        h * head_dim
+                    )
+                    for p in range(head_dim):
+                        Y_ptr[y_out_base + p] = Y_chunked_ptr[y_in_base + p]
+
+
+# ===----------------------------------------------------------------------=== #
+# CPU dispatch — runs all four stages
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_chunk_scan_combined_cpu[
+    dtype: DType,
+](
+    batch: Int,
+    seqlen: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    chunk_size: Int,
+    x_ptr: UnsafePointer[Scalar[dtype], ...],
+    dt_ptr: UnsafePointer[Scalar[dtype], ...],
+    A_ptr: UnsafePointer[Scalar[dtype], ...],
+    B_ptr: UnsafePointer[Scalar[dtype], ...],
+    C_ptr: UnsafePointer[Scalar[dtype], ...],
+    Y_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+    final_state_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+) raises:
+    """Run the full SSD chunk-scan-combined on CPU.
+
+    ``final_state_ptr`` is filled with the post-last-chunk SSM state, shape
+    ``[batch, n_heads, head_dim, state_dim]`` row-major. Callers use it to seed
+    the step-mode SSM cache; pass a dummy buffer of the right size if the
+    state is not needed.
+    """
+    if seqlen % chunk_size != 0:
+        raise Error(
+            "ssd_chunk_scan_combined: seqlen must be divisible by chunk_size"
+        )
+    var n_chunks = seqlen // chunk_size
+
+    # Heap allocations for intermediates. Sized once and zeroed where needed.
+    var x_disc_size = batch * n_chunks * n_heads * chunk_size * head_dim
+    var a_disc_size = batch * n_chunks * n_heads * chunk_size
+    var bc_chunk_size = batch * n_chunks * n_heads * chunk_size * state_dim
+    var y_diag_size = x_disc_size  # same shape as X_disc
+    var chunk_states_size = batch * n_chunks * n_heads * head_dim * state_dim
+    var entering_size = chunk_states_size
+    var final_size = batch * n_heads * head_dim * state_dim
+    var cd_size = batch * n_chunks * n_heads
+    var y_chunked_size = x_disc_size
+
+    var X_disc = List[Scalar[dtype]](length=x_disc_size, fill=Scalar[dtype](0))
+    var A_disc = List[Scalar[dtype]](length=a_disc_size, fill=Scalar[dtype](0))
+    var B_chunk = List[Scalar[dtype]](
+        length=bc_chunk_size, fill=Scalar[dtype](0)
+    )
+    var C_chunk = List[Scalar[dtype]](
+        length=bc_chunk_size, fill=Scalar[dtype](0)
+    )
+    var Y_diag = List[Scalar[dtype]](length=y_diag_size, fill=Scalar[dtype](0))
+    var chunk_states = List[Scalar[dtype]](
+        length=chunk_states_size, fill=Scalar[dtype](0)
+    )
+    var entering = List[Scalar[dtype]](
+        length=entering_size, fill=Scalar[dtype](0)
+    )
+    var final = List[Scalar[dtype]](length=final_size, fill=Scalar[dtype](0))
+    var chunk_decays = List[Scalar[dtype]](
+        length=cd_size, fill=Scalar[dtype](0)
+    )
+    var Y_chunked = List[Scalar[dtype]](
+        length=y_chunked_size, fill=Scalar[dtype](0)
+    )
+
+    # Stage 0: discretize + chunked reshape.
+    _ssd_combined_precompute_cpu[dtype](
+        batch,
+        seqlen,
+        n_heads,
+        head_dim,
+        state_dim,
+        n_chunks,
+        chunk_size,
+        x_ptr,
+        dt_ptr,
+        A_ptr,
+        B_ptr,
+        C_ptr,
+        X_disc.unsafe_ptr(),
+        A_disc.unsafe_ptr(),
+        B_chunk.unsafe_ptr(),
+        C_chunk.unsafe_ptr(),
+        chunk_decays.unsafe_ptr(),
+    )
+
+    # Build LayoutTensors over the intermediate buffers (row-major).
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var X_disc_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_disc.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, head_dim)
+        ),
+    )
+    var A_disc_lt = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_disc.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size)
+        ),
+    )
+    var B_chunk_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_chunk.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, state_dim)
+        ),
+    )
+    var C_chunk_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        C_chunk.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, state_dim)
+        ),
+    )
+    var Y_diag_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_diag.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, head_dim)
+        ),
+    )
+    var chunk_states_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        chunk_states.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    var entering_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        entering.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    var final_lt = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        final.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_heads, head_dim, state_dim)
+        ),
+    )
+    var chunk_decays_lt = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        chunk_decays.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_3d].row_major(Index(batch, n_chunks, n_heads)),
+    )
+    var Y_chunked_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_chunked.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, head_dim)
+        ),
+    )
+
+    # Stage 1: intra-chunk diagonal -> Y_diag.
+    # The kernel accumulates into Y, so Y_diag is pre-zeroed above.
+    ssd_intra_chunk_fwd_cpu[
+        dtype,
+        C_chunk_lt.layout,
+        B_chunk_lt.layout,
+        X_disc_lt.layout,
+        A_disc_lt.layout,
+        Y_diag_lt.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_size,
+        state_dim,
+        head_dim,
+        C_chunk_lt,
+        B_chunk_lt,
+        X_disc_lt,
+        A_disc_lt,
+        Y_diag_lt,
+    )
+
+    # Stage 2: per-chunk end-states.
+    ssd_chunk_state_fwd_cpu[
+        dtype,
+        B_chunk_lt.layout,
+        X_disc_lt.layout,
+        A_disc_lt.layout,
+        chunk_states_lt.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_size,
+        state_dim,
+        head_dim,
+        B_chunk_lt,
+        X_disc_lt,
+        A_disc_lt,
+        chunk_states_lt,
+    )
+
+    # Stage 3: inter-chunk recurrence.
+    ssd_chunk_scan_fwd_cpu[
+        dtype,
+        chunk_states_lt.layout,
+        chunk_decays_lt.layout,
+        entering_lt.layout,
+        final_lt.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        head_dim,
+        state_dim,
+        chunk_states_lt,
+        chunk_decays_lt,
+        entering_lt,
+        final_lt,
+    )
+
+    # Stage 4: output recombination (writes into Y_chunked, copying Y_diag in).
+    ssd_output_recombination_fwd_cpu[
+        dtype,
+        C_chunk_lt.layout,
+        entering_lt.layout,
+        A_disc_lt.layout,
+        Y_diag_lt.layout,
+        Y_chunked_lt.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_size,
+        head_dim,
+        state_dim,
+        C_chunk_lt,
+        entering_lt,
+        A_disc_lt,
+        Y_diag_lt,
+        Y_chunked_lt,
+    )
+
+    # Flatten the chunked output back to (batch, seqlen, n_heads, head_dim).
+    _ssd_combined_postprocess_cpu[dtype](
+        batch,
+        seqlen,
+        n_heads,
+        head_dim,
+        n_chunks,
+        chunk_size,
+        Y_chunked.unsafe_ptr(),
+        Y_ptr,
+    )
+
+    # Copy the post-last-chunk SSM state into the caller's final_state buffer.
+    # Shape is [batch, n_heads, head_dim, state_dim], identical to `final_lt`.
+    var final_total = batch * n_heads * head_dim * state_dim
+    var final_src = final.unsafe_ptr()
+    for i in range(final_total):
+        final_state_ptr[i] = final_src[i]
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU dispatch — fully on-device stitched pipeline
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_combined_precompute_gpu[
+    dtype: DType,
+    x_LT: TensorLayout,
+    dt_LT: TensorLayout,
+    A_LT: TensorLayout,
+    bc_LT: TensorLayout,
+    xd_LT: TensorLayout,
+    ad_LT: TensorLayout,
+    bcc_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    seqlen_i32: Int32,
+    n_heads_i32: Int32,
+    head_dim_i32: Int32,
+    state_dim_i32: Int32,
+    n_chunks_i32: Int32,
+    chunk_size_i32: Int32,
+    x: TileTensor[dtype, x_LT, MutAnyOrigin],
+    dt: TileTensor[dtype, dt_LT, MutAnyOrigin],
+    A: TileTensor[dtype, A_LT, MutAnyOrigin],
+    B: TileTensor[dtype, bc_LT, MutAnyOrigin],
+    C: TileTensor[dtype, bc_LT, MutAnyOrigin],
+    X_disc: TileTensor[dtype, xd_LT, MutAnyOrigin],
+    A_disc: TileTensor[dtype, ad_LT, MutAnyOrigin],
+    B_chunk: TileTensor[dtype, bcc_LT, MutAnyOrigin],
+    C_chunk: TileTensor[dtype, bcc_LT, MutAnyOrigin],
+):
+    """Stage 0 (GPU): discretize + chunked reshape. One thread per (b,c,h,l).
+
+    Mirrors ``_ssd_combined_precompute_cpu``: ``X_disc = x*dt`` (chunked),
+    ``A_disc = A[h]*dt`` (chunked), ``B_chunk``/``C_chunk`` pure reshape. The
+    flat ``(b,c,h,l)`` index is row-major over ``A_disc`` so ``A_disc.ptr[idx]``
+    is the destination directly.
+    """
+    var batch = Int(batch_i32)
+    var seqlen = Int(seqlen_i32)
+    var n_heads = Int(n_heads_i32)
+    var head_dim = Int(head_dim_i32)
+    var state_dim = Int(state_dim_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var chunk_size = Int(chunk_size_i32)
+    var idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total = batch * n_chunks * n_heads * chunk_size
+    if idx >= total:
+        return
+
+    var l = idx % chunk_size
+    var h = (idx // chunk_size) % n_heads
+    var c = (idx // (chunk_size * n_heads)) % n_chunks
+    var bi = idx // (chunk_size * n_heads * n_chunks)
+    var t = c * chunk_size + l
+
+    var a_h = A.ptr[h].cast[DType.float32]()
+    var dt_off = (bi * seqlen + t) * n_heads + h
+    var dt_val = dt.ptr[dt_off].cast[DType.float32]()
+    A_disc.ptr[idx] = (a_h * dt_val).cast[dtype]()
+
+    var x_in_base = ((bi * seqlen + t) * n_heads + h) * head_dim
+    var x_out_base = idx * head_dim
+    for p in range(head_dim):
+        X_disc.ptr[x_out_base + p] = (
+            x.ptr[x_in_base + p].cast[DType.float32]() * dt_val
+        ).cast[dtype]()
+
+    var bc_in_base = ((bi * seqlen + t) * n_heads + h) * state_dim
+    var bc_out_base = idx * state_dim
+    for n in range(state_dim):
+        B_chunk.ptr[bc_out_base + n] = B.ptr[bc_in_base + n]
+        C_chunk.ptr[bc_out_base + n] = C.ptr[bc_in_base + n]
+
+
+def _ssd_combined_chunk_decays_gpu[
+    dtype: DType,
+    ad_LT: TensorLayout,
+    cd_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_size_i32: Int32,
+    A_disc: TileTensor[dtype, ad_LT, MutAnyOrigin],
+    chunk_decays: TileTensor[dtype, cd_LT, MutAnyOrigin],
+):
+    """Stage 0b (GPU): ``chunk_decays[b,c,h] = sum_l A_disc[b,c,h,l]``."""
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_size = Int(chunk_size_i32)
+    var idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total = batch * n_chunks * n_heads
+    if idx >= total:
+        return
+    var base = idx * chunk_size
+    var s = Float32(0.0)
+    for l in range(chunk_size):
+        s += A_disc.ptr[base + l].cast[DType.float32]()
+    chunk_decays.ptr[idx] = s.cast[dtype]()
+
+
+def _ssd_combined_postprocess_gpu[
+    dtype: DType,
+    yc_LT: TensorLayout,
+    y_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    seqlen_i32: Int32,
+    n_heads_i32: Int32,
+    head_dim_i32: Int32,
+    n_chunks_i32: Int32,
+    chunk_size_i32: Int32,
+    Y_chunked: TileTensor[dtype, yc_LT, MutAnyOrigin],
+    Y: TileTensor[dtype, y_LT, MutAnyOrigin],
+):
+    """Stage 5 (GPU): flatten ``Y_chunked[b,c,h,l,p]`` -> ``Y[b,t,h,p]``."""
+    var batch = Int(batch_i32)
+    var seqlen = Int(seqlen_i32)
+    var n_heads = Int(n_heads_i32)
+    var head_dim = Int(head_dim_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var chunk_size = Int(chunk_size_i32)
+    var idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total = batch * n_chunks * n_heads * chunk_size * head_dim
+    if idx >= total:
+        return
+    var p = idx % head_dim
+    var l = (idx // head_dim) % chunk_size
+    var h = (idx // (head_dim * chunk_size)) % n_heads
+    var c = (idx // (head_dim * chunk_size * n_heads)) % n_chunks
+    var bi = idx // (head_dim * chunk_size * n_heads * n_chunks)
+    var t = c * chunk_size + l
+    var y_out = ((bi * seqlen + t) * n_heads + h) * head_dim + p
+    Y.ptr[y_out] = Y_chunked.ptr[idx]
+
+
+def _ssd_chunk_scan_combined_gpu[
+    dtype: DType,
+    chunk_size: Int,
+](
+    batch: Int,
+    seqlen: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    x_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dt_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    A_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    B_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    C_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    Y_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    final_state_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Fully on-device SSD chunk-scan-combined.
+
+    Runs all six stages on the GPU over device-resident buffers (no host
+    round-trip): precompute -> intra-chunk diagonal -> chunk end-state (the
+    optimized ``ssd_chunk_state`` kernel; the fused tensor-core path for the
+    gate dims, else the parallel scalar path) -> inter-chunk scan -> output
+    recombination -> postprocess. ``*_ptr`` are device pointers.
+    """
+    if seqlen % chunk_size != 0:
+        raise Error(
+            "ssd_chunk_scan_combined: seqlen must be divisible by chunk_size"
+        )
+    var n_chunks = seqlen // chunk_size
+    var num_slices = batch * n_chunks * n_heads
+
+    # Device intermediates (same shapes as the CPU dispatch).
+    var xd_n = batch * n_chunks * n_heads * chunk_size * head_dim
+    var ad_n = batch * n_chunks * n_heads * chunk_size
+    var bc_n = batch * n_chunks * n_heads * chunk_size * state_dim
+    var st_n = batch * n_chunks * n_heads * head_dim * state_dim
+    var cd_n = batch * n_chunks * n_heads
+    var fin_n = batch * n_heads * head_dim * state_dim
+
+    var X_disc_d = ctx.enqueue_create_buffer[dtype](xd_n)
+    var A_disc_d = ctx.enqueue_create_buffer[dtype](ad_n)
+    var B_chunk_d = ctx.enqueue_create_buffer[dtype](bc_n)
+    var C_chunk_d = ctx.enqueue_create_buffer[dtype](bc_n)
+    var Y_diag_d = ctx.enqueue_create_buffer[dtype](xd_n)
+    var chunk_states_d = ctx.enqueue_create_buffer[dtype](st_n)
+    var entering_d = ctx.enqueue_create_buffer[dtype](st_n)
+    var final_d = ctx.enqueue_create_buffer[dtype](fin_n)
+    var chunk_decays_d = ctx.enqueue_create_buffer[dtype](cd_n)
+    var Y_chunked_d = ctx.enqueue_create_buffer[dtype](xd_n)
+
+    # TileTensor views over inputs (device ptrs) and intermediates.
+    var x_tt = TileTensor(x_ptr, row_major(batch, seqlen, n_heads, head_dim))
+    var dt_tt = TileTensor(dt_ptr, row_major(batch, seqlen, n_heads))
+    var A_tt = TileTensor(A_ptr, row_major(n_heads))
+    var B_tt = TileTensor(B_ptr, row_major(batch, seqlen, n_heads, state_dim))
+    var C_tt = TileTensor(C_ptr, row_major(batch, seqlen, n_heads, state_dim))
+
+    var X_disc = TileTensor(
+        X_disc_d, row_major(batch, n_chunks, n_heads, chunk_size, head_dim)
+    )
+    var A_disc = TileTensor(
+        A_disc_d, row_major(batch, n_chunks, n_heads, chunk_size)
+    )
+    var B_chunk = TileTensor(
+        B_chunk_d, row_major(batch, n_chunks, n_heads, chunk_size, state_dim)
+    )
+    var C_chunk = TileTensor(
+        C_chunk_d, row_major(batch, n_chunks, n_heads, chunk_size, state_dim)
+    )
+    var Y_diag = TileTensor(
+        Y_diag_d, row_major(batch, n_chunks, n_heads, chunk_size, head_dim)
+    )
+    var chunk_states = TileTensor(
+        chunk_states_d, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var entering = TileTensor(
+        entering_d, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var final = TileTensor(
+        final_d, row_major(batch, n_heads, head_dim, state_dim)
+    )
+    var chunk_decays = TileTensor(
+        chunk_decays_d, row_major(batch, n_chunks, n_heads)
+    )
+    var Y_chunked = TileTensor(
+        Y_chunked_d, row_major(batch, n_chunks, n_heads, chunk_size, head_dim)
+    )
+    var Y_out = TileTensor(Y_ptr, row_major(batch, seqlen, n_heads, head_dim))
+
+    # Stage 0: precompute (discretize + chunked reshape) + chunk decays.
+    var pre_total = batch * n_chunks * n_heads * chunk_size
+    var pre_compiled = ctx.compile_function[
+        _ssd_combined_precompute_gpu[
+            dtype,
+            x_tt.LayoutType,
+            dt_tt.LayoutType,
+            A_tt.LayoutType,
+            B_tt.LayoutType,
+            X_disc.LayoutType,
+            A_disc.LayoutType,
+            B_chunk.LayoutType,
+        ]
+    ]()
+    var cd_compiled = ctx.compile_function[
+        _ssd_combined_chunk_decays_gpu[
+            dtype, A_disc.LayoutType, chunk_decays.LayoutType
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            pre_compiled,
+            Int32(batch),
+            Int32(seqlen),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            Int32(n_chunks),
+            Int32(chunk_size),
+            x_tt,
+            dt_tt,
+            A_tt,
+            B_tt,
+            C_tt,
+            X_disc,
+            A_disc,
+            B_chunk,
+            C_chunk,
+            grid_dim=(ceildiv(pre_total, _SSD_GPU_BLOCK),),
+            block_dim=(_SSD_GPU_BLOCK,),
+        )
+        ctx.enqueue_function(
+            cd_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_size),
+            A_disc,
+            chunk_decays,
+            grid_dim=(ceildiv(cd_n, _SSD_GPU_BLOCK),),
+            block_dim=(_SSD_GPU_BLOCK,),
+        )
+
+    # Stage 1: intra-chunk diagonal -> Y_diag (host launcher).
+    ssd_intra_chunk_fwd_gpu[
+        dtype,
+        C_chunk.LayoutType,
+        B_chunk.LayoutType,
+        X_disc.LayoutType,
+        A_disc.LayoutType,
+        Y_diag.LayoutType,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_size,
+        state_dim,
+        head_dim,
+        C_chunk,
+        B_chunk,
+        X_disc,
+        A_disc,
+        Y_diag,
+        ctx,
+    )
+
+    # Stage 2: per-chunk end-states (optimized chunk_state).
+    # Fused tensor-core path for the gate dims; parallel scalar path otherwise.
+    if state_dim == 128 and head_dim == 64:
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_size,
+            128,
+            64,
+            B_chunk.LayoutType,
+            X_disc.LayoutType,
+            A_disc.LayoutType,
+            chunk_states.LayoutType,
+        ](batch, n_chunks, n_heads, B_chunk, X_disc, A_disc, chunk_states, ctx)
+    else:
+        var cs_compiled = ctx.compile_function[
+            ssd_chunk_state_fwd_gpu[
+                dtype,
+                B_chunk.LayoutType,
+                X_disc.LayoutType,
+                A_disc.LayoutType,
+                chunk_states.LayoutType,
+            ]
+        ]()
+        with ctx.push_context():
+            ctx.enqueue_function(
+                cs_compiled,
+                Int32(batch),
+                Int32(n_chunks),
+                Int32(n_heads),
+                Int32(chunk_size),
+                Int32(state_dim),
+                Int32(head_dim),
+                B_chunk,
+                X_disc,
+                A_disc,
+                chunk_states,
+                grid_dim=(num_slices, 1),
+                block_dim=(chunk_size,),
+            )
+
+    # Stage 3: inter-chunk recurrence (device kernel).
+    var scan_total = batch * n_heads * head_dim * state_dim
+    var scan_compiled = ctx.compile_function[
+        ssd_chunk_scan_fwd_gpu[
+            dtype,
+            chunk_states.LayoutType,
+            chunk_decays.LayoutType,
+            entering.LayoutType,
+            final.LayoutType,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            scan_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            chunk_states,
+            chunk_decays,
+            entering,
+            final,
+            grid_dim=(ceildiv(scan_total, _SSD_GPU_BLOCK),),
+            block_dim=(_SSD_GPU_BLOCK,),
+        )
+
+    # Stage 4: output recombination (device kernel). Fused single-pass
+    # tensor-core path for the gate dims (head_dim=64, state_dim=128); the
+    # fused path needs chunk_size a multiple of 128 (comptime tiling), so guard
+    # its instantiation at compile time. Scalar fallback otherwise.
+    var comb_total = batch * n_chunks * n_heads * chunk_size * head_dim
+    var used_fused = False
+
+    comptime if chunk_size % 128 == 0:
+        if state_dim == 128 and head_dim == 64:
+            used_fused = True
+            ssd_output_recombination_fwd_gpu_fused[
+                dtype,
+                chunk_size,
+                128,
+                64,
+                C_chunk.LayoutType,
+                entering.LayoutType,
+                A_disc.LayoutType,
+                Y_diag.LayoutType,
+                Y_chunked.LayoutType,
+            ](
+                batch,
+                n_chunks,
+                n_heads,
+                C_chunk,
+                entering,
+                A_disc,
+                Y_diag,
+                Y_chunked,
+                ctx,
+            )
+
+    if not used_fused:
+        var comb_compiled = ctx.compile_function[
+            ssd_output_recombination_fwd_gpu[
+                dtype,
+                C_chunk.LayoutType,
+                entering.LayoutType,
+                A_disc.LayoutType,
+                Y_diag.LayoutType,
+                Y_chunked.LayoutType,
+            ]
+        ]()
+        with ctx.push_context():
+            ctx.enqueue_function(
+                comb_compiled,
+                Int32(batch),
+                Int32(n_chunks),
+                Int32(n_heads),
+                Int32(chunk_size),
+                Int32(head_dim),
+                Int32(state_dim),
+                C_chunk,
+                entering,
+                A_disc,
+                Y_diag,
+                Y_chunked,
+                grid_dim=(ceildiv(comb_total, _SSD_GPU_BLOCK),),
+                block_dim=(_SSD_GPU_BLOCK,),
+            )
+
+    # Stage 5: postprocess (un-chunk) + copy final state to the output buffer.
+    var post_compiled = ctx.compile_function[
+        _ssd_combined_postprocess_gpu[
+            dtype, Y_chunked.LayoutType, Y_out.LayoutType
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            post_compiled,
+            Int32(batch),
+            Int32(seqlen),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(n_chunks),
+            Int32(chunk_size),
+            Y_chunked,
+            Y_out,
+            grid_dim=(ceildiv(comb_total, _SSD_GPU_BLOCK),),
+            block_dim=(_SSD_GPU_BLOCK,),
+        )
+        ctx.enqueue_copy(final_state_ptr, final_d.unsafe_ptr(), fin_n)
+    ctx.synchronize()
+
+
+# ===----------------------------------------------------------------------=== #
+# @extensibility.register entry point
+# ===----------------------------------------------------------------------=== #
+
+
+@extensibility.register("ssd_chunk_scan_combined")
+struct SSDChunkScanCombined[chunk_size: Int = 256]:
+    """Fused Mamba2 SSD chunk-scan combined op.
+
+    Stitches the four verified SSD stage kernels into a single op matching the
+    torch ``mamba_chunk_scan_combined`` fused contract.
+
+    Parameters:
+        chunk_size: Tokens per chunk. Must divide ``seqlen`` evenly. The
+            default (256) matches the upstream Mamba2 prefill setting.
+
+    Tensor Shapes:
+        - output Y:           ``(batch, seqlen, n_heads, head_dim)``
+        - output final_state: ``(batch, n_heads, head_dim, state_dim)``
+        - x:                  ``(batch, seqlen, n_heads, head_dim)``
+        - dt:                 ``(batch, seqlen, n_heads)``
+        - A:                  ``(n_heads,)``
+        - B:                  ``(batch, seqlen, n_heads, state_dim)``
+        - C:                  ``(batch, seqlen, n_heads, state_dim)``
+    """
+
+    @staticmethod
+    def execute[
+        dtype: DType,
+        target: StaticString,
+    ](
+        Y: OutputTensor[dtype=dtype, rank=4, ...],
+        final_state: OutputTensor[dtype=dtype, rank=4, ...],
+        x: InputTensor[dtype=dtype, rank=4, ...],
+        dt: InputTensor[dtype=dtype, rank=3, ...],
+        A: InputTensor[dtype=dtype, rank=1, ...],
+        B: InputTensor[dtype=dtype, rank=4, ...],
+        C: InputTensor[dtype=dtype, rank=4, ...],
+        ctx: DeviceContext,
+    ) capturing raises:
+        if Y.shape() != x.shape():
+            raise Error("ssd_chunk_scan_combined: Y shape must match x shape")
+
+        var batch = x.dim_size(0)
+        var seqlen = x.dim_size(1)
+        var n_heads = x.dim_size(2)
+        var head_dim = x.dim_size(3)
+        var state_dim = B.dim_size(3)
+
+        if (
+            final_state.dim_size(0) != batch
+            or final_state.dim_size(1) != n_heads
+            or final_state.dim_size(2) != head_dim
+            or final_state.dim_size(3) != state_dim
+        ):
+            raise Error(
+                "ssd_chunk_scan_combined: final_state shape must be"
+                " [batch, n_heads, head_dim, state_dim]"
+            )
+
+        comptime if is_cpu[target]():
+            _ssd_chunk_scan_combined_cpu[dtype](
+                batch,
+                seqlen,
+                n_heads,
+                head_dim,
+                state_dim,
+                Self.chunk_size,
+                x.unsafe_ptr(),
+                dt.unsafe_ptr(),
+                A.unsafe_ptr(),
+                B.unsafe_ptr(),
+                C.unsafe_ptr(),
+                Y.unsafe_ptr(),
+                final_state.unsafe_ptr(),
+            )
+        elif is_gpu[target]():
+            # Fully on-device stitched dispatch: all six stages run on the GPU
+            # over device-resident intermediates (no host round-trip). Stage 2
+            # uses the optimized ssd_chunk_state kernel (fused tensor-core path
+            # for the gate dims, parallel scalar otherwise).
+            _ssd_chunk_scan_combined_gpu[dtype, Self.chunk_size](
+                batch,
+                seqlen,
+                n_heads,
+                head_dim,
+                state_dim,
+                x.unsafe_ptr(),
+                dt.unsafe_ptr(),
+                A.unsafe_ptr(),
+                B.unsafe_ptr(),
+                C.unsafe_ptr(),
+                Y.unsafe_ptr(),
+                final_state.unsafe_ptr(),
+                ctx,
+            )
+        else:
+            raise Error("ssd_chunk_scan_combined: unsupported target")
+
+
+@extensibility.register_shape_function("ssd_chunk_scan_combined")
+def ssd_chunk_scan_combined_shape[
+    dtype: DType,
+](
+    x: InputTensor[dtype=dtype, rank=4, ...],
+    dt: InputTensor[dtype=dtype, rank=3, ...],
+    A: InputTensor[dtype=dtype, rank=1, ...],
+    B: InputTensor[dtype=dtype, rank=4, ...],
+    C: InputTensor[dtype=dtype, rank=4, ...],
+) -> IndexList[4]:
+    """Returns the primary (`Y`) output shape for `ssd_chunk_scan_combined`.
+
+    The op has two outputs (`Y` and `final_state`); the graph-side wrapper
+    (`functional_ops.ssd_chunk_scan_combined`) passes both `out_types`
+    explicitly. Only the primary shape is returned here: a `Tuple` return
+    trips the kernel-package loader's parameter-name mapping for `Tuple`
+    ("struct decl not present in the loaded package and not in the stdlib
+    slot-name table") on the prebuilt toolchain.
+
+    Parameters:
+        dtype: Element type of the input tensors.
+
+    Args:
+        x: Input tensor with shape `(batch, seqlen, n_heads, head_dim)`.
+        dt: Time-step tensor with shape `(batch, seqlen, n_heads)`.
+        A: Per-head decay with shape `(n_heads,)`.
+        B: Input projection with shape `(batch, seqlen, n_heads, state_dim)`.
+        C: Output projection with shape `(batch, seqlen, n_heads, state_dim)`.
+
+    Returns:
+        The `Y` output shape, equal to `x.shape()`.
+    """
+    return x.shape()

--- a/max/kernels/src/state_space/ssd_chunk_scan.mojo
+++ b/max/kernels/src/state_space/ssd_chunk_scan.mojo
@@ -1,0 +1,331 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Structured state space duality (SSD) inter-chunk scan kernel.
+
+This implements stage 3 of the SSD chunk-scan algorithm used by Mamba2: the
+"inter-chunk recurrence". After stage 2 (``ssd_chunk_state``) has reduced each
+chunk down to a per-chunk end-state, this stage threads a single sequential
+recurrence across the chunks, per ``(batch, head)``, to produce the state
+*entering* each chunk and the final state after the last chunk.
+
+For a sequence of ``C`` chunks with state dim ``N`` and head dim ``P``:
+
+- Inputs:
+  - ``chunk_states: [C, P, N]`` (per-chunk end-states, the stage-2 output).
+  - ``chunk_decays: [C]`` (per-chunk total decay = sum of ``A`` over the chunk).
+- Recurrence (running ``state`` of shape ``[P, N]``, initialized to 0):
+  ```
+  entering[c] = state                                # state ENTERING chunk c
+  state       = chunk_states[c] + exp(chunk_decays[c]) * state
+  ```
+- Outputs:
+  - ``entering: [C, P, N]`` (the running state entering each chunk; the entry
+    for chunk 0 is all zeros).
+  - ``final: [P, N]`` (the running state after the last chunk).
+
+This matches the reference recurrence (stage 3 of ``ssd_minimal_discrete``)
+that carries inter-chunk information forward so the per-chunk outputs can be
+corrected by the contribution of preceding chunks.
+
+The chunk loop is inherently SEQUENTIAL: chunk ``c`` depends on the state left
+by chunk ``c-1``, so chunks cannot be parallelized. On GPU we parallelize over
+``(batch, head, p, n)`` instead — one thread owns a single ``(p, n)`` scalar of
+the running state and walks the chunk axis sequentially.
+"""
+
+from layout import Layout, LayoutTensor, TensorLayout, TileTensor
+from std.math import exp
+from std.gpu import (
+    block_dim,
+    block_idx,
+    thread_idx,
+)
+from std.utils.index import IndexList
+
+# Stride helpers for indexing the flat row-major buffers.
+comptime Strides3D = IndexList[3]
+comptime Strides4D = IndexList[4]
+comptime Strides5D = IndexList[5]
+
+
+def _row_major_strides_3d(d0: Int, d1: Int, d2: Int) -> Strides3D:
+    """Row-major strides for a 3D shape ``(d0, d1, d2)``."""
+    return Strides3D(d1 * d2, d2, 1)
+
+
+def _row_major_strides_4d(d0: Int, d1: Int, d2: Int, d3: Int) -> Strides4D:
+    """Row-major strides for a 4D shape ``(d0, d1, d2, d3)``."""
+    return Strides4D(d1 * d2 * d3, d2 * d3, d3, 1)
+
+
+def _row_major_strides_5d(
+    d0: Int, d1: Int, d2: Int, d3: Int, d4: Int
+) -> Strides5D:
+    """Row-major strides for a 5D shape ``(d0, d1, d2, d3, d4)``."""
+    return Strides5D(d1 * d2 * d3 * d4, d2 * d3 * d4, d3 * d4, d4, 1)
+
+
+def ssd_chunk_scan_fwd_cpu[
+    kernel_dtype: DType,
+    chunk_states_layout: Layout,
+    chunk_decays_layout: Layout,
+    entering_layout: Layout,
+    final_layout: Layout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    chunk_states: LayoutTensor[kernel_dtype, chunk_states_layout, MutAnyOrigin],
+    chunk_decays: LayoutTensor[kernel_dtype, chunk_decays_layout, MutAnyOrigin],
+    entering: LayoutTensor[kernel_dtype, entering_layout, MutAnyOrigin],
+    final: LayoutTensor[kernel_dtype, final_layout, MutAnyOrigin],
+):
+    """Compute the SSD inter-chunk scan on CPU.
+
+    Threads a sequential recurrence across chunks, per ``(batch, head)``, over
+    the supplied row-major tensors.
+
+    Tensor shapes (row-major):
+        - ``chunk_states``: ``[batch, n_chunks, n_heads, head_dim, state_dim]``
+        - ``chunk_decays``: ``[batch, n_chunks, n_heads]``
+        - ``entering``: ``[batch, n_chunks, n_heads, head_dim, state_dim]`` (out)
+        - ``final``: ``[batch, n_heads, head_dim, state_dim]`` (output)
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        chunk_states_layout: Layout of the ``chunk_states`` tensor.
+        chunk_decays_layout: Layout of the ``chunk_decays`` tensor.
+        entering_layout: Layout of the ``entering`` output tensor.
+        final_layout: Layout of the ``final`` output tensor.
+
+    Args:
+        batch: Number of batch elements.
+        n_chunks: Number of chunks per sequence (``C``).
+        n_heads: Number of heads.
+        head_dim: Head dimension (``P``).
+        state_dim: State dimension (``N``).
+        chunk_states: Per-chunk end-states,
+            shape ``[batch, n_chunks, n_heads, P, N]``.
+        chunk_decays: Per-chunk total decay,
+            shape ``[batch, n_chunks, n_heads]``.
+        entering: Output state entering each chunk,
+            shape ``[batch, n_chunks, n_heads, P, N]``.
+        final: Output final state after the last chunk,
+            shape ``[batch, n_heads, P, N]``.
+    """
+    # Row-major strides for the flat backing buffers.
+    var cs_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, head_dim, state_dim
+    )
+    var cd_strides = _row_major_strides_3d(batch, n_chunks, n_heads)
+    var ent_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, head_dim, state_dim
+    )
+    var final_strides = _row_major_strides_4d(
+        batch, n_heads, head_dim, state_dim
+    )
+
+    for bi in range(batch):
+        for h in range(n_heads):
+            # Running state for this (batch, head), shape (P, N), init 0.
+            var state = List[Float32](length=head_dim * state_dim, fill=0.0)
+
+            for c in range(n_chunks):
+                # entering[c] = state (the state ENTERING chunk c).
+                var ent_base = (
+                    bi * ent_strides[0]
+                    + c * ent_strides[1]
+                    + h * ent_strides[2]
+                )
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var ent_off = (
+                            ent_base + p * ent_strides[3] + n * ent_strides[4]
+                        )
+                        entering.ptr[ent_off] = state[p * state_dim + n].cast[
+                            kernel_dtype
+                        ]()
+
+                # decay = exp(chunk_decays[c]).
+                var cd_off = (
+                    bi * cd_strides[0] + c * cd_strides[1] + h * cd_strides[2]
+                )
+                var decay = exp(chunk_decays.ptr[cd_off].cast[DType.float32]())
+
+                # state = chunk_states[c] + decay * state.
+                var cs_base = (
+                    bi * cs_strides[0] + c * cs_strides[1] + h * cs_strides[2]
+                )
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var cs_off = (
+                            cs_base + p * cs_strides[3] + n * cs_strides[4]
+                        )
+                        var cs_val = chunk_states.ptr[cs_off].cast[
+                            DType.float32
+                        ]()
+                        var prev = state[p * state_dim + n]
+                        state[p * state_dim + n] = cs_val + decay * prev
+
+            # final = state after the last chunk.
+            var final_base = bi * final_strides[0] + h * final_strides[1]
+            for p in range(head_dim):
+                for n in range(state_dim):
+                    var final_off = (
+                        final_base + p * final_strides[2] + n * final_strides[3]
+                    )
+                    final.ptr[final_off] = state[p * state_dim + n].cast[
+                        kernel_dtype
+                    ]()
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU Implementation
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_chunk_scan_fwd_gpu[
+    kernel_dtype: DType,
+    chunk_states_LT: TensorLayout,
+    chunk_decays_LT: TensorLayout,
+    entering_LT: TensorLayout,
+    final_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    head_dim_i32: Int32,
+    state_dim_i32: Int32,
+    chunk_states: TileTensor[kernel_dtype, chunk_states_LT, MutUntrackedOrigin],
+    chunk_decays: TileTensor[kernel_dtype, chunk_decays_LT, MutUntrackedOrigin],
+    entering: TileTensor[kernel_dtype, entering_LT, MutUntrackedOrigin],
+    final: TileTensor[kernel_dtype, final_LT, MutUntrackedOrigin],
+):
+    """Compute the SSD inter-chunk scan on GPU.
+
+    The chunk recurrence is inherently sequential, so we do NOT parallelize over
+    chunks. Instead each GPU thread owns a single ``(batch, head, p, n)`` scalar
+    of the running state and walks the chunk axis sequentially. This keeps the
+    recurrence dependency local to one thread (no cross-thread sync) while still
+    exposing ``batch * n_heads * head_dim * state_dim``-way parallelism.
+
+    The same math as the CPU kernel, for the scalar ``state[p, n]``:
+        - ``entering[c, p, n] = state`` (before updating)
+        - ``state = chunk_states[c, p, n] + exp(chunk_decays[c]) * state``
+        - ``final[p, n] = state`` (after the last chunk)
+
+    Tensor shapes (row-major):
+        - ``chunk_states``: ``[batch, n_chunks, n_heads, head_dim, state_dim]``
+        - ``chunk_decays``: ``[batch, n_chunks, n_heads]``
+        - ``entering``: ``[batch, n_chunks, n_heads, head_dim, state_dim]`` (out)
+        - ``final``: ``[batch, n_heads, head_dim, state_dim]`` (output)
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        chunk_states_LT: Layout of the ``chunk_states`` tensor.
+        chunk_decays_LT: Layout of the ``chunk_decays`` tensor.
+        entering_LT: Layout of the ``entering`` output tensor.
+        final_LT: Layout of the ``final`` output tensor.
+
+    Args:
+        batch_i32: Number of batch elements.
+        n_chunks_i32: Number of chunks per sequence (``C``).
+        n_heads_i32: Number of heads.
+        head_dim_i32: Head dimension (``P``).
+        state_dim_i32: State dimension (``N``).
+        chunk_states: Per-chunk end-states,
+            shape ``[batch, n_chunks, n_heads, P, N]``.
+        chunk_decays: Per-chunk total decay,
+            shape ``[batch, n_chunks, n_heads]``.
+        entering: Output state entering each chunk,
+            shape ``[batch, n_chunks, n_heads, P, N]``.
+        final: Output final state after the last chunk,
+            shape ``[batch, n_heads, P, N]``.
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var head_dim = Int(head_dim_i32)
+    var state_dim = Int(state_dim_i32)
+    var flat_idx = Int(block_dim.x) * Int(block_idx.x) + Int(thread_idx.x)
+    var total_threads = batch * n_heads * head_dim * state_dim
+    if flat_idx >= total_threads:
+        return
+
+    # Decompose the flat thread index into (batch, head, p, n).
+    var n = flat_idx % state_dim
+    var p = (flat_idx // state_dim) % head_dim
+    var h = (flat_idx // (state_dim * head_dim)) % n_heads
+    var bi = flat_idx // (state_dim * head_dim * n_heads)
+
+    # Row-major strides for the flat backing buffers.
+    var cs_n_stride = 1
+    var cs_p_stride = state_dim
+    var cs_h_stride = head_dim * cs_p_stride
+    var cs_c_stride = n_heads * cs_h_stride
+    var cs_b_stride = n_chunks * cs_c_stride
+
+    var cd_h_stride = 1
+    var cd_c_stride = n_heads
+    var cd_b_stride = n_chunks * cd_c_stride
+
+    # entering shares chunk_states' shape/strides.
+    var ent_n_stride = 1
+    var ent_p_stride = state_dim
+    var ent_h_stride = head_dim * ent_p_stride
+    var ent_c_stride = n_heads * ent_h_stride
+    var ent_b_stride = n_chunks * ent_c_stride
+
+    var final_n_stride = 1
+    var final_p_stride = state_dim
+    var final_h_stride = head_dim * final_p_stride
+    var final_b_stride = n_heads * final_h_stride
+
+    # Sequential recurrence over chunks for this single (p, n) scalar.
+    var state = Float32(0.0)
+    for c in range(n_chunks):
+        # entering[c] = state (before update).
+        var ent_off = (
+            bi * ent_b_stride
+            + c * ent_c_stride
+            + h * ent_h_stride
+            + p * ent_p_stride
+            + n * ent_n_stride
+        )
+        entering.ptr[ent_off] = state.cast[kernel_dtype]()
+
+        # decay = exp(chunk_decays[c]).
+        var cd_off = bi * cd_b_stride + c * cd_c_stride + h * cd_h_stride
+        var decay = exp(chunk_decays.ptr[cd_off].cast[DType.float32]())
+
+        # state = chunk_states[c, p, n] + decay * state.
+        var cs_off = (
+            bi * cs_b_stride
+            + c * cs_c_stride
+            + h * cs_h_stride
+            + p * cs_p_stride
+            + n * cs_n_stride
+        )
+        var cs_val = chunk_states.ptr[cs_off].cast[DType.float32]()
+        state = cs_val + decay * state
+
+    # final[p, n] = state after the last chunk.
+    var final_off = (
+        bi * final_b_stride
+        + h * final_h_stride
+        + p * final_p_stride
+        + n * final_n_stride
+    )
+    final.ptr[final_off] = state.cast[kernel_dtype]()

--- a/max/kernels/src/state_space/ssd_chunk_state.mojo
+++ b/max/kernels/src/state_space/ssd_chunk_state.mojo
@@ -1,0 +1,862 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Structured state space duality (SSD) chunk-state kernel.
+
+This implements stage 2 of the SSD chunk-scan algorithm used by Mamba2: the
+"chunk end-state". For each ``(batch, chunk, head)`` it reduces the chunk down
+to a single ``[head_dim, state_dim]`` end-state by summing the decay-weighted
+outer products of the per-token key-like and value-like projections.
+
+For a chunk of ``L`` tokens with state dim ``N`` and head dim ``P``:
+
+- Inputs: ``B: [L, N]``, ``X: [L, P]``, ``A: [L]`` (a scalar decay per token).
+- Cumulative decay: ``A_cumsum[l] = sum_{k=0..l} A[k]``.
+- Per-token decay toward the chunk end:
+  ``decay[l] = exp(A_cumsum[L-1] - A_cumsum[l])``. Note ``decay[L-1] = 1``.
+- End-state: ``state[p, n] = sum_{l=0..L-1} B[l, n] * decay[l] * X[l, p]``.
+
+This matches the reference einsum
+``state = einsum("ln,l,lp->pn", B, decay, X)`` (stage 2 of
+``ssd_minimal_discrete``), producing one end-state per ``(batch, chunk, head)``.
+"""
+
+from layout import (
+    Idx,
+    Layout,
+    LayoutTensor,
+    TensorLayout,
+    TileTensor,
+    row_major,
+)
+from std.math import exp
+from max.gpu.sync import barrier as gpu_barrier
+from std.gpu import (
+    WARP_SIZE,
+    block_dim,
+    block_idx,
+    grid_dim,
+    thread_idx,
+)
+from max.gpu.host import DeviceContext
+from std.memory import AddressSpace
+from std.memory import unsafe_stack_allocation as mem_stack_allocation
+from std.utils.index import IndexList
+from linalg.bmm import batched_matmul
+from layout.layout_tensor import copy_local_to_dram
+from layout.tensor_core import TensorCore, get_fragment_size, get_mma_shape
+
+# Stride helpers for indexing the flat row-major buffers.
+comptime Strides4D = IndexList[4]
+comptime Strides5D = IndexList[5]
+
+# Upper bound on chunk_len for the shared-memory decay scratch (one Float32
+# per token). The host launches one block per slice with block_dim == chunk_len
+# (see ``ssd_chunk_state_fwd_gpu``), so this also bounds the launch block size.
+# Mirrors ``SCAN_MAX_CHUNK`` in ``ssd_chunk.mojo``.
+comptime STATE_MAX_CHUNK = 1024
+
+
+def _row_major_strides_4d(d0: Int, d1: Int, d2: Int, d3: Int) -> Strides4D:
+    """Row-major strides for a 4D shape ``(d0, d1, d2, d3)``."""
+    return Strides4D(d1 * d2 * d3, d2 * d3, d3, 1)
+
+
+def _row_major_strides_5d(
+    d0: Int, d1: Int, d2: Int, d3: Int, d4: Int
+) -> Strides5D:
+    """Row-major strides for a 5D shape ``(d0, d1, d2, d3, d4)``."""
+    return Strides5D(d1 * d2 * d3 * d4, d2 * d3 * d4, d3 * d4, d4, 1)
+
+
+def ssd_chunk_state_fwd_cpu[
+    kernel_dtype: DType,
+    B_layout: Layout,
+    X_layout: Layout,
+    A_layout: Layout,
+    state_layout: Layout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    B: LayoutTensor[kernel_dtype, B_layout, MutAnyOrigin],
+    X: LayoutTensor[kernel_dtype, X_layout, MutAnyOrigin],
+    A: LayoutTensor[kernel_dtype, A_layout, MutAnyOrigin],
+    state: LayoutTensor[kernel_dtype, state_layout, MutAnyOrigin],
+):
+    """Compute the SSD chunk end-state on CPU.
+
+    Operates per ``(batch, chunk, head)`` over the supplied row-major tensors,
+    reducing each chunk down to a single ``[head_dim, state_dim]`` end-state.
+
+    Tensor shapes (row-major):
+        - ``B``: ``[batch, n_chunks, n_heads, chunk_len, state_dim]``
+        - ``X``: ``[batch, n_chunks, n_heads, chunk_len, head_dim]``
+        - ``A``: ``[batch, n_chunks, n_heads, chunk_len]``
+        - ``state``: ``[batch, n_chunks, n_heads, head_dim, state_dim]`` (output)
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        B_layout: Layout of the ``B`` tensor.
+        X_layout: Layout of the ``X`` tensor.
+        A_layout: Layout of the ``A`` tensor.
+        state_layout: Layout of the ``state`` output tensor.
+
+    Args:
+        batch: Number of batch elements.
+        n_chunks: Number of chunks per sequence.
+        n_heads: Number of heads.
+        chunk_len: Tokens per chunk (``L``).
+        state_dim: State dimension (``N``).
+        head_dim: Head dimension (``P``).
+        B: Key-like projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        X: Value-like input, shape ``[batch, n_chunks, n_heads, L, P]``.
+        A: Per-token scalar decay, shape ``[batch, n_chunks, n_heads, L]``.
+        state: Output end-state, shape ``[batch, n_chunks, n_heads, P, N]``.
+    """
+    # Row-major strides for the flat backing buffers.
+    var b_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, state_dim
+    )
+    var x_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, chunk_len, head_dim
+    )
+    var a_strides = _row_major_strides_4d(batch, n_chunks, n_heads, chunk_len)
+    var state_strides = _row_major_strides_5d(
+        batch, n_chunks, n_heads, head_dim, state_dim
+    )
+
+    for bi in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                # Base offsets for this (batch, chunk, head) slice.
+                var b_base = (
+                    bi * b_strides[0] + c * b_strides[1] + h * b_strides[2]
+                )
+                var x_base = (
+                    bi * x_strides[0] + c * x_strides[1] + h * x_strides[2]
+                )
+                var a_base = (
+                    bi * a_strides[0] + c * a_strides[1] + h * a_strides[2]
+                )
+                var state_base = (
+                    bi * state_strides[0]
+                    + c * state_strides[1]
+                    + h * state_strides[2]
+                )
+
+                # Inclusive prefix sum of the per-token decay: A_cumsum[l].
+                var a_cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var running = Float32(0.0)
+                for l in range(chunk_len):
+                    var a_off = a_base + l * a_strides[3]
+                    running += A.ptr[a_off].cast[DType.float32]()
+                    a_cumsum[l] = running
+
+                # decay[l] = exp(A_cumsum[L-1] - A_cumsum[l]); decay[L-1] = 1.
+                var cum_end = a_cumsum[chunk_len - 1]
+                var decay = List[Float32](length=chunk_len, fill=0.0)
+                for l in range(chunk_len):
+                    decay[l] = exp(cum_end - a_cumsum[l])
+
+                # state[p, n] = sum_l B[l, n] * decay[l] * X[l, p]
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var acc = Float32(0.0)
+                        for l in range(chunk_len):
+                            var bv = B.ptr[
+                                b_base + l * b_strides[3] + n * b_strides[4]
+                            ].cast[DType.float32]()
+                            var xv = X.ptr[
+                                x_base + l * x_strides[3] + p * x_strides[4]
+                            ].cast[DType.float32]()
+                            acc += bv * decay[l] * xv
+                        var state_off = (
+                            state_base
+                            + p * state_strides[3]
+                            + n * state_strides[4]
+                        )
+                        state.ptr[state_off] = acc.cast[kernel_dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# GPU Implementation
+# ===----------------------------------------------------------------------=== #
+
+
+def ssd_chunk_state_fwd_gpu[
+    kernel_dtype: DType,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    state_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    state_dim_i32: Int32,
+    head_dim_i32: Int32,
+    B: TileTensor[kernel_dtype, B_LT, MutUntrackedOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutUntrackedOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutUntrackedOrigin],
+    state: TileTensor[kernel_dtype, state_LT, MutUntrackedOrigin],
+):
+    """Compute the SSD chunk end-state on GPU.
+
+    Launched over a 2D grid ``(total_slices, n_p_tiles)`` with
+    ``block_dim == chunk_len``. ``block_idx.x`` selects the ``(batch, chunk,
+    head)`` slice; ``block_idx.y`` selects a tile of ``head_dim`` rows (the tile
+    height is ``ceildiv(head_dim, grid_dim.y)``, so the kernel adapts to
+    whatever ``grid_dim.y`` the host picks — ``grid_dim.y == 1`` means one block
+    computes the whole slice). Splitting each slice across several blocks raises
+    the block count and warps-in-flight on GB10's many small SMs.
+
+    Each block first computes the per-token decay
+    ``decay[l] = exp(A_cumsum[L-1] - A_cumsum[l])`` once, cooperatively, into
+    shared memory (a Hillis-Steele inclusive prefix sum over ``A`` followed by
+    the exp; recomputed per p-tile, which is cheap), then the block's threads
+    split its tile of the ``head_dim * state_dim`` output elements and each
+    accumulates its end-state entry over ``l``.
+
+    This replaces the original one-thread-per-slice port, which launched a
+    single block (occupancy/latency bound: ~0.1% compute, ~4% memory of GB10
+    peak) and recomputed ``decay[l]`` for every one of the ``head_dim *
+    state_dim`` outputs. The decay is now computed once per slice and shared.
+    It is still not tensor-core optimized; the reduction reads ``B``/``X`` from
+    global memory (the kernel is far from bandwidth bound).
+
+    The same math as the CPU kernel:
+        - ``A_cumsum[l] = sum_{k<=l} A[k]``
+        - ``decay[l] = exp(A_cumsum[L-1] - A_cumsum[l])``
+        - ``state[p, n] = sum_l B[l, n] * decay[l] * X[l, p]``
+
+    Tensor shapes (row-major):
+        - ``B``: ``[batch, n_chunks, n_heads, chunk_len, state_dim]``
+        - ``X``: ``[batch, n_chunks, n_heads, chunk_len, head_dim]``
+        - ``A``: ``[batch, n_chunks, n_heads, chunk_len]``
+        - ``state``: ``[batch, n_chunks, n_heads, head_dim, state_dim]`` (output)
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        B_LT: Layout of the ``B`` tensor.
+        X_LT: Layout of the ``X`` tensor.
+        A_LT: Layout of the ``A`` tensor.
+        state_LT: Layout of the ``state`` output tensor.
+
+    Args:
+        batch_i32: Number of batch elements.
+        n_chunks_i32: Number of chunks per sequence.
+        n_heads_i32: Number of heads.
+        chunk_len_i32: Tokens per chunk (``L``).
+        state_dim_i32: State dimension (``N``).
+        head_dim_i32: Head dimension (``P``).
+        B: Key-like projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        X: Value-like input, shape ``[batch, n_chunks, n_heads, L, P]``.
+        A: Per-token scalar decay, shape ``[batch, n_chunks, n_heads, L]``.
+        state: Output end-state, shape ``[batch, n_chunks, n_heads, P, N]``.
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var state_dim = Int(state_dim_i32)
+    var head_dim = Int(head_dim_i32)
+    var slice_idx = Int(block_idx.x)
+    var total_slices = batch * n_chunks * n_heads
+    if slice_idx >= total_slices:
+        return
+
+    var tid = Int(thread_idx.x)
+    var nthreads = Int(block_dim.x)
+
+    # Decompose the flat slice index into (batch, chunk, head).
+    var h = slice_idx % n_heads
+    var c = (slice_idx // n_heads) % n_chunks
+    var bi = slice_idx // (n_heads * n_chunks)
+
+    # Row-major strides for the flat backing buffers.
+    var b_n_stride = 1
+    var b_l_stride = state_dim
+    var b_h_stride = chunk_len * b_l_stride
+    var b_c_stride = n_heads * b_h_stride
+    var b_b_stride = n_chunks * b_c_stride
+
+    var x_p_stride = 1
+    var x_l_stride = head_dim
+    var x_h_stride = chunk_len * x_l_stride
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_l_stride = 1
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var state_n_stride = 1
+    var state_p_stride = state_dim
+    var state_h_stride = head_dim * state_p_stride
+    var state_c_stride = n_heads * state_h_stride
+    var state_b_stride = n_chunks * state_c_stride
+
+    var b_base = bi * b_b_stride + c * b_c_stride + h * b_h_stride
+    var x_base = bi * x_b_stride + c * x_c_stride + h * x_h_stride
+    var a_base = bi * a_b_stride + c * a_c_stride + h * a_h_stride
+    var state_base = (
+        bi * state_b_stride + c * state_c_stride + h * state_h_stride
+    )
+
+    # ── Per-token decay into shared memory (computed once per slice) ──────────
+    # decay[l] = exp(A_cumsum[L-1] - A_cumsum[l]); A_cumsum is the inclusive
+    # prefix sum of A. Hillis-Steele scan in shared memory: block_dim ==
+    # chunk_len threads, one element each, log2(chunk_len) doubling steps.
+    var decay = mem_stack_allocation[
+        STATE_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+
+    if tid < chunk_len:
+        decay[tid] = A.ptr[a_base + tid * a_l_stride].cast[DType.float32]()
+    gpu_barrier()
+
+    var offset = 1
+    while offset < chunk_len:
+        var add: Float32 = 0.0
+        if tid < chunk_len and tid >= offset:
+            add = decay[tid - offset]
+        gpu_barrier()
+        if tid < chunk_len and tid >= offset:
+            decay[tid] += add
+        gpu_barrier()
+        offset *= 2
+
+    # decay[] now holds A_cumsum[l]. Convert to the decay weight in place.
+    # Every thread reads cum_end before any thread overwrites its slot.
+    var cum_end = decay[chunk_len - 1]
+    gpu_barrier()
+    if tid < chunk_len:
+        decay[tid] = exp(cum_end - decay[tid])
+    gpu_barrier()
+
+    # ── End-state reduction: state[p, n] = sum_l B[l, n] * decay[l] * X[l, p] ─
+    # This block owns p-rows [p_start, p_end); its threads split that tile's
+    # (p_end - p_start) * state_dim output elements.
+    var n_p_tiles = Int(grid_dim.y)
+    var p_per_tile = (head_dim + n_p_tiles - 1) // n_p_tiles
+    var p_start = Int(block_idx.y) * p_per_tile
+    var p_end = min(p_start + p_per_tile, head_dim)
+    if p_start >= head_dim:
+        return
+
+    var n_out = (p_end - p_start) * state_dim
+    var idx = tid
+    while idx < n_out:
+        var p = p_start + idx // state_dim
+        var n = idx % state_dim
+        var acc = Float32(0.0)
+        for l in range(chunk_len):
+            var bv = B.ptr[b_base + l * b_l_stride + n * b_n_stride].cast[
+                DType.float32
+            ]()
+            var xv = X.ptr[x_base + l * x_l_stride + p * x_p_stride].cast[
+                DType.float32
+            ]()
+            acc += bv * decay[l] * xv
+        var state_off = state_base + p * state_p_stride + n * state_n_stride
+        state.ptr[state_off] = acc.cast[kernel_dtype]()
+        idx += nthreads
+
+
+# ===----------------------------------------------------------------------=== #
+# Tensor-core path: decay-weighted transpose + batched matmul
+# ===----------------------------------------------------------------------=== #
+
+
+def _ssd_chunk_state_decay_xt_gpu[
+    kernel_dtype: DType,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    xdt_LT: TensorLayout,
+](
+    batch_i32: Int32,
+    n_chunks_i32: Int32,
+    n_heads_i32: Int32,
+    chunk_len_i32: Int32,
+    head_dim_i32: Int32,
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    Xd_T: TileTensor[kernel_dtype, xdt_LT, MutAnyOrigin],
+):
+    """Materialise the decay-weighted, transposed value tensor.
+
+    One block per ``(batch, chunk, head)`` slice (``block_dim == chunk_len``).
+    Computes the per-token decay ``decay[l] = exp(A_cumsum[L-1] - A_cumsum[l])``
+    once into shared memory (same scan as ``ssd_chunk_state_fwd_gpu``), then
+    writes the **transposed** product
+
+        ``Xd_T[slice, p, l] = decay[l] * X[slice, l, p]``
+
+    into a contiguous ``[num_slices, head_dim, chunk_len]`` buffer. Transposing
+    here puts the reduction dim ``l`` last in the left matmul operand, so
+    ``state = Xd_T @ B`` (``[P,L] @ [L,N] -> [P,N]``) is a plain
+    ``batched_matmul`` with no transpose — and its output ``N`` columns hit the
+    A100 tensor-core gate. Thread ``tid`` owns token ``l = tid`` and loops over
+    ``p`` so consecutive threads write consecutive ``l`` (coalesced).
+    """
+    var batch = Int(batch_i32)
+    var n_chunks = Int(n_chunks_i32)
+    var n_heads = Int(n_heads_i32)
+    var chunk_len = Int(chunk_len_i32)
+    var head_dim = Int(head_dim_i32)
+    var slice_idx = Int(block_idx.x)
+    var total_slices = batch * n_chunks * n_heads
+    if slice_idx >= total_slices:
+        return
+
+    var tid = Int(thread_idx.x)
+
+    var h = slice_idx % n_heads
+    var c = (slice_idx // n_heads) % n_chunks
+    var bi = slice_idx // (n_heads * n_chunks)
+
+    var x_l_stride = head_dim
+    var x_h_stride = chunk_len * x_l_stride
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var x_base = bi * x_b_stride + c * x_c_stride + h * x_h_stride
+    var a_base = bi * a_b_stride + c * a_c_stride + h * a_h_stride
+
+    # Per-token decay into shared memory (Hillis-Steele inclusive prefix sum of
+    # A, then exp) — identical to ssd_chunk_state_fwd_gpu.
+    var decay = mem_stack_allocation[
+        STATE_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+
+    if tid < chunk_len:
+        decay[tid] = A.ptr[a_base + tid].cast[DType.float32]()
+    gpu_barrier()
+
+    var offset = 1
+    while offset < chunk_len:
+        var add: Float32 = 0.0
+        if tid < chunk_len and tid >= offset:
+            add = decay[tid - offset]
+        gpu_barrier()
+        if tid < chunk_len and tid >= offset:
+            decay[tid] += add
+        gpu_barrier()
+        offset *= 2
+
+    var cum_end = decay[chunk_len - 1]
+    gpu_barrier()
+    if tid < chunk_len:
+        decay[tid] = exp(cum_end - decay[tid])
+    gpu_barrier()
+
+    # Xd_T[slice, p, l] = decay[l] * X[slice, l, p]. Output is row-major
+    # [num_slices, head_dim, chunk_len]; this slice starts at slice*P*L.
+    if tid < chunk_len:
+        var d = decay[tid]
+        var xdt_base = slice_idx * head_dim * chunk_len
+        for p in range(head_dim):
+            var xv = X.ptr[x_base + tid * x_l_stride + p].cast[DType.float32]()
+            Xd_T.ptr[xdt_base + p * chunk_len + tid] = (d * xv).cast[
+                kernel_dtype
+            ]()
+
+
+def ssd_chunk_state_fwd_gpu_static[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    state_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    state: TileTensor[kernel_dtype, state_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Static-shape, tensor-core variant of ``ssd_chunk_state_fwd_gpu``.
+
+    Computes the chunk end-state as a batched matmul on tensor cores:
+
+        ``Xd_T[p, l] = decay[l] * X[l, p]``   (decay kernel, one launch)
+        ``state[p, n] = sum_l Xd_T[p, l] * B[l, n] = (Xd_T @ B)[p, n]``
+
+    Knowing ``chunk_len`` / ``state_dim`` / ``head_dim`` at compile time lets
+    ``batched_matmul`` see ``has_static_NK`` and, since the output has
+    ``state_dim`` (== matmul ``N``) columns and ``chunk_len`` (== ``K``) is a
+    multiple of 32 and ``>= 128``, pick its A100 multistage tensor-core batched
+    path (one launch for all ``batch * n_chunks * n_heads`` slices) instead of
+    the scalar reduction in ``ssd_chunk_state_fwd_gpu``.
+
+    The scalar kernel remains the all-shape-correct fallback for shapes that
+    miss the gate (e.g. ``state_dim`` not a multiple of 128).
+
+    Parameters:
+        kernel_dtype: The element type of every tensor (e.g. ``float32``).
+        chunk_len_ct: Tokens per chunk (``L``), compile-time.
+        state_dim_ct: State dimension (``N``), compile-time.
+        head_dim_ct: Head dimension (``P``), compile-time.
+        B_LT: Layout of the ``B`` tensor.
+        X_LT: Layout of the ``X`` tensor.
+        A_LT: Layout of the ``A`` tensor.
+        state_LT: Layout of the ``state`` output tensor.
+
+    Args:
+        batch: Number of batch elements.
+        n_chunks: Number of chunks per sequence.
+        n_heads: Number of heads.
+        B: Key-like projection, shape ``[batch, n_chunks, n_heads, L, N]``.
+        X: Value-like input, shape ``[batch, n_chunks, n_heads, L, P]``.
+        A: Per-token scalar decay, shape ``[batch, n_chunks, n_heads, L]``.
+        state: Output end-state, shape ``[batch, n_chunks, n_heads, P, N]``.
+        ctx: The device context to enqueue work on.
+    """
+    var num_slices = batch * n_chunks * n_heads
+
+    # Scratch for the decay-weighted, transposed values: [num_slices, P, L].
+    var xdt_device = ctx.enqueue_create_buffer[kernel_dtype](
+        num_slices * head_dim_ct * chunk_len_ct
+    )
+    var Xd_T = TileTensor(
+        xdt_device,
+        row_major(batch, n_chunks, n_heads, head_dim_ct, chunk_len_ct),
+    )
+
+    # Stage 1: Xd_T[p, l] = decay[l] * X[l, p] (one block per slice).
+    var decay_compiled = ctx.compile_function[
+        _ssd_chunk_state_decay_xt_gpu[
+            kernel_dtype,
+            X_LT,
+            A_LT,
+            Xd_T.LayoutType,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            decay_compiled,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len_ct),
+            Int32(head_dim_ct),
+            X,
+            A,
+            Xd_T,
+            grid_dim=(num_slices,),
+            block_dim=(chunk_len_ct,),
+        )
+
+    # Stage 2: state = Xd_T @ B (batched tensor-core matmul, one launch).
+    # state[P, N] = Xd_T[P, L] @ B[L, N]; static dims let batched_matmul take
+    # the A100 multistage path (c_n=N % 128 == 0, a_k=L % 32 == 0, L >= 128).
+    var Xd_T3 = TileTensor(
+        xdt_device,
+        row_major(num_slices, Idx[head_dim_ct], Idx[chunk_len_ct]),
+    )
+    var B3 = TileTensor(
+        B.ptr,
+        row_major(num_slices, Idx[chunk_len_ct], Idx[state_dim_ct]),
+    )
+    var state3 = TileTensor(
+        state.ptr,
+        row_major(num_slices, Idx[head_dim_ct], Idx[state_dim_ct]),
+    )
+
+    with ctx.push_context():
+        batched_matmul[target="gpu", transpose_b=False](
+            state3, Xd_T3, B3, context=ctx
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Fused single-pass tensor-core path
+# ===----------------------------------------------------------------------=== #
+
+# Warp grid over the per-slice [head_dim, state_dim] output tile. 2x4 warps =
+# 8 warps = 256 threads, which also covers chunk_len=256 for the decay scan.
+comptime STATE_FUSED_WARPS_M = 2
+comptime STATE_FUSED_WARPS_N = 4
+# K (chunk-length) step for the fused MMA. Tuned on GB10 at the Mamba2 profile:
+# BK=16 is the sweet spot (nc=4: 0.033 ms) — smaller shared tiles overlap the
+# global load with the MMA better at this L2-resident size. 8/32/64 all gave
+# 0.043/0.043/0.050 ms. Must be a multiple of MMA_K (8) and divide chunk_len.
+comptime STATE_FUSED_BK = 16
+# Split each slice's state_dim output across this many blocks (grid.y). Tried as
+# a "more blocks" occupancy lever, but it REGRESSED (n_split=2: 0.043 -> 0.069 ms
+# at the Mamba2 profile) because each N tile re-reads all of X — the extra
+# traffic outweighs the occupancy gain. Kept as infra; default 1 (no split).
+comptime STATE_FUSED_N_SPLIT = 1
+
+
+def _ssd_chunk_state_fused_mma_gpu[
+    kernel_dtype: DType,
+    P: Int,
+    N: Int,
+    L: Int,
+    BK: Int,
+    num_warps_m: Int,
+    num_warps_n: Int,
+    n_split: Int,
+    X_LT: TensorLayout,
+    B_LT: TensorLayout,
+    A_LT: TensorLayout,
+    state_LT: TensorLayout,
+](
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    state: TileTensor[kernel_dtype, state_LT, MutAnyOrigin],
+):
+    """Fused, single-pass tensor-core chunk end-state (one block per slice).
+
+    Computes ``state[p,n] = sum_l decay[l] * X[l,p] * B[l,n]`` for one
+    ``(batch, chunk, head)`` slice as a transpose-A tensor-core GEMM, **without**
+    materialising the decay-weighted transpose in DRAM (the cost the 2-pass
+    ``ssd_chunk_state_fwd_gpu_static`` pays). Per K-tile the block streams
+    ``X``/``B`` from global once, applies ``decay[l]`` while transposing ``X``
+    into a shared tile (``As[p, l]``), and accumulates the warp-tiled MMA. This
+    mirrors what Triton's ``_chunk_state_fwd`` does in a single kernel.
+
+    Compile-time tiling: block tile is the whole ``[P, N]`` output; warps tile
+    it ``num_warps_m x num_warps_n``; ``BK`` is the K (chunk-length) step. Slices
+    are contiguous in every buffer, so ``slice_idx`` alone indexes them.
+    """
+    comptime accum_type = DType.float32
+    comptime mma_shape = get_mma_shape[kernel_dtype, accum_type]()
+    comptime MMA_M = mma_shape[0]
+    comptime MMA_N = mma_shape[1]
+    comptime MMA_K = mma_shape[2]
+    # This block computes a [P, Nblk] tile; block_idx.y picks the N tile.
+    comptime Nblk = N // n_split
+    comptime WM = P // num_warps_m
+    comptime WN = Nblk // num_warps_n
+    comptime num_m_mmas = WM // MMA_M
+    comptime num_n_mmas = WN // MMA_N
+    comptime num_k_mmas = BK // MMA_K
+    comptime fs = get_fragment_size[mma_shape]()
+    comptime a_frag_size = fs[0]
+    comptime b_frag_size = fs[1]
+    comptime c_frag_size = fs[2]
+    comptime num_threads = num_warps_m * num_warps_n * WARP_SIZE
+
+    var slice_idx = Int(block_idx.x)
+    var n_tile = Int(block_idx.y)
+    var n_offset = n_tile * Nblk
+    var tid = Int(thread_idx.x)
+    var warp_id = tid // WARP_SIZE
+    var warp_y = warp_id // num_warps_n
+    var warp_x = warp_id % num_warps_n
+
+    var x_base = slice_idx * L * P
+    var b_base = slice_idx * L * N
+    var a_base = slice_idx * L
+    var state_base = slice_idx * P * N
+
+    # ── Per-token decay into shared memory (Hillis-Steele, then exp) ──────────
+    var decay = mem_stack_allocation[
+        STATE_MAX_CHUNK, Float32, address_space=AddressSpace.SHARED
+    ]()
+    if tid < L:
+        decay[tid] = A.ptr[a_base + tid].cast[DType.float32]()
+    gpu_barrier()
+    var offset = 1
+    while offset < L:
+        var add: Float32 = 0.0
+        if tid < L and tid >= offset:
+            add = decay[tid - offset]
+        gpu_barrier()
+        if tid < L and tid >= offset:
+            decay[tid] += add
+        gpu_barrier()
+        offset *= 2
+    var cum_end = decay[L - 1]
+    gpu_barrier()
+    if tid < L:
+        decay[tid] = exp(cum_end - decay[tid])
+    gpu_barrier()
+
+    # ── Shared tiles: As is decay-scaled X transposed to [P, BK]; Bs is [BK, N].
+    var As = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(P, BK),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+    var Bs = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(BK, Nblk),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+    ].stack_allocation()
+
+    # ── Register tiles ───────────────────────────────────────────────────────
+    var c_reg = (
+        LayoutTensor[
+            accum_type,
+            Layout.row_major(num_m_mmas * num_n_mmas, c_frag_size),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ]
+        .stack_allocation()
+        .fill(0)
+    )
+    var a_reg = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(num_m_mmas, a_frag_size),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ].stack_allocation()
+    var b_reg = LayoutTensor[
+        kernel_dtype,
+        Layout.row_major(num_n_mmas, b_frag_size),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ].stack_allocation()
+
+    var mma_op = TensorCore[accum_type, kernel_dtype, mma_shape, False]()
+
+    # ── K-loop over chunk length ─────────────────────────────────────────────
+    var k0 = 0
+    while k0 < L:
+        # Stage As[p, kl] = decay[k0+kl] * X[k0+kl, p] (coalesced read over p).
+        var idx = tid
+        while idx < P * BK:
+            var kl = idx // P
+            var p = idx % P
+            As[p, kl] = (
+                decay[k0 + kl]
+                * X.ptr[x_base + (k0 + kl) * P + p].cast[DType.float32]()
+            ).cast[kernel_dtype]()
+            idx += num_threads
+        # Stage Bs[kl, n] = B[k0+kl, n_offset+n] (this block's N tile).
+        idx = tid
+        while idx < BK * Nblk:
+            var kl = idx // Nblk
+            var nn = idx % Nblk
+            Bs[kl, nn] = B.ptr[b_base + (k0 + kl) * N + n_offset + nn]
+            idx += num_threads
+        gpu_barrier()
+
+        var a_warp_tile = As.tile[WM, BK](warp_y, 0)
+        var b_warp_tile = Bs.tile[BK, WN](0, warp_x)
+
+        # NOTE: As/Bs are written to shared memory unswizzled, so load_a/load_b
+        # must read unswizzled too (no swizzle arg). Adding a swizzle would
+        # require applying the same permutation on the shared-memory store.
+        comptime for k_mma in range(num_k_mmas):
+            mma_op.load_a(a_warp_tile, a_reg.vectorize[1, a_frag_size](), k_mma)
+            mma_op.load_b(
+                b_warp_tile, b_reg.vectorize[1, b_frag_size](), k_mma, warp_x
+            )
+            mma_op.mma(
+                a_reg.vectorize[1, a_frag_size](),
+                b_reg.vectorize[1, b_frag_size](),
+                c_reg.vectorize[1, c_frag_size](),
+            )
+        gpu_barrier()
+        k0 += BK
+
+    # ── Store the warp's [WM, WN] output tile to global state ────────────────
+    # The warp's global N-tile index folds in this block's N offset.
+    var c_slice = LayoutTensor[
+        kernel_dtype, Layout.row_major(P, N), MutAnyOrigin
+    ](state.ptr + state_base)
+    var c_warp_tile = c_slice.tile[WM, WN](
+        warp_y, n_tile * num_warps_n + warp_x
+    )
+    copy_local_to_dram[dst_thread_layout=Layout.row_major(8, 4)](
+        c_warp_tile.vectorize[1, 2](),
+        c_reg.vectorize[1, 2]().transpose(),
+    )
+
+
+def ssd_chunk_state_fwd_gpu_fused[
+    kernel_dtype: DType,
+    chunk_len_ct: Int,
+    state_dim_ct: Int,
+    head_dim_ct: Int,
+    B_LT: TensorLayout,
+    X_LT: TensorLayout,
+    A_LT: TensorLayout,
+    state_LT: TensorLayout,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    B: TileTensor[kernel_dtype, B_LT, MutAnyOrigin],
+    X: TileTensor[kernel_dtype, X_LT, MutAnyOrigin],
+    A: TileTensor[kernel_dtype, A_LT, MutAnyOrigin],
+    state: TileTensor[kernel_dtype, state_LT, MutAnyOrigin],
+    ctx: DeviceContext,
+) raises:
+    """Fused single-pass tensor-core chunk end-state (Triton-parity target).
+
+    One block per ``(batch, chunk, head)`` slice runs
+    ``_ssd_chunk_state_fused_mma_gpu``, which streams ``X``/``B`` once, applies
+    decay while transposing ``X`` in shared memory, and accumulates the
+    end-state on tensor cores — no DRAM round-trip for the decayed/transposed
+    values (unlike ``ssd_chunk_state_fwd_gpu_static``).
+
+    Requires ``head_dim % (16 * num_warps_m) == 0``,
+    ``state_dim % (8 * num_warps_n) == 0``, ``chunk_len % BK == 0``, and the
+    launch block (``num_warps_m * num_warps_n * 32`` threads) ``>= chunk_len``
+    for the shared-memory decay scan. The static batched-matmul path
+    (``ssd_chunk_state_fwd_gpu_static``) is the fallback for other shapes.
+    """
+    comptime num_threads = (
+        STATE_FUSED_WARPS_M * STATE_FUSED_WARPS_N * WARP_SIZE
+    )
+    var num_slices = batch * n_chunks * n_heads
+
+    var compiled = ctx.compile_function[
+        _ssd_chunk_state_fused_mma_gpu[
+            kernel_dtype,
+            head_dim_ct,
+            state_dim_ct,
+            chunk_len_ct,
+            STATE_FUSED_BK,
+            STATE_FUSED_WARPS_M,
+            STATE_FUSED_WARPS_N,
+            STATE_FUSED_N_SPLIT,
+            X_LT,
+            B_LT,
+            A_LT,
+            state_LT,
+        ]
+    ]()
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled,
+            X,
+            B,
+            A,
+            state,
+            grid_dim=(num_slices, STATE_FUSED_N_SPLIT),
+            block_dim=(num_threads,),
+        )

--- a/max/kernels/test/gpu/state_space/BUILD.bazel
+++ b/max/kernels/test/gpu/state_space/BUILD.bazel
@@ -49,6 +49,10 @@ _EXTRA_CONSTRAINTS = {
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    "test_ssd_chunk_state.mojo": select({
+        "//:apple_gpu": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 }
 
 _GPU_MEMORY = {

--- a/max/kernels/test/gpu/state_space/BUILD.bazel
+++ b/max/kernels/test/gpu/state_space/BUILD.bazel
@@ -37,6 +37,10 @@ _EXTRA_CONSTRAINTS = {
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    "test_ssd_chunk.mojo": select({
+        "//:apple_gpu": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     "test_gated_delta.mojo": select({
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],

--- a/max/kernels/test/gpu/state_space/BUILD.bazel
+++ b/max/kernels/test/gpu/state_space/BUILD.bazel
@@ -57,6 +57,10 @@ _EXTRA_CONSTRAINTS = {
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    "test_ssd_chunk_combine.mojo": select({
+        "//:apple_gpu": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 }
 
 _GPU_MEMORY = {

--- a/max/kernels/test/gpu/state_space/BUILD.bazel
+++ b/max/kernels/test/gpu/state_space/BUILD.bazel
@@ -53,6 +53,10 @@ _EXTRA_CONSTRAINTS = {
         "//:apple_gpu": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+    "test_ssd_chunk_scan.mojo": select({
+        "//:apple_gpu": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 }
 
 _GPU_MEMORY = {

--- a/max/kernels/test/gpu/state_space/test_ssd_chunk.mojo
+++ b/max/kernels/test/gpu/state_space/test_ssd_chunk.mojo
@@ -1,0 +1,758 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import exp
+
+from max.gpu.host import DeviceContext
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    row_major,
+)
+from std.random import rand
+from state_space.ssd_chunk import (
+    ssd_intra_chunk_fwd_gpu,
+    ssd_intra_chunk_fwd_gpu_naive,
+    ssd_intra_chunk_fwd_gpu_fused,
+    ssd_intra_chunk_fwd_gpu_static,
+    ssd_intra_chunk_fwd_gpu_static_mma,
+)
+from std.testing import TestSuite, assert_almost_equal
+from std.utils.index import Index
+
+
+def run_ssd_intra_chunk_gpu[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Run the optimized SSD intra-chunk GPU path and check against a reference.
+
+    Uses batched ``C @ B^T`` (Modular tensor-core matmul) plus a Triton-style
+    tiled chunk-scan kernel. Validates against the same independent scalar
+    reference used by the CPU test.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    # ── Host tensors ─────────────────────────────────────────────────────────
+    var C_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    var C_h = LayoutTensor[dtype, layout_5d, _](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](C_h.ptr, C_h.size())
+
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    var B_h = LayoutTensor[dtype, layout_5d, _](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](B_h.ptr, B_h.size())
+
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+    var X_h = LayoutTensor[dtype, layout_5d, _](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](X_h.ptr, X_h.size())
+
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var A_h = LayoutTensor[dtype, layout_4d, _](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](A_h.ptr, A_h.size())
+    # Make A negative-ish (a real SSM decays) so exp(cumsum diffs) stays
+    # bounded. `rand` fills in [0, 1); map into a small negative range.
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        # Map [0, 1) -> [-0.6, -0.1].
+        var scaled = Float32(-0.6) + Float32(0.5) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    var Y_gpu_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+    var Y_gpu_h = LayoutTensor[dtype, layout_5d, _](
+        Y_gpu_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # ── Device buffers ───────────────────────────────────────────────────────
+    var C_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y_device = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(C_device, C_h.ptr)
+        ctx.enqueue_copy(B_device, B_h.ptr)
+        ctx.enqueue_copy(X_device, X_h.ptr)
+        ctx.enqueue_copy(A_device, A_h.ptr)
+
+    var C_tt = TileTensor(
+        C_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var B_tt = TileTensor(
+        B_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var X_tt = TileTensor(
+        X_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var A_tt = TileTensor(
+        A_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var Y_tt = TileTensor(
+        Y_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+
+    with ctx.push_context():
+        ssd_intra_chunk_fwd_gpu[
+            dtype,
+            C_tt.LayoutType,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            Y_tt.LayoutType,
+        ](
+            batch,
+            n_chunks,
+            n_heads,
+            chunk_len,
+            state_dim,
+            head_dim,
+            C_tt,
+            B_tt,
+            X_tt,
+            A_tt,
+            Y_tt,
+            ctx,
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(Y_gpu_h.ptr, Y_device)
+    ctx.synchronize()
+
+    # ── CPU reference: naive triple-loop of the SSD intra-chunk formula ──────
+    var ref_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+
+    var cb_h_stride = chunk_len * state_dim
+    var cb_c_stride = n_heads * cb_h_stride
+    var cb_b_stride = n_chunks * cb_c_stride
+
+    var xy_h_stride = chunk_len * head_dim
+    var xy_c_stride = n_heads * xy_h_stride
+    var xy_b_stride = n_chunks * xy_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var cb_base = (
+                    b * cb_b_stride + c * cb_c_stride + h * cb_h_stride
+                )
+                var xy_base = (
+                    b * xy_b_stride + c * xy_c_stride + h * xy_h_stride
+                )
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                for l in range(chunk_len):
+                    for p in range(head_dim):
+                        var y_acc = Float32(0.0)
+                        for s in range(l + 1):
+                            var dot = Float32(0.0)
+                            for n in range(state_dim):
+                                var cv = C_h.ptr[
+                                    cb_base + l * state_dim + n
+                                ].cast[DType.float32]()
+                                var bv = B_h.ptr[
+                                    cb_base + s * state_dim + n
+                                ].cast[DType.float32]()
+                                dot += cv * bv
+                            var decay = exp(cumsum[l] - cumsum[s])
+                            var xv = X_h.ptr[xy_base + s * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            y_acc += dot * decay * xv
+                        ref_heap[xy_base + l * head_dim + p] = Scalar[dtype](
+                            y_acc
+                        )
+
+    # ── Compare GPU vs CPU reference ─────────────────────────────────────────
+    for i in range(xy_count):
+        assert_almost_equal(Y_gpu_h.ptr[i], ref_heap[i], rtol=rtol)
+
+
+def run_ssd_intra_chunk_gpu_static[
+    dtype: DType,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    use_mma: Bool = False,
+    use_fused: Bool = False,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+    a_min: Float32 = -0.6,
+    a_max: Float32 = -0.1,
+) raises:
+    """Exercise a static-shape path against the scalar CPU reference.
+
+    ``use_mma=False`` drives the default scalar-scan static path
+    (``ssd_intra_chunk_fwd_gpu_static``); ``use_mma=True`` drives the
+    tensor-core path that materialises ``M = causal_decay(CB)`` and computes
+    ``Y = M @ X`` via two batched matmuls
+    (``ssd_intra_chunk_fwd_gpu_static_mma``). ``chunk_len`` / ``state_dim`` /
+    ``head_dim`` are comptime so ``batched_matmul`` sees static N/K.
+
+    ``a_min`` / ``a_max`` bound the per-token decay ``A``. The scan factors
+    ``exp(cum_l−cum_s) = exp(cum_l)·exp(−cum_s)``; the intermediate
+    ``exp(−cum_s)`` can overflow FP32 once ``|cum|`` exceeds ~88, so long
+    ``chunk_len`` tests use a milder range to stay in the regime real Mamba2
+    decay rates occupy.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    var C_h = LayoutTensor[dtype, layout_5d, _](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](C_h.ptr, C_h.size())
+
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    var B_h = LayoutTensor[dtype, layout_5d, _](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](B_h.ptr, B_h.size())
+
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+    var X_h = LayoutTensor[dtype, layout_5d, _](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](X_h.ptr, X_h.size())
+
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var A_h = LayoutTensor[dtype, layout_4d, _](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](A_h.ptr, A_h.size())
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        var scaled = a_min + (a_max - a_min) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    var Y_gpu_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+
+    var C_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y_device = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(C_device, C_h.ptr)
+        ctx.enqueue_copy(B_device, B_h.ptr)
+        ctx.enqueue_copy(X_device, X_h.ptr)
+        ctx.enqueue_copy(A_device, A_h.ptr)
+
+    var C_tt = TileTensor(
+        C_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var Y_tt = TileTensor(
+        Y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    with ctx.push_context():
+        comptime if use_fused:
+            ssd_intra_chunk_fwd_gpu_fused[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        elif use_mma:
+            ssd_intra_chunk_fwd_gpu_static_mma[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+        else:
+            ssd_intra_chunk_fwd_gpu_static[
+                dtype,
+                chunk_len,
+                state_dim,
+                head_dim,
+                C_tt.LayoutType,
+                B_tt.LayoutType,
+                X_tt.LayoutType,
+                A_tt.LayoutType,
+                Y_tt.LayoutType,
+            ](batch, n_chunks, n_heads, C_tt, B_tt, X_tt, A_tt, Y_tt, ctx)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(Y_gpu_heap, Y_device)
+    ctx.synchronize()
+
+    var ref_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+
+    var cb_h_stride = chunk_len * state_dim
+    var cb_c_stride = n_heads * cb_h_stride
+    var cb_b_stride = n_chunks * cb_c_stride
+    var xy_h_stride = chunk_len * head_dim
+    var xy_c_stride = n_heads * xy_h_stride
+    var xy_b_stride = n_chunks * xy_c_stride
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var cb_base = (
+                    b * cb_b_stride + c * cb_c_stride + h * cb_h_stride
+                )
+                var xy_base = (
+                    b * xy_b_stride + c * xy_c_stride + h * xy_h_stride
+                )
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                for l in range(chunk_len):
+                    for p in range(head_dim):
+                        var y_acc = Float32(0.0)
+                        for s in range(l + 1):
+                            var dot = Float32(0.0)
+                            for n in range(state_dim):
+                                var cv = C_h.ptr[
+                                    cb_base + l * state_dim + n
+                                ].cast[DType.float32]()
+                                var bv = B_h.ptr[
+                                    cb_base + s * state_dim + n
+                                ].cast[DType.float32]()
+                                dot += cv * bv
+                            var decay = exp(cumsum[l] - cumsum[s])
+                            var xv = X_h.ptr[xy_base + s * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            y_acc += dot * decay * xv
+                        ref_heap[xy_base + l * head_dim + p] = Scalar[dtype](
+                            y_acc
+                        )
+
+    for i in range(xy_count):
+        assert_almost_equal(Y_gpu_heap[i], ref_heap[i], rtol=rtol)
+
+
+def test_ssd_intra_chunk_gpu_static_scalar() raises:
+    """Static-shape scalar-scan path against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=16, state_dim=16, head_dim=8
+    ](batch=1, n_chunks=3, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_mma() raises:
+    """Static-shape tensor-core MMA path against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=16, state_dim=16, head_dim=8, use_mma=True
+    ](batch=1, n_chunks=3, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_fused_small() raises:
+    """Fused single-pass MMA path (RFC 0009), small gate-hitting dims."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32,
+        chunk_len=64,
+        state_dim=128,
+        head_dim=64,
+        use_fused=True,
+    ](batch=1, n_chunks=2, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_fused_mamba2() raises:
+    """Fused single-pass MMA path at the Mamba2-130m profile (L=256,P=64,N=128).
+    """
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32,
+        chunk_len=256,
+        state_dim=128,
+        head_dim=64,
+        use_fused=True,
+    ](batch=1, n_chunks=2, n_heads=4, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_mma_multi_batch() raises:
+    """Static-shape MMA path with multiple batch elements."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=8, state_dim=8, head_dim=4, use_mma=True
+    ](batch=2, n_chunks=2, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_a100_mma_shape() raises:
+    """Production-shape static scalar path exercising the changed GPU paths.
+
+    Covers the code paths the GPU optimizations actually changed, which the
+    tiny shapes above do NOT:
+
+    - ``state_dim=128`` + ``chunk_len=128`` (multiple of 128) makes the
+      ``CB = C @ B^T`` stage take ``batched_matmul``'s **A100 batched
+      tensor-core path** (``multistage_gemm_cond``: N%128==0, K%32==0, K>=128).
+    - ``chunk_len=128`` > ``SCAN_BLOCK_M`` (32 on GB10) → **4 M-tiles**, so the
+      causal early-exit / tail-balancing across M-tiles is exercised.
+    - ``head_dim=64`` > ``SCAN_BLOCK_N`` (32) → **2 N-tiles**.
+    - The parallel cumsum runs one block per slice with ``block_dim=128``.
+    """
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=128, state_dim=128, head_dim=64
+    ](batch=1, n_chunks=1, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_mma_a100_shape() raises:
+    """Production-shape MMA path: decay kernel + ``Y = M @ X`` at the shape
+    where the ``CB`` matmul takes the A100 batched tensor-core path
+    (``state_dim=128``, ``chunk_len=128``)."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32,
+        chunk_len=128,
+        state_dim=128,
+        head_dim=64,
+        use_mma=True,
+    ](batch=1, n_chunks=1, n_heads=2, ctx=ctx)
+
+
+def test_ssd_intra_chunk_gpu_static_long_chunk() raises:
+    """Full Mamba2 ``chunk_len=256`` with realistic (mild) decay.
+
+    Covers the production chunk length: the Hillis-Steele cumsum at
+    ``block_dim=256``, 8 scan M-tiles, and the A100 batched MMA. Uses a milder
+    decay range so the factored ``exp(-cum_s)`` stays well within FP32 — the
+    regime real Mamba2 dt*A rates occupy (aggressive decay over 256 tokens can
+    push ``|cum|`` past the ~88 FP32-exp overflow point; see helper docstring).
+    """
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu_static[
+        DType.float32, chunk_len=256, state_dim=128, head_dim=16
+    ](batch=1, n_chunks=1, n_heads=2, ctx=ctx, a_min=-0.08, a_max=-0.01)
+
+
+def test_ssd_intra_chunk_gpu_multi_m_tile() raises:
+    """Dynamic-shape path with ``chunk_len=64`` > ``SCAN_BLOCK_M`` so the scan
+    spans multiple M-tiles (the tiny dynamic tests above are all single-tile).
+    """
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=64,
+        state_dim=32,
+        head_dim=16,
+        ctx=ctx,
+    )
+
+
+def test_ssd_intra_chunk_gpu_golden() raises:
+    """Golden-parity test on GPU against the canonical PyTorch SSD reference.
+
+    Same FIXED tiny input as the CPU golden test (batch=1, n_chunks=1,
+    n_heads=1, L=4, N=3, P=2). Pins the GPU kernel to ``intra_chunk_diag`` in
+    ``.planning/parity/ssd_minimal_ref.py``.
+    """
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    var C_vals = [
+        Float32(-0.15),
+        0.79,
+        0.95,
+        -1.11,
+        1.69,
+        -0.89,
+        -0.36,
+        1.23,
+        0.14,
+        -1.68,
+        0.32,
+        0.13,
+    ]
+    var B_vals = [
+        Float32(0.14),
+        0.24,
+        1.40,
+        1.35,
+        2.44,
+        0.20,
+        2.45,
+        2.03,
+        1.78,
+        -0.92,
+        -0.46,
+        -0.72,
+    ]
+    var X_vals = [
+        Float32(1.28),
+        -0.99,
+        1.81,
+        -0.60,
+        1.61,
+        1.93,
+        -0.42,
+        -0.08,
+    ]
+    var A_vals = [Float32(-0.43), -0.34, -0.49, -0.46]
+    var Y_expected = [
+        Float32(1.918208),
+        -1.483614,
+        3.522012,
+        -0.766567,
+        6.067267,
+        2.472605,
+        -4.850489,
+        -3.713203,
+    ]
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    # Host buffers from fixed literals.
+    var C_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    for i in range(cb_count):
+        C_heap[i] = Scalar[dtype](C_vals[i])
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](cb_count)
+    for i in range(cb_count):
+        B_heap[i] = Scalar[dtype](B_vals[i])
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+    for i in range(xy_count):
+        X_heap[i] = Scalar[dtype](X_vals[i])
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    for i in range(a_count):
+        A_heap[i] = Scalar[dtype](A_vals[i])
+    var Y_heap = ctx.enqueue_create_host_buffer[dtype](xy_count)
+
+    var C_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var B_device = ctx.enqueue_create_buffer[dtype](cb_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](xy_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var Y_device = ctx.enqueue_create_buffer[dtype](xy_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(C_device, C_heap)
+        ctx.enqueue_copy(B_device, B_heap)
+        ctx.enqueue_copy(X_device, X_heap)
+        ctx.enqueue_copy(A_device, A_heap)
+
+    var C_tt = TileTensor(
+        C_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var B_tt = TileTensor(
+        B_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var X_tt = TileTensor(
+        X_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var A_tt = TileTensor(
+        A_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var Y_tt = TileTensor(
+        Y_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_intra_chunk_fwd_gpu_naive[
+            dtype,
+            C_tt.LayoutType,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            Y_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            C_tt,
+            B_tt,
+            X_tt,
+            A_tt,
+            Y_tt,
+            grid_dim=(1,),
+            block_dim=(total_slices,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(Y_heap, Y_device)
+    ctx.synchronize()
+
+    for i in range(xy_count):
+        assert_almost_equal(
+            Y_heap[i],
+            Scalar[dtype](Y_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_intra_chunk_gpu_basic() raises:
+    """Basic single-batch, single-chunk case against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=16,
+        head_dim=8,
+        ctx=ctx,
+    )
+
+
+def test_ssd_intra_chunk_gpu_multi_chunk() raises:
+    """Multiple chunks and heads against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu[DType.float32](
+        batch=1,
+        n_chunks=3,
+        n_heads=2,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=8,
+        ctx=ctx,
+    )
+
+
+def test_ssd_intra_chunk_gpu_multi_batch() raises:
+    """Multiple batch elements against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_intra_chunk_gpu[DType.float32](
+        batch=2,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=4,
+        ctx=ctx,
+    )
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/gpu/state_space/test_ssd_chunk_combine.mojo
+++ b/max/kernels/test/gpu/state_space/test_ssd_chunk_combine.mojo
@@ -1,0 +1,640 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import ceildiv, exp
+
+from max.gpu.host import DeviceContext
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    row_major,
+)
+from std.random import rand
+from state_space.ssd_chunk_combine import (
+    ssd_output_recombination_fwd_gpu,
+    ssd_output_recombination_fwd_gpu_fused,
+    ssd_output_recombination_fwd_gpu_static,
+)
+from std.testing import TestSuite, assert_almost_equal
+from std.utils.index import Index
+
+
+def run_ssd_output_recombination_gpu[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Run the SSD output-recombination GPU kernel and check vs a CPU ref.
+
+    One GPU thread per ``(batch, chunk, head, l, p)`` output scalar; this
+    validates the result against the same naive recombination used by the CPU
+    test.
+    """
+    comptime SCALAR_BLOCK_SIZE = 128
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    # ── Host tensors ─────────────────────────────────────────────────────────
+    var c_heap = ctx.enqueue_create_host_buffer[dtype](c_count)
+    var c_h = LayoutTensor[dtype, layout_5d, _](
+        c_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](c_h.ptr, c_h.size())
+
+    var ent_heap = ctx.enqueue_create_host_buffer[dtype](ent_count)
+    var ent_h = LayoutTensor[dtype, layout_5d, _](
+        ent_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    rand[dtype](ent_h.ptr, ent_h.size())
+
+    var a_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var a_h = LayoutTensor[dtype, layout_4d, _](
+        a_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](a_h.ptr, a_h.size())
+    # Make A negative (a real SSM decays). `rand` fills in [0, 1); map into
+    # [-0.6, -0.1] like a real per-token in-chunk log-decay.
+    for i in range(a_count):
+        var v = a_h.ptr[i].cast[DType.float32]()
+        # Map [0, 1) -> [-0.6, -0.1].
+        var scaled = Float32(-0.6) + Float32(0.5) * v
+        a_h.ptr[i] = Scalar[dtype](scaled)
+
+    var yd_heap = ctx.enqueue_create_host_buffer[dtype](y_count)
+    var yd_h = LayoutTensor[dtype, layout_5d, _](
+        yd_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](yd_h.ptr, yd_h.size())
+
+    var y_gpu_heap = ctx.enqueue_create_host_buffer[dtype](y_count)
+
+    # ── Device buffers ───────────────────────────────────────────────────────
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(c_device, c_h.ptr)
+        ctx.enqueue_copy(ent_device, ent_h.ptr)
+        ctx.enqueue_copy(a_device, a_h.ptr)
+        ctx.enqueue_copy(yd_device, yd_h.ptr)
+
+    var c_tt = TileTensor(
+        c_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var ent_tt = TileTensor(
+        ent_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+    var a_tt = TileTensor(
+        a_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var yd_tt = TileTensor(
+        yd_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var y_tt = TileTensor(
+        y_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+
+    var total_threads = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var compiled_func = ctx.compile_function[
+        ssd_output_recombination_fwd_gpu[
+            dtype,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            Int32(state_dim),
+            c_tt,
+            ent_tt,
+            a_tt,
+            yd_tt,
+            y_tt,
+            grid_dim=(ceildiv(total_threads, SCALAR_BLOCK_SIZE),),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(y_gpu_heap, y_device)
+    ctx.synchronize()
+
+    # ── CPU reference: naive output recombination ────────────────────────────
+    var ref_y = ctx.enqueue_create_host_buffer[dtype](y_count)
+
+    var c_l_stride = state_dim
+    var c_h_stride = chunk_len * c_l_stride
+    var c_c_stride = n_heads * c_h_stride
+    var c_b_stride = n_chunks * c_c_stride
+
+    var ent_p_stride = state_dim
+    var ent_h_stride = head_dim * ent_p_stride
+    var ent_c_stride = n_heads * ent_h_stride
+    var ent_b_stride = n_chunks * ent_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var y_l_stride = head_dim
+    var y_h_stride = chunk_len * y_l_stride
+    var y_c_stride = n_heads * y_h_stride
+    var y_b_stride = n_chunks * y_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var c_base = b * c_b_stride + c * c_c_stride + h * c_h_stride
+                var ent_base = (
+                    b * ent_b_stride + c * ent_c_stride + h * ent_h_stride
+                )
+                var y_base = b * y_b_stride + c * y_c_stride + h * y_h_stride
+
+                var a_cumsum = Float32(0.0)
+                for l in range(chunk_len):
+                    a_cumsum += a_h.ptr[a_base + l].cast[DType.float32]()
+                    var decay = exp(a_cumsum)
+                    for p in range(head_dim):
+                        var acc = Float32(0.0)
+                        for n in range(state_dim):
+                            var c_val = c_h.ptr[
+                                c_base + l * c_l_stride + n
+                            ].cast[DType.float32]()
+                            var ent_val = ent_h.ptr[
+                                ent_base + p * ent_p_stride + n
+                            ].cast[DType.float32]()
+                            acc += c_val * ent_val
+                        var y_off = decay * acc
+                        var yd_val = yd_h.ptr[y_base + l * y_l_stride + p].cast[
+                            DType.float32
+                        ]()
+                        ref_y[y_base + l * y_l_stride + p] = Scalar[dtype](
+                            yd_val + y_off
+                        )
+
+    # ── Compare GPU vs CPU reference ─────────────────────────────────────────
+    for i in range(y_count):
+        assert_almost_equal(y_gpu_heap[i], ref_y[i], rtol=rtol)
+
+
+def test_ssd_output_recombination_gpu_golden() raises:
+    """Golden-parity test on GPU against the canonical PyTorch SSD reference.
+
+    Same FIXED tiny input as the CPU golden test (batch=1, n_chunks=1,
+    n_heads=1, L=4, N=3, P=2). Pins the GPU kernel to the stage-4 output
+    recombination of ``ssd_minimal_discrete``.
+    """
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    var c_vals = [
+        Float32(0.35),
+        -0.57,
+        -0.39,
+        -0.29,
+        -0.45,
+        0.92,
+        -0.76,
+        1.06,
+        -0.12,
+        0.58,
+        0.47,
+        0.30,
+    ]
+    var ent_vals = [
+        Float32(0.56),
+        2.29,
+        2.11,
+        0.30,
+        0.03,
+        -0.57,
+    ]
+    var a_vals = [Float32(-0.51), -0.14, -0.32, -0.54]
+    var yd_vals = [
+        Float32(0.24),
+        0.69,
+        1.40,
+        -0.14,
+        -0.35,
+        -2.05,
+        -0.44,
+        -1.53,
+    ]
+    var y_expected = [
+        Float32(-0.920277),
+        0.876274,
+        1.790647,
+        -0.466226,
+        0.312865,
+        -2.098447,
+        0.009353,
+        -1.526222,
+    ]
+
+    var c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    # Host buffers from fixed literals.
+    var c_heap = ctx.enqueue_create_host_buffer[dtype](c_count)
+    for i in range(c_count):
+        c_heap[i] = Scalar[dtype](c_vals[i])
+    var ent_heap = ctx.enqueue_create_host_buffer[dtype](ent_count)
+    for i in range(ent_count):
+        ent_heap[i] = Scalar[dtype](ent_vals[i])
+    var a_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    for i in range(a_count):
+        a_heap[i] = Scalar[dtype](a_vals[i])
+    var yd_heap = ctx.enqueue_create_host_buffer[dtype](y_count)
+    for i in range(y_count):
+        yd_heap[i] = Scalar[dtype](yd_vals[i])
+    var y_heap = ctx.enqueue_create_host_buffer[dtype](y_count)
+
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(c_device, c_heap)
+        ctx.enqueue_copy(ent_device, ent_heap)
+        ctx.enqueue_copy(a_device, a_heap)
+        ctx.enqueue_copy(yd_device, yd_heap)
+
+    var c_tt = TileTensor(
+        c_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var ent_tt = TileTensor(
+        ent_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+    var a_tt = TileTensor(
+        a_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var yd_tt = TileTensor(
+        yd_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var y_tt = TileTensor(
+        y_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+
+    var total_threads = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var compiled_func = ctx.compile_function[
+        ssd_output_recombination_fwd_gpu[
+            dtype,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(head_dim),
+            Int32(state_dim),
+            c_tt,
+            ent_tt,
+            a_tt,
+            yd_tt,
+            y_tt,
+            grid_dim=(1,),
+            block_dim=(total_threads,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(y_heap, y_device)
+    ctx.synchronize()
+
+    for i in range(y_count):
+        assert_almost_equal(
+            y_heap[i],
+            Scalar[dtype](y_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_output_recombination_gpu_basic() raises:
+    """Basic single-batch case against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_output_recombination_gpu[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        head_dim=8,
+        state_dim=16,
+        ctx=ctx,
+    )
+
+
+def test_ssd_output_recombination_gpu_multi_batch() raises:
+    """Multiple batch elements and heads against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_output_recombination_gpu[DType.float32](
+        batch=2,
+        n_chunks=3,
+        n_heads=3,
+        chunk_len=5,
+        head_dim=4,
+        state_dim=8,
+        ctx=ctx,
+    )
+
+
+def run_ssd_output_recombination_gpu_static[
+    dtype: DType,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+    use_fused: Bool = False,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Validate the static / fused tensor-core path vs the naive CPU reference.
+
+    Uses gate-hitting compile-time dims (``chunk_len % 128 == 0``,
+    ``state_dim % 32 == 0`` and ``>= 128``) so ``batched_matmul`` takes the A100
+    multistage path. With ``use_fused=True``, exercises the single-pass fused
+    MMA path instead.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var c_heap = ctx.enqueue_create_host_buffer[dtype](c_count)
+    var c_h = LayoutTensor[dtype, layout_5d, _](
+        c_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](c_h.ptr, c_h.size())
+
+    var ent_heap = ctx.enqueue_create_host_buffer[dtype](ent_count)
+    var ent_h = LayoutTensor[dtype, layout_5d, _](
+        ent_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    rand[dtype](ent_h.ptr, ent_h.size())
+
+    var a_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var a_h = LayoutTensor[dtype, layout_4d, _](
+        a_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](a_h.ptr, a_h.size())
+    for i in range(a_count):
+        var v = a_h.ptr[i].cast[DType.float32]()
+        a_h.ptr[i] = Scalar[dtype](Float32(-0.6) + Float32(0.5) * v)
+
+    var yd_heap = ctx.enqueue_create_host_buffer[dtype](y_count)
+    var yd_h = LayoutTensor[dtype, layout_5d, _](
+        yd_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](yd_h.ptr, yd_h.size())
+
+    var y_gpu_heap = ctx.enqueue_create_host_buffer[dtype](y_count)
+
+    var c_device = ctx.enqueue_create_buffer[dtype](c_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var a_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var yd_device = ctx.enqueue_create_buffer[dtype](y_count)
+    var y_device = ctx.enqueue_create_buffer[dtype](y_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(c_device, c_h.ptr)
+        ctx.enqueue_copy(ent_device, ent_h.ptr)
+        ctx.enqueue_copy(a_device, a_h.ptr)
+        ctx.enqueue_copy(yd_device, yd_h.ptr)
+
+    var c_tt = TileTensor(
+        c_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var ent_tt = TileTensor(
+        ent_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+    var a_tt = TileTensor(
+        a_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var yd_tt = TileTensor(
+        yd_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var y_tt = TileTensor(
+        y_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+
+    comptime if use_fused:
+        ssd_output_recombination_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, c_tt, ent_tt, a_tt, yd_tt, y_tt, ctx)
+    else:
+        ssd_output_recombination_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            c_tt.LayoutType,
+            ent_tt.LayoutType,
+            a_tt.LayoutType,
+            yd_tt.LayoutType,
+            y_tt.LayoutType,
+        ](batch, n_chunks, n_heads, c_tt, ent_tt, a_tt, yd_tt, y_tt, ctx)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(y_gpu_heap, y_device)
+    ctx.synchronize()
+
+    # ── CPU reference: naive output recombination ────────────────────────────
+    var ref_y = ctx.enqueue_create_host_buffer[dtype](y_count)
+    var c_l_stride = state_dim
+    var c_h_stride = chunk_len * c_l_stride
+    var c_c_stride = n_heads * c_h_stride
+    var c_b_stride = n_chunks * c_c_stride
+    var ent_p_stride = state_dim
+    var ent_h_stride = head_dim * ent_p_stride
+    var ent_c_stride = n_heads * ent_h_stride
+    var ent_b_stride = n_chunks * ent_c_stride
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+    var y_l_stride = head_dim
+    var y_h_stride = chunk_len * y_l_stride
+    var y_c_stride = n_heads * y_h_stride
+    var y_b_stride = n_chunks * y_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var c_base = b * c_b_stride + c * c_c_stride + h * c_h_stride
+                var ent_base = (
+                    b * ent_b_stride + c * ent_c_stride + h * ent_h_stride
+                )
+                var y_base = b * y_b_stride + c * y_c_stride + h * y_h_stride
+                var a_cumsum = Float32(0.0)
+                for l in range(chunk_len):
+                    a_cumsum += a_h.ptr[a_base + l].cast[DType.float32]()
+                    var decay = exp(a_cumsum)
+                    for p in range(head_dim):
+                        var acc = Float32(0.0)
+                        for n in range(state_dim):
+                            var c_val = c_h.ptr[
+                                c_base + l * c_l_stride + n
+                            ].cast[DType.float32]()
+                            var ent_val = ent_h.ptr[
+                                ent_base + p * ent_p_stride + n
+                            ].cast[DType.float32]()
+                            acc += c_val * ent_val
+                        var yd_val = yd_h.ptr[y_base + l * y_l_stride + p].cast[
+                            DType.float32
+                        ]()
+                        ref_y[y_base + l * y_l_stride + p] = Scalar[dtype](
+                            yd_val + decay * acc
+                        )
+
+    for i in range(y_count):
+        assert_almost_equal(y_gpu_heap[i], ref_y[i], rtol=rtol)
+
+
+def test_ssd_output_recombination_gpu_static_golden() raises:
+    """Static tensor-core path vs naive reference, gate-hitting dims."""
+    var ctx = DeviceContext()
+    run_ssd_output_recombination_gpu_static[
+        DType.float32, chunk_len=128, head_dim=64, state_dim=128
+    ](batch=1, n_chunks=2, n_heads=2, ctx=ctx)
+
+
+def test_ssd_output_recombination_gpu_static_mamba2() raises:
+    """Static path at the Mamba2-130m prefill profile (L=256, P=64, N=128)."""
+    var ctx = DeviceContext()
+    run_ssd_output_recombination_gpu_static[
+        DType.float32, chunk_len=256, head_dim=64, state_dim=128
+    ](batch=1, n_chunks=2, n_heads=4, ctx=ctx)
+
+
+def test_ssd_output_recombination_gpu_fused_golden() raises:
+    """Fused single-pass MMA path vs naive reference, gate-hitting dims."""
+    var ctx = DeviceContext()
+    run_ssd_output_recombination_gpu_static[
+        DType.float32,
+        chunk_len=128,
+        head_dim=64,
+        state_dim=128,
+        use_fused=True,
+    ](batch=1, n_chunks=2, n_heads=2, ctx=ctx)
+
+
+def test_ssd_output_recombination_gpu_fused_mamba2() raises:
+    """Fused path at the Mamba2-130m prefill profile (L=256, P=64, N=128)."""
+    var ctx = DeviceContext()
+    run_ssd_output_recombination_gpu_static[
+        DType.float32,
+        chunk_len=256,
+        head_dim=64,
+        state_dim=128,
+        use_fused=True,
+    ](batch=1, n_chunks=2, n_heads=4, ctx=ctx)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/gpu/state_space/test_ssd_chunk_scan.mojo
+++ b/max/kernels/test/gpu/state_space/test_ssd_chunk_scan.mojo
@@ -1,0 +1,388 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import ceildiv, exp
+
+from max.gpu.host import DeviceContext
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    row_major,
+)
+from std.random import rand
+from state_space.ssd_chunk_scan import ssd_chunk_scan_fwd_gpu
+from std.testing import TestSuite, assert_almost_equal
+from std.utils.index import Index
+
+
+def run_ssd_chunk_scan_gpu[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Run the SSD inter-chunk scan GPU kernel and check it against a CPU ref.
+
+    One GPU thread per ``(batch, head, p, n)`` scalar walks the chunk axis
+    sequentially; this validates the result against the same naive recurrence
+    used by the CPU test.
+    """
+    comptime SCALAR_BLOCK_SIZE = 128
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var cs_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var cd_count = batch * n_chunks * n_heads
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var final_count = batch * n_heads * head_dim * state_dim
+
+    # ── Host tensors ─────────────────────────────────────────────────────────
+    var cs_heap = ctx.enqueue_create_host_buffer[dtype](cs_count)
+    var cs_h = LayoutTensor[dtype, layout_5d, _](
+        cs_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    rand[dtype](cs_h.ptr, cs_h.size())
+
+    var cd_heap = ctx.enqueue_create_host_buffer[dtype](cd_count)
+    var cd_h = LayoutTensor[dtype, layout_3d, _](
+        cd_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, n_chunks, n_heads)),
+    )
+    rand[dtype](cd_h.ptr, cd_h.size())
+    # Make chunk_decays negative (a real SSM decays). `rand` fills in [0, 1);
+    # map into [-1.2, -0.3] like a real per-chunk total decay.
+    for i in range(cd_count):
+        var v = cd_h.ptr[i].cast[DType.float32]()
+        # Map [0, 1) -> [-1.2, -0.3].
+        var scaled = Float32(-1.2) + Float32(0.9) * v
+        cd_h.ptr[i] = Scalar[dtype](scaled)
+
+    var ent_gpu_heap = ctx.enqueue_create_host_buffer[dtype](ent_count)
+    var ent_gpu_h = LayoutTensor[dtype, layout_5d, _](
+        ent_gpu_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    var final_gpu_heap = ctx.enqueue_create_host_buffer[dtype](final_count)
+    var final_gpu_h = LayoutTensor[dtype, layout_4d, _](
+        final_gpu_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # ── Device buffers ───────────────────────────────────────────────────────
+    var cs_device = ctx.enqueue_create_buffer[dtype](cs_count)
+    var cd_device = ctx.enqueue_create_buffer[dtype](cd_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var final_device = ctx.enqueue_create_buffer[dtype](final_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(cs_device, cs_h.ptr)
+        ctx.enqueue_copy(cd_device, cd_h.ptr)
+
+    var cs_tt = TileTensor(
+        cs_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+    var cd_tt = TileTensor(
+        cd_device,
+        row_major(batch, n_chunks, n_heads),
+    )
+    var ent_tt = TileTensor(
+        ent_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+    var final_tt = TileTensor(
+        final_device,
+        row_major(batch, n_heads, head_dim, state_dim),
+    )
+
+    var total_threads = batch * n_heads * head_dim * state_dim
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_scan_fwd_gpu[
+            dtype,
+            cs_tt.LayoutType,
+            cd_tt.LayoutType,
+            ent_tt.LayoutType,
+            final_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            cs_tt,
+            cd_tt,
+            ent_tt,
+            final_tt,
+            grid_dim=(ceildiv(total_threads, SCALAR_BLOCK_SIZE),),
+            block_dim=(SCALAR_BLOCK_SIZE,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(ent_gpu_h.ptr, ent_device)
+        ctx.enqueue_copy(final_gpu_h.ptr, final_device)
+    ctx.synchronize()
+
+    # ── CPU reference: naive sequential recurrence over chunks ───────────────
+    var ref_ent = ctx.enqueue_create_host_buffer[dtype](ent_count)
+    var ref_final = ctx.enqueue_create_host_buffer[dtype](final_count)
+
+    var cs_h_stride = head_dim * state_dim
+    var cs_c_stride = n_heads * cs_h_stride
+    var cs_b_stride = n_chunks * cs_c_stride
+
+    var cd_c_stride = n_heads
+    var cd_b_stride = n_chunks * cd_c_stride
+
+    var ent_h_stride = head_dim * state_dim
+    var ent_c_stride = n_heads * ent_h_stride
+    var ent_b_stride = n_chunks * ent_c_stride
+
+    var final_h_stride = head_dim * state_dim
+    var final_b_stride = n_heads * final_h_stride
+
+    for b in range(batch):
+        for h in range(n_heads):
+            var state = List[Float32](length=head_dim * state_dim, fill=0.0)
+            for c in range(n_chunks):
+                var ent_base = (
+                    b * ent_b_stride + c * ent_c_stride + h * ent_h_stride
+                )
+                for pn in range(head_dim * state_dim):
+                    ref_ent[ent_base + pn] = Scalar[dtype](state[pn])
+
+                var cd_off = b * cd_b_stride + c * cd_c_stride + h
+                var decay = exp(cd_h.ptr[cd_off].cast[DType.float32]())
+
+                var cs_base = (
+                    b * cs_b_stride + c * cs_c_stride + h * cs_h_stride
+                )
+                for pn in range(head_dim * state_dim):
+                    var cs_val = cs_h.ptr[cs_base + pn].cast[DType.float32]()
+                    state[pn] = cs_val + decay * state[pn]
+
+            var final_base = b * final_b_stride + h * final_h_stride
+            for pn in range(head_dim * state_dim):
+                ref_final[final_base + pn] = Scalar[dtype](state[pn])
+
+    # ── Compare GPU vs CPU reference ─────────────────────────────────────────
+    for i in range(ent_count):
+        assert_almost_equal(ent_gpu_h.ptr[i], ref_ent[i], rtol=rtol)
+    for i in range(final_count):
+        assert_almost_equal(final_gpu_h.ptr[i], ref_final[i], rtol=rtol)
+
+
+def test_ssd_chunk_scan_gpu_golden() raises:
+    """Golden-parity test on GPU against the canonical PyTorch SSD reference.
+
+    Same FIXED tiny input as the CPU golden test (batch=1, n_chunks=3,
+    n_heads=1, P=2, N=3). Pins the GPU kernel to the inter-chunk recurrence
+    (stage 3 of ``ssd_minimal_discrete``).
+    """
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 3
+    comptime n_heads = 1
+    comptime head_dim = 2
+    comptime state_dim = 3
+
+    var cs_vals = [
+        Float32(-0.90),
+        0.57,
+        0.91,
+        0.43,
+        1.29,
+        -0.17,
+        -0.86,
+        -0.66,
+        -0.70,
+        -0.10,
+        -0.62,
+        -0.63,
+        -0.58,
+        0.59,
+        0.12,
+        0.09,
+        1.04,
+        -0.18,
+    ]
+    var cd_vals = [Float32(-0.61), -1.03, -0.79]
+    var entering_expected = [
+        Float32(0.0),
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        -0.90,
+        0.57,
+        0.91,
+        0.43,
+        1.29,
+        -0.17,
+        -1.181306,
+        -0.456506,
+        -0.375124,
+        0.053513,
+        -0.159461,
+        -0.690691,
+    ]
+    var final_expected = [
+        Float32(-1.116130),
+        0.382817,
+        -0.050248,
+        0.114287,
+        0.967629,
+        -0.493467,
+    ]
+
+    var cs_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var cd_count = batch * n_chunks * n_heads
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var final_count = batch * n_heads * head_dim * state_dim
+
+    # Host buffers from fixed literals.
+    var cs_heap = ctx.enqueue_create_host_buffer[dtype](cs_count)
+    for i in range(cs_count):
+        cs_heap[i] = Scalar[dtype](cs_vals[i])
+    var cd_heap = ctx.enqueue_create_host_buffer[dtype](cd_count)
+    for i in range(cd_count):
+        cd_heap[i] = Scalar[dtype](cd_vals[i])
+    var ent_heap = ctx.enqueue_create_host_buffer[dtype](ent_count)
+    var final_heap = ctx.enqueue_create_host_buffer[dtype](final_count)
+
+    var cs_device = ctx.enqueue_create_buffer[dtype](cs_count)
+    var cd_device = ctx.enqueue_create_buffer[dtype](cd_count)
+    var ent_device = ctx.enqueue_create_buffer[dtype](ent_count)
+    var final_device = ctx.enqueue_create_buffer[dtype](final_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(cs_device, cs_heap)
+        ctx.enqueue_copy(cd_device, cd_heap)
+
+    var cs_tt = TileTensor(
+        cs_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+    var cd_tt = TileTensor(
+        cd_device,
+        row_major(batch, n_chunks, n_heads),
+    )
+    var ent_tt = TileTensor(
+        ent_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+    var final_tt = TileTensor(
+        final_device,
+        row_major(batch, n_heads, head_dim, state_dim),
+    )
+
+    var total_threads = batch * n_heads * head_dim * state_dim
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_scan_fwd_gpu[
+            dtype,
+            cs_tt.LayoutType,
+            cd_tt.LayoutType,
+            ent_tt.LayoutType,
+            final_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(head_dim),
+            Int32(state_dim),
+            cs_tt,
+            cd_tt,
+            ent_tt,
+            final_tt,
+            grid_dim=(1,),
+            block_dim=(total_threads,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(ent_heap, ent_device)
+        ctx.enqueue_copy(final_heap, final_device)
+    ctx.synchronize()
+
+    for i in range(ent_count):
+        assert_almost_equal(
+            ent_heap[i],
+            Scalar[dtype](entering_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+    for i in range(final_count):
+        assert_almost_equal(
+            final_heap[i],
+            Scalar[dtype](final_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_chunk_scan_gpu_basic() raises:
+    """Basic single-batch case against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_scan_gpu[DType.float32](
+        batch=1,
+        n_chunks=4,
+        n_heads=2,
+        head_dim=8,
+        state_dim=16,
+        ctx=ctx,
+    )
+
+
+def test_ssd_chunk_scan_gpu_multi_batch() raises:
+    """Multiple batch elements and heads against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_scan_gpu[DType.float32](
+        batch=2,
+        n_chunks=5,
+        n_heads=3,
+        head_dim=4,
+        state_dim=8,
+        ctx=ctx,
+    )
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/gpu/state_space/test_ssd_chunk_state.mojo
+++ b/max/kernels/test/gpu/state_space/test_ssd_chunk_state.mojo
@@ -1,0 +1,647 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from std.math import exp
+
+from max.gpu.host import DeviceContext
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    row_major,
+)
+from std.random import rand
+from state_space.ssd_chunk_state import (
+    ssd_chunk_state_fwd_gpu,
+    ssd_chunk_state_fwd_gpu_static,
+    ssd_chunk_state_fwd_gpu_fused,
+)
+from std.testing import TestSuite, assert_almost_equal
+from std.utils.index import Index
+
+
+def run_ssd_chunk_state_gpu[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+    num_p_tiles: Int = 1,
+) raises:
+    """Run the SSD chunk-state GPU kernel and check it against a CPU reference.
+
+    One block per ``(batch, chunk, head)`` slice (``block_dim == chunk_len``)
+    reduces the chunk to its ``[head_dim, state_dim]`` end-state; this validates
+    the result against the same naive reference used by the CPU test.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    # ── Host tensors ─────────────────────────────────────────────────────────
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](b_count)
+    var B_h = LayoutTensor[dtype, layout_5d, _](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](B_h.ptr, B_h.size())
+
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](x_count)
+    var X_h = LayoutTensor[dtype, layout_5d, _](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](X_h.ptr, X_h.size())
+
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var A_h = LayoutTensor[dtype, layout_4d, _](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](A_h.ptr, A_h.size())
+    # Make A negative-ish (a real SSM decays) so exp(cumsum diffs) stays
+    # bounded. `rand` fills in [0, 1); map into a small negative range.
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        # Map [0, 1) -> [-0.6, -0.1].
+        var scaled = Float32(-0.6) + Float32(0.5) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    var state_gpu_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+    var state_gpu_h = LayoutTensor[dtype, layout_5d, _](
+        state_gpu_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # ── Device buffers ───────────────────────────────────────────────────────
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(B_device, B_h.ptr)
+        ctx.enqueue_copy(X_device, X_h.ptr)
+        ctx.enqueue_copy(A_device, A_h.ptr)
+
+    var B_tt = TileTensor(
+        B_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var X_tt = TileTensor(
+        X_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var A_tt = TileTensor(
+        A_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var state_tt = TileTensor(
+        state_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_state_fwd_gpu[
+            dtype,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices, num_p_tiles),
+            block_dim=(chunk_len,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(state_gpu_h.ptr, state_device)
+    ctx.synchronize()
+
+    # ── CPU reference: naive reduction of the SSD chunk-state formula ────────
+    var ref_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+
+    var b_h_stride = chunk_len * state_dim
+    var b_c_stride = n_heads * b_h_stride
+    var b_b_stride = n_chunks * b_c_stride
+
+    var x_h_stride = chunk_len * head_dim
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var state_h_stride = head_dim * state_dim
+    var state_c_stride = n_heads * state_h_stride
+    var state_b_stride = n_chunks * state_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var b_base = b * b_b_stride + c * b_c_stride + h * b_h_stride
+                var x_base = b * x_b_stride + c * x_c_stride + h * x_h_stride
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var state_base = (
+                    b * state_b_stride + c * state_c_stride + h * state_h_stride
+                )
+
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                var cum_end = cumsum[chunk_len - 1]
+
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var s_acc = Float32(0.0)
+                        for l in range(chunk_len):
+                            var bv = B_h.ptr[b_base + l * state_dim + n].cast[
+                                DType.float32
+                            ]()
+                            var xv = X_h.ptr[x_base + l * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            var decay = exp(cum_end - cumsum[l])
+                            s_acc += bv * decay * xv
+                        ref_heap[state_base + p * state_dim + n] = Scalar[
+                            dtype
+                        ](s_acc)
+
+    # ── Compare GPU vs CPU reference ─────────────────────────────────────────
+    for i in range(state_count):
+        assert_almost_equal(state_gpu_h.ptr[i], ref_heap[i], rtol=rtol)
+
+
+def run_ssd_chunk_state_gpu_static[
+    dtype: DType,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    fused: Bool = False,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    ctx: DeviceContext,
+    rtol: Float64 = 0.01,
+) raises:
+    """Run a static tensor-core chunk-state entry and check it vs a CPU ref.
+
+    With ``fused=False`` runs ``ssd_chunk_state_fwd_gpu_static`` (2-pass
+    decay-transpose + batched_matmul); with ``fused=True`` runs the fused
+    single-pass kernel ``ssd_chunk_state_fwd_gpu_fused``. Both take compile-time
+    dims and the same argument list.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](b_count)
+    var B_h = LayoutTensor[dtype, layout_5d, _](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    rand[dtype](B_h.ptr, B_h.size())
+
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](x_count)
+    var X_h = LayoutTensor[dtype, layout_5d, _](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    rand[dtype](X_h.ptr, X_h.size())
+
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    var A_h = LayoutTensor[dtype, layout_4d, _](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    rand[dtype](A_h.ptr, A_h.size())
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        A_h.ptr[i] = Scalar[dtype](Float32(-0.6) + Float32(0.5) * v)
+
+    var state_gpu_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(B_device, B_h.ptr)
+        ctx.enqueue_copy(X_device, X_h.ptr)
+        ctx.enqueue_copy(A_device, A_h.ptr)
+
+    var B_tt = TileTensor(
+        B_device, row_major(batch, n_chunks, n_heads, chunk_len, state_dim)
+    )
+    var X_tt = TileTensor(
+        X_device, row_major(batch, n_chunks, n_heads, chunk_len, head_dim)
+    )
+    var A_tt = TileTensor(
+        A_device, row_major(batch, n_chunks, n_heads, chunk_len)
+    )
+    var state_tt = TileTensor(
+        state_device, row_major(batch, n_chunks, n_heads, head_dim, state_dim)
+    )
+
+    comptime if fused:
+        ssd_chunk_state_fwd_gpu_fused[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+    else:
+        ssd_chunk_state_fwd_gpu_static[
+            dtype,
+            chunk_len,
+            state_dim,
+            head_dim,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ](batch, n_chunks, n_heads, B_tt, X_tt, A_tt, state_tt, ctx)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(state_gpu_heap, state_device)
+    ctx.synchronize()
+
+    # ── CPU reference ────────────────────────────────────────────────────────
+    var ref_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+    var b_h_stride = chunk_len * state_dim
+    var b_c_stride = n_heads * b_h_stride
+    var b_b_stride = n_chunks * b_c_stride
+    var x_h_stride = chunk_len * head_dim
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+    var state_h_stride = head_dim * state_dim
+    var state_c_stride = n_heads * state_h_stride
+    var state_b_stride = n_chunks * state_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var b_base = b * b_b_stride + c * b_c_stride + h * b_h_stride
+                var x_base = b * x_b_stride + c * x_c_stride + h * x_h_stride
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var state_base = (
+                    b * state_b_stride + c * state_c_stride + h * state_h_stride
+                )
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+                var cum_end = cumsum[chunk_len - 1]
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var s_acc = Float32(0.0)
+                        for l in range(chunk_len):
+                            var bv = B_h.ptr[b_base + l * state_dim + n].cast[
+                                DType.float32
+                            ]()
+                            var xv = X_h.ptr[x_base + l * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            s_acc += bv * exp(cum_end - cumsum[l]) * xv
+                        ref_heap[state_base + p * state_dim + n] = Scalar[
+                            dtype
+                        ](s_acc)
+
+    for i in range(state_count):
+        assert_almost_equal(state_gpu_heap[i], ref_heap[i], rtol=rtol)
+
+
+def test_ssd_chunk_state_gpu_golden() raises:
+    """Golden-parity test on GPU against the canonical PyTorch SSD reference.
+
+    Same FIXED tiny input as the CPU golden test (batch=1, n_chunks=1,
+    n_heads=1, L=4, N=3, P=2). Pins the GPU kernel to the chunk end-state
+    reduction (stage 2 of ``ssd_minimal_discrete``).
+    """
+    var ctx = DeviceContext()
+
+    comptime dtype = DType.float32
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    var B_vals = [
+        Float32(0.74),
+        1.95,
+        -0.70,
+        -1.30,
+        -0.51,
+        -0.27,
+        0.25,
+        0.48,
+        0.45,
+        -0.96,
+        1.50,
+        -0.31,
+    ]
+    var X_vals = [
+        Float32(-0.23),
+        -1.07,
+        0.16,
+        0.12,
+        0.38,
+        -0.12,
+        0.89,
+        -0.49,
+    ]
+    var A_vals = [Float32(-0.45), -0.18, -0.36, -0.50]
+    var state_expected = [
+        Float32(-0.944955),
+        1.252577,
+        -0.133558,
+        0.106325,
+        -1.533317,
+        0.370175,
+    ]
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    # Host buffers from fixed literals.
+    var B_heap = ctx.enqueue_create_host_buffer[dtype](b_count)
+    for i in range(b_count):
+        B_heap[i] = Scalar[dtype](B_vals[i])
+    var X_heap = ctx.enqueue_create_host_buffer[dtype](x_count)
+    for i in range(x_count):
+        X_heap[i] = Scalar[dtype](X_vals[i])
+    var A_heap = ctx.enqueue_create_host_buffer[dtype](a_count)
+    for i in range(a_count):
+        A_heap[i] = Scalar[dtype](A_vals[i])
+    var state_heap = ctx.enqueue_create_host_buffer[dtype](state_count)
+
+    var B_device = ctx.enqueue_create_buffer[dtype](b_count)
+    var X_device = ctx.enqueue_create_buffer[dtype](x_count)
+    var A_device = ctx.enqueue_create_buffer[dtype](a_count)
+    var state_device = ctx.enqueue_create_buffer[dtype](state_count)
+
+    with ctx.push_context():
+        ctx.enqueue_copy(B_device, B_heap)
+        ctx.enqueue_copy(X_device, X_heap)
+        ctx.enqueue_copy(A_device, A_heap)
+
+    var B_tt = TileTensor(
+        B_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, state_dim),
+    )
+    var X_tt = TileTensor(
+        X_device,
+        row_major(batch, n_chunks, n_heads, chunk_len, head_dim),
+    )
+    var A_tt = TileTensor(
+        A_device,
+        row_major(batch, n_chunks, n_heads, chunk_len),
+    )
+    var state_tt = TileTensor(
+        state_device,
+        row_major(batch, n_chunks, n_heads, head_dim, state_dim),
+    )
+
+    var total_slices = batch * n_chunks * n_heads
+
+    var compiled_func = ctx.compile_function[
+        ssd_chunk_state_fwd_gpu[
+            dtype,
+            B_tt.LayoutType,
+            X_tt.LayoutType,
+            A_tt.LayoutType,
+            state_tt.LayoutType,
+        ]
+    ]()
+
+    with ctx.push_context():
+        ctx.enqueue_function(
+            compiled_func,
+            Int32(batch),
+            Int32(n_chunks),
+            Int32(n_heads),
+            Int32(chunk_len),
+            Int32(state_dim),
+            Int32(head_dim),
+            B_tt,
+            X_tt,
+            A_tt,
+            state_tt,
+            grid_dim=(total_slices,),
+            block_dim=(chunk_len,),
+        )
+
+    with ctx.push_context():
+        ctx.enqueue_copy(state_heap, state_device)
+    ctx.synchronize()
+
+    for i in range(state_count):
+        assert_almost_equal(
+            state_heap[i],
+            Scalar[dtype](state_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_chunk_state_gpu_basic() raises:
+    """Basic single-batch, single-chunk case against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=16,
+        head_dim=8,
+        ctx=ctx,
+    )
+
+
+def test_ssd_chunk_state_gpu_multi_chunk() raises:
+    """Multiple chunks and heads against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=1,
+        n_chunks=3,
+        n_heads=2,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=8,
+        ctx=ctx,
+    )
+
+
+def test_ssd_chunk_state_gpu_multi_batch() raises:
+    """Multiple batch elements against the naive reference."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=2,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=4,
+        ctx=ctx,
+    )
+
+
+def test_ssd_chunk_state_gpu_ptiled() raises:
+    """Multi-block-per-slice (grid_dim.y > 1) path, head_dim divisible by tiles.
+
+    Splits each slice across 4 p-tiles (head_dim=16, tile height 4); checks the
+    tiled result still matches the naive reference.
+    """
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=3,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=16,
+        ctx=ctx,
+        num_p_tiles=4,
+    )
+
+
+def test_ssd_chunk_state_gpu_ptiled_ragged() raises:
+    """Multi-block-per-slice path with head_dim NOT divisible by the tile count.
+
+    head_dim=10 over 4 p-tiles → tile height ceildiv(10,4)=3, so tiles cover
+    rows [0,3) [3,6) [6,9) [9,10); the last tile is a partial row and an extra
+    block would early-return. Exercises the ragged tail and bounds handling.
+    """
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=10,
+        ctx=ctx,
+        num_p_tiles=4,
+    )
+
+
+def test_ssd_chunk_state_gpu_static_mma() raises:
+    """Tensor-core batched-matmul path at gate-satisfying dims.
+
+    state_dim=128 (matmul N % 128 == 0), chunk_len=128 (K % 32 == 0, >= 128) so
+    ssd_chunk_state_fwd_gpu_static takes the A100 multistage path. Checked vs
+    the naive CPU reference.
+    """
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu_static[
+        DType.float32, chunk_len=128, state_dim=128, head_dim=64
+    ](batch=1, n_chunks=2, n_heads=4, ctx=ctx)
+
+
+def test_ssd_chunk_state_gpu_static_mma_profile() raises:
+    """Tensor-core path at the Mamba2-130m prefill profile (L=256, P=64, N=128).
+    """
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu_static[
+        DType.float32, chunk_len=256, state_dim=128, head_dim=64
+    ](batch=1, n_chunks=4, n_heads=24, ctx=ctx)
+
+
+def test_ssd_chunk_state_gpu_fused_mma() raises:
+    """Fused single-pass tensor-core path at gate-satisfying dims."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu_static[
+        DType.float32,
+        chunk_len=128,
+        state_dim=128,
+        head_dim=64,
+        fused=True,
+    ](batch=1, n_chunks=2, n_heads=4, ctx=ctx)
+
+
+def test_ssd_chunk_state_gpu_fused_mma_profile() raises:
+    """Fused path at the Mamba2-130m prefill profile (L=256, P=64, N=128)."""
+    var ctx = DeviceContext()
+    run_ssd_chunk_state_gpu_static[
+        DType.float32,
+        chunk_len=256,
+        state_dim=128,
+        head_dim=64,
+        fused=True,
+    ](batch=1, n_chunks=4, n_heads=24, ctx=ctx)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_mamba_split_conv1d_scan_combined_op.mojo
+++ b/max/kernels/test/state_space/test_mamba_split_conv1d_scan_combined_op.mojo
@@ -1,0 +1,320 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Op-registration smoke test for `mamba_split_conv1d_scan_combined`.
+
+Numerical parity is covered by `test_mamba_split_conv1d_scan_combined.mojo`;
+this file exists to ensure the @extensibility.register wrapper in
+`selective_scan_ops.mojo` is built into the state_space library (a malformed
+@extensibility.register block fails the library build), and that the underlying
+kernel is reachable via the same import path the wrapper uses.
+"""
+
+from std.math import ceildiv
+
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    UNKNOWN_VALUE,
+    row_major,
+)
+from layout._fillers import random
+from state_space.selective_scan import mamba_split_conv1d_scan_combined_cpu
+
+# Importing the ops module ensures the @extensibility.register-decorated structs
+# are part of the build graph for the consumer of the smoke test.
+import state_space.selective_scan_ops
+
+from std.testing import TestSuite, assert_true
+from std.utils.index import Index
+
+
+def test_mamba_split_conv1d_scan_combined_op_registered() raises:
+    """Smoke test: mamba_split_conv1d_scan_combined op + underlying CPU kernel
+    are callable.
+
+    Constructs tiny LayoutTensor inputs, invokes the CPU implementation that
+    the registered op dispatches to, and verifies the output buffer is finite
+    (no NaN/Inf) and shape-correct.
+    """
+    comptime dtype = DType.float32
+    comptime DSTATE = 8
+
+    var batch = 1
+    var nheads = 1
+    var headdim = 2
+    var dim = nheads * headdim
+    var seqlen = 4
+    var ngroups = 1
+    var width = 3
+    var chunk_size = 2048
+    var n_chunks = ceildiv(seqlen, chunk_size)
+
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_2d = Layout.row_major[2]()
+    comptime layout_1d = Layout(UNKNOWN_VALUE)
+
+    var zxbcdt_channels = 2 * dim + 2 * ngroups * DSTATE + nheads
+    var zxbcdt_heap = List(
+        length=batch * seqlen * zxbcdt_channels, fill=Scalar[dtype](0)
+    )
+    var zxbcdt_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        zxbcdt_heap,
+        RuntimeLayout[layout_3d].row_major(
+            Index(batch, seqlen, zxbcdt_channels)
+        ),
+    )
+    var zxbcdt_tt = TileTensor(
+        zxbcdt_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, seqlen, zxbcdt_channels),
+    )
+
+    var conv_weight_channels = dim + 2 * ngroups * DSTATE
+    var conv_weight_heap = List(
+        length=conv_weight_channels * width, fill=Scalar[dtype](0)
+    )
+    var conv_weight_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        conv_weight_heap,
+        RuntimeLayout[layout_2d].row_major(Index(conv_weight_channels, width)),
+    )
+    var conv_weight_tt = TileTensor(
+        conv_weight_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(conv_weight_channels, width),
+    )
+
+    var conv_bias_heap = List(
+        length=conv_weight_channels, fill=Scalar[dtype](0)
+    )
+    var conv_bias_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        conv_bias_heap,
+        RuntimeLayout[layout_1d].row_major(Index(conv_weight_channels)),
+    )
+    var conv_bias_tt = TileTensor(
+        conv_bias_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(conv_weight_channels),
+    )
+
+    var dt_bias_heap = List(length=nheads, fill=Scalar[dtype](0))
+    var dt_bias_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        dt_bias_heap, RuntimeLayout[layout_1d].row_major(Index(nheads))
+    )
+    var dt_bias_tt = TileTensor(
+        dt_bias_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(nheads)
+    )
+
+    var A_heap = List(length=nheads, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        A_heap, RuntimeLayout[layout_1d].row_major(Index(nheads))
+    )
+    var A_tt = TileTensor(
+        A_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(nheads)
+    )
+
+    var D_heap = List(length=nheads * headdim, fill=Scalar[dtype](0))
+    var D_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        D_heap,
+        RuntimeLayout[layout_2d].row_major(Index(nheads, headdim)),
+    )
+    var D_tt = TileTensor(
+        D_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(nheads, headdim)
+    )
+
+    var x_heap = List(
+        length=batch * dim * n_chunks * 2 * DSTATE, fill=Scalar[dtype](0)
+    )
+    var x_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        x_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, dim, n_chunks, 2 * DSTATE)
+        ),
+    )
+    var x_tt = TileTensor(
+        x_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, n_chunks, 2 * DSTATE),
+    )
+
+    var out_z_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var out_z_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        out_z_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var out_z_tt = TileTensor(
+        out_z_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var dt_heap = List(length=batch * nheads * seqlen, fill=Scalar[dtype](0))
+    var dt_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        dt_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, nheads, seqlen)),
+    )
+    var dt_tt = TileTensor(
+        dt_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, nheads, seqlen),
+    )
+
+    var B_heap = List(
+        length=batch * ngroups * DSTATE * seqlen, fill=Scalar[dtype](0)
+    )
+    var B_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, ngroups, DSTATE, seqlen)
+        ),
+    )
+    var B_tt = TileTensor(
+        B_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, ngroups, DSTATE, seqlen),
+    )
+
+    var C_heap = List(
+        length=batch * ngroups * DSTATE * seqlen, fill=Scalar[dtype](0)
+    )
+    var C_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, ngroups, DSTATE, seqlen)
+        ),
+    )
+    var C_tt = TileTensor(
+        C_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, ngroups, DSTATE, seqlen),
+    )
+
+    var z_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var z_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        z_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var z_tt = TileTensor(
+        z_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var rmsnorm_weight_heap = List(length=dim, fill=Scalar[dtype](0))
+    var rmsnorm_weight_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        rmsnorm_weight_heap, RuntimeLayout[layout_1d].row_major(Index(dim))
+    )
+    var rmsnorm_weight_tt = TileTensor(
+        rmsnorm_weight_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(dim)
+    )
+
+    var outproj_weight_heap = List(length=1, fill=Scalar[dtype](0))
+    var outproj_weight_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        outproj_weight_heap,
+        RuntimeLayout[layout_2d].row_major(Index(0, 0)),
+    )
+    var outproj_weight_tt = TileTensor(
+        outproj_weight_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(0, 0)
+    )
+
+    var outproj_bias_heap = List(length=1, fill=Scalar[dtype](0))
+    var outproj_bias_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        outproj_bias_heap, RuntimeLayout[layout_1d].row_major(Index(0))
+    )
+    var outproj_bias_tt = TileTensor(
+        outproj_bias_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(0)
+    )
+
+    var output_heap = List(length=batch * seqlen * dim, fill=Scalar[dtype](0))
+    var output_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        output_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, seqlen, dim)),
+    )
+    var output_tt = TileTensor(
+        output_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, seqlen, dim),
+    )
+
+    random(zxbcdt_h)
+    random(conv_weight_h)
+    random(conv_bias_h)
+    random(dt_bias_h)
+    random(A_h)
+    random(D_h)
+    random(rmsnorm_weight_h)
+    # Keep RMSNorm weight positive.
+    for i in range(dim):
+        rmsnorm_weight_h.ptr[i] = abs(rmsnorm_weight_h.ptr[i]) + Scalar[dtype](
+            0.1
+        )
+
+    var epsilon = Scalar[dtype](0.001)
+
+    mamba_split_conv1d_scan_combined_cpu[
+        dtype,
+        DSTATE,
+        zxbcdt_tt.LayoutType,
+        conv_weight_tt.LayoutType,
+        conv_bias_tt.LayoutType,
+        output_tt.LayoutType,
+        x_tt.LayoutType,
+        out_z_tt.LayoutType,
+        dt_tt.LayoutType,
+        A_tt.LayoutType,
+        B_tt.LayoutType,
+        C_tt.LayoutType,
+        D_tt.LayoutType,
+        z_tt.LayoutType,
+        dt_bias_tt.LayoutType,
+        rmsnorm_weight_tt.LayoutType,
+        outproj_weight_tt.LayoutType,
+        outproj_bias_tt.LayoutType,
+    ](
+        batch,
+        seqlen,
+        dim,
+        nheads,
+        headdim,
+        ngroups,
+        width,
+        chunk_size,
+        Int8(0),  # delta_softplus
+        Int8(0),  # norm_before_gate
+        Int8(1),  # has_rmsnorm
+        Int8(0),  # has_outproj
+        zxbcdt_tt,
+        conv_weight_tt,
+        conv_bias_tt,
+        dt_bias_tt,
+        A_tt,
+        D_tt,
+        x_tt,
+        out_z_tt,
+        dt_tt,
+        B_tt,
+        C_tt,
+        z_tt,
+        rmsnorm_weight_tt,
+        outproj_weight_tt,
+        outproj_bias_tt,
+        output_tt,
+        epsilon,
+    )
+
+    # Shape check + finite check.
+    assert_true(output_h.dim(0) == batch)
+    assert_true(output_h.dim(1) == seqlen)
+    assert_true(output_h.dim(2) == dim)
+
+    var out_size = batch * seqlen * dim
+    for i in range(out_size):
+        var v = Float32(output_h.ptr[i])
+        assert_true(v == v, "output contains NaN")
+        assert_true((v - v) == 0.0, "output contains Inf")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_chunk.mojo
+++ b/max/kernels/test/state_space/test_ssd_chunk.mojo
@@ -1,0 +1,519 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from layout import Layout, LayoutTensor, RuntimeLayout
+from layout._fillers import random
+from state_space.ssd_chunk import (
+    ssd_intra_chunk_fwd_cpu,
+    ssd_intra_chunk_fwd_cpu_naive,
+)
+from std.math import exp
+from std.testing import TestSuite, assert_almost_equal
+
+from std.utils.index import Index
+
+
+def run_ssd_intra_chunk[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test the optimized SSD intra-chunk CPU kernel against an independent reference.
+    """
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    # C: [batch, n_chunks, n_heads, chunk_len, state_dim]
+    var C_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var C_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+
+    # B: [batch, n_chunks, n_heads, chunk_len, state_dim]
+    var B_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+
+    # X: [batch, n_chunks, n_heads, chunk_len, head_dim]
+    var X_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # A: [batch, n_chunks, n_heads, chunk_len]
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+
+    # Y: [batch, n_chunks, n_heads, chunk_len, head_dim]
+    var Y_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var Y_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # Initialize inputs.
+    random(C_h)
+    random(B_h)
+    random(X_h)
+    random(A_h)
+
+    # Make A negative-ish (a real SSM decays), so exp(cumsum diffs) stays
+    # bounded. `random` fills in roughly [-1, 1]; map it into a small negative
+    # range like real Mamba2 dt*A values.
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        # Map [-1, 1] -> [-0.6, -0.1].
+        var scaled = Float32(-0.35) + Float32(0.25) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    # Call the optimized kernel.
+    ssd_intra_chunk_fwd_cpu[
+        dtype,
+        C_h.layout,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        Y_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        C_h,
+        B_h,
+        X_h,
+        A_h,
+        Y_h,
+        ctx=None,
+    )
+
+    # Independent naive reference. Recompute strides from scratch and use a
+    # straightforward triple-loop of the formula:
+    #   A_cumsum[l] = sum_{k<=l} A[k]
+    #   Ldecay[l,s] = exp(A_cumsum[l] - A_cumsum[s])  for s <= l
+    #   scores[l,s] = (sum_n C[l,n]*B[s,n]) * Ldecay[l,s]
+    #   Y[l,p]      = sum_{s<=l} scores[l,s] * X[s,p]
+    var ref_heap = List(length=xy_count, fill=Scalar[dtype](0))
+
+    var cb_h_stride = chunk_len * state_dim
+    var cb_c_stride = n_heads * cb_h_stride
+    var cb_b_stride = n_chunks * cb_c_stride
+
+    var xy_h_stride = chunk_len * head_dim
+    var xy_c_stride = n_heads * xy_h_stride
+    var xy_b_stride = n_chunks * xy_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var cb_base = (
+                    b * cb_b_stride + c * cb_c_stride + h * cb_h_stride
+                )
+                var xy_base = (
+                    b * xy_b_stride + c * xy_c_stride + h * xy_h_stride
+                )
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+
+                # Prefix sum of A over the chunk.
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                for l in range(chunk_len):
+                    for p in range(head_dim):
+                        var y_acc = Float32(0.0)
+                        for s in range(l + 1):
+                            # dot(C[l,:], B[s,:]).
+                            var dot = Float32(0.0)
+                            for n in range(state_dim):
+                                var cv = C_h.ptr[
+                                    cb_base + l * state_dim + n
+                                ].cast[DType.float32]()
+                                var bv = B_h.ptr[
+                                    cb_base + s * state_dim + n
+                                ].cast[DType.float32]()
+                                dot += cv * bv
+                            var decay = exp(cumsum[l] - cumsum[s])
+                            var xv = X_h.ptr[xy_base + s * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            y_acc += dot * decay * xv
+                        ref_heap[xy_base + l * head_dim + p] = Scalar[dtype](
+                            y_acc
+                        )
+
+    # Compare kernel output against the reference.
+    for i in range(xy_count):
+        assert_almost_equal(
+            Y_h.ptr[i],
+            ref_heap[i],
+            rtol=rtol,
+        )
+
+
+def test_ssd_intra_chunk_golden() raises:
+    """Golden-parity test against the canonical PyTorch SSD reference.
+
+    Pins ``ssd_intra_chunk_fwd_cpu_naive`` to a FIXED tiny input whose expected
+    output was computed independently by ``intra_chunk_diag`` in
+    ``.planning/parity/ssd_minimal_ref.py`` (the vendored pure-PyTorch
+    ``ssd_minimal_discrete`` stage-1 diagonal block).
+
+    Shapes: batch=1, n_chunks=1, n_heads=1, chunk_len L=4, state_dim N=3,
+    head_dim P=2; all tensors row-major.
+    """
+    comptime dtype = DType.float32
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    # Fixed literals (row-major). These mirror the values in the parity
+    # reference; Y_expected is the reference's output for these inputs.
+    var C_vals = [
+        Float32(-0.15),
+        0.79,
+        0.95,
+        -1.11,
+        1.69,
+        -0.89,
+        -0.36,
+        1.23,
+        0.14,
+        -1.68,
+        0.32,
+        0.13,
+    ]
+    var B_vals = [
+        Float32(0.14),
+        0.24,
+        1.40,
+        1.35,
+        2.44,
+        0.20,
+        2.45,
+        2.03,
+        1.78,
+        -0.92,
+        -0.46,
+        -0.72,
+    ]
+    var X_vals = [
+        Float32(1.28),
+        -0.99,
+        1.81,
+        -0.60,
+        1.61,
+        1.93,
+        -0.42,
+        -0.08,
+    ]
+    var A_vals = [Float32(-0.43), -0.34, -0.49, -0.46]
+    var Y_expected = [
+        Float32(1.918208),
+        -1.483614,
+        3.522012,
+        -0.766567,
+        6.067267,
+        2.472605,
+        -4.850489,
+        -3.713203,
+    ]
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    # Build LayoutTensors from the fixed literals (not random).
+    var C_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var C_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    for i in range(cb_count):
+        C_h.ptr[i] = Scalar[dtype](C_vals[i])
+
+    var B_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    for i in range(cb_count):
+        B_h.ptr[i] = Scalar[dtype](B_vals[i])
+
+    var X_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    for i in range(xy_count):
+        X_h.ptr[i] = Scalar[dtype](X_vals[i])
+
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    for i in range(a_count):
+        A_h.ptr[i] = Scalar[dtype](A_vals[i])
+
+    var Y_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var Y_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    ssd_intra_chunk_fwd_cpu_naive[
+        dtype,
+        C_h.layout,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        Y_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        C_h,
+        B_h,
+        X_h,
+        A_h,
+        Y_h,
+    )
+
+    # Pin to the canonical PyTorch reference numerics.
+    for i in range(xy_count):
+        assert_almost_equal(
+            Y_h.ptr[i],
+            Scalar[dtype](Y_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_intra_chunk_basic() raises:
+    """Basic single-batch, single-chunk case."""
+    run_ssd_intra_chunk[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=16,
+        head_dim=8,
+    )
+
+
+def test_ssd_intra_chunk_multi_chunk() raises:
+    """Multiple chunks and heads."""
+    run_ssd_intra_chunk[DType.float32](
+        batch=1,
+        n_chunks=3,
+        n_heads=2,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=8,
+    )
+
+
+def test_ssd_intra_chunk_multi_batch() raises:
+    """Multiple batch elements."""
+    run_ssd_intra_chunk[DType.float32](
+        batch=2,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=4,
+    )
+
+
+def test_ssd_intra_chunk_chunk_len_one() raises:
+    """Degenerate chunk length of one (only the diagonal term)."""
+    run_ssd_intra_chunk[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=1,
+        chunk_len=1,
+        state_dim=4,
+        head_dim=4,
+    )
+
+
+def test_ssd_intra_chunk_optimized_matches_naive() raises:
+    """Optimized CPU kernel matches the naive scalar reference."""
+    comptime dtype = DType.float32
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    comptime batch = 1
+    comptime n_chunks = 2
+    comptime n_heads = 2
+    comptime chunk_len = 16
+    comptime state_dim = 16
+    comptime head_dim = 8
+
+    var cb_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var xy_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+
+    var C_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var C_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    var B_heap = List(length=cb_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    var X_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    var Y_fast_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var Y_fast_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_fast_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    var Y_naive_heap = List(length=xy_count, fill=Scalar[dtype](0))
+    var Y_naive_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_naive_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    random(C_h)
+    random(B_h)
+    random(X_h)
+    random(A_h)
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        A_h.ptr[i] = Scalar[dtype](Float32(-0.35) + Float32(0.25) * v)
+
+    ssd_intra_chunk_fwd_cpu[
+        dtype,
+        C_h.layout,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        Y_fast_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        C_h,
+        B_h,
+        X_h,
+        A_h,
+        Y_fast_h,
+    )
+    ssd_intra_chunk_fwd_cpu_naive[
+        dtype,
+        C_h.layout,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        Y_naive_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        C_h,
+        B_h,
+        X_h,
+        A_h,
+        Y_naive_h,
+    )
+
+    for i in range(xy_count):
+        assert_almost_equal(Y_fast_h.ptr[i], Y_naive_h.ptr[i], rtol=1e-4)
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_chunk_combine.mojo
+++ b/max/kernels/test/state_space/test_ssd_chunk_combine.mojo
@@ -1,0 +1,375 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from layout import Layout, LayoutTensor, RuntimeLayout
+from layout._fillers import random
+from state_space.ssd_chunk_combine import ssd_output_recombination_fwd_cpu
+from std.math import exp
+from std.testing import TestSuite, assert_almost_equal
+
+from std.utils.index import Index
+
+
+def run_ssd_output_recombination[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    head_dim: Int,
+    state_dim: Int,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test the SSD output-recombination kernel against an independent ref."""
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    # C: [batch, n_chunks, n_heads, chunk_len, state_dim]
+    var c_heap = List(length=c_count, fill=Scalar[dtype](0))
+    var c_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        c_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+
+    # entering_state: [batch, n_chunks, n_heads, head_dim, state_dim]
+    var ent_heap = List(length=ent_count, fill=Scalar[dtype](0))
+    var ent_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        ent_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # A: [batch, n_chunks, n_heads, chunk_len]
+    var a_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var a_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        a_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+
+    # Y_diag: [batch, n_chunks, n_heads, chunk_len, head_dim]
+    var yd_heap = List(length=y_count, fill=Scalar[dtype](0))
+    var yd_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        yd_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # Y: [batch, n_chunks, n_heads, chunk_len, head_dim]
+    var y_heap = List(length=y_count, fill=Scalar[dtype](0))
+    var y_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        y_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # Initialize inputs.
+    random(c_h)
+    random(ent_h)
+    random(a_h)
+    random(yd_h)
+
+    # Make A negative (a real SSM decays). `random` fills in roughly [-1, 1];
+    # map it into [-0.6, -0.1] like a real per-token in-chunk log-decay.
+    for i in range(a_count):
+        var v = a_h.ptr[i].cast[DType.float32]()
+        # Map [-1, 1] -> [-0.6, -0.1].
+        var scaled = Float32(-0.35) + Float32(0.25) * v
+        a_h.ptr[i] = Scalar[dtype](scaled)
+
+    # Call the kernel.
+    ssd_output_recombination_fwd_cpu[
+        dtype,
+        c_h.layout,
+        ent_h.layout,
+        a_h.layout,
+        yd_h.layout,
+        y_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        head_dim,
+        state_dim,
+        c_h,
+        ent_h,
+        a_h,
+        yd_h,
+        y_h,
+    )
+
+    # Independent naive reference. Recompute strides from scratch:
+    #   A_cumsum[l] = sum_{k<=l} A[k]
+    #   decay[l]    = exp(A_cumsum[l])
+    #   Y_off[l,p]  = decay[l] * sum_n C[l,n] * entering[p,n]
+    #   Y[l,p]      = Y_diag[l,p] + Y_off[l,p]
+    var ref_y = List(length=y_count, fill=Scalar[dtype](0))
+
+    var c_l_stride = state_dim
+    var c_h_stride = chunk_len * c_l_stride
+    var c_c_stride = n_heads * c_h_stride
+    var c_b_stride = n_chunks * c_c_stride
+
+    var ent_p_stride = state_dim
+    var ent_h_stride = head_dim * ent_p_stride
+    var ent_c_stride = n_heads * ent_h_stride
+    var ent_b_stride = n_chunks * ent_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var y_l_stride = head_dim
+    var y_h_stride = chunk_len * y_l_stride
+    var y_c_stride = n_heads * y_h_stride
+    var y_b_stride = n_chunks * y_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var c_base = b * c_b_stride + c * c_c_stride + h * c_h_stride
+                var ent_base = (
+                    b * ent_b_stride + c * ent_c_stride + h * ent_h_stride
+                )
+                var y_base = b * y_b_stride + c * y_c_stride + h * y_h_stride
+
+                var a_cumsum = Float32(0.0)
+                for l in range(chunk_len):
+                    a_cumsum += a_h.ptr[a_base + l].cast[DType.float32]()
+                    var decay = exp(a_cumsum)
+                    for p in range(head_dim):
+                        var acc = Float32(0.0)
+                        for n in range(state_dim):
+                            var c_val = c_h.ptr[
+                                c_base + l * c_l_stride + n
+                            ].cast[DType.float32]()
+                            var ent_val = ent_h.ptr[
+                                ent_base + p * ent_p_stride + n
+                            ].cast[DType.float32]()
+                            acc += c_val * ent_val
+                        var y_off = decay * acc
+                        var yd_val = yd_h.ptr[y_base + l * y_l_stride + p].cast[
+                            DType.float32
+                        ]()
+                        ref_y[y_base + l * y_l_stride + p] = Scalar[dtype](
+                            yd_val + y_off
+                        )
+
+    # Compare kernel output against the reference.
+    for i in range(y_count):
+        assert_almost_equal(y_h.ptr[i], ref_y[i], rtol=rtol)
+
+
+def test_ssd_output_recombination_golden() raises:
+    """Golden-parity test against the canonical PyTorch SSD reference.
+
+    Pins ``ssd_output_recombination_fwd_cpu`` to a FIXED tiny input whose
+    expected output was computed independently by the stage-4 output
+    recombination of ``ssd_minimal_discrete``.
+
+    Shapes: batch=1, n_chunks=1, n_heads=1, chunk_len L=4, state_dim N=3,
+    head_dim P=2; all tensors row-major.
+    """
+    comptime dtype = DType.float32
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    # Fixed literals (row-major).
+    # C is L x N; entering is P x N; A is L; Y_diag is L x P.
+    var c_vals = [
+        Float32(0.35),
+        -0.57,
+        -0.39,
+        -0.29,
+        -0.45,
+        0.92,
+        -0.76,
+        1.06,
+        -0.12,
+        0.58,
+        0.47,
+        0.30,
+    ]
+    var ent_vals = [
+        Float32(0.56),
+        2.29,
+        2.11,
+        0.30,
+        0.03,
+        -0.57,
+    ]
+    var a_vals = [Float32(-0.51), -0.14, -0.32, -0.54]
+    var yd_vals = [
+        Float32(0.24),
+        0.69,
+        1.40,
+        -0.14,
+        -0.35,
+        -2.05,
+        -0.44,
+        -1.53,
+    ]
+    var y_expected = [
+        Float32(-0.920277),
+        0.876274,
+        1.790647,
+        -0.466226,
+        0.312865,
+        -2.098447,
+        0.009353,
+        -1.526222,
+    ]
+
+    var c_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var y_count = batch * n_chunks * n_heads * chunk_len * head_dim
+
+    var c_heap = List(length=c_count, fill=Scalar[dtype](0))
+    var c_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        c_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    for i in range(c_count):
+        c_h.ptr[i] = Scalar[dtype](c_vals[i])
+
+    var ent_heap = List(length=ent_count, fill=Scalar[dtype](0))
+    var ent_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        ent_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    for i in range(ent_count):
+        ent_h.ptr[i] = Scalar[dtype](ent_vals[i])
+
+    var a_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var a_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        a_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    for i in range(a_count):
+        a_h.ptr[i] = Scalar[dtype](a_vals[i])
+
+    var yd_heap = List(length=y_count, fill=Scalar[dtype](0))
+    var yd_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        yd_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    for i in range(y_count):
+        yd_h.ptr[i] = Scalar[dtype](yd_vals[i])
+
+    var y_heap = List(length=y_count, fill=Scalar[dtype](0))
+    var y_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        y_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    ssd_output_recombination_fwd_cpu[
+        dtype,
+        c_h.layout,
+        ent_h.layout,
+        a_h.layout,
+        yd_h.layout,
+        y_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        head_dim,
+        state_dim,
+        c_h,
+        ent_h,
+        a_h,
+        yd_h,
+        y_h,
+    )
+
+    # Pin to the canonical PyTorch reference numerics.
+    for i in range(y_count):
+        assert_almost_equal(
+            y_h.ptr[i],
+            Scalar[dtype](y_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_output_recombination_basic() raises:
+    """Basic single-batch, single-head case against the naive reference."""
+    run_ssd_output_recombination[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        head_dim=8,
+        state_dim=16,
+    )
+
+
+def test_ssd_output_recombination_multi_batch() raises:
+    """Multiple batch elements and heads against the naive reference."""
+    run_ssd_output_recombination[DType.float32](
+        batch=2,
+        n_chunks=3,
+        n_heads=3,
+        chunk_len=5,
+        head_dim=4,
+        state_dim=8,
+    )
+
+
+def test_ssd_output_recombination_single_chunk() raises:
+    """Single chunk, single token edge case against the naive reference."""
+    run_ssd_output_recombination[DType.float32](
+        batch=2,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=1,
+        head_dim=4,
+        state_dim=4,
+    )
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_chunk_combined_ops.mojo
+++ b/max/kernels/test/state_space/test_ssd_chunk_combined_ops.mojo
@@ -1,0 +1,217 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""End-to-end parity test for the fused SSD ``ssd_chunk_scan_combined`` op.
+
+Mirrors the golden literals from RFC 0002's pipeline checkpoint
+(b=1, seqlen=4, n_heads=1, head_dim=2, state_dim=3, chunk_size=2),
+where the expected output was independently computed via the vendored
+``ssd_minimal_discrete`` reference. The test calls the CPU implementation
+that backs the ``@extensibility.register("ssd_chunk_scan_combined")`` op and
+asserts the per-element output matches the reference golden within the
+parity tolerance (rtol=1e-3, atol=1e-3).
+
+The `@extensibility.register` registration itself is validated at build time:
+if the struct's ``execute`` signature does not match the extensibility ABI,
+the ``//max/kernels/src/state_space:state_space`` library fails to compile.
+"""
+
+from state_space.ssd_chunk_combined_ops import _ssd_chunk_scan_combined_cpu
+from std.testing import TestSuite, assert_almost_equal
+
+
+def test_ssd_chunk_scan_combined_cpu_golden_parity() raises:
+    """Parity vs golden: b=1, seqlen=4, n_heads=1, head_dim=2, state_dim=3.
+
+    Golden Y_expected (row-major, shape [batch, seqlen, n_heads, head_dim]):
+        [ 0.126999, -0.028039,
+          0.191223, -0.003887,
+         -0.370202, -0.111640,
+         -0.005157, -0.252940 ]
+    """
+    comptime dtype = DType.float32
+
+    var batch = 1
+    var seqlen = 4
+    var n_heads = 1
+    var head_dim = 2
+    var state_dim = 3
+    var chunk_size = 2
+
+    var x_size = batch * seqlen * n_heads * head_dim
+    var dt_size = batch * seqlen * n_heads
+    var A_size = n_heads
+    var bc_size = batch * seqlen * n_heads * state_dim
+    var y_size = x_size
+    var final_state_size = batch * n_heads * head_dim * state_dim
+
+    # x: [batch, seqlen, n_heads, head_dim], row-major
+    var x = List[Scalar[dtype]](length=x_size, fill=Scalar[dtype](0))
+    var x_vals: List[Float32] = [
+        0.77,
+        -0.17,
+        -0.66,
+        -0.39,
+        0.31,
+        -0.62,
+        -1.19,
+        -1.28,
+    ]
+    for i in range(x_size):
+        x[i] = x_vals[i].cast[dtype]()
+
+    # dt: [batch, seqlen, n_heads]
+    var dt = List[Scalar[dtype]](length=dt_size, fill=Scalar[dtype](0))
+    var dt_vals: List[Float32] = [0.33, 0.26, 0.12, 0.24]
+    for i in range(dt_size):
+        dt[i] = dt_vals[i].cast[dtype]()
+
+    # A: [n_heads]
+    var A = List[Scalar[dtype]](length=A_size, fill=Scalar[dtype](0))
+    A[0] = Scalar[dtype](-1.2)
+
+    # B: [batch, seqlen, n_heads, state_dim]
+    var B = List[Scalar[dtype]](length=bc_size, fill=Scalar[dtype](0))
+    var B_vals: List[Float32] = [
+        -0.91,
+        0.56,
+        -1.13,
+        -0.41,
+        0.59,
+        0.28,
+        1.46,
+        0.67,
+        0.19,
+        -0.05,
+        0.00,
+        -0.72,
+    ]
+    for i in range(bc_size):
+        B[i] = B_vals[i].cast[dtype]()
+
+    # C: [batch, seqlen, n_heads, state_dim]
+    var C = List[Scalar[dtype]](length=bc_size, fill=Scalar[dtype](0))
+    var C_vals: List[Float32] = [
+        0.64,
+        -0.61,
+        -1.26,
+        -1.05,
+        -1.03,
+        -0.35,
+        1.92,
+        0.30,
+        1.47,
+        -0.55,
+        1.06,
+        -0.74,
+    ]
+    for i in range(bc_size):
+        C[i] = C_vals[i].cast[dtype]()
+
+    var Y = List[Scalar[dtype]](length=y_size, fill=Scalar[dtype](0))
+    var final_state = List[Scalar[dtype]](
+        length=final_state_size, fill=Scalar[dtype](0)
+    )
+
+    _ssd_chunk_scan_combined_cpu[dtype](
+        batch,
+        seqlen,
+        n_heads,
+        head_dim,
+        state_dim,
+        chunk_size,
+        x.unsafe_ptr(),
+        dt.unsafe_ptr(),
+        A.unsafe_ptr(),
+        B.unsafe_ptr(),
+        C.unsafe_ptr(),
+        Y.unsafe_ptr(),
+        final_state.unsafe_ptr(),
+    )
+
+    # Expected golden, row-major [batch, seqlen, n_heads, head_dim].
+    var expected: List[Float32] = [
+        0.126999,
+        -0.028039,
+        0.191223,
+        -0.003887,
+        -0.370202,
+        -0.111640,
+        -0.005157,
+        -0.252940,
+    ]
+
+    for i in range(y_size):
+        assert_almost_equal(
+            Y[i],
+            expected[i].cast[dtype](),
+            atol=1e-3,
+            rtol=1e-3,
+        )
+
+    # Expected golden for final_state, row-major
+    # [batch, n_heads, head_dim, state_dim]. Computed by the vendored
+    # ``ssd_minimal_discrete`` reference for the same inputs (see
+    # .planning/parity/ssd_minimal_ref.py).
+    var expected_final_state: List[Float32] = [
+        -0.009206,
+        0.020579,
+        0.043290,
+        -0.014832,
+        -0.091143,
+        0.222278,
+    ]
+
+    for i in range(final_state_size):
+        assert_almost_equal(
+            final_state[i],
+            expected_final_state[i].cast[dtype](),
+            atol=1e-3,
+            rtol=1e-3,
+        )
+
+
+def test_ssd_chunk_scan_combined_cpu_chunk_divides_seqlen() raises:
+    """The op must raise when seqlen is not divisible by chunk_size."""
+    comptime dtype = DType.float32
+    var x = List[Scalar[dtype]](length=4, fill=Scalar[dtype](0))
+    var dt = List[Scalar[dtype]](length=4, fill=Scalar[dtype](0))
+    var A = List[Scalar[dtype]](length=1, fill=Scalar[dtype](0))
+    var B = List[Scalar[dtype]](length=4, fill=Scalar[dtype](0))
+    var C = List[Scalar[dtype]](length=4, fill=Scalar[dtype](0))
+    var Y = List[Scalar[dtype]](length=4, fill=Scalar[dtype](0))
+    var final_state = List[Scalar[dtype]](length=1, fill=Scalar[dtype](0))
+    var raised = False
+    try:
+        _ssd_chunk_scan_combined_cpu[dtype](
+            1,  # batch
+            4,  # seqlen
+            1,  # n_heads
+            1,  # head_dim
+            1,  # state_dim
+            3,  # chunk_size (4 % 3 != 0)
+            x.unsafe_ptr(),
+            dt.unsafe_ptr(),
+            A.unsafe_ptr(),
+            B.unsafe_ptr(),
+            C.unsafe_ptr(),
+            Y.unsafe_ptr(),
+            final_state.unsafe_ptr(),
+        )
+    except _:
+        raised = True
+    if not raised:
+        raise Error("Expected divisibility check to raise")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_chunk_mamba2_coverage.mojo
+++ b/max/kernels/test/state_space/test_ssd_chunk_mamba2_coverage.mojo
@@ -1,0 +1,662 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""End-to-end Mamba2-dim coverage test for the SSD chunk-scan chain.
+
+Exercises the four SSD stage kernels (intra-chunk diagonal, chunk end-state,
+inter-chunk recurrence, output recombination) chained together as
+``SSDChunkScanCombined.execute`` does, at Mamba2-representative dimensions
+(``head_dim`` in 64-128 and ``state_dim`` in 64-128) plus a small Mamba1
+non-regression case. The reference is an in-test unrolled SSD scan that
+implements the discretized state-space recurrence directly via nested loops,
+so it shares no infrastructure with the stage kernels under test.
+
+RFC 0002 item 8: verify SSD prefill works at Mamba2 dims without regressing
+Mamba1. The kernels take dims as runtime args, so this is a test-only
+deliverable -- no kernel edits.
+"""
+
+from std.math import exp
+from std.random import seed
+
+from layout import Layout, LayoutTensor, RuntimeLayout
+from layout._fillers import random
+from std.testing import TestSuite, assert_almost_equal
+from std.utils.index import Index
+
+from state_space.ssd_chunk import ssd_intra_chunk_fwd_cpu
+from state_space.ssd_chunk_state import ssd_chunk_state_fwd_cpu
+from state_space.ssd_chunk_scan import ssd_chunk_scan_fwd_cpu
+from state_space.ssd_chunk_combine import ssd_output_recombination_fwd_cpu
+
+
+# ===----------------------------------------------------------------------=== #
+# In-test naive reference
+# ===----------------------------------------------------------------------=== #
+
+
+def _naive_ssd_reference[
+    dtype: DType,
+](
+    batch: Int,
+    seqlen: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    x_ptr: UnsafePointer[Scalar[dtype], ...],
+    dt_ptr: UnsafePointer[Scalar[dtype], ...],
+    A_ptr: UnsafePointer[Scalar[dtype], ...],
+    B_ptr: UnsafePointer[Scalar[dtype], ...],
+    C_ptr: UnsafePointer[Scalar[dtype], ...],
+    Y_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+):
+    """Compute Y via the unrolled discretized SSD recurrence.
+
+    For each ``(b, h)``, threads a single token-level recurrence (no chunking)
+    over a per-head state ``s`` of shape ``(head_dim, state_dim)``:
+
+        a_t   = exp(A[h] * dt[b, t, h])
+        bx_t  = dt[b, t, h] * x[b, t, h, :]    # length head_dim
+        s     = a_t * s + outer(bx_t, B[b, t, h, :])
+        y_t,p = sum_n C[b, t, h, n] * s[p, n]
+
+    This is intentionally written with plain nested loops -- no LayoutTensor
+    strides, no chunk math -- so it serves as an independent oracle for the
+    four-stage chained pipeline.
+
+    All buffers are row-major contiguous in the canonical layouts:
+        x:  [batch, seqlen, n_heads, head_dim]
+        dt: [batch, seqlen, n_heads]
+        A:  [n_heads]
+        B:  [batch, seqlen, n_heads, state_dim]
+        C:  [batch, seqlen, n_heads, state_dim]
+        Y:  [batch, seqlen, n_heads, head_dim]
+    """
+    for b in range(batch):
+        for h in range(n_heads):
+            var a_h = A_ptr[h].cast[DType.float32]()
+            # Per-(b, h) running state, shape (head_dim, state_dim).
+            var state = List[Float32](
+                length=head_dim * state_dim, fill=Float32(0.0)
+            )
+
+            for t in range(seqlen):
+                var dt_off = (b * seqlen + t) * n_heads + h
+                var dt_val = dt_ptr[dt_off].cast[DType.float32]()
+                var a_t = exp(a_h * dt_val)
+
+                var bc_base = ((b * seqlen + t) * n_heads + h) * state_dim
+                var x_base = ((b * seqlen + t) * n_heads + h) * head_dim
+
+                # state[p, n] = a_t * state[p, n]
+                #             + (dt_val * x[t, p]) * B[t, n]
+                for p in range(head_dim):
+                    var xv = x_ptr[x_base + p].cast[DType.float32]() * dt_val
+                    for n in range(state_dim):
+                        var bv = B_ptr[bc_base + n].cast[DType.float32]()
+                        var prev = state[p * state_dim + n]
+                        state[p * state_dim + n] = a_t * prev + xv * bv
+
+                # y[t, p] = sum_n C[t, n] * state[p, n]
+                var y_base = ((b * seqlen + t) * n_heads + h) * head_dim
+                for p in range(head_dim):
+                    var acc = Float32(0.0)
+                    for n in range(state_dim):
+                        var cv = C_ptr[bc_base + n].cast[DType.float32]()
+                        acc += cv * state[p * state_dim + n]
+                    Y_ptr[y_base + p] = acc.cast[dtype]()
+
+
+# ===----------------------------------------------------------------------=== #
+# Pre-stage helpers (CPU): discretization + reshape
+# ===----------------------------------------------------------------------=== #
+
+
+def _precompute_chunked[
+    dtype: DType,
+](
+    batch: Int,
+    seqlen: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    n_chunks: Int,
+    chunk_size: Int,
+    x_ptr: UnsafePointer[Scalar[dtype], ...],
+    dt_ptr: UnsafePointer[Scalar[dtype], ...],
+    A_ptr: UnsafePointer[Scalar[dtype], ...],
+    B_ptr: UnsafePointer[Scalar[dtype], ...],
+    C_ptr: UnsafePointer[Scalar[dtype], ...],
+    X_disc_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+    A_disc_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+    B_chunk_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+    C_chunk_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+    chunk_decays_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+):
+    """Discretize and chunk-reshape inputs for the four-stage chain.
+
+    Same layout contract as ``_ssd_combined_precompute_cpu`` in the op wrapper:
+        X_disc[b, c, h, l, p] = x[b, c*L+l, h, p] * dt[b, c*L+l, h]
+        A_disc[b, c, h, l]    = A[h] * dt[b, c*L+l, h]
+        B_chunk / C_chunk     = pure reshapes of B / C
+        chunk_decays[b, c, h] = sum_l A_disc[b, c, h, l]
+    """
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var a_h = A_ptr[h].cast[DType.float32]()
+                var chunk_sum = Float32(0.0)
+                for l in range(chunk_size):
+                    var t = c * chunk_size + l
+                    var dt_off = (b * seqlen + t) * n_heads + h
+                    var dt_val = dt_ptr[dt_off].cast[DType.float32]()
+                    var a_disc_val = a_h * dt_val
+                    chunk_sum += a_disc_val
+
+                    var a_disc_off = (
+                        (b * n_chunks + c) * n_heads + h
+                    ) * chunk_size + l
+                    A_disc_ptr[a_disc_off] = a_disc_val.cast[dtype]()
+
+                    var x_in_base = ((b * seqlen + t) * n_heads + h) * head_dim
+                    var x_out_base = (
+                        ((b * n_chunks + c) * n_heads + h) * chunk_size + l
+                    ) * head_dim
+                    for p in range(head_dim):
+                        var x_val = x_ptr[x_in_base + p].cast[DType.float32]()
+                        X_disc_ptr[x_out_base + p] = (x_val * dt_val).cast[
+                            dtype
+                        ]()
+
+                    var bc_in_base = (
+                        (b * seqlen + t) * n_heads + h
+                    ) * state_dim
+                    var bc_out_base = (
+                        ((b * n_chunks + c) * n_heads + h) * chunk_size + l
+                    ) * state_dim
+                    for n in range(state_dim):
+                        B_chunk_ptr[bc_out_base + n] = B_ptr[bc_in_base + n]
+                        C_chunk_ptr[bc_out_base + n] = C_ptr[bc_in_base + n]
+
+                var cd_off = (b * n_chunks + c) * n_heads + h
+                chunk_decays_ptr[cd_off] = chunk_sum.cast[dtype]()
+
+
+def _postprocess_chunked[
+    dtype: DType,
+](
+    batch: Int,
+    seqlen: Int,
+    n_heads: Int,
+    head_dim: Int,
+    n_chunks: Int,
+    chunk_size: Int,
+    Y_chunked_ptr: UnsafePointer[Scalar[dtype], ...],
+    Y_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+):
+    """Flatten chunked output back to ``[batch, seqlen, n_heads, head_dim]``."""
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                for l in range(chunk_size):
+                    var t = c * chunk_size + l
+                    var y_in_base = (
+                        ((b * n_chunks + c) * n_heads + h) * chunk_size + l
+                    ) * head_dim
+                    var y_out_base = (
+                        b * seqlen + t
+                    ) * n_heads * head_dim + h * head_dim
+                    for p in range(head_dim):
+                        Y_ptr[y_out_base + p] = Y_chunked_ptr[y_in_base + p]
+
+
+# ===----------------------------------------------------------------------=== #
+# Drive the four-stage SSD chain directly (CPU).
+# ===----------------------------------------------------------------------=== #
+
+
+def _run_chained_chain[
+    dtype: DType,
+](
+    batch: Int,
+    seqlen: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    chunk_size: Int,
+    x_ptr: UnsafePointer[Scalar[dtype], ...],
+    dt_ptr: UnsafePointer[Scalar[dtype], ...],
+    A_ptr: UnsafePointer[Scalar[dtype], ...],
+    B_ptr: UnsafePointer[Scalar[dtype], ...],
+    C_ptr: UnsafePointer[Scalar[dtype], ...],
+    Y_ptr: UnsafePointer[mut=True, Scalar[dtype], ...],
+) raises:
+    """Run discretize -> stage1 -> stage2 -> stage3 -> stage4 -> flatten."""
+    var n_chunks = seqlen // chunk_size
+
+    var x_disc_size = batch * n_chunks * n_heads * chunk_size * head_dim
+    var a_disc_size = batch * n_chunks * n_heads * chunk_size
+    var bc_chunk_size = batch * n_chunks * n_heads * chunk_size * state_dim
+    var chunk_states_size = batch * n_chunks * n_heads * head_dim * state_dim
+    var final_size = batch * n_heads * head_dim * state_dim
+    var cd_size = batch * n_chunks * n_heads
+
+    var X_disc = List[Scalar[dtype]](length=x_disc_size, fill=Scalar[dtype](0))
+    var A_disc = List[Scalar[dtype]](length=a_disc_size, fill=Scalar[dtype](0))
+    var B_chunk = List[Scalar[dtype]](
+        length=bc_chunk_size, fill=Scalar[dtype](0)
+    )
+    var C_chunk = List[Scalar[dtype]](
+        length=bc_chunk_size, fill=Scalar[dtype](0)
+    )
+    var Y_diag = List[Scalar[dtype]](length=x_disc_size, fill=Scalar[dtype](0))
+    var chunk_states = List[Scalar[dtype]](
+        length=chunk_states_size, fill=Scalar[dtype](0)
+    )
+    var entering = List[Scalar[dtype]](
+        length=chunk_states_size, fill=Scalar[dtype](0)
+    )
+    var final = List[Scalar[dtype]](length=final_size, fill=Scalar[dtype](0))
+    var chunk_decays = List[Scalar[dtype]](
+        length=cd_size, fill=Scalar[dtype](0)
+    )
+    var Y_chunked = List[Scalar[dtype]](
+        length=x_disc_size, fill=Scalar[dtype](0)
+    )
+
+    _precompute_chunked[dtype](
+        batch,
+        seqlen,
+        n_heads,
+        head_dim,
+        state_dim,
+        n_chunks,
+        chunk_size,
+        x_ptr,
+        dt_ptr,
+        A_ptr,
+        B_ptr,
+        C_ptr,
+        X_disc.unsafe_ptr(),
+        A_disc.unsafe_ptr(),
+        B_chunk.unsafe_ptr(),
+        C_chunk.unsafe_ptr(),
+        chunk_decays.unsafe_ptr(),
+    )
+
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var X_disc_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_disc.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, head_dim)
+        ),
+    )
+    var A_disc_lt = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_disc.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size)
+        ),
+    )
+    var B_chunk_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_chunk.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, state_dim)
+        ),
+    )
+    var C_chunk_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        C_chunk.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, state_dim)
+        ),
+    )
+    var Y_diag_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_diag.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, head_dim)
+        ),
+    )
+    var chunk_states_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        chunk_states.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    var entering_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        entering.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    var final_lt = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        final.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_heads, head_dim, state_dim)
+        ),
+    )
+    var chunk_decays_lt = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        chunk_decays.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_3d].row_major(Index(batch, n_chunks, n_heads)),
+    )
+    var Y_chunked_lt = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        Y_chunked.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_size, head_dim)
+        ),
+    )
+
+    # Stage 1: intra-chunk diagonal.
+    ssd_intra_chunk_fwd_cpu[
+        dtype,
+        C_chunk_lt.layout,
+        B_chunk_lt.layout,
+        X_disc_lt.layout,
+        A_disc_lt.layout,
+        Y_diag_lt.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_size,
+        state_dim,
+        head_dim,
+        C_chunk_lt,
+        B_chunk_lt,
+        X_disc_lt,
+        A_disc_lt,
+        Y_diag_lt,
+    )
+
+    # Stage 2: per-chunk end-states.
+    ssd_chunk_state_fwd_cpu[
+        dtype,
+        B_chunk_lt.layout,
+        X_disc_lt.layout,
+        A_disc_lt.layout,
+        chunk_states_lt.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_size,
+        state_dim,
+        head_dim,
+        B_chunk_lt,
+        X_disc_lt,
+        A_disc_lt,
+        chunk_states_lt,
+    )
+
+    # Stage 3: inter-chunk recurrence.
+    ssd_chunk_scan_fwd_cpu[
+        dtype,
+        chunk_states_lt.layout,
+        chunk_decays_lt.layout,
+        entering_lt.layout,
+        final_lt.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        head_dim,
+        state_dim,
+        chunk_states_lt,
+        chunk_decays_lt,
+        entering_lt,
+        final_lt,
+    )
+
+    # Stage 4: output recombination.
+    ssd_output_recombination_fwd_cpu[
+        dtype,
+        C_chunk_lt.layout,
+        entering_lt.layout,
+        A_disc_lt.layout,
+        Y_diag_lt.layout,
+        Y_chunked_lt.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_size,
+        head_dim,
+        state_dim,
+        C_chunk_lt,
+        entering_lt,
+        A_disc_lt,
+        Y_diag_lt,
+        Y_chunked_lt,
+    )
+
+    _postprocess_chunked[dtype](
+        batch,
+        seqlen,
+        n_heads,
+        head_dim,
+        n_chunks,
+        chunk_size,
+        Y_chunked.unsafe_ptr(),
+        Y_ptr,
+    )
+
+
+# ===----------------------------------------------------------------------=== #
+# Shared test driver
+# ===----------------------------------------------------------------------=== #
+
+
+def _run_case[
+    dtype: DType,
+](
+    batch: Int,
+    seqlen: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    chunk_size: Int,
+    seed_val: Int,
+    rtol: Float64 = 1e-2,
+    atol: Float64 = 1e-2,
+) raises:
+    """Allocate inputs, run the chain + reference, and compare element-wise."""
+    seed(seed_val)
+
+    comptime layout_1d = Layout.row_major[1]()
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_4d = Layout.row_major[4]()
+
+    # Input allocations -- the chain consumes these flat row-major buffers.
+    var x_heap = List[Scalar[dtype]](
+        length=batch * seqlen * n_heads * head_dim, fill=Scalar[dtype](0)
+    )
+    var x_lt = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        x_heap.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, seqlen, n_heads, head_dim)
+        ),
+    )
+
+    var dt_heap = List[Scalar[dtype]](
+        length=batch * seqlen * n_heads, fill=Scalar[dtype](0)
+    )
+    var dt_lt = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        dt_heap.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_3d].row_major(Index(batch, seqlen, n_heads)),
+    )
+
+    var A_heap = List[Scalar[dtype]](length=n_heads, fill=Scalar[dtype](0))
+    var A_lt = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        A_heap.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_1d].row_major(Index(n_heads)),
+    )
+
+    var B_heap = List[Scalar[dtype]](
+        length=batch * seqlen * n_heads * state_dim, fill=Scalar[dtype](0)
+    )
+    var B_lt = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        B_heap.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, seqlen, n_heads, state_dim)
+        ),
+    )
+
+    var C_heap = List[Scalar[dtype]](
+        length=batch * seqlen * n_heads * state_dim, fill=Scalar[dtype](0)
+    )
+    var C_lt = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        C_heap.unsafe_ptr().as_unsafe_any_origin(),
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, seqlen, n_heads, state_dim)
+        ),
+    )
+
+    # Fill inputs.
+    random(x_lt, min=Scalar[dtype](-1), max=Scalar[dtype](1))
+    # Keep dt small and positive so the per-token decay is well-conditioned.
+    random(dt_lt, min=Scalar[dtype](0.05), max=Scalar[dtype](0.5))
+    random(B_lt, min=Scalar[dtype](-1), max=Scalar[dtype](1))
+    random(C_lt, min=Scalar[dtype](-1), max=Scalar[dtype](1))
+    # A in [-0.6, -0.1] (negative log-decay per head).
+    random(A_lt, min=Scalar[dtype](-0.6), max=Scalar[dtype](-0.1))
+
+    # Outputs.
+    var y_size = batch * seqlen * n_heads * head_dim
+    var y_chain_heap = List[Scalar[dtype]](length=y_size, fill=Scalar[dtype](0))
+    var y_ref_heap = List[Scalar[dtype]](length=y_size, fill=Scalar[dtype](0))
+
+    # Run the four-stage SSD chain.
+    _run_chained_chain[dtype](
+        batch,
+        seqlen,
+        n_heads,
+        head_dim,
+        state_dim,
+        chunk_size,
+        x_heap.unsafe_ptr(),
+        dt_heap.unsafe_ptr(),
+        A_heap.unsafe_ptr(),
+        B_heap.unsafe_ptr(),
+        C_heap.unsafe_ptr(),
+        y_chain_heap.unsafe_ptr(),
+    )
+
+    # Run the independent naive reference (unrolled recurrence, no chunking).
+    _naive_ssd_reference[dtype](
+        batch,
+        seqlen,
+        n_heads,
+        head_dim,
+        state_dim,
+        x_heap.unsafe_ptr(),
+        dt_heap.unsafe_ptr(),
+        A_heap.unsafe_ptr(),
+        B_heap.unsafe_ptr(),
+        C_heap.unsafe_ptr(),
+        y_ref_heap.unsafe_ptr(),
+    )
+
+    for i in range(y_size):
+        assert_almost_equal(
+            y_chain_heap[i],
+            y_ref_heap[i],
+            atol=atol,
+            rtol=rtol,
+        )
+
+
+# ===----------------------------------------------------------------------=== #
+# Test cases
+# ===----------------------------------------------------------------------=== #
+
+
+def test_mamba1_tiny_non_regression() raises:
+    """Tiny Mamba1-style case: shows the chain still works at small dims."""
+    _run_case[DType.float32](
+        batch=1,
+        seqlen=8,
+        n_heads=1,
+        head_dim=2,
+        state_dim=3,
+        chunk_size=4,
+        seed_val=11,
+    )
+
+
+def test_mamba2_hd64_dstate64_seqlen8() raises:
+    """Mamba2 lower-bound dims: head_dim=64, state_dim=64, two chunks of 4."""
+    _run_case[DType.float32](
+        batch=1,
+        seqlen=8,
+        n_heads=1,
+        head_dim=64,
+        state_dim=64,
+        chunk_size=4,
+        seed_val=23,
+    )
+
+
+def test_mamba2_hd64_dstate128_seqlen8() raises:
+    """Mamba2 wider state: head_dim=64, state_dim=128."""
+    _run_case[DType.float32](
+        batch=1,
+        seqlen=8,
+        n_heads=1,
+        head_dim=64,
+        state_dim=128,
+        chunk_size=4,
+        seed_val=37,
+    )
+
+
+def test_mamba2_hd128_dstate128_seqlen8() raises:
+    """Mamba2 upper-bound dims: head_dim=128, state_dim=128."""
+    _run_case[DType.float32](
+        batch=1,
+        seqlen=8,
+        n_heads=1,
+        head_dim=128,
+        state_dim=128,
+        chunk_size=4,
+        seed_val=53,
+    )
+
+
+def test_mamba2_hd64_dstate64_seqlen16_multi_chunk() raises:
+    """Multi-chunk case: seqlen=16, chunk_size=8 -> two chunks."""
+    _run_case[DType.float32](
+        batch=1,
+        seqlen=16,
+        n_heads=1,
+        head_dim=64,
+        state_dim=64,
+        chunk_size=8,
+        seed_val=71,
+    )
+
+
+def test_mamba2_hd64_dstate64_two_heads() raises:
+    """Two-head case to exercise the per-head A indexing."""
+    _run_case[DType.float32](
+        batch=1,
+        seqlen=8,
+        n_heads=2,
+        head_dim=64,
+        state_dim=64,
+        chunk_size=4,
+        seed_val=97,
+    )
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_chunk_scan.mojo
+++ b/max/kernels/test/state_space/test_ssd_chunk_scan.mojo
@@ -1,0 +1,345 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from layout import Layout, LayoutTensor, RuntimeLayout
+from layout._fillers import random
+from state_space.ssd_chunk_scan import ssd_chunk_scan_fwd_cpu
+from std.math import exp
+from std.testing import TestSuite, assert_almost_equal
+
+from std.utils.index import Index
+
+
+def run_ssd_chunk_scan[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    head_dim: Int,
+    state_dim: Int,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test the SSD inter-chunk scan kernel against an independent reference."""
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var cs_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var cd_count = batch * n_chunks * n_heads
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var final_count = batch * n_heads * head_dim * state_dim
+
+    # chunk_states: [batch, n_chunks, n_heads, head_dim, state_dim]
+    var cs_heap = List(length=cs_count, fill=Scalar[dtype](0))
+    var cs_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        cs_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # chunk_decays: [batch, n_chunks, n_heads]
+    var cd_heap = List(length=cd_count, fill=Scalar[dtype](0))
+    var cd_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        cd_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, n_chunks, n_heads)),
+    )
+
+    # entering: [batch, n_chunks, n_heads, head_dim, state_dim]
+    var ent_heap = List(length=ent_count, fill=Scalar[dtype](0))
+    var ent_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        ent_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # final: [batch, n_heads, head_dim, state_dim]
+    var final_heap = List(length=final_count, fill=Scalar[dtype](0))
+    var final_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        final_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # Initialize inputs.
+    random(cs_h)
+    random(cd_h)
+
+    # Make chunk_decays negative (a real SSM decays). `random` fills in roughly
+    # [-1, 1]; map it into [-1.2, -0.3] like a real per-chunk total decay.
+    for i in range(cd_count):
+        var v = cd_h.ptr[i].cast[DType.float32]()
+        # Map [-1, 1] -> [-1.2, -0.3].
+        var scaled = Float32(-0.75) + Float32(0.45) * v
+        cd_h.ptr[i] = Scalar[dtype](scaled)
+
+    # Call the kernel.
+    ssd_chunk_scan_fwd_cpu[
+        dtype,
+        cs_h.layout,
+        cd_h.layout,
+        ent_h.layout,
+        final_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        head_dim,
+        state_dim,
+        cs_h,
+        cd_h,
+        ent_h,
+        final_h,
+    )
+
+    # Independent naive reference. Recompute strides from scratch and run the
+    # sequential recurrence per (batch, head):
+    #   state init 0
+    #   entering[c] = state
+    #   state = chunk_states[c] + exp(chunk_decays[c]) * state
+    #   final = state after the last chunk
+    var ref_ent = List(length=ent_count, fill=Scalar[dtype](0))
+    var ref_final = List(length=final_count, fill=Scalar[dtype](0))
+
+    var cs_h_stride = head_dim * state_dim
+    var cs_c_stride = n_heads * cs_h_stride
+    var cs_b_stride = n_chunks * cs_c_stride
+
+    var cd_c_stride = n_heads
+    var cd_b_stride = n_chunks * cd_c_stride
+
+    var ent_h_stride = head_dim * state_dim
+    var ent_c_stride = n_heads * ent_h_stride
+    var ent_b_stride = n_chunks * ent_c_stride
+
+    var final_h_stride = head_dim * state_dim
+    var final_b_stride = n_heads * final_h_stride
+
+    for b in range(batch):
+        for h in range(n_heads):
+            var state = List[Float32](length=head_dim * state_dim, fill=0.0)
+            for c in range(n_chunks):
+                var ent_base = (
+                    b * ent_b_stride + c * ent_c_stride + h * ent_h_stride
+                )
+                for pn in range(head_dim * state_dim):
+                    ref_ent[ent_base + pn] = Scalar[dtype](state[pn])
+
+                var cd_off = b * cd_b_stride + c * cd_c_stride + h
+                var decay = exp(cd_h.ptr[cd_off].cast[DType.float32]())
+
+                var cs_base = (
+                    b * cs_b_stride + c * cs_c_stride + h * cs_h_stride
+                )
+                for pn in range(head_dim * state_dim):
+                    var cs_val = cs_h.ptr[cs_base + pn].cast[DType.float32]()
+                    state[pn] = cs_val + decay * state[pn]
+
+            var final_base = b * final_b_stride + h * final_h_stride
+            for pn in range(head_dim * state_dim):
+                ref_final[final_base + pn] = Scalar[dtype](state[pn])
+
+    # Compare kernel output against the reference.
+    for i in range(ent_count):
+        assert_almost_equal(ent_h.ptr[i], ref_ent[i], rtol=rtol)
+    for i in range(final_count):
+        assert_almost_equal(final_h.ptr[i], ref_final[i], rtol=rtol)
+
+
+def test_ssd_chunk_scan_golden() raises:
+    """Golden-parity test against the canonical PyTorch SSD reference.
+
+    Pins ``ssd_chunk_scan_fwd_cpu`` to a FIXED tiny input whose expected output
+    was computed independently by the inter-chunk recurrence (stage 3 of
+    ``ssd_minimal_discrete``).
+
+    Shapes: batch=1, n_chunks=3, n_heads=1, head_dim P=2, state_dim N=3;
+    all tensors row-major.
+    """
+    comptime dtype = DType.float32
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    comptime batch = 1
+    comptime n_chunks = 3
+    comptime n_heads = 1
+    comptime head_dim = 2
+    comptime state_dim = 3
+
+    # Fixed literals (row-major). chunk_states is C x P x N; chunk_decays is C.
+    # entering_expected / final_expected are the reference's outputs.
+    var cs_vals = [
+        Float32(-0.90),
+        0.57,
+        0.91,
+        0.43,
+        1.29,
+        -0.17,
+        -0.86,
+        -0.66,
+        -0.70,
+        -0.10,
+        -0.62,
+        -0.63,
+        -0.58,
+        0.59,
+        0.12,
+        0.09,
+        1.04,
+        -0.18,
+    ]
+    var cd_vals = [Float32(-0.61), -1.03, -0.79]
+    var entering_expected = [
+        Float32(0.0),
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        -0.90,
+        0.57,
+        0.91,
+        0.43,
+        1.29,
+        -0.17,
+        -1.181306,
+        -0.456506,
+        -0.375124,
+        0.053513,
+        -0.159461,
+        -0.690691,
+    ]
+    var final_expected = [
+        Float32(-1.116130),
+        0.382817,
+        -0.050248,
+        0.114287,
+        0.967629,
+        -0.493467,
+    ]
+
+    var cs_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var cd_count = batch * n_chunks * n_heads
+    var ent_count = batch * n_chunks * n_heads * head_dim * state_dim
+    var final_count = batch * n_heads * head_dim * state_dim
+
+    # Build LayoutTensors from the fixed literals (not random).
+    var cs_heap = List(length=cs_count, fill=Scalar[dtype](0))
+    var cs_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        cs_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+    for i in range(cs_count):
+        cs_h.ptr[i] = Scalar[dtype](cs_vals[i])
+
+    var cd_heap = List(length=cd_count, fill=Scalar[dtype](0))
+    var cd_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        cd_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, n_chunks, n_heads)),
+    )
+    for i in range(cd_count):
+        cd_h.ptr[i] = Scalar[dtype](cd_vals[i])
+
+    var ent_heap = List(length=ent_count, fill=Scalar[dtype](0))
+    var ent_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        ent_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    var final_heap = List(length=final_count, fill=Scalar[dtype](0))
+    var final_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        final_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    ssd_chunk_scan_fwd_cpu[
+        dtype,
+        cs_h.layout,
+        cd_h.layout,
+        ent_h.layout,
+        final_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        head_dim,
+        state_dim,
+        cs_h,
+        cd_h,
+        ent_h,
+        final_h,
+    )
+
+    # Pin to the canonical PyTorch reference numerics.
+    for i in range(ent_count):
+        assert_almost_equal(
+            ent_h.ptr[i],
+            Scalar[dtype](entering_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+    for i in range(final_count):
+        assert_almost_equal(
+            final_h.ptr[i],
+            Scalar[dtype](final_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_chunk_scan_basic() raises:
+    """Basic single-batch, single-head case against the naive reference."""
+    run_ssd_chunk_scan[DType.float32](
+        batch=1,
+        n_chunks=4,
+        n_heads=2,
+        head_dim=8,
+        state_dim=16,
+    )
+
+
+def test_ssd_chunk_scan_multi_batch() raises:
+    """Multiple batch elements and heads against the naive reference."""
+    run_ssd_chunk_scan[DType.float32](
+        batch=2,
+        n_chunks=5,
+        n_heads=3,
+        head_dim=4,
+        state_dim=8,
+    )
+
+
+def test_ssd_chunk_scan_single_chunk() raises:
+    """Degenerate single chunk (entering is all zeros, final == chunk_states).
+    """
+    run_ssd_chunk_scan[DType.float32](
+        batch=2,
+        n_chunks=1,
+        n_heads=2,
+        head_dim=4,
+        state_dim=4,
+    )
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_chunk_state.mojo
+++ b/max/kernels/test/state_space/test_ssd_chunk_state.mojo
@@ -1,0 +1,359 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from layout import Layout, LayoutTensor, RuntimeLayout
+from layout._fillers import random
+from state_space.ssd_chunk_state import ssd_chunk_state_fwd_cpu
+from std.math import exp
+from std.testing import TestSuite, assert_almost_equal
+
+from std.utils.index import Index
+
+
+def run_ssd_chunk_state[
+    dtype: DType,
+](
+    batch: Int,
+    n_chunks: Int,
+    n_heads: Int,
+    chunk_len: Int,
+    state_dim: Int,
+    head_dim: Int,
+    rtol: Float64 = 0.01,
+) raises:
+    """Test the SSD chunk-state kernel against an independent reference."""
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    # B: [batch, n_chunks, n_heads, chunk_len, state_dim]
+    var B_heap = List(length=b_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+
+    # X: [batch, n_chunks, n_heads, chunk_len, head_dim]
+    var X_heap = List(length=x_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+
+    # A: [batch, n_chunks, n_heads, chunk_len]
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+
+    # state: [batch, n_chunks, n_heads, head_dim, state_dim]
+    var state_heap = List(length=state_count, fill=Scalar[dtype](0))
+    var state_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        state_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    # Initialize inputs.
+    random(B_h)
+    random(X_h)
+    random(A_h)
+
+    # Make A negative-ish (a real SSM decays), so exp(cumsum diffs) stays
+    # bounded. `random` fills in roughly [-1, 1]; map it into a small negative
+    # range like real Mamba2 dt*A values.
+    for i in range(a_count):
+        var v = A_h.ptr[i].cast[DType.float32]()
+        # Map [-1, 1] -> [-0.6, -0.1].
+        var scaled = Float32(-0.35) + Float32(0.25) * v
+        A_h.ptr[i] = Scalar[dtype](scaled)
+
+    # Call the kernel.
+    ssd_chunk_state_fwd_cpu[
+        dtype,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        state_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        B_h,
+        X_h,
+        A_h,
+        state_h,
+    )
+
+    # Independent naive reference. Recompute strides from scratch and use a
+    # straightforward loop of the formula:
+    #   A_cumsum[l] = sum_{k<=l} A[k]
+    #   decay[l]    = exp(A_cumsum[L-1] - A_cumsum[l])
+    #   state[p,n]  = sum_l B[l,n] * decay[l] * X[l,p]
+    var ref_heap = List(length=state_count, fill=Scalar[dtype](0))
+
+    var b_h_stride = chunk_len * state_dim
+    var b_c_stride = n_heads * b_h_stride
+    var b_b_stride = n_chunks * b_c_stride
+
+    var x_h_stride = chunk_len * head_dim
+    var x_c_stride = n_heads * x_h_stride
+    var x_b_stride = n_chunks * x_c_stride
+
+    var a_h_stride = chunk_len
+    var a_c_stride = n_heads * a_h_stride
+    var a_b_stride = n_chunks * a_c_stride
+
+    var state_h_stride = head_dim * state_dim
+    var state_c_stride = n_heads * state_h_stride
+    var state_b_stride = n_chunks * state_c_stride
+
+    for b in range(batch):
+        for c in range(n_chunks):
+            for h in range(n_heads):
+                var b_base = b * b_b_stride + c * b_c_stride + h * b_h_stride
+                var x_base = b * x_b_stride + c * x_c_stride + h * x_h_stride
+                var a_base = b * a_b_stride + c * a_c_stride + h * a_h_stride
+                var state_base = (
+                    b * state_b_stride + c * state_c_stride + h * state_h_stride
+                )
+
+                # Prefix sum of A over the chunk.
+                var cumsum = List[Float32](length=chunk_len, fill=0.0)
+                var acc = Float32(0.0)
+                for l in range(chunk_len):
+                    acc += A_h.ptr[a_base + l].cast[DType.float32]()
+                    cumsum[l] = acc
+
+                var cum_end = cumsum[chunk_len - 1]
+
+                for p in range(head_dim):
+                    for n in range(state_dim):
+                        var s_acc = Float32(0.0)
+                        for l in range(chunk_len):
+                            var bv = B_h.ptr[b_base + l * state_dim + n].cast[
+                                DType.float32
+                            ]()
+                            var xv = X_h.ptr[x_base + l * head_dim + p].cast[
+                                DType.float32
+                            ]()
+                            var decay = exp(cum_end - cumsum[l])
+                            s_acc += bv * decay * xv
+                        ref_heap[state_base + p * state_dim + n] = Scalar[
+                            dtype
+                        ](s_acc)
+
+    # Compare kernel output against the reference.
+    for i in range(state_count):
+        assert_almost_equal(
+            state_h.ptr[i],
+            ref_heap[i],
+            rtol=rtol,
+        )
+
+
+def test_ssd_chunk_state_golden() raises:
+    """Golden-parity test against the canonical PyTorch SSD reference.
+
+    Pins ``ssd_chunk_state_fwd_cpu`` to a FIXED tiny input whose expected
+    output was computed independently by the chunk end-state reduction (stage 2
+    of ``ssd_minimal_discrete``).
+
+    Shapes: batch=1, n_chunks=1, n_heads=1, chunk_len L=4, state_dim N=3,
+    head_dim P=2; all tensors row-major.
+    """
+    comptime dtype = DType.float32
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_5d = Layout.row_major[5]()
+
+    comptime batch = 1
+    comptime n_chunks = 1
+    comptime n_heads = 1
+    comptime chunk_len = 4
+    comptime state_dim = 3
+    comptime head_dim = 2
+
+    # Fixed literals (row-major). These mirror the values in the parity
+    # reference; state_expected is the reference's output for these inputs.
+    var B_vals = [
+        Float32(0.74),
+        1.95,
+        -0.70,
+        -1.30,
+        -0.51,
+        -0.27,
+        0.25,
+        0.48,
+        0.45,
+        -0.96,
+        1.50,
+        -0.31,
+    ]
+    var X_vals = [
+        Float32(-0.23),
+        -1.07,
+        0.16,
+        0.12,
+        0.38,
+        -0.12,
+        0.89,
+        -0.49,
+    ]
+    var A_vals = [Float32(-0.45), -0.18, -0.36, -0.50]
+    var state_expected = [
+        Float32(-0.944955),
+        1.252577,
+        -0.133558,
+        0.106325,
+        -1.533317,
+        0.370175,
+    ]
+
+    var b_count = batch * n_chunks * n_heads * chunk_len * state_dim
+    var x_count = batch * n_chunks * n_heads * chunk_len * head_dim
+    var a_count = batch * n_chunks * n_heads * chunk_len
+    var state_count = batch * n_chunks * n_heads * head_dim * state_dim
+
+    # Build LayoutTensors from the fixed literals (not random).
+    var B_heap = List(length=b_count, fill=Scalar[dtype](0))
+    var B_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, state_dim)
+        ),
+    )
+    for i in range(b_count):
+        B_h.ptr[i] = Scalar[dtype](B_vals[i])
+
+    var X_heap = List(length=x_count, fill=Scalar[dtype](0))
+    var X_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        X_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len, head_dim)
+        ),
+    )
+    for i in range(x_count):
+        X_h.ptr[i] = Scalar[dtype](X_vals[i])
+
+    var A_heap = List(length=a_count, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        A_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_chunks, n_heads, chunk_len)
+        ),
+    )
+    for i in range(a_count):
+        A_h.ptr[i] = Scalar[dtype](A_vals[i])
+
+    var state_heap = List(length=state_count, fill=Scalar[dtype](0))
+    var state_h = LayoutTensor[dtype, layout_5d, MutAnyOrigin](
+        state_heap,
+        RuntimeLayout[layout_5d].row_major(
+            Index(batch, n_chunks, n_heads, head_dim, state_dim)
+        ),
+    )
+
+    ssd_chunk_state_fwd_cpu[
+        dtype,
+        B_h.layout,
+        X_h.layout,
+        A_h.layout,
+        state_h.layout,
+    ](
+        batch,
+        n_chunks,
+        n_heads,
+        chunk_len,
+        state_dim,
+        head_dim,
+        B_h,
+        X_h,
+        A_h,
+        state_h,
+    )
+
+    # Pin to the canonical PyTorch reference numerics.
+    for i in range(state_count):
+        assert_almost_equal(
+            state_h.ptr[i],
+            Scalar[dtype](state_expected[i]),
+            rtol=1e-3,
+            atol=1e-3,
+        )
+
+
+def test_ssd_chunk_state_basic() raises:
+    """Basic single-batch, single-chunk case."""
+    run_ssd_chunk_state[DType.float32](
+        batch=1,
+        n_chunks=1,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=16,
+        head_dim=8,
+    )
+
+
+def test_ssd_chunk_state_multi_chunk() raises:
+    """Multiple chunks and heads."""
+    run_ssd_chunk_state[DType.float32](
+        batch=1,
+        n_chunks=3,
+        n_heads=2,
+        chunk_len=16,
+        state_dim=16,
+        head_dim=8,
+    )
+
+
+def test_ssd_chunk_state_multi_batch() raises:
+    """Multiple batch elements."""
+    run_ssd_chunk_state[DType.float32](
+        batch=2,
+        n_chunks=2,
+        n_heads=2,
+        chunk_len=8,
+        state_dim=8,
+        head_dim=4,
+    )
+
+
+def test_ssd_chunk_state_chunk_len_one() raises:
+    """Degenerate chunk length of one (decay is exactly 1)."""
+    run_ssd_chunk_state[DType.float32](
+        batch=1,
+        n_chunks=2,
+        n_heads=1,
+        chunk_len=1,
+        state_dim=4,
+        head_dim=4,
+    )
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/kernels/test/state_space/test_ssd_combined_op.mojo
+++ b/max/kernels/test/state_space/test_ssd_combined_op.mojo
@@ -1,0 +1,270 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Op-registration smoke test for the `ssd_combined` MAX graph op.
+
+Numerical parity is covered by `test_ssd_combined.mojo`; this file exists to
+ensure the @extensibility.register wrapper in `selective_scan_ops.mojo` is built
+into the state_space library (a malformed @extensibility.register block fails the
+library build), and that the underlying kernel is reachable via the same
+import path the wrapper uses.
+"""
+
+from layout import (
+    Layout,
+    LayoutTensor,
+    RuntimeLayout,
+    TileTensor,
+    UNKNOWN_VALUE,
+    row_major,
+)
+from layout._fillers import random
+from state_space.selective_scan import ssd_combined_cpu
+
+# Importing the ops module ensures the @extensibility.register-decorated structs
+# are part of the build graph for the consumer of the smoke test.
+import state_space.selective_scan_ops
+
+from std.testing import TestSuite, assert_true
+from std.utils.index import Index
+
+comptime MAX_DSTATE_LOCAL = 16
+
+
+def test_ssd_combined_op_registered() raises:
+    """Smoke test: ssd_combined op + underlying CPU kernel are callable.
+
+    Constructs tiny LayoutTensor inputs, invokes the CPU implementation that
+    the registered op dispatches to, and verifies the output buffer is finite
+    (no NaN/Inf) and shape-correct. Full numerical parity lives elsewhere.
+    """
+    comptime dtype = DType.float32
+    comptime DSTATE = 8
+    var batch = 1
+    var dim = 4
+    var seqlen = 4
+    var n_groups = 1
+    var group_size = dim // n_groups
+    var chunk_size = 2048
+    var n_chunks = (seqlen + chunk_size - 1) // chunk_size
+
+    comptime layout_3d = Layout.row_major[3]()
+    comptime layout_4d = Layout.row_major[4]()
+    comptime layout_2d = Layout.row_major[2]()
+    comptime layout_1d = Layout(UNKNOWN_VALUE)
+
+    var output_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var output_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        output_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var output_tt = TileTensor(
+        output_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var x_heap = List(
+        length=batch * dim * n_chunks * 2 * DSTATE, fill=Scalar[dtype](0)
+    )
+    var x_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        x_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, dim, n_chunks, 2 * DSTATE)
+        ),
+    )
+    var x_tt = TileTensor(
+        x_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, n_chunks, 2 * DSTATE),
+    )
+
+    var out_z_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var out_z_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        out_z_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var out_z_tt = TileTensor(
+        out_z_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var residual_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var residual_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        residual_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var residual_tt = TileTensor(
+        residual_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var u_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var u_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        u_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var u_tt = TileTensor(
+        u_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var delta_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var delta_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        delta_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var delta_tt = TileTensor(
+        delta_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var A_heap = List(length=dim * DSTATE, fill=Scalar[dtype](0))
+    var A_h = LayoutTensor[dtype, layout_2d, MutAnyOrigin](
+        A_heap, RuntimeLayout[layout_2d].row_major(Index(dim, DSTATE))
+    )
+    var A_tt = TileTensor(
+        A_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(dim, DSTATE)
+    )
+
+    var B_heap = List(
+        length=batch * n_groups * DSTATE * seqlen, fill=Scalar[dtype](0)
+    )
+    var B_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        B_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_groups, DSTATE, seqlen)
+        ),
+    )
+    var B_tt = TileTensor(
+        B_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, n_groups, DSTATE, seqlen),
+    )
+
+    var C_heap = List(
+        length=batch * n_groups * DSTATE * seqlen, fill=Scalar[dtype](0)
+    )
+    var C_h = LayoutTensor[dtype, layout_4d, MutAnyOrigin](
+        C_heap,
+        RuntimeLayout[layout_4d].row_major(
+            Index(batch, n_groups, DSTATE, seqlen)
+        ),
+    )
+    var C_tt = TileTensor(
+        C_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, n_groups, DSTATE, seqlen),
+    )
+
+    var D_heap = List(length=dim, fill=Scalar[dtype](0))
+    var D_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        D_heap, RuntimeLayout[layout_1d].row_major(Index(dim))
+    )
+    var D_tt = TileTensor(
+        D_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(dim)
+    )
+
+    var z_heap = List(length=batch * dim * seqlen, fill=Scalar[dtype](0))
+    var z_h = LayoutTensor[dtype, layout_3d, MutAnyOrigin](
+        z_heap,
+        RuntimeLayout[layout_3d].row_major(Index(batch, dim, seqlen)),
+    )
+    var z_tt = TileTensor(
+        z_heap.unsafe_ptr().as_unsafe_any_origin(),
+        row_major(batch, dim, seqlen),
+    )
+
+    var delta_bias_heap = List(length=dim, fill=Scalar[dtype](0))
+    var delta_bias_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        delta_bias_heap, RuntimeLayout[layout_1d].row_major(Index(dim))
+    )
+    var delta_bias_tt = TileTensor(
+        delta_bias_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(dim)
+    )
+
+    var gamma_heap = List(length=dim, fill=Scalar[dtype](0))
+    var gamma_h = LayoutTensor[dtype, layout_1d, MutAnyOrigin](
+        gamma_heap, RuntimeLayout[layout_1d].row_major(Index(dim))
+    )
+    var gamma_tt = TileTensor(
+        gamma_heap.unsafe_ptr().as_unsafe_any_origin(), row_major(dim)
+    )
+
+    random(u_h)
+    random(delta_h)
+    random(residual_h)
+    random(A_h)
+    random(B_h)
+    random(C_h)
+    random(D_h)
+    random(z_h)
+    random(delta_bias_h)
+    random(gamma_h)
+
+    # Keep gamma positive for RMSNorm stability.
+    for i in range(dim):
+        gamma_h.ptr[i] = abs(gamma_h.ptr[i]) + Scalar[dtype](0.1)
+
+    var epsilon = Scalar[dtype](0.001)
+    var weight_offset = Scalar[dtype](0.0)
+
+    ssd_combined_cpu[
+        dtype,
+        DSTATE,
+        output_tt.LayoutType,
+        x_tt.LayoutType,
+        out_z_tt.LayoutType,
+        residual_tt.LayoutType,
+        u_tt.LayoutType,
+        delta_tt.LayoutType,
+        A_tt.LayoutType,
+        B_tt.LayoutType,
+        C_tt.LayoutType,
+        D_tt.LayoutType,
+        z_tt.LayoutType,
+        delta_bias_tt.LayoutType,
+        gamma_tt.LayoutType,
+    ](
+        batch,
+        dim,
+        seqlen,
+        group_size,
+        Int8(0),
+        output_tt,
+        x_tt,
+        out_z_tt,
+        residual_tt,
+        u_tt,
+        delta_tt,
+        A_tt,
+        B_tt,
+        C_tt,
+        D_tt,
+        z_tt,
+        delta_bias_tt,
+        gamma_tt,
+        epsilon,
+        weight_offset,
+    )
+
+    # Shape check + finite check.
+    assert_true(output_h.dim(0) == batch)
+    assert_true(output_h.dim(1) == dim)
+    assert_true(output_h.dim(2) == seqlen)
+
+    var out_size = batch * dim * seqlen
+    for i in range(out_size):
+        var v = Float32(output_h.ptr[i])
+        assert_true(v == v, "output contains NaN")
+        # Inf check: an infinite float fails (v - v) == 0.
+        assert_true((v - v) == 0.0, "output contains Inf")
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/max/python/max/pipelines/architectures/__init__.py
+++ b/max/python/max/pipelines/architectures/__init__.py
@@ -233,6 +233,7 @@ def register_all_models() -> None:
             "llama4_conditional_arch",
         ),
         _LazyArch("MambaForCausalLM", ".mamba", "mamba_arch"),
+        _LazyArch("Mamba2ForCausalLM", ".mamba2", "mamba2_arch"),
         _LazyArch("MiniMaxM2ForCausalLM", ".minimax_m2", "minimax_m2_arch"),
         _LazyArch("NemotronHForCausalLM", ".nemotron_h", "nemotron_h_arch"),
         _LazyArch("MistralForCausalLM", ".mistral", "mistral_arch"),

--- a/max/python/max/pipelines/architectures/all_arches.bzl
+++ b/max/python/max/pipelines/architectures/all_arches.bzl
@@ -47,6 +47,7 @@ ALL_ARCHITECTURES = [
     "//max/python/max/pipelines/architectures/llama3_modulev3",
     "//max/python/max/pipelines/architectures/llama4",
     "//max/python/max/pipelines/architectures/mamba",
+    "//max/python/max/pipelines/architectures/mamba2",
     "//max/python/max/pipelines/architectures/minimax_m2",
     "//max/python/max/pipelines/architectures/nemotron_h",
     "//max/python/max/pipelines/architectures/mistral",

--- a/max/python/max/pipelines/architectures/mamba2/BUILD.bazel
+++ b/max/python/max/pipelines/architectures/mamba2/BUILD.bazel
@@ -1,0 +1,11 @@
+load("//bazel:api.bzl", "modular_py_library")
+
+package(default_visibility = ["//max:consumers"])
+
+modular_py_library(
+    name = "mamba2",
+    srcs = glob(["**/*.py"]),
+    deps = [
+        "//max/python/max/graph",
+    ],
+)

--- a/max/python/max/pipelines/architectures/mamba2/BUILD.bazel
+++ b/max/python/max/pipelines/architectures/mamba2/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:api.bzl", "modular_py_library")
+load("//bazel:api.bzl", "modular_py_library", "requirement")
 
 package(default_visibility = ["//max:consumers"])
 
@@ -10,12 +10,19 @@ modular_py_library(
         "//max/python/max/nn/hooks",
     ],
     deps = [
+        requirement("numpy"),
+        requirement("transformers"),
+        requirement("typing-extensions"),
+        "//max/python/max/dtype",
         "//max/python/max/experimental",
         "//max/python/max/experimental/nn",
         "//max/python/max/graph",
+        "//max/python/max/nn",
         # Hooks added for convenience for when we want to print the model layers
         "//max/python/max/nn/hooks",
         "//max/python/max/pipelines/architectures/mamba",
+        "//max/python/max/pipelines/lib",
+        "//max/python/max/pipelines/modeling",
         "//max/python/max:tensor",
     ],
 )

--- a/max/python/max/pipelines/architectures/mamba2/BUILD.bazel
+++ b/max/python/max/pipelines/architectures/mamba2/BUILD.bazel
@@ -13,7 +13,9 @@ modular_py_library(
         requirement("numpy"),
         requirement("transformers"),
         requirement("typing-extensions"),
+        "//max/python/max/driver",
         "//max/python/max/dtype",
+        "//max/python/max/engine",
         "//max/python/max/experimental",
         "//max/python/max/experimental/nn",
         "//max/python/max/graph",
@@ -21,8 +23,12 @@ modular_py_library(
         # Hooks added for convenience for when we want to print the model layers
         "//max/python/max/nn/hooks",
         "//max/python/max/pipelines/architectures/mamba",
+        "//max/python/max/pipelines/context",
+        "//max/python/max/pipelines/kv_cache",
         "//max/python/max/pipelines/lib",
         "//max/python/max/pipelines/modeling",
+        "//max/python/max/profiler",
+        "//max/python/max/support",
         "//max/python/max:tensor",
     ],
 )

--- a/max/python/max/pipelines/architectures/mamba2/BUILD.bazel
+++ b/max/python/max/pipelines/architectures/mamba2/BUILD.bazel
@@ -5,7 +5,17 @@ package(default_visibility = ["//max:consumers"])
 modular_py_library(
     name = "mamba2",
     srcs = glob(["**/*.py"]),
+    ignore_extra_deps = [
+        # Hooks added for convenience for when we want to print the model layers
+        "//max/python/max/nn/hooks",
+    ],
     deps = [
+        "//max/python/max/experimental",
+        "//max/python/max/experimental/nn",
         "//max/python/max/graph",
+        # Hooks added for convenience for when we want to print the model layers
+        "//max/python/max/nn/hooks",
+        "//max/python/max/pipelines/architectures/mamba",
+        "//max/python/max:tensor",
     ],
 )

--- a/max/python/max/pipelines/architectures/mamba2/__init__.py
+++ b/max/python/max/pipelines/architectures/mamba2/__init__.py
@@ -14,13 +14,39 @@
 
 This package is the Python counterpart of the Mojo
 ``max/kernels/src/state_space/ssd_*`` kernels registered under the
-``ssd_chunk_scan_combined`` op name. The first deliverable exposes the
-functional-op wrapper; NN modules and the full pipeline land in later
-RFC 0003 increments.
+``ssd_chunk_scan_combined`` op name. RFC 0003 item 5 wires the full
+prefill/step pipeline:
+
+* :func:`ssd_chunk_scan_combined` — functional-op wrapper.
+* :class:`Mamba2Mixer` / :class:`Mamba2Block` — standalone NN modules.
+* :class:`Mamba2Prefill` / :class:`Mamba2Step` — compile-time MAX-graph
+  Modules consumed by the pipeline model.
+* :class:`Mamba2SSMStateCache` — per-slot conv/SSM state cache (mirrors
+  the Mamba1 :class:`SSMStateCache`).
+* :class:`Mamba2Model` / :class:`Mamba2ModelInputs` — the pipeline
+  model with prefill/step dispatch.
 """
 
+from .arch import mamba2_arch
 from .functional_ops import ssd_chunk_scan_combined
+from .mamba2 import Mamba2Block, Mamba2Mixer, mamba2_dims
+from .mamba2_module import Mamba2Prefill, Mamba2Step
+from .model import Mamba2Model, Mamba2ModelInputs
+from .model_config import Mamba2Config
+from .ssm_cache import Mamba2SSMStateCache
+from .weight_adapters import convert_mamba2_state_dict
 
 __all__ = [
+    "Mamba2Block",
+    "Mamba2Config",
+    "Mamba2Mixer",
+    "Mamba2Model",
+    "Mamba2ModelInputs",
+    "Mamba2Prefill",
+    "Mamba2SSMStateCache",
+    "Mamba2Step",
+    "convert_mamba2_state_dict",
+    "mamba2_arch",
+    "mamba2_dims",
     "ssd_chunk_scan_combined",
 ]

--- a/max/python/max/pipelines/architectures/mamba2/__init__.py
+++ b/max/python/max/pipelines/architectures/mamba2/__init__.py
@@ -1,0 +1,26 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Mamba2 state-space architecture (SSD chunk-scan path).
+
+This package is the Python counterpart of the Mojo
+``max/kernels/src/state_space/ssd_*`` kernels registered under the
+``ssd_chunk_scan_combined`` op name. The first deliverable exposes the
+functional-op wrapper; NN modules and the full pipeline land in later
+RFC 0003 increments.
+"""
+
+from .functional_ops import ssd_chunk_scan_combined
+
+__all__ = [
+    "ssd_chunk_scan_combined",
+]

--- a/max/python/max/pipelines/architectures/mamba2/arch.py
+++ b/max/python/max/pipelines/architectures/mamba2/arch.py
@@ -1,0 +1,56 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+from __future__ import annotations
+
+from max.graph.weights import WeightsFormat
+from max.pipelines.context import TextContext
+from max.pipelines.lib import SupportedArchitecture
+from max.pipelines.modeling.types import PipelineTask
+
+from . import weight_adapters
+from .batch_processor import Mamba2BatchProcessor
+from .memory_planner import Mamba2MemoryPlanner
+from .model import Mamba2Model
+from .model_config import Mamba2ArchConfig
+from .tokenizer import Mamba2Tokenizer
+
+mamba2_arch = SupportedArchitecture(
+    name="Mamba2ForCausalLM",
+    example_repo_ids=[
+        "state-spaces/mamba2-130m",
+        "state-spaces/mamba2-370m",
+        "state-spaces/mamba2-780m",
+        "state-spaces/mamba2-1.3b",
+        "state-spaces/mamba2-2.7b",
+    ],
+    default_encoding="float32",
+    supported_encodings={
+        "float32",
+        "bfloat16",
+    },
+    pipeline_model=Mamba2Model,
+    batching=Mamba2BatchProcessor,
+    tokenizer=Mamba2Tokenizer,
+    context_type=TextContext,
+    default_weights_format=WeightsFormat.safetensors,
+    multi_gpu_supported=False,
+    weight_adapters={
+        WeightsFormat.safetensors: weight_adapters.convert_mamba2_state_dict,
+    },
+    task=PipelineTask.TEXT_GENERATION,
+    config=Mamba2ArchConfig,
+    memory_planner=Mamba2MemoryPlanner,
+    supports_overlap_scheduler=False,
+    supports_device_graph_capture=False,
+)

--- a/max/python/max/pipelines/architectures/mamba2/batch_processor.py
+++ b/max/python/max/pipelines/architectures/mamba2/batch_processor.py
@@ -1,0 +1,139 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Input batching for Mamba2 pipeline models.
+
+Mirrors :mod:`max.pipelines.architectures.mamba.batch_processor`: ragged
+batching extended with the per-request SSM state slots that the step-mode
+decode graph consumes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import numpy as np
+from max.driver import Buffer
+from max.graph import BufferType, DeviceRef, TensorType
+from max.nn.kv_cache import KVCacheInputsInterface
+from max.nn.kv_cache.cache_params import KVCacheParamInterface
+from max.pipelines.context import TextContext
+from max.pipelines.lib.interfaces.batch_processor import (
+    RaggedBatchProcessor,
+    process_ragged_kv_outputs,
+    ragged_kv_symbolic_inputs,
+)
+from max.pipelines.lib.interfaces.pipeline_model import ModelOutputs
+
+if TYPE_CHECKING:
+    from .model import Mamba2ModelInputs
+    from .ssm_cache import Mamba2SSMStateCache
+
+
+class Mamba2BatchProcessor(
+    RaggedBatchProcessor[TextContext, "Mamba2ModelInputs"]
+):
+    """Ragged batching extended with per-request SSM state slots."""
+
+    _ssm_cache: Mamba2SSMStateCache | None = None
+
+    def get_symbolic_inputs(
+        self,
+        *,
+        kv_params: KVCacheParamInterface,
+        device_refs: list[DeviceRef],
+    ) -> list[TensorType | BufferType]:
+        return ragged_kv_symbolic_inputs(
+            kv_params=kv_params,
+            device_refs=device_refs,
+            include_signal_buffers=False,
+        )
+
+    def bind_ssm_cache(self, ssm_cache: Mamba2SSMStateCache) -> None:
+        """Wires the SSM state cache created during model ``__init__``."""
+        self._ssm_cache = ssm_cache
+
+    def prepare_initial_token_inputs(
+        self,
+        replica_batches: Sequence[Sequence[TextContext]],
+        kv_cache_inputs: KVCacheInputsInterface[Buffer, Buffer] | None = None,
+        return_n_logits: int = 1,
+    ) -> Mamba2ModelInputs:
+        from .model import Mamba2ModelInputs
+
+        assert self._ssm_cache is not None, (
+            "Mamba2 SSM cache must be bound before "
+            "prepare_initial_token_inputs()"
+        )
+
+        if len(replica_batches) != 1:
+            raise ValueError("Mamba2 does not support DP>1")
+
+        context_batch = replica_batches[0]
+        request_ids = [ctx.request_id for ctx in context_batch]
+
+        for rid in request_ids:
+            self._ssm_cache.claim(rid)
+
+        device0 = self.runtime.devices[0]
+
+        input_row_offsets = np.cumsum(
+            [0] + [ctx.tokens.active_length for ctx in context_batch],
+            dtype=np.uint32,
+        )
+        tokens = np.concatenate([ctx.tokens.active for ctx in context_batch])
+
+        tokens_buf = Buffer.from_numpy(tokens).to(device0)
+        offsets_buf = Buffer.from_numpy(input_row_offsets).to(device0)
+        n_logits_buf = Buffer.from_numpy(
+            np.array([return_n_logits], dtype=np.int64)
+        )
+
+        # If any request already has computed states (continuation), use
+        # step mode: SSM state is not reconstructable from tokens alone,
+        # it must be carried forward.
+        has_existing_states = any(
+            self._ssm_cache.contains(rid)
+            and self._ssm_cache.has_valid_state(rid)
+            for rid in request_ids
+        )
+
+        if has_existing_states:
+            layer_states = self._ssm_cache.get_states(request_ids)
+            inputs = Mamba2ModelInputs(
+                tokens_buf,
+                offsets_buf,
+                n_logits_buf,
+                is_prefill=False,
+                layer_states=layer_states,
+                request_ids=request_ids,
+            )
+        else:
+            inputs = Mamba2ModelInputs(
+                tokens_buf,
+                offsets_buf,
+                n_logits_buf,
+                is_prefill=True,
+                request_ids=request_ids,
+            )
+        inputs.kv_cache_inputs = kv_cache_inputs
+        return inputs
+
+    def process_outputs(
+        self, outputs: Sequence[Buffer | object]
+    ) -> ModelOutputs:
+        return process_ragged_kv_outputs(
+            outputs,
+            return_logits=self.runtime.return_logits,
+            return_hidden_states=self.runtime.return_hidden_states,
+        )

--- a/max/python/max/pipelines/architectures/mamba2/functional_ops.py
+++ b/max/python/max/pipelines/architectures/mamba2/functional_ops.py
@@ -1,0 +1,184 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Functional-op wrappers for the Mamba2 SSD chunk-scan kernels.
+
+The Mojo side registers the fused chunk-scan op under the name
+``ssd_chunk_scan_combined`` in
+``max/kernels/src/state_space/ssd_chunk_combined_ops.mojo``:
+
+    @compiler.register("ssd_chunk_scan_combined")
+    struct SSDChunkScanCombined[chunk_size: Int = 256]: ...
+
+This wrapper builds the corresponding ``ops.custom`` graph node so the
+op can be composed inside a ``Graph(...)`` block. The wrapper mirrors
+the style of ``architectures.mamba.functional_ops.selective_scan_fwd``
+(``delta_softplus: Bool`` is forwarded via ``parameters={...}``), with
+``chunk_size`` taking the same template-parameter slot.
+
+ABI (locked by RFC 0002 item 6 + final_state follow-up):
+
+* op name: ``"ssd_chunk_scan_combined"``
+* ``values=[x, dt, A, B, C]`` in exactly that order
+* two outputs in this order:
+    1. ``Y`` of shape ``[batch, seqlen, n_heads, head_dim]``
+    2. ``final_state`` of shape ``[batch, n_heads, head_dim, state_dim]`` —
+       the post-last-chunk SSM state, used to seed the step-mode SSM cache.
+  Both outputs share the dtype of the inputs.
+* compile-time ``chunk_size: Int = 256`` passed as
+  ``parameters={"chunk_size": chunk_size}``
+* assumes ``ngroups == n_heads`` (caller broadcasts otherwise)
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+from pathlib import Path
+
+from max.graph import Graph, TensorType, TensorValue, ops
+
+logger = logging.getLogger("max.pipelines.mamba2")
+
+_MODULAR_MOJO_MAX_IMPORT_PATH = "MODULAR_MOJO_MAX_IMPORT_PATH"
+
+
+@functools.cache
+def _get_state_space_paths() -> tuple[Path, ...]:
+    """Locate the ``state_space.mojoc`` kernel libraries.
+
+    Mirrors ``architectures.mamba.functional_ops._get_state_space_paths``:
+    read ``MODULAR_MOJO_MAX_IMPORT_PATH`` (set by Bazel ``mojo_deps`` and
+    by the wheel/conda packaging) and pick out the state_space artifact.
+    Results are cached since the search is paths-only.
+    """
+    import_path_env = os.environ.get(_MODULAR_MOJO_MAX_IMPORT_PATH, "")
+    if not import_path_env:
+        site_packages = Path(__file__).resolve().parents[4]
+        wheel_layout = site_packages / "modular"
+        conda_layout = site_packages.parent.parent.parent
+        for root in (wheel_layout, conda_layout):
+            mojo_lib = root / "lib" / "mojo"
+            if mojo_lib.is_dir():
+                import_path_env = str(mojo_lib)
+                break
+    if not import_path_env:
+        logger.warning(
+            "MODULAR_MOJO_MAX_IMPORT_PATH not set for mamba2.functional_ops"
+        )
+        return ()
+
+    paths: list[Path] = []
+    for entry in import_path_env.split(","):
+        if not entry.strip():
+            continue
+        entry_path = Path(entry.strip())
+        if not entry_path.is_absolute():
+            resolved = Path.cwd() / entry_path
+            if not resolved.exists():
+                resolved = entry_path
+            entry_path = resolved
+        if not entry_path.exists():
+            continue
+        if entry_path.suffix == ".mojoc":
+            if "state_space" in entry_path.name:
+                paths.append(entry_path.resolve())
+            continue
+        if entry_path.is_dir():
+            for mojoc in entry_path.rglob("*.mojoc"):
+                if "state_space" in mojoc.name and (
+                    mojoc.is_file() or mojoc.is_symlink()
+                ):
+                    paths.append(mojoc.resolve())
+    logger.info(
+        f"mamba2.functional_ops found {len(paths)} state_space paths: {paths}"
+    )
+    return tuple(paths)
+
+
+def ssd_chunk_scan_combined(
+    x: TensorValue,
+    dt: TensorValue,
+    A: TensorValue,
+    B: TensorValue,
+    C: TensorValue,
+    chunk_size: int = 256,
+    custom_extensions: tuple[Path, ...] | None = None,
+) -> tuple[TensorValue, TensorValue]:
+    """Mamba2 SSD chunk-scan combined op (prefill, full sequence).
+
+    Builds an ``ops.custom("ssd_chunk_scan_combined", ...)`` node that
+    invokes the fused four-stage SSD chunk-scan kernel registered in
+    ``max/kernels/src/state_space/ssd_chunk_combined_ops.mojo``.
+
+    Args:
+        x: Input projection of shape ``(batch, seqlen, n_heads, head_dim)``.
+        dt: Per-token time-step of shape ``(batch, seqlen, n_heads)``.
+        A: Diagonal state-decay vector of shape ``(n_heads,)``.
+        B: Input projection of shape
+            ``(batch, seqlen, n_heads, state_dim)``. The kernel assumes
+            ``ngroups == n_heads``; callers with fewer groups must
+            broadcast before calling.
+        C: Output projection of shape
+            ``(batch, seqlen, n_heads, state_dim)``.
+        chunk_size: Tokens per chunk for the chunked scan. Must divide
+            ``seqlen`` evenly. Forwarded as the compile-time parameter
+            ``SSDChunkScanCombined[chunk_size=...]``. Defaults to ``256``
+            to match upstream Mamba2 prefill.
+        custom_extensions: Optional paths to ``state_space.mojoc``
+            kernel libraries. ``None`` triggers auto-discovery from
+            ``MODULAR_MOJO_MAX_IMPORT_PATH`` (Bazel/wheel/conda layouts).
+
+    Returns:
+        ``(Y, final_state)`` where:
+
+        * ``Y`` is the prefill output of shape
+          ``(batch, seqlen, n_heads, head_dim)``.
+        * ``final_state`` is the post-last-chunk SSM state of shape
+          ``(batch, n_heads, head_dim, state_dim)`` — caller passes this
+          into the step-mode SSM cache so decode picks up where prefill
+          left off.
+
+        Both share the dtype and device of ``x``.
+    """
+    if custom_extensions is None:
+        custom_extensions = _get_state_space_paths()
+
+    # Register the kernel library with the current Graph so ops.custom can
+    # resolve ``ssd_chunk_scan_combined``. ``_import_kernels`` is a no-op
+    # if the path is already loaded.
+    if custom_extensions:
+        Graph.current._import_kernels(list(custom_extensions))
+
+    y_type = TensorType(dtype=x.dtype, shape=x.shape, device=x.device)
+
+    # final_state shape: [batch, n_heads, head_dim, state_dim]. State dim is
+    # B's last axis; head_dim is x's last axis; n_heads is x's third axis.
+    batch_dim = x.shape[0]
+    n_heads_dim = x.shape[2]
+    head_dim = x.shape[3]
+    state_dim = B.shape[3]
+    final_state_type = TensorType(
+        dtype=x.dtype,
+        shape=[batch_dim, n_heads_dim, head_dim, state_dim],
+        device=x.device,
+    )
+
+    results = ops.custom(
+        "ssd_chunk_scan_combined",
+        device=x.device,
+        values=[x, dt, A, B, C],
+        out_types=[y_type, final_state_type],
+        parameters={"chunk_size": int(chunk_size)},
+    )
+    return results[0].tensor, results[1].tensor

--- a/max/python/max/pipelines/architectures/mamba2/mamba2.py
+++ b/max/python/max/pipelines/architectures/mamba2/mamba2.py
@@ -1,0 +1,433 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Mamba2 NN modules (mixer + block).
+
+Mirrors :mod:`max.pipelines.architectures.mamba.mamba_module` for the
+SSD-based Mamba2 architecture. The mixer composes:
+
+* a single fused ``in_proj`` matmul producing ``zxbcdt``
+* a depthwise causal-conv1d on the ``xBC`` slice (reuses the Mamba1
+  ``causal_conv1d`` wrapper which is registered in the shared
+  ``state_space`` kernel package)
+* the chunk-scan-combined SSD op
+  (:func:`mamba2.functional_ops.ssd_chunk_scan_combined`)
+* a SiLU gate from ``z``, an RMSNorm on the mixer output, and the
+  ``out_proj`` matmul.
+
+Reference: ``mamba_ssm.modules.mamba2.Mamba2`` (non-tensor-parallel
+branch with ``rmsnorm=True`` and ``use_mem_eff_path=False``). We pick
+that branch because (a) it uses the same fused ``mamba_chunk_scan_combined``
+op our SSD kernels target, and (b) it matches the Phase-1 shape
+conventions in :mod:`...mamba.mamba_module`.
+
+Shape conventions / constraints:
+
+* ``ngroups == nheads`` (matches the kernel ABI documented in
+  :mod:`.functional_ops`; the reference allows ``ngroups < nheads``
+  but the kernel assumes the broadcast has already happened).
+* Token-major input ``u: (batch, seqlen, hidden)`` rather than the
+  Phase-1 ``(seqlen, hidden)`` flat layout, because the SSD op
+  signature is token-major.
+
+The runtime kernel-package loader is currently blocked upstream — see
+``proposed/approvals/causal_conv1d_ops-tuple-shape-bug.md`` — so this
+module is shipped without an end-to-end smoke test. A construction-only
+test (no compile / no execute) will land alongside the integration task
+once the loader fix unblocks both Mamba1 and Mamba2.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import cast as typing_cast
+
+from max.experimental import functional as F
+from max.experimental.nn import Module
+from max.experimental.nn.linear import Linear
+from max.experimental.nn.norm import RMSNorm, rms_norm
+from max.experimental.tensor import Tensor
+
+from ..mamba.functional_ops import causal_conv1d, rms_norm_fused_residual
+from .functional_ops import ssd_chunk_scan_combined
+
+
+def _silu(x: Tensor) -> Tensor:
+    """SiLU activation as a plain ``Tensor -> Tensor`` callable.
+
+    ``max.experimental.functional.silu`` returns a ``Tensor`` already;
+    this thin wrapper is only here to give the call site a stable name
+    matching the reference (``F.silu(z) * y``). The cast is defensive:
+    some functional ops in the experimental namespace are typed as
+    ``Tensor | Any`` due to dispatch-engine generics.
+    """
+    return typing_cast(Tensor, F.silu(x))
+
+
+class Mamba2Mixer(Module[[Tensor], Tensor]):
+    """Mamba2 SSD mixer (prefill-only path).
+
+    Forward signature: ``u: (batch, seqlen, d_model) -> (batch, seqlen, d_model)``.
+
+    Weights:
+
+    * ``in_proj``: ``Linear(d_model, d_in_proj)`` where
+      ``d_in_proj = 2*d_inner + 2*ngroups*d_state + nheads``.
+    * ``out_proj``: ``Linear(d_inner, d_model)``.
+    * ``conv1d_weight``: depthwise conv weight of shape
+      ``(conv_dim, d_conv)`` with ``conv_dim = d_inner + 2*ngroups*d_state``.
+    * ``conv1d_bias``: optional bias of shape ``(conv_dim,)``.
+    * ``A_log``: log-space diagonal state-decay of shape ``(nheads,)``.
+      ``A = -exp(A_log)`` is computed lazily.
+    * ``dt_bias``: per-head time-step bias of shape ``(nheads,)``. The
+      SSD op does its own softplus, but the bias is added before the
+      kernel by the reference; we follow the same convention by adding
+      it to ``dt`` prior to calling :func:`ssd_chunk_scan_combined`.
+    * ``D``: per-head skip-connection coefficient of shape ``(nheads,)``.
+      Not consumed by the current SSD kernel (the wrapper does not
+      forward ``D``); we hold the weight so the same state_dict loads
+      cleanly and so a future kernel-level pass-through is a no-op for
+      callers.
+    * ``norm``: :class:`RMSNorm` over the mixer-output channel dim
+      (``d_inner``).
+    """
+
+    in_proj: Linear
+    out_proj: Linear
+    conv1d_weight: Tensor
+    A_log: Tensor
+    dt_bias: Tensor
+    D: Tensor
+    norm: RMSNorm
+
+    def __init__(
+        self,
+        d_model: int,
+        *,
+        d_state: int = 128,
+        d_conv: int = 4,
+        expand: int = 2,
+        headdim: int = 64,
+        ngroups: int | None = None,
+        chunk_size: int = 256,
+        use_bias: bool = False,
+        use_conv_bias: bool = True,
+        rms_norm_eps: float = 1e-5,
+    ) -> None:
+        d_inner = expand * d_model
+        if d_inner % headdim != 0:
+            raise ValueError(
+                f"d_inner ({d_inner}) must be divisible by headdim ({headdim})"
+            )
+        nheads = d_inner // headdim
+        # Kernel ABI assumption (see functional_ops.py): ngroups == nheads.
+        # Default to nheads when caller leaves it unspecified.
+        if ngroups is None:
+            ngroups = nheads
+        if ngroups != nheads:
+            raise ValueError(
+                "Mamba2Mixer currently requires ngroups == nheads "
+                f"(got ngroups={ngroups}, nheads={nheads}); the SSD kernel "
+                "does not yet handle ngroups < nheads broadcast internally."
+            )
+
+        d_in_proj = 2 * d_inner + 2 * ngroups * d_state + nheads
+        conv_dim = d_inner + 2 * ngroups * d_state
+
+        self._d_model = d_model
+        self._d_state = d_state
+        self._d_conv = d_conv
+        self._d_inner = d_inner
+        self._headdim = headdim
+        self._nheads = nheads
+        self._ngroups = ngroups
+        self._chunk_size = chunk_size
+        self._conv_dim = conv_dim
+        self._rms_norm_eps = rms_norm_eps
+        self._use_conv_bias = use_conv_bias
+
+        self.in_proj = Linear(d_model, d_in_proj, bias=use_bias)
+        self.out_proj = Linear(d_inner, d_model, bias=use_bias)
+
+        self.conv1d_weight = Tensor.zeros([conv_dim, d_conv])
+        if use_conv_bias:
+            self.conv1d_bias: Tensor | None = Tensor.zeros([conv_dim])
+        else:
+            self.conv1d_bias = None
+
+        self.A_log = Tensor.zeros([nheads])
+        self.dt_bias = Tensor.zeros([nheads])
+        self.D = Tensor.zeros([nheads])
+        self.norm = RMSNorm(d_inner, eps=rms_norm_eps)
+
+    # -- properties -----------------------------------------------------
+
+    @property
+    def d_model(self) -> int:
+        """Hidden width of the residual stream."""
+        return self._d_model
+
+    @property
+    def d_inner(self) -> int:
+        """Per-head channel sum (``expand * d_model``)."""
+        return self._d_inner
+
+    @property
+    def nheads(self) -> int:
+        """Number of SSM heads."""
+        return self._nheads
+
+    @property
+    def d_state(self) -> int:
+        """SSM state width."""
+        return self._d_state
+
+    # -- forward --------------------------------------------------------
+
+    def _get_A(self) -> Tensor:
+        """Compute ``A = -exp(A_log)`` from the log-space weight."""
+        return -F.exp(self.A_log)
+
+    def forward(self, u: Tensor) -> Tensor:
+        """Run the Mamba2 SSD mixer on a full prefill sequence.
+
+        Args:
+            u: Input of shape ``(batch, seqlen, d_model)``.
+
+        Returns:
+            Mixer output of shape ``(batch, seqlen, d_model)``.
+        """
+        batch = u.shape[0]
+        seqlen = u.shape[1]
+        d_inner = self._d_inner
+        nheads = self._nheads
+        ngroups = self._ngroups
+        d_state = self._d_state
+        headdim = self._headdim
+
+        # 1) Fused input projection: (B, L, d_model) -> (B, L, d_in_proj).
+        zxbcdt = self.in_proj(u)
+
+        # 2) Split along the last axis into z, xBC, dt.
+        #    Order matches the reference's non-mem-eff path
+        #    (without ``d_mlp``): [z, xBC, dt].
+        z_raw, xBC_raw, dt_raw = F.split(
+            zxbcdt,
+            [d_inner, d_inner + 2 * ngroups * d_state, nheads],
+            axis=-1,
+        )
+        z = typing_cast(Tensor, z_raw)
+        xBC = typing_cast(Tensor, xBC_raw)
+        dt = typing_cast(Tensor, dt_raw)
+
+        # 3) Depthwise causal conv1d over xBC. The wrapper expects
+        #    ``(batch, channels, seqlen)`` so we permute, run, permute
+        #    back. Activation "silu" matches the reference default.
+        xBC_bcs = xBC.permute([0, 2, 1])  # (B, conv_dim, L)
+        xBC_bcs = causal_conv1d(
+            xBC_bcs,
+            self.conv1d_weight,
+            bias=self.conv1d_bias,
+            activation="silu",
+        )
+        xBC_post = xBC_bcs.permute([0, 2, 1])  # (B, L, conv_dim)
+
+        # 4) Split xBC into x, B, C.
+        x_raw, B_raw, C_raw = F.split(
+            xBC_post,
+            [d_inner, ngroups * d_state, ngroups * d_state],
+            axis=-1,
+        )
+        x = typing_cast(Tensor, x_raw)
+        B = typing_cast(Tensor, B_raw)
+        C = typing_cast(Tensor, C_raw)
+
+        # 5) Reshape for the SSD op.
+        #    x: (B, L, d_inner) -> (B, L, nheads, headdim).
+        #    B, C: (B, L, ngroups*d_state) -> (B, L, ngroups, d_state).
+        #    With ngroups == nheads (enforced in __init__), B/C broadcast
+        #    1:1 to the per-head shape the kernel expects.
+        x4 = F.reshape(x, [batch, seqlen, nheads, headdim])
+        B4 = F.reshape(B, [batch, seqlen, ngroups, d_state])
+        C4 = F.reshape(C, [batch, seqlen, ngroups, d_state])
+
+        # Add dt_bias before passing to the kernel. The reference
+        # ``mamba_chunk_scan_combined`` consumes ``dt_bias`` directly,
+        # but our op wrapper doesn't expose a bias slot — instead we
+        # fold the bias here. The kernel itself applies softplus
+        # internally per the RFC 0002 ABI lock.
+        dt_with_bias = dt + self.dt_bias
+
+        A = self._get_A()
+
+        # 6) Run the SSD chunk-scan combined op. The wrapper takes
+        #    ``TensorValue`` directly (it uses the lower-level
+        #    ``ops.custom`` interface), so we bridge from the experimental
+        #    ``Tensor`` view via ``__tensorvalue__`` / ``from_graph_value``.
+        y, _final_state = ssd_chunk_scan_combined(
+            x=x4.__tensorvalue__(),
+            dt=dt_with_bias.__tensorvalue__(),
+            A=A.__tensorvalue__(),
+            B=B4.__tensorvalue__(),
+            C=C4.__tensorvalue__(),
+            chunk_size=self._chunk_size,
+        )
+        y_tensor = Tensor.from_graph_value(y)
+
+        # 7) Gate by SiLU(z). Reference path with ``rmsnorm=True`` passes
+        #    ``z=None`` to the kernel and instead applies ``norm(y, z)``
+        #    (gated RMSNorm) afterward. We approximate that by:
+        #      y_gated = y * silu(z)  (per-channel gate, then norm)
+        #    which matches the un-gated-RMSNorm fallback the reference
+        #    uses when ``rmsnorm=False`` and ``z`` is passed into the
+        #    kernel. Faithful gated-RMSNorm needs a separate kernel and
+        #    is left to a follow-up RFC item (parity tracker).
+        y_flat = F.reshape(y_tensor, [batch, seqlen, d_inner])
+        z_gate = _silu(z)
+        y_gated = y_flat * z_gate
+
+        # 8) RMSNorm over the channel axis, then out_proj.
+        y_norm = self.norm(y_gated)
+        out = self.out_proj(y_norm)
+        return typing_cast(Tensor, out)
+
+
+class Mamba2Block(Module[[Tensor, Tensor], tuple[Tensor, Tensor]]):
+    """Mamba2 block: ``RMSNorm(u + residual) -> Mamba2Mixer -> (out, residual)``.
+
+    Mirrors the carry convention from :mod:`...mamba.mamba_module` so
+    stacked blocks can keep accumulating the residual stream:
+
+    * On the very first block, ``residual`` is conventionally the
+      pre-embedding hidden state (so ``u + residual`` is just ``u +
+      embedding``); downstream wiring decides whether to seed
+      ``residual`` to zero or to a copy of ``u``.
+    * On every subsequent block, ``residual`` is the carry returned by
+      the previous block (``u_prev + residual_prev``), which means the
+      norm runs on the fully-accumulated stream and the mixer reads from
+      that normalized view.
+
+    Forward returns ``(mixer_out, u + residual)`` so the next block can
+    keep the chain going.
+    """
+
+    norm: RMSNorm
+    mixer: Mamba2Mixer
+
+    def __init__(
+        self,
+        d_model: int,
+        *,
+        d_state: int = 128,
+        d_conv: int = 4,
+        expand: int = 2,
+        headdim: int = 64,
+        ngroups: int | None = None,
+        chunk_size: int = 256,
+        use_bias: bool = False,
+        use_conv_bias: bool = True,
+        rms_norm_eps: float = 1e-5,
+        residual_in_fp32: bool = False,
+        fused_residual: bool = True,
+    ) -> None:
+        self.norm = RMSNorm(d_model, eps=rms_norm_eps)
+        self.mixer = Mamba2Mixer(
+            d_model,
+            d_state=d_state,
+            d_conv=d_conv,
+            expand=expand,
+            headdim=headdim,
+            ngroups=ngroups,
+            chunk_size=chunk_size,
+            use_bias=use_bias,
+            use_conv_bias=use_conv_bias,
+            rms_norm_eps=rms_norm_eps,
+        )
+        self._rms_norm_eps = rms_norm_eps
+        self._residual_in_fp32 = residual_in_fp32
+        self._fused_residual = fused_residual
+
+    def forward(self, u: Tensor, residual: Tensor) -> tuple[Tensor, Tensor]:
+        """Apply norm-then-mixer with a residual carry.
+
+        Args:
+            u: New token-major hidden state from the previous mixer
+                output, shape ``(batch, seqlen, d_model)``.
+            residual: Accumulated residual stream from upstream blocks,
+                same shape as ``u``.
+
+        Returns:
+            ``(mixer_out, new_residual)`` where ``new_residual = u +
+            residual`` so a stack of blocks can chain without re-summing.
+        """
+        if self._fused_residual:
+            # rms_norm_fused_residual returns (normed, updated_residual)
+            # and matches the Phase-1 convention exactly.
+            normed, new_residual = rms_norm_fused_residual(
+                u,
+                residual,
+                self.norm.weight,
+                self._rms_norm_eps,
+            )
+        else:
+            new_residual = typing_cast(Tensor, u + residual)
+            normed = rms_norm(
+                new_residual, self.norm.weight, self._rms_norm_eps
+            )
+        mixer_out = self.mixer(normed)
+        return mixer_out, new_residual
+
+
+# Helper for downstream wiring: re-derive the same arithmetic the
+# reference uses (d_inner / nheads / d_in_proj / conv_dim). Kept as a
+# free function (not a method) so the model config / weight adapter
+# tasks can call it before constructing modules.
+def mamba2_dims(
+    d_model: int,
+    *,
+    d_state: int = 128,
+    expand: int = 2,
+    headdim: int = 64,
+    ngroups: int | None = None,
+) -> dict[str, int]:
+    """Derive the Mamba2 shape parameters from a config.
+
+    Returns a dict with keys ``d_inner``, ``nheads``, ``ngroups``,
+    ``d_in_proj``, ``conv_dim`` — useful for the weight adapter and
+    integration test to validate shapes without instantiating the
+    module.
+    """
+    d_inner = expand * d_model
+    if d_inner % headdim != 0:
+        raise ValueError(
+            f"d_inner ({d_inner}) must be divisible by headdim ({headdim})"
+        )
+    nheads = d_inner // headdim
+    if ngroups is None:
+        ngroups = nheads
+    d_in_proj = 2 * d_inner + 2 * ngroups * d_state + nheads
+    conv_dim = d_inner + 2 * ngroups * d_state
+    # ``math.gcd`` is only imported defensively below; surface a stable
+    # error if the caller asked for a non-divisible ngroups so config
+    # validation has a single chokepoint.
+    if math.gcd(ngroups, nheads) != min(ngroups, nheads):
+        raise ValueError(
+            f"ngroups ({ngroups}) does not divide nheads ({nheads}); "
+            "the SSD kernel currently requires ngroups == nheads."
+        )
+    return {
+        "d_inner": d_inner,
+        "nheads": nheads,
+        "ngroups": ngroups,
+        "d_in_proj": d_in_proj,
+        "conv_dim": conv_dim,
+    }

--- a/max/python/max/pipelines/architectures/mamba2/mamba2_module.py
+++ b/max/python/max/pipelines/architectures/mamba2/mamba2_module.py
@@ -1,0 +1,586 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Mamba2 prefill + step modules for the MAX-graph pipeline.
+
+Mirrors :mod:`max.pipelines.architectures.mamba.mamba_module`'s
+``MambaPrefill`` / ``MambaStep`` split for the Mamba2 SSD architecture:
+
+* :class:`Mamba2Prefill` stacks :class:`Mamba2Block` over a full-prompt
+  sequence and returns ``(logits, ssm_state_0, ..., ssm_state_{N-1})``.
+  The :func:`ssd_chunk_scan_combined` op exposes its post-last-chunk SSM
+  state as ``final_state``; the prefill module forwards each layer's
+  final state so :class:`Mamba2Model` can seed the SSM cache and the
+  subsequent step kernel picks up where prefill left off. Conv state
+  is still zero-initialised at the prefill→step boundary (the
+  ``causal_conv1d`` wrapper does not surface its rolling tail), which
+  is tracked as a separate follow-up.
+* :class:`Mamba2Step` consumes the cached per-layer ``(conv_state,
+  ssm_state)`` tuples and runs a single-token update via the existing
+  :func:`selective_scan_update` decode kernel. The kernel's
+  ``(batch, dim, dstate)`` state layout is reached by flattening
+  ``(nheads, head_dim) -> d_inner`` at the call site, and the
+  per-head Mamba2 ``A`` / ``dt_bias`` / ``D`` vectors are broadcast to
+  per-channel ``(d_inner,)`` / ``(d_inner, d_state)`` before calling.
+
+Both modules share the same weight namespace as the standalone
+:class:`Mamba2Block` so the existing weight adapter (item 4) loads
+unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import cast as typing_cast
+
+from max.dtype import DType
+from max.experimental import functional as F
+from max.experimental.nn import Module
+from max.experimental.nn.embedding import Embedding
+from max.experimental.nn.linear import Linear
+from max.experimental.nn.norm import RMSNorm, rms_norm
+from max.experimental.nn.sequential import ModuleList
+from max.experimental.tensor import Tensor
+
+from ..mamba.functional_ops import (
+    causal_conv1d,
+    causal_conv1d_update,
+    rms_norm_fused_residual,
+    selective_scan_update,
+)
+from .functional_ops import ssd_chunk_scan_combined
+from .model_config import Mamba2Config
+
+
+def _silu(x: Tensor) -> Tensor:
+    """SiLU as a plain ``Tensor -> Tensor`` callable (matches mamba2.py)."""
+    return typing_cast(Tensor, F.silu(x))
+
+
+def _softplus(x: Tensor) -> Tensor:
+    """Stable softplus: ``relu(x) + log(1 + exp(-|x|))``.
+
+    The naive ``log(1 + exp(x))`` overflows for large positive x in float32.
+    The absolute-value form is bit-equivalent under exact arithmetic and
+    stays finite for any real input — matches the reference Mamba2 path
+    (``F.softplus(dt + dt_bias)``).
+    """
+    return typing_cast(
+        Tensor,
+        F.relu(x) + F.log(F.exp(-F.abs(x)) + 1.0),
+    )
+
+
+class _Mamba2MixerForGraph(Module[[Tensor], Tensor]):
+    """Internal mixer that exposes ``prefill()`` and ``step()`` methods.
+
+    Mirrors the weight layout and forward of :class:`Mamba2Mixer`
+    (``mamba2.mamba2``) so the same weight-adapter state dict loads here
+    unchanged. The difference is structural: this version splits prefill
+    and step into separate callables so :class:`Mamba2Prefill` and
+    :class:`Mamba2Step` can compile independently.
+    """
+
+    in_proj: Linear
+    out_proj: Linear
+    conv1d_weight: Tensor
+    A_log: Tensor
+    dt_bias: Tensor
+    D: Tensor
+    norm: RMSNorm
+
+    def __init__(self, config: Mamba2Config) -> None:
+        d_model = config.d_model
+        d_inner = config.d_inner
+        nheads = config.nheads
+        ngroups = config.ngroups
+        d_state = config.d_state
+        headdim = config.headdim
+        d_conv = config.d_conv
+        conv_dim = config.conv_dim
+        d_in_proj = config.d_in_proj
+
+        self._d_model = d_model
+        self._d_state = d_state
+        self._d_conv = d_conv
+        self._d_inner = d_inner
+        self._headdim = headdim
+        self._nheads = nheads
+        self._ngroups = ngroups
+        self._chunk_size = config.chunk_size
+        self._conv_dim = conv_dim
+        self._d_in_proj = d_in_proj
+        self._rms_norm_eps = config.rms_norm_eps
+        self._use_conv_bias = config.use_conv_bias
+
+        self.in_proj = Linear(d_model, d_in_proj, bias=config.use_bias)
+        self.out_proj = Linear(d_inner, d_model, bias=config.use_bias)
+
+        self.conv1d_weight = Tensor.zeros([conv_dim, d_conv])
+        if config.use_conv_bias:
+            self.conv1d_bias: Tensor | None = Tensor.zeros([conv_dim])
+        else:
+            self.conv1d_bias = None
+
+        self.A_log = Tensor.zeros([nheads])
+        self.dt_bias = Tensor.zeros([nheads])
+        self.D = Tensor.zeros([nheads])
+        self.norm = RMSNorm(d_inner, eps=config.rms_norm_eps)
+
+    def forward(self, x: Tensor) -> Tensor:
+        raise NotImplementedError("Use prefill() or step() directly")
+
+    def _get_A(self) -> Tensor:
+        """Compute ``A = -exp(A_log)`` (per-head scalar of shape ``(nheads,)``)."""
+        return -F.exp(self.A_log)
+
+    # -- prefill --------------------------------------------------------
+
+    def prefill(self, u: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+        """Run the Mamba2 SSD mixer over a full prefill sequence.
+
+        Args:
+            u: ``(batch, seqlen, d_model)`` — token-major hidden states.
+
+        Returns:
+            ``(output, final_conv_state, final_ssm_state)`` where:
+
+            * ``output`` is ``(batch, seqlen, d_model)`` — mixer output.
+            * ``final_conv_state`` is ``(batch, conv_dim, d_conv-1)`` — the
+              last ``d_conv-1`` pre-conv xBC tokens, in the layout the
+              decode kernel's rolling conv state expects.
+            * ``final_ssm_state`` is
+              ``(batch, nheads, head_dim, d_state)`` — the post-last-chunk
+              SSM state surfaced by ``ssd_chunk_scan_combined``. Caller
+              writes both into the per-slot cache so step-mode decode
+              picks up where prefill left off.
+        """
+        batch = u.shape[0]
+        seqlen = u.shape[1]
+        d_inner = self._d_inner
+        nheads = self._nheads
+        ngroups = self._ngroups
+        d_state = self._d_state
+        headdim = self._headdim
+        d_conv = self._d_conv
+
+        zxbcdt = self.in_proj(u)
+        z_raw, xBC_raw, dt_raw = F.split(
+            zxbcdt,
+            [d_inner, d_inner + 2 * ngroups * d_state, nheads],
+            axis=-1,
+        )
+        z = typing_cast(Tensor, z_raw)
+        xBC = typing_cast(Tensor, xBC_raw)
+        dt = typing_cast(Tensor, dt_raw)
+
+        # Causal conv1d wrapper expects (batch, channels, seqlen).
+        xBC_bcs = xBC.permute([0, 2, 1])
+
+        # Slice the last ``d_conv - 1`` pre-conv tokens off the input as the
+        # rolling conv state for the next step. The decode kernel
+        # (``causal_conv1d_update``) expects ``[batch, conv_dim, d_conv-1]``
+        # of *pre-conv, pre-activation* history — exactly a tail slice of
+        # the prefill conv input. Padding for ``seqlen < d_conv-1`` is not
+        # required: the embedding context always has at least ``d_conv``
+        # tokens for any non-degenerate prompt.
+        final_conv_state = xBC_bcs[:, :, seqlen - (d_conv - 1) :]
+
+        xBC_bcs = causal_conv1d(
+            xBC_bcs,
+            self.conv1d_weight,
+            bias=self.conv1d_bias,
+            activation="silu",
+        )
+        xBC_post = xBC_bcs.permute([0, 2, 1])  # (B, L, conv_dim)
+
+        x_raw, B_raw, C_raw = F.split(
+            xBC_post,
+            [d_inner, ngroups * d_state, ngroups * d_state],
+            axis=-1,
+        )
+        x = typing_cast(Tensor, x_raw)
+        B = typing_cast(Tensor, B_raw)
+        C = typing_cast(Tensor, C_raw)
+
+        x4 = F.reshape(x, [batch, seqlen, nheads, headdim])
+        B4 = F.reshape(B, [batch, seqlen, ngroups, d_state])
+        C4 = F.reshape(C, [batch, seqlen, ngroups, d_state])
+        # Discretization gate: reference Mamba2 applies softplus(dt + dt_bias)
+        # before the SSD scan so dt is strictly positive. The raw additive
+        # form was a known-incorrect approximation.
+        dt_with_bias = _softplus(dt + self.dt_bias)
+
+        A = self._get_A()
+
+        # The SSD kernel requires ``seqlen % chunk_size == 0``. Pad with
+        # zeros along the seqlen axis so any prompt length is admissible.
+        # Padding ``dt_with_bias`` with zeros makes the SSM scan a no-op
+        # at the padded positions (X_disc = x*dt = 0, A_disc = A*dt = 0,
+        # decay = exp(0) = 1, so ``final_state`` is exactly the state at
+        # the real last token). Y at padded positions is discarded by the
+        # post-op slice below; final_state passes through untouched.
+        chunk_size = self._chunk_size
+        padded_seqlen = ((seqlen + chunk_size - 1) // chunk_size) * chunk_size
+        pad_len = padded_seqlen - seqlen
+
+        zero_scalar = typing_cast(
+            Tensor, F.constant(0.0, dtype=x4.dtype, device=x4.device)
+        )
+        x_pad = F.broadcast_to(zero_scalar, [batch, pad_len, nheads, headdim])
+        dt_pad = F.broadcast_to(zero_scalar, [batch, pad_len, nheads])
+        B_pad = F.broadcast_to(zero_scalar, [batch, pad_len, ngroups, d_state])
+        C_pad = F.broadcast_to(zero_scalar, [batch, pad_len, ngroups, d_state])
+        x4_p = F.concat([x4, x_pad], axis=1)
+        dt_p = F.concat([dt_with_bias, dt_pad], axis=1)
+        B4_p = F.concat([B4, B_pad], axis=1)
+        C4_p = F.concat([C4, C_pad], axis=1)
+
+        y, final_state = ssd_chunk_scan_combined(
+            x=x4_p.__tensorvalue__(),
+            dt=dt_p.__tensorvalue__(),
+            A=A.__tensorvalue__(),
+            B=B4_p.__tensorvalue__(),
+            C=C4_p.__tensorvalue__(),
+            chunk_size=chunk_size,
+        )
+        y_padded = Tensor.from_graph_value(y)
+        # Slice y back to the original seqlen so downstream shapes
+        # (gate, RMSNorm, out_proj) see the real length.
+        y_tensor = y_padded[:, :seqlen, :, :]
+        final_state_tensor = Tensor.from_graph_value(final_state)
+
+        # D skip-connection: reference adds ``D * x`` to y per head before the
+        # gate/norm. ``D`` is per-head ``(nheads,)``; broadcast over ``(B, L,
+        # H, P)``. The kernel does not consume ``D`` yet; applying here keeps
+        # the per-head semantic correct.
+        D_b = F.reshape(self.D, [1, 1, nheads, 1])
+        y_with_D = y_tensor + D_b * x4
+
+        y_flat = F.reshape(y_with_D, [batch, seqlen, d_inner])
+
+        # Gate then RMSNorm then out_proj — matches the reference's
+        # ``RMSNormGated(..., norm_before_gate=False)`` semantics, which is
+        # algorithmically ``rms_norm(y * silu(z))``. The reference fuses
+        # the gate * norm * silu pass for performance and upcasts to fp32
+        # internally; we keep the unfused form here and accept the small
+        # bf16 precision delta.
+        z_gate = _silu(z)
+        y_gated = y_flat * z_gate
+        y_norm = self.norm(y_gated)
+        out = typing_cast(Tensor, self.out_proj(y_norm))
+        return out, final_conv_state, final_state_tensor
+
+    # -- step -----------------------------------------------------------
+
+    def step(
+        self,
+        u: Tensor,
+        conv_state: Tensor,
+        ssm_state: Tensor,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """Single-token Mamba2 SSD update using cached states.
+
+        Args:
+            u: ``(batch, d_model)`` — newest token hidden state.
+            conv_state: ``(batch, conv_dim, d_conv - 1)`` — rolling
+                pre-conv history for the xBC slot.
+            ssm_state: ``(batch, nheads, head_dim, d_state)`` — per-head
+                SSM state. Reshaped to ``(batch, d_inner, d_state)``
+                before calling :func:`selective_scan_update`, then
+                reshaped back on return so the cache layout stays the
+                Mamba2-native per-head one.
+
+        Returns:
+            ``(output, updated_conv_state, updated_ssm_state)`` with the
+            same shapes as the inputs (mixer output is
+            ``(batch, d_model)``).
+        """
+        batch = u.shape[0]
+        d_inner = self._d_inner
+        nheads = self._nheads
+        ngroups = self._ngroups
+        d_state = self._d_state
+        headdim = self._headdim
+        conv_dim = self._conv_dim
+
+        # 1) in_proj on a single token.
+        zxbcdt = self.in_proj(u)
+        z_raw, xBC_raw, dt_raw = F.split(
+            zxbcdt,
+            [d_inner, d_inner + 2 * ngroups * d_state, nheads],
+            axis=-1,
+        )
+        z = typing_cast(Tensor, z_raw)  # (B, d_inner)
+        xBC = typing_cast(Tensor, xBC_raw)  # (B, conv_dim)
+        dt = typing_cast(Tensor, dt_raw)  # (B, nheads)
+
+        # 2) Causal conv1d update. Wrapper expects
+        # (batch, channels, 1) input.
+        xBC_3d = F.reshape(xBC, [batch, conv_dim, 1])
+        x_conv, updated_conv = causal_conv1d_update(
+            xBC_3d,
+            conv_state,
+            self.conv1d_weight,
+            bias=self.conv1d_bias,
+            activation="silu",
+        )
+        # Drop the singleton seq dim -> (B, conv_dim).
+        x_flat_conv = F.reshape(x_conv, [batch, conv_dim])
+
+        # 3) Split conv-updated xBC into x, B, C.
+        x_raw, B_raw, C_raw = F.split(
+            x_flat_conv,
+            [d_inner, ngroups * d_state, ngroups * d_state],
+            axis=-1,
+        )
+        x_flat = typing_cast(Tensor, x_raw)  # (B, d_inner)
+        B_lin = typing_cast(Tensor, B_raw)  # (B, ngroups*d_state)
+        C_lin = typing_cast(Tensor, C_raw)  # (B, ngroups*d_state)
+
+        B_g = F.reshape(B_lin, [batch, ngroups, d_state])
+        C_g = F.reshape(C_lin, [batch, ngroups, d_state])
+
+        # 4) Broadcast per-head Mamba2 weights to the per-channel layout
+        #    that ``selective_scan_update`` expects.
+        #
+        #    The kernel signature is documented in
+        #    ``selective_scan_ops.mojo``: state (batch, dim, dstate),
+        #    A (dim, dstate), dt (batch, dim), D (dim,), z (batch, dim).
+        #    Mamba2 stores ``A_log`` / ``dt_bias`` / ``D`` as
+        #    ``(nheads,)`` and the SSM state as
+        #    ``(batch, nheads, head_dim, d_state)``. With
+        #    ``ngroups == nheads`` (enforced upstream), the kernel's
+        #    ``group_size = dim // n_groups`` works out to ``headdim``
+        #    which is exactly what we want.
+        #
+        #    Broadcast pattern:
+        #      A:       (nheads,)        -> (nheads, 1, 1)   -> (d_inner, d_state)
+        #      dt_bias: (nheads,)        -> (1, nheads, 1)   -> (B, d_inner)
+        #      D:       (nheads,)        -> (1, nheads, 1)   -> (B, d_inner)  [bias slot]
+        #      dt:      (B, nheads)      -> (B, nheads, 1)   -> (B, d_inner)
+        #    The repeats are along the per-head ``headdim`` axis.
+        dt_3d = F.reshape(dt, [batch, nheads, 1])
+        dt_full = F.reshape(
+            dt_3d.broadcast_to([batch, nheads, headdim]),
+            [batch, d_inner],
+        )
+
+        A_per_head = self._get_A()  # (nheads,)
+        A_2d = F.reshape(A_per_head, [nheads, 1, 1])
+        A_full = F.reshape(
+            A_2d.broadcast_to([nheads, headdim, d_state]),
+            [d_inner, d_state],
+        )
+
+        D_3d = F.reshape(self.D, [1, nheads, 1])
+        D_full = F.reshape(
+            D_3d.broadcast_to([batch, nheads, headdim]),
+            [batch, d_inner],
+        ).cast(self.D.dtype)
+        # ``selective_scan_update`` consumes D as ``(dim,)``; the kernel
+        # iterates over the batch dim itself so for batch=1 we can just
+        # take the first row. For batch>1 every row is identical (the
+        # bias is data-independent) so a single-row slice is correct.
+        D_vec = D_full[0]  # (d_inner,)
+
+        dt_bias_3d = F.reshape(self.dt_bias, [1, nheads, 1])
+        dt_bias_full = F.reshape(
+            dt_bias_3d.broadcast_to([batch, nheads, headdim]),
+            [batch, d_inner],
+        )
+        dt_bias_vec = dt_bias_full[0]  # (d_inner,)
+
+        # 5) Flatten the per-head SSM state to the kernel layout.
+        ssm_state_2d = F.reshape(ssm_state, [batch, d_inner, d_state])
+
+        # 6) Run the existing decode kernel.
+        updated_ssm_2d, y_flat = selective_scan_update(
+            state=ssm_state_2d,
+            x=x_flat,
+            dt=dt_full,
+            A=A_full,
+            B=B_g,
+            C=C_g,
+            D=D_vec,
+            z=z,
+            dt_bias=dt_bias_vec,
+            dt_softplus=True,
+        )
+
+        # 7) Reshape SSM state back to the cache's per-head layout.
+        updated_ssm = F.reshape(
+            updated_ssm_2d, [batch, nheads, headdim, d_state]
+        )
+
+        # 8) Norm + out_proj. The mixer's ``norm`` weight lives over
+        #    ``d_inner``; we use the unfused path since we already have
+        #    the gate baked into the scan (the kernel applies ``z`` as
+        #    a gate when supplied).
+        y_norm = self.norm(y_flat)
+        out = typing_cast(Tensor, self.out_proj(y_norm))
+        return out, updated_conv, updated_ssm
+
+
+class _Mamba2LayerForGraph(Module[[Tensor], Tensor]):
+    """Pre-norm + mixer pair for a single Mamba2 block in graph land."""
+
+    norm: RMSNorm
+    mixer: _Mamba2MixerForGraph
+
+    def __init__(self, config: Mamba2Config) -> None:
+        self.norm = RMSNorm(config.d_model, eps=config.rms_norm_eps)
+        self.mixer = _Mamba2MixerForGraph(config)
+
+    def forward(self, x: Tensor) -> Tensor:
+        raise NotImplementedError("Use Mamba2Prefill / Mamba2Step")
+
+
+class _Mamba2Base(Module[[Tensor, Tensor], tuple[Tensor, ...]]):
+    """Shared weight structure for prefill and step graph modules."""
+
+    embedding: Embedding
+    layers: ModuleList[_Mamba2LayerForGraph]
+    norm: RMSNorm
+
+    def __init__(self, config: Mamba2Config) -> None:
+        self.embedding = Embedding(config.padded_vocab_size, dim=config.d_model)
+        self.layers = ModuleList(
+            [_Mamba2LayerForGraph(config) for _ in range(config.n_layer)]
+        )
+        self.norm = RMSNorm(config.d_model, eps=config.rms_norm_eps)
+        self._num_layers = config.n_layer
+        self._residual_in_fp32 = config.residual_in_fp32
+
+    def forward(self, tokens: Tensor, aux: Tensor) -> tuple[Tensor, ...]:
+        raise NotImplementedError("Use Mamba2Prefill or Mamba2Step")
+
+    def _apply_layer_norm(
+        self,
+        h: Tensor,
+        residual: Tensor,
+        norm_weight: Tensor,
+        eps: float,
+        layer_idx: int,
+    ) -> tuple[Tensor, Tensor]:
+        """Norm with fused residual after the first layer (mirrors Phase-1)."""
+        if layer_idx == 0:
+            return rms_norm(h, norm_weight, eps), h
+        if self._residual_in_fp32:
+            h_fp32 = h.cast(DType.float32)
+            res_fp32 = residual.cast(DType.float32)
+            h_normed, residual = rms_norm_fused_residual(
+                h_fp32, res_fp32, norm_weight, eps
+            )
+            return h_normed.cast(h.dtype), residual.cast(h.dtype)
+        return rms_norm_fused_residual(h, residual, norm_weight, eps)
+
+
+class Mamba2Prefill(_Mamba2Base):
+    """Prefill graph: full-sequence forward returning logits + per-layer states.
+
+    Output layout is ``(logits, conv_0, ssm_0, conv_1, ssm_1, ...)`` matching the
+    Mamba1 interleaved convention. The model wrapper writes both halves into the
+    per-slot cache so step-mode decode resumes from the exact state the prefill
+    recurrence ended on. Conv state is sliced from the last ``d_conv-1`` pre-conv
+    xBC tokens; SSM state is surfaced by ``ssd_chunk_scan_combined.final_state``.
+    """
+
+    def forward(
+        self, tokens: Tensor, input_row_offsets: Tensor
+    ) -> tuple[Tensor, ...]:
+        h = self.embedding(tokens)
+        # Add a synthetic batch axis so the mixer's (batch, seqlen, ...)
+        # shape contract holds: Mamba1 used a flat (seqlen, hidden)
+        # layout because its functional ops are batch-1 implicit; the
+        # Mamba2 SSD wrapper is explicitly batched.
+        seqlen = h.shape[0]
+        hidden = h.shape[1]
+        h = F.reshape(h, [1, seqlen, hidden])
+
+        layer_states: list[Tensor] = []
+        residual = h  # placeholder; overwritten by _apply_layer_norm.
+        for i in range(self._num_layers):
+            layer = self.layers[i]
+            h_normed, residual = self._apply_layer_norm(
+                h, residual, layer.norm.weight, layer.norm.eps, i
+            )
+            h, conv_state, ssm_state = layer.mixer.prefill(h_normed)
+            layer_states.append(conv_state)
+            layer_states.append(ssm_state)
+
+        h = h + residual
+        h = rms_norm(h, self.norm.weight, self.norm.eps)
+
+        # Drop the synthetic batch axis -> (seqlen, hidden).
+        h = F.reshape(h, [seqlen, hidden])
+
+        # Gather last-token hidden states per batch element.
+        last_indices = input_row_offsets[1:] - 1
+        last_h = F.gather(h, last_indices, axis=0)
+
+        # Tied lm_head via embedding.weight.T.
+        logits = (last_h @ self.embedding.weight.T).cast(DType.float32)
+        return (logits, *layer_states)
+
+
+class Mamba2Step(_Mamba2Base):
+    """Step graph for Mamba2: single-token update with cached states.
+
+    Forward signature: ``(tokens, *layer_states) -> (logits, *updated_states)``
+    matching :class:`max.pipelines.architectures.mamba.mamba_module.MambaStep`.
+    The layer_states list is laid out as
+    ``[conv_0, ssm_0, conv_1, ssm_1, ...]`` per Mamba1 convention.
+    """
+
+    def forward(
+        self, tokens: Tensor, *layer_states: Tensor
+    ) -> tuple[Tensor, ...]:
+        num_layers = self._num_layers
+        if len(layer_states) != 2 * num_layers:
+            raise ValueError(
+                f"Mamba2Step expected {2 * num_layers} layer state "
+                f"tensors, got {len(layer_states)}"
+            )
+        conv_states = [layer_states[2 * i] for i in range(num_layers)]
+        ssm_states = [layer_states[2 * i + 1] for i in range(num_layers)]
+
+        h = self.embedding(tokens)
+        # (batch, d_model) -> (batch, 1, d_model) so the in_proj path is
+        # symmetric with the prefill mixer's token-major layout.
+        batch = h.shape[0]
+        hidden = h.shape[1]
+        h = F.reshape(h, [batch, 1, hidden])
+
+        updated: list[Tensor] = []
+        residual = h
+        for i in range(num_layers):
+            layer = self.layers[i]
+            h_normed, residual = self._apply_layer_norm(
+                h, residual, layer.norm.weight, layer.norm.eps, i
+            )
+            # The mixer's step path consumes (batch, d_model); drop the
+            # synthetic seq axis.
+            h_normed_2d = F.reshape(h_normed, [batch, hidden])
+            out_2d, conv_s, ssm_s = layer.mixer.step(
+                h_normed_2d, conv_states[i], ssm_states[i]
+            )
+            # Re-add the synthetic seq axis for the residual chain.
+            h = F.reshape(out_2d, [batch, 1, hidden])
+            updated.append(conv_s)
+            updated.append(ssm_s)
+
+        h = h + residual
+        h = rms_norm(h, self.norm.weight, self.norm.eps)
+        h_2d = F.reshape(h, [batch, hidden])
+
+        logits = (h_2d @ self.embedding.weight.T).cast(DType.float32)
+        return (logits, *updated)

--- a/max/python/max/pipelines/architectures/mamba2/memory_planner.py
+++ b/max/python/max/pipelines/architectures/mamba2/memory_planner.py
@@ -1,0 +1,85 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Memory planner for the Mamba2 (SSD) architecture."""
+
+from __future__ import annotations
+
+from max.driver import Device
+from max.dtype import DType
+from max.pipelines.kv_cache.memory_planner import PagedMemoryPlanner
+from max.pipelines.lib.config import PipelineConfig
+from max.pipelines.modeling.config_enums import supported_encoding_dtype
+from transformers import AutoConfig
+
+from .model_config import Mamba2Config
+
+
+class Mamba2MemoryPlanner(PagedMemoryPlanner):
+    """Paged planner that also reserves the per-request SSM state pool.
+
+    Mamba2 keeps its real per-request state in
+    :class:`~.ssm_cache.Mamba2SSMStateCache`, not in the (dummy) paged KV
+    cache. Surfacing the pool size as activation memory keeps the cache
+    allocator's budget consistent with what the model actually allocates.
+    """
+
+    #: Set by :meth:`infer_max_batch_size`; consumed by
+    #: :meth:`estimate_activation_memory` when the user left
+    #: ``max_batch_size`` unset.
+    _inferred_max_batch_size: int | None = None
+
+    def infer_max_batch_size(
+        self,
+        pipeline_config: PipelineConfig,
+        devices: list[Device],
+        weights_size: int,
+    ) -> int | None:
+        inferred = super().infer_max_batch_size(
+            pipeline_config, devices, weights_size
+        )
+        self._inferred_max_batch_size = inferred
+        return inferred
+
+    def estimate_activation_memory(
+        self,
+        pipeline_config: PipelineConfig,
+        huggingface_config: AutoConfig,
+    ) -> int:
+        """Reserve GPU memory for the per-request SSM state pool.
+
+        The SSM cache holds ``num_layers`` x ``(conv_state + ssm_state)``
+        per slot:
+
+        * ``conv_state``: ``conv_dim * (d_conv - 1)`` elements
+        * ``ssm_state``:  ``nheads * head_dim * d_state`` elements
+        """
+        cfg = Mamba2Config.from_hf_config(huggingface_config)
+
+        max_batch = pipeline_config.runtime.max_batch_size
+        if max_batch is None:
+            max_batch = self._inferred_max_batch_size
+        if max_batch is None:
+            max_batch = 1
+
+        encoding = pipeline_config.model.quantization_encoding
+        state_dtype = (
+            supported_encoding_dtype(encoding)
+            if encoding is not None
+            else DType.float32
+        )
+        dtype_bytes = state_dtype.size_in_bytes
+
+        conv_state_elems = cfg.conv_dim * (cfg.d_conv - 1)
+        ssm_state_elems = cfg.nheads * cfg.headdim * cfg.d_state
+        per_layer_bytes = (conv_state_elems + ssm_state_elems) * dtype_bytes
+        return max_batch * cfg.n_layer * per_layer_bytes

--- a/max/python/max/pipelines/architectures/mamba2/model.py
+++ b/max/python/max/pipelines/architectures/mamba2/model.py
@@ -1,0 +1,432 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Pipeline-level Mamba2Model wiring (prefill + step + SSM cache).
+
+Mirrors :mod:`max.pipelines.architectures.mamba.model` for the SSD
+architecture. Key differences from Phase-1:
+
+* The SSD prefill kernel now exposes ``final_state`` alongside ``Y``;
+  :class:`Mamba2Prefill` forwards each layer's final SSM state and the
+  tail of its pre-conv xBC input as the rolling conv state, and
+  :class:`Mamba2Model.execute` seeds both halves of the per-slot cache
+  before step-mode decode runs. The conv-state slice is purely Python-side
+  (no kernel change needed) — the last ``d_conv-1`` tokens of the conv
+  input are exactly the decode kernel's expected rolling-history layout.
+* Per-slot cache shapes match the Mamba2 mixer layout
+  (``conv_state: [1, conv_dim, d_conv-1]``,
+  ``ssm_state: [1, nheads, head_dim, d_state]``).
+
+Batching (initial-token inputs, SSM slot claiming) lives in
+:class:`Mamba2BatchProcessor`; the model binds its SSM cache to the
+processor at construction, mirroring the Mamba1 wiring.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar, cast
+
+import numpy as np
+from max.driver import Buffer, Device
+from max.dtype import DType
+from max.engine import InferenceSession, Model
+from max.graph import DeviceRef
+from max.graph.weights import Weights, WeightsAdapter
+from max.nn.kv_cache import MHAKVCacheParams
+from max.nn.kv_cache.cache_params import KVCacheParamInterface
+from max.nn.transformer import ReturnHiddenStates, ReturnLogits
+from max.pipelines.context import LogProbabilities, TextContext
+from max.pipelines.lib import (
+    KVCacheConfig,
+    ModelInputs,
+    ModelOutputs,
+    PipelineConfig,
+    PipelineModelWithKVCache,
+)
+from max.pipelines.lib.log_probabilities import (
+    compute_log_probabilities_ragged,
+    log_probabilities_ragged_graph,
+)
+from max.pipelines.lib.memory_estimation import MemoryPlan
+from max.pipelines.lib.utils import parse_state_dict_from_weights
+from max.pipelines.modeling.types import RequestID
+from max.profiler import traced
+from transformers import AutoConfig
+
+from .batch_processor import Mamba2BatchProcessor
+from .functional_ops import _get_state_space_paths
+from .model_config import Mamba2ArchConfig, Mamba2Config
+from .ssm_cache import Mamba2SSMStateCache
+from .weight_adapters import convert_mamba2_state_dict
+
+logger = logging.getLogger("max.pipelines.mamba2")
+
+
+class Mamba2ModelInputs(ModelInputs):
+    """Inputs for the Mamba2 pipeline model.
+
+    Mirrors :class:`max.pipelines.architectures.mamba.model.MambaModelInputs`
+    exactly — same flag semantics, same layer_states convention
+    (``[conv_0, ssm_0, conv_1, ssm_1, ...]`` per Mamba1 ordering).
+    """
+
+    tokens: Buffer
+    input_row_offsets: Buffer
+    return_n_logits: Buffer
+    is_prefill: bool
+    layer_states: list[Buffer]
+    request_ids: list[RequestID]
+
+    def __init__(
+        self,
+        tokens: Buffer,
+        input_row_offsets: Buffer,
+        return_n_logits: Buffer,
+        is_prefill: bool = True,
+        layer_states: list[Buffer] | None = None,
+        request_ids: list[RequestID] | None = None,
+    ) -> None:
+        self.tokens = tokens
+        self.input_row_offsets = input_row_offsets
+        self.return_n_logits = return_n_logits
+        self.is_prefill = is_prefill
+        self.layer_states = layer_states or []
+        self.request_ids = request_ids or []
+
+
+class Mamba2Model(PipelineModelWithKVCache[TextContext]):
+    """Mamba2 pipeline model with incremental SSM state caching.
+
+    The model compiles two separate MAX-graph modules:
+
+    * :class:`Mamba2Prefill` — full-prompt forward, returns
+      ``(logits, conv_0, ssm_0, ..., conv_{N-1}, ssm_{N-1})``. After
+      execute, the per-layer ``(conv, ssm)`` pairs are written into the
+      cache via :meth:`Mamba2SSMStateCache.update_states` so step-mode
+      decode resumes from prefill's exact final state.
+    * :class:`Mamba2Step` — single-token forward consuming the per-slot
+      ``(conv_state, ssm_state)`` tuples and producing updated states
+      that are stored back into the cache.
+    """
+
+    model_config_cls: ClassVar[type[Any]] = Mamba2ArchConfig
+    batch_processor_cls: ClassVar[type[Mamba2BatchProcessor]] = (
+        Mamba2BatchProcessor
+    )
+
+    def __init__(
+        self,
+        pipeline_config: PipelineConfig,
+        session: InferenceSession,
+        devices: list[Device],
+        kv_cache_config: KVCacheConfig,
+        weights: Weights,
+        *,
+        memory_plan: MemoryPlan,
+        adapter: WeightsAdapter | None = None,
+        return_logits: ReturnLogits = ReturnLogits.LAST_TOKEN,
+        return_hidden_states: ReturnHiddenStates = ReturnHiddenStates.NONE,
+        max_batch_size: int = 1,
+    ) -> None:
+        super().__init__(
+            pipeline_config,
+            session,
+            devices,
+            kv_cache_config,
+            weights,
+            adapter=adapter,
+            return_logits=return_logits,
+            return_hidden_states=return_hidden_states,
+            max_batch_size=max_batch_size,
+            memory_plan=memory_plan,
+        )
+        self._prefill_model, self._step_model = self._load_models(session)
+        self._ssm_cache = self._create_ssm_cache()
+        if self._batch_processor is not None:
+            bind = getattr(self._batch_processor, "bind_ssm_cache", None)
+            if bind is not None:
+                bind(self._ssm_cache)
+        self.logprobs_device = devices[0]
+        self.logprobs_model = self._load_logprobs_model(session)
+
+        # SSM and conv state are both seeded across the prefill -> step
+        # boundary. The SSD op exposes ``final_state`` (SSM half); the
+        # conv half is sliced Python-side from the last ``d_conv - 1``
+        # pre-conv xBC tokens.
+
+    # -- cache setup ----------------------------------------------------
+
+    def _create_ssm_cache(self) -> Mamba2SSMStateCache:
+        """Pre-allocate per-slot conv/ssm state buffers from the model config."""
+        cfg = self._model_config
+        max_slots = self.max_batch_size
+        return Mamba2SSMStateCache(
+            num_layers=cfg.n_layer,
+            conv_dim=cfg.conv_dim,
+            d_conv=cfg.d_conv,
+            nheads=cfg.nheads,
+            head_dim=cfg.headdim,
+            d_state=cfg.d_state,
+            dtype=self.dtype,
+            max_slots=max_slots,
+            device=self.devices[0],
+        )
+
+    # -- interface contract ---------------------------------------------
+
+    @classmethod
+    def get_num_layers(cls, huggingface_config: AutoConfig) -> int:
+        n_layer = getattr(
+            huggingface_config, "num_hidden_layers", None
+        ) or getattr(huggingface_config, "n_layer", None)
+        if n_layer is None:
+            raise ValueError(
+                "HF config is missing both `num_hidden_layers` and `n_layer`"
+            )
+        return int(n_layer)
+
+    @classmethod
+    def get_kv_params(
+        cls,
+        huggingface_config: AutoConfig,
+        pipeline_config: PipelineConfig,
+        devices: list[DeviceRef],
+        kv_cache_config: KVCacheConfig,
+        cache_dtype: DType,
+    ) -> KVCacheParamInterface:
+        """Return minimal dummy KV cache params (SSM cache lives separately).
+
+        Mirrors Phase-1: Mamba2 uses :class:`Mamba2SSMStateCache` for the
+        real per-request state. The dummy KV params satisfy the
+        :class:`PipelineModelWithKVCache` interface with negligible
+        memory overhead so the standard scheduler keeps working.
+        """
+        return MHAKVCacheParams(
+            dtype=cache_dtype or DType.float32,
+            n_kv_heads=1,
+            head_dim=1,
+            num_layers=1,
+            devices=devices,
+            page_size=128,
+        )
+
+    # -- compilation ----------------------------------------------------
+
+    def _load_logprobs_model(self, session: InferenceSession) -> Model:
+        graph = log_probabilities_ragged_graph(
+            DeviceRef.from_device(self.logprobs_device), levels=3
+        )
+        return session.load(graph)
+
+    def _build_model_config(self) -> Mamba2Config:
+        """Bridge the HF config to a :class:`Mamba2Config`.
+
+        :class:`Mamba2Config` is a self-contained shape dataclass (it
+        doesn't subclass :class:`ArchConfigWithKVCache`), so we use its
+        :meth:`from_hf_config` loader rather than a Phase-1-style
+        ``initialize`` / ``finalize`` pair. The pipeline config's
+        ``max_length`` plumbing is honored by the registry-facing
+        :class:`Mamba2ArchConfig` (``self.arch_config``), so the shape
+        dataclass intentionally does not carry a ``max_seq_len`` field.
+        """
+        return Mamba2Config.from_hf_config(self.huggingface_config)
+
+    @traced
+    def _load_models(self, session: InferenceSession) -> tuple[Any, Any]:
+        from max.experimental import functional as F
+        from max.experimental.tensor import default_dtype
+        from max.graph import TensorType
+        from max.pipelines.lib import CompilationTimer
+
+        from .mamba2_module import Mamba2Prefill, Mamba2Step
+
+        assert self.max_batch_size, "Expected max_batch_size to be set"
+        self._input_row_offsets_prealloc = Buffer.from_numpy(
+            np.arange(
+                self.max_batch_size + 1,
+                dtype=np.uint32,
+            )
+        ).to(self.devices[0])
+
+        # Build the Mamba2 config from the HF AutoConfig. The weight
+        # adapter consumes the same dataclass so prefill and step
+        # compile against an identical view of the shapes.
+        model_config = self._build_model_config()
+        self._model_config = model_config
+
+        # Parse the safetensor state dict via the standard utility, then
+        # run it through the Mamba2 adapter so the MAX-side names match
+        # what `Mamba2Prefill` / `Mamba2Step` expect.
+        raw_state_dict = parse_state_dict_from_weights(
+            self.pipeline_config, self.weights, self.adapter
+        )
+        # The standard utility may have already invoked an adapter; if
+        # the caller didn't pass one, fall through to our adapter.
+        if self.adapter is None:
+            # raw_state_dict here is just the safetensor view — feed it
+            # through the Mamba2 adapter.
+            state_dict = convert_mamba2_state_dict(
+                cast(Any, self.weights), model_config
+            )
+        else:
+            state_dict = raw_state_dict
+
+        device0 = self.devices[0]
+        device_ref = DeviceRef(device0.label, device0.id)
+
+        # Stash shape values for step-mode TensorType construction.
+        num_layers = model_config.n_layer
+        conv_dim = model_config.conv_dim
+        d_conv = model_config.d_conv
+        nheads = model_config.nheads
+        head_dim = model_config.headdim
+        d_state = model_config.d_state
+
+        kernel_paths = list(_get_state_space_paths())
+
+        # --- Compile prefill model ---
+        tokens_type = TensorType(
+            DType.int64, shape=["total_seq_len"], device=device_ref
+        )
+        row_offsets_type = TensorType(
+            DType.uint32, shape=["row_offsets_len"], device=device_ref
+        )
+
+        with CompilationTimer("prefill") as timer:
+            with F.lazy(), default_dtype(self.dtype):
+                prefill_module = Mamba2Prefill(model_config)
+                prefill_module.to(device0)
+
+            timer.mark_build_complete()
+            prefill_model = prefill_module.compile(
+                tokens_type,
+                row_offsets_type,
+                weights=state_dict,
+                custom_extensions=kernel_paths,
+            )
+
+        # --- Compile step model ---
+        step_tokens_type = TensorType(
+            DType.int64, shape=["batch"], device=device_ref
+        )
+        layer_state_types: list[TensorType] = []
+        for _ in range(num_layers):
+            # conv_state: [batch, conv_dim, d_conv - 1]
+            layer_state_types.append(
+                TensorType(
+                    self.dtype,
+                    shape=["batch", conv_dim, d_conv - 1],
+                    device=device_ref,
+                )
+            )
+            # ssm_state: [batch, nheads, head_dim, d_state]
+            layer_state_types.append(
+                TensorType(
+                    self.dtype,
+                    shape=["batch", nheads, head_dim, d_state],
+                    device=device_ref,
+                )
+            )
+
+        with CompilationTimer("step") as timer:
+            with F.lazy(), default_dtype(self.dtype):
+                step_module = Mamba2Step(model_config)
+                step_module.to(device0)
+
+            timer.mark_build_complete()
+            step_model = step_module.compile(
+                step_tokens_type,
+                *layer_state_types,
+                weights=state_dict,
+                custom_extensions=kernel_paths,
+            )
+
+        return prefill_model, step_model
+
+    # -- execution ------------------------------------------------------
+
+    def execute(self, model_inputs: ModelInputs) -> ModelOutputs:
+        assert isinstance(model_inputs, Mamba2ModelInputs)
+
+        if model_inputs.is_prefill:
+            outputs = self._prefill_model(
+                model_inputs.tokens,
+                model_inputs.input_row_offsets,
+            )
+        else:
+            outputs = self._step_model(
+                model_inputs.tokens,
+                *model_inputs.layer_states,
+            )
+
+        # First output is logits. The remaining outputs are interleaved
+        # ``[conv_0, ssm_0, conv_1, ssm_1, ...]`` for both prefill and
+        # step paths, so a single ``update_states`` call seeds the cache
+        # in either mode.
+        logits = cast(Buffer, outputs[0].driver_tensor)
+        new_states = [s.driver_tensor for s in outputs[1:]]
+        if model_inputs.request_ids and new_states:
+            self._ssm_cache.update_states(model_inputs.request_ids, new_states)
+
+        # DEBUG(parity): dump prefill logits to disk for HF comparison.
+        import os as _os
+
+        dump_path = _os.environ.get("MAMBA2_DUMP_PREFILL_LOGITS")
+        if dump_path and model_inputs.is_prefill:
+            import numpy as _np
+
+            _np.save(dump_path, logits.to_numpy())
+            logger.info(
+                f"MAMBA2_DUMP_PREFILL_LOGITS: wrote logits shape "
+                f"{logits.to_numpy().shape} to {dump_path}"
+            )
+
+        return ModelOutputs(
+            logits=logits,
+            next_token_logits=logits,
+        )
+
+    def release(self, request_id: RequestID) -> None:
+        """Release SSM cache slot when a request completes."""
+        self._ssm_cache.release(request_id)
+
+    def compute_log_probabilities(
+        self,
+        session: InferenceSession,
+        model_inputs: ModelInputs,
+        model_outputs: ModelOutputs,
+        next_tokens: Buffer,
+        batch_top_n: list[int],
+        batch_echo: list[bool],
+    ) -> list[LogProbabilities | None]:
+        logits = model_outputs.logits
+        assert model_outputs.next_token_logits is not None
+        next_token_logits = model_outputs.next_token_logits
+
+        assert isinstance(model_inputs, Mamba2ModelInputs)
+
+        sampled_tokens = next_tokens.to_numpy()
+        tokens = model_inputs.tokens.to_numpy()
+        input_row_offsets = model_inputs.input_row_offsets.to_numpy()
+
+        return compute_log_probabilities_ragged(
+            self.logprobs_device,
+            self.logprobs_model,
+            input_row_offsets=input_row_offsets,
+            logits=logits,
+            next_token_logits=next_token_logits,
+            tokens=tokens,
+            sampled_tokens=sampled_tokens,
+            batch_top_n=batch_top_n,
+            batch_echo=batch_echo,
+        )

--- a/max/python/max/pipelines/architectures/mamba2/model_config.py
+++ b/max/python/max/pipelines/architectures/mamba2/model_config.py
@@ -1,0 +1,572 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Configuration dataclass for the Mamba2 SSD architecture.
+
+This is the minimal "shape & policy" config consumed by the Mamba2
+weight adapter and the NN modules in :mod:`.mamba2`. It deliberately
+does NOT subclass :class:`max.pipelines.lib.MAXModelConfig` /
+:class:`ArchConfigWithKVCache` — that integration lands in a later
+RFC 0003 item that wires the full pipeline (graph build + cache mgr).
+For now the dataclass is the source of truth for:
+
+* the Mamba2 reference defaults (mirrors
+  ``mamba_ssm/models/config_mamba.py``), and
+* the HF-checkpoint loader that bridges
+  :class:`transformers.Mamba2Config` (a.k.a. ``model_type="mamba2"``)
+  into our shape vocabulary.
+
+Two-name reality of "Mamba2 config" upstream:
+
+1. ``mamba_ssm.models.config_mamba.MambaConfig`` (reference repo): uses
+   ``d_model``, ``n_layer``, ``ssm_cfg`` dict for the mixer knobs
+   (``d_state``, ``d_conv``, ``expand``, ``headdim``, ``ngroups``,
+   ``chunk_size``).
+2. ``transformers.Mamba2Config``: uses ``hidden_size``,
+   ``num_hidden_layers``, and exposes the mixer knobs as flat fields
+   (``state_size``, ``conv_kernel``, ``expand``, ``head_dim``,
+   ``n_groups``, ``chunk_size``). Field naming follows HF conventions
+   (``num_heads``, ``head_dim``, ``n_groups``).
+
+:meth:`Mamba2Config.from_huggingface` accepts either flavour and emits
+a single canonical Mamba2Config.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from max.dtype import DType
+from max.graph import DeviceRef
+from max.nn.kv_cache import MHAKVCacheParams
+from max.pipelines.lib import upper_bounded_default
+from transformers import AutoConfig
+from typing_extensions import Self
+
+if TYPE_CHECKING:
+    from max.nn.kv_cache.cache_params import KVCacheParamInterface
+    from max.pipelines.lib import PipelineConfig
+    from max.pipelines.lib.config.model_config import MAXModelConfig
+
+logger_name = "max.pipelines.mamba2"
+
+# Re-derive the shape tuple from the NN module so config-time validation
+# matches what construction would do.
+from .mamba2 import mamba2_dims
+
+
+@dataclass
+class Mamba2Config:
+    """Minimal Mamba2 shape + policy config.
+
+    The fields mirror ``mamba_ssm.models.config_mamba.MambaConfig`` with
+    the mixer-specific keys pulled out of ``ssm_cfg`` into top-level
+    fields. Defaults match the reference repo so a bare
+    ``Mamba2Config(d_model=..., n_layer=..., vocab_size=...)`` produces
+    the same mixer shapes the reference uses for the 2.7B/2.8B SSM
+    checkpoints (``d_state=128, d_conv=4, expand=2, headdim=64,
+    ngroups=1, chunk_size=256``).
+
+    Constraints enforced at construction time
+    (``mamba2_dims`` chokepoint):
+
+    * ``d_inner = expand * d_model`` must be divisible by ``headdim``.
+    * ``nheads = d_inner // headdim``.
+    * ``ngroups`` must divide ``nheads`` (the SSD kernel currently
+      requires ``ngroups == nheads`` — :class:`Mamba2Mixer` enforces
+      that stricter rule; the config-level check is the looser
+      gcd-divisibility one so adapters that broadcast can still
+      construct the config).
+    """
+
+    # -- core architecture ------------------------------------------------
+    d_model: int
+    n_layer: int
+    vocab_size: int
+    pad_vocab_size_multiple: int = 8
+
+    # -- Mamba2 mixer knobs (mirrors `ssm_cfg` defaults) ------------------
+    d_state: int = 128
+    d_conv: int = 4
+    expand: int = 2
+    headdim: int = 64
+    ngroups: int = 1
+    # Original ``n_groups`` value from the source HF config, BEFORE the
+    # ``from_hf_config`` override that bumps ``ngroups`` up to ``nheads``.
+    # The weight adapter needs the original value to correctly compute
+    # the HF in_proj row layout (``2*d_mlp + 2*d_inner + 2*src_ngroups*d_state + nheads``)
+    # before broadcasting B/C to the kernel's ``ngroups == nheads`` ABI.
+    # Defaults to ``None`` for configs constructed without the HF loader;
+    # in that case the adapter falls back to ``ngroups``.
+    source_ngroups: int | None = None
+    chunk_size: int = 256
+
+    # -- normalization / dtype policy -------------------------------------
+    rms_norm_eps: float = 1e-5
+    residual_in_fp32: bool = True
+    fused_add_norm: bool = True
+    tie_embeddings: bool = True
+
+    # -- mixer toggles (not in reference config; pulled from the mixer's
+    # constructor defaults so the dataclass is the single source of truth
+    # for everything the adapter / NN module needs) ----------------------
+    use_bias: bool = False
+    use_conv_bias: bool = True
+
+    # -- init knobs (reference defaults; not consumed at runtime from HF
+    # — we mirror the reference values so a future trainer can read the
+    # config without a second source). ----------------------------------
+    A_init_range: tuple[float, float] = (1.0, 16.0)
+    dt_min: float = 0.001
+    dt_max: float = 0.1
+    dt_init_floor: float = 1e-4
+
+    # -- derived dims (filled in __post_init__) ---------------------------
+    d_inner: int = field(init=False)
+    nheads: int = field(init=False)
+    d_in_proj: int = field(init=False)
+    conv_dim: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        # `mamba2_dims` validates `d_inner % headdim == 0` and the
+        # ngroups/nheads divisibility rule, raising a `ValueError`
+        # otherwise. Surface the same error here so a malformed config
+        # fails fast instead of at module-construction time.
+        dims = mamba2_dims(
+            self.d_model,
+            d_state=self.d_state,
+            expand=self.expand,
+            headdim=self.headdim,
+            ngroups=self.ngroups,
+        )
+        self.d_inner = dims["d_inner"]
+        self.nheads = dims["nheads"]
+        self.d_in_proj = dims["d_in_proj"]
+        self.conv_dim = dims["conv_dim"]
+        self._validate_config()
+
+    def _validate_config(self) -> None:
+        """Lightweight self-check on derived dims.
+
+        Catches a class of subtle bugs where the dataclass is constructed
+        by hand and a derived field is later mutated to an inconsistent
+        value. Kept as a one-liner so the cost is negligible.
+        """
+        expected_d_inner = self.expand * self.d_model
+        if self.d_inner != expected_d_inner:
+            raise ValueError(
+                f"d_inner ({self.d_inner}) does not match expand*d_model "
+                f"({expected_d_inner})"
+            )
+        expected_nheads = self.d_inner // self.headdim
+        if self.nheads != expected_nheads:
+            raise ValueError(
+                f"nheads ({self.nheads}) does not match d_inner//headdim "
+                f"({expected_nheads})"
+            )
+        expected_d_in_proj = (
+            2 * self.d_inner + 2 * self.ngroups * self.d_state + self.nheads
+        )
+        if self.d_in_proj != expected_d_in_proj:
+            raise ValueError(
+                f"d_in_proj ({self.d_in_proj}) does not match "
+                f"2*d_inner + 2*ngroups*d_state + nheads "
+                f"({expected_d_in_proj})"
+            )
+        expected_conv_dim = self.d_inner + 2 * self.ngroups * self.d_state
+        if self.conv_dim != expected_conv_dim:
+            raise ValueError(
+                f"conv_dim ({self.conv_dim}) does not match "
+                f"d_inner + 2*ngroups*d_state ({expected_conv_dim})"
+            )
+        if self.vocab_size <= 0:
+            raise ValueError(f"vocab_size must be > 0 (got {self.vocab_size})")
+        if self.n_layer <= 0:
+            raise ValueError(f"n_layer must be > 0 (got {self.n_layer})")
+        # The SSD kernel currently assumes ngroups == nheads (item-3
+        # constraint); the broader gcd rule is already enforced by
+        # `mamba2_dims`, but warn loudly here so a config with
+        # ngroups < nheads doesn't silently slip into the adapter — the
+        # adapter has to broadcast B/C and a non-tiled checkpoint would
+        # surface as a shape mismatch much later.
+        if (
+            self.ngroups != self.nheads
+            and math.gcd(self.nheads, self.ngroups) != self.ngroups
+        ):
+            raise ValueError(
+                f"ngroups ({self.ngroups}) must divide nheads ({self.nheads}); "
+                "non-divisible groups are not supported by the SSD kernel."
+            )
+
+    @property
+    def padded_vocab_size(self) -> int:
+        """``vocab_size`` rounded up to ``pad_vocab_size_multiple``.
+
+        Mirrors the reference's vocab-padding behaviour (used when
+        constructing the embedding/lm_head). Returned as a property so
+        the dataclass stays small and ``__post_init__`` doesn't have to
+        re-validate when the field changes.
+        """
+        m = self.pad_vocab_size_multiple
+        if m <= 0:
+            return self.vocab_size
+        return ((self.vocab_size + m - 1) // m) * m
+
+    # -- HF loaders --------------------------------------------------------
+
+    @classmethod
+    def from_huggingface(
+        cls, name_or_path: str, **overrides: Any
+    ) -> Mamba2Config:
+        """Load a :class:`Mamba2Config` from an HF model repo or local dir.
+
+        Uses :func:`transformers.AutoConfig.from_pretrained` to load
+        whatever config the checkpoint ships and then maps the known
+        Mamba2 field names into our vocabulary.
+
+        Two HF dialects are supported:
+
+        * **transformers.Mamba2Config** (``model_type="mamba2"``): flat
+          fields — ``hidden_size``, ``num_hidden_layers``, ``vocab_size``,
+          ``num_heads``, ``head_dim``, ``state_size``, ``conv_kernel``,
+          ``expand``, ``n_groups``, ``chunk_size``, ``layer_norm_epsilon``,
+          ``residual_in_fp32``, ``tie_word_embeddings``,
+          ``pad_token_id`` (no ``pad_vocab_size_multiple``).
+        * **mamba_ssm reference config** (loaded as a generic
+          ``PretrainedConfig`` when the repo ships the mamba_ssm
+          variant): ``d_model``, ``n_layer``, ``ssm_cfg`` dict,
+          ``rms_norm`` toggle, ``fused_add_norm``, ``tie_embeddings``,
+          ``pad_vocab_size_multiple``.
+
+        Args:
+            name_or_path: HF Hub repo id or local directory path.
+            **overrides: Any keyword args here override the values
+                pulled from the HF config (useful for tests where the
+                checkpoint disagrees with what we want to instantiate).
+
+        Returns:
+            A populated :class:`Mamba2Config`.
+        """
+        # Import here so test-only `Mamba2Config()` use doesn't require
+        # transformers at module-import time.
+        from transformers import AutoConfig
+
+        hf_cfg = AutoConfig.from_pretrained(name_or_path)
+        return cls.from_hf_config(hf_cfg, **overrides)
+
+    @classmethod
+    def from_hf_config(cls, hf_cfg: Any, **overrides: Any) -> Mamba2Config:
+        """Build a :class:`Mamba2Config` from an already-loaded HF config.
+
+        Separated from :meth:`from_huggingface` so callers that already
+        loaded an :class:`AutoConfig` (e.g. via the pipeline-config
+        machinery) can reuse it without a second disk/network hit.
+        """
+        # ssm_cfg defaults: reference repo nests the mixer knobs in a
+        # dict. transformers.Mamba2Config lifts them to flat fields.
+        # Read both, with the flat fields winning when both are present.
+        ssm_cfg: dict[str, Any] = dict(getattr(hf_cfg, "ssm_cfg", None) or {})
+
+        # `d_model` (reference) vs `hidden_size` (transformers) — both
+        # surface here; reference repo doesn't have `hidden_size` so the
+        # getattr chain prefers the reference name and falls back.
+        d_model = getattr(hf_cfg, "d_model", None) or getattr(
+            hf_cfg, "hidden_size", None
+        )
+        if d_model is None:
+            raise ValueError(
+                "HF config is missing both `d_model` and `hidden_size`; "
+                "cannot determine Mamba2 hidden width."
+            )
+
+        n_layer = getattr(hf_cfg, "n_layer", None) or getattr(
+            hf_cfg, "num_hidden_layers", None
+        )
+        if n_layer is None:
+            raise ValueError(
+                "HF config is missing both `n_layer` and "
+                "`num_hidden_layers`; cannot determine Mamba2 depth."
+            )
+
+        vocab_size = getattr(hf_cfg, "vocab_size", None)
+        if vocab_size is None:
+            raise ValueError("HF config is missing `vocab_size`.")
+
+        # Mixer knobs: try the transformers field name first, then the
+        # ssm_cfg dict, then the reference field name, then the dataclass
+        # default. The fallback chain captures both HF dialects without
+        # branching on the model_type string (which not every repo
+        # bothers to set correctly).
+        def _pick(*names: str, default: Any) -> Any:
+            for n in names:
+                v = getattr(hf_cfg, n, None)
+                if v is not None:
+                    return v
+                if n in ssm_cfg and ssm_cfg[n] is not None:
+                    return ssm_cfg[n]
+            return default
+
+        d_state = int(_pick("state_size", "d_state", default=128))
+        d_conv = int(_pick("conv_kernel", "d_conv", default=4))
+        expand = int(_pick("expand", default=2))
+        # transformers uses `head_dim`, reference uses `headdim`.
+        headdim = int(_pick("head_dim", "headdim", default=64))
+        # transformers uses `n_groups`, reference uses `ngroups`.
+        # Override to ``nheads`` whenever the checkpoint ships
+        # ``n_groups < nheads`` (the common HF case — AntonV/mamba2-130m-hf
+        # uses ``n_groups=1`` while ``nheads=24``). The SSD kernel ABI
+        # requires ``ngroups == nheads``; the weight adapter's
+        # :func:`_broadcast_in_proj_BC` tiles B/C up to ``nheads`` so the
+        # in_proj weight matches our mixer's parameter shape. Keeping
+        # ``config.ngroups == nheads`` makes the model's ``d_in_proj``
+        # consistent with the broadcasted weight tensor.
+        nheads_for_groups = (expand * int(d_model)) // headdim
+        raw_ngroups = int(_pick("n_groups", "ngroups", default=1))
+        ngroups = max(raw_ngroups, nheads_for_groups)
+        source_ngroups = raw_ngroups
+        chunk_size = int(_pick("chunk_size", default=256))
+
+        # Eps: transformers calls it `layer_norm_epsilon`, reference
+        # plumbs it via `rms_norm` toggles (no explicit eps field — the
+        # mixer hardcodes 1e-5). Use the explicit value if present.
+        rms_norm_eps = float(
+            _pick("layer_norm_epsilon", "rms_norm_eps", default=1e-5)
+        )
+
+        residual_in_fp32 = bool(_pick("residual_in_fp32", default=True))
+        # transformers Mamba2Config doesn't surface `fused_add_norm`;
+        # the reference does. Default to True (matches both the
+        # reference and what `Mamba2Block` does when constructed with
+        # default args).
+        fused_add_norm = bool(_pick("fused_add_norm", default=True))
+
+        # transformers uses `tie_word_embeddings`, reference uses
+        # `tie_embeddings`. Reference Mamba2 defaults to True; HF
+        # `transformers.Mamba2Config` defaults to False — pick whichever
+        # the checkpoint actually set, falling back to True (the
+        # state-spaces/mamba2 repos all ship with tied embeddings).
+        # TODO(verify-vs-hf): the HF default differing from the
+        # reference is the most likely source of a silent regression.
+        # An integration test should load a real checkpoint and check
+        # that `lm_head.weight` resolution matches.
+        tie_embeddings = bool(
+            _pick("tie_embeddings", "tie_word_embeddings", default=True)
+        )
+
+        # Mixer toggles — transformers exposes these directly, reference
+        # uses ssm_cfg defaults that match.
+        use_bias = bool(_pick("use_bias", "bias", default=False))
+        use_conv_bias = bool(_pick("use_conv_bias", "conv_bias", default=True))
+
+        pad_vocab_size_multiple = int(
+            _pick("pad_vocab_size_multiple", default=8)
+        )
+
+        # Init knobs — reference exposes these in `ssm_cfg`; transformers
+        # has flat `time_step_min` / `time_step_max` / `time_step_floor`.
+        # TODO(verify-vs-hf): A_init_range isn't in transformers config;
+        # we always use the reference default. If a future checkpoint
+        # ships with a custom A init the adapter must read it from there
+        # instead.
+        dt_min = float(_pick("time_step_min", "dt_min", default=0.001))
+        dt_max = float(_pick("time_step_max", "dt_max", default=0.1))
+        dt_init_floor = float(
+            _pick("time_step_floor", "dt_init_floor", default=1e-4)
+        )
+        a_init_range_raw = _pick("A_init_range", default=(1.0, 16.0))
+        if (
+            isinstance(a_init_range_raw, (list, tuple))
+            and len(a_init_range_raw) == 2
+        ):
+            a_init_range = (
+                float(a_init_range_raw[0]),
+                float(a_init_range_raw[1]),
+            )
+        else:
+            a_init_range = (1.0, 16.0)
+
+        kwargs: dict[str, Any] = dict(
+            d_model=int(d_model),
+            n_layer=int(n_layer),
+            vocab_size=int(vocab_size),
+            pad_vocab_size_multiple=pad_vocab_size_multiple,
+            d_state=d_state,
+            d_conv=d_conv,
+            expand=expand,
+            headdim=headdim,
+            ngroups=ngroups,
+            source_ngroups=source_ngroups,
+            chunk_size=chunk_size,
+            rms_norm_eps=rms_norm_eps,
+            residual_in_fp32=residual_in_fp32,
+            fused_add_norm=fused_add_norm,
+            tie_embeddings=tie_embeddings,
+            use_bias=use_bias,
+            use_conv_bias=use_conv_bias,
+            A_init_range=a_init_range,
+            dt_min=dt_min,
+            dt_max=dt_max,
+            dt_init_floor=dt_init_floor,
+        )
+        kwargs.update(overrides)
+        return cls(**kwargs)
+
+
+@dataclass
+class Mamba2ArchConfig(Mamba2Config):
+    """Registry-facing :class:`Mamba2Config` that satisfies :class:`ArchConfigWithKVCache`.
+
+    :class:`Mamba2Config` is intentionally a pure shape dataclass and does
+    not implement the :class:`~max.pipelines.lib.interfaces.ArchConfig`
+    protocol (full pipeline-config integration lands in a later RFC 0003
+    item). The registry, however, calls ``arch.config.initialize()`` and
+    ``arch_config.get_max_seq_len()`` to size the tokenizer. This thin
+    subclass bridges that gap by delegating to
+    :meth:`Mamba2Config.from_hf_config` for initialization and to the
+    HF-config's ``max_position_embeddings`` (capped by the user's
+    ``--max-length``) for the sequence-length estimate, matching the
+    policy implemented by :meth:`calculate_max_seq_len`.
+    """
+
+    # Cached max sequence length plumbed through from `initialize` so
+    # `get_max_seq_len` can return it without re-reading the pipeline
+    # config. Not part of the shape-config surface — kept as a plain
+    # field with a sentinel default for mypy.
+    _max_seq_len: int = 0
+
+    # Devices the model runs on. Required by the runtime-checkable
+    # ``ModelConfig`` / ``ModelConfigWithKVCache`` protocols consumed by
+    # :class:`~max.pipelines.kv_cache.memory_planner.PagedMemoryPlanner`
+    # (which ``isinstance``-checks for a ``devices`` attribute). Mirrors
+    # Mamba1's :class:`MambaConfig.devices`.
+    devices: list[DeviceRef] = field(default_factory=list)
+
+    @classmethod
+    def initialize(
+        cls,
+        pipeline_config: PipelineConfig,
+        model_config: MAXModelConfig | None = None,
+        *,
+        max_seq_len: int,
+    ) -> Self:
+        """Build the arch config from a :class:`PipelineConfig`.
+
+        Reads the HF config off ``model_config.huggingface_config`` (or
+        ``pipeline_config.model.huggingface_config`` when no explicit
+        model config is given) and maps it through
+        :meth:`Mamba2Config.from_hf_config`. ``max_seq_len`` is received
+        from the caller (the memory plan's VRAM-clamped length, or the
+        construction-resolved ``model_config.max_length``), never derived
+        here; see :meth:`calculate_max_seq_len` for the bounding policy.
+        """
+        model_config = model_config or pipeline_config.model
+        huggingface_config = model_config.huggingface_config
+        if huggingface_config is None:
+            raise ValueError(
+                f"HuggingFace config is required for "
+                f"'{model_config.model_path}', but config could not be "
+                "loaded."
+            )
+
+        shape_cfg = Mamba2Config.from_hf_config(huggingface_config)
+
+        n_devices = len(pipeline_config.model.device_specs)
+        device_refs = [
+            DeviceRef(spec.device_type, spec.id)
+            for spec in model_config.device_specs[:n_devices]
+        ]
+
+        # Construct via the subclass with all of `Mamba2Config`'s
+        # required fields. The derived fields (`d_inner`, `nheads`, ...)
+        # are recomputed by `__post_init__` so they match `shape_cfg`.
+        return cls(
+            d_model=shape_cfg.d_model,
+            n_layer=shape_cfg.n_layer,
+            vocab_size=shape_cfg.vocab_size,
+            pad_vocab_size_multiple=shape_cfg.pad_vocab_size_multiple,
+            d_state=shape_cfg.d_state,
+            d_conv=shape_cfg.d_conv,
+            expand=shape_cfg.expand,
+            headdim=shape_cfg.headdim,
+            ngroups=shape_cfg.ngroups,
+            source_ngroups=shape_cfg.source_ngroups,
+            chunk_size=shape_cfg.chunk_size,
+            rms_norm_eps=shape_cfg.rms_norm_eps,
+            residual_in_fp32=shape_cfg.residual_in_fp32,
+            fused_add_norm=shape_cfg.fused_add_norm,
+            tie_embeddings=shape_cfg.tie_embeddings,
+            use_bias=shape_cfg.use_bias,
+            use_conv_bias=shape_cfg.use_conv_bias,
+            A_init_range=shape_cfg.A_init_range,
+            dt_min=shape_cfg.dt_min,
+            dt_max=shape_cfg.dt_max,
+            dt_init_floor=shape_cfg.dt_init_floor,
+            _max_seq_len=int(max_seq_len),
+            devices=device_refs,
+        )
+
+    @classmethod
+    def calculate_max_seq_len(
+        cls,
+        huggingface_config: AutoConfig,
+        model_config: MAXModelConfig,
+    ) -> int:
+        """Bound ``max_length`` by ``max_position_embeddings``.
+
+        Mamba2 has no positional embeddings, so any reasonable upper bound
+        works; respect a configured ``max_position_embeddings`` if the
+        checkpoint ships one, else default to 2048.
+        """
+        upper_bound = getattr(
+            huggingface_config, "max_position_embeddings", 2048
+        )
+        try:
+            return upper_bounded_default(
+                upper_bound=upper_bound,
+                default=model_config.max_length,
+            )
+        except ValueError as e:
+            raise ValueError(
+                "Unable to infer max_length for Mamba2; "
+                f"max_length ({model_config.max_length}) exceeds "
+                f"max_position_embeddings ({upper_bound})."
+            ) from e
+
+    def get_max_seq_len(self) -> int:
+        """Maximum sequence length plumbed from the pipeline config."""
+        return self._max_seq_len
+
+    def get_kv_params(self) -> KVCacheParamInterface:
+        """Dummy KV-cache params so the pipeline allocator has a budget.
+
+        Mamba2's real per-request state lives in :class:`Mamba2SSMStateCache`,
+        not in a paged KV cache. But the pipeline's memory estimator runs
+        ``_calculate_kv_cache_size`` only when the arch config satisfies
+        :class:`ArchConfigWithKVCache`; otherwise it returns 0 and
+        ``load_kv_manager`` then refuses to allocate a single page.
+        Mirroring Mamba1's :class:`MambaConfig`, we expose a minimal stub
+        here (n_kv_heads=1, head_dim=1, num_layers=1) so the allocator
+        reserves a few KiB and the rest of the pipeline plumbing works.
+        The actual SSM state pool is sized via
+        :meth:`Mamba2MemoryPlanner.estimate_activation_memory` (the
+        GatedDeltaNetStateCache pattern from qwen3_5).
+        """
+        return MHAKVCacheParams(
+            dtype=DType.float32,
+            n_kv_heads=1,
+            head_dim=1,
+            num_layers=1,
+            devices=self.devices or [DeviceRef.CPU()],
+            page_size=128,
+        )

--- a/max/python/max/pipelines/architectures/mamba2/ssm_cache.py
+++ b/max/python/max/pipelines/architectures/mamba2/ssm_cache.py
@@ -1,0 +1,391 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Slot-based SSM state cache for the Mamba2 SSD architecture.
+
+Mirrors :mod:`max.pipelines.architectures.mamba.ssm_cache` ; only the
+per-slot buffer shapes change to match the Mamba2 mixer layout:
+
+* ``conv_state``: ``[1, conv_dim, d_conv-1]`` where
+  ``conv_dim = d_inner + 2 * ngroups * d_state`` (the post-projection
+  xBC slot that the depthwise causal conv runs over).
+* ``ssm_state``: ``[1, nheads, head_dim, d_state]`` — Mamba2 stores SSM
+  state per-head; the existing :func:`selective_scan_update` decode
+  kernel expects ``(batch, dim, dstate)`` so callers flatten
+  ``(nheads, head_dim) -> dim = d_inner`` at the call site.
+
+Lifecycle, free-list semantics, and the get/update concatenation path
+match Phase-1 exactly so the same code review patterns apply.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from max.driver import Buffer, Device
+from max.dtype import DType
+from max.pipelines.modeling.types import RequestID
+from max.support.human_readable_formatter import to_human_readable_bytes
+
+logger = logging.getLogger("max.pipelines")
+
+
+class Mamba2SSMStateCache:
+    """Fixed-size slot-based cache for Mamba2 SSD conv and scan states.
+
+    Pre-allocates state buffers for ``max_slots`` concurrent requests.
+    Each slot holds one set of per-layer ``(conv_state, ssm_state)``
+    tensors with the Mamba2 shapes documented at module level.
+
+    Lifecycle:
+        1. :meth:`claim` — assign a free slot, zero its states.
+        2. :meth:`get_states` — retrieve states for a batch.
+        3. :meth:`update_states` — store updated states back.
+        4. :meth:`release` — free the slot.
+
+    For ``batch_size == 1`` (the common serving case), get/update are
+    zero-copy and just return/replace the slot's buffer references. For
+    ``batch > 1``, states are concatenated along dim 0 for get, and
+    split back for update — exactly mirroring the Mamba1 cache.
+    """
+
+    def __init__(
+        self,
+        num_layers: int,
+        conv_dim: int,
+        d_conv: int,
+        nheads: int,
+        head_dim: int,
+        d_state: int,
+        dtype: DType,
+        max_slots: int,
+        device: Device,
+    ) -> None:
+        if d_conv < 2:
+            raise ValueError(
+                f"d_conv must be >= 2 for a rolling conv state (got {d_conv})"
+            )
+        self._num_layers = num_layers
+        self._conv_dim = conv_dim
+        self._d_conv = d_conv
+        self._nheads = nheads
+        self._head_dim = head_dim
+        self._d_state = d_state
+        self._dtype = dtype
+        self._max_slots = max_slots
+        self._device = device
+
+        # Per-slot state storage: ``_slots[slot_idx]`` is a list of
+        # ``2 * num_layers`` Buffers alternating
+        # ``[conv_state, ssm_state, ...]`` per layer.
+        self._slots: list[list[Buffer]] = []
+        for _ in range(max_slots):
+            self._slots.append(self._make_zero_states())
+
+        # Slot tracking.
+        self._free_slots: set[int] = set(range(max_slots))
+        self._request_to_slot: dict[RequestID, int] = {}
+        # Tracks whether a slot has been written to by model execution
+        # (as opposed to being freshly claimed with zero states).
+        self._valid_states: set[int] = set()
+
+        # Conv state holds ``d_conv - 1`` historical tokens (rolling
+        # buffer convention shared with the Mamba1 causal_conv1d_update
+        # kernel). SSM state is the full per-head decoder state.
+        conv_elems = conv_dim * (d_conv - 1)
+        ssm_elems = nheads * head_dim * d_state
+        total_bytes = (
+            max_slots
+            * num_layers
+            * (conv_elems + ssm_elems)
+            * dtype.size_in_bytes
+        )
+        logger.info(
+            f"Mamba2 SSM cache: {max_slots} slots x {num_layers} layers = "
+            f"{to_human_readable_bytes(total_bytes)} "
+            f"(conv_dim={conv_dim}, d_conv={d_conv}, nheads={nheads}, "
+            f"head_dim={head_dim}, d_state={d_state})"
+        )
+
+    def _make_zero_states(self) -> list[Buffer]:
+        """Create a fresh set of zero-filled state buffers for one slot."""
+        states: list[Buffer] = []
+        conv_history = self._d_conv - 1
+        for _ in range(self._num_layers):
+            states.append(
+                Buffer(
+                    self._dtype,
+                    [1, self._conv_dim, conv_history],
+                    self._device,
+                )
+            )
+            states.append(
+                Buffer(
+                    self._dtype,
+                    [1, self._nheads, self._head_dim, self._d_state],
+                    self._device,
+                )
+            )
+        return states
+
+    @property
+    def num_free_slots(self) -> int:
+        return len(self._free_slots)
+
+    @property
+    def num_active_slots(self) -> int:
+        return len(self._request_to_slot)
+
+    @property
+    def max_slots(self) -> int:
+        return self._max_slots
+
+    def claim(self, request_id: RequestID) -> int:
+        """Assign a slot to a request, zeroing its state buffers.
+
+        If the request is already claimed, returns the existing slot.
+
+        Returns:
+            The slot index assigned to this request.
+
+        Raises:
+            RuntimeError: If no free slots are available.
+        """
+        if request_id in self._request_to_slot:
+            return self._request_to_slot[request_id]
+        if not self._free_slots:
+            raise RuntimeError(
+                f"No free Mamba2 SSM cache slots ({self._max_slots} in use). "
+                "Increase max_batch_size or reduce concurrent requests."
+            )
+        slot = self._free_slots.pop()
+        self._request_to_slot[request_id] = slot
+        # Zero the slot — replace with fresh zero buffers.
+        self._slots[slot] = self._make_zero_states()
+        return slot
+
+    def release(self, request_id: RequestID) -> None:
+        """Free a slot, making it available for future requests."""
+        if request_id not in self._request_to_slot:
+            return
+        slot = self._request_to_slot.pop(request_id)
+        self._valid_states.discard(slot)
+        self._free_slots.add(slot)
+
+    def contains(self, request_id: RequestID) -> bool:
+        return request_id in self._request_to_slot
+
+    def has_valid_state(self, request_id: RequestID) -> bool:
+        """Check if a request's slot has been written to by model execution."""
+        if request_id not in self._request_to_slot:
+            return False
+        return self._request_to_slot[request_id] in self._valid_states
+
+    def get_states(self, request_ids: list[RequestID]) -> list[Buffer]:
+        """Retrieve state buffers for a batch of requests.
+
+        Args:
+            request_ids: Ordered list of request IDs forming the batch.
+
+        Returns:
+            List of ``2 * num_layers`` Buffers. For ``batch=1`` each is
+            shaped exactly as the per-slot buffer (conv:
+            ``[1, conv_dim, d_conv-1]``, ssm:
+            ``[1, nheads, head_dim, d_state]``). For ``batch>1`` states
+            are concatenated along dim 0 to give a leading ``batch``
+            axis.
+        """
+        if not request_ids:
+            raise ValueError("request_ids must not be empty")
+
+        for rid in request_ids:
+            if rid not in self._request_to_slot:
+                raise KeyError(
+                    f"Request {rid} not found in Mamba2 SSM cache. "
+                    "Call claim() before get_states()."
+                )
+
+        # Fast path: batch=1, return slot buffers directly (zero-copy).
+        if len(request_ids) == 1:
+            slot = self._request_to_slot[request_ids[0]]
+            return list(self._slots[slot])
+
+        # batch>1: concatenate per-slot buffers along dim 0.
+        num_state_tensors = 2 * self._num_layers
+        slots = [self._request_to_slot[rid] for rid in request_ids]
+        result: list[Buffer] = []
+        for state_idx in range(num_state_tensors):
+            slot_bufs = [self._slots[s][state_idx] for s in slots]
+            result.append(_cat_buffers(slot_bufs, self._device))
+        return result
+
+    def update_states(
+        self, request_ids: list[RequestID], new_states: list[Buffer]
+    ) -> None:
+        """Store updated state buffers back into their slots.
+
+        Args:
+            request_ids: Ordered list of request IDs matching the batch dim.
+            new_states: ``2 * num_layers`` Buffers from model output. For
+                ``batch=1``, shapes match the per-slot buffers. For
+                ``batch>1``, each has a leading ``batch`` axis.
+        """
+        if len(new_states) != 2 * self._num_layers:
+            raise ValueError(
+                f"Expected {2 * self._num_layers} state tensors, "
+                f"got {len(new_states)}"
+            )
+
+        # Fast path: batch=1, just store buffer references directly.
+        if len(request_ids) == 1:
+            slot = self._request_to_slot[request_ids[0]]
+            self._slots[slot] = list(new_states)
+            self._valid_states.add(slot)
+            return
+
+        # batch>1: split along dim 0 and store per-slot.
+        for state_idx, state_buf in enumerate(new_states):
+            for batch_idx, rid in enumerate(request_ids):
+                slot = self._request_to_slot[rid]
+                # Slice out this request's state and make a contiguous copy.
+                self._slots[slot][state_idx] = state_buf[
+                    batch_idx : batch_idx + 1
+                ].contiguous()
+
+        for rid in request_ids:
+            self._valid_states.add(self._request_to_slot[rid])
+
+    def update_ssm_states(
+        self, request_ids: list[RequestID], ssm_states: list[Buffer]
+    ) -> None:
+        """Store updated SSM-only state buffers back into their slots.
+
+        Used by the prefill path, which surfaces per-layer SSM ``final_state``
+        via the ``ssd_chunk_scan_combined`` op but does not (yet) surface a
+        rolling conv-state tail. The slot's conv buffer is left untouched —
+        if the slot was freshly claimed it stays zero, which is the same
+        behavior as before plus a correctly-seeded SSM state. Marks the slot
+        as valid so subsequent ``has_valid_state`` checks route to step mode.
+
+        Args:
+            request_ids: Ordered list of request IDs matching the batch dim.
+            ssm_states: ``num_layers`` buffers, one per layer's SSM state.
+                For ``batch=1`` each shape matches the per-slot SSM buffer;
+                for ``batch>1`` each carries a leading ``batch`` axis.
+        """
+        if len(ssm_states) != self._num_layers:
+            raise ValueError(
+                f"Expected {self._num_layers} SSM state tensors, "
+                f"got {len(ssm_states)}"
+            )
+
+        if len(request_ids) == 1:
+            slot = self._request_to_slot[request_ids[0]]
+            for layer_idx, ssm_buf in enumerate(ssm_states):
+                self._slots[slot][2 * layer_idx + 1] = ssm_buf
+            self._valid_states.add(slot)
+            return
+
+        for layer_idx, state_buf in enumerate(ssm_states):
+            for batch_idx, rid in enumerate(request_ids):
+                slot = self._request_to_slot[rid]
+                self._slots[slot][2 * layer_idx + 1] = state_buf[
+                    batch_idx : batch_idx + 1
+                ].contiguous()
+
+        for rid in request_ids:
+            self._valid_states.add(self._request_to_slot[rid])
+
+
+def _cat_buffers(buffers: list[Buffer], device: Device) -> Buffer:
+    """Concatenate buffers along dim 0 via numpy round-trip.
+
+    Acceptable for small SSM states (the Mamba2 prefill state is
+    typically <2MB per layer per request). For high-throughput
+    ``batch>1`` serving this could be replaced with a compiled
+    concatenation kernel — same follow-up note as Phase-1.
+    """
+    import numpy as np
+
+    arrays = [b.to_numpy() for b in buffers]
+    combined = np.concatenate(arrays, axis=0)
+    return Buffer.from_numpy(combined).to(device)
+
+
+# ---------------------------------------------------------------------------
+# Smoke test — exercises the cache shape arithmetic without any kernel
+# load (the SSD kernel is currently blocked by the upstream Tuple-shape
+# bug, see ``proposed/approvals/causal_conv1d_ops-tuple-shape-bug.md``).
+# Run via:
+#   python -m max.pipelines.architectures.mamba2.ssm_cache
+# ---------------------------------------------------------------------------
+
+
+def _smoke() -> None:
+    """Construct the cache with a synthetic config and assert buffer dims."""
+    from max.driver import CPU
+
+    # Small synthetic config — matches the ``mamba2.weight_adapters`` smoke.
+    num_layers = 2
+    nheads = 8
+    head_dim = 32
+    d_state = 16
+    d_conv = 4
+    ngroups = nheads  # mixer enforces ngroups == nheads
+    d_inner = nheads * head_dim
+    conv_dim = d_inner + 2 * ngroups * d_state
+
+    cache = Mamba2SSMStateCache(
+        num_layers=num_layers,
+        conv_dim=conv_dim,
+        d_conv=d_conv,
+        nheads=nheads,
+        head_dim=head_dim,
+        d_state=d_state,
+        dtype=DType.float32,
+        max_slots=2,
+        device=CPU(),
+    )
+
+    assert cache.max_slots == 2
+    assert cache.num_free_slots == 2
+    assert cache.num_active_slots == 0
+
+    rid = RequestID("smoke-0")
+
+    # Claim a slot and check buffer shapes.
+    slot = cache.claim(rid)
+    assert slot in (0, 1)
+    assert cache.num_active_slots == 1
+    assert not cache.has_valid_state(rid)
+
+    states = cache.get_states([rid])
+    assert len(states) == 2 * num_layers
+    for i in range(num_layers):
+        conv = states[2 * i]
+        ssm = states[2 * i + 1]
+        assert tuple(conv.shape) == (1, conv_dim, d_conv - 1), (
+            f"conv_state shape mismatch at layer {i}: {tuple(conv.shape)}"
+        )
+        assert tuple(ssm.shape) == (1, nheads, head_dim, d_state), (
+            f"ssm_state shape mismatch at layer {i}: {tuple(ssm.shape)}"
+        )
+
+    # Release frees the slot.
+    cache.release(rid)
+    assert cache.num_free_slots == 2
+
+    print("mamba2 ssm_cache smoke: OK")
+
+
+if __name__ == "__main__":
+    _smoke()

--- a/max/python/max/pipelines/architectures/mamba2/tokenizer.py
+++ b/max/python/max/pipelines/architectures/mamba2/tokenizer.py
@@ -1,0 +1,42 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Mamba2-specific tokenizer with default chat template support.
+
+Mamba2 base models (like ``state-spaces/mamba2-130m``) ship without a chat
+template in their tokenizer configuration. This tokenizer reuses the same
+passthrough chat-template behavior as the Mamba1
+:class:`~max.pipelines.architectures.mamba.tokenizer.MambaTokenizer` so the
+OpenAI-compatible ``/v1/chat/completions`` endpoint can run against base
+Mamba2 checkpoints out of the box.
+
+For chat applications, consider an instruction-tuned Mamba2 variant or pass
+``--chat-template`` to override the default.
+"""
+
+from __future__ import annotations
+
+from ..mamba.tokenizer import MambaTokenizer
+
+
+class Mamba2Tokenizer(MambaTokenizer):
+    """Mamba2 tokenizer wrapper.
+
+    Identical behavior to :class:`MambaTokenizer`: a thin
+    :class:`~max.pipelines.lib.TextTokenizer` adapter that installs a simple
+    passthrough chat template when the underlying HF tokenizer does not
+    define one. Kept as a distinct class so the architecture registry binds
+    the Mamba2 entry to a Mamba2-named tokenizer (matching the rest of the
+    package), and so future Mamba2-specific behavior can be added without
+    touching the Mamba1 path.
+    """

--- a/max/python/max/pipelines/architectures/mamba2/weight_adapters.py
+++ b/max/python/max/pipelines/architectures/mamba2/weight_adapters.py
@@ -1,0 +1,649 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""HuggingFace -> MAX weight adapter for the Mamba2 SSD architecture.
+
+Mirrors :mod:`max.pipelines.architectures.mamba.weight_adapters` for the
+Mamba2 mixer layout. The adapter consumes a :class:`Weights` accessor
+(the same one the safetensor loader produces in the pipeline runtime)
+and emits a ``dict[str, WeightData]`` keyed by the MAX weight names
+expected by :class:`Mamba2Block` / :class:`Mamba2Mixer`.
+
+Two non-trivial transformations live here:
+
+1. **in_proj.weight slice.** HF stores the fused ``in_proj`` weight as
+   ``[projection_size, d_model]`` where ``projection_size = 2*d_mlp +
+   d_inner + (d_inner + 2*ngroups*d_state) + nheads`` and the row
+   ordering is ``[d_mlp, d_mlp, gate, hidden_states_B_C, dt]`` (see
+   ``transformers.models.mamba2.modeling_mamba2``'s split call). Our
+   :class:`Mamba2Mixer` was built with ``d_ssm == d_inner`` so it
+   expects ``[z, xBC, dt]`` (3 slots, no MLP). The adapter drops the
+   leading ``2 * d_mlp`` rows. With the state-spaces/mamba2 reference
+   checkpoints ``d_mlp == 0`` and the slice is a no-op; we still issue
+   the slice unconditionally so adapter behaviour is the same on every
+   checkpoint.
+2. **conv1d.weight squeeze.** HF stores depthwise conv weights as
+   ``[conv_dim, 1, d_conv]``; our NN module's ``conv1d_weight`` is
+   ``[conv_dim, d_conv]``. Mirrors the Mamba1 adapter.
+
+Other tensors (``A_log``, ``D``, ``dt_bias``, ``embeddings.weight``,
+``norm_f.weight``, ``out_proj.weight``, per-layer ``norm.weight``) only
+need the prefix/name rename pass and — for ``A_log`` / ``dt_bias`` —
+an explicit ``astype(float32)``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from typing import Any
+
+import numpy as np
+from max.dtype import DType
+from max.graph.weights import WeightData, Weights
+from max.pipelines.lib.config.model_config import _select_dtype_cast
+from max.pipelines.modeling.config_enums import supported_encoding_dtype
+
+from .model_config import Mamba2Config
+
+logger = logging.getLogger("max.pipelines.mamba2")
+
+
+# Ordered rename map; mirrors `MAMBA_SAFETENSOR_MAPPING`. Replacements
+# are applied in order — `backbone.` strip must run before `model.` for
+# any future repo that nests both.
+MAMBA2_SAFETENSOR_MAPPING: OrderedDict[str, str] = OrderedDict(
+    [
+        ("backbone.", ""),
+        ("model.", ""),
+        # HF "embeddings" (plural) -> MAX "embedding" (singular).
+        ("embeddings.weight", "embedding.weight"),
+        # HF final norm `norm_f` -> MAX `norm`.
+        ("norm_f.weight", "norm.weight"),
+        # HF dotted depthwise conv params -> MAX underscored attribute
+        # names (Mamba2Mixer stores `conv1d_weight` / `conv1d_bias`
+        # rather than a sub-Module with a `weight` / `bias` field).
+        ("conv1d.weight", "conv1d_weight"),
+        ("conv1d.bias", "conv1d_bias"),
+    ]
+)
+
+
+def _rename(name: str) -> str:
+    """Apply :data:`MAMBA2_SAFETENSOR_MAPPING` to ``name`` in order."""
+    out = name
+    for before, after in MAMBA2_SAFETENSOR_MAPPING.items():
+        out = out.replace(before, after)
+    return out
+
+
+def _as_numpy(wd: WeightData) -> np.ndarray:
+    """Materialize a :class:`WeightData` as a contiguous numpy array.
+
+    Uses the DLPack protocol so this works regardless of whether the
+    underlying storage is a numpy view, a torch tensor, or a safetensor
+    buffer. The ``.copy()`` is defensive — slicing in numpy returns a
+    view, and downstream consumers expect a standalone buffer.
+    """
+    return np.from_dlpack(wd).copy()
+
+
+def _slice_in_proj(wd: WeightData, config: Mamba2Config) -> WeightData:
+    """Drop the leading ``2*d_mlp`` rows from an HF ``in_proj.weight``.
+
+    HF row ordering: ``[d_mlp, d_mlp, gate, hidden_states_B_C, dt]`` with
+    sizes ``[d_mlp, d_mlp, d_inner, conv_dim, nheads]``. Our NN module
+    expects ``[z, xBC, dt]`` (no MLP, ``d_ssm == d_inner``).
+
+    The slice is taken along axis 0 (the ``projection_size`` axis); axis
+    1 is ``d_model`` and unchanged. Concatenation isn't needed because
+    the surviving three slots are already contiguous in HF's layout.
+
+    With ``d_mlp == 0`` (the only configuration the state-spaces/mamba2
+    family of repos ships) this is a no-op and we keep the original
+    buffer. With ``d_mlp > 0`` we slice and rewrap.
+    """
+    shape = tuple(int(d) for d in wd.shape)
+    if len(shape) != 2:
+        raise ValueError(f"in_proj.weight expected 2D, got shape {shape}")
+    projection_size, d_model = shape
+    if d_model != config.d_model:
+        raise ValueError(
+            f"in_proj.weight axis-1 ({d_model}) does not match config "
+            f"d_model ({config.d_model})"
+        )
+
+    # HF's projection_size when `d_ssm == d_inner`:
+    #   projection_size = 2 * d_mlp + d_in_proj_hf
+    # where ``d_in_proj_hf`` is the HF in_proj row count BEFORE the
+    # B/C broadcast (i.e. computed with the source checkpoint's
+    # ``n_groups``, not our post-broadcast ``config.ngroups``).
+    # ``config.source_ngroups`` is populated by ``from_hf_config`` for
+    # this purpose; non-HF callers (``ngroups`` already final) fall back
+    # to ``config.d_in_proj``.
+    if (
+        config.source_ngroups is not None
+        and config.source_ngroups != config.ngroups
+    ):
+        expected_d_in_proj = (
+            2 * config.d_inner
+            + 2 * config.source_ngroups * config.d_state
+            + config.nheads
+        )
+    else:
+        expected_d_in_proj = config.d_in_proj
+    extra = projection_size - expected_d_in_proj
+    if extra < 0 or extra % 2 != 0:
+        raise ValueError(
+            f"in_proj.weight projection_size={projection_size} is not "
+            f"compatible with config d_in_proj={expected_d_in_proj}; "
+            "expected a non-negative even surplus for the d_mlp slot."
+        )
+    d_mlp = extra // 2
+
+    if d_mlp == 0:
+        return wd
+
+    logger.info(
+        f"Mamba2 adapter: dropping {2 * d_mlp} d_mlp rows from "
+        f"in_proj.weight (projection_size={projection_size}, "
+        f"d_in_proj={expected_d_in_proj})"
+    )
+
+    arr = _as_numpy(wd)
+    # Drop the first `2 * d_mlp` rows; surviving order is
+    # [z (d_inner), xBC (HF conv_dim), dt (nheads)], which matches what
+    # ``Mamba2Mixer.in_proj`` produces under the HF group layout. When
+    # ``source_ngroups < nheads`` the surviving rows total
+    # ``2*d_inner + 2*source_ngroups*d_state + nheads``; the subsequent
+    # ``_broadcast_in_proj_BC`` step tiles B/C up to ``nheads``.
+    sliced = arr[2 * d_mlp :, :]
+    src_ngroups = (
+        config.source_ngroups
+        if config.source_ngroups is not None
+        else config.ngroups
+    )
+    expected_rows = (
+        2 * config.d_inner + 2 * src_ngroups * config.d_state + config.nheads
+    )
+    if sliced.shape[0] != expected_rows:
+        raise ValueError(
+            f"in_proj.weight slice produced shape {sliced.shape}, "
+            f"expected ({expected_rows}, {config.d_model})"
+        )
+    return WeightData.from_numpy(sliced.copy(), wd.name)
+
+
+def _broadcast_in_proj_BC(wd: WeightData, config: Mamba2Config) -> WeightData:
+    """If ``ngroups < nheads``, tile the ``B`` / ``C`` slots of the
+    already-sliced ``in_proj.weight`` so the kernel ABI's
+    ``ngroups == nheads`` assumption holds.
+
+    Row ordering after :func:`_slice_in_proj`:
+    ``[z (d_inner), x (d_inner), B (ngroups*d_state), C (ngroups*d_state), dt (nheads)]``
+    where ``z + x`` together form the gate + ``x``-projection slots and
+    are independent of ``ngroups``. We tile only ``B`` and ``C``.
+
+    Note: this isn't reachable from `Mamba2Mixer` directly (item 3
+    forces ``ngroups == nheads`` at construction time), but the adapter
+    needs to handle it because HF's ``transformers.Mamba2Config`` ships
+    with ``n_groups=8`` while ``num_heads=128`` — the only way to load
+    a real upstream checkpoint into our mixer is to broadcast at the
+    weight-loading stage.
+    """
+    # ``config.ngroups`` is the *post-broadcast* group count (forced to
+    # ``nheads`` for HF checkpoints by ``from_hf_config``). Read the source
+    # group count from ``config.source_ngroups`` so we can detect whether
+    # broadcasting is actually needed.
+    src_ngroups = (
+        config.source_ngroups
+        if config.source_ngroups is not None
+        else config.ngroups
+    )
+    if src_ngroups == config.nheads:
+        return wd
+    if config.nheads % src_ngroups != 0:
+        raise ValueError(
+            f"source_ngroups ({src_ngroups}) must divide nheads "
+            f"({config.nheads}) to broadcast B/C in in_proj.weight."
+        )
+    tile = config.nheads // src_ngroups
+
+    arr = _as_numpy(wd)
+    if arr.ndim != 2 or arr.shape[1] != config.d_model:
+        raise ValueError(
+            f"in_proj.weight slice has unexpected shape {arr.shape}; "
+            f"expected (*, {config.d_model})."
+        )
+
+    # Slice along axis 0 in the canonical order produced by
+    # `_slice_in_proj`: [z, x, B, C, dt].
+    d_inner = config.d_inner
+    nheads = config.nheads
+    d_state = config.d_state
+    # `z` and `x` live in the gate + xBC slots from our Mixer's POV.
+    # After the slice, the rows are laid out as:
+    #   [z: d_inner, x: d_inner, B: src_ngroups*d_state, C: src_ngroups*d_state, dt: nheads]
+    # When ``src_ngroups < nheads`` we tile B and C along the group axis.
+    src_bc_block = src_ngroups * d_state
+    offsets = [
+        0,
+        d_inner,  # end of z
+        2 * d_inner,  # end of x
+        2 * d_inner + src_bc_block,  # end of B
+        2 * d_inner + 2 * src_bc_block,  # end of C
+        2 * d_inner + 2 * src_bc_block + nheads,  # end of dt
+    ]
+    if arr.shape[0] != offsets[-1]:
+        raise ValueError(
+            f"in_proj.weight slice rows={arr.shape[0]} does not match "
+            f"expected {offsets[-1]} for tiling."
+        )
+
+    z = arr[offsets[0] : offsets[1], :]
+    x = arr[offsets[1] : offsets[2], :]
+    B = arr[offsets[2] : offsets[3], :]
+    C = arr[offsets[3] : offsets[4], :]
+    dt = arr[offsets[4] : offsets[5], :]
+
+    # Reshape B / C to (src_ngroups, d_state, d_model), tile along the
+    # group axis to nheads, then flatten back.
+    B_g = B.reshape(src_ngroups, d_state, config.d_model)
+    C_g = C.reshape(src_ngroups, d_state, config.d_model)
+    B_tiled = np.repeat(B_g, tile, axis=0).reshape(
+        nheads * d_state, config.d_model
+    )
+    C_tiled = np.repeat(C_g, tile, axis=0).reshape(
+        nheads * d_state, config.d_model
+    )
+
+    new = np.concatenate([z, x, B_tiled, C_tiled, dt], axis=0)
+    expected_rows = 2 * d_inner + 2 * nheads * d_state + nheads
+    if new.shape[0] != expected_rows:
+        raise ValueError(
+            f"in_proj.weight tile produced shape {new.shape}, "
+            f"expected ({expected_rows}, {config.d_model})"
+        )
+    return WeightData.from_numpy(new.copy(), wd.name)
+
+
+def _squeeze_conv1d_weight(wd: WeightData) -> WeightData:
+    """Reshape ``[conv_dim, 1, d_conv]`` -> ``[conv_dim, d_conv]``.
+
+    HF stores depthwise conv1d weights with an explicit
+    in-channels-per-group axis of size 1; our :class:`Mamba2Mixer`
+    stores it as a plain 2D matrix.
+    """
+    shape = tuple(int(d) for d in wd.shape)
+    if len(shape) == 3 and shape[1] == 1:
+        arr = _as_numpy(wd)
+        arr = arr.reshape(shape[0], shape[2]).copy()
+        return WeightData.from_numpy(arr, wd.name)
+    if len(shape) == 2:
+        # Already squeezed (e.g. converted by an upstream tool); pass
+        # through unchanged.
+        return wd
+    raise ValueError(
+        f"conv1d.weight expected shape [conv_dim, 1, d_conv] or "
+        f"[conv_dim, d_conv], got {shape}"
+    )
+
+
+def _broadcast_conv1d_BC(
+    wd: WeightData, config: Mamba2Config, axis0_is_bias: bool = False
+) -> WeightData:
+    """Tile the B and C channel slots of a conv1d weight or bias.
+
+    HF stores the depthwise conv over ``conv_dim_hf == d_inner + 2 *
+    source_ngroups * d_state`` channels. Our mixer's conv operates over
+    ``conv_dim == d_inner + 2 * nheads * d_state`` (the post-broadcast
+    group count, matching the SSD kernel ABI). When ``source_ngroups <
+    nheads`` we tile the per-channel B and C slots so each per-head B/C
+    column gets its own conv filter (replicated from the source group).
+
+    For ``axis0_is_bias=False`` (weight): shape is ``(conv_dim, d_conv)``.
+    For ``axis0_is_bias=True`` (bias): shape is ``(conv_dim,)``.
+    Tiling happens along the channel axis (axis 0).
+    """
+    src_ngroups = (
+        config.source_ngroups
+        if config.source_ngroups is not None
+        else config.ngroups
+    )
+    if src_ngroups == config.nheads:
+        return wd
+    if config.nheads % src_ngroups != 0:
+        raise ValueError(
+            f"source_ngroups ({src_ngroups}) must divide nheads "
+            f"({config.nheads}) to broadcast conv1d B/C."
+        )
+
+    arr = _as_numpy(wd)
+    d_inner = config.d_inner
+    d_state = config.d_state
+    nheads = config.nheads
+    tile = nheads // src_ngroups
+    src_bc = src_ngroups * d_state
+
+    expected_axis0 = d_inner + 2 * src_bc
+    if arr.shape[0] != expected_axis0:
+        raise ValueError(
+            f"conv1d weight/bias axis-0 ({arr.shape[0]}) does not match "
+            f"expected pre-broadcast {expected_axis0} "
+            f"(d_inner={d_inner}, src_ngroups={src_ngroups}, d_state={d_state})."
+        )
+
+    if axis0_is_bias:
+        x_part = arr[:d_inner]
+        B_part = arr[d_inner : d_inner + src_bc]
+        C_part = arr[d_inner + src_bc : d_inner + 2 * src_bc]
+        B_g: np.ndarray = B_part.reshape(src_ngroups, d_state)
+        C_g: np.ndarray = C_part.reshape(src_ngroups, d_state)
+        B_tiled: np.ndarray = np.repeat(B_g, tile, axis=0).reshape(
+            nheads * d_state
+        )
+        C_tiled: np.ndarray = np.repeat(C_g, tile, axis=0).reshape(
+            nheads * d_state
+        )
+        new = np.concatenate([x_part, B_tiled, C_tiled], axis=0)
+    else:
+        d_conv = arr.shape[1]
+        x_part = arr[:d_inner, :]
+        B_part = arr[d_inner : d_inner + src_bc, :]
+        C_part = arr[d_inner + src_bc : d_inner + 2 * src_bc, :]
+        B_g = B_part.reshape(src_ngroups, d_state, d_conv)
+        C_g = C_part.reshape(src_ngroups, d_state, d_conv)
+        B_tiled = np.repeat(B_g, tile, axis=0).reshape(nheads * d_state, d_conv)
+        C_tiled = np.repeat(C_g, tile, axis=0).reshape(nheads * d_state, d_conv)
+        new = np.concatenate([x_part, B_tiled, C_tiled], axis=0)
+
+    return WeightData.from_numpy(new.copy(), wd.name)
+
+
+def convert_mamba2_state_dict(
+    weights: Weights | dict[str, Weights],
+    config: Mamba2Config | None = None,
+    *,
+    huggingface_config: Any = None,
+    pipeline_config: Any = None,
+    **_unused: Any,
+) -> dict[str, WeightData]:
+    """Translate an HF Mamba2 state dict into the MAX weight namespace.
+
+    The pipeline registry invokes adapters with
+    ``adapter(weights_dict, huggingface_config=..., pipeline_config=...)``.
+    Standalone test/script callers pass a :class:`Mamba2Config` via
+    ``config`` directly. We accept either form: if ``config`` is omitted
+    we build it from ``huggingface_config``.
+
+    Args:
+        weights: The :class:`Weights` accessor produced by the
+            safetensor loader (or any mapping from weight name to
+            :class:`Weights`). A plain ``dict[str, Weights]`` is
+            accepted for ease of testing.
+        config: The :class:`Mamba2Config` describing the target shape.
+            If ``None``, derived from ``huggingface_config``.
+        huggingface_config: The HF ``AutoConfig`` (pipeline-supplied).
+        pipeline_config: The MAX ``PipelineConfig`` (unused by this
+            adapter, but accepted to satisfy the registry's call shape).
+
+    Returns:
+        Dictionary mapping MAX weight names to :class:`WeightData`. Use
+        this directly as the ``state_dict`` argument when calling
+        ``Mamba2Block.load_state_dict(...)`` / equivalent.
+    """
+    if config is None:
+        if huggingface_config is None:
+            raise ValueError(
+                "convert_mamba2_state_dict requires either `config` or "
+                "`huggingface_config` to be provided."
+            )
+        config = Mamba2Config.from_hf_config(huggingface_config)
+    # Normalize to an iterator of (name, Weights) pairs.
+    if isinstance(weights, dict):
+        items = list(weights.items())
+    else:
+        items = list(weights.items())
+
+    new_state_dict: dict[str, WeightData] = {}
+
+    for hf_name, weight in items:
+        max_name = _rename(hf_name)
+        wd = weight.data()
+
+        # in_proj weight needs the d_mlp slice (axis-0 drop), then a
+        # B/C broadcast when `ngroups < nheads`. Catch both `in_proj.weight`
+        # and any quantized variant (`in_proj.scales` / `.qweight`) by
+        # keying on the *.in_proj. prefix — but only mutate `.weight`
+        # since that's the only tensor with the per-row block layout.
+        # TODO(verify-vs-hf): if a real INT-quantized checkpoint surfaces,
+        # the scales tensor will need the same row-slice. Cross that
+        # bridge in the integration test.
+        if max_name.endswith("in_proj.weight"):
+            wd = _slice_in_proj(wd, config)
+            wd = _broadcast_in_proj_BC(wd, config)
+
+        elif "conv1d_weight" in max_name:
+            wd = _squeeze_conv1d_weight(wd)
+            wd = _broadcast_conv1d_BC(wd, config, axis0_is_bias=False)
+
+        elif "conv1d_bias" in max_name:
+            wd = _broadcast_conv1d_BC(wd, config, axis0_is_bias=True)
+
+        # Force fp32 for A_log and dt_bias — both feed math paths
+        # (the `-exp(A_log)` in the mixer and the `softplus(dt + dt_bias)`
+        # inside the SSD kernel) that lose accuracy in lower precision.
+        # The reference module declares both as fp32 parameters; HF
+        # checkpoints sometimes ship them as bf16/fp16.
+        elif max_name.endswith(("A_log", "dt_bias")):
+            if wd.dtype != DType.float32:
+                wd = wd.astype(DType.float32)
+
+        new_state_dict[max_name] = wd
+
+    # Apply the pipeline's resolved load-time dtype cast (main casts
+    # float32 checkpoints to bfloat16 on GPU) so the loaded tensors match
+    # the dtype the NN modules are built with under ``default_dtype``.
+    # Mirrors Mamba1's adapter. The SSD kernels are dtype-generic and do
+    # their accumulation in fp32 internally, so a bf16 ``A_log`` /
+    # ``dt_bias`` only costs the storage precision of the parameters.
+    # TODO(MXF-517): this should be resolved by the ArchConfig, not the adapter.
+    if pipeline_config is not None:
+        cast_from, cast_to = _select_dtype_cast(
+            pipeline_config.model, "float32"
+        )
+        if cast_from:
+            assert cast_to, (
+                "Invalid configuration: applied_dtype_cast_to is not set "
+                "but applied_dtype_cast_from is set. This should not happen."
+            )
+            from_dtype = supported_encoding_dtype(cast_from)
+            to_dtype = supported_encoding_dtype(cast_to)
+            for key, wd in new_state_dict.items():
+                if wd.dtype == from_dtype:
+                    new_state_dict[key] = wd.astype(to_dtype)
+
+    return new_state_dict
+
+
+__all__ = [
+    "MAMBA2_SAFETENSOR_MAPPING",
+    "convert_mamba2_state_dict",
+]
+
+
+# ---------------------------------------------------------------------------
+# Smoke test (no real checkpoint required).
+#
+# Run via:
+#   python -m max.pipelines.architectures.mamba2.weight_adapters
+#
+# Exercises the dataclass + adapter on a synthetic state dict so a future
+# refactor of the slicing math gets an immediate signal. Loading a real
+# HF checkpoint is blocked at runtime by the same `state_space.mojoc`
+# Tuple-shape bug that blocks the NN modules, so this `__main__` block
+# is the closest thing to a unit test that fits in-scope.
+# ---------------------------------------------------------------------------
+
+
+def _smoke() -> None:
+    """Construct a fake HF state dict and run the adapter end-to-end."""
+    import dataclasses
+
+    # Use a small config so the synthetic tensors are tiny.
+    cfg = Mamba2Config(
+        d_model=128,
+        n_layer=2,
+        vocab_size=256,
+        d_state=16,
+        d_conv=4,
+        expand=2,
+        headdim=32,
+        # `ngroups == nheads` to exercise the no-broadcast path; the
+        # broadcast path has its own assertion at construction time.
+        ngroups=8,
+        chunk_size=64,
+    )
+    assert cfg.d_inner == 256
+    assert cfg.nheads == 8
+    assert cfg.ngroups == cfg.nheads
+    assert cfg.d_in_proj == 2 * 256 + 2 * 8 * 16 + 8 == 776
+    assert cfg.conv_dim == 256 + 2 * 8 * 16 == 512
+
+    # Cover the HF d_mlp=0 path: projection_size == d_in_proj.
+    in_proj_hf = np.random.randn(cfg.d_in_proj, cfg.d_model).astype(np.float32)
+    # Cover conv1d: HF shape [conv_dim, 1, d_conv].
+    conv1d_w_hf = np.random.randn(cfg.conv_dim, 1, cfg.d_conv).astype(
+        np.float32
+    )
+    conv1d_b_hf = np.random.randn(cfg.conv_dim).astype(np.float32)
+    A_log_hf = np.random.randn(cfg.nheads).astype(np.float16)  # bf16-ish
+    dt_bias_hf = np.random.randn(cfg.nheads).astype(np.float16)
+    D_hf = np.random.randn(cfg.nheads).astype(np.float32)
+    embed_hf = np.random.randn(cfg.vocab_size, cfg.d_model).astype(np.float32)
+    norm_w_hf = np.random.randn(cfg.d_model).astype(np.float32)
+    out_proj_hf = np.random.randn(cfg.d_model, cfg.d_inner).astype(np.float32)
+    layer_norm_w_hf = np.random.randn(cfg.d_model).astype(np.float32)
+
+    # Fake `Weights`-like wrapper: just needs `.data()` -> WeightData.
+    @dataclasses.dataclass
+    class _FakeWeight:
+        wd: WeightData
+
+        def data(self) -> WeightData:
+            return self.wd
+
+    def _w(arr: np.ndarray, name: str) -> _FakeWeight:
+        return _FakeWeight(WeightData.from_numpy(arr, name))
+
+    fake_state: dict[str, _FakeWeight] = {
+        "backbone.embeddings.weight": _w(embed_hf, "embed"),
+        "backbone.norm_f.weight": _w(norm_w_hf, "norm_f"),
+        "backbone.layers.0.norm.weight": _w(layer_norm_w_hf, "norm0"),
+        "backbone.layers.0.mixer.in_proj.weight": _w(in_proj_hf, "in_proj0"),
+        "backbone.layers.0.mixer.conv1d.weight": _w(conv1d_w_hf, "conv1d_w0"),
+        "backbone.layers.0.mixer.conv1d.bias": _w(conv1d_b_hf, "conv1d_b0"),
+        "backbone.layers.0.mixer.A_log": _w(A_log_hf, "A_log0"),
+        "backbone.layers.0.mixer.dt_bias": _w(dt_bias_hf, "dt_bias0"),
+        "backbone.layers.0.mixer.D": _w(D_hf, "D0"),
+        "backbone.layers.0.mixer.out_proj.weight": _w(out_proj_hf, "out_proj0"),
+    }
+
+    out = convert_mamba2_state_dict(fake_state, cfg)  # type: ignore[arg-type]
+
+    # Rename checks.
+    assert "embedding.weight" in out
+    assert "norm.weight" in out
+    assert "layers.0.mixer.in_proj.weight" in out
+    assert "layers.0.mixer.conv1d_weight" in out
+    assert "layers.0.mixer.conv1d_bias" in out
+    assert "layers.0.mixer.A_log" in out
+    assert "layers.0.mixer.dt_bias" in out
+
+    # Shape checks.
+    assert tuple(
+        int(d) for d in out["layers.0.mixer.in_proj.weight"].shape
+    ) == (
+        cfg.d_in_proj,
+        cfg.d_model,
+    )
+    assert tuple(int(d) for d in out["layers.0.mixer.conv1d_weight"].shape) == (
+        cfg.conv_dim,
+        cfg.d_conv,
+    )
+
+    # dtype promotions.
+    assert out["layers.0.mixer.A_log"].dtype == DType.float32
+    assert out["layers.0.mixer.dt_bias"].dtype == DType.float32
+
+    # Now exercise the d_mlp > 0 path: prepend 2*d_mlp rows to in_proj
+    # and re-run. The adapter should slice them off.
+    d_mlp = 4
+    in_proj_hf_padded = np.concatenate(
+        [
+            np.random.randn(2 * d_mlp, cfg.d_model).astype(np.float32),
+            in_proj_hf,
+        ],
+        axis=0,
+    )
+    fake_state["backbone.layers.0.mixer.in_proj.weight"] = _w(
+        in_proj_hf_padded, "in_proj_padded"
+    )
+    out2 = convert_mamba2_state_dict(fake_state, cfg)  # type: ignore[arg-type]
+    assert tuple(
+        int(d) for d in out2["layers.0.mixer.in_proj.weight"].shape
+    ) == (
+        cfg.d_in_proj,
+        cfg.d_model,
+    )
+
+    # And the broadcast path: a config where ngroups < nheads.
+    cfg_bcast = Mamba2Config(
+        d_model=128,
+        n_layer=2,
+        vocab_size=256,
+        d_state=16,
+        d_conv=4,
+        expand=2,
+        headdim=32,
+        ngroups=2,  # nheads=8, tile=4
+        chunk_size=64,
+    )
+    # HF's projection_size for ngroups=2 (smaller than the ngroups=8
+    # config above) — re-derive locally rather than reusing cfg.d_in_proj.
+    in_proj_bcast = np.random.randn(
+        cfg_bcast.d_in_proj, cfg_bcast.d_model
+    ).astype(np.float32)
+    fake_state_bcast = {
+        "backbone.layers.0.mixer.in_proj.weight": _w(
+            in_proj_bcast, "in_proj_bcast"
+        ),
+    }
+    out_bcast = convert_mamba2_state_dict(fake_state_bcast, cfg_bcast)  # type: ignore[arg-type]
+    # Post-broadcast rows = 2*d_inner + 2*nheads*d_state + nheads.
+    expected_rows = (
+        2 * cfg_bcast.d_inner
+        + 2 * cfg_bcast.nheads * cfg_bcast.d_state
+        + cfg_bcast.nheads
+    )
+    assert tuple(
+        int(d) for d in out_bcast["layers.0.mixer.in_proj.weight"].shape
+    ) == (
+        expected_rows,
+        cfg_bcast.d_model,
+    )
+
+    print("mamba2 weight_adapters smoke: OK")
+
+
+if __name__ == "__main__":
+    _smoke()

--- a/max/python/max/pipelines/lib/config/model_config.py
+++ b/max/python/max/pipelines/lib/config/model_config.py
@@ -705,6 +705,15 @@ def _resolve_weights_and_encoding(
     return encoding, (cast_from, cast_to), weight_path, device_specs
 
 
+# Fallback mapping for HF checkpoints that ship a populated ``model_type`` but
+# leave the ``architectures`` field unset (e.g. ``AntonV/mamba2-130m-hf``).
+# Keep entries here narrow: they should only cover ``model_type`` values
+# that map unambiguously to one registered ``SupportedArchitecture.name``.
+_MODEL_TYPE_TO_ARCHITECTURE: dict[str, str] = {
+    "mamba2": "Mamba2ForCausalLM",
+}
+
+
 class MAXModelConfigBase(ConfigFileModel):
     """Abstract base class for MAX model configuration.
 
@@ -1293,13 +1302,30 @@ class MAXModelConfig(MAXModelConfigBase):
         """Returns the architecture class name from the HuggingFace config.
 
         For transformers models, returns ``architectures[0]`` from the
-        HuggingFace config.
+        HuggingFace config. Some HF-flavored checkpoints (e.g.
+        ``AntonV/mamba2-130m-hf``) ship a config with ``model_type`` set
+        but ``architectures`` unset; in that case we fall back to a
+        ``model_type -> architecture-class`` mapping so the registry
+        lookup still resolves.
         """
         hf_config = self.huggingface_config
         if hf_config is not None:
             architectures = getattr(hf_config, "architectures", None)
             if architectures:
                 return architectures[0]
+            model_type = getattr(hf_config, "model_type", None)
+            if model_type:
+                fallback = _MODEL_TYPE_TO_ARCHITECTURE.get(model_type)
+                if fallback is not None:
+                    return fallback
+            # state-spaces reference checkpoints (e.g.
+            # ``state-spaces/mamba2-130m``) ship a bare ``config.json`` with
+            # neither ``architectures`` nor ``model_type``; the mixer is
+            # selected via ``ssm_cfg.layer``. Map that to the Mamba2 arch so
+            # the registry lookup resolves.
+            ssm_cfg = getattr(hf_config, "ssm_cfg", None)
+            if isinstance(ssm_cfg, dict) and ssm_cfg.get("layer") == "Mamba2":
+                return "Mamba2ForCausalLM"
         return None
 
     @property

--- a/max/tests/integration/architectures/mamba2/BUILD.bazel
+++ b/max/tests/integration/architectures/mamba2/BUILD.bazel
@@ -1,0 +1,35 @@
+load(
+    "//bazel:api.bzl",
+    "modular_py_test",
+    "requirement",
+)
+
+package(default_visibility = [
+    "//:__pkg__",
+    "//SDK/integration-test:__subpackages__",
+    "//max/tests:__subpackages__",
+    "//oss/modular/max/tests:__subpackages__",
+])
+
+# Graph-construction smoke test for the Mamba2 SSD functional-op wrapper.
+# The underlying ssd_chunk_scan_combined kernel is currently CPU-only;
+# the GPU dispatch raises explicitly until later RFC 0002 phases, so this
+# target does not require GPU. The state_space mojo package is registered
+# via mojo_deps so ops.custom("ssd_chunk_scan_combined", ...) resolves at
+# graph-verification time without needing custom_extensions paths.
+modular_py_test(
+    name = "test_mamba2_functional_ops",
+    size = "medium",
+    srcs = ["test_mamba2_functional_ops.py"],
+    mojo_deps = [
+        "//max:state_space",
+    ],
+    deps = [
+        "//max/python/max/driver",
+        "//max/python/max/dtype",
+        "//max/python/max/engine",
+        "//max/python/max/graph",
+        "//max/python/max/pipelines/architectures/mamba2",
+        requirement("numpy"),
+    ],
+)

--- a/max/tests/integration/architectures/mamba2/__init__.py
+++ b/max/tests/integration/architectures/mamba2/__init__.py
@@ -1,0 +1,13 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+

--- a/max/tests/integration/architectures/mamba2/test_mamba2_functional_ops.py
+++ b/max/tests/integration/architectures/mamba2/test_mamba2_functional_ops.py
@@ -1,0 +1,130 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""Graph-construction smoke test for the Mamba2 SSD functional-op wrapper.
+
+This verifies that ``ssd_chunk_scan_combined`` from
+``max.pipelines.architectures.mamba2.functional_ops`` resolves through
+``ops.custom`` to the registered ``ssd_chunk_scan_combined`` Mojo kernel,
+compiles inside a ``Graph``, executes end-to-end, and returns a tensor
+of the expected shape with all finite values.
+
+The current Mojo kernel
+(``max/kernels/src/state_space/ssd_chunk_combined_ops.mojo``) only wires
+the CPU dispatch — the GPU branch raises explicitly until later RFC 0002
+phases. The smoke test therefore runs on CPU regardless of the host's
+accelerator count. Numerical parity vs the torch reference is intentionally
+NOT asserted here; that is covered by the model-level parity gate in
+RFC 0003 item 7.
+"""
+
+from __future__ import annotations
+
+import max.driver as md
+import numpy as np
+from max.driver import CPU
+from max.dtype import DType
+from max.engine import InferenceSession
+from max.graph import DeviceRef, Graph, TensorType
+from max.pipelines.architectures.mamba2.functional_ops import (
+    ssd_chunk_scan_combined,
+)
+
+
+def test_ssd_chunk_scan_combined_smoke() -> None:
+    """Build, compile, and run a minimal SSD chunk-scan graph on CPU.
+
+    Shapes are intentionally small but obey the kernel's invariants:
+
+    * ``seqlen`` (4) is divisible by ``chunk_size`` (2);
+    * ``B``/``C`` use ``ngroups == n_heads == 1``.
+    """
+    cpu = DeviceRef.CPU()
+    batch = 1
+    seqlen = 4
+    n_heads = 1
+    head_dim = 2
+    state_dim = 3
+    chunk_size = 2
+
+    with Graph(
+        "mamba2_ssd_chunk_scan_combined_smoke",
+        input_types=[
+            TensorType(
+                DType.float32, [batch, seqlen, n_heads, head_dim], device=cpu
+            ),
+            TensorType(DType.float32, [batch, seqlen, n_heads], device=cpu),
+            TensorType(DType.float32, [n_heads], device=cpu),
+            TensorType(
+                DType.float32,
+                [batch, seqlen, n_heads, state_dim],
+                device=cpu,
+            ),
+            TensorType(
+                DType.float32,
+                [batch, seqlen, n_heads, state_dim],
+                device=cpu,
+            ),
+        ],
+    ) as graph:
+        x_v = graph.inputs[0].tensor
+        dt_v = graph.inputs[1].tensor
+        A_v = graph.inputs[2].tensor
+        B_v = graph.inputs[3].tensor
+        C_v = graph.inputs[4].tensor
+
+        y_v, final_state_v = ssd_chunk_scan_combined(
+            x_v, dt_v, A_v, B_v, C_v, chunk_size=chunk_size
+        )
+        graph.output(y_v, final_state_v)
+
+    session = InferenceSession(devices=[CPU()])
+    model = session.load(graph)
+    cpu_device = model.input_devices[0]
+
+    rng = np.random.default_rng(0)
+    x_np = rng.standard_normal((batch, seqlen, n_heads, head_dim)).astype(
+        np.float32
+    )
+    # Small positive dt keeps the discretized decay well-behaved.
+    dt_np = (
+        np.abs(rng.standard_normal((batch, seqlen, n_heads))) * 0.1
+    ).astype(np.float32)
+    # Negative A produces a contracting state recurrence (Mamba2 convention).
+    A_np = -np.abs(rng.standard_normal((n_heads,))).astype(np.float32)
+    B_np = rng.standard_normal((batch, seqlen, n_heads, state_dim)).astype(
+        np.float32
+    )
+    C_np = rng.standard_normal((batch, seqlen, n_heads, state_dim)).astype(
+        np.float32
+    )
+
+    outs = model.execute(
+        md.Buffer.from_numpy(x_np).to(cpu_device),
+        md.Buffer.from_numpy(dt_np).to(cpu_device),
+        md.Buffer.from_numpy(A_np).to(cpu_device),
+        md.Buffer.from_numpy(B_np).to(cpu_device),
+        md.Buffer.from_numpy(C_np).to(cpu_device),
+    )
+
+    # Outputs are on CPU, so Buffer.to_numpy() round-trips without dlpack.
+    y = outs[0].to_numpy()
+    assert y.shape == (batch, seqlen, n_heads, head_dim)
+    assert np.all(np.isfinite(y)), (
+        "ssd_chunk_scan_combined Y output has non-finite values"
+    )
+
+    final_state = outs[1].to_numpy()
+    assert final_state.shape == (batch, n_heads, head_dim, state_dim)
+    assert np.all(np.isfinite(final_state)), (
+        "ssd_chunk_scan_combined final_state output has non-finite values"
+    )

--- a/mojo/proposals/ssd-chunk-kernels.md
+++ b/mojo/proposals/ssd-chunk-kernels.md
@@ -1,0 +1,113 @@
+# Proposal: Mamba2 SSD chunk-scan prefill kernels
+
+- **Status:** Draft (proposal)
+- **Author:** Evan Owen
+- **Area:** MAX AI kernels (`max/kernels/src/state_space/`)
+- **Tracking:** Phase 2 of the Linear-Attention / SSM roadmap
+
+## Summary
+
+Add the State Space Duality (SSD) **chunk-scan prefill** algorithm for Mamba2
+as a set of Mojo kernels under `max/kernels/src/state_space/`, plus a graph op
+`ssd_chunk_scan_combined`. This is the only genuinely new kernel work for
+Mamba2 — the decode path and all preprocessing already exist (see *Reuse*).
+Because state-space kernels are not on the
+[`max/kernels/CONTRIBUTING.md`](../../max/kernels/CONTRIBUTING.md) "changes we
+accept" list, this proposal seeks a kernels-lead go-ahead before
+implementation PRs.
+
+## Motivation
+
+Mamba2 ([Transformers are SSMs](https://arxiv.org/abs/2405.21060)) replaces
+Mamba1's diagonal selective scan with a scalar-times-identity `A` per head,
+which makes the recurrence equivalent to a structured form of linear attention.
+That equivalence lets prefill be computed **chunk-wise with dense matmuls** that
+map onto tensor cores, instead of a sequential scan. Mamba2 reference
+implementations report 2–8× faster training/prefill from this. MAX currently
+has no chunk-SSD kernel: the existing `ssd_combined` (`selective_scan.mojo`) is,
+despite its name, a Mamba1 *sequential* scan fused with norm+residual.
+
+## Reuse (no new work)
+
+Confirmed present in `max/kernels/src/state_space/`:
+
+| Capability                     | Symbol / file                                                                  | Mamba2 role                                                                                                    |
+|--------------------------------|--------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| Causal conv1d (prefill+update) | `causal_conv1d.mojo`                                                           | identical, reused                                                                                              |
+| Varlen conv1d                  | `varlen_causal_conv1d.mojo`                                                    | identical, reused                                                                                              |
+| Fused RMSNorm + residual       | `rms_norm_fused_residual.mojo`                                                 | identical, reused                                                                                              |
+| Single-token update (scalar A) | `selective_scan_update` (`selective_scan.mojo`)                                | **decode path**, reused as-is                                                                                  |
+| Fused conv+scan, multi-head    | `mamba_split_conv1d_scan_combined_{cpu,gpu}` (`selective_scan.mojo:2260,2766`) | usable Mamba2 **decode** path (already has `nheads`/`headdim`/`ngroups`, scalar A/head; sequential internally) |
+
+So **only the prefill chunk algorithm is new.**
+
+## Proposed design
+
+New file `max/kernels/src/state_space/ssd_chunk.mojo` (keep the 3.2k-line
+`selective_scan.mojo` untouched). The reference is `ssd_minimal_discrete`
+(Listing 1 of the paper). Note the discretization contract: the fused op takes
+raw `x, dt, A, B, C` and internally applies `x ← x·dt`, `A ← A·dt` — i.e. the
+op equals `ssd_minimal_discrete(x·dt, A·dt, B, C, chunk_size)`. Decompose into
+four kernels (each a separate PR), all operating on chunked
+tensors `(batch, n_chunks, chunk_len, n_heads, …)`:
+
+1. **Intra-chunk (diagonal) output.** Within-chunk token×token contribution.
+   `L = exp(segsum(A))`;
+   `Y_diag = einsum("bclhn,bcshn,bhcls,bcshp->bclhp", C, B, L, X)`.
+   Dense GEMM over `chunk_len`; the tensor-core hot path.
+2. **Per-chunk state.** Reduce each chunk to its end-state.
+   `decay = exp(A_cumsum[...,-1:] − A_cumsum)`;
+   `states = einsum("bclhn,bhcl,bclhp->bchpn", B, decay, X)`.
+3. **Inter-chunk recurrence.** Sequential scan over the per-chunk states
+   (length = `n_chunks` ≪ `seqlen`).
+   `decay_chunk = exp(segsum(pad(A_cumsum[...,−1])))`;
+   `new_states = einsum("bhzc,bchpn->bzhpn", decay_chunk, states)`; carries an
+   optional `initial_states` for varlen / cache continuation, emits
+   `final_state` for the SSM cache.
+4. **Output recombination.** Add the inter-chunk contribution.
+   `Y_off = einsum("bclhn,bchpn,bhcl->bclhp", C, states, exp(A_cumsum))`;
+   `Y = Y_diag + Y_off`.
+
+A combined op `ssd_chunk_scan_combined` (registered like
+`selective_scan_ops.mojo`'s `@compiler.register`) fuses dt-discretization,
+conv (optional), the four stages, and the final-state write so the Python
+pipeline calls a single op.
+
+### Dimensions & dtypes
+
+- `n_heads · head_dim = d_model`; `head_dim` 64–128; scalar `A` per head;
+  `n_groups` for B/C sharing; `d_state` (`N`) 64–128.
+- `chunk_size` tunable 64–256, default **128** (trades tensor-core utilization
+  against per-chunk state overhead).
+- Compute in fp32 accumulation; inputs bf16/fp16/fp32. The varlen scan path
+  already supports `MAX_DSTATE=256`, covering Mamba2's range.
+
+## Correctness / parity
+
+Gate every kernel against the PyTorch/CUDA reference: compare
+`ssd_chunk_scan_combined` to `mamba_chunk_scan_combined` and the pure-torch
+`ssd_minimal_discrete` on identical seeded inputs. Tolerances: fp32 rtol
+1e-5/atol 1e-6; fp16 1e-2/1e-3; bf16 2e-2/1e-2. Capture goldens for in-tree
+`assert_almost_equal` tests (`max/kernels/test/{,gpu/}state_space/`), so
+committed tests need no CUDA.
+
+## Testing
+
+- Mojo `std.testing` (`assert_almost_equal`), GPU tests gated on accelerator
+  count; CPU reference path where practical.
+- Per-stage unit tests + a combined-op test + the parity golden test.
+
+## Alternatives considered
+
+- **Extend `ssd_combined`** — rejected: it is Mamba1 sequential scan fused with
+  norm; the chunk algorithm is structurally different.
+- **Sequential scan for prefill** (reuse `mamba_split_conv1d_scan_combined`) —
+  works and is the decode path, but forgoes the tensor-core speedup that is the
+  entire point of Mamba2 prefill.
+
+## Rollout (PR split)
+
+One PR each: (1) intra-chunk kernel, (2) chunk-state kernel, (3) inter-chunk
+scan, (4) output recombination, (5) `ssd_chunk_scan_combined` op wrapper,
+(6) ops wrappers for the existing fused kernels (closes `TODO(MSTDL-2472)`),
+(7) Mamba2 dim parameterization. Each carries its own tests and parity report.


### PR DESCRIPTION
## Linked issue

Part of #5772 (Phase 2: Mamba2 / SSD). Design: the SSD chunk-kernels proposal in this stack.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [X] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Registers `Mamba2ForCausalLM`: the `SupportedArchitecture` entry, a passthrough-chat-template `Mamba2Tokenizer` reusing the Mamba1 tokenizer, and wiring into the lazy architecture registry and `all_arches.bzl`. With this PR the full stack serves a Mamba2 model.

## What changed

Add the SupportedArchitecture entry, Mamba2Tokenizer (passthrough chat
template, reusing the Mamba1 tokenizer), and wire Mamba2ForCausalLM into
the lazy architecture registry and ALL_ARCHITECTURES. Depends on the
preceding Mamba2 model / SSM cache / batch processor / memory planner
link in this stack and on the ssd_chunk_scan_combined kernels.

```
max/python/max/pipelines/architectures/__init__.py |  1 +
 .../max/pipelines/architectures/all_arches.bzl     |  1 +
 .../max/pipelines/architectures/mamba2/__init__.py | 32 +++++++++++--
 .../max/pipelines/architectures/mamba2/arch.py     | 56 ++++++++++++++++++++++
 .../pipelines/architectures/mamba2/tokenizer.py    | 42 ++++++++++++++++
 5 files changed, 129 insertions(+), 3 deletions(-)
```

## Testing

`//max/python/max/pipelines/architectures/...` builds; `pydeps` tests pass. End to end on GB10 (integrated branch): `max generate --model-path AntonV/mamba2-130m-hf --prompt "The capital of France is" --max-new-tokens 20` produces coherent text, 33/33 `state_space` kernel tests pass.

## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [X] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [X] I ran `./bazelw run format` to format my changes
- [X] I added or updated tests to cover my changes

---

## Stack: Mamba2 (SSD) architecture

**Stacked on #6998.** This PR's diff on GitHub includes its prerequisites; review the last commit only (`34704b568e`). It should merge after #6998.

Related but independent (not prerequisites): the Mamba1 kernel PRs #6628, #6632 (causal conv1d) and #6622, #6633 (selective scan) improve the conv/decode paths the Mamba2 model also uses; the SSD stack does not depend on them.

Full series (kernels first, then the MAX pipeline):

1. [Mojo] Propose Mamba2 SSD chunk-kernels algorithm (#6986)
2. [Kernels] Add Mamba2 SSD intra-chunk kernels (scalar + fused MMA) with tests and benches (#6987)
3. [Kernels] Add Mamba2 SSD chunk-state kernel (fused tensor-core path) with tests and benches (#6988)
4. [Kernels] Add Mamba2 SSD inter-chunk state-passing scan kernel with tests and benches (#6989)
5. [Kernels] Add Mamba2 SSD output-recombination kernel (tensor-core + fused stage-4 path) with tests and benches (#6990)
6. [Kernels] Add ssd_chunk_scan_combined op wrapper with final_state output (#6991)
7. [Kernels] Add ssd_combined and mamba_split_conv1d_scan_combined op wrappers (#6992)
8. [Kernels] Add Mamba2-dimension coverage test for the SSD prefill path (#6993)
9. [MAX] Fall back to model_type when the architectures field is missing from a HF config (#6994)
10. [MAX] Mamba2: add ssd_chunk_scan_combined functional-op wrapper (#6995)
11. [MAX] Mamba2: add Mamba2Mixer and Mamba2Block NN modules (#6996)
12. [MAX] Mamba2: add model config and HF weight adapters (#6997)
13. [MAX] Mamba2: add model, SSM cache, batch processor and memory planner (#6998)
14. **[MAX] Mamba2: register the Mamba2ForCausalLM architecture** (#6999)
15. [MAX] Mamba2: add MAX-vs-HF parity integration test (#7000)
