### PR TITLE
[BUG] Reproducer for #7042: resource destroyed before derived-address use completes

### DIFF
--- a/compiler-repro/movable-destroyed-before-derived-address-use/leaf_externs.mojo
+++ b/compiler-repro/movable-destroyed-before-derived-address-use/leaf_externs.mojo
@@ -1,0 +1,60 @@
+# spike/stack_switch/leaf_externs.mojo — M1.4 (#128), memory half.
+#
+# LEAF MODULE, same discipline as spike/abi/externs_leaf.mojo and every
+# externs.mojo under mojito_sys/: ONLY @extern declarations, the comptime
+# pointer aliases they need, and tiny non-raising probe_* call shims. No
+# imports, no Movable structs, no raise sites. This keeps the raw libc
+# bindings out of the same frame as NativeStack's raising, Movable-struct
+# machinery (the #49/#29/#30 misbind/crash shape); spike/abi's own
+# ordinary_frame_test.mojo already measured that combination to be SAFE for
+# this exact mmap/munmap/mprotect call shape on this toolchain (FINDINGS.md,
+# M1.2), so this split is precautionary consistency with repo convention
+# rather than a proven-necessary workaround for this leg specifically.
+#
+# Bindings mirror spike/abi/externs_leaf.mojo's already-measured-correct
+# signatures verbatim (same symbols, same argument widths) rather than
+# re-deriving them, since #124 already proved these exact shapes byte-exact
+# against a C oracle on macOS arm64.
+#
+# Toolchain: Mojo 1.0.0b2 (2cf4d08a).
+
+@extern("mmap")
+def mjo_mmap(
+    addr: UInt64, length: UInt64, prot: Int32, flags: Int32, fd: Int32, offset: Int64
+) abi("C") -> UInt64: ...
+
+@extern("munmap")
+def mjo_munmap(addr: UInt64, length: UInt64) abi("C") -> Int32: ...
+
+@extern("mprotect")
+def mjo_mprotect(addr: UInt64, length: UInt64, prot: Int32) abi("C") -> Int32: ...
+
+@extern("sysconf")
+def mjo_sysconf(name: Int32) abi("C") -> Int64: ...
+
+# errno accessor: Darwin's libc exposes __error() -> int*; glibc exposes
+# __errno_location() -> int*. Only the platform-matching one is ever called
+# (comptime-if at the call site, mirroring spike/abi/libc_calls_test.mojo).
+@extern("__error")
+def mjo_error_ptr_macos() abi("C") -> UInt64: ...
+@extern("__errno_location")
+def mjo_errno_location_linux() abi("C") -> UInt64: ...
+
+
+def probe_mmap(addr: UInt64, length: UInt64, prot: Int32, flags: Int32, fd: Int32, offset: Int64) -> UInt64:
+    return mjo_mmap(addr, length, prot, flags, fd, offset)
+
+def probe_munmap(addr: UInt64, length: UInt64) -> Int32:
+    return mjo_munmap(addr, length)
+
+def probe_mprotect(addr: UInt64, length: UInt64, prot: Int32) -> Int32:
+    return mjo_mprotect(addr, length, prot)
+
+def probe_sysconf(name: Int32) -> Int64:
+    return mjo_sysconf(name)
+
+def probe_error_ptr_macos() -> UInt64:
+    return mjo_error_ptr_macos()
+
+def probe_errno_location_linux() -> UInt64:
+    return mjo_errno_location_linux()

