### PR TITLE
[Kernels] Simplify `MaskStrategy` initialization and equality

### DIFF
--- a/max/kernels/src/nn/attention/mha_mask.mojo
+++ b/max/kernels/src/nn/attention/mha_mask.mojo
@@ -121,7 +121,8 @@ struct TileMaskStatus(
         writer.write("unknown mask")
 
 
-struct MaskStrategy(TrivialRegisterPassable):
+@fieldwise_init
+struct MaskStrategy(Equatable, TrivialRegisterPassable):
     """Bit-flag enum that selects the masking strategy for a tile iteration set.
 
     Strategies are combined with bitwise OR. `NO_MASK` skips masking
@@ -155,18 +156,6 @@ struct MaskStrategy(TrivialRegisterPassable):
     `UPPER_TRIANGULAR` (and `OUT_OF_BOUNDS` for masks that fold it into
     `mask_bits`).
     """
-
-    @always_inline
-    def __init__(out self, value: Int32):
-        self._value = value
-
-    @always_inline
-    def __eq__(self, other: Self) -> Bool:
-        return self._value == other._value
-
-    @always_inline
-    def __ne__(self, other: Self) -> Bool:
-        return self._value != other._value
 
     @always_inline
     def __and__(self, other: Self) -> Self:


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [x] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Structs of the following format:

```mojo
struct SomeStruct:

    var value: Int

    @always_inline # Optional
    def __init__(out self, value: Int):
        self.value = value
   
   @always_inline # Optional
   def __eq__(self, other: Self) -> Bool:
       return self.value == other.value
       
  @always_inline # Optional
  def __ne__(self, other: Self) -> Bool:
      return self.value != other.value
```

Can be written using `fieldwise_init` decorator and default implementation of the `Equatable` trait. 

```mojo
@fieldwise_init
struct SomeStruct(Equatable):
    var value: Int
```

## What changed

Performed the refactor above.

## Testing

Ran the existing tests.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
