### PR TITLE
[BUG] Reproducer for #7036: legacy __moveinit__ accepted via import, rejected as entry file

### DIFF
--- a/compiler-repro/moveinit-owned-param-main-vs-import/lib.mojo
+++ b/compiler-repro/moveinit-owned-param-main-vs-import/lib.mojo
@@ -1,0 +1,19 @@
+# Companion module for m1-3-owned-param-main-vs-import.mojo /
+# m1-3-owned-param-via-import.mojo — byte-for-byte the same struct,
+# defined here so it can be IMPORTED rather than run directly. See the
+# other two files for what this demonstrates.
+
+struct IoEventLike(ImplicitlyCopyable):
+    var token: UInt64
+    var fd: Int32
+    var events: UInt32
+
+    def __init__(out self):
+        self.token = 0
+        self.fd = -1
+        self.events = 0
+
+    def __moveinit__(out self, owned existing: Self):
+        self.token = existing.token
+        self.fd = existing.fd
+        self.events = existing.events

--- a/compiler-repro/moveinit-owned-param-main-vs-import/lib.mojo
+++ b/compiler-repro/moveinit-owned-param-main-vs-import/lib.mojo
@@ -1,7 +1,9 @@
-# Companion module for m1-3-owned-param-main-vs-import.mojo /
-# m1-3-owned-param-via-import.mojo — byte-for-byte the same struct,
-# defined here so it can be IMPORTED rather than run directly. See the
-# other two files for what this demonstrates.
+# Companion module for via_import.mojo: byte-for-byte the same struct as
+# the one defined inline in main_vs_import.mojo, placed here so it can be
+# IMPORTED rather than compiled as the entry file. The legacy
+# `__moveinit__` spelling below was removed in 1.0.0b1 (unified-__init__
+# migration), yet this file still compiles fine when imported. See
+# main_vs_import.mojo for the full write-up.
 
 struct IoEventLike(ImplicitlyCopyable):
     var token: UInt64

--- a/compiler-repro/moveinit-owned-param-main-vs-import/main_vs_import.mojo
+++ b/compiler-repro/moveinit-owned-param-main-vs-import/main_vs_import.mojo
@@ -1,0 +1,59 @@
+# M1.3 (#126) compiler defect reproducer: `owned` as a parameter-convention
+# keyword in a __moveinit__ signature PARSES when the struct's file is
+# IMPORTED as a module, but FAILS TO PARSE the identical source when that
+# same file is run directly as the `mojo run` entry file.
+#
+# This is not a hypothetical: mojito_sys/io/poller.mojo:78 and
+# mojito_sys/io/handle.mojo:65 both already contain
+# `def __moveinit__(out self, owned existing: Self):` (or `fn` in
+# handle.mojo's case) in the committed repository, and every existing test
+# that imports those modules (e.g. tests/s6/io/poller/conformance.mojo)
+# compiles them fine. But running EITHER FILE DIRECTLY as a `mojo run`
+# entry point fails to parse:
+#
+#     mojo run -I . mojito_sys/io/poller.mojo
+#     # error: expected ')' in argument list
+#     #     def __moveinit__(out self, owned existing: Self):
+#     #                                ^
+#
+# Minimized here to a plain struct with no mojito_sys dependency, in two
+# files:
+#   - THIS file (m1-3-owned-param-main-vs-import.mojo) reproduces the FAIL
+#     path: `mojo run m1-3-owned-param-main-vs-import.mojo` fails to parse.
+#   - m1-3-owned-param-via-import.mojo (same directory) reproduces the
+#     PASS path: importing the identical struct from a SEPARATE main file
+#     compiles and runs cleanly.
+#
+# This repo's OWN dominant convention for __moveinit__ (14 of 16 call
+# sites, grep-counted) uses `mut self, mut existing: Self` instead, which
+# parses identically in BOTH contexts (also verified, not shown here) —
+# that is almost certainly why this asymmetry has not caused a visible
+# failure anywhere in this repo's test suite to date: nothing happens to
+# `mojo run` poller.mojo or handle.mojo directly, only import them.
+#
+# Toolchain: Mojo 1.0.0b2 (2cf4d08a), macOS arm64 (Darwin 25.6.0).
+# Run: mojo run m1-3-owned-param-main-vs-import.mojo
+# Expected (defect): fails to parse — "expected ')' in argument list" at
+# the `owned existing: Self` parameter.
+# Contrast: mojo run m1-3-owned-param-via-import.mojo — PASSES, importing
+# the byte-for-byte identical struct definition from its own module file.
+
+struct IoEventLike(ImplicitlyCopyable):
+    var token: UInt64
+    var fd: Int32
+    var events: UInt32
+
+    def __init__(out self):
+        self.token = 0
+        self.fd = -1
+        self.events = 0
+
+    def __moveinit__(out self, owned existing: Self):
+        self.token = existing.token
+        self.fd = existing.fd
+        self.events = existing.events
+
+
+def main():
+    var e = IoEventLike()
+    print(e.fd)