--- a/compiler-repro/movable-destroyed-before-derived-address-use/native_stack.mojo
+++ b/compiler-repro/movable-destroyed-before-derived-address-use/native_stack.mojo
@@ -1,0 +1,216 @@
+# spike/stack_switch/native_stack.mojo — M1.4 (#128), memory half.
+#
+# Mojo-owned, non-moving, guarded native stack built directly over
+# mmap/mprotect/munmap (spike/stack_switch/leaf_externs.mojo) — no C
+# substrate anywhere in the loop. This is the Mojo-first counterpart to
+# native/posix/mjs_stack.c: same layout, same acceptance bar (spec §10,
+# SYS-6), but the syscalls are made directly from Mojo rather than through
+# a C function this migration is trying to retire (spec §0).
+#
+# Layout of one reservation (mirrors native/posix/mjs_stack.c exactly, so
+# the two are differentially comparable — see tests/spike/ns6_c_oracle_diff.mojo):
+#
+#   base                     base+guard              base+guard+usable = top
+#   | guard pages            | uncommitted span  | committed top span  |
+#   | PROT_NONE              | PROT_NONE          | PROT_READ|PROT_WRITE|
+#   +-----------------------+-------------------+----------------------+
+#
+#   - ONE fixed mmap for the whole reservation; the virtual address never
+#     changes for the life of the stack (SYS-6). Moving the Mojo value that
+#     owns it (a plain struct move) does not touch the mapping at all.
+#   - guard_bytes is rounded UP to whole pages (minimum one page) and
+#     painted PROT_NONE, so underflow off the bottom of the usable range
+#     faults instead of corrupting adjacent memory.
+#   - initial_commit_bytes (rounded up to pages, clamped to the usable
+#     span) is committed PROT_READ|PROT_WRITE at the TOP of the usable
+#     range; the rest of the usable span stays PROT_NONE (reserved only).
+#   - top = highest usable address. mmap returns a page-aligned base and
+#     every size here is a page multiple, so top is always 16-byte
+#     aligned (AAPCS64 SP-at-entry requirement).
+#   - release happens exactly once, in __del__, on every path (including
+#     an error raised after a partially-constructed stack — see
+#     tests/spike/ns5_dtor_exactly_once_on_raise.mojo).
+#
+# DESTRUCTOR SPELLING (load-bearing, filed as mojito-sys#200): on the
+# pinned Mojo 1.0.0b2 (2cf4d08a) toolchain, `__deinit__(deinit self)` --
+# the spelling this migration's own planning material names as current,
+# and what a dozen existing mojito_sys/* wrapper files already use -- is
+# measured to be SILENTLY NEVER INVOKED (compiles cleanly, never runs; see
+# docs/defects/m1-4-deinit-silently-inert.mojo). `__del__(deinit self)` --
+# the spelling spike/context_switch/SPIKE_REPORT.md item 1 recorded the S0
+# spike settling on -- IS invoked reliably on this toolchain, under both
+# `mojo run` and `mojo build`. This type therefore uses `__del__`,
+# deliberately, not `__deinit__`.
+#
+# Move-only: NativeStack conforms to Movable and NOT Copyable. No
+# `__init__(out self, *, copy: Self)` exists, so `var b = a` (without `^`)
+# is a compile error ("value of type 'NativeStack' cannot be implicitly
+# copied, it does not conform to 'ImplicitlyCopyable'") -- double release
+# by accidental copy is impossible by construction, not by convention (see
+# tests/spike/ns4_copy_is_compile_error.mojo, a compile-fail test).
+#
+# Compiler workarounds carried over from mojito_sys/memory/stack.mojo /
+# virtual_memory.mojo (b2, issue #29/#30 fold):
+#   - every raising member here has EXACTLY ONE raise site, funneled
+#     through `_raise_stack_error(rc)` at the tail -- no String literal
+#     reaches a `raise` through a control-flow merge in a body that also
+#     lowers an @extern call;
+#   - page rounding uses bit masks, never `/` or `%` (host page sizes are
+#     powers of two) -- integer division/remainder in the same raising,
+#     extern-lowering body has been observed to SIGSEGV this compiler.
+
+from std.memory import stack_allocation
+
+from leaf_externs import (
+    probe_mmap,
+    probe_munmap,
+    probe_mprotect,
+    probe_sysconf,
+    probe_error_ptr_macos,
+    probe_errno_location_linux,
+)
+
+comptime _PROT_NONE = Int32(0x00)
+comptime _PROT_READ = Int32(0x01)
+comptime _PROT_WRITE = Int32(0x02)
+comptime _PROT_RW = Int32(0x03)
+comptime _MAP_PRIVATE_ANON = Int32(0x1002)  # MAP_PRIVATE(0x02) | MAP_ANON(0x1000), macOS
+comptime _SC_PAGESIZE = Int32(29)  # macOS; see module note for Linux (30)
+
+comptime _MAP_FAILED = UInt64(0xFFFFFFFFFFFFFFFF)
+
+
+def _read_errno() -> Int32:
+    comptime IS_MACOS = True  # this leg targets macOS arm64 (see README)
+    var addr: UInt64
+    comptime if IS_MACOS:
+        addr = probe_error_ptr_macos()
+    else:
+        addr = probe_errno_location_linux()
+    var p = UnsafePointer[Int32, MutAnyOrigin](unsafe_from_address=Int(addr))
+    return p[]
+
+
+def _raise_stack_error(rc: Int32) raises:
+    raise Error("NativeStack: syscall failed, errno=" + String(rc))
+
+
+def page_size() -> Int:
+    return Int(probe_sysconf(_SC_PAGESIZE))
+
+
+def _round_up(n: Int, page: Int) -> Int:
+    var mask = page - 1
+    return (n + mask) & ~mask
+
+
+struct NativeStack(Movable):
+    """A Mojo-owned, non-moving, guarded native stack reservation, built
+    directly over mmap/mprotect/munmap. See module header for the full
+    contract; mirrors native/posix/mjs_stack.c's layout exactly.
+    """
+
+    var base: Int
+    var guard_bytes: Int
+    var reserved_bytes: Int
+    var committed_bytes: Int
+    var top: Int
+
+    def __init__(out self):
+        self.base = 0
+        self.guard_bytes = 0
+        self.reserved_bytes = 0
+        self.committed_bytes = 0
+        self.top = 0
+
+    @staticmethod
+    def create(
+        reserve_bytes: Int,
+        initial_commit_bytes: Int,
+        guard_bytes: Int,
+    ) raises -> Self:
+        """Reserve a guarded stack. Raises on any syscall failure or an
+        invalid guard_bytes (must be a positive page multiple, mirroring
+        mjs_stack_alloc's frozen -EINVAL contract)."""
+        var ps = page_size()
+        var rc = Int32(0)
+
+        if guard_bytes <= 0 or (guard_bytes & (ps - 1)) != 0:
+            rc = Int32(-22)  # EINVAL
+
+        var guard = 0
+        var total = 0
+        var commit = 0
+        var base_addr = UInt64(0)
+
+        if rc == 0:
+            guard = guard_bytes
+            var usable = _round_up(reserve_bytes if reserve_bytes > 0 else ps, ps)
+            total = guard + usable
+            commit = _round_up(initial_commit_bytes, ps)
+            if commit > usable:
+                commit = usable
+
+            base_addr = probe_mmap(0, UInt64(total), _PROT_NONE, _MAP_PRIVATE_ANON, -1, 0)
+            if base_addr == _MAP_FAILED:
+                rc = _read_errno()
+
+        if rc == 0 and commit > 0:
+            var commit_off = total - commit
+            var mprc = probe_mprotect(base_addr + UInt64(commit_off), UInt64(commit), _PROT_RW)
+            if mprc != 0:
+                rc = _read_errno()
+                _ = probe_munmap(base_addr, UInt64(total))
+                base_addr = 0
+
+        if rc != 0:
+            _raise_stack_error(rc)
+
+        var ns = NativeStack()
+        ns.base = Int(base_addr)
+        ns.guard_bytes = guard
+        ns.reserved_bytes = total
+        ns.committed_bytes = commit
+        ns.top = ns.base + total
+        return ns^
+
+    def __moveinit__(mut self, mut existing: Self):
+        self.base = existing.base
+        self.guard_bytes = existing.guard_bytes
+        self.reserved_bytes = existing.reserved_bytes
+        self.committed_bytes = existing.committed_bytes
+        self.top = existing.top
+        existing.base = 0
+        existing.guard_bytes = 0
+        existing.reserved_bytes = 0
+        existing.committed_bytes = 0
+        existing.top = 0
+
+    def __del__(deinit self):
+        if self.base != 0:
+            _ = probe_munmap(UInt64(self.base), UInt64(self.reserved_bytes))
+
+    def is_live(self) -> Bool:
+        return self.base != 0
+
+    def base_address(self) -> Int:
+        return self.base
+
+    def guard_low_address(self) -> Int:
+        return self.base + self.guard_bytes
+
+    def top_address(self) -> Int:
+        return self.top
+
+    def total_reserved(self) -> Int:
+        return self.reserved_bytes
+
+    def committed(self) -> Int:
+        return self.committed_bytes
+
+    def check_geometry(self) -> Bool:
+        """base < guard_low <= top and top is 16-byte aligned."""
+        var gl = self.guard_low_address()
+        if self.base < gl and gl <= self.top:
+            return self.top % 16 == 0
+        return False

