### PR TITLE
[Kernels] Simplify `MaskName` initialization and equality

### DIFF
--- a/max/kernels/src/nn/attention/mha_mask.mojo
+++ b/max/kernels/src/nn/attention/mha_mask.mojo
@@ -31,7 +31,8 @@ from std.builtin.device_passable import DevicePassable, DeviceTypeEncoder
 # ===-----------------------------------------------------------------------===#
 
 
-struct MaskName(Writable):
+@fieldwise_init
+struct MaskName(Equatable, Writable):
     """A canonical string name identifying a mask type."""
 
     var name: String
@@ -45,9 +46,6 @@ struct MaskName(Writable):
     comptime CHUNKED_CAUSAL = Self("chunked_causal")
     comptime CAUSAL_PADDING = Self("causal_padding")
 
-    def __init__(out self, name: String):
-        self.name = name
-
     def write_to(self, mut writer: Some[Writer]):
         """Writes the mask name.
 
@@ -56,14 +54,8 @@ struct MaskName(Writable):
         """
         writer.write_string(self.name)
 
-    def __eq__(self, rhs: Self) -> Bool:
-        return self.name == rhs.name
-
     def __eq__(self, rhs: String) -> Bool:
         return self.name == rhs
-
-    def __ne__(self, rhs: Self) -> Bool:
-        return self.name != rhs.name
 
 
 # ===-----------------------------------------------------------------------===#


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [x] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Structs of the following format:

```mojo
struct SomeStruct:

    var value: Int

    @always_inline # Optional
    def __init__(out self, value: Int):
        self.value = value
   
   @always_inline # Optional
   def __eq__(self, other: Self) -> Bool:
       return self.value == other.value
       
  @always_inline # Optional
  def __ne__(self, other: Self) -> Bool:
      return self.value != other.value
```

Can be written using `fieldwise_init` decorator and default implementation of the `Equatable` trait. 

```mojo
@fieldwise_init
struct SomeStruct(Equatable):
    var value: Int
```

## What changed

Performed the refactor above.

## Testing

Ran the existing tests.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
