### PR TITLE
[BUG] Reproducer for #7030: SIMD[DType.uint8, N] struct field mismatches C layout

### DIFF
--- a/compiler-repro/simd-field-c-layout-mismatch/repro.mojo
+++ b/compiler-repro/simd-field-c-layout-mismatch/repro.mojo
@@ -1,0 +1,56 @@
+from std.memory import stack_allocation
+
+
+struct WithSimdField:
+    var a: UInt8
+    var b: UInt8
+    var c: UInt16
+    var d: UInt32
+    var e: SIMD[DType.uint8, 16]  # BUG: should sit at C-compatible offset 8
+    var f: UInt32
+
+    def __init__(out self, a: UInt8, b: UInt8, c: UInt16, d: UInt32, f: UInt32):
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+        self.e = SIMD[DType.uint8, 16](0)
+        self.f = f
+
+
+struct WithInlineArrayField:
+    var a: UInt8
+    var b: UInt8
+    var c: UInt16
+    var d: UInt32
+    var e: InlineArray[UInt8, 16]  # control: matches C layout exactly
+    var f: UInt32
+
+    def __init__(out self, a: UInt8, b: UInt8, c: UInt16, d: UInt32, f: UInt32):
+        self.a = a
+        self.b = b
+        self.c = c
+        self.d = d
+        self.e = InlineArray[UInt8, 16](fill=0)
+        self.f = f
+
+
+def main() raises:
+    var p1 = stack_allocation[2, WithSimdField]()
+    var size1 = Int(p1 + 1) - Int(p1)
+    var s1 = WithSimdField(1, 2, 3, 4, 5)
+    var sp1 = UnsafePointer(to=s1)
+    var off1 = Int(UnsafePointer(to=s1.e)) - Int(sp1)
+    print("SIMD field: size", size1, "(C-correct: 28), offset e", off1, "(C-correct: 8)")
+
+    var p2 = stack_allocation[2, WithInlineArrayField]()
+    var size2 = Int(p2 + 1) - Int(p2)
+    var s2 = WithInlineArrayField(1, 2, 3, 4, 5)
+    var sp2 = UnsafePointer(to=s2)
+    var off2 = Int(UnsafePointer(to=s2.e)) - Int(sp2)
+    print("InlineArray field (control): size", size2, ", offset e", off2)
+
+    if size1 != 28 or off1 != 8:
+        print("BUG CONFIRMED: SIMD[DType.uint8, 16] struct field does not match C layout")
+    else:
+        print("no mismatch observed on this build")

--- a/compiler-repro/simd-field-c-layout-mismatch/run.sh
+++ b/compiler-repro/simd-field-c-layout-mismatch/run.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Reproduces: SIMD[DType.uint8, N] as a struct field gets vector alignment
+# instead of natural 1-byte alignment, mismatching the equivalent C layout.
+#
+# Expected (bug-free) output: "size 28 ... offset e 8".
+# Actual output on Mojo 1.0.0b2 (2cf4d08a): "size 48 ... offset e 16".
+set -e
+cd "$(dirname "$0")"
+mojo run repro.mojo


### PR DESCRIPTION
Ref #7030. Draft, not intended for merge.

Adds `compiler-repro/simd-field-c-layout-mismatch/` with a minimal reproducer: a struct using `SIMD[DType.uint8, 16]` as a fixed byte-array field, next to a control struct using `InlineArray[UInt8, 16]` in the identical position.

```sh
cd compiler-repro/simd-field-c-layout-mismatch && ./run.sh
```

Expected (bug-free): `size 28 ... offset e 8` for both structs.
Actual on Mojo 1.0.0b2 (2cf4d08a), macOS arm64: the SIMD-field struct prints `size 48 ... offset e 16`; the InlineArray control prints the correct `28`/`8`.

Full write-up and impact are in the linked issue. Happy to move this into a proper regression test once I know where compiler layout tests for this live.