--- a/compiler-repro/movable-destroyed-before-derived-address-use/repro.mojo
+++ b/compiler-repro/movable-destroyed-before-derived-address-use/repro.mojo
@@ -1,0 +1,86 @@
+# M1.4 (#128) compiler-defect reproducer: a Movable resource (NativeStack)
+# is destroyed -- __del__ runs, munmap'ing its backing memory -- BEFORE a
+# subsequent call finishes using addresses derived from it, even though
+# that call is the very next statement and textually depends on the
+# memory still being mapped. Deterministic (5/5 in my testing), not the
+# separate flaky #202 compiler-crash pattern -- this is a runtime SIGSEGV
+# on unmapped memory, with the compiler producing a normal binary that
+# then faults.
+#
+# Mechanism: `stack`'s LAST Mojo-visible use is the pair of accessor calls
+# below (`stack.guard_low_address()` / `stack.top_address()`), which each
+# return a plain `Int` -- the compiler has no way to know that Int is a
+# derived address into `stack`'s own mapping, so once those two reads
+# complete it treats `stack` as dead and destroys it right there. The very
+# next statement, `write_it(...)`, then dereferences that now-freed address
+# and SIGSEGVs. `write_it` itself doesn't need to be `@extern`, doesn't
+# need to `raise`, and doesn't need to live in a different module -- a
+# plain same-file Mojo function reproduces it. Adding ANY extra reference
+# to `stack` textually AFTER the call that consumes the derived addresses
+# (see `probe6`-style fix noted at the bottom) reliably avoids it, which is
+# the workaround used throughout tests/spike/t8_*.mojo through t13_*.mojo.
+#
+# Bisection notes:
+#   - reproduces with a plain (non-raising, non-extern) local function --
+#     ruling out "extern FFI boundary" and "raises" as necessary
+#     ingredients (both were tried in isolation and still crashed).
+#   - reproduces whether `stack` is a fresh `var stack = NativeStack.create(...)`
+#     or a pre-declared-then-reassigned-via-try/except `stack` (mirroring
+#     the T1-T7 driver shape) -- ruling out "reassignment vs fresh
+#     declaration" as the deciding factor.
+#   - reproduces with or without unrelated trailing statements after the
+#     crashing call (a trailing `while` loop referencing unrelated locals
+#     does not save it) -- ruling out "more code after" as sufficient
+#     protection on its own.
+#   - does NOT reproduce once an explicit extra reference to `stack` is
+#     added textually after the crashing call (`_ = stack.base_address()`);
+#     this is the fix applied throughout the M1.4 switch-half tests.
+#   - tests/spike/t1_address_stability.mojo through t7 use this exact
+#     "derive two Ints, pass them to a later call, never touch `stack`
+#     again" shape too, and do NOT crash -- those drivers are considerably
+#     larger (stack_allocation'd context buffers, structs, multi-statement
+#     switch loops) and something about that shape avoids triggering the
+#     early free here, but I could not isolate a single factor that
+#     explains the difference within the scope of this leg. Treat T1-T7's
+#     safety as UNCONFIRMED-BY-PRINCIPLE rather than proven-safe-by-design
+#     until someone bisects that gap specifically.
+#
+# Toolchain: Mojo 1.0.0b2 (2cf4d08a), macOS arm64.
+#
+# $ mojo build -I spike/stack_switch docs/defects/m1-4-native-stack-use-after-free-across-call.mojo -o /tmp/repro
+# $ /tmp/repro
+# Stack dump without symbol names ...
+# ... EXC_BAD_ACCESS, deterministic, 5/5 in my testing
+
+from native_stack import NativeStack, page_size
+
+
+def write_it(stack_low: Int, stack_top: Int) -> Int:
+    """Writes one byte 16 below the top of [stack_low, stack_top) and
+    reads it back. No @extern, no raises -- a plain Mojo function is
+    enough to reproduce this."""
+    var p = UnsafePointer[UInt8, MutAnyOrigin](unsafe_from_address=stack_top - 16)
+    p[] = 0x5A
+    return Int(p[])
+
+
+def main() raises:
+    var ps = page_size()
+    var stack = NativeStack.create(256 * 1024, 256 * 1024, ps)
+
+    # `stack`'s last Mojo-visible use is these two accessor reads. On this
+    # toolchain that is enough for `stack` to be destroyed (munmap) before
+    # `write_it` below runs, even though `write_it` is the very next
+    # statement and dereferences memory `stack` still owns at this point
+    # in program order.
+    var r = write_it(stack.guard_low_address(), stack.top_address())
+
+    # A trailing loop over unrelated locals does not save it -- included
+    # here to rule that out explicitly (see bisection notes above).
+    var extra = 0
+    var i = 0
+    while i < 3:
+        extra += i
+        i += 1
+
+    print("readback=", r, "extra=", extra)

