### PR TITLE
  [stdlib] Fix Turn list literal arity mismatch into a compile error for SIMD , Scalar, IndexList

### DIFF
--- a/mojo/stdlib/std/builtin/simd.mojo
+++ b/mojo/stdlib/std/builtin/simd.mojo
@@ -927,10 +927,13 @@ struct SIMD[dtype: DType, length: SIMDLength](
         """
         _simd_construction_checks[Self.dtype, Self.length]()
 
-        # TODO: Make this a compile-time check when possible.
-        assert Self.length == len(
-            elems
-        ), "mismatch in the number of elements in the SIMD variadic constructor"
+        debug_assert[assert_mode="safe"](
+            Self.length == len(elems),
+            "SIMD: expected ",
+            Int(Self.length),
+            " elements, received ",
+            len(elems),
+        )
 
         __mlir_op.`lit.ownership.mark_initialized`(__get_mvalue_as_litref(self))
 

--- a/mojo/stdlib/std/utils/index.mojo
+++ b/mojo/stdlib/std/utils/index.mojo
@@ -248,9 +248,13 @@ struct IndexList[size: Int, *, element_type: DType = .int64](
         ), "Element type must be of integral type."
         var num_elements = len(elems)
 
-        assert (
-            Self.size == num_elements
-        ), "[IndexList] mismatch in the number of elements"
+        debug_assert[assert_mode="safe"](
+            Self.size == num_elements,
+            "IndexList: expected ",
+            Self.size,
+            " elements, received ",
+            num_elements,
+        )
 
         self = Self()
         comptime for idx in range(Self.size):

--- a/mojo/stdlib/test/builtin/compile_fail/BUILD.bazel
+++ b/mojo/stdlib/test/builtin/compile_fail/BUILD.bazel
@@ -1,0 +1,17 @@
+load("//bazel:api.bzl", "lit_tests")
+
+package(default_visibility = ["//visibility:private"])
+
+lit_tests(
+    name = "lit_tests",
+    size = "large",
+    srcs = glob(["*.mojo"]),
+    mojo_deps = [
+        "@mojo//:std",
+    ],
+    target_compatible_with = select({
+        "//:asan": ["@platforms//:incompatible"],
+        "//:tsan": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+)

--- a/mojo/stdlib/test/builtin/compile_fail/indexlist_literal_arity.mojo
+++ b/mojo/stdlib/test/builtin/compile_fail/indexlist_literal_arity.mojo
@@ -1,0 +1,7 @@
+# RUN: not %mojo %s 2>&1 | FileCheck %s
+from std.utils import IndexList
+
+
+def main():
+    # CHECK: IndexList: expected 3 elements, received 2
+    var j: IndexList[3] = [1, 2]

--- a/mojo/stdlib/test/builtin/compile_fail/simd_literal_arity_scalar.mojo
+++ b/mojo/stdlib/test/builtin/compile_fail/simd_literal_arity_scalar.mojo
@@ -1,0 +1,4 @@
+# RUN: not %mojo %s 2>&1 | FileCheck %s
+def main():
+    # CHECK: SIMD: expected 1 elements, received 3
+    var x: Int = [42, 43, 44]

--- a/mojo/stdlib/test/builtin/compile_fail/simd_literal_arity_too_few.mojo
+++ b/mojo/stdlib/test/builtin/compile_fail/simd_literal_arity_too_few.mojo
@@ -1,0 +1,4 @@
+# RUN: not %mojo %s 2>&1 | FileCheck %s
+def main():
+    # CHECK: SIMD: expected 4 elements, received 2
+    var v2: SIMD[DType.int32, 4] = [1, 2]

--- a/mojo/stdlib/test/builtin/compile_fail/simd_literal_arity_too_many.mojo
+++ b/mojo/stdlib/test/builtin/compile_fail/simd_literal_arity_too_many.mojo
@@ -1,0 +1,4 @@
+# RUN: not %mojo %s 2>&1 | FileCheck %s
+def main():
+    # CHECK: SIMD: expected 2 elements, received 4
+    var v1: SIMD[DType.int32, 2] = [1, 2, 3, 4]


### PR DESCRIPTION
  ### Description
  
  
    **Bug Summary:**
    Previously, list-literal initialization of `SIMD`, `Scalar`, and `IndexList` performed an element-count (arity) check   
  using an untagged `assert`. Because untagged asserts default to debug mode, they are completely compiled out at the       
  default `-D ASSERT=safe` level. This meant that mismatched literal counts (both too many and too few) were silently       
  accepted during compilation, leading to runtime undefined behavior or silent truncations.
  
    **What this PR does:**
    - Replaces the untagged `assert` in the variadic list-literal `__init__` for `SIMD` and `IndexList` (which also covers  
  `Scalar`) with `debug_assert[assert_mode="safe"]`.
    - Because both the expected target size and the size of the variadic list literal pack are compile-time constants, the  
  Mojo compiler's constant-folder evaluates this safe debug assertion entirely at compile time.
    - Size mismatches are now cleanly rejected during compilation with a clear error message (e.g., `SIMD: expected 2       
  elements, received 4`) instead of trapping at runtime or silently accepting invalid code.
    - This brings the behavior perfectly in line with how `Array` already handles its list-literal arity checks.            
    - Adds `lit` tests to `test/builtin/compile_fail` to explicitly test that over-sized and under-sized literals trigger compilation errors.


Fixes #6856
