### PR TITLE
[docs] Simplify Meters initialization and equality

### DIFF
--- a/mojo/docs/code/reference/cheat-sheets/test_traits.mojo
+++ b/mojo/docs/code/reference/cheat-sheets/test_traits.mojo
@@ -33,14 +33,9 @@ from std.math import ceil, floor, trunc
 # Implementing only the required methods (__eq__, __lt__, write_to) and letting
 # the rest be provided/synthesized is itself the test: it compiles only if the
 # card's required-method claims are correct.
+@fieldwise_init
 struct Meters(Comparable, Copyable, Movable, Writable):
     var v: Int
-
-    def __init__(out self, v: Int):
-        self.v = v
-
-    def __eq__(self, other: Self) -> Bool:
-        return self.v == other.v
 
     def __lt__(self, rhs: Self) -> Bool:
         return self.v < rhs.v


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [x] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Structs of the following format:

```mojo
struct SomeStruct:

    var value: Int

    @always_inline # Optional
    def __init__(out self, value: Int):
        self.value = value
   
   @always_inline # Optional
   def __eq__(self, other: Self) -> Bool:
       return self.value == other.value
       
  @always_inline # Optional
  def __ne__(self, other: Self) -> Bool:
      return self.value != other.value
```

Can be written using `fieldwise_init` decorator and default implementation of the `Equatable` trait. 

```mojo
@fieldwise_init
struct SomeStruct(Equatable):
    var value: Int
```

## What changed

Performed the refactor above.

## Testing

Ran the existing tests.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
