### PR TITLE
[Kernels] Simplify `IO` equality

### DIFF
--- a/max/kernels/src/graph_compiler/extensibility/managed_tensor_slice.mojo
+++ b/max/kernels/src/graph_compiler/extensibility/managed_tensor_slice.mojo
@@ -67,7 +67,8 @@ from .decorators import register_internal
 # ===----------------------------------------------------------------------=== #
 
 
-struct IO(TrivialRegisterPassable):
+@fieldwise_init
+struct IO(Equatable, TrivialRegisterPassable):
     """Tags the direction and fusion kind of a tensor argument to a DPS kernel.
 
     An `IO` value distinguishes plain inputs, outputs, mutable inputs, and the
@@ -96,16 +97,6 @@ struct IO(TrivialRegisterPassable):
 
     # Output fusion using a tile-based store lambda (the fusion owns the store).
     comptime _FusedOutputTile = IO(33)
-
-    @always_inline("builtin")
-    def __init__(out self, value: Int):
-        self.value = value
-
-    def __eq__(self, other: IO) -> Bool:
-        return self.value == other.value
-
-    def __ne__(self, other: IO) -> Bool:
-        return self.value != other.value
 
     @always_inline("nodebug")
     def is_fused(self) -> Bool:

--- a/max/kernels/src/graph_compiler/extensibility/managed_tensor_slice.mojo
+++ b/max/kernels/src/graph_compiler/extensibility/managed_tensor_slice.mojo
@@ -67,7 +67,6 @@ from .decorators import register_internal
 # ===----------------------------------------------------------------------=== #
 
 
-@fieldwise_init
 struct IO(Equatable, TrivialRegisterPassable):
     """Tags the direction and fusion kind of a tensor argument to a DPS kernel.
 
@@ -97,6 +96,10 @@ struct IO(Equatable, TrivialRegisterPassable):
 
     # Output fusion using a tile-based store lambda (the fusion owns the store).
     comptime _FusedOutputTile = IO(33)
+
+    @always_inline("builtin")
+    def __init__(out self, value: Int):
+        self.value = value
 
     @always_inline("nodebug")
     def is_fused(self) -> Bool:


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [x] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Structs of the following format:

```mojo
struct SomeStruct:

    var value: Int

    @always_inline # Optional
    def __init__(out self, value: Int):
        self.value = value
   
   @always_inline # Optional
   def __eq__(self, other: Self) -> Bool:
       return self.value == other.value
       
  @always_inline # Optional
  def __ne__(self, other: Self) -> Bool:
      return self.value != other.value
```

Can be written using `fieldwise_init` decorator and default implementation of the `Equatable` trait. 

```mojo
@fieldwise_init
struct SomeStruct(Equatable):
    var value: Int
```

## What changed

Performed the refactor above. Since `__init__` here is `@always_inline("builtin")` I left it as-is.

## Testing

Ran the existing tests.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
