### PR TITLE
[kernels] Added GPU launcher for resize with linear interpolation.

### DIFF
--- a/max/kernels/src/graph_compiler/builtin_kernels/quantization.mojo
+++ b/max/kernels/src/graph_compiler/builtin_kernels/quantization.mojo
@@ -277,20 +277,26 @@ struct ResizeLinear:
 
     @staticmethod
     def execute[
+        dtype: DType,
+        //,
         coordinate_transform_mode: Int,
         antialias: Bool,
         rank: Int,
-        dtype: DType,
+        target: StaticString,
     ](
         output: OutputTensor[dtype=dtype, rank=rank, ...],
         input: InputTensor[dtype=dtype, rank=rank, ...],
         size: InputTensor[rank=1, ...],
-    ):
+        ctx: DeviceContext,
+    ) raises:
         resize_linear[
-            CoordinateTransformationMode(coordinate_transform_mode), antialias
+            CoordinateTransformationMode(coordinate_transform_mode),
+            antialias,
+            target=target,
         ](
             input.to_tile_tensor[.int64](),
             output.to_tile_tensor[.int64](),
+            ctx,
         )
 
 

--- a/max/kernels/src/nn/resize.mojo
+++ b/max/kernels/src/nn/resize.mojo
@@ -17,7 +17,8 @@ from std.math import ceil, floor
 
 from max.algorithm.functional import elementwise
 from max.algorithm.reduction import _get_nd_indices_from_flat_index
