### PR TITLE
[Kernels][GPU] qmatmul: mask A-tile load when M < BM

### DIFF
--- a/max/kernels/src/quantization/qmatmul_gpu.mojo
+++ b/max/kernels/src/quantization/qmatmul_gpu.mojo
@@ -135,6 +135,7 @@ def multistage_mma_q[
     b_next_gmem_layout: Layout = Layout(),
     b_next_smem_layout: Layout = Layout(),
     next_op_b_iter_alignment: Int = align_of[b_type](),
+    mask_a: Bool = False,
 ](
     c: LayoutTensor[mut=True, c_type, c_layout, address_space=.LOCAL, ...],
     a_iter_arg: LayoutTensorIter[_, a_layout, ...],
@@ -164,6 +165,7 @@ def multistage_mma_q[
     /,
     *,
     num_b_rows: Optional[Int] = None,
+    num_a_rows: OptionalReg[Int] = None,
 ):
     """Performs the multi-stage tensor-core MMA loop for a quantized matrix multiplication tile.
 
@@ -201,6 +203,10 @@ def multistage_mma_q[
         b_next_gmem_layout: The global-memory layout of the next op's B matrix.
         b_next_smem_layout: The shared-memory layout of the next op's B matrix.
         next_op_b_iter_alignment: The required alignment for the next op's B iterator.
+        mask_a: When `True`, the A-tile global-to-shared copies are bounds-checked
+            against `num_a_rows` so rows past the valid M extent are zero-filled
+            instead of read out of bounds. Defaults to `False` (the legacy
+            unmasked copy) so non-quant callers are unchanged.
 
     Args:
         c: The local accumulator tile receiving the MMA results.
@@ -212,6 +218,9 @@ def multistage_mma_q[
         scales_iter_arg: The global-memory iterator over scale tiles.
         num_iters: The number of K-tile iterations to execute.
         num_b_rows: The runtime row count of the B matrix, if known.
+        num_a_rows: The number of valid A rows in this block's M-tile
+            (`clamp(M - block_m * BM, 0, BM)`), used as the masked bound when
+            `mask_a` is `True`. `None` disables the bound (full-tile copy).
     """
     comptime simd_size = simd_width_of[a_type]()
     comptime simd_b_size = simd_width_of[b_type]()
@@ -303,18 +312,39 @@ def multistage_mma_q[
     def _async_copy_a_tile(
         dst: LayoutTensor[mut=True, a_type, address_space=.SHARED, ...],
         src: LayoutTensor[a_type, address_space=.GENERIC, ...],
+        num_valid_rows: OptionalReg[Int],
     ):
-        GenericToSharedAsyncTileCopier[
-            async_copy_a_layout_tt,
-            swizzle=async_swizzle_a,
-        ]().copy(
-            lt_to_tt_idx[linear_idx_type=a_idx_t](dst).vectorize[
-                1, simd_size
-            ](),
-            lt_to_tt_idx[linear_idx_type=a_idx_t](src).vectorize[
-                1, simd_size
-            ](),
-        )
+        # A comes from `a.tiled_iterator[BM, BK]`, whose tile view carries a
+        # static `BM` row dim and does not runtime-clip dim0. When `mask_a` is
+        # set, bound the copy to `num_valid_rows` (the valid M rows of this
+        # block) so rows `>= M` are zero-filled by `cp.async` instead of read
+        # out of bounds. See issue modular#7069.
+        comptime if mask_a:
+            GenericToSharedAsyncTileCopier[
+                async_copy_a_layout_tt,
+                swizzle=async_swizzle_a,
+                masked=True,
+            ]().copy_bounded(
+                lt_to_tt_idx[linear_idx_type=a_idx_t](dst).vectorize[
+                    1, simd_size
+                ](),
+                lt_to_tt_idx[linear_idx_type=a_idx_t](src).vectorize[
+                    1, simd_size
+                ](),
+                num_valid_rows,
+            )
+        else:
+            GenericToSharedAsyncTileCopier[
+                async_copy_a_layout_tt,
+                swizzle=async_swizzle_a,
+            ]().copy(
+                lt_to_tt_idx[linear_idx_type=a_idx_t](dst).vectorize[
+                    1, simd_size
+                ](),
+                lt_to_tt_idx[linear_idx_type=a_idx_t](src).vectorize[
+                    1, simd_size
+                ](),
+            )
 
     @always_inline
     @__parameter
@@ -342,6 +372,7 @@ def multistage_mma_q[
                 _async_copy_a_tile(
                     a_smem_tile,
                     a_iter[].bitcast[a_type, target_address_space=.GENERIC](),
+                    num_a_rows,
                 )
 
                 a_iter._incr()
@@ -562,6 +593,7 @@ def multistage_mma_q[
                                 a_type,
                                 target_address_space=.GENERIC,
                             ](),
+                            num_a_rows,
                         )
 
                         a_iter._incr()
@@ -847,6 +879,13 @@ def multistage_qgemm_kernel[
         .fill(0)
     )
 
+    # Valid A rows for this block's M-tile. Configs with BM > M (every decode
+    # shape, M=1) or a partial tail block (M % BM != 0) would otherwise copy
+    # rows past the [M, K] A buffer; mask the copy to this bound. `block_idx`
+    # here is the (swizzled) block coordinate, so this must be computed at the
+    # call site, not from the raw builtin inside multistage_mma_q. See #7069.
+    var a_valid_rows = max(0, min(Int(BM), M - block_idx[1] * BM))
+
     multistage_mma_q[
         BM,
         BN,
@@ -858,6 +897,7 @@ def multistage_qgemm_kernel[
         transpose_b,
         group_size,
         pack_factor,
+        mask_a=True,
     ](
         c_reg_tile,
         a_gmem_iter,
@@ -867,6 +907,7 @@ def multistage_qgemm_kernel[
         scales_smem_iter,
         scales_gmem_iter,
         ceildiv(K // num_warp_k_partitions, BK),
+        num_a_rows=OptionalReg[Int](a_valid_rows),
     )
 
     # reduce within the threadblock

--- a/max/kernels/test/gpu/quantization/BUILD.bazel
+++ b/max/kernels/test/gpu/quantization/BUILD.bazel
@@ -91,6 +91,7 @@ _EXTRA_CONSTRAINTS = {
         ["**/*.mojo"],
         exclude = [
             "test_multistage_gemm_q.mojo",
+            "test_qmatmul_guardpage_7069.mojo",
         ] + _FP8_FP4_TESTS,
     )
 ]
@@ -106,6 +107,21 @@ mojo_test(
     },
     tags = ["gpu"],
     # FIXME: KERN-1377 and move this into the glob above
+    target_compatible_with = ["//:nvidia_gpu"],
+    deps = _DEPS,
+)
+
+# modular#7069 guard-page regression test. NVIDIA-only: it builds a CUDA VMM
+# guard page via the driver API (libcuda) so the M<BM A-tile over-read faults
+# deterministically instead of depending on the pooled allocator's layout.
+mojo_test(
+    name = "test_qmatmul_guardpage_7069.mojo.test",
+    srcs = ["test_qmatmul_guardpage_7069.mojo"],
+    copts = IGNORED_POINTER_DEPRECATIONS_COPTS,
+    exec_properties = {
+        "test.resources:gpu-memory": "3",
+    },
+    tags = ["gpu"],
     target_compatible_with = ["//:nvidia_gpu"],
     deps = _DEPS,
 )

--- a/max/kernels/test/gpu/quantization/test_multistage_gemm_q.mojo
+++ b/max/kernels/test/gpu/quantization/test_multistage_gemm_q.mojo
@@ -832,3 +832,18 @@ def main() raises:
         test_quantized[.uint8](ctx, Int(482), Idx[28672], Idx[4096])
         test_quantized[.uint8](ctx, Int(482), Idx[4096], Idx[14336])
         test_quantized[.uint8](ctx, Int(482), Idx[128256], Idx[4096])
+
+        # Coverage for modular#7069: the A-tile copy is unmasked for M < BM.
+        # This test forces BM=128 (config ampere_128x128_4), so every case
+        # below has M < BM and drives the masked A copy. The over-read itself
+        # does not corrupt output (rows >= M are never stored) and only faults
+        # when it crosses an unmapped page, so these check that masking keeps
+        # the decode/partial-tile results correct against the fp32 dequant ref:
+        # M=1 decode shapes plus non-multiple-of-BM tails (M=3, M=7).
+        test_quantized[.uint8](ctx, Idx[1], Idx[4096], Idx[14336])
+        test_quantized[.uint8](ctx, Idx[1], Idx[4096], Idx[4096])
+        test_quantized[.uint8](ctx, Idx[1], Idx[6144], Idx[4096])
+        test_quantized[.uint8](ctx, Idx[3], Idx[4096], Idx[14336])
+        test_quantized[.uint8](ctx, Idx[7], Idx[28672], Idx[4096])
+        test_quantized[.uint8](ctx, Int(1), Idx[4096], Idx[14336])
+        test_quantized[.uint8](ctx, Int(3), Idx[4096], Idx[4096])

--- a/max/kernels/test/gpu/quantization/test_qmatmul_guardpage_7069.mojo
+++ b/max/kernels/test/gpu/quantization/test_qmatmul_guardpage_7069.mojo
@@ -1,0 +1,175 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright (c) 2026, Modular Inc. All rights reserved.
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions:
+# https://llvm.org/LICENSE.txt
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+# Deterministic memory-safety regression test for modular#7069: the unmasked
+# A-tile global->shared copy in multistage_mma_q reads (BM - M) * K elements past
+# the [M, K] A buffer when M < BM. The over-read never corrupts output (the
+# epilogue stores only rows < M), so it is invisible to a correctness test; the
+# only symptom is CUDA_ERROR_ILLEGAL_ADDRESS when the over-read crosses an
+# unmapped page. A pooled allocator maps a big arena, so the fault is normally
+# allocation-layout dependent and does not reproduce in a plain test.
+#
+# This test removes that dependence with a CUDA VMM guard page: A's valid rows are
+# placed at the very end of a mapped region whose next page is reserved but
+# UNMAPPED, so ANY read past row M faults deterministically. On buggy code the
+# kernel faults; with the mask_a fix the OOB rows are zero-filled (cp.async
+# src-size 0) and never touch the guard page, so the kernel completes.
+#
+# Runs a Llama-3 down_proj decode shape (N=4096, K=14336) at M=1 with a BM=128
+# config, so every A tile has M < BM and drives the masked copy.
+from std.ffi import OwnedDLHandle
+from std.memory import OpaquePointer
+
+from layout import Coord, Idx, TileTensor, row_major
+from linalg.utils_gpu import MatmulKernels
+from max.gpu.host import DeviceContext, DeviceBuffer
+from quantization.qmatmul_gpu import multistage_gemm_q
+
+comptime N = 4096
+comptime K = 14336
+comptime GROUP_SIZE = 128
+comptime PACK_FACTOR = 8
+comptime GROUP_BYTES = GROUP_SIZE // 2 + 2  # 66
+comptime A_TYPE = DType.bfloat16
+comptime B_TYPE = DType.uint8
+
+
+def _u32(base: UInt64, byte_off: Int, val: UInt32):
+    OpaquePointer[MutUntrackedOrigin](
+        unsafe_from_address=Int(base) + byte_off
+    ).bitcast[UInt32]()[0] = val
+
+
+def main() raises:
+    with DeviceContext() as ctx:
+        print("device:", ctx.name())
+        comptime M = 1
+        var lib = OwnedDLHandle(path="libcuda.so.1")
+
+        var cuMemGetAllocationGranularity = lib._handle.get_function[
+            def(UInt64, UInt64, Int32) thin abi("C") -> Int32
+        ]("cuMemGetAllocationGranularity")
+        var cuMemCreate = lib._handle.get_function[
+            def(UInt64, UInt64, UInt64, UInt64) thin abi("C") -> Int32
+        ]("cuMemCreate")
+        var cuMemAddressReserve = lib._handle.get_function[
+            def(UInt64, UInt64, UInt64, UInt64, UInt64) thin abi("C") -> Int32
+        ]("cuMemAddressReserve")
+        var cuMemMap = lib._handle.get_function[
+            def(UInt64, UInt64, UInt64, UInt64, UInt64) thin abi("C") -> Int32
+        ]("cuMemMap")
+        var cuMemSetAccess = lib._handle.get_function[
+            def(UInt64, UInt64, UInt64, UInt64) thin abi("C") -> Int32
+        ]("cuMemSetAccess")
+        var cuMemUnmap = lib._handle.get_function[
+            def(UInt64, UInt64) thin abi("C") -> Int32
+        ]("cuMemUnmap")
+        var cuMemRelease = lib._handle.get_function[
+            def(UInt64) thin abi("C") -> Int32
+        ]("cuMemRelease")
+        var cuMemAddressFree = lib._handle.get_function[
+            def(UInt64, UInt64) thin abi("C") -> Int32
+        ]("cuMemAddressFree")
+
+        # CUmemAllocationProp (32B): type=PINNED(1)@0, loc.type=DEVICE(1)@8, id=0@12
+        var prop = ctx.enqueue_create_host_buffer[DType.uint8](32)
+        for i in range(32):
+            prop.unsafe_ptr()[i] = 0
+        var prop_addr = UInt64(Int(prop.unsafe_ptr()))
+        _u32(prop_addr, 0, 1)
+        _u32(prop_addr, 8, 1)
+        _u32(prop_addr, 12, 0)
+
+        # Driver out-params live in real host memory (see feasibility probe notes).
+        var outbuf = ctx.enqueue_create_host_buffer[DType.uint64](3)
+        var out64 = outbuf.unsafe_ptr()
+        out64[0] = 0
+        out64[1] = 0
+        out64[2] = 0
+
+        _ = cuMemGetAllocationGranularity(UInt64(Int(out64)), prop_addr, 0)
+        var chunk = out64[0]
+        var reserve = chunk * 2
+
+        _ = cuMemAddressReserve(UInt64(Int(out64) + 8), reserve, 0, 0, 0)
+        var base = out64[1]
+        _ = cuMemCreate(UInt64(Int(out64) + 16), chunk, prop_addr, 0)
+        var handle = out64[2]
+        _ = cuMemMap(base, chunk, 0, handle, 0)
+
+        # CUmemAccessDesc (16B): loc.type=DEVICE(1)@0, id=0@4, flags=RW(3)@8
+        var desc = ctx.enqueue_create_host_buffer[DType.uint8](16)
+        for i in range(16):
+            desc.unsafe_ptr()[i] = 0
+        var desc_addr = UInt64(Int(desc.unsafe_ptr()))
+        _u32(desc_addr, 0, 1)
+        _u32(desc_addr, 8, 3)
+        _ = cuMemSetAccess(base, chunk, desc_addr, 1)
+
+        # Place A's valid rows [M, K] at the TAIL of the mapped chunk, so the very
+        # next byte after row M-1 is the unmapped guard page.
+        comptime a_bytes = M * K * 2  # bf16
+        var a_addr = base + chunk - a_bytes
+        print(
+            "guard page: mapped [", base, ",", base + chunk, "), A at", a_addr
+        )
+
+        # Wrap the raw VMM device address as a non-owning DeviceBuffer.
+        var a_ptr = Pointer[Scalar[A_TYPE], MutUntrackedOrigin](
+            unsafe_from_address=Int(a_addr)
+        )
+        var a_device = DeviceBuffer[A_TYPE](ctx, a_ptr, M * K, owning=False)
+
+        # B (packed weights) and C: ordinary pooled buffers. Values are irrelevant
+        # to the memory-safety check; sizes must be correct so B/scales stay in
+        # bounds and only the A copy can fault.
+        comptime b_cols = (K // GROUP_SIZE) * GROUP_BYTES
+        var b_device = ctx.enqueue_create_buffer[B_TYPE](N * b_cols)
+        var c_device = ctx.enqueue_create_buffer[A_TYPE](M * N)
+        b_device.enqueue_fill(0)
+        c_device.enqueue_fill(0)
+
+        var a_tt = TileTensor(a_device, row_major(Coord(M, Idx[K])))
+        var b_tt = TileTensor(b_device, row_major(Coord(Idx[N], Idx[b_cols])))
+        var c_tt = TileTensor(c_device, row_major(Coord(M, Idx[N])))
+
+        comptime kernels = MatmulKernels[A_TYPE, B_TYPE, A_TYPE, True]()
+        comptime config = kernels.ampere_128x128_4  # BM=128 -> M=1 < BM
+
+        print(
+            "launching multistage_gemm_q M=",
+            M,
+            " N=",
+            N,
+            " K=",
+            K,
+            " BM=",
+            config.block_tile_shape[0],
+        )
+        multistage_gemm_q[
+            group_size=GROUP_SIZE, pack_factor=PACK_FACTOR, config=config
+        ](
+            c_tt.to_layout_tensor(),
+            a_tt.to_layout_tensor(),
+            b_tt.to_layout_tensor(),
+            config,
+            ctx,
+        )
+        ctx.synchronize()
+        print("SURVIVED: kernel completed with no illegal access (fix present)")
+
+        _ = a_device^
+        _ = b_device^
+        _ = c_device^
+        _ = cuMemUnmap(base, chunk)
+        _ = cuMemRelease(handle)
+        _ = cuMemAddressFree(base, reserve)


### PR DESCRIPTION
## Linked issue

Fixes #7069

> Opened as a **draft** for visibility and coordination. The issue is labeled
> `bug_feature_triaged`; happy to adjust the approach before this is picked up
> for review.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Motivation

`multistage_mma_q` (the quantized multi-stage matmul mainloop in
`qmatmul_gpu.mojo`) copies a `BM x BK` A-tile (activations) from global to
shared memory with **no runtime `M` bound**. When the selected config has
`BM > M` — which is every decode shape, where `M = 1` — or `M` is not a multiple
of `BM`, the async copy issues `cp.async` loads for all `BM` rows and reads up
to `(BM - M_tail) * K` elements past the end of the `[M, K]` A buffer.

This is an out-of-bounds global read. Importantly, it does **not** corrupt
results: the epilogue only stores rows `< M`, and each stored row's MMA depends
only on in-bounds A rows, so the garbage/extra rows are never observed in the
output. Its only symptom is `CUDA_ERROR_ILLEGAL_ADDRESS`, and only when the
over-read crosses an unmapped page — so whether it faults is
**allocation-layout dependent**.

The dense multi-stage GEMM (`_multistage_gemm_gpu.mojo`) does not have this bug:
it bounds its tail copy. The quantized path was adapted from it and dropped the
masking.

## What changed

`GenericToSharedAsyncTileCopier` already supports a bounds-checked copy
(`masked=True` + `copy_bounded(dst, src, src_num_valid_rows)`), which issues
zero-byte `cp.async` (with `fill=0`) for vectors past the valid extent. The fix
reuses it for the A copies:

- Add an opt-in comptime `mask_a` flag and a runtime
  `num_a_rows: OptionalReg[Int]` to `multistage_mma_q`.
- Route both A copy sites (prefetch + steady-state) through `copy_bounded` when
  `mask_a` is set.
- Compute the per-block bound `num_a_rows = clamp(M - block_m*BM, 0, BM)` **at
  the call site** in `multistage_qgemm_kernel`, because `block_idx` there is the
  *swizzled* block coordinate; the raw builtin inside `multistage_mma_q` would
  not match when block swizzling is active. Unlike the dense B bound, the A bound
  does not depend on the K-stage (A rows map to `M`, constant across K).
- `mask_a` defaults to `False`, so the only caller that opts in is the quantized
  kernel; every other caller of `multistage_mma_q` is byte-for-byte unchanged.

The masked path adds a per-vector comptime-unrolled bound compare on the A copy
only; the A tile is a small fraction of traffic next to the quantized B load.

## Testing

Built and run on an **RTX 3090 (sm_86)**, CUDA 13.3:

```
./bazelw test --config=prebuilt-mojo \
  //max/kernels/test/gpu/quantization:test_multistage_gemm_q.mojo.test
# Executed 1 out of 1 test: 1 test passes.
```

Added `M < BM` cases to `test_multistage_gemm_q` (its config forces `BM = 128`):
`M = 1` decode shapes and non-multiple-of-`BM` tails (`M = 3`, `M = 7`), all
validated against the dense fp32 dequant reference.

Honest caveat on the repro: the illegal-address fault was originally observed in
a standalone harness (forcing `BM = 128` at `N=4096, K=14336, M=1` on sm_86)
where the A buffer sat near the end of the mapped region. In this bazel test the
`DeviceContext` pooled allocator maps a large contiguous region, so with masking
disabled the over-read lands in mapped memory and neither faults nor is flagged
by `compute-sanitizer memcheck` (which sees the whole pool as one allocation) —
I verified this directly. The over-read is nonetheless real (confirmed by code
inspection of the unmasked `async_copy` path in `tile_io.mojo`), and the added
tests lock in that masking keeps decode/partial-tile results correct. A
guard-page (VMM) test would deterministically catch the fault; happy to add one
if maintainers prefer.

## Coordination

`#6708` (draft, NVFP4 GEMM on this skeleton) touches the same copy sites but does
not add A-row masking — no overlap; this is intended to land independently.

## Checklist

- [ ] Linked issue reviewed/agreed by a maintainer (draft — not yet)
- [x] PR is small and focused
- [x] I ran `./bazelw run format`
- [x] I added tests to cover my changes
- [x] AI assistance disclosed

Assisted-by: Claude (claude-opus-4-8) via Claude Code
