### PR TITLE
[Kernels] Simplify `InitializationType` initialization and equality

### DIFF
--- a/max/kernels/src/internal_utils/_utils.mojo
+++ b/max/kernels/src/internal_utils/_utils.mojo
@@ -33,6 +33,7 @@ from std.random import Random
 from std.utils import IndexList
 
 
+@fieldwise_init
 struct InitializationType(DevicePassable, Equatable, TrivialRegisterPassable):
     var _value: Int
     comptime zero = InitializationType(0)
@@ -52,17 +53,8 @@ struct InitializationType(DevicePassable, Equatable, TrivialRegisterPassable):
     def get_type_name() -> String:
         return "InitializationType"
 
-    def __init__(out self, value: Int):
-        self._value = value
-
     def __init__(out self, value: Float64):
         self._value = Int(value)
-
-    def __eq__(self, other: Self) -> Bool:
-        return self._value == other._value
-
-    def __ne__(self, other: Self) -> Bool:
-        return self._value != other._value
 
     @staticmethod
     def from_str(str: String) raises -> Self:


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [x] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

Structs of the following format:

```mojo
struct SomeStruct:

    var value: Int

    @always_inline # Optional
    def __init__(out self, value: Int):
        self.value = value
   
   @always_inline # Optional
   def __eq__(self, other: Self) -> Bool:
       return self.value == other.value
       
  @always_inline # Optional
  def __ne__(self, other: Self) -> Bool:
      return self.value != other.value
```

Can be written using `fieldwise_init` decorator and default implementation of the `Equatable` trait. 

```mojo
@fieldwise_init
struct SomeStruct(Equatable):
    var value: Int
```

## What changed

Performed the refactor above.

## Testing

Ran the existing tests.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