-from max.gpu.host import DeviceContext
+from max.gpu.host import DeviceBuffer, DeviceContext
+from max.gpu.host.info import is_cpu, is_gpu
 from layout import (
     Coord,
     TensorLayout,
@@ -25,28 +26,22 @@ from layout import (
     coord_to_index_list,
     row_major,
 )
-from std.memory import unsafe_memcpy
 
+from std.memory import unsafe_memcpy
 from std.utils import IndexList, StaticTuple
 
 
-struct CoordinateTransformationMode(ImplicitlyCopyable):
+@fieldwise_init
+struct CoordinateTransformationMode(Equatable, ImplicitlyCopyable):
     """Specifies how output coordinates map to input coordinates during resize.
     """
 
     var value: Int
+
     comptime HalfPixel = CoordinateTransformationMode(0)
     comptime AlignCorners = CoordinateTransformationMode(1)
     comptime Asymmetric = CoordinateTransformationMode(2)
     comptime HalfPixel1D = CoordinateTransformationMode(3)
-
-    @always_inline
-    def __init__(out self, value: Int):
-        self.value = value
-
-    @always_inline
-    def __eq__(self, other: CoordinateTransformationMode) -> Bool:
-        return self.value == other.value
 
 
 @__parameter
@@ -87,47 +82,36 @@ def coord_transform[
         if out_dim == 1:
             return 0
         # note: resized image will have same corners as original image
-        return (
-            out_coord_f32
-            * (Float64(in_dim - 1) / Float64(out_dim - 1)).cast[.float32]()
-        )
+        return out_coord_f32 * (Float32(in_dim - 1) / Float32(out_dim - 1))
     elif mode == CoordinateTransformationMode.Asymmetric:
         return out_coord_f32 / scale
     else:
         comptime assert False, "coordinate_transformation_mode not implemented"
 
 
-struct RoundMode(ImplicitlyCopyable):
+@fieldwise_init
+struct RoundMode(Equatable, ImplicitlyCopyable):
     """Specifies how fractional coordinates are rounded to integer indices during nearest-neighbor resize.
     """
 
     var value: Int
+
     comptime HalfDown = RoundMode(0)
     comptime HalfUp = RoundMode(1)
     comptime Floor = RoundMode(2)
     comptime Ceil = RoundMode(3)
 
-    @always_inline
-    def __init__(out self, value: Int):
-        self.value = value
-
-    @always_inline
-    def __eq__(self, other: RoundMode) -> Bool:
-        return self.value == other.value
-
 
 @fieldwise_init
-struct InterpolationMode(ImplicitlyCopyable):
+struct InterpolationMode(Equatable, ImplicitlyCopyable):
     """Specifies the interpolation method used during resize."""
 
     var value: Int
+
     comptime Linear = InterpolationMode(0)
 
-    @always_inline
-    def __eq__(self, other: InterpolationMode) -> Bool:
-        return self.value == other.value
 
-
+@fieldwise_init
 struct Interpolator[mode: InterpolationMode](
     Defaultable, TrivialRegisterPassable
 ):
@@ -135,10 +119,6 @@ struct Interpolator[mode: InterpolationMode](
     """
 
     var cubic_coeff: Float32
-
-    @always_inline
-    def __init__(out self, cubic_coeff: Float32):
-        self.cubic_coeff = cubic_coeff
 
     @always_inline
     def __init__(out self):
@@ -158,6 +138,23 @@ struct Interpolator[mode: InterpolationMode](
             Self.mode == InterpolationMode.Linear
         ), "InterpolationMode not supported"
         return linear_filter(x)
+
+
+@always_inline
+def linear_filter(x: Float32) -> Float32:
+    """This is a tent filter.
+
+    f(x) = 1 + x, x < 0
+    f(x) = 1 - x, 0 <= x < 1
+    f(x) = 0, x >= 1
+
+    """
+    var coeff = x
+    if x < 0:
+        coeff = -x
+    if x < 1:
+        return 1 - coeff
+    return 0
 
 
 def resize_nearest_neighbor[
@@ -233,49 +230,30 @@ def resize_nearest_neighbor[
     elementwise[1](nn_interpolate, output.layout.shape_coord(), ctx)
 
 
-@always_inline
-def linear_filter(x: Float32) -> Float32:
-    """This is a tent filter.
-
-    f(x) = 1 + x, x < 0
-    f(x) = 1 - x, 0 <= x < 1
-    f(x) = 0, x >= 1
-
-    """
-    var coeff = x
-    if x < 0:
-        coeff = -x
-    if x < 1:
-        return 1 - coeff
-    return 0
-
-
 @__parameter
 @always_inline
 def interpolate_point_1d[
     InputLayoutType: TensorLayout,
+    dtype: DType,
     //,
     coordinate_transformation_mode: CoordinateTransformationMode,
     antialias: Bool,
-    dtype: DType,
     interpolation_mode: InterpolationMode,
 ](
     interpolator: Interpolator[interpolation_mode],
     dim: Int,
     out_coords: IndexList[InputLayoutType.rank],
     scale: Float32,
-    input: TileTensor[
-        mut=False, dtype, InputLayoutType, address_space=.GENERIC, ...
-    ],
-    output: TileTensor[mut=True, dtype, address_space=.GENERIC, ...],
+    input: TileTensor[mut=False, dtype, InputLayoutType, ...],
+    output: TileTensor[mut=True, dtype, ...],
 ):
     """Computes one-dimensional interpolation for a single output point along a given dimension.
 
     Parameters:
         InputLayoutType: The layout type of the input tensor.
+        dtype: The element type of the input and output tensors.
         coordinate_transformation_mode: The coordinate transformation mode to apply.
         antialias: Whether to stretch the filter to antialias when downsampling.
-        dtype: The element type of the input and output tensors.
         interpolation_mode: The interpolation mode to use.
 
     Args:
@@ -317,37 +295,73 @@ def interpolate_point_1d[
 
 
 def resize_linear[
+    dtype: DType,
+    //,
     coordinate_transformation_mode: CoordinateTransformationMode,
     antialias: Bool,
-    dtype: DType,
+    target: StaticString = "cpu",
 ](
     input: TileTensor[mut=True, dtype, address_space=.GENERIC, ...],
     output: TileTensor[mut=True, dtype, address_space=.GENERIC, ...],
-):
+    ctx: Optional[DeviceContext] = None,
+) raises:
     """Resizes input to output shape using linear interpolation.
 
     Parameters:
+        dtype: Type of input and output.
         coordinate_transformation_mode: How to map a coordinate in output to a coordinate in input.
         antialias: Whether or not to use an antialiasing linear/cubic filter, which when downsampling, uses
             more points to avoid aliasing artifacts. Effectively stretches the filter by a factor of 1 / scale.
-        dtype: Type of input and output.
+        target: Execution target, either "cpu" or "gpu".
 
     Args:
         input: The input to be resized.
         output: The output containing the resized input.
-
-
+        ctx: The DeviceContext to use for GPU execution.
     """
-    _resize[
+    comptime if is_cpu[target]():
+        resize_linear_cpu[coordinate_transformation_mode, antialias](
+            input, output
+        )
+    elif is_gpu[target]():
+        resize_linear_gpu[coordinate_transformation_mode, antialias](
+            input, output, ctx.value()
+        )
+    else:
+        comptime assert False, "Unknown target " + target
+
+
+def resize_linear_cpu[
+    dtype: DType,
+    //,
+    coordinate_transformation_mode: CoordinateTransformationMode,
+    antialias: Bool,
+](
+    input: TileTensor[mut=True, dtype, address_space=.GENERIC, ...],
+    output: TileTensor[mut=True, dtype, address_space=.GENERIC, ...],
+):
+    """Resizes input to output shape on CPU using linear interpolation.
+
+    Parameters:
+        dtype: Type of input and output.
+        coordinate_transformation_mode: How to map a coordinate in output to a coordinate in input.
+        antialias: Whether to stretch the filter to antialias when downsampling.
+
+    Args:
+        input: The input to be resized.
+        output: The output containing the resized input.
+    """
+    _resize_cpu[
         InterpolationMode.Linear, coordinate_transformation_mode, antialias
     ](input, output)
 
 
-def _resize[
+def _resize_cpu[
+    dtype: DType,
+    //,
     interpolation_mode: InterpolationMode,
     coordinate_transformation_mode: CoordinateTransformationMode,
     antialias: Bool,
-    dtype: DType,
 ](
     input: TileTensor[mut=True, dtype, address_space=.GENERIC, ...],
     output: TileTensor[mut=True, dtype, address_space=.GENERIC, ...],
@@ -364,6 +378,7 @@ def _resize[
         return unsafe_memcpy(
             dest=output.ptr, src=input.ptr, count=input.num_elements()
         )
+
     var scales = StaticTuple[Float32, input.rank]()
     var resize_dims = List[Int](capacity=input.rank)
     var tmp_dims = IndexList[input.rank](0)
@@ -379,7 +394,7 @@ def _resize[
 
     var in_ptr = input.ptr.unsafe_origin_cast[MutUntrackedOrigin]()
     # SAFETY: Placeholder; always overwritten below.
-    var out_ptr = UnsafePointer[Scalar[dtype], MutAnyOrigin].unsafe_dangling()
+    var out_ptr = Pointer[Scalar[dtype], MutAnyOrigin].unsafe_dangling()
 
     var using_tmp1 = False
     var tmp_buffer1 = List[Scalar[dtype]]()
@@ -443,5 +458,171 @@ def _resize[
         ).as_unsafe_any_origin()
         using_tmp1 = not using_tmp1
 
+    _ = tmp_buffer1^
+    _ = tmp_buffer2^
+
+
+def resize_linear_gpu[
+    dtype: DType,
+    //,
+    coordinate_transformation_mode: CoordinateTransformationMode,
+    antialias: Bool,
+](
+    input: TileTensor[mut=True, dtype, address_space=.GENERIC, ...],
+    output: TileTensor[mut=True, dtype, address_space=.GENERIC, ...],
+    ctx: DeviceContext,
+) raises:
+    """Resizes input to output shape on GPU using linear interpolation.
+
+    Parameters:
+        dtype: Type of input and output.
+        coordinate_transformation_mode: How to map a coordinate in output to a coordinate in input.
+        antialias: Whether to stretch the filter to antialias when downsampling.
+
+    Args:
+        input: The input to be resized.
+        output: The output containing the resized input.
+        ctx: The device context used to launch the kernels.
+    """
+    _resize_gpu[
+        InterpolationMode.Linear, coordinate_transformation_mode, antialias
+    ](input, output, ctx)
+
+
+def _resize_gpu[
+    dtype: DType,
+    //,
+    interpolation_mode: InterpolationMode,
+    coordinate_transformation_mode: CoordinateTransformationMode,
+    antialias: Bool,
+](
+    input: TileTensor[mut=True, dtype, address_space=.GENERIC, ...],
+    output: TileTensor[mut=True, dtype, address_space=.GENERIC, ...],
+    ctx: DeviceContext,
+) raises:
+    comptime assert (
+        input.rank == output.rank
+    ), "input rank must match output rank"
+
+    var scales = StaticTuple[Float32, input.rank]()
+    var resize_dims = List[Int](capacity=input.rank)
+    var tmp_dims = IndexList[input.rank](0)
+    for i in range(input.rank):
+        # need to consider output dims when upsampling and input dims when downsampling
+        tmp_dims[i] = max(Int(input.dim(i)), Int(output.dim(i)))
+        scales[i] = (Float64(output.dim(i)) / Float64(input.dim(i))).cast[
+            DType.float32
+        ]()
+        if Int(input.dim(i)) != Int(output.dim(i)):
+            resize_dims.append(i)
+
+    # Every dimension already matches, so the resize is the identity. The pass
+    # loop below iterates zero times in that case and would leave `output`
+    # untouched, so this copy is required for correctness, not just speed. It
+    # goes through `elementwise` rather than a driver-level `enqueue_copy` so
+    # that non-contiguous layouts stay correct.
+    if len(resize_dims) == 0:
+
+        def copy[simd_width: Int, alignment: Int = 1](out_coords: Coord) {var}:
+            var coords = IndexList[input.rank](0)
+
+            comptime for i in range(input.rank):
+                coords[i] = Int(out_coords[i].value())
+
+            output.raw_store(
+                output.layout(Coord(coords)),
+                input.raw_load(input.layout(Coord(coords))),
+            )
+
+        return elementwise[1, target="gpu"](
+            copy, output.layout.shape_coord(), ctx
+        )
+
+    var interpolator = Interpolator[interpolation_mode]()
+
+    var in_ptr = input.ptr.unsafe_origin_cast[MutUntrackedOrigin]()
+    # SAFETY: Placeholder; always overwritten below.
+    var out_ptr = Pointer[Scalar[dtype], MutAnyOrigin].unsafe_dangling()
+
+    var using_tmp1 = False
+    var tmp_buffer1 = Optional[DeviceBuffer[dtype]](None)
+    var tmp_buffer2 = Optional[DeviceBuffer[dtype]](None)
+
+    # ping pong between using tmp_buffer1 and tmp_buffer2 to store outputs
+    # of 1d interpolation pass across one of the dimensions
+    if len(resize_dims) == 1:  # avoid allocating tmp_buffer
+        out_ptr = output.ptr.unsafe_origin_cast[MutAnyOrigin]()
+    if len(resize_dims) > 1:  # avoid allocating second tmp_buffer
+        tmp_buffer1 = ctx.enqueue_create_buffer[dtype](
+            tmp_dims.flattened_length()
+        )
+        out_ptr = tmp_buffer1.value().unsafe_ptr().as_unsafe_any_origin()
+        using_tmp1 = True
+    if len(resize_dims) > 2:  # need a second tmp_buffer
+        # TODO: if you are upsampling all dims, you can use the output in place of tmp_buffer2
+        # as long as you make sure that the last iteration uses tmp1_buffer as the input
+        # and tmp_buffer2 (output) as the output
+        tmp_buffer2 = ctx.enqueue_create_buffer[dtype](
+            tmp_dims.flattened_length()
+        )
+
+    var in_shape = coord_to_index_list(input.layout.shape_coord())
+    var out_shape = coord_to_index_list(input.layout.shape_coord())
+    # interpolation is separable, so perform 1d interpolation across each
+    # interpolated dimension
+    for dim_idx in range(len(resize_dims)):
+        if dim_idx == len(resize_dims) - 1:
+            out_ptr = output.ptr.unsafe_origin_cast[MutAnyOrigin]()
+        var resize_dim = resize_dims[dim_idx]
+        out_shape[resize_dim] = Int(output.dim(resize_dim))
+
+        var in_buf = TileTensor(in_ptr, row_major(Coord(in_shape)))
+        var out_buf = TileTensor(out_ptr, row_major(Coord(out_shape)))
+
+        # `elementwise` hands back the full nd coordinate, so unlike the CPU
+        # path there is no flat-index decomposition to undo.
+        def interpolate[
+            simd_width: Int, alignment: Int = 1
+        ](out_coords: Coord) {var}:
+            var coords = IndexList[in_buf.rank](0)
+
+            comptime for i in range(in_buf.rank):
+                coords[i] = Int(out_coords[i].value())
+
+            interpolate_point_1d[
+                InputLayoutType=in_buf.LayoutType,
+                coordinate_transformation_mode,
+                antialias,
+            ](
+                interpolator,
+                resize_dim,
+                coords,
+                scales[resize_dim],
+                in_buf,
+                out_buf,
+            )
+
+        # Passes are stream-ordered, so pass N+1 observes pass N's writes.
+        elementwise[1, target="gpu"](
+            interpolate, out_buf.layout.shape_coord(), ctx
+        )
+
+        in_shape = out_shape
+        in_ptr = out_ptr.unsafe_origin_cast[MutUntrackedOrigin]()
+
+        # Point at the other scratch buffer for the next pass. The final pass
+        # retargets `out_ptr` at `output` on entry, so this only runs when a
+        # scratch buffer is genuinely needed -- which is also the only case in
+        # which these `Optional`s hold a value. (The CPU path can skip the
+        # guard because `List.unsafe_ptr()` on an empty list is harmless.)
+        if dim_idx + 2 < len(resize_dims):
+            out_ptr = (
+                tmp_buffer2.value()
+                .unsafe_ptr() if using_tmp1 else tmp_buffer1.value()
+                .unsafe_ptr()
+            ).as_unsafe_any_origin()
+        using_tmp1 = not using_tmp1
+
+    # Keep the scratch allocations alive until every launch above is enqueued.
     _ = tmp_buffer1^
     _ = tmp_buffer2^

--- a/max/kernels/test/gpu/nn/test_resize_linear.mojo
+++ b/max/kernels/test/gpu/nn/test_resize_linear.mojo
@@ -1,0 +1,255 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+"""GPU `resize_linear` tests against torch reference values.
+
+Reference values are the torch outputs already pinned by the CPU suite in
+`max/kernels/test/nn/test_resize.mojo`; each case names the torch invocation it
+came from.
+
+Two tolerance tiers, because reference precision -- not kernel accuracy -- is
+the binding constraint:
+
+- `EXACT_*`: the expected values are dyadic rationals (halves and quarters), so
+  they are exactly representable in float32 and the reference literals are not
+  truncated. These get a tight tolerance.
+- `TRUNC_*`: the expected values are thirds or sevenths written to five decimal
+  places, so the literal itself is up to ~5e-6 off. The tolerance has to cover
+  that, which means a perturbation below ~1e-4 at magnitude 1 will not be
+  caught by those cases. Any real algorithmic error is orders of magnitude
+  larger.
+"""
+
+from layout import TensorLayout, TileTensor, coord, row_major
+from max.gpu.host import DeviceContext
+from nn.resize import CoordinateTransformationMode, resize_linear
+from std.testing import assert_almost_equal
+
+# Exactly-representable references; bounded only by cross-vendor FMA
+# contraction, not by the literals.
+comptime EXACT_ATOL = 1e-6
+comptime EXACT_RTOL = 1e-6
+
+# References truncated to five decimal places in the torch transcript.
+comptime TRUNC_ATOL = 1e-5
+comptime TRUNC_RTOL = 1e-4
+
+
+def _check[
+    InLayoutType: TensorLayout,
+    OutLayoutType: TensorLayout,
+    //,
+    coordinate_transformation_mode: CoordinateTransformationMode,
+    antialias: Bool,
+](
+    ctx: DeviceContext,
+    name: StaticString,
+    input_layout: InLayoutType,
+    output_layout: OutLayoutType,
+    data: List[Float32],
+    reference: List[Float32],
+    atol: Float64,
+    rtol: Float64,
+) raises:
+    """Resizes `data` on the GPU and compares against `reference`.
+
+    Args:
+        ctx: The device context used to launch the kernels.
+        name: Case name, printed so a failure identifies itself.
+        input_layout: Layout of the input tensor.
+        output_layout: Layout of the output tensor.
+        data: Input values, laid out row-major.
+        reference: Expected output values, laid out row-major.
+        atol: Absolute tolerance for the comparison.
+        rtol: Relative tolerance for the comparison.
+    """
+    print("== ", name)
+    var n_in = len(data)
+    var n_out = len(reference)
+
+    var input_host = ctx.enqueue_create_host_buffer[DType.float32](n_in)
+    var output_host = ctx.enqueue_create_host_buffer[DType.float32](n_out)
+    ctx.synchronize()
+
+    for i in range(n_in):
+        input_host[i] = data[i]
+
+    # Zero-fill the output so an element the kernel never writes is caught
+    # rather than read back as stale device memory.
+    for i in range(n_out):
+        output_host[i] = 0
+
+    var input_device = ctx.enqueue_create_buffer[DType.float32](n_in)
+    var output_device = ctx.enqueue_create_buffer[DType.float32](n_out)
+    ctx.enqueue_copy(input_device, input_host)
+    ctx.enqueue_copy(output_device, output_host)
+
+    resize_linear[coordinate_transformation_mode, antialias, target="gpu"](
+        TileTensor(input_device, input_layout),
+        TileTensor(output_device, output_layout),
+        ctx,
+    )
+
+    ctx.enqueue_copy(output_host, output_device)
+    ctx.synchronize()
+
+    for i in range(n_out):
+        assert_almost_equal(output_host[i], reference[i], atol=atol, rtol=rtol)
+
+    _ = input_device
+    _ = output_device
+
+
+def main() raises:
+    with DeviceContext() as ctx:
+        # fmt: off
+
+        # One resized dim: single launch, writes straight to `output`, no
+        # scratch buffer. Expected values are exact quarters, derived by hand
+        # from the half-pixel mapping rather than transcribed from torch.
+        _check[CoordinateTransformationMode.HalfPixel, False](
+            ctx,
+            "one_pass_inner_dim",
+            row_major(coord[1, 1, 2, 2]),
+            row_major(coord[1, 1, 2, 4]),
+            [Float32(1), 2, 3, 4],
+            [Float32(1.0), 1.25, 1.75, 2.0, 3.0, 3.25, 3.75, 4.0],
+            EXACT_ATOL, EXACT_RTOL,
+        )
+
+        # Two resized dims: allocates tmp_buffer1 and ping-pongs once.
+        # x = np.arange(1, 5).reshape((1, 1, 2, 2))
+        # torch.nn.functional.interpolate(torch.Tensor(x), (4, 4), mode="bilinear")
+        _check[CoordinateTransformationMode.HalfPixel, False](
+            ctx,
+            "upsample_sizes_linear",
+            row_major(coord[1, 1, 2, 2]),
+            row_major(coord[1, 1, 4, 4]),
+            [Float32(1), 2, 3, 4],
+            [
+                Float32(1.0000), 1.2500, 1.7500, 2.0000,
+                1.5000, 1.7500, 2.2500, 2.5000,
+                2.5000, 2.7500, 3.2500, 3.5000,
+                3.0000, 3.2500, 3.7500, 4.0000,
+            ],
+            EXACT_ATOL, EXACT_RTOL,
+        )
+
+        # Same shape, align_corners=True: the mapping uses (in-1)/(out-1), so
+        # the expected values are thirds and the literals are truncated.
+        # torch...interpolate(
+        #   torch.Tensor(x), (4, 4), mode="bilinear", align_corners=True
+        # )
+        _check[CoordinateTransformationMode.AlignCorners, False](
+            ctx,
+            "upsample_sizes_linear_align_corners",
+            row_major(coord[1, 1, 2, 2]),
+            row_major(coord[1, 1, 4, 4]),
+            [Float32(1), 2, 3, 4],
+            [
+                Float32(1.0000), 1.3333, 1.6667, 2.0000,
+                1.6667, 2.0000, 2.3333, 2.6667,
+                2.3333, 2.6667, 3.0000, 3.3333,
+                3.0000, 3.3333, 3.6667, 4.0000,
+            ],
+            TRUNC_ATOL, TRUNC_RTOL,
+        )
+
+        # Downsample across two dims.
+        # x = np.arange(1, 9).reshape((1, 1, 2, 4))
+        # torch...interpolate(torch.Tensor(x), (1, 2), mode="bilinear")
+        _check[CoordinateTransformationMode.HalfPixel, False](
+            ctx,
+            "downsample_sizes_linear",
+            row_major(coord[1, 1, 2, 4]),
+            row_major(coord[1, 1, 1, 2]),
+            [Float32(1), 2, 3, 4, 5, 6, 7, 8],
+            [Float32(3.5), 5.5],
+            EXACT_ATOL, EXACT_RTOL,
+        )
+
+        # Same, align_corners=True -- exercises the `out_dim == 1` early return
+        # in `coord_transform`, where AlignCorners and HalfPixel diverge.
+        _check[CoordinateTransformationMode.AlignCorners, False](
+            ctx,
+            "downsample_sizes_linear_align_corners",
+            row_major(coord[1, 1, 2, 4]),
+            row_major(coord[1, 1, 1, 2]),
+            [Float32(1), 2, 3, 4, 5, 6, 7, 8],
+            [Float32(1), 4],
+            EXACT_ATOL, EXACT_RTOL,
+        )
+
+        # Three resized dims: allocates both scratch buffers and exercises the
+        # ping-pong guard at the tail of the pass loop in `_resize_gpu`.
+        # x = np.arange(16).reshape((1, 1, 4, 2, 2))
+        # torch...interpolate(torch.Tensor(x), (6, 4, 4), mode="trilinear")
+        _check[CoordinateTransformationMode.HalfPixel, False](
+            ctx,
+            "upsample_sizes_trilinear",
+            row_major(coord[1, 4, 2, 2]),
+            row_major(coord[1, 6, 4, 4]),
+            [
+                Float32(0), 1, 2, 3, 4, 5, 6, 7,
+                8, 9, 10, 11, 12, 13, 14, 15,
+            ],
+            [
+                Float32(0.00000),  0.25000,  0.75000,  1.00000,  0.50000,  0.75000,  1.25000,
+                1.50000,  1.50000,  1.75000,  2.25000,  2.50000,  2.00000,  2.25000,
+                2.75000,  3.00000,  2.00000,  2.25000,  2.75000,  3.00000,  2.50000,
+                2.75000,  3.25000,  3.50000,  3.50000,  3.75000,  4.25000,  4.50000,
+                4.00000,  4.25000,  4.75000,  5.00000,  4.66667,  4.91667,  5.41667,
+                5.66667,  5.16667,  5.41667,  5.91667,  6.16667,  6.16667,  6.41667,
+                6.91667,  7.16667,  6.66667,  6.91667,  7.41667,  7.66667,  7.33333,
+                7.58333,  8.08333,  8.33333,  7.83333,  8.08333,  8.58333,  8.83333,
+                8.83333,  9.08333,  9.58333,  9.83333,  9.33333,  9.58333, 10.08333,
+                10.33333, 10.00000, 10.25000, 10.75000, 11.00000, 10.50000, 10.75000,
+                11.25000, 11.50000, 11.50000, 11.75000, 12.25000, 12.50000, 12.00000,
+                12.25000, 12.75000, 13.00000, 12.00000, 12.25000, 12.75000, 13.00000,
+                12.50000, 12.75000, 13.25000, 13.50000, 13.50000, 13.75000, 14.25000,
+                14.50000, 14.00000, 14.25000, 14.75000, 15.00000,
+            ],
+            TRUNC_ATOL, TRUNC_RTOL,
+        )
+
+        # Antialiased downsample: the stretched filter widens the tap window, so
+        # the per-thread trip count varies across the warp. Expected values are
+        # sevenths, hence truncated literals.
+        # x = np.arange(16).reshape((1, 1, 4, 4))
+        # torch...interpolate(torch.Tensor(x), (2, 2), mode="bilinear", antialias=True)
+        _check[CoordinateTransformationMode.HalfPixel, True](
+            ctx,
+            "downsample_sizes_linear_antialias",
+            row_major(coord[1, 1, 4, 4]),
+            row_major(coord[1, 1, 2, 2]),
+            [
+                Float32(0), 1, 2, 3, 4, 5, 6, 7,
+                8, 9, 10, 11, 12, 13, 14, 15,
+            ],
+            [Float32(3.57143), 5.14286, 9.85714, 11.42857],
+            TRUNC_ATOL, TRUNC_RTOL,
+        )
+
+        # Identity: no dim changes, so the pass loop runs zero times and the
+        # early-out copy is the only thing that writes `output`. Values are
+        # distinct so a copy that shifts or transposes is caught.
+        _check[CoordinateTransformationMode.HalfPixel, False](
+            ctx,
+            "no_resize",
+            row_major(coord[1, 1, 2, 2]),
+            row_major(coord[1, 1, 2, 2]),
+            [Float32(1), 2, 3, 4],
+            [Float32(1), 2, 3, 4],
+            EXACT_ATOL, EXACT_RTOL,
+        )
+
+        # fmt: on


### PR DESCRIPTION
## Linked issue

Fixes #6781 (together with PR #6981 ). 

An accompanying internal graph-compiler change is required to remove the `MO_HostOnly` constraint from `mo.resize.linear` ( @joshpeterson , see also comment from @JoeLoser ).
## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [x] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Linear resize currently cannot be used with accelerator-backed MAX graph tensors. This affects every accelerator backend, not only Metal (see issue #6781 ).

The graph compiler rejects the operation during device placement because mo.resize.linear is declared host-only. On the kernel side, resize_linear previously targeted only CPU.

## What changed

- I added a launcher for GPU to `resize_linear` (`resize_linear_gpu`). This closely follows the preparation of `resize_linear_cpu`. I thought the first iteration should fix the issue and then we can improve on it.
- Used f32 in coordinate transformations. This is so that the kernel can run on Metal.
- Updated `ResizeLinear.execute` to accept and forward the graph compiler’s selected target.
- Added a GPU kernel test comparing with torch reference, taken from `max/kernels/test/nn/test_resize.mojo`.

## Testing

Added a GPU kernel test comparing with torch reference, taken from `max/kernels/test/nn/test_resize.mojo`.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
