### PR TITLE
[Feature Request] TDD red test for #7040: struct packed attribute

### DIFF
--- a/feature-repro/struct-packed-attribute/repro.mojo
+++ b/feature-repro/struct-packed-attribute/repro.mojo
@@ -1,0 +1,57 @@
+# M1.2 (#124) feature-gap reproducer (not a crash — an expressiveness
+# gap issue #124 explicitly asks to be written up "with what it would
+# need"): Mojo 1.0.0b2 has no attribute or mechanism to declare a struct
+# with alignment LESS than its members' natural alignment — i.e. no
+# equivalent of C's `#pragma pack(N)` / `__attribute__((packed))`.
+#
+# This matters for real: Apple's <sys/event.h> wraps `struct kevent` in
+# `#pragma pack(4)`, which forces the struct's own alignment to 4 despite
+# every member being naturally 8-byte aligned (ident/data/udata are
+# uintptr_t/intptr_t/void*) — confirmed on this host via
+# spike/abi/oracle.c (`_Alignof(struct kevent)` reports 4). A plain Mojo
+# struct with the identical field types (spike/abi/types.mojo's `Kevent`)
+# computes alignment 8, matching neither `@packed` (doesn't exist, tried
+# below) nor any other override.
+#
+# Consequence for THIS specific struct: harmless, because kevent's last
+# field ends at byte offset 32, already a multiple of 8, so the extra
+# alignment Mojo computes doesn't change the struct's own size or its
+# stride inside an array (verified: spike/abi/struct_layout_test.mojo's
+# kevent size/offset checks all pass). It WOULD matter for a
+# hypothetical struct whose tail field ended on a 4-but-not-8 byte
+# boundary, where Mojo's over-alignment would insert real trailing
+# padding a C caller does not expect.
+#
+# What full fidelity would need: a struct-level attribute (e.g.
+# `@packed(4)`) or an alternate declaration form that lets a struct's
+# reported/enforced alignment be set below its natural maximum-member
+# alignment — either a compiler feature or, short of that, a documented
+# policy that any struct needing sub-natural alignment is described as a
+# byte blob with manual offset arithmetic instead of a native Mojo struct
+# (the AGGREGATE RULE convention mojito_sys/io/externs.mojo already uses
+# for cases it treats as opaque).
+#
+# Toolchain: Mojo 1.0.0b2 (2cf4d08a), macOS arm64.
+# Run: mojo run m1-2-no-packed-struct-attribute.mojo
+# Expected (gap): fails to parse — "use of unknown declaration 'packed'".
+
+@packed
+struct Kevent:
+    var ident: UInt64
+    var filter: Int16
+    var flags: UInt16
+    var fflags: UInt32
+    var data: Int64
+    var udata: UInt64
+
+    def __init__(out self, ident: UInt64, filter: Int16, flags: UInt16, fflags: UInt32, data: Int64, udata: UInt64):
+        self.ident = ident
+        self.filter = filter
+        self.flags = flags
+        self.fflags = fflags
+        self.data = data
+        self.udata = udata
+
+
+def main():
+    pass

--- a/feature-repro/struct-packed-attribute/repro.mojo
+++ b/feature-repro/struct-packed-attribute/repro.mojo
@@ -1,39 +1,32 @@
-# M1.2 (#124) feature-gap reproducer (not a crash — an expressiveness
-# gap issue #124 explicitly asks to be written up "with what it would
-# need"): Mojo 1.0.0b2 has no attribute or mechanism to declare a struct
-# with alignment LESS than its members' natural alignment — i.e. no
-# equivalent of C's `#pragma pack(N)` / `__attribute__((packed))`.
+# TDD red test for a feature gap: Mojo has no way to force a struct's
+# alignment BELOW its members' natural alignment, i.e. no equivalent of
+# C's `#pragma pack(N)` / `__attribute__((packed))`.
 #
-# This matters for real: Apple's <sys/event.h> wraps `struct kevent` in
-# `#pragma pack(4)`, which forces the struct's own alignment to 4 despite
-# every member being naturally 8-byte aligned (ident/data/udata are
-# uintptr_t/intptr_t/void*) — confirmed on this host via
-# spike/abi/oracle.c (`_Alignof(struct kevent)` reports 4). A plain Mojo
-# struct with the identical field types (spike/abi/types.mojo's `Kevent`)
-# computes alignment 8, matching neither `@packed` (doesn't exist, tried
-# below) nor any other override.
+# What exists today is `@align(N)`, and it is explicitly a MINIMUM: the
+# decorator reference says "You can't reduce alignment below the natural
+# alignment of the struct." Verified on both 1.0.0b2 and 1.0.0:
+# `@align(4)` on a struct of 8-aligned members is accepted SILENTLY and
+# clamped to 8 (align_of still reports 8). That silent clamp is its own
+# little trap for anyone mirroring a `#pragma pack(4)` C struct, since
+# it reads like success; the linked issue asks for a warning there even
+# if the packing feature itself is declined.
 #