--- a/compiler-repro/moveinit-owned-param-main-vs-import/main_vs_import.mojo
+++ b/compiler-repro/moveinit-owned-param-main-vs-import/main_vs_import.mojo
@@ -1,42 +1,42 @@
-# M1.3 (#126) compiler defect reproducer: `owned` as a parameter-convention
-# keyword in a __moveinit__ signature PARSES when the struct's file is
-# IMPORTED as a module, but FAILS TO PARSE the identical source when that
-# same file is run directly as the `mojo run` entry file.
+# Reproducer for: the removal of the legacy `__moveinit__`/`__copyinit__`
+# spellings (deprecated in 0.26.2, removed in 1.0.0b1 per its release
+# notes: "no longer auto-rewritten... now fail to compile") is enforced
+# ONLY when the file is the compilation entry point. The byte-for-byte
+# identical struct, imported as a module, still accepts the legacy
+# spelling silently.
 #
-# This is not a hypothetical: mojito_sys/io/poller.mojo:78 and
-# mojito_sys/io/handle.mojo:65 both already contain
-# `def __moveinit__(out self, owned existing: Self):` (or `fn` in
-# handle.mojo's case) in the committed repository, and every existing test
-# that imports those modules (e.g. tests/s6/io/poller/conformance.mojo)
-# compiles them fine. But running EITHER FILE DIRECTLY as a `mojo run`
-# entry point fails to parse:
+# THIS file defines the struct inline and is meant to be run directly:
+#   mojo run main_vs_import.mojo
+# It fails, which is the CORRECT half (the spelling is removed), though
+# with a misleading diagnostic: `owned existing` gets
+# "expected ')' in argument list" (owned itself was removed in 0.26.2),
+# and the current-convention spellings get something worse. The same
+# struct with `deinit existing: Self` or `var existing: Self`, or a
+# legacy `__copyinit__(out self, existing: Self)`, fails as an entry
+# file with "'None' has no attributes" pointing at the first use of the
+# parameter. None of these is the advertised "no matching function in
+# initialization" error, and none carries a fix-it toward the unified
+# `__init__` rename.
 #
-#     mojo run -I . mojito_sys/io/poller.mojo
-#     # error: expected ')' in argument list
-#     #     def __moveinit__(out self, owned existing: Self):
-#     #                                ^
+# via_import.mojo (same directory) is the DEFECT half: it imports the
+# identical struct from lib.mojo and compiles and runs cleanly, so a
+# library full of legacy spellings keeps working for everyone who
+# imports it and breaks only for whoever compiles a file directly.
 #
