### PR TITLE
[Kernels] Simplify `ReduceTier` initialization and equality

### DIFF
--- a/max/kernels/src/algorithm/rowwise_types.mojo
+++ b/max/kernels/src/algorithm/rowwise_types.mojo
@@ -84,7 +84,8 @@ def tile_alignment[dtype: DType, ws: Int, target: StaticString]() -> Int:
 # ===-----------------------------------------------------------------------===#
 
 
-struct ReduceTier(ImplicitlyCopyable, TrivialRegisterPassable):
+@fieldwise_init
+struct ReduceTier(Equatable, ImplicitlyCopyable, TrivialRegisterPassable):
     """GPU tier discriminator for the row-wise scaffolder. Mutually
     exclusive by construction (a single field, not independent bools):
     `Block` is the default (also every CPU tier, where only
@@ -109,18 +110,6 @@ struct ReduceTier(ImplicitlyCopyable, TrivialRegisterPassable):
     comptime Splitk = ReduceTier(3)
     """Multiple blocks cooperate on one row when `num_rows < sm_count`
     would otherwise leave SMs idle (GPU only)."""
-
-    @always_inline
-    def __init__(out self, value: Int):
-        self.value = value
-
-    @always_inline
-    def __eq__(self, other: Self) -> Bool:
-        return self.value == other.value
-
-    @always_inline
-    def __ne__(self, other: Self) -> Bool:
-        return self.value != other.value
 
 
 struct ContextParams(TrivialRegisterPassable):


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [x] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Structs of the following format:

```mojo
struct SomeStruct:

    var value: Int

    @always_inline # Optional
    def __init__(out self, value: Int):
        self.value = value
   
   @always_inline # Optional
   def __eq__(self, other: Self) -> Bool:
       return self.value == other.value
       
  @always_inline # Optional
  def __ne__(self, other: Self) -> Bool:
      return self.value != other.value
```

Can be written using `fieldwise_init` decorator and default implementation of the `Equatable` trait. 

```mojo
@fieldwise_init
struct SomeStruct(Equatable):
    var value: Int
```

## What changed

Performed the refactor above.

## Testing

Ran the existing tests.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
