### PR TITLE
[BUG] Reproducer for #7046: flaky compiler crash on raise+live Movable+extern in a loop

### DIFF
--- a/compiler-repro/flaky-raise-through-live-movable-extern/leaf_externs.mojo
+++ b/compiler-repro/flaky-raise-through-live-movable-extern/leaf_externs.mojo
@@ -1,0 +1,60 @@
+# spike/stack_switch/leaf_externs.mojo — M1.4 (#128), memory half.
+#
+# LEAF MODULE, same discipline as spike/abi/externs_leaf.mojo and every
+# externs.mojo under mojito_sys/: ONLY @extern declarations, the comptime
+# pointer aliases they need, and tiny non-raising probe_* call shims. No
+# imports, no Movable structs, no raise sites. This keeps the raw libc
+# bindings out of the same frame as NativeStack's raising, Movable-struct
+# machinery (the #49/#29/#30 misbind/crash shape); spike/abi's own
+# ordinary_frame_test.mojo already measured that combination to be SAFE for
+# this exact mmap/munmap/mprotect call shape on this toolchain (FINDINGS.md,
+# M1.2), so this split is precautionary consistency with repo convention
+# rather than a proven-necessary workaround for this leg specifically.
+#
+# Bindings mirror spike/abi/externs_leaf.mojo's already-measured-correct
+# signatures verbatim (same symbols, same argument widths) rather than
+# re-deriving them, since #124 already proved these exact shapes byte-exact
+# against a C oracle on macOS arm64.
+#
+# Toolchain: Mojo 1.0.0b2 (2cf4d08a).
+
+@extern("mmap")
+def mjo_mmap(
+    addr: UInt64, length: UInt64, prot: Int32, flags: Int32, fd: Int32, offset: Int64
+) abi("C") -> UInt64: ...
+
+@extern("munmap")
+def mjo_munmap(addr: UInt64, length: UInt64) abi("C") -> Int32: ...
+
+@extern("mprotect")
+def mjo_mprotect(addr: UInt64, length: UInt64, prot: Int32) abi("C") -> Int32: ...
+
+@extern("sysconf")
+def mjo_sysconf(name: Int32) abi("C") -> Int64: ...
+
+# errno accessor: Darwin's libc exposes __error() -> int*; glibc exposes
+# __errno_location() -> int*. Only the platform-matching one is ever called
+# (comptime-if at the call site, mirroring spike/abi/libc_calls_test.mojo).
+@extern("__error")
+def mjo_error_ptr_macos() abi("C") -> UInt64: ...
+@extern("__errno_location")
+def mjo_errno_location_linux() abi("C") -> UInt64: ...
+
+
+def probe_mmap(addr: UInt64, length: UInt64, prot: Int32, flags: Int32, fd: Int32, offset: Int64) -> UInt64:
+    return mjo_mmap(addr, length, prot, flags, fd, offset)
+
+def probe_munmap(addr: UInt64, length: UInt64) -> Int32:
+    return mjo_munmap(addr, length)
+
+def probe_mprotect(addr: UInt64, length: UInt64, prot: Int32) -> Int32:
+    return mjo_mprotect(addr, length, prot)
+
+def probe_sysconf(name: Int32) -> Int64:
+    return mjo_sysconf(name)
+
+def probe_error_ptr_macos() -> UInt64:
+    return mjo_error_ptr_macos()
+
+def probe_errno_location_linux() -> UInt64:
+    return mjo_errno_location_linux()

