### PR TITLE
[stdlib] Skip Py_Initialize when CPython init already failed

### DIFF
--- a/Mojo/stdlib/std/python/_cpython.mojo
+++ b/Mojo/stdlib/std/python/_cpython.mojo
@@ -1761,8 +1761,10 @@ struct CPython(Defaultable, Movable):
         if not self.init_error:
             if not self.lib.check_symbol("Py_Initialize"):
                 self.init_error = "compatible Python library not found"
-            self.lib.call["Py_Initialize"]()
-            self.version = PythonVersion(_py_get_version(self.lib.borrow()))
+                self.version = PythonVersion(0, 0, 0)
+            else:
+                self.lib.call["Py_Initialize"]()
+                self.version = PythonVersion(_py_get_version(self.lib.borrow()))
         else:
             self.version = PythonVersion(0, 0, 0)
 

--- a/Mojo/stdlib/test/python/test_python_cpython.mojo
+++ b/Mojo/stdlib/test/python/test_python_cpython.mojo
@@ -579,5 +579,16 @@ def test_pymoduledef_write_repr_to() raises:
     assert_true("size=" in s)
 
 
+def test_cpython_init_populates_version() raises:
+    # A successful CPython initialization must record a real interpreter
+    # version. The init path only calls Py_Initialize and reads the version
+    # when the compatible library symbol is present; a regression there would
+    # leave the version at 0.0.0 even though the interpreter loaded.
+    var python = Python()
+    ref cpython = python.cpython()
+    assert_true(cpython.version.major >= 3)
+    assert_true(cpython.version.minor >= 0)
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/Mojo/stdlib/test/python/test_python_cpython.mojo
+++ b/Mojo/stdlib/test/python/test_python_cpython.mojo
@@ -580,10 +580,7 @@ def test_pymoduledef_write_repr_to() raises:
 
 
 def test_cpython_init_populates_version() raises:
-    # A successful CPython initialization must record a real interpreter
-    # version. The init path only calls Py_Initialize and reads the version
-    # when the compatible library symbol is present; a regression there would
-    # leave the version at 0.0.0 even though the interpreter loaded.
+    # Successful CPython initialization records a real interpreter version.
     var python = Python()
     ref cpython = python.cpython()
     assert_true(cpython.version.major >= 3)

--- a/Mojo/stdlib/test/python/test_python_cpython.mojo
+++ b/Mojo/stdlib/test/python/test_python_cpython.mojo
@@ -584,7 +584,6 @@ def test_cpython_init_populates_version() raises:
     var python = Python()
     ref cpython = python.cpython()
     assert_true(cpython.version.major >= 3)
-    assert_true(cpython.version.minor >= 0)
 
 
 def main() raises:


### PR DESCRIPTION
## Linked issue

Fixes #7062

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation

In `CPython.__init__` (`mojo/stdlib/std/python/_cpython.mojo`), `init_error` is
a `StaticString` that is empty on success; consumers treat a non-empty value as
"Python is unusable" (`check_init_error` raises on it). But when the compatible
Python library was missing, `__init__` set `init_error = "compatible Python
library not found"` and then still called `Py_Initialize` and read the version —
running the exact initialization path the error state was meant to prevent.

## What changed

Added the missing `else` so `Py_Initialize` / version-read only run when the
symbol is present, and the failure path sets a zero version instead. No public
API or behavior change on the success path.

## Testing

Built the toolchain with `pixi` and ran the existing CPython test suite against
the fixed file:

```
pixi run mojo run -I stdlib/std stdlib/test/python/test_python_cpython.mojo
...
Summary [ 162.341 ] 26 tests run: 26 passed , 0 failed , 0 skipped
```

`pixi run mojo format stdlib/std/python/_cpython.mojo` reports the file unchanged
(already formatted). The failure branch requires a host with no compatible
libpython, which I couldn't reproduce here (the pixi env ships CPython), so I
verified the guard by inspection and confirmed the success path is unaffected by
the full suite above.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is agreed-upon (labeled `accepted`, `good first issue`)
- [x] PR is small and focused
- [x] I ran the formatter on my changes
- [x] Existing tests cover the success path; the added guard is a one-line control-flow fix
- [x] `Assisted-by:` trailer included in the commit message
