### PR TITLE
[Kernels] Simplify `PDLLevel` initialization and equality

### DIFF
--- a/max/mojo/max/gpu/primitives/grid_controls.mojo
+++ b/max/mojo/max/gpu/primitives/grid_controls.mojo
@@ -133,7 +133,8 @@ def wait_on_dependent_grids():
         __mlir_op.`nvvm.griddepcontrol`[kind=kind_attr, _type=None]()
 
 
-struct PDLLevel(Defaultable, TrivialRegisterPassable):
+@fieldwise_init
+struct PDLLevel(Defaultable, Equatable, TrivialRegisterPassable):
     """Programmatic Dependency Launch (PDL) level."""
 
     var _level: Int
@@ -159,27 +160,6 @@ struct PDLLevel(Defaultable, TrivialRegisterPassable):
         self = PDLLevel.OFF
 
     @always_inline
-    def __init__(out self, level: Int):
-        """Initialize the PDL level.
-
-        Args:
-            level: The PDL level to initialize.
-        """
-        self._level = level
-
-    @always_inline
-    def __eq__(self, other: PDLLevel) -> Bool:
-        """Check if the PDL level is equal to another PDL level.
-
-        Args:
-            other: The other PDL level to compare against.
-
-        Returns:
-            True if the PDL level is equal to the other PDL level, False otherwise.
-        """
-        return self._level == other._level
-
-    @always_inline
     def __eq__(self, other: Int) -> Bool:
         """Check if the PDL level is equal to another PDL level.
 
@@ -190,18 +170,6 @@ struct PDLLevel(Defaultable, TrivialRegisterPassable):
             True if the PDL level is equal to the other PDL level, False otherwise.
         """
         return self._level == other
-
-    @always_inline
-    def __ne__(self, other: PDLLevel) -> Bool:
-        """Check if the PDL level is not equal to another PDL level.
-
-        Args:
-            other: The other PDL level to compare against.
-
-        Returns:
-            True if the PDL level is not equal to the other PDL level, False otherwise.
-        """
-        return self._level != other._level
 
     @always_inline
     def __gt__(self, other: PDLLevel) -> Bool:


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [x] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Structs of the following format:

```mojo
struct SomeStruct:

    var value: Int

    @always_inline # Optional
    def __init__(out self, value: Int):
        self.value = value
   
   @always_inline # Optional
   def __eq__(self, other: Self) -> Bool:
       return self.value == other.value
       
  @always_inline # Optional
  def __ne__(self, other: Self) -> Bool:
      return self.value != other.value
```

Can be written using `fieldwise_init` decorator and default implementation of the `Equatable` trait. 

```mojo
@fieldwise_init
struct SomeStruct(Equatable):
    var value: Int
```

## What changed

Performed the refactor above.

## Testing

Ran the existing tests.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