--- a/compiler-repro/flaky-raise-through-live-movable-extern/native_stack.mojo
+++ b/compiler-repro/flaky-raise-through-live-movable-extern/native_stack.mojo
@@ -1,0 +1,216 @@
+# spike/stack_switch/native_stack.mojo — M1.4 (#128), memory half.
+#
+# Mojo-owned, non-moving, guarded native stack built directly over
+# mmap/mprotect/munmap (spike/stack_switch/leaf_externs.mojo) — no C
+# substrate anywhere in the loop. This is the Mojo-first counterpart to
+# native/posix/mjs_stack.c: same layout, same acceptance bar (spec §10,
+# SYS-6), but the syscalls are made directly from Mojo rather than through
+# a C function this migration is trying to retire (spec §0).
+#
+# Layout of one reservation (mirrors native/posix/mjs_stack.c exactly, so
+# the two are differentially comparable — see tests/spike/ns6_c_oracle_diff.mojo):
+#
+#   base                     base+guard              base+guard+usable = top
+#   | guard pages            | uncommitted span  | committed top span  |
+#   | PROT_NONE              | PROT_NONE          | PROT_READ|PROT_WRITE|
+#   +-----------------------+-------------------+----------------------+
+#
+#   - ONE fixed mmap for the whole reservation; the virtual address never
+#     changes for the life of the stack (SYS-6). Moving the Mojo value that
+#     owns it (a plain struct move) does not touch the mapping at all.
+#   - guard_bytes is rounded UP to whole pages (minimum one page) and
+#     painted PROT_NONE, so underflow off the bottom of the usable range
+#     faults instead of corrupting adjacent memory.
+#   - initial_commit_bytes (rounded up to pages, clamped to the usable
+#     span) is committed PROT_READ|PROT_WRITE at the TOP of the usable
+#     range; the rest of the usable span stays PROT_NONE (reserved only).
+#   - top = highest usable address. mmap returns a page-aligned base and
+#     every size here is a page multiple, so top is always 16-byte
+#     aligned (AAPCS64 SP-at-entry requirement).
+#   - release happens exactly once, in __del__, on every path (including
+#     an error raised after a partially-constructed stack — see
+#     tests/spike/ns5_dtor_exactly_once_on_raise.mojo).
+#
+# DESTRUCTOR SPELLING (load-bearing, filed as mojito-sys#200): on the
+# pinned Mojo 1.0.0b2 (2cf4d08a) toolchain, `__deinit__(deinit self)` --
+# the spelling this migration's own planning material names as current,
+# and what a dozen existing mojito_sys/* wrapper files already use -- is
+# measured to be SILENTLY NEVER INVOKED (compiles cleanly, never runs; see
+# docs/defects/m1-4-deinit-silently-inert.mojo). `__del__(deinit self)` --
+# the spelling spike/context_switch/SPIKE_REPORT.md item 1 recorded the S0
+# spike settling on -- IS invoked reliably on this toolchain, under both
+# `mojo run` and `mojo build`. This type therefore uses `__del__`,
+# deliberately, not `__deinit__`.
+#
+# Move-only: NativeStack conforms to Movable and NOT Copyable. No
+# `__init__(out self, *, copy: Self)` exists, so `var b = a` (without `^`)
+# is a compile error ("value of type 'NativeStack' cannot be implicitly
+# copied, it does not conform to 'ImplicitlyCopyable'") -- double release
+# by accidental copy is impossible by construction, not by convention (see
+# tests/spike/ns4_copy_is_compile_error.mojo, a compile-fail test).
+#
+# Compiler workarounds carried over from mojito_sys/memory/stack.mojo /
+# virtual_memory.mojo (b2, issue #29/#30 fold):
+#   - every raising member here has EXACTLY ONE raise site, funneled
+#     through `_raise_stack_error(rc)` at the tail -- no String literal
+#     reaches a `raise` through a control-flow merge in a body that also
+#     lowers an @extern call;
+#   - page rounding uses bit masks, never `/` or `%` (host page sizes are
+#     powers of two) -- integer division/remainder in the same raising,
+#     extern-lowering body has been observed to SIGSEGV this compiler.
+
+from std.memory import stack_allocation
+
+from leaf_externs import (
+    probe_mmap,
+    probe_munmap,
+    probe_mprotect,
+    probe_sysconf,
+    probe_error_ptr_macos,
+    probe_errno_location_linux,
+)
+
+comptime _PROT_NONE = Int32(0x00)
+comptime _PROT_READ = Int32(0x01)
+comptime _PROT_WRITE = Int32(0x02)
+comptime _PROT_RW = Int32(0x03)
+comptime _MAP_PRIVATE_ANON = Int32(0x1002)  # MAP_PRIVATE(0x02) | MAP_ANON(0x1000), macOS
+comptime _SC_PAGESIZE = Int32(29)  # macOS; see module note for Linux (30)
+
+comptime _MAP_FAILED = UInt64(0xFFFFFFFFFFFFFFFF)
+
+
+def _read_errno() -> Int32:
+    comptime IS_MACOS = True  # this leg targets macOS arm64 (see README)
+    var addr: UInt64
+    comptime if IS_MACOS:
+        addr = probe_error_ptr_macos()
+    else:
+        addr = probe_errno_location_linux()
+    var p = UnsafePointer[Int32, MutAnyOrigin](unsafe_from_address=Int(addr))
+    return p[]
+
+
+def _raise_stack_error(rc: Int32) raises:
+    raise Error("NativeStack: syscall failed, errno=" + String(rc))
+
+
+def page_size() -> Int:
+    return Int(probe_sysconf(_SC_PAGESIZE))
+
+
+def _round_up(n: Int, page: Int) -> Int:
+    var mask = page - 1
+    return (n + mask) & ~mask
+
+
+struct NativeStack(Movable):
+    """A Mojo-owned, non-moving, guarded native stack reservation, built
+    directly over mmap/mprotect/munmap. See module header for the full
+    contract; mirrors native/posix/mjs_stack.c's layout exactly.
+    """
+
+    var base: Int
+    var guard_bytes: Int
+    var reserved_bytes: Int
+    var committed_bytes: Int
+    var top: Int
+
+    def __init__(out self):
+        self.base = 0
+        self.guard_bytes = 0
+        self.reserved_bytes = 0
+        self.committed_bytes = 0
+        self.top = 0
+
+    @staticmethod
+    def create(
+        reserve_bytes: Int,
+        initial_commit_bytes: Int,
+        guard_bytes: Int,
+    ) raises -> Self:
+        """Reserve a guarded stack. Raises on any syscall failure or an
+        invalid guard_bytes (must be a positive page multiple, mirroring
+        mjs_stack_alloc's frozen -EINVAL contract)."""
+        var ps = page_size()
+        var rc = Int32(0)
+
+        if guard_bytes <= 0 or (guard_bytes & (ps - 1)) != 0:
+            rc = Int32(-22)  # EINVAL
+
+        var guard = 0
+        var total = 0
+        var commit = 0
+        var base_addr = UInt64(0)
+
+        if rc == 0:
+            guard = guard_bytes
+            var usable = _round_up(reserve_bytes if reserve_bytes > 0 else ps, ps)
+            total = guard + usable
+            commit = _round_up(initial_commit_bytes, ps)
+            if commit > usable:
+                commit = usable
+
+            base_addr = probe_mmap(0, UInt64(total), _PROT_NONE, _MAP_PRIVATE_ANON, -1, 0)
+            if base_addr == _MAP_FAILED:
+                rc = _read_errno()
+
+        if rc == 0 and commit > 0:
+            var commit_off = total - commit
+            var mprc = probe_mprotect(base_addr + UInt64(commit_off), UInt64(commit), _PROT_RW)
+            if mprc != 0:
+                rc = _read_errno()
+                _ = probe_munmap(base_addr, UInt64(total))
+                base_addr = 0
+
+        if rc != 0:
+            _raise_stack_error(rc)
+
+        var ns = NativeStack()
+        ns.base = Int(base_addr)
+        ns.guard_bytes = guard
+        ns.reserved_bytes = total
+        ns.committed_bytes = commit
+        ns.top = ns.base + total
+        return ns^
+
+    def __moveinit__(mut self, mut existing: Self):
+        self.base = existing.base
+        self.guard_bytes = existing.guard_bytes
+        self.reserved_bytes = existing.reserved_bytes
+        self.committed_bytes = existing.committed_bytes
+        self.top = existing.top
+        existing.base = 0
+        existing.guard_bytes = 0
+        existing.reserved_bytes = 0
+        existing.committed_bytes = 0
+        existing.top = 0
+
+    def __del__(deinit self):
+        if self.base != 0:
+            _ = probe_munmap(UInt64(self.base), UInt64(self.reserved_bytes))
+
+    def is_live(self) -> Bool:
+        return self.base != 0
+
+    def base_address(self) -> Int:
+        return self.base
+
+    def guard_low_address(self) -> Int:
+        return self.base + self.guard_bytes
+
+    def top_address(self) -> Int:
+        return self.top
+
+    def total_reserved(self) -> Int:
+        return self.reserved_bytes
+
+    def committed(self) -> Int:
+        return self.committed_bytes
+
+    def check_geometry(self) -> Bool:
+        """base < guard_low <= top and top is 16-byte aligned."""
+        var gl = self.guard_low_address()
+        if self.base < gl and gl <= self.top:
+            return self.top % 16 == 0
+        return False

