### PR TITLE
[stdlib] Fix `exp` flushing subnormal results to zero and overflowing early

### DIFF
--- a/Mojo/docs/site/nightly-changelog.md
+++ b/Mojo/docs/site/nightly-changelog.md
@@ -497,6 +497,13 @@ This release completes the removal of APIs deprecated during the v1.0 cycle.
 
 ## Fixed
 
+- [`exp()`](/docs/std/math/math/exp/) no longer flushes subnormal results to
+  zero, and no longer overflows to infinity just short of the true overflow
+  point. `exp(-708.745)` returned `0.0` and `exp(709.4365)` returned `inf`;
+  both now match the C library. [`ldexp()`](/docs/std/math/math/ldexp/) is
+  likewise correct for exponents outside the range a single biased exponent
+  field can hold.
+
 - `unsafe_uninit_move_n()` and `unsafe_uninit_copy_n()` with `overlapping=True`
   now handle an overlap in either direction when `T` is not trivially movable
   or copyable. They always walked front-to-back, so a `dest` above `src`

--- a/Mojo/stdlib/std/math/math.mojo
+++ b/Mojo/stdlib/std/math/math.mojo
@@ -519,14 +519,22 @@ def _ldexp_impl[
         return res
 
     comptime integral_type = FPUtils[dtype].integral_type
-    var m = exp.cast[integral_type]() + SIMD[integral_type, width](
-        FPUtils[dtype].exponent_bias()
-    )
 
-    return x * type_of(x)(
-        from_bits=m
-        << SIMD[integral_type, width](FPUtils[dtype].mantissa_width())
-    )
+    @always_inline
+    def pow2(e: SIMD[dtype, width]) -> SIMD[dtype, width]:
+        var m = e.cast[integral_type]() + SIMD[integral_type, width](
+            FPUtils[dtype].exponent_bias()
+        )
+        return SIMD[dtype, width](
+            from_bits=m
+            << SIMD[integral_type, width](FPUtils[dtype].mantissa_width())
+        )
+
+    # Halving keeps both factors within the representable exponent range, so
+    # exponents that would encode as 0 or as the inf/nan pattern still scale
+    # correctly and underflow stays gradual.
+    var half = floor(exp * 0.5)
+    return x * pow2(half) * pow2(exp - half)
 
 
 @always_inline
@@ -645,11 +653,11 @@ def exp[
     var max_val: SIMD[dtype, width]
 
     comptime if dtype == .float64:
-        min_val = -709.436139303
-        max_val = 709.437
+        min_val = -745.2
+        max_val = 709.79
     else:
-        min_val = -88.3762626647949
-        max_val = 88.3762626647950
+        min_val = -104.0
+        max_val = 88.73
 
     var xc = x.clamp(min_val, max_val)
     var k = floor(xc.fma(log2e, 0.5))

--- a/Mojo/stdlib/test/math/test_exp.mojo
+++ b/Mojo/stdlib/test/math/test_exp.mojo
@@ -11,12 +11,18 @@
 # limitations under the License.
 # ===----------------------------------------------------------------------=== #
 
+from std.math import isfinite
 from std.math.math import _Expable, exp
 from std.random import randn_float64, seed
 from std.sys import CompilationTarget
 
 from test_utils import libm_call
-from std.testing import assert_almost_equal, assert_equal, TestSuite
+from std.testing import (
+    assert_almost_equal,
+    assert_equal,
+    assert_true,
+    TestSuite,
+)
 
 
 def test_exp_bfloat16() raises:
@@ -48,6 +54,27 @@ def test_exp_float64() raises:
     # FIXME (40568) should remove str
     assert_equal(String(exp(Float64(89))), String(4.4896128193366053e38))
     assert_equal(String(exp(Float64(108.5230))), String(1.3518859659123633e47))
+
+
+def test_exp_float32_extremes() raises:
+    # Underflow is gradual, so results below the smallest normal are subnormal
+    # rather than zero.
+    assert_true(exp(Float32(-103.0)) > 0)
+    assert_equal(exp(Float32(-104.0)), 0)
+    assert_true(isfinite(exp(Float32(88.72))))
+    assert_equal(String(exp(Float32(89))), "inf")
+
+
+def test_exp_float64_extremes() raises:
+    assert_almost_equal(
+        exp(Float64(-708.745)), 1.570208859696427e-308, atol=0, rtol=1e-9
+    )
+    assert_equal(exp(Float64(-745.0)), 5e-324)
+    assert_equal(exp(Float64(-745.2)), 0)
+    assert_almost_equal(
+        exp(Float64(709.4365)), 1.2716195926832784e308, atol=0, rtol=1e-9
+    )
+    assert_equal(String(exp(Float64(710))), "inf")
 
 
 @always_inline

--- a/Mojo/stdlib/test/math/test_ldexp.mojo
+++ b/Mojo/stdlib/test/math/test_ldexp.mojo
@@ -42,6 +42,13 @@ def test_ldexp_vector() raises:
     )
 
 
+def test_ldexp_out_of_range_exponent() raises:
+    # The exponent does not have to fit a single biased exponent field.
+    assert_equal(ldexp(Float64(1.0), Int32(-1074)), 5e-324)
+    assert_equal(ldexp(Float64(1.0), Int32(-1075)), 0)
+    assert_equal(ldexp(Float64(0.5), Int32(1024)), 8.98846567431158e307)
+
+
 def ldexp_libm[
     dtype: DType, simd_width: SIMDLength
 ](arg: SIMD[dtype, simd_width], e: SIMD[.int32, simd_width]) -> SIMD[


### PR DESCRIPTION
## Linked issue

Fixes #7098

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Performance improvement (includes benchmark results below)
- [ ] Documentation update
- [ ] New feature or public API (requires prior proposal or issue approval)
- [ ] Refactor / internal cleanup (no user-visible change)
- [ ] Build, CI, or tooling change

## Motivation

`exp` returns `0.0` whenever the true result is subnormal, and `inf` just
short of real overflow. Softmax hits the first one routinely: a small
probability becomes exactly zero, then `-inf` through `log`.

## What changed

`_ldexp_impl` scaled by writing `exp + bias` into the exponent field, which
only encodes `[-1022, 1023]`. `exp` reaches `-1023` and `1024`, the reserved
zero and inf patterns. It now scales in two halves so neither factor leaves
the range, which fixes `ldexp` too, and the clamps in `exp` widen to the
real limits.

Float32 had the same bug. Its existing test wanted `inf` from `exp(89)` and
was getting it from the broken scale factor, so it failed once the scaling
was right.

## Checklist

- [x] The linked issue above has been reviewed by a maintainer and is
      agreed-upon, or this is a trivial fix that does not need prior
      approval
- [x] PR is small and focused — I've split larger changes into a sequence of
      smaller PRs where possible (see
      [pull request sizes](https://github.com/modular/modular/blob/main/Mojo/docs/contributing/issue-pr-etiquette.md#keep-pull-requests-small))
- [x] I ran `./bazelw run format` to format my changes
- [x] I added or updated tests to cover my changes
- [x] If AI tools assisted with this contribution, I have included an
      `Assisted-by:` trailer in my commit message or this PR description (see
      [AI Tool Use Policy](https://github.com/modular/modular/blob/main/AI_TOOL_POLICY.md))