--- a/compiler-repro/movable-destroyed-before-derived-address-use/run.sh
+++ b/compiler-repro/movable-destroyed-before-derived-address-use/run.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Reproduces: a Movable resource's destructor runs (freeing/unmapping its
+# backing memory) before the very next statement finishes using plain Int
+# addresses derived from it earlier in the same statement.
+#
+# Expected (bug-free) output: "readback= 90 extra= 3"
+# Actual on Mojo 1.0.0b2 (2cf4d08a), macOS arm64: deterministic SIGSEGV
+# inside write_it() (5/5 in my testing) -- NativeStack.__del__ (munmap)
+# runs before write_it dereferences the address it was just handed.
+set -e
+cd "$(dirname "$0")"
+mojo build -I . repro.mojo -o /tmp/mojo-native-stack-uaf-repro
+/tmp/mojo-native-stack-uaf-repro


### PR DESCRIPTION
Ref #7042. Draft, not intended for merge.

Adds `compiler-repro/movable-destroyed-before-derived-address-use/` with the actual verified reproducer, plus its two small dependency files (`native_stack.mojo`, `leaf_externs.mojo`, a minimal mmap-backed Movable resource type). This could probably be trimmed further, but I'm including exactly what I tested rather than a hand-shrunk untested variant.

```sh
cd compiler-repro/movable-destroyed-before-derived-address-use && ./run.sh
```

Expected (bug-free): `readback= 90 extra= 3`.
Actual on Mojo 1.0.0b2 (2cf4d08a), macOS arm64: deterministic `SIGSEGV` inside `write_it()`, 5/5 in my testing.

Full bisection notes are in `repro.mojo`'s own header comment and in the linked issue. Happy to move this into a proper regression test, and to try trimming the dependency files further, once I know where lifetime/destructor-timing tests for this live.