--- a/compiler-repro/flaky-raise-through-live-movable-extern/repro.mojo
+++ b/compiler-repro/flaky-raise-through-live-movable-extern/repro.mojo
@@ -1,0 +1,85 @@
+# M1.4 (#128) compiler-defect reproducer: `mojo build` intermittently
+# (probabilistically, NOT deterministically) crashes the compiler itself
+# when an ordinary Mojo `raise` propagates through several call frames
+# while an ancestor frame holds a live value of a Movable struct whose
+# construction lowers @extern calls (spike/stack_switch/native_stack.mojo's
+# NativeStack, in this repro) -- REPEATED inside a loop in the same
+# compiled function. A single, unlooped instance of this shape essentially
+# never crashes in measurement; the crash rate rises with how many times
+# the shape repeats in one compilation unit.
+#
+# Bisection history (each row isolates one variable; only the combination
+# below reproduces at all):
+#   - raise through ONE extra (non-recursive) frame, no loop: never crashed
+#     (dozens of trials across several variants).
+#   - raise through a SELF-RECURSIVE chain (depth 1 or 5), no loop, called
+#     ONCE: never crashed in isolation across 20+ trials.
+#   - the SAME recursive-chain-through-a-live-NativeStack call, called ONCE
+#     per `mojo build` invocation, REPEATED across many separate `mojo
+#     build` invocations: crashed roughly 1 in 20-25 invocations.
+#   - the identical call REPEATED 200 times inside a `while` loop in ONE
+#     compiled function: crashed roughly 2 of 3 invocations.
+#   - the identical call repeated only 20 times inside the loop: 0 crashes
+#     in 5 invocations (comfortable margin, not a proof of absence).
+#   - a Movable struct with the SAME shape (raising @staticmethod
+#     factory, __moveinit__, __del__) but NO @extern calls inside the
+#     factory: never crashed, including with the loop. Removing the
+#     @extern calls (mmap/munmap) from the factory while keeping
+#     everything else identical is what stopped the crash from
+#     reproducing, so the @extern-lowering inside the raising factory
+#     appears to be a necessary ingredient, not merely a live Movable
+#     value.
+#   - whether the raise chain is self-recursive or a fixed sequence of
+#     DISTINCT nested functions did not change the qualitative outcome:
+#     both reproduce under the loop, at similar rates.
+#
+# This file is the loop shape that reproduces reliably enough to observe
+# in a handful of tries (unlike the single-call shape, which needs dozens
+# of `mojo build` invocations to see once). It is NOT a minimal single-line
+# reproducer -- every attempt to shrink it below "a live NativeStack across
+# a multi-frame raise, repeated" stopped reproducing, which is itself part
+# of what makes this a genuine crash rather than a simple logic bug: it
+# depends on something ambient in the compiler's own state, not purely on
+# the source text.
+#
+# Toolchain: Mojo 1.0.0b2 (2cf4d08a), macOS arm64, `mojo build` (also
+# reproduces under `mojo run`, less frequently).
+#
+# Run (repeat several times -- this is flaky, not deterministic):
+#   mojo build -I spike/stack_switch \
+#     docs/defects/m1-4-flaky-crash-raise-through-live-movable.mojo \
+#     -o /tmp/m1-4-repro
+# Expected (bug, on an unlucky run): `mojo build` itself aborts with
+#   "Please submit a bug report to https://github.com/modular/modular/issues"
+# and a native stack dump, before producing any binary -- this is a
+# COMPILER crash, not a runtime failure of the compiled program.
+
+from native_stack import NativeStack, page_size
+
+
+def raiser_bottom(depth: Int) raises:
+    if depth == 0:
+        raise Error("boom")
+    raiser_bottom(depth - 1)
+
+
+def guarded(ps: Int) raises:
+    var s = NativeStack.create(65536, ps, ps)
+    raiser_bottom(5)
+
+
+def main() raises:
+    var ps = page_size()
+    var i = 0
+    var ok = True
+    while i < 200:
+        var raised = False
+        try:
+            guarded(ps)
+        except e:
+            raised = True
+            _ = e
+        if not raised:
+            ok = False
+        i += 1
+    print("ok=", ok, "(expect True; the BUG is mojo build itself crashing before this ever runs)")

