### PR TITLE
[docs] Add a parallelism page for MAX inference

### DIFF
--- a/docs/max/packages.mdx
+++ b/docs/max/packages.mdx
@@ -438,7 +438,8 @@ have to fit in memory alongside everything else the system is running.
 
 - MAX can serve models on either CPU or GPU, but some models require one or
 more GPUs. When you browse our [supported models](/models/), you can check
-for multi-GPU support.
+for multi-GPU support. To serve a model across multiple GPUs, see
+[Parallelism](/serve/parallelism/).
 
 - For comprehensive GPU hardware tables, arch targets, and troubleshooting, see
 the

--- a/docs/max/serve/parallelism.mdx
+++ b/docs/max/serve/parallelism.mdx
@@ -106,7 +106,8 @@ combinations depend on support for the selected model.
 
 Because the tensor parallelism degree is derived rather than set directly, you
 choose a hybrid configuration by combining a device count, a data parallelism
-degree, and an expert parallelism size. On eight GPUs:
+degree, and an expert parallelism size. For example, if you have
+8 GPUs, you have the following hybrid options:
 
 | `--data-parallel-degree` | `--ep-size` | Resulting configuration                                                                                          |
 |--------------------------|-------------|------------------------------------------------------------------------------------------------------------------|

--- a/docs/max/serve/parallelism.mdx
+++ b/docs/max/serve/parallelism.mdx
@@ -1,0 +1,208 @@
+---
+title: Parallelism
+description: Distribute a model across multiple GPUs with tensor, data, or expert parallelism
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Parallelism distributes model computation or incoming requests across multiple
+GPUs. You might consider parallelism when a model doesn't fit comfortably on a
+single GPU or when distributing work could help meet your throughput or
+concurrency goals.
+
+MAX supports tensor parallelism, data parallelism, and expert parallelism on a
+single node. For certain models, you can combine strategies to match the model
+architecture and available hardware.
+
+## Supported strategies
+
+The following table summarizes how each strategy works, when to use it, and the
+relevant MAX CLI options.
+
+| Strategy                    | How it works                                                              | When to use it                                                              | CLI options                          |
+|-----------------------------|---------------------------------------------------------------------------|-----------------------------------------------------------------------------|--------------------------------------|
+| Tensor parallelism (TP)     | Splits model weights and layer computation across GPUs                    | A model doesn't fit on one GPU                                              | None, TP is implicit in `--devices`  |
+| Data parallelism (DP)       | Runs multiple model replicas and distributes incoming requests among them | A model fits in each replica, and you need higher throughput or concurrency | `--data-parallel-degree`             |
+| Expert parallelism (EP)     | Distributes Mixture of Experts (MoE) expert weights across GPUs           | You need to distribute the expert weights of a supported MoE model          | `--ep-size`                          |
+
+:::note
+
+MAX currently doesn't support pipeline parallelism.
+
+:::
+
+For more conceptual information, see
+[data, tensor, pipeline, expert, and hybrid parallelism](https://handbook.modular.com/inference-optimization/data-tensor-pipeline-expert-hybrid-parallelism/)
+in the LLM Inference Handbook.
+
+## Serve a model on multiple GPUs
+
+The following examples all run on a single node.
+
+### Tensor parallelism
+
+MAX doesn't provide a separate tensor parallelism flag. For a model that
+supports tensor parallelism, use `--devices` to select the GPUs you want to
+shard across. This example serves a model with TP=4:
+
+```bash
+max serve \
+  --model google/gemma-3-27b-it \
+  --devices gpu:0,1,2,3
+```
+
+MAX applies tensor parallelism automatically across the devices you give it. It
+derives the tensor parallelism degree from the device count and the data
+parallelism degree:
+
+```text
+tensor parallelism degree = number of devices / data parallelism degree
+```
+
+The device count must be divisible by the data parallelism degree. With the
+default `--data-parallel-degree 1`, serving this model on four GPUs gives you
+TP=4.
+
+### Data parallelism
+
+Set `--data-parallel-degree` to the number of replicas you want. This example
+serves two independent replicas, one per GPU:
+
+```bash
+max serve \
+  --model meta-llama/Llama-3.1-8B-Instruct \
+  --devices gpu:0,1 \
+  --data-parallel-degree 2
+```
+
+When data parallelism is active, `--max-batch-size` sets the maximum batch size
+**per replica**, not across the whole server. For example,
+`--data-parallel-degree 8` with `--max-batch-size 32` allows up to 32 requests
+per replica and 256 requests across the server.
+
+This changed in [MAX 26.1](/releases/v26.1/#26-1-max-serve). Before that
+release, the same flags meant an aggregate maximum of 32 requests, with each
+replica capped at 4. When carrying a configuration forward from an earlier
+version, divide the previous `--max-batch-size` by the data parallelism degree
+to keep the same aggregate maximum.
+
+### Expert parallelism
+
+Expert parallelism applies only to supported MoE models. Set `--ep-size` to the
+total number of GPUs:
+
+```bash
+max serve \
+  --model nvidia/DeepSeek-V3.1-NVFP4 \
+  --devices gpu:0,1,2,3,4,5,6,7 \
+  --ep-size 8
+```
+
+For a single-node deployment, `--ep-size` must be either `1` (EP disabled, the
+default) or the total GPU count. Values in between are not supported.
+
+### Hybrid parallelism
+
+Some models and inference workloads benefit from combining parallelism
+strategies. This approach can distribute model computation, requests, and MoE
+expert weights in different ways across the same set of GPUs. The available
+combinations depend on support for the selected model.
+
+Because the tensor parallelism degree is derived rather than set directly, you
+choose a hybrid configuration by combining a device count, a data parallelism
+degree, and an expert parallelism size. On eight GPUs:
+
+| `--data-parallel-degree` | `--ep-size` | Resulting configuration                                                                                          |
+|--------------------------|-------------|------------------------------------------------------------------------------------------------------------------|
+| `1` (default)            | unset       | TP=8, DP=1: one replica, weights sharded across all GPUs                                                         |
+| `2`                      | unset       | TP=4, DP=2: two replicas, each sharded across four GPUs                                                          |
+| `1`                      | `8`         | TP=8, EP=8: attention layers tensor-sharded across all eight GPUs; MoE experts distributed across all eight GPUs |
+| `8`                      | `8`         | DP=8, EP=8: each GPU runs one attention replica; requests and MoE experts distributed across all eight GPUs      |
+
+<Tabs>
+  <TabItem value="tp-dp" label="TP+DP">
+
+Set `--data-parallel-degree` to the replica count. This example serves eight
+GPUs as two data-parallel replicas of a TP=4 model:
+
+```bash
+max serve \
+  --model google/gemma-4-31B-it \
+  --devices gpu:0,1,2,3,4,5,6,7 \
+  --data-parallel-degree 2
+```
+
+  </TabItem>
+  <TabItem value="tp-ep" label="TP+EP">
+
+Keep `--data-parallel-degree` at the default of `1` and set `--ep-size` to the
+device count:
+
+```bash
+max serve \
+  --model nvidia/DeepSeek-V3.1-NVFP4 \
+  --devices gpu:0,1,2,3,4,5,6,7 \
+  --data-parallel-degree 1 \
+  --ep-size 8
+```
+
+  </TabItem>
+  <TabItem value="dp-ep" label="DP+EP">
+
+To give each GPU a separate batch shard for attention, set both
+`--data-parallel-degree` and `--ep-size` to the device count. Dense components
+such as attention and MLP layers, along with shared experts, are replicated on
+each GPU, while routed experts are divided across all eight GPUs:
+
+```bash
+max serve \
+  --model nvidia/DeepSeek-V3.1-NVFP4 \
+  --devices gpu:0,1,2,3,4,5,6,7 \
+  --data-parallel-degree 8 \
+  --ep-size 8
+```
+
+  </TabItem>
+</Tabs>
+
+Not every model supports parallelism, and support for the hybrid combinations
+above is added per architecture. To check whether a specific model supports
+multi-GPU execution, see the **Multi-GPU** column in [MAX models](/models).
+
+:::note
+
+The examples on this page cover a single node. For multi-node and large-scale
+workloads, use [Modular Cloud](https://docs.modular.com/), which manages
+distributed deployment for you.
+
+:::
+
+## Tune parallelism
+
+After choosing a strategy, use the following flags to tune the behavior. The
+**Config** column shows the config class each flag maps to when you configure a
+pipeline programmatically.
+
+| Flag                                    | Description                                                                                                                                                                                                          | Config                                                                               |
+|-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| `--ep-use-allreduce`                    | Uses allreduce for cross-device communication in expert parallelism. Performance depends on the model and interconnect, so benchmark your deployment first.                                                          | [`PipelineRuntimeConfig`](/api/python/generated/max.pipelines.PipelineRuntimeConfig) |
+| `--eplb-profile`                        | Enables expert-parallel load balancing (EPLB) MoE routing histogram profiling. You can also set the `MAX_SERVE_EPLB_PROFILE` environment variable. See [Environment variables](/environment-variables).              | [`PipelineRuntimeConfig`](/api/python/generated/max.pipelines.PipelineRuntimeConfig) |
+| `--eplb-replicas-per-gpu`               | Adds redundant expert replicas per GPU to reduce routing imbalance when EPLB is active. The default, `0`, adds no replication. Setting `k` adds `k` extra replicas per GPU; total redundant slots = k * ep_size.     | [`PipelineRuntimeConfig`](/api/python/generated/max.pipelines.PipelineRuntimeConfig) |
+| `--enable-dp-cross-replica-prefix-copy` | Lets MAX serve a prefix-cache hit that lives on the GPU of another data-parallel replica by copying the block device-to-device. Enabled by default. See [Prefix caching with PagedAttention](/serve/prefix-caching). | [`KVCacheConfig`](/api/python/generated/max.pipelines.kv_cache.KVCacheConfig/)       |
+
+:::caution
+
+The `--eplb-*` flags are experimental and support only a subset of the MoE
+models available in MAX. Behavior and model coverage can change.
+
+:::
+
+## Next steps
+
+- [Benchmark MAX on NVIDIA or AMD GPUs](/serve/benchmark): Measure the
+  throughput and latency of a parallelism configuration before committing to it.
+- [Prefix caching with PagedAttention](/serve/prefix-caching): Combine
+  parallelism with prefix caching.
+- [Deploy MAX on GPU with self-hosted endpoints](/serve/local-to-cloud): Take a
+  multi-GPU configuration to a cloud deployment.

--- a/docs/max/serve/parallelism.mdx
+++ b/docs/max/serve/parallelism.mdx
@@ -109,7 +109,7 @@ choose a hybrid configuration by combining a device count, a data parallelism
 degree, and an expert parallelism size. For example, if you have
 8 GPUs, you have the following hybrid options:
 
-| `--data-parallel-degree` | `--ep-size` | Resulting configuration                                                                                          |
+| <code style={{whiteSpace:'nowrap'}}>--data-parallel-degree</code> | <code style={{whiteSpace:'nowrap'}}>--ep-size</code> | Resulting configuration                                                                                          |
 |--------------------------|-------------|------------------------------------------------------------------------------------------------------------------|
 | `1` (default)            | unset       | TP=8, DP=1: one replica, weights sharded across all GPUs                                                         |
 | `2`                      | unset       | TP=4, DP=2: two replicas, each sharded across four GPUs                                                          |

--- a/docs/max/serve/parallelism.mdx
+++ b/docs/max/serve/parallelism.mdx
@@ -23,8 +23,8 @@ relevant MAX CLI options.
 | Strategy                    | How it works                                                              | When to use it                                                              | CLI options                          |
 |-----------------------------|---------------------------------------------------------------------------|-----------------------------------------------------------------------------|--------------------------------------|
 | Tensor parallelism (TP)     | Splits model weights and layer computation across GPUs                    | A model doesn't fit on one GPU                                              | [`--devices`](/cli/serve/#--devices-devices) with multiple GPU IDs  |
-| Data parallelism (DP)       | Runs multiple model replicas and distributes incoming requests among them | A model fits in each replica, and you need higher throughput or concurrency | `--data-parallel-degree`             |
-| Expert parallelism (EP)     | Distributes Mixture of Experts (MoE) expert weights across GPUs           | You need to distribute the expert weights of a supported MoE model          | `--ep-size`                          |
+| Data parallelism (DP)       | Runs multiple model replicas and distributes incoming requests among them | A model fits in each replica, and you need higher throughput or concurrency | [`--data-parallel-degree`] (/cli/serve/#--data-parallel-degree-data_parallel_degree)            |
+| Expert parallelism (EP)     | Distributes Mixture of Experts (MoE) expert weights across GPUs           | You need to distribute the expert weights of a supported MoE model          | [`--ep-size`](/cli/serve/#--ep-size-ep_size)                          |
 
 :::note
 

--- a/docs/max/serve/parallelism.mdx
+++ b/docs/max/serve/parallelism.mdx
@@ -22,7 +22,7 @@ relevant MAX CLI options.
 
 | Strategy                    | How it works                                                              | When to use it                                                              | CLI options                          |
 |-----------------------------|---------------------------------------------------------------------------|-----------------------------------------------------------------------------|--------------------------------------|
-| Tensor parallelism (TP)     | Splits model weights and layer computation across GPUs                    | A model doesn't fit on one GPU                                              | None, TP is implicit in `--devices`  |
+| Tensor parallelism (TP)     | Splits model weights and layer computation across GPUs                    | A model doesn't fit on one GPU                                              | [`--devices`](/cli/serve/#--devices-devices) with multiple GPU IDs  |
 | Data parallelism (DP)       | Runs multiple model replicas and distributes incoming requests among them | A model fits in each replica, and you need higher throughput or concurrency | `--data-parallel-degree`             |
 | Expert parallelism (EP)     | Distributes Mixture of Experts (MoE) expert weights across GPUs           | You need to distribute the expert weights of a supported MoE model          | `--ep-size`                          |
 

--- a/docs/max/serve/parallelism.mdx
+++ b/docs/max/serve/parallelism.mdx
@@ -81,11 +81,6 @@ When data parallelism is active, `--max-batch-size` sets the maximum batch size
 `--data-parallel-degree 8` with `--max-batch-size 32` allows up to 32 requests
 per replica and 256 requests across the server.
 
-This changed in [MAX 26.1](/releases/v26.1/#26-1-max-serve). Before that
-release, the same flags meant an aggregate maximum of 32 requests, with each
-replica capped at 4. When carrying a configuration forward from an earlier
-version, divide the previous `--max-batch-size` by the data parallelism degree
-to keep the same aggregate maximum.
 
 ### Expert parallelism
 

--- a/docs/max/serve/parallelism.mdx
+++ b/docs/max/serve/parallelism.mdx
@@ -42,7 +42,7 @@ As summarized in the table above, you can serve a model across multiple GPUs usi
 
 ### Tensor parallelism
 
-MAX doesn't provide a separate tensor parallelism flag. For a model that
+For a model that
 supports tensor parallelism, use `--devices` to select the GPUs you want to
 shard across. This example serves a model with TP=4:
 

--- a/docs/max/serve/parallelism.mdx
+++ b/docs/max/serve/parallelism.mdx
@@ -20,11 +20,11 @@ architecture and available hardware.
 The following table summarizes how each strategy works, when to use it, and the
 relevant MAX CLI options.
 
-| Strategy                    | How it works                                                              | When to use it                                                              | CLI options                          |
-|-----------------------------|---------------------------------------------------------------------------|-----------------------------------------------------------------------------|--------------------------------------|
-| Tensor parallelism (TP)     | Splits model weights and layer computation across GPUs                    | A model doesn't fit on one GPU                                              | [`--devices`](/cli/serve/#--devices-devices) with multiple GPU IDs  |
-| Data parallelism (DP)       | Runs multiple model replicas and distributes incoming requests among them | A model fits in each replica, and you need higher throughput or concurrency | [`--data-parallel-degree`] (/cli/serve/#--data-parallel-degree-data_parallel_degree)            |
-| Expert parallelism (EP)     | Distributes Mixture of Experts (MoE) expert weights across GPUs           | You need to distribute the expert weights of a supported MoE model          | [`--ep-size`](/cli/serve/#--ep-size-ep_size)                          |
+| Strategy                | How it works                                                              | When to use it                                                              | CLI options                                                                         |
+|-------------------------|---------------------------------------------------------------------------|-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| Tensor parallelism (TP) | Splits model weights and layer computation across GPUs                    | A model doesn't fit on one GPU                                              | [`--devices`](/cli/serve/#--devices-devices) with multiple GPU IDs                  |
+| Data parallelism (DP)   | Runs multiple model replicas and distributes incoming requests among them | A model fits in each replica, and you need higher throughput or concurrency | [`--data-parallel-degree`](/cli/serve/#--data-parallel-degree-data_parallel_degree) |
+| Expert parallelism (EP) | Distributes Mixture of Experts (MoE) weights across GPUs                  | You need to distribute the expert weights of a supported MoE model          | [`--ep-size`](/cli/serve/#--ep-size-ep_size)                                        |
 
 :::note
 
@@ -38,13 +38,14 @@ in the LLM Inference Handbook.
 
 ## Serve a model on multiple GPUs
 
-As summarized in the table above, you can serve a model across multiple GPUs using one or more parallelism strategies. The following sections provide more information about how to parallelize a model with `max serve` on a single node.
+As summarized in the table above, you can serve a model across multiple GPUs
+using one or more parallelism strategies. The following sections provide more
+information about how to parallelize a model with `max serve` on a single node.
 
 ### Tensor parallelism
 
-For a model that
-supports tensor parallelism, use `--devices` to select the GPUs you want to
-shard across. This example serves a model with TP=4:
+For a model that supports tensor parallelism, use `--devices` to select the GPUs
+you want to shard across. This example serves a model with TP=4:
 
 ```bash
 max serve \
@@ -52,22 +53,22 @@ max serve \
   --devices gpu:0,1,2,3
 ```
 
-MAX applies tensor parallelism automatically across the devices you give it. It
-derives the tensor parallelism degree from the device count and the data
-parallelism degree:
+MAX applies tensor parallelism automatically across the devices you give it.
+
+### Data parallelism
+
+Set `--data-parallel-degree` to the number of replicas you want, combined
+with `--devices` to select which GPUs to use.
+
+The parallelism degree can't exceed the number of devices available. If the
+parallelism degree is less than the number of devices, MAX will enable tensor
+parallelism to a degree based on this simple formula:
 
 ```text
 tensor parallelism degree = number of devices / data parallelism degree
 ```
 
-The device count must be divisible by the data parallelism degree. With the
-default `--data-parallel-degree 1`, serving this model on four GPUs gives you
-TP=4.
-
-### Data parallelism
-
-Set `--data-parallel-degree` to the number of replicas you want. This example
-serves two independent replicas, one per GPU:
+This example serves two independent replicas, one per GPU:
 
 ```bash
 max serve \
@@ -80,7 +81,6 @@ When data parallelism is active, `--max-batch-size` sets the maximum batch size
 **per replica**, not across the whole server. For example,
 `--data-parallel-degree 8` with `--max-batch-size 32` allows up to 32 requests
 per replica and 256 requests across the server.
-
 
 ### Expert parallelism
 
@@ -110,11 +110,14 @@ degree, and an expert parallelism size. For example, if you have
 8 GPUs, you have the following hybrid options:
 
 | <code style={{whiteSpace:'nowrap'}}>--data-parallel-degree</code> | <code style={{whiteSpace:'nowrap'}}>--ep-size</code> | Resulting configuration                                                                                          |
-|--------------------------|-------------|------------------------------------------------------------------------------------------------------------------|
-| `1` (default)            | unset       | TP=8, DP=1: one replica, weights sharded across all GPUs                                                         |
-| `2`                      | unset       | TP=4, DP=2: two replicas, each sharded across four GPUs                                                          |
-| `1`                      | `8`         | TP=8, EP=8: attention layers tensor-sharded across all eight GPUs; MoE experts distributed across all eight GPUs |
-| `8`                      | `8`         | DP=8, EP=8: each GPU runs one attention replica; requests and MoE experts distributed across all eight GPUs      |
+|-------------------------------------------------------------------|------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| `1` (default)                                                     | unset                                                | TP=8, DP=1: one replica, weights sharded across all GPUs                                                         |
+| `2`                                                               | unset                                                | TP=4, DP=2: two replicas, each sharded across four GPUs                                                          |
+| `1`                                                               | `8`                                                  | TP=8, EP=8: attention layers tensor-sharded across all eight GPUs; MoE experts distributed across all eight GPUs |
+| `8`                                                               | `8`                                                  | DP=8, EP=8: each GPU runs one attention replica; requests and MoE experts distributed across all eight GPUs      |
+
+The following examples show the `max serve` command for each hybrid
+combination:
 
 <Tabs>
   <TabItem value="tp-dp" label="TP+DP">

--- a/docs/max/serve/parallelism.mdx
+++ b/docs/max/serve/parallelism.mdx
@@ -38,7 +38,7 @@ in the LLM Inference Handbook.
 
 ## Serve a model on multiple GPUs
 
-The following examples all run on a single node.
+As summarized in the table above, you can serve a model across multiple GPUs using one or more parallelism strategies. The following sections provide more information about how to parallelize a model with `max serve` on a single node.
 
 ### Tensor parallelism
 

--- a/docs/max/tile-tensor/layouts.mdx
+++ b/docs/max/tile-tensor/layouts.mdx
@@ -374,7 +374,7 @@ var row_major_mixed = row_major((rows, Idx[columns]))
 Sometimes you need a more complicated memory layout. For example, to
 improve the efficiency of memory accesses, you may want to load your
 data into memory using a tile-major layout. "tile-major" describes a
-layout where a the overall layout is divided into rectangular "tiles"
+layout where the overall layout is divided into rectangular "tiles"
 and elements inside a tile are laid out consecutively in memory.
 
 The following is an example of a tile-major layout:

--- a/docs/sidebars.json
+++ b/docs/sidebars.json
@@ -54,6 +54,7 @@
         "serve/prefix-caching",
         "serve/lora-adapters",
         "serve/speculative-decoding",
+        "serve/parallelism",
         "serve/recipes",
         "serve/metrics"
       ]


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Your contribution is appreciated.

Before you open this PR, please make sure the change has been discussed and
agreed upon with a maintainer. For anything beyond a trivial fix (typo,
one-line bug fix, doc tweak), we ask that you first open a GitHub issue or
proposal and get a maintainer's go-ahead. This helps us avoid situations
where a PR sits unreviewed because the change isn't aligned with the
team's direction. See our [contributor guide](https://github.com/modular/modular/blob/main/CONTRIBUTING.md) for
details.
-->

## Linked issue

<!--
Replace `NNN` with the issue number. For anything non-trivial, a linked
issue that a maintainer has agreed to is expected before review.

- Trivial fix (typo, comment, small doc fix): you can write "N/A — trivial".
- Everything else: `Fixes #NNN` or `Related to #NNN`.
-->

Fixes https://github.com/modular/modular/issues/6926

## Type of change

<!-- Check all that apply. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [x] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

<!--
Why is this change needed? What problem does it solve, or what use case
does it enable? If this is a bug fix, describe the bug and how a user
would hit it. If this is a new feature, explain the user-facing value.

Please write prose here — don't just restate the PR title.
-->

MAX supports tensor, data, and expert parallelism for inference, but no page in the docs explained any of them. The material that existed was spread across the `max serve` CLI reference and release notes. Learn more in https://github.com/modular/modular/issues/6926

## What changed

<!--
Describe the change at a high level. Call out anything non-obvious: API
changes, behavior changes, performance characteristics, or tricky
implementation details.
-->

- Added a dedicated parallelism page at `docs/max/serve/parallelism.mdx`, under the Deployment chapter in the sidebar. It covers single node only, per reviewer guidance. There's no multi-node section; instead a short call-out points multi-node workloads at Modular Cloud.
- Fixed a typo on the layouts page

## Testing

<!--
Describe how you validated your changes.

- Code changes: what tests did you run, and what were the results? Did
  you add a new test that would have caught the bug?
- Performance changes: include before/after numbers from a benchmark.
- Documentation: describe how you verified accuracy (built the docs,
  ran the example, etc.).
-->

Didn't test the commands on GPUs, but every command (except the TP+DP example) on the page was checked against architecture code and the recipe configs in `max/python/max/pipelines/architectures/*/recipes/`:

- TP+EP (`--data-parallel-degree 1 --ep-size 8`) matches `deepseekV3/recipes/nvfp4_tpep_8x_b200.yaml`.
- DP+EP (`--data-parallel-degree 8 --ep-size 8`) matches `deepseekV3/recipes/nvfp4_8x_b200.yaml`.
- The DP example matches the `--data-parallel-degree 2 --devices gpu:0,1` example from the 25.6 release notes.
- The `--ep-size` constraint (1 or the total GPU count on a single node) is enforced in `deepseekV3/model.py:124-129` and `qwen3/model.py:117`.
- The DP+EP description (dense components and shared experts replicated, routed experts divided) follows `deepseekV3/model.py:91-93`, `nn/moe/moe.py:359` (routed experts divided by `ep_size`), and `nn/moe/moe.py:387-397` (shared experts built with no `ep_size` division).

One question about TP+DP: is this actually supported? The TP+DP tab uses `--data-parallel-degree 2` on eight GPUs, expecting TP=4 per replica, but I did not find any recipe using a partial degree.

BTW, I am not able to preview the doc page locally, so please help build it to see if the build succeeds. Thanks. 

## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [ ] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/mojo/CONTRIBUTING.md#about-pull-request-sizes))
- [x] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [ ] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