-# Minimized here to a plain struct with no mojito_sys dependency, in two
-# files:
-#   - THIS file (m1-3-owned-param-main-vs-import.mojo) reproduces the FAIL
-#     path: `mojo run m1-3-owned-param-main-vs-import.mojo` fails to parse.
-#   - m1-3-owned-param-via-import.mojo (same directory) reproduces the
-#     PASS path: importing the identical struct from a SEPARATE main file
-#     compiles and runs cleanly.
+# This is NOT a general legacy-leniency mode on the import path: the
+# removed `inout` keyword is rejected in both contexts. The acceptance
+# is specific to the legacy dunder handling.
 #
-# This repo's OWN dominant convention for __moveinit__ (14 of 16 call
-# sites, grep-counted) uses `mut self, mut existing: Self` instead, which
-# parses identically in BOTH contexts (also verified, not shown here) —
-# that is almost certainly why this asymmetry has not caused a visible
-# failure anywhere in this repo's test suite to date: nothing happens to
-# `mojo run` poller.mojo or handle.mojo directly, only import them.
+# The unified spelling, def __init__(out self, *, deinit take: Self),
+# compiles in BOTH contexts (verified).
 #
-# Toolchain: Mojo 1.0.0b2 (2cf4d08a), macOS arm64 (Darwin 25.6.0).
-# Run: mojo run m1-3-owned-param-main-vs-import.mojo
-# Expected (defect): fails to parse — "expected ')' in argument list" at
-# the `owned existing: Self` parameter.
-# Contrast: mojo run m1-3-owned-param-via-import.mojo — PASSES, importing
-# the byte-for-byte identical struct definition from its own module file.
+# Verified identical on Mojo 1.0.0b2 (2cf4d08a) and 1.0.0 (ed45d567),
+# macOS arm64 (Darwin 25.6.0).
+#
+# Run: mojo run main_vs_import.mojo
+# Expected today: fails, "expected ')' in argument list" at the
+# `owned existing: Self` parameter.
+# Contrast: mojo run -I . via_import.mojo passes and prints -1.
 
 struct IoEventLike(ImplicitlyCopyable):
     var token: UInt64

--- a/compiler-repro/moveinit-owned-param-main-vs-import/run.sh
+++ b/compiler-repro/moveinit-owned-param-main-vs-import/run.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Reproduces: `def __moveinit__(out self, owned existing: Self):` parses
+# fine when the struct lives in a file that gets IMPORTED as a module,
+# but fails to parse the byte-for-byte identical source when that file is
+# run directly as the `mojo run` entry point.
+set -e
+cd "$(dirname "$0")"
+
+echo "--- via_import.mojo (imports lib.mojo): expected PASS, prints -1 ---"
+mojo run -I . via_import.mojo
+
+echo
+echo "--- main_vs_import.mojo (identical struct, defined inline, run directly): expected FAIL to parse ---"
+mojo run main_vs_import.mojo

--- a/compiler-repro/moveinit-owned-param-main-vs-import/run.sh
+++ b/compiler-repro/moveinit-owned-param-main-vs-import/run.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
-# Reproduces: `def __moveinit__(out self, owned existing: Self):` parses
-# fine when the struct lives in a file that gets IMPORTED as a module,
-# but fails to parse the byte-for-byte identical source when that file is
-# run directly as the `mojo run` entry point.
+# Reproduces: the 1.0.0b1 removal of the legacy __moveinit__/__copyinit__
+# spellings is enforced only for the entry file. Imported modules still
+# silently accept (and rewrite) them; the entry file rejects them with
+# misleading errors.
 set -e
 cd "$(dirname "$0")"
 
-echo "--- via_import.mojo (imports lib.mojo): expected PASS, prints -1 ---"
+echo "--- via_import.mojo (imports lib.mojo): compiles+runs today, prints -1 (the acceptance is the bug) ---"
 mojo run -I . via_import.mojo
 
 echo
-echo "--- main_vs_import.mojo (identical struct, defined inline, run directly): expected FAIL to parse ---"
+echo "--- main_vs_import.mojo (identical struct inline, run directly): fails today (correct, but with a misleading error) ---"
 mojo run main_vs_import.mojo