-# Consequence for THIS specific struct: harmless, because kevent's last
-# field ends at byte offset 32, already a multiple of 8, so the extra
-# alignment Mojo computes doesn't change the struct's own size or its
-# stride inside an array (verified: spike/abi/struct_layout_test.mojo's
-# kevent size/offset checks all pass). It WOULD matter for a
-# hypothetical struct whose tail field ended on a 4-but-not-8 byte
-# boundary, where Mojo's over-alignment would insert real trailing
-# padding a C caller does not expect.
+# Why it matters: Apple's <sys/event.h> wraps `struct kevent` in
+# `#pragma pack(4)`, forcing alignment 4 despite every member being
+# naturally 8-byte aligned. Confirmed with a C oracle on macOS arm64:
+# _Alignof(struct kevent) == 4, sizeof == 32. A Mojo struct with the
+# identical field types computes alignment 8. For kevent itself that is
+# harmless (the last field ends on an 8-byte boundary), but any packed
+# struct whose tail ends on a 4-but-not-8 boundary would silently gain
+# trailing padding a C caller does not have.
 #
-# What full fidelity would need: a struct-level attribute (e.g.
-# `@packed(4)`) or an alternate declaration form that lets a struct's
-# reported/enforced alignment be set below its natural maximum-member
-# alignment — either a compiler feature or, short of that, a documented
-# policy that any struct needing sub-natural alignment is described as a
-# byte blob with manual offset arithmetic instead of a native Mojo struct
-# (the AGGREGATE RULE convention mojito_sys/io/externs.mojo already uses
-# for cases it treats as opaque).
-#
-# Toolchain: Mojo 1.0.0b2 (2cf4d08a), macOS arm64.
-# Run: mojo run m1-2-no-packed-struct-attribute.mojo
-# Expected (gap): fails to parse — "use of unknown declaration 'packed'".
+# Toolchains checked: Mojo 1.0.0b2 (2cf4d08a) and 1.0.0 (ed45d567),
+# macOS arm64.
+# Run: mojo run repro.mojo
+# Expected (gap, today): fails to parse,
+#   "use of unknown declaration 'packed'".
+# Goes green once some below-natural alignment override ships (whether
+# that is @packed, @packed(N), or @align(N) learning to reduce).
 
 @packed
 struct Kevent:

--- a/feature-repro/struct-packed-attribute/run.sh
+++ b/feature-repro/struct-packed-attribute/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# TDD red test for a feature request: `@packed` does not exist yet, so
+# this file fails to parse today. It should go GREEN (parse and run,
+# printing nothing since main() is empty) once a struct-level
+# alignment-override attribute ships (equivalent of C's
+# `#pragma pack(N)` / `__attribute__((packed))`).
+#
+# Current (red) result on Mojo 1.0.0b2 (2cf4d08a):
+#   error: use of unknown declaration 'packed'
+set -e
+cd "$(dirname "$0")"
+mojo run repro.mojo

--- a/feature-repro/struct-packed-attribute/run.sh
+++ b/feature-repro/struct-packed-attribute/run.sh
@@ -1,11 +1,10 @@
 #!/bin/sh
-# TDD red test for a feature request: `@packed` does not exist yet, so
-# this file fails to parse today. It should go GREEN (parse and run,
-# printing nothing since main() is empty) once a struct-level
-# alignment-override attribute ships (equivalent of C's
-# `#pragma pack(N)` / `__attribute__((packed))`).
+# TDD red test for a feature request: no below-natural alignment
+# override exists. `@packed` fails to parse, and the existing `@align(N)`
+# is documented (and verified) as a minimum that silently clamps
+# below-natural requests up to the natural alignment.
 #
-# Current (red) result on Mojo 1.0.0b2 (2cf4d08a):
+# Current (red) result on Mojo 1.0.0b2 (2cf4d08a) and 1.0.0 (ed45d567):
 #   error: use of unknown declaration 'packed'
 set -e
 cd "$(dirname "$0")"


### PR DESCRIPTION
Ref #7040. Draft, not intended for merge.

Adds `feature-repro/struct-packed-attribute/` as a TDD red test: a `kevent`-shaped struct under a `@packed` decorator, which fails to parse today (`use of unknown declaration 'packed'`, verified on 1.0.0b2 and 1.0.0). It should go green once some spelling of a below-natural alignment override ships.

Corrected framing since the first version of this PR: `@align(N)` exists and I originally failed to mention it. It does not cover this: the decorator is documented as a minimum, and `@align(4)` on an 8-aligned struct is accepted silently and clamped to 8 (verified on both toolchains), which is its own little trap for anyone mirroring `#pragma pack(4)`. The C-side numbers in the issue are oracle-verified on macOS arm64 (`_Alignof(struct kevent)` is 4).
