### PR TITLE
[Kernels] Simplify `SHMEMScope` initialization and equality

### DIFF
--- a/max/kernels/src/shmem/shmem_api.mojo
+++ b/max/kernels/src/shmem/shmem_api.mojo
@@ -108,6 +108,7 @@ from ._nvshmem import (
 comptime shmem_team_t = c_int
 
 
+@fieldwise_init
 struct SHMEMScope(Equatable, ImplicitlyCopyable):
     """Enables following the OpenSHMEM spec by default for put/get/iput/iget
     etc. While allowing NVIDIA extensions for block and warp scopes by passing a
@@ -121,12 +122,6 @@ struct SHMEMScope(Equatable, ImplicitlyCopyable):
     """Execute RMA operation at thread block scope (NVIDIA extension)."""
     comptime warp = Self("_warp")
     """Execute RMA operation at warp scope (NVIDIA extension)."""
-
-    def __init__(out self, value: StaticString):
-        self.value = value
-
-    def __eq__(self, other: Self) -> Bool:
-        return self.value == other.value
 
 
 # ===----------------------------------------------------------------------=== #


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [x] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Structs of the following format:

```mojo
struct SomeStruct:

    var value: Int

    @always_inline # Optional
    def __init__(out self, value: Int):
        self.value = value
   
   @always_inline # Optional
   def __eq__(self, other: Self) -> Bool:
       return self.value == other.value
       
  @always_inline # Optional
  def __ne__(self, other: Self) -> Bool:
      return self.value != other.value
```

Can be written using `fieldwise_init` decorator and default implementation of the `Equatable` trait. 

```mojo
@fieldwise_init
struct SomeStruct(Equatable):
    var value: Int
```

## What changed

Performed the refactor above.

## Testing

Ran the existing tests.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
