### PR TITLE
[ci] Replace deprecated app-id in actions/create-github-app-token

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -31,10 +31,9 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
         with:
-          app-id: ${{ vars.CLA_BOT_CLIENT_ID }}
-          private-key: ${{ secrets.CLA_BOT_PRIVATE_KEY }}
+          client-id: ${{ vars.GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
           owner: modular
           repositories: cla
           permission-contents: write


### PR DESCRIPTION
I am not sure if this change is helpful. Two warnings remain and `contributor-assistant/github-action` is discontinued (the repository is marked as archived). Might require a new approach altogether.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [x] Build, CI, or tooling change

## Motivation

Deprecation warning in CI.

## What changed

Adapt way how to pass secrets to actions/create-github-app-token.

## Testing

Works, but warnings remain.

## Checklist

- [ ] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [ ] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/Mojo/docs/contributing/issue-pr-etiquette.md#keep-pull-requests-small))
- [ ] I ran `./bazelw run format` to format my changes
- [ ] I added or updated tests to cover my changes
- [ ] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
