### PR TITLE
[BUG] Reproducer for #7032: @extern("write") conflicts with std.io's internal binding

### DIFF
--- a/compiler-repro/extern-write-stdio-conflict/repro.mojo
+++ b/compiler-repro/extern-write-stdio-conflict/repro.mojo
@@ -1,0 +1,15 @@
+from std.memory import stack_allocation
+
+comptime OpaqueBuf = UnsafePointer[NoneType, MutAnyOrigin]
+
+
+@extern("write")
+def mjo_write(fd: Int, buf: OpaqueBuf, count: Int) abi("C") -> Int: ...
+
+
+def main() raises:
+    print("this print() pulls in the stdlib's own write() binding")
+    var buf = stack_allocation[4, Byte]()
+    buf[0] = 65
+    var n = mjo_write(1, buf.bitcast[NoneType](), 1)
+    print("wrote", n, "bytes via the custom binding")

--- a/compiler-repro/extern-write-stdio-conflict/run.sh
+++ b/compiler-repro/extern-write-stdio-conflict/run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Reproduces: a module that also uses print()/std.io cannot declare its own
+# @extern("write") binding, even with an exactly-matching C signature,
+# because @extern treats the C symbol name as a whole-program uniqueness
+# key rather than a per-module one, and collides with std.io's own
+# internal write() binding used by FileDescriptor.write() / print().
+#
+# Expected (bug-free) output: both prints succeed.
+# Actual output on Mojo 1.0.0b2 (2cf4d08a): fails to lower with
+#   "error: existing function with conflicting attributes"
+# (see file_descriptor.mojo's own internal write() call site in the trace).
+set -e
+cd "$(dirname "$0")"
+mojo run repro.mojo


### PR DESCRIPTION
Ref #7032. Draft, not intended for merge.

Adds `compiler-repro/extern-write-stdio-conflict/` with a minimal reproducer: a module declaring `@extern("write")` alongside a `print()` call.

```sh
cd compiler-repro/extern-write-stdio-conflict && ./run.sh
```

Expected (bug-free): both prints succeed.
Actual on Mojo 1.0.0b2 (2cf4d08a): fails to lower with "existing function with conflicting attributes", tracing into `std/io/file_descriptor.mojo`'s own internal `write()` binding.

Bisection notes (signature variants tried) are in the linked issue. Happy to move this into a proper regression test once I know where extern-conflict tests for this live.