--- a/compiler-repro/flaky-raise-through-live-movable-extern/run.sh
+++ b/compiler-repro/flaky-raise-through-live-movable-extern/run.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Reproduces (FLAKY, not deterministic -- rerun a few times): mojo build
+# intermittently crashes the compiler itself when a raise propagates
+# through frames holding a live Movable value whose construction lowers
+# @extern calls, repeated in a loop.
+#
+# Expected (bug-free): builds and runs clean every time, prints
+#   ok= True (expect True; the BUG is mojo build itself crashing before this ever runs)
+# Actual on Mojo 1.0.0b2 (2cf4d08a): roughly 2 of 3 `mojo build` invocations
+# abort the compiler itself before producing a binary ("Please submit a
+# bug report..." + native stack dump). Rerun this script several times if
+# the first attempt happens to land in the lucky 1-in-3.
+set -e
+cd "$(dirname "$0")"
+mojo build -I . repro.mojo -o /tmp/mojo-flaky-raise-crash-repro
+/tmp/mojo-flaky-raise-crash-repro


### PR DESCRIPTION
Ref #7046. Draft, not intended for merge.

Adds `compiler-repro/flaky-raise-through-live-movable-extern/` with the actual verified reproducer, plus its one dependency file (`native_stack.mojo`/`leaf_externs.mojo`, a minimal mmap-backed Movable resource), included verbatim rather than hand-shrunk and untested.

```sh
cd compiler-repro/flaky-raise-through-live-movable-extern && ./run.sh
```

This is FLAKY, so rerun a few times. Expected (bug-free): always builds and runs clean, prints `ok= True`. Actual on Mojo 1.0.0b2 (2cf4d08a): roughly 2 of 3 `mojo build` invocations abort the compiler itself before producing a binary.

Full bisection history is in `repro.mojo`'s own header comment and the linked issue. Happy to help narrow this down further or move it into a proper regression/fuzz test once I know where compiler-crash regression tests for this live.