--- a/compiler-repro/moveinit-owned-param-main-vs-import/via_import.mojo
+++ b/compiler-repro/moveinit-owned-param-main-vs-import/via_import.mojo
@@ -1,0 +1,18 @@
+# M1.3 (#126) compiler defect reproducer, PASS side: see
+# m1-3-owned-param-main-vs-import.mojo for the full write-up. This file
+# imports the BYTE-FOR-BYTE IDENTICAL struct (m1_3_owned_param_lib.mojo,
+# same directory) instead of defining it inline, and compiles/runs
+# cleanly — the same `owned existing: Self` __moveinit__ parameter that
+# fails to PARSE as a main-file entry point parses fine as an imported
+# module member.
+#
+# Toolchain: Mojo 1.0.0b2 (2cf4d08a), macOS arm64 (Darwin 25.6.0).
+# Run: mojo run -I <this-directory> m1-3-owned-param-via-import.mojo
+# Expected: PASSES, prints "-1".
+
+from lib import IoEventLike
+
+
+def main():
+    var e = IoEventLike()
+    print(e.fd)

--- a/compiler-repro/moveinit-owned-param-main-vs-import/via_import.mojo
+++ b/compiler-repro/moveinit-owned-param-main-vs-import/via_import.mojo
@@ -1,14 +1,13 @@
-# M1.3 (#126) compiler defect reproducer, PASS side: see
-# m1-3-owned-param-main-vs-import.mojo for the full write-up. This file
-# imports the BYTE-FOR-BYTE IDENTICAL struct (m1_3_owned_param_lib.mojo,
-# same directory) instead of defining it inline, and compiles/runs
-# cleanly — the same `owned existing: Self` __moveinit__ parameter that
-# fails to PARSE as a main-file entry point parses fine as an imported
-# module member.
+# Defect half of this reproducer: imports the byte-for-byte identical
+# struct from lib.mojo (same directory) instead of defining it inline,
+# and compiles and runs cleanly, even though the legacy `__moveinit__`
+# spelling it contains was removed in 1.0.0b1 and the same source is
+# rejected when compiled as the entry file. See main_vs_import.mojo for
+# the full write-up and the per-spelling error matrix.
 #
-# Toolchain: Mojo 1.0.0b2 (2cf4d08a), macOS arm64 (Darwin 25.6.0).
-# Run: mojo run -I <this-directory> m1-3-owned-param-via-import.mojo
-# Expected: PASSES, prints "-1".
+# Verified on Mojo 1.0.0b2 (2cf4d08a) and 1.0.0 (ed45d567), macOS arm64.
+# Run: mojo run -I <this-directory> via_import.mojo
+# Today: PASSES and prints "-1" (that acceptance is the bug).
 
 from lib import IoEventLike
 


### PR DESCRIPTION
Ref #7036. Draft, not intended for merge.

Adds `compiler-repro/moveinit-owned-param-main-vs-import/`: the same struct with a legacy `__moveinit__` in three files, one run directly (fails), one importing it from `lib.mojo` (compiles and runs).

```sh
cd compiler-repro/moveinit-owned-param-main-vs-import && ./run.sh
```

Corrected framing since the first version of this PR: `__moveinit__`/`__copyinit__` are removed legacy spellings as of 1.0.0b1 (unified-`__init__` migration from 0.26.2), so the entry-file rejection is the intended behavior and the import-path acceptance is the defect, an incompletely applied removal. The entry-file diagnostics are also not the advertised ones: `owned existing` gets `expected ')' in argument list` and the current-convention spellings (`deinit`/`var`/plain) get `'None' has no attributes` at the first parameter use. Verified identical on 1.0.0b2 (2cf4d08a) and 1.0.0 (ed45d567), macOS arm64. Full matrix in the issue.
